### PR TITLE
[Qt 6 preparation] Simplify propagating model data into delegate in GridViewSectional

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/GridViewSectional.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/GridViewSectional.qml
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2.12
+import QtQuick 2.15
 
 import "internal"
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/internal/GridViewDelegate.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/internal/GridViewDelegate.qml
@@ -99,12 +99,8 @@ Item {
 
                 anchors.centerIn: parent
 
-                property var itemModel: null
+                property var itemModel: model
                 sourceComponent: root.itemDelegate
-
-                onLoaded: {
-                    itemModel = Qt.binding( function() { return Boolean(model) ? model : null });
-                }
             }
         }
     }

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/internal/GridViewSection.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/internal/GridViewSection.qml
@@ -23,19 +23,16 @@ import QtQuick 2.15
 
 Item {
     id: root
+
     property alias sectionDelegate: loader.sourceComponent
+
+    //visible: loader.item ? loader.item.visible : true
 
     Loader {
         id: loader
         anchors.fill: parent
 
-        property var itemModel: null
-        property int itemIndex: 0
-
-        onLoaded: {
-            itemModel = Qt.binding( function() { return Boolean(modelData) ? modelData : null });
-            itemIndex = index
-    //        root.visible = Qt.binding( function() { return Boolean(item) ? item.visible : false })
-        }
+        readonly property var itemModel: modelData
+        readonly property int itemIndex: model.index
     }
 }


### PR DESCRIPTION
Cherry-picked from #10108

I found out that one of the preferred ways to propagate properties to a Loader's sourceComponent is to set those properties on the Loader itself. The Loader will set itself as the _context_ for the sourceComponent, so that the sourceComponent can use those properties. So, it seems that we won't need `onLoaded: { … }` in some cases. When writing new code or refactoring old code, we can keep this in mind. 

In Qt 6, the old way did not work with the icons in the Note Input Bar. (_Why_ that is the case, is still a big riddle to me...) Luckily, the new way does work.