### PR TITLE
[MU4] Fix #329469: Editing Measure numbers causes crash

### DIFF
--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -3066,21 +3066,28 @@ AccessibleItem* TextBase::createAccessible()
 
 void TextBase::notifyAboutTextCursorChanged()
 {
-    accessible()->accessiblePropertyChanged().send(accessibility::IAccessible::Property::TextCursor, Val());
+    if (accessible()) {
+        accessible()->accessiblePropertyChanged().send(accessibility::IAccessible::Property::TextCursor,
+                                                       Val());
+    }
 }
 
 void TextBase::notifyAboutTextInserted(int startPosition, int endPosition, const QString& text)
 {
-    auto range = accessibility::IAccessible::TextRange(startPosition, endPosition, text);
-    accessible()->accessiblePropertyChanged().send(accessibility::IAccessible::Property::TextInsert,
-                                                   Val(range.toMap()));
+    if (accessible()) {
+        auto range = accessibility::IAccessible::TextRange(startPosition, endPosition, text);
+        accessible()->accessiblePropertyChanged().send(accessibility::IAccessible::Property::TextInsert,
+                                                       Val(range.toMap()));
+    }
 }
 
 void TextBase::notifyAboutTextRemoved(int startPosition, int endPosition, const QString& text)
 {
-    auto range = accessibility::IAccessible::TextRange(startPosition, endPosition, text);
-    accessible()->accessiblePropertyChanged().send(accessibility::IAccessible::Property::TextRemove,
-                                                   Val(range.toMap()));
+    if (accessible()) {
+        auto range = accessibility::IAccessible::TextRange(startPosition, endPosition, text);
+        accessible()->accessiblePropertyChanged().send(accessibility::IAccessible::Property::TextRemove,
+                                                       Val(range.toMap()));
+    }
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
While at it fix other potential crashes in the same area

Resolves: https://musescore.org/en/node/329469

I'm not sure at all whether this is the right way to fix this. Probably measure numbers should not pretend to be editable in the first place, or need to get made editable.