### PR TITLE
Fix #8241: [MU4 Issue] No file path visible in recent score list

### DIFF
--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -120,7 +120,7 @@ void AppMenuModel::setupConnections()
         workspacesItem.setSubitems(makeWorkspacesItems());
     });
 
-    connect(qApp, &QApplication::applicationStateChanged, this, [this](Qt::ApplicationState state){
+    connect(qApp, &QApplication::applicationStateChanged, this, [this](Qt::ApplicationState state) {
         if (state != Qt::ApplicationActive) {
             resetNavigation();
         }
@@ -372,7 +372,12 @@ MenuItemList AppMenuModel::makeRecentScoresItems()
 
         UiAction action;
         action.code = "file-open";
-        action.title = !meta.title.isEmpty() ? meta.title : meta.fileName.toQString();
+        if (!meta.title.isEmpty()) {
+            QString recentFilePath = meta.filePath.toQString().prepend(" (").append(")");
+            action.title = meta.title + recentFilePath;
+        } else {
+            action.title = meta.fileName.toQString();
+        }
         item->setAction(action);
 
         item->setId(makeId(item->action().code, index++));

--- a/src/project/qml/MuseScore/Project/internal/RecentScoresView.qml
+++ b/src/project/qml/MuseScore/Project/internal/RecentScoresView.qml
@@ -104,7 +104,8 @@ GridView {
                 }
             }
 
-            title: score.title
+            title: (score.fileNameWithExtension != undefined) ? score.title + score.fileNameWithExtension : score.title
+            toolTipTitle: (score.path != null) ? score.path : "Create a new Score"
             thumbnail: score.thumbnail
             isAdd: score.isAddNew
             timeSinceModified: !isAdd ? score.timeSinceModified : ""

--- a/src/project/qml/MuseScore/Project/internal/ScoreItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoreItem.qml
@@ -30,6 +30,7 @@ FocusScope {
     id: root
 
     property string title: ""
+    property string toolTipTitle: ""
     property alias timeSinceModified: timeSinceModified.text
     property alias thumbnail: loader.thumbnail
     property bool isAdd: false
@@ -217,7 +218,17 @@ FocusScope {
         hoverEnabled: true
 
         onClicked: {
+            ui.tooltip.hide(root)
             root.clicked()
         }
+
+        onEntered: {
+            ui.tooltip.show(root, root.toolTipTitle)        
+        }
+
+        onExited: {
+            ui.tooltip.hide(root)
+        }
+
     }
 }

--- a/src/project/view/recentprojectsmodel.cpp
+++ b/src/project/view/recentprojectsmodel.cpp
@@ -34,6 +34,7 @@ using namespace mu::notation;
 namespace {
 const QString SCORE_TITLE_KEY("title");
 const QString SCORE_PATH_KEY("path");
+const QString SCORE_FILENAME_KEY("fileNameWithExtension");
 const QString SCORE_THUMBNAIL_KEY("thumbnail");
 const QString SCORE_TIME_SINCE_MODIFIED_KEY("timeSinceModified");
 const QString SCORE_ADD_NEW_KEY("isAddNew");
@@ -115,6 +116,7 @@ void RecentProjectsModel::updateRecentScores(const ProjectMetaList& recentProjec
 
         obj[SCORE_TITLE_KEY] = !meta.title.isEmpty() ? meta.title : meta.fileName.toQString();
         obj[SCORE_PATH_KEY] = meta.filePath.toQString();
+        obj[SCORE_FILENAME_KEY] = fileNameWithExtensionProvider(meta.filePath.toQString());
         obj[SCORE_THUMBNAIL_KEY] = meta.thumbnail;
         obj[SCORE_TIME_SINCE_MODIFIED_KEY] = DataFormatter::formatTimeSince(QFileInfo(meta.filePath.toQString()).lastModified().date());
         obj[SCORE_ADD_NEW_KEY] = false;
@@ -129,4 +131,11 @@ void RecentProjectsModel::updateRecentScores(const ProjectMetaList& recentProjec
     recentScores.prepend(QVariant::fromValue(obj));
 
     setRecentScores(recentScores);
+}
+
+QString RecentProjectsModel::fileNameWithExtensionProvider(QString paths)
+{
+    QString fileNameWithExtension = paths.remove(0, paths.lastIndexOf("/") + 1);
+    fileNameWithExtension.prepend("(").append(")");
+    return fileNameWithExtension;
 }

--- a/src/project/view/recentprojectsmodel.h
+++ b/src/project/view/recentprojectsmodel.h
@@ -58,6 +58,7 @@ private:
 
     void updateRecentScores(const ProjectMetaList& recentProjectsList);
     void setRecentScores(const QVariantList& recentScores);
+    QString fileNameWithExtensionProvider(QString paths);
 
     QVariantList m_recentScores;
     QHash<int, QByteArray> m_roles;


### PR DESCRIPTION
Resolves: #8241 

Swapped the positions of the order of White and Black Theme codes returned by allStandardThemeCodes(), changed the default value of High Contrast Theme and reordered the instances of Black and White Theme code usages.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://musescore.org/en/cla)
- [X] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [X] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
