### PR TITLE
Fix #10292: emit signal when floating state changed to make the display be expected

### DIFF
--- a/src/appshell/view/dockwindow/internal/dockbase.cpp
+++ b/src/appshell/view/dockwindow/internal/dockbase.cpp
@@ -298,8 +298,15 @@ void DockBase::setFloating(bool floating)
         return;
     }
 
+    if (floating == m_floating) {
+        return;
+    }
+
+    m_floating = floating;
     m_dockWidget->setFloating(floating);
+    emit floatingChanged();
 }
+
 
 void DockBase::init()
 {

--- a/src/appshell/view/dockwindow/internal/dockbase.cpp
+++ b/src/appshell/view/dockwindow/internal/dockbase.cpp
@@ -307,7 +307,6 @@ void DockBase::setFloating(bool floating)
     emit floatingChanged();
 }
 
-
 void DockBase::init()
 {
     IF_ASSERT_FAILED(m_dockWidget) {


### PR DESCRIPTION
Resolves: [(#10292)](https://github.com/musescore/MuseScore/issues/10292)

Changes I make: Emit signal floatingChanged() in function DockBase::setFloating() which is in dockbase.cpp Then the handler function listenFloatingChanged() in dockpanelview.cpp could be called to make the title "dock" to "undock".


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
