### PR TITLE
Restored the ability to save Uncompressed MuseScore files

### DIFF
--- a/build/Linux+BSD/mscore.1.in
+++ b/build/Linux+BSD/mscore.1.in
@@ -100,7 +100,7 @@ GNU General Public Licence (GPLv2).
 @MAN_PORTABLE@Create symbolic links to make it easier to launch
 @MAN_PORTABLE@MuseScore from the command line when needed.
 @MAN_PORTABLE@.It
-@MAN_PORTABLE@Make sure MSCZ, MSCX and MusicXML files are recognised
+@MAN_PORTABLE@Make sure .MSCZ, .MSCX, .MSCS and MusicXML files are recognised
 @MAN_PORTABLE@by the system and the correct icons are displayed.
 @MAN_PORTABLE@.El
 @MAN_PORTABLE@.Pp
@@ -350,10 +350,12 @@ internal file sanity check log (JSON)
 MPEG Layer III (lossy compressed audio)
 .It Li mpos
 measure positions (XML)
-.It Li mscx
-uncompressed MuseScore file
 .It Li mscz
-compressed MuseScore file
+MuseScore File
+.It Li mscx
+MuseScore Uncompressed File
+.It Li mscs
+MuseScore Uncompressed File
 .It Li musicxml
 uncompressed MusicXML file
 .It Li mxl

--- a/build/Linux+BSD/musescore.xml.in
+++ b/build/Linux+BSD/musescore.xml.in
@@ -4,15 +4,30 @@
     <!-- MuseScore documents -->
 
     <mime-type type="application/x-musescore">
-        <comment>MuseScore compressed score</comment>
+        <comment>MuseScore File</comment>
         <glob pattern="*.mscz"/>
         <sub-class-of type="application/zip"/>
         <icon name="application-x-musescore@MSCORE_INSTALL_SUFFIX@"/>
     </mime-type>
 
     <mime-type type="application/x-musescore+xml">
-        <comment>MuseScore uncompressed score</comment>
+        <comment>MuseScore Uncompressed File</comment>
         <glob pattern="*.mscx"/>
+        <sub-class-of type="application/xml"/>
+        <root-XML namespaceURI="" localName="museScore"/>
+        <icon name="application-x-musescore@MSCORE_INSTALL_SUFFIX@+xml"/>
+        <magic>
+            <match type="string" value="&lt;?xml" offset="0">
+                <match type="string" value="&lt;museScore" offset="0:128">
+                    <match type="string" value="&lt;Score" offset="0:512"/>
+                </match>
+            </match>
+        </magic>
+    </mime-type>
+
+    <mime-type type="application/x-musescore+xml">
+        <comment>MuseScore Uncompressed File</comment>
+        <glob pattern="*.mscsx"/>
         <sub-class-of type="application/xml"/>
         <root-XML namespaceURI="" localName="museScore"/>
         <icon name="application-x-musescore@MSCORE_INSTALL_SUFFIX@+xml"/>

--- a/build/MacOSXBundleInfo.plist.in
+++ b/build/MacOSXBundleInfo.plist.in
@@ -12,9 +12,31 @@
 		<!-- MuseScore documents -->
 		<dict>
 			<key>UTTypeIdentifier</key>
-			<string>org.musescore.mscx</string>
+			<string>org.musescore.mscz</string>
 			<key>UTTypeDescription</key>
 			<string>MuseScore File</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.content</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mscz</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/x-musescore</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>org.musescore.mscx</string>
+			<key>UTTypeDescription</key>
+			<string>MuseScore Uncompressed File</string>
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.data</string>
@@ -34,9 +56,9 @@
 		</dict>
 		<dict>
 			<key>UTTypeIdentifier</key>
-			<string>org.musescore.mscz</string>
+			<string>org.musescore.mscs</string>
 			<key>UTTypeDescription</key>
-			<string>MuseScore Compressed File</string>
+			<string>MuseScore Uncompressed File</string>
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.data</string>
@@ -46,11 +68,11 @@
 			<dict>
 				<key>public.filename-extension</key>
 				<array>
-					<string>mscz</string>
+					<string>mscs</string>
 				</array>
 				<key>public.mime-type</key>
 				<array>
-					<string>application/x-musescore</string>
+					<string>application/x-musescore+xml</string>
 				</array>
 			</dict>
 		</dict>

--- a/build/Packaging.cmake
+++ b/build/Packaging.cmake
@@ -56,12 +56,14 @@ IF(MINGW OR MSVC)
       SET(CPACK_NSIS_DEFINES "!include ${PROJECT_SOURCE_DIR}/build/packaging\\\\FileAssociation.nsh")
 
       SET(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
-            \\\${registerExtension} \\\"MuseScore File\\\" \\\".mscx\\\" \\\"\\\$INSTDIR\\\\bin\\\\${MSCORE_EXECUTABLE_NAME}.exe\\\"
-            \\\${registerExtension} \\\"Compressed MuseScore File\\\" \\\".mscz\\\" \\\"\\\$INSTDIR\\\\bin\\\\${MSCORE_EXECUTABLE_NAME}.exe\\\"
+            \\\${registerExtension} \\\"MuseScore File\\\" \\\".mscz\\\" \\\"\\\$INSTDIR\\\\bin\\\\${MSCORE_EXECUTABLE_NAME}.exe\\\"
+            \\\${registerExtension} \\\"MuseScore Uncompressed File\\\" \\\".mscx\\\" \\\"\\\$INSTDIR\\\\bin\\\\${MSCORE_EXECUTABLE_NAME}.exe\\\"
+            \\\${registerExtension} \\\"MuseScore Uncompressde File\\\" \\\".mscs\\\" \\\"\\\$INSTDIR\\\\bin\\\\${MSCORE_EXECUTABLE_NAME}.exe\\\"
       ")
       SET(CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS "
-            \\\${unregisterExtension} \\\".mscx\\\" \\\"MuseScore File\\\"
-            \\\${unregisterExtension} \\\".mscz\\\" \\\"Compressed MuseScore File\\\"
+            \\\${unregisterExtension} \\\".mscz\\\" \\\"MuseScore File\\\"
+            \\\${unregisterExtension} \\\".mscx\\\" \\\"MuseScore Uncompressed File\\\"
+            \\\${unregisterExtension} \\\".mscs\\\" \\\"MuseScore Uncompressed File\\\"
       ")
 
       list(APPEND CPACK_WIX_CANDLE_EXTRA_FLAGS -dCPACK_WIX_FILE_ASSOCIATION=ON)

--- a/build/PortableApps/appinfo.ini.in
+++ b/build/PortableApps/appinfo.ini.in
@@ -27,8 +27,9 @@ Icons=1
 Start=MuseScorePortable.exe
 
 [Associations]
-FileTypes=mscx, mscz
+FileTypes=mscz, mscx, mscs
 
 [FileTypeIcons]
-mscx=custom
 mscz=custom
+mscx=custom
+mscs=custom

--- a/build/cmake/SetupAppImagePackaging.cmake
+++ b/build/cmake/SetupAppImagePackaging.cmake
@@ -93,7 +93,7 @@ if (NOT MINGW AND NOT MSVC AND NOT APPLE)
      else (LN_EXECUTABLE)
          message(STATUS "'ln' not found (it is optional). No symlink aliases will be created.")
      endif (LN_EXECUTABLE)
-    # Add .MSCZ and .MSCX to MIME database (informs system that filetypes .MSCZ & .MSCX are MuseScore files)
+    # Add .MSCZ, .MSCX and .MSCS to MIME database (informs system that filetypes .MSCZ, .MSCX and .MSCS are MuseScore files)
     configure_file(build/Linux+BSD/musescore.xml.in musescore${MSCORE_INSTALL_SUFFIX}.xml)
     install( FILES ${PROJECT_BINARY_DIR}/musescore${MSCORE_INSTALL_SUFFIX}.xml DESTINATION share/mime/packages COMPONENT doc)
     # Note: Must now run "update-mime-database" to apply changes.

--- a/build/packaging/WIX.template.in
+++ b/build/packaging/WIX.template.in
@@ -78,11 +78,13 @@
             <?if $(var.CPACK_WIX_FILE_ASSOCIATION) = ON ?>
                 <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\FileAssociations" Name=".mscz" Value="MuseScore.mscz" Type="string" />
                 <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\FileAssociations" Name=".mscx" Value="MuseScore.mscx" Type="string" />
+                <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\FileAssociations" Name=".mscs" Value="MuseScore.mscs" Type="string" />
 
                 <!-- TODO add more types?-->
             
                 <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\MIMEAssociations" Name="application/x-musescore" Value="MuseScore.mscz" Type="string" />
                 <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\MIMEAssociations" Name="application/x-musescore+xml" Value="MuseScore.mscx" Type="string" />
+                <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\MIMEAssociations" Name="application/x-musescore+xml" Value="MuseScore.mscs" Type="string" />
             <?endif?>
 
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\$(var.ShortProdName)\Capabilities\shell\open\command" Value="&quot;[INSTALL_ROOT]bin\$(var.ExeName)&quot; &quot;%1&quot;" Type="string" />
@@ -95,6 +97,7 @@
             <!-- Extend to the "open with" list + Win7 jump menu pinning  -->
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".mscz" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".mscx" Value="" Type="string" />
+            <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".mscs" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".xml" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".musicxml" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".mxl" Value="" Type="string" />
@@ -125,7 +128,7 @@
 
             <!-- MyApp.Document ProgIDs -->
             <?if $(var.CPACK_WIX_FILE_ASSOCIATION) = ON ?>
-                <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\MuseScore.mscz" Value="Compressed MuseScore File" Type="string"/>
+                <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\MuseScore.mscz" Value="MuseScore File" Type="string"/>
                 <ProgId Id="MuseScore.mscz" Description="Compressed MuseScore File" Advertise="no" Icon="$(var.ExeId)" IconIndex="1">
                     <Extension Id="mscz" Advertise="no">
                         <Verb Id="open" TargetFile="$(var.ExeId)" Command="Open" Argument="&quot;%1&quot;" />
@@ -133,9 +136,17 @@
                     </Extension>
                 </ProgId>
 
-                <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\MuseScore.mscx" Value="MuseScore File" Type="string" />
+                <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\MuseScore.mscx" Value="MuseScore Uncompressed File" Type="string" />
                 <ProgId Id="MuseScore.mscx" Description="MuseScore File" Advertise="no" Icon="$(var.ExeId)" IconIndex="1">
                     <Extension Id="mscx" Advertise="no">
+                        <Verb Id="open" TargetFile="$(var.ExeId)" Command="Open" Argument="&quot;%1&quot;" />
+                        <MIME Advertise="no" ContentType="application/x-musescore+xml" Default="no" />
+                    </Extension>
+                </ProgId>
+
+                <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\MuseScore.mscs" Value="MuseScore Uncompressed File" Type="string" />
+                <ProgId Id="MuseScore.mscs" Description="MuseScore File" Advertise="no" Icon="$(var.ExeId)" IconIndex="1">
+                    <Extension Id="mscs" Advertise="no">
                         <Verb Id="open" TargetFile="$(var.ExeId)" Command="Open" Argument="&quot;%1&quot;" />
                         <MIME Advertise="no" ContentType="application/x-musescore+xml" Default="no" />
                     </Extension>

--- a/src/autobot/internal/autobotscriptsrepository.cpp
+++ b/src/autobot/internal/autobotscriptsrepository.cpp
@@ -34,7 +34,7 @@ Scripts AutobotScriptsRepository::scripts() const
     io::paths scriptsDirs = configuration()->scriptsDirPaths();
     io::paths scriptsPaths;
     for (const io::path& dir : scriptsDirs) {
-        RetVal<io::paths> paths = fileSystem()->scanFiles(dir, { "*.js" }, io::IFileSystem::ScanMode::OnlyCurrentDir);
+        RetVal<io::paths> paths = fileSystem()->scanFiles(dir, { "*.js" }, io::IFileSystem::ScanMode::FilesInCurrentDir);
         scriptsPaths.insert(scriptsPaths.end(), paths.val.begin(), paths.val.end());
     }
 

--- a/src/diagnostics/internal/crashhandler/crashhandler.cpp
+++ b/src/diagnostics/internal/crashhandler/crashhandler.cpp
@@ -99,7 +99,7 @@ void CrashHandler::removePendingLockFiles(const io::path& dumpsDir)
     return;
 #else
     io::path pendingDir = dumpsDir + "/pending";
-    RetVal<io::paths> rv = fileSystem()->scanFiles(pendingDir, { "*.lock" }, io::IFileSystem::ScanMode::OnlyCurrentDir);
+    RetVal<io::paths> rv = fileSystem()->scanFiles(pendingDir, { "*.lock" }, io::IFileSystem::ScanMode::FilesInCurrentDir);
     if (!rv.ret) {
         LOGE() << "failed get pending lock files, err: " << rv.ret.toString();
         return;

--- a/src/engraving/infrastructure/io/mscio.h
+++ b/src/engraving/infrastructure/io/mscio.h
@@ -85,6 +85,11 @@ inline io::path mainFilePath(const io::path& path)
 
     return path.appendingComponent(io::filename(path)).appendingSuffix(MSCX);
 }
+
+inline io::path mainFileName(const io::path& path)
+{
+    return io::filename(path, !isMuseScoreFile(io::suffix(path))).appendingSuffix(MSCX);
+}
 }
 
 #endif // MU_ENGRAVING_MSCIO_H

--- a/src/engraving/infrastructure/io/mscio.h
+++ b/src/engraving/infrastructure/io/mscio.h
@@ -24,6 +24,8 @@
 
 #include <string>
 
+#include "io/path.h"
+
 namespace mu::engraving {
 //! NOTE The main format is MuseScore, is a zip archive with a specific structure
 static const std::string MSCZ = "mscz";
@@ -64,6 +66,24 @@ inline MscIoMode mscIoModeBySuffix(const std::string& suffix)
         return MscIoMode::XmlFile;
     }
     return MscIoMode::Unknown;
+}
+
+inline io::path containerPath(const io::path& path)
+{
+    if (io::suffix(path) == MSCX) {
+        return io::absoluteDirpath(path);
+    }
+
+    return path;
+}
+
+inline io::path mainFilePath(const io::path& path)
+{
+    if (isMuseScoreFile(io::suffix(path))) {
+        return path;
+    }
+
+    return path.appendingComponent(io::filename(path)).appendingSuffix(MSCX);
 }
 }
 

--- a/src/engraving/infrastructure/io/mscreader.cpp
+++ b/src/engraving/infrastructure/io/mscreader.cpp
@@ -449,6 +449,7 @@ QByteArray MscReader::XmlFileReader::fileData(const QString& fileName) const
 
             QStringRef file = xml.attributes().value("name");
             if (file != fileName) {
+                xml.skipCurrentElement();
                 continue;
             }
 

--- a/src/engraving/infrastructure/io/mscreader.cpp
+++ b/src/engraving/infrastructure/io/mscreader.cpp
@@ -306,12 +306,13 @@ bool MscReader::DirReader::open(QIODevice* device, const QString& filePath)
         return false;
     }
 
-    m_rootPath = QFileInfo(filePath).absolutePath();
-
-    if (!QFileInfo::exists(m_rootPath)) {
-        LOGD() << "not exists path: " << m_rootPath;
+    QFileInfo fi(filePath);
+    if (!fi.exists()) {
+        LOGD() << "not exists path: " << filePath;
         return false;
     }
+
+    m_rootPath = containerPath(filePath).toQString();
 
     return true;
 }

--- a/src/engraving/infrastructure/io/mscreader.cpp
+++ b/src/engraving/infrastructure/io/mscreader.cpp
@@ -117,9 +117,28 @@ QByteArray MscReader::readStyleFile() const
     return fileData("score_style.mss");
 }
 
+QString MscReader::mainFileName() const
+{
+    if (!m_params.mainFileName.isEmpty()) {
+        return m_params.mainFileName;
+    }
+
+    QString name = "score.mscx";
+    if (m_params.filePath.isEmpty()) {
+        return name;
+    }
+
+    QString completeBaseName = QFileInfo(m_params.filePath).completeBaseName();
+    if (completeBaseName.isEmpty()) {
+        return name;
+    }
+
+    return completeBaseName + ".mscx";
+}
+
 QByteArray MscReader::readScoreFile() const
 {
-    QString mscxFileName = QFileInfo(m_params.filePath).completeBaseName() + ".mscx";
+    QString mscxFileName = mainFileName();
     QByteArray data = fileData(mscxFileName);
     if (data.isEmpty() && reader()->isContainer()) {
         QStringList files = reader()->fileList();

--- a/src/engraving/infrastructure/io/mscreader.h
+++ b/src/engraving/infrastructure/io/mscreader.h
@@ -40,6 +40,7 @@ public:
     {
         QIODevice* device = nullptr;
         QString filePath;
+        QString mainFileName;
         MscIoMode mode = MscIoMode::Zip;
     };
 
@@ -129,6 +130,8 @@ private:
 
     IReader* reader() const;
     QByteArray fileData(const QString& fileName) const;
+
+    QString mainFileName() const;
 
     Params m_params;
     mutable IReader* m_reader = nullptr;

--- a/src/engraving/infrastructure/io/mscwriter.cpp
+++ b/src/engraving/infrastructure/io/mscwriter.cpp
@@ -128,14 +128,28 @@ void MscWriter::writeStyleFile(const QByteArray& data)
     addFileData("score_style.mss", data);
 }
 
+QString MscWriter::mainFileName() const
+{
+    if (!m_params.mainFileName.isEmpty()) {
+        return m_params.mainFileName;
+    }
+
+    QString name = "score.mscx";
+    if (m_params.filePath.isEmpty()) {
+        return name;
+    }
+
+    QString completeBaseName = QFileInfo(m_params.filePath).completeBaseName();
+    if (completeBaseName.isEmpty()) {
+        return name;
+    }
+
+    return completeBaseName + ".mscx";
+}
+
 void MscWriter::writeScoreFile(const QByteArray& data)
 {
-    QString completeBaseName = QFileInfo(m_params.filePath).completeBaseName();
-    IF_ASSERT_FAILED(!completeBaseName.isEmpty()) {
-        completeBaseName = "score";
-    }
-    QString fileName = completeBaseName + ".mscx";
-    addFileData(fileName, data);
+    addFileData(mainFileName(), data);
 }
 
 void MscWriter::addExcerptStyleFile(const QString& name, const QByteArray& data)

--- a/src/engraving/infrastructure/io/mscwriter.cpp
+++ b/src/engraving/infrastructure/io/mscwriter.cpp
@@ -298,14 +298,12 @@ bool MscWriter::DirWriter::open(QIODevice* device, const QString& filePath)
         return false;
     }
 
-    QFileInfo fi(filePath);
-
-    if (fi.absolutePath().isEmpty()) {
+    if (filePath.isEmpty()) {
         LOGE() << "file path is empty";
         return false;
     }
 
-    m_rootPath = fi.absolutePath() + "/" + fi.completeBaseName();
+    m_rootPath = containerPath(filePath).toQString();
 
     QDir dir(m_rootPath);
     if (!dir.removeRecursively()) {

--- a/src/engraving/infrastructure/io/mscwriter.h
+++ b/src/engraving/infrastructure/io/mscwriter.h
@@ -40,6 +40,7 @@ public:
     {
         QIODevice* device = nullptr;
         QString filePath;
+        QString mainFileName;
         MscIoMode mode = MscIoMode::Zip;
     };
 
@@ -126,6 +127,8 @@ private:
 
     void writeMeta();
     void writeContainer(const std::vector<QString>& paths);
+
+    QString mainFileName() const;
 
     Params m_params;
     mutable IWriter* m_writer = nullptr;

--- a/src/framework/global/io/ifilesystem.h
+++ b/src/framework/global/io/ifilesystem.h
@@ -36,6 +36,7 @@ public:
 
     virtual Ret exists(const io::path& path) const = 0;
     virtual Ret remove(const io::path& path) const = 0;
+    virtual Ret removeFolderIfEmpty(const io::path& path) const = 0;
     virtual Ret copy(const io::path& src, const io::path& dst, bool replace = false) const = 0;
     virtual Ret move(const io::path& src, const io::path& dst, bool replace = false) const = 0;
 
@@ -44,12 +45,13 @@ public:
     virtual RetVal<uint64_t> fileSize(const io::path& path) const = 0;
 
     enum class ScanMode {
-        OnlyCurrentDir,
-        IncludeSubdirs
+        FilesInCurrentDir,
+        FilesAndFoldersInCurrentDir,
+        FilesInCurrentDirAndSubdirs
     };
 
     virtual RetVal<io::paths> scanFiles(const io::path& rootDir, const QStringList& filters,
-                                        ScanMode mode = ScanMode::IncludeSubdirs) const = 0;
+                                        ScanMode mode = ScanMode::FilesInCurrentDirAndSubdirs) const = 0;
 
     enum class Attribute {
         Hidden

--- a/src/framework/global/io/internal/filesystem.cpp
+++ b/src/framework/global/io/internal/filesystem.cpp
@@ -56,6 +56,11 @@ Ret FileSystem::remove(const io::path& path_) const
     return make_ret(Err::NoError);
 }
 
+Ret FileSystem::removeFolderIfEmpty(const io::path& path) const
+{
+    return removeDir(path, false);
+}
+
 Ret FileSystem::copy(const io::path& src, const io::path& dst, bool replace) const
 {
     QFileInfo srcFileInfo(src.toQString());
@@ -172,7 +177,7 @@ RetVal<uint64_t> FileSystem::fileSize(const io::path& path) const
     return rv;
 }
 
-RetVal<io::paths> FileSystem::scanFiles(const io::path& rootDir, const QStringList& filters, ScanMode mode) const
+RetVal<io::paths> FileSystem::scanFiles(const io::path& rootDir, const QStringList& nameFilters, ScanMode mode) const
 {
     RetVal<io::paths> result;
     Ret ret = exists(rootDir);
@@ -181,8 +186,23 @@ RetVal<io::paths> FileSystem::scanFiles(const io::path& rootDir, const QStringLi
         return result;
     }
 
-    QDirIterator::IteratorFlags flags = (mode == ScanMode::IncludeSubdirs ? QDirIterator::Subdirectories : QDirIterator::NoIteratorFlags);
-    QDirIterator it(rootDir.toQString(), filters, QDir::NoDotAndDotDot | QDir::NoSymLinks | QDir::Readable | QDir::Files, flags);
+    QDirIterator::IteratorFlags flags = QDirIterator::NoIteratorFlags;
+    QDir::Filters filters = QDir::NoDotAndDotDot | QDir::NoSymLinks | QDir::Readable;
+
+    switch (mode) {
+    case ScanMode::FilesInCurrentDir:
+        filters |= QDir::Files;
+        break;
+    case IFileSystem::ScanMode::FilesAndFoldersInCurrentDir:
+        filters |= QDir::Files | QDir::Dirs;
+        break;
+    case IFileSystem::ScanMode::FilesInCurrentDirAndSubdirs:
+        flags |= QDirIterator::Subdirectories;
+        filters |= QDir::Files;
+        break;
+    }
+
+    QDirIterator it(rootDir.toQString(), nameFilters, filters, flags);
 
     while (it.hasNext()) {
         result.val.push_back(it.next());
@@ -202,9 +222,14 @@ Ret FileSystem::removeFile(const io::path& path) const
     return make_ret(Err::NoError);
 }
 
-Ret FileSystem::removeDir(const io::path& path) const
+Ret FileSystem::removeDir(const io::path& path, bool recursively) const
 {
     QDir dir(path.toQString());
+
+    if (!recursively && !dir.isEmpty()) {
+        return make_ret(Err::FSDirNotEmptyError);
+    }
+
     if (!dir.removeRecursively()) {
         return make_ret(Err::FSRemoveError);
     }

--- a/src/framework/global/io/internal/filesystem.h
+++ b/src/framework/global/io/internal/filesystem.h
@@ -30,6 +30,7 @@ class FileSystem : public IFileSystem
 public:
     Ret exists(const io::path& path) const override;
     Ret remove(const io::path& path) const override;
+    Ret removeFolderIfEmpty(const io::path& path) const override;
     Ret copy(const io::path& src, const io::path& dst, bool replace = false) const override;
     Ret move(const io::path& src, const io::path& dst, bool replace = false) const override;
 
@@ -38,7 +39,7 @@ public:
     RetVal<uint64_t> fileSize(const io::path& path) const override;
 
     RetVal<io::paths> scanFiles(const io::path& rootDir, const QStringList& filters,
-                                ScanMode mode = ScanMode::IncludeSubdirs) const override;
+                                ScanMode mode = ScanMode::FilesInCurrentDirAndSubdirs) const override;
 
     RetVal<QByteArray> readFile(const io::path& filePath) const override;
     Ret writeToFile(const io::path& filePath, const QByteArray& data) const override;
@@ -47,7 +48,7 @@ public:
 
 private:
     Ret removeFile(const io::path& path) const;
-    Ret removeDir(const io::path& path) const;
+    Ret removeDir(const io::path& path, bool recursively = true) const;
     Ret copyRecursively(const io::path& src, const io::path& dst) const;
 };
 }

--- a/src/framework/global/io/ioretcodes.h
+++ b/src/framework/global/io/ioretcodes.h
@@ -34,6 +34,7 @@ enum class Err {
     FSNotExist,
     FSIsExist,
     FSRemoveError,
+    FSDirNotEmptyError,
     FSReadError,
     FSWriteError,
     FSMakingError,
@@ -52,6 +53,7 @@ inline Ret make_ret(Err e)
     case Err::FSNotExist: return Ret(retCode, trc("system", "The file does not exist"));
     case Err::FSIsExist: return Ret(retCode, trc("system", "The file is exist"));
     case Err::FSRemoveError: return Ret(retCode, trc("system", "The file could not be removed"));
+    case Err::FSDirNotEmptyError: return Ret(retCode, trc("system", "The directory is not empty"));
     case Err::FSReadError: return Ret(retCode, trc("system", "An error occurred when reading from the file"));
     case Err::FSWriteError: return Ret(retCode, trc("system", "An error occurred when writing to the file"));
     case Err::FSMakingError: return Ret(retCode, trc("system", "An error occurred when making a path"));

--- a/src/framework/global/tests/mocks/filesystemmock.h
+++ b/src/framework/global/tests/mocks/filesystemmock.h
@@ -32,6 +32,7 @@ class FileSystemMock : public IFileSystem
 public:
     MOCK_METHOD(Ret, exists, (const io::path&), (const, override));
     MOCK_METHOD(Ret, remove, (const io::path&), (const, override));
+    MOCK_METHOD(Ret, removeFolderIfEmpty, (const io::path&), (const, override));
     MOCK_METHOD(Ret, copy, (const io::path& src, const io::path& dst, bool replace), (const, override));
     MOCK_METHOD(Ret, move, (const io::path& src, const io::path& dst, bool replace), (const, override));
 

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -22,6 +22,7 @@
 #include "notationproject.h"
 
 #include <QBuffer>
+#include <QDir>
 #include <QFile>
 
 #include "engraving/engravingproject.h"
@@ -420,12 +421,16 @@ mu::Ret NotationProject::save(const io::path& path, SaveMode saveMode)
         return ret;
     }
     case SaveMode::AutoSave:
-        io::path complateBasename = io::completeBasename(path);
-
-        std::string suffix = io::suffix(complateBasename);
-        if (suffix.empty()) {
-            suffix = io::suffix(path);
+        std::string suffix = io::suffix(path);
+        if (suffix == IProjectAutoSaver::AUTOSAVE_SUFFIX) {
+            suffix = io::suffix(io::completeBasename(path));
         }
+
+        if (suffix.empty()) {
+            // Then it must be a MSCX folder
+            suffix = engraving::MSCX;
+        }
+
         return saveScore(path, suffix);
     }
 
@@ -463,9 +468,10 @@ mu::Ret NotationProject::saveScore(const io::path& path, const std::string& file
 
 mu::Ret NotationProject::doSave(const io::path& path, bool generateBackup, engraving::MscIoMode ioMode)
 {
-    QString currentPath = engraving::containerPath(path).toQString();
-    io::path currentMainFilePath = engraving::mainFilePath(path);
-    QString savePath = currentPath + "_saving";
+    QString targetContainerPath = engraving::containerPath(path).toQString();
+    io::path targetMainFilePath = engraving::mainFilePath(path);
+    io::path targetMainFileName = engraving::mainFileName(path);
+    QString savePath = targetContainerPath + "_saving";
 
     // Step 1: check writable
     {
@@ -474,12 +480,21 @@ mu::Ret NotationProject::doSave(const io::path& path, bool generateBackup, engra
             LOGE() << "failed save, not writable path: " << savePath;
             return make_ret(notation::Err::UnknownError);
         }
+
+        if (ioMode == engraving::MscIoMode::Dir) {
+            // Dir needs to be created, otherwise we can't move to it
+            if (!QDir(targetContainerPath).mkpath(".")) {
+                LOGE() << "Couldn't create container directory";
+                return make_ret(notation::Err::UnknownError);
+            }
+        }
     }
 
     // Step 2: write project
     {
         MscWriter::Params params;
         params.filePath = savePath;
+        params.mainFileName = targetMainFileName.toQString();
         params.mode = ioMode;
         IF_ASSERT_FAILED(params.mode != MscIoMode::Unknown) {
             return make_ret(Ret::Code::InternalError);
@@ -504,18 +519,32 @@ mu::Ret NotationProject::doSave(const io::path& path, bool generateBackup, engra
 
     // Step 4: replace to saved file
     {
-        Ret ret = fileSystem()->move(savePath, currentPath, true);
-        if (!ret) {
-            return ret;
-        }
-
         if (ioMode == MscIoMode::Dir) {
-            // Need to move the inner file too
-            // (from MyScore/MyScore_saving.mscx to MyScore/MyScore.mscx)
-            io::path innerFilePath = io::dirpath(currentMainFilePath)
-                                     .appendingComponent(io::filename(currentMainFilePath, false) + "_saving")
-                                     .appendingSuffix(engraving::MSCX);
-            ret = fileSystem()->move(innerFilePath, currentMainFilePath, true);
+            RetVal<io::paths> filesToBeMoved
+                = fileSystem()->scanFiles(savePath, { "*" }, io::IFileSystem::ScanMode::FilesAndFoldersInCurrentDir);
+            if (!filesToBeMoved.ret) {
+                return filesToBeMoved.ret;
+            }
+
+            Ret ret = make_ok();
+
+            for (const io::path& fileToBeMoved : filesToBeMoved.val) {
+                io::path destinationFile
+                    = io::path(targetContainerPath).appendingComponent(io::filename(fileToBeMoved));
+                LOGD() << fileToBeMoved << " to " << destinationFile;
+                ret = fileSystem()->move(fileToBeMoved, destinationFile, true);
+                if (!ret) {
+                    return ret;
+                }
+            }
+
+            // Try to remove the temp save folder (not problematic if fails)
+            ret = fileSystem()->removeFolderIfEmpty(savePath);
+            if (!ret) {
+                LOGW() << ret.toString();
+            }
+        } else {
+            Ret ret = fileSystem()->move(savePath, targetContainerPath, true);
             if (!ret) {
                 return ret;
             }
@@ -524,11 +553,11 @@ mu::Ret NotationProject::doSave(const io::path& path, bool generateBackup, engra
 
     // make file readable by all
     {
-        QFile::setPermissions(currentMainFilePath.toQString(),
+        QFile::setPermissions(targetMainFilePath.toQString(),
                               QFile::ReadOwner | QFile::WriteOwner | QFile::ReadUser | QFile::ReadGroup | QFile::ReadOther);
     }
 
-    LOGI() << "success save file: " << currentPath;
+    LOGI() << "success save file: " << targetContainerPath;
     return make_ret(Ret::Code::Ok);
 }
 

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -595,7 +595,7 @@ void ProjectActionsController::printScore()
 
 io::path ProjectActionsController::selectScoreOpeningFile()
 {
-    QString allExt = "*.mscz *.mxl *.musicxml *.xml *.mid *.midi *.kar *.md *.mgu *.sgu *.cap *.capx"
+    QString allExt = "*.mscz *.mxl *.musicxml *.xml *.mid *.midi *.kar *.md *.mgu *.sgu *.cap *.capx "
                      "*.ove *.scw *.bmw *.bww *.gtp *.gp3 *.gp4 *.gp5 *.gpx *.gp *.ptb *.mscx *.mscs *.mscz~";
 
     QStringList filter;

--- a/src/project/internal/projectautosaver.cpp
+++ b/src/project/internal/projectautosaver.cpp
@@ -101,15 +101,17 @@ bool ProjectAutoSaver::isAutosaveOfNewlyCreatedProject(const io::path& projectPa
 mu::io::path ProjectAutoSaver::projectOriginalPath(const mu::io::path& projectAutoSavePath) const
 {
     IF_ASSERT_FAILED(io::suffix(projectAutoSavePath) == AUTOSAVE_SUFFIX) {
-        return projectAutoSavePath;
+        return engraving::mainFilePath(projectAutoSavePath);
     }
 
-    return io::absolutePath(projectAutoSavePath) + "/" + io::filename(projectAutoSavePath, false);
+    io::path withoutAutosaveSuffix = io::filename(projectAutoSavePath, false);
+
+    return engraving::mainFilePath(io::absoluteDirpath(projectAutoSavePath).appendingComponent(withoutAutosaveSuffix));
 }
 
 mu::io::path ProjectAutoSaver::projectAutoSavePath(const io::path& projectPath) const
 {
-    return projectPath.appendingSuffix(AUTOSAVE_SUFFIX);
+    return engraving::containerPath(projectPath).appendingSuffix(AUTOSAVE_SUFFIX);
 }
 
 INotationProjectPtr ProjectAutoSaver::currentProject() const

--- a/src/project/internal/projectautosaver.cpp
+++ b/src/project/internal/projectautosaver.cpp
@@ -23,8 +23,6 @@
 
 #include "log.h"
 
-static const std::string AUTOSAVE_SUFFIX = "autosave";
-
 using namespace mu::project;
 
 void ProjectAutoSaver::init()

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -288,6 +288,7 @@ io::path ProjectConfiguration::defaultSavingFilePath(INotationProjectPtr project
     } else if (project->isCloudProject()) {
         // TODO(save-to-cloud)
     } else {
+        projectPath = engraving::containerPath(projectPath);
         folderPath = io::dirpath(projectPath);
         filename = io::filename(projectPath, false);
 

--- a/src/project/internal/saveprojectscenario.cpp
+++ b/src/project/internal/saveprojectscenario.cpp
@@ -104,13 +104,21 @@ RetVal<io::path> SaveProjectScenario::askLocalPath(INotationProjectPtr project, 
 
     QStringList filter;
     filter << qtrc("project", "MuseScore file") + " (*.mscz)"
-           << qtrc("project", "Uncompressed MuseScore folder (experimental)") + " (*.mscx)"
+           << qtrc("project", "Uncompressed MuseScore folder (experimental)")
            << qtrc("project", "Uncompressed MuseScore file") + " (*.mscs)";
 
     io::path selectedPath = interactive()->selectSavingFile(dialogTitle, defaultPath, filter.join(";;"));
 
     if (selectedPath.empty()) {
         return make_ret(Ret::Code::Cancel);
+    }
+
+    if (!engraving::isMuseScoreFile(io::suffix(selectedPath))) {
+        // Then it must be that the user is trying to save a mscx file.
+        // At the selected path, a folder will be created,
+        // and inside the folder, a mscx file will be created.
+        // We should return the path to the mscx file.
+        selectedPath = selectedPath.appendingComponent(io::filename(selectedPath)).appendingSuffix(engraving::MSCX);
     }
 
     configuration()->setLastSavedProjectsPath(io::dirpath(selectedPath));

--- a/src/project/internal/saveprojectscenario.cpp
+++ b/src/project/internal/saveprojectscenario.cpp
@@ -102,9 +102,12 @@ RetVal<io::path> SaveProjectScenario::askLocalPath(INotationProjectPtr project, 
 
     io::path defaultPath = configuration()->defaultSavingFilePath(project, filenameAddition);
 
-    QString filter = qtrc("project", "MuseScore File") + " (*.mscz)";
+    QStringList filter;
+    filter << qtrc("project", "MuseScore file") + " (*.mscz)"
+           << qtrc("project", "Uncompressed MuseScore folder (experimental)") + " (*.mscx)"
+           << qtrc("project", "Uncompressed MuseScore file") + " (*.mscs)";
 
-    io::path selectedPath = interactive()->selectSavingFile(dialogTitle, defaultPath, filter);
+    io::path selectedPath = interactive()->selectSavingFile(dialogTitle, defaultPath, filter.join(";;"));
 
     if (selectedPath.empty()) {
         return make_ret(Ret::Code::Cancel);

--- a/src/project/internal/saveprojectscenario.cpp
+++ b/src/project/internal/saveprojectscenario.cpp
@@ -102,10 +102,15 @@ RetVal<io::path> SaveProjectScenario::askLocalPath(INotationProjectPtr project, 
 
     io::path defaultPath = configuration()->defaultSavingFilePath(project, filenameAddition);
 
-    QStringList filter;
-    filter << qtrc("project", "MuseScore file") + " (*.mscz)"
-           << qtrc("project", "Uncompressed MuseScore folder (experimental)")
-           << qtrc("project", "Uncompressed MuseScore file") + " (*.mscs)";
+    QStringList filter {
+        qtrc("project", "MuseScore file") + " (*.mscz)",
+        qtrc("project", "Uncompressed MuseScore folder (experimental)")
+#ifdef Q_OS_WIN
+        + " (*.)"
+#else
+        + " (*)"
+#endif
+    };
 
     io::path selectedPath = interactive()->selectSavingFile(dialogTitle, defaultPath, filter.join(";;"));
 

--- a/src/project/iprojectautosaver.h
+++ b/src/project/iprojectautosaver.h
@@ -41,6 +41,8 @@ public:
 
     virtual io::path projectOriginalPath(const io::path& projectAutoSavePath) const = 0;
     virtual io::path projectAutoSavePath(const io::path& projectPath) const = 0;
+
+    static inline const std::string AUTOSAVE_SUFFIX = "autosave";
 };
 }
 

--- a/src/project/tests/templatesrepositorytest.cpp
+++ b/src/project/tests/templatesrepositorytest.cpp
@@ -141,7 +141,7 @@ TEST_F(TemplatesRepositoryTest, Templates)
     };
 
     QStringList filters = { "*.mscz", "*.mscx" };
-    ON_CALL(*m_fileSystem, scanFiles(otherUserTemplatesDir, filters, IFileSystem::ScanMode::IncludeSubdirs))
+    ON_CALL(*m_fileSystem, scanFiles(otherUserTemplatesDir, filters, IFileSystem::ScanMode::FilesInCurrentDirAndSubdirs))
     .WillByDefault(Return(RetVal<io::paths>::make_ok(otherUserTemplates)));
 
     // [GIVEN] All templates


### PR DESCRIPTION
Resolves: #9132
Resolves: #10658 (as far as possible)

Now, you can select a file type in the "Save score" dialog:
<img width="802" alt="Schermafbeelding 2022-02-23 om 17 15 22" src="https://user-images.githubusercontent.com/48658420/155360185-3c887c8a-0ef4-4e10-a14b-b7b8abcc63b9.png">

When you change the file type using this dropdown, the extension in the filename field is automatically updated. However, it does not work the other way round: if you type "mscx" as the extension while "Compressed MuseScore file" is selected in the dropdown, macOS will show the dialog as in #10658. We can't change this, since it is entirely controlled by Qt and macOS.

Also interesting: if you type an extension that is not registered with any app (for example, if you end the filename with ".hello"), macOS will add ".mscz" without letting you know (or mscx or mscs, based on the currently selected option in the dropdown). So "Score.hello" would be changed to "Score.hello.mscz".

I noticed that saving in mscx and mscs format reveals at least three bugs:
- Mscs files are not registered with the operating system, so macOS has no idea what it should do with them and opens them desperately in Text Editor

- When saving as mscx, a folder with the given filename is created, and inside that folder, a mscx file is created. But when opening that mscx file the next time and then saving it, another folder is created at the same level as the mscx file, and another mscx file is created inside that new folder. This gives a structure like this:
    ```
    Scores
     |-- MyScore
         |--MyScore.mscx
         |--style.mss
         |--…
         |--MyScore
             |--MyScore.mscx
             |--style.mss
             |--…
    ```
    This can continue endlessly...

- When selecting the save location for the new score, macOS thinks that a mscx file will be created in the selected folder. So, if a mscx file with the same name already exists in that directory, it will warn the user about replacing the file. However, in practice, a folder is created (and the mscx file will be inside), and macOS does not warn about replacing any existing folder with the same name. 

So, considering all these bugs, I'm not sure how good of an idea it is to expose these options to regular users...