### PR TITLE
Fix #10411: Insert measures box stays open

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/measures/InsertMeasuresPopup.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/measures/InsertMeasuresPopup.qml
@@ -44,8 +44,6 @@ Column {
         numberOfMeasures.navigation.requestActive()
     }
 
-    signal closeRequested()
-
     RowLayout {
         width: parent.width
         spacing: 4
@@ -109,7 +107,6 @@ Column {
 
         onClicked: {
             model.insertMeasures(numberOfMeasures.currentValue, targetDropdown.currentValue)
-            root.closeRequested()
         }
     }
 }

--- a/src/inspector/view/qml/MuseScore/Inspector/measures/MeasuresInspectorView.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/measures/MeasuresInspectorView.qml
@@ -60,10 +60,6 @@ InspectorSectionView {
                     model: root.model
 
                     navigationPanel: insertMeasuresPopupButton.popupNavigationPanel
-
-                    onCloseRequested: {
-                        insertMeasuresPopupButton.closePopup()
-                    }
                 }
 
                 onEnsureContentVisibleRequested: function(invisibleContentHeight) {


### PR DESCRIPTION
Resolves: #10411 

The insert measures box now stays open after inserting. The approach used is simple, so let me know if this is what was required
The UI is changed whenever you select a new measure, so all I am doing is (apart from removing a close request in the qml) is to keep the current selection selected after inserting measures because if someone wants to spam the insert measures button, keeping the same thing selected makes more sense
(I would rather double tap insert measures, rather than select two in count and then clicking insert i.e. small counts justify the current item being selected)


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
