### PR TITLE
fix #10497 Custom Key Sig, accidentals placement in scaled line distance

### DIFF
--- a/src/engraving/libmscore/keysig.cpp
+++ b/src/engraving/libmscore/keysig.cpp
@@ -133,8 +133,9 @@ void KeySig::layout()
     setbbox(RectF());
 
     if (isCustom() && !isAtonal()) {
+        qreal step = _spatium * (staff() ? staff()->staffTypeForElement(this)->lineDistance().val() : 1);
         for (KeySym& ks: _sig.keySymbols()) {
-            ks.pos = ks.spos * _spatium;
+            ks.pos = PointF((ks.spos.x() * _spatium), (ks.spos.y() * step));
             addbbox(symBbox(ks.sym).translated(ks.pos));
         }
         return;


### PR DESCRIPTION
Resolves: *(#10497)*

*(If line distance was different than 1, accidentals in custom key signatures were placed in wrong vertical position. Fixed.)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made

![fix_scaling_bug](https://user-images.githubusercontent.com/1646034/153302654-27fdbdbe-4b21-4229-ac80-a60b0f09c3a8.png)