### PR TITLE
[MU4] fix #10642: Double-click measures to enter note input mode

### DIFF
--- a/src/notation/view/notationcontextmenumodel.cpp
+++ b/src/notation/view/notationcontextmenumodel.cpp
@@ -173,10 +173,26 @@ MenuItemList NotationContextMenuModel::makeSelectItems()
 
 MenuItemList NotationContextMenuModel::makeElementItems()
 {
-    MenuItemList items = makeDefaultCopyPasteItems();
+    // The element context menu is divided into two sections:
+    // 1. the copy-paste items, and
+    // 2. everything else.
+    MenuItemList copyPasteItems = makeDefaultCopyPasteItems();
+    MenuItemList otherItems = {};
+
+    if (isSingleSelection()) {
+        otherItems << makeMenuItem("edit-element");
+    }
+
     MenuItemList selectItems = makeSelectItems();
     if (!selectItems.isEmpty()) {
-        items << makeMenu(qtrc("notation", "Select"), selectItems);
+        otherItems << makeMenu(qtrc("notation", "Select"), selectItems);
+    }
+
+    MenuItemList items = {};
+    items << copyPasteItems;
+    if (!otherItems.isEmpty()) {
+        items << makeSeparator();
+        items << otherItems;
     }
     return items;
 }

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -714,14 +714,11 @@ void NotationViewInputController::handleLeftClickRelease(const QPointF& releaseP
         return;
     }
 
-    engraving::staff_idx_t staffIndex = ctx.staff ? ctx.staff->idx() : mu::nidx;
-
-    INotationInteractionPtr interaction = viewInteraction();
-    interaction->select({ ctx.element }, SelectType::SINGLE, staffIndex);
-
     if (ctx.element != m_prevHitElement) {
         return;
     }
+
+    INotationInteractionPtr interaction = viewInteraction();
 
     if (interaction->isTextEditingStarted()) {
         return;
@@ -732,17 +729,16 @@ void NotationViewInputController::handleLeftClickRelease(const QPointF& releaseP
     }
 }
 
-void NotationViewInputController::mouseDoubleClickEvent(QMouseEvent*)
+void NotationViewInputController::mouseDoubleClickEvent(QMouseEvent* event)
 {
+    PointF logicPos = PointF(m_view->toLogical(event->pos()));
+    EngravingItem* hitElement = viewInteraction()->hitElement(logicPos, hitWidth());
+
     if (m_view->isNoteEnterMode()) {
-        return;
+        // do nothing
+    } else if (hitElement && hitElement->isMeasure() && event->modifiers() == Qt::NoModifier) {
+        dispatcher()->dispatch("note-input", ActionData::make_arg1<PointF>(m_beginPoint));
     }
-
-    if (viewInteraction()->isElementEditStarted()) {
-        return;
-    }
-
-    dispatcher()->dispatch("edit-element", ActionData::make_arg1<PointF>(m_beginPoint));
 }
 
 void NotationViewInputController::hoverMoveEvent(QHoverEvent* event)


### PR DESCRIPTION
Resolves: <https://github.com/musescore/MuseScore/issues/10642> "Quality of Life Improvement: Double Click to enter Note Input Mode"

These changes are a small convenience to make it easier to add notes to a measure. :slightly_smiling_face:

**Details:**

- Double-clicking a measure does nothing if modifier keys are held. This keeps the user from accidentally entering note input mode in the middle of a multiple-selection action.

- Edit: Double-clicking a note or rest (or other score element) will do nothing.<br>~~As before, double-clicking a note or rest will still take you to edit mode, not note input mode. We may want to consider changing this behavior, so that double-clicking a note would take you to note input mode, but that's an ongoing discussion. (See <https://github.com/musescore/MuseScore/issues/10642> for more.)~~

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
  - Unit tests are currently disabled for `notationviewinputcontroller.cpp`. (Follow-up issue filed: <https://github.com/musescore/MuseScore/issues/10667>.)
  - Script-tests and vtests don't have facilities for testing mouse events (at least from what I can tell).