### PR TITLE
Solves a crash (call to qFatal()) when retrieving properties of type …

### DIFF
--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1410,6 +1410,8 @@ PropertyValue EditStyle::getValue(StyleId idx)
         }
         return v.toBool();
     } break;
+    case P_TYPE::PLACEMENT_H:
+    case P_TYPE::PLACEMENT_V:
     case P_TYPE::INT: {
         if (qobject_cast<QComboBox*>(sw.widget)) {
             QComboBox* cb = qobject_cast<QComboBox*>(sw.widget);


### PR DESCRIPTION
Resolves: #10528

Solves a crash (call to `qFatal()`) when retrieving properties of type `PLACEMENT_V` or `PLACEMENT_H`.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
