### PR TITLE
Custom Key Sig editor - accidentals horizontal auto spacing

### DIFF
--- a/src/palette/view/widgets/keyedit.cpp
+++ b/src/palette/view/widgets/keyedit.cpp
@@ -276,10 +276,18 @@ void KeyCanvas::dropEvent(QDropEvent*)
 void KeyCanvas::snap(Accidental* a)
 {
     double y        = a->ipos().y();
-    double spatium2 = gpaletteScore->spatium() * .5;
-    int line        = int((y + spatium2 * .5) / spatium2);
+    double x        = a->ipos().x();
+    double _spatium = gpaletteScore->spatium();
+    double spatium2 = _spatium * .5;
+    double step     = _spatium * KeySigEvent().xstep();
+    int line        = round(y / spatium2);
+    int stepx       = round(x / step);
     y               = line * spatium2;
+    x               = stepx * step;
     a->rypos()      = y;
+    if (!QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
+        a->rxpos()  = x;
+    }
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: *([329084](https://musescore.org/en/node/329084))*

When accidental is added, its h-position is shifted to normal position.
If Control is pressed, free placement is enabled (unshifted placement like it was by default before).

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
