### PR TITLE
[MU4] Top-staff system objects maintain position

### DIFF
--- a/src/engraving/libmscore/engravingitem.cpp
+++ b/src/engraving/libmscore/engravingitem.cpp
@@ -462,8 +462,9 @@ int EngravingItem::staffIdxOrNextVisible() const
         return si;
     }
     int firstVis = m->system()->firstVisibleStaff();
-    if (track() == 0) {
-        // original OR first system object in excerpt, put on the top of the score
+    if (!isLinked() || (track() == 0 && (_links->mainElement()->score() != score()
+                                         || !toEngravingItem(_links->mainElement())->enabled()))) {
+        // original, put on the top of the score
         return firstVis;
     }
     if (si <= firstVis) {

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -859,15 +859,15 @@ void Segment::sortStaves(QList<int>& dst)
     }
     for (EngravingItem* e : _annotations) {
         ElementType et = e->type();
-        if (!e->systemFlag()
-            || (et == ElementType::REHEARSAL_MARK)
-            || (et == ElementType::SYSTEM_TEXT)
-            || (et == ElementType::PLAYTECH_ANNOTATION)
-            || (et == ElementType::JUMP)
-            || (et == ElementType::MARKER)
-            || (et == ElementType::TEMPO_TEXT)
-            || (et == ElementType::VOLTA)
-            || (et == ElementType::TEXTLINE && e->systemFlag())) {
+        if (!e->systemFlag() || (e->isLinked()
+                                 && ((et == ElementType::REHEARSAL_MARK)
+                                     || (et == ElementType::SYSTEM_TEXT)
+                                     || (et == ElementType::PLAYTECH_ANNOTATION)
+                                     || (et == ElementType::JUMP)
+                                     || (et == ElementType::MARKER)
+                                     || (et == ElementType::TEMPO_TEXT)
+                                     || (et == ElementType::VOLTA)
+                                     || (et == ElementType::TEXTLINE && e->systemFlag())))) {
             e->setTrack(map[e->staffIdx()] * VOICES + e->voice());
         }
     }

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -859,15 +859,18 @@ void Segment::sortStaves(QList<int>& dst)
     }
     for (EngravingItem* e : _annotations) {
         ElementType et = e->type();
-        if (!e->systemFlag() || (e->isLinked()
-                                 && ((et == ElementType::REHEARSAL_MARK)
-                                     || (et == ElementType::SYSTEM_TEXT)
-                                     || (et == ElementType::PLAYTECH_ANNOTATION)
-                                     || (et == ElementType::JUMP)
-                                     || (et == ElementType::MARKER)
-                                     || (et == ElementType::TEMPO_TEXT)
-                                     || (et == ElementType::VOLTA)
-                                     || (et == ElementType::TEXTLINE && e->systemFlag())))) {
+        // the set of system objects that are allowed to move staves if they are clones / excerpts
+        static const std::set<ElementType> allowedTypes {
+            ElementType::REHEARSAL_MARK,
+            ElementType::SYSTEM_TEXT,
+            ElementType::PLAYTECH_ANNOTATION,
+            ElementType::JUMP,
+            ElementType::MARKER,
+            ElementType::TEMPO_TEXT,
+            ElementType::VOLTA,
+            ElementType::TEXTLINE
+        };
+        if (!e->systemFlag() || (e->isLinked() && (allowedTypes.find(et) != allowedTypes.end()))) {
             e->setTrack(map[e->staffIdx()] * VOICES + e->voice());
         }
     }


### PR DESCRIPTION
Top-staff system objects would be moved around with the staff they're attached to. This is the behavior of non-top staff system objects, but I added an exception for ones on track 0.