### PR TITLE
[MU4] Fix #10574: Templates are open not in usual style format and cause a crash after entering notes

### DIFF
--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -234,10 +234,6 @@ mu::Ret MasterNotation::setupNewScore(Ms::MasterScore* score, const ScoreCreateO
 
     applyOptions(score, scoreOptions);
 
-    {
-        Ms::ScoreLoad sl;
-        score->doLayout();
-    }
     initExcerptNotations(score->excerpts());
     addExcerptsToMasterScore(score->excerpts());
 
@@ -446,6 +442,11 @@ void MasterNotation::applyOptions(Ms::MasterScore* score, const ScoreCreateOptio
     }
 
     score->setUpTempoMap();
+
+    {
+        Ms::ScoreLoad sl;
+        score->doLayout();
+    }
 }
 
 mu::RetVal<bool> MasterNotation::created() const


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10574