### PR TITLE
[MU4] fix #8930: Can't edit text in text frames (or resize them)

### DIFF
--- a/src/engraving/libmscore/box.cpp
+++ b/src/engraving/libmscore/box.cpp
@@ -923,4 +923,19 @@ QString TBox::accessibleExtraInfo() const
     QString rez = _text->screenReaderInfo();
     return rez;
 }
+
+int TBox::gripsCount() const
+{
+    return 0;
+}
+
+Grip TBox::initialEditModeGrip() const
+{
+    return Grip::NO_GRIP;
+}
+
+Grip TBox::defaultGrip() const
+{
+    return Grip::NO_GRIP;
+}
 }

--- a/src/engraving/libmscore/textframe.h
+++ b/src/engraving/libmscore/textframe.h
@@ -42,23 +42,28 @@ public:
     TBox(const TBox&);
     ~TBox();
 
+    Text* text() const { return _text; }
+
     // Score Tree functions
     EngravingObject* scanParent() const override;
     EngravingObject* scanChild(int idx) const override;
     int scanChildCount() const override;
 
-    virtual TBox* clone() const override { return new TBox(*this); }
+    TBox* clone() const override { return new TBox(*this); }
 
-    virtual void write(XmlWriter&) const override;
+    void write(XmlWriter&) const override;
     using VBox::write;
-    virtual void read(XmlReader&) override;
-    virtual EngravingItem* drop(EditData&) override;
-    virtual void add(EngravingItem* e) override;
-    virtual void remove(EngravingItem* el) override;
+    void read(XmlReader&) override;
+    EngravingItem* drop(EditData&) override;
+    void add(EngravingItem* e) override;
+    void remove(EngravingItem* el) override;
 
-    virtual void layout() override;
-    virtual QString accessibleExtraInfo() const override;
-    Text* text() const { return _text; }
+    void layout() override;
+    QString accessibleExtraInfo() const override;
+
+    int gripsCount() const override;
+    Grip initialEditModeGrip() const override;
+    Grip defaultGrip() const override;
 
     EditBehavior normalModeEditBehavior() const override { return EditBehavior::SelectOnly; }
 };


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8930