### PR TITLE
[MU4] Fix staccato and tenuto appearing below notes when they shouldn't

### DIFF
--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -3746,18 +3746,19 @@ void Chord::layoutArticulations()
         bool headSide = bottom == up();
         qreal x = centerX();
         qreal y = 0.0;
-
+        const qreal halfBeamSp = score()->styleS(Sid::beamWidth).val() * score()->spatium() * 0.5;
         if (bottom) {
             if (!headSide && stem()) {
+                auto userLen = stem()->userLength();
                 if (_up) {
-                    y = downPos() - stem()->length();
+                    y = downPos() - stem()->length() - userLen;
                     if (beam()) {
-                        y -= score()->styleS(Sid::beamWidth).val() * _spatium * .5;
+                        y -= halfBeamSp * beam()->mag();
                     }
                 } else {
-                    y = upPos() + stem()->length();
+                    y = upPos() + stem()->length() - userLen;
                     if (beam()) {
-                        y += score()->styleS(Sid::beamWidth).val() * _spatium * .5;
+                        y += halfBeamSp * beam()->mag();
                     }
                 }
                 int line   = lrint((y + 0.5 * _spStaff) / _spStaff);
@@ -3789,15 +3790,16 @@ void Chord::layoutArticulations()
             y -= a->height() * .5;              // center symbol
         } else {
             if (!headSide && stem()) {
+                auto userLen = stem()->userLength();
                 if (_up) {
-                    y = downPos() - stem()->length();
+                    y = downPos() - stem()->length() + userLen;
                     if (beam()) {
-                        y -= score()->styleS(Sid::beamWidth).val() * _spatium * .5;
+                        y -= halfBeamSp * beam()->mag();
                     }
                 } else {
-                    y = upPos() + stem()->length();
+                    y = upPos() + stem()->length() + userLen;
                     if (beam()) {
-                        y += score()->styleS(Sid::beamWidth).val() * _spatium * .5;
+                        y += halfBeamSp * beam()->mag();
                     }
                 }
                 int line   = lrint((y - 0.5 * _spStaff) / _spStaff);

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -3749,9 +3749,16 @@ void Chord::layoutArticulations()
 
         if (bottom) {
             if (!headSide && stem()) {
-                y = upPos() + stem()->length();
-                if (beam()) {
-                    y += score()->styleS(Sid::beamWidth).val() * _spatium * .5;
+                if (_up) {
+                    y = downPos() - stem()->length();
+                    if (beam()) {
+                        y -= score()->styleS(Sid::beamWidth).val() * _spatium * .5;
+                    }
+                } else {
+                    y = upPos() + stem()->length();
+                    if (beam()) {
+                        y += score()->styleS(Sid::beamWidth).val() * _spatium * .5;
+                    }
                 }
                 int line   = lrint((y + 0.5 * _spStaff) / _spStaff);
                 if (line < staffType->lines()) {        // align between staff lines
@@ -3782,9 +3789,16 @@ void Chord::layoutArticulations()
             y -= a->height() * .5;              // center symbol
         } else {
             if (!headSide && stem()) {
-                y = downPos() + stem()->length();
-                if (beam()) {
-                    y -= score()->styleS(Sid::beamWidth).val() * _spatium * .5;
+                if (_up) {
+                    y = downPos() - stem()->length();
+                    if (beam()) {
+                        y -= score()->styleS(Sid::beamWidth).val() * _spatium * .5;
+                    }
+                } else {
+                    y = upPos() + stem()->length();
+                    if (beam()) {
+                        y += score()->styleS(Sid::beamWidth).val() * _spatium * .5;
+                    }
                 }
                 int line   = lrint((y - 0.5 * _spStaff) / _spStaff);
                 if (line >= 0) {        // align between staff lines


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/89263931/155583644-26a8baaa-ad76-41b9-be2f-2bd5766ff74b.png)

After:
![image](https://user-images.githubusercontent.com/89263931/155583809-b6341555-34df-42c4-b6e2-8dc7c2b09b8a.png)

There was just some non-direction-agnostic code in the laying out of certain articulations, so that's been fixed.