### PR TITLE
Clean up some code relating to paths and saving status, preparing for Save to Cloud features

### DIFF
--- a/src/appshell/internal/sessionsmanager.h
+++ b/src/appshell/internal/sessionsmanager.h
@@ -52,6 +52,8 @@ public:
     void reset() override;
 
 private:
+    void update();
+
     void removeProjectFromSession(const io::path& projectPath);
     void addProjectToSession(const io::path& projectPath);
 

--- a/src/appshell/view/mainwindowtitleprovider.cpp
+++ b/src/appshell/view/mainwindowtitleprovider.cpp
@@ -34,12 +34,15 @@ void MainWindowTitleProvider::load()
 {
     update();
 
-    context()->currentMasterNotationChanged().onNotify(this, [this]() {
+    context()->currentNotationChanged().onNotify(this, [this]() {
         update();
 
-        IMasterNotationPtr masterNotation = context()->currentMasterNotation();
-        if (masterNotation) {
-            masterNotation->needSave().notification.onNotify(this, [this]() {
+        if (auto project = context()->currentProject()) {
+            project->pathChanged().onNotify(this, [this]() {
+                update();
+            });
+
+            project->masterNotation()->needSave().notification.onNotify(this, [this]() {
                 update();
             });
         }
@@ -61,7 +64,7 @@ bool MainWindowTitleProvider::fileModified() const
     return m_fileModified;
 }
 
-void MainWindowTitleProvider::setTitle(QString title)
+void MainWindowTitleProvider::setTitle(const QString& title)
 {
     if (title == m_title) {
         return;
@@ -71,7 +74,7 @@ void MainWindowTitleProvider::setTitle(QString title)
     emit titleChanged(title);
 }
 
-void MainWindowTitleProvider::setFilePath(QString filePath)
+void MainWindowTitleProvider::setFilePath(const QString& filePath)
 {
     if (filePath == m_filePath) {
         return;

--- a/src/appshell/view/mainwindowtitleprovider.cpp
+++ b/src/appshell/view/mainwindowtitleprovider.cpp
@@ -109,6 +109,6 @@ void MainWindowTitleProvider::update()
     setTitle(notation->projectNameAndPartName());
 
     project::ProjectMeta meta = project->metaInfo();
-    setFilePath(project->created().val ? "" : meta.filePath.toQString());
+    setFilePath(project->isNewlyCreated().val ? "" : meta.filePath.toQString());
     setFileModified(project->needSave().val);
 }

--- a/src/appshell/view/mainwindowtitleprovider.cpp
+++ b/src/appshell/view/mainwindowtitleprovider.cpp
@@ -108,7 +108,7 @@ void MainWindowTitleProvider::update()
     INotationPtr notation = context()->currentNotation();
     setTitle(notation->projectNameAndPartName());
 
-    project::ProjectMeta meta = project->metaInfo();
-    setFilePath(project->isNewlyCreated().val ? "" : meta.filePath.toQString());
+    setFilePath((project->isNewlyCreated() || project->isCloudProject())
+                ? "" : project->path().toQString());
     setFileModified(project->needSave().val);
 }

--- a/src/appshell/view/mainwindowtitleprovider.h
+++ b/src/appshell/view/mainwindowtitleprovider.h
@@ -53,8 +53,8 @@ signals:
 private:
     void update();
 
-    void setTitle(QString title);
-    void setFilePath(QString filePath);
+    void setTitle(const QString& title);
+    void setFilePath(const QString& filePath);
     void setFileModified(bool fileModified);
 
     QString m_title;

--- a/src/engraving/engravingproject.cpp
+++ b/src/engraving/engravingproject.cpp
@@ -109,7 +109,7 @@ Err EngravingProject::doSetupMasterScore(Ms::MasterScore* score)
     score->updateChannel();
     //score->updateExpressive(MuseScore::synthesizer("Fluid"));
     score->setSaved(true);
-    score->setCreated(false);
+    score->setNewlyCreated(false);
     score->update();
 
     if (!score->sanityCheck(QString())) {

--- a/src/engraving/engravingproject.cpp
+++ b/src/engraving/engravingproject.cpp
@@ -108,8 +108,6 @@ Err EngravingProject::doSetupMasterScore(Ms::MasterScore* score)
     }
     score->updateChannel();
     //score->updateExpressive(MuseScore::synthesizer("Fluid"));
-    score->setSaved(true);
-    score->setNewlyCreated(false);
     score->update();
 
     if (!score->sanityCheck(QString())) {
@@ -140,8 +138,6 @@ bool EngravingProject::writeMscz(mu::engraving::MscWriter& writer, bool onlySele
 {
     bool ok = m_masterScore->writeMscz(writer, onlySelection, createThumbnail);
     if (ok && !onlySelection) {
-        m_masterScore->undoStack()->setClean();
-        m_masterScore->setSaved(true);
         m_masterScore->update();
     }
 

--- a/src/engraving/libmscore/masterscore.cpp
+++ b/src/engraving/libmscore/masterscore.cpp
@@ -138,6 +138,36 @@ void MasterScore::setFileInfoProvider(IFileInfoProviderPtr fileInfoProvider)
     m_fileInfoProvider = fileInfoProvider;
 }
 
+bool MasterScore::isNewlyCreated() const
+{
+    return m_isNewlyCreated;
+}
+
+void MasterScore::setNewlyCreated(bool val)
+{
+    m_isNewlyCreated = val;
+}
+
+bool MasterScore::saved() const
+{
+    return m_saved;
+}
+
+void MasterScore::setSaved(bool v)
+{
+    m_saved = v;
+}
+
+bool MasterScore::autosaveDirty() const
+{
+    return m_autosaveDirty;
+}
+
+void MasterScore::setAutosaveDirty(bool v)
+{
+    m_autosaveDirty = v;
+}
+
 QString MasterScore::name() const
 {
     return fileInfo()->fileName(false).toQString();

--- a/src/engraving/libmscore/masterscore.h
+++ b/src/engraving/libmscore/masterscore.h
@@ -112,6 +112,10 @@ class MasterScore : public Score
     // We can't yet, because m_project is not set on every MasterScore
     IFileInfoProviderPtr m_fileInfoProvider;
 
+    bool m_isNewlyCreated { false }; /// true if the file has never been saved yet
+    bool m_saved { false };
+    bool m_autosaveDirty { true };
+
     void reorderMidiMapping();
     void rebuildExcerptsMidiMapping();
     void removeDeletedMidiMapping();
@@ -221,6 +225,15 @@ public:
 
     IFileInfoProviderPtr fileInfo() const;
     void setFileInfoProvider(IFileInfoProviderPtr fileInfoProvider);
+
+    bool isNewlyCreated() const;
+    void setNewlyCreated(bool val);
+
+    bool saved() const;
+    void setSaved(bool v);
+
+    bool autosaveDirty() const;
+    void setAutosaveDirty(bool v);
 
     QString name() const override;
 

--- a/src/engraving/libmscore/musescoreCore.h
+++ b/src/engraving/libmscore/musescoreCore.h
@@ -52,8 +52,8 @@ public:
     virtual void setCurrentView(int /*tabIdx*/, int /*idx*/) {}
 
     virtual int appendScore(MasterScore* s) { scoreList.append(s); return 0; }
-    virtual Score* openScore(const QString& /*fn*/, bool /*switchTab*/, bool considerInCurrentSession = true,
-                             const QString& /*withFilename*/ = "") { Q_UNUSED(considerInCurrentSession); return 0; }
+    virtual MasterScore* openScore(const QString& /*fn*/, bool /*switchTab*/, bool considerInCurrentSession = true,
+                                   const QString& /*withFilename*/ = "") { Q_UNUSED(considerInCurrentSession); return 0; }
     QList<MasterScore*>& scores() { return scoreList; }
 };
 } // namespace Ms

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -324,8 +324,6 @@ Score::Score()
 
     _fileDivision           = Constant::division;
     _style  = DefaultStyle::defaultStyle();
-//      accInfo = tr("No selection");     // ??
-    accInfo = "No selection";
 
     m_rootItem = new mu::engraving::RootItem(this);
     m_rootItem->init();

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -4520,15 +4520,6 @@ EngravingItem* Score::getScoreElementOfMeasureBase(MeasureBase* mb) const
 }
 
 //---------------------------------------------------------
-//   setImportedFilePath
-//---------------------------------------------------------
-
-void Score::setImportedFilePath(const QString& filePath)
-{
-    _importedFilePath = filePath;
-}
-
-//---------------------------------------------------------
 //   nmeasure
 //---------------------------------------------------------
 

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -436,8 +436,6 @@ private:
     ChordList _chordList;
 
     bool m_isNewlyCreated { false };    ///< file is never saved, has generated name
-    QString _tmpName;                   ///< auto saved with this name if not empty
-    QString _importedFilePath;          // file from which the score was imported, or empty
 
     bool _showInvisible         { true };
     bool _showUnprintable       { true };
@@ -858,9 +856,6 @@ public:
     int fileDivision(int t) const { return ((qint64)t * Constant::division + _fileDivision / 2) / _fileDivision; }
     void setFileDivision(int t) { _fileDivision = t; }
 
-    QString importedFilePath() const { return _importedFilePath; }
-    void setImportedFilePath(const QString& filePath);
-
     bool dirty() const;
     ScoreContentState state() const;
     void setNewlyCreated(bool val) { m_isNewlyCreated = val; }
@@ -1046,8 +1041,6 @@ public:
     void scanElementsInRange(void* data, void (* func)(void*, EngravingItem*), bool all = true);
     int fileDivision() const { return _fileDivision; }   ///< division of current loading *.msc file
     void splitStaff(int staffIdx, int splitPoint);
-    QString tmpName() const { return _tmpName; }
-    void setTmpName(const QString& s) { _tmpName = s; }
     Lyrics* addLyrics();
     FiguredBass* addFiguredBass();
     void expandVoice(Segment* s, int track);

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -467,8 +467,6 @@ private:
     PlayMode _playMode { PlayMode::SYNTHESIZER };
 
     qreal _noteHeadWidth { 0.0 };         // cached value
-    QString accInfo;                      ///< information about selected element(s) for use by screen-readers
-    QString accMessage;                   ///< temporary status message for use by screen-readers
 
     mu::engraving::RootItem* m_rootItem = nullptr;
     mu::engraving::Layout m_layout;
@@ -1219,9 +1217,6 @@ public:
 
     Measure* firstTrailingMeasure(ChordRest** cr = nullptr);
     ChordRest* cmdTopStaff(ChordRest* cr = nullptr);
-
-    void setAccessibleInfo(QString s) { accInfo = s.remove(":").remove(";"); }
-    QString accessibleInfo() const { return accInfo; }
 
     std::shared_ptr<mu::draw::Pixmap> createThumbnail();
     QString createRehearsalMarkText(RehearsalMark* current) const;

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -435,7 +435,7 @@ private:
     MStyle _style;
     ChordList _chordList;
 
-    bool _created { false };            ///< file is never saved, has generated name
+    bool m_isNewlyCreated { false };    ///< file is never saved, has generated name
     QString _tmpName;                   ///< auto saved with this name if not empty
     QString _importedFilePath;          // file from which the score was imported, or empty
 
@@ -865,8 +865,8 @@ public:
 
     bool dirty() const;
     ScoreContentState state() const;
-    void setCreated(bool val) { _created = val; }
-    bool created() const { return _created; }
+    void setNewlyCreated(bool val) { m_isNewlyCreated = val; }
+    bool isNewlyCreated() const { return m_isNewlyCreated; }
     bool savedCapture() const { return _savedCapture; }
     bool saved() const { return _saved; }
     void setSaved(bool v) { _saved = v; }

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -451,7 +451,7 @@ private:
     bool _saved                 { false };      ///< True if project was already saved; only on first
                                                 ///< save a backup file will be created, subsequent
                                                 ///< saves will not overwrite the backup file.
-    bool _defaultsRead        { false };        ///< defaults were read at MusicXML import, allow export of defaults in convertermode
+
     ScoreOrder _scoreOrder;                     ///< used for score ordering
     bool _resetAutoplace{ false };
     bool _resetDefaults{ false };
@@ -973,8 +973,6 @@ public:
     void setPause(const Fraction& tick, qreal seconds);
     BeatsPerSecond tempo(const Fraction& tick) const;
 
-    bool defaultsRead() const { return _defaultsRead; }
-    void setDefaultsRead(bool b) { _defaultsRead = b; }
     Text* getText(TextStyleType subtype) const;
 
     bool enableVerticalSpread() const;

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -435,8 +435,6 @@ private:
     MStyle _style;
     ChordList _chordList;
 
-    bool m_isNewlyCreated { false };    ///< file is never saved, has generated name
-
     bool _showInvisible         { true };
     bool _showUnprintable       { true };
     bool _showFrames            { true };
@@ -444,11 +442,7 @@ private:
     bool _markIrregularMeasures { true };
     bool _showInstrumentNames   { true };
     bool _printing              { false };        ///< True if we are drawing to a printer
-    bool _autosaveDirty         { true };
     bool _savedCapture          { false };        ///< True if we saved an image capture
-    bool _saved                 { false };      ///< True if project was already saved; only on first
-                                                ///< save a backup file will be created, subsequent
-                                                ///< saves will not overwrite the backup file.
 
     ScoreOrder _scoreOrder;                     ///< used for score ordering
     bool _resetAutoplace{ false };
@@ -858,16 +852,10 @@ public:
 
     bool dirty() const;
     ScoreContentState state() const;
-    void setNewlyCreated(bool val) { m_isNewlyCreated = val; }
-    bool isNewlyCreated() const { return m_isNewlyCreated; }
     bool savedCapture() const { return _savedCapture; }
-    bool saved() const { return _saved; }
-    void setSaved(bool v) { _saved = v; }
     void setSavedCapture(bool v) { _savedCapture = v; }
     bool printing() const { return _printing; }
     void setPrinting(bool val) { _printing = val; }
-    void setAutosaveDirty(bool v) { _autosaveDirty = v; }
-    bool autosaveDirty() const { return _autosaveDirty; }
     virtual bool playlistDirty() const;
     virtual void setPlaylistDirty();
 

--- a/src/engraving/rw/compat/read114.cpp
+++ b/src/engraving/rw/compat/read114.cpp
@@ -3138,7 +3138,7 @@ Score::FileError Read114::read114(MasterScore* masterScore, XmlReader& e, ReadCo
 
     // treat reading a 1.14 file as import
     // on save warn if old file will be overwritten
-    masterScore->setCreated(true);
+    masterScore->setNewlyCreated(true);
     // don't autosave (as long as there's no change to the score)
     masterScore->setAutosaveDirty(false);
 

--- a/src/engraving/rw/compat/read206.cpp
+++ b/src/engraving/rw/compat/read206.cpp
@@ -3453,7 +3453,7 @@ Score::FileError Read206::read206(Ms::MasterScore* masterScore, XmlReader& e, Re
 
     // treat reading a 2.06 file as import
     // on save warn if old file will be overwritten
-    masterScore->setCreated(true);
+    masterScore->setNewlyCreated(true);
     // don't autosave (as long as there's no change to the score)
     masterScore->setAutosaveDirty(false);
 

--- a/src/engraving/rw/compat/readstyle.cpp
+++ b/src/engraving/rw/compat/readstyle.cpp
@@ -85,19 +85,15 @@ void ReadStyleHook::setupDefaultStyle()
         return;
     }
 
-    if (m_score->isNewlyCreated() && DefaultStyle::isHasDefaultStyle()) {
-        m_score->setStyle(DefaultStyle::defaultStyle());
+    int defaultsVersion = -1;
+    if (m_score->isMaster()) {
+        defaultsVersion = readStyleDefaultsVersion(m_score->masterScore(), m_scoreData, m_completeBaseName);
     } else {
-        int defaultsVersion = -1;
-        if (m_score->isMaster()) {
-            defaultsVersion = readStyleDefaultsVersion(m_score->masterScore(), m_scoreData, m_completeBaseName);
-        } else {
-            defaultsVersion = m_score->masterScore()->style().defaultStyleVersion();
-        }
-
-        m_score->setStyle(DefaultStyle::resolveStyleDefaults(defaultsVersion));
-        m_score->style().setDefaultStyleVersion(defaultsVersion);
+        defaultsVersion = m_score->masterScore()->style().defaultStyleVersion();
     }
+
+    m_score->setStyle(DefaultStyle::resolveStyleDefaults(defaultsVersion));
+    m_score->style().setDefaultStyleVersion(defaultsVersion);
 }
 
 void ReadStyleHook::setupDefaultStyle(Ms::Score* score)

--- a/src/engraving/rw/compat/readstyle.cpp
+++ b/src/engraving/rw/compat/readstyle.cpp
@@ -85,7 +85,7 @@ void ReadStyleHook::setupDefaultStyle()
         return;
     }
 
-    if (m_score->created() && DefaultStyle::isHasDefaultStyle()) {
+    if (m_score->isNewlyCreated() && DefaultStyle::isHasDefaultStyle()) {
         m_score->setStyle(DefaultStyle::defaultStyle());
     } else {
         int defaultsVersion = -1;

--- a/src/engraving/rw/scorereader.cpp
+++ b/src/engraving/rw/scorereader.cpp
@@ -188,7 +188,7 @@ Err ScoreReader::read(MasterScore* score, XmlReader& e, ReadContext& ctx, compat
                 err = doRead(score, e, ctx);
             }
 
-            score->setCreated(false);
+            score->setNewlyCreated(false);
             score->setExcerptsChanged(false);
             return err;
         } else {

--- a/src/framework/global/io/path.cpp
+++ b/src/framework/global/io/path.cpp
@@ -29,6 +29,11 @@
 
 using namespace mu::io;
 
+path::path(const QByteArray& s)
+    : m_path(s)
+{
+}
+
 path::path(const QString& s)
     : m_path(s.toUtf8())
 {
@@ -47,6 +52,24 @@ path::path(const char* s)
 bool path::empty() const
 {
     return m_path.isEmpty();
+}
+
+path path::appendingComponent(const path& other) const
+{
+    if (m_path.endsWith('/') || other.m_path.startsWith('/')) {
+        return m_path + other.m_path;
+    }
+
+    return m_path + '/' + other.m_path;
+}
+
+path path::appendingSuffix(const path& suffix) const
+{
+    if (suffix.m_path.startsWith('.')) {
+        return m_path + suffix.m_path;
+    }
+
+    return m_path + '.' + suffix.m_path;
 }
 
 QString path::toQString() const
@@ -118,6 +141,11 @@ mu::io::path mu::io::dirpath(const mu::io::path& path)
 mu::io::path mu::io::absoluteDirpath(const mu::io::path& path)
 {
     return QFileInfo(path.toQString()).dir().absolutePath();
+}
+
+bool mu::io::isAbsolute(const path& path)
+{
+    return QFileInfo(path.toQString()).isAbsolute();
 }
 
 bool mu::io::isAllowedFileName(const path& fn_)

--- a/src/framework/global/io/path.h
+++ b/src/framework/global/io/path.h
@@ -31,11 +31,15 @@ using paths = std::vector<path>;
 struct path {
     path() = default;
     path(const path&) = default;
+    path(const QByteArray& s);
     path(const QString& s);
     path(const std::string& s);
     path(const char* s);
 
     bool empty() const;
+
+    path appendingComponent(const path& other) const;
+    path appendingSuffix(const path& suffix) const;
 
     inline path& operator=(const QString& other) { m_path = other.toUtf8(); return *this; }
 
@@ -79,6 +83,8 @@ path absolutePath(const path& path);
 path dirname(const path& path);
 path dirpath(const path& path);
 path absoluteDirpath(const path& path);
+
+bool isAbsolute(const path& path);
 
 bool isAllowedFileName(const path& fn);
 path escapeFileName(const path& fn);

--- a/src/importexport/braille/tests/tst_braille_io.cpp
+++ b/src/importexport/braille/tests/tst_braille_io.cpp
@@ -129,7 +129,7 @@ static void fixupScore(Score* score)
 {
     score->connectTies();
     score->masterScore()->rebuildMidiMapping();
-    score->setCreated(false);
+    score->setNewlyCreated(false);
     score->setSaved(false);
 }
 

--- a/src/importexport/braille/tests/tst_braille_io.cpp
+++ b/src/importexport/braille/tests/tst_braille_io.cpp
@@ -125,7 +125,7 @@ void TestBrailleIO::initTestCase()
 //   see mscore/file.cpp MuseScore::readScore(Score* score, QString name)
 //---------------------------------------------------------
 
-static void fixupScore(Score* score)
+static void fixupScore(MasterScore* score)
 {
     score->connectTies();
     score->masterScore()->rebuildMidiMapping();

--- a/src/importexport/bww/internal/bww/importbww.cpp
+++ b/src/importexport/bww/internal/bww/importbww.cpp
@@ -565,7 +565,7 @@ Score::FileError importBww(MasterScore* score, const QString& path)
     p.parse();
 
     score->setSaved(false);
-    score->setCreated(true);
+    score->setNewlyCreated(true);
     score->connectTies();
     qDebug("Score::importBww() done");
     return Score::FileError::FILE_NO_ERROR;        // OK

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -3092,7 +3092,7 @@ Score::FileError importGTP(MasterScore* score, const QString& name)
     //      album
     //      copyright
 
-    score->setCreated(true);
+    score->setNewlyCreated(true);
     delete gp;
 
     return Score::FileError::FILE_NO_ERROR;

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -1581,8 +1581,6 @@ void MusicXMLParserPass1::defaults()
            qPrintable(lyricFontFamily), qPrintable(lyricFontSize));
     */
     updateStyles(_score, wordFontFamily, wordFontSize, lyricFontFamily, lyricFontSize);
-
-    _score->setDefaultsRead(true);   // TODO only if actually succeeded ?
 }
 
 //---------------------------------------------------------

--- a/src/importexport/musicxml/tests/tst_mxml_io.cpp
+++ b/src/importexport/musicxml/tests/tst_mxml_io.cpp
@@ -261,7 +261,7 @@ void TestMxmlIO::initTestCase()
 //   see mscore/file.cpp MuseScore::readScore(Score* score, QString name)
 //---------------------------------------------------------
 
-static void fixupScore(Score* score)
+static void fixupScore(MasterScore* score)
 {
     score->connectTies();
     score->masterScore()->rebuildMidiMapping();

--- a/src/importexport/musicxml/tests/tst_mxml_io.cpp
+++ b/src/importexport/musicxml/tests/tst_mxml_io.cpp
@@ -265,7 +265,7 @@ static void fixupScore(Score* score)
 {
     score->connectTies();
     score->masterScore()->rebuildMidiMapping();
-    score->setCreated(false);
+    score->setNewlyCreated(false);
     score->setSaved(false);
 }
 

--- a/src/notation/imasternotation.h
+++ b/src/notation/imasternotation.h
@@ -39,7 +39,7 @@ class IMasterNotation
 public:
     virtual INotationPtr notation() = 0;
 
-    virtual RetVal<bool> created() const = 0;
+    virtual RetVal<bool> isNewlyCreated() const = 0;
     virtual ValNt<bool> needSave() const = 0;
 
     virtual IExcerptNotationPtr newExcerptBlankNotation() const = 0;

--- a/src/notation/imasternotation.h
+++ b/src/notation/imasternotation.h
@@ -39,7 +39,7 @@ class IMasterNotation
 public:
     virtual INotationPtr notation() = 0;
 
-    virtual RetVal<bool> isNewlyCreated() const = 0;
+    virtual bool isNewlyCreated() const = 0;
     virtual ValNt<bool> needSave() const = 0;
 
     virtual IExcerptNotationPtr newExcerptBlankNotation() const = 0;

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -449,15 +449,13 @@ void MasterNotation::applyOptions(Ms::MasterScore* score, const ScoreCreateOptio
     }
 }
 
-mu::RetVal<bool> MasterNotation::isNewlyCreated() const
+bool MasterNotation::isNewlyCreated() const
 {
-    RetVal<bool> result;
-    if (!score()) {
-        result.ret = make_ret(Err::NoScore);
-        return result;
+    IF_ASSERT_FAILED(masterScore()) {
+        return true;
     }
 
-    return RetVal<bool>::make_ok(masterScore()->isNewlyCreated());
+    return masterScore()->isNewlyCreated();
 }
 
 mu::ValNt<bool> MasterNotation::needSave() const

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -457,7 +457,7 @@ mu::RetVal<bool> MasterNotation::isNewlyCreated() const
         return result;
     }
 
-    return RetVal<bool>::make_ok(score()->isNewlyCreated());
+    return RetVal<bool>::make_ok(masterScore()->isNewlyCreated());
 }
 
 mu::ValNt<bool> MasterNotation::needSave() const

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -271,7 +271,7 @@ void MasterNotation::applyOptions(Ms::MasterScore* score, const ScoreCreateOptio
     }
 
     score->setSaved(true);
-    score->setCreated(true);
+    score->setNewlyCreated(true);
 
     score->checkChordList();
 
@@ -449,7 +449,7 @@ void MasterNotation::applyOptions(Ms::MasterScore* score, const ScoreCreateOptio
     }
 }
 
-mu::RetVal<bool> MasterNotation::created() const
+mu::RetVal<bool> MasterNotation::isNewlyCreated() const
 {
     RetVal<bool> result;
     if (!score()) {
@@ -457,7 +457,7 @@ mu::RetVal<bool> MasterNotation::created() const
         return result;
     }
 
-    return RetVal<bool>::make_ok(score()->created());
+    return RetVal<bool>::make_ok(score()->isNewlyCreated());
 }
 
 mu::ValNt<bool> MasterNotation::needSave() const

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -617,12 +617,6 @@ ExcerptNotationList MasterNotation::potentialExcerpts() const
     return result;
 }
 
-void MasterNotation::onSaveCopy()
-{
-    score()->setCreated(false);
-    undoStack()->stackChanged().notify();
-}
-
 void MasterNotation::initExcerptNotations(const QList<Ms::Excerpt*>& excerpts)
 {
     TRACEFUNC;

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -51,7 +51,7 @@ public:
 
     INotationPtr notation() override;
 
-    RetVal<bool> created() const override;
+    RetVal<bool> isNewlyCreated() const override;
 
     mu::ValNt<bool> needSave() const override;
 

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -51,8 +51,7 @@ public:
 
     INotationPtr notation() override;
 
-    RetVal<bool> isNewlyCreated() const override;
-
+    bool isNewlyCreated() const override;
     mu::ValNt<bool> needSave() const override;
 
     IExcerptNotationPtr newExcerptBlankNotation() const override;

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -48,7 +48,6 @@ public:
     void setMasterScore(Ms::MasterScore* masterScore);
     Ret setupNewScore(Ms::MasterScore* score, const ScoreCreateOptions& scoreOptions);
     void applyOptions(Ms::MasterScore* score, const ScoreCreateOptions& scoreOptions, bool createdFromTemplate = false);
-    void onSaveCopy();
 
     INotationPtr notation() override;
 

--- a/src/notation/view/notationswitchlistmodel.cpp
+++ b/src/notation/view/notationswitchlistmodel.cpp
@@ -25,6 +25,7 @@
 #include "log.h"
 
 using namespace mu::notation;
+using namespace mu::project;
 
 NotationSwitchListModel::NotationSwitchListModel(QObject* parent)
     : QAbstractListModel(parent)
@@ -35,9 +36,9 @@ void NotationSwitchListModel::load()
 {
     TRACEFUNC;
 
-    onMasterNotationChanged();
-    context()->currentMasterNotationChanged().onNotify(this, [this]() {
-        onMasterNotationChanged();
+    onCurrentProjectChanged();
+    context()->currentProjectChanged().onNotify(this, [this]() {
+        onCurrentProjectChanged();
     });
 
     onCurrentNotationChanged();
@@ -46,20 +47,20 @@ void NotationSwitchListModel::load()
     });
 }
 
-void NotationSwitchListModel::onMasterNotationChanged()
+void NotationSwitchListModel::onCurrentProjectChanged()
 {
     loadNotations();
 
-    IMasterNotationPtr master = masterNotation();
-    if (!master) {
+    INotationProjectPtr project = context()->currentProject();
+    if (!project) {
         return;
     }
 
-    master->excerpts().ch.onReceive(this, [this](ExcerptNotationList) {
+    project->masterNotation()->excerpts().ch.onReceive(this, [this](ExcerptNotationList) {
         loadNotations();
     });
 
-    listenNotationSavingStatus(master);
+    listenProjectSavingStatusChanged(project);
 }
 
 void NotationSwitchListModel::onCurrentNotationChanged()
@@ -129,12 +130,18 @@ void NotationSwitchListModel::listenNotationTitleChanged(INotationPtr notation)
     });
 }
 
-void NotationSwitchListModel::listenNotationSavingStatus(IMasterNotationPtr masterNotation)
+void NotationSwitchListModel::listenProjectSavingStatusChanged(project::INotationProjectPtr project)
 {
-    masterNotation->needSave().notification.onNotify(this, [this, masterNotation]() {
-        int index = m_notations.indexOf(masterNotation->notation());
+    project->needSave().notification.onNotify(this, [this, project]() {
+        int index = m_notations.indexOf(project->masterNotation()->notation());
         QModelIndex modelIndex = this->index(index);
         emit dataChanged(modelIndex, modelIndex, { RoleNeedSave });
+    });
+
+    project->pathChanged().onNotify(this, [this, project]() {
+        int index = m_notations.indexOf(project->masterNotation()->notation());
+        QModelIndex modelIndex = this->index(index);
+        emit dataChanged(modelIndex, modelIndex, { RoleTitle });
     });
 }
 

--- a/src/notation/view/notationswitchlistmodel.h
+++ b/src/notation/view/notationswitchlistmodel.h
@@ -29,6 +29,7 @@
 #include "async/asyncable.h"
 #include "context/iglobalcontext.h"
 #include "actions/iactionsdispatcher.h"
+#include "project/inotationproject.h"
 
 namespace mu::notation {
 class NotationSwitchListModel : public QAbstractListModel, public async::Asyncable
@@ -53,15 +54,15 @@ signals:
     void currentNotationIndexChanged(int index);
 
 private:
-    void onMasterNotationChanged();
+    void onCurrentProjectChanged();
     void onCurrentNotationChanged();
 
     IMasterNotationPtr masterNotation() const;
 
     void loadNotations();
+    void listenProjectSavingStatusChanged(project::INotationProjectPtr project);
     void listenNotationOpeningStatus(INotationPtr notation);
     void listenNotationTitleChanged(INotationPtr notation);
-    void listenNotationSavingStatus(IMasterNotationPtr masterNotation);
     bool isIndexValid(int index) const;
 
     bool isMasterNotation(const INotationPtr notation) const;

--- a/src/notation/view/widgets/editstafftype.cpp
+++ b/src/notation/view/widgets/editstafftype.cpp
@@ -198,15 +198,6 @@ mu::Ret EditStaffType::loadScore(Ms::MasterScore* score, const mu::io::path& pat
 {
     Ms::ScoreLoad sl;
 
-    return doLoadScore(score, path);
-}
-
-mu::Ret EditStaffType::doLoadScore(Ms::MasterScore* score, const mu::io::path& path) const
-{
-    QFileInfo fi(path.toQString());
-    score->setImportedFilePath(fi.filePath());
-    score->setMetaTag("originalFormat", fi.suffix().toLower());
-
     if (compat::loadMsczOrMscx(score, path.toQString()) != Ms::Score::FileError::FILE_NO_ERROR) {
         return make_ret(Ret::Code::UnknownError);
     }

--- a/src/notation/view/widgets/editstafftype.h
+++ b/src/notation/view/widgets/editstafftype.h
@@ -79,7 +79,6 @@ public:
 
 private:
     mu::Ret loadScore(Ms::MasterScore* score, const io::path& path);
-    mu::Ret doLoadScore(Ms::MasterScore* score, const io::path& path) const;
 };
 }
 #endif

--- a/src/plugins/api/qmlpluginapi.cpp
+++ b/src/plugins/api/qmlpluginapi.cpp
@@ -131,7 +131,7 @@ bool PluginAPI::writeScore(Score* s, const QString& name, const QString& ext)
 
 Score* PluginAPI::readScore(const QString& name, bool noninteractive)
 {
-    Ms::Score* score = msc()->openScore(name, !noninteractive);
+    Ms::MasterScore* score = msc()->openScore(name, !noninteractive);
     if (score) {
         if (noninteractive) {
             score->setNewlyCreated(false);

--- a/src/plugins/api/qmlpluginapi.cpp
+++ b/src/plugins/api/qmlpluginapi.cpp
@@ -134,7 +134,7 @@ Score* PluginAPI::readScore(const QString& name, bool noninteractive)
     Ms::Score* score = msc()->openScore(name, !noninteractive);
     if (score) {
         if (noninteractive) {
-            score->setCreated(false);
+            score->setNewlyCreated(false);
         }
     }
     return wrap<Score>(score, Ownership::SCORE);

--- a/src/project/inotationproject.h
+++ b/src/project/inotationproject.h
@@ -46,7 +46,7 @@ public:
 
     virtual bool isCloudProject() const = 0;
 
-    virtual RetVal<bool> created() const = 0;
+    virtual RetVal<bool> isNewlyCreated() const = 0;
     virtual ValNt<bool> needSave() const = 0;
 
     virtual Ret save(const io::path& path = io::path(), SaveMode saveMode = SaveMode::Save) = 0;

--- a/src/project/inotationproject.h
+++ b/src/project/inotationproject.h
@@ -39,6 +39,7 @@ public:
     virtual ~INotationProject() = default;
 
     virtual io::path path() const = 0;
+    virtual async::Notification pathChanged() const = 0;
 
     virtual Ret load(const io::path& path, const io::path& stylePath = io::path(), bool forceMode = false) = 0;
     virtual Ret createNew(const ProjectCreateOptions& projectInfo) = 0;

--- a/src/project/inotationproject.h
+++ b/src/project/inotationproject.h
@@ -44,6 +44,8 @@ public:
     virtual Ret load(const io::path& path, const io::path& stylePath = io::path(), bool forceMode = false) = 0;
     virtual Ret createNew(const ProjectCreateOptions& projectInfo) = 0;
 
+    virtual bool isCloudProject() const = 0;
+
     virtual RetVal<bool> created() const = 0;
     virtual ValNt<bool> needSave() const = 0;
 

--- a/src/project/inotationproject.h
+++ b/src/project/inotationproject.h
@@ -46,7 +46,7 @@ public:
 
     virtual bool isCloudProject() const = 0;
 
-    virtual RetVal<bool> isNewlyCreated() const = 0;
+    virtual bool isNewlyCreated() const = 0;
     virtual ValNt<bool> needSave() const = 0;
 
     virtual Ret save(const io::path& path = io::path(), SaveMode saveMode = SaveMode::Save) = 0;

--- a/src/project/internal/exportprojectscenario.cpp
+++ b/src/project/internal/exportprojectscenario.cpp
@@ -151,15 +151,9 @@ bool ExportProjectScenario::isMainNotation(INotationPtr notation) const
 mu::io::path ExportProjectScenario::askExportPath(const INotationPtrList& notations, const ExportType& exportType,
                                                   INotationWriter::UnitType unitType) const
 {
-    INotationProjectPtr currentNotationProject = context()->currentProject();
+    INotationProjectPtr project = context()->currentProject();
 
-    io::path suggestedPath = configuration()->userProjectsPath();
-    io::path notationProjectDirPath = io::dirpath(currentNotationProject->path());
-    if (!notationProjectDirPath.empty()) {
-        suggestedPath = notationProjectDirPath;
-    }
-
-    suggestedPath += "/" + io::filename(currentNotationProject->path(), false);
+    QString filenameAddition;
 
     // If only one file will be created, the filename will be exactly what the user
     // types in the save dialog and therefore we can put the file dialog in charge of
@@ -174,24 +168,24 @@ mu::io::path ExportProjectScenario::askExportPath(const INotationPtrList& notati
         }) != notations.cend();
 
         if (containsMaster) {
-            suggestedPath += "-" + qtrc("project", "Score_and_Parts", "Used in export filename suggestion");
+            filenameAddition = "-" + qtrc("project", "Score_and_Parts", "Used in export filename suggestion");
         } else {
-            suggestedPath += "-" + qtrc("project", "Parts", "Used in export filename suggestion");
+            filenameAddition = "-" + qtrc("project", "Parts", "Used in export filename suggestion");
         }
     } else if (isExportingOnlyOneScore) {
         if (!isMainNotation(notations.front())) {
-            suggestedPath += "-" + io::escapeFileName(notations.front()->name());
+            filenameAddition = "-" + io::escapeFileName(notations.front()->name()).toQString();
         }
 
         if (unitType == INotationWriter::UnitType::PER_PAGE && isCreatingOnlyOneFile) {
             // So there is only one page
-            suggestedPath += "-1";
+            filenameAddition += "-1";
         }
     }
 
-    suggestedPath += "." + exportType.suffixes.front();
+    io::path defaultPath = configuration()->defaultSavingFilePath(project, filenameAddition, exportType.suffixes.front());
 
-    return interactive()->selectSavingFile(qtrc("project", "Export"), suggestedPath,
+    return interactive()->selectSavingFile(qtrc("project", "Export"), defaultPath,
                                            exportType.filter(), isCreatingOnlyOneFile);
 }
 

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -299,6 +299,26 @@ mu::Ret NotationProject::createNew(const ProjectCreateOptions& projectOptions)
     return make_ret(Ret::Code::Ok);
 }
 
+mu::Ret NotationProject::loadTemplate(const ProjectCreateOptions& projectOptions)
+{
+    TRACEFUNC;
+
+    Ret ret = load(projectOptions.templatePath);
+
+    if (ret) {
+        setPath(projectOptions.title.isEmpty() ? qtrc("project", "Untitled") : projectOptions.title);
+
+        Ms::MasterScore* masterScore = m_masterNotation->masterScore();
+        setupScoreMetaTags(masterScore, projectOptions);
+
+        m_masterNotation->undoStack()->lock();
+        m_masterNotation->applyOptions(masterScore, projectOptions.scoreOptions, true /*createdFromTemplate*/);
+        m_masterNotation->undoStack()->unlock();
+    }
+
+    return ret;
+}
+
 io::path NotationProject::path() const
 {
     return m_path;
@@ -319,24 +339,9 @@ void NotationProject::setPath(const io::path& path)
     m_pathChanged.notify();
 }
 
-mu::Ret NotationProject::loadTemplate(const ProjectCreateOptions& projectOptions)
+bool NotationProject::isCloudProject() const
 {
-    TRACEFUNC;
-
-    Ret ret = load(projectOptions.templatePath);
-
-    if (ret) {
-        setPath(projectOptions.title.isEmpty() ? qtrc("project", "Untitled") : projectOptions.title);
-
-        Ms::MasterScore* masterScore = m_masterNotation->masterScore();
-        setupScoreMetaTags(masterScore, projectOptions);
-
-        m_masterNotation->undoStack()->lock();
-        m_masterNotation->applyOptions(masterScore, projectOptions.scoreOptions, true /*createdFromTemplate*/);
-        m_masterNotation->undoStack()->unlock();
-    }
-
-    return ret;
+    return configuration()->isCloudProject(m_path);
 }
 
 mu::Ret NotationProject::save(const io::path& path, SaveMode saveMode)

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -482,7 +482,7 @@ mu::Ret NotationProject::doSave(const io::path& path, bool generateBackup, engra
 
 mu::Ret NotationProject::makeCurrentFileAsBackup()
 {
-    if (isNewlyCreated().val) {
+    if (isNewlyCreated()) {
         LOGD() << "project just created";
         return make_ret(Ret::Code::Ok);
     }
@@ -602,7 +602,7 @@ IMasterNotationPtr NotationProject::masterNotation() const
     return m_masterNotation;
 }
 
-mu::RetVal<bool> NotationProject::isNewlyCreated() const
+bool NotationProject::isNewlyCreated() const
 {
     return m_masterNotation->isNewlyCreated();
 }

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -152,8 +152,8 @@ mu::Ret NotationProject::load(const io::path& path, const io::path& stylePath, b
         return ret;
     }
 
-    m_masterNotation->score()->setNewlyCreated(false);
-    m_masterNotation->score()->setSaved(!needRestoreUnsavedChanges);
+    m_masterNotation->masterScore()->setNewlyCreated(false);
+    m_masterNotation->masterScore()->setSaved(!needRestoreUnsavedChanges);
 
     return ret;
 }
@@ -375,8 +375,8 @@ mu::Ret NotationProject::save(const io::path& path, SaveMode saveMode)
         if (ret) {
             if (saveMode != SaveMode::SaveCopy) {
                 setPath(savePath);
-                m_masterNotation->score()->setNewlyCreated(false);
-                m_masterNotation->score()->setSaved(true);
+                m_masterNotation->masterScore()->setNewlyCreated(false);
+                m_masterNotation->masterScore()->setSaved(true);
                 m_masterNotation->undoStack()->stackChanged().notify();
             }
         }

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -260,7 +260,7 @@ mu::Ret NotationProject::doImport(const io::path& path, const io::path& stylePat
 
     // Set current if all success
     m_masterNotation->setMasterScore(score);
-    score->setCreated(true);
+    score->setNewlyCreated(true);
 
     return make_ret(Ret::Code::Ok);
 }
@@ -371,7 +371,7 @@ mu::Ret NotationProject::save(const io::path& path, SaveMode saveMode)
                 m_masterNotation->score()->setSaved(false);
             } else {
                 setPath(savePath);
-                m_masterNotation->score()->setCreated(false);
+                m_masterNotation->score()->setNewlyCreated(false);
                 m_masterNotation->undoStack()->stackChanged().notify();
             }
         }
@@ -482,7 +482,7 @@ mu::Ret NotationProject::doSave(const io::path& path, bool generateBackup, engra
 
 mu::Ret NotationProject::makeCurrentFileAsBackup()
 {
-    if (!created().val) {
+    if (isNewlyCreated().val) {
         LOGD() << "project just created";
         return make_ret(Ret::Code::Ok);
     }
@@ -602,9 +602,9 @@ IMasterNotationPtr NotationProject::masterNotation() const
     return m_masterNotation;
 }
 
-mu::RetVal<bool> NotationProject::created() const
+mu::RetVal<bool> NotationProject::isNewlyCreated() const
 {
-    return m_masterNotation->created();
+    return m_masterNotation->isNewlyCreated();
 }
 
 mu::ValNt<bool> NotationProject::needSave() const

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -66,7 +66,7 @@ public:
 
     bool isCloudProject() const override;
 
-    RetVal<bool> isNewlyCreated() const override;
+    bool isNewlyCreated() const override;
     ValNt<bool> needSave() const override;
 
     Ret save(const io::path& path = io::path(), SaveMode saveMode = SaveMode::Save) override;

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -80,7 +80,7 @@ private:
     Ret doLoad(engraving::MscReader& reader, const io::path& stylePath, bool forceMode);
     Ret doImport(const io::path& path, const io::path& stylePath, bool forceMode);
 
-    void setSaveLocation(const SaveLocation& saveLocation);
+    void setPath(const io::path& path);
 
     Ret saveScore(const io::path& path, const std::string& fileSuffix);
     Ret saveSelectionOnScore(const io::path& path = io::path());
@@ -94,7 +94,7 @@ private:
     ProjectAudioSettingsPtr m_projectAudioSettings = nullptr;
     ProjectViewSettingsPtr m_viewSettings = nullptr;
 
-    SaveLocation m_saveLocation = SaveLocation::makeInvalid();
+    io::path m_path = "";
 };
 }
 

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -26,6 +26,7 @@
 
 #include "modularity/ioc.h"
 #include "system/ifilesystem.h"
+#include "iprojectconfiguration.h"
 #include "inotationreadersregister.h"
 #include "inotationwritersregister.h"
 #include "iprojectautosaver.h"
@@ -47,6 +48,7 @@ namespace mu::project {
 class NotationProject : public INotationProject
 {
     INJECT(project, system::IFileSystem, fileSystem)
+    INJECT(project, IProjectConfiguration, configuration)
     INJECT(project, INotationReadersRegister, readers)
     INJECT(project, INotationWritersRegister, writers)
     INJECT(project, IProjectMigrator, migrator)
@@ -61,6 +63,8 @@ public:
 
     io::path path() const override;
     async::Notification pathChanged() const override;
+
+    bool isCloudProject() const override;
 
     RetVal<bool> created() const override;
     ValNt<bool> needSave() const override;

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -60,6 +60,7 @@ public:
     Ret createNew(const ProjectCreateOptions& projectInfo) override;
 
     io::path path() const override;
+    async::Notification pathChanged() const override;
 
     RetVal<bool> created() const override;
     ValNt<bool> needSave() const override;
@@ -94,7 +95,8 @@ private:
     ProjectAudioSettingsPtr m_projectAudioSettings = nullptr;
     ProjectViewSettingsPtr m_viewSettings = nullptr;
 
-    io::path m_path = "";
+    io::path m_path;
+    async::Notification m_pathChanged;
 };
 }
 

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -66,7 +66,7 @@ public:
 
     bool isCloudProject() const override;
 
-    RetVal<bool> created() const override;
+    RetVal<bool> isNewlyCreated() const override;
     ValNt<bool> needSave() const override;
 
     Ret save(const io::path& path = io::path(), SaveMode saveMode = SaveMode::Save) override;

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -279,7 +279,6 @@ bool ProjectActionsController::closeOpenedProject(bool quitApp)
     }
 
     bool result = true;
-    bool needRemoveUnsavedChanges = false;
 
     if (project->needSave().val) {
         IInteractive::Button btn = askAboutSavingScore(project->path());
@@ -290,12 +289,7 @@ bool ProjectActionsController::closeOpenedProject(bool quitApp)
             result = saveProject();
         } else if (btn == IInteractive::Button::DontSave) {
             result = true;
-            needRemoveUnsavedChanges = true;
         }
-    }
-
-    if (needRemoveUnsavedChanges) {
-        projectAutoSaver()->removeProjectUnsavedChanges(project->path());
     }
 
     if (result) {

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -340,7 +340,7 @@ bool ProjectActionsController::saveProject(const io::path& path)
         return false;
     }
 
-    if (!project->isNewlyCreated().val) {
+    if (!project->isNewlyCreated()) {
         return doSaveScore();
     }
 
@@ -448,7 +448,7 @@ void ProjectActionsController::saveOnline()
         meta.source = newSource;
         project->setMetaInfo(meta);
 
-        if (!project->isNewlyCreated().val) {
+        if (!project->isNewlyCreated()) {
             project->save();
         }
     }, Asyncable::AsyncMode::AsyncSetRepeat);

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -570,10 +570,6 @@ bool ProjectActionsController::doSaveScore(const io::path& filePath, project::Sa
         return false;
     }
 
-    if (oldPath != filePath) {
-        globalContext()->currentMasterNotationChanged().notify();
-    }
-
     prependToRecentScoreList(filePath);
     return true;
 }

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -346,7 +346,7 @@ bool ProjectActionsController::saveProject(const io::path& path)
         return false;
     }
 
-    if (!project->created().val) {
+    if (!project->isNewlyCreated().val) {
         return doSaveScore();
     }
 
@@ -454,7 +454,7 @@ void ProjectActionsController::saveOnline()
         meta.source = newSource;
         project->setMetaInfo(meta);
 
-        if (project->created().val) {
+        if (!project->isNewlyCreated().val) {
             project->save();
         }
     }, Asyncable::AsyncMode::AsyncSetRepeat);

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -606,16 +606,6 @@ void ProjectActionsController::prependToRecentScoreList(const io::path& filePath
     platformRecentFilesController()->addRecentFile(filePath);
 }
 
-bool ProjectActionsController::isProjectOpened() const
-{
-    return currentNotationProject() != nullptr;
-}
-
-bool ProjectActionsController::isNeedSaveScore() const
-{
-    return currentNotationProject() && currentNotationProject()->needSave().val;
-}
-
 bool ProjectActionsController::hasSelection() const
 {
     return currentNotationSelection() ? !currentNotationSelection()->isNone() : false;

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -340,12 +340,13 @@ IInteractive::Button ProjectActionsController::askAboutSavingScore(const io::pat
 
 bool ProjectActionsController::saveProject(const io::path& path)
 {
-    if (!currentNotationProject()) {
+    auto project = currentNotationProject();
+    if (!project) {
         LOGW() << "no current project";
         return false;
     }
 
-    if (!currentNotationProject()->created().val) {
+    if (!project->created().val) {
         return doSaveScore();
     }
 
@@ -353,7 +354,7 @@ bool ProjectActionsController::saveProject(const io::path& path)
     if (!path.empty()) {
         filePath = path;
     } else {
-        io::path defaultFilePath = defaultSavingFilePath();
+        io::path defaultFilePath = configuration()->defaultSavingFilePath(project);
         filePath = selectScoreSavingFile(defaultFilePath, qtrc("project", "Save score"));
     }
 
@@ -371,7 +372,8 @@ bool ProjectActionsController::saveProject(const io::path& path)
 
 void ProjectActionsController::saveProjectAs()
 {
-    io::path defaultFilePath = defaultSavingFilePath();
+    auto project = currentNotationProject();
+    io::path defaultFilePath = configuration()->defaultSavingFilePath(project);
     io::path selectedFilePath = selectScoreSavingFile(defaultFilePath, qtrc("project", "Save score"));
     if (selectedFilePath.empty()) {
         return;
@@ -382,7 +384,10 @@ void ProjectActionsController::saveProjectAs()
 
 void ProjectActionsController::saveProjectCopy()
 {
-    io::path defaultFilePath = defaultSavingFilePath();
+    auto project = currentNotationProject();
+    QString fileNameAddition = " " + qtrc("project", "(copy)");
+
+    io::path defaultFilePath = configuration()->defaultSavingFilePath(project, fileNameAddition);
     io::path selectedFilePath = selectScoreSavingFile(defaultFilePath, qtrc("project", "Save a copy"));
     if (selectedFilePath.empty()) {
         return;
@@ -393,7 +398,10 @@ void ProjectActionsController::saveProjectCopy()
 
 void ProjectActionsController::saveSelection()
 {
-    io::path defaultFilePath = defaultSavingFilePath();
+    auto project = currentNotationProject();
+    QString fileNameAddition = " " + qtrc("project", "(selection)");
+
+    io::path defaultFilePath = configuration()->defaultSavingFilePath(project, fileNameAddition);
     io::path selectedFilePath = selectScoreSavingFile(defaultFilePath, qtrc("project", "Save selection"));
     if (selectedFilePath.empty()) {
         return;
@@ -572,20 +580,6 @@ bool ProjectActionsController::doSaveScore(const io::path& filePath, project::Sa
 
     prependToRecentScoreList(filePath);
     return true;
-}
-
-io::path ProjectActionsController::defaultSavingFilePath() const
-{
-    ProjectMeta scoreMetaInfo = currentNotationProject()->metaInfo();
-
-    io::path fileName = scoreMetaInfo.fileName();
-
-    // If not saved yet, fall back to the title entered in the New Score Dialog
-    if (fileName.empty()) {
-        fileName = scoreMetaInfo.title;
-    }
-
-    return configuration()->defaultSavingFilePath(fileName);
 }
 
 void ProjectActionsController::prependToRecentScoreList(const io::path& filePath)

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -112,8 +112,6 @@ private:
 
     void prependToRecentScoreList(const io::path& filePath);
 
-    bool isProjectOpened() const;
-    bool isNeedSaveScore() const;
     bool hasSelection() const;
 
     bool m_isProjectProcessing = false;

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -108,8 +108,6 @@ private:
     void exportScore();
     void printScore();
 
-    io::path defaultSavingFilePath() const;
-
     void prependToRecentScoreList(const io::path& filePath);
 
     bool hasSelection() const;

--- a/src/project/internal/projectautosaver.cpp
+++ b/src/project/internal/projectautosaver.cpp
@@ -105,7 +105,7 @@ void ProjectAutoSaver::onTrySave()
         return;
     }
 
-    if (project->created().val) {
+    if (project->isNewlyCreated().val) {
         LOGD() << "[autosave] project just created";
         return;
     }

--- a/src/project/internal/projectautosaver.cpp
+++ b/src/project/internal/projectautosaver.cpp
@@ -104,7 +104,7 @@ void ProjectAutoSaver::update()
     io::path newProjectPath;
 
     auto project = currentProject();
-    if (project && !project->isNewlyCreated().val && project->needSave().val) {
+    if (project && !project->isNewlyCreated() && project->needSave().val) {
         newProjectPath = project->path();
     }
 
@@ -124,7 +124,7 @@ void ProjectAutoSaver::onTrySave()
         return;
     }
 
-    if (project->isNewlyCreated().val) {
+    if (project->isNewlyCreated()) {
         LOGD() << "[autosave] project just created";
         return;
     }

--- a/src/project/internal/projectautosaver.h
+++ b/src/project/internal/projectautosaver.h
@@ -54,9 +54,12 @@ public:
 private:
     INotationProjectPtr currentProject() const;
 
+    void update();
+
     void onTrySave();
 
     QTimer m_timer;
+    io::path m_lastProjectPathNeedingAutosave;
 };
 }
 

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -218,7 +218,7 @@ io::path ProjectConfiguration::defaultSavingFilePath(INotationProjectPtr project
 
     io::path projectPath = project->path();
 
-    if (project->isNewlyCreated().val) {
+    if (project->isNewlyCreated()) {
         if (io::isAbsolute(projectPath)) {
             folderPath = io::dirpath(projectPath);
         }

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -218,7 +218,7 @@ io::path ProjectConfiguration::defaultSavingFilePath(INotationProjectPtr project
 
     io::path projectPath = project->path();
 
-    if (project->created().val) {
+    if (project->isNewlyCreated().val) {
         if (io::isAbsolute(projectPath)) {
             folderPath = io::dirpath(projectPath);
         }

--- a/src/project/internal/projectconfiguration.h
+++ b/src/project/internal/projectconfiguration.h
@@ -59,7 +59,11 @@ public:
     void setUserProjectsPath(const io::path& path) override;
     async::Channel<io::path> userProjectsPathChanged() const override;
 
-    io::path defaultSavingFilePath(const io::path& fileName) const override;
+    io::path cloudProjectsPath() const override;
+    bool isCloudProject(const io::path& path) const override;
+
+    io::path defaultSavingFilePath(INotationProjectPtr project, const QString& filenameAddition = QString(),
+                                   const QString& suffix = QString()) const override;
 
     SaveLocationType lastUsedSaveLocationType() const override;
     void setLastUsedSaveLocationType(SaveLocationType type) override;

--- a/src/project/internal/projectfileinfoprovider.cpp
+++ b/src/project/internal/projectfileinfoprovider.cpp
@@ -34,7 +34,7 @@ ProjectFileInfoProvider::ProjectFileInfoProvider(NotationProject* project)
 {
 }
 
-//! TODO: update this class when SaveLocation gets implemented further
+//! TODO: maybe implement this class further for Cloud Projects
 io::path ProjectFileInfoProvider::path() const
 {
     return m_project->path();

--- a/src/project/iprojectconfiguration.h
+++ b/src/project/iprojectconfiguration.h
@@ -29,6 +29,7 @@
 #include "io/path.h"
 #include "async/channel.h"
 #include "async/notification.h"
+#include "inotationproject.h"
 #include "projecttypes.h"
 
 namespace mu::project {
@@ -56,7 +57,11 @@ public:
     virtual void setUserProjectsPath(const io::path& path) = 0;
     virtual async::Channel<io::path> userProjectsPathChanged() const = 0;
 
-    virtual io::path defaultSavingFilePath(const io::path& fileName) const = 0;
+    virtual io::path cloudProjectsPath() const = 0;
+    virtual bool isCloudProject(const io::path& path) const = 0;
+
+    virtual io::path defaultSavingFilePath(INotationProjectPtr project,
+                                           const QString& filenameAddition = QString(), const QString& suffix = QString()) const = 0;
 
     virtual SaveLocationType lastUsedSaveLocationType() const = 0;
     virtual void setLastUsedSaveLocationType(SaveLocationType type) = 0;

--- a/src/project/projecttypes.h
+++ b/src/project/projecttypes.h
@@ -73,60 +73,6 @@ enum class SaveLocationType
     Cloud
 };
 
-struct SaveLocation {
-    struct LocalInfo {
-        io::path path;
-    };
-
-    struct CloudInfo {
-        // TODO
-    };
-
-    SaveLocationType type = SaveLocationType::Undefined;
-    std::variant<LocalInfo, CloudInfo> info;
-
-    bool isLocal() const
-    {
-        return type == SaveLocationType::Local
-               && std::holds_alternative<LocalInfo>(info);
-    }
-
-    bool isCloud() const
-    {
-        return type == SaveLocationType::Cloud
-               && std::holds_alternative<CloudInfo>(info);
-    }
-
-    bool isValid() const
-    {
-        return isLocal() || isCloud();
-    }
-
-    io::path localPath() const
-    {
-        IF_ASSERT_FAILED(isLocal()) {
-            return {};
-        }
-
-        return std::get<LocalInfo>(info).path;
-    }
-
-    static SaveLocation makeInvalid()
-    {
-        return {};
-    }
-
-    static SaveLocation makeLocal(const io::path& path)
-    {
-        return { SaveLocationType::Local, LocalInfo { path } };
-    }
-
-    static SaveLocation makeCloud()
-    {
-        return { SaveLocationType::Cloud, CloudInfo {} };
-    }
-};
-
 struct ProjectMeta
 {
     io::path filePath;

--- a/src/project/tests/mocks/projectconfigurationmock.h
+++ b/src/project/tests/mocks/projectconfigurationmock.h
@@ -47,7 +47,10 @@ public:
     MOCK_METHOD(void, setUserProjectsPath, (const io::path&), (override));
     MOCK_METHOD(async::Channel<io::path>, userProjectsPathChanged, (), (const, override));
 
-    MOCK_METHOD(io::path, defaultSavingFilePath, (const io::path&), (const, override));
+    MOCK_METHOD(io::path, cloudProjectsPath, (), (const, override));
+    MOCK_METHOD(bool, isCloudProject, (const io::path&), (const, override));
+
+    MOCK_METHOD(io::path, defaultSavingFilePath, (INotationProjectPtr, const QString&, const QString&), (const, override));
 
     MOCK_METHOD(SaveLocationType, lastUsedSaveLocationType, (), (const, override));
     MOCK_METHOD(void, setLastUsedSaveLocationType, (SaveLocationType), (override));


### PR DESCRIPTION
Closes: #10552
Resolves: #10288
Resolves: #10631

The solution with "SaveLocation" was unnecessarily complicated, so we keep it simple and identify scores by an `io::path`. There will be a hidden directory where cloud projects are stored/cached. We distinguish cloud scores by checking if their path is inside that hidden directory. 