### PR TITLE
[MU4] Fix #10578: Crash after adding rests with Repeat command or adding bars to the end with shortcut holding the keys

### DIFF
--- a/src/inspector/models/inspectorlistmodel.h
+++ b/src/inspector/models/inspectorlistmodel.h
@@ -52,7 +52,7 @@ private:
         InspectorSectionModelRole = Qt::UserRole + 1
     };
 
-    void onNotationChanged();
+    void listenSelectionChanged();
 
     void setElementList(const QList<Ms::EngravingItem*>& selectedElementList,
                         notation::SelectionState selectionState = notation::SelectionState::NONE);
@@ -61,7 +61,7 @@ private:
     void buildModelsForSelectedElements(const ElementKeySet& selectedElementKeySet, bool isRangeSelection);
 
     void createModelsBySectionType(const QList<InspectorSectionType>& sectionTypeList, const ElementKeySet& selectedElementKeySet = {});
-    void removeUnusedModels(const ElementKeySet& newElementKeySet,
+    void removeUnusedModels(const ElementKeySet& newElementKeySet, bool isRangeSelection,
                             const QList<InspectorSectionType>& exclusions = QList<InspectorSectionType>());
 
     bool isModelAllowed(const AbstractInspectorModel* model, const InspectorModelTypeSet& allowedModelTypes,

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -478,11 +478,18 @@ Ms::Score* NotationNoteInput::score() const
 void NotationNoteInput::startEdit()
 {
     m_undoStack->prepareChanges();
+
+    score()->setSelectionChanged(false);
 }
 
 void NotationNoteInput::apply()
 {
     m_undoStack->commitChanges();
+
+    if (score()->selectionChanged()) {
+        m_interaction->selectionChanged().notify();
+        score()->setSelectionChanged(false);
+    }
 }
 
 void NotationNoteInput::updateInputState()


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10578