### PR TITLE
Fix #10339- Palette properties not working

### DIFF
--- a/src/palette/internal/paletteprovider.cpp
+++ b/src/palette/internal/paletteprovider.cpp
@@ -490,7 +490,7 @@ void UserPaletteController::editPaletteProperties(const QModelIndex& index)
 
     QVariantMap properties;
     properties["paletteId"] = palette->id();
-    properties["name"] = palette->translatedName();
+    properties["name"] = QString(palette->translatedName().toUtf8().toPercentEncoding());
     properties["cellWidth"] = palette->gridSize().width();
     properties["cellHeight"] = palette->gridSize().height();
     properties["scale"] = palette->mag();

--- a/src/palette/view/palettepropertiesmodel.cpp
+++ b/src/palette/view/palettepropertiesmodel.cpp
@@ -32,7 +32,7 @@ void PalettePropertiesModel::load(const QVariant& properties)
     QVariantMap map = document.toVariant().toMap();
 
     m_paletteId = map["paletteId"].toString();
-    m_originConfig.name = map["name"].toString();
+    m_originConfig.name = QString(QByteArray::fromPercentEncoding(map["name"].toByteArray()));
     m_originConfig.size.setWidth(map["cellWidth"].toInt());
     m_originConfig.size.setHeight(map["cellHeight"].toInt());
     m_originConfig.scale = map["scale"].toDouble();


### PR DESCRIPTION
Resolves: #10339 

*(short description of the changes and the motivation to make the changes)*

This commit fixes the issue of palette properties not appearing on
clicking "Palette properties" of some palettes. The problem lies in the
'&' in the names of the affected palettes. uri.cpp tries to parce
parameters on the basis of the '&' which results in the palette name
being mutilated and causes this bug. The fix is to use percent encoding

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
