### PR TITLE
[MU4] Fix #10517 KeySig refactor

### DIFF
--- a/src/engraving/libmscore/key.cpp
+++ b/src/engraving/libmscore/key.cpp
@@ -247,8 +247,7 @@ void AccidentalState::init(const KeySigEvent& keySig, ClefType clef)
         memset(state, ACC_STATE_NATURAL, MAX_ACC_STATE);
         for (const KeySym& s : keySig.keySymbols()) {
             AccidentalVal a = sym2accidentalVal(s.sym);
-            int line = int(s.spos.y() * 2);
-            int idx       = relStep(line, clef) % 7;
+            int idx = absStep(s.line, clef) % 7;
             for (int octave = 0; octave < (11 * 7); octave += 7) {
                 int i = idx + octave;
                 if (i >= MAX_ACC_STATE) {

--- a/src/engraving/libmscore/key.h
+++ b/src/engraving/libmscore/key.h
@@ -77,8 +77,8 @@ static inline Key operator-=(Key& a, const Key& b) { return a = Key(static_cast<
 
 struct KeySym {
     SymId sym;
-    mu::PointF spos;       // position in spatium units
-    mu::PointF pos;        // actual pixel position on screen (set by layout)
+    int line;       // relative line position (first staffline: line == 0, first gap: line == 1, ...)
+    double xPos;    // x position in staff spatium units
 };
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/keysig.h
+++ b/src/engraving/libmscore/keysig.h
@@ -50,7 +50,7 @@ class KeySig final : public EngravingItem
     KeySig(Segment* = 0);
     KeySig(const KeySig&);
 
-    void addLayout(SymId sym, int y);
+    void addLayout(SymId sym, int line);
 
 public:
 

--- a/src/engraving/rw/xml.h
+++ b/src/engraving/rw/xml.h
@@ -308,6 +308,7 @@ public:
     void tag(const char* name, const QString& s) { tag(name, QVariant(s)); }
     void tag(const char* name, const mu::PointF& v);
     void tag(const char* name, const Fraction& v, const Fraction& def = Fraction());
+    void tag(const char* name, const KeySym& ks);
 
     void comment(const QString&);
 

--- a/src/engraving/rw/xmlwriter.cpp
+++ b/src/engraving/rw/xmlwriter.cpp
@@ -470,6 +470,12 @@ void XmlWriter::tag(const char* name, const mu::PointF& p)
     *this << QString("<%1 x=\"%2\" y=\"%3\"/>\n").arg(name).arg(p.x()).arg(p.y());
 }
 
+void XmlWriter::tag(const char* name, const KeySym& ks)
+{
+    putLevel();
+    *this << QString("<%1 xPos=\"%2\" line=\"%3\"/>\n").arg(name).arg(ks.xPos).arg(ks.line);
+}
+
 void XmlWriter::tag(const char* name, const Fraction& v, const Fraction& def)
 {
     if (v == def) {

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -2148,12 +2148,11 @@ void ExportMusicXml::keysig(const KeySig* ks, ClefType ct, int staff, bool visib
         // first put the KeySyms in a map
         QMap<qreal, KeySym> map;
         for (const KeySym& ksym : keysyms) {
-            map.insert(ksym.spos.x(), ksym);
+            map.insert(ksym.xPos, ksym);
         }
         // then write them (automatically sorted on key)
         for (const KeySym& ksym : map) {
-            int line = static_cast<int>(round(2 * ksym.spos.y()));
-            int step = (po - line) % 7;
+            int step = (po - ksym.line) % 7;
             //qDebug(" keysym sym %d spos %g,%g pos %g,%g -> line %d step %d",
             //       ksym.sym, ksym.spos.x(), ksym.spos.y(), ksym.pos.x(), ksym.pos.y(), line, step);
             _xml.tag("key-step", QString(QChar(table2[step])));

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -3611,7 +3611,8 @@ static void addSymToSig(KeySigEvent& sig, const QString& step, const QString& al
         if (line >= 0) {
             KeySym ks;
             ks.sym  = id;
-            ks.spos = QPointF(x, qreal(line) * 0.5);
+            ks.xPos = x;
+            ks.line = line;
             sig.keySymbols().append(ks);
             sig.setCustom(true);
         }

--- a/src/palette/view/widgets/keyedit.cpp
+++ b/src/palette/view/widgets/keyedit.cpp
@@ -377,9 +377,10 @@ void KeyEditor::addClicked()
     for (Accidental* a : al) {
         KeySym s;
         s.sym       = a->symbol();
-        PointF pos = a->ipos();
+        PointF pos  = a->ipos();
         pos.rx()   -= xoff;
-        s.spos      = pos / spatium;
+        s.xPos      = pos.x() / spatium;
+        s.line      = static_cast<int>(round((pos.y() / spatium) * 2));
         e.keySymbols().append(s);
     }
     auto ks = Factory::makeKeySig(gpaletteScore->dummy()->segment());


### PR DESCRIPTION
Resolves: #10517 
Also Resolves: #10497, Closes: #10516, Closes: #10543 

Remove `KeySym` members `pos` and `spos`, and instead of them, add
```
int line;
double xPos; // in staff spatium units
```
### Why?
`pos` and `spos` are "visual" members (spos.y depends on line distance), so same Key Signature had different Key Symbols spos values in different staff settings.
In custom key signatures, spos was (incorrectly) used as "logical" member instead, which caused visual bug https://github.com/musescore/MuseScore/issues/10497 in staffs with altered line distance.

`line` and `xPos` are "logical" members, which clean up code logic and brings more flexibility to Key Signatures.
(For example it opens up opportunities to adapt custom key signatures per clef, or to transpose them in future)

### Save / Import Export
KeySym is saved into file like this:
```
<KeySym>
  <sym>accidentalSharp</sym>
  <pos xPos="0" line="0"/>
  </KeySym>

```
Before this change, it was `<pos x="0" y="0"/>`. Code is compatible with old files, they are opened correctly.

Import and export to musicxml works too.

--
I used `qreal stepDistance = staff() ? staff()->staffTypeForElement(this)->lineDistance().val() * 0.5 : 0.5;` in few places, so I also changed `qreal stepDistance = staff() ? staff()->lineDistance(tick()) * 0.5 : 0.5;` in one place to it, in case of consistency.

--
tested on Linux (Ubuntu Studio 21.10)


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
