### PR TITLE
Preserve the Theme setting while enabling/disabling High contrast

### DIFF
--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -37,8 +37,6 @@ using namespace mu::framework;
 using namespace mu::async;
 
 static const Settings::Key UI_THEMES_KEY("ui", "ui/application/themes");
-static const Settings::Key UI_PREVIOUS_GENERAL_THEME("ui", "ui/application/previousGeneralTheme");
-static const Settings::Key UI_PREVIOUS_HIGH_CONTRAST_THEME("ui", "ui/application/previousHighContrastTheme");
 static const Settings::Key UI_CURRENT_THEME_CODE_KEY("ui", "ui/application/currentThemeCode");
 static const Settings::Key UI_FONT_FAMILY_KEY("ui", "ui/theme/fontFamily");
 static const Settings::Key UI_FONT_SIZE_KEY("ui", "ui/theme/fontSize");
@@ -161,8 +159,6 @@ static const QMap<ThemeStyleKey, QVariant> HIGH_CONTRAST_WHITE_THEME_VALUES {
 void UiConfiguration::init()
 {
     settings()->setDefaultValue(UI_CURRENT_THEME_CODE_KEY, Val(LIGHT_THEME_CODE));
-    settings()->setDefaultValue(UI_PREVIOUS_GENERAL_THEME, Val(LIGHT_THEME_CODE));
-    settings()->setDefaultValue(UI_PREVIOUS_HIGH_CONTRAST_THEME, Val(HIGH_CONTRAST_WHITE_THEME_CODE));
     settings()->setDefaultValue(UI_FONT_FAMILY_KEY, Val("Fira Sans"));
     settings()->setDefaultValue(UI_FONT_SIZE_KEY, Val(12));
     settings()->setDefaultValue(UI_ICONS_FONT_FAMILY_KEY, Val("MusescoreIcon"));
@@ -440,21 +436,24 @@ bool UiConfiguration::isHighContrast() const
 
 void UiConfiguration::setIsHighContrast(bool highContrast)
 {
+    ThemeCode currentThemeCode = currentThemeCodeKey();
     if (highContrast) {
-        setCurrentTheme(settings()->value(UI_PREVIOUS_HIGH_CONTRAST_THEME).toQString().QString::toStdString());
+        if (currentThemeCode == LIGHT_THEME_CODE) {
+            setCurrentTheme(HIGH_CONTRAST_WHITE_THEME_CODE);
+        } else {
+            setCurrentTheme(HIGH_CONTRAST_BLACK_THEME_CODE);
+        }
     } else {
-        setCurrentTheme(settings()->value(UI_PREVIOUS_GENERAL_THEME).toQString().QString::toStdString());
+        if (currentThemeCode == HIGH_CONTRAST_WHITE_THEME_CODE) {
+            setCurrentTheme(LIGHT_THEME_CODE);
+        } else {
+            setCurrentTheme(DARK_THEME_CODE);
+        }
     }
 }
 
 void UiConfiguration::setCurrentTheme(const ThemeCode& codeKey)
 {
-    if (isHighContrast()) {
-        settings()->setSharedValue(UI_PREVIOUS_HIGH_CONTRAST_THEME, Val(currentThemeCodeKey()));
-    } else {
-        settings()->setSharedValue(UI_PREVIOUS_GENERAL_THEME, Val(currentThemeCodeKey()));
-    }
-
     settings()->setSharedValue(UI_CURRENT_THEME_CODE_KEY, Val(codeKey));
 }
 


### PR DESCRIPTION
Resolves: #9220 

Add some cases to switch back to the same mode of Theme instead of switching back
to the previous mode of enabled-high-contrast or disabled-high-contrast modes.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://musescore.org/en/cla)
- [X] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [X] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made

