### PR TITLE
[MU4] Fix GH#10653: Crash converting to whole note

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -4830,6 +4830,9 @@ static EngravingItem* findLinkedVoiceElement(EngravingItem* e, Staff* nstaff)
     Measure* measure = segment->measure();
     Measure* m       = score->tick2measure(measure->tick());
     Segment* s       = m->findSegment(segment->segmentType(), segment->tick());
+    if (!s) {
+        return 0;
+    }
     return s->element(dtrack);
 }
 
@@ -4874,6 +4877,9 @@ static Chord* findLinkedChord(Chord* c, Staff* nstaff)
     }
     Measure* nm = nstaff->score()->tick2measure(s->tick());
     Segment* ns = nm->findSegment(s->segmentType(), s->tick());
+    if (!ns) {
+        return 0;
+    }
     EngravingItem* ne = ns->element(dtrack);
     if (!ne->isChord()) {
         return 0;
@@ -5668,6 +5674,9 @@ void Score::undoAddElement(EngravingItem* element, bool ctrlModifier)
                     sm = static_cast<int>(cr2->staffIdx() - cr1->staffIdx());
                 }
                 Chord* c1 = findLinkedChord(cr1, score->staff(staffIdx));
+                if (!c1) {
+                    return;
+                }
                 Chord* c2 = findLinkedChord(cr2, score->staff(staffIdx + sm));
                 Note* nn1 = c1->findNote(n1->pitch(), n1->unisonIndex());
                 Note* nn2 = c2 ? c2->findNote(n2->pitch(), n2->unisonIndex()) : 0;


### PR DESCRIPTION
Resolves: #10653

Same issue with (and originally reported for) MU3