### PR TITLE
[MU4] Fix #10078: Score position changes after selecting a bar with some lines even those are not out of the screen

### DIFF
--- a/src/notation/internal/notationselection.cpp
+++ b/src/notation/internal/notationselection.cpp
@@ -101,27 +101,17 @@ mu::RectF NotationSelection::canvasBoundingRect() const
         return RectF();
     }
 
-    Ms::EngravingItem* el = score()->selection().element();
-    if (el) {
-        return el->canvasBoundingRect();
+    if (const Ms::EngravingItem* element = score()->selection().element()) {
+        return element->canvasBoundingRect();
     }
 
-    QList<Ms::EngravingItem*> els = score()->selection().elements();
-    if (els.isEmpty()) {
-        LOGW() << "selection not none, but no elements";
-        return RectF();
+    RectF result;
+
+    for (const RectF& rect : range()->boundingArea()) {
+        result = result.united(rect);
     }
 
-    RectF rect;
-    for (const Ms::EngravingItem* elm: els) {
-        if (rect.isNull()) {
-            rect = elm->canvasBoundingRect();
-        } else {
-            rect = rect.united(elm->canvasBoundingRect());
-        }
-    }
-
-    return rect;
+    return result;
 }
 
 INotationSelectionRangePtr NotationSelection::range() const

--- a/src/notation/internal/notationselectionrange.cpp
+++ b/src/notation/internal/notationselectionrange.cpp
@@ -30,7 +30,7 @@
 
 #include "log.h"
 
-static const int SELECTION_SIDE_PADDING = 8;
+static constexpr int SELECTION_SIDE_PADDING = 8;
 
 using namespace mu::notation;
 
@@ -80,8 +80,8 @@ std::vector<mu::RectF> NotationSelectionRange::boundingArea() const
         return {};
     }
 
-    Ms::Segment* startSegment = rangeStartSegment();
-    Ms::Segment* endSegment = rangeEndSegment();
+    const Ms::Segment* startSegment = rangeStartSegment();
+    const Ms::Segment* endSegment = rangeEndSegment();
     if (!endSegment) {
         endSegment = score()->lastSegment();
     }
@@ -101,8 +101,8 @@ std::vector<mu::RectF> NotationSelectionRange::boundingArea() const
         const Ms::Segment* sectionStartSegment = rangeSection.startSegment;
         const Ms::Segment* sectionEndSegment = rangeSection.endSegment;
 
-        Ms::SysStaff* segmentFirstStaff = sectionSystem->staff(score()->selection().staffStart());
-        Ms::SysStaff* segmentLastStaff = sectionSystem->staff(lastStaff);
+        const Ms::SysStaff* segmentFirstStaff = sectionSystem->staff(score()->selection().staffStart());
+        const Ms::SysStaff* segmentLastStaff = sectionSystem->staff(lastStaff);
 
         int topY = sectionElementsMaxY(rangeSection);
         int bottomY = sectionElementsMinY(rangeSection);

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -999,6 +999,7 @@ bool NotationPaintView::isInited() const
 void NotationPaintView::onPlayingChanged()
 {
     TRACEFUNC;
+
     if (!notationPlayback()) {
         return;
     }
@@ -1018,12 +1019,17 @@ void NotationPaintView::onPlayingChanged()
 void NotationPaintView::movePlaybackCursor(uint32_t tick)
 {
     TRACEFUNC;
+
     if (!notationPlayback()) {
         return;
     }
 
     RectF cursorRect = notationPlayback()->playbackCursorRectByTick(tick);
     m_playbackCursor->setRect(cursorRect);
+
+    if (!m_playbackCursor->visible()) {
+        return;
+    }
 
     if (configuration()->isAutomaticallyPanEnabled()) {
         adjustCanvasPosition(cursorRect);

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -350,7 +350,10 @@ void NotationPaintView::onSelectionChanged()
         return;
     }
 
-    adjustCanvasPosition(selectionRect);
+    if (adjustCanvasPosition(selectionRect)) {
+        return;
+    }
+
     update();
 }
 
@@ -646,18 +649,19 @@ qreal NotationPaintView::startVerticalScrollPosition() const
     return (viewport.top() - contentRect.top()) / contentRect.height();
 }
 
-void NotationPaintView::adjustCanvasPosition(const RectF& logicRect)
+bool NotationPaintView::adjustCanvasPosition(const RectF& logicRect)
 {
     TRACEFUNC;
+
     RectF viewRect = viewport();
     RectF showRect = logicRect;
 
     if (viewRect.isEmpty()) {
-        return;
+        return false;
     }
 
     if (viewRect.contains(showRect)) {
-        return;
+        return false;
     }
 
     constexpr int BORDER_SPACING_RATIO = 3;
@@ -691,17 +695,16 @@ void NotationPaintView::adjustCanvasPosition(const RectF& logicRect)
     pos = alignToCurrentPageBorder(showRect, pos);
 
     if (pos == oldPos) {
-        return;
+        return false;
     }
 
-    moveCanvasToPosition(pos);
-
-    update();
+    return moveCanvasToPosition(pos);
 }
 
 void NotationPaintView::ensureViewportInsideScrollableArea()
 {
     TRACEFUNC;
+
     auto [dx, dy] = constraintCanvas(0, 0);
     if (qFuzzyIsNull(dx) && qFuzzyIsNull(dy)) {
         return;
@@ -711,11 +714,12 @@ void NotationPaintView::ensureViewportInsideScrollableArea()
     update();
 }
 
-void NotationPaintView::moveCanvasToPosition(const PointF& logicPos)
+bool NotationPaintView::moveCanvasToPosition(const PointF& logicPos)
 {
     TRACEFUNC;
+
     PointF viewTopLeft = viewportTopLeft();
-    moveCanvas(viewTopLeft.x() - logicPos.x(), viewTopLeft.y() - logicPos.y());
+    return moveCanvas(viewTopLeft.x() - logicPos.x(), viewTopLeft.y() - logicPos.y());
 }
 
 bool NotationPaintView::moveCanvas(qreal dx, qreal dy)
@@ -1032,7 +1036,9 @@ void NotationPaintView::movePlaybackCursor(uint32_t tick)
     }
 
     if (configuration()->isAutomaticallyPanEnabled()) {
-        adjustCanvasPosition(cursorRect);
+        if (adjustCanvasPosition(cursorRect)) {
+            return;
+        }
     }
 
     update(); //! TODO set rect to optimization

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -344,11 +344,11 @@ void NotationPaintView::followNoteInputCursor()
 void NotationPaintView::onSelectionChanged()
 {
     TRACEFUNC;
-    if (notationSelection()->isNone()) {
-        return;
-    }
 
     RectF selectionRect = notationSelection()->canvasBoundingRect();
+    if (selectionRect.isNull()) {
+        return;
+    }
 
     adjustCanvasPosition(selectionRect);
     update();

--- a/src/notation/view/notationpaintview.h
+++ b/src/notation/view/notationpaintview.h
@@ -141,7 +141,7 @@ protected:
     void setReadonly(bool readonly);
 
     void moveCanvasToCenter();
-    void moveCanvasToPosition(const PointF& logicPos);
+    bool moveCanvasToPosition(const PointF& logicPos);
 
     RectF notationContentRect() const override;
 
@@ -191,7 +191,7 @@ private:
     qreal horizontalScrollableSize() const;
     qreal verticalScrollableSize() const;
 
-    void adjustCanvasPosition(const RectF& logicRect);
+    bool adjustCanvasPosition(const RectF& logicRect);
 
     void onNoteInputModeChanged();
     void onSelectionChanged();

--- a/src/notation/view/playbackcursor.cpp
+++ b/src/notation/view/playbackcursor.cpp
@@ -42,14 +42,20 @@ void PlaybackCursor::setRect(const RectF& rect)
     m_rect = rect;
 }
 
+bool PlaybackCursor::visible() const
+{
+    return m_visible;
+}
+
 void PlaybackCursor::setVisible(bool arg)
 {
     m_visible = arg;
 }
 
-QColor PlaybackCursor::color()
+QColor PlaybackCursor::color() const
 {
     QColor color = configuration()->playbackCursorColor();
     color.setAlpha(configuration()->cursorOpacity());
+
     return color;
 }

--- a/src/notation/view/playbackcursor.h
+++ b/src/notation/view/playbackcursor.h
@@ -41,10 +41,11 @@ public:
     const RectF& rect() const;
     void setRect(const RectF& rect);
 
+    bool visible() const;
     void setVisible(bool arg);
 
 private:
-    QColor color();
+    QColor color() const;
 
     bool m_visible = false;
     RectF m_rect;


### PR DESCRIPTION
Resolves:
https://github.com/musescore/MuseScore/issues/10078
https://github.com/musescore/MuseScore/issues/9780
https://github.com/musescore/MuseScore/issues/10168