### PR TITLE
Finessing spacing formula

### DIFF
--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -4033,11 +4033,8 @@ static bool hasAccidental(Segment* s)
 //---------------------------------------------------------
 float Measure::durationStretch(Fraction curTicks, const Fraction minTicks) const
 {
-    qreal userSlope = userStretch() * score()->styleD(Sid::measureSpacing);
-    static constexpr qreal baseSlope = 0.647;
-    qreal slope = userSlope * baseSlope;
-    // The slope of the spacing formula is determined by the multiplication of user-defined settings and baseSlope.
-    // The value of baseSlope is chosen such that the curve matches the "ideal" one when user settings are at default.
+    qreal slope = 0.7764;
+    // Chosen such that the curve matches the "ideal" one.
     // See documentation PDF for more detail.
 
     static constexpr int maxMMRestWidth = 20; // At most, MM rests will be spaced "as if" they were 20 bars long.


### PR DESCRIPTION
With the new spacing algorithm, the `spacing` parameter (from Style -> Measure) and the `stretch` parameter are acting not only as an overall multiplier to the horizontal spacing, but they also affect the slope of the spacing formula. The slope of the formula is part of what determines the ratio between the space assigned to longer vs shorter notes. The original reasoning behing this decision is that it makes the stretch "{" and "}" commands "feel better", more responsive.

However, I've now realised that `spacing` and `stretch` should only act as multipliers, and *not* affect the spacing formula. There are several reasons for this.
1) The spacing formula is something delicate, and we shouldn't let the user interact with it unknowingly. Also because
2) I'm expecting future upgrades where we may allow full user-customization of the spacing formula through dedicated settings, in which case there shouldn't be other parameters messing with it.
3) It can cause some unintuitive behaviour. To visualize it, consider a case where I force a single measure to occupy the whole system. As a user, I would expect the spacing and stretch parameters to do nothing, because the measure is anyway forced to a given width. However, because they interact with the spacing formula, they change the spacing ratios between long and short notes (see picture), which shouldn't happen.
![comparison](https://user-images.githubusercontent.com/93707756/154241372-c54e94de-5229-476e-aefe-905742f3ba1c.png)

I am now correcting that. 

Note: **this change does _not_ affect the default layout**. All tests should remain identical, except for tests explicitely using `spacing` and `stretch` parameters that are not default. 

Needs review by @oktophonie 