### PR TITLE
[Save to Cloud] SaveLocation infrastructure

### DIFF
--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -86,7 +86,8 @@ void ApplicationActionController::onDropEvent(QDropEvent* event)
     if (urls.count() > 0) {
         QString file = urls.first().toLocalFile();
         LOGD() << file;
-        projectFilesController()->openProject(io::path(file));
+        project::SaveLocation location = project::SaveLocation::makeLocal(file);
+        projectFilesController()->openProject(location);
         event->ignore();
     }
 }
@@ -105,7 +106,8 @@ bool ApplicationActionController::eventFilter(QObject* watched, QEvent* event)
         QString filePath = openEvent->file();
 
         if (startupScenario()->startupCompleted()) {
-            dispatcher()->dispatch("file-open", ActionData::make_arg1<io::path>(filePath));
+            auto location = project::SaveLocation::makeLocal(filePath);
+            dispatcher()->dispatch("file-open", ActionData::make_arg1<project::SaveLocation>(location));
         } else {
             startupScenario()->setStartupScorePath(filePath);
         }

--- a/src/appshell/internal/sessionsmanager.h
+++ b/src/appshell/internal/sessionsmanager.h
@@ -22,6 +22,8 @@
 #ifndef MU_APPSHELL_SESSIONSMANAGER_H
 #define MU_APPSHELL_SESSIONSMANAGER_H
 
+#include <optional>
+
 #include "istartupscenario.h"
 
 #include "async/asyncable.h"
@@ -33,6 +35,10 @@
 #include "iappshellconfiguration.h"
 
 #include "isessionsmanager.h"
+
+namespace mu::project {
+struct SaveLocation;
+}
 
 namespace mu::appshell {
 class SessionsManager : public ISessionsManager, public async::Asyncable
@@ -52,10 +58,12 @@ public:
     void reset() override;
 
 private:
-    void removeProjectFromSession(const io::path& projectPath);
-    void addProjectToSession(const io::path& projectPath);
+    void update();
 
-    io::path m_lastOpenedProjectPath;
+    void removeProjectFromSession(const project::SaveLocation& projectPath);
+    void addProjectToSession(const project::SaveLocation& projectPath);
+
+    std::optional<project::SaveLocation> m_lastOpenedProjectLocation = std::nullopt;
 };
 }
 

--- a/src/appshell/internal/startupscenario.cpp
+++ b/src/appshell/internal/startupscenario.cpp
@@ -22,6 +22,8 @@
 
 #include "startupscenario.h"
 
+#include "project/projecttypes.h"
+
 #include "async/async.h"
 #include "translation.h"
 #include "log.h"
@@ -161,7 +163,8 @@ mu::Uri StartupScenario::startupPageUri(StartupModeType modeType) const
 
 void StartupScenario::openScore(const io::path& path)
 {
-    dispatcher()->dispatch("file-open", ActionData::make_arg1<io::path>(path));
+    auto saveLocation = project::SaveLocation::makeLocal(path);
+    dispatcher()->dispatch("file-open", ActionData::make_arg1<project::SaveLocation>(saveLocation));
 }
 
 void StartupScenario::restoreLastSession()

--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -377,7 +377,7 @@ MenuItemList AppMenuModel::makeRecentScoresItems()
 
         UiAction action;
         action.code = "file-open";
-        action.title = meta.fileName().toQString();
+        action.title = meta.saveLocation.userFriendlyName();
         item->setAction(action);
 
         item->setId(makeId(item->action().code, index++));
@@ -387,7 +387,7 @@ MenuItemList AppMenuModel::makeRecentScoresItems()
         item->setState(state);
 
         item->setSelectable(true);
-        item->setArgs(ActionData::make_arg1<io::path>(meta.filePath));
+        item->setArgs(ActionData::make_arg1<project::SaveLocation>(meta.saveLocation));
 
         items << item;
     }

--- a/src/appshell/view/mainwindowtitleprovider.cpp
+++ b/src/appshell/view/mainwindowtitleprovider.cpp
@@ -24,6 +24,7 @@
 
 using namespace mu::appshell;
 using namespace mu::notation;
+using namespace mu::project;
 
 MainWindowTitleProvider::MainWindowTitleProvider(QObject* parent)
     : QObject(parent)
@@ -93,7 +94,7 @@ void MainWindowTitleProvider::setFileModified(bool fileModified)
 
 void MainWindowTitleProvider::update()
 {
-    project::INotationProjectPtr project = context()->currentProject();
+    INotationProjectPtr project = context()->currentProject();
 
     if (!project) {
         setTitle(qtrc("appshell", "MuseScore 4"));
@@ -105,7 +106,8 @@ void MainWindowTitleProvider::update()
     INotationPtr notation = context()->currentNotation();
     setTitle(notation->projectNameAndPartName());
 
-    project::ProjectMeta meta = project->metaInfo();
-    setFilePath(project->isNewlyCreated() ? "" : meta.filePath.toQString());
+    SaveLocation saveLocation = project->saveLocation();
+    setFilePath(saveLocation.isLocal() ? saveLocation.localInfo().path.toQString() : "");
+
     setFileModified(project->needSave().val);
 }

--- a/src/appshell/view/mainwindowtitleprovider.cpp
+++ b/src/appshell/view/mainwindowtitleprovider.cpp
@@ -35,12 +35,15 @@ void MainWindowTitleProvider::load()
 {
     update();
 
-    context()->currentMasterNotationChanged().onNotify(this, [this]() {
+    context()->currentNotationChanged().onNotify(this, [this]() {
         update();
 
-        IMasterNotationPtr masterNotation = context()->currentMasterNotation();
-        if (masterNotation) {
-            masterNotation->needSave().notification.onNotify(this, [this]() {
+        if (auto project = context()->currentProject()) {
+            project->saveLocationChanged().onNotify(this, [this]() {
+                update();
+            });
+
+            project->needSave().notification.onNotify(this, [this]() {
                 update();
             });
         }

--- a/src/appshell/view/mainwindowtitleprovider.cpp
+++ b/src/appshell/view/mainwindowtitleprovider.cpp
@@ -106,6 +106,6 @@ void MainWindowTitleProvider::update()
     setTitle(notation->projectNameAndPartName());
 
     project::ProjectMeta meta = project->metaInfo();
-    setFilePath(project->created().val ? "" : meta.filePath.toQString());
+    setFilePath(project->isNewlyCreated() ? "" : meta.filePath.toQString());
     setFileModified(project->needSave().val);
 }

--- a/src/autobot/internal/api/autobotapi.cpp
+++ b/src/autobot/internal/api/autobotapi.cpp
@@ -110,8 +110,8 @@ void AutobotApi::fatal(const QString& msg)
 bool AutobotApi::openProject(const QString& name)
 {
     io::path dir = autobotConfiguration()->testingFilesDirPath();
-    io::path filePath = dir + "/" + name;
-    Ret ret = projectFilesController()->openProject(filePath);
+    project::SaveLocation saveLocation = project::SaveLocation::makeLocal(dir + "/" + name);
+    Ret ret = projectFilesController()->openProject(saveLocation);
     return ret;
 }
 

--- a/src/converter/internal/compat/backendapi.cpp
+++ b/src/converter/internal/compat/backendapi.cpp
@@ -733,5 +733,5 @@ Ret BackendApi::updateSource(const io::path& in, const std::string& newSource, b
 
     project.val->setMetaInfo(meta);
 
-    return project.val->save();
+    return project.val->saveToFile();
 }

--- a/src/engraving/engravingproject.cpp
+++ b/src/engraving/engravingproject.cpp
@@ -108,8 +108,6 @@ Err EngravingProject::doSetupMasterScore(Ms::MasterScore* score)
     }
     score->updateChannel();
     //score->updateExpressive(MuseScore::synthesizer("Fluid"));
-    score->setSaved(true);
-    score->setCreated(false);
     score->update();
 
     if (!score->sanityCheck(QString())) {
@@ -141,7 +139,6 @@ bool EngravingProject::writeMscz(mu::engraving::MscWriter& writer, bool onlySele
     bool ok = m_masterScore->writeMscz(writer, onlySelection, createThumbnail);
     if (ok && !onlySelection) {
         m_masterScore->undoStack()->setClean();
-        m_masterScore->setSaved(true);
         m_masterScore->update();
     }
 

--- a/src/engraving/engravingproject.cpp
+++ b/src/engraving/engravingproject.cpp
@@ -138,7 +138,6 @@ bool EngravingProject::writeMscz(mu::engraving::MscWriter& writer, bool onlySele
 {
     bool ok = m_masterScore->writeMscz(writer, onlySelection, createThumbnail);
     if (ok && !onlySelection) {
-        m_masterScore->undoStack()->setClean();
         m_masterScore->update();
     }
 

--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -308,7 +308,6 @@ void Score::endCmd(bool rollback)
 
     if (dirty()) {
         masterScore()->setPlaylistDirty(); // TODO: flag individual operations
-        masterScore()->setAutosaveDirty(true);
     }
 
     cmdState().reset();

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -4512,15 +4512,6 @@ EngravingItem* Score::getScoreElementOfMeasureBase(MeasureBase* mb) const
 }
 
 //---------------------------------------------------------
-//   setImportedFilePath
-//---------------------------------------------------------
-
-void Score::setImportedFilePath(const QString& filePath)
-{
-    _importedFilePath = filePath;
-}
-
-//---------------------------------------------------------
 //   nmeasure
 //---------------------------------------------------------
 

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -435,10 +435,6 @@ private:
     MStyle _style;
     ChordList _chordList;
 
-    bool _created { false };            ///< file is never saved, has generated name
-    QString _tmpName;                   ///< auto saved with this name if not empty
-    QString _importedFilePath;          // file from which the score was imported, or empty
-
     bool _showInvisible         { true };
     bool _showUnprintable       { true };
     bool _showFrames            { true };
@@ -446,11 +442,7 @@ private:
     bool _markIrregularMeasures { true };
     bool _showInstrumentNames   { true };
     bool _printing              { false };        ///< True if we are drawing to a printer
-    bool _autosaveDirty         { true };
     bool _savedCapture          { false };        ///< True if we saved an image capture
-    bool _saved                 { false };      ///< True if project was already saved; only on first
-                                                ///< save a backup file will be created, subsequent
-                                                ///< saves will not overwrite the backup file.
     bool _defaultsRead        { false };        ///< defaults were read at MusicXML import, allow export of defaults in convertermode
     ScoreOrder _scoreOrder;                     ///< used for score ordering
     bool _resetAutoplace{ false };
@@ -854,21 +846,12 @@ public:
     int fileDivision(int t) const { return ((qint64)t * Constant::division + _fileDivision / 2) / _fileDivision; }
     void setFileDivision(int t) { _fileDivision = t; }
 
-    QString importedFilePath() const { return _importedFilePath; }
-    void setImportedFilePath(const QString& filePath);
-
     bool dirty() const;
     ScoreContentState state() const;
-    void setCreated(bool val) { _created = val; }
-    bool created() const { return _created; }
     bool savedCapture() const { return _savedCapture; }
-    bool saved() const { return _saved; }
-    void setSaved(bool v) { _saved = v; }
     void setSavedCapture(bool v) { _savedCapture = v; }
     bool printing() const { return _printing; }
     void setPrinting(bool val) { _printing = val; }
-    void setAutosaveDirty(bool v) { _autosaveDirty = v; }
-    bool autosaveDirty() const { return _autosaveDirty; }
     virtual bool playlistDirty() const;
     virtual void setPlaylistDirty();
 
@@ -1041,8 +1024,6 @@ public:
     void scanElementsInRange(void* data, void (* func)(void*, EngravingItem*), bool all = true);
     int fileDivision() const { return _fileDivision; }   ///< division of current loading *.msc file
     void splitStaff(int staffIdx, int splitPoint);
-    QString tmpName() const { return _tmpName; }
-    void setTmpName(const QString& s) { _tmpName = s; }
     Lyrics* addLyrics();
     FiguredBass* addFiguredBass();
     void expandVoice(Segment* s, int track);

--- a/src/engraving/rw/compat/read114.cpp
+++ b/src/engraving/rw/compat/read114.cpp
@@ -3136,11 +3136,5 @@ Score::FileError Read114::read114(MasterScore* masterScore, XmlReader& e, ReadCo
     masterScore->rebuildMidiMapping();
     masterScore->updateChannel();
 
-    // treat reading a 1.14 file as import
-    // on save warn if old file will be overwritten
-    masterScore->setCreated(true);
-    // don't autosave (as long as there's no change to the score)
-    masterScore->setAutosaveDirty(false);
-
     return Score::FileError::FILE_NO_ERROR;
 }

--- a/src/engraving/rw/compat/read206.cpp
+++ b/src/engraving/rw/compat/read206.cpp
@@ -3451,11 +3451,5 @@ Score::FileError Read206::read206(Ms::MasterScore* masterScore, XmlReader& e, Re
         i.first->setOffset(i.second - i.first->pos());
     }
 
-    // treat reading a 2.06 file as import
-    // on save warn if old file will be overwritten
-    masterScore->setCreated(true);
-    // don't autosave (as long as there's no change to the score)
-    masterScore->setAutosaveDirty(false);
-
     return Score::FileError::FILE_NO_ERROR;
 }

--- a/src/engraving/rw/compat/readstyle.cpp
+++ b/src/engraving/rw/compat/readstyle.cpp
@@ -85,19 +85,15 @@ void ReadStyleHook::setupDefaultStyle()
         return;
     }
 
-    if (m_score->created() && DefaultStyle::isHasDefaultStyle()) {
-        m_score->setStyle(DefaultStyle::defaultStyle());
+    int defaultsVersion = -1;
+    if (m_score->isMaster()) {
+        defaultsVersion = readStyleDefaultsVersion(m_score->masterScore(), m_scoreData, m_completeBaseName);
     } else {
-        int defaultsVersion = -1;
-        if (m_score->isMaster()) {
-            defaultsVersion = readStyleDefaultsVersion(m_score->masterScore(), m_scoreData, m_completeBaseName);
-        } else {
-            defaultsVersion = m_score->masterScore()->style().defaultStyleVersion();
-        }
-
-        m_score->setStyle(DefaultStyle::resolveStyleDefaults(defaultsVersion));
-        m_score->style().setDefaultStyleVersion(defaultsVersion);
+        defaultsVersion = m_score->masterScore()->style().defaultStyleVersion();
     }
+
+    m_score->setStyle(DefaultStyle::resolveStyleDefaults(defaultsVersion));
+    m_score->style().setDefaultStyleVersion(defaultsVersion);
 }
 
 void ReadStyleHook::setupDefaultStyle(Ms::Score* score)

--- a/src/engraving/rw/scorereader.cpp
+++ b/src/engraving/rw/scorereader.cpp
@@ -188,7 +188,6 @@ Err ScoreReader::read(MasterScore* score, XmlReader& e, ReadContext& ctx, compat
                 err = doRead(score, e, ctx);
             }
 
-            score->setCreated(false);
             score->setExcerptsChanged(false);
             return err;
         } else {

--- a/src/framework/global/io/path.cpp
+++ b/src/framework/global/io/path.cpp
@@ -120,6 +120,11 @@ mu::io::path mu::io::absoluteDirpath(const mu::io::path& path)
     return QFileInfo(path.toQString()).dir().absolutePath();
 }
 
+bool mu::io::isAbsolute(const path& path)
+{
+    return QFileInfo(path.toQString()).isAbsolute();
+}
+
 bool mu::io::isAllowedFileName(const path& fn_)
 {
     QString fn = basename(fn_).toQString();

--- a/src/framework/global/io/path.h
+++ b/src/framework/global/io/path.h
@@ -80,6 +80,8 @@ path dirname(const path& path);
 path dirpath(const path& path);
 path absoluteDirpath(const path& path);
 
+bool isAbsolute(const path& path);
+
 bool isAllowedFileName(const path& fn);
 path escapeFileName(const path& fn);
 

--- a/src/importexport/braille/tests/tst_braille_io.cpp
+++ b/src/importexport/braille/tests/tst_braille_io.cpp
@@ -129,8 +129,6 @@ static void fixupScore(Score* score)
 {
     score->connectTies();
     score->masterScore()->rebuildMidiMapping();
-    score->setCreated(false);
-    score->setSaved(false);
 }
 
 //---------------------------------------------------------

--- a/src/importexport/bww/internal/bww/importbww.cpp
+++ b/src/importexport/bww/internal/bww/importbww.cpp
@@ -564,8 +564,6 @@ Score::FileError importBww(MasterScore* score, const QString& path)
     Bww::Parser p(lex, wrt);
     p.parse();
 
-    score->setSaved(false);
-    score->setCreated(true);
     score->connectTies();
     qDebug("Score::importBww() done");
     return Score::FileError::FILE_NO_ERROR;        // OK

--- a/src/importexport/guitarpro_old/internal/importgtp.cpp
+++ b/src/importexport/guitarpro_old/internal/importgtp.cpp
@@ -3058,7 +3058,6 @@ Score::FileError importGTP(MasterScore* score, const QString& name)
     //      album
     //      copyright
 
-    score->setCreated(true);
     delete gp;
 
     return Score::FileError::FILE_NO_ERROR;

--- a/src/importexport/musicxml/tests/tst_mxml_io.cpp
+++ b/src/importexport/musicxml/tests/tst_mxml_io.cpp
@@ -265,8 +265,6 @@ static void fixupScore(Score* score)
 {
     score->connectTies();
     score->masterScore()->rebuildMidiMapping();
-    score->setCreated(false);
-    score->setSaved(false);
 }
 
 void TestMxmlIO::setValue(const std::string& key, const Val& value)

--- a/src/multiinstances/imultiinstancesprovider.h
+++ b/src/multiinstances/imultiinstancesprovider.h
@@ -26,11 +26,14 @@
 #include <vector>
 
 #include "modularity/imoduleexport.h"
-#include "io/path.h"
 #include "mitypes.h"
 #include "async/notification.h"
 #include "async/channel.h"
 #include "val.h"
+
+namespace mu::project {
+struct SaveLocation;
+}
 
 namespace mu::mi {
 class IMultiInstancesProvider : MODULE_EXPORT_INTERFACE
@@ -40,8 +43,8 @@ public:
     virtual ~IMultiInstancesProvider() = default;
 
     // Project opening
-    virtual bool isProjectAlreadyOpened(const io::path& projectPath) const = 0;
-    virtual void activateWindowWithProject(const io::path& projectPath) = 0;
+    virtual bool isProjectAlreadyOpened(const project::SaveLocation& location) const = 0;
+    virtual void activateWindowWithProject(const project::SaveLocation& location) = 0;
     virtual bool isHasAppInstanceWithoutProject() const = 0;
     virtual void activateWindowWithoutProject() = 0;
     virtual bool openNewAppInstance(const QStringList& args) = 0;

--- a/src/multiinstances/internal/multiinstancesprovider.h
+++ b/src/multiinstances/internal/multiinstancesprovider.h
@@ -34,6 +34,7 @@
 #include "actions/actionable.h"
 #include "iinteractive.h"
 #include "async/asyncable.h"
+#include "project/projecttypes.h"
 #include "project/iprojectfilescontroller.h"
 #include "ui/imainwindow.h"
 
@@ -52,8 +53,8 @@ public:
     void init();
 
     // Project opening
-    bool isProjectAlreadyOpened(const io::path& projectPath) const override;
-    void activateWindowWithProject(const io::path& projectPath) override;
+    bool isProjectAlreadyOpened(const project::SaveLocation& location) const override;
+    void activateWindowWithProject(const project::SaveLocation& location) override;
     bool isHasAppInstanceWithoutProject() const override;
     void activateWindowWithoutProject() override;
     bool openNewAppInstance(const QStringList& args) override;

--- a/src/notation/imasternotation.h
+++ b/src/notation/imasternotation.h
@@ -39,7 +39,6 @@ class IMasterNotation
 public:
     virtual INotationPtr notation() = 0;
 
-    virtual RetVal<bool> created() const = 0;
     virtual ValNt<bool> needSave() const = 0;
 
     virtual IExcerptNotationPtr newExcerptBlankNotation() const = 0;

--- a/src/notation/internal/inotationundostack.h
+++ b/src/notation/internal/inotationundostack.h
@@ -23,6 +23,8 @@
 #ifndef MU_SCENE_NOTATION_INOTATIONUNDOSTACK_H
 #define MU_SCENE_NOTATION_INOTATIONUNDOSTACK_H
 
+#include <optional>
+
 #include "async/notification.h"
 #include "async/channel.h"
 
@@ -51,6 +53,9 @@ public:
     virtual void lock() = 0;
     virtual void unlock() = 0;
     virtual bool isLocked() const = 0;
+
+    virtual bool isStackClean() const = 0;
+    virtual void setCleanOverride(std::optional<bool> cleanOverride) = 0;
 
     virtual async::Notification stackChanged() const = 0;
     virtual async::Channel<int /*tickFrom*/, int /*tickTo*/,

--- a/src/notation/internal/inotationundostack.h
+++ b/src/notation/internal/inotationundostack.h
@@ -55,6 +55,7 @@ public:
     virtual bool isLocked() const = 0;
 
     virtual bool isStackClean() const = 0;
+    virtual void setClean() = 0;
     virtual void setCleanOverride(std::optional<bool> cleanOverride) = 0;
 
     virtual async::Notification stackChanged() const = 0;

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -274,9 +274,6 @@ void MasterNotation::applyOptions(Ms::MasterScore* score, const ScoreCreateOptio
         score->setSystemObjectStaves(); // use the template to determine where system objects go
     }
 
-    score->setSaved(true);
-    score->setCreated(true);
-
     score->checkChordList();
 
     createMeasures(score, scoreOptions);
@@ -448,21 +445,10 @@ void MasterNotation::applyOptions(Ms::MasterScore* score, const ScoreCreateOptio
     score->setUpTempoMap();
 }
 
-mu::RetVal<bool> MasterNotation::created() const
-{
-    RetVal<bool> result;
-    if (!score()) {
-        result.ret = make_ret(Err::NoScore);
-        return result;
-    }
-
-    return RetVal<bool>::make_ok(score()->created());
-}
-
 mu::ValNt<bool> MasterNotation::needSave() const
 {
     ValNt<bool> needSave;
-    needSave.val = !masterScore()->saved();
+    needSave.val = !undoStack()->isStackClean();
     needSave.notification = m_needSaveNotification;
 
     return needSave;
@@ -607,12 +593,6 @@ ExcerptNotationList MasterNotation::potentialExcerpts() const
     }
 
     return result;
-}
-
-void MasterNotation::onSaveCopy()
-{
-    score()->setCreated(false);
-    undoStack()->stackChanged().notify();
 }
 
 void MasterNotation::initExcerptNotations(const QList<Ms::Excerpt*>& excerpts)

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -48,11 +48,8 @@ public:
     void setMasterScore(Ms::MasterScore* masterScore);
     Ret setupNewScore(Ms::MasterScore* score, const ScoreCreateOptions& scoreOptions);
     void applyOptions(Ms::MasterScore* score, const ScoreCreateOptions& scoreOptions, bool createdFromTemplate = false);
-    void onSaveCopy();
 
     INotationPtr notation() override;
-
-    RetVal<bool> created() const override;
 
     mu::ValNt<bool> needSave() const override;
 

--- a/src/notation/internal/notationundostack.cpp
+++ b/src/notation/internal/notationundostack.cpp
@@ -164,7 +164,14 @@ bool NotationUndoStack::isStackClean() const
     return undoStack()->isClean();
 }
 
-void NotationUndoStack::setCleanOverride(std::optional<bool> cleanOverride){
+void NotationUndoStack::setClean()
+{
+    undoStack()->setClean();
+    m_stackStateChanged.notify();
+}
+
+void NotationUndoStack::setCleanOverride(std::optional<bool> cleanOverride)
+{
     if (m_cleanOverride == cleanOverride) {
         return;
     }

--- a/src/notation/internal/notationundostack.h
+++ b/src/notation/internal/notationundostack.h
@@ -56,6 +56,7 @@ public:
     bool isLocked() const override;
 
     bool isStackClean() const override;
+    void setClean() override;
     void setCleanOverride(std::optional<bool> cleanOverride) override;
 
     async::Notification stackChanged() const override;

--- a/src/notation/internal/notationundostack.h
+++ b/src/notation/internal/notationundostack.h
@@ -55,6 +55,9 @@ public:
     void unlock() override;
     bool isLocked() const override;
 
+    bool isStackClean() const override;
+    void setCleanOverride(std::optional<bool> cleanOverride) override;
+
     async::Notification stackChanged() const override;
     async::Channel<int /*tickFrom*/, int /*tickTo*/,
                    int /*staffIdxFrom*/, int /*staffIdxTo*/> notationChangesRange() const override;
@@ -72,11 +75,8 @@ private:
     void notifyAboutUndo();
     void notifyAboutRedo();
 
-    bool isStackClean() const;
-
     NotationChangesRange changesRange() const;
     Ms::Score* score() const;
-    Ms::MasterScore* masterScore() const;
     Ms::UndoStack* undoStack() const;
 
     IGetScore* m_getScore = nullptr;
@@ -88,6 +88,7 @@ private:
     async::Channel<int /*tickFrom*/, int /*tickTo*/, int /*staffIdxFrom*/, int /*staffIdxTo*/> m_notationChangesChannel;
 
     bool m_isLocked = false;
+    std::optional<bool> m_cleanOverride = std::nullopt;
 };
 }
 

--- a/src/notation/view/notationswitchlistmodel.h
+++ b/src/notation/view/notationswitchlistmodel.h
@@ -29,6 +29,7 @@
 #include "async/asyncable.h"
 #include "context/iglobalcontext.h"
 #include "actions/iactionsdispatcher.h"
+#include "project/inotationproject.h"
 
 namespace mu::notation {
 class NotationSwitchListModel : public QAbstractListModel, public async::Asyncable
@@ -53,15 +54,15 @@ signals:
     void currentNotationIndexChanged(int index);
 
 private:
-    void onMasterNotationChanged();
+    void onCurrentProjectChanged();
     void onCurrentNotationChanged();
 
     IMasterNotationPtr masterNotation() const;
 
     void loadNotations();
+    void listenProjectSavingStatusChanged(project::INotationProjectPtr project);
     void listenNotationOpeningStatus(INotationPtr notation);
     void listenNotationTitleChanged(INotationPtr notation);
-    void listenNotationSavingStatus(IMasterNotationPtr masterNotation);
     bool isIndexValid(int index) const;
 
     bool isMasterNotation(const INotationPtr notation) const;

--- a/src/notation/view/widgets/editstafftype.cpp
+++ b/src/notation/view/widgets/editstafftype.cpp
@@ -194,18 +194,9 @@ void EditStaffType::setInstrument(const Instrument& instrument)
     templateCombo->setCurrentIndex(-1);
 }
 
-mu::Ret EditStaffType::loadScore(Ms::MasterScore* score, const mu::io::path& path)
+mu::Ret EditStaffType::loadScore(Ms::MasterScore* score, const mu::io::path& path) const
 {
     Ms::ScoreLoad sl;
-
-    return doLoadScore(score, path);
-}
-
-mu::Ret EditStaffType::doLoadScore(Ms::MasterScore* score, const mu::io::path& path) const
-{
-    QFileInfo fi(path.toQString());
-    score->setImportedFilePath(fi.filePath());
-    score->setMetaTag("originalFormat", fi.suffix().toLower());
 
     if (compat::loadMsczOrMscx(score, path.toQString()) != Ms::Score::FileError::FILE_NO_ERROR) {
         return make_ret(Ret::Code::UnknownError);
@@ -225,7 +216,6 @@ mu::Ret EditStaffType::doLoadScore(Ms::MasterScore* score, const mu::io::path& p
     }
     score->updateChannel();
     //score->updateExpressive(MuseScore::synthesizer("Fluid"));
-    score->setSaved(true);
     score->update();
 
     if (!score->sanityCheck(QString())) {

--- a/src/notation/view/widgets/editstafftype.h
+++ b/src/notation/view/widgets/editstafftype.h
@@ -78,8 +78,7 @@ public:
     void setInstrument(const Instrument& instrument);
 
 private:
-    mu::Ret loadScore(Ms::MasterScore* score, const io::path& path);
-    mu::Ret doLoadScore(Ms::MasterScore* score, const io::path& path) const;
+    mu::Ret loadScore(Ms::MasterScore* score, const io::path& path) const;
 };
 }
 #endif

--- a/src/notation/view/widgets/scoreproperties.cpp
+++ b/src/notation/view/widgets/scoreproperties.cpp
@@ -72,7 +72,15 @@ ScorePropertiesDialog::ScorePropertiesDialog(QWidget* parent)
         revision->setText(QString::number(rev, 10));
     }
 
-    filePath->setText(meta.filePath.toQString());
+    if (meta.saveLocation.isLocal()) {
+        io::path path = meta.saveLocation.localInfo().path;
+        filePath->setText(path.toQString());
+        revealButton->setEnabled(fileSystem()->exists(path));
+    } else {
+        filePath->setText(qtrc("project", "Not applicable"));
+        filePath->setEnabled(false);
+        revealButton->setEnabled(false);
+    }
 
     initTags();
 
@@ -80,10 +88,6 @@ ScorePropertiesDialog::ScorePropertiesDialog(QWidget* parent)
 
     connect(newButton,  &QPushButton::clicked, this, &ScorePropertiesDialog::newClicked);
     connect(saveButton, &QPushButton::clicked, this, &ScorePropertiesDialog::save);
-
-    if (!fileSystem()->exists(meta.filePath)) {
-        revealButton->setEnabled(false);
-    }
 
     WidgetUtils::setWidgetIcon(revealButton, IconCode::Code::OPEN_FILE);
     connect(revealButton, &QPushButton::clicked, this, &ScorePropertiesDialog::openFileLocation);

--- a/src/plugins/api/qmlpluginapi.cpp
+++ b/src/plugins/api/qmlpluginapi.cpp
@@ -126,17 +126,12 @@ bool PluginAPI::writeScore(Score* s, const QString& name, const QString& ext)
 ///   \param noninteractive Can be used to avoid a "save
 ///   changes" dialog on closing a score that is either
 ///   imported or was created with an older version of
-///   MuseScore.
+///   MuseScore. //TODO: Reimplement this for MU4
 //---------------------------------------------------------
 
 Score* PluginAPI::readScore(const QString& name, bool noninteractive)
 {
     Ms::Score* score = msc()->openScore(name, !noninteractive);
-    if (score) {
-        if (noninteractive) {
-            score->setCreated(false);
-        }
-    }
     return wrap<Score>(score, Ownership::SCORE);
 }
 

--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -95,6 +95,9 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/iexportprojectscenario.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/exportprojectscenario.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/exportprojectscenario.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/isaveprojectscenario.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/saveprojectscenario.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/saveprojectscenario.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/recentprojectsprovider.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/recentprojectsprovider.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/mscmetareader.cpp

--- a/src/project/inotationproject.h
+++ b/src/project/inotationproject.h
@@ -46,8 +46,8 @@ public:
     virtual bool isNewlyCreated() const = 0;
     virtual ValNt<bool> needSave() const = 0;
 
-    virtual Ret save(const io::path& path = io::path(), SaveMode saveMode = SaveMode::Save) = 0;
-    virtual Ret writeToDevice(io::Device* device) = 0;
+    virtual Ret saveToFile(const io::path& path = io::path(), SaveMode saveMode = SaveMode::Save) = 0;
+    virtual Ret saveToDevice(io::Device* device, const SaveLocation& saveLocation = {}, SaveMode saveMode = SaveMode::Save) = 0;
 
     virtual ProjectMeta metaInfo() const = 0;
     virtual void setMetaInfo(const ProjectMeta& meta) = 0;

--- a/src/project/inotationproject.h
+++ b/src/project/inotationproject.h
@@ -43,7 +43,7 @@ public:
     virtual Ret load(const io::path& path, const io::path& stylePath = io::path(), bool forceMode = false) = 0;
     virtual Ret createNew(const ProjectCreateOptions& projectInfo) = 0;
 
-    virtual RetVal<bool> created() const = 0;
+    virtual bool isNewlyCreated() const = 0;
     virtual ValNt<bool> needSave() const = 0;
 
     virtual Ret save(const io::path& path = io::path(), SaveMode saveMode = SaveMode::Save) = 0;

--- a/src/project/inotationproject.h
+++ b/src/project/inotationproject.h
@@ -44,7 +44,6 @@ public:
     virtual Ret load(const io::path& path, const io::path& stylePath = io::path(), bool forceMode = false) = 0;
     virtual Ret createNew(const ProjectCreateOptions& projectInfo) = 0;
 
-    virtual bool isNewlyCreated() const = 0;
     virtual ValNt<bool> needSave() const = 0;
 
     virtual Ret saveToFile(const io::path& path = io::path(), SaveMode saveMode = SaveMode::Save) = 0;

--- a/src/project/inotationproject.h
+++ b/src/project/inotationproject.h
@@ -38,7 +38,7 @@ class INotationProject
 public:
     virtual ~INotationProject() = default;
 
-    virtual io::path path() const = 0;
+    virtual SaveLocation saveLocation() const = 0;
 
     virtual Ret load(const io::path& path, const io::path& stylePath = io::path(), bool forceMode = false) = 0;
     virtual Ret createNew(const ProjectCreateOptions& projectInfo) = 0;

--- a/src/project/inotationproject.h
+++ b/src/project/inotationproject.h
@@ -39,6 +39,7 @@ public:
     virtual ~INotationProject() = default;
 
     virtual SaveLocation saveLocation() const = 0;
+    virtual async::Notification saveLocationChanged() const = 0;
 
     virtual Ret load(const io::path& path, const io::path& stylePath = io::path(), bool forceMode = false) = 0;
     virtual Ret createNew(const ProjectCreateOptions& projectInfo) = 0;

--- a/src/project/internal/isaveprojectscenario.h
+++ b/src/project/internal/isaveprojectscenario.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2022 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_PROJECT_ISAVEPROJECTSCENARIO_H
+#define MU_PROJECT_ISAVEPROJECTSCENARIO_H
+
+#include "modularity/imoduleexport.h"
+#include "inotationproject.h"
+
+#include "retval.h"
+
+namespace mu::project {
+class ISaveProjectScenario : MODULE_EXPORT_INTERFACE
+{
+    INTERFACE_ID(ISaveProjectScenario)
+
+public:
+    virtual RetVal<SaveLocation> askSaveLocation(INotationProjectPtr project, const QString& dialogTitle = "") const = 0;
+    virtual RetVal<io::path> askLocalPath(INotationProjectPtr project, const QString& dialogTitle = "") const = 0;
+};
+}
+
+#endif // MU_PROJECT_ISAVEPROJECTSCENARIO_H

--- a/src/project/internal/mscmetareader.cpp
+++ b/src/project/internal/mscmetareader.cpp
@@ -71,7 +71,7 @@ mu::RetVal<ProjectMeta> MscMetaReader::readMeta(const io::path& filePath) const
         meta.val.thumbnail.loadFromData(thumbnailData, "PNG");
     }
 
-    meta.val.filePath = filePath;
+    meta.val.saveLocation = SaveLocation::makeLocal(filePath);
 
     return meta;
 }

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -307,9 +307,19 @@ SaveLocation NotationProject::saveLocation() const
     return m_saveLocation;
 }
 
+async::Notification NotationProject::saveLocationChanged() const
+{
+    return m_saveLocationChanged;
+}
+
 void NotationProject::setSaveLocation(const SaveLocation& saveLocation)
 {
+    if (m_saveLocation == saveLocation) {
+        return;
+    }
+
     m_saveLocation = saveLocation;
+    m_saveLocationChanged.notify();
 }
 
 mu::Ret NotationProject::loadTemplate(const ProjectCreateOptions& projectOptions)

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -100,7 +100,7 @@ static void setupScoreMetaTags(Ms::MasterScore* masterScore, const ProjectCreate
 
 NotationProject::NotationProject()
 {
-    setSaveLocation(SaveLocation::makeLocal(""));
+    m_saveLocation = SaveLocation::makeUnsaved();
     m_engravingProject = EngravingProject::create();
     m_engravingProject->setFileInfoProvider(std::make_shared<ProjectFileInfoProvider>(this));
     m_masterNotation = std::shared_ptr<MasterNotation>(new MasterNotation());
@@ -230,6 +230,7 @@ mu::Ret NotationProject::doImport(const io::path& path, const io::path& stylePat
 
     // Read(import) master score
     Ms::ScoreLoad sl;
+    setSaveLocation(SaveLocation::makeUnsaved(path));
     m_engravingProject->setFileInfoProvider(std::make_shared<ProjectFileInfoProvider>(this));
     Ms::MasterScore* score = m_engravingProject->masterScore();
     Ret ret = scoreReader->read(score, path, options);
@@ -275,9 +276,9 @@ mu::Ret NotationProject::createNew(const ProjectCreateOptions& projectOptions)
     }
 
     // Create new engraving project
-    setSaveLocation(SaveLocation::makeLocal(projectOptions.title.isEmpty()
-                                            ? qtrc("project", "Untitled")
-                                            : projectOptions.title));
+    setSaveLocation(SaveLocation::makeUnsaved(projectOptions.title.isEmpty()
+                                              ? qtrc("project", "Untitled")
+                                              : projectOptions.title));
     m_engravingProject->setFileInfoProvider(std::make_shared<ProjectFileInfoProvider>(this));
 
     Ms::MasterScore* masterScore = m_engravingProject->masterScore();
@@ -318,9 +319,9 @@ mu::Ret NotationProject::loadTemplate(const ProjectCreateOptions& projectOptions
     Ret ret = load(projectOptions.templatePath);
 
     if (ret) {
-        setSaveLocation(SaveLocation::makeLocal(projectOptions.title.isEmpty()
-                                                ? qtrc("project", "Untitled")
-                                                : projectOptions.title));
+        setSaveLocation(SaveLocation::makeUnsaved(projectOptions.title.isEmpty()
+                                                  ? qtrc("project", "Untitled")
+                                                  : projectOptions.title));
 
         Ms::MasterScore* masterScore = m_masterNotation->masterScore();
         setupScoreMetaTags(masterScore, projectOptions);

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -301,9 +301,9 @@ mu::Ret NotationProject::createNew(const ProjectCreateOptions& projectOptions)
     return make_ret(Ret::Code::Ok);
 }
 
-io::path NotationProject::path() const
+SaveLocation NotationProject::saveLocation() const
 {
-    return m_saveLocation.isLocal() ? m_saveLocation.localInfo().path : "";
+    return m_saveLocation;
 }
 
 void NotationProject::setSaveLocation(const SaveLocation& saveLocation)
@@ -588,9 +588,10 @@ ProjectMeta NotationProject::metaInfo() const
 {
     TRACEFUNC;
 
-    Ms::MasterScore* score = m_masterNotation->masterScore();
-
     ProjectMeta meta;
+    meta.saveLocation = m_saveLocation;
+
+    Ms::MasterScore* score = m_masterNotation->masterScore();
     auto allTags = score->metaTags();
 
     meta.title = allTags[WORK_TITLE_TAG];
@@ -614,8 +615,6 @@ ProjectMeta NotationProject::metaInfo() const
 
         meta.additionalTags[tag] = allTags[tag];
     }
-
-    meta.filePath = path();
 
     meta.partsCount = score->excerpts().count();
 

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -490,13 +490,8 @@ mu::Ret NotationProject::doSave(const io::path& path, bool generateBackup, engra
 
 mu::Ret NotationProject::makeCurrentFileAsBackup()
 {
-    if (isNewlyCreated()) {
-        LOGD() << "project just created";
-        return make_ret(Ret::Code::Ok);
-    }
-
     if (!m_saveLocation.isLocal()) {
-        LOGD() << "not a local project on disk";
+        LOGD() << "project is not saved locally";
         return make_ret(Ret::Code::Ok);
     }
 
@@ -609,11 +604,6 @@ mu::Ret NotationProject::exportProject(const io::path& path, const std::string& 
 IMasterNotationPtr NotationProject::masterNotation() const
 {
     return m_masterNotation;
-}
-
-bool NotationProject::isNewlyCreated() const
-{
-    return m_saveLocation.isUnsaved();
 }
 
 mu::ValNt<bool> NotationProject::needSave() const

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -60,6 +60,7 @@ public:
     Ret createNew(const ProjectCreateOptions& projectInfo) override;
 
     SaveLocation saveLocation() const override;
+    async::Notification saveLocationChanged() const override;
 
     bool isNewlyCreated() const override;
     ValNt<bool> needSave() const override;
@@ -96,6 +97,7 @@ private:
     ProjectViewSettingsPtr m_viewSettings = nullptr;
 
     SaveLocation m_saveLocation = SaveLocation::makeUnsaved();
+    async::Notification m_saveLocationChanged;
 };
 }
 

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -64,8 +64,8 @@ public:
     bool isNewlyCreated() const override;
     ValNt<bool> needSave() const override;
 
-    Ret save(const io::path& path = io::path(), SaveMode saveMode = SaveMode::Save) override;
-    Ret writeToDevice(io::Device* device) override;
+    Ret saveToFile(const io::path& path = io::path(), SaveMode saveMode = SaveMode::Save) override;
+    Ret saveToDevice(io::Device* device, const SaveLocation& saveLocation = {}, SaveMode saveMode = SaveMode::Save) override;
 
     ProjectMeta metaInfo() const override;
     void setMetaInfo(const ProjectMeta& meta) override;
@@ -80,6 +80,7 @@ private:
     Ret doLoad(engraving::MscReader& reader, const io::path& stylePath, bool forceMode);
     Ret doImport(const io::path& path, const io::path& stylePath, bool forceMode);
 
+    void onSaved(const SaveLocation& saveLocation, SaveMode saveMode);
     void setSaveLocation(const SaveLocation& saveLocation);
 
     Ret saveScore(const io::path& path, const std::string& fileSuffix);
@@ -87,7 +88,7 @@ private:
     Ret exportProject(const io::path& path, const std::string& suffix);
     Ret doSave(const io::path& path, bool generateBackup, engraving::MscIoMode ioMode);
     Ret makeCurrentFileAsBackup();
-    Ret writeProject(engraving::MscWriter& msczWriter, bool onlySelection);
+    Ret writeProject(engraving::MscWriter& msczWriter, bool onlySelection = false);
 
     mu::engraving::EngravingProjectPtr m_engravingProject = nullptr;
     notation::MasterNotationPtr m_masterNotation = nullptr;

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -62,7 +62,6 @@ public:
     SaveLocation saveLocation() const override;
     async::Notification saveLocationChanged() const override;
 
-    bool isNewlyCreated() const override;
     ValNt<bool> needSave() const override;
 
     Ret saveToFile(const io::path& path = io::path(), SaveMode saveMode = SaveMode::Save) override;

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -59,7 +59,7 @@ public:
     Ret load(const io::path& path, const io::path& stylePath = io::path(), bool forceMode = false) override;
     Ret createNew(const ProjectCreateOptions& projectInfo) override;
 
-    io::path path() const override;
+    SaveLocation saveLocation() const override;
 
     bool isNewlyCreated() const override;
     ValNt<bool> needSave() const override;

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -61,7 +61,7 @@ public:
 
     io::path path() const override;
 
-    RetVal<bool> created() const override;
+    bool isNewlyCreated() const override;
     ValNt<bool> needSave() const override;
 
     Ret save(const io::path& path = io::path(), SaveMode saveMode = SaveMode::Save) override;

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -95,7 +95,7 @@ private:
     ProjectAudioSettingsPtr m_projectAudioSettings = nullptr;
     ProjectViewSettingsPtr m_viewSettings = nullptr;
 
-    SaveLocation m_saveLocation = SaveLocation::makeInvalid();
+    SaveLocation m_saveLocation = SaveLocation::makeUnsaved();
 };
 }
 

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -345,7 +345,7 @@ bool ProjectActionsController::saveProject(const io::path& path)
         return false;
     }
 
-    if (!currentNotationProject()->created().val) {
+    if (!currentNotationProject()->isNewlyCreated()) {
         return doSaveScore();
     }
 
@@ -446,7 +446,7 @@ void ProjectActionsController::saveOnline()
         meta.source = newSource;
         project->setMetaInfo(meta);
 
-        if (project->created().val) {
+        if (!project->isNewlyCreated()) {
             project->save();
         }
     }, Asyncable::AsyncMode::AsyncSetRepeat);

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -636,16 +636,6 @@ void ProjectActionsController::prependToRecentScoreList(const io::path& filePath
     platformRecentFilesController()->addRecentFile(filePath);
 }
 
-bool ProjectActionsController::isProjectOpened() const
-{
-    return currentNotationProject() != nullptr;
-}
-
-bool ProjectActionsController::isNeedSaveScore() const
-{
-    return currentNotationProject() && currentNotationProject()->needSave().val;
-}
-
 bool ProjectActionsController::hasSelection() const
 {
     return currentNotationSelection() ? !currentNotationSelection()->isNone() : false;

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -288,7 +288,6 @@ bool ProjectActionsController::closeOpenedProject(bool quitApp)
     }
 
     bool result = true;
-    bool needRemoveUnsavedChanges = false;
 
     if (project->needSave().val) {
         IInteractive::Button btn = askAboutSavingScore(project);
@@ -299,15 +298,6 @@ bool ProjectActionsController::closeOpenedProject(bool quitApp)
             result = saveCurrentProject();
         } else if (btn == IInteractive::Button::DontSave) {
             result = true;
-            needRemoveUnsavedChanges = true;
-        }
-    }
-
-    if (needRemoveUnsavedChanges) {
-        SaveLocation saveLocation = project->saveLocation();
-#warning TODO: support all SaveLocationTypes
-        if (saveLocation.isLocal()) {
-            projectAutoSaver()->removeProjectUnsavedChanges(saveLocation.localInfo().path);
         }
     }
 

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -450,7 +450,6 @@ bool ProjectActionsController::saveCurrentProjectAt(const SaveLocation& saveLoca
 
 bool ProjectActionsController::saveProjectLocally(const io::path& filePath, SaveMode saveMode)
 {
-#warning TODO: notify about potentially path changed
     Ret ret = currentNotationProject()->saveToFile(filePath, saveMode);
     if (!ret) {
         LOGE() << ret.toString();

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -84,12 +84,16 @@ private:
     void newProject();
 
     bool checkCanIgnoreError(const Ret& ret, const io::path& filePath);
-    framework::IInteractive::Button askAboutSavingScore(const io::path& filePath);
+    framework::IInteractive::Button askAboutSavingScore(INotationProjectPtr project);
 
+    bool saveCurrentProject();
     void saveProjectAs();
     void saveProjectCopy();
     void saveSelection();
     void saveOnline();
+
+    bool saveCurrentProjectAt(const SaveLocation& saveLocation, SaveMode saveMode = SaveMode::Save);
+    bool saveProjectLocally(const io::path& path, SaveMode saveMode = SaveMode::Save);
 
     void importPdf();
 
@@ -101,7 +105,6 @@ private:
     io::path selectScoreSavingFile(const io::path& defaultFilePath, const QString& saveTitle);
 
     Ret doOpenProject(const io::path& filePath);
-    bool doSaveScore(const io::path& filePath = io::path(), project::SaveMode saveMode = project::SaveMode::Save);
 
     Ret openPageIfNeed(Uri pageUri);
 

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -65,9 +65,9 @@ public:
     void init();
 
     bool isFileSupported(const io::path& path) const override;
-    Ret openProject(const io::path& projectPath) override;
+    Ret openProject(const SaveLocation& projectPath) override;
     bool closeOpenedProject(bool quitApp = false) override;
-    bool isProjectOpened(const io::path& scorePath) const override;
+    bool isProjectOpened(const SaveLocation& scorePath) const override;
     bool isAnyProjectOpened() const override;
     bool saveProject(const io::path& path = io::path()) override;
 
@@ -80,8 +80,10 @@ private:
     notation::INotationInteractionPtr currentInteraction() const;
     notation::INotationSelectionPtr currentNotationSelection() const;
 
-    void openProject(const actions::ActionData& args);
     void newProject();
+
+    void openProject(const actions::ActionData& args);
+    Ret openLocalProject(const io::path& filePath);
 
     bool checkCanIgnoreError(const Ret& ret, const io::path& filePath);
     framework::IInteractive::Button askAboutSavingScore(INotationProjectPtr project);
@@ -103,8 +105,6 @@ private:
 
     io::path selectScoreOpeningFile();
     io::path selectScoreSavingFile(const io::path& defaultFilePath, const QString& saveTitle);
-
-    Ret doOpenProject(const io::path& filePath);
 
     Ret openPageIfNeed(Uri pageUri);
 

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -115,8 +115,6 @@ private:
 
     void prependToRecentScoreList(const io::path& filePath);
 
-    bool isProjectOpened() const;
-    bool isNeedSaveScore() const;
     bool hasSelection() const;
 
     bool m_isProjectProcessing = false;

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -36,6 +36,7 @@
 #include "playback/iplaybackcontroller.h"
 #include "print/iprintprovider.h"
 #include "inotationreadersregister.h"
+#include "isaveprojectscenario.h"
 
 #include "async/asyncable.h"
 
@@ -52,6 +53,7 @@ class ProjectActionsController : public IProjectFilesController, public QObject,
     INJECT(project, IProjectCreator, projectCreator)
     INJECT(project, IPlatformRecentFilesController, platformRecentFilesController)
     INJECT(project, IProjectAutoSaver, projectAutoSaver)
+    INJECT(project, ISaveProjectScenario, saveProjectScenario)
 
     INJECT(project, actions::IActionsDispatcher, dispatcher)
     INJECT(project, framework::IInteractive, interactive)
@@ -83,6 +85,7 @@ private:
     void newProject();
 
     void openProject(const actions::ActionData& args);
+    io::path selectScoreOpeningFile();
     Ret openLocalProject(const io::path& filePath);
 
     bool checkCanIgnoreError(const Ret& ret, const io::path& filePath);
@@ -103,15 +106,10 @@ private:
 
     void continueLastSession();
 
-    io::path selectScoreOpeningFile();
-    io::path selectScoreSavingFile(const io::path& defaultFilePath, const QString& saveTitle);
-
     Ret openPageIfNeed(Uri pageUri);
 
     void exportScore();
     void printScore();
-
-    io::path defaultSavingFilePath() const;
 
     void prependToRecentScoreList(const io::path& filePath);
 

--- a/src/project/internal/projectautosaver.cpp
+++ b/src/project/internal/projectautosaver.cpp
@@ -105,7 +105,7 @@ void ProjectAutoSaver::onTrySave()
         return;
     }
 
-    if (project->created().val) {
+    if (project->isNewlyCreated()) {
         LOGD() << "[autosave] project just created";
         return;
     }

--- a/src/project/internal/projectautosaver.h
+++ b/src/project/internal/projectautosaver.h
@@ -54,9 +54,12 @@ public:
 private:
     INotationProjectPtr currentProject() const;
 
+    void update();
+
     void onTrySave();
 
     QTimer m_timer;
+    io::path m_lastAutosavedProjectPath;
 };
 }
 

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -70,7 +70,7 @@ void ProjectConfiguration::init()
     Val preferredScoreCreationMode = Val(PreferredScoreCreationMode::FromInstruments);
     settings()->setDefaultValue(PREFERRED_SCORE_CREATION_MODE_KEY, preferredScoreCreationMode);
 
-    settings()->setDefaultValue(LAST_USED_SAVE_LOCATION_TYPE, Val(SaveLocationType::Undefined));
+    settings()->setDefaultValue(LAST_USED_SAVE_LOCATION_TYPE, Val(SaveLocationType::None));
 
     settings()->setDefaultValue(AUTOSAVE_ENABLED_KEY, Val(true));
     settings()->valueChanged(AUTOSAVE_ENABLED_KEY).onReceive(nullptr, [this](const Val& val) {

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -199,11 +199,6 @@ async::Channel<io::path> ProjectConfiguration::userProjectsPathChanged() const
     return m_userScoresPathChanged;
 }
 
-io::path ProjectConfiguration::defaultSavingFilePath(const io::path& fileName) const
-{
-    return userProjectsPath() + "/" + fileName + DEFAULT_FILE_SUFFIX;
-}
-
 SaveLocationType ProjectConfiguration::lastUsedSaveLocationType() const
 {
     return settings()->value(LAST_USED_SAVE_LOCATION_TYPE).toEnum<SaveLocationType>();

--- a/src/project/internal/projectconfiguration.h
+++ b/src/project/internal/projectconfiguration.h
@@ -59,8 +59,6 @@ public:
     void setUserProjectsPath(const io::path& path) override;
     async::Channel<io::path> userProjectsPathChanged() const override;
 
-    io::path defaultSavingFilePath(const io::path& fileName) const override;
-
     SaveLocationType lastUsedSaveLocationType() const override;
     void setLastUsedSaveLocationType(SaveLocationType type) override;
 

--- a/src/project/internal/projectfileinfoprovider.cpp
+++ b/src/project/internal/projectfileinfoprovider.cpp
@@ -37,7 +37,16 @@ ProjectFileInfoProvider::ProjectFileInfoProvider(NotationProject* project)
 //! TODO: update this class when SaveLocation gets implemented further
 io::path ProjectFileInfoProvider::path() const
 {
-    return m_project->path();
+    SaveLocation saveLocation = m_project->saveLocation();
+    switch (saveLocation.type) {
+    case SaveLocationType::None:
+        return saveLocation.unsavedInfo().pathOrNameHint;
+    case SaveLocationType::Local:
+        return saveLocation.localInfo().path;
+    case SaveLocationType::Cloud:
+        // TODO(save-to-cloud)
+        return {};
+    }
 }
 
 io::path ProjectFileInfoProvider::fileName(bool includingExtension) const

--- a/src/project/internal/saveprojectscenario.cpp
+++ b/src/project/internal/saveprojectscenario.cpp
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2022 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "saveprojectscenario.h"
+
+using namespace mu;
+using namespace mu::project;
+
+RetVal<SaveLocation> SaveProjectScenario::askSaveLocation(INotationProjectPtr project, const QString& dialogTitle) const
+{
+    // TODO(save-to-cloud): add ability to ask cloud location
+    RetVal<io::path> localPath = askLocalPath(project, dialogTitle);
+    if (!localPath.ret) {
+        return localPath.ret;
+    }
+
+    return RetVal<SaveLocation>::make_ok(SaveLocation::makeLocal(localPath.val));
+}
+
+RetVal<io::path> SaveProjectScenario::askLocalPath(INotationProjectPtr project, const QString& dialogTitle) const
+{
+    QString title = dialogTitle.isEmpty() ? qtrc("project", "Save score") : dialogTitle;
+    io::path defaultPath = defaultLocalPath(project);
+    QString filter = qtrc("project", "MuseScore File") + " (*.mscz)";
+
+    io::path filePath = interactive()->selectSavingFile(title, defaultPath, filter);
+    if (filePath.empty()) {
+        return make_ret(Ret::Code::Cancel);
+    }
+
+    return RetVal<io::path>::make_ok(filePath);
+}
+
+io::path SaveProjectScenario::defaultLocalPath(INotationProjectPtr project) const
+{
+    io::path folderPath;
+    io::path filename;
+
+    SaveLocation saveLocation = project->saveLocation();
+    switch (saveLocation.type) {
+    case SaveLocationType::None: {
+        io::path pathOrNameHint = saveLocation.unsavedInfo().pathOrNameHint;
+        if (io::isAbsolute(pathOrNameHint)) {
+            folderPath = io::dirpath(pathOrNameHint);
+        }
+        filename = io::filename(pathOrNameHint, false);
+    } break;
+    case SaveLocationType::Local: {
+        io::path projectPath = saveLocation.localInfo().path;
+        folderPath = io::dirpath(projectPath);
+        filename = io::filename(projectPath, false);
+    } break;
+    case SaveLocationType::Cloud: {
+        // TODO(save-to-cloud)
+        //filename = ???
+    } break;
+    }
+
+    if (folderPath.empty()) {
+        folderPath = configuration()->userProjectsPath();
+    }
+
+    if (filename.empty()) {
+        filename = qtrc("project", "Untitled");
+    }
+
+    return folderPath + "/" + filename + "." + engraving::MSCZ;
+}

--- a/src/project/internal/saveprojectscenario.h
+++ b/src/project/internal/saveprojectscenario.h
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2022 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_PROJECT_SAVEPROJECTSCENARIO_H
+#define MU_PROJECT_SAVEPROJECTSCENARIO_H
+
+#include "isaveprojectscenario.h"
+
+#include "modularity/ioc.h"
+#include "iprojectconfiguration.h"
+#include "global/iinteractive.h"
+
+namespace mu::project {
+class SaveProjectScenario : public ISaveProjectScenario
+{
+    INJECT(project, IProjectConfiguration, configuration)
+    INJECT(project, framework::IInteractive, interactive)
+
+public:
+    SaveProjectScenario() = default;
+
+    RetVal<SaveLocation> askSaveLocation(INotationProjectPtr project, const QString& dialogTitle = "") const override;
+    RetVal<io::path> askLocalPath(INotationProjectPtr project, const QString& dialogTitle = "") const override;
+
+private:
+    io::path defaultLocalPath(INotationProjectPtr project) const;
+};
+}
+
+#endif // MU_PROJECT_SAVEPROJECTSCENARIO_H

--- a/src/project/iprojectconfiguration.h
+++ b/src/project/iprojectconfiguration.h
@@ -56,8 +56,6 @@ public:
     virtual void setUserProjectsPath(const io::path& path) = 0;
     virtual async::Channel<io::path> userProjectsPathChanged() const = 0;
 
-    virtual io::path defaultSavingFilePath(const io::path& fileName) const = 0;
-
     virtual SaveLocationType lastUsedSaveLocationType() const = 0;
     virtual void setLastUsedSaveLocationType(SaveLocationType type) = 0;
 

--- a/src/project/iprojectfilescontroller.h
+++ b/src/project/iprojectfilescontroller.h
@@ -25,6 +25,7 @@
 #include "modularity/imoduleexport.h"
 #include "ret.h"
 #include "io/path.h"
+#include "projecttypes.h"
 
 namespace mu::project {
 class IProjectFilesController : MODULE_EXPORT_INTERFACE
@@ -35,9 +36,9 @@ public:
     virtual ~IProjectFilesController() = default;
 
     virtual bool isFileSupported(const io::path& path) const = 0;
-    virtual Ret openProject(const io::path& path) = 0;
+    virtual Ret openProject(const SaveLocation& path) = 0;
     virtual bool closeOpenedProject(bool quitApp = false) = 0;
-    virtual bool isProjectOpened(const io::path& path) const = 0;
+    virtual bool isProjectOpened(const SaveLocation& path) const = 0;
     virtual bool isAnyProjectOpened() const = 0;
     virtual bool saveProject(const io::path& path = io::path()) = 0;
 };

--- a/src/project/projectmodule.cpp
+++ b/src/project/projectmodule.cpp
@@ -31,6 +31,7 @@
 #include "internal/projectactionscontroller.h"
 #include "internal/projectuiactions.h"
 #include "internal/projectconfiguration.h"
+#include "internal/saveprojectscenario.h"
 #include "internal/exportprojectscenario.h"
 #include "internal/recentprojectsprovider.h"
 #include "internal/mscmetareader.h"
@@ -82,6 +83,7 @@ void ProjectModule::registerExports()
     ioc()->registerExport<INotationReadersRegister>(moduleName(), new NotationReadersRegister());
     ioc()->registerExport<INotationWritersRegister>(moduleName(), new NotationWritersRegister());
     ioc()->registerExport<IProjectFilesController>(moduleName(), s_actionsController);
+    ioc()->registerExport<ISaveProjectScenario>(moduleName(), new SaveProjectScenario());
     ioc()->registerExport<IExportProjectScenario>(moduleName(), new ExportProjectScenario());
     ioc()->registerExport<IRecentProjectsProvider>(moduleName(), s_recentProjectsProvider);
     ioc()->registerExport<IMscMetaReader>(moduleName(), new MscMetaReader());

--- a/src/project/projecttypes.h
+++ b/src/project/projecttypes.h
@@ -147,9 +147,9 @@ struct SaveLocation {
         return std::get<CloudInfo>(info);
     }
 
-    static SaveLocation makeInvalid()
+    static SaveLocation makeUnsaved(const io::path& pathOrNameHint = {})
     {
-        return {};
+        return { SaveLocationType::None, UnsavedInfo { pathOrNameHint } };
     }
 
     static SaveLocation makeLocal(const io::path& path)

--- a/src/project/projecttypes.h
+++ b/src/project/projecttypes.h
@@ -80,6 +80,11 @@ struct SaveLocation {
 
     struct LocalInfo {
         io::path path;
+
+        io::path fileName(bool includingExtension = true) const
+        {
+            return io::filename(path, includingExtension);
+        }
     };
 
     struct CloudInfo {
@@ -112,13 +117,34 @@ struct SaveLocation {
         return isUnsaved() || isLocal() || isCloud();
     }
 
-    LocalInfo localInfo() const
+    const UnsavedInfo& unsavedInfo() const
+    {
+        IF_ASSERT_FAILED(isUnsaved()) {
+            static UnsavedInfo null;
+            return null;
+        }
+
+        return std::get<UnsavedInfo>(info);
+    }
+
+    const LocalInfo& localInfo() const
     {
         IF_ASSERT_FAILED(isLocal()) {
-            return {};
+            static LocalInfo null;
+            return null;
         }
 
         return std::get<LocalInfo>(info);
+    }
+
+    const CloudInfo& cloudInfo() const
+    {
+        IF_ASSERT_FAILED(isCloud()) {
+            static CloudInfo null;
+            return null;
+        }
+
+        return std::get<CloudInfo>(info);
     }
 
     static SaveLocation makeInvalid()
@@ -139,7 +165,7 @@ struct SaveLocation {
 
 struct ProjectMeta
 {
-    io::path filePath;
+    SaveLocation saveLocation;
 
     QString title;
     QString subtitle;
@@ -159,11 +185,6 @@ struct ProjectMeta
     int mscVersion = 0;
 
     QVariantMap additionalTags;
-
-    io::path fileName(bool includingExtension = true) const
-    {
-        return io::filename(filePath, includingExtension);
-    }
 };
 
 using ProjectMetaList = QList<ProjectMeta>;

--- a/src/project/projecttypes.h
+++ b/src/project/projecttypes.h
@@ -77,6 +77,15 @@ struct SaveLocation {
     struct UnsavedInfo {
         io::path pathOrNameHint;
 
+        QString userFriendlyName() const
+        {
+            if (pathOrNameHint.empty()) {
+                return qtrc("project", "Untitled");
+            }
+
+            return io::filename(pathOrNameHint, false).toQString();
+        }
+
         bool operator ==(const UnsavedInfo& other) const
         {
             return pathOrNameHint == other.pathOrNameHint;
@@ -89,6 +98,17 @@ struct SaveLocation {
         io::path fileName(bool includingExtension = true) const
         {
             return io::filename(path, includingExtension);
+        }
+
+        QString userFriendlyName() const
+        {
+            if (path.empty()) {
+                return qtrc("project", "Untitled");
+            }
+
+            std::string suffix = io::suffix(path);
+            bool isExtensionInteresting = suffix != engraving::MSCZ && !suffix.empty();
+            return io::filename(path, isExtensionInteresting).toQString();
         }
 
         bool operator ==(const LocalInfo& other) const
@@ -160,6 +180,24 @@ struct SaveLocation {
         }
 
         return std::get<CloudInfo>(info);
+    }
+
+    QString userFriendlyName() const
+    {
+        if (isUnsaved()) {
+            return unsavedInfo().userFriendlyName();
+        }
+
+        if (isLocal()) {
+            return localInfo().userFriendlyName();
+        }
+
+        if (isCloud()) {
+            return ""; // TODO
+        }
+
+        UNREACHABLE;
+        return {};
     }
 
     bool operator ==(const SaveLocation& other) const

--- a/src/project/projecttypes.h
+++ b/src/project/projecttypes.h
@@ -76,6 +76,11 @@ enum class SaveLocationType
 struct SaveLocation {
     struct UnsavedInfo {
         io::path pathOrNameHint;
+
+        bool operator ==(const UnsavedInfo& other) const
+        {
+            return pathOrNameHint == other.pathOrNameHint;
+        }
     };
 
     struct LocalInfo {
@@ -85,10 +90,20 @@ struct SaveLocation {
         {
             return io::filename(path, includingExtension);
         }
+
+        bool operator ==(const LocalInfo& other) const
+        {
+            return path == other.path;
+        }
     };
 
     struct CloudInfo {
         // TODO
+
+        bool operator ==(const CloudInfo& /*other*/) const
+        {
+            return true;
+        }
     };
 
     SaveLocationType type = SaveLocationType::None;
@@ -145,6 +160,12 @@ struct SaveLocation {
         }
 
         return std::get<CloudInfo>(info);
+    }
+
+    bool operator ==(const SaveLocation& other) const
+    {
+        return type == other.type
+               && info == other.info;
     }
 
     static SaveLocation makeUnsaved(const io::path& pathOrNameHint = {})

--- a/src/project/projecttypes.h
+++ b/src/project/projecttypes.h
@@ -206,6 +206,11 @@ struct SaveLocation {
                && info == other.info;
     }
 
+    bool operator !=(const SaveLocation& other) const
+    {
+        return !(*this == other);
+    }
+
     static SaveLocation makeUnsaved(const io::path& pathOrNameHint = {})
     {
         return { SaveLocationType::None, UnsavedInfo { pathOrNameHint } };

--- a/src/project/tests/mocks/projectconfigurationmock.h
+++ b/src/project/tests/mocks/projectconfigurationmock.h
@@ -47,8 +47,6 @@ public:
     MOCK_METHOD(void, setUserProjectsPath, (const io::path&), (override));
     MOCK_METHOD(async::Channel<io::path>, userProjectsPathChanged, (), (const, override));
 
-    MOCK_METHOD(io::path, defaultSavingFilePath, (const io::path&), (const, override));
-
     MOCK_METHOD(SaveLocationType, lastUsedSaveLocationType, (), (const, override));
     MOCK_METHOD(void, setLastUsedSaveLocationType, (SaveLocationType), (override));
 

--- a/src/project/tests/templatesrepositorytest.cpp
+++ b/src/project/tests/templatesrepositorytest.cpp
@@ -68,7 +68,7 @@ protected:
         Template templ;
         templ.categoryTitle = categoryTitle;
         templ.meta.title = path.toQString();
-        templ.meta.filePath = path;
+        templ.meta.saveLocation = SaveLocation::makeLocal(path);
         templ.meta.creationDate = QDate::currentDate();
 
         return templ;
@@ -175,7 +175,8 @@ TEST_F(TemplatesRepositoryTest, Templates)
     }
 
     for (const Template& templ : expectedTemplates) {
-        ON_CALL(*m_msczReader, readMeta(templ.meta.filePath))
+        // Safe to assume that saveLocation.isLocal()
+        ON_CALL(*m_msczReader, readMeta(templ.meta.saveLocation.localInfo().path))
         .WillByDefault(Return(RetVal<ProjectMeta>::make_ok(templ.meta)));
     }
 

--- a/src/project/view/templatesmodel.cpp
+++ b/src/project/view/templatesmodel.cpp
@@ -65,7 +65,8 @@ QString TemplatesModel::currentTemplatePath() const
         return QString();
     }
 
-    return m_visibleTemplates[m_currentTemplateIndex].meta.filePath.toQString();
+    // Safe to assume that saveLocation.isLocal()
+    return m_visibleTemplates[m_currentTemplateIndex].meta.saveLocation.localInfo().path.toQString();
 }
 
 QStringList TemplatesModel::templatesTitles() const


### PR DESCRIPTION
This PR introduces the SaveLocation type and uses it throughout the code. 

It is quite big, but could not have been split into parts because then it simply wouldn't compile and run. All changes are causing one another, like in a chain reaction.

Of course, this SaveLocation type complicates the code quite a bit. I still think it is a relatively elegant way to handle "cloud projects". I'd be happy to hear feedback on this choice.

From now on, I'll just need to fill a few places with some code to open and save cloud projects. 

The only change in behaviour caused by this PR should be that you'll see a filename extension iff the extension is not equal to "mscz". And it
Resolves: #10288 