### PR TITLE
Fix #10156

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -629,8 +629,11 @@ void NotationInteraction::selectSection()
 
 void NotationInteraction::selectFirstElement(bool frame)
 {
-    if (EngravingItem* element = score()->firstElement(frame)) {
-        select({ element }, SelectType::SINGLE, element->staffIdx());
+    for (EngravingItem* element = score()->firstElement(frame); element; element = element->nextSegmentElement()) {
+        if (element->isNote() || element->isRestFamily()) {
+            select({ element }, SelectType::SINGLE, element->staffIdx());
+            break;
+        }
     }
 }
 


### PR DESCRIPTION
Resolves: [*#10156*](https://github.com/musescore/MuseScore/issues/10156)

Following cbjeukendrup's suggestion, I worked with the 'NotationInteraction::selectFirstElement' function so that when opening a recent score, the first note or rest would be selected by default. I took inspiration from the for loop implementation in 'MasterNotation::applyOptions'  line 288, and I adapted it to work with the notes and rests in question.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [] I created the test (mtest, vtest, script test) to verify the changes I made
