### PR TITLE
[MU4] Slur Revamp

### DIFF
--- a/src/engraving/layout/layoutsystem.h
+++ b/src/engraving/layout/layoutsystem.h
@@ -46,6 +46,7 @@ private:
     static void hideEmptyStaves(Ms::Score* score, Ms::System* system, bool isFirstSystem);
     static void processLines(Ms::System* system, std::vector<Ms::Spanner*> lines, bool align);
     static void layoutTies(Ms::Chord* ch, Ms::System* system, const Ms::Fraction& stick);
+    static void doLayoutTies(Ms::System* system, std::vector<Ms::Segment*> sl, const Fraction& stick, const Fraction& etick);
 };
 }
 

--- a/src/engraving/libmscore/slur.h
+++ b/src/engraving/libmscore/slur.h
@@ -52,7 +52,7 @@ public:
     bool edit(EditData&) override;
 
     Slur* slur() const { return toSlur(spanner()); }
-
+    void adjustEndpoints();
     void computeBezier(mu::PointF so = mu::PointF()) override;
 };
 

--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -1809,6 +1809,53 @@ qreal System::lastNoteRestSegmentX(bool trailing)
 }
 
 //---------------------------------------------------------
+//   lastChordRest
+//    returns the last chordrest of a system for a particular track
+//---------------------------------------------------------
+
+ChordRest* System::lastChordRest(int track)
+{
+    for (auto measureBaseIter = measures().rbegin(); measureBaseIter != measures().rend(); measureBaseIter++) {
+        if ((*measureBaseIter)->isMeasure()) {
+            const Measure* measure = static_cast<const Measure*>(*measureBaseIter);
+            for (const Segment* seg = measure->last(); seg; seg = seg->prev()) {
+                if (seg->isChordRestType()) {
+                    ChordRest* cr = seg->cr(track);
+                    if (cr) {
+                        return cr;
+                    }
+                }
+            }
+        }
+    }
+    return nullptr;
+}
+
+//---------------------------------------------------------
+//   firstChordRest
+//    returns the last chordrest of a system for a particular track
+//---------------------------------------------------------
+
+ChordRest* System::firstChordRest(int track)
+{
+    qreal margin = score()->spatium();
+    for (const MeasureBase* mb : measures()) {
+        if (!mb->isMeasure()) {
+            continue;
+        }
+        const Measure* measure = static_cast<const Measure*>(mb);
+        for (const Segment* seg = measure->first(); seg; seg = seg->next()) {
+            if (seg->isChordRestType()) {
+                ChordRest* cr = seg->cr(track);
+                if (cr) {
+                    return cr;
+                }
+            }
+        }
+    }
+}
+
+//---------------------------------------------------------
 //   pageBreak
 //---------------------------------------------------------
 

--- a/src/engraving/libmscore/system.h
+++ b/src/engraving/libmscore/system.h
@@ -222,6 +222,8 @@ public:
 
     qreal firstNoteRestSegmentX(bool leading = false);
     qreal lastNoteRestSegmentX(bool trailing = false);
+    ChordRest* lastChordRest(int track);
+    ChordRest* firstChordRest(int track);
 
     bool hasFixedDownDistance() const { return fixedDownDistance; }
     int firstVisibleStaff() const;


### PR DESCRIPTION
This is a first step on the journey to having better-handled slurs. There are still some strange behaviors that need to be sussed out and fixed, but we don't have a lot of time to spend making it perfect, so for the time being, here are the changes.
- "Floating" endpoint vertical positioning fixed
- Collision avoidance between stem-side slurs and hooks
- Collisions between slurs and ties no longer happen
- Collisions between slurs and other slurs (both nested and similar start/end points)
- Slur endpoints now anchor to the middle of tenuto marks if necessary
- Endpoint _and_ height adjustment for slurs interacting with objects on the staff (this is one that still needs some work)
- Endpoint staff line avoidance

I expect the vtests to explode in a fiery ball of failure, by the way, so that's next