### PR TITLE
[MU4] Fix #329470: Wrong/missing transpositioning on MusicXML import

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -36,6 +36,7 @@
 #include "engraving/libmscore/timesig.h"
 #include "engraving/libmscore/spanner.h"
 #include "engraving/libmscore/bracketItem.h"
+#include "engraving/libmscore/utils.h"
 
 #include "engraving/types/symnames.h"
 #include "engraving/style/style.h"
@@ -2496,6 +2497,9 @@ void MusicXMLParserPass1::transpose(const QString& partId, const Fraction& tick)
     }
 
     if (_parts[partId]._intervals.count(tick) == 0) {
+        if (!interval.diatonic && interval.chromatic) {
+            interval.diatonic = chromatic2diatonic(interval.chromatic);
+        }
         _parts[partId]._intervals[tick] = interval;
     } else {
         qDebug("duplicate transpose at tick %s", qPrintable(tick.toString()));

--- a/src/importexport/musicxml/tests/data/TODO
+++ b/src/importexport/musicxml/tests/data/TODO
@@ -1,6 +1,6 @@
 2.2.2020 lv
       Convert files Page*.xml and Title*.xml into regular testfiles.
-      Note: depends on fixing MusicXML export for the fetaures tested.
+      Note: depends on fixing MusicXML export for the features tested.
 6.2.2015 ws
       Test Wedge2 needs checking.
       A Hairpin() changes its tick length in checkSpanners().

--- a/src/importexport/musicxml/tests/data/testChangeTranspose-no-diatonic.xml
+++ b/src/importexport/musicxml/tests/data/testChangeTranspose-no-diatonic.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-number>MuseScore testfile</work-number>
+    <work-title>Change transpose (no diatonic)</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Leon Vinken</creator>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>A Clarinet</part-name>
+      <part-abbreviation>A Cl.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>A Clarinet</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I2">
+        <instrument-name>B♭ Clarinet</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>72</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-device id="P1-I2" port="1"></midi-device>
+      <midi-instrument id="P1-I2">
+        <midi-channel>2</midi-channel>
+        <midi-program>72</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-3</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <instruments>2</instruments>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <chromatic>-3</chromatic>
+          </transpose>
+        </attributes>
+      <attributes>
+        <measure-style>
+          <multiple-rest>2</multiple-rest>
+          </measure-style>
+        </attributes>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="3">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>4</duration>
+        <instrument id="P1-I1"/>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    <measure number="4">
+      <attributes>
+        <key>
+          <fifths>2</fifths>
+          </key>
+        </attributes>
+      <attributes>
+        <transpose>
+          <chromatic>-2</chromatic>
+          </transpose>
+        </attributes>
+      <direction placement="above">
+        <direction-type>
+          <words font-weight="bold" font-size="12">To B♭ Clarinet</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>4</duration>
+        <instrument id="P1-I2"/>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/data/testChangeTranspose-no-diatonic_ref.xml
+++ b/src/importexport/musicxml/tests/data/testChangeTranspose-no-diatonic_ref.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-number>MuseScore testfile</work-number>
+    <work-title>Change transpose (no diatonic)</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Leon Vinken</creator>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>A Clarinet</part-name>
+      <part-abbreviation>A Cl.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>A Clarinet</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I2">
+        <instrument-name>B♭ Clarinet</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>72</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-device id="P1-I2" port="1"></midi-device>
+      <midi-instrument id="P1-I2">
+        <midi-channel>2</midi-channel>
+        <midi-program>72</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-3</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <instruments>2</instruments>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>-2</diatonic>
+          <chromatic>-3</chromatic>
+          </transpose>
+        </attributes>
+      <attributes>
+        <measure-style>
+          <multiple-rest>2</multiple-rest>
+          </measure-style>
+        </attributes>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="3">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>4</duration>
+        <instrument id="P1-I1"/>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    <measure number="4">
+      <attributes>
+        <key>
+          <fifths>2</fifths>
+          </key>
+        </attributes>
+      <attributes>
+        <transpose>
+          <diatonic>-1</diatonic>
+          <chromatic>-2</chromatic>
+          </transpose>
+        </attributes>
+      <direction placement="above">
+        <direction-type>
+          <words font-weight="bold" font-size="12">To B♭ Clarinet</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>4</duration>
+        <instrument id="P1-I2"/>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/data/testGraceAfter1.xml
+++ b/src/importexport/musicxml/tests/data/testGraceAfter1.xml
@@ -6,7 +6,7 @@
     <work-title>Grace after 1: implied grace after</work-title>
     </work>
   <identification>
-  <creator type="composer">Leon Vinken</creator>
+    <creator type="composer">Leon Vinken</creator>
     <encoding>
       <software>MuseScore 0.7.0</software>
       <encoding-date>2007-09-10</encoding-date>

--- a/src/importexport/musicxml/tests/tst_mxml_io.cpp
+++ b/src/importexport/musicxml/tests/tst_mxml_io.cpp
@@ -93,14 +93,21 @@ private slots:
     void barStyles() { mxmlIoTest("testBarStyles"); }
     void barStyles2() { mxmlIoTest("testBarStyles2"); }
     void barStyles3() { mxmlIoTest("testBarStyles3"); }
+    // void beamEnd() { mxmlIoTest("testBeamEnd"); } fails
+    void beams1() { mxmlIoTest("testBeams1"); }
+    void beams2() { mxmlIoTest("testBeams2"); }
+    void beams3() { mxmlIoTestRef("testBeams3"); }
     void breaksImplExpl() { mxmlMscxExportTestRefBreaks("testBreaksImplExpl"); }
     void breaksMMRest() { mxmlMscxExportTestRefBreaks("testBreaksMMRest"); }
     // void breaksManual() { mxmlIoTestRefBreaks("testBreaksManual"); } fail after sync with 3.x
     // void breaksPage() { mxmlMscxExportTestRefBreaks("testBreaksPage"); } fail after sync with 3.x
-    // void breaksSystem() { mxmlMscxExportTestRefBreaks("testBreaksSystem"); } fail after sync with 3.x
+    void breaksSystem() { mxmlMscxExportTestRefBreaks("testBreaksSystem"); }
+    void changeTranspose() { mxmlIoTest("testChangeTranspose"); }
+    void changeTransposeNoDiatonic() { mxmlIoTestRef("testChangeTranspose-no-diatonic"); }
     void chordDiagrams1() { mxmlIoTest("testChordDiagrams1"); }
     void chordNoVoice() { mxmlIoTestRef("testChordNoVoice"); }
     void clefs1() { mxmlIoTest("testClefs1"); }
+    void clefs2() { mxmlIoTest("testClefs2"); }
     void completeMeasureRests() { mxmlIoTest("testCompleteMeasureRests"); }
     void cueNotes() { mxmlIoTest("testCueNotes"); }
     void cueNotes2() { mxmlMscxExportTestRef("testCueNotes2"); }
@@ -120,6 +127,7 @@ private slots:
     void dynamics3() { mxmlIoTestRef("testDynamics3"); }
     void emptyMeasure() { mxmlIoTestRef("testEmptyMeasure"); }
     void emptyVoice1() { mxmlIoTestRef("testEmptyVoice1"); }
+    void excludeInvisibleElements() { mxmlMscxExportTestRefInvisibleElements("testExcludeInvisibleElements"); }
     void extendedLyrics() { mxmlIoTestRef("testExtendedLyrics"); }
     void figuredBass1() { mxmlIoTest("testFiguredBass1"); }
     void figuredBass2() { mxmlIoTest("testFiguredBass2"); }
@@ -130,6 +138,10 @@ private slots:
     void fractionTicks() { mxmlIoTestRef("testFractionTicks"); }
     void grace1() { mxmlIoTest("testGrace1"); }
     void grace2() { mxmlIoTest("testGrace2"); }
+    void graceAfter1() { mxmlIoTest("testGraceAfter1"); }
+    // void graceAfter2() { mxmlIoTest("testGraceAfter2"); } fails
+    // void graceAfter3() { mxmlIoTest("testGraceAfter3"); } fails
+    // void graceAfter4() { mxmlIoTest("testGraceAfter4"); } fails
     void hairpinDynamics() { mxmlMscxExportTestRef("testHairpinDynamics"); }
     void harmony1() { mxmlIoTest("testHarmony1"); }
     void harmony2() { mxmlIoTest("testHarmony2"); }
@@ -141,6 +153,8 @@ private slots:
     void helloReadCompr() { mxmlReadTestCompr("testHello"); }
     void helloReadWriteCompr() { mxmlReadWriteTestCompr("testHello"); }
     void implicitMeasure1() { mxmlIoTest("testImplicitMeasure1"); }
+    // void incompleteTuplet() { mxmlIoTestRef("testIncomplteTuplet"); } fails
+    // void incorrectMidiProgram() { mxmlIoTestRef("testIncorrectMidiProgram"); } fails
     void incorrectStaffNumber1() { mxmlIoTestRef("testIncorrectStaffNumber1"); }
     void incorrectStaffNumber2() { mxmlIoTestRef("testIncorrectStaffNumber2"); }
     void instrumentChangeMIDIportExport() { mxmlMscxExportTestRef("testInstrumentChangeMIDIportExport"); }
@@ -161,11 +175,13 @@ private slots:
     void measureLength() { mxmlIoTestRef("testMeasureLength"); }
     void measureNumbers() { mxmlIoTest("testMeasureNumbers"); }
     void measureRepeats1() { mxmlIoTestRef("testMeasureRepeats1"); }
-    //void measureRepeats2() { mxmlIoTestRef("testMeasureRepeats2"); } fail libmscore/style.cpp Q_ASSERT(idx == textStyles[int(idx)].tid);
+    // void measureRepeats2() { mxmlIoTestRef("testMeasureRepeats2"); } fail libmscore/style.cpp Q_ASSERT(idx == textStyles[int(idx)].tid);
     void measureRepeats3() { mxmlIoTest("testMeasureRepeats3"); }
+    // void measureStyleSlash() { mxmlIoTestRef("testMeasureStyleSlash"); } fails
     void midiPortExport() { mxmlMscxExportTestRef("testMidiPortExport"); }
     void multiInstrumentPart1() { mxmlIoTest("testMultiInstrumentPart1"); }
     void multiInstrumentPart2() { mxmlIoTest("testMultiInstrumentPart2"); }
+    // void multiInstrumentPart3() { mxmlIoTest("testMultiInstrumentPart3"); } fails
     void multiMeasureRest1() { mxmlIoTestRef("testMultiMeasureRest1"); }
     void multiMeasureRest2() { mxmlIoTestRef("testMultiMeasureRest2"); }
     void multiMeasureRest3() { mxmlIoTestRef("testMultiMeasureRest3"); }
@@ -176,7 +192,7 @@ private slots:
     void nonStandardKeySig3() { mxmlIoTest("testNonStandardKeySig3"); }
     void nonUniqueThings() { mxmlIoTestRef("testNonUniqueThings"); }
     void noteAttributes1() { mxmlIoTest("testNoteAttributes1"); }
-    //void noteAttributes2() { mxmlIoTestRef("testNoteAttributes2"); }
+    void noteAttributes2() { mxmlIoTestRef("testNoteAttributes2"); }
     void noteAttributes3() { mxmlIoTest("testNoteAttributes3"); }
     void noteColor() { mxmlIoTest("testNoteColor"); }
     void noteheadParentheses() { mxmlIoTest("testNoteheadParentheses"); }
@@ -218,6 +234,9 @@ private slots:
     void tempo2() { mxmlIoTestRef("testTempo2"); }
     void tempo3() { mxmlIoTestRef("testTempo3"); }
     void tempo4() { mxmlIoTestRef("testTempo4"); }
+    // void tempoOverlap() { mxmlIoTestRef("testTempoOverlap"); } fails
+    void tempoPrecision() { mxmlMscxExportTestRef("testTempoPrecision"); }
+    void textLines() { mxmlMscxExportTestRef("testTextLines"); }
     void timesig1() { mxmlIoTest("testTimesig1"); }
     void timesig3() { mxmlIoTest("testTimesig3"); }
     void trackHandling() { mxmlIoTest("testTrackHandling"); }
@@ -242,9 +261,9 @@ private slots:
     void wedge1() { mxmlIoTest("testWedge1"); }
     void wedge2() { mxmlIoTest("testWedge2"); }
     void wedge3() { mxmlIoTest("testWedge3"); }
+    // void wedge4() { mxmlIoTestRef("testWedge4"); } fails
     void words1() { mxmlIoTest("testWords1"); }
     void words2() { mxmlIoTest("testWords2"); }
-    void excludeInvisibleElements() { mxmlMscxExportTestRefInvisibleElements("testExcludeInvisibleElements"); }
 };
 
 //---------------------------------------------------------


### PR DESCRIPTION
If the optional element "diatonic" is missing, calculate it from "chromatic".

Resolves: https://musescore.org/en/node/329470
Same issue in 3.x.

Also adds/enables all (most?) available MusicXML unit tests (commenting out those that fail, working on those is out of score of this PR).