### PR TITLE
Fix #328003 score property crash

### DIFF
--- a/src/notation/view/widgets/scoreproperties.cpp
+++ b/src/notation/view/widgets/scoreproperties.cpp
@@ -249,7 +249,7 @@ bool ScorePropertiesDialog::save()
         QLayoutItem* valueItem = scrollAreaLayout->itemAtPosition(i, 1);
         if (tagItem && valueItem) {
             QString tagText = "";
-            
+
             // Is the property a standard one?
             QLabel* labelItem = dynamic_cast<QLabel*>(tagItem->widget());
             if (labelItem) {
@@ -263,21 +263,21 @@ bool ScorePropertiesDialog::save()
                     // Validate none standard properties names (empty / reserved or duplicates)
                     if (tagText.isEmpty()) {
                         interactive()->warning(trc("notation", "MuseScore"),
-                            trc("notation", "Tags can't have empty names."));
+                                               trc("notation", "Tags can't have empty names."));
                         lineEditItem->setFocus();
                         return false;
                     }
                     if (map.contains(tagText)) {
                         if (isStandardTag(tagText)) {
                             interactive()->warning(trc("notation", "MuseScore"),
-                                qtrc("notation",
-                                    "%1 is a reserved builtin tag.\n It can't be used.").arg(tagText).toStdString());
+                                                   qtrc("notation",
+                                                        "%1 is a reserved builtin tag.\n It can't be used.").arg(tagText).toStdString());
                             lineEditItem->setFocus();
                             return false;
                         }
 
                         interactive()->warning(trc("notation", "MuseScore"),
-                            trc("notation", "You have multiple tags with the same name."));
+                                               trc("notation", "You have multiple tags with the same name."));
                         lineEditItem->setFocus();
                         return false;
                     }

--- a/src/notation/view/widgets/scoreproperties.cpp
+++ b/src/notation/view/widgets/scoreproperties.cpp
@@ -245,17 +245,29 @@ bool ScorePropertiesDialog::save()
     const int idx = scrollAreaLayout->rowCount();
     QVariantMap map;
     for (int i = 0; i < idx; ++i) {
-        QLayoutItem* tagItem   = scrollAreaLayout->itemAtPosition(i, 0);
+        QLayoutItem* tagItem  = scrollAreaLayout->itemAtPosition(i, 0);
         QLayoutItem* valueItem = scrollAreaLayout->itemAtPosition(i, 1);
         if (tagItem && valueItem) {
-            QLineEdit* tag   = static_cast<QLineEdit*>(tagItem->widget());
+
+            // Label could be a line edit (for none standard properties) or a label widget (for standard properties)
+            QString tagText = "";
+            
+            QLineEdit* lineEditItem = dynamic_cast<QLineEdit*>(tagItem);
+            if (lineEditItem) {
+                tagText = lineEditItem->text();
+            }
+
+            QLabel* labelItem = dynamic_cast<QLabel*>(tagItem);
+            if (labelItem) {
+                tagText = labelItem->text();
+            }
+
             QLineEdit* value = static_cast<QLineEdit*>(valueItem->widget());
 
-            QString tagText = tag->text();
             if (tagText.isEmpty()) {
                 interactive()->warning(trc("notation", "MuseScore"),
                                        trc("notation", "Tags can't have empty names."));
-                tag->setFocus();
+                lineEditItem->setFocus();
                 return false;
             }
             if (map.contains(tagText)) {
@@ -263,13 +275,13 @@ bool ScorePropertiesDialog::save()
                     interactive()->warning(trc("notation", "MuseScore"),
                                            qtrc("notation",
                                                 "%1 is a reserved builtin tag.\n It can't be used.").arg(tagText).toStdString());
-                    tag->setFocus();
+                    lineEditItem->setFocus();
                     return false;
                 }
 
                 interactive()->warning(trc("notation", "MuseScore"),
                                        trc("notation", "You have multiple tags with the same name."));
-                tag->setFocus();
+                lineEditItem->setFocus();
                 return false;
             }
             map.insert(tagText, value->text());


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/328003

Following accessibility changes saving score properties causes MuseScore to crash

[ x] I signed CLA
[ x] I made sure the code in the PR follows the coding rules
[ x] I made sure the code compiles on my machine
[ x] I made sure there are no unnecessary changes in the code
[ x] I made sure the title of the PR reflects the core meaning of the issue you are solving
[ x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
[ x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
[ ] I created the test (mtest, vtest, script test) to verify the changes I made