### PR TITLE
[MU4] Fix #328488: Crash when trying to drag anchor point of glissando

### DIFF
--- a/src/engraving/libmscore/line.cpp
+++ b/src/engraving/libmscore/line.cpp
@@ -218,7 +218,9 @@ void LineSegment::startDrag(EditData& ed)
 {
     SpannerSegment::startDrag(ed);
     ElementEditDataPtr eed = ed.getData(this);
-    eed->pushProperty(Pid::OFFSET2);
+    if (eed) {
+        eed->pushProperty(Pid::OFFSET2);
+    }
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/328488
Applies to 3.x too