### PR TITLE
Fix preview in Staff/Part Properties > Advanced

### DIFF
--- a/src/commonscene/exampleview.cpp
+++ b/src/commonscene/exampleview.cpp
@@ -145,6 +145,7 @@ void ExampleView::setScore(Score* s)
 
     ScoreLoad sl;
     _score->doLayout();
+    resetMatrix();
     update();
 }
 

--- a/src/commonscene/exampleview.cpp
+++ b/src/commonscene/exampleview.cpp
@@ -41,32 +41,29 @@ using namespace mu;
 using namespace mu::engraving;
 
 namespace Ms {
-//---------------------------------------------------------
-//   ExampleView
-//---------------------------------------------------------
-
 ExampleView::ExampleView(QWidget* parent)
     : QFrame(parent)
 {
-    _score = 0;
+    m_score = nullptr;
     setAcceptDrops(true);
     setFocusPolicy(Qt::StrongFocus);
     resetMatrix();
-    _fgPixmap = nullptr;
-    _fgColor  = Qt::white;
+    m_backgroundPixmap = nullptr;
+    m_backgroundColor  = Qt::white;
 
     if (notationConfiguration()->foregroundUseColor()) {
-        _fgColor = notationConfiguration()->foregroundColor();
+        m_backgroundColor = notationConfiguration()->foregroundColor();
     } else {
         QString wallpaperPath = notationConfiguration()->foregroundWallpaperPath().toQString();
 
-        _fgPixmap = new QPixmap(wallpaperPath);
-        if (_fgPixmap == 0 || _fgPixmap->isNull()) {
+        m_backgroundPixmap = new QPixmap(wallpaperPath);
+        if (m_backgroundPixmap == 0 || m_backgroundPixmap->isNull()) {
             qDebug("no valid pixmap %s", qPrintable(wallpaperPath));
         }
     }
+
     // setup drag canvas state
-    sm          = new QStateMachine(this);
+    m_stateMachine = new QStateMachine(this);
     QState* stateActive = new QState;
 
     QState* s1 = new QState(stateActive);
@@ -81,38 +78,28 @@ ExampleView::ExampleView(QWidget* parent)
     s->addTransition(cl);
     s1->addTransition(new DragTransitionExampleView(this));
 
-    sm->addState(stateActive);
+    m_stateMachine->addState(stateActive);
     stateActive->setInitialState(s1);
-    sm->setInitialState(stateActive);
+    m_stateMachine->setInitialState(stateActive);
 
-    sm->start();
+    m_stateMachine->start();
 
     m_defaultScaling = 0.9 * uiConfiguration()->dpi() / DPI; // 90% of nominal
 }
 
-//---------------------------------------------------------
-//   ~ExampleView
-//---------------------------------------------------------
-
 ExampleView::~ExampleView()
 {
-    if (_fgPixmap) {
-        delete _fgPixmap;
+    if (m_backgroundPixmap) {
+        delete m_backgroundPixmap;
     }
 }
-
-//---------------------------------------------------------
-//   resetMatrix
-//    used to reset scrolling in case time signature num or denom changed
-//---------------------------------------------------------
 
 void ExampleView::resetMatrix()
 {
     double mag = m_defaultScaling;
     qreal _spatium = SPATIUM20 * mag;
     // example would normally be 10sp from top of page; this leaves 3sp margin above
-    _matrix  = QTransform(mag, 0.0, 0.0, mag, _spatium, -_spatium * 7.0);
-    imatrix  = _matrix.inverted();
+    m_matrix = mu::Transform(mag, 0.0, 0.0, mag, _spatium, -_spatium * 7.0);
 }
 
 void ExampleView::layoutChanged()
@@ -132,19 +119,15 @@ void ExampleView::adjustCanvasPosition(const EngravingItem* /*el*/, bool /*playB
 {
 }
 
-//---------------------------------------------------------
-//   setScore
-//---------------------------------------------------------
-
 void ExampleView::setScore(Score* s)
 {
-    delete _score;
-    _score = s;
-    _score->addViewer(this);
-    _score->setLayoutMode(LayoutMode::LINE);
+    delete m_score;
+    m_score = s;
+    m_score->addViewer(this);
+    m_score->setLayoutMode(LayoutMode::LINE);
 
     ScoreLoad sl;
-    _score->doLayout();
+    m_score->doLayout();
     resetMatrix();
     update();
 }
@@ -167,16 +150,12 @@ void ExampleView::cmdAddSlur(Note* /*firstNote*/, Note* /*lastNote*/)
 
 void ExampleView::drawBackground(mu::draw::Painter* p, const RectF& r) const
 {
-    if (_fgPixmap == 0 || _fgPixmap->isNull()) {
-        p->fillRect(r, _fgColor);
+    if (m_backgroundPixmap == 0 || m_backgroundPixmap->isNull()) {
+        p->fillRect(r, m_backgroundColor);
     } else {
-        p->drawTiledPixmap(r, *_fgPixmap, r.topLeft() - PointF(lrint(_matrix.dx()), lrint(_matrix.dy())));
+        p->drawTiledPixmap(r, *m_backgroundPixmap, r.topLeft() - PointF(m_matrix.dx(), m_matrix.dy()));
     }
 }
-
-//---------------------------------------------------------
-//   drawElements
-//---------------------------------------------------------
 
 void ExampleView::drawElements(mu::draw::Painter& painter, const QList<EngravingItem*>& el)
 {
@@ -189,34 +168,27 @@ void ExampleView::drawElements(mu::draw::Painter& painter, const QList<Engraving
     }
 }
 
-//---------------------------------------------------------
-//   paintEvent
-//---------------------------------------------------------
-
-void ExampleView::paintEvent(QPaintEvent* ev)
+void ExampleView::paintEvent(QPaintEvent* event)
 {
-    if (_score) {
-        mu::draw::Painter p(this, "exampleview");
-        p.setAntialiasing(true);
-        const RectF r = RectF::fromQRectF(ev->rect());
+    QFrame::paintEvent(event);
 
-        drawBackground(&p, r);
-
-        p.setWorldTransform(mu::Transform::fromQTransform(_matrix));
-        QRectF fr = imatrix.mapRect(r.toQRectF());
-
-        QRegion r1(r.toQRect());
-        Page* page = _score->pages().front();
-        QList<EngravingItem*> ell = page->items(RectF::fromQRectF(fr));
-        std::stable_sort(ell.begin(), ell.end(), elementLessThan);
-        drawElements(p, ell);
+    if (!m_score) {
+        return;
     }
-    QFrame::paintEvent(ev);
-}
 
-//---------------------------------------------------------
-//   dragEnterEvent
-//---------------------------------------------------------
+    mu::draw::Painter painter(this, "exampleview");
+    painter.setAntialiasing(true);
+    const RectF rect = RectF::fromQRectF(event->rect());
+
+    drawBackground(&painter, rect);
+
+    painter.setWorldTransform(m_matrix);
+
+    Page* page = m_score->pages().front();
+    QList<EngravingItem*> ell = page->items(m_matrix.inverted().map(rect));
+    std::stable_sort(ell.begin(), ell.end(), elementLessThan);
+    drawElements(painter, ell);
+}
 
 void ExampleView::dragEnterEvent(QDragEnterEvent* event)
 {
@@ -233,32 +205,24 @@ void ExampleView::dragEnterEvent(QDragEnterEvent* event)
         Fraction duration;      // dummy
         ElementType type = EngravingItem::readType(e, &dragOffset, &duration);
 
-        dragElement = Factory::createItem(type, _score->dummy());
-        if (dragElement) {
-            dragElement->resetExplicitParent();
-            dragElement->read(e);
-            dragElement->layout();
+        m_dragElement = Factory::createItem(type, m_score->dummy());
+        if (m_dragElement) {
+            m_dragElement->resetExplicitParent();
+            m_dragElement->read(e);
+            m_dragElement->layout();
         }
         return;
     }
 }
 
-//---------------------------------------------------------
-//   dragLeaveEvent
-//---------------------------------------------------------
-
 void ExampleView::dragLeaveEvent(QDragLeaveEvent*)
 {
-    if (dragElement) {
-        delete dragElement;
-        dragElement = 0;
+    if (m_dragElement) {
+        delete m_dragElement;
+        m_dragElement = 0;
     }
     setDropTarget(0);
 }
-
-//---------------------------------------------------------
-//   moveElement
-//---------------------------------------------------------
 
 struct MoveContext
 {
@@ -274,20 +238,16 @@ static void moveElement(void* data, EngravingItem* e)
     ctx->score->addRefresh(e->canvasBoundingRect());
 }
 
-//---------------------------------------------------------
-//   dragMoveEvent
-//---------------------------------------------------------
-
 void ExampleView::dragMoveEvent(QDragMoveEvent* event)
 {
     event->acceptProposedAction();
 
-    if (!dragElement || dragElement->isActionIcon()) {
+    if (!m_dragElement || m_dragElement->isActionIcon()) {
         return;
     }
 
-    PointF pos = PointF::fromQPointF(imatrix.map(QPointF(event->pos())));
-    QList<EngravingItem*> el = elementsAt(pos);
+    PointF position = m_matrix.inverted().map(PointF::fromQPointF(event->posF()));
+    QList<EngravingItem*> el = elementsAt(position);
     bool found = false;
     foreach (const EngravingItem* e, el) {
         if (e->type() == ElementType::NOTE) {
@@ -300,59 +260,53 @@ void ExampleView::dragMoveEvent(QDragMoveEvent* event)
         setDropTarget(0);
     }
 
-    MoveContext ctx{ pos, _score };
-    dragElement->scanElements(&ctx, moveElement, false);
-    _score->update();
+    MoveContext ctx{ position, m_score };
+    m_dragElement->scanElements(&ctx, moveElement, false);
+    m_score->update();
     return;
 }
 
-//---------------------------------------------------------
-//   setDropTarget
-//---------------------------------------------------------
-
 void ExampleView::setDropTarget(const EngravingItem* el)
 {
-    if (dropTarget != el) {
-        if (dropTarget) {
-            dropTarget->setDropTarget(false);
-            dropTarget = 0;
+    if (m_dropTarget != el) {
+        if (m_dropTarget) {
+            m_dropTarget->setDropTarget(false);
+            m_dropTarget = 0;
         }
-        dropTarget = el;
-        if (dropTarget) {
-            dropTarget->setDropTarget(true);
+        m_dropTarget = el;
+        if (m_dropTarget) {
+            m_dropTarget->setDropTarget(true);
         }
     }
-    if (!dropAnchor.isNull()) {
+    if (!m_dropAnchor.isNull()) {
         QRectF r;
-        r.setTopLeft(dropAnchor.p1());
-        r.setBottomRight(dropAnchor.p2());
-        dropAnchor = QLineF();
+        r.setTopLeft(m_dropAnchor.p1());
+        r.setBottomRight(m_dropAnchor.p2());
+        m_dropAnchor = QLineF();
     }
-    if (dropRectangle.isValid()) {
-        dropRectangle = QRectF();
+    if (m_dropRectangle.isValid()) {
+        m_dropRectangle = QRectF();
     }
     update();
 }
 
-//---------------------------------------------------------
-//   dropEvent
-//---------------------------------------------------------
-
 void ExampleView::dropEvent(QDropEvent* event)
 {
-    PointF pos = PointF::fromQPointF(imatrix.map(QPointF(event->pos())));
+    PointF position = m_matrix.inverted().map(PointF::fromQPointF(event->posF()));
 
-    if (!dragElement) {
+    if (!m_dragElement) {
         return;
     }
-    if (dragElement->isActionIcon()) {
-        delete dragElement;
-        dragElement = 0;
+
+    if (m_dragElement->isActionIcon()) {
+        delete m_dragElement;
+        m_dragElement = 0;
         return;
     }
-    foreach (EngravingItem* e, elementsAt(pos)) {
+
+    foreach (EngravingItem* e, elementsAt(position)) {
         if (e->type() == ElementType::NOTE) {
-            ActionIcon* icon = static_cast<ActionIcon*>(dragElement);
+            ActionIcon* icon = static_cast<ActionIcon*>(m_dragElement);
             Chord* chord = static_cast<Note*>(e)->chord();
             emit beamPropertyDropped(chord, icon);
             switch (icon->actionType()) {
@@ -375,32 +329,25 @@ void ExampleView::dropEvent(QDropEvent* event)
             break;
         }
     }
-    event->acceptProposedAction();
-    delete dragElement;
-    dragElement = 0;
-    setDropTarget(0);
-}
 
-//---------------------------------------------------------
-//   mousePressEvent
-//---------------------------------------------------------
+    event->acceptProposedAction();
+    delete m_dragElement;
+    m_dragElement = nullptr;
+    setDropTarget(nullptr);
+}
 
 void ExampleView::mousePressEvent(QMouseEvent* event)
 {
-    startMove  = imatrix.map(QPointF(event->pos()));
-    PointF pos = PointF::fromQPointF(imatrix.map(QPointF(event->pos())));
+    PointF position = m_matrix.inverted().map(PointF::fromQPointF(event->pos()));
+    m_moveStartPoint = position;
 
-    foreach (EngravingItem* e, elementsAt(pos)) {
+    foreach (EngravingItem* e, elementsAt(position)) {
         if (e->type() == ElementType::NOTE) {
             emit noteClicked(static_cast<Note*>(e));
             break;
         }
     }
 }
-
-//---------------------------------------------------------
-//   sizeHint
-//---------------------------------------------------------
 
 QSize ExampleView::sizeHint() const
 {
@@ -419,10 +366,10 @@ QSize ExampleView::sizeHint() const
 //     constrained scrolling ensuring that this ExampleView won't be moved past the borders of its QFrame
 //---------------------------------------------------------
 
-void ExampleView::dragExampleView(QMouseEvent* ev)
+void ExampleView::dragExampleView(QMouseEvent* event)
 {
-    QPoint d = ev->pos() - _matrix.map(startMove).toPoint();
-    int dx   = d.x();
+    PointF delta = PointF::fromQPointF(event->pos()) - m_matrix.map(m_moveStartPoint);
+    int dx = delta.x();
     if (dx == 0) {
         return;
     }
@@ -430,22 +377,16 @@ void ExampleView::dragExampleView(QMouseEvent* ev)
     constraintCanvas(&dx);
 
     // Perform the actual scrolling
-    _matrix.setMatrix(_matrix.m11(), _matrix.m12(), _matrix.m13(), _matrix.m21(),
-                      _matrix.m22(), _matrix.m23(), _matrix.dx() + dx, _matrix.dy(), _matrix.m33());
-    imatrix = _matrix.inverted();
+    m_matrix.translate(dx, 0);
     scroll(dx, 0);
 }
 
-void DragTransitionExampleView::onTransition(QEvent* e)
+void DragTransitionExampleView::onTransition(QEvent* event)
 {
-    QStateMachine::WrappedEvent* we = static_cast<QStateMachine::WrappedEvent*>(e);
-    QMouseEvent* me = static_cast<QMouseEvent*>(we->event());
-    canvas->dragExampleView(me);
+    QStateMachine::WrappedEvent* wrappedEvent = static_cast<QStateMachine::WrappedEvent*>(event);
+    QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(wrappedEvent->event());
+    canvas->dragExampleView(mouseEvent);
 }
-
-//---------------------------------------------------------
-//   wheelEvent
-//---------------------------------------------------------
 
 void ExampleView::wheelEvent(QWheelEvent* event)
 {
@@ -470,9 +411,7 @@ void ExampleView::wheelEvent(QWheelEvent* event)
 
     constraintCanvas(&dx);
 
-    _matrix.setMatrix(_matrix.m11(), _matrix.m12(), _matrix.m13(), _matrix.m21(),
-                      _matrix.m22(), _matrix.m23(), _matrix.dx() + dx, _matrix.dy(), _matrix.m33());
-    imatrix = _matrix.inverted();
+    m_matrix.translate(dx, 0);
     scroll(dx, 0);
 }
 
@@ -484,13 +423,13 @@ void ExampleView::constraintCanvas(int* dxx)
 {
     int dx = *dxx;
 
-    Q_ASSERT(_score->pages().front()->system(0));   // should exist if doLayout ran
+    Q_ASSERT(m_score->pages().front()->system(0));   // should exist if doLayout ran
 
     // form rectangle bounding the system with a spatium margin and translate relative to view space
-    qreal xstart = _score->pages().front()->system(0)->bbox().left() - SPATIUM20;
-    qreal xend = _score->pages().front()->system(0)->bbox().right() + 2.0 * SPATIUM20;
-    QRectF systemScaledViewRect(xstart * _matrix.m11(), 0, xend * _matrix.m11(), 0);
-    systemScaledViewRect.translate(_matrix.dx(), 0);
+    qreal xstart = m_score->pages().front()->system(0)->bbox().left() - SPATIUM20;
+    qreal xend = m_score->pages().front()->system(0)->bbox().right() + 2.0 * SPATIUM20;
+    QRectF systemScaledViewRect(xstart * m_matrix.m11(), 0, xend * m_matrix.m11(), 0);
+    systemScaledViewRect.translate(m_matrix.dx(), 0);
 
     qreal frameWidth = static_cast<QFrame*>(this)->frameRect().width();
 

--- a/src/commonscene/exampleview.cpp
+++ b/src/commonscene/exampleview.cpp
@@ -84,7 +84,7 @@ ExampleView::ExampleView(QWidget* parent)
 
     m_stateMachine->start();
 
-    m_defaultScaling = 0.9 * uiConfiguration()->dpi() / DPI; // 90% of nominal
+    m_defaultScaling = 0.8 * notationConfiguration()->guiScaling() * notationConfiguration()->notationScaling();
 }
 
 ExampleView::~ExampleView()
@@ -96,10 +96,9 @@ ExampleView::~ExampleView()
 
 void ExampleView::resetMatrix()
 {
-    double mag = m_defaultScaling;
-    qreal _spatium = SPATIUM20 * mag;
+    qreal _spatium = SPATIUM20 * m_defaultScaling;
     // example would normally be 10sp from top of page; this leaves 3sp margin above
-    m_matrix = mu::Transform(mag, 0.0, 0.0, mag, _spatium, -_spatium * 7.0);
+    m_matrix = mu::Transform(m_defaultScaling, 0.0, 0.0, m_defaultScaling, _spatium, -_spatium * 7.0);
 }
 
 void ExampleView::layoutChanged()

--- a/src/commonscene/exampleview.h
+++ b/src/commonscene/exampleview.h
@@ -41,11 +41,6 @@ class Score;
 class Note;
 class Chord;
 class ActionIcon;
-enum class Grip : int;
-
-//---------------------------------------------------------
-//   ExampleView
-//---------------------------------------------------------
 
 class ExampleView : public QFrame, public MuseScoreView
 {
@@ -54,53 +49,54 @@ class ExampleView : public QFrame, public MuseScoreView
     INJECT(commonscene, mu::ui::IUiConfiguration, uiConfiguration)
     INJECT(commonscene, mu::notation::INotationConfiguration, notationConfiguration)
 
-    QTransform _matrix, imatrix;
-    QColor _fgColor;
-    QPixmap* _fgPixmap;
-    EngravingItem* dragElement = 0;
-    const EngravingItem* dropTarget = 0;        ///< current drop target during dragMove
-    QRectF dropRectangle;                 ///< current drop rectangle during dragMove
-    QLineF dropAnchor;                    ///< line to current anchor point during dragMove
+public:
+    ExampleView(QWidget* parent = 0);
+    ~ExampleView();
+    void resetMatrix();
+    void layoutChanged() override;
+    void dataChanged(const mu::RectF&) override;
+    void updateAll() override;
+    void adjustCanvasPosition(const EngravingItem* el, bool playBack, int staff = -1) override;
+    void setScore(Score*) override;
+    void removeScore() override;
 
-    QStateMachine* sm;
-    QPointF startMove;
-
-    double m_defaultScaling = 0;
-
-    void drawElements(mu::draw::Painter& painter, const QList<EngravingItem*>& el);
-    void setDropTarget(const EngravingItem* el) override;
-
-    virtual void paintEvent(QPaintEvent*) override;
-    virtual void dragEnterEvent(QDragEnterEvent*) override;
-    virtual void dragLeaveEvent(QDragLeaveEvent*) override;
-    virtual void dragMoveEvent(QDragMoveEvent*) override;
-    virtual void wheelEvent(QWheelEvent*) override;
-    virtual void dropEvent(QDropEvent*) override;
-    virtual void mousePressEvent(QMouseEvent*) override;
-    void constraintCanvas(int* dxx);
-    virtual QSize sizeHint() const override;
+    void changeEditElement(EngravingItem*) override;
+    void setDropRectangle(const mu::RectF&) override;
+    void cmdAddSlur(Note* firstNote, Note* lastNote);
+    void drawBackground(mu::draw::Painter*, const mu::RectF&) const override;
+    void dragExampleView(QMouseEvent* ev);
+    const mu::Rect geometry() const override { return mu::Rect(QFrame::geometry()); }
 
 signals:
     void noteClicked(Note*);
     void beamPropertyDropped(Chord*, ActionIcon*);
 
-public:
-    ExampleView(QWidget* parent = 0);
-    ~ExampleView();
-    void resetMatrix();
-    virtual void layoutChanged() override;
-    virtual void dataChanged(const mu::RectF&) override;
-    virtual void updateAll() override;
-    virtual void adjustCanvasPosition(const EngravingItem* el, bool playBack, int staff = -1) override;
-    virtual void setScore(Score*) override;
-    virtual void removeScore() override;
+private:
+    void drawElements(mu::draw::Painter& painter, const QList<EngravingItem*>& el);
+    void setDropTarget(const EngravingItem* el) override;
 
-    virtual void changeEditElement(EngravingItem*) override;
-    virtual void setDropRectangle(const mu::RectF&) override;
-    virtual void cmdAddSlur(Note* firstNote, Note* lastNote);
-    virtual void drawBackground(mu::draw::Painter*, const mu::RectF&) const override;
-    void dragExampleView(QMouseEvent* ev);
-    const mu::Rect geometry() const override { return mu::Rect(QFrame::geometry()); }
+    void paintEvent(QPaintEvent*) override;
+    void dragEnterEvent(QDragEnterEvent*) override;
+    void dragLeaveEvent(QDragLeaveEvent*) override;
+    void dragMoveEvent(QDragMoveEvent*) override;
+    void wheelEvent(QWheelEvent*) override;
+    void dropEvent(QDropEvent*) override;
+    void mousePressEvent(QMouseEvent*) override;
+    void constraintCanvas(int* dxx);
+    QSize sizeHint() const override;
+
+    mu::Transform m_matrix;
+    QColor m_backgroundColor;
+    QPixmap* m_backgroundPixmap;
+    EngravingItem* m_dragElement = 0;
+    const EngravingItem* m_dropTarget = 0; ///< current drop target during dragMove
+    QRectF m_dropRectangle;                ///< current drop rectangle during dragMove
+    QLineF m_dropAnchor;                   ///< line to current anchor point during dragMove
+
+    QStateMachine* m_stateMachine;
+    mu::PointF m_moveStartPoint;
+
+    double m_defaultScaling = 0;
 };
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/mscoreview.h
+++ b/src/engraving/libmscore/mscoreview.h
@@ -56,7 +56,7 @@ public:
     virtual void moveCursor() {}
 
     virtual void adjustCanvasPosition(const EngravingItem*, bool /*playBack*/, int /*staffIdx*/ = -1) {}
-    virtual void setScore(Score* s) { _score = s; }
+    virtual void setScore(Score* s) { m_score = s; }
     virtual void removeScore() {}
 
     virtual void changeEditElement(EngravingItem*) {}
@@ -76,10 +76,10 @@ public:
 
     const QList<EngravingItem*> elementsAt(const mu::PointF&) const;
     EngravingItem* elementNear(const mu::PointF& pos) const;
-    Score* score() const { return _score; }
+    Score* score() const { return m_score; }
 
 protected:
-    Score* _score = nullptr;
+    Score* m_score = nullptr;
 
 private:
     Page* point2page(const mu::PointF&) const;

--- a/src/palette/view/widgets/noteGroups.cpp
+++ b/src/palette/view/widgets/noteGroups.cpp
@@ -123,9 +123,6 @@ void NoteGroups::setSig(Fraction sig, const Groups& g, const QString& z, const Q
     view16->setScore(createScore(nn, DurationType::V_16TH, &chords16));
     nn   = f.numerator() * (32 / f.denominator());
     view32->setScore(createScore(nn, DurationType::V_32ND, &chords32));
-    view8->resetMatrix();
-    view16->resetMatrix();
-    view32->resetMatrix();
 }
 
 Groups NoteGroups::groups()


### PR DESCRIPTION
Resolves: #9106 

Now, the scaling of the previews in Staff/Part Properties > Advanced and in the Time Sig Properties dialog should be similar to MuseScore 3. This would need to be tested with various kinds of platforms and monitors.