### PR TITLE
[MU4] Fix #10666: When adding/replacing some shortcuts, the conflict message about existed shortcut doesn't appear

### DIFF
--- a/src/framework/shortcuts/view/editshortcutmodel.h
+++ b/src/framework/shortcuts/view/editshortcutmodel.h
@@ -66,10 +66,9 @@ private:
 
     void validateInputedSequence();
 
-    QVariantList m_allShortcuts;
+    QVariantList m_potentialConflictShortcuts;
     QKeySequence m_inputedSequence;
     QString m_originSequence;
-    QVariant m_originShortcutContext;
     QString m_errorMessage;
 };
 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10666