### PR TITLE
Fix #9381: set correct color for brackets in palette

### DIFF
--- a/src/palette/internal/palettecelliconengine.cpp
+++ b/src/palette/internal/palettecelliconengine.cpp
@@ -27,6 +27,7 @@
 #include "engraving/libmscore/actionicon.h"
 #include "engraving/libmscore/engravingitem.h"
 #include "engraving/libmscore/masterscore.h"
+#include "engraving/libmscore/bracket.h"
 #include "engraving/style/defaultstyle.h"
 
 #include "log.h"

--- a/src/palette/internal/palettecelliconengine.cpp
+++ b/src/palette/internal/palettecelliconengine.cpp
@@ -73,7 +73,7 @@ void PaletteCellIconEngine::paintCell(Painter& painter, const RectF& rect, bool 
 
     painter.setPen(configuration()->elementsColor());
 
-    if (dynamic_cast<Bracket*>(element) != nullptr) {
+    if (element->isBracket()) {
         element->setColor(mu::draw::Color(uiConfiguration()->currentTheme().values[FONT_PRIMARY_COLOR].toString()));
     }
 

--- a/src/palette/internal/palettecelliconengine.cpp
+++ b/src/palette/internal/palettecelliconengine.cpp
@@ -72,7 +72,7 @@ void PaletteCellIconEngine::paintCell(Painter& painter, const RectF& rect, bool 
     }
 
     painter.setPen(configuration()->elementsColor());
-    
+
     if (dynamic_cast<Bracket*>(element) != nullptr) {
         element->setColor(mu::draw::Color(uiConfiguration()->currentTheme().values[FONT_PRIMARY_COLOR].toString()));
     }

--- a/src/palette/internal/palettecelliconengine.cpp
+++ b/src/palette/internal/palettecelliconengine.cpp
@@ -71,6 +71,10 @@ void PaletteCellIconEngine::paintCell(Painter& painter, const RectF& rect, bool 
     }
 
     painter.setPen(configuration()->elementsColor());
+    
+    if (dynamic_cast<Bracket*>(element) != nullptr) {
+        element->setColor(mu::draw::Color(uiConfiguration()->currentTheme().values[FONT_PRIMARY_COLOR].toString()));
+    }
 
     if (element->isActionIcon()) {
         paintActionIcon(painter, rect, element);

--- a/src/palette/internal/palettecelliconengine.cpp
+++ b/src/palette/internal/palettecelliconengine.cpp
@@ -27,7 +27,6 @@
 #include "engraving/libmscore/actionicon.h"
 #include "engraving/libmscore/engravingitem.h"
 #include "engraving/libmscore/masterscore.h"
-#include "engraving/libmscore/bracket.h"
 #include "engraving/style/defaultstyle.h"
 
 #include "log.h"


### PR DESCRIPTION
Resolves: [#9381](https://github.com/musescore/MuseScore/issues/9381)

Add special judgment for brackets in painting palettecell icon.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
