### PR TITLE
Automatic bracketing and instruments with multiple staves

### DIFF
--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -3808,6 +3808,52 @@ void Score::setScoreOrder(ScoreOrder order)
 }
 
 //---------------------------------------------------------
+//   updateBracesAndBarlines
+//---------------------------------------------------------
+
+void Score::updateBracesAndBarlines(Part* part, size_t newIndex)
+{
+    bool noBracesFound = true;
+    for (size_t indexInPart = 0; indexInPart < part->nstaves(); ++indexInPart) {
+        size_t indexInScore = part->staves()[indexInPart]->idx();
+        for (BracketItem* bi : staff(indexInScore)->brackets()) {
+            noBracesFound = false;
+            if (bi->bracketType() == BracketType::BRACE) {
+                if ((indexInPart <= newIndex) && (newIndex <= (bi->bracketSpan()))) {
+                    bi->undoChangeProperty(Pid::BRACKET_SPAN, bi->bracketSpan() + 1);
+                }
+            }
+        }
+    }
+
+    auto updateBracketSpan = [this, part](size_t modIndex, size_t refIndex) {
+        Staff* modStaff = staff(part->staves()[modIndex]->idx());
+        Staff* refStaff = staff(part->staves()[refIndex]->idx());
+        if (modStaff->getProperty(Pid::STAFF_BARLINE_SPAN) != refStaff->getProperty(Pid::STAFF_BARLINE_SPAN)) {
+            modStaff->undoChangeProperty(Pid::STAFF_BARLINE_SPAN, refStaff->getProperty(Pid::STAFF_BARLINE_SPAN));
+        }
+    };
+
+    if (newIndex >= 2) {
+        updateBracketSpan(newIndex - 1, newIndex - 2);
+    }
+
+    if (part->nstaves() == 2) {
+        InstrumentTemplate* tp = searchTemplate(part->instrumentId());
+        if (tp) {
+            if (tp->barlineSpan[0] > 0) {
+                staff(part->staves()[0]->idx())->undoChangeProperty(Pid::STAFF_BARLINE_SPAN, tp->barlineSpan[0]);
+            }
+            if (noBracesFound && (tp->bracket[0] != BracketType::NO_BRACKET)) {
+                undoAddBracket(part->staves()[0], 0, tp->bracket[0], part->nstaves());
+            }
+        }
+    } else {
+        updateBracketSpan(newIndex, newIndex - 1);
+    }
+}
+
+//---------------------------------------------------------
 //   setBracketsAndBarlines
 //---------------------------------------------------------
 
@@ -5206,6 +5252,24 @@ void Score::addRefresh(const mu::RectF& r)
 {
     _updateState.refresh.unite(r);
     cmdState().setUpdateMode(UpdateMode::Update);
+}
+
+//---------------------------------------------------------
+//   staffIdx
+//
+//  Return index for the staff in the score.
+//---------------------------------------------------------
+
+staff_idx_t Score::staffIdx(const Staff* staff) const
+{
+    staff_idx_t idx = 0;
+    for (Staff* s : _staves) {
+        if (s == staff) {
+            break;
+        }
+        ++idx;
+    }
+    return idx;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -657,6 +657,7 @@ public:
     size_t nstaves() const { return _staves.size(); }
     size_t ntracks() const { return _staves.size() * VOICES; }
 
+    staff_idx_t staffIdx(const Staff*) const;
     staff_idx_t staffIdx(const Part*) const;
     Staff* staff(size_t n) const { return (n < _staves.size()) ? _staves.at(n) : nullptr; }
     Staff* staffById(const ID& staffId) const;
@@ -985,6 +986,7 @@ public:
 
     ScoreOrder scoreOrder() const;
     void setScoreOrder(ScoreOrder order);
+    void updateBracesAndBarlines(Part* part, size_t index);
     void setBracketsAndBarlines();
 
     void lassoSelect(const mu::RectF&);

--- a/src/instrumentsscene/view/staffcontroltreeitem.cpp
+++ b/src/instrumentsscene/view/staffcontroltreeitem.cpp
@@ -44,10 +44,17 @@ void StaffControlTreeItem::appendNewItem()
         return;
     }
 
-    size_t lastStaffIndex = part->nstaves();
+    size_t insertStaffIndex = part->nstaves();
+    const AbstractInstrumentsPanelTreeItem* par = parentItem();
+    for (int row = 0; row < par->childCount() - 1; ++row) {
+        if (par->childAtRow(row)->isSelected()) {
+            insertStaffIndex = row + 1;
+        }
+    }
 
     Staff* staff = engraving::Factory::createStaff(const_cast<Part*>(part));
-    staff->setDefaultClefType(part->instrument()->clefType(lastStaffIndex));
 
-    masterNotation()->parts()->appendStaff(staff, m_partId);
+    staff->setDefaultClefType(part->staff(insertStaffIndex - 1)->defaultClefType());
+
+    masterNotation()->parts()->insertStaff(staff, m_partId, insertStaffIndex);
 }

--- a/src/notation/inotationparts.h
+++ b/src/notation/inotationparts.h
@@ -69,7 +69,7 @@ public:
     virtual void moveParts(const IDList& sourcePartsIds, const ID& destinationPartId, InsertMode mode = InsertMode::Before) = 0;
     virtual void moveStaves(const IDList& sourceStavesIds, const ID& destinationStaffId, InsertMode mode = InsertMode::Before) = 0;
 
-    virtual void appendStaff(Staff* staff, const ID& destinationPartId) = 0;
+    virtual void insertStaff(Staff* staff, const ID& destinationPartId, size_t index = 0) = 0;
     virtual void appendLinkedStaff(Staff* staff, const ID& sourceStaffId, const ID& destinationPartId) = 0;
 
     virtual void insertPart(Part* part, size_t index) = 0;

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -82,7 +82,7 @@ void MasterNotationParts::removeStaves(const IDList& stavesIds)
     endGlobalEdit();
 }
 
-void MasterNotationParts::appendStaff(Staff* staff, const ID& destinationPartId)
+void MasterNotationParts::insertStaff(Staff* staff, const ID& destinationPartId, size_t index)
 {
     TRACEFUNC;
 
@@ -91,11 +91,19 @@ void MasterNotationParts::appendStaff(Staff* staff, const ID& destinationPartId)
     //! NOTE: will be generated later after adding to the score
     staff->setId(mu::engraving::INVALID_ID);
 
-    NotationParts::appendStaff(staff, destinationPartId);
+    NotationParts::insertStaff(staff, destinationPartId, index);
+
+    size_t firstStaffInPartIndex = 0;
+    for (const Part* part : partList()) {
+        if (part->id() == destinationPartId) {
+            break;
+        }
+        firstStaffInPartIndex += part->nstaves();
+    }
 
     for (INotationPartsPtr parts : excerptsParts()) {
         Staff* excerptStaff = mu::engraving::toStaff(staff->linkedClone());
-        parts->appendStaff(excerptStaff, destinationPartId);
+        parts->insertStaff(excerptStaff, destinationPartId, index - firstStaffInPartIndex);
     }
 
     endGlobalEdit();

--- a/src/notation/internal/masternotationparts.h
+++ b/src/notation/internal/masternotationparts.h
@@ -37,7 +37,7 @@ public:
     void removeParts(const IDList& partsIds) override;
     void removeStaves(const IDList& stavesIds) override;
 
-    void appendStaff(Staff* staff, const ID& destinationPartId) override;
+    void insertStaff(Staff* staff, const ID& destinationPartId, size_t index=0) override;
     void appendLinkedStaff(Staff* staff, const ID& sourceStaffId, const ID& destinationPartId) override;
 
     void replaceInstrument(const InstrumentKey& instrumentKey, const Instrument& newInstrument) override;

--- a/src/notation/internal/notationparts.h
+++ b/src/notation/internal/notationparts.h
@@ -64,7 +64,7 @@ public:
     void moveParts(const IDList& sourcePartsIds, const ID& destinationPartId, InsertMode mode = InsertMode::Before) override;
     void moveStaves(const IDList& sourceStavesIds, const ID& destinationStaffId, InsertMode mode = InsertMode::Before) override;
 
-    void appendStaff(Staff* staff, const ID& destinationPartId) override;
+    void insertStaff(Staff* staff, const ID& destinationPartId, size_t index=0) override;
     void appendLinkedStaff(Staff* staff, const ID& sourceStaffId, const ID& destinationPartId) override;
 
     void insertPart(Part* part, size_t index) override;
@@ -90,7 +90,7 @@ private:
     void doSetScoreOrder(const ScoreOrder& order);
     void doMoveStaves(const std::vector<Staff*>& staves, engraving::staff_idx_t destinationStaffIndex, Part* destinationPart = nullptr);
     void doRemoveParts(const std::vector<Part*>& parts);
-    void doAppendStaff(Staff* staff, Part* destinationPart);
+    void doInsertStaff(Staff* staff, Part* destinationPart, size_t staffLocalIndex = 0);
     void doSetStaffConfig(Staff* staff, const StaffConfig& config);
     void doInsertPart(Part* part, size_t index);
 


### PR DESCRIPTION
Resolves: #10034
Resolves: #10040

With this PR automatic bracketing will no longer (re-)generate braces but leave these braces as they are, except when a brace will span only one staff in which case the brace is deleted.
Also the code for changing the bar line space is optimized.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
