### PR TITLE
[MU4] Fix #310158: Don't null terminate MIDI text meta events

### DIFF
--- a/src/engraving/compat/midi/midifile.cpp
+++ b/src/engraving/compat/midi/midifile.cpp
@@ -144,8 +144,14 @@ void MidiFile::writeEvent(const MidiEvent& event)
     case ME_META:
         put(ME_META);
         put(event.metaType());
-        putvl(event.len());
-        write(event.edata(), event.len());
+        // Don't null terminate text meta events
+        if (event.metaType() >= 0x1 && event.metaType() <= 0x14) {
+            putvl(event.len() - 1);
+            write(event.edata(), event.len() - 1);
+        } else {
+            putvl(event.len());
+            write(event.edata(), event.len());
+        }
         resetRunningStatus();               // really ?!
         break;
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/310158

Port of PR #7003 to the master branch

This PR prevents the null terminator of MIDI text meta events from getting exported into the MIDI files.

Apparently the unit tests for MIDI import/export are a) currently disabled and b) only for import anyway, unlike the 3.x branch, so no tests have been amended in this PR