### PR TITLE
[MU4] Fix duplicate system object on load

### DIFF
--- a/share/instruments/orders.xml
+++ b/share/instruments/orders.xml
@@ -39,7 +39,7 @@
         <section id="voices" barLineSpan="false">
             <family>voices</family>
         </section>
-        <section id="strings" showSystemMarkings="true">
+        <section id="strings">
             <family>orchestral-strings</family>
         </section>
         <unsorted/>

--- a/src/engraving/libmscore/scoreorder.cpp
+++ b/src/engraving/libmscore/scoreorder.cpp
@@ -330,10 +330,8 @@ void ScoreOrder::setBracketsAndBarlines(Score* score)
 
 void ScoreOrder::setSystemObjectStaves(Score* score)
 {
-    // the cool thing is that the template is populated by both the full template used
-    // and also orders.xml. If we want to do some jiggery-pokery with adding system object
-    // staves in the situation where the user has added the instruments manually, orders.xml
-    // is the place to go, and will likely need special handling here.
+    // for now, orders.xml doesn't contain any system object information, but can be used in the future
+    // when we start phase 2 of the system objects thing (post 4.0)
     if (!score->getSystemObjectStaves().isEmpty()) {
         return;
     }


### PR DESCRIPTION
On load, some scores would use the orders.xml information to add system objects to staves, and if that staff is the top staff, a duplicate system object is added. For example, orders.xml says that the strings have system objects on them, and you load a score that has only one violin part, a system object is added because of the template, along with the system object for being the top staff (because system objects are always shown on top).

This doesn't create any graphical problems, because one of the system objects is always overwritten by the other, but in the future, this behavior _may_ be useful, for when the user creates a score with a violin part and then adds all the other instruments in an orchestra--the "duplicate" system object will move down with the staff, and the other will remain at the top. However, for right now, because the only extra system objects staves will be taken from the template files (instead of orders.xml), the fix for this one is as easy as removing system object information from orders.xml.

This will be revisited when we move on to phase two of the system objects spec!