### PR TITLE
fix #9210 fix #10038 Score ordering

### DIFF
--- a/src/engraving/libmscore/instrtemplate.cpp
+++ b/src/engraving/libmscore/instrtemplate.cpp
@@ -45,6 +45,19 @@ QList<InstrumentFamily*> instrumentFamilies;
 QList<ScoreOrder> instrumentOrders;
 
 //---------------------------------------------------------
+//   InstrumentIndex
+//---------------------------------------------------------
+
+InstrumentIndex::InstrumentIndex(int g, int i, InstrumentTemplate* it)
+    : groupIndex{g}, instrIndex{i}, instrTemplate{it}
+{
+    templateCount = 0;
+    for (InstrumentGroup* g : qAsConst(instrumentGroups)) {
+        templateCount += g->instrumentTemplates.size();
+    }
+}
+
+//---------------------------------------------------------
 //   searchInstrumentGenre
 //---------------------------------------------------------
 
@@ -851,7 +864,7 @@ InstrumentIndex searchTemplateIndexForId(const QString& id)
         }
         ++grpIndex;
     }
-    return InstrumentIndex(-1, -1, nullptr);
+    return InstrumentIndex(-1, instIndex, nullptr);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/instrtemplate.h
+++ b/src/engraving/libmscore/instrtemplate.h
@@ -157,12 +157,12 @@ struct InstrumentGroup {
 //---------------------------------------------------------
 
 struct InstrumentIndex {
-    int groupIndex;
-    int instrIndex;
-    InstrumentTemplate* instrTemplate;
+    int groupIndex = 0;
+    int instrIndex = 0;
+    int templateCount = 0;
+    InstrumentTemplate* instrTemplate = nullptr;
 
-    InstrumentIndex(int g, int i, InstrumentTemplate* it)
-        : groupIndex{g}, instrIndex{i}, instrTemplate{it} {}
+    InstrumentIndex(int g, int i, InstrumentTemplate* it);
 };
 
 extern QList<InstrumentGenre*> instrumentGenres;

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -3713,7 +3713,9 @@ qreal Score::maxSystemDistance() const
 
 ScoreOrder Score::scoreOrder() const
 {
-    return _scoreOrder;
+    ScoreOrder order = _scoreOrder;
+    order.customized = !order.isScoreOrder(this);
+    return order;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/scoreorder.cpp
+++ b/src/engraving/libmscore/scoreorder.cpp
@@ -40,6 +40,36 @@ static const QString SOLOISTS_ID("<soloists>");
 static const QString UNSORTED_ID("<unsorted>");
 
 //---------------------------------------------------------
+//   clone
+//---------------------------------------------------------
+
+ScoreOrder ScoreOrder::clone() const
+{
+    ScoreOrder newOrder;
+
+    newOrder.id = id;
+    newOrder.name = name;
+    newOrder.customized = customized;
+    newOrder.instrumentMap = instrumentMap;
+
+    for (const ScoreGroup& sg : groups) {
+        ScoreGroup newGroup;
+
+        newGroup.family = sg.family;
+        newGroup.section = sg.section;
+        newGroup.unsorted = sg.unsorted;
+        newGroup.bracket = sg.bracket;
+        newGroup.showSystemMarkings = sg.showSystemMarkings;
+        newGroup.barLineSpan = sg.barLineSpan;
+        newGroup.thinBracket = sg.thinBracket;
+
+        newOrder.groups << newGroup;
+    }
+
+    return newOrder;
+}
+
+//---------------------------------------------------------
 //   readBoolAttribute
 //---------------------------------------------------------
 
@@ -176,6 +206,24 @@ bool ScoreOrder::isValid() const
 }
 
 //---------------------------------------------------------
+//   isCustom
+//---------------------------------------------------------
+
+bool ScoreOrder::isCustom() const
+{
+    return id == QString("custom");
+}
+
+//---------------------------------------------------------
+//   getName
+//---------------------------------------------------------
+
+QString ScoreOrder::getName() const
+{
+    return customized ? qtrc("OrderXML", "%1 (Customized)").arg(name) : name;
+}
+
+//---------------------------------------------------------
 //   getFamilyName
 //---------------------------------------------------------
 
@@ -193,6 +241,23 @@ QString ScoreOrder::getFamilyName(const InstrumentTemplate* instrTemplate, bool 
         return instrTemplate->family->id;
     }
     return QString("<unsorted>");
+}
+
+//---------------------------------------------------------
+//   newUnsortedGroup
+//---------------------------------------------------------
+
+ScoreGroup ScoreOrder::newUnsortedGroup(const QString group, const QString section) const
+{
+    ScoreGroup sg;
+    sg.family = QString(UNSORTED_ID);
+    sg.section = section;
+    sg.unsorted = group;
+    sg.bracket = false;
+    sg.showSystemMarkings = false;
+    sg.barLineSpan = false;
+    sg.thinBracket = false;
+    return sg;
 }
 
 //---------------------------------------------------------
@@ -224,6 +289,89 @@ ScoreGroup ScoreOrder::getGroup(const QString family, const QString instrumentGr
         }
     }
     return unsortedScoreGroup;
+}
+
+//---------------------------------------------------------
+//   instrumentSortingIndex
+//---------------------------------------------------------
+
+int ScoreOrder::instrumentSortingIndex(const QString& instrumentId, bool isSoloist) const
+{
+    static const QString SoloistsGroup("<soloists>");
+    static const QString UnsortedGroup("<unsorted>");
+
+    enum class Priority {
+        Undefined,
+        Unsorted,
+        UnsortedGroup,
+        Family,
+        Soloist
+    };
+
+    InstrumentIndex ii { searchTemplateIndexForId(instrumentId) };
+    if (!ii.instrTemplate) {
+        return 0;
+    }
+
+    QString family = instrumentMap.contains(instrumentId) ? instrumentMap[instrumentId].id : ii.instrTemplate->familyId();
+
+    int index = groups.size();
+
+    auto calculateIndex = [instrumentId, &ii](int index) {
+        return index * ii.templateCount + ii.instrTemplate->sequenceOrder;
+    };
+
+    Priority priority = Priority::Undefined;
+
+    for (int i = 0; i < groups.size(); ++i) {
+        const ScoreGroup& sg = groups[i];
+
+        if ((sg.family == SoloistsGroup) && isSoloist) {
+            return calculateIndex(i);
+        } else if ((priority < Priority::Family) && (sg.family == family)) {
+            index = i;
+            priority = Priority::Family;
+        } else if ((priority < Priority::UnsortedGroup) && (sg.family == UnsortedGroup)
+                   && (sg.unsorted == ii.instrTemplate->groupId)) {
+            index = i;
+            priority = Priority::UnsortedGroup;
+        } else if ((priority < Priority::Unsorted) && (sg.family == UnsortedGroup)) {
+            index = i;
+            priority = Priority::Unsorted;
+        }
+    }
+
+    return calculateIndex(index);
+}
+
+//---------------------------------------------------------
+//   isScoreOrder
+//---------------------------------------------------------
+
+bool ScoreOrder::isScoreOrder(const QList<int>& indices) const
+{
+    if (isCustom()) {
+        return true;
+    }
+
+    int prvIndex { -1 };
+    for (int curIndex : indices) {
+        if (curIndex < prvIndex) {
+            return false;
+        }
+        prvIndex = curIndex;
+    }
+    return true;
+}
+
+bool ScoreOrder::isScoreOrder(const Score* score) const
+{
+    QList<int> indices;
+    for (const Part* part : score->parts()) {
+        indices << instrumentSortingIndex(part->instrument()->id(), part->soloist());
+    }
+
+    return isScoreOrder(indices);
 }
 
 //---------------------------------------------------------
@@ -383,24 +531,19 @@ void ScoreOrder::read(Ms::XmlReader& reader)
         } else if (reader.name() == "unsorted") {
             QString group { reader.attribute("group", QString("")) };
 
-            if (hasGroup(UNSORTED_ID, group)) {
-                reader.skipCurrentElement();
-                return;
+            if (!hasGroup(UNSORTED_ID, group)) {
+                groups << newUnsortedGroup(group, sectionId);
             }
 
-            ScoreGroup sg;
-            sg.family = QString(UNSORTED_ID);
-            sg.section = sectionId;
-            sg.unsorted = group;
-            sg.bracket = false;
-            sg.showSystemMarkings = false;
-            sg.barLineSpan = false;
-            sg.thinBracket = false;
-            groups << sg;
             reader.skipCurrentElement();
         } else {
             reader.unknown();
         }
+    }
+
+    QString group { QString("") };
+    if (!hasGroup(UNSORTED_ID, group)) {
+        groups << newUnsortedGroup(group, id);
     }
 }
 

--- a/src/engraving/libmscore/scoreorder.h
+++ b/src/engraving/libmscore/scoreorder.h
@@ -63,9 +63,11 @@ struct ScoreOrder
     QString name { QString() };
     QMap<QString, InstrumentOverwrite> instrumentMap;
     QList<ScoreGroup> groups;
+    bool customized = false;
 
     ScoreOrder() = default;
 
+    ScoreOrder clone() const;
     bool operator==(const ScoreOrder& order) const;
     bool operator!=(const ScoreOrder& order) const;
 
@@ -76,8 +78,14 @@ struct ScoreOrder
     bool hasGroup(const QString& id, const QString& group=QString()) const;
 
     bool isValid() const;
+    bool isCustom() const;
+    QString getName() const;
     QString getFamilyName(const InstrumentTemplate* instrTemplate, bool soloist) const;
+    ScoreGroup newUnsortedGroup(const QString group, const QString section) const;
     ScoreGroup getGroup(const QString family, const QString instrumentGroup) const;
+    int instrumentSortingIndex(const QString& instrumentId, bool isSoloist) const;
+    bool isScoreOrder(const QList<int>& indices) const;
+    bool isScoreOrder(const Score* score) const;
 
     void setBracketsAndBarlines(Score* score);
     void setSystemObjectStaves(Score* score);

--- a/src/instrumentsscene/view/instrumentsonscorelistmodel.h
+++ b/src/instrumentsscene/view/instrumentsonscorelistmodel.h
@@ -72,15 +72,21 @@ private:
 
     void loadOrders();
 
+    int resolveInstrumentSequenceNumber(const QString& instrumentId) const;
     void updateInstrumentsOrder();
     void sortInstruments(ItemList& instruments);
-    int sortInstrumentsIndex(const notation::ScoreOrder& order, const InstrumentItem& instrument) const;
+    void insertInstrument(ItemList& instruments, InstrumentItem* newInstrument);
 
     InstrumentItem* modelIndexToItem(const QModelIndex& index) const;
     const notation::ScoreOrder& currentScoreOrder() const;
 
     void onRowsMoved() override;
+    void onRowsRemoved() override;
     void doSetCurrentOrderIndex(int index);
+    bool matchesScoreOrder() const;
+    void verifyScoreOrder();
+    int createCustomizedScoreOrder(const notation::ScoreOrder& order);
+    void removeCustomizedScoreOrder(const notation::ScoreOrder& order);
 
     notation::ScoreOrderList m_scoreOrders;
     int m_currentOrderIndex = 0;

--- a/src/instrumentsscene/view/instrumentspanelcontextmenumodel.h
+++ b/src/instrumentsscene/view/instrumentspanelcontextmenumodel.h
@@ -46,6 +46,7 @@ public:
 
 private:
     void loadItems();
+    void buildMenu();
     void setInstrumentsOrder(const actions::ActionData& args);
     void updateOrderingMenu(const QString& newOrderId);
 

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -826,10 +826,6 @@ void NotationParts::moveParts(const IDList& sourcePartsIds, const ID& destinatio
     endInteractionWithScore();
     startEdit();
 
-    if (scoreOrder() != customOrder()) {
-        doSetScoreOrder(customOrder());
-    }
-
     sortParts(parts, score()->staves());
 
     setBracketsAndBarlines();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9210
Resolves: https://github.com/musescore/MuseScore/issues/10038

If the instrument order is changed manually, a customized version of the existing score order is created instead of switching the "Custom" score order.
This effects the automatic creation of brackets and braces:
- For "Custom" score orders, no automatic creation of brackets and braces is performed. As a result, existing brackets remain.
- For "customized" score orders, all existing brackets and braces are removed and newly generated.

Key method in this is the method `ScoreOrder::isScore()` which returns true if the specified score (or instrument order) matches the score order.

After every change in the instrument order the score is checked again:
- If the new order matches the score order **and** the score order is a customized score order, use the standard, non customized, score order and remove the customized score order.
- If the new order doesn't match the score order **and** the score order is a standard, non customized, score order, create a new customized version of the score order and select this customized score order.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
