### PR TITLE
`Val` type: add convenience methods for working with enums

### DIFF
--- a/src/appshell/internal/appshellconfiguration.cpp
+++ b/src/appshell/internal/appshellconfiguration.cpp
@@ -62,7 +62,7 @@ void AppShellConfiguration::init()
 {
     settings()->setDefaultValue(HAS_COMPLETED_FIRST_LAUNCH_SETUP, Val(false));
 
-    settings()->setDefaultValue(STARTUP_MODE_TYPE, Val(static_cast<int>(StartupModeType::StartEmpty)));
+    settings()->setDefaultValue(STARTUP_MODE_TYPE, Val(StartupModeType::StartEmpty));
     settings()->setDefaultValue(STARTUP_SCORE_PATH, Val(projectConfiguration()->myFirstProjectPath().toStdString()));
 
     settings()->setDefaultValue(CHECK_FOR_UPDATE_KEY, Val(isAppUpdatable()));
@@ -82,12 +82,12 @@ void AppShellConfiguration::setHasCompletedFirstLaunchSetup(bool has)
 
 StartupModeType AppShellConfiguration::startupModeType() const
 {
-    return static_cast<StartupModeType>(settings()->value(STARTUP_MODE_TYPE).toInt());
+    return settings()->value(STARTUP_MODE_TYPE).toEnum<StartupModeType>();
 }
 
 void AppShellConfiguration::setStartupModeType(StartupModeType type)
 {
-    settings()->setSharedValue(STARTUP_MODE_TYPE, Val(static_cast<int>(type)));
+    settings()->setSharedValue(STARTUP_MODE_TYPE, Val(type));
 }
 
 mu::io::path AppShellConfiguration::startupScorePath() const

--- a/src/converter/internal/compat/backendapi.cpp
+++ b/src/converter/internal/compat/backendapi.cpp
@@ -575,7 +575,7 @@ Ret BackendApi::doExportScorePartsPdfs(const IMasterNotationPtr masterNotation, 
     jsonForPdfs["scoreFullPostfix"] = QString("-Score_and_parts") + ".pdf";
 
     INotationWriter::Options options {
-        { INotationWriter::OptionKey::UNIT_TYPE, Val(static_cast<int>(INotationWriter::UnitType::MULTI_PART)) }
+        { INotationWriter::OptionKey::UNIT_TYPE, Val(INotationWriter::UnitType::MULTI_PART) }
     };
 
     QByteArray fullScoreData = processWriter(PDF_WRITER_NAME, notations, options).val;

--- a/src/converter/internal/convertercontroller.cpp
+++ b/src/converter/internal/convertercontroller.cpp
@@ -237,7 +237,7 @@ mu::Ret ConverterController::convertScorePartsToPdf(INotationWriterPtr writer, I
     }
 
     INotationWriter::Options options {
-        { INotationWriter::OptionKey::UNIT_TYPE, Val(static_cast<int>(INotationWriter::UnitType::MULTI_PART)) },
+        { INotationWriter::OptionKey::UNIT_TYPE, Val(INotationWriter::UnitType::MULTI_PART) },
     };
 
     Ret ret = writer->writeList(notations, file, options);

--- a/src/framework/global/val.h
+++ b/src/framework/global/val.h
@@ -55,6 +55,12 @@ public:
     explicit Val(int val);
     explicit Val(const io::path& path);
 
+    template<class E, typename = std::enable_if_t<std::is_enum_v<E> > >
+    explicit Val(E val)
+        : Val{static_cast<std::underlying_type_t<E> >(val)}
+    {
+    }
+
     void setType(Type t);
     Type type() const;
 
@@ -65,6 +71,12 @@ public:
     bool toBool() const;
     int toInt() const;
     io::path toPath() const;
+
+    template<class E, typename = std::enable_if_t<std::is_enum_v<E> > >
+    E toEnum() const
+    {
+        return static_cast<E>(toInt());
+    }
 
 #ifndef NO_QT_SUPPORT
     explicit Val(QColor color);

--- a/src/importexport/audioexport/internal/abstractaudiowriter.cpp
+++ b/src/importexport/audioexport/internal/abstractaudiowriter.cpp
@@ -44,7 +44,7 @@ mu::Ret AbstractAudioWriter::write(INotationPtr, io::Device&, const Options& opt
         return Ret(Ret::Code::NotSupported);
     }
 
-    if (supportsUnitType(static_cast<UnitType>(options.value(OptionKey::UNIT_TYPE, Val(0)).toInt()))) {
+    if (supportsUnitType(options.value(OptionKey::UNIT_TYPE, Val(UnitType::PER_PAGE)).toEnum<UnitType>())) {
         NOT_IMPLEMENTED;
         return Ret(Ret::Code::NotImplemented);
     }
@@ -59,7 +59,7 @@ mu::Ret AbstractAudioWriter::writeList(const INotationPtrList&, io::Device&, con
         return Ret(Ret::Code::NotSupported);
     }
 
-    if (supportsUnitType(static_cast<UnitType>(options.value(OptionKey::UNIT_TYPE, Val(0)).toInt()))) {
+    if (supportsUnitType(options.value(OptionKey::UNIT_TYPE, Val(UnitType::PER_PAGE)).toEnum<UnitType>())) {
         NOT_IMPLEMENTED;
         return Ret(Ret::Code::NotImplemented);
     }
@@ -86,7 +86,7 @@ INotationWriter::UnitType AbstractAudioWriter::unitTypeFromOptions(const Options
     }
 
     UnitType defaultUnitType = supported.front();
-    UnitType unitType = static_cast<UnitType>(options.value(OptionKey::UNIT_TYPE, Val(static_cast<int>(defaultUnitType))).toInt());
+    UnitType unitType = options.value(OptionKey::UNIT_TYPE, Val(defaultUnitType)).toEnum<UnitType>();
     if (!supportsUnitType(unitType)) {
         return defaultUnitType;
     }

--- a/src/importexport/imagesexport/internal/abstractimagewriter.cpp
+++ b/src/importexport/imagesexport/internal/abstractimagewriter.cpp
@@ -44,7 +44,7 @@ mu::Ret AbstractImageWriter::write(INotationPtr, io::Device&, const Options& opt
         return Ret(Ret::Code::NotSupported);
     }
 
-    if (supportsUnitType(static_cast<UnitType>(options.value(OptionKey::UNIT_TYPE, Val(0)).toInt()))) {
+    if (supportsUnitType(options.value(OptionKey::UNIT_TYPE, Val(UnitType::PER_PAGE)).toEnum<UnitType>())) {
         NOT_IMPLEMENTED;
         return Ret(Ret::Code::NotImplemented);
     }
@@ -59,7 +59,7 @@ mu::Ret AbstractImageWriter::writeList(const INotationPtrList&, io::Device&, con
         return Ret(Ret::Code::NotSupported);
     }
 
-    if (supportsUnitType(static_cast<UnitType>(options.value(OptionKey::UNIT_TYPE, Val(0)).toInt()))) {
+    if (supportsUnitType(options.value(OptionKey::UNIT_TYPE, Val(UnitType::PER_PAGE)).toEnum<UnitType>())) {
         NOT_IMPLEMENTED;
         return Ret(Ret::Code::NotImplemented);
     }
@@ -86,7 +86,7 @@ INotationWriter::UnitType AbstractImageWriter::unitTypeFromOptions(const Options
     }
 
     UnitType defaultUnitType = supported.front();
-    UnitType unitType = static_cast<UnitType>(options.value(OptionKey::UNIT_TYPE, Val(static_cast<int>(defaultUnitType))).toInt());
+    UnitType unitType = options.value(OptionKey::UNIT_TYPE, Val(defaultUnitType)).toEnum<UnitType>();
     if (!supportsUnitType(unitType)) {
         return defaultUnitType;
     }

--- a/src/importexport/musicxml/internal/musicxmlconfiguration.cpp
+++ b/src/importexport/musicxml/internal/musicxmlconfiguration.cpp
@@ -42,7 +42,7 @@ void MusicXmlConfiguration::init()
     settings()->setDefaultValue(MUSICXML_IMPORT_BREAKS_KEY, Val(true));
     settings()->setDefaultValue(MUSICXML_IMPORT_LAYOUT_KEY, Val(true));
     settings()->setDefaultValue(MUSICXML_EXPORT_LAYOUT_KEY, Val(true));
-    settings()->setDefaultValue(MUSICXML_EXPORT_BREAKS_TYPE_KEY, Val(static_cast<int>(MusicxmlExportBreaksType::All)));
+    settings()->setDefaultValue(MUSICXML_EXPORT_BREAKS_TYPE_KEY, Val(MusicxmlExportBreaksType::All));
     settings()->setDefaultValue(MUSICXML_EXPORT_INVISIBLE_ELEMENTS_KEY, Val(false));
     settings()->setDefaultValue(MIGRATION_NOT_ASK_AGAING_KEY, Val(false));
 }
@@ -79,12 +79,12 @@ void MusicXmlConfiguration::setMusicxmlExportLayout(bool value)
 
 MusicXmlConfiguration::MusicxmlExportBreaksType MusicXmlConfiguration::musicxmlExportBreaksType() const
 {
-    return static_cast<MusicxmlExportBreaksType>(settings()->value(MUSICXML_EXPORT_BREAKS_TYPE_KEY).toInt());
+    return settings()->value(MUSICXML_EXPORT_BREAKS_TYPE_KEY).toEnum<MusicxmlExportBreaksType>();
 }
 
 void MusicXmlConfiguration::setMusicxmlExportBreaksType(MusicxmlExportBreaksType breaksType)
 {
-    settings()->setSharedValue(MUSICXML_EXPORT_BREAKS_TYPE_KEY, Val(static_cast<int>(breaksType)));
+    settings()->setSharedValue(MUSICXML_EXPORT_BREAKS_TYPE_KEY, Val(breaksType));
 }
 
 bool MusicXmlConfiguration::musicxmlExportInvisibleElements() const

--- a/src/importexport/musicxml/tests/tst_mxml_io.cpp
+++ b/src/importexport/musicxml/tests/tst_mxml_io.cpp
@@ -283,7 +283,7 @@ void TestMxmlIO::mxmlIoTest(const char* file)
 {
     MScore::debugMode = true;
 
-    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(static_cast<int>(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual)));
+    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual));
     setValue(PREF_IMPORT_MUSICXML_IMPORTBREAKS, Val(true));
     setValue(PREF_EXPORT_MUSICXML_EXPORTLAYOUT, Val(false));
     setValue(PREF_EXPORT_MUSICXML_EXPORTINVISIBLE, Val(true));
@@ -306,7 +306,7 @@ void TestMxmlIO::mxmlIoTestRef(const char* file)
 {
     MScore::debugMode = true;
 
-    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(static_cast<int>(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual)));
+    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual));
     setValue(PREF_IMPORT_MUSICXML_IMPORTBREAKS, Val(true));
     setValue(PREF_EXPORT_MUSICXML_EXPORTINVISIBLE, Val(true));
 
@@ -338,17 +338,17 @@ void TestMxmlIO::mxmlIoTestRefBreaks(const char* file)
     fixupScore(score);
     score->doLayout();
 
-    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(static_cast<int>(IMusicXmlConfiguration::MusicxmlExportBreaksType::No)));
+    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(IMusicXmlConfiguration::MusicxmlExportBreaksType::No));
 
     QVERIFY(saveMusicXml(score, QString(file) + ".xml"));
     QVERIFY(saveCompareMusicXmlScore(score, QString(file) + ".xml", XML_IO_DATA_DIR + file + "_no_ref.xml"));
 
-    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(static_cast<int>(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual)));
+    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual));
 
     QVERIFY(saveMusicXml(score, QString(file) + ".xml"));
     QVERIFY(saveCompareMusicXmlScore(score, QString(file) + ".xml", XML_IO_DATA_DIR + file + "_manual_ref.xml"));
 
-    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(static_cast<int>(IMusicXmlConfiguration::MusicxmlExportBreaksType::All)));
+    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(IMusicXmlConfiguration::MusicxmlExportBreaksType::All));
 
     QVERIFY(saveMusicXml(score, QString(file) + ".xml"));
     QVERIFY(saveCompareMusicXmlScore(score, QString(file) + ".xml", XML_IO_DATA_DIR + file + "_all_ref.xml"));
@@ -364,7 +364,7 @@ void TestMxmlIO::mxmlMscxExportTestRef(const char* file)
 {
     MScore::debugMode = true;
 
-    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(static_cast<int>(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual)));
+    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual));
     setValue(PREF_EXPORT_MUSICXML_EXPORTLAYOUT, Val(false));
     setValue(PREF_EXPORT_MUSICXML_EXPORTINVISIBLE, Val(true));
 
@@ -387,7 +387,7 @@ void TestMxmlIO::mxmlMscxExportTestRefBreaks(const char* file)
 {
     MScore::debugMode = true;
 
-    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(static_cast<int>(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual)));
+    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual));
     setValue(PREF_EXPORT_MUSICXML_EXPORTLAYOUT, Val(false));
     setValue(PREF_EXPORT_MUSICXML_EXPORTINVISIBLE, Val(true));
 
@@ -396,17 +396,17 @@ void TestMxmlIO::mxmlMscxExportTestRefBreaks(const char* file)
     fixupScore(score);
     score->doLayout();
 
-    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(static_cast<int>(IMusicXmlConfiguration::MusicxmlExportBreaksType::No)));
+    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(IMusicXmlConfiguration::MusicxmlExportBreaksType::No));
 
     QVERIFY(saveMusicXml(score, QString(file) + ".xml"));
     QVERIFY(saveCompareMusicXmlScore(score, QString(file) + ".xml", XML_IO_DATA_DIR + file + "_no_ref.xml"));
 
-    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(static_cast<int>(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual)));
+    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual));
 
     QVERIFY(saveMusicXml(score, QString(file) + ".xml"));
     QVERIFY(saveCompareMusicXmlScore(score, QString(file) + ".xml", XML_IO_DATA_DIR + file + "_manual_ref.xml"));
 
-    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(static_cast<int>(IMusicXmlConfiguration::MusicxmlExportBreaksType::All)));
+    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(IMusicXmlConfiguration::MusicxmlExportBreaksType::All));
 
     QVERIFY(saveMusicXml(score, QString(file) + ".xml"));
     QVERIFY(saveCompareMusicXmlScore(score, QString(file) + ".xml", XML_IO_DATA_DIR + file + "_all_ref.xml"));
@@ -417,7 +417,7 @@ void TestMxmlIO::mxmlMscxExportTestRefInvisibleElements(const char* file)
 {
     MScore::debugMode = true;
 
-    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(static_cast<int>(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual)));
+    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual));
     setValue(PREF_EXPORT_MUSICXML_EXPORTLAYOUT, Val(false));
 
     MasterScore* score = readScore(XML_IO_DATA_DIR + file + ".mscx");
@@ -447,7 +447,7 @@ void TestMxmlIO::mxmlReadTestCompr(const char* file)
 {
     MScore::debugMode = true;
 
-    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(static_cast<int>(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual)));
+    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual));
     setValue(PREF_IMPORT_MUSICXML_IMPORTBREAKS, Val(true));
     setValue(PREF_EXPORT_MUSICXML_EXPORTINVISIBLE, Val(true));
 
@@ -471,7 +471,7 @@ void TestMxmlIO::mxmlReadWriteTestCompr(const char* file)
     // read xml
     MScore::debugMode = true;
 
-    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(static_cast<int>(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual)));
+    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual));
     setValue(PREF_IMPORT_MUSICXML_IMPORTBREAKS, Val(true));
     setValue(PREF_EXPORT_MUSICXML_EXPORTINVISIBLE, Val(true));
 
@@ -501,7 +501,7 @@ void TestMxmlIO::mxmlReadWriteTestCompr(const char* file)
 void TestMxmlIO::mxmlImportTestRef(const char* file)
 {
     MScore::debugMode = false;
-    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(static_cast<int>(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual)));
+    setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual));
     setValue(PREF_EXPORT_MUSICXML_EXPORTLAYOUT, Val(false));
 
     MasterScore* score = readScore(XML_IO_DATA_DIR + file + ".xml");

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -147,7 +147,7 @@ void NotationConfiguration::init()
         m_foregroundChanged.notify();
     });
 
-    settings()->setDefaultValue(DEFAULT_ZOOM_TYPE, Val(static_cast<int>(ZoomType::Percentage)));
+    settings()->setDefaultValue(DEFAULT_ZOOM_TYPE, Val(ZoomType::Percentage));
     settings()->setDefaultValue(DEFAULT_ZOOM, Val(100));
     settings()->setDefaultValue(KEYBOARD_ZOOM_PRECISION, Val(2));
     settings()->setDefaultValue(MOUSE_ZOOM_PRECISION, Val(6));
@@ -382,12 +382,12 @@ void NotationConfiguration::setSelectionProximity(int proxymity)
 
 ZoomType NotationConfiguration::defaultZoomType() const
 {
-    return static_cast<ZoomType>(settings()->value(DEFAULT_ZOOM_TYPE).toInt());
+    return settings()->value(DEFAULT_ZOOM_TYPE).toEnum<ZoomType>();
 }
 
 void NotationConfiguration::setDefaultZoomType(ZoomType zoomType)
 {
-    settings()->setSharedValue(DEFAULT_ZOOM_TYPE, Val(static_cast<int>(zoomType)));
+    settings()->setSharedValue(DEFAULT_ZOOM_TYPE, Val(zoomType));
 }
 
 int NotationConfiguration::defaultZoom() const

--- a/src/playback/internal/playbackconfiguration.cpp
+++ b/src/playback/internal/playbackconfiguration.cpp
@@ -64,7 +64,7 @@ void PlaybackConfiguration::init()
     settings()->setDefaultValue(PLAY_NOTES_WHEN_EDITING, Val(true));
     settings()->setDefaultValue(PLAY_CHORD_WHEN_EDITING, Val(true));
     settings()->setDefaultValue(PLAY_HARMONY_WHEN_EDITING, Val(true));
-    settings()->setDefaultValue(PLAYBACK_CURSOR_TYPE_KEY, Val(static_cast<int>(PlaybackCursorType::STEPPED)));
+    settings()->setDefaultValue(PLAYBACK_CURSOR_TYPE_KEY, Val(PlaybackCursorType::STEPPED));
 
     for (MixerSectionType sectionType : allMixerSectionTypes()) {
         bool sectionEnabledByDefault = sectionType != MixerSectionType::Volume;
@@ -104,7 +104,7 @@ void PlaybackConfiguration::setPlayHarmonyWhenEditing(bool value)
 
 PlaybackCursorType PlaybackConfiguration::cursorType() const
 {
-    return static_cast<PlaybackCursorType>(settings()->value(PLAYBACK_CURSOR_TYPE_KEY).toInt());
+    return settings()->value(PLAYBACK_CURSOR_TYPE_KEY).toEnum<PlaybackCursorType>();
 }
 
 bool PlaybackConfiguration::isMixerSectionVisible(MixerSectionType sectionType) const

--- a/src/project/internal/exportprojectscenario.cpp
+++ b/src/project/internal/exportprojectscenario.cpp
@@ -75,7 +75,7 @@ bool ExportProjectScenario::exportScores(const INotationPtrList& notations, cons
         for (INotationPtr notation : notations) {
             for (int page = 0; page < notation->elements()->msScore()->pages().size(); page++) {
                 INotationWriter::Options options {
-                    { INotationWriter::OptionKey::UNIT_TYPE, Val(static_cast<int>(unitType)) },
+                    { INotationWriter::OptionKey::UNIT_TYPE, Val(unitType) },
                     { INotationWriter::OptionKey::PAGE_NUMBER, Val(page) },
                     { INotationWriter::OptionKey::TRANSPARENT_BACKGROUND,
                       Val(imagesExportConfiguration()->exportPngWithTransparentBackground()) }
@@ -96,7 +96,7 @@ bool ExportProjectScenario::exportScores(const INotationPtrList& notations, cons
     case INotationWriter::UnitType::PER_PART: {
         for (INotationPtr notation : notations) {
             INotationWriter::Options options {
-                { INotationWriter::OptionKey::UNIT_TYPE, Val(static_cast<int>(unitType)) },
+                { INotationWriter::OptionKey::UNIT_TYPE, Val(unitType) },
                 { INotationWriter::OptionKey::TRANSPARENT_BACKGROUND,
                   Val(imagesExportConfiguration()->exportPngWithTransparentBackground()) }
             };
@@ -114,7 +114,7 @@ bool ExportProjectScenario::exportScores(const INotationPtrList& notations, cons
     } break;
     case INotationWriter::UnitType::MULTI_PART: {
         INotationWriter::Options options {
-            { INotationWriter::OptionKey::UNIT_TYPE, Val(static_cast<int>(unitType)) },
+            { INotationWriter::OptionKey::UNIT_TYPE, Val(unitType) },
             { INotationWriter::OptionKey::TRANSPARENT_BACKGROUND, Val(imagesExportConfiguration()->exportPngWithTransparentBackground()) }
         };
 

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -66,7 +66,7 @@ void ProjectConfiguration::init()
         m_recentProjectPathsChanged.send(paths);
     });
 
-    Val preferredScoreCreationMode = Val(static_cast<int>(PreferredScoreCreationMode::FromInstruments));
+    Val preferredScoreCreationMode = Val(PreferredScoreCreationMode::FromInstruments);
     settings()->setDefaultValue(PREFERRED_SCORE_CREATION_MODE_KEY, preferredScoreCreationMode);
 
     settings()->setDefaultValue(AUTOSAVE_ENABLED_KEY, Val(true));
@@ -216,12 +216,12 @@ async::Notification ProjectConfiguration::templatePreviewBackgroundChanged() con
 
 ProjectConfiguration::PreferredScoreCreationMode ProjectConfiguration::preferredScoreCreationMode() const
 {
-    return static_cast<PreferredScoreCreationMode>(settings()->value(PREFERRED_SCORE_CREATION_MODE_KEY).toInt());
+    return settings()->value(PREFERRED_SCORE_CREATION_MODE_KEY).toEnum<PreferredScoreCreationMode>();
 }
 
 void ProjectConfiguration::setPreferredScoreCreationMode(PreferredScoreCreationMode mode)
 {
-    settings()->setSharedValue(PREFERRED_SCORE_CREATION_MODE_KEY, Val(static_cast<int>(mode)));
+    settings()->setSharedValue(PREFERRED_SCORE_CREATION_MODE_KEY, Val(mode));
 }
 
 MigrationOptions ProjectConfiguration::migrationOptions(MigrationType type) const

--- a/src/project/internal/projectmigrator.cpp
+++ b/src/project/internal/projectmigrator.cpp
@@ -105,7 +105,7 @@ Ret ProjectMigrator::askAboutMigration(MigrationOptions& out, const QString& app
 {
     UriQuery query(MIGRATION_DIALOG_URI);
     query.addParam("appVersion", Val(appVersion));
-    query.addParam("migrationType", Val(static_cast<int>(migrationType)));
+    query.addParam("migrationType", Val(migrationType));
     query.addParam("isApplyLeland", Val(out.isApplyLeland));
     query.addParam("isApplyEdwin", Val(out.isApplyEdwin));
     query.addParam("isApplyAutoSpacing", Val(out.isApplyAutoSpacing));


### PR DESCRIPTION
I think this is just nice to have: now we can do `Val(someEnumValue)` and `someVal.toEnum<SomeEnumType>()` instead of explicitly casting to/from `int` every time.