### PR TITLE
Fix: #9488: homeMenu-icon-only-view

### DIFF
--- a/src/appshell/qml/HomePage/HomeMenu.qml
+++ b/src/appshell/qml/HomePage/HomeMenu.qml
@@ -32,10 +32,10 @@ Item {
 
     property string currentPageName: ""
     property int toggleWidth: 135
+    property int minimumWidth: 76
+    property int maximumWidth: 280
 
     signal selected(string name)
-
-    width: parent.width
 
     NavigationSection {
         id: navSec
@@ -56,16 +56,12 @@ Item {
     }
 
     ColumnLayout {
-        id: layout
-
-        property alias accountInfoButton: accountInfo
-
         anchors.fill: parent
 
         spacing: 20
 
         AccountInfoButton {
-            id: accountInfo
+            id: accountInfoButton
 
             Layout.fillWidth: true
             Layout.preferredHeight: 60
@@ -82,14 +78,6 @@ Item {
 
             onUserAuthorizedChanged: {
                 root.selected("scores")
-            }
-
-            function showAvatarOnly() {
-                textShowed = ""
-            }
-
-            function showNormal() {
-                textShowed = title
             }
         }
 
@@ -137,23 +125,17 @@ Item {
                     radioButtonList.currentIndex = index
                     root.selected(modelData["name"])
                 }
-
-                onWidthChanged: {
-                    if (width < root.toggleWidth) {
-                        textShowed = ""
-                    } else {
-                        textShowed = title
-                    }
-                }
             }
         }
     }
 
     onWidthChanged: {
         if (width < root.toggleWidth) {
-            layout.accountInfoButton.showAvatarOnly()
+            width = root.minimumWidth
+            accountInfoButton.title = ""
         } else {
-            layout.accountInfoButton.showNormal()
+            width = root.maximumWidth
+            accountInfoButton.title = accountInfoButton.userName
         }
     }
 }

--- a/src/appshell/qml/HomePage/HomeMenu.qml
+++ b/src/appshell/qml/HomePage/HomeMenu.qml
@@ -31,8 +31,11 @@ Item {
     id: root
 
     property string currentPageName: ""
+    property int toggleWidth: 135
 
     signal selected(string name)
+
+    width: parent.width
 
     NavigationSection {
         id: navSec
@@ -53,11 +56,17 @@ Item {
     }
 
     ColumnLayout {
+        id: layout
+
+        property alias accountInfoButton: accountInfo
+
         anchors.fill: parent
 
         spacing: 20
 
         AccountInfoButton {
+            id: accountInfo
+
             Layout.fillWidth: true
             Layout.preferredHeight: 60
 
@@ -73,6 +82,14 @@ Item {
 
             onUserAuthorizedChanged: {
                 root.selected("scores")
+            }
+
+            function showAvatarOnly() {
+                textShowed = ""
+            }
+
+            function showNormal() {
+                textShowed = title
             }
         }
 
@@ -120,7 +137,23 @@ Item {
                     radioButtonList.currentIndex = index
                     root.selected(modelData["name"])
                 }
+
+                onWidthChanged: {
+                    if (width < root.toggleWidth) {
+                        textShowed = ""
+                    } else {
+                        textShowed = title
+                    }
+                }
             }
+        }
+    }
+
+    onWidthChanged: {
+        if (width < root.toggleWidth) {
+            layout.accountInfoButton.showAvatarOnly()
+        } else {
+            layout.accountInfoButton.showNormal()
         }
     }
 }

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/PageTabButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/PageTabButton.qml
@@ -38,7 +38,6 @@ RadioDelegate {
     property var selectedStateFont: ui.theme.largeBodyBoldFont
 
     property alias navigation: navCtrl
-    property alias textShowed: content.transitText1
 
     height: isVertical ? 36 : 44
 
@@ -122,10 +121,6 @@ RadioDelegate {
     }
 
     contentItem: Item {
-        id: content
-
-        property alias transitText1: contentRow.transitText2
-
         anchors.fill: parent
         anchors.leftMargin: root.leftPadding
         anchors.rightMargin: root.rightPadding
@@ -136,9 +131,6 @@ RadioDelegate {
 
         Row {
             id: contentRow
-
-            property alias transitText2: textLabel.text
-
             anchors.fill: parent
             spacing: root.spacing
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/PageTabButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/PageTabButton.qml
@@ -38,6 +38,7 @@ RadioDelegate {
     property var selectedStateFont: ui.theme.largeBodyBoldFont
 
     property alias navigation: navCtrl
+    property alias textShowed: content.transitText1
 
     height: isVertical ? 36 : 44
 
@@ -121,6 +122,10 @@ RadioDelegate {
     }
 
     contentItem: Item {
+        id: content
+
+        property alias transitText1: contentRow.transitText2
+
         anchors.fill: parent
         anchors.leftMargin: root.leftPadding
         anchors.rightMargin: root.rightPadding
@@ -131,6 +136,9 @@ RadioDelegate {
 
         Row {
             id: contentRow
+
+            property alias transitText2: textLabel.text
+
             anchors.fill: parent
             spacing: root.spacing
 


### PR DESCRIPTION
Resolves: [#9488](https://github.com/musescore/MuseScore/issues/9488)

make Sidebar collapse to icon-only view when resized


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made

https://user-images.githubusercontent.com/71218187/152671936-295fd86e-fda8-4709-bfb4-18cf1378cb4b.mp4

