### PR TITLE
Fix #10490: Spacing breaks by changing minimum measure width

### DIFF
--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -391,10 +391,14 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
     qreal stretchCoeff = 1;
     qreal prevWidth = 0;
     int iter = 0;
-    static double epsilon = score->spatium() * 0.05; // For reference: this is smaller than the width of a note stem
-    static constexpr int maxIter = 400; // Limits the number of iterations, just for safety. In reality, less than 3 iterations are required on average.
+    double epsilon = score->spatium() * 0.05; // For reference: this is smaller than the width of a note stem
     static constexpr float multiplier = 1.4; // Empirically optimized value which allows the fastest convergence of the following algorithm.
-
+    static constexpr int maxIter = 400;
+    // Different systems need different numbers of iterations of the following loop to reach the target width.
+    // The average is less than 3 iterations, and the maximum I've ever seen (very rare) is 30-40 iterations.
+    // maxIter just serves as a safety exit to not get stuck in the loop in case a system can't be justified
+    // (which can only happen if errors are made before getting here). It's set to a very high value to make
+    // that the system really can't be justified, and it isn't just a "tricky" one needing more iterations.
     while (abs(newRest) > epsilon && iter < maxIter) {
         stretchCoeff *= (1 + multiplier * newRest / curSysWidth);
         for (MeasureBase* mb : system->measures()) {

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -393,12 +393,12 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
     int iter = 0;
     double epsilon = score->spatium() * 0.05; // For reference: this is smaller than the width of a note stem
     static constexpr float multiplier = 1.4; // Empirically optimized value which allows the fastest convergence of the following algorithm.
-    static constexpr int maxIter = 400;
+    static constexpr int maxIter = 100;
     // Different systems need different numbers of iterations of the following loop to reach the target width.
     // The average is less than 3 iterations, and the maximum I've ever seen (very rare) is 30-40 iterations.
     // maxIter just serves as a safety exit to not get stuck in the loop in case a system can't be justified
     // (which can only happen if errors are made before getting here). It's set to a very high value to make
-    // that the system really can't be justified, and it isn't just a "tricky" one needing more iterations.
+    // sure that the system really can't be justified, and it isn't just a "tricky" one needing more iterations.
     while (abs(newRest) > epsilon && iter < maxIter) {
         stretchCoeff *= (1 + multiplier * newRest / curSysWidth);
         for (MeasureBase* mb : system->measures()) {

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -4257,7 +4257,12 @@ void Measure::setWidthToTargetValue(Segment* s, qreal x, bool isSystemHeader, Fr
     // The input parameters of this method rely on Measure::computeWidth(), so always call this method from there
     const double epsilon = 0.1 * spatium();
     static constexpr double multiplier = 1.4; // Empirical value for fastest convergence of the following loop
-    static constexpr int maxIter = 200; // Just for safety, in reality just 2 iterations are typically needed.
+    static constexpr int maxIter = 200;
+    // Different measures need different numbers of iterations of the following loop to reach the target width.
+    // The average is about 2 iterations, and the maximum I've ever seen (very rare) is around 10-15 iterations.
+    // maxIter just serves as a safety exit to not get stuck in the loop in case a measure can't be justified
+    // (which can only happen if errors are made before getting here). It's set to a very high value to make
+    // sure that the measure really can't be justified, and it isn't just a "tricky" one needing more iterations.
     int iter = 0;
     for (double rest = targetWidth - width(); abs(rest) > epsilon && iter < maxIter; rest = targetWidth - width()) {
         stretchCoeff *= (1 + multiplier * rest / width());

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -4240,8 +4240,10 @@ void Measure::computeWidth(Fraction minTicks, qreal stretchCoeff)
 
     computeWidth(s, x, isSystemHeader, minTicks, stretchCoeff);
 
-    // Check against minimum permitted width and increase if needed
-    const double minWidth = isMMRest() ? score()->styleMM(Sid::minMMRestWidth) : score()->styleMM(Sid::minMeasureWidth);
+    // Check against minimum width and increase if needed
+    double minWidth = isMMRest() ? score()->styleMM(Sid::minMMRestWidth) : score()->styleMM(Sid::minMeasureWidth);
+    double maxWidth = system()->width() - system()->leftMargin(); // maximum available system width (left margin accounts for possible indentation)
+    minWidth = std::min(minWidth, maxWidth); // Accounts for a case where the user may set the minMeasureWidth to a value larger than the available system width
     if (width() < minWidth) {
         double epsilon = 0.1 * spatium();
         double multiplier = 1.4; // Empirical value for fastest convergence of the following loop
@@ -4250,6 +4252,7 @@ void Measure::computeWidth(Fraction minTicks, qreal stretchCoeff)
         for (double rest = minWidth - width(); abs(rest) > epsilon && iter < maxIter; rest = minWidth - width()) {
             stretchCoeff *= (1 + multiplier * rest / width());
             computeWidth(s, x, isSystemHeader, minTicks, stretchCoeff);
+            iter++;
         }
         setWidthLocked(true);
     } else {

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -4245,18 +4245,24 @@ void Measure::computeWidth(Fraction minTicks, qreal stretchCoeff)
     double maxWidth = system()->width() - system()->leftMargin(); // maximum available system width (left margin accounts for possible indentation)
     minWidth = std::min(minWidth, maxWidth); // Accounts for a case where the user may set the minMeasureWidth to a value larger than the available system width
     if (width() < minWidth) {
-        double epsilon = 0.1 * spatium();
-        double multiplier = 1.4; // Empirical value for fastest convergence of the following loop
-        int iter = 0;
-        int maxIter = 200; // Just for safety, in reality just 2 iterations are typically needed.
-        for (double rest = minWidth - width(); abs(rest) > epsilon && iter < maxIter; rest = minWidth - width()) {
-            stretchCoeff *= (1 + multiplier * rest / width());
-            computeWidth(s, x, isSystemHeader, minTicks, stretchCoeff);
-            iter++;
-        }
+        setWidthToTargetValue(s, x, isSystemHeader, minTicks, stretchCoeff, minWidth);
         setWidthLocked(true);
     } else {
         setWidthLocked(false);
+    }
+}
+
+void Measure::setWidthToTargetValue(Segment* s, qreal x, bool isSystemHeader, Fraction minTicks, qreal stretchCoeff, qreal targetWidth)
+{
+    // The input parameters of this method rely on Measure::computeWidth(), so always call this method from there
+    const double epsilon = 0.1 * spatium();
+    static constexpr double multiplier = 1.4; // Empirical value for fastest convergence of the following loop
+    static constexpr int maxIter = 200; // Just for safety, in reality just 2 iterations are typically needed.
+    int iter = 0;
+    for (double rest = targetWidth - width(); abs(rest) > epsilon && iter < maxIter; rest = targetWidth - width()) {
+        stretchCoeff *= (1 + multiplier * rest / width());
+        computeWidth(s, x, isSystemHeader, minTicks, stretchCoeff);
+        iter++;
     }
 }
 

--- a/src/engraving/libmscore/measure.h
+++ b/src/engraving/libmscore/measure.h
@@ -342,8 +342,12 @@ public:
     void computeWidth(Fraction minTicks, qreal stretchCoeff);
     void checkHeader();
     void checkTrailer();
-    void setStretchedWidth(qreal);
     void layoutStaffLines();
+
+    bool isWidthLocked() const { return _isWidthLocked; }
+    // A measure is widthLocked if its width has been locked by the minMeasureWidth (or minMMRestWidth)
+    // parameter, meaning it can't be any narrower than it currently is.
+    void setWidthLocked(bool b) { _isWidthLocked = b; }
 
     //! puts segments on the positions according to their length
     void layoutSegmentsInPracticeMode(const std::vector<int>& visibleParts);
@@ -397,6 +401,7 @@ private:
     Fraction m_quantumOfSegmentCell = { 1, 16 };
 
     double m_layoutStretch = 1.0;
+    bool _isWidthLocked = false;
 };
 }     // namespace Ms
 #endif

--- a/src/engraving/libmscore/measure.h
+++ b/src/engraving/libmscore/measure.h
@@ -375,6 +375,7 @@ private:
 
     void fillGap(const Fraction& pos, const Fraction& len, int track, const Fraction& stretch, bool useGapRests = true);
     void computeWidth(Segment* s, qreal x, bool isSystemHeader, Fraction minTicks, qreal stretchCoeff);
+    void setWidthToTargetValue(Segment* s, qreal x, bool isSystemHeader, Fraction minTicks, qreal stretchCoeff, qreal targetWidth);
 
     MStaff* mstaff(int staffIndex) const;
 

--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -1901,20 +1901,24 @@ Fraction System::minSysTicks() const
 
 //---------------------------------------------------------
 //      isSqueezable
-//      we say that a system is squeezable if at least some
-//      of its measures can be made narrower. Returns true if
-//      at least two measures (or one measure if the system has
-//      2 or less measures in total) are not widthLocked.
-//      This information is useful for system
-//      justification (see layoutSystem.cpp)
+//      A system is squeezable if at least some of its measures can be made narrower.
+//      Typical examples of measures that can NOT be narrower are withLocked measures
+//      or measures that have already very tight spacing. This information is useful
+//      for system justification.
 //---------------------------------------------------------
 
 bool System::isSqueezable() const
 {
     int nonLocked = 0;
+    double generalSpacing = score()->styleD(Sid::measureSpacing);
+    double measureSpacing = 0;
     for (auto mb : measures()) {
-        if (mb->isMeasure() && !toMeasure(mb)->isWidthLocked()) {
-            ++nonLocked;
+        if (mb->isMeasure()) {
+            auto m = toMeasure(mb);
+            measureSpacing = m->userStretch() * generalSpacing;
+            if (!m->isWidthLocked() && measureSpacing > 1) {
+                ++nonLocked;
+            }
         }
         if (nonLocked > 2) {
             return true;

--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -1898,4 +1898,32 @@ Fraction System::minSysTicks() const
     }
     return minTicks;
 }
+
+//---------------------------------------------------------
+//      isSqueezable
+//      we say that a system is squeezable if at least some
+//      of its measures can be made narrower. Returns true if
+//      at least two measures (or one measure if the system has
+//      2 or less measures in total) are not widthLocked.
+//      This information is useful for system
+//      justification (see layoutSystem.cpp)
+//---------------------------------------------------------
+
+bool System::isSqueezable() const
+{
+    int nonLocked = 0;
+    for (auto mb : measures()) {
+        if (mb->isMeasure() && !toMeasure(mb)->isWidthLocked()) {
+            ++nonLocked;
+        }
+        if (nonLocked > 2) {
+            return true;
+        }
+    }
+    if (measures().size() <= 2 && nonLocked > 0) {
+        return true;
+    } else {
+        return false;
+    }
+}
 }

--- a/src/engraving/libmscore/system.h
+++ b/src/engraving/libmscore/system.h
@@ -235,6 +235,8 @@ public:
     int lastVisibleSysStaffOfPart(const Part* part) const;
 
     Fraction minSysTicks() const;
+
+    bool isSqueezable() const;
 };
 
 typedef QList<System*>::iterator iSystem;

--- a/src/engraving/utests/beam_data/Beam-D.mscx
+++ b/src/engraving/utests/beam_data/Beam-D.mscx
@@ -751,8 +751,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>32</l1>
-            <l2>38</l2>
+            <l1>38</l1>
+            <l2>40</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -790,7 +790,7 @@
             </Chord>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>38</l1>
+            <l1>40</l1>
             <l2>44</l2>
             </Beam>
           <Chord>
@@ -814,7 +814,7 @@
         <voice>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>42</l1>
+            <l1>44</l1>
             <l2>48</l2>
             </Beam>
           <Chord>


### PR DESCRIPTION
Resolves [10490](https://github.com/musescore/MuseScore/issues/10490)

The changes to horizontal spacing had broken this functionality. It is now restored. Also the minimum width of multimeasure rests should now work as expected.