### PR TITLE
fix #10288: Save Copy works as intended

### DIFF
--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -360,14 +360,14 @@ mu::Ret NotationProject::save(const io::path& path, SaveMode saveMode)
     case SaveMode::SaveSelection:
         return saveSelectionOnScore(path);
     case SaveMode::Save:
-    case SaveMode::SaveAs:
-    case SaveMode::SaveCopy: {
+    case SaveMode::SaveAs: {
         io::path oldFilePath = m_engravingProject->path();
 
         io::path savePath = path;
         if (!savePath.empty()) {
             m_engravingProject->setPath(savePath.toQString());
-        } else {
+        }
+        else {
             savePath = m_engravingProject->path();
         }
 
@@ -380,6 +380,21 @@ mu::Ret NotationProject::save(const io::path& path, SaveMode saveMode)
             }
         }
 
+        return ret;
+    }
+    case SaveMode::SaveCopy: {
+        io::path originalPath = m_engravingProject->path();
+        std::string suffix = io::suffix(originalPath);
+        
+        io::path savePath = path;
+        if (savePath.empty() || savePath  == originalPath) {
+            std::string originalPath_s = originalPath.toStdString();
+            originalPath_s.erase(originalPath_s.end() - (suffix.length() + 1), originalPath_s.end());
+            originalPath_s += (" (Copy)." + suffix);
+            savePath = originalPath_s;
+        }
+        
+        Ret ret = saveScore(savePath, suffix);
         return ret;
     }
     case SaveMode::AutoSave:


### PR DESCRIPTION
Resolves: #10288 

The save a copy now makes another file and does not change the current project

I have moved the current code which was common for Save, SaveAs and SaveCopy without modifying it
Please let me know if that requires any modification (one of the conditions at line 378 (after the PR changes) in it is null and void, so I am not sure whether to remove it or if there is some better condition that should be put in its place)

The above mentioned condition is this (line 378)
`if (saveMode != SaveMode::SaveCopy || oldFilePath == savePath) `

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
