### PR TITLE
[DAISY] Fix #303350: Cross-staff and cross-voice slur input via keyboard

### DIFF
--- a/src/engraving/libmscore/navigate.cpp
+++ b/src/engraving/libmscore/navigate.cpp
@@ -378,7 +378,7 @@ ChordRest* Score::downStaff(ChordRest* cr)
         return cr;
     }
 
-    for (int track = (cr->staffIdx() + 1) * VOICES; track < tracks; --track) {
+    for (int track = (cr->staffIdx() + 1) * VOICES; track < tracks; ++track) {
         EngravingItem* el = segment->element(track);
         if (!el) {
             continue;

--- a/src/engraving/libmscore/slur.h
+++ b/src/engraving/libmscore/slur.h
@@ -33,6 +33,8 @@ namespace Ms {
 
 class SlurSegment final : public SlurTieSegment
 {
+    mutable ChordRest* _savedCR = nullptr; // used during editing of cross-track slurs
+
 protected:
     qreal _extraHeight = 0.0;
     void changeAnchor(EditData&, EngravingItem*) override;
@@ -49,6 +51,11 @@ public:
 
     bool isEdited() const;
     bool edit(EditData&) override;
+    void startEdit(EditData&) override;
+    void endEdit(EditData&) override;
+
+    bool nextGrip(EditData&) const override;
+    bool prevGrip(EditData&) const override;
 
     Slur* slur() const { return toSlur(spanner()); }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/303350

This refers to slurs that start on a chord in one staff/voice and end on a chord in a different staff/voice (e.g. across a grand staff). It was actually already possible to create these slurs with the keyboard by using Shift+Up and Shift+Down key combinations to move the slur's grip handle between staves/voices, but it only worked when the rhythm in the target staff/voice was the same, or nearly the same, as the rhythm in the original staff/voice. This commit enables it to work regardless of any difference in rhythm.

 The change also include some UX improvements:
 - It is no longer possible to enter non-musical 'backward' slurs that   end before they start, or 'vertical' slurs that end at the same tick   as they start, albeit in a different staff/voice.
 - When moving a grip handle up or down, it will always go to a chord in   the nearest voice in that direction. Previously the algorithm would   prefer to keep the grip handle at the exact same tick even if that   meant skipping voices with a chord at almost (but not quite) the same   tick as the original.
 - When moving across multiple voices (i.e. after multiple presses of   Shift+Up or Shift+Down) the grip handle will always jump to the chord   closest to the **original** chord regardless of the location of any   intermediate chords. This means pressing Shift+Up several times,   followed by Shift+Down the same number of times, is guaranteed to   return the grip handle to the original chord it started on regardless   of the rhythms in other voices. This is similar to moving a text   cursor between lines in a text editor, which will maintain the column   (horizontal position) even after crossing a line with too few   characters to reach up to this column.