### PR TITLE
[MU4] Fix #10644: Percussion Input Tab is unusable in dark mode. Positioning broken. Shortcut visualisations missing

### DIFF
--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -372,9 +372,15 @@ DockPage {
             objectName: pageModel.drumsetPanelName()
             title: qsTrc("appshell", "Drumset Tools")
 
-            height: 100
-            minimumHeight: 100
-            maximumHeight: 200
+            height: 64
+            minimumHeight: 64
+            maximumHeight: 64
+
+            //! NOTE: hidden by default
+            visible: false
+
+            //! NOTE: the user cannot close or undock this panel
+            persistent: true
 
             location: Location.Bottom
 

--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -372,8 +372,9 @@ DockPage {
             objectName: pageModel.drumsetPanelName()
             title: qsTrc("appshell", "Drumset Tools")
 
-            minimumHeight: 30
-            maximumHeight: 30
+            height: 100
+            minimumHeight: 100
+            maximumHeight: 200
 
             location: Location.Bottom
 

--- a/src/engraving/iengravingconfiguration.h
+++ b/src/engraving/iengravingconfiguration.h
@@ -50,6 +50,7 @@ public:
     virtual std::string iconsFontFamily() const = 0;
 
     virtual draw::Color defaultColor() const = 0;
+    virtual draw::Color scoreInversionColor() const = 0;
     virtual draw::Color invisibleColor() const = 0;
     virtual draw::Color lassoColor() const = 0;
     virtual draw::Color warningColor() const = 0;

--- a/src/engraving/infrastructure/internal/engravingconfiguration.cpp
+++ b/src/engraving/infrastructure/internal/engravingconfiguration.cpp
@@ -104,6 +104,12 @@ Color EngravingConfiguration::defaultColor() const
     return Color::black;
 }
 
+Color EngravingConfiguration::scoreInversionColor() const
+{
+    // slightly dulled white for less strain on the eyes
+    return Color(220, 220, 220);
+}
+
 Color EngravingConfiguration::invisibleColor() const
 {
     return "#808080";

--- a/src/engraving/infrastructure/internal/engravingconfiguration.h
+++ b/src/engraving/infrastructure/internal/engravingconfiguration.h
@@ -46,6 +46,7 @@ public:
     std::string iconsFontFamily() const override;
 
     draw::Color defaultColor() const override;
+    draw::Color scoreInversionColor() const override;
     draw::Color invisibleColor() const override;
     draw::Color lassoColor() const override;
     draw::Color warningColor() const override;

--- a/src/engraving/libmscore/engravingitem.cpp
+++ b/src/engraving/libmscore/engravingitem.cpp
@@ -621,28 +621,31 @@ mu::draw::Color EngravingItem::curColor(bool isVisible, Color normalColor) const
 
     bool marked = false;
     if (isNote()) {
-        //const Note* note = static_cast<const Note*>(this);
         marked = toNote(this)->mark();
     }
+
     if (selected() || marked) {
-        mu::draw::Color originalColor = engravingConfiguration()->selectionColor(track() == -1 ? 0 : voice());
+        Color originalColor = engravingConfiguration()->selectionColor(track() == -1 ? 0 : voice());
 
         if (isVisible) {
             return originalColor;
-        } else {
-            int red = originalColor.red();
-            int green = originalColor.green();
-            int blue = originalColor.blue();
-            float tint = .6f; // Between 0 and 1. Higher means lighter, lower means darker
-            return mu::draw::Color(red + tint * (255 - red), green + tint * (255 - green), blue + tint * (255 - blue));
         }
+
+        constexpr float tint = .6f; // Between 0 and 1. Higher means lighter, lower means darker
+
+        int red = originalColor.red();
+        int green = originalColor.green();
+        int blue = originalColor.blue();
+
+        return Color(red + tint * (255 - red), green + tint * (255 - green), blue + tint * (255 - blue));
     }
+
     if (!isVisible) {
         return engravingConfiguration()->invisibleColor();
     }
-    if (engravingConfiguration()->scoreInversionEnabled()
-        && !score()->isPaletteScore()) {
-        return mu::draw::Color(220, 220, 220); //slightly dulled white for less strain on the eyes
+
+    if (m_colorsInversionEnabled && engravingConfiguration()->scoreInversionEnabled()) {
+        return engravingConfiguration()->scoreInversionColor();
     }
 
     return normalColor;
@@ -2383,6 +2386,16 @@ void EngravingItem::endEdit(EditData&)
 qreal EngravingItem::styleP(Sid idx) const
 {
     return score()->styleMM(idx);
+}
+
+bool EngravingItem::colorsInversionEnabled() const
+{
+    return m_colorsInversionEnabled;
+}
+
+void EngravingItem::setColorsInverionEnabled(bool enabled)
+{
+    m_colorsInversionEnabled = enabled;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/engravingitem.h
+++ b/src/engraving/libmscore/engravingitem.h
@@ -210,6 +210,8 @@ class EngravingItem : public EngravingObject
 
     mu::engraving::AccessibleItem* m_accessible = nullptr;
 
+    bool m_colorsInversionEnabled = true;
+
 protected:
     mutable int _z;
     mu::draw::Color _color;                ///< element color attribute
@@ -588,6 +590,9 @@ public:
     bool rebaseMinDistance(qreal& md, qreal& yd, qreal sp, qreal rebase, bool above, bool fix);
 
     qreal styleP(Sid idx) const;
+
+    bool colorsInversionEnabled() const;
+    void setColorsInverionEnabled(bool enabled);
 };
 
 using ElementPtr = std::shared_ptr<EngravingItem>;

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -207,6 +207,10 @@ void NotationConfiguration::init()
     settings()->setDefaultValue(NEED_TO_SHOW_ADD_FIGURED_BASS_ERROR_MESSAGE_KEY, Val(true));
     settings()->setDefaultValue(NEED_TO_SHOW_ADD_BOXES_ERROR_MESSAGE_KEY, Val(true));
 
+    engravingConfiguration()->scoreInversionChanged().onNotify(this, [this]() {
+        m_foregroundChanged.notify();
+    });
+
     Ms::MScore::warnPitchRange = colorNotesOusideOfUsablePitchRange();
     Ms::MScore::defaultPlayDuration = notePlayDurationMilliseconds();
 

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -451,10 +451,6 @@ void NotationPaintView::onNotationSetup()
         update();
     });
 
-    engravingConfiguration()->scoreInversionChanged().onNotify(this, [this]() {
-        update();
-    });
-
     uiConfiguration()->currentThemeChanged().onNotify(this, [this]() {
         update();
     });

--- a/src/palette/internal/palette.cpp
+++ b/src/palette/internal/palette.cpp
@@ -96,14 +96,14 @@ Palette::Type Palette::contentType() const
     return t;
 }
 
-PaletteCellPtr Palette::insertElement(size_t idx, ElementPtr element, const QString& name, qreal mag)
+PaletteCellPtr Palette::insertElement(size_t idx, ElementPtr element, const QString& name, qreal mag, const QString& tag)
 {
     if (element) {
         // layout may be important for comparing cells, e.g. filtering "More" popup content
         element->layout();
     }
 
-    PaletteCellPtr cell = std::make_shared<PaletteCell>(element, name, mag, this);
+    PaletteCellPtr cell = std::make_shared<PaletteCell>(element, name, mag, tag, this);
 
     auto cellHandler = cellHandlerByPaletteType(m_type);
     if (cellHandler) {
@@ -114,14 +114,14 @@ PaletteCellPtr Palette::insertElement(size_t idx, ElementPtr element, const QStr
     return cell;
 }
 
-PaletteCellPtr Palette::appendElement(ElementPtr element, const QString& name, qreal mag)
+PaletteCellPtr Palette::appendElement(ElementPtr element, const QString& name, qreal mag, const QString& tag)
 {
     if (element) {
         // layout may be important for comparing cells, e.g. filtering "More" popup content
         element->layout();
     }
 
-    PaletteCellPtr cell = std::make_shared<PaletteCell>(element, name, mag, this);
+    PaletteCellPtr cell = std::make_shared<PaletteCell>(element, name, mag, tag, this);
 
     auto cellHandler = cellHandlerByPaletteType(m_type);
     if (cellHandler) {

--- a/src/palette/internal/palette.h
+++ b/src/palette/internal/palette.h
@@ -99,8 +99,8 @@ public:
 
     Type contentType() const;
 
-    PaletteCellPtr insertElement(size_t idx, Ms::ElementPtr element, const QString& name, qreal mag = 1.0);
-    PaletteCellPtr appendElement(Ms::ElementPtr element, const QString& name, qreal mag = 1.0);
+    PaletteCellPtr insertElement(size_t idx, Ms::ElementPtr element, const QString& name, qreal mag = 1.0, const QString& tag = "");
+    PaletteCellPtr appendElement(Ms::ElementPtr element, const QString& name, qreal mag = 1.0, const QString& tag = "");
     PaletteCellPtr appendActionIcon(Ms::ActionIconType type, actions::ActionCode code);
 
     bool insertCell(size_t idx, PaletteCellPtr cell);

--- a/src/palette/internal/palettecell.cpp
+++ b/src/palette/internal/palettecell.cpp
@@ -67,7 +67,7 @@ PaletteCell::PaletteCell(QObject* parent)
     id = makeId();
 }
 
-PaletteCell::PaletteCell(ElementPtr e, const QString& _name, qreal _mag, const QString &_tag, QObject* parent)
+PaletteCell::PaletteCell(ElementPtr e, const QString& _name, qreal _mag, const QString& _tag, QObject* parent)
     : QObject(parent), element(e), name(_name), mag(_mag), tag(_tag)
 {
     id = makeId();

--- a/src/palette/internal/palettecell.cpp
+++ b/src/palette/internal/palettecell.cpp
@@ -67,8 +67,8 @@ PaletteCell::PaletteCell(QObject* parent)
     id = makeId();
 }
 
-PaletteCell::PaletteCell(ElementPtr e, const QString& _name, qreal _mag, QObject* parent)
-    : QObject(parent), element(e), name(_name), mag(_mag)
+PaletteCell::PaletteCell(ElementPtr e, const QString& _name, qreal _mag, const QString &_tag, QObject* parent)
+    : QObject(parent), element(e), name(_name), mag(_mag), tag(_tag)
 {
     id = makeId();
     drawStaff = needsStaff(element);
@@ -194,6 +194,8 @@ bool PaletteCell::read(XmlReader& e)
             yoffset = e.readDouble();
         } else if (s == "mag") {
             mag = e.readDouble();
+        } else if (s == "tag") {
+            tag = e.readElementText();
         }
         // added on palettes rework
         // TODO: remove or leave to switch from using attributes later?
@@ -251,6 +253,9 @@ void PaletteCell::write(XmlWriter& xml) const
     }
     if (yoffset) {
         xml.tag("yoffset", yoffset);
+    }
+    if (!tag.isEmpty()) {
+        xml.tag("tag", tag);
     }
     if (mag != 1.0) {
         xml.tag("mag", mag);

--- a/src/palette/internal/palettecell.h
+++ b/src/palette/internal/palettecell.h
@@ -70,7 +70,7 @@ class PaletteCell : public QObject
 
 public:
     explicit PaletteCell(QObject* parent = nullptr);
-    PaletteCell(Ms::ElementPtr e, const QString& _name, qreal _mag = 1.0, QObject* parent = nullptr);
+    PaletteCell(Ms::ElementPtr e, const QString& _name, qreal _mag = 1.0, const QString& tag = "", QObject* parent = nullptr);
 
     static QAccessibleInterface* accessibleInterface(QObject* object);
 
@@ -93,6 +93,7 @@ public:
     Ms::ElementPtr untranslatedElement;
     QString id;
     QString name; // used for tool tip
+    QString tag;
 
     bool drawStaff { false };
     double xoffset { 0.0 }; // in spatium units of "gscore"

--- a/src/palette/internal/palettecelliconengine.cpp
+++ b/src/palette/internal/palettecelliconengine.cpp
@@ -184,25 +184,36 @@ void PaletteCellIconEngine::paintScoreElement(Painter& painter, EngravingItem* e
 
     painter.translate(-1.0 * origin); // shift coordinates so element is drawn at correct position
 
-    element->scanElements(&painter, paintPaletteElement);
+    PaintContext ctx;
+    ctx.painter = &painter;
+
+    element->scanElements(&ctx, paintPaletteElement);
     painter.restore();
 }
 
-void PaletteCellIconEngine::paintPaletteElement(void* data, EngravingItem* element)
+void PaletteCellIconEngine::paintPaletteElement(void* context, EngravingItem* element)
 {
-    Painter* painter = static_cast<Painter*>(data);
+    PaintContext* ctx = static_cast<PaintContext*>(context);
+    Painter* painter = ctx->painter;
+
     painter->save();
     painter->translate(element->pos()); // necessary for drawing child elements
 
-    auto colorBackup = element->getProperty(Pid::COLOR).value<Color>();
-    auto frameColorBackup = element->getProperty(Pid::FRAME_FG_COLOR).value<Color>();
+    Color colorBackup = element->getProperty(Pid::COLOR).value<Color>();
+    Color frameColorBackup = element->getProperty(Pid::FRAME_FG_COLOR).value<Color>();
+    bool colorsInversionEnabledBackup = element->colorsInversionEnabled();
 
-    auto color = Color::fromQColor(configuration()->elementsColor());
-    element->setProperty(Pid::COLOR, color);
-    element->setProperty(Pid::FRAME_FG_COLOR, color);
+    element->setColorsInverionEnabled(ctx->colorsInversionEnabled);
+
+    if (!ctx->useElementColors) {
+        Color color = configuration()->elementsColor();
+        element->setProperty(Pid::COLOR, color);
+        element->setProperty(Pid::FRAME_FG_COLOR, color);
+    }
 
     element->draw(painter);
 
+    element->setColorsInverionEnabled(colorsInversionEnabledBackup);
     element->setProperty(Pid::COLOR, colorBackup);
     element->setProperty(Pid::FRAME_FG_COLOR, frameColorBackup);
 

--- a/src/palette/internal/palettecelliconengine.h
+++ b/src/palette/internal/palettecelliconengine.h
@@ -30,6 +30,10 @@
 #include "ipaletteconfiguration.h"
 #include "ui/iuiconfiguration.h"
 
+namespace mu::draw {
+class Painter;
+}
+
 namespace mu::palette {
 class PaletteCellIconEngine : public QIconEngine
 {
@@ -43,7 +47,14 @@ public:
 
     void paint(QPainter* painter, const QRect& rect, QIcon::Mode mode, QIcon::State state) override;
 
-    static void paintPaletteElement(void* data, Ms::EngravingItem* element);
+    struct PaintContext
+    {
+        mu::draw::Painter* painter = nullptr;
+        bool useElementColors = false;
+        bool colorsInversionEnabled = false;
+    };
+
+    static void paintPaletteElement(void* context, Ms::EngravingItem* element);
 
 private:
     void paintCell(draw::Painter& painter, const RectF& rect, bool selected, bool current) const;

--- a/src/palette/qml/MuseScore/Palette/DrumsetPanel.qml
+++ b/src/palette/qml/MuseScore/Palette/DrumsetPanel.qml
@@ -29,10 +29,10 @@ import MuseScore.Palette 1.0
 Item {
     RowLayout {
         anchors.fill: parent
-        anchors.leftMargin: 26
-        anchors.rightMargin: 26
+        anchors.leftMargin: 12
+        anchors.rightMargin: 8
 
-        spacing: 26
+        spacing: 12
 
         Column {
             Layout.alignment: Qt.AlignVCenter

--- a/src/palette/view/drumsetpanelview.h
+++ b/src/palette/view/drumsetpanelview.h
@@ -28,14 +28,19 @@
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
 #include "actions/iactionsdispatcher.h"
+#include "notation/inotationconfiguration.h"
+#include "engraving/iengravingconfiguration.h"
 
 namespace mu::palette {
+class DrumsetPaletteAdapter;
 class DrumsetPanelView : public ui::WidgetView, public async::Asyncable
 {
     Q_OBJECT
 
     INJECT(palette, context::IGlobalContext, globalContext)
     INJECT(palette, actions::IActionsDispatcher, dispatcher)
+    INJECT(palette, notation::INotationConfiguration, notationConfiguration)
+    INJECT(palette, engraving::IEngravingConfiguration, engravingConfiguration)
 
     Q_PROPERTY(QString pitchName READ pitchName NOTIFY pitchNameChanged)
 
@@ -52,7 +57,14 @@ signals:
 private:
     void componentComplete() override;
 
+    void initDrumsetPalette();
+    void updateColors();
+
+    void setPitchName(const QString& name);
+
     QString m_pitchName;
+
+    std::shared_ptr<DrumsetPaletteAdapter> m_adapter;
 };
 }
 

--- a/src/palette/view/widgets/drumsetpalette.cpp
+++ b/src/palette/view/widgets/drumsetpalette.cpp
@@ -140,7 +140,12 @@ void DrumsetPalette::updateDrumset()
 
         note->setCachedNoteheadSym(noteheadSym);     // we use the cached notehead so we don't recompute it at each layout
         chord->add(note);
-        m_drumPalette->appendElement(chord, mu::qtrc("drumset", m_drumset->name(pitch).toUtf8().data()));
+
+        int shortcutCode = m_drumset->shortcut(pitch);
+        QString shortcut = shortcutCode != 0 ? QChar(shortcutCode) : QString();
+
+        m_drumset->shortcut(pitch);
+        m_drumPalette->appendElement(chord, mu::qtrc("drumset", m_drumset->name(pitch).toUtf8().data()), 1.0, shortcut);
     }
 
     noteInput->setDrumNote(selectedDrumNote());

--- a/src/palette/view/widgets/drumsetpalette.cpp
+++ b/src/palette/view/widgets/drumsetpalette.cpp
@@ -144,7 +144,6 @@ void DrumsetPalette::updateDrumset()
         int shortcutCode = m_drumset->shortcut(pitch);
         QString shortcut = shortcutCode != 0 ? QChar(shortcutCode) : QString();
 
-        m_drumset->shortcut(pitch);
         m_drumPalette->appendElement(chord, mu::qtrc("drumset", m_drumset->name(pitch).toUtf8().data()), 1.0, shortcut);
     }
 
@@ -241,6 +240,11 @@ bool DrumsetPalette::handleEvent(QEvent* event)
 mu::async::Channel<QString> DrumsetPalette::pitchNameChanged() const
 {
     return m_pitchNameChanged;
+}
+
+PaletteWidget* DrumsetPalette::paletteWidget() const
+{
+    return m_drumPalette;
 }
 
 INotationNoteInputPtr DrumsetPalette::noteInput() const

--- a/src/palette/view/widgets/drumsetpalette.h
+++ b/src/palette/view/widgets/drumsetpalette.h
@@ -38,7 +38,7 @@ class DrumsetPalette : public PaletteScrollArea
 {
     Q_OBJECT
 
-    INJECT(Ms, mu::actions::IActionsDispatcher, dispatcher)
+    INJECT(palette, actions::IActionsDispatcher, dispatcher)
 
 public:
     explicit DrumsetPalette(QWidget* parent = nullptr);
@@ -48,6 +48,8 @@ public:
     bool handleEvent(QEvent* event);
 
     mu::async::Channel<QString> pitchNameChanged() const;
+
+    PaletteWidget* paletteWidget() const;
 
 private slots:
     void drumNoteSelected(int val);

--- a/src/palette/view/widgets/palettewidget.cpp
+++ b/src/palette/view/widgets/palettewidget.cpp
@@ -152,9 +152,9 @@ ElementPtr PaletteWidget::elementForCellAt(int idx) const
     return cell ? cell->element : nullptr;
 }
 
-PaletteCellPtr PaletteWidget::insertElement(int idx, ElementPtr element, const QString& name, qreal mag)
+PaletteCellPtr PaletteWidget::insertElement(int idx, ElementPtr element, const QString& name, qreal mag, const QString& tag)
 {
-    PaletteCellPtr cell = m_palette->insertElement(idx, element, name, mag);
+    PaletteCellPtr cell = m_palette->insertElement(idx, element, name, mag, tag);
 
     update();
     updateGeometry();
@@ -162,9 +162,9 @@ PaletteCellPtr PaletteWidget::insertElement(int idx, ElementPtr element, const Q
     return cell;
 }
 
-PaletteCellPtr PaletteWidget::appendElement(ElementPtr element, const QString& name, qreal mag)
+PaletteCellPtr PaletteWidget::appendElement(ElementPtr element, const QString& name, qreal mag, const QString& tag)
 {
-    PaletteCellPtr cell = m_palette->appendElement(element, name, mag);
+    PaletteCellPtr cell = m_palette->appendElement(element, name, mag, tag);
 
     setFixedHeight(heightForWidth(width()));
     updateGeometry();
@@ -973,7 +973,9 @@ void PaletteWidget::paintEvent(QPaintEvent* /*event*/)
     // draw symbols
     //
     for (int idx = 0; idx < int(actualCellsList().size()); ++idx) {
+        int yoffset = _spatium * yOffset();
         RectF r = RectF::fromQRectF(rectForCellAt(idx));
+        RectF rShift = r.translated(0, yoffset);
         QColor c(configuration()->accentColor());
 
         PaletteCellPtr currentCell = actualCellsList().at(idx);
@@ -1001,6 +1003,15 @@ void PaletteWidget::paintEvent(QPaintEvent* /*event*/)
         } else if (idx == m_currentIdx) {
             c.setAlphaF(0.2);
             painter.fillRect(r, c);
+        }
+
+        QString tag = currentCell->tag;
+        if (!tag.isEmpty()) {
+            painter.setPen(QColor(Qt::darkGray));
+            Font font(painter.font());
+            font.setPointSizeF(uiConfiguration()->fontSize(ui::FontSizeType::BODY));
+            painter.setFont(font);
+            painter.drawText(rShift, Qt::AlignLeft | Qt::AlignTop, tag);
         }
 
         draw::Pen pen(configuration()->elementsColor());

--- a/src/palette/view/widgets/palettewidget.h
+++ b/src/palette/view/widgets/palettewidget.h
@@ -158,6 +158,17 @@ public:
     // events
     bool handleEvent(QEvent* event);
 
+    struct PaintOptions {
+        mu::draw::Color backgroundColor;
+        mu::draw::Color selectionColor;
+        mu::draw::Color linesColor;
+        bool useElementColors = false;
+        bool colorsInverionsEnabled = false;
+    };
+
+    const PaintOptions& paintOptions() const;
+    void setPaintOptions(const PaintOptions& options);
+
 signals:
     void changed();
     void boxClicked(int index);
@@ -212,6 +223,8 @@ private:
     int m_dragIdx = -1;
     int m_selectedIdx = -1;
     QPoint m_dragStartPosition;
+
+    PaintOptions m_paintOptions;
 };
 
 class PaletteScrollArea : public QScrollArea

--- a/src/palette/view/widgets/palettewidget.h
+++ b/src/palette/view/widgets/palettewidget.h
@@ -89,8 +89,8 @@ public:
     PaletteCellPtr cellAt(size_t index) const;
     Ms::ElementPtr elementForCellAt(int idx) const;
 
-    PaletteCellPtr insertElement(int idx, Ms::ElementPtr element, const QString& name, qreal mag = 1.0);
-    PaletteCellPtr appendElement(Ms::ElementPtr element, const QString& name, qreal mag = 1.0);
+    PaletteCellPtr insertElement(int idx, Ms::ElementPtr element, const QString& name, qreal mag = 1.0, const QString& tag = "");
+    PaletteCellPtr appendElement(Ms::ElementPtr element, const QString& name, qreal mag = 1.0, const QString& tag = "");
     PaletteCellPtr appendActionIcon(Ms::ActionIconType type, actions::ActionCode code);
 
     void clear();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10644