### PR TITLE
fix #10316: fixed slide in/out layout

### DIFF
--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -621,6 +621,7 @@ void Chord::add(EngravingItem* e)
         _hook = toHook(e);
         break;
     case ElementType::CHORDLINE:
+    case ElementType::SLIDE:
         el().push_back(e);
         break;
     case ElementType::STEM_SLASH:

--- a/src/engraving/libmscore/chordline.cpp
+++ b/src/engraving/libmscore/chordline.cpp
@@ -43,8 +43,8 @@ const char* scorelineNames[] = {
 //   ChordLine
 //---------------------------------------------------------
 
-ChordLine::ChordLine(Chord* parent)
-    : EngravingItem(ElementType::CHORDLINE, parent, ElementFlag::MOVABLE)
+ChordLine::ChordLine(Chord* parent, const ElementType& type)
+    : EngravingItem(type, parent, ElementFlag::MOVABLE)
 {
     modified = false;
     _chordLineType = ChordLineType::NOTYPE;

--- a/src/engraving/libmscore/chordline.h
+++ b/src/engraving/libmscore/chordline.h
@@ -45,8 +45,10 @@ enum class ChordLineType : char {
 ///    implements fall, doit, plop, bend
 //---------------------------------------------------------
 
-class ChordLine final : public EngravingItem
+class ChordLine : public EngravingItem
 {
+protected:
+
     ChordLineType _chordLineType;
     bool _straight;
     mu::PainterPath path;
@@ -56,7 +58,8 @@ class ChordLine final : public EngravingItem
     const int _initialLength = 2;
 
     friend class mu::engraving::Factory;
-    ChordLine(Chord* parent);
+
+    ChordLine(Chord* parent, const ElementType& type = ElementType::CHORDLINE);
     ChordLine(const ChordLine&);
 
 public:

--- a/src/engraving/libmscore/engravingitem.cpp
+++ b/src/engraving/libmscore/engravingitem.cpp
@@ -84,6 +84,7 @@
 #include "score.h"
 #include "scorefont.h"
 #include "segment.h"
+#include "slide.h"
 #include "slur.h"
 #include "spacer.h"
 #include "staff.h"

--- a/src/engraving/libmscore/engravingobject.h
+++ b/src/engraving/libmscore/engravingobject.h
@@ -129,6 +129,7 @@ class StaffState;
 class Arpeggio;
 class Image;
 class ChordLine;
+class Slide;
 class SlurTieSegment;
 class FretDiagram;
 class StaffTypeChange;
@@ -381,6 +382,7 @@ public:
     CONVERT(Arpeggio,      ARPEGGIO)
     CONVERT(Image,         IMAGE)
     CONVERT(ChordLine,     CHORDLINE)
+    CONVERT(Slide,         SLIDE)
     CONVERT(FretDiagram,   FRET_DIAGRAM)
     CONVERT(Page,          PAGE)
     CONVERT(Text,          TEXT)
@@ -697,6 +699,7 @@ CONVERT(StaffState)
 CONVERT(Arpeggio)
 CONVERT(Image)
 CONVERT(ChordLine)
+CONVERT(Slide)
 CONVERT(FretDiagram)
 CONVERT(Page)
 CONVERT(SystemText)

--- a/src/engraving/libmscore/factory.cpp
+++ b/src/engraving/libmscore/factory.cpp
@@ -54,6 +54,7 @@
 #include "chord.h"
 #include "fermata.h"
 #include "chordline.h"
+#include "slide.h"
 #include "accidental.h"
 #include "measurenumber.h"
 #include "mmrestrange.h"
@@ -138,6 +139,7 @@ static const ElementName elementNames[] = {
     { ElementType::ARTICULATION,         "Articulation",         QT_TRANSLATE_NOOP("elementName", "Articulation") },
     { ElementType::FERMATA,              "Fermata",              QT_TRANSLATE_NOOP("elementName", "Fermata") },
     { ElementType::CHORDLINE,            "ChordLine",            QT_TRANSLATE_NOOP("elementName", "Chord line") },
+    { ElementType::SLIDE,                "Slide",                QT_TRANSLATE_NOOP("elementName", "Slide") },
     { ElementType::DYNAMIC,              "Dynamic",              QT_TRANSLATE_NOOP("elementName", "Dynamic") },
     { ElementType::BEAM,                 "Beam",                 QT_TRANSLATE_NOOP("elementName", "Beam") },
     { ElementType::HOOK,                 "Hook",                 QT_TRANSLATE_NOOP("elementName", "Flag") }, // internally called "Hook", but "Flag" in SMuFL, so here externally too
@@ -258,6 +260,7 @@ EngravingItem* Factory::doCreateItem(ElementType type, EngravingItem* parent)
     case ElementType::ARTICULATION:      return new Articulation(parent->isChordRest() ? toChordRest(parent) : dummy->chord());
     case ElementType::FERMATA:           return new Fermata(parent);
     case ElementType::CHORDLINE:         return new ChordLine(parent->isChord() ? toChord(parent) : dummy->chord());
+    case ElementType::SLIDE:             return new Slide(parent->isChord() ? toChord(parent) : dummy->chord());
     case ElementType::ACCIDENTAL:        return new Accidental(parent);
     case ElementType::DYNAMIC:           return new Dynamic(parent->isSegment() ? toSegment(parent) : dummy->segment());
     case ElementType::TEXT:              return new Text(parent);
@@ -589,6 +592,10 @@ Ms::Segment* Factory::createSegment(Ms::Measure* parent, Ms::SegmentType type, c
 
     return s;
 }
+
+CREATE_ITEM_IMPL(Slide, ElementType::SLIDE, Chord, setupAccessible)
+COPY_ITEM_IMPL(Slide)
+MAKE_ITEM_IMPL(Slide, Chord)
 
 CREATE_ITEM_IMPL(Slur, ElementType::SLUR, EngravingItem, setupAccessible)
 MAKE_ITEM_IMPL(Slur, EngravingItem)

--- a/src/engraving/libmscore/factory.h
+++ b/src/engraving/libmscore/factory.h
@@ -83,6 +83,10 @@ public:
     static Ms::ChordLine* copyChordLine(const Ms::ChordLine& src);
     static std::shared_ptr<Ms::ChordLine> makeChordLine(Ms::Chord* parent);
 
+    static Ms::Slide* createSlide(Ms::Chord* parent, bool setupAccessible = true);
+    static Ms::Slide* copySlide(const Ms::Slide& src);
+    static std::shared_ptr<Ms::Slide> makeSlide(Ms::Chord* parent);
+
     static Ms::Clef* createClef(Ms::Segment* parent, bool setupAccessible = true);
     static Ms::Clef* copyClef(const Ms::Clef& src);
     static std::shared_ptr<Ms::Clef> makeClef(Ms::Segment* parent);

--- a/src/engraving/libmscore/libmscore.cmake
+++ b/src/engraving/libmscore/libmscore.cmake
@@ -253,6 +253,8 @@ set(LIBMSCORE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/sig.h
     ${CMAKE_CURRENT_LIST_DIR}/skyline.cpp
     ${CMAKE_CURRENT_LIST_DIR}/skyline.h
+    ${CMAKE_CURRENT_LIST_DIR}/slide.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/slide.h
     ${CMAKE_CURRENT_LIST_DIR}/slur.cpp
     ${CMAKE_CURRENT_LIST_DIR}/slur.h
     ${CMAKE_CURRENT_LIST_DIR}/slurtie.cpp

--- a/src/engraving/libmscore/slide.cpp
+++ b/src/engraving/libmscore/slide.cpp
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "slide.h"
+
+#include "chord.h"
+
+using namespace mu;
+using namespace mu::draw;
+using namespace mu::engraving;
+
+namespace Ms {
+//---------------------------------------------------------
+//   Slide
+//---------------------------------------------------------
+
+Slide::Slide(Chord* parent)
+    : ChordLine(parent, ElementType::SLIDE)
+{
+}
+
+Slide::Slide(const Slide& cl)
+    : ChordLine(cl)
+{
+}
+
+//---------------------------------------------------------
+//   layout
+//---------------------------------------------------------
+
+void Slide::layout()
+{
+    if (!modified) {
+        qreal x2 = 0;
+        qreal y2 = 0;
+        qreal halfLength = _initialLength / 2;
+
+        if (_chordLineType != ChordLineType::NOTYPE) {
+            path = PainterPath();
+            x2 = halfLength;
+            y2 = halfLength;
+            if (onTheRight()) {
+                if (_chordLineType == ChordLineType::DOIT) {
+                    y2 *= -1;
+                }
+                path.lineTo(x2, y2);
+            } else {
+                x2 *= -1;
+                if (_chordLineType == ChordLineType::PLOP) {
+                    y2 *= -1;
+                }
+                path.lineTo(x2, y2);
+            }
+        }
+    }
+
+    qreal sp = spatium();
+    if (_note && explicitParent() && _chordLineType != ChordLineType::NOTYPE) {
+        PointF p(_note->pos());
+        qreal offset = 0.5;
+        setPos(p.x() + offset * sp * (onTheRight() ? 4 : -1), p.y() + offset * sp * (topToBottom() ? 1 : -1));
+    } else {
+        setPos(0.0, 0.0);
+    }
+    RectF r = path.boundingRect();
+
+    bbox().setRect(r.x() * sp, r.y() * sp, r.width() * sp, r.height() * sp);
+}
+
+//---------------------------------------------------------
+//   Symbol::draw
+//---------------------------------------------------------
+
+void Slide::draw(mu::draw::Painter* painter) const
+{
+    TRACE_OBJ_DRAW;
+
+    qreal sp = spatium();
+    painter->scale(sp, sp);
+
+    Pen pen(curColor(), .15, PenStyle::SolidLine);
+
+    painter->setPen(pen);
+    painter->setBrush(BrushStyle::NoBrush);
+    painter->drawPath(path);
+
+    painter->scale(1.0 / sp, 1.0 / sp);
+}
+}

--- a/src/engraving/libmscore/slide.h
+++ b/src/engraving/libmscore/slide.h
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef __SLIDE_H__
+#define __SLIDE_H__
+
+#include "chordline.h"
+#include "note.h"
+
+namespace mu::engraving {
+class Factory;
+}
+
+namespace Ms {
+class Chord;
+
+//---------------------------------------------------------
+//   @@ Slide
+///    straight line attached to the note
+///    implements slide-in-above, slide-in-below, slide-out-up, slide-out-down
+//---------------------------------------------------------
+
+class Slide final : public ChordLine
+{
+    Slide(Chord* parent);
+    Slide(const Slide&);
+
+    bool onTheRight() const { return _chordLineType == ChordLineType::FALL || _chordLineType == ChordLineType::DOIT; }  // chordlines to the right of the note
+    bool onTheLeft() const { return _chordLineType == ChordLineType::PLOP || _chordLineType == ChordLineType::SCOOP; }  // chordlines to the left of the note
+    bool topToBottom() const { return _chordLineType == ChordLineType::DOIT || _chordLineType == ChordLineType::PLOP; }
+    bool bottomToTop() const { return _chordLineType == ChordLineType::FALL || _chordLineType == ChordLineType::SCOOP; }
+
+    Note* _note = nullptr;
+
+public:
+
+    friend class mu::engraving::Factory;
+
+    Slide* clone() const override { return new Slide(*this); }
+
+    void layout() override;
+    void draw(mu::draw::Painter*) const override;
+    void setNote(Note* note) { _note = note; }
+    Note* note() const { return _note; }
+};
+}     // namespace Ms
+#endif

--- a/src/engraving/libmscore/types.h
+++ b/src/engraving/libmscore/types.h
@@ -79,6 +79,7 @@ enum class ElementType {
     ARTICULATION,
     FERMATA,
     CHORDLINE,
+    SLIDE,
     DYNAMIC,
     BEAM,
     HOOK,

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -11,7 +11,6 @@
 #include "libmscore/bracketItem.h"
 #include "libmscore/clef.h"
 #include "libmscore/chord.h"
-#include "libmscore/chordline.h"
 #include "libmscore/drumset.h"
 #include "libmscore/dynamic.h"
 #include "libmscore/factory.h"
@@ -30,6 +29,7 @@
 #include "libmscore/rest.h"
 #include "libmscore/rehearsalmark.h"
 #include "libmscore/score.h"
+#include "libmscore/slide.h"
 #include "libmscore/slur.h"
 #include "libmscore/spanner.h"
 #include "libmscore/stafftext.h"
@@ -1167,7 +1167,6 @@ void GPConverter::addSlide(const GPNote* gpnote, Note* note)
 
 void GPConverter::addSingleSlide(const GPNote* gpnote, Note* note)
 {
-    //!@TODO add slide in note, slide out of note
     auto slideType = [](size_t flagIdx) {
         if (flagIdx == 2) {
             return ChordLineType::FALL;
@@ -1184,10 +1183,11 @@ void GPConverter::addSingleSlide(const GPNote* gpnote, Note* note)
         if (gpnote->slides()[flagIdx]) {
             auto type = slideType(flagIdx);
 
-            ChordLine* cl = mu::engraving::Factory::createChordLine(_score->dummy()->chord());
-            cl->setChordLineType(type);
-            cl->setStraight(true);
-            note->add(cl);
+            Slide* slide = mu::engraving::Factory::createSlide(_score->dummy()->chord());
+            slide->setChordLineType(type);
+            note->chord()->add(slide);
+
+            slide->setNote(note);
         }
     }
 }

--- a/src/importexport/guitarpro/internal/importgtp-gp4.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp4.cpp
@@ -448,18 +448,19 @@ bool GuitarPro4::readNote(int string, int staffIdx, Note* note)
     note->setString(string);
     note->setPitch(std::min(pitch, 127));
 
+    auto alignCenter = Align(AlignH::HCENTER, AlignV::VCENTER);
     if (modMask2 & 0x10) {
         int type = readUChar();          // harmonic kind
         if (type == 1) {   //Natural
             // TODO-ws note->setHarmonic(false);
         } else if (type == 3) { // Tapped
-            addTextToNote("T.H.", Align::CENTER, note);
+            addTextToNote("T.H.", alignCenter, note);
         } else if (type == 4) { //Pinch
-            addTextToNote("P.H.", Align::CENTER, note);
+            addTextToNote("P.H.", alignCenter, note);
         } else if (type == 5) { //semi
-            addTextToNote("S.H.", Align::CENTER, note);
+            addTextToNote("S.H.", alignCenter, note);
         } else {   //Artificial
-            addTextToNote("A.H.", Align::CENTER, note);
+            addTextToNote("A.H.", alignCenter, note);
             int harmonicFret = note->fret();
             harmonicFret += type - 10;
             Note* harmonicNote = Factory::createNote(note->chord());

--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -372,7 +372,7 @@ Fraction GuitarPro5::readBeat(const Fraction& tick, int voice, Measure* measure,
             cr->add(lyrics);
         }
         if (free_text.length() && _note) {
-            addTextToNote(free_text, Align::CENTER, _note);
+            addTextToNote(free_text, { AlignH::HCENTER, AlignV::VCENTER }, _note);
         }
     }
     int rr = readChar();
@@ -1147,7 +1147,7 @@ bool GuitarPro5::readNoteEffects(Note* note)
             harmonicNote->setFret(fret);
             harmonicNote->setPitch(staff->part()->instrument()->stringData()->getPitch(note->string(), fret, nullptr));
             harmonicNote->setTpcFromPitch();
-            addTextToNote("A.H.", Align::CENTER, harmonicNote);
+            addTextToNote("A.H.", { AlignH::HCENTER, AlignV::VCENTER }, harmonicNote);
         }
     }
 

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -70,7 +70,7 @@
 #include <libmscore/fret.h>
 #include <libmscore/instrtemplate.h>
 #include <libmscore/glissando.h>
-#include <libmscore/chordline.h>
+#include <libmscore/slide.h>
 #include <libmscore/instrtemplate.h>
 #include <libmscore/hairpin.h>
 #include <libmscore/ottava.h>
@@ -539,7 +539,7 @@ void GuitarPro::addVibrato(Note* note, Vibrato::Type type)
 
 void GuitarPro::addTap(Note* note)
 {
-    addTextToNote("T", Align::CENTER, note);
+    addTextToNote("T", { AlignH::HCENTER, AlignV::VCENTER }, note);
 }
 
 //---------------------------------------------------------
@@ -548,7 +548,7 @@ void GuitarPro::addTap(Note* note)
 
 void GuitarPro::addSlap(Note* note)
 {
-    addTextToNote("S", Align::CENTER, note);
+    addTextToNote("S", { AlignH::HCENTER, AlignV::VCENTER }, note);
 }
 
 //---------------------------------------------------------
@@ -557,7 +557,7 @@ void GuitarPro::addSlap(Note* note)
 
 void GuitarPro::addPop(Note* note)
 {
-    addTextToNote("P", Align::CENTER, note);
+    addTextToNote("P", { AlignH::HCENTER, AlignV::VCENTER }, note);
 }
 
 //---------------------------------------------------------
@@ -803,7 +803,7 @@ void GuitarPro::readLyrics()
 //   createSlide
 //---------------------------------------------------------
 
-void GuitarPro::createSlide(int sl, ChordRest* cr, int staffIdx, Note* /*note*/)
+void GuitarPro::createSlide(int sl, ChordRest* cr, int staffIdx, Note* note)
 {
     // shift / legato slide
     if (sl == SHIFT_SLIDE || sl == LEGATO_SLIDE) {
@@ -847,35 +847,31 @@ void GuitarPro::createSlide(int sl, ChordRest* cr, int staffIdx, Note* /*note*/)
     }
     // slide out downwards (fall)
     if (sl & SLIDE_OUT_DOWN) {
-        ChordLine* cl = Factory::createChordLine(Ms::toChord(cr));
-        cl->setChordLineType(ChordLineType::FALL);
-        cl->setStraight(true);
-        //TODO-ws		cl->setNote(note);
-        cr->add(cl);
+        Slide* sl = Factory::createSlide(Ms::toChord(cr));
+        sl->setChordLineType(ChordLineType::FALL);
+        sl->setNote(note);
+        cr->add(sl);
     }
     // slide out upwards (doit)
     if (sl & SLIDE_OUT_UP) {
-        ChordLine* cl = Factory::createChordLine(Ms::toChord(cr));
-        cl->setChordLineType(ChordLineType::DOIT);
-        cl->setStraight(true);
-        //TODO-ws            cl->setNote(note);
-        cr->add(cl);
+        Slide* sl = Factory::createSlide(Ms::toChord(cr));
+        sl->setChordLineType(ChordLineType::DOIT);
+        sl->setNote(note);
+        cr->add(sl);
     }
     // slide in from below (plop)
     if (sl & SLIDE_IN_BELOW) {
-        ChordLine* cl = Factory::createChordLine(Ms::toChord(cr));
-        cl->setChordLineType(ChordLineType::PLOP);
-        cl->setStraight(true);
-        //TODO-ws		cl->setNote(note);
-        cr->add(cl);
+        Slide* sl = Factory::createSlide(Ms::toChord(cr));
+        sl->setChordLineType(ChordLineType::PLOP);
+        sl->setNote(note);
+        cr->add(sl);
     }
     // slide in from above (scoop)
     if (sl & SLIDE_IN_ABOVE) {
-        ChordLine* cl = Factory::createChordLine(Ms::toChord(cr));
-        cl->setChordLineType(ChordLineType::SCOOP);
-        cl->setStraight(true);
-        //TODO-ws		cl->setNote(note);
-        cr->add(cl);
+        Slide* sl = Factory::createSlide(Ms::toChord(cr));
+        sl->setChordLineType(ChordLineType::SCOOP);
+        sl->setNote(note);
+        cr->add(sl);
     }
 }
 


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/10316*

*Added implementation of slides that layout correctly (next to the note, not "into" it like chordline, see the issue)
Now supported types are slide-in, slide-out - both up and down.*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
