### PR TITLE
[MU4] Score migration of style defaults for 3.6 scores

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ set(YOUTUBE_API_KEY "" CACHE STRING "YouTube API key")
 
 option(ENGRAVING_PAINT_DEBUGGER_ENABLED "Enable diagnostic engraving paint debugger" OFF)
 # Temporary flags for MU3 compatibility to make testing easier.
-option(ENGRAVING_COMPAT_WRITESTYLE_302 "Write style to score xml file" ON)
+option(ENGRAVING_COMPAT_WRITESTYLE_302 "Write style to score xml file" OFF)
 option(ENGRAVING_COMPAT_WRITEEXCERPTS_302 "Write excerpts to score xml file" ON)
 # -----
 

--- a/src/engraving/data/styles/legacy-style-defaults-v302.mss
+++ b/src/engraving/data/styles/legacy-style-defaults-v302.mss
@@ -1,0 +1,1271 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.00">
+  <Style>
+    <pageWidth>8.5</pageWidth>
+    <pageHeight>11</pageHeight>
+    <pagePrintableWidth>7.08661</pagePrintableWidth>
+    <pageEvenLeftMargin>0.590551</pageEvenLeftMargin>
+    <pageOddLeftMargin>0.590551</pageOddLeftMargin>
+    <pageEvenTopMargin>0.590551</pageEvenTopMargin>
+    <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
+    <pageOddTopMargin>0.590551</pageOddTopMargin>
+    <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+    <pageTwosided>1</pageTwosided>
+    <staffUpperBorder>7</staffUpperBorder>
+    <staffLowerBorder>7</staffLowerBorder>
+    <staffDistance>6.5</staffDistance>
+    <akkoladeDistance>6.5</akkoladeDistance>
+    <minSystemDistance>8.5</minSystemDistance>
+    <maxSystemDistance>15</maxSystemDistance>
+    <enableVerticalSpread>1</enableVerticalSpread>
+    <spreadSystem>2.5</spreadSystem>
+    <spreadSquareBracket>1.2</spreadSquareBracket>
+    <spreadCurlyBracket>1.1</spreadCurlyBracket>
+    <minSystemSpread>8.5</minSystemSpread>
+    <maxSystemSpread>32</maxSystemSpread>
+    <minSpreadSpread>3.5</minSpreadSpread>
+    <maxSpreadSpread>20</maxSpreadSpread>
+    <maxAkkoladeDistance>6.5</maxAkkoladeDistance>
+    <maxPageFillSpread>6</maxPageFillSpread>
+    <lyricsPlacement>1</lyricsPlacement>
+    <lyricsPosAbove x="0" y="-2"/>
+    <lyricsPosBelow x="0" y="3"/>
+    <lyricsMinTopDistance>1</lyricsMinTopDistance>
+    <lyricsMinBottomDistance>2</lyricsMinBottomDistance>
+    <lyricsMinDistance>0.25</lyricsMinDistance>
+    <lyricsLineHeight>1</lyricsLineHeight>
+    <lyricsDashMinLength>0.4</lyricsDashMinLength>
+    <lyricsDashMaxLength>0.8</lyricsDashMaxLength>
+    <lyricsDashMaxDistance>16</lyricsDashMaxDistance>
+    <lyricsDashForce>1</lyricsDashForce>
+    <lyricsAlignVerseNumber>1</lyricsAlignVerseNumber>
+    <lyricsLineThickness>0.1</lyricsLineThickness>
+    <lyricsMelismaAlign>left,baseline</lyricsMelismaAlign>
+    <lyricsMelismaPad>0.1</lyricsMelismaPad>
+    <lyricsDashPad>0.05</lyricsDashPad>
+    <lyricsDashLineThickness>0.15</lyricsDashLineThickness>
+    <lyricsDashYposRatio>0.6</lyricsDashYposRatio>
+    <lyricsOddFontFace>Edwin</lyricsOddFontFace>
+    <lyricsOddFontSize>10</lyricsOddFontSize>
+    <lyricsOddLineSpacing>1</lyricsOddLineSpacing>
+    <lyricsOddFontSpatiumDependent>1</lyricsOddFontSpatiumDependent>
+    <lyricsOddFontStyle>0</lyricsOddFontStyle>
+    <lyricsOddColor r="0" g="0" b="0" a="255"/>
+    <lyricsOddAlign>center,baseline</lyricsOddAlign>
+    <lyricsOddFrameType>0</lyricsOddFrameType>
+    <lyricsOddFramePadding>0.2</lyricsOddFramePadding>
+    <lyricsOddFrameWidth>0.1</lyricsOddFrameWidth>
+    <lyricsOddFrameRound>0</lyricsOddFrameRound>
+    <lyricsOddFrameFgColor r="0" g="0" b="0" a="255"/>
+    <lyricsOddFrameBgColor r="255" g="255" b="255" a="0"/>
+    <lyricsEvenFontFace>Edwin</lyricsEvenFontFace>
+    <lyricsEvenFontSize>10</lyricsEvenFontSize>
+    <lyricsEvenLineSpacing>1</lyricsEvenLineSpacing>
+    <lyricsEvenFontSpatiumDependent>1</lyricsEvenFontSpatiumDependent>
+    <lyricsEvenFontStyle>0</lyricsEvenFontStyle>
+    <lyricsEvenColor r="0" g="0" b="0" a="255"/>
+    <lyricsEvenAlign>center,baseline</lyricsEvenAlign>
+    <lyricsEvenFrameType>0</lyricsEvenFrameType>
+    <lyricsEvenFramePadding>0.2</lyricsEvenFramePadding>
+    <lyricsEvenFrameWidth>0.1</lyricsEvenFrameWidth>
+    <lyricsEvenFrameRound>0</lyricsEvenFrameRound>
+    <lyricsEvenFrameFgColor r="0" g="0" b="0" a="255"/>
+    <lyricsEvenFrameBgColor r="255" g="255" b="255" a="0"/>
+    <figuredBassFontFamily>MScoreBC</figuredBassFontFamily>
+    <figuredBassYOffset>6</figuredBassYOffset>
+    <figuredBassLineHeight>1</figuredBassLineHeight>
+    <figuredBassAlignment>0</figuredBassAlignment>
+    <figuredBassStyle>0</figuredBassStyle>
+    <systemFrameDistance>7</systemFrameDistance>
+    <frameSystemDistance>7</frameSystemDistance>
+    <minMeasureWidth>5</minMeasureWidth>
+    <barWidth>0.18</barWidth>
+    <doubleBarWidth>0.18</doubleBarWidth>
+    <endBarWidth>0.55</endBarWidth>
+    <doubleBarDistance>0.55</doubleBarDistance>
+    <endBarDistance>0.7</endBarDistance>
+    <repeatBarlineDotSeparation>0.7</repeatBarlineDotSeparation>
+    <repeatBarTips>0</repeatBarTips>
+    <startBarlineSingle>0</startBarlineSingle>
+    <startBarlineMultiple>1</startBarlineMultiple>
+    <bracketWidth>0.44</bracketWidth>
+    <bracketDistance>0.1</bracketDistance>
+    <akkoladeWidth>1.6</akkoladeWidth>
+    <akkoladeBarDistance>0.4</akkoladeBarDistance>
+    <dividerLeft>0</dividerLeft>
+    <dividerLeftSym>systemDivider</dividerLeftSym>
+    <dividerLeftX>0</dividerLeftX>
+    <dividerLeftY>0</dividerLeftY>
+    <dividerRight>0</dividerRight>
+    <dividerRightSym>systemDivider</dividerRightSym>
+    <dividerRightX>0</dividerRightX>
+    <dividerRightY>0</dividerRightY>
+    <clefLeftMargin>0.8</clefLeftMargin>
+    <keysigLeftMargin>0.5</keysigLeftMargin>
+    <ambitusMargin>0.5</ambitusMargin>
+    <timesigLeftMargin>0.63</timesigLeftMargin>
+    <timesigScale w="1" h="1"/>
+    <midClefKeyRightMargin>1</midClefKeyRightMargin>
+    <clefKeyRightMargin>0.8</clefKeyRightMargin>
+    <clefKeyDistance>1</clefKeyDistance>
+    <clefTimesigDistance>1</clefTimesigDistance>
+    <keyTimesigDistance>1</keyTimesigDistance>
+    <keyBarlineDistance>1</keyBarlineDistance>
+    <systemHeaderDistance>2.5</systemHeaderDistance>
+    <systemHeaderTimeSigDistance>2</systemHeaderTimeSigDistance>
+    <clefBarlineDistance>0.5</clefBarlineDistance>
+    <timesigBarlineDistance>0.5</timesigBarlineDistance>
+    <stemWidth>0.11</stemWidth>
+    <shortenStem>1</shortenStem>
+    <shortStemProgression>0.25</shortStemProgression>
+    <shortestStem>2.25</shortestStem>
+    <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
+    <minNoteDistance>0.2</minNoteDistance>
+    <barNoteDistance>1.3</barNoteDistance>
+    <barAccidentalDistance>0.65</barAccidentalDistance>
+    <multiMeasureRestMargin>1.2</multiMeasureRestMargin>
+    <noteBarDistance>1.5</noteBarDistance>
+    <measureSpacing>1.2</measureSpacing>
+    <staffLineWidth>0.11</staffLineWidth>
+    <ledgerLineWidth>0.16</ledgerLineWidth>
+    <ledgerLineLength>0.35</ledgerLineLength>
+    <accidentalDistance>0.22</accidentalDistance>
+    <accidentalNoteDistance>0.25</accidentalNoteDistance>
+    <bracketedAccidentalPadding>0.175</bracketedAccidentalPadding>
+    <alignAccidentalsLeft>0</alignAccidentalsLeft>
+    <beamWidth>0.5</beamWidth>
+    <beamDistance>0.5</beamDistance>
+    <beamMinLen>1.3</beamMinLen>
+    <beamNoSlope>0</beamNoSlope>
+    <dotMag>1</dotMag>
+    <dotNoteDistance>0.5</dotNoteDistance>
+    <dotRestDistance>0.25</dotRestDistance>
+    <dotDotDistance>0.65</dotDotDistance>
+    <propertyDistanceHead>1</propertyDistanceHead>
+    <propertyDistanceStem>1.8</propertyDistanceStem>
+    <propertyDistance>1</propertyDistance>
+    <articulationMag>1</articulationMag>
+    <articulationPosAbove x="0" y="0"/>
+    <articulationAnchorDefault>2</articulationAnchorDefault>
+    <articulationAnchorLuteFingering>4</articulationAnchorLuteFingering>
+    <articulationAnchorOther>0</articulationAnchorOther>
+    <lastSystemFillLimit>0.3</lastSystemFillLimit>
+    <hairpinPlacement>1</hairpinPlacement>
+    <hairpinPosAbove x="0" y="-2"/>
+    <hairpinPosBelow x="0" y="2"/>
+    <hairpinLinePosAbove x="0" y="-3"/>
+    <hairpinLinePosBelow x="0" y="4"/>
+    <hairpinHeight>1.15</hairpinHeight>
+    <hairpinContHeight>0.5</hairpinContHeight>
+    <hairpinWidth>0.12</hairpinWidth>
+    <hairpinFontFace>Edwin</hairpinFontFace>
+    <hairpinFontSize>10</hairpinFontSize>
+    <hairpinLineSpacing>1</hairpinLineSpacing>
+    <hairpinFontSpatiumDependent>1</hairpinFontSpatiumDependent>
+    <hairpinFontStyle>2</hairpinFontStyle>
+    <hairpinColor r="0" g="0" b="0" a="255"/>
+    <hairpinTextAlign>left,baseline</hairpinTextAlign>
+    <hairpinFrameType>0</hairpinFrameType>
+    <hairpinFramePadding>0.2</hairpinFramePadding>
+    <hairpinFrameWidth>0.1</hairpinFrameWidth>
+    <hairpinFrameRound>0</hairpinFrameRound>
+    <hairpinFrameFgColor r="0" g="0" b="0" a="255"/>
+    <hairpinFrameBgColor r="255" g="255" b="255" a="0"/>
+    <hairpinText></hairpinText>
+    <hairpinCrescText>cresc.</hairpinCrescText>
+    <hairpinDecrescText>dim.</hairpinDecrescText>
+    <hairpinCrescContText>(cresc.)</hairpinCrescContText>
+    <hairpinDecrescContText>(dim.)</hairpinDecrescContText>
+    <hairpinLineStyle>1</hairpinLineStyle>
+    <hairpinLineLineStyle>6</hairpinLineLineStyle>
+    <pedalPlacement>1</pedalPlacement>
+    <pedalPosAbove x="0" y="-1"/>
+    <pedalPosBelow x="0" y="2.5"/>
+    <pedalLineWidth>0.11</pedalLineWidth>
+    <pedalListStyle>1</pedalListStyle>
+    <pedalBeginTextOffset x="0" y="0.15"/>
+    <pedalHookHeight>-1.2</pedalHookHeight>
+    <pedalFontFace>Edwin</pedalFontFace>
+    <pedalFontSize>12</pedalFontSize>
+    <pedalLineSpacing>1</pedalLineSpacing>
+    <pedalFontSpatiumDependent>1</pedalFontSpatiumDependent>
+    <pedalFontStyle>0</pedalFontStyle>
+    <pedalColor r="0" g="0" b="0" a="255"/>
+    <pedalTextAlign>left,baseline</pedalTextAlign>
+    <pedalFrameType>0</pedalFrameType>
+    <pedalFramePadding>0.2</pedalFramePadding>
+    <pedalFrameWidth>0.1</pedalFrameWidth>
+    <pedalFrameRound>0</pedalFrameRound>
+    <pedalFrameFgColor r="0" g="0" b="0" a="255"/>
+    <pedalFrameBgColor r="255" g="255" b="255" a="0"/>
+    <trillPlacement>0</trillPlacement>
+    <trillPosAbove x="0" y="-0.5"/>
+    <trillPosBelow x="0" y="2"/>
+    <vibratoPlacement>0</vibratoPlacement>
+    <vibratoPosAbove x="0" y="-1"/>
+    <vibratoPosBelow x="0" y="1"/>
+    <harmonyFretDist>1</harmonyFretDist>
+    <minHarmonyDistance>0.5</minHarmonyDistance>
+    <maxHarmonyBarDistance>3</maxHarmonyBarDistance>
+    <maxChordShiftAbove>0</maxChordShiftAbove>
+    <maxChordShiftBelow>0</maxChordShiftBelow>
+    <harmonyPlacement>0</harmonyPlacement>
+    <romanNumeralPlacement>1</romanNumeralPlacement>
+    <nashvilleNumberPlacement>0</nashvilleNumberPlacement>
+    <harmonyPlay>1</harmonyPlay>
+    <harmonyVoiceLiteral>1</harmonyVoiceLiteral>
+    <harmonyVoicing>0</harmonyVoicing>
+    <harmonyDuration>0</harmonyDuration>
+    <chordSymbolPosAbove x="0" y="-2.5"/>
+    <chordSymbolPosBelow x="0" y="3.5"/>
+    <chordSymbolBPosAbove x="0" y="-5"/>
+    <chordSymbolBPosBelow x="0" y="3.5"/>
+    <romanNumeralPosAbove x="0" y="-2.5"/>
+    <romanNumeralPosBelow x="0" y="3.5"/>
+    <nashvilleNumberPosAbove x="0" y="-2.5"/>
+    <nashvilleNumberPosBelow x="0" y="3.5"/>
+    <chordSymbolAFontFace>Edwin</chordSymbolAFontFace>
+    <chordSymbolAFontSize>11</chordSymbolAFontSize>
+    <chordSymbolALineSpacing>1</chordSymbolALineSpacing>
+    <chordSymbolAFontSpatiumDependent>1</chordSymbolAFontSpatiumDependent>
+    <chordSymbolAFontStyle>0</chordSymbolAFontStyle>
+    <chordSymbolAColor r="0" g="0" b="0" a="255"/>
+    <chordSymbolAAlign>left,baseline</chordSymbolAAlign>
+    <chordSymbolAFrameType>0</chordSymbolAFrameType>
+    <chordSymbolAFramePadding>0.2</chordSymbolAFramePadding>
+    <chordSymbolAFrameWidth>0.1</chordSymbolAFrameWidth>
+    <chordSymbolAFrameRound>0</chordSymbolAFrameRound>
+    <chordSymbolAFrameFgColor r="0" g="0" b="0" a="255"/>
+    <chordSymbolAFrameBgColor r="255" g="255" b="255" a="0"/>
+    <chordSymbolBFontFace>Edwin</chordSymbolBFontFace>
+    <chordSymbolBFontSize>11</chordSymbolBFontSize>
+    <chordSymbolBLineSpacing>1</chordSymbolBLineSpacing>
+    <chordSymbolBFontSpatiumDependent>1</chordSymbolBFontSpatiumDependent>
+    <chordSymbolBFontStyle>2</chordSymbolBFontStyle>
+    <chordSymbolBColor r="0" g="0" b="0" a="255"/>
+    <chordSymbolBAlign>left,baseline</chordSymbolBAlign>
+    <chordSymbolBFrameType>0</chordSymbolBFrameType>
+    <chordSymbolBFramePadding>0.2</chordSymbolBFramePadding>
+    <chordSymbolBFrameWidth>0.1</chordSymbolBFrameWidth>
+    <chordSymbolBFrameRound>0</chordSymbolBFrameRound>
+    <chordSymbolBFrameFgColor r="0" g="0" b="0" a="255"/>
+    <chordSymbolBFrameBgColor r="255" g="255" b="255" a="0"/>
+    <romanNumeralFontFace>Campania</romanNumeralFontFace>
+    <romanNumeralFontSize>12</romanNumeralFontSize>
+    <romanNumeralLineSpacing>1</romanNumeralLineSpacing>
+    <romanNumeralFontSpatiumDependent>1</romanNumeralFontSpatiumDependent>
+    <romanNumeralFontStyle>0</romanNumeralFontStyle>
+    <romanNumeralColor r="0" g="0" b="0" a="255"/>
+    <romanNumeralAlign>left,baseline</romanNumeralAlign>
+    <romanNumeralFrameType>0</romanNumeralFrameType>
+    <romanNumeralFramePadding>0.2</romanNumeralFramePadding>
+    <romanNumeralFrameWidth>0.1</romanNumeralFrameWidth>
+    <romanNumeralFrameRound>0</romanNumeralFrameRound>
+    <romanNumeralFrameFgColor r="0" g="0" b="0" a="255"/>
+    <romanNumeralFrameBgColor r="255" g="255" b="255" a="0"/>
+    <nashvilleNumberFontFace>Edwin</nashvilleNumberFontFace>
+    <nashvilleNumberFontSize>12</nashvilleNumberFontSize>
+    <nashvilleNumberLineSpacing>1</nashvilleNumberLineSpacing>
+    <nashvilleNumberFontSpatiumDependent>1</nashvilleNumberFontSpatiumDependent>
+    <nashvilleNumberFontStyle>0</nashvilleNumberFontStyle>
+    <nashvilleNumberColor r="0" g="0" b="0" a="255"/>
+    <nashvilleNumberAlign>left,baseline</nashvilleNumberAlign>
+    <nashvilleNumberFrameType>0</nashvilleNumberFrameType>
+    <nashvilleNumberFramePadding>0.2</nashvilleNumberFramePadding>
+    <nashvilleNumberFrameWidth>0.1</nashvilleNumberFrameWidth>
+    <nashvilleNumberFrameRound>0</nashvilleNumberFrameRound>
+    <nashvilleNumberFrameFgColor r="0" g="0" b="0" a="255"/>
+    <nashvilleNumberFrameBgColor r="255" g="255" b="255" a="0"/>
+    <capoPosition>0</capoPosition>
+    <fretNumMag>2</fretNumMag>
+    <fretNumPos>0</fretNumPos>
+    <fretY>1</fretY>
+    <fretMinDistance>0.5</fretMinDistance>
+    <fretMag>1</fretMag>
+    <fretPlacement>0</fretPlacement>
+    <fretStrings>6</fretStrings>
+    <fretFrets>5</fretFrets>
+    <fretNut>1</fretNut>
+    <fretDotSize>1</fretDotSize>
+    <fretStringSpacing>0.7</fretStringSpacing>
+    <fretFretSpacing>0.8</fretFretSpacing>
+    <fretOrientation>0</fretOrientation>
+    <maxFretShiftAbove>0</maxFretShiftAbove>
+    <maxFretShiftBelow>0</maxFretShiftBelow>
+    <showPageNumber>1</showPageNumber>
+    <showPageNumberOne>0</showPageNumberOne>
+    <pageNumberOddEven>1</pageNumberOddEven>
+    <showMeasureNumber>1</showMeasureNumber>
+    <showMeasureNumberOne>0</showMeasureNumberOne>
+    <measureNumberInterval>5</measureNumberInterval>
+    <measureNumberSystem>1</measureNumberSystem>
+    <measureNumberAllStaffs>0</measureNumberAllStaffs>
+    <smallNoteMag>0.7</smallNoteMag>
+    <graceNoteMag>0.7</graceNoteMag>
+    <smallStaffMag>0.7</smallStaffMag>
+    <smallClefMag>0.8</smallClefMag>
+    <genClef>1</genClef>
+    <genKeysig>1</genKeysig>
+    <genCourtesyTimesig>1</genCourtesyTimesig>
+    <genCourtesyKeysig>1</genCourtesyKeysig>
+    <genCourtesyClef>1</genCourtesyClef>
+    <swingRatio>60</swingRatio>
+    <swingUnit></swingUnit>
+    <useStandardNoteNames>1</useStandardNoteNames>
+    <useGermanNoteNames>0</useGermanNoteNames>
+    <useFullGermanNoteNames>0</useFullGermanNoteNames>
+    <useSolfeggioNoteNames>0</useSolfeggioNoteNames>
+    <useFrenchNoteNames>0</useFrenchNoteNames>
+    <automaticCapitalization>1</automaticCapitalization>
+    <lowerCaseMinorChords>0</lowerCaseMinorChords>
+    <lowerCaseBassNotes>0</lowerCaseBassNotes>
+    <allCapsNoteNames>0</allCapsNoteNames>
+    <chordStyle>std</chordStyle>
+    <chordsXmlFile>0</chordsXmlFile>
+    <chordDescriptionFile>chords_std.xml</chordDescriptionFile>
+    <chordExtensionMag>1</chordExtensionMag>
+    <chordExtensionAdjust>0</chordExtensionAdjust>
+    <chordModifierMag>1</chordModifierMag>
+    <chordModifierAdjust>0</chordModifierAdjust>
+    <concertPitch>0</concertPitch>
+    <createMultiMeasureRests>0</createMultiMeasureRests>
+    <minEmptyMeasures>2</minEmptyMeasures>
+    <minMMRestWidth>4</minMMRestWidth>
+    <mmRestNumberPos>-1.5</mmRestNumberPos>
+    <hideEmptyStaves>0</hideEmptyStaves>
+    <dontHidStavesInFirstSystm>1</dontHidStavesInFirstSystm>
+    <enableIndentationOnFirstSystem>1</enableIndentationOnFirstSystem>
+    <firstSystemIndentationValue>5</firstSystemIndentationValue>
+    <alwaysShowBracketsWhenEmptyStavesAreHidden>0</alwaysShowBracketsWhenEmptyStavesAreHidden>
+    <hideInstrumentNameIfOneInstrument>1</hideInstrumentNameIfOneInstrument>
+    <gateTime>100</gateTime>
+    <tenutoGateTime>100</tenutoGateTime>
+    <staccatoGateTime>50</staccatoGateTime>
+    <slurGateTime>100</slurGateTime>
+    <ArpeggioNoteDistance>0.5</ArpeggioNoteDistance>
+    <ArpeggioLineWidth>0.18</ArpeggioLineWidth>
+    <ArpeggioHookLen>0.8</ArpeggioHookLen>
+    <ArpeggioHiddenInStdIfTab>0</ArpeggioHiddenInStdIfTab>
+    <slurEndWidth>0.07</slurEndWidth>
+    <slurMidWidth>0.21</slurMidWidth>
+    <slurDottedWidth>0.1</slurDottedWidth>
+    <minTieLength>1</minTieLength>
+    <slurMinDistance>0.5</slurMinDistance>
+    <sectionPause>3</sectionPause>
+    <musicalSymbolFont>Leland</musicalSymbolFont>
+    <musicalTextFont>Leland Text</musicalTextFont>
+    <showHeader>1</showHeader>
+    <headerFirstPage>0</headerFirstPage>
+    <headerOddEven>1</headerOddEven>
+    <evenHeaderL>$p</evenHeaderL>
+    <evenHeaderC></evenHeaderC>
+    <evenHeaderR></evenHeaderR>
+    <oddHeaderL></oddHeaderL>
+    <oddHeaderC></oddHeaderC>
+    <oddHeaderR>$p</oddHeaderR>
+    <showFooter>1</showFooter>
+    <footerFirstPage>1</footerFirstPage>
+    <footerOddEven>1</footerOddEven>
+    <evenFooterL></evenFooterL>
+    <evenFooterC>$:copyright:</evenFooterC>
+    <evenFooterR></evenFooterR>
+    <oddFooterL></oddFooterL>
+    <oddFooterC>$:copyright:</oddFooterC>
+    <oddFooterR></oddFooterR>
+    <voltaPosAbove x="0" y="-3"/>
+    <voltaHook>2.2</voltaHook>
+    <voltaLineWidth>0.11</voltaLineWidth>
+    <voltaLineStyle>1</voltaLineStyle>
+    <voltaFontFace>Edwin</voltaFontFace>
+    <voltaFontSize>11</voltaFontSize>
+    <voltaLineSpacing>1</voltaLineSpacing>
+    <voltaFontSpatiumDependent>1</voltaFontSpatiumDependent>
+    <voltaFontStyle>1</voltaFontStyle>
+    <voltaColor r="0" g="0" b="0" a="255"/>
+    <voltaAlign>left,baseline</voltaAlign>
+    <voltaOffset x="0.6" y="2.2"/>
+    <voltaFrameType>0</voltaFrameType>
+    <voltaFramePadding>0.2</voltaFramePadding>
+    <voltaFrameWidth>0.1</voltaFrameWidth>
+    <voltaFrameRound>0</voltaFrameRound>
+    <voltaFrameFgColor r="0" g="0" b="0" a="255"/>
+    <voltaFrameBgColor r="255" g="255" b="255" a="0"/>
+    <ottava8VAPlacement>0</ottava8VAPlacement>
+    <ottava8VBPlacement>1</ottava8VBPlacement>
+    <ottava15MAPlacement>0</ottava15MAPlacement>
+    <ottava15MBPlacement>1</ottava15MBPlacement>
+    <ottava22MAPlacement>0</ottava22MAPlacement>
+    <ottava22MBPlacement>1</ottava22MBPlacement>
+    <ottava8VAText>&lt;sym&gt;ottavaAlta&lt;/sym&gt;</ottava8VAText>
+    <ottava8VAContinueText>&lt;sym&gt;ottavaAlta&lt;/sym&gt;</ottava8VAContinueText>
+    <ottava8VBText>&lt;sym&gt;ottavaBassa&lt;/sym&gt;</ottava8VBText>
+    <ottava8VBContinueText>&lt;sym&gt;ottavaBassa&lt;/sym&gt;</ottava8VBContinueText>
+    <ottava15MAText>&lt;sym&gt;quindicesimaAlta&lt;/sym&gt;</ottava15MAText>
+    <ottava15MAContinueText>&lt;sym&gt;quindicesimaAlta&lt;/sym&gt;</ottava15MAContinueText>
+    <ottava15MBText>&lt;sym&gt;quindicesimaBassa&lt;/sym&gt;</ottava15MBText>
+    <ottava15MBContinueText>&lt;sym&gt;quindicesimaBassa&lt;/sym&gt;</ottava15MBContinueText>
+    <ottava22MAText>&lt;sym&gt;ventiduesimaAlta&lt;/sym&gt;</ottava22MAText>
+    <ottava22MAContinueText>&lt;sym&gt;ventiduesimaAlta&lt;/sym&gt;</ottava22MAContinueText>
+    <ottava22MBText>&lt;sym&gt;ventiduesimaBassa&lt;/sym&gt;</ottava22MBText>
+    <ottava22MBContinueText>&lt;sym&gt;ventiduesimaBassa&lt;/sym&gt;</ottava22MBContinueText>
+    <ottava8VAnoText>&lt;sym&gt;ottava&lt;/sym&gt;</ottava8VAnoText>
+    <ottava8VAnoContinueText>&lt;sym&gt;ottava&lt;/sym&gt;</ottava8VAnoContinueText>
+    <ottava8VBnoText>&lt;sym&gt;ottava&lt;/sym&gt;</ottava8VBnoText>
+    <ottava8VBnoContinueText>&lt;sym&gt;ottava&lt;/sym&gt;</ottava8VBnoContinueText>
+    <ottava15MAnoText>&lt;sym&gt;quindicesima&lt;/sym&gt;</ottava15MAnoText>
+    <ottava15MAnoContinueText>&lt;sym&gt;quindicesima&lt;/sym&gt;</ottava15MAnoContinueText>
+    <ottava15MBnoText>&lt;sym&gt;quindicesima&lt;/sym&gt;</ottava15MBnoText>
+    <ottava15MBnoContinueText>&lt;sym&gt;quindicesima&lt;/sym&gt;</ottava15MBnoContinueText>
+    <ottava22MAnoText>&lt;sym&gt;ventiduesima&lt;/sym&gt;</ottava22MAnoText>
+    <ottava22MAnoContinueText>&lt;sym&gt;ventiduesima&lt;/sym&gt;</ottava22MAnoContinueText>
+    <ottava22MBnoText>&lt;sym&gt;ventiduesima&lt;/sym&gt;</ottava22MBnoText>
+    <ottava22MBnoContinueText>&lt;sym&gt;ventiduesima&lt;/sym&gt;</ottava22MBnoContinueText>
+    <ottavaPosAbove x="0" y="-2"/>
+    <ottavaPosBelow x="0" y="2"/>
+    <ottavaHookAbove>1</ottavaHookAbove>
+    <ottavaHookBelow>-1</ottavaHookBelow>
+    <ottavaLineWidth>0.11</ottavaLineWidth>
+    <ottavaLineStyle>2</ottavaLineStyle>
+    <ottavaNumbersOnly>1</ottavaNumbersOnly>
+    <ottavaFontFace>Edwin</ottavaFontFace>
+    <ottavaFontSize>10</ottavaFontSize>
+    <ottavaLineSpacing>1</ottavaLineSpacing>
+    <ottavaFontSpatiumDependent>1</ottavaFontSpatiumDependent>
+    <ottavaFontStyle>0</ottavaFontStyle>
+    <ottavaColor r="0" g="0" b="0" a="255"/>
+    <ottavaTextAlign>left,center</ottavaTextAlign>
+    <ottavaFrameType>0</ottavaFrameType>
+    <ottavaFramePadding>0.2</ottavaFramePadding>
+    <ottavaFrameWidth>0.1</ottavaFrameWidth>
+    <ottavaFrameRound>0</ottavaFrameRound>
+    <ottavaFrameFgColor r="0" g="0" b="0" a="255"/>
+    <ottavaFrameBgColor r="255" g="255" b="255" a="0"/>
+    <tabClef>31</tabClef>
+    <tremoloWidth>1.2</tremoloWidth>
+    <tremoloBoxHeight>0.65</tremoloBoxHeight>
+    <tremoloLineWidth>0.5</tremoloLineWidth>
+    <tremoloDistance>0.8</tremoloDistance>
+    <tremoloStrokeStyle>0</tremoloStrokeStyle>
+    <tremoloStrokeLengthMultiplier>0.62</tremoloStrokeLengthMultiplier>
+    <linearStretch>1.5</linearStretch>
+    <crossMeasureValues>0</crossMeasureValues>
+    <keySigNaturals>0</keySigNaturals>
+    <tupletMaxSlope>0.5</tupletMaxSlope>
+    <tupletOufOfStaff>1</tupletOufOfStaff>
+    <tupletVHeadDistance>0.5</tupletVHeadDistance>
+    <tupletVStemDistance>0.5</tupletVStemDistance>
+    <tupletStemLeftDistance>0</tupletStemLeftDistance>
+    <tupletStemRightDistance>0.5</tupletStemRightDistance>
+    <tupletNoteLeftDistance>-0.5</tupletNoteLeftDistance>
+    <tupletNoteRightDistance>0</tupletNoteRightDistance>
+    <tupletBracketWidth>0.1</tupletBracketWidth>
+    <tupletDirection>0</tupletDirection>
+    <tupletNumberType>0</tupletNumberType>
+    <tupletBracketType>0</tupletBracketType>
+    <tupletFontFace>Edwin</tupletFontFace>
+    <tupletFontSize>9</tupletFontSize>
+    <tupletLineSpacing>1</tupletLineSpacing>
+    <tupletFontSpatiumDependent>1</tupletFontSpatiumDependent>
+    <tupletFontStyle>2</tupletFontStyle>
+    <tupletColor r="0" g="0" b="0" a="255"/>
+    <tupletAlign>center,center</tupletAlign>
+    <tupletBracketHookHeight>0.75</tupletBracketHookHeight>
+    <tupletOffset x="0" y="0"/>
+    <tupletFrameType>0</tupletFrameType>
+    <tupletFramePadding>0.2</tupletFramePadding>
+    <tupletFrameWidth>0.1</tupletFrameWidth>
+    <tupletFrameRound>0</tupletFrameRound>
+    <tupletFrameFgColor r="0" g="0" b="0" a="255"/>
+    <tupletFrameBgColor r="255" g="255" b="255" a="0"/>
+    <barreLineWidth>1</barreLineWidth>
+    <scaleBarlines>1</scaleBarlines>
+    <barGraceDistance>1</barGraceDistance>
+    <minVerticalDistance>0.5</minVerticalDistance>
+    <ornamentStyle>0</ornamentStyle>
+    <autoplaceHairpinDynamicsDistance>0.5</autoplaceHairpinDynamicsDistance>
+    <dynamicsPlacement>1</dynamicsPlacement>
+    <dynamicsPosAbove x="0" y="-1.5"/>
+    <dynamicsPosBelow x="0" y="2.5"/>
+    <dynamicsMinDistance>0.5</dynamicsMinDistance>
+    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
+    <textLinePlacement>0</textLinePlacement>
+    <textLinePosAbove x="0" y="-1"/>
+    <textLinePosBelow x="0" y="1"/>
+    <textLineFrameType>0</textLineFrameType>
+    <textLineFramePadding>0.2</textLineFramePadding>
+    <textLineFrameWidth>0.1</textLineFrameWidth>
+    <textLineFrameRound>0</textLineFrameRound>
+    <textLineFrameFgColor r="0" g="0" b="0" a="255"/>
+    <textLineFrameBgColor r="255" g="255" b="255" a="0"/>
+    <systemTextLinePlacement>0</systemTextLinePlacement>
+    <systemTextLinePosAbove x="0" y="-1"/>
+    <systemTextLinePosBelow x="0" y="1"/>
+    <systemTextLineFrameType>0</systemTextLineFrameType>
+    <systemTextLineFramePadding>0.2</systemTextLineFramePadding>
+    <systemTextLineFrameWidth>0.1</systemTextLineFrameWidth>
+    <systemTextLineFrameRound>0</systemTextLineFrameRound>
+    <systemTextLineFrameFgColor r="0" g="0" b="0" a="255"/>
+    <systemTextLineFrameBgColor r="255" g="255" b="255" a="0"/>
+    <tremoloBarLineWidth>0.12</tremoloBarLineWidth>
+    <jumpPosAbove x="0" y="-2"/>
+    <markerPosAbove x="0" y="-2"/>
+    <defaultFontFace>Edwin</defaultFontFace>
+    <defaultFontSize>10</defaultFontSize>
+    <defaultLineSpacing>1</defaultLineSpacing>
+    <defaultFontSpatiumDependent>1</defaultFontSpatiumDependent>
+    <defaultFontStyle>0</defaultFontStyle>
+    <defaultColor r="0" g="0" b="0" a="255"/>
+    <defaultAlign>left,top</defaultAlign>
+    <defaultFrameType>0</defaultFrameType>
+    <defaultFramePadding>0.2</defaultFramePadding>
+    <defaultFrameWidth>0.1</defaultFrameWidth>
+    <defaultFrameRound>0</defaultFrameRound>
+    <defaultFrameFgColor r="0" g="0" b="0" a="255"/>
+    <defaultFrameBgColor r="255" g="255" b="255" a="0"/>
+    <defaultOffset x="0" y="0"/>
+    <defaultOffsetType>1</defaultOffsetType>
+    <defaultSystemFlag>0</defaultSystemFlag>
+    <defaultText></defaultText>
+    <titleFontFace>Edwin</titleFontFace>
+    <titleFontSize>22</titleFontSize>
+    <titleLineSpacing>1</titleLineSpacing>
+    <titleFontSpatiumDependent>0</titleFontSpatiumDependent>
+    <titleFontStyle>0</titleFontStyle>
+    <titleColor r="0" g="0" b="0" a="255"/>
+    <titleAlign>center,top</titleAlign>
+    <titleOffset x="0" y="0"/>
+    <titleOffsetType>0</titleOffsetType>
+    <titleFrameType>0</titleFrameType>
+    <titleFramePadding>0.2</titleFramePadding>
+    <titleFrameWidth>0.1</titleFrameWidth>
+    <titleFrameRound>0</titleFrameRound>
+    <titleFrameFgColor r="0" g="0" b="0" a="255"/>
+    <titleFrameBgColor r="255" g="255" b="255" a="0"/>
+    <subTitleFontFace>Edwin</subTitleFontFace>
+    <subTitleFontSize>16</subTitleFontSize>
+    <subTitleLineSpacing>1</subTitleLineSpacing>
+    <subTitleFontSpatiumDependent>0</subTitleFontSpatiumDependent>
+    <subTitleFontStyle>0</subTitleFontStyle>
+    <subTitleColor r="0" g="0" b="0" a="255"/>
+    <subTitleAlign>center,top</subTitleAlign>
+    <subTitleOffset x="0" y="10"/>
+    <subTitleOffsetType>0</subTitleOffsetType>
+    <subTitleFrameType>0</subTitleFrameType>
+    <subTitleFramePadding>0.2</subTitleFramePadding>
+    <subTitleFrameWidth>0.1</subTitleFrameWidth>
+    <subTitleFrameRound>0</subTitleFrameRound>
+    <subTitleFrameFgColor r="0" g="0" b="0" a="255"/>
+    <subTitleFrameBgColor r="255" g="255" b="255" a="0"/>
+    <composerFontFace>Edwin</composerFontFace>
+    <composerFontSize>10</composerFontSize>
+    <composerLineSpacing>1</composerLineSpacing>
+    <composerFontSpatiumDependent>0</composerFontSpatiumDependent>
+    <composerFontStyle>0</composerFontStyle>
+    <composerColor r="0" g="0" b="0" a="255"/>
+    <composerAlign>right,bottom</composerAlign>
+    <composerOffset x="0" y="0"/>
+    <composerOffsetType>0</composerOffsetType>
+    <composerFrameType>0</composerFrameType>
+    <composerFramePadding>0.2</composerFramePadding>
+    <composerFrameWidth>0.1</composerFrameWidth>
+    <composerFrameRound>0</composerFrameRound>
+    <composerFrameFgColor r="0" g="0" b="0" a="255"/>
+    <composerFrameBgColor r="255" g="255" b="255" a="0"/>
+    <lyricistFontFace>Edwin</lyricistFontFace>
+    <lyricistFontSize>10</lyricistFontSize>
+    <lyricistLineSpacing>1</lyricistLineSpacing>
+    <lyricistFontSpatiumDependent>0</lyricistFontSpatiumDependent>
+    <lyricistFontStyle>0</lyricistFontStyle>
+    <lyricistColor r="0" g="0" b="0" a="255"/>
+    <lyricistAlign>left,bottom</lyricistAlign>
+    <lyricistOffset x="0" y="0"/>
+    <lyricistOffsetType>0</lyricistOffsetType>
+    <lyricistFrameType>0</lyricistFrameType>
+    <lyricistFramePadding>0.2</lyricistFramePadding>
+    <lyricistFrameWidth>0.1</lyricistFrameWidth>
+    <lyricistFrameRound>0</lyricistFrameRound>
+    <lyricistFrameFgColor r="0" g="0" b="0" a="255"/>
+    <lyricistFrameBgColor r="255" g="255" b="255" a="0"/>
+    <fingeringFontFace>Edwin</fingeringFontFace>
+    <fingeringFontSize>8</fingeringFontSize>
+    <fingeringLineSpacing>1</fingeringLineSpacing>
+    <fingeringFontSpatiumDependent>1</fingeringFontSpatiumDependent>
+    <fingeringFontStyle>0</fingeringFontStyle>
+    <fingeringColor r="0" g="0" b="0" a="255"/>
+    <fingeringAlign>center,center</fingeringAlign>
+    <fingeringFrameType>0</fingeringFrameType>
+    <fingeringFramePadding>0.2</fingeringFramePadding>
+    <fingeringFrameWidth>0.1</fingeringFrameWidth>
+    <fingeringFrameRound>0</fingeringFrameRound>
+    <fingeringFrameFgColor r="0" g="0" b="0" a="255"/>
+    <fingeringFrameBgColor r="255" g="255" b="255" a="0"/>
+    <fingeringOffset x="0" y="0"/>
+    <lhGuitarFingeringFontFace>Edwin</lhGuitarFingeringFontFace>
+    <lhGuitarFingeringFontSize>8</lhGuitarFingeringFontSize>
+    <lhGuitarFingeringLineSpacing>1</lhGuitarFingeringLineSpacing>
+    <lhGuitarFingeringFontSpatiumDependent>1</lhGuitarFingeringFontSpatiumDependent>
+    <lhGuitarFingeringFontStyle>0</lhGuitarFingeringFontStyle>
+    <lhGuitarFingeringColor r="0" g="0" b="0" a="255"/>
+    <lhGuitarFingeringAlign>right,center</lhGuitarFingeringAlign>
+    <lhGuitarFingeringFrameType>0</lhGuitarFingeringFrameType>
+    <lhGuitarFingeringFramePadding>0.2</lhGuitarFingeringFramePadding>
+    <lhGuitarFingeringFrameWidth>0.1</lhGuitarFingeringFrameWidth>
+    <lhGuitarFingeringFrameRound>0</lhGuitarFingeringFrameRound>
+    <lhGuitarFingeringFrameFgColor r="0" g="0" b="0" a="255"/>
+    <lhGuitarFingeringFrameBgColor r="255" g="255" b="255" a="0"/>
+    <lhGuitarFingeringOffset x="-0.5" y="0"/>
+    <rhGuitarFingeringFontFace>Edwin</rhGuitarFingeringFontFace>
+    <rhGuitarFingeringFontSize>8</rhGuitarFingeringFontSize>
+    <rhGuitarFingeringLineSpacing>1</rhGuitarFingeringLineSpacing>
+    <rhGuitarFingeringFontSpatiumDependent>1</rhGuitarFingeringFontSpatiumDependent>
+    <rhGuitarFingeringFontStyle>2</rhGuitarFingeringFontStyle>
+    <rhGuitarFingeringColor r="0" g="0" b="0" a="255"/>
+    <rhGuitarFingeringAlign>center,center</rhGuitarFingeringAlign>
+    <rhGuitarFingeringFrameType>0</rhGuitarFingeringFrameType>
+    <rhGuitarFingeringFramePadding>0.2</rhGuitarFingeringFramePadding>
+    <rhGuitarFingeringFrameWidth>0.1</rhGuitarFingeringFrameWidth>
+    <rhGuitarFingeringFrameRound>0</rhGuitarFingeringFrameRound>
+    <rhGuitarFingeringFrameFgColor r="0" g="0" b="0" a="255"/>
+    <rhGuitarFingeringFrameBgColor r="255" g="255" b="255" a="0"/>
+    <rhGuitarFingeringOffset x="0" y="0"/>
+    <stringNumberFontFace>Edwin</stringNumberFontFace>
+    <stringNumberFontSize>8</stringNumberFontSize>
+    <stringNumberLineSpacing>1</stringNumberLineSpacing>
+    <stringNumberFontSpatiumDependent>1</stringNumberFontSpatiumDependent>
+    <stringNumberFontStyle>0</stringNumberFontStyle>
+    <stringNumberColor r="0" g="0" b="0" a="255"/>
+    <stringNumberAlign>center,center</stringNumberAlign>
+    <stringNumberFrameType>2</stringNumberFrameType>
+    <stringNumberFramePadding>0.2</stringNumberFramePadding>
+    <stringNumberFrameWidth>0.1</stringNumberFrameWidth>
+    <stringNumberFrameRound>0</stringNumberFrameRound>
+    <stringNumberFrameFgColor r="0" g="0" b="0" a="255"/>
+    <stringNumberFrameBgColor r="255" g="255" b="255" a="0"/>
+    <stringNumberOffset x="0" y="0"/>
+    <longInstrumentFontFace>Edwin</longInstrumentFontFace>
+    <longInstrumentFontSize>10</longInstrumentFontSize>
+    <longInstrumentLineSpacing>1</longInstrumentLineSpacing>
+    <longInstrumentFontSpatiumDependent>1</longInstrumentFontSpatiumDependent>
+    <longInstrumentFontStyle>0</longInstrumentFontStyle>
+    <longInstrumentColor r="0" g="0" b="0" a="255"/>
+    <longInstrumentAlign>right,center</longInstrumentAlign>
+    <longInstrumentOffset x="0" y="0"/>
+    <longInstrumentFrameType>0</longInstrumentFrameType>
+    <longInstrumentFramePadding>0.2</longInstrumentFramePadding>
+    <longInstrumentFrameWidth>0.1</longInstrumentFrameWidth>
+    <longInstrumentFrameRound>0</longInstrumentFrameRound>
+    <longInstrumentFrameFgColor r="0" g="0" b="0" a="255"/>
+    <longInstrumentFrameBgColor r="255" g="255" b="255" a="0"/>
+    <shortInstrumentFontFace>Edwin</shortInstrumentFontFace>
+    <shortInstrumentFontSize>10</shortInstrumentFontSize>
+    <shortInstrumentLineSpacing>1</shortInstrumentLineSpacing>
+    <shortInstrumentFontSpatiumDependent>1</shortInstrumentFontSpatiumDependent>
+    <shortInstrumentFontStyle>0</shortInstrumentFontStyle>
+    <shortInstrumentColor r="0" g="0" b="0" a="255"/>
+    <shortInstrumentAlign>right,center</shortInstrumentAlign>
+    <shortInstrumentOffset x="0" y="0"/>
+    <shortInstrumentFrameType>0</shortInstrumentFrameType>
+    <shortInstrumentFramePadding>0.2</shortInstrumentFramePadding>
+    <shortInstrumentFrameWidth>0.1</shortInstrumentFrameWidth>
+    <shortInstrumentFrameRound>0</shortInstrumentFrameRound>
+    <shortInstrumentFrameFgColor r="0" g="0" b="0" a="255"/>
+    <shortInstrumentFrameBgColor r="255" g="255" b="255" a="0"/>
+    <partInstrumentFontFace>Edwin</partInstrumentFontFace>
+    <partInstrumentFontSize>14</partInstrumentFontSize>
+    <partInstrumentLineSpacing>1</partInstrumentLineSpacing>
+    <partInstrumentFontSpatiumDependent>0</partInstrumentFontSpatiumDependent>
+    <partInstrumentFontStyle>0</partInstrumentFontStyle>
+    <partInstrumentColor r="0" g="0" b="0" a="255"/>
+    <partInstrumentAlign>left,top</partInstrumentAlign>
+    <partInstrumentOffset x="0" y="0"/>
+    <partInstrumentFrameType>0</partInstrumentFrameType>
+    <partInstrumentFramePadding>0.2</partInstrumentFramePadding>
+    <partInstrumentFrameWidth>0.1</partInstrumentFrameWidth>
+    <partInstrumentFrameRound>0</partInstrumentFrameRound>
+    <partInstrumentFrameFgColor r="0" g="0" b="0" a="255"/>
+    <partInstrumentFrameBgColor r="255" g="255" b="255" a="0"/>
+    <dynamicsFontFace>Edwin</dynamicsFontFace>
+    <dynamicsFontSize>11</dynamicsFontSize>
+    <dynamicsLineSpacing>1</dynamicsLineSpacing>
+    <dynamicsFontSpatiumDependent>1</dynamicsFontSpatiumDependent>
+    <dynamicsFontStyle>2</dynamicsFontStyle>
+    <dynamicsColor r="0" g="0" b="0" a="255"/>
+    <dynamicsAlign>center,baseline</dynamicsAlign>
+    <dynamicsFrameType>0</dynamicsFrameType>
+    <dynamicsFramePadding>0.2</dynamicsFramePadding>
+    <dynamicsFrameWidth>0.1</dynamicsFrameWidth>
+    <dynamicsFrameRound>0</dynamicsFrameRound>
+    <dynamicsFrameFgColor r="0" g="0" b="0" a="255"/>
+    <dynamicsFrameBgColor r="255" g="255" b="255" a="0"/>
+    <expressionFontFace>Edwin</expressionFontFace>
+    <expressionFontSize>10</expressionFontSize>
+    <expressionLineSpacing>1</expressionLineSpacing>
+    <expressionFontSpatiumDependent>1</expressionFontSpatiumDependent>
+    <expressionFontStyle>2</expressionFontStyle>
+    <expressionColor r="0" g="0" b="0" a="255"/>
+    <expressionAlign>left,baseline</expressionAlign>
+    <expressionPlacement>1</expressionPlacement>
+    <expressionOffset x="0" y="2.5"/>
+    <expressionFrameType>0</expressionFrameType>
+    <expressionFramePadding>0.2</expressionFramePadding>
+    <expressionFrameWidth>0.1</expressionFrameWidth>
+    <expressionFrameRound>0</expressionFrameRound>
+    <expressionFrameFgColor r="0" g="0" b="0" a="255"/>
+    <expressionFrameBgColor r="255" g="255" b="255" a="0"/>
+    <tempoFontFace>Edwin</tempoFontFace>
+    <tempoFontSize>12</tempoFontSize>
+    <tempoLineSpacing>1</tempoLineSpacing>
+    <tempoFontSpatiumDependent>1</tempoFontSpatiumDependent>
+    <tempoFontStyle>1</tempoFontStyle>
+    <tempoColor r="0" g="0" b="0" a="255"/>
+    <tempoAlign>left,baseline</tempoAlign>
+    <tempoSystemFlag>1</tempoSystemFlag>
+    <tempoPlacement>0</tempoPlacement>
+    <tempoPosAbove x="0" y="-2"/>
+    <tempoPosBelow x="0" y="3"/>
+    <tempoMinDistance>0.5</tempoMinDistance>
+    <tempoFrameType>0</tempoFrameType>
+    <tempoFramePadding>0.2</tempoFramePadding>
+    <tempoFrameWidth>0.1</tempoFrameWidth>
+    <tempoFrameRound>0</tempoFrameRound>
+    <tempoFrameFgColor r="0" g="0" b="0" a="255"/>
+    <tempoFrameBgColor r="255" g="255" b="255" a="0"/>
+    <metronomeFontFace>Edwin</metronomeFontFace>
+    <metronomeFontSize>12</metronomeFontSize>
+    <metronomeLineSpacing>1</metronomeLineSpacing>
+    <metronomeFontSpatiumDependent>0</metronomeFontSpatiumDependent>
+    <metronomeFontStyle>0</metronomeFontStyle>
+    <metronomeColor r="0" g="0" b="0" a="255"/>
+    <metronomePlacement>0</metronomePlacement>
+    <metronomeAlign>left,top</metronomeAlign>
+    <metronomeOffset x="0" y="0"/>
+    <metronomeFrameType>0</metronomeFrameType>
+    <metronomeFramePadding>0.2</metronomeFramePadding>
+    <metronomeFrameWidth>0.1</metronomeFrameWidth>
+    <metronomeFrameRound>0</metronomeFrameRound>
+    <metronomeFrameFgColor r="0" g="0" b="0" a="255"/>
+    <metronomeFrameBgColor r="255" g="255" b="255" a="0"/>
+    <measureNumberFontFace>Edwin</measureNumberFontFace>
+    <measureNumberFontSize>8</measureNumberFontSize>
+    <measureNumberLineSpacing>1</measureNumberLineSpacing>
+    <measureNumberFontSpatiumDependent>0</measureNumberFontSpatiumDependent>
+    <measureNumberFontStyle>2</measureNumberFontStyle>
+    <measureNumberColor r="0" g="0" b="0" a="255"/>
+    <measureNumberOffset x="0" y="-2"/>
+    <measureNumberPosBelow x="0" y="2"/>
+    <measureNumberOffsetType>1</measureNumberOffsetType>
+    <measureNumberVPlacement>0</measureNumberVPlacement>
+    <measureNumberHPlacement>0</measureNumberHPlacement>
+    <measureNumberAlign>left,baseline</measureNumberAlign>
+    <measureNumberFrameType>0</measureNumberFrameType>
+    <measureNumberFramePadding>0.2</measureNumberFramePadding>
+    <measureNumberFrameWidth>0.1</measureNumberFrameWidth>
+    <measureNumberFrameRound>0</measureNumberFrameRound>
+    <measureNumberFrameFgColor r="0" g="0" b="0" a="255"/>
+    <measureNumberFrameBgColor r="255" g="255" b="255" a="0"/>
+    <mmRestShowMeasureNumberRange>0</mmRestShowMeasureNumberRange>
+    <mmRestRangeBracketType>0</mmRestRangeBracketType>
+    <mmRestRangeFontFace>Edwin</mmRestRangeFontFace>
+    <mmRestRangeFontSize>8</mmRestRangeFontSize>
+    <mmRestRangeFontSpatiumDependent>0</mmRestRangeFontSpatiumDependent>
+    <mmRestRangeFontStyle>2</mmRestRangeFontStyle>
+    <mmRestRangeColor r="0" g="0" b="0" a="255"/>
+    <measureNumberPosAbove x="0" y="-3"/>
+    <measureNumberPosBelow x="0" y="1"/>
+    <mmRestRangeOffsetType>1</mmRestRangeOffsetType>
+    <mmRestRangeVPlacement>1</mmRestRangeVPlacement>
+    <mmRestRangeHPlacement>1</mmRestRangeHPlacement>
+    <mmRestRangeAlign>center,baseline</mmRestRangeAlign>
+    <mmRestRangeFrameType>0</mmRestRangeFrameType>
+    <mmRestRangeFramePadding>0.2</mmRestRangeFramePadding>
+    <mmRestRangeFrameWidth>0.1</mmRestRangeFrameWidth>
+    <mmRestRangeFrameRound>0</mmRestRangeFrameRound>
+    <mmRestRangeFrameFgColor r="0" g="0" b="0" a="255"/>
+    <mmRestRangeFrameBgColor r="255" g="255" b="255" a="0"/>
+    <translatorFontFace>Edwin</translatorFontFace>
+    <translatorFontSize>10</translatorFontSize>
+    <translatorLineSpacing>1</translatorLineSpacing>
+    <translatorFontSpatiumDependent>0</translatorFontSpatiumDependent>
+    <translatorFontStyle>0</translatorFontStyle>
+    <translatorColor r="0" g="0" b="0" a="255"/>
+    <translatorAlign>left,top</translatorAlign>
+    <translatorOffset x="0" y="0"/>
+    <translatorFrameType>0</translatorFrameType>
+    <translatorFramePadding>0.2</translatorFramePadding>
+    <translatorFrameWidth>0.1</translatorFrameWidth>
+    <translatorFrameRound>0</translatorFrameRound>
+    <translatorFrameFgColor r="0" g="0" b="0" a="255"/>
+    <translatorFrameBgColor r="255" g="255" b="255" a="0"/>
+    <systemFontFace>Edwin</systemFontFace>
+    <systemFontSize>10</systemFontSize>
+    <systemTextLineSpacing>1</systemTextLineSpacing>
+    <systemFontSpatiumDependent>1</systemFontSpatiumDependent>
+    <systemFontStyle>0</systemFontStyle>
+    <systemTextColor r="0" g="0" b="0" a="255"/>
+    <systemAlign>left,baseline</systemAlign>
+    <systemOffsetType>1</systemOffsetType>
+    <systemPlacement>0</systemPlacement>
+    <systemPosAbove x="0" y="-2"/>
+    <systemPosBelow x="0" y="3.5"/>
+    <systemMinDistance>0.5</systemMinDistance>
+    <systemFrameType>0</systemFrameType>
+    <systemFramePadding>0.2</systemFramePadding>
+    <systemFrameWidth>0.1</systemFrameWidth>
+    <systemFrameRound>0</systemFrameRound>
+    <systemFrameFgColor r="0" g="0" b="0" a="255"/>
+    <systemFrameBgColor r="255" g="255" b="255" a="0"/>
+    <staffFontFace>Edwin</staffFontFace>
+    <staffFontSize>10</staffFontSize>
+    <staffTextLineSpacing>1</staffTextLineSpacing>
+    <staffFontSpatiumDependent>1</staffFontSpatiumDependent>
+    <staffFontStyle>0</staffFontStyle>
+    <staffTextColor r="0" g="0" b="0" a="255"/>
+    <staffAlign>left,baseline</staffAlign>
+    <systemOffsetType>1</systemOffsetType>
+    <staffPlacement>0</staffPlacement>
+    <staffPosAbove x="0" y="-1"/>
+    <staffPosBelow x="0" y="2.5"/>
+    <staffMinDistance>0.5</staffMinDistance>
+    <staffFrameType>0</staffFrameType>
+    <staffFramePadding>0.2</staffFramePadding>
+    <staffFrameWidth>0.1</staffFrameWidth>
+    <staffFrameRound>0</staffFrameRound>
+    <staffFrameFgColor r="0" g="0" b="0" a="255"/>
+    <staffFrameBgColor r="255" g="255" b="255" a="0"/>
+    <rehearsalMarkFontFace>Edwin</rehearsalMarkFontFace>
+    <rehearsalMarkFontSize>14</rehearsalMarkFontSize>
+    <rehearsalMarkLineSpacing>1</rehearsalMarkLineSpacing>
+    <rehearsalMarkFontSpatiumDependent>1</rehearsalMarkFontSpatiumDependent>
+    <rehearsalMarkFontStyle>1</rehearsalMarkFontStyle>
+    <rehearsalMarkColor r="0" g="0" b="0" a="255"/>
+    <rehearsalMarkAlign>center,baseline</rehearsalMarkAlign>
+    <rehearsalMarkFrameType>1</rehearsalMarkFrameType>
+    <rehearsalMarkFramePadding>0.5</rehearsalMarkFramePadding>
+    <rehearsalMarkFrameWidth>0.16</rehearsalMarkFrameWidth>
+    <rehearsalMarkFrameRound>0</rehearsalMarkFrameRound>
+    <rehearsalMarkFrameFgColor r="0" g="0" b="0" a="255"/>
+    <rehearsalMarkFrameBgColor r="255" g="255" b="255" a="0"/>
+    <rehearsalMarkPlacement>0</rehearsalMarkPlacement>
+    <rehearsalMarkPosAbove x="0" y="-3"/>
+    <rehearsalMarkPosBelow x="0" y="4"/>
+    <rehearsalMarkMinDistance>0.5</rehearsalMarkMinDistance>
+    <repeatLeftFontFace>Edwin</repeatLeftFontFace>
+    <repeatLeftFontSize>18</repeatLeftFontSize>
+    <repeatLeftLineSpacing>1</repeatLeftLineSpacing>
+    <repeatLeftFontSpatiumDependent>1</repeatLeftFontSpatiumDependent>
+    <repeatLeftFontStyle>0</repeatLeftFontStyle>
+    <repeatLeftColor r="0" g="0" b="0" a="255"/>
+    <repeatLeftAlign>left,baseline</repeatLeftAlign>
+    <repeatLeftPlacement>0</repeatLeftPlacement>
+    <repeatLeftFrameType>0</repeatLeftFrameType>
+    <repeatLeftFramePadding>0.2</repeatLeftFramePadding>
+    <repeatLeftFrameWidth>0.1</repeatLeftFrameWidth>
+    <repeatLeftFrameRound>0</repeatLeftFrameRound>
+    <repeatLeftFrameFgColor r="0" g="0" b="0" a="255"/>
+    <repeatLeftFrameBgColor r="255" g="255" b="255" a="0"/>
+    <repeatRightFontFace>Edwin</repeatRightFontFace>
+    <repeatRightFontSize>11</repeatRightFontSize>
+    <repeatRightLineSpacing>1</repeatRightLineSpacing>
+    <repeatRightFontSpatiumDependent>1</repeatRightFontSpatiumDependent>
+    <repeatRightFontStyle>0</repeatRightFontStyle>
+    <repeatRightColor r="0" g="0" b="0" a="255"/>
+    <repeatRightAlign>right,baseline</repeatRightAlign>
+    <repeatRightPlacement>0</repeatRightPlacement>
+    <repeatRightFrameType>0</repeatRightFrameType>
+    <repeatRightFramePadding>0.2</repeatRightFramePadding>
+    <repeatRightFrameWidth>0.1</repeatRightFrameWidth>
+    <repeatRightFrameRound>0</repeatRightFrameRound>
+    <repeatRightFrameFgColor r="0" g="0" b="0" a="255"/>
+    <repeatRightFrameBgColor r="255" g="255" b="255" a="0"/>
+    <frameFontFace>Edwin</frameFontFace>
+    <frameFontSize>10</frameFontSize>
+    <frameLineSpacing>1</frameLineSpacing>
+    <frameFontSpatiumDependent>0</frameFontSpatiumDependent>
+    <frameFontStyle>0</frameFontStyle>
+    <frameColor r="0" g="0" b="0" a="255"/>
+    <frameAlign>left,top</frameAlign>
+    <frameOffset x="0" y="0"/>
+    <frameFrameType>0</frameFrameType>
+    <frameFramePadding>0.2</frameFramePadding>
+    <frameFrameWidth>0.1</frameFrameWidth>
+    <frameFrameRound>0</frameFrameRound>
+    <frameFrameFgColor r="0" g="0" b="0" a="255"/>
+    <frameFrameBgColor r="255" g="255" b="255" a="0"/>
+    <textLineFontFace>Edwin</textLineFontFace>
+    <textLineFontSize>10</textLineFontSize>
+    <textLineLineSpacing>1</textLineLineSpacing>
+    <textLineFontSpatiumDependent>1</textLineFontSpatiumDependent>
+    <textLineFontStyle>0</textLineFontStyle>
+    <textLineColor r="0" g="0" b="0" a="255"/>
+    <textLineTextAlign>left,center</textLineTextAlign>
+    <textLineSystemFlag>0</textLineSystemFlag>
+    <systemTextLineFontFace>Edwin</systemTextLineFontFace>
+    <systemTextLineFontSize>12</systemTextLineFontSize>
+    <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
+    <systemTextLineFontStyle>0</systemTextLineFontStyle>
+    <systemTextLineColor r="0" g="0" b="0" a="255"/>
+    <systemTextLineTextAlign>left,center</systemTextLineTextAlign>
+    <systemTextLineSystemFlag>1</systemTextLineSystemFlag>
+    <glissandoFontFace>Edwin</glissandoFontFace>
+    <glissandoFontSize>8</glissandoFontSize>
+    <glissandoLineSpacing>1</glissandoLineSpacing>
+    <glissandoFontSpatiumDependent>1</glissandoFontSpatiumDependent>
+    <glissandoFontStyle>2</glissandoFontStyle>
+    <glissandoColor r="0" g="0" b="0" a="255"/>
+    <glissandoAlign>left,top</glissandoAlign>
+    <glissandoOffset x="0" y="0"/>
+    <glissandoFrameType>0</glissandoFrameType>
+    <glissandoFramePadding>0.2</glissandoFramePadding>
+    <glissandoFrameWidth>0.1</glissandoFrameWidth>
+    <glissandoFrameRound>0</glissandoFrameRound>
+    <glissandoFrameFgColor r="0" g="0" b="0" a="255"/>
+    <glissandoFrameBgColor r="255" g="255" b="255" a="0"/>
+    <glissandoLineWidth>0.15</glissandoLineWidth>
+    <glissandoText>gliss.</glissandoText>
+    <bendFontFace>Edwin</bendFontFace>
+    <bendFontSize>8</bendFontSize>
+    <bendLineSpacing>1</bendLineSpacing>
+    <bendFontSpatiumDependent>1</bendFontSpatiumDependent>
+    <bendFontStyle>0</bendFontStyle>
+    <bendColor r="0" g="0" b="0" a="255"/>
+    <bendAlign>left,baseline</bendAlign>
+    <bendOffset x="0" y="0"/>
+    <bendFrameType>0</bendFrameType>
+    <bendFramePadding>0.2</bendFramePadding>
+    <bendFrameWidth>0.1</bendFrameWidth>
+    <bendFrameRound>0</bendFrameRound>
+    <bendFrameFgColor r="0" g="0" b="0" a="255"/>
+    <bendFrameBgColor r="255" g="255" b="255" a="0"/>
+    <bendLineWidth>0.15</bendLineWidth>
+    <bendArrowWidth>0.5</bendArrowWidth>
+    <headerFontFace>Edwin</headerFontFace>
+    <headerFontSize>11</headerFontSize>
+    <headerLineSpacing>1</headerLineSpacing>
+    <headerFontSpatiumDependent>0</headerFontSpatiumDependent>
+    <headerFontStyle>1</headerFontStyle>
+    <headerColor r="0" g="0" b="0" a="255"/>
+    <headerAlign>center,center</headerAlign>
+    <headerOffset x="0" y="0"/>
+    <headerFrameType>0</headerFrameType>
+    <headerFramePadding>0.2</headerFramePadding>
+    <headerFrameWidth>0.1</headerFrameWidth>
+    <headerFrameRound>0</headerFrameRound>
+    <headerFrameFgColor r="0" g="0" b="0" a="255"/>
+    <headerFrameBgColor r="255" g="255" b="255" a="0"/>
+    <footerFontFace>Edwin</footerFontFace>
+    <footerFontSize>9</footerFontSize>
+    <footerLineSpacing>1</footerLineSpacing>
+    <footerFontSpatiumDependent>0</footerFontSpatiumDependent>
+    <footerFontStyle>0</footerFontStyle>
+    <footerColor r="0" g="0" b="0" a="255"/>
+    <footerAlign>center,center</footerAlign>
+    <footerOffset x="0" y="5"/>
+    <footerFrameType>0</footerFrameType>
+    <footerFramePadding>0.2</footerFramePadding>
+    <footerFrameWidth>0.1</footerFrameWidth>
+    <footerFrameRound>0</footerFrameRound>
+    <footerFrameFgColor r="0" g="0" b="0" a="255"/>
+    <footerFrameBgColor r="255" g="255" b="255" a="0"/>
+    <instrumentChangeFontFace>Edwin</instrumentChangeFontFace>
+    <instrumentChangeFontSize>10</instrumentChangeFontSize>
+    <instrumentChangeLineSpacing>1</instrumentChangeLineSpacing>
+    <instrumentChangeFontSpatiumDependent>1</instrumentChangeFontSpatiumDependent>
+    <instrumentChangeFontStyle>1</instrumentChangeFontStyle>
+    <instrumentChangeColor r="0" g="0" b="0" a="255"/>
+    <instrumentChangeAlign>left,baseline</instrumentChangeAlign>
+    <instrumentChangeOffset x="0" y="0"/>
+    <instrumentChangePlacement>0</instrumentChangePlacement>
+    <instrumentChangePosAbove x="0" y="-2"/>
+    <instrumentChangePosBelow x="0" y="3.5"/>
+    <instrumentChangeMinDistance>0.5</instrumentChangeMinDistance>
+    <instrumentChangeFrameType>0</instrumentChangeFrameType>
+    <instrumentChangeFramePadding>0.2</instrumentChangeFramePadding>
+    <instrumentChangeFrameWidth>0.1</instrumentChangeFrameWidth>
+    <instrumentChangeFrameRound>0</instrumentChangeFrameRound>
+    <instrumentChangeFrameFgColor r="0" g="0" b="0" a="255"/>
+    <instrumentChangeFrameBgColor r="255" g="255" b="255" a="0"/>
+    <stickingFontFace>Edwin</stickingFontFace>
+    <stickingFontSize>10</stickingFontSize>
+    <stickingLineSpacing>1</stickingLineSpacing>
+    <stickingFontSpatiumDependent>1</stickingFontSpatiumDependent>
+    <stickingFontStyle>0</stickingFontStyle>
+    <stickingColor r="0" g="0" b="0" a="255"/>
+    <stickingAlign>left,baseline</stickingAlign>
+    <stickingOffset x="0" y="0"/>
+    <stickingPlacement>1</stickingPlacement>
+    <stickingPosAbove x="0" y="-2"/>
+    <stickingPosBelow x="0" y="2"/>
+    <stickingMinDistance>0.5</stickingMinDistance>
+    <stickingFrameType>0</stickingFrameType>
+    <stickingFramePadding>0.2</stickingFramePadding>
+    <stickingFrameWidth>0.1</stickingFrameWidth>
+    <stickingFrameRound>0</stickingFrameRound>
+    <stickingFrameFgColor r="0" g="0" b="0" a="255"/>
+    <stickingFrameBgColor r="255" g="255" b="255" a="0"/>
+    <figuredBassFontFace>MScoreBC</figuredBassFontFace>
+    <figuredBassFontSize>8</figuredBassFontSize>
+    <figuredBassLineSpacing>1</figuredBassLineSpacing>
+    <figuredBassFontSpatiumDependent>1</figuredBassFontSpatiumDependent>
+    <figuredBassFontStyle>0</figuredBassFontStyle>
+    <figuredBassColor r="0" g="0" b="0" a="255"/>
+    <user1Name></user1Name>
+    <user1FontFace>Edwin</user1FontFace>
+    <user1FontSize>10</user1FontSize>
+    <user1LineSpacing>1</user1LineSpacing>
+    <user1FontSpatiumDependent>1</user1FontSpatiumDependent>
+    <user1FontStyle>0</user1FontStyle>
+    <user1Color r="0" g="0" b="0" a="255"/>
+    <user1Align>left,top</user1Align>
+    <user1Offset x="0" y="0"/>
+    <user1OffsetType>1</user1OffsetType>
+    <user1FrameType>0</user1FrameType>
+    <user1FramePadding>0.2</user1FramePadding>
+    <user1FrameWidth>0.1</user1FrameWidth>
+    <user1FrameRound>0</user1FrameRound>
+    <user1FrameFgColor r="0" g="0" b="0" a="255"/>
+    <user1FrameBgColor r="255" g="255" b="255" a="0"/>
+    <user2Name></user2Name>
+    <user2FontFace>Edwin</user2FontFace>
+    <user2FontSize>10</user2FontSize>
+    <user2LineSpacing>1</user2LineSpacing>
+    <user2FontSpatiumDependent>1</user2FontSpatiumDependent>
+    <user2FontStyle>0</user2FontStyle>
+    <user2Color r="0" g="0" b="0" a="255"/>
+    <user2Align>left,top</user2Align>
+    <user2Offset x="0" y="0"/>
+    <user2OffsetType>1</user2OffsetType>
+    <user2FrameType>0</user2FrameType>
+    <user2FramePadding>0.2</user2FramePadding>
+    <user2FrameWidth>0.1</user2FrameWidth>
+    <user2FrameRound>0</user2FrameRound>
+    <user2FrameFgColor r="0" g="0" b="0" a="255"/>
+    <user2FrameBgColor r="255" g="255" b="255" a="0"/>
+    <user3Name></user3Name>
+    <user3FontFace>Edwin</user3FontFace>
+    <user3FontSize>10</user3FontSize>
+    <user3LineSpacing>1</user3LineSpacing>
+    <user3FontSpatiumDependent>1</user3FontSpatiumDependent>
+    <user3FontStyle>0</user3FontStyle>
+    <user3Color r="0" g="0" b="0" a="255"/>
+    <user3Align>left,top</user3Align>
+    <user3Offset x="0" y="0"/>
+    <user3OffsetType>1</user3OffsetType>
+    <user3FrameType>0</user3FrameType>
+    <user3FramePadding>0.2</user3FramePadding>
+    <user3FrameWidth>0.1</user3FrameWidth>
+    <user3FrameRound>0</user3FrameRound>
+    <user3FrameFgColor r="0" g="0" b="0" a="255"/>
+    <user3FrameBgColor r="255" g="255" b="255" a="0"/>
+    <user4Name></user4Name>
+    <user4FontFace>Edwin</user4FontFace>
+    <user4FontSize>10</user4FontSize>
+    <user4LineSpacing>1</user4LineSpacing>
+    <user4FontSpatiumDependent>1</user4FontSpatiumDependent>
+    <user4FontStyle>0</user4FontStyle>
+    <user4Color r="0" g="0" b="0" a="255"/>
+    <user4Align>left,top</user4Align>
+    <user4Offset x="0" y="0"/>
+    <user4OffsetType>1</user4OffsetType>
+    <user4FrameType>0</user4FrameType>
+    <user4FramePadding>0.2</user4FramePadding>
+    <user4FrameWidth>0.1</user4FrameWidth>
+    <user4FrameRound>0</user4FrameRound>
+    <user4FrameFgColor r="0" g="0" b="0" a="255"/>
+    <user4FrameBgColor r="255" g="255" b="255" a="0"/>
+    <user5Name></user5Name>
+    <user5FontFace>Edwin</user5FontFace>
+    <user5FontSize>10</user5FontSize>
+    <user5LineSpacing>1</user5LineSpacing>
+    <user5FontSpatiumDependent>1</user5FontSpatiumDependent>
+    <user5FontStyle>0</user5FontStyle>
+    <user5Color r="0" g="0" b="0" a="255"/>
+    <user5Align>left,top</user5Align>
+    <user5Offset x="0" y="0"/>
+    <user5OffsetType>1</user5OffsetType>
+    <user5FrameType>0</user5FrameType>
+    <user5FramePadding>0.2</user5FramePadding>
+    <user5FrameWidth>0.1</user5FrameWidth>
+    <user5FrameRound>0</user5FrameRound>
+    <user5FrameFgColor r="0" g="0" b="0" a="255"/>
+    <user5FrameBgColor r="255" g="255" b="255" a="0"/>
+    <user6Name></user6Name>
+    <user6FontFace>Edwin</user6FontFace>
+    <user6FontSize>10</user6FontSize>
+    <user6LineSpacing>1</user6LineSpacing>
+    <user6FontSpatiumDependent>1</user6FontSpatiumDependent>
+    <user6FontStyle>0</user6FontStyle>
+    <user6Color r="0" g="0" b="0" a="255"/>
+    <user6Align>left,top</user6Align>
+    <user6Offset x="0" y="0"/>
+    <user6OffsetType>1</user6OffsetType>
+    <user6FrameType>0</user6FrameType>
+    <user6FramePadding>0.2</user6FramePadding>
+    <user6FrameWidth>0.1</user6FrameWidth>
+    <user6FrameRound>0</user6FrameRound>
+    <user6FrameFgColor r="0" g="0" b="0" a="255"/>
+    <user6FrameBgColor r="255" g="255" b="255" a="0"/>
+    <user7Name></user7Name>
+    <user7FontFace>Edwin</user7FontFace>
+    <user7FontSize>10</user7FontSize>
+    <user7LineSpacing>1</user7LineSpacing>
+    <user7FontSpatiumDependent>1</user7FontSpatiumDependent>
+    <user7FontStyle>0</user7FontStyle>
+    <user7Color r="0" g="0" b="0" a="255"/>
+    <user7Align>left,top</user7Align>
+    <user7Offset x="0" y="0"/>
+    <user7OffsetType>1</user7OffsetType>
+    <user7FrameType>0</user7FrameType>
+    <user7FramePadding>0.2</user7FramePadding>
+    <user7FrameWidth>0.1</user7FrameWidth>
+    <user7FrameRound>0</user7FrameRound>
+    <user7FrameFgColor r="0" g="0" b="0" a="255"/>
+    <user7FrameBgColor r="255" g="255" b="255" a="0"/>
+    <user8Name></user8Name>
+    <user8FontFace>Edwin</user8FontFace>
+    <user8FontSize>10</user8FontSize>
+    <user8LineSpacing>1</user8LineSpacing>
+    <user8FontSpatiumDependent>1</user8FontSpatiumDependent>
+    <user8FontStyle>0</user8FontStyle>
+    <user8Color r="0" g="0" b="0" a="255"/>
+    <user8Align>left,top</user8Align>
+    <user8Offset x="0" y="0"/>
+    <user8OffsetType>1</user8OffsetType>
+    <user8FrameType>0</user8FrameType>
+    <user8FramePadding>0.2</user8FramePadding>
+    <user8FrameWidth>0.1</user8FrameWidth>
+    <user8FrameRound>0</user8FrameRound>
+    <user8FrameFgColor r="0" g="0" b="0" a="255"/>
+    <user8FrameBgColor r="255" g="255" b="255" a="0"/>
+    <user9Name></user9Name>
+    <user9FontFace>Edwin</user9FontFace>
+    <user9FontSize>10</user9FontSize>
+    <user9LineSpacing>1</user9LineSpacing>
+    <user9FontSpatiumDependent>1</user9FontSpatiumDependent>
+    <user9FontStyle>0</user9FontStyle>
+    <user9Color r="0" g="0" b="0" a="255"/>
+    <user9Align>left,top</user9Align>
+    <user9Offset x="0" y="0"/>
+    <user9OffsetType>1</user9OffsetType>
+    <user9FrameType>0</user9FrameType>
+    <user9FramePadding>0.2</user9FramePadding>
+    <user9FrameWidth>0.1</user9FrameWidth>
+    <user9FrameRound>0</user9FrameRound>
+    <user9FrameFgColor r="0" g="0" b="0" a="255"/>
+    <user9FrameBgColor r="255" g="255" b="255" a="0"/>
+    <user10Name></user10Name>
+    <user10FontFace>Edwin</user10FontFace>
+    <user10FontSize>10</user10FontSize>
+    <user10LineSpacing>1</user10LineSpacing>
+    <user10FontSpatiumDependent>1</user10FontSpatiumDependent>
+    <user10FontStyle>0</user10FontStyle>
+    <user10Color r="0" g="0" b="0" a="255"/>
+    <user10Align>left,top</user10Align>
+    <user10Offset x="0" y="0"/>
+    <user10OffsetType>1</user10OffsetType>
+    <user10FrameType>0</user10FrameType>
+    <user10FramePadding>0.2</user10FramePadding>
+    <user10FrameWidth>0.1</user10FrameWidth>
+    <user10FrameRound>0</user10FrameRound>
+    <user10FrameFgColor r="0" g="0" b="0" a="255"/>
+    <user10FrameBgColor r="255" g="255" b="255" a="0"/>
+    <user11Name></user11Name>
+    <user11FontFace>Edwin</user11FontFace>
+    <user11FontSize>10</user11FontSize>
+    <user11LineSpacing>1</user11LineSpacing>
+    <user11FontSpatiumDependent>1</user11FontSpatiumDependent>
+    <user11FontStyle>0</user11FontStyle>
+    <user11Color r="0" g="0" b="0" a="255"/>
+    <user11Align>left,top</user11Align>
+    <user11Offset x="0" y="0"/>
+    <user11OffsetType>1</user11OffsetType>
+    <user11FrameType>0</user11FrameType>
+    <user11FramePadding>0.2</user11FramePadding>
+    <user11FrameWidth>0.1</user11FrameWidth>
+    <user11FrameRound>0</user11FrameRound>
+    <user11FrameFgColor r="0" g="0" b="0" a="255"/>
+    <user11FrameBgColor r="255" g="255" b="255" a="0"/>
+    <user12Name></user12Name>
+    <user12FontFace>Edwin</user12FontFace>
+    <user12FontSize>10</user12FontSize>
+    <user12LineSpacing>1</user12LineSpacing>
+    <user12FontSpatiumDependent>1</user12FontSpatiumDependent>
+    <user12FontStyle>0</user12FontStyle>
+    <user12Color r="0" g="0" b="0" a="255"/>
+    <user12Align>left,top</user12Align>
+    <user12Offset x="0" y="0"/>
+    <user12OffsetType>1</user12OffsetType>
+    <user12FrameType>0</user12FrameType>
+    <user12FramePadding>0.2</user12FramePadding>
+    <user12FrameWidth>0.1</user12FrameWidth>
+    <user12FrameRound>0</user12FrameRound>
+    <user12FrameFgColor r="0" g="0" b="0" a="255"/>
+    <user12FrameBgColor r="255" g="255" b="255" a="0"/>
+    <letRingFontFace>Edwin</letRingFontFace>
+    <letRingFontSize>10</letRingFontSize>
+    <letRingLineSpacing>1</letRingLineSpacing>
+    <letRingFontSpatiumDependent>1</letRingFontSpatiumDependent>
+    <letRingFontStyle>0</letRingFontStyle>
+    <letRingColor r="0" g="0" b="0" a="255"/>
+    <letRingTextAlign>left,center</letRingTextAlign>
+    <letRingHookHeight>0.6</letRingHookHeight>
+    <letRingPlacement>1</letRingPlacement>
+    <letRingPosAbove x="0" y="0"/>
+    <letRingPosBelow x="0" y="0"/>
+    <letRingLineWidth>0.15</letRingLineWidth>
+    <letRingLineStyle>2</letRingLineStyle>
+    <letRingBeginTextOffset x="0" y="0.15"/>
+    <letRingText>let ring</letRingText>
+    <letRingFrameType>0</letRingFrameType>
+    <letRingFramePadding>0.2</letRingFramePadding>
+    <letRingFrameWidth>0.1</letRingFrameWidth>
+    <letRingFrameRound>0</letRingFrameRound>
+    <letRingFrameFgColor r="0" g="0" b="0" a="255"/>
+    <letRingFrameBgColor r="255" g="255" b="255" a="0"/>
+    <letRingEndHookType>3</letRingEndHookType>
+    <palmMuteFontFace>Edwin</palmMuteFontFace>
+    <palmMuteFontSize>10</palmMuteFontSize>
+    <palmMuteLineSpacing>1</palmMuteLineSpacing>
+    <palmMuteFontSpatiumDependent>1</palmMuteFontSpatiumDependent>
+    <palmMuteFontStyle>0</palmMuteFontStyle>
+    <palmMuteColor r="0" g="0" b="0" a="255"/>
+    <palmMuteTextAlign>left,center</palmMuteTextAlign>
+    <palmMuteHookHeight>0.6</palmMuteHookHeight>
+    <palmMutePlacement>1</palmMutePlacement>
+    <palmMutePosAbove x="0" y="-4"/>
+    <palmMutePosBelow x="0" y="4"/>
+    <palmMuteLineWidth>0.15</palmMuteLineWidth>
+    <palmMuteLineStyle>2</palmMuteLineStyle>
+    <palmMuteBeginTextOffset x="0" y="0.15"/>
+    <palmMuteText>P.M.</palmMuteText>
+    <palmMuteFrameType>0</palmMuteFrameType>
+    <palmMuteFramePadding>0.2</palmMuteFramePadding>
+    <palmMuteFrameWidth>0.1</palmMuteFrameWidth>
+    <palmMuteFrameRound>0</palmMuteFrameRound>
+    <palmMuteFrameFgColor r="0" g="0" b="0" a="255"/>
+    <palmMuteFrameBgColor r="255" g="255" b="255" a="0"/>
+    <palmMuteEndHookType>3</palmMuteEndHookType>
+    <fermataPosAbove x="0" y="-0.5"/>
+    <fermataPosBelow x="0" y="0.5"/>
+    <fermataMinDistance>0.4</fermataMinDistance>
+    <fingeringPlacement>0</fingeringPlacement>
+    <articulationMinDistance>0.5</articulationMinDistance>
+    <fingeringMinDistance>0.5</fingeringMinDistance>
+    <hairpinMinDistance>0.7</hairpinMinDistance>
+    <letRingMinDistance>0.7</letRingMinDistance>
+    <ottavaMinDistance>0.7</ottavaMinDistance>
+    <palmMuteMinDistance>0.7</palmMuteMinDistance>
+    <pedalMinDistance>0.7</pedalMinDistance>
+    <repeatMinDistance>0.5</repeatMinDistance>
+    <textLineMinDistance>0.7</textLineMinDistance>
+    <systemTextLineMinDistance>0.7</systemTextLineMinDistance>
+    <trillMinDistance>0.5</trillMinDistance>
+    <vibratoMinDistance>1</vibratoMinDistance>
+    <voltaMinDistance>1</voltaMinDistance>
+    <figuredBassMinDistance>0.5</figuredBassMinDistance>
+    <tupletMinDistance>0.5</tupletMinDistance>
+    <autoplaceEnabled>1</autoplaceEnabled>
+    <usePre_3_6_defaults>0</usePre_3_6_defaults>
+    <defaultsVersion>302</defaultsVersion>
+    <Spatium>1.74978</Spatium>
+    </Style>
+  </museScore>

--- a/src/engraving/engraving.qrc
+++ b/src/engraving/engraving.qrc
@@ -7,5 +7,6 @@
         <file alias="engraving/styles/legacy-style-defaults-v3.mss">data/styles/legacy-style-defaults-v3.mss</file>
         <file alias="engraving/styles/migration-306-style-Leland.mss">data/styles/migration-306-style-Leland.mss</file>
         <file alias="engraving/styles/migration-306-style-Edwin.mss">data/styles/migration-306-style-Edwin.mss</file>
+        <file alias="engraving/styles/legacy-style-defaults-v302.mss">data/styles/legacy-style-defaults-v302.mss</file>
     </qresource>
 </RCC>

--- a/src/engraving/rw/compat/readstyle.cpp
+++ b/src/engraving/rw/compat/readstyle.cpp
@@ -56,11 +56,15 @@ ReadStyleHook::ReadStyleHook(Ms::Score* score, const QByteArray& scoreData, cons
 
 int ReadStyleHook::styleDefaultByMscVersion(const int mscVer)
 {
+    constexpr int LEGACY_MSC_VERSION_V302 = 302;
     constexpr int LEGACY_MSC_VERSION_V3 = 301;
     constexpr int LEGACY_MSC_VERSION_V2 = 206;
     constexpr int LEGACY_MSC_VERSION_V1 = 114;
 
-    if (mscVer > LEGACY_MSC_VERSION_V2 && mscVer < MSCVERSION) {
+    if (mscVer > LEGACY_MSC_VERSION_V3 && mscVer < MSCVERSION) {
+        return LEGACY_MSC_VERSION_V302;
+    }
+    if (mscVer > LEGACY_MSC_VERSION_V2 && mscVer <= LEGACY_MSC_VERSION_V3) {
         return LEGACY_MSC_VERSION_V3;
     }
 

--- a/src/engraving/style/defaultstyle.cpp
+++ b/src/engraving/style/defaultstyle.cpp
@@ -28,6 +28,7 @@
 using namespace mu::engraving;
 using namespace Ms;
 
+static const int LEGACY_MSC_VERSION_V302 = 302;
 static const int LEGACY_MSC_VERSION_V3 = 301;
 static const int LEGACY_MSC_VERSION_V2 = 206;
 static const int LEGACY_MSC_VERSION_V1 = 114;
@@ -35,6 +36,7 @@ static const int LEGACY_MSC_VERSION_V1 = 114;
 static const QString LEGACY_MSS_V1_PATH(":/engraving/styles/legacy-style-defaults-v1.mss");
 static const QString LEGACY_MSS_V2_PATH(":/engraving/styles/legacy-style-defaults-v2.mss");
 static const QString LEGACY_MSS_V3_PATH(":/engraving/styles/legacy-style-defaults-v3.mss");
+static const QString LEGACY_MSS_V302_PATH(":/engraving/styles/legacy-style-defaults-v302.mss");
 
 DefaultStyle* DefaultStyle::instance()
 {
@@ -120,6 +122,11 @@ const MStyle& DefaultStyle::resolveStyleDefaults(const int defaultsVersion)
     };
 
     switch (defaultsVersion) {
+    case LEGACY_MSC_VERSION_V302: {
+        static MStyle style_v302;
+        static bool loaded_v302 = false;
+        return loadedStyle(style_v302, LEGACY_MSS_V302_PATH, loaded_v302);
+    } break;
     case LEGACY_MSC_VERSION_V3: {
         static MStyle style_v3;
         static bool loaded_v3 = false;

--- a/src/engraving/utests/tools_data/change-enharmonic-both-01-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-both-01-ref.mscx
@@ -5,7 +5,8 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <defaultsVersion>301</defaultsVersion>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
       <Spatium>1.74978</Spatium>
       </Style>
     <showInvisible>1</showInvisible>

--- a/src/engraving/utests/tools_data/change-enharmonic-both-02-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-both-02-ref.mscx
@@ -5,7 +5,8 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <defaultsVersion>301</defaultsVersion>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
       <Spatium>1.74978</Spatium>
       </Style>
     <showInvisible>1</showInvisible>

--- a/src/engraving/utests/tools_data/change-enharmonic-both-03-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-both-03-ref.mscx
@@ -5,7 +5,8 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <defaultsVersion>301</defaultsVersion>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
       <Spatium>1.74978</Spatium>
       </Style>
     <showInvisible>1</showInvisible>

--- a/src/engraving/utests/tools_data/change-enharmonic-both-04-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-both-04-ref.mscx
@@ -5,7 +5,8 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <defaultsVersion>301</defaultsVersion>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
       <Spatium>1.74978</Spatium>
       </Style>
     <showInvisible>1</showInvisible>

--- a/src/engraving/utests/tools_data/change-enharmonic-both-05-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-both-05-ref.mscx
@@ -5,7 +5,8 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <defaultsVersion>301</defaultsVersion>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
       <Spatium>1.74978</Spatium>
       </Style>
     <showInvisible>1</showInvisible>

--- a/src/engraving/utests/tools_data/change-enharmonic-current-01-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-current-01-ref.mscx
@@ -5,7 +5,8 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <defaultsVersion>301</defaultsVersion>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
       <Spatium>1.74978</Spatium>
       </Style>
     <showInvisible>1</showInvisible>

--- a/src/engraving/utests/tools_data/change-enharmonic-current-02-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-current-02-ref.mscx
@@ -5,7 +5,8 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <defaultsVersion>301</defaultsVersion>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
       <Spatium>1.74978</Spatium>
       </Style>
     <showInvisible>1</showInvisible>

--- a/src/engraving/utests/tools_data/change-enharmonic-current-03-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-current-03-ref.mscx
@@ -5,7 +5,8 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <defaultsVersion>301</defaultsVersion>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
       <Spatium>1.74978</Spatium>
       </Style>
     <showInvisible>1</showInvisible>

--- a/src/engraving/utests/tools_data/change-enharmonic-current-04-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-current-04-ref.mscx
@@ -5,7 +5,8 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <defaultsVersion>301</defaultsVersion>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
       <Spatium>1.74978</Spatium>
       </Style>
     <showInvisible>1</showInvisible>

--- a/src/engraving/utests/tools_data/change-enharmonic-current-05-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-current-05-ref.mscx
@@ -5,7 +5,8 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <defaultsVersion>301</defaultsVersion>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
       <Spatium>1.74978</Spatium>
       </Style>
     <showInvisible>1</showInvisible>


### PR DESCRIPTION
Added a new `.mss` file and logic to make sure that 3.6 styles are respected.

Fixes #9070 