### PR TITLE
[MU4] Expose Measure::noText, mmRangeText to plugin API

### DIFF
--- a/src/plugins/api/elements.h
+++ b/src/plugins/api/elements.h
@@ -32,6 +32,8 @@
 #include "libmscore/hook.h"
 #include "libmscore/lyrics.h"
 #include "libmscore/measure.h"
+#include "libmscore/measurenumber.h"
+#include "libmscore/mmrestrange.h"
 #include "libmscore/note.h"
 #include "libmscore/notedot.h"
 #include "libmscore/page.h"
@@ -853,6 +855,9 @@ public:
 
     Measure* prevMeasureMM() { return wrap<Measure>(measure()->prevMeasureMM(), Ownership::SCORE); }
     Measure* nextMeasureMM() { return wrap<Measure>(measure()->nextMeasureMM(), Ownership::SCORE); }
+
+    Q_INVOKABLE Ms::PluginAPI::EngravingItem* noText(int staffIdx) { return wrap(measure()->noText(staffIdx)); }
+    Q_INVOKABLE Ms::PluginAPI::EngravingItem* mmRangeText(int staffIdx) { return wrap(measure()->mmRangeText(staffIdx)); }
 
     QQmlListProperty<EngravingItem> elements() { return wrapContainerProperty<EngravingItem>(this, measure()->el()); }
     /// \endcond


### PR DESCRIPTION
Previously, MeasureNumber/MMRestRange elements could not be accessed by plugin unless manually selected by the user. This change enables plugins to programmatically access MeasureNumber/MMRestRange elements, for example, to change the visibility or offset.

See also https://musescore.org/en/node/328678.

(I note that MStaff also has a number of other properties not exposed through the plugin API, e.g. *visible*, *stemless*. I imagine it might be helpful to expose some of these as well? But some of these seem internal and I'm not sure how they relate to user-facing functionality, so I didn't include them.)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
