### PR TITLE
[MU4] Fix #10655: Correct footer space in vertical justified layout calculations

### DIFF
--- a/src/engraving/layout/layoutpage.cpp
+++ b/src/engraving/layout/layoutpage.cpp
@@ -562,10 +562,14 @@ void LayoutPage::distributeStaves(const LayoutContext& ctx, Page* page, qreal fo
         }
     }
     --ngaps;
+    const qreal staffLowerBorder = score->styleMM(Sid::staffLowerBorder);
+    const qreal extraHeight = yBottom - prevYBottom;
+    const qreal combinedBottomMargin = page->bm() + footerPadding;
+    const qreal marginToStaff = page->bm() + staffLowerBorder;
+    qreal spaceRemaining{ qMin(page->height() - combinedBottomMargin - yBottom, page->height() - marginToStaff - prevYBottom) };
 
-    qreal spaceRemaining { page->height() - page->bm() - footerPadding - score->styleMM(Sid::staffLowerBorder) - yBottom };
     if (nextSpacer) {
-        spaceRemaining -= qMax(0.0, nextSpacer->gap() - spacerOffset - score->styleMM(Sid::staffLowerBorder));
+        spaceRemaining -= qMax(0.0, nextSpacer->gap() - spacerOffset - staffLowerBorder);
     }
     if (spaceRemaining <= 0.0) {
         return;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10655

The original issue describes the issue very well with lots of useful visuals. This ended up being an error in the calculation of the 'remaining' space after the first layout pass. `footerMusicGap` is a const that represents the gap between the top of the footer and the bottom of the music in the bottom staff, labeled in the image in the linked issue as '1sp'.