### PR TITLE
Fix unpredictable jumping when zooming while there is a selection

### DIFF
--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -22,7 +22,6 @@
 #include "notationpaintview.h"
 
 #include <QPainter>
-#include <QWindow>
 
 #include "actions/actiontypes.h"
 #include "stringutils.h"
@@ -503,6 +502,11 @@ std::pair<qreal, qreal> NotationPaintView::constraintCanvas(qreal dx, qreal dy) 
     return { dx, dy };
 }
 
+PointF NotationPaintView::viewportTopLeft() const
+{
+    return toLogical(PointF(0.0, 0.0));
+}
+
 RectF NotationPaintView::viewport() const
 {
     return toLogical(RectF(0.0, 0.0, width(), height()));
@@ -710,7 +714,7 @@ void NotationPaintView::ensureViewportInsideScrollableArea()
 void NotationPaintView::moveCanvasToPosition(const PointF& logicPos)
 {
     TRACEFUNC;
-    PointF viewTopLeft = canvasPos();
+    PointF viewTopLeft = viewportTopLeft();
     moveCanvas(viewTopLeft.x() - logicPos.x(), viewTopLeft.y() - logicPos.y());
 }
 
@@ -956,11 +960,6 @@ qreal NotationPaintView::width() const
 qreal NotationPaintView::height() const
 {
     return QQuickPaintedItem::height();
-}
-
-PointF NotationPaintView::canvasPos() const
-{
-    return toLogical(PointF(0.0, 0.0));
 }
 
 PointF NotationPaintView::toLogical(const PointF& point) const

--- a/src/notation/view/notationpaintview.h
+++ b/src/notation/view/notationpaintview.h
@@ -86,10 +86,11 @@ public:
     qreal width() const override;
     qreal height() const override;
 
-    PointF canvasPos() const override;
-
     PointF toLogical(const PointF& point) const override;
     PointF toLogical(const QPointF& point) const override;
+    RectF toLogical(const RectF& rect) const;
+
+    PointF fromLogical(const PointF& point) const override;
     RectF fromLogical(const RectF& rect) const override;
 
     Q_INVOKABLE bool moveCanvas(qreal dx, qreal dy) override;
@@ -115,6 +116,7 @@ public:
     qreal startVerticalScrollPosition() const;
     qreal verticalScrollbarSize() const;
 
+    PointF viewportTopLeft() const override;
     RectF viewport() const;
     QRectF viewport_property() const;
 
@@ -142,9 +144,6 @@ protected:
     void moveCanvasToPosition(const PointF& logicPos);
 
     RectF notationContentRect() const override;
-
-    RectF toLogical(const RectF& rect) const;
-    PointF fromLogical(const PointF& point) const;
 
     // Draw
     void paint(QPainter* painter) override;

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -150,16 +150,24 @@ void NotationViewInputController::zoomOut()
 
 PointF NotationViewInputController::findZoomFocusPoint() const
 {
+    double resultX = 0.0;
+    double resultY = 0.0;
+
     INotationSelectionPtr selection = m_view->notationInteraction()->selection();
 
-    // No selection: zoom at the center of the view
     if (selection->isNone()) {
-        return PointF(m_view->width() / 2, m_view->height() / 2);
+        // No selection: zoom at the center of the view
+        resultX = m_view->width() / 2;
+        resultY = m_view->height() / 2;
+    } else {
+        // Selection: zoom at the center of the selection
+        PointF result = m_view->fromLogical(selection->canvasBoundingRect().center());
+        resultX = result.x();
+        resultY = result.y();
     }
 
-    // Selection: zoom at the center of the selection
-    return (selection->canvasBoundingRect().center() * m_view->currentScaling())
-           + m_view->canvasPos();
+    return PointF(std::clamp(resultX, 0.0, m_view->width()),
+                  std::clamp(resultY, 0.0, m_view->height()));
 }
 
 void NotationViewInputController::zoomToPageWidth()

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -45,7 +45,7 @@ public:
     virtual qreal width() const = 0;
     virtual qreal height() const = 0;
 
-    virtual PointF canvasPos() const = 0;
+    virtual PointF viewportTopLeft() const = 0;
 
     //! Returns true if the canvas has been moved
     virtual bool moveCanvas(qreal dx, qreal dy) = 0;
@@ -58,6 +58,7 @@ public:
 
     virtual PointF toLogical(const PointF& p) const = 0;
     virtual PointF toLogical(const QPointF& p) const = 0;
+    virtual PointF fromLogical(const PointF& r) const = 0;
     virtual RectF fromLogical(const RectF& r) const = 0;
 
     virtual bool isNoteEnterMode() const = 0;


### PR DESCRIPTION
Resolves: not reported yet

The idea is that the pressing Ctrl++ or Ctrl+- would zoom to the center of the selection if there is a selection, otherwise to the center of the view. The former was not implemented correctly (`selection->canvasBoundingRect()` is in logical coordinates and needs to be converted to "physical" coordinates, but this was done incorrectly).