### PR TITLE
Brackets inspector: limit the values for 'span' and 'column' fields

### DIFF
--- a/src/engraving/libmscore/bracketItem.h
+++ b/src/engraving/libmscore/bracketItem.h
@@ -58,7 +58,7 @@ public:
     BracketType bracketType() const { return _bracketType; }
     void setBracketSpan(int v) { _bracketSpan = v; }
     void setBracketType(BracketType v) { _bracketType = v; }
-    Staff* staff() { return _staff; }
+    Staff* staff() const { return _staff; }
     void setStaff(Staff* s) { _staff = s; }
     int column() const { return _column; }
     void setColumn(int v) { _column = v; }

--- a/src/inspector/internal/services/elementrepositoryservice.cpp
+++ b/src/inspector/internal/services/elementrepositoryservice.cpp
@@ -136,6 +136,11 @@ QList<Ms::EngravingItem*> ElementRepositoryService::exposeRawElements(const QLis
     QList<Ms::EngravingItem*> resultList;
 
     for (const Ms::EngravingItem* element : rawElementList) {
+        if (element->type() == Ms::ElementType::BRACKET) {
+            resultList << Ms::toBracket(element)->bracketItem();
+            continue;
+        }
+
         if (!resultList.contains(element->elementBase())) {
             resultList << element->elementBase();
         }
@@ -385,12 +390,8 @@ QList<Ms::EngravingItem*> ElementRepositoryService::findBrackets() const
     QList<Ms::EngravingItem*> resultList;
 
     for (Ms::EngravingItem* element : m_exposedElementList) {
-        if (element->isBracket()) {
-            const Ms::Bracket* bracket = Ms::toBracket(element);
-
-            if (bracket && bracket->bracketItem()) {
-                resultList << bracket->bracketItem();
-            }
+        if (element->isBracketItem()) {
+            resultList << element;
         }
     }
 

--- a/src/inspector/models/notation/brackets/bracketsettingsmodel.cpp
+++ b/src/inspector/models/notation/brackets/bracketsettingsmodel.cpp
@@ -43,6 +43,13 @@ void BracketSettingsModel::createProperties()
     m_bracketSpanStaves = buildPropertyItem(Ms::Pid::BRACKET_SPAN);
 }
 
+void BracketSettingsModel::requestElements()
+{
+    m_elementList = m_repository->findElementsByType(Ms::ElementType::BRACKET);
+
+    emit selectionChanged();
+}
+
 void BracketSettingsModel::loadProperties()
 {
     loadPropertyItem(m_bracketColumnPosition);
@@ -68,4 +75,9 @@ PropertyItem* BracketSettingsModel::bracketColumnPosition() const
 PropertyItem* BracketSettingsModel::bracketSpanStaves() const
 {
     return m_bracketSpanStaves;
+}
+
+bool BracketSettingsModel::areSettingsAvailable() const
+{
+    return m_elementList.count() == 1; // Brackets inspector doesn't support multiple selection
 }

--- a/src/inspector/models/notation/brackets/bracketsettingsmodel.cpp
+++ b/src/inspector/models/notation/brackets/bracketsettingsmodel.cpp
@@ -37,6 +37,9 @@ BracketSettingsModel::BracketSettingsModel(QObject* parent, IElementRepositorySe
     setTitle(qtrc("inspector", "Bracket"));
     setIcon(ui::IconCode::Code::BRACKET);
     createProperties();
+
+    connect(this, &BracketSettingsModel::selectionChanged, this, &BracketSettingsModel::maxBracketColumnPositionChanged);
+    connect(m_bracketSpanStaves, &PropertyItem::propertyModified, this, &BracketSettingsModel::maxBracketColumnPositionChanged);
 }
 
 void BracketSettingsModel::createProperties()

--- a/src/inspector/models/notation/brackets/bracketsettingsmodel.h
+++ b/src/inspector/models/notation/brackets/bracketsettingsmodel.h
@@ -33,6 +33,8 @@ class BracketSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(PropertyItem * bracketSpanStaves READ bracketSpanStaves CONSTANT)
 
     Q_PROPERTY(bool areSettingsAvailable READ areSettingsAvailable NOTIFY selectionChanged)
+    Q_PROPERTY(int maxBracketColumnPosition READ maxBracketColumnPosition NOTIFY selectionChanged)
+    Q_PROPERTY(int maxBracketSpanStaves READ maxBracketSpanStaves NOTIFY selectionChanged)
 
 public:
 
@@ -47,6 +49,8 @@ public:
     PropertyItem* bracketSpanStaves() const;
 
     bool areSettingsAvailable() const;
+    int maxBracketColumnPosition() const;
+    int maxBracketSpanStaves() const;
 
 signals:
     void selectionChanged();

--- a/src/inspector/models/notation/brackets/bracketsettingsmodel.h
+++ b/src/inspector/models/notation/brackets/bracketsettingsmodel.h
@@ -33,7 +33,7 @@ class BracketSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(PropertyItem * bracketSpanStaves READ bracketSpanStaves CONSTANT)
 
     Q_PROPERTY(bool areSettingsAvailable READ areSettingsAvailable NOTIFY selectionChanged)
-    Q_PROPERTY(int maxBracketColumnPosition READ maxBracketColumnPosition NOTIFY selectionChanged)
+    Q_PROPERTY(int maxBracketColumnPosition READ maxBracketColumnPosition NOTIFY maxBracketColumnPositionChanged)
     Q_PROPERTY(int maxBracketSpanStaves READ maxBracketSpanStaves NOTIFY selectionChanged)
 
 public:
@@ -54,6 +54,7 @@ public:
 
 signals:
     void selectionChanged();
+    void maxBracketColumnPositionChanged();
 
 private:
     void updatePropertiesOnNotationChanged() override;

--- a/src/inspector/models/notation/brackets/bracketsettingsmodel.h
+++ b/src/inspector/models/notation/brackets/bracketsettingsmodel.h
@@ -32,16 +32,24 @@ class BracketSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(PropertyItem * bracketColumnPosition READ bracketColumnPosition CONSTANT)
     Q_PROPERTY(PropertyItem * bracketSpanStaves READ bracketSpanStaves CONSTANT)
 
+    Q_PROPERTY(bool areSettingsAvailable READ areSettingsAvailable NOTIFY selectionChanged)
+
 public:
 
     explicit BracketSettingsModel(QObject* parent, IElementRepositoryService* repository);
 
     void createProperties() override;
+    void requestElements() override;
     void loadProperties() override;
     void resetProperties() override;
 
     PropertyItem* bracketColumnPosition() const;
     PropertyItem* bracketSpanStaves() const;
+
+    bool areSettingsAvailable() const;
+
+signals:
+    void selectionChanged();
 
 private:
     void updatePropertiesOnNotationChanged() override;

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/brackets/BracketSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/brackets/BracketSettings.qml
@@ -61,7 +61,7 @@ Column {
 
             step: 1
             decimals: 0
-            maxValue: 127
+            maxValue: root.model ? root.model.maxBracketColumnPosition : 0
             minValue: 0
 
             navigationPanel: root.navigationPanel
@@ -79,8 +79,8 @@ Column {
 
             step: 1
             decimals: 0
-            maxValue: 127
-            minValue: 0
+            maxValue: root.model ? root.model.maxBracketSpanStaves : 0
+            minValue: 1
 
             navigationPanel: root.navigationPanel
             navigationRowStart: columnSection.navigationRowEnd + 1

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/brackets/BracketSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/brackets/BracketSettings.qml
@@ -43,30 +43,54 @@ Column {
         columnSection.focusOnFirst()
     }
 
-    SpinBoxPropertyView {
-        id: columnSection
-        titleText: qsTrc("inspector", "Column")
-        propertyItem: root.model ? root.model.bracketColumnPosition : nul
+    Item {
+        height: childrenRect.height
+        width: parent.width
 
-        step: 1
-        decimals: 0
-        maxValue: 127
-        minValue: 0
+        enabled: root.model ? root.model.areSettingsAvailable : false
 
-        navigationPanel: root.navigationPanel
-        navigationRowStart: root.navigationRowStart + 1
+        SpinBoxPropertyView {
+            id: columnSection
+            anchors.left: parent.left
+            anchors.right: parent.horizontalCenter
+            anchors.rightMargin: 2
+
+            titleText: qsTrc("inspector", "Column")
+            propertyItem: root.model ? root.model.bracketColumnPosition : null
+            showButton: false
+
+            step: 1
+            decimals: 0
+            maxValue: 127
+            minValue: 0
+
+            navigationPanel: root.navigationPanel
+            navigationRowStart: root.navigationRowStart + 1
+        }
+
+        SpinBoxPropertyView {
+            anchors.left: parent.horizontalCenter
+            anchors.leftMargin: 2
+            anchors.right: parent.right
+
+            titleText: qsTrc("inspector", "Span")
+            propertyItem: root.model ? root.model.bracketSpanStaves : null
+            showButton: false
+
+            step: 1
+            decimals: 0
+            maxValue: 127
+            minValue: 0
+
+            navigationPanel: root.navigationPanel
+            navigationRowStart: columnSection.navigationRowEnd + 1
+        }
     }
 
-    SpinBoxPropertyView {
-        titleText: qsTrc("inspector", "Span")
-        propertyItem: root.model ? root.model.bracketSpanStaves : nul
-
-        step: 1
-        decimals: 0
-        maxValue: 127
-        minValue: 0
-
-        navigationPanel: root.navigationPanel
-        navigationRowStart: columnSection.navigationRowEnd + 1
+    StyledTextLabel {
+        width: parent.width
+        visible: root.model ? !root.model.areSettingsAvailable : false
+        text: qsTrc("inspector", "You have multiple brackets selected. Select a single bracket to edit its settings.")
+        wrapMode: Text.Wrap
     }
 }

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/fretdiagrams/FretDiagramSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/fretdiagrams/FretDiagramSettings.qml
@@ -100,7 +100,7 @@ Item {
         anchors.fill: parent
 
         wrapMode: Text.Wrap
-        text: qsTrc("inspector", "You have multiple fretboard diagrams selected. Select a single diagram to edit its settings")
+        text: qsTrc("inspector", "You have multiple fretboard diagrams selected. Select a single diagram to edit its settings.")
         visible: root.model ? !root.model.areSettingsAvailable : false
     }
 }

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/tremolobars/TremoloBarSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/tremolobars/TremoloBarSettings.qml
@@ -148,7 +148,7 @@ Item {
         anchors.fill: parent
 
         wrapMode: Text.Wrap
-        text: qsTrc("inspector", "You have multiple tremolo bars selected. Select a single one to edit its settings")
+        text: qsTrc("inspector", "You have multiple tremolo bars selected. Select a single one to edit its settings.")
         visible: root.model ? !root.model.areSettingsAvailable : false
     }
 }


### PR DESCRIPTION
Resolves: #10548 

When multiple brackets are selected, the fields are disabled and a message like this is shown:
<img width="301" alt="Schermafbeelding 2022-02-27 om 23 43 22" src="https://user-images.githubusercontent.com/48658420/155903042-b6ae8f8a-890c-4d02-af36-78934b0d0ca3.png">

I also fixed a crash that had to do with other inspector models, but made it almost impossible to test this. However, this fix breaks the possibility to edit properties in those other models (actually only the 'General' section), since they now modify the `BracketItem` element instead of the `Bracket` element. (A `BracketItem` is a kind of template/description for a bracket for the whole score, where a `Bracket` is a 'realization' of it, on a single system. `Brackets` get deleted and recreated on every layout, which causes a crash when the Inspector models still use pointers to them). 
It would be a separate task to fix that. MuseScore 3's solution seems to be: not showing those settings at all for brackets.