### PR TITLE
Fix #329608: [MusicXML export] custom ending text not exported

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -1714,7 +1714,11 @@ static void ending(XmlWriter& xml, Volta* v, bool left)
     }
     QString voltaXml = QString("ending number=\"%1\" type=\"%2\"").arg(number, type);
     voltaXml += ExportMusicXml::positioningAttributes(v, left);
-    xml.tagE(voltaXml);
+    if (left) {
+        xml.tag(voltaXml, v->text().toHtmlEscaped());
+    } else {
+        xml.tagE(voltaXml);
+    }
 }
 
 //---------------------------------------------------------

--- a/src/importexport/musicxml/tests/data/testVolta2.xml
+++ b/src/importexport/musicxml/tests/data/testVolta2.xml
@@ -3,7 +3,7 @@
 <score-partwise version="3.1">
   <work>
     <work-number>MuseScore testfile</work-number>
-    <work-title>Volta 1</work-title>
+    <work-title>Volta 2</work-title>
     </work>
   <identification>
     <creator type="composer">Leon Vinken</creator>
@@ -56,7 +56,7 @@
       </measure>
     <measure number="2">
       <barline location="left">
-        <ending number="1" type="start">1</ending>
+        <ending number="1, 2, 3" type="start">1-3</ending>
         </barline>
       <note>
         <pitch>
@@ -69,13 +69,13 @@
         </note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>
-        <ending number="1" type="stop"/>
+        <ending number="1, 2, 3" type="stop"/>
         <repeat direction="backward"/>
         </barline>
       </measure>
     <measure number="3">
       <barline location="left">
-        <ending number="2" type="start">2</ending>
+        <ending number="4" type="start">4</ending>
         </barline>
       <note>
         <pitch>
@@ -87,94 +87,13 @@
         <type>whole</type>
         </note>
       <barline location="right">
-        <ending number="2" type="discontinue"/>
+        <ending number="4" type="discontinue"/>
         </barline>
       </measure>
     <measure number="4">
       <note>
         <pitch>
           <step>C</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-        </note>
-      </measure>
-    <measure number="5">
-      <print new-system="yes"/>
-      <note>
-        <pitch>
-          <step>G</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-        </note>
-      </measure>
-    <measure number="6">
-      <barline location="left">
-        <ending number="1" type="start">1</ending>
-        </barline>
-      <note>
-        <pitch>
-          <step>A</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-        </note>
-      </measure>
-    <measure number="7">
-      <note>
-        <pitch>
-          <step>B</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-        </note>
-      <barline location="right">
-        <bar-style>light-heavy</bar-style>
-        <ending number="1" type="stop"/>
-        <repeat direction="backward"/>
-        </barline>
-      </measure>
-    <measure number="8">
-      <barline location="left">
-        <ending number="2" type="start">2</ending>
-        </barline>
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-        </note>
-      </measure>
-    <measure number="9">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-        </note>
-      <barline location="right">
-        <ending number="2" type="discontinue"/>
-        </barline>
-      </measure>
-    <measure number="10">
-      <note>
-        <pitch>
-          <step>E</step>
           <octave>5</octave>
           </pitch>
         <duration>4</duration>

--- a/src/importexport/musicxml/tests/tst_mxml_io.cpp
+++ b/src/importexport/musicxml/tests/tst_mxml_io.cpp
@@ -239,6 +239,7 @@ private slots:
     void voiceMapper3() { mxmlIoTestRef("testVoiceMapper3"); }
     void voicePiano1() { mxmlIoTest("testVoicePiano1"); }
     void volta1() { mxmlIoTest("testVolta1"); }
+    void volta2() { mxmlIoTest("testVolta2"); }
     void wedge1() { mxmlIoTest("testWedge1"); }
     void wedge2() { mxmlIoTest("testWedge2"); }
     void wedge3() { mxmlIoTest("testWedge3"); }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/329608

Export the volta text to the MusicXML ending element, allowing custom text such as "1-3".

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
