### PR TITLE
[MU4] Fix #10449: Unable to extend slur to the next system (using shortcut)

### DIFF
--- a/src/engraving/libmscore/mscoreview.h
+++ b/src/engraving/libmscore/mscoreview.h
@@ -61,7 +61,6 @@ public:
 
     virtual void changeEditElement(EngravingItem*) {}
     virtual void setDropRectangle(const mu::RectF&) {}
-    virtual void startEdit(EngravingItem*, Grip /*startGrip*/) {}
     virtual void startNoteEntryMode() {}
     virtual void drawBackground(mu::draw::Painter*, const mu::RectF&) const = 0;
     virtual void setDropTarget(const EngravingItem*) {}

--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -262,7 +262,7 @@ void SlurSegment::changeAnchor(EditData& ed, EngravingItem* element)
     if (spanner()->spannerSegments().size() != segments) {
         const std::vector<SpannerSegment*>& ss = spanner()->spannerSegments();
         SlurSegment* newSegment = toSlurSegment(ed.curGrip == Grip::END ? ss.back() : ss.front());
-        ed.view()->startEdit(newSegment, ed.curGrip);
+        ed.view()->changeEditElement(newSegment);
         triggerLayout();
     }
 }

--- a/src/engraving/libmscore/tie.cpp
+++ b/src/engraving/libmscore/tie.cpp
@@ -163,7 +163,7 @@ void TieSegment::changeAnchor(EditData& ed, EngravingItem* element)
         TieSegment* newSegment = toTieSegment(ed.curGrip == Grip::END ? ss.back() : ss.front());
         score()->endCmd();
         score()->startCmd();
-        ed.view()->startEdit(newSegment, ed.curGrip);
+        ed.view()->changeEditElement(newSegment);
         triggerLayoutAll();
     }
 }

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2763,8 +2763,16 @@ void NotationInteraction::changeEditElement(EngravingItem* newElement)
         return;
     }
 
+    Ms::Grip currentGrip = m_editData.curGrip;
+    bool gripEditStarted = isGripEditStarted();
+
     doEndEditElement();
-    startEditElement(newElement);
+
+    if (gripEditStarted) {
+        startEditGrip(newElement, currentGrip);
+    } else {
+        startEditElement(newElement);
+    }
 }
 
 void NotationInteraction::editElement(QKeyEvent* event)


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10449