### PR TITLE
Restore Palettes panel context menu options

### DIFF
--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -214,6 +214,10 @@ DockPage {
 
             PalettesPanel {
                 navigationSection: palettesPanel.navigationSection
+
+                Component.onCompleted: {
+                    palettesPanel.contextMenuModel = contextMenuModel
+                }
             }
         },
 

--- a/src/framework/uicomponents/view/menuitem.h
+++ b/src/framework/uicomponents/view/menuitem.h
@@ -25,6 +25,8 @@
 #include <QObject>
 #include <QString>
 
+#include "async/asyncable.h"
+
 #include "ui/uitypes.h"
 
 namespace mu::uicomponents {
@@ -39,7 +41,7 @@ enum class MenuItemRole {
     QuitRole
 };
 
-class MenuItem : public QObject
+class MenuItem : public QObject, public async::Asyncable
 {
     Q_OBJECT
 

--- a/src/palette/CMakeLists.txt
+++ b/src/palette/CMakeLists.txt
@@ -67,6 +67,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/palettepropertiesmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/palettecellpropertiesmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/palettecellpropertiesmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/palettespanelcontextmenumodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/palettespanelcontextmenumodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/drumsetpanelview.h
     ${CMAKE_CURRENT_LIST_DIR}/view/drumsetpanelview.cpp
     )

--- a/src/palette/internal/paletteconfiguration.cpp
+++ b/src/palette/internal/paletteconfiguration.cpp
@@ -38,8 +38,14 @@ void PaletteConfiguration::init()
 {
     settings()->setDefaultValue(PALETTE_SCALE, Val(1.0));
     settings()->setCanBeMannualyEdited(PALETTE_SCALE, true);
+
     settings()->setDefaultValue(PALETTE_USE_SINGLE, Val(false));
     settings()->setCanBeMannualyEdited(PALETTE_USE_SINGLE, true);
+
+    m_isSinglePalette.val = settings()->value(PALETTE_USE_SINGLE).toBool();
+    settings()->valueChanged(PALETTE_USE_SINGLE).onReceive(this, [this](const Val& newValue) {
+        m_isSinglePalette.set(newValue.toBool());
+    });
 }
 
 double PaletteConfiguration::paletteScaling() const
@@ -61,9 +67,9 @@ double PaletteConfiguration::paletteSpatium() const
     return PALETTE_SPATIUM;
 }
 
-bool PaletteConfiguration::isSinglePalette() const
+mu::ValCh<bool> PaletteConfiguration::isSinglePalette() const
 {
-    return settings()->value(PALETTE_USE_SINGLE).toBool();
+    return m_isSinglePalette;
 }
 
 void PaletteConfiguration::setIsSinglePalette(bool isSingle)

--- a/src/palette/internal/paletteconfiguration.cpp
+++ b/src/palette/internal/paletteconfiguration.cpp
@@ -48,7 +48,7 @@ void PaletteConfiguration::init()
         m_isSinglePalette.set(newValue.toBool());
     });
 
-    settings()->setDefaultValue(IS_SINGLE_CLICK_TO_OPEN_PALETTE, Val(false));
+    settings()->setDefaultValue(IS_SINGLE_CLICK_TO_OPEN_PALETTE, Val(true));
     settings()->setCanBeMannualyEdited(IS_SINGLE_CLICK_TO_OPEN_PALETTE, true);
 
     m_isSingleClickToOpenPalette.val = settings()->value(IS_SINGLE_CLICK_TO_OPEN_PALETTE).toBool();

--- a/src/palette/internal/paletteconfiguration.cpp
+++ b/src/palette/internal/paletteconfiguration.cpp
@@ -33,6 +33,7 @@ using namespace mu::ui;
 static const std::string MODULE_NAME("palette");
 static const Settings::Key PALETTE_SCALE(MODULE_NAME, "application/paletteScale");
 static const Settings::Key PALETTE_USE_SINGLE(MODULE_NAME, "application/useSinglePalette");
+static const Settings::Key IS_SINGLE_CLICK_TO_OPEN_PALETTE(MODULE_NAME, "application/singleClickToOpenPalette");
 
 void PaletteConfiguration::init()
 {
@@ -45,6 +46,14 @@ void PaletteConfiguration::init()
     m_isSinglePalette.val = settings()->value(PALETTE_USE_SINGLE).toBool();
     settings()->valueChanged(PALETTE_USE_SINGLE).onReceive(this, [this](const Val& newValue) {
         m_isSinglePalette.set(newValue.toBool());
+    });
+
+    settings()->setDefaultValue(IS_SINGLE_CLICK_TO_OPEN_PALETTE, Val(false));
+    settings()->setCanBeMannualyEdited(IS_SINGLE_CLICK_TO_OPEN_PALETTE, true);
+
+    m_isSingleClickToOpenPalette.val = settings()->value(IS_SINGLE_CLICK_TO_OPEN_PALETTE).toBool();
+    settings()->valueChanged(IS_SINGLE_CLICK_TO_OPEN_PALETTE).onReceive(this, [this](const Val& newValue) {
+        m_isSingleClickToOpenPalette.set(newValue.toBool());
     });
 }
 
@@ -75,6 +84,16 @@ mu::ValCh<bool> PaletteConfiguration::isSinglePalette() const
 void PaletteConfiguration::setIsSinglePalette(bool isSingle)
 {
     settings()->setSharedValue(PALETTE_USE_SINGLE, Val(isSingle));
+}
+
+mu::ValCh<bool> PaletteConfiguration::isSingleClickToOpenPalette() const
+{
+    return m_isSingleClickToOpenPalette;
+}
+
+void PaletteConfiguration::setIsSingleClickToOpenPalette(bool isSingleClick)
+{
+    settings()->setSharedValue(IS_SINGLE_CLICK_TO_OPEN_PALETTE, Val(isSingleClick));
 }
 
 QColor PaletteConfiguration::elementsBackgroundColor() const

--- a/src/palette/internal/paletteconfiguration.h
+++ b/src/palette/internal/paletteconfiguration.h
@@ -23,13 +23,14 @@
 #define MU_PALETTE_PALETTECONFIGURATION_H
 
 #include "../ipaletteconfiguration.h"
+#include "async/asyncable.h"
 
 #include "modularity/ioc.h"
 #include "iglobalconfiguration.h"
 #include "ui/iuiconfiguration.h"
 
 namespace mu::palette {
-class PaletteConfiguration : public IPaletteConfiguration
+class PaletteConfiguration : public IPaletteConfiguration, public async::Asyncable
 {
     INJECT(palette, ui::IUiConfiguration, uiConfiguration)
     INJECT(palette, framework::IGlobalConfiguration, globalConfiguration)
@@ -42,7 +43,7 @@ public:
 
     double paletteSpatium() const override;
 
-    bool isSinglePalette() const override;
+    ValCh<bool> isSinglePalette() const override;
     void setIsSinglePalette(bool isSingle) override;
 
     QColor elementsBackgroundColor() const override;
@@ -65,6 +66,8 @@ public:
 
 private:
     QColor themeColor(ui::ThemeStyleKey key) const;
+
+    ValCh<bool> m_isSinglePalette;
 
     mutable QHash<QString, ValCh<PaletteConfig> > m_paletteConfigs;
     mutable QHash<QString, ValCh<PaletteCellConfig> > m_paletteCellsConfigs;

--- a/src/palette/internal/paletteconfiguration.h
+++ b/src/palette/internal/paletteconfiguration.h
@@ -46,6 +46,9 @@ public:
     ValCh<bool> isSinglePalette() const override;
     void setIsSinglePalette(bool isSingle) override;
 
+    ValCh<bool> isSingleClickToOpenPalette() const override;
+    void setIsSingleClickToOpenPalette(bool isSingleClick) override;
+
     QColor elementsBackgroundColor() const override;
     QColor elementsColor() const override;
     QColor gridColor() const override;
@@ -68,6 +71,7 @@ private:
     QColor themeColor(ui::ThemeStyleKey key) const;
 
     ValCh<bool> m_isSinglePalette;
+    ValCh<bool> m_isSingleClickToOpenPalette;
 
     mutable QHash<QString, ValCh<PaletteConfig> > m_paletteConfigs;
     mutable QHash<QString, ValCh<PaletteCellConfig> > m_paletteCellsConfigs;

--- a/src/palette/internal/paletteprovider.cpp
+++ b/src/palette/internal/paletteprovider.cpp
@@ -611,6 +611,10 @@ void PaletteProvider::init()
     configuration()->isSinglePalette().ch.onReceive(this, [this](bool) {
         emit isSinglePaletteChanged();
     });
+
+    configuration()->isSingleClickToOpenPalette().ch.onReceive(this, [this](bool) {
+        emit isSingleClickToOpenPaletteChanged();
+    });
 }
 
 void PaletteProvider::setSearching(bool searching)
@@ -629,6 +633,11 @@ void PaletteProvider::setSearching(bool searching)
 bool PaletteProvider::isSinglePalette() const
 {
     return configuration()->isSinglePalette().val;
+}
+
+bool PaletteProvider::isSingleClickToOpenPalette() const
+{
+    return configuration()->isSingleClickToOpenPalette().val;
 }
 
 QAbstractItemModel* PaletteProvider::mainPaletteModel()

--- a/src/palette/internal/paletteprovider.cpp
+++ b/src/palette/internal/paletteprovider.cpp
@@ -607,6 +607,10 @@ void PaletteProvider::init()
     m_visibilityFilterModel->setFilterRole(PaletteTreeModel::VisibleRole);
     m_visibilityFilterModel->setFilterFixedString("true");
     m_visibilityFilterModel->setSourceModel(m_userPaletteModel);
+
+    configuration()->isSinglePalette().ch.onReceive(this, [this](bool) {
+        emit isSinglePaletteChanged();
+    });
 }
 
 void PaletteProvider::setSearching(bool searching)
@@ -620,6 +624,11 @@ void PaletteProvider::setSearching(bool searching)
     m_mainPalette = nullptr;
     m_mainPaletteController = nullptr;
     emit mainPaletteChanged();
+}
+
+bool PaletteProvider::isSinglePalette() const
+{
+    return configuration()->isSinglePalette().val;
 }
 
 QAbstractItemModel* PaletteProvider::mainPaletteModel()

--- a/src/palette/internal/paletteprovider.h
+++ b/src/palette/internal/paletteprovider.h
@@ -214,6 +214,7 @@ class PaletteProvider : public QObject, public mu::palette::IPaletteProvider, pu
         Ms::AbstractPaletteController * customElementsPaletteController READ customElementsPaletteController CONSTANT)
 
     Q_PROPERTY(bool isSinglePalette READ isSinglePalette NOTIFY isSinglePaletteChanged)
+    Q_PROPERTY(bool isSingleClickToOpenPalette READ isSingleClickToOpenPalette NOTIFY isSingleClickToOpenPaletteChanged)
 
 public:
     void init() override;
@@ -258,12 +259,14 @@ public:
     }
 
     bool isSinglePalette() const;
+    bool isSingleClickToOpenPalette() const;
 
 signals:
     void userPaletteChanged();
     void mainPaletteChanged();
 
     void isSinglePaletteChanged();
+    void isSingleClickToOpenPaletteChanged();
 
 private slots:
     void notifyAboutUserPaletteChanged()

--- a/src/palette/internal/paletteprovider.h
+++ b/src/palette/internal/paletteprovider.h
@@ -199,10 +199,11 @@ public:
 //   PaletteProvider
 // ========================================================
 
-class PaletteProvider : public QObject, public mu::palette::IPaletteProvider
+class PaletteProvider : public QObject, public mu::palette::IPaletteProvider, public mu::async::Asyncable
 {
     Q_OBJECT
 
+    INJECT(palette, mu::palette::IPaletteConfiguration, configuration)
     INJECT(palette, mu::framework::IInteractive, interactive)
 
     Q_PROPERTY(QAbstractItemModel * mainPaletteModel READ mainPaletteModel NOTIFY mainPaletteChanged)
@@ -211,6 +212,8 @@ class PaletteProvider : public QObject, public mu::palette::IPaletteProvider
     Q_PROPERTY(Ms::FilterPaletteTreeModel * customElementsPaletteModel READ customElementsPaletteModel CONSTANT)
     Q_PROPERTY(
         Ms::AbstractPaletteController * customElementsPaletteController READ customElementsPaletteController CONSTANT)
+
+    Q_PROPERTY(bool isSinglePalette READ isSinglePalette NOTIFY isSinglePaletteChanged)
 
 public:
     void init() override;
@@ -254,9 +257,13 @@ public:
         m_defaultPaletteModel->retranslate();
     }
 
+    bool isSinglePalette() const;
+
 signals:
     void userPaletteChanged();
     void mainPaletteChanged();
+
+    void isSinglePaletteChanged();
 
 private slots:
     void notifyAboutUserPaletteChanged()

--- a/src/palette/ipaletteconfiguration.h
+++ b/src/palette/ipaletteconfiguration.h
@@ -46,6 +46,9 @@ public:
     virtual ValCh<bool> isSinglePalette() const = 0;
     virtual void setIsSinglePalette(bool isSingle) = 0;
 
+    virtual ValCh<bool> isSingleClickToOpenPalette() const = 0;
+    virtual void setIsSingleClickToOpenPalette(bool isSingleClick) = 0;
+
     virtual QColor elementsBackgroundColor() const = 0;
     virtual QColor elementsColor() const = 0;
     virtual QColor gridColor() const = 0;

--- a/src/palette/ipaletteconfiguration.h
+++ b/src/palette/ipaletteconfiguration.h
@@ -43,7 +43,7 @@ public:
     virtual double paletteScaling() const = 0;
     virtual void setPaletteScaling(double scale) = 0;
 
-    virtual bool isSinglePalette() const = 0;
+    virtual ValCh<bool> isSinglePalette() const = 0;
     virtual void setIsSinglePalette(bool isSingle) = 0;
 
     virtual QColor elementsBackgroundColor() const = 0;

--- a/src/palette/palettemodule.cpp
+++ b/src/palette/palettemodule.cpp
@@ -42,6 +42,7 @@
 #include "view/paletterootmodel.h"
 #include "view/palettepropertiesmodel.h"
 #include "view/palettecellpropertiesmodel.h"
+#include "view/palettespanelcontextmenumodel.h"
 #include "view/drumsetpanelview.h"
 
 #include "view/widgets/masterpalette.h"
@@ -133,6 +134,7 @@ void PaletteModule::registerUiTypes()
     qmlRegisterUncreatableType<PaletteElementEditor>("MuseScore.Palette", 1, 0, "PaletteElementEditor", "Cannot ...");
     qmlRegisterUncreatableType<PaletteTreeModel>("MuseScore.Palette", 1, 0, "PaletteTreeModel",  "Cannot create");
     qmlRegisterUncreatableType<FilterPaletteTreeModel>("MuseScore.Palette", 1, 0, "FilterPaletteTreeModel", "Cannot");
+    qmlRegisterType<PalettesPanelContextMenuModel>("MuseScore.Palette", 1, 0, "PalettesPanelContextMenuModel");
 
     qmlRegisterType<PaletteRootModel>("MuseScore.Palette", 1, 0, "PaletteRootModel");
     qmlRegisterType<PalettePropertiesModel>("MuseScore.Palette", 1, 0, "PalettePropertiesModel");

--- a/src/palette/qml/MuseScore/Palette/PalettesPanel.qml
+++ b/src/palette/qml/MuseScore/Palette/PalettesPanel.qml
@@ -48,6 +48,10 @@ Item {
 
     PalettesPanelContextMenuModel {
         id: contextMenuModel
+
+        onExpandCollapseAllRequested: function(expand) {
+            paletteTree.expandCollapseAll(expand)
+        }
     }
 
     Component.onCompleted: {

--- a/src/palette/qml/MuseScore/Palette/PalettesPanel.qml
+++ b/src/palette/qml/MuseScore/Palette/PalettesPanel.qml
@@ -33,6 +33,7 @@ Item {
     id: root
 
     property NavigationSection navigationSection: null
+    property alias contextMenuModel: contextMenuModel
 
     readonly property PaletteProvider paletteProvider: paletteRootModel.paletteProvider
 
@@ -43,6 +44,14 @@ Item {
 
     function applyCurrentPaletteElement() {
         paletteTree.applyCurrentElement();
+    }
+
+    PalettesPanelContextMenuModel {
+        id: contextMenuModel
+    }
+
+    Component.onCompleted: {
+        contextMenuModel.load()
     }
 
     PaletteRootModel {

--- a/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
@@ -325,7 +325,7 @@ StyledListView {
 
             property bool selected: paletteSelectionModel.hasSelection ? paletteSelectionModel.isSelected(modelIndex) : false
 
-            function doItemClicked() {
+            onClicked: {
                 forceActiveFocus();
 
                 if (paletteProvider.isSingleClickToOpenPalette) {
@@ -339,12 +339,9 @@ StyledListView {
                 } else {
                     const cmd = selected ? ItemSelectionModel.Toggle : ItemSelectionModel.ClearAndSelect;
                     paletteSelectionModel.setCurrentIndex(modelIndex, cmd);
-                    paletteTree.currentIndex = index;
                 }
-            }
 
-            onClicked: {
-                control.doItemClicked()
+                paletteTree.currentIndex = index;
             }
 
             onDoubleClicked: {
@@ -368,10 +365,19 @@ StyledListView {
                 navigation.accessible.name: control.text
                 enabled: control.visible
                 navigation.onActiveChanged: {
-                    if (navigation.active && !control.selected) {
-                        control.doItemClicked()
+                    if (navigation.active) {
+                        forceActiveFocus();
+
+                        if (!control.selected) {
+                            paletteSelectionModel.setCurrentIndex(modelIndex, ItemSelectionModel.ClearAndSelect);
+                        }
+
+                        paletteTree.currentIndex = index;
+                        paletteTree.positionViewAtIndex(control.rowIndex, ListView.Contain);
                     }
-                    paletteTree.positionViewAtIndex(control.rowIndex, ListView.Contain);
+                }
+                navigation.onTriggered: {
+                    control.toggleExpand()
                 }
             }
 

--- a/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
@@ -327,9 +327,20 @@ StyledListView {
 
             function doItemClicked() {
                 forceActiveFocus();
-                const cmd = selected ? ItemSelectionModel.Toggle : ItemSelectionModel.ClearAndSelect;
-                paletteSelectionModel.setCurrentIndex(modelIndex, cmd);
-                paletteTree.currentIndex = index;
+
+                if (paletteProvider.isSingleClickToOpenPalette) {
+                    toggleExpand()
+
+                    if (selected && !expanded) {
+                        paletteSelectionModel.clearSelection();
+                    } else if (!selected) {
+                        paletteSelectionModel.setCurrentIndex(modelIndex, ItemSelectionModel.ClearAndSelect);
+                    }
+                } else {
+                    const cmd = selected ? ItemSelectionModel.Toggle : ItemSelectionModel.ClearAndSelect;
+                    paletteSelectionModel.setCurrentIndex(modelIndex, cmd);
+                    paletteTree.currentIndex = index;
+                }
             }
 
             onClicked: {
@@ -337,6 +348,10 @@ StyledListView {
             }
 
             onDoubleClicked: {
+                if (paletteProvider.isSingleClickToOpenPalette) {
+                    return;
+                }
+
                 forceActiveFocus();
                 paletteSelectionModel.setCurrentIndex(modelIndex, ItemSelectionModel.Deselect);
                 toggleExpand();

--- a/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
@@ -561,9 +561,13 @@ StyledListView {
 
                         drag.axis: Drag.YAxis
 
-                        onPressed: control.grabToImage(function(result) {
-                            control.Drag.imageSource = result.url
-                        })
+                        onPressed: function(mouse) {
+                            control.grabToImage(function(result) {
+                                control.Drag.imageSource = result.url
+                                control.Drag.hotSpot.x = mouse.x
+                                control.Drag.hotSpot.y = mouse.y
+                            })
+                        }
 
                         onClicked: function(mouse) { control.clicked() }
                         onDoubleClicked: function(mouse) { control.doubleClicked() }

--- a/src/palette/view/palettemodel.cpp
+++ b/src/palette/view/palettemodel.cpp
@@ -416,7 +416,7 @@ bool PaletteTreeModel::setData(const QModelIndex& index, const QVariant& value, 
             if (value.canConvert<bool>()) {
                 const bool val = value.toBool();
                 if (val != pp->isExpanded()) {
-                    const bool singlePalette = configuration()->isSinglePalette();
+                    const bool singlePalette = configuration()->isSinglePalette().val;
 
                     if (singlePalette && val) {
                         for (auto& palette : palettes()) {

--- a/src/palette/view/palettespanelcontextmenumodel.cpp
+++ b/src/palette/view/palettespanelcontextmenumodel.cpp
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "palettespanelcontextmenumodel.h"
+
+#include "log.h"
+#include "translation.h"
+
+#include "actions/actiontypes.h"
+
+using namespace mu::palette;
+using namespace mu::actions;
+using namespace mu::ui;
+using namespace mu::uicomponents;
+
+static const ActionCode TOGGLE_SINGLE_PALETTE_CODE("toggle-single-palette");
+
+PalettesPanelContextMenuModel::PalettesPanelContextMenuModel(QObject* parent)
+    : AbstractMenuModel(parent)
+{
+}
+
+void PalettesPanelContextMenuModel::load()
+{
+    setItems({
+        createIsSinglePaletteItem(),
+    });
+}
+
+MenuItem* PalettesPanelContextMenuModel::createIsSinglePaletteItem()
+{
+    MenuItem* item = new MenuItem(this);
+
+    UiAction action;
+    action.title = qtrc("palette", "Open only one Palette at a time");
+    action.code = TOGGLE_SINGLE_PALETTE_CODE;
+    action.checkable = Checkable::Yes;
+    item->setAction(action);
+
+    ValCh<bool> checked = configuration()->isSinglePalette();
+
+    UiActionState state;
+    state.enabled = true;
+    state.checked = checked.val;
+    item->setState(state);
+
+    checked.ch.onReceive(item, [item](bool newValue) {
+        UiActionState state = item->state();
+        state.checked = newValue;
+        item->setState(state);
+    });
+
+    dispatcher()->reg(this, TOGGLE_SINGLE_PALETTE_CODE, [this, item]() {
+        bool newValue = !item->state().checked;
+        configuration()->setIsSinglePalette(newValue);
+    });
+
+    return item;
+}

--- a/src/palette/view/palettespanelcontextmenumodel.h
+++ b/src/palette/view/palettespanelcontextmenumodel.h
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_PALETTE_PALETTESPANELCONTEXTMENUMODEL_H
+#define MU_PALETTE_PALETTESPANELCONTEXTMENUMODEL_H
+
+#include "uicomponents/view/abstractmenumodel.h"
+#include "actions/actionable.h"
+
+#include "modularity/ioc.h"
+#include "ipaletteconfiguration.h"
+#include "actions/iactionsdispatcher.h"
+
+namespace mu::palette {
+class PalettesPanelContextMenuModel : public uicomponents::AbstractMenuModel, public actions::Actionable
+{
+    Q_OBJECT
+
+    INJECT(palette, IPaletteConfiguration, configuration)
+    INJECT(palette, actions::IActionsDispatcher, dispatcher)
+
+public:
+    explicit PalettesPanelContextMenuModel(QObject* parent = nullptr);
+
+    Q_INVOKABLE void load() override;
+
+private:
+    void buildMenu();
+
+    uicomponents::MenuItem* createIsSinglePaletteItem();
+};
+}
+
+#endif // MU_PALETTE_PALETTESPANELCONTEXTMENUMODEL_H

--- a/src/palette/view/palettespanelcontextmenumodel.h
+++ b/src/palette/view/palettespanelcontextmenumodel.h
@@ -42,10 +42,14 @@ public:
 
     Q_INVOKABLE void load() override;
 
+signals:
+    void expandCollapseAllRequested(bool expand);
+
 private:
     void buildMenu();
 
     uicomponents::MenuItem* createIsSinglePaletteItem();
+    uicomponents::MenuItem* createExpandCollapseAllItem(bool expand);
 };
 }
 

--- a/src/palette/view/palettespanelcontextmenumodel.h
+++ b/src/palette/view/palettespanelcontextmenumodel.h
@@ -48,6 +48,7 @@ signals:
 private:
     void buildMenu();
 
+    uicomponents::MenuItem* createIsSingleClickToOpenPaletteItem();
     uicomponents::MenuItem* createIsSinglePaletteItem();
     uicomponents::MenuItem* createExpandCollapseAllItem(bool expand);
 };


### PR DESCRIPTION
Resolves: #10618
Resolves: https://musescore.org/en/node/305131
<img width="338" alt="Schermafbeelding 2022-02-20 om 00 59 16" src="https://user-images.githubusercontent.com/48658420/154823184-66a817c5-64ce-4dd4-9e37-77458e83ea6f.png">

Until very recently I did not know about the 'Single-click to open a palette' option; that must have been before my time. I hope that it works as desired. I wonder why that has been absent since MU3.4, since it was not _that_ difficult to implement, and things like dragging still work. Hopefully I'm not missing something.

I also made a refinement for dragging palettes: now, the dragged palette will be positioned correctly relative to the mouse (instead of just with the top left corner at the position of the mouse).