### PR TITLE
fix #10376: fixed tempo placement of gp files

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -934,7 +934,8 @@ void GPConverter::addTempoMap()
         auto range = _tempoMap.equal_range(measureIdx); //one measure can have several tempo changing
         measureIdx++;
         for (auto tempIt = range.first; tempIt != range.second; tempIt++) {
-            Fraction tick = m->tick() + tempIt->second.position * m->ticks();
+            Fraction tick = m->tick() + Fraction::fromTicks(
+                tempIt->second.position * Constant::division * 4 * m->ticks().numerator() / m->ticks().denominator());
             Segment* segment = m->getSegment(SegmentType::ChordRest, tick);
             int realTemp = realTempo(tempIt->second);
             TempoText* tt = Factory::createTempoText(segment);


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/10376*

*fixed positioning of tempotext imported from guitar pro*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
