### PR TITLE
[MU4] Fix #10262: Text fields not recognising some accented characters in MacOS

### DIFF
--- a/src/engraving/libmscore/engravingitem.h
+++ b/src/engraving/libmscore/engravingitem.h
@@ -156,6 +156,7 @@ public:
     int key                          { 0 };
     Qt::KeyboardModifiers modifiers  { /*0*/ };   // '0' initialized via default constructor, doing it here too results in compiler warning with Qt 5.15
     QString s;
+    QString preeditString;
 
     Qt::MouseButtons buttons         { Qt::NoButton };
 

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -120,6 +120,7 @@ public:
     virtual bool isTextEditingStarted() const = 0;
     virtual bool textEditingAllowed(const EngravingItem* element) const = 0;
     virtual void startEditText(EngravingItem* element, const PointF& elementPos = PointF()) = 0;
+    virtual void editText(QInputMethodEvent* event) = 0;
     virtual void endEditText() = 0;
     virtual void changeTextCursorPosition(const PointF& newCursorPos) = 0;
     virtual const TextBase* editedText() const = 0;
@@ -138,7 +139,6 @@ public:
     virtual void startEditElement(EngravingItem* element) = 0;
     virtual void changeEditElement(EngravingItem* newElement) = 0;
     virtual void editElement(QKeyEvent* event) = 0;
-    virtual void editText(QInputMethodEvent* event) = 0;
     virtual void endEditElement() = 0;
 
     virtual void splitSelectedMeasure() = 0;

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -22,7 +22,6 @@
 #ifndef MU_NOTATION_INOTATIONINTERACTION_H
 #define MU_NOTATION_INOTATIONINTERACTION_H
 
-#include <QKeyEvent>
 #include <functional>
 
 #include "async/notification.h"
@@ -31,6 +30,9 @@
 #include "inotationnoteinput.h"
 #include "inotationselection.h"
 #include "actions/actiontypes.h"
+
+class QKeyEvent;
+class QInputMethodEvent;
 
 namespace mu::notation {
 class INotationInteraction
@@ -136,6 +138,7 @@ public:
     virtual void startEditElement(EngravingItem* element) = 0;
     virtual void changeEditElement(EngravingItem* newElement) = 0;
     virtual void editElement(QKeyEvent* event) = 0;
+    virtual void editText(QInputMethodEvent* event) = 0;
     virtual void endEditElement() = 0;
 
     virtual void splitSelectedMeasure() = 0;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -128,6 +128,7 @@ public:
     bool isTextEditingStarted() const override;
     bool textEditingAllowed(const EngravingItem* element) const override;
     void startEditText(EngravingItem* element, const PointF& cursorPos = PointF()) override;
+    void editText(QInputMethodEvent* event) override;
     void endEditText() override;
     void changeTextCursorPosition(const PointF& newCursorPos) override;
     const TextBase* editedText() const override;

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -239,7 +239,7 @@ void NotationPaintView::onCurrentNotationChanged()
     m_loopInMarker->setStyle(m_notation->style());
     m_loopOutMarker->setStyle(m_notation->style());
 
-    notation()->accessibility()->setMapToScreenFunc([this](const RectF& elementRect){
+    notation()->accessibility()->setMapToScreenFunc([this](const RectF& elementRect) {
         auto res = fromLogical(elementRect);
         res = RectF(PointF::fromQPointF(mapToGlobal(res.topLeft().toQPointF())), SizeF(res.width(), res.height()));
 
@@ -893,6 +893,15 @@ void NotationPaintView::inputMethodEvent(QInputMethodEvent* event)
     if (isInited()) {
         m_inputController->inputMethodEvent(event);
     }
+}
+
+QVariant NotationPaintView::inputMethodQuery(Qt::InputMethodQuery query) const
+{
+    if (isInited() && m_inputController->canHandleInputMethodQuery(query)) {
+        return m_inputController->inputMethodQuery(query);
+    }
+
+    return QQuickPaintedItem::inputMethodQuery(query);
 }
 
 void NotationPaintView::dragEnterEvent(QDragEnterEvent* event)

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -41,6 +41,7 @@ NotationPaintView::NotationPaintView(QQuickItem* parent)
 {
     setFlag(ItemHasContents, true);
     setFlag(ItemAcceptsDrops, true);
+    setFlag(ItemAcceptsInputMethod, true);
     setAcceptedMouseButtons(Qt::AllButtons);
     setAntialiasing(true);
 
@@ -885,6 +886,13 @@ bool NotationPaintView::eventFilter(QObject* obj, QEvent* ev)
         }
     }
     return QObject::eventFilter(obj, ev);
+}
+
+void NotationPaintView::inputMethodEvent(QInputMethodEvent* event)
+{
+    if (isInited()) {
+        m_inputController->inputMethodEvent(event);
+    }
 }
 
 void NotationPaintView::dragEnterEvent(QDragEnterEvent* event)

--- a/src/notation/view/notationpaintview.h
+++ b/src/notation/view/notationpaintview.h
@@ -90,6 +90,7 @@ public:
 
     PointF toLogical(const PointF& point) const override;
     PointF toLogical(const QPointF& point) const override;
+    RectF fromLogical(const RectF& rect) const override;
 
     Q_INVOKABLE bool moveCanvas(qreal dx, qreal dy) override;
     void moveCanvasVertical(qreal dy) override;
@@ -144,7 +145,6 @@ protected:
 
     RectF toLogical(const RectF& rect) const;
     PointF fromLogical(const PointF& point) const;
-    RectF fromLogical(const RectF& rect) const;
 
     // Draw
     void paint(QPainter* painter) override;
@@ -184,6 +184,7 @@ private:
     void dropEvent(QDropEvent* event) override;
     bool eventFilter(QObject* obj, QEvent* event) override;
     void inputMethodEvent(QInputMethodEvent* event) override;
+    QVariant inputMethodQuery(Qt::InputMethodQuery query) const override;
 
     void ensureViewportInsideScrollableArea();
 

--- a/src/notation/view/notationpaintview.h
+++ b/src/notation/view/notationpaintview.h
@@ -183,6 +183,7 @@ private:
     void dragMoveEvent(QDragMoveEvent* event) override;
     void dropEvent(QDropEvent* event) override;
     bool eventFilter(QObject* obj, QEvent* event) override;
+    void inputMethodEvent(QInputMethodEvent* event) override;
 
     void ensureViewportInsideScrollableArea();
 

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -642,6 +642,13 @@ void NotationViewInputController::keyPressEvent(QKeyEvent* event)
     }
 }
 
+void NotationViewInputController::inputMethodEvent(QInputMethodEvent* event)
+{
+    if (viewInteraction()->isTextEditingStarted()) {
+        viewInteraction()->editText(event);
+    }
+}
+
 void NotationViewInputController::dragEnterEvent(QDragEnterEvent* event)
 {
     const QMimeData* mimeData = event->mimeData();

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -101,6 +101,7 @@ public:
     void mouseDoubleClickEvent(QMouseEvent* event);
     void hoverMoveEvent(QHoverEvent* event);
     void keyPressEvent(QKeyEvent* event);
+    void inputMethodEvent(QInputMethodEvent* event);
 
     void dragEnterEvent(QDragEnterEvent* event);
     void dragLeaveEvent(QDragLeaveEvent* event);

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -58,6 +58,7 @@ public:
 
     virtual PointF toLogical(const PointF& p) const = 0;
     virtual PointF toLogical(const QPointF& p) const = 0;
+    virtual RectF fromLogical(const RectF& r) const = 0;
 
     virtual bool isNoteEnterMode() const = 0;
     virtual void showShadowNote(const PointF& pos) = 0;
@@ -102,6 +103,9 @@ public:
     void hoverMoveEvent(QHoverEvent* event);
     void keyPressEvent(QKeyEvent* event);
     void inputMethodEvent(QInputMethodEvent* event);
+
+    bool canHandleInputMethodQuery(Qt::InputMethodQuery query) const;
+    QVariant inputMethodQuery(Qt::InputMethodQuery query) const;
 
     void dragEnterEvent(QDragEnterEvent* event);
     void dragLeaveEvent(QDragLeaveEvent* event);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10262