### PR TITLE
[MU4] Calculate new bar distances only if stylesheet not applied

### DIFF
--- a/src/project/internal/projectmigrator.cpp
+++ b/src/project/internal/projectmigrator.cpp
@@ -185,10 +185,12 @@ Ret ProjectMigrator::migrateProject(engraving::EngravingProjectPtr project, cons
     bool ok = true;
     if (opt.isApplyLeland) {
         ok = applyLelandStyle(score);
+        m_resetStyleSettings = false;
     }
 
     if (ok && opt.isApplyEdwin) {
         ok = applyEdwinStyle(score);
+        m_resetStyleSettings = false;
     }
 
     if (ok && opt.isApplyAutoSpacing) {
@@ -201,7 +203,7 @@ Ret ProjectMigrator::migrateProject(engraving::EngravingProjectPtr project, cons
         score->undo(new Ms::ChangeMetaText(score, "mscVersion", MSC_VERSION));
     }
 
-    if (m_resetStyleSettings) {
+    if (ok && m_resetStyleSettings) {
         resetStyleSettings(score);
     }
 


### PR DESCRIPTION
This PR created a system by which old scores' barline distance settings could be inferred from the widths of the barlines. Now that the "apply leland" and "apply edwin" stylesheets are updated with the modern values, this PR's calculation should not be done if a stylesheet has been applied.