### PR TITLE
Improvements to horizontal spacing

### DIFF
--- a/share/templates/01-General/01-Treble_Clef/score_style.mss
+++ b/share/templates/01-General/01-Treble_Clef/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/01-General/02-Bass_Clef/score_style.mss
+++ b/share/templates/01-General/02-Bass_Clef/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/01-General/03-Grand_Staff/score_style.mss
+++ b/share/templates/01-General/03-Grand_Staff/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/02-Choral/01-SATB/score_style.mss
+++ b/share/templates/02-Choral/01-SATB/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/02-Choral/02-SATB_+_Organ/score_style.mss
+++ b/share/templates/02-Choral/02-SATB_+_Organ/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/02-Choral/03-SATB_+_Piano/score_style.mss
+++ b/share/templates/02-Choral/03-SATB_+_Piano/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/02-Choral/04-SATB_Closed_Score/score_style.mss
+++ b/share/templates/02-Choral/04-SATB_Closed_Score/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/02-Choral/05-SATB_Closed_Score_+_Organ/score_style.mss
+++ b/share/templates/02-Choral/05-SATB_Closed_Score_+_Organ/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/02-Choral/06-SATB_Closed_Score_+_Piano/score_style.mss
+++ b/share/templates/02-Choral/06-SATB_Closed_Score_+_Piano/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/02-Choral/07-Voice_+_Piano/score_style.mss
+++ b/share/templates/02-Choral/07-Voice_+_Piano/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/02-Choral/08-Barbershop_Quartet_(Men)/score_style.mss
+++ b/share/templates/02-Choral/08-Barbershop_Quartet_(Men)/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/02-Choral/09-Barbershop_Quartet_(Women)/score_style.mss
+++ b/share/templates/02-Choral/09-Barbershop_Quartet_(Women)/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/02-Choral/10-Liturgical_Unmetrical/score_style.mss
+++ b/share/templates/02-Choral/10-Liturgical_Unmetrical/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/02-Choral/11-Liturgical_Unmetrical_+_Organ/score_style.mss
+++ b/share/templates/02-Choral/11-Liturgical_Unmetrical_+_Organ/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.2</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/03-Chamber_Music/01-String_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/01-String_Quartet/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/03-Chamber_Music/02-Wind_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/02-Wind_Quartet/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/03-Chamber_Music/03-Wind_Quintet/score_style.mss
+++ b/share/templates/03-Chamber_Music/03-Wind_Quintet/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/03-Chamber_Music/04-Saxophone_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/04-Saxophone_Quartet/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/03-Chamber_Music/05-Brass_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/05-Brass_Quartet/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/03-Chamber_Music/06-Brass_Quintet/score_style.mss
+++ b/share/templates/03-Chamber_Music/06-Brass_Quintet/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/04-Solo/01-Guitar/score_style.mss
+++ b/share/templates/04-Solo/01-Guitar/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/04-Solo/02-Guitar_+_Tablature/score_style.mss
+++ b/share/templates/04-Solo/02-Guitar_+_Tablature/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/04-Solo/03-Guitar_Tablature/score_style.mss
+++ b/share/templates/04-Solo/03-Guitar_Tablature/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/04-Solo/04-Piano/score_style.mss
+++ b/share/templates/04-Solo/04-Piano/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/05-Jazz/01-Jazz_Lead_Sheet/score_style.mss
+++ b/share/templates/05-Jazz/01-Jazz_Lead_Sheet/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/05-Jazz/02-Big_Band/score_style.mss
+++ b/share/templates/05-Jazz/02-Big_Band/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/05-Jazz/03-Jazz_Combo/score_style.mss
+++ b/share/templates/05-Jazz/03-Jazz_Combo/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/06-Popular/01-Rock_Band/score_style.mss
+++ b/share/templates/06-Popular/01-Rock_Band/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/06-Popular/02-Bluegrass_Band/score_style.mss
+++ b/share/templates/06-Popular/02-Bluegrass_Band/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/07-Band_and_Percussion/01-Concert_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/01-Concert_Band/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/07-Band_and_Percussion/02-Small_Concert_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/02-Small_Concert_Band/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/07-Band_and_Percussion/03-Brass_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/03-Brass_Band/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/07-Band_and_Percussion/04-Marching_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/04-Marching_Band/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/07-Band_and_Percussion/05-Small_Marching_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/05-Small_Marching_Band/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/07-Band_and_Percussion/06-Battery_Percussion/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/06-Battery_Percussion/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/07-Band_and_Percussion/07-Large_Pit_Percussion/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/07-Large_Pit_Percussion/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/07-Band_and_Percussion/08-Small_Pit_Percussion/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/08-Small_Pit_Percussion/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/07-Band_and_Percussion/09-European_Concert_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/09-European_Concert_Band/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/08-Orchestral/01-Classical_Orchestra/score_style.mss
+++ b/share/templates/08-Orchestral/01-Classical_Orchestra/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/08-Orchestral/02-Symphony_Orchestra/score_style.mss
+++ b/share/templates/08-Orchestral/02-Symphony_Orchestra/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/share/templates/08-Orchestral/03-String_Orchestra/score_style.mss
+++ b/share/templates/08-Orchestral/03-String_Orchestra/score_style.mss
@@ -135,7 +135,7 @@
     <barNoteDistance>1.3</barNoteDistance>
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <measureRepeatNumberPos>-0.5</measureRepeatNumberPos>
     <mrNumberSeries>0</mrNumberSeries>
     <mrNumberEveryXMeasures>4</mrNumberEveryXMeasures>

--- a/src/engraving/data/styles/legacy-style-defaults-v1.mss
+++ b/src/engraving/data/styles/legacy-style-defaults-v1.mss
@@ -112,7 +112,7 @@
     <barAccidentalDistance>0.3</barAccidentalDistance>
     <multiMeasureRestMargin>1.2</multiMeasureRestMargin>
     <noteBarDistance>1</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <staffLineWidth>0.08</staffLineWidth>
     <ledgerLineWidth>0.12</ledgerLineWidth>
     <ledgerLineLength>0.38</ledgerLineLength>

--- a/src/engraving/data/styles/legacy-style-defaults-v2.mss
+++ b/src/engraving/data/styles/legacy-style-defaults-v2.mss
@@ -112,7 +112,7 @@
     <barAccidentalDistance>0.3</barAccidentalDistance>
     <multiMeasureRestMargin>1.2</multiMeasureRestMargin>
     <noteBarDistance>1</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <staffLineWidth>0.08</staffLineWidth>
     <ledgerLineWidth>0.16</ledgerLineWidth>
     <ledgerLineLength>0.38</ledgerLineLength>

--- a/src/engraving/data/styles/legacy-style-defaults-v3.mss
+++ b/src/engraving/data/styles/legacy-style-defaults-v3.mss
@@ -112,7 +112,7 @@
     <barAccidentalDistance>0.3</barAccidentalDistance>
     <multiMeasureRestMargin>1.2</multiMeasureRestMargin>
     <noteBarDistance>1</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <staffLineWidth>0.08</staffLineWidth>
     <ledgerLineWidth>0.16</ledgerLineWidth>
     <ledgerLineLength>0.38</ledgerLineLength>

--- a/src/engraving/data/styles/legacy-style-defaults-v302.mss
+++ b/src/engraving/data/styles/legacy-style-defaults-v302.mss
@@ -125,7 +125,7 @@
     <barAccidentalDistance>0.65</barAccidentalDistance>
     <multiMeasureRestMargin>1.2</multiMeasureRestMargin>
     <noteBarDistance>1.5</noteBarDistance>
-    <measureSpacing>1.2</measureSpacing>
+    <measureSpacing>1.5</measureSpacing>
     <staffLineWidth>0.11</staffLineWidth>
     <ledgerLineWidth>0.16</ledgerLineWidth>
     <ledgerLineLength>0.35</ledgerLineLength>

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -104,9 +104,9 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
         // we need to recompute the layout of the previous measures. When updating the width of these
         // measures, curSysWidth must be updated accordingly.
         if (ctx.curMeasure->isMeasure()) {
-            if (toMeasure(ctx.curMeasure)->computeTicks() < minTicks) {
+            if (toMeasure(ctx.curMeasure)->shortestChordRest() < minTicks) {
                 prevMinTicks = minTicks; // We save the previous value in case we need to restore it (see later)
-                minTicks = toMeasure(ctx.curMeasure)->computeTicks();
+                minTicks = toMeasure(ctx.curMeasure)->shortestChordRest();
                 changeMinSysTicks = true;
                 for (MeasureBase* mb : system->measures()) {
                     if (mb == ctx.curMeasure) {

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -171,9 +171,10 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
         // check if lc.curMeasure fits, remove if not
         // collect at least one measure and the break
 
-        double acceptanceRange = system->isSqueezable() ? 1.025 : 1; // A value slightly larger than 1 allows systems
-        // to be initially slightly larger than the target width and be justified by tightening rather than stretching.
-        // However, we must first make sure that the system *can* be tightened. isSqueezable() checks for that.
+        // acceptanceRange slightly larger than 1 allows systems to be initially slightly larger than the target width
+        // and be justified by squeezing rather than stretching. However, we must first make sure that the system *can*
+        // be squeezed. I'm temporarily rolling back the idea (still a bit too risky in some edge cases) [M.S.]
+        double acceptanceRange = 1;
         bool doBreak = (system->measures().size() > 1) && ((curSysWidth + ww) > systemWidth * acceptanceRange);
         if (doBreak) {
             breakMeasure = ctx.curMeasure;

--- a/src/engraving/libmscore/measure.h
+++ b/src/engraving/libmscore/measure.h
@@ -215,6 +215,7 @@ public:
 
     void layoutMeasureElements();
     Fraction computeTicks();
+    Fraction maxTicks() const;
     void layout2();
 
     bool showsMeasureNumber();

--- a/src/engraving/libmscore/measure.h
+++ b/src/engraving/libmscore/measure.h
@@ -215,6 +215,7 @@ public:
 
     void layoutMeasureElements();
     Fraction computeTicks();
+    Fraction shortestChordRest() const;
     Fraction maxTicks() const;
     void layout2();
 

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -2691,4 +2691,27 @@ qreal Segment::minHorizontalDistance(Segment* ns, bool systemHeaderGap) const
     }
     return w;
 }
+
+//------------------------------------------------------
+// shortestChordRest()
+// returns the shortest chordRest of a segment. IMPORTANT:
+// this is not the same as the ticks() of the segment. The
+// actual duration of the segment may be shorter than its
+// shortest chordRest.
+//------------------------------------------------------
+Fraction Segment::shortestChordRest() const
+{
+    Fraction shortest = Fraction::max(); // Initializing at arbitrary high value
+    Fraction cur = Fraction::max();
+    for (auto elem : elist()) {
+        if (!elem || !elem->staff()->show() || !elem->isChordRest()) {
+            continue;
+        }
+        cur = toChordRest(elem)->actualTicks();
+        if (cur < shortest) {
+            shortest = cur;
+        }
+    }
+    return shortest;
+}
 }           // namespace Ms

--- a/src/engraving/libmscore/segment.h
+++ b/src/engraving/libmscore/segment.h
@@ -289,6 +289,8 @@ public:
     bool isTimeSigAnnounceType() const { return _segmentType == SegmentType::TimeSigAnnounce; }
     bool isMMRestSegment() const;
 
+    Fraction shortestChordRest() const;
+
     static constexpr SegmentType durationSegmentsMask = SegmentType::ChordRest;   // segment types which may have non-zero tick length
 };
 

--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -1945,7 +1945,7 @@ Fraction System::minSysTicks() const
     for (MeasureBase* mb : measures()) {
         if (mb->isMeasure()) {
             Measure* m = toMeasure(mb);
-            minTicks = std::min(m->computeTicks(), minTicks);
+            minTicks = std::min(m->shortestChordRest(), minTicks);
         }
     }
     return minTicks;

--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -1982,4 +1982,15 @@ bool System::isSqueezable() const
         return false;
     }
 }
+
+Fraction System::maxSysTicks() const
+{
+    Fraction maxTicks = Fraction(0, 1);
+    for (auto mb : measures()) {
+        if (mb->isMeasure()) {
+            maxTicks = std::max(maxTicks, toMeasure(mb)->maxTicks());
+        }
+    }
+    return maxTicks;
+}
 }

--- a/src/engraving/libmscore/system.h
+++ b/src/engraving/libmscore/system.h
@@ -237,6 +237,7 @@ public:
     int lastVisibleSysStaffOfPart(const Part* part) const;
 
     Fraction minSysTicks() const;
+    Fraction maxSysTicks() const;
 
     bool isSqueezable() const;
 };

--- a/src/engraving/rw/compat/read114.cpp
+++ b/src/engraving/rw/compat/read114.cpp
@@ -3096,9 +3096,7 @@ Score::FileError Read114::read114(MasterScore* masterScore, XmlReader& e, ReadCo
         masterScore->style().set(Sid::minEmptyMeasures, 1);
     }
     masterScore->style().set(Sid::frameSystemDistance, masterScore->styleS(Sid::frameSystemDistance) + Spatium(6.0));
-    // hack: net overall effect of layout changes has been for things to take slightly more room
-    qreal adjustedSpacing = qMax(masterScore->styleD(Sid::measureSpacing) * 0.95, 1.0);
-    masterScore->style().set(Sid::measureSpacing, adjustedSpacing);
+    masterScore->resetStyleValue(Sid::measureSpacing);
 
     // add invisible tempo text if necessary
     // some 1.3 scores have tempolist but no tempo text

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -194,7 +194,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
 
     { Sid::barAccidentalDistance,   "barAccidentalDistance",   Spatium(0.65) },
     { Sid::noteBarDistance,         "noteBarDistance",         Spatium(1.5) },
-    { Sid::measureSpacing,          "measureSpacing",          1.2 },
+    { Sid::measureSpacing,          "measureSpacing",          1.5 },
     { Sid::measureRepeatNumberPos,  "measureRepeatNumberPos",  Spatium(-0.5) },
     { Sid::mrNumberSeries,          "mrNumberSeries",          false },
     { Sid::mrNumberEveryXMeasures,  "mrNumberEveryXMeasures",  4 },

--- a/src/engraving/utests/beam_data/Beam-E.mscx
+++ b/src/engraving/utests/beam_data/Beam-E.mscx
@@ -387,7 +387,7 @@
         <voice>
           <Beam>
             <l1>-16</l1>
-            <l2>-10</l2>
+            <l2>-12</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -406,7 +406,7 @@
           <Beam>
             <StemDirection>up</StemDirection>
             <l1>-16</l1>
-            <l2>-10</l2>
+            <l2>-12</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -426,7 +426,7 @@
           <Beam>
             <StemDirection>up</StemDirection>
             <l1>-16</l1>
-            <l2>-10</l2>
+            <l2>-12</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -791,8 +791,8 @@
             </Chord>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>32</l1>
-            <l2>38</l2>
+            <l1>38</l1>
+            <l2>40</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -834,7 +834,7 @@
         <voice>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>38</l1>
+            <l1>40</l1>
             <l2>44</l2>
             </Beam>
           <Chord>
@@ -852,7 +852,7 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>42</l1>
+            <l1>44</l1>
             <l2>48</l2>
             </Beam>
           <Chord>
@@ -872,7 +872,7 @@
             </Chord>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>46</l1>
+            <l1>48</l1>
             <l2>52</l2>
             </Beam>
           <Chord>

--- a/src/engraving/utests/beam_data/Beam-F.mscx
+++ b/src/engraving/utests/beam_data/Beam-F.mscx
@@ -388,7 +388,7 @@
           <Beam>
             <StemDirection>up</StemDirection>
             <l1>-20</l1>
-            <l2>-14</l2>
+            <l2>-16</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -407,7 +407,7 @@
           <Beam>
             <StemDirection>up</StemDirection>
             <l1>-20</l1>
-            <l2>-14</l2>
+            <l2>-16</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -427,7 +427,7 @@
           <Beam>
             <StemDirection>up</StemDirection>
             <l1>-20</l1>
-            <l2>-14</l2>
+            <l2>-16</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -811,8 +811,8 @@
             </Chord>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>32</l1>
-            <l2>38</l2>
+            <l1>38</l1>
+            <l2>40</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -853,7 +853,7 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>38</l1>
+            <l1>40</l1>
             <l2>44</l2>
             </Beam>
           <Chord>
@@ -873,7 +873,7 @@
             </Chord>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>42</l1>
+            <l1>44</l1>
             <l2>48</l2>
             </Beam>
           <Chord>

--- a/src/engraving/utests/beam_data/Beam-G.mscx
+++ b/src/engraving/utests/beam_data/Beam-G.mscx
@@ -807,8 +807,8 @@
         <voice>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>32</l1>
-            <l2>38</l2>
+            <l1>38</l1>
+            <l2>40</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -845,7 +845,7 @@
             </Chord>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>38</l1>
+            <l1>40</l1>
             <l2>44</l2>
             </Beam>
           <Chord>

--- a/src/engraving/utests/exchangevoices_data/undoChangeVoice01-ref.mscx
+++ b/src/engraving/utests/exchangevoices_data/undoChangeVoice01-ref.mscx
@@ -525,7 +525,7 @@
             <durationType>quarter</durationType>
             </Rest>
           <Beam>
-            <l1>42</l1>
+            <l1>38</l1>
             <l2>44</l2>
             </Beam>
           <Chord>
@@ -1159,7 +1159,7 @@
               <durationType>quarter</durationType>
               </Rest>
             <Beam>
-              <l1>42</l1>
+              <l1>38</l1>
               <l2>44</l2>
               </Beam>
             <Chord>

--- a/src/engraving/utests/exchangevoices_data/undoChangeVoice02-ref.mscx
+++ b/src/engraving/utests/exchangevoices_data/undoChangeVoice02-ref.mscx
@@ -520,7 +520,7 @@
             <durationType>eighth</durationType>
             </Rest>
           <Beam>
-            <l1>42</l1>
+            <l1>38</l1>
             <l2>44</l2>
             </Beam>
           <Chord>
@@ -1135,7 +1135,7 @@
               <durationType>eighth</durationType>
               </Rest>
             <Beam>
-              <l1>42</l1>
+              <l1>38</l1>
               <l2>44</l2>
               </Beam>
             <Chord>

--- a/src/engraving/utests/implode_explode_data/implode1-ref.mscx
+++ b/src/engraving/utests/implode_explode_data/implode1-ref.mscx
@@ -483,7 +483,7 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>100</l1>
+            <l1>102</l1>
             <l2>104</l2>
             </Beam>
           <Chord>
@@ -525,7 +525,7 @@
             </Chord>
           <Beam>
             <l1>100</l1>
-            <l2>96</l2>
+            <l2>98</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -1154,7 +1154,7 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-6</l1>
+            <l1>-8</l1>
             <l2>-10</l2>
             </Beam>
           <Chord>

--- a/src/engraving/utests/implode_explode_data/implode1.mscx
+++ b/src/engraving/utests/implode_explode_data/implode1.mscx
@@ -739,7 +739,7 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-6</l1>
+            <l1>-8</l1>
             <l2>-10</l2>
             </Beam>
           <Chord>

--- a/src/importexport/bww/internal/bww/importbww.cpp
+++ b/src/importexport/bww/internal/bww/importbww.cpp
@@ -560,7 +560,7 @@ Score::FileError importBww(MasterScore* score, const QString& path)
     Bww::Lexer lex(&fp);
     Bww::MsScWriter wrt;
     wrt.setScore(score);
-    score->style().set(Sid::measureSpacing, 1.0);
+    score->resetStyleValue(Sid::measureSpacing);
     Bww::Parser p(lex, wrt);
     p.parse();
 

--- a/src/importexport/capella/tests/data/test7.cap-ref.mscx
+++ b/src/importexport/capella/tests/data/test7.cap-ref.mscx
@@ -808,7 +808,7 @@
             <accidental>-7</accidental>
             </KeySig>
           <Beam>
-            <l1>2</l1>
+            <l1>8</l1>
             <l2>0</l2>
             </Beam>
           <Chord>

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -235,7 +235,7 @@
      </widget>
      <widget class="QStackedWidget" name="pageStack">
       <property name="currentIndex">
-       <number>0</number>
+       <number>8</number>
       </property>
       <widget class="QWidget" name="PageScore">
        <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -273,8 +273,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>623</width>
-                <height>696</height>
+                <width>711</width>
+                <height>570</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -847,8 +847,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>634</width>
-                <height>674</height>
+                <width>659</width>
+                <height>630</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_4">
@@ -2161,8 +2161,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>738</width>
-             <height>392</height>
+             <width>717</width>
+             <height>362</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -2912,8 +2912,7 @@
             <widget class="mu::notation::OffsetSelect" name="measureNumberPosAbove" native="true"/>
            </item>
            <item row="1" column="6">
-            <widget class="QToolButton" name="resetMeasureNumberHPlacement">
-            </widget>
+            <widget class="QToolButton" name="resetMeasureNumberHPlacement"/>
            </item>
            <item row="4" column="4" rowspan="2" colspan="2">
             <widget class="mu::notation::OffsetSelect" name="measureNumberPosBelow" native="true"/>
@@ -2926,8 +2925,7 @@
             </widget>
            </item>
            <item row="0" column="6">
-            <widget class="QToolButton" name="resetMeasureNumberVPlacement">
-            </widget>
+            <widget class="QToolButton" name="resetMeasureNumberVPlacement"/>
            </item>
            <item row="1" column="4" colspan="2">
             <widget class="QComboBox" name="measureNumberHPlacement"/>
@@ -2981,8 +2979,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_48">
            <item row="0" column="2">
-            <widget class="QToolButton" name="resetMmRestRangeBracketType">
-            </widget>
+            <widget class="QToolButton" name="resetMmRestRangeBracketType"/>
            </item>
            <item row="0" column="1">
             <widget class="QComboBox" name="mmRestRangeBracketType"/>
@@ -3049,8 +3046,7 @@
             </widget>
            </item>
            <item row="1" column="2">
-            <widget class="QToolButton" name="resetMmRestRangeVPlacement">
-            </widget>
+            <widget class="QToolButton" name="resetMmRestRangeVPlacement"/>
            </item>
            <item row="2" column="0">
             <widget class="QLabel" name="label_166">
@@ -3063,8 +3059,7 @@
             </widget>
            </item>
            <item row="2" column="2">
-            <widget class="QToolButton" name="resetMmRestRangeHPlacement">
-            </widget>
+            <widget class="QToolButton" name="resetMmRestRangeHPlacement"/>
            </item>
            <item row="4" column="0">
             <widget class="QLabel" name="mmRestRangePosBelowLabel">
@@ -3799,8 +3794,8 @@ By default, they will be placed such as that their right end are at the same lev
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>422</width>
-                <height>900</height>
+                <width>711</width>
+                <height>680</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_56">
@@ -4013,7 +4008,7 @@ By default, they will be placed such as that their right end are at the same lev
                <item row="1" column="0">
                 <widget class="QLabel" name="label_11">
                  <property name="text">
-                  <string>Spacing (1=tight):</string>
+                  <string>Spacing curve:</string>
                  </property>
                  <property name="buddy">
                   <cstring>measureSpacing</cstring>
@@ -4394,8 +4389,14 @@ By default, they will be placed such as that their right end are at the same lev
                  <property name="minimum">
                   <double>1.000000000000000</double>
                  </property>
+                 <property name="maximum">
+                  <double>2.000000000000000</double>
+                 </property>
                  <property name="singleStep">
                   <double>0.100000000000000</double>
+                 </property>
+                 <property name="value">
+                  <double>1.500000000000000</double>
                  </property>
                 </widget>
                </item>
@@ -5749,8 +5750,8 @@ By default, they will be placed such as that their right end are at the same lev
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>572</width>
-                <height>527</height>
+                <width>556</width>
+                <height>496</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_54">
@@ -9231,8 +9232,8 @@ By default, they will be placed such as that their right end are at the same lev
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>584</width>
-             <height>465</height>
+             <width>595</width>
+             <height>420</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout_57">
@@ -10527,7 +10528,7 @@ By default, they will be placed such as that their right end are at the same lev
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>574</width>
+                <width>613</width>
                 <height>551</height>
                </rect>
               </property>

--- a/src/project/internal/projectmigrator.cpp
+++ b/src/project/internal/projectmigrator.cpp
@@ -171,6 +171,7 @@ void ProjectMigrator::resetStyleSettings(Ms::MasterScore* score)
     qreal dotWidth = score->scoreFont()->width(Ms::SymId::repeatDot, 1.0);
     repeatBarlineDotSeparation -= (style->styleMM(Ms::Sid::barWidth) + dotWidth) / 2;
     style->set(Ms::Sid::repeatBarlineDotSeparation, repeatBarlineDotSeparation / sp);
+    score->resetStyleValue(Ms::Sid::measureSpacing);
     score->setResetDefaults();
 }
 

--- a/vtest/scores/accidental-mirror.mscx
+++ b/vtest/scores/accidental-mirror.mscx
@@ -23,7 +23,7 @@
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>
-      <measureSpacing>1</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <pedalPosBelow>0</pedalPosBelow>
       <trillPosAbove>0</trillPosAbove>
       <showMeasureNumber>0</showMeasureNumber>

--- a/vtest/scores/beams-10.mscx
+++ b/vtest/scores/beams-10.mscx
@@ -9,7 +9,7 @@
       </Synthesizer>
     <Division>480</Division>
     <Style>
-      <measureSpacing>1</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <showMeasureNumber>0</showMeasureNumber>
       <showFooter>0</showFooter>
       <evenFooterL>&lt;font size=&quot;13&quot;/&gt;&lt;font face=&quot;.Helvetica Neue DeskInterface&quot;/&gt;$p</evenFooterL>

--- a/vtest/scores/beams-11.mscx
+++ b/vtest/scores/beams-11.mscx
@@ -9,7 +9,7 @@
       </Synthesizer>
     <Division>480</Division>
     <Style>
-      <measureSpacing>1</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <showMeasureNumber>0</showMeasureNumber>
       <showFooter>0</showFooter>
       <evenFooterL>&lt;font size=&quot;13&quot;/&gt;&lt;font face=&quot;.Helvetica Neue DeskInterface&quot;/&gt;$p</evenFooterL>

--- a/vtest/scores/beams-12.mscx
+++ b/vtest/scores/beams-12.mscx
@@ -9,7 +9,7 @@
       </Synthesizer>
     <Division>480</Division>
     <Style>
-      <measureSpacing>1</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <showMeasureNumber>0</showMeasureNumber>
       <showFooter>0</showFooter>
       <evenFooterL>&lt;font size=&quot;13&quot;/&gt;&lt;font face=&quot;.Helvetica Neue DeskInterface&quot;/&gt;$p</evenFooterL>

--- a/vtest/scores/beams-13.mscx
+++ b/vtest/scores/beams-13.mscx
@@ -10,7 +10,7 @@
     <Division>480</Division>
     <Style>
       <minSystemDistance>7.5</minSystemDistance>
-      <measureSpacing>1</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <showMeasureNumber>0</showMeasureNumber>
       <showFooter>0</showFooter>
       <evenFooterL>&lt;font size=&quot;13&quot;/&gt;&lt;font face=&quot;.Helvetica Neue DeskInterface&quot;/&gt;$p</evenFooterL>

--- a/vtest/scores/beams-14.mscx
+++ b/vtest/scores/beams-14.mscx
@@ -10,7 +10,7 @@
     <Division>480</Division>
     <Style>
       <minSystemDistance>7.5</minSystemDistance>
-      <measureSpacing>1</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <showMeasureNumber>0</showMeasureNumber>
       <showFooter>0</showFooter>
       <evenFooterL>&lt;font size=&quot;13&quot;/&gt;&lt;font face=&quot;.Helvetica Neue DeskInterface&quot;/&gt;$p</evenFooterL>

--- a/vtest/scores/beams-17.mscx
+++ b/vtest/scores/beams-17.mscx
@@ -10,7 +10,7 @@
     <Division>480</Division>
     <Style>
       <minSystemDistance>7.5</minSystemDistance>
-      <measureSpacing>1</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <showMeasureNumber>0</showMeasureNumber>
       <showFooter>0</showFooter>
       <evenFooterL>&lt;font size=&quot;13&quot;/&gt;&lt;font face=&quot;.Helvetica Neue DeskInterface&quot;/&gt;$p</evenFooterL>

--- a/vtest/scores/beams-3.mscx
+++ b/vtest/scores/beams-3.mscx
@@ -9,7 +9,7 @@
       </Synthesizer>
     <Division>480</Division>
     <Style>
-      <measureSpacing>1</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <showMeasureNumber>0</showMeasureNumber>
       <showFooter>0</showFooter>
       <evenFooterL>&lt;font size=&quot;13&quot;/&gt;&lt;font face=&quot;.Helvetica Neue DeskInterface&quot;/&gt;$p</evenFooterL>

--- a/vtest/scores/beams-4.mscx
+++ b/vtest/scores/beams-4.mscx
@@ -9,7 +9,7 @@
       </Synthesizer>
     <Division>480</Division>
     <Style>
-      <measureSpacing>1</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <showMeasureNumber>0</showMeasureNumber>
       <showFooter>0</showFooter>
       <evenFooterL>&lt;font size=&quot;13&quot;/&gt;&lt;font face=&quot;Sans&quot;/&gt;&amp;lt;font size=&amp;quot;13&amp;quot;/&amp;gt;&amp;lt;font face=&amp;quot;Sans&amp;quot;/&amp;gt;&amp;amp;lt;font size=&amp;amp;quot;13&amp;amp;quot;/&amp;amp;gt;&amp;amp;lt;font face=&amp;amp;quot;.Helvetica Neue DeskInterface&amp;amp;quot;/&amp;amp;gt;$p</evenFooterL>

--- a/vtest/scores/beams-5.mscx
+++ b/vtest/scores/beams-5.mscx
@@ -9,7 +9,7 @@
       </Synthesizer>
     <Division>480</Division>
     <Style>
-      <measureSpacing>1</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <showMeasureNumber>0</showMeasureNumber>
       <showFooter>0</showFooter>
       <evenFooterL>&lt;font size=&quot;13&quot;/&gt;&lt;font face=&quot;Sans&quot;/&gt;&amp;lt;font size=&amp;quot;13&amp;quot;/&amp;gt;&amp;lt;font face=&amp;quot;Sans&amp;quot;/&amp;gt;&amp;amp;lt;font size=&amp;amp;quot;13&amp;amp;quot;/&amp;amp;gt;&amp;amp;lt;font face=&amp;amp;quot;.Helvetica Neue DeskInterface&amp;amp;quot;/&amp;amp;gt;$p</evenFooterL>

--- a/vtest/scores/beams-6.mscx
+++ b/vtest/scores/beams-6.mscx
@@ -9,7 +9,7 @@
       </Synthesizer>
     <Division>480</Division>
     <Style>
-      <measureSpacing>1</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <showMeasureNumber>0</showMeasureNumber>
       <showFooter>0</showFooter>
       <evenFooterL>&lt;font size=&quot;13&quot;/&gt;&lt;font face=&quot;Sans&quot;/&gt;&amp;lt;font size=&amp;quot;13&amp;quot;/&amp;gt;&amp;lt;font face=&amp;quot;Sans&amp;quot;/&amp;gt;&amp;amp;lt;font size=&amp;amp;quot;13&amp;amp;quot;/&amp;amp;gt;&amp;amp;lt;font face=&amp;amp;quot;.Helvetica Neue DeskInterface&amp;amp;quot;/&amp;amp;gt;$p</evenFooterL>

--- a/vtest/scores/beams-7.mscx
+++ b/vtest/scores/beams-7.mscx
@@ -9,7 +9,7 @@
       </Synthesizer>
     <Division>480</Division>
     <Style>
-      <measureSpacing>1</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <showMeasureNumber>0</showMeasureNumber>
       <showFooter>0</showFooter>
       <evenFooterL>&lt;font size=&quot;13&quot;/&gt;&lt;font face=&quot;Sans&quot;/&gt;&amp;lt;font size=&amp;quot;13&amp;quot;/&amp;gt;&amp;lt;font face=&amp;quot;Sans&amp;quot;/&amp;gt;&amp;amp;lt;font size=&amp;amp;quot;13&amp;amp;quot;/&amp;amp;gt;&amp;amp;lt;font face=&amp;amp;quot;.Helvetica Neue DeskInterface&amp;amp;quot;/&amp;amp;gt;$p</evenFooterL>

--- a/vtest/scores/beams-8.mscx
+++ b/vtest/scores/beams-8.mscx
@@ -9,7 +9,7 @@
       </Synthesizer>
     <Division>480</Division>
     <Style>
-      <measureSpacing>1</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <showMeasureNumber>0</showMeasureNumber>
       <showFooter>0</showFooter>
       <evenFooterL>&lt;font size=&quot;13&quot;/&gt;&lt;font face=&quot;Sans&quot;/&gt;&amp;lt;font size=&amp;quot;13&amp;quot;/&amp;gt;&amp;lt;font face=&amp;quot;Sans&amp;quot;/&amp;gt;&amp;amp;lt;font size=&amp;amp;quot;13&amp;amp;quot;/&amp;amp;gt;&amp;amp;lt;font face=&amp;amp;quot;.Helvetica Neue DeskInterface&amp;amp;quot;/&amp;amp;gt;$p</evenFooterL>

--- a/vtest/scores/beams-9.mscx
+++ b/vtest/scores/beams-9.mscx
@@ -9,7 +9,7 @@
       </Synthesizer>
     <Division>480</Division>
     <Style>
-      <measureSpacing>1</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <showMeasureNumber>0</showMeasureNumber>
       <showFooter>0</showFooter>
       <evenFooterL>&lt;font size=&quot;13&quot;/&gt;&lt;font face=&quot;.Helvetica Neue DeskInterface&quot;/&gt;$p</evenFooterL>

--- a/vtest/scores/harmony-10.mscx
+++ b/vtest/scores/harmony-10.mscx
@@ -18,7 +18,7 @@
       <bracketDistance>0.2</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>
       <minNoteDistance>0.4</minNoteDistance>
-      <measureSpacing>1.14</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <ledgerLineWidth>0.12</ledgerLineWidth>
       <beamWidth>0.48</beamWidth>
       <beamMinLen>1.25</beamMinLen>

--- a/vtest/scores/harmony-11.mscx
+++ b/vtest/scores/harmony-11.mscx
@@ -18,7 +18,7 @@
       <bracketDistance>0.2</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>
       <minNoteDistance>0.4</minNoteDistance>
-      <measureSpacing>1.14</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <ledgerLineWidth>0.12</ledgerLineWidth>
       <beamWidth>0.48</beamWidth>
       <beamMinLen>1.25</beamMinLen>

--- a/vtest/scores/harmony-5.mscx
+++ b/vtest/scores/harmony-5.mscx
@@ -18,7 +18,7 @@
       <bracketDistance>0.2</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>
       <minNoteDistance>0.4</minNoteDistance>
-      <measureSpacing>1.14</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <ledgerLineWidth>0.12</ledgerLineWidth>
       <beamWidth>0.48</beamWidth>
       <beamMinLen>1.25</beamMinLen>

--- a/vtest/scores/harmony-7.mscx
+++ b/vtest/scores/harmony-7.mscx
@@ -18,7 +18,7 @@
       <bracketDistance>0.2</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>
       <minNoteDistance>0.4</minNoteDistance>
-      <measureSpacing>1.14</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <ledgerLineWidth>0.12</ledgerLineWidth>
       <beamWidth>0.48</beamWidth>
       <beamMinLen>1.25</beamMinLen>

--- a/vtest/scores/harmony-8.mscx
+++ b/vtest/scores/harmony-8.mscx
@@ -18,7 +18,7 @@
       <bracketDistance>0.2</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>
       <minNoteDistance>0.4</minNoteDistance>
-      <measureSpacing>1.14</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <ledgerLineWidth>0.12</ledgerLineWidth>
       <beamWidth>0.48</beamWidth>
       <beamMinLen>1.25</beamMinLen>

--- a/vtest/scores/harmony-9.mscx
+++ b/vtest/scores/harmony-9.mscx
@@ -18,7 +18,7 @@
       <bracketDistance>0.2</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>
       <minNoteDistance>0.4</minNoteDistance>
-      <measureSpacing>1.14</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <ledgerLineWidth>0.12</ledgerLineWidth>
       <beamWidth>0.48</beamWidth>
       <beamMinLen>1.25</beamMinLen>

--- a/vtest/scores/slash-1.mscx
+++ b/vtest/scores/slash-1.mscx
@@ -9,7 +9,7 @@
       </Synthesizer>
     <Division>480</Division>
     <Style>
-      <measureSpacing>1</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <showMeasureNumber>0</showMeasureNumber>
       <showFooter>0</showFooter>
       <evenFooterL>&lt;font size=&quot;13&quot;/&gt;&lt;font face=&quot;Sans&quot;/&gt;&amp;lt;font size=&amp;quot;13&amp;quot;/&amp;gt;&amp;lt;font face=&amp;quot;Sans&amp;quot;/&amp;gt;&amp;amp;lt;font size=&amp;amp;quot;13&amp;amp;quot;/&amp;amp;gt;&amp;amp;lt;font face=&amp;amp;quot;.Helvetica Neue DeskInterface&amp;amp;quot;/&amp;amp;gt;$p</evenFooterL>

--- a/vtest/scores/slash-2.mscx
+++ b/vtest/scores/slash-2.mscx
@@ -9,7 +9,7 @@
       </Synthesizer>
     <Division>480</Division>
     <Style>
-      <measureSpacing>1</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <showMeasureNumber>0</showMeasureNumber>
       <showFooter>0</showFooter>
       <evenFooterL>&lt;font size=&quot;13&quot;/&gt;&lt;font face=&quot;Sans&quot;/&gt;&amp;lt;font size=&amp;quot;13&amp;quot;/&amp;gt;&amp;lt;font face=&amp;quot;Sans&amp;quot;/&amp;gt;&amp;amp;lt;font size=&amp;amp;quot;13&amp;amp;quot;/&amp;amp;gt;&amp;amp;lt;font face=&amp;amp;quot;.Helvetica Neue DeskInterface&amp;amp;quot;/&amp;amp;gt;$p</evenFooterL>

--- a/vtest/scores/small-1.mscx
+++ b/vtest/scores/small-1.mscx
@@ -26,7 +26,7 @@
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>
-      <measureSpacing>1</measureSpacing>
+      <measureSpacing>1.5</measureSpacing>
       <showMeasureNumber>0</showMeasureNumber>
       <showFooter>0</showFooter>
       <evenFooterL>&lt;font size=&quot;13&quot;/&gt;&lt;font face=&quot;.Helvetica Neue DeskInterface&quot;/&gt;$p</evenFooterL>


### PR DESCRIPTION
This PR contains several improvements that @oktophonie and I have been working on. Apart from posssible bug fixes or small corrections, this may be somewhat the "definitive" horizontal spacing for MU4.

The PR is split into 3 commits which are logically separate and may be also reviewed and merged separately, if needed.

1. I've rolled back the `acceptanceRange` concept. This used to let systems be initially slightly wider than the margins, and justify them by squeezing rather than stretching. The idea is good, but it is still too risky and it can break under some edge cases. Hopefully I can bring it back in future.

2. I've developed better logic to prevent the spacing of long notes to explode in the presence of very short ones. The previous logic was hacky and only worked with one specific spacing formula. The new one is mathematically solid, and works in general regardless of which spacing formula one may choose.

3. An overall improvement of the spacing algorithm.
- The spacing formula has been changed in favor of a better one.
- Some parameters, namely `minNoteDistance`, `stretch`, and `measureSpacing` interact differently with the spacing algorithm. The most significant change is `measureSpacing`. This parameter now does not act as an overall multiplier, but affects the *ratio* between the space assigned to longer vs shorter notes. This also required a minor UI change. The "Measure -> Spacing" style setting has been renamed to "Measure -> Spacing curve". Now this parameter can only take values between 1 and 2, where 1 corresponds to a flat spacing curve (meaning all notes receive equal space regardless of duration), and 2 corresponds to strict time-space layout. The default value of "Measure -> Spacing curve" is now 1.5. This required to change all the template files so that they load with the correct value. Additionally, I'm making sure that the value is reset to default for any score migrating from an older version of Musescore.