### PR TITLE
Fix #9769: rewrite-text-size-menu

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/Dropdown.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/Dropdown.qml
@@ -44,6 +44,8 @@ Item {
 
     property int popupWidth: root.width
     property int popupItemsCount: 18
+    property alias popupX: popup.x
+    property alias popupY: popup.y
 
     property alias dropIcon: dropIconItem
     property alias label: mainItem.label

--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextInspectorView.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextInspectorView.qml
@@ -116,7 +116,7 @@ InspectorSectionView {
                 }
             }
 
-            DropdownPropertyView {
+            InspectorPropertyView {
                 id: sizeSection
                 anchors.left: parent.horizontalCenter
                 anchors.leftMargin: 2
@@ -125,24 +125,72 @@ InspectorSectionView {
                 navigationName: "Size"
                 navigationPanel: root.navigationPanel
                 navigationRowStart: styleSection.navigationRowEnd + 1
+                navigationRowEnd: dropdownItem.navigation.row
 
                 titleText: qsTrc("inspector", "Size")
                 propertyItem: root.model ? root.model.fontSize : null
 
-                model: [
-                    { text: "8",  value: 8 },
-                    { text: "9",  value: 9 },
-                    { text: "10", value: 10 },
-                    { text: "11", value: 11 },
-                    { text: "12", value: 12 },
-                    { text: "14", value: 14 },
-                    { text: "16", value: 16 },
-                    { text: "18", value: 18 },
-                    { text: "24", value: 24 },
-                    { text: "30", value: 30 },
-                    { text: "36", value: 36 },
-                    { text: "48", value: 48 }
-                ]
+                Row {
+                    TextInputField {
+                        id: textInputField
+                        width: sizeSection.width - dropdownItem.width
+
+                        IntInputValidator {
+                            id: intInputValidator
+                            top: 64
+                            bottom: 4
+                        }
+                        validator:intInputValidator
+
+                        containsMouse: mouseArea.containsMouse
+
+                        currentText:dropdownItem.currentText
+
+                        onCurrentTextEdited: function(newTextValue) {
+                            sizeSection.propertyItem.value = newTextValue
+                            dropdownItem.currentText = newTextValue
+                        }
+                    }
+
+                    Dropdown {
+                        id: dropdownItem
+                        width: 32
+                        displayText: ""
+                        popupWidth: sizeSection.width
+                        popupX: width - sizeSection.width
+                        model: [
+                           { text: "8",  value: 8 },
+                           { text: "9",  value: 9 },
+                           { text: "10", value: 10 },
+                           { text: "11", value: 11 },
+                           { text: "12", value: 12 },
+                           { text: "14", value: 14 },
+                           { text: "16", value: 16 },
+                           { text: "18", value: 18 },
+                           { text: "24", value: 24 },
+                           { text: "30", value: 30 },
+                           { text: "36", value: 36 },
+                           { text: "48", value: 48 }
+                        ]
+
+                        navigation.name: sizeSection.navigationName + " Dropdown"
+                        navigation.panel: sizeSection.navigationPanel
+                        navigation.row: sizeSection.navigationRowStart + 1
+                        navigation.accessible.name: sizeSection.titleText + " " + currentText
+
+                        currentIndex: sizeSection.propertyItem && !sizeSection.propertyItem.isUndefined
+                                      ? indexOfValue(sizeSection.propertyItem.value)
+                                      : -1
+
+                        onCurrentValueChanged: {
+                            if (!sizeSection.propertyItem || currentIndex === -1) {
+                                return
+                            }
+
+                            sizeSection.propertyItem.value = currentValue
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Resolves: [#9769](https://github.com/musescore/MuseScore/issues/9769)

 make size menu be an editable text box + context menu containing preset sizes.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made

https://user-images.githubusercontent.com/71218187/153905265-ddba03fb-7049-4266-be0e-6d52e9f5d11a.mp4

