### PR TITLE
[MU4] Fix #9636: disabled the volume section by default

### DIFF
--- a/src/playback/internal/playbackconfiguration.cpp
+++ b/src/playback/internal/playbackconfiguration.cpp
@@ -67,7 +67,8 @@ void PlaybackConfiguration::init()
     settings()->setDefaultValue(PLAYBACK_CURSOR_TYPE_KEY, Val(static_cast<int>(PlaybackCursorType::STEPPED)));
 
     for (MixerSectionType sectionType : allMixerSectionTypes()) {
-        settings()->setDefaultValue(mixerSectionVisibleKey(sectionType), Val(true));
+        bool sectionEnabledByDefault = sectionType != MixerSectionType::Volume;
+        settings()->setDefaultValue(mixerSectionVisibleKey(sectionType), Val(sectionEnabledByDefault));
     }
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9636