### PR TITLE
Fix #9892: Add new beam_end group to palette and properties

### DIFF
--- a/src/engraving/libmscore/actionicon.h
+++ b/src/engraving/libmscore/actionicon.h
@@ -40,6 +40,7 @@ enum class ActionIconType {
 
     BEAM_START,
     BEAM_MID,
+    BEAM_END,
     BEAM_NONE,
     BEAM_BEGIN_32,
     BEAM_BEGIN_64,

--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -1675,6 +1675,8 @@ ActionIconType Beam::actionIconTypeForBeamMode(BeamMode mode)
         return ActionIconType::BEAM_START;
     case BeamMode::MID:
         return ActionIconType::BEAM_MID;
+    case BeamMode::END:
+        return ActionIconType::BEAM_END;
     case BeamMode::NONE:
         return ActionIconType::BEAM_NONE;
     case BeamMode::BEGIN32:

--- a/src/engraving/libmscore/chordrest.cpp
+++ b/src/engraving/libmscore/chordrest.cpp
@@ -569,6 +569,9 @@ EngravingItem* ChordRest::drop(EditData& data)
         case ActionIconType::BEAM_MID:
             undoChangeProperty(Pid::BEAM_MODE, BeamMode::MID);
             break;
+        case ActionIconType::BEAM_END:
+            undoChangeProperty(Pid::BEAM_MODE, BeamMode::END);
+            break;
         case ActionIconType::BEAM_NONE:
             undoChangeProperty(Pid::BEAM_MODE, BeamMode::NONE);
             break;

--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -1707,6 +1707,7 @@ bool Note::acceptDrop(EditData& data) const
            || (type == ElementType::ACTION_ICON && toActionIcon(e)->actionType() == ActionIconType::BEAM_START)
            || (type == ElementType::ACTION_ICON && toActionIcon(e)->actionType() == ActionIconType::BEAM_MID)
            || (type == ElementType::ACTION_ICON && toActionIcon(e)->actionType() == ActionIconType::BEAM_NONE)
+           || (type == ElementType::ACTION_ICON && toActionIcon(e)->actionType() == ActionIconType::BEAM_END)
            || (type == ElementType::ACTION_ICON && toActionIcon(e)->actionType() == ActionIconType::BEAM_BEGIN_32)
            || (type == ElementType::ACTION_ICON && toActionIcon(e)->actionType() == ActionIconType::BEAM_BEGIN_64)
            || (type == ElementType::ACTION_ICON && toActionIcon(e)->actionType() == ActionIconType::BEAM_AUTO)
@@ -1833,6 +1834,7 @@ EngravingItem* Note::drop(EditData& data)
         case ActionIconType::BEAM_START:
         case ActionIconType::BEAM_MID:
         case ActionIconType::BEAM_NONE:
+        case ActionIconType::BEAM_END:
         case ActionIconType::BEAM_BEGIN_32:
         case ActionIconType::BEAM_BEGIN_64:
         case ActionIconType::BEAM_AUTO:

--- a/src/framework/ui/view/iconcodes.h
+++ b/src/framework/ui/view/iconcodes.h
@@ -204,6 +204,7 @@ public:
         NOTE_HEAD_EIGHTH = 0xF33A,
         BEAM_START = 0xF33B,
         BEAM_MIDDLE = 0xF33D,
+        BEAM_END = 0xF33C,
         BEAM_32 = 0xF33E,
         BEAM_64 = 0xF33F,
 

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/notes/internal/BeamTypeSelector.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/notes/internal/BeamTypeSelector.qml
@@ -60,6 +60,7 @@ InspectorPropertyView {
                 { value: Beam.MODE_AUTO, iconCode: IconCode.AUTO_TEXT, hint: qsTrc("inspector", "Auto") },
                 { value: Beam.MODE_BEGIN, iconCode: IconCode.BEAM_START, hint: qsTrc("inspector", "Begin") },
                 { value: Beam.MODE_MID, iconCode: IconCode.BEAM_MIDDLE, hint: qsTrc("inspector", "Middle") },
+                { value: Beam.MODE_END, iconCode: IconCode.BEAM_END, hint: qsTrc("inspector", "End") },
                 { value: Beam.MODE_NONE, iconCode: IconCode.NOTE_HEAD_EIGHTH, hint: qsTrc("inspector", "None") },
                 { value: Beam.MODE_BEGIN32, iconCode: IconCode.BEAM_32, hint: qsTrc("inspector", "Begin 32") },
                 { value: Beam.MODE_BEGIN64, iconCode: IconCode.BEAM_64, hint: qsTrc("inspector", "Begin 64") }

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -329,6 +329,7 @@ void NotationActionController::init()
 
     registerAction("beam-start", &Interaction::addBeamToSelectedChordRests, BeamMode::BEGIN);
     registerAction("beam-mid", &Interaction::addBeamToSelectedChordRests, BeamMode::MID);
+    registerAction("beam-end", &Interaction::addBeamToSelectedChordRests, BeamMode::END);
     registerAction("no-beam", &Interaction::addBeamToSelectedChordRests, BeamMode::NONE);
     registerAction("beam-32", &Interaction::addBeamToSelectedChordRests, BeamMode::BEGIN32);
     registerAction("beam-64", &Interaction::addBeamToSelectedChordRests, BeamMode::BEGIN64);

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -566,6 +566,11 @@ const UiActionList NotationUiActions::m_actions = {
              QT_TRANSLATE_NOOP("action", "Beam middle"),
              IconCode::Code::BEAM_MIDDLE
              ),
+    UiAction("beam-end",
+            mu::context::UiCtxNotationOpened,
+            QT_TRANSLATE_NOOP("action", "Beam end"),
+            IconCode::Code::BEAM_END
+    ),
     UiAction("no-beam",
              mu::context::UiCtxNotationOpened,
              QT_TRANSLATE_NOOP("action", "No beam"),

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -184,6 +184,7 @@ PalettePtr PaletteCreator::newBeamPalette()
 
     sp->appendActionIcon(ActionIconType::BEAM_START, "beam-start");
     sp->appendActionIcon(ActionIconType::BEAM_MID, "beam-mid");
+    sp->appendActionIcon(ActionIconType::BEAM_END, "beam-end");
     sp->appendActionIcon(ActionIconType::BEAM_NONE, "no-beam");
     sp->appendActionIcon(ActionIconType::BEAM_BEGIN_32, "beam32");
     sp->appendActionIcon(ActionIconType::BEAM_BEGIN_64, "beam64");

--- a/src/palette/view/widgets/noteGroups.cpp
+++ b/src/palette/view/widgets/noteGroups.cpp
@@ -86,6 +86,7 @@ NoteGroups::NoteGroups(QWidget* parent)
 
     iconPalette->appendActionIcon(ActionIconType::BEAM_START, "beam-start");
     iconPalette->appendActionIcon(ActionIconType::BEAM_MID, "beam-mid");
+    iconPalette->appendActionIcon(ActionIconType::BEAM_END, "beam-end");
     iconPalette->appendActionIcon(ActionIconType::BEAM_BEGIN_32, "beam32");
     iconPalette->appendActionIcon(ActionIconType::BEAM_BEGIN_64, "beam64");
 
@@ -166,6 +167,9 @@ void NoteGroups::beamPropertyDropped(Chord* chord, ActionIcon* icon)
         break;
     case ActionIconType::BEAM_MID:
         updateBeams(chord, BeamMode::AUTO);
+        break;
+    case ActionIconType::BEAM_END:
+        updateBeams(chord, BeamMode::END);
         break;
     case ActionIconType::BEAM_BEGIN_32:
         updateBeams(chord, BeamMode::BEGIN32);


### PR DESCRIPTION
Resolves: [*(direct link to the issue)*](https://github.com/musescore/MuseScore/issues/9892)

*TODO*
-fix LayoutBeam::createBeams
 -beam_end only beams properly as the third note in a group
 -consecutive beam_end notes dont beam properly

- [ ] I signed [CLA](https://musescore.org/en/cla)
- [ ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
