### PR TITLE
|MU4] Revert renaming of chantCaesura's name

### DIFF
--- a/src/engraving/types/symnames.cpp
+++ b/src/engraving/types/symnames.cpp
@@ -3805,7 +3805,7 @@ constexpr const std::array<const char*, size_t(SymId::lastSym) + 1> SymNames::s_
     "Punctum auctum, ascending",
     "Punctum auctum, descending",
     "Augmentum (mora)",
-    QT_TRANSLATE_NOOP("symUserNames", "Chant caesura"),
+    QT_TRANSLATE_NOOP("symUserNames", "Caesura"),
     "Plainchant C clef",
     "Circulus above",
     "Circulus below",


### PR DESCRIPTION
This is not the name used in SMuFL!
Yes, the glyph is `chantCaesura`, but the clear text name is "Caesura".
See fonts/smufl/glyphnames.json:
```
	"chantCaesura": {
		"codepoint": "U+E8F8",
		"description": "Caesura"
	},

```
Whenever ...tools/fonttools/smufl2sym.{sh,bat} is run again, it'd revert this change.

See  #6152, when this got added to 3.x and 7d70696 for master, esp. the commented out code in the mtests checking for duplicates, as in 3.x this was only in the master palette.

I've submitted https://github.com/w3c/smufl/issues/215, maybe this will change in the futur. Until then we have this PR here ;-)