### PR TITLE
Fix #10489: prevent clipping in RadioButtonGroup.qml

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/RadioButtonGroup.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/RadioButtonGroup.qml
@@ -35,6 +35,7 @@ StyledListView {
     opacity: root.enabled ? 1.0 : ui.theme.itemOpacityDisabled
     orientation: ListView.Horizontal
     interactive: false
+    clip: false
 
     ButtonGroup {
         id: buttonGroup


### PR DESCRIPTION
Resolves: #10489

Added `clip: false`  in `RadioButtonGroup.qml` to prevent clipping of `Additional Score Information>Time Signature>Popup`

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
