### PR TITLE
Fix #7684: Disable menu when no enabled items

### DIFF
--- a/src/framework/uicomponents/view/abstractmenumodel.cpp
+++ b/src/framework/uicomponents/view/abstractmenumodel.cpp
@@ -178,6 +178,18 @@ MenuItem& AbstractMenuModel::findMenu(const QString& menuId)
 MenuItem* AbstractMenuModel::makeMenu(const QString& title, const MenuItemList& items,
                                       const QString& menuId, bool enabled)
 {
+    bool hasEnabledChildItems = false;
+    for (const MenuItem menuItem: items) {
+        if (menuItem.state().enabled) {
+            hasEnabledChildItems = true;
+            break;
+        }
+    }
+
+    if (!hasEnabledChildItems) {
+        enabled = false;
+    }
+
     MenuItem* item = new MenuItem(this);
     item->setId(menuId);
     item->setSubitems(items);


### PR DESCRIPTION
Resolves: #7684

*(short description of the changes and the motivation to make the changes)*

This commit disables menu (Not ones like File or Edit, but "Sub Menus") when all of its items are disabled

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
