### PR TITLE
fix #10310, #10306: displaying dead notes as crosses and ghost notes …

### DIFF
--- a/src/engraving/libmscore/note.h
+++ b/src/engraving/libmscore/note.h
@@ -155,7 +155,8 @@ public:
     };
 
 private:
-    bool _ghost         { false };        ///< ghost note (guitar: death note)
+    bool _ghost         { false };        ///< ghost note
+    bool _deadNote      { false };        ///< dead note
     bool _hidden        { false };        ///< marks this note as the hidden one if there are
                                           ///< overlapping notes; hidden notes are not played
                                           ///< and heads + accidentals are not shown
@@ -335,6 +336,9 @@ public:
     void setString(int val);
     bool ghost() const { return _ghost; }
     void setGhost(bool val) { _ghost = val; }
+    bool deadNote() const { return _deadNote; }
+    void setDeadNote(bool deadNote) { _deadNote = deadNote; }
+
     bool fretConflict() const { return _fretConflict; }
     void setFretConflict(bool val) { _fretConflict = val; }
 

--- a/src/engraving/libmscore/stafftype.cpp
+++ b/src/engraving/libmscore/stafftype.cpp
@@ -695,13 +695,13 @@ qreal StaffType::chordStemLength(const Chord* chord) const
 
 static const QString unknownFret = QString("?");
 
-QString StaffType::fretString(int fret, int string, bool ghost) const
+QString StaffType::fretString(int fret, int string, bool deadNote) const
 {
     if (fret == INVALID_FRET_INDEX) {
         return unknownFret;
     }
-    if (ghost) {
-        return _fretFonts[_fretFontIdx].ghostChar;
+    if (deadNote) {
+        return _fretFonts[_fretFontIdx].deadNoteChar;
     } else {
         bool hasFret;
         QString text  = tabBassStringPrefix(string, &hasFret);
@@ -1066,7 +1066,7 @@ bool TablatureFretFont::read(XmlReader& e)
             if (sval == "x") {
                 xChar = txt[0];
             } else if (sval == "ghost") {
-                ghostChar = txt[0];
+                deadNoteChar = txt[0];
             } else if (sval == "slash") {
                 // limit within legal range
                 if (num < 1) {

--- a/src/engraving/libmscore/stafftype.h
+++ b/src/engraving/libmscore/stafftype.h
@@ -105,7 +105,7 @@ struct TablatureFretFont {
     qreal defPitch;                             // the default size of the font
     qreal defYOffset;                           // the default Y displacement
     QChar xChar;                                // the char to use for 'x'
-    QChar ghostChar;                            // the char to use for ghost notes
+    QChar deadNoteChar;                            // the char to use for dead notes
     QString slashChar[NUM_OF_BASSSTRING_SLASHES];  // the char used to draw one or more '/' symbols
     QString displayDigit[NUM_OF_DIGITFRETS];    // the string to draw for digit frets
     QChar displayLetter[NUM_OF_LETTERFRETS];    // the char to use for letter frets
@@ -346,7 +346,7 @@ public:
     void setNoteHeadScheme(NoteHeadScheme s) { _noteHeadScheme = s; }
     NoteHeadScheme noteHeadScheme() const { return _noteHeadScheme; }
 
-    QString fretString(int fret, int string, bool ghost) const;     // returns a string with the text for fret
+    QString fretString(int fret, int string, bool deadNote) const;     // returns a string with the text for fret
     QString durationString(DurationType type, int dots) const;
 
     // functions to cope with historic TAB's peculiarities, like upside-down, bass string notations

--- a/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
@@ -870,7 +870,7 @@ void GP67DomBuilder::readNoteProperties(QDomNode* propertiesNode, GPNote* note)
             }
         } else if (propertyName == "Muted") {
             //! property muted in GP means dead note
-            if (propetryNode.firstChild().toElement().text() == "Enable") {
+            if (propetryNode.firstChild().nodeName() == "Enable") {
                 note->setMute(true);
             }
         } else if (propertyName == "Slide") {

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1214,8 +1214,8 @@ void GPConverter::configureNote(const GPNote* gpnote, Note* note)
 
     addLetRing(gpnote, note);
     addPalmMute(gpnote, note);
-
-//!@TODO addGhost addIsDeadNote
+    note->setGhost(gpnote->ghostNote());
+    note->setDeadNote(gpnote->muted());
 }
 
 void GPConverter::addAccent(const GPNote* gpnote, Note* note)

--- a/src/importexport/guitarpro/internal/importgtp-gp4.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp4.cpp
@@ -207,7 +207,7 @@ bool GuitarPro4::readNote(int string, int staffIdx, Note* note)
             tieNote = true;
         } else if (variant == 3) {                   // dead notes = ghost note
             note->setHeadGroup(NoteHeadGroup::HEAD_CROSS);
-            note->setGhost(true);
+            note->setDeadNote(true);
         } else {
             qDebug("unknown note variant: %d", variant);
         }

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -1896,7 +1896,7 @@ bool GuitarPro1::readNote(int string, Note* note)
             tieNote = true;
         } else if (variant == 3) {                   // dead notes
             note->setHeadGroup(NoteHeadGroup::HEAD_CROSS);
-            note->setGhost(true);
+            note->setDeadNote(true);
         } else {
             qDebug("unknown note variant: %d", variant);
         }


### PR DESCRIPTION
*Displaying dead notes as crosses and ghost notes with parenthesis*

Resolves: 
- *https://github.com/musescore/MuseScore/issues/10306*
- *https://github.com/musescore/MuseScore/issues/10310* (had to fix import on new guitar pro import version)

*It's also possible to implement drawing of both symbol and/or text in any notation,
but for now I left how it was - symbols in standard and text in tab notation.*

*That's why crosses look differently and there is no parenthesis in standard notation.*

*Before:*
![Screenshot 2022-02-03 at 23 45 43](https://user-images.githubusercontent.com/24373905/152425856-94d78856-aa78-4256-8378-a67062a1176d.png)

*Now:*
![Screenshot 2022-02-03 at 23 26 06](https://user-images.githubusercontent.com/24373905/152423212-fe2b3e6e-c492-4c34-84fb-4ae67e42ca12.png)
(<-- ghost note, dead note -->)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
