### PR TITLE
[MU4] Fix #10072: When triggering Note Input mode, the cursor (incorrectly) always defaults to the start of the score

### DIFF
--- a/src/engraving/libmscore/input.cpp
+++ b/src/engraving/libmscore/input.cpp
@@ -214,9 +214,11 @@ void InputState::update(Selection& selection)
     setArticulationIds(joinArticulations(articulationSymbolIds));
 
     EngravingItem* e = selection.element();
-    if (e == 0) {
-        setTrack(selection.activeTrack());
-        setSegment(selection.startSegment());
+    if (!e) {
+        if (!selection.isNone()) {
+            setTrack(selection.activeTrack());
+            setSegment(selection.startSegment());
+        }
         return;
     }
 

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -79,6 +79,7 @@ NoteInputState NotationNoteInput::state() const
     return noteInputState;
 }
 
+//! NOTE Coped from `void ScoreView::startNoteEntry()`
 void NotationNoteInput::startNoteInput()
 {
     TRACEFUNC;
@@ -87,14 +88,18 @@ void NotationNoteInput::startNoteInput()
         return;
     }
 
-    //! NOTE Coped from `void ScoreView::startNoteEntry()`
     Ms::InputState& is = score()->inputState();
-    is.setSegment(0);
 
     //! TODO Find out what does and why.
     EngravingItem* el = score()->selection().element();
     if (!el) {
         el = score()->selection().firstChordRest();
+    }
+
+    if (!el) {
+        if (const Ms::Segment* segment = is.lastSegment()) {
+            el = segment->element(is.track());
+        }
     }
 
     if (el == nullptr

--- a/src/notation/internal/notationnoteinput.h
+++ b/src/notation/internal/notationnoteinput.h
@@ -78,6 +78,8 @@ public:
 private:
     Ms::Score* score() const;
 
+    Ms::EngravingItem* resolveNoteInputStartPosition() const;
+
     void startEdit();
     void apply();
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10072
