### PR TITLE
[Qt 6 preparation] Replace `QDateTime::toTime_t()` with `QDateTime::toSecsSinceEpoch()`

### DIFF
--- a/src/plugins/api/util.cpp
+++ b/src/plugins/api/util.cpp
@@ -134,7 +134,7 @@ int FileIO::modifiedTime()
         source = url.toLocalFile();
     }
     QFileInfo fileInfo(source);
-    return fileInfo.lastModified().toTime_t();
+    return fileInfo.lastModified().toSecsSinceEpoch();
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Cherry-picked from #10108