### PR TITLE
[MU4] Fix #9228: VST: When launching popup, they appear in the wrong position and the window is too small 

### DIFF
--- a/src/framework/vst/view/abstractvsteditorview.h
+++ b/src/framework/vst/view/abstractvsteditorview.h
@@ -45,7 +45,7 @@ class AbstractVstEditorView : public QDialog, public Steinberg::IPlugFrame, publ
 
 public:
     AbstractVstEditorView(QWidget* parent = nullptr);
-    ~AbstractVstEditorView();
+    ~AbstractVstEditorView() override;
 
     Steinberg::tresult resizeView(Steinberg::IPlugView* view, Steinberg::ViewRect* newSize) override;
 
@@ -62,10 +62,16 @@ signals:
 protected:
     virtual bool isAbleToWrapPlugin() const = 0;
     virtual VstPluginPtr getPluginPtr() const = 0;
+
     void wrapPluginView();
 
 private:
     void attachView(VstPluginPtr pluginPtr);
+
+    void setupWindowGeometry();
+    void moveViewToMainWindowCenter();
+
+    void showEvent(QShowEvent* event) override;
 
     FIDString currentPlatformUiType() const;
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9228