### PR TITLE
Bug fix: incorrect layout of multimeasure rests

### DIFF
--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -4212,7 +4212,7 @@ void Measure::computeWidth(Fraction minTicks, qreal stretchCoeff)
     //
     Shape ls(first ? RectF(0.0, -1000000.0, 0.0, 2000000.0) : RectF(0.0, 0.0, 0.0, spatium() * 4));
 
-    x = s->minLeft(ls);
+    x = s->isMMRestSegment() ? 0 : s->minLeft(ls);
 
     if (s->isStartRepeatBarLineType()) {
         System* sys = system();

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -2526,6 +2526,15 @@ qreal Segment::elementsBottomOffsetFromSkyline(int staffIndex) const
 }
 
 //---------------------------------------------------------
+// isMMRestSegment()
+//  true if the segment is a MM rest
+//---------------------------------------------------------
+bool Segment::isMMRestSegment() const
+{
+    return measure()->isMMRest() && isChordRestType();
+}
+
+//---------------------------------------------------------
 //   minHorizontalDistance
 //    calculate the minimum layout distance to Segment ns
 //---------------------------------------------------------
@@ -2535,11 +2544,9 @@ qreal Segment::minHorizontalDistance(Segment* ns, bool systemHeaderGap) const
     qreal ww = -1000000.0;          // can remain negative
     double d = 0.0;
     for (unsigned staffIdx = 0; staffIdx < _shapes.size(); ++staffIdx) {
-        if (isChordRestType() && measure()->isMMRest()) {
-            d = score()->styleMM(Sid::minMMRestWidth);
-            // A MMRest segment must be treated separately because the
-            // associated shape has variable width.
-        } else {
+        if (!isMMRestSegment() && !ns->isMMRestSegment()) {
+            // MM rest segments must be treated separately because
+            // the associated shapes have variable width
             d = ns ? staffShape(staffIdx).minHorizontalDistance(ns->staffShape(staffIdx)) : 0.0;
         }
         // first chordrest of a staff should clear the widest header for any staff

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -2533,8 +2533,15 @@ qreal Segment::elementsBottomOffsetFromSkyline(int staffIndex) const
 qreal Segment::minHorizontalDistance(Segment* ns, bool systemHeaderGap) const
 {
     qreal ww = -1000000.0;          // can remain negative
+    double d = 0.0;
     for (unsigned staffIdx = 0; staffIdx < _shapes.size(); ++staffIdx) {
-        qreal d = ns ? staffShape(staffIdx).minHorizontalDistance(ns->staffShape(staffIdx)) : 0.0;
+        if (isChordRestType() && measure()->isMMRest()) {
+            d = score()->styleMM(Sid::minMMRestWidth);
+            // A MMRest segment must be treated separately because the
+            // associated shape has variable width.
+        } else {
+            d = ns ? staffShape(staffIdx).minHorizontalDistance(ns->staffShape(staffIdx)) : 0.0;
+        }
         // first chordrest of a staff should clear the widest header for any staff
         // so make sure segment is as wide as it needs to be
         if (systemHeaderGap) {

--- a/src/engraving/libmscore/segment.h
+++ b/src/engraving/libmscore/segment.h
@@ -287,6 +287,7 @@ public:
     bool isEndBarLineType() const { return _segmentType == SegmentType::EndBarLine; }
     bool isKeySigAnnounceType() const { return _segmentType == SegmentType::KeySigAnnounce; }
     bool isTimeSigAnnounceType() const { return _segmentType == SegmentType::TimeSigAnnounce; }
+    bool isMMRestSegment() const;
 
     static constexpr SegmentType durationSegmentsMask = SegmentType::ChordRest;   // segment types which may have non-zero tick length
 };


### PR DESCRIPTION
Bug description:
Multimeasure rests are initially layed out correctly (hence why it went unnoticed), but during any editing operation their width can only increase, and never decrease, so they quickly get messed up (see screeshot). 
![Screenshot from 2022-02-06 16-58-54](https://user-images.githubusercontent.com/93707756/152692500-2f3e3a4c-2c88-48cf-a34e-1e18f0ddf6a7.png)

How to replicate:
Create multimeasure rests and play around with them using stretch commands or line breaks.

Solution:
The error started from this [commit](https://github.com/musescore/MuseScore/commit/427f573f34a39cc9f8c8244a022dd14d662d9670) of my horizontal spacing PR, specifically from eliminating this [block of code](https://github.com/musescore/MuseScore/commit/427f573f34a39cc9f8c8244a022dd14d662d9670#diff-52ba1d84eecac29ce33da0360e3bc07d8a7ae6f1b7230763caa1dcd31af4a9a9L4219-L4232). However, this code was simply covering a deeper error, namely the fact that the minimum horizontal distance of a segment was calculated via the width of the corresponding shape, but this doesn't make sense for MM rests because their width (unlike all other shapes) changes with context. I think this should fix it.