### PR TITLE
fix #10360: add mmRangeText to list of object to be drawn

### DIFF
--- a/src/engraving/libmscore/scoretree.cpp
+++ b/src/engraving/libmscore/scoretree.cpp
@@ -40,6 +40,7 @@
 #include "lyrics.h"
 #include "measure.h"
 #include "measurenumber.h"
+#include "mmrestrange.h"
 #include "note.h"
 #include "page.h"
 #include "rest.h"
@@ -251,6 +252,12 @@ EngravingObject* Measure::scanChild(int idx) const
             }
             idx--;
         }
+        if (mmRangeText(staffIdx)) {
+            if (idx == 0) {
+                return mmRangeText(staffIdx);
+            }
+            idx--;
+        }
     }
 
     const std::multimap<int, Ms::Spanner*>& spannerMap = score()->spanner();
@@ -297,6 +304,9 @@ int Measure::scanChildCount() const
             numChildren++;
         }
         if (noText(staffIdx)) {
+            numChildren++;
+        }
+        if (mmRangeText(staffIdx)) {
             numChildren++;
         }
     }

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -484,7 +484,8 @@ EditStyle::EditStyle(QWidget* parent)
         tempoTextPlacement,
         staffTextPlacement,
         rehearsalMarkPlacement,
-        measureNumberVPlacement
+        measureNumberVPlacement,
+        mmRestRangeVPlacement
     };
 
     for (QComboBox* cb : verticalPlacementComboBoxes) {


### PR DESCRIPTION
Resolves: #10360

`mmRangeText` was missing in both `Measure::scanChild()` and `Measure::scanChildCount()`. As a result the range was added to list element to be drawn.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
