### PR TITLE
Shrink dock panel tabs proportionally in case of overflow

### DIFF
--- a/src/appshell/qml/dockwindow/DockFrame.qml
+++ b/src/appshell/qml/dockwindow/DockFrame.qml
@@ -151,10 +151,28 @@ Rectangle {
             currentIndex: tabsPanel.currentIndex
             model: frameModel.tabs
 
+            readonly property real implicitWidthOfActiveTab: currentItem ? currentItem.implicitWidth : 0
+            readonly property real implicitWidthOfAllTabsTogether: {
+                let result = 0
+                for (let i = 0; i < count; i++) {
+                    let item = itemAtIndex(i)
+                    if (item) {
+                        result += item.implicitWidth
+                    }
+                }
+                return result
+            }
+
             delegate: DockPanelTab {
                 text: modelData.title
                 isCurrent: tabsPanel && (tabsPanel.currentIndex === model.index)
                 contextMenuModel: modelData.contextMenuModel
+
+                width: isCurrent
+                       ? implicitWidth
+                       : Math.min((tabsPanel.width + 1 - tabs.implicitWidthOfActiveTab) // +1, because we don't need the rightmost separator
+                                  / (tabs.implicitWidthOfAllTabsTogether - tabs.implicitWidthOfActiveTab),
+                                  1) * implicitWidth
 
                 navigation.name: text
                 navigation.panel: navPanel

--- a/src/appshell/qml/dockwindow/DockPanelTab.qml
+++ b/src/appshell/qml/dockwindow/DockPanelTab.qml
@@ -45,6 +45,8 @@ StyledTabButton {
     topPadding: 0
     bottomPadding: 1 // For separator
 
+    clip: true
+
     contentItem: Row {
         spacing: root.buttonPadding
 
@@ -94,57 +96,78 @@ StyledTabButton {
         }
     }
 
-    background: Item {
-        Rectangle {
-            id: backgroundRect
-            anchors.left: parent.left
-            anchors.top: parent.top
-            anchors.right: rightSeparator.left
-            anchors.bottom: root.isCurrent ? parent.bottom : bottomSeparator.top
+    background: Rectangle {
+        id: backgroundRect
+        anchors.fill: root
 
-            NavigationFocusBorder{
-                navigationCtrl: root.navigation
-                drawOutsideParent: false
-            }
+        NavigationFocusBorder {
+            navigationCtrl: root.navigation
+            drawOutsideParent: false
+        }
 
-            color: ui.theme.backgroundSecondaryColor
-            opacity: 1
+        color: ui.theme.backgroundSecondaryColor
+        opacity: 1
 
-            states: [
-                State {
-                    name: "HOVERED"
-                    when: root.hovered && !root.isCurrent
+        states: [
+            State {
+                name: "HOVERED"
+                when: root.hovered && !root.isCurrent
 
-                    PropertyChanges {
-                        target: backgroundRect
-                        color: ui.theme.backgroundPrimaryColor
-                        opacity: ui.theme.buttonOpacityHover
-                    }
-                },
-
-                State {
-                    name: "SELECTED"
-                    when: root.isCurrent
-
-                    PropertyChanges {
-                        target: backgroundRect
-                        color: ui.theme.backgroundPrimaryColor
-                    }
+                PropertyChanges {
+                    target: backgroundRect
+                    color: ui.theme.backgroundPrimaryColor
+                    opacity: ui.theme.buttonOpacityHover
                 }
-            ]
-        }
+            },
 
-        SeparatorLine {
-            id: rightSeparator
-            anchors.right: parent.right
-            orientation: Qt.Vertical
-        }
+            State {
+                name: "SELECTED"
+                when: root.isCurrent
 
-        SeparatorLine {
-            id: bottomSeparator
-            anchors.bottom: parent.bottom
-            visible: !root.isCurrent
+                PropertyChanges {
+                    target: backgroundRect
+                    color: ui.theme.backgroundPrimaryColor
+                }
+            }
+        ]
+    }
+
+    Rectangle {
+        visible: root.width < root.implicitWidth
+
+        anchors.top: root.top
+        anchors.right: root.right
+        anchors.rightMargin: 1
+        anchors.bottom: root.bottom
+        anchors.bottomMargin: root.isCurrent ? 0 : 1
+
+        width: 20
+
+        opacity: 0.7
+        gradient: Gradient {
+            orientation: Qt.Horizontal
+
+            GradientStop {
+                position: 0.0
+                color: "transparent"
+            }
+            GradientStop {
+                position: 1.0
+                color: backgroundRect.color
+            }
         }
+    }
+
+    SeparatorLine {
+        id: rightSeparator
+        anchors.right: root.right
+        orientation: Qt.Vertical
+    }
+
+    SeparatorLine {
+        id: bottomSeparator
+        anchors.bottom: root.bottom
+        visible: !root.isCurrent
     }
 
     states: []

--- a/src/appshell/qml/dockwindow/DockPanelTab.qml
+++ b/src/appshell/qml/dockwindow/DockPanelTab.qml
@@ -100,11 +100,6 @@ StyledTabButton {
         id: backgroundRect
         anchors.fill: root
 
-        NavigationFocusBorder {
-            navigationCtrl: root.navigation
-            drawOutsideParent: false
-        }
-
         color: ui.theme.backgroundSecondaryColor
         opacity: 1
 
@@ -168,6 +163,13 @@ StyledTabButton {
         id: bottomSeparator
         anchors.bottom: root.bottom
         visible: !root.isCurrent
+    }
+
+    NavigationFocusBorder {
+        navigationCtrl: root.navigation
+        drawOutsideParent: false
+        anchors.rightMargin: 1
+        anchors.bottomMargin: root.isCurrent ? 0 : 1
     }
 
     states: []

--- a/src/notation/qml/MuseScore/NotationScene/SelectionFilterPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/SelectionFilterPanel.qml
@@ -47,7 +47,11 @@ Item {
 
     StyledListView {
         anchors.fill: parent
-        anchors.margins: 12
+
+        topMargin: 12
+        leftMargin: topMargin
+        rightMargin: topMargin
+        bottomMargin: topMargin
 
         spacing: 12
 

--- a/thirdparty/KDDockWidgets/src/private/quick/TabBarQuick.cpp
+++ b/thirdparty/KDDockWidgets/src/private/quick/TabBarQuick.cpp
@@ -124,7 +124,7 @@ QQuickItem *TabBarQuick::listView() const
 
     const QList<QQuickItem *> children = m_tabBarQmlItem->childItems();
     for (QQuickItem *child : children) {
-        if (qstrcmp(child->metaObject()->className(), "QQuickListView") == 0)
+        if (QString::fromUtf8(child->metaObject()->className()).startsWith(QString::fromUtf8("QQuickListView")))
             return child;
     }
 


### PR DESCRIPTION
Resolves: #9262
Closes: #10059

<img width="301" alt="Schermafbeelding 2022-02-21 om 13 57 07" src="https://user-images.githubusercontent.com/48658420/154959628-5acec98e-4d89-4610-b533-dd44f6168def.png"> <img width="301" alt="Schermafbeelding 2022-02-21 om 13 57 40" src="https://user-images.githubusercontent.com/48658420/154959763-398d404d-c8f0-4c60-930d-a0c033aaf6d4.png">

I experimented with this months ago, but couldn't get it to work properly. Instead, I created #10059 as an alternative solution.
However, after rebasing my old branch this morning, it magically started to work. So, I'm creating a PR for this solution too.
