### PR TITLE
fix #10295: fix string values of gp import in new version

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -675,6 +675,11 @@ void GPConverter::setUpTrack(const std::unique_ptr<GPTrack>& tR)
                 tunning = standartTuning;
             }
 
+            int transpose = tR->transponce();
+            for (auto& t : tunning) {
+                t -= transpose;
+            }
+
             StringData stringData = StringData(fretCount, static_cast<int>(tunning.size()), tunning.data());
 
             part->instrument()->setStringData(stringData);
@@ -1366,7 +1371,9 @@ void GPConverter::setPitch(Note* note, const GPNote::MidiPitch& midiPitch)
         //       instead.
         pitch = note->part()->instrument()->channel(0)->program();
     } else {
-        pitch = note->part()->instrument()->stringData()->getPitch(musescoreString, midiPitch.fret, nullptr);
+        pitch
+            = note->part()->instrument()->stringData()->getPitch(musescoreString, midiPitch.fret,
+                                                                 nullptr) + note->part()->instrument()->transpose().chromatic;
     }
 
     if (musescoreString == -1) {

--- a/src/importexport/guitarpro_old/internal/importgtp-gp6.cpp
+++ b/src/importexport/guitarpro_old/internal/importgtp-gp6.cpp
@@ -1216,21 +1216,21 @@ Fraction GuitarPro6::readBeats(QString beats, GPPartInfo* partInfo, Measure* mea
                                 }
                                 currentProperty = currentProperty.nextSibling();
                             }
-
-                            if (midi != "") {
-                                note->setPitch(midi.toInt());
-                            } else if (element != "") {
+                            if (midi == "" && element != "") {
                                 readDrumNote(note, element.toInt(), variation.toInt());
                             } else if (stringNum != "" && stringNum.toInt() >= 0 && note->headGroup() != NoteHeadGroup::HEAD_DIAMOND) {
                                 Staff* staff        = note->staff();
                                 int fretNumber      = fretNum.toInt();
                                 int musescoreString = staff->part()->instrument()->stringData()->strings() - 1 - stringNum.toInt();
-                                auto pitch          = staff->part()->instrument()->stringData()->getPitch(musescoreString, fretNumber,
-                                                                                                          nullptr);
+                                if (midi != "") {
+                                    note->setPitch(midi.toInt());
+                                } else {
+                                    auto pitch = staff->part()->instrument()->stringData()->getPitch(musescoreString, fretNumber, nullptr);
+                                    note->setPitch(pitch);
+                                }
                                 note->setFret(fretNumber);
                                 // we need to turn this string number for GP to the correct string number for musescore
                                 note->setString(musescoreString);
-                                note->setPitch(pitch);
                             } else if (tone != "") {
                                 note->setPitch((octave.toInt() * 12) + tone.toInt());                 // multiply octaves by 12 as 12 semitones in octave
                             }


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/10295*

*Making new version of gp import work: strings were 1 octave too low.
I tried to find better way than just changing tuning values, but I didn't find one.
In old version of import there is corresponding line:*

```
for (strings = 0; strings < sd->strings(); strings++) {
    tuning[strings] = sd->stringList()[strings].pitch - instr->transpose().chromatic;
}
```

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
