### PR TITLE
Fix MS #7440 Displaying custom key signatures in multiple clefs

### DIFF
--- a/src/engraving/layout/layoutmeasure.cpp
+++ b/src/engraving/layout/layoutmeasure.cpp
@@ -662,7 +662,7 @@ void LayoutMeasure::getNextMeasure(const LayoutOptions& options, LayoutContext& 
         const Drumset* drumset
             = staff->part()->instrument(measure->tick())->useDrumset() ? staff->part()->instrument(measure->tick())->drumset() : 0;
         AccidentalState as;          // list of already set accidentals for this measure
-        as.init(staff->keySigEvent(measure->tick()), staff->clef(measure->tick()));
+        as.init(staff->keySigEvent(measure->tick()));
 
         for (Segment& segment : measure->segments()) {
             // TODO? maybe we do need to process it here to make it possible to enable later
@@ -674,7 +674,7 @@ void LayoutMeasure::getNextMeasure(const LayoutOptions& options, LayoutContext& 
                     continue;
                 }
                 Fraction tick = segment.tick();
-                as.init(staff->keySigEvent(tick), staff->clef(tick));
+                as.init(staff->keySigEvent(tick));
                 ks->layout();
             } else if (segment.isChordRestType()) {
                 const StaffType* st = staff->staffTypeForElement(&segment);

--- a/src/engraving/libmscore/key.cpp
+++ b/src/engraving/libmscore/key.cpp
@@ -247,8 +247,7 @@ void AccidentalState::init(const KeySigEvent& keySig, ClefType clef)
         memset(state, ACC_STATE_NATURAL, MAX_ACC_STATE);
         for (const KeySym& s : keySig.keySymbols()) {
             AccidentalVal a = sym2accidentalVal(s.sym);
-            int line = int(s.spos.y() * 2);
-            int idx       = relStep(line, clef) % 7;
+            int idx = absStep(s.line, clef) % 7;
             for (int octave = 0; octave < (11 * 7); octave += 7) {
                 int i = idx + octave;
                 if (i >= MAX_ACC_STATE) {

--- a/src/engraving/libmscore/key.h
+++ b/src/engraving/libmscore/key.h
@@ -77,7 +77,7 @@ static inline Key operator-=(Key& a, const Key& b) { return a = Key(static_cast<
 
 struct KeySym {
     SymId sym;
-    int line;       // relative line position (first staffline: line == 0, first gap: line == 1, ...)
+    int line;       // relative line position (first staffline: line == 0, first gap: line == 1, ...) !!!in Custom Key Signatures always in treble cleff!!!
     double xPos;    // x position in staff spatium units
 };
 
@@ -135,7 +135,7 @@ class AccidentalState
 public:
     AccidentalState() {}
     void init(Key key);
-    void init(const KeySigEvent&, ClefType);
+    void init(const KeySigEvent&);
     AccidentalVal accidentalVal(int line, bool& error) const;
     AccidentalVal accidentalVal(int line) const;
     bool tieContext(int line) const;
@@ -147,5 +147,8 @@ struct Interval;
 enum class PreferSharpFlat : char;
 extern Key transposeKey(Key oldKey, const Interval&, PreferSharpFlat prefer = PreferSharpFlat(0));
 extern Interval calculateInterval(Key key1, Key key2);
+
+extern int keySymLine(KeySym ks, ClefType clefIn, ClefType clefOut);
+extern int keySymLine(KeySym ks, ClefType clef);
 }     // namespace Ms
 #endif

--- a/src/engraving/libmscore/key.h
+++ b/src/engraving/libmscore/key.h
@@ -77,8 +77,8 @@ static inline Key operator-=(Key& a, const Key& b) { return a = Key(static_cast<
 
 struct KeySym {
     SymId sym;
-    mu::PointF spos;       // position in spatium units
-    mu::PointF pos;        // actual pixel position on screen (set by layout)
+    int line;       // relative line position (first staffline: line == 0, first gap: line == 1, ...)
+    double xPos;    // x position in staff spatium units
 };
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/keysig.h
+++ b/src/engraving/libmscore/keysig.h
@@ -50,7 +50,7 @@ class KeySig final : public EngravingItem
     KeySig(Segment* = 0);
     KeySig(const KeySig&);
 
-    void addLayout(SymId sym, int y);
+    void addLayout(SymId sym, int line);
 
 public:
 

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -398,7 +398,7 @@ AccidentalVal Measure::findAccidental(Note* note) const
 {
     Chord* chord = note->chord();
     AccidentalState tversatz;    // state of already set accidentals for this measure
-    tversatz.init(chord->staff()->keySigEvent(tick()), chord->staff()->clef(tick()));
+    tversatz.init(chord->staff()->keySigEvent(tick()));
 
     for (Segment* segment = first(); segment; segment = segment->next()) {
         int startTrack = chord->staffIdx() * VOICES;
@@ -407,7 +407,7 @@ AccidentalVal Measure::findAccidental(Note* note) const
             if (!ks) {
                 continue;
             }
-            tversatz.init(chord->staff()->keySigEvent(segment->tick()), chord->staff()->clef(segment->tick()));
+            tversatz.init(chord->staff()->keySigEvent(segment->tick()));
         } else if (segment->segmentType() == SegmentType::ChordRest) {
             int endTrack   = startTrack + VOICES;
             for (int track = startTrack; track < endTrack; ++track) {
@@ -465,7 +465,7 @@ AccidentalVal Measure::findAccidental(Segment* s, int staffIdx, int line, bool& 
 {
     AccidentalState tversatz;    // state of already set accidentals for this measure
     Staff* staff = score()->staff(staffIdx);
-    tversatz.init(staff->keySigEvent(tick()), staff->clef(tick()));
+    tversatz.init(staff->keySigEvent(tick()));
 
     SegmentType st = SegmentType::ChordRest;
     int startTrack = staffIdx * VOICES;

--- a/src/engraving/libmscore/utils.h
+++ b/src/engraving/libmscore/utils.h
@@ -85,10 +85,11 @@ extern Note* searchTieNote114(Note* note);
 
 extern int absStep(int pitch);
 extern int absStep(int tpc, int pitch);
-
 extern int absStep(int line, ClefType clef);
+
 extern int relStep(int line, ClefType clef);
 extern int relStep(int pitch, int tpc, ClefType clef);
+
 extern int pitch2step(int pitch);
 extern int step2pitch(int step);
 

--- a/src/engraving/rw/xml.h
+++ b/src/engraving/rw/xml.h
@@ -308,6 +308,7 @@ public:
     void tag(const char* name, const QString& s) { tag(name, QVariant(s)); }
     void tag(const char* name, const mu::PointF& v);
     void tag(const char* name, const Fraction& v, const Fraction& def = Fraction());
+    void tag(const char* name, const KeySym& ks);
 
     void comment(const QString&);
 

--- a/src/engraving/rw/xmlwriter.cpp
+++ b/src/engraving/rw/xmlwriter.cpp
@@ -470,6 +470,12 @@ void XmlWriter::tag(const char* name, const mu::PointF& p)
     *this << QString("<%1 x=\"%2\" y=\"%3\"/>\n").arg(name).arg(p.x()).arg(p.y());
 }
 
+void XmlWriter::tag(const char* name, const KeySym& ks)
+{
+    putLevel();
+    *this << QString("<%1 xPos=\"%2\" line=\"%3\"/>\n").arg(name).arg(ks.xPos).arg(ks.line);
+}
+
 void XmlWriter::tag(const char* name, const Fraction& v, const Fraction& def)
 {
     if (v == def) {

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -2148,12 +2148,11 @@ void ExportMusicXml::keysig(const KeySig* ks, ClefType ct, int staff, bool visib
         // first put the KeySyms in a map
         QMap<qreal, KeySym> map;
         for (const KeySym& ksym : keysyms) {
-            map.insert(ksym.spos.x(), ksym);
+            map.insert(ksym.xPos, ksym);
         }
         // then write them (automatically sorted on key)
         for (const KeySym& ksym : map) {
-            int line = static_cast<int>(round(2 * ksym.spos.y()));
-            int step = (po - line) % 7;
+            int step = (po - ksym.line) % 7;
             //qDebug(" keysym sym %d spos %g,%g pos %g,%g -> line %d step %d",
             //       ksym.sym, ksym.spos.x(), ksym.spos.y(), ksym.pos.x(), ksym.pos.y(), line, step);
             _xml.tag("key-step", QString(QChar(table2[step])));

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -3611,7 +3611,8 @@ static void addSymToSig(KeySigEvent& sig, const QString& step, const QString& al
         if (line >= 0) {
             KeySym ks;
             ks.sym  = id;
-            ks.spos = QPointF(x, qreal(line) * 0.5);
+            ks.xPos = x;
+            ks.line = line;
             sig.keySymbols().append(ks);
             sig.setCustom(true);
         }

--- a/src/palette/view/widgets/keyedit.cpp
+++ b/src/palette/view/widgets/keyedit.cpp
@@ -377,9 +377,10 @@ void KeyEditor::addClicked()
     for (Accidental* a : al) {
         KeySym s;
         s.sym       = a->symbol();
-        PointF pos = a->ipos();
+        PointF pos  = a->ipos();
         pos.rx()   -= xoff;
-        s.spos      = pos / spatium;
+        s.xPos      = pos.x() / spatium;
+        s.line      = static_cast<int>(round((pos.y() / spatium) * 2));
         e.keySymbols().append(s);
     }
     auto ks = Factory::makeKeySig(gpaletteScore->dummy()->segment());


### PR DESCRIPTION
Resolves: [*(MS #7440)*](https://musescore.org/en/node/7440)

Custom key signatures are adapted to different clefs.

Changes are made on top of #10609 commit 52ee1dd753744da5659735b29df6c2c14df21c71 which assumes, it is merged first.
Actual change ("keysig per clef") for review is second commit 0bb0d5ccf8070b92cc28db7ca9291a85da523a22

Tested on Linux (Ubuntu Studio 21.10)

vtest failure expected and welcome

![KeySig_Clefs](https://user-images.githubusercontent.com/1646034/155291341-d3edb5f7-272a-4659-bf1e-216156a959da.png)

This "just works", it is not ideal, but at the moment, I dont see better solution. (May be, I miss something). It is "solution a" as described bellow.

I think, for the future, custom key signatures needs deeper rethink / refactor. See "solution b" below

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made

### Relation  between `key` and `keysignature` 
Convential
`key` is definition, `key symbols` in `keysignature` represent it, related on `clef`
`keySymbol.line` is representation of `key symbols` in concrete `clef`

Custom
definition is missing, `key symbols` are used to "fake" definition, but `clef` relation is missing inside `keysignature`.

### Possible solution
a) use `keySymbol.line` in custom key signatures as definition, which means, it is always stored as in treble clef.
- pros: easy adaptation at the moment; doesn't reuquire refactor
- cons: limited options for the future; different meaning of `keySymbol.line` in custom and convential sygnatures; 

b) add new "definition" of customkey in (or next to [^1]) `key` containing list of symbols, each defined as (my proposal):
 1) note (one of c, d, e, f, g, a, b)
 2) symbol (sharp, flat, natural, quatertone up, ...)
 3) xPos alteration (default xPos depends of symbol's index, 1.st symbol 1sp, 2.nd 2sp), so on second symbol xPos=-1 means it stays at 1sp.
 4) octave alteration (default line position depends on conventional position as defined in clefTable in clef.cpp)

- pros: clear logic; consistency of `keySymbol.line` meaning in both, conventional and custom signatures; new options and easier enhancements for future (transposing custom key signatures, microtonal accidentals, ...)
- cons: needs refactor

[^1]: Probably better to have them both, side by side, in case of possible visual modifications in editor as described in https://musescore.org/en/node/329177