### PR TITLE
[MU4] Fix #9995: Double/halve note duration skips values in note entry mode

### DIFF
--- a/src/framework/shortcuts/data/shortcuts-Mac.xml
+++ b/src/framework/shortcuts/data/shortcuts-Mac.xml
@@ -998,14 +998,6 @@
     <seq>NumPad+0</seq>
     </SC>
   <SC>
-    <key>pad-note-increase-TAB</key>
-    <seq>W</seq>
-    </SC>
-  <SC>
-    <key>pad-note-decrease-TAB</key>
-    <seq>Q</seq>
-    </SC>
-  <SC>
     <key>rest-TAB</key>
     <seq>;</seq>
     </SC>

--- a/src/framework/shortcuts/data/shortcuts.xml
+++ b/src/framework/shortcuts/data/shortcuts.xml
@@ -1022,14 +1022,6 @@
     <seq>NumPad+0</seq>
     </SC>
   <SC>
-    <key>pad-note-increase-TAB</key>
-    <seq>W</seq>
-    </SC>
-  <SC>
-    <key>pad-note-decrease-TAB</key>
-    <seq>Q</seq>
-    </SC>
-  <SC>
     <key>rest-TAB</key>
     <seq>;</seq>
     </SC>

--- a/src/framework/shortcuts/data/shortcuts_AZERTY.xml
+++ b/src/framework/shortcuts/data/shortcuts_AZERTY.xml
@@ -1020,14 +1020,6 @@
     <seq>NumPad+0</seq>
     </SC>
   <SC>
-    <key>pad-note-increase-TAB</key>
-    <seq>W</seq>
-    </SC>
-  <SC>
-    <key>pad-note-decrease-TAB</key>
-    <seq>Q</seq>
-    </SC>
-  <SC>
     <key>rest-TAB</key>
     <seq>;</seq>
     </SC>

--- a/src/notation/inotationnoteinput.h
+++ b/src/notation/inotationnoteinput.h
@@ -47,6 +47,7 @@ public:
     virtual void setArticulation(SymbolId articulationSymbolId) = 0;
     virtual void setDrumNote(int note) = 0;
     virtual void addTuplet(const TupletOptions& options) = 0;
+
     virtual void doubleNoteInputDuration() = 0;
     virtual void halveNoteInputDuration() = 0;
 

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -180,8 +180,9 @@ void NotationActionController::init()
     registerAction("pitch-down-octave", &Controller::move, MoveDirection::Down, true);
     registerAction("up-chord", [this]() { moveWithinChord(MoveDirection::Up); }, &Controller::hasSelection);
     registerAction("down-chord", [this]() { moveWithinChord(MoveDirection::Down); }, &Controller::hasSelection);
-    registerAction("double-duration", &Interaction::increaseDecreaseDuration, -1, false);
-    registerAction("half-duration", &Interaction::increaseDecreaseDuration, 1, false);
+
+    registerAction("double-duration", &Controller::doubleNoteInputDuration);
+    registerAction("half-duration", &Controller::halveNoteInputDuration);
     registerAction("inc-duration-dotted", &Interaction::increaseDecreaseDuration, -1, true);
     registerAction("dec-duration-dotted", &Interaction::increaseDecreaseDuration, 1, true);
 
@@ -398,10 +399,7 @@ void NotationActionController::init()
     registerAction("transpose-up", &Interaction::transposeSemitone, 1, PlayMode::PlayNote);
     registerAction("transpose-down", &Interaction::transposeSemitone, -1, PlayMode::PlayNote);
     registerAction("toggle-insert-mode", &Interaction::toggleGlobalOrLocalInsert);
-    registerAction("pad-note-decrease", &Controller::halveNoteInputDuration, &Controller::isNoteInputMode);
-    registerAction("pad-note-increase", &Controller::doubleNoteInputDuration, &Controller::isNoteInputMode);
-    registerAction("pad-note-decrease-TAB", &Controller::halveNoteInputDuration, &Controller::isNoteInputMode);
-    registerAction("pad-note-increase-TAB", &Controller::doubleNoteInputDuration, &Controller::isNoteInputMode);
+
     registerAction("get-location", &Interaction::getLocation, &Controller::isNotationPage);
     registerAction("toggle-mmrest", &Interaction::execute, &Ms::Score::cmdToggleMmrest);
     registerAction("toggle-hide-empty", &Interaction::execute, &Ms::Score::cmdToggleHideEmpty);
@@ -777,18 +775,36 @@ void NotationActionController::putTuplet(int tupletCount)
 void NotationActionController::doubleNoteInputDuration()
 {
     TRACEFUNC;
-    auto noteInput = currentNotationNoteInput();
-    if (noteInput) {
+
+    INotationInteractionPtr interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+
+    INotationNoteInputPtr noteInput = interaction->noteInput();
+
+    if (noteInput->isNoteInputMode()) {
         noteInput->doubleNoteInputDuration();
+    } else {
+        interaction->increaseDecreaseDuration(-1, false);
     }
 }
 
 void NotationActionController::halveNoteInputDuration()
 {
     TRACEFUNC;
-    auto noteInput = currentNotationNoteInput();
-    if (noteInput) {
+
+    INotationInteractionPtr interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+
+    INotationNoteInputPtr noteInput = interaction->noteInput();
+
+    if (noteInput->isNoteInputMode()) {
         noteInput->halveNoteInputDuration();
+    } else {
+        interaction->increaseDecreaseDuration(1, false);
     }
 }
 

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -522,7 +522,11 @@ void NotationNoteInput::doubleNoteInputDuration()
     TRACEFUNC;
 
     Ms::EditData editData(m_scoreCallbacks);
+
+    startEdit();
     score()->cmdPadNoteIncreaseTAB(editData);
+    apply();
+
     notifyAboutStateChanged();
 }
 
@@ -531,6 +535,10 @@ void NotationNoteInput::halveNoteInputDuration()
     TRACEFUNC;
 
     Ms::EditData editData(m_scoreCallbacks);
+
+    startEdit();
     score()->cmdPadNoteDecreaseTAB(editData);
+    apply();
+
     notifyAboutStateChanged();
 }

--- a/src/notation/internal/notationnoteinput.h
+++ b/src/notation/internal/notationnoteinput.h
@@ -65,8 +65,10 @@ public:
     void addSlur(Ms::Slur* slur) override;
     void resetSlur() override;
     void addTie() override;
+
     void doubleNoteInputDuration() override;
     void halveNoteInputDuration() override;
+
     void setCurrentVoiceIndex(int voiceIndex) override;
 
     void resetInputPosition() override;

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -201,15 +201,15 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("half-duration",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Half duration")
+             QT_TRANSLATE_NOOP("action", "Halve duration")
              ),
     UiAction("inc-duration-dotted",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Increase duration dotted")
+             QT_TRANSLATE_NOOP("action", "Double selected duration (dotted)")
              ),
     UiAction("dec-duration-dotted",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Decrease duration dotted")
+             QT_TRANSLATE_NOOP("action", "Halve selected duration (dotted)")
              ),
     UiAction("notation-cut",
              mu::context::UiCtxNotationOpened,
@@ -1674,22 +1674,6 @@ const UiActionList NotationUiActions::m_noteInputActions = {
              QT_TRANSLATE_NOOP("action", "Rest"),
              QT_TRANSLATE_NOOP("action", "Note input: rest"),
              IconCode::Code::REST
-             ),
-    UiAction("pad-note-increase",
-             mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Note input: double duration")
-             ),
-    UiAction("pad-note-decrease",
-             mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Note input: halve duration")
-             ),
-    UiAction("pad-note-increase-TAB",
-             mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Note input: double duration (TAB)")
-             ),
-    UiAction("pad-note-decrease-TAB",
-             mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Note input: halve duration (TAB)")
              ),
     UiAction("next-segment-element",
              mu::context::UiCtxNotationOpened,


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9995