### PR TITLE
fix #10415: adapt score orders to latest instruments.xml

### DIFF
--- a/share/instruments/orders.xml
+++ b/share/instruments/orders.xml
@@ -32,12 +32,10 @@
         <family>harps</family>
         <family>organs</family>
         <family>synths</family>
-        <section id="plucked-strings">
-            <family>plucked-strings</family>
-        </section>
         <soloists/>
         <section id="voices" barLineSpan="false">
             <family>voices</family>
+            <family>voice-groups</family>
         </section>
         <section id="strings">
             <family>orchestral-strings</family>
@@ -49,6 +47,7 @@
         <soloists/>
         <section id="voices" barLineSpan="false">
             <family>voices</family>
+            <family>voice-groups</family>
         </section>
         <family>keyboards</family>
         <family>organs</family>
@@ -129,6 +128,7 @@
         </section>
         <section id="vocals" barLineSpan="false" thinBrackets="false">
             <family>voices</family>
+            <family>voice-groups</family>
         </section>
         <unsorted/>
         <section id="guitars" thinBrackets="false">
@@ -157,6 +157,7 @@
         </instrument>
         <soloists/>
         <family>voices</family>
+        <family>voice-groups</family>
         <family>flutes</family>
         <family>clarinets</family>
         <family>flugelhorns</family>
@@ -176,6 +177,7 @@
         <name>Rock Band</name>
         <section id="vocals" barLineSpan="false" thinBrackets="false">
             <family>voices</family>
+            <family>voice-groups</family>
         </section>
         <section id="guitars" thinBrackets="false">
             <family>plucked-strings</family>

--- a/share/templates/01-General/01-Treble_Clef/01-Treble_Clef.mscx
+++ b/share/templates/01-General/01-Treble_Clef/01-Treble_Clef.mscx
@@ -19,12 +19,12 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="orchestral" customized="1">
+    <Order id="orchestral">
       <name>Orchestral</name>
       <instrument id="piano">
         <family id="keyboards">Keyboards</family>
         </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
+      <section id="woodwind">
         <family>flutes</family>
         <family>oboes</family>
         <family>clarinets</family>
@@ -32,17 +32,18 @@
         <family>bassoons</family>
         <unsorted group="woodwinds"/>
         </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="brass">
         <family>horns</family>
         <family>trumpets</family>
         <family>cornets</family>
+        <family>flugelhorns</family>
         <family>trombones</family>
         <family>tubas</family>
         </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="timpani">
         <family>timpani</family>
         </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="percussion">
         <family>keyboard-percussion</family>
         <family>drums</family>
         <family>unpitched-metal-percussion</family>
@@ -53,14 +54,12 @@
       <family>harps</family>
       <family>organs</family>
       <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
       <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="voices" barLineSpan="false">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
+      <section id="strings">
         <family>orchestral-strings</family>
         </section>
       <unsorted/>

--- a/share/templates/01-General/02-Bass_Clef/02-Bass_Clef.mscx
+++ b/share/templates/01-General/02-Bass_Clef/02-Bass_Clef.mscx
@@ -19,12 +19,12 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="orchestral" customized="1">
+    <Order id="orchestral">
       <name>Orchestral</name>
       <instrument id="piano">
         <family id="keyboards">Keyboards</family>
         </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
+      <section id="woodwind">
         <family>flutes</family>
         <family>oboes</family>
         <family>clarinets</family>
@@ -32,17 +32,18 @@
         <family>bassoons</family>
         <unsorted group="woodwinds"/>
         </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="brass">
         <family>horns</family>
         <family>trumpets</family>
         <family>cornets</family>
+        <family>flugelhorns</family>
         <family>trombones</family>
         <family>tubas</family>
         </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="timpani">
         <family>timpani</family>
         </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="percussion">
         <family>keyboard-percussion</family>
         <family>drums</family>
         <family>unpitched-metal-percussion</family>
@@ -53,14 +54,12 @@
       <family>harps</family>
       <family>organs</family>
       <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
       <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="voices" barLineSpan="false">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
+      <section id="strings">
         <family>orchestral-strings</family>
         </section>
       <unsorted/>

--- a/share/templates/01-General/03-Grand_Staff/03-Grand_Staff.mscx
+++ b/share/templates/01-General/03-Grand_Staff/03-Grand_Staff.mscx
@@ -19,12 +19,12 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="orchestral" customized="1">
+    <Order id="orchestral">
       <name>Orchestral</name>
       <instrument id="piano">
         <family id="keyboards">Keyboards</family>
         </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
+      <section id="woodwind">
         <family>flutes</family>
         <family>oboes</family>
         <family>clarinets</family>
@@ -32,17 +32,18 @@
         <family>bassoons</family>
         <unsorted group="woodwinds"/>
         </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="brass">
         <family>horns</family>
         <family>trumpets</family>
         <family>cornets</family>
+        <family>flugelhorns</family>
         <family>trombones</family>
         <family>tubas</family>
         </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="timpani">
         <family>timpani</family>
         </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="percussion">
         <family>keyboard-percussion</family>
         <family>drums</family>
         <family>unpitched-metal-percussion</family>
@@ -53,14 +54,12 @@
       <family>harps</family>
       <family>organs</family>
       <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
       <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="voices" barLineSpan="false">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
+      <section id="strings">
         <family>orchestral-strings</family>
         </section>
       <unsorted/>

--- a/share/templates/02-Choral/01-SATB/01-SATB.mscx
+++ b/share/templates/02-Choral/01-SATB/01-SATB.mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="choir" customized="1">
+    <Order id="choir">
       <name>Choir</name>
       <instrument id="alto">
         <family id="voices">Voices</family>
@@ -34,8 +34,9 @@
         <family id="voices">Voices</family>
         </instrument>
       <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="voices" barLineSpan="false">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
       <family>keyboards</family>
       <family>organs</family>

--- a/share/templates/02-Choral/02-SATB_+_Organ/02-SATB_+_Organ.mscx
+++ b/share/templates/02-Choral/02-SATB_+_Organ/02-SATB_+_Organ.mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="choir" customized="1">
+    <Order id="choir">
       <name>Choir</name>
       <instrument id="alto">
         <family id="voices">Voices</family>
@@ -37,8 +37,9 @@
         <family id="voices">Voices</family>
         </instrument>
       <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="voices" barLineSpan="false">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
       <family>keyboards</family>
       <family>organs</family>

--- a/share/templates/02-Choral/03-SATB_+_Piano/03-SATB_+_Piano.mscx
+++ b/share/templates/02-Choral/03-SATB_+_Piano/03-SATB_+_Piano.mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="choir" customized="1">
+    <Order id="choir">
       <name>Choir</name>
       <instrument id="alto">
         <family id="voices">Voices</family>
@@ -37,8 +37,9 @@
         <family id="voices">Voices</family>
         </instrument>
       <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="voices" barLineSpan="false">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
       <family>keyboards</family>
       <family>organs</family>

--- a/share/templates/02-Choral/04-SATB_Closed_Score/04-SATB_Closed_Score.mscx
+++ b/share/templates/02-Choral/04-SATB_Closed_Score/04-SATB_Closed_Score.mscx
@@ -19,17 +19,18 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="choir" customized="1">
+    <Order id="choir">
       <name>Choir</name>
       <instrument id="men">
-        <family id="voices">Voices</family>
+        <family id="voice-groups">Voice Groups</family>
         </instrument>
       <instrument id="women">
-        <family id="voices">Voices</family>
+        <family id="voice-groups">Voice Groups</family>
         </instrument>
       <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="voices" barLineSpan="false">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
       <family>keyboards</family>
       <family>organs</family>

--- a/share/templates/02-Choral/05-SATB_Closed_Score_+_Organ/05-SATB_Closed_Score_+_Organ.mscx
+++ b/share/templates/02-Choral/05-SATB_Closed_Score_+_Organ/05-SATB_Closed_Score_+_Organ.mscx
@@ -19,20 +19,21 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="choir" customized="1">
+    <Order id="choir">
       <name>Choir</name>
       <instrument id="men">
-        <family id="voices">Voices</family>
+        <family id="voice-groups">Voice Groups</family>
         </instrument>
       <instrument id="pipe-organ">
         <family id="organs">Organs</family>
         </instrument>
       <instrument id="women">
-        <family id="voices">Voices</family>
+        <family id="voice-groups">Voice Groups</family>
         </instrument>
       <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="voices" barLineSpan="false">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
       <family>keyboards</family>
       <family>organs</family>

--- a/share/templates/02-Choral/06-SATB_Closed_Score_+_Piano/06-SATB_Closed_Score_+_Piano.mscx
+++ b/share/templates/02-Choral/06-SATB_Closed_Score_+_Piano/06-SATB_Closed_Score_+_Piano.mscx
@@ -19,20 +19,21 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="choir" customized="1">
+    <Order id="choir">
       <name>Choir</name>
       <instrument id="men">
-        <family id="voices">Voices</family>
+        <family id="voice-groups">Voice Groups</family>
         </instrument>
       <instrument id="piano">
         <family id="keyboards">Keyboards</family>
         </instrument>
       <instrument id="women">
-        <family id="voices">Voices</family>
+        <family id="voice-groups">Voice Groups</family>
         </instrument>
       <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="voices" barLineSpan="false">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
       <family>keyboards</family>
       <family>organs</family>

--- a/share/templates/02-Choral/07-Voice_+_Piano/07-Voice_+_Piano.mscx
+++ b/share/templates/02-Choral/07-Voice_+_Piano/07-Voice_+_Piano.mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="choir" customized="1">
+    <Order id="choir">
       <name>Choir</name>
       <instrument id="piano">
         <family id="keyboards">Keyboards</family>
@@ -28,8 +28,9 @@
         <family id="voices">Voices</family>
         </instrument>
       <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="voices" barLineSpan="false" thinBrackets="true">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
       <family>keyboards</family>
       <family>organs</family>

--- a/share/templates/02-Choral/08-Barbershop_Quartet_(Men)/08-Barbershop_Quartet_(Men).mscx
+++ b/share/templates/02-Choral/08-Barbershop_Quartet_(Men)/08-Barbershop_Quartet_(Men).mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="choir" customized="1">
+    <Order id="choir">
       <name>Choir</name>
       <instrument id="bass">
         <family id="voices">Voices</family>
@@ -28,8 +28,9 @@
         <family id="voices">Voices</family>
         </instrument>
       <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="voices" barLineSpan="false">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
       <family>keyboards</family>
       <family>organs</family>

--- a/share/templates/02-Choral/09-Barbershop_Quartet_(Women)/09-Barbershop_Quartet_(Women).mscx
+++ b/share/templates/02-Choral/09-Barbershop_Quartet_(Women)/09-Barbershop_Quartet_(Women).mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="choir" customized="1">
+    <Order id="choir">
       <name>Choir</name>
       <instrument id="alto">
         <family id="voices">Voices</family>
@@ -28,8 +28,9 @@
         <family id="voices">Voices</family>
         </instrument>
       <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="voices" barLineSpan="false">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
       <family>keyboards</family>
       <family>organs</family>

--- a/share/templates/02-Choral/10-Liturgical_Unmetrical/10-Liturgical_Unmetrical.mscx
+++ b/share/templates/02-Choral/10-Liturgical_Unmetrical/10-Liturgical_Unmetrical.mscx
@@ -19,14 +19,15 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="choir" customized="1">
+    <Order id="choir">
       <name>Choir</name>
       <instrument id="voice">
         <family id="voices">Voices</family>
         </instrument>
       <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="voices" barLineSpan="false">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
       <family>keyboards</family>
       <family>organs</family>

--- a/share/templates/02-Choral/11-Liturgical_Unmetrical_+_Organ/11-Liturgical_Unmetrical_+_Organ.mscx
+++ b/share/templates/02-Choral/11-Liturgical_Unmetrical_+_Organ/11-Liturgical_Unmetrical_+_Organ.mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="choir" customized="1">
+    <Order id="choir">
       <name>Choir</name>
       <instrument id="pipe-organ">
         <family id="organs">Organs</family>
@@ -28,8 +28,9 @@
         <family id="voices">Voices</family>
         </instrument>
       <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="voices" barLineSpan="false">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
       <family>keyboards</family>
       <family>organs</family>

--- a/share/templates/03-Chamber_Music/01-String_Quartet/01-String_Quartet.mscx
+++ b/share/templates/03-Chamber_Music/01-String_Quartet/01-String_Quartet.mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="string-ensemble" customized="1">
+    <Order id="string-ensemble">
       <name>String Ensemble</name>
       <instrument id="viola">
         <family id="orchestral-strings">Orchestral Strings</family>
@@ -31,7 +31,7 @@
         <family id="orchestral-strings">Orchestral Strings</family>
         </instrument>
       <soloists/>
-      <section id="strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="strings" thinBrackets="false">
         <family>orchestral-strings</family>
         </section>
       <family>keyboards</family>

--- a/share/templates/03-Chamber_Music/02-Wind_Quartet/02-Wind_Quartet.mscx
+++ b/share/templates/03-Chamber_Music/02-Wind_Quartet/02-Wind_Quartet.mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="woodwind-ensemble" customized="1">
+    <Order id="woodwind-ensemble">
       <name>Woodwind Ensemble</name>
       <instrument id="bassoon">
         <family id="bassoons">Bassoons</family>
@@ -34,7 +34,7 @@
         <family id="oboes">Oboes</family>
         </instrument>
       <soloists/>
-      <section id="woodwind" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="woodwind" thinBrackets="false">
         <family>flutes</family>
         <family>oboes</family>
         <family>clarinets</family>

--- a/share/templates/03-Chamber_Music/03-Wind_Quintet/03-Wind_Quintet.mscx
+++ b/share/templates/03-Chamber_Music/03-Wind_Quintet/03-Wind_Quintet.mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="woodwind-ensemble" customized="1">
+    <Order id="woodwind-ensemble">
       <name>Woodwind Ensemble</name>
       <instrument id="bassoon">
         <family id="bassoons">Bassoons</family>
@@ -37,7 +37,7 @@
         <family id="oboes">Oboes</family>
         </instrument>
       <soloists/>
-      <section id="woodwind" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="woodwind" thinBrackets="false">
         <family>flutes</family>
         <family>oboes</family>
         <family>clarinets</family>

--- a/share/templates/03-Chamber_Music/04-Saxophone_Quartet/04-Saxophone_Quartet.mscx
+++ b/share/templates/03-Chamber_Music/04-Saxophone_Quartet/04-Saxophone_Quartet.mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="woodwind-ensemble" customized="1">
+    <Order id="woodwind-ensemble">
       <name>Woodwind Ensemble</name>
       <instrument id="alto-saxophone">
         <family id="saxophones">Saxophones</family>
@@ -34,7 +34,7 @@
         <family id="saxophones">Saxophones</family>
         </instrument>
       <soloists/>
-      <section id="woodwind" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="woodwind" thinBrackets="false">
         <family>flutes</family>
         <family>oboes</family>
         <family>clarinets</family>

--- a/share/templates/03-Chamber_Music/05-Brass_Quartet/05-Brass_Quartet.mscx
+++ b/share/templates/03-Chamber_Music/05-Brass_Quartet/05-Brass_Quartet.mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="brass-ensemble" customized="1">
+    <Order id="brass-ensemble">
       <name>Brass Ensemble</name>
       <instrument id="bb-trumpet">
         <family id="trumpets">Trumpets</family>
@@ -31,7 +31,7 @@
         <family id="tubas">Tubas</family>
         </instrument>
       <soloists/>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="brass" thinBrackets="false">
         <family>trumpets</family>
         <family>cornets</family>
         <family>flugelhorns</family>

--- a/share/templates/03-Chamber_Music/06-Brass_Quintet/06-Brass_Quintet.mscx
+++ b/share/templates/03-Chamber_Music/06-Brass_Quintet/06-Brass_Quintet.mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="brass-ensemble" customized="1">
+    <Order id="brass-ensemble">
       <name>Brass Ensemble</name>
       <instrument id="bb-trumpet">
         <family id="trumpets">Trumpets</family>
@@ -34,7 +34,7 @@
         <family id="tubas">Tubas</family>
         </instrument>
       <soloists/>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="brass" thinBrackets="false">
         <family>trumpets</family>
         <family>cornets</family>
         <family>flugelhorns</family>

--- a/share/templates/05-Jazz/02-Big_Band/02-Big_Band.mscx
+++ b/share/templates/05-Jazz/02-Big_Band/02-Big_Band.mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle">Big Band</metaTag>
-    <Order id="bigband" customized="1">
+    <Order id="bigband">
       <name>Big Band</name>
       <instrument id="acoustic-bass">
         <family id="bass-guitars">Bass Guitars</family>
@@ -55,34 +55,36 @@
         <family id="trombones">Trombones</family>
         </instrument>
       <soloists/>
-      <section id="woodwind" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="woodwind" thinBrackets="false">
         <family>flutes</family>
         <family>clarinets</family>
         <family>saxophones</family>
         </section>
-      <section id="trumpets" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="trumpets" thinBrackets="false">
         <family>trumpets</family>
+        <family>flugelhorns</family>
         </section>
-      <section id="trombones" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="trombones" thinBrackets="false">
         <family>trombones</family>
         </section>
-      <section id="vocals" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="false">
+      <section id="vocals" barLineSpan="false" thinBrackets="false">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
       <unsorted/>
-      <section id="guitars" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="guitars" thinBrackets="false">
         <family>guitars</family>
         </section>
       <family>keyboards</family>
-      <section id="basses" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="basses">
         <family>bass-guitars</family>
         <family>contrabasses</family>
         </section>
       <family>drums</family>
-      <section id="pitched-percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="pitched-percussion" thinBrackets="false">
         <unsorted group="pitched-percussion"/>
         </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="percussion" thinBrackets="false">
         <unsorted group="unpitched-percussion"/>
         </section>
       </Order>

--- a/share/templates/05-Jazz/03-Jazz_Combo/03-Jazz_Combo.mscx
+++ b/share/templates/05-Jazz/03-Jazz_Combo/03-Jazz_Combo.mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle">Jazz Combo</metaTag>
-    <Order id="jazz-combo" customized="1">
+    <Order id="jazz-combo">
       <name>Jazz Combo</name>
       <instrument id="acoustic-bass">
         <family id="bass-guitars">Bass Guitars</family>
@@ -53,8 +53,10 @@
         </instrument>
       <soloists/>
       <family>voices</family>
+      <family>voice-groups</family>
       <family>flutes</family>
       <family>clarinets</family>
+      <family>flugelhorns</family>
       <family>trumpets</family>
       <family>saxophones</family>
       <family>trombones</family>

--- a/share/templates/06-Popular/01-Rock_Band/01-Rock_Band.mscx
+++ b/share/templates/06-Popular/01-Rock_Band/01-Rock_Band.mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="rock-band" customized="1">
+    <Order id="rock-band">
       <name>Rock Band</name>
       <instrument id="bass-guitar">
         <family id="bass-guitars">Bass Guitars</family>
@@ -33,13 +33,14 @@
       <instrument id="voice">
         <family id="voices">Voices</family>
         </instrument>
-      <section id="vocals" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="false">
+      <section id="vocals" barLineSpan="false" thinBrackets="false">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
-      <section id="guitars" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="guitars" thinBrackets="false">
         <family>plucked-strings</family>
         </section>
-      <family>drumset</family>
+      <family>drums</family>
       <unsorted/>
       </Order>
     <Part>

--- a/share/templates/07-Band_and_Percussion/01-Concert_Band/01-Concert_Band.mscx
+++ b/share/templates/07-Band_and_Percussion/01-Concert_Band/01-Concert_Band.mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="concert-band" customized="1">
+    <Order id="concert-band">
       <name>Concert Band</name>
       <instrument id="alto-saxophone">
         <family id="saxophones">Saxophones</family>
@@ -40,7 +40,7 @@
         <family id="trumpets">Trumpets</family>
         </instrument>
       <instrument id="contrabass">
-        <family id="orchestral-strings">Orchestral Strings</family>
+        <family id="contrabasses">Basses</family>
         </instrument>
       <instrument id="double-bass">
         <family id="contrabasses">Basses</family>
@@ -82,19 +82,19 @@
         <family id="tubas">Tubas</family>
         </instrument>
       <soloists/>
-      <section id="woodwind" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="woodwind">
         <family>flutes</family>
         <family>oboes</family>
         <family>bassoons</family>
         </section>
-      <section id="clarinets" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="clarinets">
         <family>clarinets</family>
         </section>
-      <section id="saxophones" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="saxophones"">
         <family>saxophones</family>
         </section>
       <unsorted group="woodwinds"/>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="brass">
         <family>cornets</family>
         <family>trumpets</family>
         <family>flugelhorns</family>
@@ -108,7 +108,7 @@
       <family>guitars</family>
       <family>bass-guitars</family>
       <family>contrabasses</family>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="percussion" thinBrackets="false">
         <family>timpani</family>
         <family>keyboard-percussion</family>
         <family>drums</family>

--- a/share/templates/07-Band_and_Percussion/02-Small_Concert_Band/02-Small_Concert_Band.mscx
+++ b/share/templates/07-Band_and_Percussion/02-Small_Concert_Band/02-Small_Concert_Band.mscx
@@ -21,7 +21,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="small-concert-band" customized="1">
+    <Order id="small-concert-band">
       <name>Small Concert Band</name>
       <instrument id="alto-saxophone">
         <family id="saxophones">Saxophones</family>
@@ -78,19 +78,23 @@
         <family id="tubas">Tubas</family>
         </instrument>
       <soloists/>
-      <section id="woodwind" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="woodwind">
         <family>flutes</family>
         <family>oboes</family>
         <family>bassoons</family>
+        </section>
+      <section id="clarinets">
         <family>clarinets</family>
+        </section>
+      <section id="saxophones">
         <family>saxophones</family>
         </section>
       <unsorted group="woodwinds"/>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
+      <section id="brass">
         <family>cornets</family>
         <family>trumpets</family>
         <family>flugelhorns</family>
+        <family>horns</family>
         <family>trombones</family>
         <family>baritone-horns</family>
         <family>euphoniums</family>
@@ -100,7 +104,7 @@
       <family>guitars</family>
       <family>bass-guitars</family>
       <family>contrabasses</family>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="percussion" thinBrackets="false">
         <family>timpani</family>
         <family>keyboard-percussion</family>
         <family>drums</family>

--- a/share/templates/07-Band_and_Percussion/03-Brass_Band/03-Brass_Band.mscx
+++ b/share/templates/07-Band_and_Percussion/03-Brass_Band/03-Brass_Band.mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="brass-band" customized="1">
+    <Order id="brass-band">
       <name>Brass Band</name>
       <instrument id="baritone-horn">
         <family id="baritone-horns">Baritone Horns</family>
@@ -55,26 +55,26 @@
         <family id="tubas">Tubas</family>
         </instrument>
       <soloists/>
-      <section id="cornets" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="cornets" thinBrackets="false">
         <family>cornets</family>
         </section>
-      <section id="horns" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="horns" thinBrackets="false">
         <family>flugelhorns</family>
         <family>horns</family>
         </section>
-      <section id="baritones" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="baritones" thinBrackets="false">
         <family>baritone-horns</family>
         </section>
-      <section id="trombones" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="trombones" thinBrackets="false">
         <family>trombones</family>
         </section>
-      <section id="euphoniums" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="euphoniums" thinBrackets="false">
         <family>euphoniums</family>
         </section>
-      <section id="tubas" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="tubas" thinBrackets="false">
         <family>tubas</family>
         </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="percussion" thinBrackets="false">
         <family>timpani</family>
         <family>keyboard-percussion</family>
         <family>drums</family>

--- a/share/templates/07-Band_and_Percussion/04-Marching_Band/04-Marching_Band.mscx
+++ b/share/templates/07-Band_and_Percussion/04-Marching_Band/04-Marching_Band.mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="marching-band" customized="1">
+    <Order id="marching-band>
       <name>Marching Band</name>
       <instrument id="alto-saxophone">
         <family id="saxophones">Saxophones</family>
@@ -78,6 +78,9 @@
       <instrument id="sousaphone">
         <family id="tubas">Tubas</family>
         </instrument>
+      <instrument id="drumset">
+        <family id="drumset">Drumset</family>
+        </instrument>
       <instrument id="tenor-saxophone">
         <family id="saxophones">Saxophones</family>
         </instrument>
@@ -94,17 +97,17 @@
         <family id="keyboard-percussion">Keyboard Percussion</family>
         </instrument>
       <soloists/>
-      <section id="woodwind" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="woodwind">
         <family>flutes</family>
         <family>oboes</family>
         <family>bassoons</family>
         <family>clarinets</family>
         </section>
-      <section id="saxophones" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="saxophones">
         <family>saxophones</family>
         </section>
       <unsorted group="woodwinds"/>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="brass">
         <family>cornets</family>
         <family>trumpets</family>
         <family>flugelhorns</family>
@@ -114,18 +117,25 @@
         <family>tubas</family>
         </section>
       <unsorted group="brass"/>
-      <section id="pitched-percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>glockenspiel</family>
-        <family>xylophones</family>
-        <family>vibraphones</family>
-        <family>marimbas</family>
-        <family>timpani</family>
-        <family>percussion</family>
-        </section>
-      <section id="unpitched-percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="front-ensemble" barLineSpan="false">
+         <family>keyboard-percussion</family>
+      </section>
+      <family>timpani</family>
+      <family>synths</family>
+      <section id="rhythm-section">
+        <family>guitars</family>
+        <family>bass-guitars</family>
+        <family>drumset</family>
+      </section>
+      <!-- auxiliary -->
+      <section id="percussion">
         <family>unpitched-percussion</family>
-        </section>
+        <family>other-percussion</family>
+      </section>
       <unsorted/>
+      <section id="batterie" barLineSpan="false">
+        <family>batterie</family>
+      </section>
       </Order>
     <Part>
       <Staff id="1">

--- a/share/templates/07-Band_and_Percussion/05-Small_Marching_Band/05-Small_Marching_Band.mscx
+++ b/share/templates/07-Band_and_Percussion/05-Small_Marching_Band/05-Small_Marching_Band.mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="marching-band" customized="1">
+    <Order id="marching-band">
       <name>Marching Band</name>
       <instrument id="alto-saxophone">
         <family id="saxophones">Saxophones</family>
@@ -66,6 +66,9 @@
       <instrument id="sousaphone">
         <family id="tubas">Tubas</family>
         </instrument>
+      <instrument id="drumset">
+        <family id="drumset">Drumset</family>
+        </instrument>
       <instrument id="tenor-saxophone">
         <family id="saxophones">Saxophones</family>
         </instrument>
@@ -76,41 +79,43 @@
         <family id="keyboard-percussion">Keyboard Percussion</family>
         </instrument>
       <soloists/>
-      <section id="woodwind" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="woodwind">
         <family>flutes</family>
         <family>oboes</family>
         <family>bassoons</family>
         <family>clarinets</family>
         </section>
-      <section id="saxophones" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="saxophones">
         <family>saxophones</family>
         </section>
       <unsorted group="woodwinds"/>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="brass">
         <family>cornets</family>
         <family>trumpets</family>
+        <family>flugelhorns</family>
         <family>horns</family>
         <family>trombones</family>
         <family>baritone-horns</family>
         <family>tubas</family>
         </section>
       <unsorted group="brass"/>
-      <section id="front-ensemble" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="front-ensemble" barLineSpan="false">
         <family>keyboard-percussion</family>
         </section>
       <family>timpani</family>
       <family>synths</family>
-      <section id="rhythm-section" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="rhythm-section">
         <family>guitars</family>
         <family>bass-guitars</family>
         <family>drumset</family>
         </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <!-- auxiliary -->
+      <section id="percussion">
         <family>unpitched-percussion</family>
         <family>other-percussion</family>
         </section>
       <unsorted/>
-      <section id="batterie" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="batterie" barLineSpan="false">
         <family>batterie</family>
         </section>
       </Order>

--- a/share/templates/07-Band_and_Percussion/09-European_Concert_Band/09-European_Concert_Band.mscx
+++ b/share/templates/07-Band_and_Percussion/09-European_Concert_Band/09-European_Concert_Band.mscx
@@ -19,7 +19,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="concert-band" customized="1">
+    <Order id="concert-band">
       <name>Concert Band</name>
       <instrument id="alto-saxophone">
         <family id="saxophones">Saxophones</family>
@@ -43,7 +43,7 @@
         <family id="trumpets">Trumpets</family>
         </instrument>
       <instrument id="contrabass">
-        <family id="orchestral-strings">Orchestral Strings</family>
+        <family id="contrabasses">Basses</family>
         </instrument>
       <instrument id="double-bass">
         <family id="contrabasses">Basses</family>
@@ -85,32 +85,33 @@
         <family id="tubas">Tubas</family>
         </instrument>
       <soloists/>
-      <section id="woodwind" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="woodwind">
         <family>flutes</family>
         <family>oboes</family>
         <family>bassoons</family>
         </section>
-      <section id="clarinets" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="clarinets">
         <family>clarinets</family>
         </section>
-      <section id="saxophones" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="saxophones">
         <family>saxophones</family>
         </section>
       <unsorted group="woodwinds"/>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="brass">
         <family>cornets</family>
         <family>trumpets</family>
         <family>flugelhorns</family>
         <family>horns</family>
         <family>trombones</family>
         <family>baritone-horns</family>
+        <family>euphoniums</family>
         <family>tubas</family>
         </section>
       <unsorted group="brass"/>
       <family>guitars</family>
       <family>bass-guitars</family>
       <family>contrabasses</family>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="false">
+      <section id="percussion" thinBrackets="false">
         <family>timpani</family>
         <family>keyboard-percussion</family>
         <family>drums</family>

--- a/share/templates/08-Orchestral/01-Classical_Orchestra/01-Classical_Orchestra.mscx
+++ b/share/templates/08-Orchestral/01-Classical_Orchestra/01-Classical_Orchestra.mscx
@@ -21,7 +21,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="orchestral" customized="1">
+    <Order id="orchestral">
       <name>Orchestral</name>
       <instrument id="bassoon">
         <family id="bassoons">Bassoons</family>
@@ -47,7 +47,7 @@
       <instrument id="timpani">
         <family id="timpani">Timpani</family>
         </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="woodwind">
         <family>flutes</family>
         <family>oboes</family>
         <family>clarinets</family>
@@ -55,7 +55,7 @@
         <family>bassoons</family>
         <unsorted group="woodwinds"/>
         </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="brass">
         <family>horns</family>
         <family>trumpets</family>
         <family>cornets</family>
@@ -63,10 +63,10 @@
         <family>trombones</family>
         <family>tubas</family>
         </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="timpani">
         <family>timpani</family>
         </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="percussion">
         <family>keyboard-percussion</family>
         <family>drums</family>
         <family>unpitched-metal-percussion</family>
@@ -77,14 +77,12 @@
       <family>harps</family>
       <family>organs</family>
       <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
       <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="voices" barLineSpan="false">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
+      <section id="strings">
         <family>orchestral-strings</family>
         </section>
       <unsorted/>

--- a/share/templates/08-Orchestral/02-Symphony_Orchestra/02-Symphony_Orchestra.mscx
+++ b/share/templates/08-Orchestral/02-Symphony_Orchestra/02-Symphony_Orchestra.mscx
@@ -21,7 +21,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="orchestral" customized="1">
+    <Order id="orchestral">
       <name>Orchestral</name>
       <instrument id="bass-drum">
         <family id="drums">Drums</family>
@@ -77,7 +77,7 @@
       <instrument id="violoncellos">
         <family id="orchestral-strings">Orchestral Strings</family>
         </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="woodwind">
         <family>flutes</family>
         <family>oboes</family>
         <family>clarinets</family>
@@ -85,7 +85,7 @@
         <family>bassoons</family>
         <unsorted group="woodwinds"/>
         </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="brass">
         <family>horns</family>
         <family>trumpets</family>
         <family>cornets</family>
@@ -93,10 +93,10 @@
         <family>trombones</family>
         <family>tubas</family>
         </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="timpani">
         <family>timpani</family>
         </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="percussion">
         <family>keyboard-percussion</family>
         <family>drums</family>
         <family>unpitched-metal-percussion</family>
@@ -107,14 +107,12 @@
       <family>harps</family>
       <family>organs</family>
       <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
       <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="voices" barLineSpan="false">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
+      <section id="strings">
         <family>orchestral-strings</family>
         </section>
       <unsorted/>

--- a/share/templates/08-Orchestral/03-String_Orchestra/03-String_Orchestra.mscx
+++ b/share/templates/08-Orchestral/03-String_Orchestra/03-String_Orchestra.mscx
@@ -21,7 +21,7 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="orchestral" customized="1">
+    <Order id="orchestral">
       <name>Orchestral</name>
       <instrument id="contrabasses">
         <family id="orchestral-strings">Orchestral Strings</family>
@@ -35,7 +35,7 @@
       <instrument id="violoncellos">
         <family id="orchestral-strings">Orchestral Strings</family>
         </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="woodwind">
         <family>flutes</family>
         <family>oboes</family>
         <family>clarinets</family>
@@ -43,7 +43,7 @@
         <family>bassoons</family>
         <unsorted group="woodwinds"/>
         </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="brass">
         <family>horns</family>
         <family>trumpets</family>
         <family>cornets</family>
@@ -51,10 +51,10 @@
         <family>trombones</family>
         <family>tubas</family>
         </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="timpani">
         <family>timpani</family>
         </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="percussion">
         <family>keyboard-percussion</family>
         <family>drums</family>
         <family>unpitched-metal-percussion</family>
@@ -65,14 +65,12 @@
       <family>harps</family>
       <family>organs</family>
       <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
       <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="voices" barLineSpan="false">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
+      <section id="strings">
         <family>orchestral-strings</family>
         </section>
       <unsorted/>

--- a/share/templates/My_First_Score.mscx
+++ b/share/templates/My_First_Score.mscx
@@ -26,9 +26,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle">Title</metaTag>
-    <Order id="orchestral" customized="1">
+    <Order id="orchestral">
       <name>Orchestral</name>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
+      <section id="woodwind">
         <family>flutes</family>
         <family>oboes</family>
         <family>clarinets</family>
@@ -36,17 +36,17 @@
         <family>bassoons</family>
         <unsorted group="woodwinds"/>
         </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="brass">
         <family>horns</family>
         <family>trumpets</family>
         <family>cornets</family>
         <family>trombones</family>
         <family>tubas</family>
         </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="timpani">
         <family>timpani</family>
         </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
+      <section id="percussion">
         <family>keyboard-percussion</family>
         <family>drums</family>
         <family>unpitched-metal-percussion</family>
@@ -57,14 +57,12 @@
       <family>harps</family>
       <family>organs</family>
       <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
       <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
+      <section id="voices" barLineSpan="false">
         <family>voices</family>
+        <family>voice-groups</family>
         </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
+      <section id="strings">
         <family>orchestral-strings</family>
         </section>
       <unsorted/>


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10415

`orders.xml` adapted to latest changes in `instruments.xml`.
Cleanup of all templates so they include the score orders as defined in `orders.xml`.
Removed unnecessary attributes of the used sections in the templates.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
