### PR TITLE
[MU4] Optimized drawing of a large score

### DIFF
--- a/src/engraving/libmscore/ambitus.cpp
+++ b/src/engraving/libmscore/ambitus.cpp
@@ -554,8 +554,14 @@ void Ambitus::draw(mu::draw::Painter* painter) const
 void Ambitus::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
 {
     Q_UNUSED(all);
-    EngravingObject::scanElements(data, func, all);
     func(data, this);
+    if (_topAccid->accidentalType() != AccidentalType::NONE) {
+        func(data, _topAccid);
+    }
+
+    if (_bottomAccid->accidentalType() != AccidentalType::NONE) {
+        func(data, _bottomAccid);
+    }
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/barline.cpp
+++ b/src/engraving/libmscore/barline.cpp
@@ -1383,8 +1383,11 @@ void BarLine::scanElements(void* data, void (* func)(void*, EngravingItem*), boo
     if (width() == 0.0 && !all) {
         return;
     }
-    EngravingObject::scanElements(data, func, all);
+
     func(data, this);
+    for (EngravingItem* e : _el) {
+        e->scanElements(data, func, all);
+    }
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -1824,17 +1824,4 @@ void Beam::startDrag(EditData& editData)
 {
     initBeamEditData(editData);
 }
-
-//---------------------------------------------------------
-//   scanElements
-//---------------------------------------------------------
-
-void Beam::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
-{
-    ChordRest* cr = !_elements.isEmpty() ? _elements[0] : nullptr;
-    if (!all && cr && cr->measure()->stemless(cr->staffIdx())) {
-        return;
-    }
-    EngravingItem::scanElements(data, func, all);
-}
 }

--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -118,8 +118,6 @@ public:
     EngravingObject* scanChild(int idx) const override;
     int scanChildCount() const override;
 
-    void scanElements(void* data, void (* func)(void*, EngravingItem*), bool all=true) override;
-
     Beam* clone() const override { return new Beam(*this); }
     mu::PointF pagePos() const override;      ///< position in page coordinates
     mu::PointF canvasPos() const override;    ///< position in page coordinates

--- a/src/engraving/libmscore/box.cpp
+++ b/src/engraving/libmscore/box.cpp
@@ -80,18 +80,6 @@ void Box::layout()
 }
 
 //---------------------------------------------------------
-//   scanElements
-//---------------------------------------------------------
-
-void Box::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
-{
-    EngravingObject::scanElements(data, func, all);
-    if (all || visible() || score()->showInvisible()) {
-        func(data, this);
-    }
-}
-
-//---------------------------------------------------------
 //   computeMinWidth
 //---------------------------------------------------------
 

--- a/src/engraving/libmscore/box.h
+++ b/src/engraving/libmscore/box.h
@@ -54,8 +54,6 @@ class Box : public MeasureBase
 public:
     Box(const ElementType& type, System* parent);
 
-    void scanElements(void* data, void (* func)(void*, EngravingItem*), bool all=true) override;
-
     virtual void draw(mu::draw::Painter*) const override;
     virtual bool isEditable() const override { return true; }
 

--- a/src/engraving/libmscore/bsymbol.cpp
+++ b/src/engraving/libmscore/bsymbol.cpp
@@ -117,6 +117,18 @@ void BSymbol::add(EngravingItem* e)
 }
 
 //---------------------------------------------------------
+//   scanElements
+//---------------------------------------------------------
+
+void BSymbol::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
+{
+    func(data, this);
+    foreach (EngravingItem* e, _leafs) {
+        e->scanElements(data, func, all);
+    }
+}
+
+//---------------------------------------------------------
 //   remove
 //---------------------------------------------------------
 

--- a/src/engraving/libmscore/bsymbol.h
+++ b/src/engraving/libmscore/bsymbol.h
@@ -41,6 +41,7 @@ public:
     EngravingObject* scanParent() const override;
     EngravingObject* scanChild(int idx) const override;
     int scanChildCount() const override;
+    void scanElements(void* data, void (* func)(void*, EngravingItem*), bool all=true) override;
 
     BSymbol& operator=(const BSymbol&) = delete;
 

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -1883,6 +1883,49 @@ void Chord::layout()
 }
 
 //---------------------------------------------------------
+//   scanElements
+//---------------------------------------------------------
+
+void Chord::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
+{
+    for (Articulation* a : _articulations) {
+        func(data, a);
+    }
+    if (_hook) {
+        func(data, _hook);
+    }
+    if (_stem) {
+        func(data, _stem);
+    }
+    if (_stemSlash) {
+        func(data, _stemSlash);
+    }
+    if (_arpeggio) {
+        func(data, _arpeggio);
+    }
+    if (_tremolo && (tremoloChordType() != TremoloChordType::TremoloSecondNote)) {
+        func(data, _tremolo);
+    }
+    const Staff* st = staff();
+    if ((st && st->showLedgerLines(tick())) || !st) {       // also for palette
+        for (LedgerLine* ll = _ledgerLines; ll; ll = ll->next()) {
+            func(data, ll);
+        }
+    }
+    size_t n = _notes.size();
+    for (size_t i = 0; i < n; ++i) {
+        _notes.at(i)->scanElements(data, func, all);
+    }
+    for (Chord* chord : _graceNotes) {
+        chord->scanElements(data, func, all);
+    }
+    for (EngravingItem* e : el()) {
+        e->scanElements(data, func, all);
+    }
+    ChordRest::scanElements(data, func, all);
+}
+
+//---------------------------------------------------------
 //   layoutPitched
 //---------------------------------------------------------
 

--- a/src/engraving/libmscore/chord.h
+++ b/src/engraving/libmscore/chord.h
@@ -138,6 +138,7 @@ public:
     EngravingObject* scanParent() const override;
     EngravingObject* scanChild(int idx) const override;
     int scanChildCount() const override;
+    void scanElements(void* data, void (* func)(void*, EngravingItem*), bool all=true) override;
 
     Chord* clone() const override { return new Chord(*this, false); }
     EngravingItem* linkedClone() override { return new Chord(*this, true); }

--- a/src/engraving/libmscore/chordrest.cpp
+++ b/src/engraving/libmscore/chordrest.cpp
@@ -1173,6 +1173,29 @@ EngravingItem* ChordRest::nextSegmentElement()
 }
 
 //---------------------------------------------------------
+//   scanElements
+//---------------------------------------------------------
+
+void ChordRest::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
+{
+    if (_beam && (_beam->elements().front() == this)
+        && !measure()->stemless(staffIdx())) {
+        _beam->scanElements(data, func, all);
+    }
+    for (Lyrics* l : _lyrics) {
+        l->scanElements(data, func, all);
+    }
+    DurationElement* de = this;
+    while (de->tuplet() && de->tuplet()->elements().front() == de) {
+        de->tuplet()->scanElements(data, func, all);
+        de = de->tuplet();
+    }
+    if (_tabDur) {
+        func(data, _tabDur);
+    }
+}
+
+//---------------------------------------------------------
 //   prevSegmentElement
 //---------------------------------------------------------
 

--- a/src/engraving/libmscore/chordrest.h
+++ b/src/engraving/libmscore/chordrest.h
@@ -90,6 +90,7 @@ public:
     virtual EngravingObject* scanParent() const override;
     virtual EngravingObject* scanChild(int idx) const override;
     virtual int scanChildCount() const override;
+    virtual void scanElements(void* data, void (* func)(void*, EngravingItem*), bool all=true) override;
 
     virtual EngravingItem* drop(EditData&) override;
     virtual void undoUnlink() override;

--- a/src/engraving/libmscore/fret.cpp
+++ b/src/engraving/libmscore/fret.cpp
@@ -1258,8 +1258,11 @@ EngravingItem* FretDiagram::drop(EditData& data)
 void FretDiagram::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
 {
     Q_UNUSED(all);
-    EngravingObject::scanElements(data, func, all);
     func(data, this);
+    // don't display harmony in palette
+    if (_harmony && !!parent()) {
+        func(data, _harmony);
+    }
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/glissando.cpp
+++ b/src/engraving/libmscore/glissando.cpp
@@ -224,6 +224,21 @@ QString Glissando::glissandoTypeName() const
 }
 
 //---------------------------------------------------------
+//   scanElements
+//---------------------------------------------------------
+
+void Glissando::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
+{
+    func(data, this);
+    // don't scan segments belonging to systems; the systems themselves will scan them
+    for (SpannerSegment* seg : spannerSegments()) {
+        if (!seg->parent() || !seg->parent()->isSystem()) {
+            seg->scanElements(data, func, all);
+        }
+    }
+}
+
+//---------------------------------------------------------
 //   createLineSegment
 //---------------------------------------------------------
 

--- a/src/engraving/libmscore/glissando.h
+++ b/src/engraving/libmscore/glissando.h
@@ -86,6 +86,8 @@ public:
 
     LineSegment* createLineSegment(System* parent) override;
 
+    void scanElements(void* data, void (* func)(void*, EngravingItem*), bool all=true) override;
+
     void layout() override;
     void write(XmlWriter&) const override;
     void read(XmlReader&) override;

--- a/src/engraving/libmscore/harmony.cpp
+++ b/src/engraving/libmscore/harmony.cpp
@@ -2344,18 +2344,4 @@ Sid Harmony::getPropertyStyle(Pid pid) const
     }
     return TextBase::getPropertyStyle(pid);
 }
-
-//---------------------------------------------------------
-//   scanElements
-//---------------------------------------------------------
-
-void Harmony::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
-{
-    Q_UNUSED(all);
-    // don't display harmony in palette
-    if (!explicitParent()) {
-        return;
-    }
-    func(data, this);
-}
 }

--- a/src/engraving/libmscore/harmony.h
+++ b/src/engraving/libmscore/harmony.h
@@ -140,8 +140,6 @@ public:
     void setLeftParen(bool leftParen) { _leftParen = leftParen; }
     void setRightParen(bool rightParen) { _rightParen = rightParen; }
 
-    void scanElements(void* data, void (* func)(void*, EngravingItem*), bool all=true) override;
-
     Harmony* findNext() const;
     Harmony* findPrev() const;
     Fraction ticksTillNext(int utick, bool stopAtMeasureEnd = false) const;

--- a/src/engraving/libmscore/iname.cpp
+++ b/src/engraving/libmscore/iname.cpp
@@ -164,15 +164,4 @@ PropertyValue InstrumentName::propertyDefault(Pid id) const
         return TextBase::propertyDefault(id);
     }
 }
-
-//---------------------------------------------------------
-//   scanElements
-//---------------------------------------------------------
-
-void InstrumentName::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
-{
-    if (all || sysStaff()->show()) {
-        func(data, this);
-    }
-}
 }

--- a/src/engraving/libmscore/iname.h
+++ b/src/engraving/libmscore/iname.h
@@ -61,8 +61,6 @@ public:
     SysStaff* sysStaff() const { return _sysStaff; }
     void setSysStaff(SysStaff* s) { _sysStaff = s; }
 
-    void scanElements(void* data, void (* func)(void*, EngravingItem*), bool all=true) override;
-
     Fraction playTick() const override;
     bool isEditable() const override { return false; }
     mu::engraving::PropertyValue getProperty(Pid propertyId) const override;

--- a/src/engraving/libmscore/ledgerline.cpp
+++ b/src/engraving/libmscore/ledgerline.cpp
@@ -159,17 +159,4 @@ bool LedgerLine::readProperties(XmlReader& e)
     }
     return true;
 }
-
-//---------------------------------------------------------
-//   scanElements
-//---------------------------------------------------------
-
-void LedgerLine::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
-{
-    Staff* st = chord()->staff();
-    if (st && !st->showLedgerLines(tick())) {
-        return;
-    }
-    EngravingItem::scanElements(data, func, all);
-}
 }

--- a/src/engraving/libmscore/ledgerline.h
+++ b/src/engraving/libmscore/ledgerline.h
@@ -54,8 +54,6 @@ public:
     mu::PointF pagePos() const override;        ///< position in page coordinates
     Chord* chord() const { return toChord(explicitParent()); }
 
-    void scanElements(void* data, void (* func)(void*, EngravingItem*), bool all=true) override;
-
     qreal len() const { return _len; }
     qreal lineWidth() const { return _width; }
     void setLen(qreal v) { _len = v; }

--- a/src/engraving/libmscore/lyrics.cpp
+++ b/src/engraving/libmscore/lyrics.cpp
@@ -371,6 +371,19 @@ void Lyrics::layout()
 }
 
 //---------------------------------------------------------
+//   scanElements
+//---------------------------------------------------------
+
+void Lyrics::scanElements(void* data, void (* func)(void*, EngravingItem*), bool /*all*/)
+{
+    func(data, this);
+    /* DO NOT ADD EITHER THE LYRICSLINE OR THE SEGMENTS: segments are added through the system each belongs to;
+      LyricsLine is not needed, as it is internally manged.
+      if (_separator)
+            _separator->scanElements(data, func, all); */
+}
+
+//---------------------------------------------------------
 //   layout2
 //    compute vertical position
 //---------------------------------------------------------

--- a/src/engraving/libmscore/lyrics.h
+++ b/src/engraving/libmscore/lyrics.h
@@ -86,6 +86,8 @@ public:
     void layout() override;
     void layout2(int);
 
+    void scanElements(void* data, void (* func)(void*, EngravingItem*), bool all=true) override;
+
     void write(XmlWriter& xml) const override;
     void read(XmlReader&) override;
     bool readProperties(XmlReader&) override;

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -2132,12 +2132,31 @@ bool Measure::isFirstInSystem() const
 
 void Measure::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
 {
-    for (int i = 0; i < scanChildCount(); ++i) {
-        EngravingObject* el = scanChild(i);
-        if (el->isMeasure()) {
-            continue;  // do not scan Measures 'inside' mmrest measure
+    MeasureBase::scanElements(data, func, all);
+
+    int nstaves = score()->nstaves();
+    for (int staffIdx = 0; staffIdx < nstaves; ++staffIdx) {
+        if (!all && !(visible(staffIdx) && score()->staff(staffIdx)->show())) {
+            continue;
         }
-        el->scanElements(data, func, all);
+        MStaff* ms = m_mstaves[staffIdx];
+        func(data, ms->lines());
+        if (ms->vspacerUp()) {
+            func(data, ms->vspacerUp());
+        }
+        if (ms->vspacerDown()) {
+            func(data, ms->vspacerDown());
+        }
+        if (ms->noText()) {
+            func(data, ms->noText());
+        }
+    }
+
+    for (Segment* s = first(); s; s = s->next()) {
+        if (!s->enabled()) {
+            continue;
+        }
+        s->scanElements(data, func, all);
     }
 }
 

--- a/src/engraving/libmscore/measurebase.cpp
+++ b/src/engraving/libmscore/measurebase.cpp
@@ -357,6 +357,35 @@ void MeasureBase::triggerLayout() const
 }
 
 //---------------------------------------------------------
+//   scanElements
+//---------------------------------------------------------
+
+void MeasureBase::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
+{
+    if (isMeasure()) {
+        for (EngravingItem* e : _el) {
+            if (score()->tagIsValid(e->tag())) {
+                if (e->staffIdx() >= score()->staves().size()) {
+                    qDebug("MeasureBase::scanElements: bad staffIdx %d in element %s", e->staffIdx(), e->name());
+                }
+                if ((e->track() == -1) || e->systemFlag() || ((Measure*)this)->visible(e->staffIdx())) {
+                    e->scanElements(data, func, all);
+                }
+            }
+        }
+    } else {
+        for (EngravingItem* e : _el) {
+            if (score()->tagIsValid(e->tag())) {
+                e->scanElements(data, func, all);
+            }
+        }
+    }
+    if (isBox()) {
+        func(data, this);
+    }
+}
+
+//---------------------------------------------------------
 //   first
 //---------------------------------------------------------
 

--- a/src/engraving/libmscore/measurebase.h
+++ b/src/engraving/libmscore/measurebase.h
@@ -101,6 +101,7 @@ public:
     EngravingObject* scanParent() const override;
     EngravingObject* scanChild(int idx) const override;
     int scanChildCount() const override;
+    virtual void scanElements(void* data, void (* func)(void*, EngravingItem*), bool all=true) override;
 
     virtual void setScore(Score* s) override;
 

--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -2344,10 +2344,31 @@ QString Note::noteTypeUserName() const
 
 void Note::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
 {
-    EngravingObject::scanElements(data, func, all);
-    if (all || visible() || score()->showInvisible()) {
-        func(data, this);
+    func(data, this);
+    // tie segments are collected from System
+    //      if (_tieFor && !staff()->isTabStaff(chord->tick()))  // no ties in tablature
+    //            _tieFor->scanElements(data, func, all);
+    for (EngravingItem* e : _el) {
+        if (score()->tagIsValid(e->tag())) {
+            e->scanElements(data, func, all);
+        }
     }
+    for (Spanner* sp : _spannerFor) {
+        sp->scanElements(data, func, all);
+    }
+
+    if (!dragMode && _accidental) {
+        func(data, _accidental);
+    }
+    for (NoteDot* dot : _dots) {
+        func(data, dot);
+    }
+
+    // see above - tie segments are still collected from System!
+    // if (_tieFor && !_tieFor->spannerSegments().empty())
+    //      _tieFor->spannerSegments().front()->scanElements(data, func, all);
+    // if (_tieBack && _tieBack->spannerSegments().size() > 1)
+    //      _tieBack->spannerSegments().back()->scanElements(data, func, all);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/page.cpp
+++ b/src/engraving/libmscore/page.cpp
@@ -322,10 +322,13 @@ qreal Page::footerExtension() const
 
 void Page::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
 {
-    EngravingObject::scanElements(data, func, all);
-    if (all || visible() || score()->showInvisible()) {
-        func(data, this);
+    for (System* s :_systems) {
+        for (MeasureBase* m : s->measures()) {
+            m->scanElements(data, func, all);
+        }
+        s->scanElements(data, func, all);
     }
+    func(data, this);
 }
 
 #ifdef USE_BSP

--- a/src/engraving/libmscore/rest.cpp
+++ b/src/engraving/libmscore/rest.cpp
@@ -706,7 +706,13 @@ qreal Rest::downPos() const
 
 void Rest::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
 {
-    EngravingObject::scanElements(data, func, all);
+    ChordRest::scanElements(data, func, all);
+    for (EngravingItem* e : el()) {
+        e->scanElements(data, func, all);
+    }
+    for (NoteDot* dot : m_dots) {
+        dot->scanElements(data, func, all);
+    }
     if (!isGap()) {
         func(data, this);
     }

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -5199,6 +5199,31 @@ void Score::rebuildBspTree()
 }
 
 //---------------------------------------------------------
+//   scanElements
+//    scan all elements
+//---------------------------------------------------------
+
+void Score::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
+{
+    for (MeasureBase* mb = first(); mb; mb = mb->next()) {
+        mb->scanElements(data, func, all);
+        if (mb->type() == ElementType::MEASURE) {
+            Measure* m = toMeasure(mb);
+            Measure* mmr = m->mmRest();
+            if (mmr) {
+                mmr->scanElements(data, func, all);
+            }
+        }
+    }
+    for (Page* page : pages()) {
+        for (System* s :page->systems()) {
+            s->scanElements(data, func, all);
+        }
+        func(data, page);
+    }
+}
+
+//---------------------------------------------------------
 //   connectTies
 ///   Rebuild tie connections.
 //---------------------------------------------------------

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -552,6 +552,8 @@ public:
     EngravingObject* scanParent() const override;
     EngravingObject* scanChild(int idx) const override;
     int scanChildCount() const override;
+    void scanElements(void* data, void (* func)(void*, EngravingItem*), bool all=true) override;
+
     void dumpScoreTree();  // for debugging purposes
 
     mu::engraving::RootItem* rootItem() const { return m_rootItem; }

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -1266,15 +1266,21 @@ Ms::EngravingItem* Segment::elementAt(int track) const
 
 void Segment::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
 {
-    if (!enabled()) {
-        return;
+    for (int track = 0; track < score()->nstaves() * VOICES; ++track) {
+        int staffIdx = track / VOICES;
+        if (!all && !(measure()->visible(staffIdx) && score()->staff(staffIdx)->show())) {
+            track += VOICES - 1;
+            continue;
+        }
+        EngravingItem* e = element(track);
+        if (e == 0) {
+            continue;
+        }
+        e->scanElements(data, func, all);
     }
-
-    for (int i = 0; i < scanChildCount(); ++i) {
-        EngravingObject* el = scanChild(i);
-        EngravingItem* e = toEngravingItem(el);
-        if (all || e->systemFlag() || (score()->staff(e->staffIdx())->show() && measure()->visible(e->staffIdx()))) {
-            e->scanElements(data, func, all);
+    for (EngravingItem* e : annotations()) {
+        if (all || e->systemFlag() || measure()->visible(e->staffIdx())) {
+            e->scanElements(data,  func, all);
         }
     }
 }

--- a/src/engraving/libmscore/spacer.cpp
+++ b/src/engraving/libmscore/spacer.cpp
@@ -269,15 +269,4 @@ PropertyValue Spacer::propertyDefault(Pid id) const
         return EngravingItem::propertyDefault(id);
     }
 }
-
-//---------------------------------------------------------
-//   scanElements
-//---------------------------------------------------------
-
-void Spacer::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
-{
-    if (all || (measure()->visible(staffIdx()) && score()->staff(staffIdx())->show())) {
-        func(data, this);
-    }
-}
 }

--- a/src/engraving/libmscore/spacer.h
+++ b/src/engraving/libmscore/spacer.h
@@ -70,8 +70,6 @@ public:
 
     void draw(mu::draw::Painter*) const override;
 
-    void scanElements(void* data, void (* func)(void*, EngravingItem*), bool all=true) override;
-
     bool isEditable() const override { return true; }
     void startEditDrag(EditData&) override;
     void editDrag(EditData&) override;

--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -1286,9 +1286,57 @@ MeasureBase* System::nextMeasure(const MeasureBase* m) const
 
 void System::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
 {
-    EngravingObject::scanElements(data, func, all);
-    for (SpannerSegment* ss : qAsConst(_spannerSegments)) {
-        ss->scanElements(data, func, all);
+    if (vbox()) {
+        return;
+    }
+    for (Bracket* b : _brackets) {
+        func(data, b);
+    }
+
+    if (_systemDividerLeft) {
+        func(data, _systemDividerLeft);
+    }
+    if (_systemDividerRight) {
+        func(data, _systemDividerRight);
+    }
+
+    int idx = 0;
+    for (const SysStaff* st : _staves) {
+        if (all || st->show()) {
+            for (InstrumentName* t : st->instrumentNames) {
+                func(data, t);
+            }
+        }
+        ++idx;
+    }
+    for (SpannerSegment* ss : _spannerSegments) {
+        int staffIdx = ss->spanner()->staffIdx();
+        if (staffIdx == -1) {
+            qDebug("System::scanElements: staffIDx == -1: %s %p", ss->spanner()->name(), ss->spanner());
+            staffIdx = 0;
+        }
+        bool v = true;
+        Spanner* spanner = ss->spanner();
+        if (spanner->anchor() == Spanner::Anchor::SEGMENT || spanner->anchor() == Spanner::Anchor::CHORD) {
+            EngravingItem* se = spanner->startElement();
+            EngravingItem* ee = spanner->endElement();
+            bool v1 = true;
+            if (se && se->isChordRest()) {
+                ChordRest* cr = toChordRest(se);
+                Measure* m    = cr->measure();
+                v1            = m->visible(cr->staffIdx());
+            }
+            bool v2 = true;
+            if (!v1 && ee && ee->isChordRest()) {
+                ChordRest* cr = toChordRest(ee);
+                Measure* m    = cr->measure();
+                v2            = m->visible(cr->staffIdx());
+            }
+            v = v1 || v2;       // hide spanner if both chords are hidden
+        }
+        if (all || (score()->staff(staffIdx)->show() && _staves[staffIdx]->show() && v) || spanner->isVolta()) {
+            ss->scanElements(data, func, all);
+        }
     }
 }
 


### PR DESCRIPTION
Generally, it is reverting a part of PR #6274 because it caused lags when, for example, a note was shifted.
For now, it's easier to revert these changes than to try to optimize the current solution.

Score on which the bug can be reproduced
[smell.zip](https://github.com/musescore/MuseScore/files/8047960/smell.zip)
