### PR TITLE
GitHub Issue template: improve Platform information section

### DIFF
--- a/.github/ISSUE_TEMPLATE/-mu4--development-issue.md
+++ b/.github/ISSUE_TEMPLATE/-mu4--development-issue.md
@@ -23,8 +23,8 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
+**Platform information**
+ - OS: [e.g. macOS, Windows, Linux]
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
<details><summary>Before</summary>

**Desktop (please complete the following information):**
 - OS: [e.g. iOS]

</details>

<details><summary>After</summary>

**Platform information**
- OS: [e.g. macOS, Windows, Linux]

</details>

In particular, the mention of iOS seems not totally appropriate here.