### PR TITLE
[MU4] Fix #10098: Implement "System", "Staff" and "Capo" text lines in palettes (with corresponding Properties settings)

### DIFF
--- a/src/inspector/CMakeLists.txt
+++ b/src/inspector/CMakeLists.txt
@@ -136,8 +136,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/models/notation/lines/letringsettingsmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/models/notation/lines/palmmutesettingsmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/models/notation/lines/palmmutesettingsmodel.h
-    ${CMAKE_CURRENT_LIST_DIR}/models/notation/lines/linesettingsmodel.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/models/notation/lines/linesettingsmodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/models/notation/lines/textlinesettingsmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/models/notation/lines/textlinesettingsmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/models/notation/images/imagesettingsmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/models/notation/images/imagesettingsmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/models/notation/jumps/jumpsettingsmodel.cpp

--- a/src/inspector/internal/services/elementrepositoryservice.cpp
+++ b/src/inspector/internal/services/elementrepositoryservice.cpp
@@ -83,6 +83,7 @@ QList<Ms::EngravingItem*> ElementRepositoryService::findElementsByType(const Ms:
     case Ms::ElementType::VOLTA:
     case Ms::ElementType::LET_RING:
     case Ms::ElementType::OTTAVA:
+    case Ms::ElementType::TEXTLINE:
     case Ms::ElementType::PALM_MUTE: return findLines(elementType);
     default:
         QList<Ms::EngravingItem*> resultList;
@@ -253,7 +254,8 @@ QList<Ms::EngravingItem*> ElementRepositoryService::findLines(Ms::ElementType li
         { Ms::ElementType::VOLTA, Ms::ElementType::VOLTA_SEGMENT },
         { Ms::ElementType::LET_RING, Ms::ElementType::LET_RING_SEGMENT },
         { Ms::ElementType::PALM_MUTE, Ms::ElementType::PALM_MUTE_SEGMENT },
-        { Ms::ElementType::OTTAVA, Ms::ElementType::OTTAVA_SEGMENT }
+        { Ms::ElementType::OTTAVA, Ms::ElementType::OTTAVA_SEGMENT },
+        { Ms::ElementType::TEXTLINE, Ms::ElementType::TEXTLINE_SEGMENT }
     };
 
     QList<Ms::EngravingItem*> resultList;

--- a/src/inspector/models/abstractinspectormodel.cpp
+++ b/src/inspector/models/abstractinspectormodel.cpp
@@ -81,7 +81,9 @@ static const QMap<Ms::ElementType, InspectorModelType> NOTATION_ELEMENT_MODEL_TY
     { Ms::ElementType::TREMOLOBAR, InspectorModelType::TYPE_TREMOLOBAR },
     { Ms::ElementType::TREMOLO, InspectorModelType::TYPE_TREMOLO },
     { Ms::ElementType::MEASURE_REPEAT, InspectorModelType::TYPE_MEASURE_REPEAT },
-    { Ms::ElementType::TUPLET, InspectorModelType::TYPE_TUPLET }
+    { Ms::ElementType::TUPLET, InspectorModelType::TYPE_TUPLET },
+    { Ms::ElementType::TEXTLINE, InspectorModelType::TYPE_TEXT_LINE },
+    { Ms::ElementType::TEXTLINE_SEGMENT, InspectorModelType::TYPE_TEXT_LINE }
 };
 
 static QMap<Ms::HairpinType, InspectorModelType> HAIRPIN_ELEMENT_MODEL_TYPES = {

--- a/src/inspector/models/abstractinspectormodel.h
+++ b/src/inspector/models/abstractinspectormodel.h
@@ -113,7 +113,8 @@ public:
         TYPE_TREMOLO,
         TYPE_MEASURE_REPEAT,
         TYPE_DYNAMIC,
-        TYPE_TUPLET
+        TYPE_TUPLET,
+        TYPE_TEXT_LINE
     };
     Q_ENUM(InspectorModelType)
 

--- a/src/inspector/models/inspectormodelcreator.cpp
+++ b/src/inspector/models/inspectormodelcreator.cpp
@@ -123,6 +123,8 @@ AbstractInspectorModel* InspectorModelCreator::newInspectorModel(InspectorModelT
         return new PalmMuteSettingsModel(parent, repository);
     case InspectorModelType::TYPE_LET_RING:
         return new LetRingSettingsModel(parent, repository);
+    case InspectorModelType::TYPE_TEXT_LINE:
+        return new LineSettingsModel(parent, repository);
     case InspectorModelType::TYPE_VIBRATO:
         return new VibratoSettingsModel(parent, repository);
     case InspectorModelType::TYPE_STAFF_TYPE_CHANGES:

--- a/src/inspector/models/inspectormodelcreator.cpp
+++ b/src/inspector/models/inspectormodelcreator.cpp
@@ -124,7 +124,7 @@ AbstractInspectorModel* InspectorModelCreator::newInspectorModel(InspectorModelT
     case InspectorModelType::TYPE_LET_RING:
         return new LetRingSettingsModel(parent, repository);
     case InspectorModelType::TYPE_TEXT_LINE:
-        return new LineSettingsModel(parent, repository);
+        return new TextLineSettingsModel(parent, repository);
     case InspectorModelType::TYPE_VIBRATO:
         return new VibratoSettingsModel(parent, repository);
     case InspectorModelType::TYPE_STAFF_TYPE_CHANGES:

--- a/src/inspector/models/notation/lines/hairpinlinesettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/hairpinlinesettingsmodel.cpp
@@ -33,7 +33,7 @@ using namespace mu::inspector;
 using IconCode = mu::ui::IconCode::Code;
 
 HairpinLineSettingsModel::HairpinLineSettingsModel(QObject* parent, IElementRepositoryService* repository, HairpinLineType lineType)
-    : LineSettingsModel(parent, repository)
+    : TextLineSettingsModel(parent, repository)
 {
     if (lineType == Diminuendo) {
         setModelType(InspectorModelType::TYPE_DIMINUENDO);
@@ -50,7 +50,7 @@ HairpinLineSettingsModel::HairpinLineSettingsModel(QObject* parent, IElementRepo
 
 void HairpinLineSettingsModel::createProperties()
 {
-    LineSettingsModel::createProperties();
+    TextLineSettingsModel::createProperties();
 
     isLineVisible()->setIsVisible(true);
     allowDiagonal()->setIsVisible(false);

--- a/src/inspector/models/notation/lines/hairpinlinesettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/hairpinlinesettingsmodel.cpp
@@ -45,15 +45,6 @@ HairpinLineSettingsModel::HairpinLineSettingsModel(QObject* parent, IElementRepo
         setIcon(ui::IconCode::Code::CRESCENDO);
     }
 
-    static const QList<HookTypeInfo> hookTypes {
-        { Ms::HookType::NONE, IconCode::LINE_NORMAL, qtrc("inspector", "Normal") },
-        { Ms::HookType::HOOK_90, IconCode::LINE_WITH_END_HOOK, qtrc("inspector", "Hooked 90") },
-        { Ms::HookType::HOOK_45, IconCode::LINE_WITH_ANGLED_END_HOOK, qtrc("inspector", "Hooked 45") },
-        { Ms::HookType::HOOK_90T, IconCode::LINE_WITH_T_LIKE_END_HOOK, qtrc("inspector", "Hoocked 90 T-style") }
-    };
-
-    setPossibleEndHookTypes(hookTypes);
-
     createProperties();
 }
 
@@ -62,6 +53,7 @@ void HairpinLineSettingsModel::createProperties()
     LineSettingsModel::createProperties();
 
     allowDiagonal()->setIsVisible(false);
+    placement()->setIsVisible(true);
 }
 
 void HairpinLineSettingsModel::requestElements()

--- a/src/inspector/models/notation/lines/hairpinlinesettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/hairpinlinesettingsmodel.cpp
@@ -52,6 +52,7 @@ void HairpinLineSettingsModel::createProperties()
 {
     LineSettingsModel::createProperties();
 
+    isLineVisible()->setIsVisible(true);
     allowDiagonal()->setIsVisible(false);
     placement()->setIsVisible(true);
 }

--- a/src/inspector/models/notation/lines/hairpinlinesettingsmodel.h
+++ b/src/inspector/models/notation/lines/hairpinlinesettingsmodel.h
@@ -22,10 +22,10 @@
 #ifndef MU_INSPECTOR_HAIRPINLINESETTINGSMODEL_H
 #define MU_INSPECTOR_HAIRPINLINESETTINGSMODEL_H
 
-#include "linesettingsmodel.h"
+#include "textlinesettingsmodel.h"
 
 namespace mu::inspector {
-class HairpinLineSettingsModel : public LineSettingsModel
+class HairpinLineSettingsModel : public TextLineSettingsModel
 {
     Q_OBJECT
 

--- a/src/inspector/models/notation/lines/hairpinsettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/hairpinsettingsmodel.cpp
@@ -62,6 +62,8 @@ void HairpinSettingsModel::createProperties()
     m_height = buildPropertyItem(Ms::Pid::HAIRPIN_HEIGHT);
     m_continiousHeight = buildPropertyItem(Ms::Pid::HAIRPIN_CONT_HEIGHT);
 
+    isLineVisible()->setIsVisible(false);
+    allowDiagonal()->setIsVisible(true);
     placement()->setIsVisible(true);
 }
 

--- a/src/inspector/models/notation/lines/hairpinsettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/hairpinsettingsmodel.cpp
@@ -61,6 +61,8 @@ void HairpinSettingsModel::createProperties()
     m_isNienteCircleVisible = buildPropertyItem(Ms::Pid::HAIRPIN_CIRCLEDTIP);
     m_height = buildPropertyItem(Ms::Pid::HAIRPIN_HEIGHT);
     m_continiousHeight = buildPropertyItem(Ms::Pid::HAIRPIN_CONT_HEIGHT);
+
+    placement()->setIsVisible(true);
 }
 
 void HairpinSettingsModel::loadProperties()

--- a/src/inspector/models/notation/lines/hairpinsettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/hairpinsettingsmodel.cpp
@@ -30,7 +30,7 @@
 using namespace mu::inspector;
 
 HairpinSettingsModel::HairpinSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : LineSettingsModel(parent, repository)
+    : TextLineSettingsModel(parent, repository)
 {
     setModelType(InspectorModelType::TYPE_HAIRPIN);
     setTitle(qtrc("inspector", "Hairpin"));
@@ -56,7 +56,7 @@ PropertyItem* HairpinSettingsModel::continiousHeight() const
 
 void HairpinSettingsModel::createProperties()
 {
-    LineSettingsModel::createProperties();
+    TextLineSettingsModel::createProperties();
 
     m_isNienteCircleVisible = buildPropertyItem(Ms::Pid::HAIRPIN_CIRCLEDTIP);
     m_height = buildPropertyItem(Ms::Pid::HAIRPIN_HEIGHT);
@@ -73,7 +73,7 @@ void HairpinSettingsModel::loadProperties()
         return DataFormatter::roundDouble(elementPropertyValue.toDouble());
     };
 
-    LineSettingsModel::loadProperties();
+    TextLineSettingsModel::loadProperties();
 
     loadPropertyItem(m_isNienteCircleVisible);
     loadPropertyItem(m_height, formatDoubleFunc);
@@ -82,7 +82,7 @@ void HairpinSettingsModel::loadProperties()
 
 void HairpinSettingsModel::resetProperties()
 {
-    LineSettingsModel::resetProperties();
+    TextLineSettingsModel::resetProperties();
 
     m_isNienteCircleVisible->resetToDefault();
     m_height->resetToDefault();

--- a/src/inspector/models/notation/lines/hairpinsettingsmodel.h
+++ b/src/inspector/models/notation/lines/hairpinsettingsmodel.h
@@ -22,10 +22,10 @@
 #ifndef MU_INSPECTOR_HAIRPINSETTINGSMODEL_H
 #define MU_INSPECTOR_HAIRPINSETTINGSMODEL_H
 
-#include "linesettingsmodel.h"
+#include "textlinesettingsmodel.h"
 
 namespace mu::inspector {
-class HairpinSettingsModel : public LineSettingsModel
+class HairpinSettingsModel : public TextLineSettingsModel
 {
     Q_OBJECT
 

--- a/src/inspector/models/notation/lines/letringsettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/letringsettingsmodel.cpp
@@ -39,6 +39,8 @@ void LetRingSettingsModel::createProperties()
 {
     LineSettingsModel::createProperties();
 
+    isLineVisible()->setIsVisible(true);
+    allowDiagonal()->setIsVisible(true);
     placement()->setIsVisible(true);
     startHookType()->setIsVisible(false);
     endHookType()->setIsVisible(false);

--- a/src/inspector/models/notation/lines/letringsettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/letringsettingsmodel.cpp
@@ -25,7 +25,7 @@
 using namespace mu::inspector;
 
 LetRingSettingsModel::LetRingSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : LineSettingsModel(parent, repository, Ms::ElementType::LET_RING)
+    : TextLineSettingsModel(parent, repository, Ms::ElementType::LET_RING)
 {
     setModelType(InspectorModelType::TYPE_LET_RING);
     setTitle(qtrc("inspector", "Let ring"));
@@ -37,7 +37,7 @@ LetRingSettingsModel::LetRingSettingsModel(QObject* parent, IElementRepositorySe
 
 void LetRingSettingsModel::createProperties()
 {
-    LineSettingsModel::createProperties();
+    TextLineSettingsModel::createProperties();
 
     isLineVisible()->setIsVisible(true);
     allowDiagonal()->setIsVisible(true);

--- a/src/inspector/models/notation/lines/letringsettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/letringsettingsmodel.cpp
@@ -42,7 +42,4 @@ void LetRingSettingsModel::createProperties()
     placement()->setIsVisible(true);
     startHookType()->setIsVisible(false);
     endHookType()->setIsVisible(false);
-
-    beginingTextHorizontalOffset()->setIsVisible(false);
-    continiousTextHorizontalOffset()->setIsVisible(false);
 }

--- a/src/inspector/models/notation/lines/letringsettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/letringsettingsmodel.cpp
@@ -30,6 +30,7 @@ LetRingSettingsModel::LetRingSettingsModel(QObject* parent, IElementRepositorySe
     setModelType(InspectorModelType::TYPE_LET_RING);
     setTitle(qtrc("inspector", "Let ring"));
     setIcon(ui::IconCode::Code::LET_RING);
+    setPossibleEndHookTypes({});
 
     createProperties();
 }
@@ -38,6 +39,7 @@ void LetRingSettingsModel::createProperties()
 {
     LineSettingsModel::createProperties();
 
+    placement()->setIsVisible(true);
     startHookType()->setIsVisible(false);
     endHookType()->setIsVisible(false);
 

--- a/src/inspector/models/notation/lines/letringsettingsmodel.h
+++ b/src/inspector/models/notation/lines/letringsettingsmodel.h
@@ -22,10 +22,10 @@
 #ifndef MU_INSPECTOR_LETRINGSETTINGSMODEL_H
 #define MU_INSPECTOR_LETRINGSETTINGSMODEL_H
 
-#include "linesettingsmodel.h"
+#include "textlinesettingsmodel.h"
 
 namespace mu::inspector {
-class LetRingSettingsModel : public LineSettingsModel
+class LetRingSettingsModel : public TextLineSettingsModel
 {
     Q_OBJECT
 

--- a/src/inspector/models/notation/lines/linesettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/linesettingsmodel.cpp
@@ -56,25 +56,28 @@ void LineSettingsModel::createProperties()
         onUpdateLinePropertiesAvailability();
     };
 
-    m_lineStyle = buildPropertyItem(Ms::Pid::LINE_STYLE, applyPropertyValueAndUpdateAvailability);
     m_isLineVisible = buildPropertyItem(Ms::Pid::LINE_VISIBLE, applyPropertyValueAndUpdateAvailability);
+    m_isLineVisible->setIsVisible(false);
+
+    m_allowDiagonal = buildPropertyItem(Ms::Pid::DIAGONAL);
+    m_allowDiagonal->setIsVisible(false);
+
+    m_lineStyle = buildPropertyItem(Ms::Pid::LINE_STYLE, applyPropertyValueAndUpdateAvailability);
 
     m_startHookType = buildPropertyItem(Ms::Pid::BEGIN_HOOK_TYPE, applyPropertyValueAndUpdateAvailability);
     m_endHookType = buildPropertyItem(Ms::Pid::END_HOOK_TYPE, applyPropertyValueAndUpdateAvailability);
-
-    m_placement = buildPropertyItem(Ms::Pid::PLACEMENT);
-    m_placement->setIsVisible(false);
 
     m_thickness = buildPropertyItem(Ms::Pid::LINE_WIDTH);
     m_dashLineLength = buildPropertyItem(Ms::Pid::DASH_LINE_LEN);
     m_dashGapLength = buildPropertyItem(Ms::Pid::DASH_GAP_LEN);
 
-    m_allowDiagonal = buildPropertyItem(Ms::Pid::DIAGONAL);
-
     m_hookHeight = buildPropertyItem(Ms::Pid::END_HOOK_HEIGHT, [this](const Ms::Pid pid, const QVariant& newValue) {
         onPropertyValueChanged(pid, newValue);
         onPropertyValueChanged(Ms::Pid::BEGIN_HOOK_HEIGHT, newValue);
     });
+
+    m_placement = buildPropertyItem(Ms::Pid::PLACEMENT);
+    m_placement->setIsVisible(false);
 
     if (isTextVisible(BeginingText)) {
         m_beginingText = buildPropertyItem(Ms::Pid::BEGIN_TEXT);
@@ -108,19 +111,20 @@ void LineSettingsModel::loadProperties()
         return DataFormatter::roundDouble(elementPropertyValue.toDouble());
     };
 
+    loadPropertyItem(m_isLineVisible);
+    loadPropertyItem(m_allowDiagonal);
+
     loadPropertyItem(m_lineStyle);
-    loadPropertyItem(m_placement);
 
     loadPropertyItem(m_thickness, formatDoubleFunc);
     loadPropertyItem(m_dashLineLength, formatDoubleFunc);
     loadPropertyItem(m_dashGapLength, formatDoubleFunc);
 
-    loadPropertyItem(m_isLineVisible);
-    loadPropertyItem(m_allowDiagonal);
-
     loadPropertyItem(m_startHookType);
     loadPropertyItem(m_endHookType);
     loadPropertyItem(m_hookHeight);
+
+    loadPropertyItem(m_placement);
 
     loadPropertyItem(m_beginingText);
     loadPropertyItem(m_beginingTextVerticalOffset, [](const QVariant& elementPropertyValue) -> QVariant {
@@ -143,16 +147,16 @@ void LineSettingsModel::loadProperties()
 void LineSettingsModel::resetProperties()
 {
     QList<PropertyItem*> allProperties {
+        m_isLineVisible,
+        m_allowDiagonal,
         m_lineStyle,
-        m_placement,
         m_thickness,
         m_dashLineLength,
         m_dashGapLength,
-        m_isLineVisible,
-        m_allowDiagonal,
         m_startHookType,
         m_endHookType,
         m_hookHeight,
+        m_placement,
         m_beginingText,
         m_beginingTextVerticalOffset,
         m_continiousText,
@@ -168,14 +172,24 @@ void LineSettingsModel::resetProperties()
     }
 }
 
-PropertyItem* LineSettingsModel::thickness() const
+PropertyItem* LineSettingsModel::isLineVisible() const
 {
-    return m_thickness;
+    return m_isLineVisible;
+}
+
+PropertyItem* LineSettingsModel::allowDiagonal() const
+{
+    return m_allowDiagonal;
 }
 
 PropertyItem* LineSettingsModel::lineStyle() const
 {
     return m_lineStyle;
+}
+
+PropertyItem* LineSettingsModel::thickness() const
+{
+    return m_thickness;
 }
 
 PropertyItem* LineSettingsModel::dashLineLength() const
@@ -186,21 +200,6 @@ PropertyItem* LineSettingsModel::dashLineLength() const
 PropertyItem* LineSettingsModel::dashGapLength() const
 {
     return m_dashGapLength;
-}
-
-PropertyItem* LineSettingsModel::placement() const
-{
-    return m_placement;
-}
-
-PropertyItem* LineSettingsModel::isLineVisible() const
-{
-    return m_isLineVisible;
-}
-
-PropertyItem* LineSettingsModel::allowDiagonal() const
-{
-    return m_allowDiagonal;
 }
 
 PropertyItem* LineSettingsModel::startHookType() const
@@ -216,6 +215,11 @@ PropertyItem* LineSettingsModel::endHookType() const
 PropertyItem* LineSettingsModel::hookHeight() const
 {
     return m_hookHeight;
+}
+
+PropertyItem* LineSettingsModel::placement() const
+{
+    return m_placement;
 }
 
 PropertyItem* LineSettingsModel::beginingText() const

--- a/src/inspector/models/notation/lines/linesettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/linesettingsmodel.cpp
@@ -78,33 +78,23 @@ void LineSettingsModel::createProperties()
 
     if (isTextVisible(BeginingText)) {
         m_beginingText = buildPropertyItem(Ms::Pid::BEGIN_TEXT);
-        m_beginingTextHorizontalOffset = buildPropertyItem(Ms::Pid::BEGIN_TEXT_OFFSET, [this](const Ms::Pid pid, const QVariant& newValue) {
-            onPropertyValueChanged(pid, QPointF(newValue.toDouble(), m_beginingTextVerticalOffset->value().toDouble()));
-        });
 
         m_beginingTextVerticalOffset = buildPropertyItem(Ms::Pid::BEGIN_TEXT_OFFSET, [this](const Ms::Pid pid, const QVariant& newValue) {
-            onPropertyValueChanged(pid, QPointF(m_beginingTextHorizontalOffset->value().toDouble(), newValue.toDouble()));
+            onPropertyValueChanged(pid, QPointF(m_beginingTextVerticalOffset->value().toDouble(), newValue.toDouble()));
         });
     }
 
     if (isTextVisible(ContiniousText)) {
         m_continiousText = buildPropertyItem(Ms::Pid::CONTINUE_TEXT);
-        m_continiousTextHorizontalOffset
-            = buildPropertyItem(Ms::Pid::CONTINUE_TEXT_OFFSET, [this](const Ms::Pid pid, const QVariant& newValue) {
-            onPropertyValueChanged(pid, QPointF(newValue.toDouble(), m_continiousTextVerticalOffset->value().toDouble()));
-        });
 
         m_continiousTextVerticalOffset = buildPropertyItem(Ms::Pid::CONTINUE_TEXT_OFFSET, [this](const Ms::Pid pid,
                                                                                                  const QVariant& newValue) {
-            onPropertyValueChanged(pid, QPointF(m_continiousTextHorizontalOffset->value().toDouble(), newValue.toDouble()));
+            onPropertyValueChanged(pid, QPointF(m_continiousTextVerticalOffset->value().toDouble(), newValue.toDouble()));
         });
     }
 
     if (isTextVisible(EndText)) {
         m_endText = buildPropertyItem(Ms::Pid::END_TEXT);
-        m_endTextHorizontalOffset = buildPropertyItem(Ms::Pid::END_TEXT_OFFSET, [this](const Ms::Pid pid, const QVariant& newValue) {
-            onPropertyValueChanged(pid, QPointF(newValue.toDouble(), m_endTextHorizontalOffset->value().toDouble()));
-        });
 
         m_endTextVerticalOffset = buildPropertyItem(Ms::Pid::END_TEXT_OFFSET, [this](const Ms::Pid pid, const QVariant& newValue) {
             onPropertyValueChanged(pid, QPointF(m_endTextVerticalOffset->value().toDouble(), newValue.toDouble()));
@@ -133,25 +123,16 @@ void LineSettingsModel::loadProperties()
     loadPropertyItem(m_hookHeight);
 
     loadPropertyItem(m_beginingText);
-    loadPropertyItem(m_beginingTextHorizontalOffset, [](const QVariant& elementPropertyValue) -> QVariant {
-        return DataFormatter::roundDouble(elementPropertyValue.value<QPointF>().x());
-    });
     loadPropertyItem(m_beginingTextVerticalOffset, [](const QVariant& elementPropertyValue) -> QVariant {
         return DataFormatter::roundDouble(elementPropertyValue.value<QPointF>().y());
     });
 
     loadPropertyItem(m_continiousText);
-    loadPropertyItem(m_continiousTextHorizontalOffset, [](const QVariant& elementPropertyValue) -> QVariant {
-        return DataFormatter::roundDouble(elementPropertyValue.value<QPointF>().x());
-    });
     loadPropertyItem(m_continiousTextVerticalOffset, [](const QVariant& elementPropertyValue) -> QVariant {
         return DataFormatter::roundDouble(elementPropertyValue.value<QPointF>().y());
     });
 
     loadPropertyItem(m_endText);
-    loadPropertyItem(m_endTextHorizontalOffset, [](const QVariant& elementPropertyValue) -> QVariant {
-        return DataFormatter::roundDouble(elementPropertyValue.value<QPointF>().x());
-    });
     loadPropertyItem(m_endTextVerticalOffset, [](const QVariant& elementPropertyValue) -> QVariant {
         return DataFormatter::roundDouble(elementPropertyValue.value<QPointF>().y());
     });
@@ -173,13 +154,10 @@ void LineSettingsModel::resetProperties()
         m_endHookType,
         m_hookHeight,
         m_beginingText,
-        m_beginingTextHorizontalOffset,
         m_beginingTextVerticalOffset,
         m_continiousText,
-        m_continiousTextHorizontalOffset,
         m_continiousTextVerticalOffset,
         m_endText,
-        m_endTextHorizontalOffset,
         m_endTextVerticalOffset
     };
 
@@ -245,11 +223,6 @@ PropertyItem* LineSettingsModel::beginingText() const
     return m_beginingText;
 }
 
-PropertyItem* LineSettingsModel::beginingTextHorizontalOffset() const
-{
-    return m_beginingTextHorizontalOffset;
-}
-
 PropertyItem* LineSettingsModel::beginingTextVerticalOffset() const
 {
     return m_beginingTextVerticalOffset;
@@ -260,11 +233,6 @@ PropertyItem* LineSettingsModel::continiousText() const
     return m_continiousText;
 }
 
-PropertyItem* LineSettingsModel::continiousTextHorizontalOffset() const
-{
-    return m_continiousTextHorizontalOffset;
-}
-
 PropertyItem* LineSettingsModel::continiousTextVerticalOffset() const
 {
     return m_continiousTextVerticalOffset;
@@ -273,11 +241,6 @@ PropertyItem* LineSettingsModel::continiousTextVerticalOffset() const
 PropertyItem* LineSettingsModel::endText() const
 {
     return m_endText;
-}
-
-PropertyItem* LineSettingsModel::endTextHorizontalOffset() const
-{
-    return m_endTextHorizontalOffset;
 }
 
 PropertyItem* LineSettingsModel::endTextVerticalOffset() const

--- a/src/inspector/models/notation/lines/linesettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/linesettingsmodel.cpp
@@ -22,16 +22,30 @@
 #include "linesettingsmodel.h"
 
 #include "dataformatter.h"
-#include "log.h"
-
 #include "types/linetypes.h"
+#include "ui/view/iconcodes.h"
+#include "log.h"
 
 using namespace mu::inspector;
 using namespace mu::engraving;
 
+using IconCode = mu::ui::IconCode::Code;
+
 LineSettingsModel::LineSettingsModel(QObject* parent, IElementRepositoryService* repository, Ms::ElementType elementType)
     : AbstractInspectorModel(parent, repository, elementType)
 {
+    setModelType(InspectorModelType::TYPE_TEXT_LINE);
+    setTitle(qtrc("inspector", "Text line"));
+
+    static const QList<HookTypeInfo> endHookTypes {
+        { Ms::HookType::NONE, IconCode::LINE_NORMAL, qtrc("inspector", "Normal") },
+        { Ms::HookType::HOOK_90, IconCode::LINE_WITH_END_HOOK, qtrc("inspector", "Hooked 90") },
+        { Ms::HookType::HOOK_45, IconCode::LINE_WITH_ANGLED_END_HOOK, qtrc("inspector", "Hooked 45") },
+        { Ms::HookType::HOOK_90T, IconCode::LINE_WITH_T_LIKE_END_HOOK, qtrc("inspector", "Hooked 90 T-style") }
+    };
+
+    setPossibleEndHookTypes(endHookTypes);
+
     createProperties();
 }
 
@@ -49,6 +63,7 @@ void LineSettingsModel::createProperties()
     m_endHookType = buildPropertyItem(Ms::Pid::END_HOOK_TYPE, applyPropertyValueAndUpdateAvailability);
 
     m_placement = buildPropertyItem(Ms::Pid::PLACEMENT);
+    m_placement->setIsVisible(false);
 
     m_thickness = buildPropertyItem(Ms::Pid::LINE_WIDTH);
     m_dashLineLength = buildPropertyItem(Ms::Pid::DASH_LINE_LEN);

--- a/src/inspector/models/notation/lines/linesettingsmodel.h
+++ b/src/inspector/models/notation/lines/linesettingsmodel.h
@@ -31,19 +31,20 @@ class LineSettingsModel : public AbstractInspectorModel
 {
     Q_OBJECT
 
+    Q_PROPERTY(PropertyItem * isLineVisible READ isLineVisible CONSTANT)
+    Q_PROPERTY(PropertyItem * allowDiagonal READ allowDiagonal CONSTANT)
+
     Q_PROPERTY(PropertyItem * lineStyle READ lineStyle CONSTANT)
-    Q_PROPERTY(PropertyItem * placement READ placement CONSTANT)
 
     Q_PROPERTY(PropertyItem * thickness READ thickness CONSTANT)
     Q_PROPERTY(PropertyItem * dashLineLength READ dashLineLength CONSTANT)
     Q_PROPERTY(PropertyItem * dashGapLength READ dashGapLength CONSTANT)
 
-    Q_PROPERTY(PropertyItem * isLineVisible READ isLineVisible CONSTANT)
-    Q_PROPERTY(PropertyItem * allowDiagonal READ allowDiagonal CONSTANT)
-
     Q_PROPERTY(PropertyItem * startHookType READ startHookType CONSTANT)
     Q_PROPERTY(PropertyItem * endHookType READ endHookType CONSTANT)
     Q_PROPERTY(PropertyItem * hookHeight READ hookHeight CONSTANT)
+
+    Q_PROPERTY(PropertyItem * placement READ placement CONSTANT)
 
     Q_PROPERTY(PropertyItem * beginingText READ beginingText CONSTANT)
     Q_PROPERTY(PropertyItem * beginingTextVerticalOffset READ beginingTextVerticalOffset CONSTANT)
@@ -58,19 +59,20 @@ public:
     explicit LineSettingsModel(QObject* parent, IElementRepositoryService* repository,
                                Ms::ElementType elementType = Ms::ElementType::TEXTLINE);
 
+    PropertyItem* isLineVisible() const;
+    PropertyItem* allowDiagonal() const;
+
     PropertyItem* lineStyle() const;
-    PropertyItem* placement() const;
 
     PropertyItem* thickness() const;
     PropertyItem* dashLineLength() const;
     PropertyItem* dashGapLength() const;
 
-    PropertyItem* isLineVisible() const;
-    PropertyItem* allowDiagonal() const;
-
     PropertyItem* startHookType() const;
     PropertyItem* endHookType() const;
     PropertyItem* hookHeight() const;
+
+    PropertyItem* placement() const;
 
     PropertyItem* beginingText() const;
     PropertyItem* beginingTextVerticalOffset() const;

--- a/src/inspector/models/notation/lines/linesettingsmodel.h
+++ b/src/inspector/models/notation/lines/linesettingsmodel.h
@@ -59,7 +59,7 @@ class LineSettingsModel : public AbstractInspectorModel
 
 public:
     explicit LineSettingsModel(QObject* parent, IElementRepositoryService* repository,
-                               Ms::ElementType elementType = Ms::ElementType::INVALID);
+                               Ms::ElementType elementType = Ms::ElementType::TEXTLINE);
 
     PropertyItem* lineStyle() const;
     PropertyItem* placement() const;

--- a/src/inspector/models/notation/lines/linesettingsmodel.h
+++ b/src/inspector/models/notation/lines/linesettingsmodel.h
@@ -46,15 +46,12 @@ class LineSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(PropertyItem * hookHeight READ hookHeight CONSTANT)
 
     Q_PROPERTY(PropertyItem * beginingText READ beginingText CONSTANT)
-    Q_PROPERTY(PropertyItem * beginingTextHorizontalOffset READ beginingTextHorizontalOffset CONSTANT)
     Q_PROPERTY(PropertyItem * beginingTextVerticalOffset READ beginingTextVerticalOffset CONSTANT)
 
     Q_PROPERTY(PropertyItem * continiousText READ continiousText CONSTANT)
-    Q_PROPERTY(PropertyItem * continiousTextHorizontalOffset READ continiousTextHorizontalOffset CONSTANT)
     Q_PROPERTY(PropertyItem * continiousTextVerticalOffset READ continiousTextVerticalOffset CONSTANT)
 
     Q_PROPERTY(PropertyItem * endText READ endText CONSTANT)
-    Q_PROPERTY(PropertyItem * endTextHorizontalOffset READ endTextHorizontalOffset CONSTANT)
     Q_PROPERTY(PropertyItem * endTextVerticalOffset READ endTextVerticalOffset CONSTANT)
 
 public:
@@ -76,15 +73,12 @@ public:
     PropertyItem* hookHeight() const;
 
     PropertyItem* beginingText() const;
-    PropertyItem* beginingTextHorizontalOffset() const;
     PropertyItem* beginingTextVerticalOffset() const;
 
     PropertyItem* continiousText() const;
-    PropertyItem* continiousTextHorizontalOffset() const;
     PropertyItem* continiousTextVerticalOffset() const;
 
     PropertyItem* endText() const;
-    PropertyItem* endTextHorizontalOffset() const;
     PropertyItem* endTextVerticalOffset() const;
 
     Q_INVOKABLE QVariantList possibleStartHookTypes() const;
@@ -141,15 +135,12 @@ private:
     PropertyItem* m_hookHeight = nullptr;
 
     PropertyItem* m_beginingText = nullptr;
-    PropertyItem* m_beginingTextHorizontalOffset = nullptr;
     PropertyItem* m_beginingTextVerticalOffset = nullptr;
 
     PropertyItem* m_continiousText = nullptr;
-    PropertyItem* m_continiousTextHorizontalOffset = nullptr;
     PropertyItem* m_continiousTextVerticalOffset = nullptr;
 
     PropertyItem* m_endText = nullptr;
-    PropertyItem* m_endTextHorizontalOffset = nullptr;
     PropertyItem* m_endTextVerticalOffset = nullptr;
 
     QVariantList m_possibleStartHookTypes;

--- a/src/inspector/models/notation/lines/ottavasettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/ottavasettingsmodel.cpp
@@ -88,6 +88,10 @@ void OttavaSettingsModel::createProperties()
 
     m_ottavaType = buildPropertyItem(Ms::Pid::OTTAVA_TYPE);
     m_showNumbersOnly = buildPropertyItem(Ms::Pid::NUMBERS_ONLY);
+
+    isLineVisible()->setIsVisible(true);
+    allowDiagonal()->setIsVisible(true);
+    placement()->setIsVisible(false);
 }
 
 void OttavaSettingsModel::loadProperties()

--- a/src/inspector/models/notation/lines/ottavasettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/ottavasettingsmodel.cpp
@@ -31,7 +31,7 @@ using namespace mu::inspector;
 using IconCode = mu::ui::IconCode::Code;
 
 OttavaSettingsModel::OttavaSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : LineSettingsModel(parent, repository, Ms::ElementType::OTTAVA)
+    : TextLineSettingsModel(parent, repository, Ms::ElementType::OTTAVA)
 {
     setTitle(qtrc("inspector", "Ottava"));
     setModelType(InspectorModelType::TYPE_OTTAVA);
@@ -84,7 +84,7 @@ QVariantList OttavaSettingsModel::possibleOttavaTypes() const
 
 void OttavaSettingsModel::createProperties()
 {
-    LineSettingsModel::createProperties();
+    TextLineSettingsModel::createProperties();
 
     m_ottavaType = buildPropertyItem(Ms::Pid::OTTAVA_TYPE);
     m_showNumbersOnly = buildPropertyItem(Ms::Pid::NUMBERS_ONLY);
@@ -96,7 +96,7 @@ void OttavaSettingsModel::createProperties()
 
 void OttavaSettingsModel::loadProperties()
 {
-    LineSettingsModel::loadProperties();
+    TextLineSettingsModel::loadProperties();
 
     loadPropertyItem(m_ottavaType);
     loadPropertyItem(m_showNumbersOnly);
@@ -104,7 +104,7 @@ void OttavaSettingsModel::loadProperties()
 
 void OttavaSettingsModel::resetProperties()
 {
-    LineSettingsModel::resetProperties();
+    TextLineSettingsModel::resetProperties();
 
     m_ottavaType->resetToDefault();
     m_showNumbersOnly->resetToDefault();

--- a/src/inspector/models/notation/lines/ottavasettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/ottavasettingsmodel.cpp
@@ -88,10 +88,6 @@ void OttavaSettingsModel::createProperties()
 
     m_ottavaType = buildPropertyItem(Ms::Pid::OTTAVA_TYPE);
     m_showNumbersOnly = buildPropertyItem(Ms::Pid::NUMBERS_ONLY);
-
-    beginingTextHorizontalOffset()->setIsVisible(false);
-    continiousTextHorizontalOffset()->setIsVisible(false);
-    endTextHorizontalOffset()->setIsVisible(false);
 }
 
 void OttavaSettingsModel::loadProperties()

--- a/src/inspector/models/notation/lines/ottavasettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/ottavasettingsmodel.cpp
@@ -89,7 +89,6 @@ void OttavaSettingsModel::createProperties()
     m_ottavaType = buildPropertyItem(Ms::Pid::OTTAVA_TYPE);
     m_showNumbersOnly = buildPropertyItem(Ms::Pid::NUMBERS_ONLY);
 
-    placement()->setIsVisible(false);
     beginingTextHorizontalOffset()->setIsVisible(false);
     continiousTextHorizontalOffset()->setIsVisible(false);
     endTextHorizontalOffset()->setIsVisible(false);

--- a/src/inspector/models/notation/lines/ottavasettingsmodel.h
+++ b/src/inspector/models/notation/lines/ottavasettingsmodel.h
@@ -22,10 +22,10 @@
 #ifndef MU_INSPECTOR_OTTAVASETTINGSMODEL_H
 #define MU_INSPECTOR_OTTAVASETTINGSMODEL_H
 
-#include "linesettingsmodel.h"
+#include "textlinesettingsmodel.h"
 
 namespace mu::inspector {
-class OttavaSettingsModel : public LineSettingsModel
+class OttavaSettingsModel : public TextLineSettingsModel
 {
     Q_OBJECT
 

--- a/src/inspector/models/notation/lines/palmmutesettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/palmmutesettingsmodel.cpp
@@ -41,7 +41,4 @@ void PalmMuteSettingsModel::createProperties()
     placement()->setIsVisible(true);
     startHookType()->setIsVisible(false);
     endHookType()->setIsVisible(false);
-
-    beginingTextHorizontalOffset()->setIsVisible(false);
-    continiousTextHorizontalOffset()->setIsVisible(false);
 }

--- a/src/inspector/models/notation/lines/palmmutesettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/palmmutesettingsmodel.cpp
@@ -38,6 +38,8 @@ void PalmMuteSettingsModel::createProperties()
 {
     LineSettingsModel::createProperties();
 
+    isLineVisible()->setIsVisible(true);
+    allowDiagonal()->setIsVisible(true);
     placement()->setIsVisible(true);
     startHookType()->setIsVisible(false);
     endHookType()->setIsVisible(false);

--- a/src/inspector/models/notation/lines/palmmutesettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/palmmutesettingsmodel.cpp
@@ -29,6 +29,7 @@ PalmMuteSettingsModel::PalmMuteSettingsModel(QObject* parent, IElementRepository
     setModelType(InspectorModelType::TYPE_PALM_MUTE);
     setTitle(qtrc("inspector", "Palm mute"));
     setIcon(ui::IconCode::Code::PALM_MUTE);
+    setPossibleEndHookTypes({});
 
     createProperties();
 }
@@ -37,6 +38,7 @@ void PalmMuteSettingsModel::createProperties()
 {
     LineSettingsModel::createProperties();
 
+    placement()->setIsVisible(true);
     startHookType()->setIsVisible(false);
     endHookType()->setIsVisible(false);
 

--- a/src/inspector/models/notation/lines/palmmutesettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/palmmutesettingsmodel.cpp
@@ -24,7 +24,7 @@
 using namespace mu::inspector;
 
 PalmMuteSettingsModel::PalmMuteSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : LineSettingsModel(parent, repository, Ms::ElementType::PALM_MUTE)
+    : TextLineSettingsModel(parent, repository, Ms::ElementType::PALM_MUTE)
 {
     setModelType(InspectorModelType::TYPE_PALM_MUTE);
     setTitle(qtrc("inspector", "Palm mute"));
@@ -36,7 +36,7 @@ PalmMuteSettingsModel::PalmMuteSettingsModel(QObject* parent, IElementRepository
 
 void PalmMuteSettingsModel::createProperties()
 {
-    LineSettingsModel::createProperties();
+    TextLineSettingsModel::createProperties();
 
     isLineVisible()->setIsVisible(true);
     allowDiagonal()->setIsVisible(true);

--- a/src/inspector/models/notation/lines/palmmutesettingsmodel.h
+++ b/src/inspector/models/notation/lines/palmmutesettingsmodel.h
@@ -22,10 +22,10 @@
 #ifndef MU_INSPECTOR_PALMMUTESETTINGSMODEL_H
 #define MU_INSPECTOR_PALMMUTESETTINGSMODEL_H
 
-#include "linesettingsmodel.h"
+#include "textlinesettingsmodel.h"
 
 namespace mu::inspector {
-class PalmMuteSettingsModel : public LineSettingsModel
+class PalmMuteSettingsModel : public TextLineSettingsModel
 {
     Q_OBJECT
 

--- a/src/inspector/models/notation/lines/pedalsettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/pedalsettingsmodel.cpp
@@ -100,8 +100,6 @@ void PedalSettingsModel::createProperties()
     m_lineType = buildPropertyItem(Ms::Pid::END, [this](const Ms::Pid, const QVariant& newValue) {
         setLineType(newValue.toInt());
     });
-
-    placement()->setIsVisible(false);
 }
 
 void PedalSettingsModel::loadProperties()

--- a/src/inspector/models/notation/lines/pedalsettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/pedalsettingsmodel.cpp
@@ -100,6 +100,10 @@ void PedalSettingsModel::createProperties()
     m_lineType = buildPropertyItem(Ms::Pid::END, [this](const Ms::Pid, const QVariant& newValue) {
         setLineType(newValue.toInt());
     });
+
+    isLineVisible()->setIsVisible(false);
+    allowDiagonal()->setIsVisible(false);
+    placement()->setIsVisible(false);
 }
 
 void PedalSettingsModel::loadProperties()

--- a/src/inspector/models/notation/lines/pedalsettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/pedalsettingsmodel.cpp
@@ -33,7 +33,7 @@ using IconCode = mu::ui::IconCode::Code;
 static constexpr int HOOK_STAR = static_cast<int>(Ms::HookType::HOOK_90T) + 1;
 
 PedalSettingsModel::PedalSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : LineSettingsModel(parent, repository, Ms::ElementType::PEDAL)
+    : TextLineSettingsModel(parent, repository, Ms::ElementType::PEDAL)
 {
     setModelType(InspectorModelType::TYPE_PEDAL);
     setTitle(qtrc("inspector", "Pedal"));
@@ -87,7 +87,7 @@ void PedalSettingsModel::setPedalSymbolVisible(bool visible)
 
 void PedalSettingsModel::createProperties()
 {
-    LineSettingsModel::createProperties();
+    TextLineSettingsModel::createProperties();
 
     connect(beginingText(), &PropertyItem::isModifiedChanged, this, [this]() {
         emit pedalSymbolVisibleChanged();
@@ -108,7 +108,7 @@ void PedalSettingsModel::createProperties()
 
 void PedalSettingsModel::loadProperties()
 {
-    LineSettingsModel::loadProperties();
+    TextLineSettingsModel::loadProperties();
 
     m_lineType->setIsEnabled(true);
 

--- a/src/inspector/models/notation/lines/pedalsettingsmodel.h
+++ b/src/inspector/models/notation/lines/pedalsettingsmodel.h
@@ -22,10 +22,10 @@
 #ifndef MU_INSPECTOR_PEDALSSETTINGSMODEL_H
 #define MU_INSPECTOR_PEDALSSETTINGSMODEL_H
 
-#include "linesettingsmodel.h"
+#include "textlinesettingsmodel.h"
 
 namespace mu::inspector {
-class PedalSettingsModel : public LineSettingsModel
+class PedalSettingsModel : public TextLineSettingsModel
 {
     Q_OBJECT
 

--- a/src/inspector/models/notation/lines/textlinesettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/textlinesettingsmodel.cpp
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include "linesettingsmodel.h"
+#include "textlinesettingsmodel.h"
 
 #include "dataformatter.h"
 #include "types/linetypes.h"
@@ -31,7 +31,7 @@ using namespace mu::engraving;
 
 using IconCode = mu::ui::IconCode::Code;
 
-LineSettingsModel::LineSettingsModel(QObject* parent, IElementRepositoryService* repository, Ms::ElementType elementType)
+TextLineSettingsModel::TextLineSettingsModel(QObject* parent, IElementRepositoryService* repository, Ms::ElementType elementType)
     : AbstractInspectorModel(parent, repository, elementType)
 {
     setModelType(InspectorModelType::TYPE_TEXT_LINE);
@@ -49,7 +49,7 @@ LineSettingsModel::LineSettingsModel(QObject* parent, IElementRepositoryService*
     createProperties();
 }
 
-void LineSettingsModel::createProperties()
+void TextLineSettingsModel::createProperties()
 {
     auto applyPropertyValueAndUpdateAvailability = [this](const Ms::Pid pid, const QVariant& newValue) {
         onPropertyValueChanged(pid, newValue);
@@ -105,7 +105,7 @@ void LineSettingsModel::createProperties()
     }
 }
 
-void LineSettingsModel::loadProperties()
+void TextLineSettingsModel::loadProperties()
 {
     auto formatDoubleFunc = [](const QVariant& elementPropertyValue) -> QVariant {
         return DataFormatter::roundDouble(elementPropertyValue.toDouble());
@@ -144,7 +144,7 @@ void LineSettingsModel::loadProperties()
     onUpdateLinePropertiesAvailability();
 }
 
-void LineSettingsModel::resetProperties()
+void TextLineSettingsModel::resetProperties()
 {
     QList<PropertyItem*> allProperties {
         m_isLineVisible,
@@ -172,97 +172,97 @@ void LineSettingsModel::resetProperties()
     }
 }
 
-PropertyItem* LineSettingsModel::isLineVisible() const
+PropertyItem* TextLineSettingsModel::isLineVisible() const
 {
     return m_isLineVisible;
 }
 
-PropertyItem* LineSettingsModel::allowDiagonal() const
+PropertyItem* TextLineSettingsModel::allowDiagonal() const
 {
     return m_allowDiagonal;
 }
 
-PropertyItem* LineSettingsModel::lineStyle() const
+PropertyItem* TextLineSettingsModel::lineStyle() const
 {
     return m_lineStyle;
 }
 
-PropertyItem* LineSettingsModel::thickness() const
+PropertyItem* TextLineSettingsModel::thickness() const
 {
     return m_thickness;
 }
 
-PropertyItem* LineSettingsModel::dashLineLength() const
+PropertyItem* TextLineSettingsModel::dashLineLength() const
 {
     return m_dashLineLength;
 }
 
-PropertyItem* LineSettingsModel::dashGapLength() const
+PropertyItem* TextLineSettingsModel::dashGapLength() const
 {
     return m_dashGapLength;
 }
 
-PropertyItem* LineSettingsModel::startHookType() const
+PropertyItem* TextLineSettingsModel::startHookType() const
 {
     return m_startHookType;
 }
 
-PropertyItem* LineSettingsModel::endHookType() const
+PropertyItem* TextLineSettingsModel::endHookType() const
 {
     return m_endHookType;
 }
 
-PropertyItem* LineSettingsModel::hookHeight() const
+PropertyItem* TextLineSettingsModel::hookHeight() const
 {
     return m_hookHeight;
 }
 
-PropertyItem* LineSettingsModel::placement() const
+PropertyItem* TextLineSettingsModel::placement() const
 {
     return m_placement;
 }
 
-PropertyItem* LineSettingsModel::beginingText() const
+PropertyItem* TextLineSettingsModel::beginingText() const
 {
     return m_beginingText;
 }
 
-PropertyItem* LineSettingsModel::beginingTextVerticalOffset() const
+PropertyItem* TextLineSettingsModel::beginingTextVerticalOffset() const
 {
     return m_beginingTextVerticalOffset;
 }
 
-PropertyItem* LineSettingsModel::continiousText() const
+PropertyItem* TextLineSettingsModel::continiousText() const
 {
     return m_continiousText;
 }
 
-PropertyItem* LineSettingsModel::continiousTextVerticalOffset() const
+PropertyItem* TextLineSettingsModel::continiousTextVerticalOffset() const
 {
     return m_continiousTextVerticalOffset;
 }
 
-PropertyItem* LineSettingsModel::endText() const
+PropertyItem* TextLineSettingsModel::endText() const
 {
     return m_endText;
 }
 
-PropertyItem* LineSettingsModel::endTextVerticalOffset() const
+PropertyItem* TextLineSettingsModel::endTextVerticalOffset() const
 {
     return m_endTextVerticalOffset;
 }
 
-QVariantList LineSettingsModel::possibleStartHookTypes() const
+QVariantList TextLineSettingsModel::possibleStartHookTypes() const
 {
     return m_possibleStartHookTypes;
 }
 
-QVariantList LineSettingsModel::possibleEndHookTypes() const
+QVariantList TextLineSettingsModel::possibleEndHookTypes() const
 {
     return m_possibleEndHookTypes;
 }
 
-QVariantList LineSettingsModel::hookTypesToObjList(const QList<HookTypeInfo>& types) const
+QVariantList TextLineSettingsModel::hookTypesToObjList(const QList<HookTypeInfo>& types) const
 {
     QVariantList result;
 
@@ -278,7 +278,7 @@ QVariantList LineSettingsModel::hookTypesToObjList(const QList<HookTypeInfo>& ty
     return result;
 }
 
-void LineSettingsModel::onUpdateLinePropertiesAvailability()
+void TextLineSettingsModel::onUpdateLinePropertiesAvailability()
 {
     auto hasHook = [](const PropertyItem* item) {
         return static_cast<HookType>(item->value().toInt()) != HookType::NONE;
@@ -301,18 +301,18 @@ void LineSettingsModel::onUpdateLinePropertiesAvailability()
     m_dashGapLength->setIsEnabled(isLineAvailable && areDashPropertiesAvailable);
 }
 
-bool LineSettingsModel::isTextVisible(TextType type) const
+bool TextLineSettingsModel::isTextVisible(TextType type) const
 {
     //! NOTE: the end text is hidden for most lines by default
     return type != TextType::EndText;
 }
 
-void LineSettingsModel::setPossibleStartHookTypes(const QList<HookTypeInfo>& types)
+void TextLineSettingsModel::setPossibleStartHookTypes(const QList<HookTypeInfo>& types)
 {
     m_possibleStartHookTypes = hookTypesToObjList(types);
 }
 
-void LineSettingsModel::setPossibleEndHookTypes(const QList<HookTypeInfo>& types)
+void TextLineSettingsModel::setPossibleEndHookTypes(const QList<HookTypeInfo>& types)
 {
     m_possibleEndHookTypes = hookTypesToObjList(types);
 }

--- a/src/inspector/models/notation/lines/textlinesettingsmodel.h
+++ b/src/inspector/models/notation/lines/textlinesettingsmodel.h
@@ -19,15 +19,15 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_INSPECTOR_LINESETTINGSMODEL_H
-#define MU_INSPECTOR_LINESETTINGSMODEL_H
+#ifndef MU_INSPECTOR_TEXTLINESETTINGSMODEL_H
+#define MU_INSPECTOR_TEXTLINESETTINGSMODEL_H
 
 #include "models/abstractinspectormodel.h"
 
 #include "ui/view/iconcodes.h"
 
 namespace mu::inspector {
-class LineSettingsModel : public AbstractInspectorModel
+class TextLineSettingsModel : public AbstractInspectorModel
 {
     Q_OBJECT
 
@@ -56,8 +56,8 @@ class LineSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(PropertyItem * endTextVerticalOffset READ endTextVerticalOffset CONSTANT)
 
 public:
-    explicit LineSettingsModel(QObject* parent, IElementRepositoryService* repository,
-                               Ms::ElementType elementType = Ms::ElementType::TEXTLINE);
+    explicit TextLineSettingsModel(QObject* parent, IElementRepositoryService* repository,
+                                   Ms::ElementType elementType = Ms::ElementType::TEXTLINE);
 
     PropertyItem* isLineVisible() const;
     PropertyItem* allowDiagonal() const;
@@ -150,4 +150,4 @@ private:
 };
 }
 
-#endif // MU_INSPECTOR_LINESETTINGSMODEL_H
+#endif // MU_INSPECTOR_TEXTLINESETTINGSMODEL_H

--- a/src/inspector/models/notation/lines/voltasettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/voltasettingsmodel.cpp
@@ -58,7 +58,6 @@ void VoltaSettingsModel::createProperties()
 
     m_repeatCount = buildPropertyItem(Ms::Pid::VOLTA_ENDING);
 
-    placement()->setIsVisible(false);
     beginingTextHorizontalOffset()->setIsVisible(false);
     continiousTextHorizontalOffset()->setIsVisible(false);
 }

--- a/src/inspector/models/notation/lines/voltasettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/voltasettingsmodel.cpp
@@ -31,7 +31,7 @@ using namespace mu::inspector;
 using IconCode = mu::ui::IconCode::Code;
 
 VoltaSettingsModel::VoltaSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : LineSettingsModel(parent, repository, Ms::ElementType::VOLTA)
+    : TextLineSettingsModel(parent, repository, Ms::ElementType::VOLTA)
 {
     setModelType(InspectorModelType::TYPE_VOLTA);
     setTitle(qtrc("inspector", "Volta"));
@@ -54,7 +54,7 @@ PropertyItem* VoltaSettingsModel::repeatCount() const
 
 void VoltaSettingsModel::createProperties()
 {
-    LineSettingsModel::createProperties();
+    TextLineSettingsModel::createProperties();
 
     m_repeatCount = buildPropertyItem(Ms::Pid::VOLTA_ENDING);
 
@@ -65,14 +65,14 @@ void VoltaSettingsModel::createProperties()
 
 void VoltaSettingsModel::loadProperties()
 {
-    LineSettingsModel::loadProperties();
+    TextLineSettingsModel::loadProperties();
 
     loadPropertyItem(m_repeatCount);
 }
 
 void VoltaSettingsModel::resetProperties()
 {
-    LineSettingsModel::resetProperties();
+    TextLineSettingsModel::resetProperties();
 
     m_repeatCount->resetToDefault();
 }

--- a/src/inspector/models/notation/lines/voltasettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/voltasettingsmodel.cpp
@@ -57,9 +57,6 @@ void VoltaSettingsModel::createProperties()
     LineSettingsModel::createProperties();
 
     m_repeatCount = buildPropertyItem(Ms::Pid::VOLTA_ENDING);
-
-    beginingTextHorizontalOffset()->setIsVisible(false);
-    continiousTextHorizontalOffset()->setIsVisible(false);
 }
 
 void VoltaSettingsModel::loadProperties()

--- a/src/inspector/models/notation/lines/voltasettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/voltasettingsmodel.cpp
@@ -57,6 +57,10 @@ void VoltaSettingsModel::createProperties()
     LineSettingsModel::createProperties();
 
     m_repeatCount = buildPropertyItem(Ms::Pid::VOLTA_ENDING);
+
+    isLineVisible()->setIsVisible(true);
+    allowDiagonal()->setIsVisible(true);
+    placement()->setIsVisible(false);
 }
 
 void VoltaSettingsModel::loadProperties()

--- a/src/inspector/models/notation/lines/voltasettingsmodel.h
+++ b/src/inspector/models/notation/lines/voltasettingsmodel.h
@@ -22,10 +22,10 @@
 #ifndef MU_INSPECTOR_VOLTASETTINGSMODEL_H
 #define MU_INSPECTOR_VOLTASETTINGSMODEL_H
 
-#include "linesettingsmodel.h"
+#include "textlinesettingsmodel.h"
 
 namespace mu::inspector {
-class VoltaSettingsModel : public LineSettingsModel
+class VoltaSettingsModel : public TextLineSettingsModel
 {
     Q_OBJECT
 

--- a/src/inspector/types/texttypes.h
+++ b/src/inspector/types/texttypes.h
@@ -136,9 +136,6 @@ public:
 
 static const QList<Ms::ElementType> TEXT_ELEMENT_TYPES = {
     Ms::ElementType::TEXT,
-    Ms::ElementType::TEXTLINE,
-    Ms::ElementType::TEXTLINE_BASE,
-    Ms::ElementType::TEXTLINE_SEGMENT,
     Ms::ElementType::STAFF_TEXT,
     Ms::ElementType::SYSTEM_TEXT,
     Ms::ElementType::DYNAMIC,

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/NotationInspectorSectionLoader.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/NotationInspectorSectionLoader.qml
@@ -100,7 +100,8 @@ Loader {
             case Inspector.TYPE_OTTAVA:
             case Inspector.TYPE_PALM_MUTE:
             case Inspector.TYPE_LET_RING:
-            case Inspector.TYPE_VOLTA: return lineComp
+            case Inspector.TYPE_VOLTA:
+            case Inspector.TYPE_TEXT_LINE: return lineComp
             case Inspector.TYPE_STAFF_TYPE_CHANGES: return staffTypeComp
             case Inspector.TYPE_TEXT_FRAME: return textFrameComp
             case Inspector.TYPE_VERTICAL_FRAME: return verticalFrameComp

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/LineTextSettingsTab.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/LineTextSettingsTab.qml
@@ -58,7 +58,6 @@ FocusableItem {
 
         OffsetSection {
             id: beginningTextOffsetSection
-            horizontalOffset: root.model ? root.model.beginingTextHorizontalOffset : null
             verticalOffset: root.model ? root.model.beginingTextVerticalOffset : null
 
             navigationPanel: root.navigationPanel
@@ -78,7 +77,6 @@ FocusableItem {
 
         OffsetSection {
             id: continiousTextOffsetSection
-            horizontalOffset: root.model ? root.model.continiousTextHorizontalOffset : null
             verticalOffset: root.model ? root.model.continiousTextVerticalOffset : null
 
             navigationPanel: root.navigationPanel
@@ -100,7 +98,6 @@ FocusableItem {
         OffsetSection {
             id: endTextOffsetSection
 
-            horizontalOffset: root.model ? root.model.endTextHorizontalOffset : null
             verticalOffset: root.model ? root.model.endTextVerticalOffset : null
 
             navigationPanel: root.navigationPanel

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -1087,6 +1087,19 @@ PalettePtr PaletteCreator::newLinesPalette()
         sp->appendElement(trill, trillTable[i].userName);
     }
 
+    auto staffTextLine = makeElement<TextLine>(gpaletteScore);
+    staffTextLine->setLen(w);
+    staffTextLine->setBeginText("Staff");
+    staffTextLine->setEndHookType(HookType::HOOK_90);
+    sp->appendElement(staffTextLine, QT_TRANSLATE_NOOP("palette", "Staff Text line"));
+
+    auto systemTextLine = makeElement<TextLine>(gpaletteScore);
+    systemTextLine->setSystemFlag(true);
+    systemTextLine->setLen(w);
+    systemTextLine->setBeginText("System");
+    systemTextLine->setEndHookType(HookType::HOOK_90);
+    sp->appendElement(systemTextLine, QT_TRANSLATE_NOOP("palette", "System Text line"));
+
     auto textLine = makeElement<TextLine>(gpaletteScore);
     textLine->setLen(w);
     textLine->setBeginText("VII");


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10098