### PR TITLE
[MU4] Only apply Leland and Edwin styles if migrating pre-3.6.2 scores

### DIFF
--- a/src/project/qml/MuseScore/Project/MigrationDialog.qml
+++ b/src/project/qml/MuseScore/Project/MigrationDialog.qml
@@ -65,10 +65,16 @@ StyledDialogView {
 
         switch(dialog.migrationType) {
         case MigrationType.Pre300:
+            loader.sourceComponent = migrComp
+            break;
         case MigrationType.Post300AndPre362:
+            isApplyAutoSpacing = false
             loader.sourceComponent = migrComp
             break;
         case MigrationType.Ver362:
+            isApplyLeland = false
+            isApplyEdwin = false
+            isApplyAutoSpacing = false
             loader.sourceComponent = noteComp
             break;
         default: {


### PR DESCRIPTION
The default values for the migration dialog had the isApplyLeland and isApplyEdwin defaulting to true, which is nice because the pre-3.6.2 migration dialog defaults to the checkboxes being checked, but that default must not be in place for the 3.6.2 score migration dialog.