### PR TITLE
[MU4] Fix reset autoplace in pre-3.0 score migration

### DIFF
--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -5317,6 +5317,10 @@ void Score::doLayoutRange(const Fraction& st, const Fraction& et)
 
     m_layoutOptions.updateFromStyle(style());
     m_layout.doLayoutRange(m_layoutOptions, st, et);
+    if (_resetAutoplace) {
+        _resetAutoplace = false;
+        resetAllPositions();
+    }
 }
 
 UndoStack* Score::undoStack() const { return _masterScore->undoStack(); }

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -455,7 +455,7 @@ private:
                                                 ///< saves will not overwrite the backup file.
     bool _defaultsRead        { false };        ///< defaults were read at MusicXML import, allow export of defaults in convertermode
     ScoreOrder _scoreOrder;                     ///< used for score ordering
-
+    bool _resetAutoplace{ false };
     int _mscVersion { MSCVERSION };     ///< version of current loading *.msc file
 
     QMap<QString, QString> _metaTags;
@@ -568,6 +568,7 @@ public:
     void removeStaff(Staff*);
     void addMeasure(MeasureBase*, MeasureBase*);
     void linkMeasures(Score* score);
+    void setResetAutoplace() { _resetAutoplace = true; }
 
     Excerpt* excerpt() { return _excerpt; }
     void setExcerpt(Excerpt* e) { _excerpt = e; }

--- a/src/project/internal/projectmigrator.cpp
+++ b/src/project/internal/projectmigrator.cpp
@@ -180,6 +180,6 @@ bool ProjectMigrator::applyEdwinStyle(Ms::MasterScore* score)
 
 bool ProjectMigrator::resetAllElementsPositions(Ms::MasterScore* score)
 {
-    score->resetAllPositions();
+    score->setResetAutoplace();
     return true;
 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10498

The problem was that the autoplace code was happening before initial layout, so the code that resets the placements is skipped as it tries to go through the list of pages, which is not populated. The fix just sets a boolean field that is checked on layout so that the autoplace stuff can happen after layout happens.

The other potential fix for this would just be to call layout before the score migration stuff, but this fix strikes me as better because there aren't any unnecessary layouts, which can increase the loading time of particularly large scores by a noticeable amount.