### PR TITLE
instruments.xml: Fix saxophone pitch range and hand bell transposition

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -2963,8 +2963,8 @@
                   <musicXMLid>wind.reed.saxophone.soprano</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>56-89</aPitchRange>
-                  <pPitchRange>56-94</pPitchRange>
+                  <aPitchRange>56-87</aPitchRange>
+                  <pPitchRange>56-91</pPitchRange>
                   <transposeDiatonic>-1</transposeDiatonic>
                   <transposeChromatic>-2</transposeChromatic>
                   <Channel>
@@ -3020,8 +3020,8 @@
                   <musicXMLid>wind.reed.saxophone.alto</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>49-82</aPitchRange>
-                  <pPitchRange>49-87</pPitchRange>
+                  <aPitchRange>49-80</aPitchRange>
+                  <pPitchRange>49-92</pPitchRange>
                   <transposeDiatonic>-5</transposeDiatonic>
                   <transposeChromatic>-9</transposeChromatic>
                   <Channel>
@@ -3061,8 +3061,8 @@
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>44-77</aPitchRange>
-                  <pPitchRange>44-82</pPitchRange>
+                  <aPitchRange>44-75</aPitchRange>
+                  <pPitchRange>44-87</pPitchRange>
                   <transposeDiatonic>-8</transposeDiatonic>
                   <transposeChromatic>-14</transposeChromatic>
                   <Channel>
@@ -3080,8 +3080,8 @@
                   <transposingClef>G</transposingClef>
                   <concertClef>G8vb</concertClef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>44-77</aPitchRange>
-                  <pPitchRange>44-82</pPitchRange>
+                  <aPitchRange>44-75</aPitchRange>
+                  <pPitchRange>44-87</pPitchRange>
                   <transposeDiatonic>-8</transposeDiatonic>
                   <transposeChromatic>-14</transposeChromatic>
                   <Channel>
@@ -3105,8 +3105,8 @@
                   <transposingClef>G</transposingClef>
                   <concertClef>F</concertClef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>37-70</aPitchRange>
-                  <pPitchRange>36-75</pPitchRange>
+                  <aPitchRange>36-68</aPitchRange>
+                  <pPitchRange>36-80</pPitchRange>
                   <transposeDiatonic>-12</transposeDiatonic>
                   <transposeChromatic>-21</transposeChromatic>
                   <Channel>
@@ -6639,14 +6639,18 @@
                   <description>Tuned hand bells.</description>
                   <musicXMLid>pitched-percussion.handbells</musicXMLid>
                   <staves>2</staves>
-                  <clef>G</clef>
+                  <transposingClef>G</transposingClef>
+                  <concertClef>G8va</concertClef>
                   <bracket>1</bracket>
                   <bracketSpan>2</bracketSpan>
                   <barlineSpan>2</barlineSpan>
-                  <clef staff="2">F</clef>
+                  <transposingClef staff="2">F</transposingClef>
+                  <concertClef staff="2">F8va</concertClef>
                   <aPitchRange>36-97</aPitchRange>
                   <pPitchRange>36-97</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
+                  <transposeDiatonic>7</transposeDiatonic>
+                  <transposeChromatic>12</transposeChromatic>
                   <Channel>
                         <!--MIDI: Bank 0, Prog 112; MS General: Tinker Bell-->
                         <program value="112"/> <!--Tinkle Bell-->


### PR DESCRIPTION
Run share/instruments/update_instruments_xml.py to fetch the latest online spreadsheet. Changes introduced here:

- Resolve https://musescore.org/en/node/329569 - Saxophone pitch range.

- Fix https://musescore.org/en/node/328336 - Hand Bells should sound an octave higher than written.

The hand bells have been given an 8va octave clef in concert pitch mode but not in transposed pitch mode (normal mode). This ensures notes appear on the same staff lines in both modes.