### PR TITLE
fix #10308: displaying legato only in standard notation

### DIFF
--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -62,6 +62,9 @@ SlurSegment::SlurSegment(const SlurSegment& ss)
 void SlurSegment::draw(mu::draw::Painter* painter) const
 {
     TRACE_OBJ_DRAW;
+    if (onTabStaff()) {
+        return;
+    }
     using namespace mu::draw;
     Pen pen(curColor());
     qreal mag = staff() ? staff()->staffMag(slur()->tick()) : 1.0;
@@ -412,6 +415,9 @@ void SlurSegment::computeBezier(mu::PointF p6o)
 
 void SlurSegment::layoutSegment(const PointF& p1, const PointF& p2)
 {
+    if (onTabStaff()) {
+        return;
+    }
     setPos(PointF());
     ups(Grip::START).p = p1;
     ups(Grip::END).p   = p2;

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1354,8 +1354,9 @@ void GPConverter::setPitch(Note* note, const GPNote::MidiPitch& midiPitch)
 {
     int32_t fret = midiPitch.fret;
     int32_t musescoreString{ -1 };
+    Ms::Instrument* instrument = note->part()->instrument();
     if (midiPitch.string != -1) {
-        musescoreString = note->part()->instrument()->stringData()->strings() - 1 - midiPitch.string;
+        musescoreString = instrument->stringData()->strings() - 1 - midiPitch.string;
     }
 
     int pitch = 0;
@@ -1365,23 +1366,23 @@ void GPConverter::setPitch(Note* note, const GPNote::MidiPitch& midiPitch)
         pitch = midiPitch.octave * 12 + midiPitch.tone;
     } else if (midiPitch.variation != -1) {
         pitch = calculateDrumPitch(midiPitch.element, midiPitch.variation, note->part()->shortName());
-    } else if (note->part()->instrument()->channel(0)->channel() == 9) {
+    } else if (instrument->channel(0)->channel() == 9) {
         //!@NOTE This is a case, when part of the note is a
         //       single drum instrument. It seems, that GP
         //       sets to -1 all midi parameters for the note,
         //       but sets the midi pitch value to the program
         //       instead.
-        pitch = note->part()->instrument()->channel(0)->program();
+        pitch = instrument->channel(0)->program();
     } else {
         pitch
-            = note->part()->instrument()->stringData()->getPitch(musescoreString, midiPitch.fret,
-                                                                 nullptr) + note->part()->instrument()->transpose().chromatic;
+            = instrument->stringData()->getPitch(musescoreString, midiPitch.fret,
+                                                 nullptr) + instrument->transpose().chromatic;
     }
 
     if (musescoreString == -1) {
         musescoreString = getStringNumberFor(note, pitch);
 
-        fret = note->part()->instrument()->stringData()->fret(pitch, musescoreString, nullptr);
+        fret = instrument->stringData()->fret(pitch, musescoreString, nullptr);
     }
 
     note->setFret(fret);


### PR DESCRIPTION
Resolves: *#10308*

*displaying legato only in standard notation*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
