### PR TITLE
[MU4] fix #10208: When entering notes with keyboard, mouse cursor should not show a note symbol (MU3 missing functionality)

### DIFF
--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -209,6 +209,7 @@ void NotationNoteInput::addNote(NoteName noteName, NoteAddingMode addingMode)
     score()->cmdAddPitch(editData, inote, addToUpOnCurrentChord, insertNewChord);
     apply();
 
+    notifyNoteAddedChanged();
     notifyAboutStateChanged();
 }
 

--- a/src/notation/view/notationpaintview.h
+++ b/src/notation/view/notationpaintview.h
@@ -195,8 +195,10 @@ private:
 
     void adjustCanvasPosition(const RectF& logicRect);
 
-    void onNoteInputChanged();
+    void onNoteInputModeChanged();
     void onSelectionChanged();
+
+    void followNoteInputCursor();
 
     void onPlayingChanged();
     void movePlaybackCursor(uint32_t tick);

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -614,10 +614,18 @@ void NotationViewInputController::mouseDoubleClickEvent(QMouseEvent*)
 
 void NotationViewInputController::hoverMoveEvent(QHoverEvent* event)
 {
-    if (m_view->isNoteEnterMode()) {
-        PointF pos = m_view->toLogical(event->pos());
-        m_view->showShadowNote(pos);
+    if (!m_view->isNoteEnterMode()) {
+        return;
     }
+
+    PointF oldPos = m_view->toLogical(event->oldPosF());
+    PointF pos = m_view->toLogical(event->posF());
+
+    if (oldPos == pos) {
+        return;
+    }
+
+    m_view->showShadowNote(pos);
 }
 
 void NotationViewInputController::keyPressEvent(QKeyEvent* event)


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10208
