### PR TITLE
Fix memory management issue with StaffTypeChange

### DIFF
--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -1007,27 +1007,29 @@ void Measure::add(EngravingItem* e)
 
     case ElementType::STAFFTYPE_CHANGE:
     {
-        StaffTypeChange* stc = toStaffTypeChange(e);
-        Staff* staff = stc->staff();
-        const StaffType* st = stc->staffType();
-        StaffType* nst;
-        // st needs to point to the stafftype element within the stafftypelist for the staff
-        if (st) {
+        StaffTypeChange* staffTypeChange = toStaffTypeChange(e);
+        const StaffType* templateStaffType = staffTypeChange->staffType();
+
+        Staff* staff = staffTypeChange->staff();
+
+        // This will need to point to the stafftype element within the stafftypelist for the staff
+        StaffType* newStaffType = nullptr;
+
+        if (templateStaffType) {
             // executed on read, undo/redo, clone
-            // setStaffType adds a copy to list and returns a pointer to that element within list
-            // we won't need the original after that
-            // this requires that st was allocated via new to begin with!
-            nst = staff->setStaffType(tick(), *st);
-            delete st;
+            // setStaffType adds a copy to stafftypelist and returns a pointer to that element within stafftypelist
+            newStaffType = staff->setStaffType(tick(), *templateStaffType);
         } else {
             // executed on add from palette
             // staffType returns a pointer to the current stafftype element in the list
             // setStaffType will make a copy and return a pointer to that element within list
-            st  = staff->staffType(tick());
-            nst = staff->setStaffType(tick(), *st);
+            templateStaffType = staff->staffType(tick());
+            newStaffType = staff->setStaffType(tick(), *templateStaffType);
         }
+
         staff->staffTypeListChanged(tick());
-        stc->setStaffType(nst);
+        staffTypeChange->setStaffType(newStaffType, false);
+
         MeasureBase::add(e);
     }
     break;
@@ -1130,7 +1132,7 @@ void Measure::remove(EngravingItem* e)
             if (!tick().isZero()) {
                 staff->removeStaffType(tick());
             }
-            stc->setStaffType(st);
+            stc->setStaffType(st, true);
         }
         MeasureBase::remove(e);
     }

--- a/src/engraving/libmscore/stafftypechange.cpp
+++ b/src/engraving/libmscore/stafftypechange.cpp
@@ -45,6 +45,19 @@ StaffTypeChange::StaffTypeChange(const StaffTypeChange& lb)
     : EngravingItem(lb)
 {
     lw = lb.lw;
+    m_ownsStaffType = lb.m_ownsStaffType;
+    if (lb.m_ownsStaffType && lb.m_staffType) {
+        m_staffType = new StaffType(*lb.m_staffType);
+    } else {
+        m_staffType = lb.m_staffType;
+    }
+}
+
+StaffTypeChange::~StaffTypeChange()
+{
+    if (m_staffType && m_ownsStaffType) {
+        delete m_staffType;
+    }
 }
 
 //---------------------------------------------------------
@@ -54,8 +67,8 @@ StaffTypeChange::StaffTypeChange(const StaffTypeChange& lb)
 void StaffTypeChange::write(XmlWriter& xml) const
 {
     xml.startObject(this);
-    if (_staffType) {
-        _staffType->write(xml);
+    if (m_staffType) {
+        m_staffType->write(xml);
     }
     EngravingItem::writeProperties(xml);
     xml.endObject();
@@ -73,11 +86,21 @@ void StaffTypeChange::read(XmlReader& e)
             StaffType* st = new StaffType();
             st->read(e);
             // Measure::add() will replace this with a pointer to a copy in the staff
-            _staffType = st;
+            setStaffType(st, true);
         } else if (!EngravingItem::readProperties(e)) {
             e.unknown();
         }
     }
+}
+
+void StaffTypeChange::setStaffType(StaffType* st, bool owned)
+{
+    if (m_staffType && m_ownsStaffType) {
+        delete m_staffType;
+    }
+
+    m_staffType = st;
+    m_ownsStaffType = owned && (st != nullptr);
 }
 
 //---------------------------------------------------------
@@ -156,35 +179,35 @@ PropertyValue StaffTypeChange::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
     case Pid::STEP_OFFSET:
-        return _staffType->stepOffset();
+        return m_staffType->stepOffset();
     case Pid::STAFF_LINES:
-        return _staffType->lines();
+        return m_staffType->lines();
     case Pid::LINE_DISTANCE:
-        return _staffType->lineDistance();
+        return m_staffType->lineDistance();
     case Pid::STAFF_SHOW_BARLINES:
-        return _staffType->showBarlines();
+        return m_staffType->showBarlines();
     case Pid::STAFF_SHOW_LEDGERLINES:
-        return _staffType->showLedgerLines();
+        return m_staffType->showLedgerLines();
     case Pid::STAFF_STEMLESS:
-        return _staffType->stemless();
+        return m_staffType->stemless();
     case Pid::HEAD_SCHEME:
-        return int(_staffType->noteHeadScheme());
+        return int(m_staffType->noteHeadScheme());
     case Pid::STAFF_GEN_CLEF:
-        return _staffType->genClef();
+        return m_staffType->genClef();
     case Pid::STAFF_GEN_TIMESIG:
-        return _staffType->genTimesig();
+        return m_staffType->genTimesig();
     case Pid::STAFF_GEN_KEYSIG:
-        return _staffType->genKeysig();
+        return m_staffType->genKeysig();
     case Pid::MAG:
-        return _staffType->userMag();
+        return m_staffType->userMag();
     case Pid::SMALL:
-        return _staffType->isSmall();
+        return m_staffType->isSmall();
     case Pid::STAFF_INVISIBLE:
-        return _staffType->invisible();
+        return m_staffType->invisible();
     case Pid::STAFF_COLOR:
-        return PropertyValue::fromValue(_staffType->color());
+        return PropertyValue::fromValue(m_staffType->color());
     case Pid::STAFF_YOFFSET:
-        return _staffType->yoffset();
+        return m_staffType->yoffset();
     default:
         return EngravingItem::getProperty(propertyId);
     }
@@ -198,38 +221,38 @@ bool StaffTypeChange::setProperty(Pid propertyId, const PropertyValue& v)
 {
     switch (propertyId) {
     case Pid::STEP_OFFSET:
-        _staffType->setStepOffset(v.toInt());
+        m_staffType->setStepOffset(v.toInt());
         break;
     case Pid::STAFF_LINES:
-        _staffType->setLines(v.toInt());
+        m_staffType->setLines(v.toInt());
         break;
     case Pid::LINE_DISTANCE:
-        _staffType->setLineDistance(v.value<Spatium>());
+        m_staffType->setLineDistance(v.value<Spatium>());
         break;
     case Pid::STAFF_SHOW_BARLINES:
-        _staffType->setShowBarlines(v.toBool());
+        m_staffType->setShowBarlines(v.toBool());
         break;
     case Pid::STAFF_SHOW_LEDGERLINES:
-        _staffType->setShowLedgerLines(v.toBool());
+        m_staffType->setShowLedgerLines(v.toBool());
         break;
     case Pid::STAFF_STEMLESS:
-        _staffType->setStemless(v.toBool());
+        m_staffType->setStemless(v.toBool());
         break;
     case Pid::HEAD_SCHEME:
-        _staffType->setNoteHeadScheme(v.value<NoteHeadScheme>());
+        m_staffType->setNoteHeadScheme(v.value<NoteHeadScheme>());
         break;
     case Pid::STAFF_GEN_CLEF:
-        _staffType->setGenClef(v.toBool());
+        m_staffType->setGenClef(v.toBool());
         break;
     case Pid::STAFF_GEN_TIMESIG:
-        _staffType->setGenTimesig(v.toBool());
+        m_staffType->setGenTimesig(v.toBool());
         break;
     case Pid::STAFF_GEN_KEYSIG:
-        _staffType->setGenKeysig(v.toBool());
+        m_staffType->setGenKeysig(v.toBool());
         break;
     case Pid::MAG: {
         qreal _spatium = spatium();
-        _staffType->setUserMag(v.toDouble());
+        m_staffType->setUserMag(v.toDouble());
         Staff* _staff = staff();
         if (_staff) {
             _staff->setLocalSpatium(_spatium, spatium(), tick());
@@ -238,7 +261,7 @@ bool StaffTypeChange::setProperty(Pid propertyId, const PropertyValue& v)
     break;
     case Pid::SMALL: {
         qreal _spatium = spatium();
-        _staffType->setSmall(v.toBool());
+        m_staffType->setSmall(v.toBool());
         Staff* _staff = staff();
         if (_staff) {
             _staff->setLocalSpatium(_spatium, spatium(), tick());
@@ -246,13 +269,13 @@ bool StaffTypeChange::setProperty(Pid propertyId, const PropertyValue& v)
     }
     break;
     case Pid::STAFF_INVISIBLE:
-        _staffType->setInvisible(v.toBool());
+        m_staffType->setInvisible(v.toBool());
         break;
     case Pid::STAFF_COLOR:
-        _staffType->setColor(v.value<mu::draw::Color>());
+        m_staffType->setColor(v.value<mu::draw::Color>());
         break;
     case Pid::STAFF_YOFFSET:
-        _staffType->setYoffset(v.value<Spatium>());
+        m_staffType->setYoffset(v.value<Spatium>());
         break;
     default:
         if (!EngravingItem::setProperty(propertyId, v)) {

--- a/src/engraving/libmscore/stafftypechange.h
+++ b/src/engraving/libmscore/stafftypechange.h
@@ -34,7 +34,8 @@ class StaffType;
 
 class StaffTypeChange final : public EngravingItem
 {
-    StaffType* _staffType { 0 };
+    StaffType* m_staffType { nullptr };
+    bool m_ownsStaffType = false;
     qreal lw;
 
     friend class mu::engraving::Factory;
@@ -46,14 +47,15 @@ class StaffTypeChange final : public EngravingItem
     void draw(mu::draw::Painter*) const override;
 
 public:
+    ~StaffTypeChange() override;
 
     StaffTypeChange* clone() const override { return new StaffTypeChange(*this); }
 
     void write(XmlWriter&) const override;
     void read(XmlReader&) override;
 
-    const StaffType* staffType() const { return _staffType; }
-    void setStaffType(StaffType* st) { _staffType = st; }
+    const StaffType* staffType() const { return m_staffType; }
+    void setStaffType(StaffType* st, bool owned);
 
     Measure* measure() const { return toMeasure(explicitParent()); }
 

--- a/src/engraving/libmscore/stafftypelist.cpp
+++ b/src/engraving/libmscore/stafftypelist.cpp
@@ -33,11 +33,11 @@ namespace Ms {
 
 const StaffType& StaffTypeList::staffType(const Fraction& tick) const
 {
-    static const StaffType st;
-
     if (tick.negative()) {
+        static const StaffType st;
         return st;
     }
+
     if (staffTypeChanges.empty()) {
         return firstStaffType;
     }
@@ -46,6 +46,7 @@ const StaffType& StaffTypeList::staffType(const Fraction& tick) const
     if (i == staffTypeChanges.begin()) {
         return firstStaffType;
     }
+
     return (--i)->second;
 }
 


### PR DESCRIPTION
Resolves: [MS#329892](https://musescore.org/en/node/329892)

A crash would occur when enabling multi-measure rests where a staff type change existed at the last measure in a series of full-measure rests. In that situation, the StaffTypeChange of that last measure was `added` to the newly created MMRest measure; while doing so, there was an attempt do `delete` the StaffTypeChange's staff type, which pointed to a StaffTypeChange in the staff's StaffTypeList, and thus was a normal member, and not allocated via `new`. A crash occurs when trying to `delete` that kind of memory.

Note: this PR just solves the crash, which reveals that the interaction between mmrests and staff type changes is sometimes a bit strange...