### PR TITLE
Fix #10440: Re-add Remove measures to Context menu

### DIFF
--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -318,7 +318,8 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("time-delete",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Remove selected range")
+             QT_TRANSLATE_NOOP("action", "Remove selected range"),
+             IconCode::Code::DELETE_TANK
              ),
     UiAction("slash-fill",
              mu::context::UiCtxNotationOpened,

--- a/src/notation/view/notationcontextmenumodel.cpp
+++ b/src/notation/view/notationcontextmenumodel.cpp
@@ -21,6 +21,8 @@
  */
 #include "notationcontextmenumodel.h"
 
+#include "translation.h"
+
 #include "ui/view/iconcodes.h"
 
 using namespace mu::notation;
@@ -90,9 +92,9 @@ MenuItemList NotationContextMenuModel::makeMeasureItems()
     items << makeSeparator();
 
     MenuItem* clearItem = makeMenuItem("notation-delete");
-    clearItem->setTitle("Clear measures");
+    clearItem->setTitle(qtrc("notation", "Clear measures"));
     MenuItem* deleteItem = makeMenuItem("time-delete");
-    deleteItem->setTitle("Delete measures");
+    deleteItem->setTitle(qtrc("notation", "Delete measures"));
     items << clearItem;
     items << deleteItem;
 

--- a/src/notation/view/notationcontextmenumodel.cpp
+++ b/src/notation/view/notationcontextmenumodel.cpp
@@ -80,7 +80,22 @@ MenuItemList NotationContextMenuModel::makeDefaultCopyPasteItems()
 
 MenuItemList NotationContextMenuModel::makeMeasureItems()
 {
-    MenuItemList items = makeElementItems();
+    MenuItemList items = {
+        makeMenuItem("notation-cut"),
+        makeMenuItem("notation-copy"),
+        makeMenuItem("notation-paste"),
+        makeMenuItem("notation-swap"),
+    };
+
+    items << makeSeparator();
+
+    MenuItem* clearItem = makeMenuItem("notation-delete");
+    clearItem->setTitle("Clear measures");
+    MenuItem* deleteItem = makeMenuItem("time-delete");
+    deleteItem->setTitle("Delete measures");
+    items << clearItem;
+    items << deleteItem;
+
     items << makeSeparator();
 
     if (isDrumsetStaff()) {


### PR DESCRIPTION
Resolves: [#10440](https://github.com/musescore/MuseScore/issues/10440)

In order not to interfere with other menus，I only rewrite context menu when select measure(s).
I also add Icon to "time-delete", for it's only used here(except shortcut), I think it's ok to add that.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made

https://user-images.githubusercontent.com/71218187/153349899-d57d84c1-9a00-486c-8e81-2ccbe79d2f46.mp4

