### PR TITLE
[MU4] Fix #10593 Fix drag-and-drop of slurs

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -67,6 +67,7 @@
 #include "libmscore/mscore.h"
 #include "libmscore/linkedobjects.h"
 #include "libmscore/tuplet.h"
+#include "libmscore/slur.h"
 
 #include "masternotation.h"
 #include "scorecallbacks.h"
@@ -1200,7 +1201,6 @@ bool NotationInteraction::drop(const PointF& pos, Qt::KeyboardModifiers modifier
     case ElementType::NOTE:
     case ElementType::CHORD:
     case ElementType::SPACER:
-    case ElementType::SLUR:
     case ElementType::BAGPIPE_EMBELLISHMENT:
     case ElementType::AMBITUS:
     case ElementType::TREMOLOBAR:
@@ -1238,6 +1238,16 @@ bool NotationInteraction::drop(const PointF& pos, Qt::KeyboardModifiers modifier
             score()->addRefresh(dropElement->canvasBoundingRect());
         }
         accepted = true;
+    }
+    break;
+    case ElementType::SLUR:
+    {
+        EngravingItem* el = dropTarget(m_dropData.ed);
+        Ms::Slur* dropElement = toSlur(m_dropData.ed.dropElement);
+        if (toNote(el)->chord()) {
+            doAddSlur(toNote(el)->chord(), nullptr, dropElement);
+            accepted = true;
+        }
     }
     break;
     default:


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10593

Slurs can be added by clicking on the palette or pressing the hotkey, but dragging and dropping slurs wasn't working. This PR fixes that, but I'm not 100% confident about my fix being 'correct'. I would love some input about where this fix should have gone, if I put it in the wrong place.