### PR TITLE
Fix #324840: Ctrl+Scrollwheel zoom on Linux X11

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -398,6 +398,15 @@ void NotationViewInputController::wheelEvent(QWheelEvent* event)
     qreal stepsX = 0.0;
     qreal stepsY = 0.0;
 
+// pixelDelta is unreliable on X11
+#ifdef Q_OS_LINUX
+    if (std::getenv("WAYLAND_DISPLAY") == NULL) {
+        // Ignore pixelsScrolled unless Wayland is used
+        pixelsScrolled.setX(0);
+        pixelsScrolled.setY(0);
+    }
+#endif
+
     if (!pixelsScrolled.isNull()) {
         dx = pixelsScrolled.x();
         dy = pixelsScrolled.y();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/324840

Qt provides two methods for getting information out of a QWheelEvent: pixelDelta() and angleDelta(), which could both be used in musescore. I assume the recent changes to libinput, that created this problem, either made pixelDelta() available or changed its behavior. Either way, for me that method always returned 120 (or -120) in the y component which then gets interpreted as 24  zoom steps at once. 120 is a good value when it comes from angleDelta(), and in that case it also gets interpreted correctly.

I'm not sure where the value `PIXELSSTEPSFACTOR = 5` comes from, but I can only assume that it works for other systems. The [Qt documentation](https://doc.qt.io/qt-5/qwheelevent.html#pixelDelta) notably says:

> **Note:** On X11 this value is driver specific and unreliable, use angleDelta() instead

which is pretty much what this change does. 

As mentioned in the issue, this problem only arises when using `xf86-input-libinput` version 1.2.0 or higher. So far that mostly affects rolling release distros, but it seems like the new Ubuntu releasing April will have the [new version](https://packages.ubuntu.com/jammy/x11/xserver-xorg-input-libinput) as well.

---

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
