### PR TITLE
Fix #9220: [MU4 Issue] Enabling high-contrast switches to dark theme and swaps theme icons

### DIFF
--- a/src/appshell/view/firstlaunchsetup/themespagemodel.cpp
+++ b/src/appshell/view/firstlaunchsetup/themespagemodel.cpp
@@ -61,7 +61,7 @@ QVariantList ThemesPageModel::highContrastThemes() const
     QVariantList result;
 
     for (const ThemeInfo& theme : allThemes()) {
-        if (theme.codeKey == HIGH_CONTRAST_BLACK_THEME_CODE || theme.codeKey == HIGH_CONTRAST_WHITE_THEME_CODE) {
+        if (theme.codeKey == HIGH_CONTRAST_WHITE_THEME_CODE || theme.codeKey == HIGH_CONTRAST_BLACK_THEME_CODE) {
             result << ThemeConverter::toMap(theme);
         }
     }

--- a/src/appshell/view/preferences/appearancepreferencesmodel.cpp
+++ b/src/appshell/view/preferences/appearancepreferencesmodel.cpp
@@ -91,7 +91,7 @@ QVariantList AppearancePreferencesModel::highContrastThemes() const
     QVariantList result;
 
     for (const ThemeInfo& theme : allThemes()) {
-        if (theme.codeKey == HIGH_CONTRAST_BLACK_THEME_CODE || theme.codeKey == HIGH_CONTRAST_WHITE_THEME_CODE) {
+        if (theme.codeKey == HIGH_CONTRAST_WHITE_THEME_CODE || theme.codeKey == HIGH_CONTRAST_BLACK_THEME_CODE) {
             result << ThemeConverter::toMap(theme);
         }
     }

--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -160,7 +160,7 @@ void UiConfiguration::init()
 {
     settings()->setDefaultValue(UI_CURRENT_THEME_CODE_KEY, Val(LIGHT_THEME_CODE));
     settings()->setDefaultValue(UI_PREVIOUS_GENERAL_THEME, Val(LIGHT_THEME_CODE));
-    settings()->setDefaultValue(UI_PREVIOUS_HIGH_CONTRAST_THEME, Val(HIGH_CONTRAST_BLACK_THEME_CODE));
+    settings()->setDefaultValue(UI_PREVIOUS_HIGH_CONTRAST_THEME, Val(HIGH_CONTRAST_WHITE_THEME_CODE));
     settings()->setDefaultValue(UI_FONT_FAMILY_KEY, Val("Fira Sans"));
     settings()->setDefaultValue(UI_FONT_SIZE_KEY, Val(12));
     settings()->setDefaultValue(UI_ICONS_FONT_FAMILY_KEY, Val("MusescoreIcon"));
@@ -297,12 +297,12 @@ ThemeInfo UiConfiguration::makeStandardTheme(const ThemeCode& codeKey) const
     } else if (codeKey == DARK_THEME_CODE) {
         theme.title = trc("ui", "Dark");
         theme.values = DARK_THEME_VALUES;
-    } else if (codeKey == HIGH_CONTRAST_BLACK_THEME_CODE) {
-        theme.title = trc("ui", "Black");
-        theme.values = HIGH_CONTRAST_BLACK_THEME_VALUES;
     } else if (codeKey == HIGH_CONTRAST_WHITE_THEME_CODE) {
         theme.title = trc("ui", "White");
         theme.values = HIGH_CONTRAST_WHITE_THEME_VALUES;
+    } else if (codeKey == HIGH_CONTRAST_BLACK_THEME_CODE) {
+        theme.title = trc("ui", "Black");
+        theme.values = HIGH_CONTRAST_BLACK_THEME_VALUES;
     }
 
     return theme;
@@ -433,7 +433,7 @@ bool UiConfiguration::isHighContrast() const
 {
     ThemeCode currentThemeCode = currentThemeCodeKey();
 
-    return currentThemeCode == HIGH_CONTRAST_BLACK_THEME_CODE || currentThemeCode == HIGH_CONTRAST_WHITE_THEME_CODE;
+    return currentThemeCode == HIGH_CONTRAST_WHITE_THEME_CODE || currentThemeCode == HIGH_CONTRAST_BLACK_THEME_CODE;
 }
 
 void UiConfiguration::setIsHighContrast(bool highContrast)

--- a/src/framework/ui/uitypes.h
+++ b/src/framework/ui/uitypes.h
@@ -39,16 +39,16 @@ using ThemeCode = std::string;
 
 static const ThemeCode DARK_THEME_CODE("dark");
 static const ThemeCode LIGHT_THEME_CODE("light");
-static const ThemeCode HIGH_CONTRAST_BLACK_THEME_CODE("high_contrast_black");
 static const ThemeCode HIGH_CONTRAST_WHITE_THEME_CODE("high_contrast_white");
+static const ThemeCode HIGH_CONTRAST_BLACK_THEME_CODE("high_contrast_black");
 
 inline std::vector<ThemeCode> allStandardThemeCodes()
 {
     return {
         LIGHT_THEME_CODE,
         DARK_THEME_CODE,
-        HIGH_CONTRAST_BLACK_THEME_CODE,
-        HIGH_CONTRAST_WHITE_THEME_CODE
+        HIGH_CONTRAST_WHITE_THEME_CODE,
+        HIGH_CONTRAST_BLACK_THEME_CODE
     };
 }
 


### PR DESCRIPTION
Resolves: #9220 

Swapped the positions of the order of White and Black Theme codes returned by allStandardThemeCodes(), changed the default value of High Contrast Theme and reordered the instances of Black and White Theme code usages.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://musescore.org/en/cla)
- [X] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [X] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
