### PR TITLE
[MU4] notation_changes_range

### DIFF
--- a/src/engraving/libmscore/undo.cpp
+++ b/src/engraving/libmscore/undo.cpp
@@ -607,6 +607,26 @@ void UndoMacro::append(UndoMacro&& other)
     }
 }
 
+const InputState& UndoMacro::undoInputState() const
+{
+    return m_undoInputState;
+}
+
+const InputState& UndoMacro::redoInputState() const
+{
+    return m_redoInputState;
+}
+
+const UndoMacro::SelectionInfo& UndoMacro::undoSelectionInfo() const
+{
+    return m_undoSelectionInfo;
+}
+
+const UndoMacro::SelectionInfo& UndoMacro::redoSelectionInfo() const
+{
+    return m_redoSelectionInfo;
+}
+
 //---------------------------------------------------------
 //   CloneVoice
 //---------------------------------------------------------

--- a/src/engraving/libmscore/undo.cpp
+++ b/src/engraving/libmscore/undo.cpp
@@ -556,49 +556,54 @@ void UndoMacro::applySelectionInfo(const SelectionInfo& info, Selection& sel)
 }
 
 UndoMacro::UndoMacro(Score* s)
-    : undoInputState(s->inputState()), score(s)
+    : m_undoInputState(s->inputState()), m_score(s)
 {
-    fillSelectionInfo(undoSelectionInfo, s->selection());
+    fillSelectionInfo(m_undoSelectionInfo, s->selection());
 }
 
 void UndoMacro::undo(EditData* ed)
 {
-    redoInputState = score->inputState();
-    fillSelectionInfo(redoSelectionInfo, score->selection());
-    score->deselectAll();
+    m_redoInputState = m_score->inputState();
+    fillSelectionInfo(m_redoSelectionInfo, m_score->selection());
+    m_score->deselectAll();
 
     // Undo for child commands.
     UndoCommand::undo(ed);
 
-    score->setInputState(undoInputState);
-    if (undoSelectionInfo.isValid()) {
-        score->deselectAll();
-        applySelectionInfo(undoSelectionInfo, score->selection());
+    m_score->setInputState(m_undoInputState);
+    if (m_undoSelectionInfo.isValid()) {
+        m_score->deselectAll();
+        applySelectionInfo(m_undoSelectionInfo, m_score->selection());
     }
 }
 
 void UndoMacro::redo(EditData* ed)
 {
-    undoInputState = score->inputState();
-    fillSelectionInfo(undoSelectionInfo, score->selection());
-    score->deselectAll();
+    m_undoInputState = m_score->inputState();
+    fillSelectionInfo(m_undoSelectionInfo, m_score->selection());
+    m_score->deselectAll();
 
     // Redo for child commands.
     UndoCommand::redo(ed);
 
-    score->setInputState(redoInputState);
-    if (redoSelectionInfo.isValid()) {
-        score->deselectAll();
-        applySelectionInfo(redoSelectionInfo, score->selection());
+    m_score->setInputState(m_redoInputState);
+    if (m_redoSelectionInfo.isValid()) {
+        m_score->deselectAll();
+        applySelectionInfo(m_redoSelectionInfo, m_score->selection());
     }
+}
+
+bool UndoMacro::empty() const
+{
+    return childCount() == 0;
 }
 
 void UndoMacro::append(UndoMacro&& other)
 {
     appendChildren(&other);
-    if (score == other.score) {
-        redoInputState = std::move(other.redoInputState);
-        redoSelectionInfo = std::move(other.redoSelectionInfo);
+    if (m_score == other.m_score) {
+        m_redoInputState = std::move(other.m_redoInputState);
+        m_redoSelectionInfo = std::move(other.m_redoSelectionInfo);
     }
 }
 

--- a/src/engraving/libmscore/undo.h
+++ b/src/engraving/libmscore/undo.h
@@ -91,7 +91,7 @@ enum class PlayEventType : char;
 class Excerpt;
 class EditData;
 
-#define UNDO_NAME(a)  virtual const char* name() const override { return a; }
+#define UNDO_NAME(a) const char* name() const override { return a; }
 
 //---------------------------------------------------------
 //   UndoCommand
@@ -143,6 +143,7 @@ public:
 
 class UndoMacro : public UndoCommand
 {
+public:
     struct SelectionInfo {
         std::vector<EngravingItem*> elements;
         Fraction tickStart;
@@ -153,26 +154,26 @@ class UndoMacro : public UndoCommand
         bool isValid() const { return !elements.empty() || staffStart != -1; }
     };
 
-    InputState undoInputState;
-    InputState redoInputState;
-    SelectionInfo undoSelectionInfo;
-    SelectionInfo redoSelectionInfo;
-
-    Score* score;
-
-    static void fillSelectionInfo(SelectionInfo&, const Selection&);
-    static void applySelectionInfo(const SelectionInfo&, Selection&);
-
-public:
     UndoMacro(Score* s);
-    virtual void undo(EditData*) override;
-    virtual void redo(EditData*) override;
-    bool empty() const { return childCount() == 0; }
+    void undo(EditData*) override;
+    void redo(EditData*) override;
+    bool empty() const;
     void append(UndoMacro&& other);
 
     static bool canRecordSelectedElement(const EngravingItem* e);
 
     UNDO_NAME("UndoMacro");
+
+private:
+    InputState m_undoInputState;
+    InputState m_redoInputState;
+    SelectionInfo m_undoSelectionInfo;
+    SelectionInfo m_redoSelectionInfo;
+
+    Score* m_score = nullptr;
+
+    static void fillSelectionInfo(SelectionInfo&, const Selection&);
+    static void applySelectionInfo(const SelectionInfo&, Selection&);
 };
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/undo.h
+++ b/src/engraving/libmscore/undo.h
@@ -160,6 +160,11 @@ public:
     bool empty() const;
     void append(UndoMacro&& other);
 
+    const InputState& undoInputState() const;
+    const InputState& redoInputState() const;
+    const SelectionInfo& undoSelectionInfo() const;
+    const SelectionInfo& redoSelectionInfo() const;
+
     static bool canRecordSelectedElement(const EngravingItem* e);
 
     UNDO_NAME("UndoMacro");

--- a/src/notation/internal/inotationundostack.h
+++ b/src/notation/internal/inotationundostack.h
@@ -24,6 +24,7 @@
 #define MU_SCENE_NOTATION_INOTATIONUNDOSTACK_H
 
 #include "async/notification.h"
+#include "async/channel.h"
 
 namespace Ms {
 class EditData;
@@ -52,6 +53,7 @@ public:
     virtual bool isLocked() const = 0;
 
     virtual async::Notification stackChanged() const = 0;
+    virtual async::Channel<int /*tickFrom*/, int /*tickTo*/> notationChangesRange() const = 0;
 };
 
 using INotationUndoStackPtr = std::shared_ptr<INotationUndoStack>;

--- a/src/notation/internal/notationundostack.h
+++ b/src/notation/internal/notationundostack.h
@@ -56,15 +56,22 @@ public:
     bool isLocked() const override;
 
     async::Notification stackChanged() const override;
+    async::Channel<int /*tickFrom*/, int /*tickTo*/> notationChangesRange() const override;
 
 private:
+    struct NotationChangesRange {
+        int tickFrom = 0;
+        int tickTo = 0;
+    };
+
     void notifyAboutNotationChanged();
-    void notifyAboutStateChanged();
+    void notifyAboutStateChanged(NotationChangesRange&& range);
     void notifyAboutUndo();
     void notifyAboutRedo();
 
     bool isStackClean() const;
 
+    NotationChangesRange changesRange() const;
     Ms::Score* score() const;
     Ms::MasterScore* masterScore() const;
     Ms::UndoStack* undoStack() const;
@@ -75,6 +82,7 @@ private:
     async::Notification m_stackStateChanged;
     async::Notification m_undoNotification;
     async::Notification m_redoNotification;
+    async::Channel<int, int> m_notationChangesChannel;
 
     bool m_isLocked = false;
 };


### PR DESCRIPTION
Preparation for the MPE playback model.

We need to know exact range of changes on the notation, otherwise we'd need to re-render the entire score's playback model over and over again