### PR TITLE
[MU4] Fix #9906: Changing stem direction for note groups in Properties is broken

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -1344,14 +1344,19 @@ std::vector<PointF> Beam::gripsPositions(const EditData& ed) const
 
 void Beam::setBeamDirection(DirectionV d)
 {
+    if (_direction == d) {
+        return;
+    }
+
     _direction = d;
+
     if (d != DirectionV::AUTO) {
         _up = d == DirectionV::UP;
-        if (!_elements.empty()) {
-            Chord* c = toChord(_elements.first());
-            if (c) {
-                c->setStemDirection(d, d);
-            }
+    }
+
+    for (ChordRest* rest : elements()) {
+        if (Chord* chord = toChord(rest)) {
+            chord->setStemDirection(d);
         }
     }
 }
@@ -1519,7 +1524,7 @@ void Beam::setUserModified(bool val)
 PropertyValue Beam::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
-    case Pid::STEM_DIRECTION : return beamDirection();
+    case Pid::STEM_DIRECTION: return beamDirection();
     case Pid::DISTRIBUTE:     return distribute();
     case Pid::GROW_LEFT:      return growLeft();
     case Pid::GROW_RIGHT:     return growRight();

--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -107,6 +107,8 @@ class Beam final : public EngravingItem
     void addChordRest(ChordRest* a);
     void removeChordRest(ChordRest* a);
 
+    const Chord* findChordWithCustomStemDirection() const;
+
 public:
     ~Beam();
 

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -922,6 +922,12 @@ void Chord::computeUp()
 
     _usesAutoUp = false;
 
+    bool hasCustomStemDirection = _stemDirection != DirectionV::AUTO;
+    if (hasCustomStemDirection) {
+        _up = _stemDirection == DirectionV::UP;
+        return;
+    }
+
     if (_beam) {
         _up = _beam->up();
         return;
@@ -943,12 +949,6 @@ void Chord::computeUp()
     bool isTabStaff  = tab && tab->isTabStaff();
     if (isTabStaff && (tab->stemless() || !tab->stemThrough())) {
         _up = tab->stemless() ? false : !tab->stemsDown();
-        return;
-    }
-
-    bool hasCustomStemDirection = _stemDirection != DirectionV::AUTO;
-    if (hasCustomStemDirection) {
-        _up = _stemDirection == DirectionV::UP;
         return;
     }
 

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -2843,20 +2843,9 @@ qreal Chord::dotPosX() const
 //   setStemDirection
 //---------------------------------------------------------
 
-void Chord::setStemDirection(DirectionV d, DirectionV beamDir)
+void Chord::setStemDirection(DirectionV d)
 {
     _stemDirection = d;
-    if (beam()) {
-        for (ChordRest* cr : beam()->elements()) {
-            Chord* c = toChord(cr);
-            if (c) {
-                c->_stemDirection = d;
-            }
-        }
-        if (beamDir == DirectionV::AUTO) {
-            beam()->setBeamDirection(beamDir);
-        }
-    }
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/chord.h
+++ b/src/engraving/libmscore/chord.h
@@ -153,7 +153,7 @@ public:
     EngravingItem* drop(EditData&) override;
 
     void setColor(const mu::draw::Color& c) override;
-    void setStemDirection(DirectionV d, DirectionV beamDir = DirectionV::AUTO);
+    void setStemDirection(DirectionV d);
     DirectionV stemDirection() const { return _stemDirection; }
 
     void setIsUiItem(bool val) { _isUiItem = val; }

--- a/src/engraving/utests/beam_data/beamStemDir-01-ref.mscx
+++ b/src/engraving/utests/beam_data/beamStemDir-01-ref.mscx
@@ -108,8 +108,9 @@
             <sigD>4</sigD>
             </TimeSig>
           <Beam>
-            <l1>-5</l1>
-            <l2>-5</l2>
+            <StemDirection>up</StemDirection>
+            <l1>-10</l1>
+            <l2>-10</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -150,9 +151,41 @@
         </Measure>
       <Measure>
         <voice>
+          <Beam>
+            <StemDirection>down</StemDirection>
+            <l1>44</l1>
+            <l2>44</l2>
+            </Beam>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
           <Rest>
-            <durationType>measure</durationType>
-            <duration>4/4</duration>
+            <durationType>half</durationType>
             </Rest>
           </voice>
         </Measure>

--- a/src/engraving/utests/beam_data/beamStemDir.mscx
+++ b/src/engraving/utests/beam_data/beamStemDir.mscx
@@ -108,8 +108,6 @@
             <sigD>4</sigD>
             </TimeSig>
           <Beam>
-            <l1>17</l1>
-            <l2>17</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -150,9 +148,39 @@
         </Measure>
       <Measure>
         <voice>
+          <Beam>
+            <StemDirection>down</StemDirection>
+            </Beam>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
           <Rest>
-            <durationType>measure</durationType>
-            <duration>4/4</duration>
+            <durationType>half</durationType>
             </Rest>
           </voice>
         </Measure>

--- a/src/engraving/utests/beam_data/flipBeamStemDir-01-ref.mscx
+++ b/src/engraving/utests/beam_data/flipBeamStemDir-01-ref.mscx
@@ -108,8 +108,9 @@
             <sigD>4</sigD>
             </TimeSig>
           <Beam>
-            <l1>17</l1>
-            <l2>17</l2>
+            <StemDirection>down</StemDirection>
+            <l1>34</l1>
+            <l2>34</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -150,9 +151,41 @@
         </Measure>
       <Measure>
         <voice>
+          <Beam>
+            <StemDirection>down</StemDirection>
+            <l1>44</l1>
+            <l2>44</l2>
+            </Beam>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
           <Rest>
-            <durationType>measure</durationType>
-            <duration>4/4</duration>
+            <durationType>half</durationType>
             </Rest>
           </voice>
         </Measure>

--- a/src/engraving/utests/beam_data/flipBeamStemDir.mscx
+++ b/src/engraving/utests/beam_data/flipBeamStemDir.mscx
@@ -108,8 +108,6 @@
             <sigD>4</sigD>
             </TimeSig>
           <Beam>
-            <l1>17</l1>
-            <l2>17</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -150,9 +148,39 @@
         </Measure>
       <Measure>
         <voice>
+          <Beam>
+            <StemDirection>down</StemDirection>
+            </Beam>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
           <Rest>
-            <durationType>measure</durationType>
-            <duration>4/4</duration>
+            <durationType>half</durationType>
             </Rest>
           </voice>
         </Measure>

--- a/src/engraving/utests/beam_tests.cpp
+++ b/src/engraving/utests/beam_tests.cpp
@@ -120,20 +120,20 @@ TEST_F(BeamTests, flatBeams)
 
 // cross staff beaming is not yet supported
 // in the new beams code
-// TEST_F(BeamTests, beamCrossMeasure2)
-// {
-//     beam("Beam-CrossM2.mscx");
-// }
+TEST_F(BeamTests, DISABLED_beamCrossMeasure2)
+{
+    beam("Beam-CrossM2.mscx");
+}
 
-// TEST_F(BeamTests, beamCrossMeasure3)
-// {
-//     beam("Beam-CrossM3.mscx");
-// }
+TEST_F(BeamTests, DISABLED_beamCrossMeasure3)
+{
+    beam("Beam-CrossM3.mscx");
+}
 
-// TEST_F(BeamTests, beamCrossMeasure4)
-// {
-//     beam("Beam-CrossM4.mscx");
-// }
+TEST_F(BeamTests, DISABLED_beamCrossMeasure4)
+{
+    beam("Beam-CrossM4.mscx");
+}
 
 //---------------------------------------------------------
 //   beamCrossMeasure1
@@ -144,73 +144,85 @@ TEST_F(BeamTests, flatBeams)
 
 // cross measure beams are not yet supported
 // in the refactored beams code
-// TEST_F(BeamTests, beamCrossMeasure1)
-// {
-//     MasterScore* score = ScoreRW::readScore(BEAM_DATA_DIR + "Beam-CrossM1.mscx");
-//     EXPECT_TRUE(score);
+TEST_F(BeamTests, DISABLED_beamCrossMeasure1)
+{
+    MasterScore* score = ScoreRW::readScore(BEAM_DATA_DIR + "Beam-CrossM1.mscx");
+    EXPECT_TRUE(score);
 
-//     Measure* first_measure = score->firstMeasure();
-//     EXPECT_TRUE(first_measure);
+    Measure* first_measure = score->firstMeasure();
+    EXPECT_TRUE(first_measure);
 
-//     // find the first segment that has a chord
-//     Segment* s = first_measure->first(SegmentType::ChordRest);
-//     while (s && !s->element(0)->isChord()) {
-//         s = s->next(SegmentType::ChordRest);
-//     }
-//     EXPECT_TRUE(s);
+    // find the first segment that has a chord
+    Segment* s = first_measure->first(SegmentType::ChordRest);
+    while (s && !s->element(0)->isChord()) {
+        s = s->next(SegmentType::ChordRest);
+    }
+    EXPECT_TRUE(s);
 
-//     // locate the first beam
-//     ChordRest* first_note = toChordRest(s->element(0));
-//     EXPECT_TRUE(first_note);
+    // locate the first beam
+    ChordRest* first_note = toChordRest(s->element(0));
+    EXPECT_TRUE(first_note);
 
-//     Beam* b = first_note->beam();
-//     score->update();
-//     // locate the beam again, and check if it is still b
-//     Beam* new_b = first_note->beam();
+    Beam* b = first_note->beam();
+    score->update();
+    // locate the beam again, and check if it is still b
+    Beam* new_b = first_note->beam();
 
-//     EXPECT_EQ(new_b, b);
+    EXPECT_EQ(new_b, b);
 
-//     delete score;
-// }
+    delete score;
+}
 
 //---------------------------------------------------------
 //   beamStemDir
-//   This method tests if a beam's stem direction can be
-//   set with a note other than the first one.
+//   This method tests if a beam's stem direction will be set to
+//   all its chords and will not affect other beams in score
 //---------------------------------------------------------
 
-// TEST_F(BeamTests, beamStemDir)
-// {
-//     MasterScore* score = ScoreRW::readScore(BEAM_DATA_DIR + "beamStemDir.mscx");
-//     EXPECT_TRUE(score);
-//     Measure* m1 = score->firstMeasure();
-//     ChordRest* cr = toChordRest(m1->findSegment(SegmentType::ChordRest, m1->tick())->element(0));
-//     Chord* c2 = toChord(cr->beam()->elements()[1]);
-//     c2->setStemDirection(DirectionV::UP);
-//     score->update();
-//     score->doLayout();
-//     EXPECT_TRUE(ScoreComp::saveCompareScore(score, "beamStemDir-01.mscx", BEAM_DATA_DIR + "beamStemDir-01-ref.mscx"));
-//     delete score;
-// }
+TEST_F(BeamTests, beamStemDir)
+{
+    MasterScore* score = ScoreRW::readScore(BEAM_DATA_DIR + "beamStemDir.mscx");
+    EXPECT_TRUE(score);
+
+    Measure* m1 = score->firstMeasure();
+    ChordRest* cr = toChordRest(m1->findSegment(SegmentType::ChordRest, m1->tick())->element(0));
+
+    cr->beam()->setBeamDirection(DirectionV::UP);
+
+    score->update();
+    score->doLayout();
+
+    EXPECT_TRUE(ScoreComp::saveCompareScore(score, "beamStemDir-01.mscx", BEAM_DATA_DIR + "beamStemDir-01-ref.mscx"));
+
+    delete score;
+}
 
 //---------------------------------------------------------
 //   flipBeamStemDir
-//   This method tests if a beam's stem direction can be
-//   set with a note after its direction has been set
-//   with the beam's own setBeamDirection method.
+//   This method tests if a beam's stem direction will be set to
+//   all its chords and will not affect other beams in score
+//   after using the flip command
 //---------------------------------------------------------
 
-//TEST_F(BeamTests, flipBeamStemDir)
-//{
-//    MasterScore* score = ScoreRW::readScore(BEAM_DATA_DIR + "flipBeamStemDir.mscx");
-//    EXPECT_TRUE(score);
-//    Measure* m1 = score->firstMeasure();
-//    ChordRest* cr = toChordRest(m1->findSegment(SegmentType::ChordRest, m1->tick())->element(0));
-//    Chord* c2 = toChord(cr->beam()->elements()[1]);
-//    cr->beam()->setBeamDirection(DirectionV::UP);
-//    c2->setStemDirection(DirectionV::DOWN);
-//    score->update();
-//    score->doLayout();
-//    EXPECT_TRUE(ScoreComp::saveCompareScore(score, "flipBeamStemDir-01.mscx", BEAM_DATA_DIR + "flipBeamStemDir-01-ref.mscx"));
-//    delete score;
-//}
+TEST_F(BeamTests, flipBeamStemDir)
+{
+    MasterScore* score = ScoreRW::readScore(BEAM_DATA_DIR + "flipBeamStemDir.mscx");
+    EXPECT_TRUE(score);
+
+    Measure* m1 = score->firstMeasure();
+    ChordRest* cr = toChordRest(m1->findSegment(SegmentType::ChordRest, m1->tick())->element(0));
+    Chord* c2 = toChord(cr->beam()->elements()[1]);
+
+    score->select(c2);
+    score->startCmd();
+    score->cmdFlip();
+    score->endCmd();
+    cr->beam()->setBeamDirection(DirectionV::DOWN);
+
+    score->update();
+    score->doLayout();
+
+    EXPECT_TRUE(ScoreComp::saveCompareScore(score, "flipBeamStemDir-01.mscx", BEAM_DATA_DIR + "flipBeamStemDir-01-ref.mscx"));
+
+    delete score;
+}

--- a/src/importexport/musicxml/tests/data/testCueNotes2_ref.xml
+++ b/src/importexport/musicxml/tests/data/testCueNotes2_ref.xml
@@ -120,7 +120,7 @@
         <duration>1</duration>
         <voice>1</voice>
         <type>eighth</type>
-        <stem>down</stem>
+        <stem>up</stem>
         <beam number="1">begin</beam>
         <notations>
           <tied type="start"/>
@@ -139,7 +139,7 @@
         <duration>1</duration>
         <voice>1</voice>
         <type>eighth</type>
-        <stem>down</stem>
+        <stem>up</stem>
         <beam number="1">end</beam>
         <notations>
           <tied type="stop"/>

--- a/src/importexport/musicxml/tests/data/testVoiceMapper1_ref.xml
+++ b/src/importexport/musicxml/tests/data/testVoiceMapper1_ref.xml
@@ -90,7 +90,7 @@
         <voice>2</voice>
         <type>half</type>
         <dot/>
-        <stem>down</stem>
+        <stem>up</stem>
         </note>
       <backup>
         <duration>3</duration>

--- a/src/inspector/models/notation/notes/stems/stemsettingsmodel.h
+++ b/src/inspector/models/notation/notes/stems/stemsettingsmodel.h
@@ -68,6 +68,8 @@ protected:
     void resetProperties() override;
 
 private:
+    void onStemDirectionChanged(Ms::DirectionV newDirection);
+
     PropertyItem* m_isStemHidden = nullptr;
     PropertyItem* m_thickness = nullptr;
     PropertyItem* m_length = nullptr;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9906