### PR TITLE
fix #10481: fixed import of trill and wah

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1058,17 +1058,17 @@ void GPConverter::addFingering(const GPNote* gpnote, Note* note)
     }
 }
 
-void GPConverter::addTrill(const GPNote* gpnote, Note* /*note*/)
+void GPConverter::addTrill(const GPNote* gpnote, Note* note)
 {
     if (gpnote->trill().auxillaryFret == -1) {
         return;
     }
 
-    //!@TODO add trill
-
-//    Trill* art = new Trill(_score);
-//    if (!_score->addArticulation(note, art))
-//        delete art;
+    Articulation* art = Factory::createArticulation(note->score()->dummy()->chord());
+    art->setSymId(SymId::ornamentTrill);
+    if (!note->score()->toggleArticulation(note, art)) {
+        delete art;
+    }
 }
 
 void GPConverter::addOrnament(const GPNote* gpnote, Note* note)
@@ -2019,7 +2019,18 @@ void GPConverter::addWah(const GPBeat* beat, ChordRest* cr)
         return;
     }
 
-    //!@TODO add wah
+    auto scoreWah = [] (const auto& wah) {
+        if (wah == GPBeat::Wah::Open) {
+            return SymId::brassMuteOpen;
+        }
+        return SymId::brassMuteClosed;
+    };
+
+    Articulation* art = Factory::createArticulation(_score->dummy()->chord());
+    art->setSymId(scoreWah(beat->wah()));
+    if (!_score->toggleArticulation(static_cast<Chord*>(cr)->upNote(), art)) {
+        delete art;
+    }
 }
 
 void GPConverter::addBarre(const GPBeat* beat, ChordRest* cr)

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -3028,8 +3028,8 @@ Score::FileError importGTP(MasterScore* score, const QString& name)
         }
 
         Excerpt* excerpt = new Excerpt(score);
-        excerpt->setPartScore(pscore);
-        excerpt->setTracks(tracks);
+        excerpt->setExcerptScore(pscore);
+        excerpt->setTracksMapping(tracks);
         pscore->setExcerpt(excerpt);
         excerpt->setTitle(part->partName());
         excerpt->parts().append(part);

--- a/src/importexport/guitarpro/internal/importptb.cpp
+++ b/src/importexport/guitarpro/internal/importptb.cpp
@@ -1315,8 +1315,8 @@ Score::FileError PowerTab::read()
         }
 
         Excerpt* excerpt = new Excerpt(score);
-        excerpt->setTracks(tracks);
-        excerpt->setPartScore(pscore);
+        excerpt->setTracksMapping(tracks);
+        excerpt->setExcerptScore(pscore);
         //title?
         excerpt->setTitle(part->instrument()->longNames()[0].name());
         pscore->setExcerpt(excerpt);


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/10481*

*fixed import of trill and wah*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
