### PR TITLE
Fix #10441 - Omit lyrics extender line if too short

### DIFF
--- a/src/engraving/libmscore/lyricsline.cpp
+++ b/src/engraving/libmscore/lyricsline.cpp
@@ -417,8 +417,10 @@ void LyricsLineSegment::layout()
 
     // MELISMA vs. DASHES
     const double minMelismaLen = 1 * sp; // TODO: style setting
+    const double minDashLen  = score()->styleS(Sid::lyricsDashMinLength).val() * sp;
+    const double maxDashDist = score()->styleS(Sid::lyricsDashMaxDistance).val() * sp;
+    double len = pos2().rx();
     if (isEndMelisma) {                   // melisma
-        double len = pos2().rx();
         if (len < minMelismaLen) { // Omit the extender line if too short
             _numOfDashes = 0;
         } else {
@@ -435,9 +437,6 @@ void LyricsLineSegment::layout()
         // set conventional dash Y pos
         rypos() -= lyr->fontMetrics().xHeight() * score()->styleD(Sid::lyricsDashYposRatio);
         _dashLength = score()->styleMM(Sid::lyricsDashMaxLength) * mag();      // and dash length
-        qreal len         = pos2().x();
-        qreal minDashLen  = score()->styleS(Sid::lyricsDashMinLength).val() * sp;
-        qreal maxDashDist = score()->styleS(Sid::lyricsDashMaxDistance).val() * sp;
         if (len < minDashLen) {                                               // if no room for a dash
             // if at end of system or dash is forced
             if (endOfSystem || score()->styleB(Sid::lyricsDashForce)) {

--- a/src/engraving/libmscore/lyricsline.cpp
+++ b/src/engraving/libmscore/lyricsline.cpp
@@ -416,8 +416,14 @@ void LyricsLineSegment::layout()
     }
 
     // MELISMA vs. DASHES
+    const double minMelismaLen = 1 * sp; // TODO: style setting
     if (isEndMelisma) {                   // melisma
-        _numOfDashes = 1;
+        double len = pos2().rx();
+        if (len < minMelismaLen) { // Omit the extender line if too short
+            _numOfDashes = 0;
+        } else {
+            _numOfDashes = 1;
+        }
         rypos()      -= lyricsLine()->lineWidth() * .5;     // let the line 'sit on' the base line
         // if not final segment, shorten it (why? -AS)
         /*


### PR DESCRIPTION
Comment

Resolves: [10441](https://github.com/musescore/MuseScore/issues/10441)

As discussed in the related issue, the extender line for lyrics should be omitted when too short, as it serves no purpose. See the screen capture attached for a quick look. The threshold value is now hardcoded to 1 sp as suggested by @oktophonie. In future, it probably deserves a dedicated style setting.


https://user-images.githubusercontent.com/93707756/152693861-5bb7c9bc-e270-46bd-bb68-6c26afd77ca7.mp4


