### PR TITLE
fix #10315: displaying continious slides correctly

### DIFF
--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -3645,4 +3645,47 @@ void Note::undoUnlink()
         e->undoUnlink();
     }
 }
+
+//---------------------------------------------------------
+//   slides
+//---------------------------------------------------------
+
+bool Note::isSlideToNote() const
+{
+    if (!_attachedSlide.isValid()) {
+        return false;
+    }
+
+    if (_attachedSlide.is(Note::SlideType::Lift)
+        || _attachedSlide.is(Note::SlideType::Plop)) {
+        return true;
+    }
+
+    return false;
+}
+
+bool Note::isSlideOutNote() const
+{
+    if (!_attachedSlide.isValid()) {
+        return false;
+    }
+
+    if (_attachedSlide.is(Note::SlideType::Doit)
+        || _attachedSlide.is(Note::SlideType::Fall)) {
+        return true;
+    }
+
+    return false;
+}
+
+bool Note::isSlideStart() const
+{
+    return _attachedSlide.isValid() && _attachedSlide.startNote == this;
+}
+
+bool Note::isSlideEnd() const
+{
+    return (_attachedSlide.isValid() && _attachedSlide.endNote == this)
+           || (_relatedSlide && _relatedSlide->endNote == this);
+}
 }


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/10315*

*Displaying shift-slide and legato-slide*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
