### PR TITLE
Fix #10421: Migration dialog X now works as cancel

### DIFF
--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -179,6 +179,11 @@ mu::Ret NotationProject::doLoad(engraving::MscReader& reader, const io::path& st
     // Migration
     if (migrator()) {
         Ret ret = migrator()->migrateEngravingProjectIfNeed(project);
+
+        if (ret.code() == static_cast<int>(Ret::Code::Cancel)) {
+            return make_ret(Ret::Code::Cancel);
+        }
+
         if (!ret) {
             return ret;
         }

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -174,6 +174,10 @@ Ret ProjectActionsController::doOpenProject(const io::path& filePath)
 
     Ret ret = project->load(filePath);
 
+    if (!ret && ret.code() == static_cast<int>(Ret::Code::Cancel)) {
+        return ret;
+    }
+
     if (!ret && checkCanIgnoreError(ret, filePath)) {
         constexpr auto NO_STYLE = "";
         constexpr bool FORCE_MODE = true;

--- a/src/project/internal/projectmigrator.cpp
+++ b/src/project/internal/projectmigrator.cpp
@@ -77,7 +77,7 @@ Ret ProjectMigrator::migrateEngravingProjectIfNeed(engraving::EngravingProjectPt
         Ret ret = askAboutMigration(migrationOptions, project->appVersion(), migrationType);
 
         if (ret.code() == static_cast<int>(Ret::Code::Cancel)) {
-            return make_ok();
+            return make_ret(Ret::Code::Cancel);
         }
 
         if (!ret) {


### PR DESCRIPTION
Fix #10421: Migration dialog X now works as cancel and wont open the score anymore

Resolves: [#10421](https://github.com/musescore/MuseScore/issues/10421)

Changed the process of loading a project so it checks if migration got canceled by user and if so it will abort the loading.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
