### PR TITLE
[MU4] Remove all showSystemObjects functionality from ScoreGroup

### DIFF
--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -3805,15 +3805,6 @@ void Score::setBracketsAndBarlines()
 }
 
 //---------------------------------------------------------
-//   setSystemObjectStaves
-//---------------------------------------------------------
-
-void Score::setSystemObjectStaves()
-{
-    scoreOrder().setSystemObjectStaves(this);
-}
-
-//---------------------------------------------------------
 //   lassoSelect
 //---------------------------------------------------------
 

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -983,7 +983,6 @@ public:
     ScoreOrder scoreOrder() const;
     void setScoreOrder(ScoreOrder order);
     void setBracketsAndBarlines();
-    void setSystemObjectStaves();
 
     void lassoSelect(const mu::RectF&);
     void lassoSelectEnd(bool);

--- a/src/engraving/libmscore/scoreorder.cpp
+++ b/src/engraving/libmscore/scoreorder.cpp
@@ -61,7 +61,6 @@ ScoreOrder ScoreOrder::clone() const
         newGroup.section = sg.section;
         newGroup.unsorted = sg.unsorted;
         newGroup.bracket = sg.bracket;
-        newGroup.showSystemMarkings = sg.showSystemMarkings;
         newGroup.barLineSpan = sg.barLineSpan;
         newGroup.thinBracket = sg.thinBracket;
 
@@ -147,7 +146,6 @@ void ScoreOrder::readSoloists(Ms::XmlReader& reader, const QString section)
 void ScoreOrder::readSection(Ms::XmlReader& reader)
 {
     QString sectionId { reader.attribute("id") };
-    bool showSystemMarkings = readBoolAttribute(reader, "showSystemMarkings", false);
     bool barLineSpan = readBoolAttribute(reader, "barLineSpan", true);
     bool thinBrackets = readBoolAttribute(reader, "thinBrackets", true);
     while (reader.readNextStartElement()) {
@@ -156,7 +154,6 @@ void ScoreOrder::readSection(Ms::XmlReader& reader)
             sg.family = reader.readElementText().toUtf8().data();
             sg.section = sectionId;
             sg.bracket = true;
-            sg.showSystemMarkings = showSystemMarkings;
             sg.barLineSpan = barLineSpan;
             sg.thinBracket = thinBrackets;
             groups.push_back(sg);
@@ -173,7 +170,6 @@ void ScoreOrder::readSection(Ms::XmlReader& reader)
             sg.section = sectionId;
             sg.unsorted = group;
             sg.bracket = true;
-            sg.showSystemMarkings = readBoolAttribute(reader, "showSystemMarkings", false);
             sg.barLineSpan = readBoolAttribute(reader, "barLineSpan", true);
             sg.thinBracket = readBoolAttribute(reader, "thinBrackets", true);
             groups.push_back(sg);
@@ -256,7 +252,6 @@ ScoreGroup ScoreOrder::newUnsortedGroup(const QString group, const QString secti
     sg.section = section;
     sg.unsorted = group;
     sg.bracket = false;
-    sg.showSystemMarkings = false;
     sg.barLineSpan = false;
     sg.thinBracket = false;
     return sg;
@@ -522,7 +517,6 @@ void ScoreOrder::read(Ms::XmlReader& reader)
             sg.family = reader.readElementText().toUtf8().data();
             sg.section = sectionId;
             sg.bracket = false;
-            sg.showSystemMarkings = false;
             sg.barLineSpan = false;
             sg.thinBracket = false;
             groups.push_back(sg);
@@ -574,10 +568,9 @@ void ScoreOrder::write(Ms::XmlWriter& xml) const
             }
             if (!sg.section.isEmpty()) {
                 xml.startObject(QString(
-                                    "section id=\"%1\" brackets=\"%2\" showSystemMarkings=\"%3\" barLineSpan=\"%4\" thinBrackets=\"%5\"")
+                                    "section id=\"%1\" brackets=\"%2\" barLineSpan=\"%3\" thinBrackets=\"%4\"")
                                 .arg(sg.section,
                                      sg.bracket ? "true" : "false",
-                                     sg.showSystemMarkings ? "true" : "false",
                                      sg.barLineSpan ? "true" : "false",
                                      sg.thinBracket ? "true" : "false"));
             }

--- a/src/engraving/libmscore/scoreorder.cpp
+++ b/src/engraving/libmscore/scoreorder.cpp
@@ -470,34 +470,6 @@ void ScoreOrder::setBracketsAndBarlines(Score* score)
 }
 
 //---------------------------------------------------------
-//   setSystemObjectStaves
-//---------------------------------------------------------
-
-void ScoreOrder::setSystemObjectStaves(Score* score)
-{
-    // for now, orders.xml doesn't contain any system object information, but can be used in the future
-    // when we start phase 2 of the system objects thing (post 4.0)
-    if (!score->getSystemObjectStaves().empty()) {
-        return;
-    }
-    score->clearSystemObjectStaves();
-
-    QString prvSection = "";
-    for (Part* part : score->parts()) {
-        InstrumentIndex ii = searchTemplateIndexForId(part->instrument()->id());
-        if (!ii.instrTemplate) {
-            continue;
-        }
-        QString family{ getFamilyName(ii.instrTemplate, part->soloist()) };
-        const ScoreGroup sg = getGroup(family, instrumentGroups[ii.groupIndex]->id);
-        if (sg.section != prvSection && sg.showSystemMarkings) {
-            score->addSystemObjectStaff(part->staff(0));
-        }
-        prvSection = sg.section;
-    }
-}
-
-//---------------------------------------------------------
 //   read
 //---------------------------------------------------------
 

--- a/src/engraving/libmscore/scoreorder.h
+++ b/src/engraving/libmscore/scoreorder.h
@@ -40,7 +40,6 @@ struct ScoreGroup
                                        // isEmpty()  : equal to <unsorted/>
                                        // !isEmpty() : equal to <unsorted group="unsorted"/>
     bool bracket { false };
-    bool showSystemMarkings { false };
     bool barLineSpan { true };
     bool thinBracket { true };
 };
@@ -90,7 +89,6 @@ struct ScoreOrder
     bool isScoreOrder(const Score* score) const;
 
     void setBracketsAndBarlines(Score* score);
-    void setSystemObjectStaves(Score* score);
 
     void read(Ms::XmlReader& reader);
     void write(Ms::XmlWriter& xml) const;

--- a/src/engraving/utests/beam_data/beamNoSlope.mscx
+++ b/src/engraving/utests/beam_data/beamNoSlope.mscx
@@ -24,53 +24,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="voice">
-        <family id="voices">Voices</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/beam_data/beamPositions.mscx
+++ b/src/engraving/utests/beam_data/beamPositions.mscx
@@ -23,53 +23,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="voice">
-        <family id="voices">Voices</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/beam_data/beamStemDir-01-ref.mscx
+++ b/src/engraving/utests/beam_data/beamStemDir-01-ref.mscx
@@ -23,53 +23,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="piano">
-        <family id="keyboards">Keyboards</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/beam_data/beamStemDir.mscx
+++ b/src/engraving/utests/beam_data/beamStemDir.mscx
@@ -23,53 +23,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="piano">
-        <family id="keyboards">Keyboards</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/beam_data/flatBeams.mscx
+++ b/src/engraving/utests/beam_data/flatBeams.mscx
@@ -23,53 +23,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="alto-saxophone">
-        <family id="saxophones">Saxophones</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/beam_data/flipBeamStemDir-01-ref.mscx
+++ b/src/engraving/utests/beam_data/flipBeamStemDir-01-ref.mscx
@@ -23,53 +23,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="piano">
-        <family id="keyboards">Keyboards</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/beam_data/flipBeamStemDir.mscx
+++ b/src/engraving/utests/beam_data/flipBeamStemDir.mscx
@@ -23,53 +23,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="piano">
-        <family id="keyboards">Keyboards</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/beam_data/flippedDirection.mscx
+++ b/src/engraving/utests/beam_data/flippedDirection.mscx
@@ -23,53 +23,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="voice">
-        <family id="voices">Voices</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/beam_data/wideBeams.mscx
+++ b/src/engraving/utests/beam_data/wideBeams.mscx
@@ -24,53 +24,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="voice">
-        <family id="voices">Voices</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/keysig_data/keysig03-ref.mscx
+++ b/src/engraving/utests/keysig_data/keysig03-ref.mscx
@@ -23,53 +23,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="piano">
-        <family id="keyboards">Keyboards</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/keysig_data/keysigMode.mscx
+++ b/src/engraving/utests/keysig_data/keysigMode.mscx
@@ -23,53 +23,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="piano">
-        <family id="keyboards">Keyboards</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/tools_data/change-enharmonic-both-01-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-both-01-ref.mscx
@@ -24,53 +24,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle">x</metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="bb-trumpet">
-        <family id="trumpets">Trumpets</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/tools_data/change-enharmonic-both-02-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-both-02-ref.mscx
@@ -24,53 +24,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle">x</metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="bb-trumpet">
-        <family id="trumpets">Trumpets</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/tools_data/change-enharmonic-both-03-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-both-03-ref.mscx
@@ -24,53 +24,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle">x</metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="bb-trumpet">
-        <family id="trumpets">Trumpets</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/tools_data/change-enharmonic-both-04-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-both-04-ref.mscx
@@ -24,53 +24,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle">x</metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="bb-trumpet">
-        <family id="trumpets">Trumpets</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/tools_data/change-enharmonic-both-05-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-both-05-ref.mscx
@@ -24,53 +24,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle">x</metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="bb-trumpet">
-        <family id="trumpets">Trumpets</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/tools_data/change-enharmonic-current-01-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-current-01-ref.mscx
@@ -24,53 +24,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle">x</metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="bb-trumpet">
-        <family id="trumpets">Trumpets</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/tools_data/change-enharmonic-current-02-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-current-02-ref.mscx
@@ -24,53 +24,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle">x</metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="bb-trumpet">
-        <family id="trumpets">Trumpets</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/tools_data/change-enharmonic-current-03-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-current-03-ref.mscx
@@ -24,53 +24,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle">x</metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="bb-trumpet">
-        <family id="trumpets">Trumpets</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/tools_data/change-enharmonic-current-04-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-current-04-ref.mscx
@@ -24,53 +24,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle">x</metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="bb-trumpet">
-        <family id="trumpets">Trumpets</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/tools_data/change-enharmonic-current-05-ref.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic-current-05-ref.mscx
@@ -24,53 +24,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle">x</metaTag>
-    <Order id="orchestral">
-      <name>Orchestral</name>
-      <instrument id="bb-trumpet">
-        <family id="trumpets">Trumpets</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/engraving/utests/tools_data/change-enharmonic.mscx
+++ b/src/engraving/utests/tools_data/change-enharmonic.mscx
@@ -28,53 +28,6 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle">x</metaTag>
-    <Order id="orchestral" customized="1">
-      <name>Orchestral</name>
-      <instrument id="bb-trumpet">
-        <family id="trumpets">Trumpets</family>
-        </instrument>
-      <section id="woodwind" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>flutes</family>
-        <family>oboes</family>
-        <family>clarinets</family>
-        <family>saxophones</family>
-        <family>bassoons</family>
-        <unsorted group="woodwinds"/>
-        </section>
-      <section id="brass" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>horns</family>
-        <family>trumpets</family>
-        <family>cornets</family>
-        <family>flugelhorns</family>
-        <family>trombones</family>
-        <family>tubas</family>
-        </section>
-      <section id="timpani" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>timpani</family>
-        </section>
-      <section id="percussion" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>keyboard-percussion</family>
-        <family>drums</family>
-        <family>unpitched-metal-percussion</family>
-        <family>unpitched-wooden-percussion</family>
-        <family>other-percussion</family>
-        </section>
-      <family>keyboards</family>
-      <family>harps</family>
-      <family>organs</family>
-      <family>synths</family>
-      <section id="plucked-strings" brackets="true" showSystemMarkings="false" barLineSpan="true" thinBrackets="true">
-        <family>plucked-strings</family>
-        </section>
-      <soloists/>
-      <section id="voices" brackets="true" showSystemMarkings="false" barLineSpan="false" thinBrackets="true">
-        <family>voices</family>
-        </section>
-      <section id="strings" brackets="true" showSystemMarkings="true" barLineSpan="true" thinBrackets="true">
-        <family>orchestral-strings</family>
-        </section>
-      <unsorted/>
-      </Order>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -94,7 +94,6 @@ void MasterNotation::setMasterScore(Ms::MasterScore* score)
     TRACEFUNC;
 
     setScore(score);
-    score->setSystemObjectStaves();
     m_notationPlayback->init(m_undoStack);
     initExcerptNotations(masterScore()->excerpts());
 }
@@ -273,7 +272,6 @@ void MasterNotation::applyOptions(Ms::MasterScore* score, const ScoreCreateOptio
             nvb->setRightMargin(tvb->rightMargin());
             nvb->setAutoSizeEnabled(tvb->isAutoSizeEnabled());
         }
-        score->setSystemObjectStaves(); // use the template to determine where system objects go
     }
 
     score->setSaved(true);


### PR DESCRIPTION
system object information does not rely on orders.xml anymore, so it shouldn't ever be in the <Section> xml element. ignore from previous versions.

This may cause the utests to fail because the xml is going to be slightly different, so let's see how that goes