### PR TITLE
Fix 9407: fix reset for inpectors which have two properties

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/common/InspectorPropertyView.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/common/InspectorPropertyView.qml
@@ -44,7 +44,10 @@ Column {
     property alias showButton: buttonLoader.visible
 
     readonly property bool isStyled: propertyItem ? propertyItem.isStyled : false
-    readonly property bool isModified: propertyItem ? propertyItem.isModified : false
+    property bool isModified: propertyItem ? propertyItem.isModified : false
+
+    signal requestResetToDefault()
+    signal requestApplyToStyle()
 
     function requestActiveFocus() {
         if (buttonLoader.item && buttonLoader.item.navigation) {
@@ -64,6 +67,14 @@ Column {
         if (buttonLoader.item && buttonLoader.item.navigation) {
             buttonLoader.item.navigation.requestActive()
         }
+    }
+
+    onRequestResetToDefault:  {
+        root.propertyItem.resetToDefault()
+    }
+
+    onRequestApplyToStyle: {
+        root.propertyItem.applyToStyle()
     }
 
     RowLayout {
@@ -110,7 +121,7 @@ Column {
                     enabled: root.isModified
 
                     onClicked: {
-                        root.propertyItem.resetToDefault()
+                        root.requestResetToDefault()
                     }
                 }
             }
@@ -146,10 +157,10 @@ Column {
                     onHandleMenuItem: function(itemId) {
                         switch (itemId) {
                         case "reset":
-                            root.propertyItem.resetToDefault()
+                            root.requestResetToDefault()
                             break
                         case "save":
-                            root.propertyItem.applyToStyle()
+                            root.requestApplyToStyle()
                             break
                         }
                     }

--- a/src/inspector/view/qml/MuseScore/Inspector/common/OffsetSection.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/common/OffsetSection.qml
@@ -44,7 +44,19 @@ InspectorPropertyView {
     navigationName: "OffsetSection"
     navigationRowEnd: verticalOffsetControl.navigation.row
 
+    isModified: (Boolean(horizontalOffset) ? horizontalOffset.isModified : false)
+                || (Boolean(verticalOffset) ? verticalOffset.isModified : false)
     visible: Boolean(horizontalOffset) || Boolean(verticalOffset)
+
+    onRequestResetToDefault: {
+        if(Boolean(horizontalOffset)) {
+            horizontalOffset.resetToDefault()
+        }
+
+        if(Boolean(verticalOffset)) {
+            verticalOffset.resetToDefault()
+        }
+    }
 
     RowLayout {
         id: row

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/notes/BeamSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/notes/BeamSettings.qml
@@ -221,6 +221,16 @@ FocusableItem {
                         navigationRowStart: showItem.navigation.row + 1
                         navigationRowEnd: beamHeightLeftControl.navigation.row
 
+                        isModified: root.model ? (root.model.beamVectorX.isModified
+                                                  || root.model.beamVectorY.isModified) : false
+
+                        onRequestResetToDefault: {
+                            if (root.model) {
+                                root.model.beamVectorX.resetToDefault()
+                                root.model.beamVectorY.resetToDefault()
+                            }
+                        }
+
                         Item {
                             height: childrenRect.height
                             width: parent.width

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/timesignatures/TimeSignatureSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/timesignatures/TimeSignatureSettings.qml
@@ -54,6 +54,23 @@ Column {
         navigationRowStart: root.navigationRowStart + 1
         navigationRowEnd: verticalScaleControl.navigation.row
 
+        isModified: root.model ? (root.model.horizontalScale.isModified
+                                  || root.model.verticalScale.isModified) : false
+
+        onRequestResetToDefault: {
+            if (root.model) {
+                root.model.horizontalScale.resetToDefault()
+                root.model.verticalScale.resetToDefault()
+            }
+        }
+
+        onRequestApplyToStyle: {
+            if (root.model) {
+                root.model.horizontalScale.applyToStyle()
+                root.model.verticalScale.applyToStyle()
+            }
+        }
+
         Item {
             height: childrenRect.height
             width: parent.width

--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextInspectorView.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextInspectorView.qml
@@ -156,6 +156,23 @@ InspectorSectionView {
             navigationRowStart: sizeSection.navigationRowEnd + 1
             navigationRowEnd: verticalAlignmentButtonList.navigationRowEnd
 
+            isModified: root.model ? (root.model.horizontalAlignment.isModified
+                                      || root.model.verticalAlignment.isModified) : false
+
+            onRequestResetToDefault: {
+                if (root.model) {
+                    root.model.horizontalAlignment.resetToDefault()
+                    root.model.verticalAlignment.resetToDefault()
+                }
+            }
+
+            onRequestApplyToStyle: {
+                if (root.model) {
+                    root.model.horizontalAlignment.applyToStyle()
+                    root.model.verticalAlignment.applyToStyle()
+                }
+            }
+
             Item {
                 height: childrenRect.height
                 width: parent.width


### PR DESCRIPTION
Resolves: [#9407](https://github.com/musescore/MuseScore/issues/9407)

Send signal when reset and override the listen function when needed.
Besides, save feature has simillar issue, I fixed it by the way.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made

https://user-images.githubusercontent.com/71218187/154523768-d51c1621-ebed-4e28-91f2-c57891b70007.mp4

