### PR TITLE
"Last system fill threshold" should also apply to section breaks

### DIFF
--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -381,8 +381,9 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
     // proportional to the difference between the current length and the target length.
     // After few iterations, the length will converge to the target length.
     qreal newRest = systemWidth - curSysWidth;
-    if (ctx.curMeasure == 0 && ((curSysWidth / systemWidth) <= score->styleD(Sid::lastSystemFillLimit))) {
-        // We do not stretch last system if curSysWidth is <= lastSystemFillLimit
+    if ((ctx.curMeasure == 0 || (lm && lm->sectionBreak()))
+        && ((curSysWidth / systemWidth) <= score->styleD(Sid::lastSystemFillLimit))) {
+        // We do not stretch last system of a section (or the last of the piece) if curSysWidth is <= lastSystemFillLimit
         newRest = 0;
     }
     if (MScore::noHorizontalStretch) { // Debug feature


### PR DESCRIPTION
This is a tiny fix.
The setting "Last system fill threshold" (from Style -> Page), by which we don't justify the last system if its width is smaller than a given amount, should also apply to section breaks.
For reference, this is what the program does now (and also MU3.6)
![Screenshot from 2022-02-07 10-52-09](https://user-images.githubusercontent.com/93707756/154065217-a5771966-3846-464f-9024-846cf8514f14.png)
but this would be the correct layout
![Screenshot from 2022-02-07 10-53-49](https://user-images.githubusercontent.com/93707756/154065575-06bf6a69-6552-4333-9258-db22616deb69.png)

I don't see any obvious downsides to making this the default behaviour. @oktophonie 
