### PR TITLE
refine 'auto' tuplet bracket mode behaviour

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -812,7 +812,7 @@ void Beam::createBeamletSegment(Chord* chord, bool isBefore, int level)
         );
 }
 
-void Beam::calcBeamBreaks(Chord* chord, int level, bool& isBroken32, bool& isBroken64) const
+void Beam::calcBeamBreaks(const Chord* chord, int level, bool& isBroken32, bool& isBroken64) const
 {
     BeamMode beamMode = chord->beamMode();
 

--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -102,7 +102,6 @@ class Beam final : public EngravingItem
     bool calcIsBeamletBefore(Chord* chord, int i, int level, bool isAfter32Break, bool isAfter64Break) const;
     void createBeamSegment(Chord* startChord, Chord* endChord, int level);
     void createBeamletSegment(Chord* chord, bool isBefore, int level);
-    void calcBeamBreaks(Chord* chord, int level, bool& isBroken32, bool& isBroken64) const;
     void createBeamSegments(std::vector<ChordRest*> chordRests);
     void layout2(std::vector<ChordRest*>, SpannerSegmentType, int frag);
     void addChordRest(ChordRest* a);
@@ -164,6 +163,8 @@ public:
 
     void setBeamDirection(DirectionV d);
     DirectionV beamDirection() const { return _direction; }
+
+    void calcBeamBreaks(const Chord* chord, int level, bool& isBroken32, bool& isBroken64) const;
 
     //!Note Unfortunately we have no FEATHERED_BEAM_MODE for now int BeamMode enum, so we'll handle this locally
     void setAsFeathered(const bool slower);

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -1556,6 +1556,24 @@ qreal Chord::calcDefaultStemLength()
     return (stemLength + chordHeight) / 4.0 * _spatium;
 }
 
+Chord* Chord::prev() const
+{
+    ChordRest* prev = prevChordRest(const_cast<Chord*>(this));
+    if (prev && prev->isChord()) {
+        return static_cast<Chord*>(prev);
+    }
+    return nullptr;
+}
+
+Chord* Chord::next() const
+{
+    ChordRest* next = nextChordRest(const_cast<Chord*>(this));
+    if (next && next->isChord()) {
+        return static_cast<Chord*>(next);
+    }
+    return nullptr;
+}
+
 void Chord::setBeamExtension(qreal extension)
 {
     if (_stem) {

--- a/src/engraving/libmscore/chord.h
+++ b/src/engraving/libmscore/chord.h
@@ -157,6 +157,9 @@ public:
     void setStemDirection(DirectionV d);
     DirectionV stemDirection() const { return _stemDirection; }
 
+    Chord* prev() const;
+    Chord* next() const;
+
     void setIsUiItem(bool val) { _isUiItem = val; }
 
     LedgerLine* ledgerLines() { return _ledgerLines; }

--- a/src/engraving/libmscore/tuplet.h
+++ b/src/engraving/libmscore/tuplet.h
@@ -69,6 +69,8 @@ class Tuplet final : public DurationElement
 
     Fraction addMissingElement(const Fraction& startTick, const Fraction& endTick);
 
+    bool calcHasBracket(const DurationElement* cr1, const DurationElement* cr2) const;
+
 public:
     Tuplet(Measure* parent);
     Tuplet(const Tuplet&);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8969

Improves the 'auto' behavior for tuplet brackets. In short, if a tuplet's start/end notes are ambiguous, a bracket is automatically added.

Notes:

- This PR follows the guidelines laid out in #8969 with one addition. For a tuplet to not have brackets, it must be defined by beam breaks _and_ all notes inside the tuplet must have the same number of beams. For instance, the following example doesn't have a bracket:<img width="253" alt="Screen Shot 2022-03-02 at 8 22 30 PM" src="https://user-images.githubusercontent.com/5659171/156495723-986c060d-91ea-4a30-8f7d-f14eccabbfe1.png">
Yet the following example does need a bracket even though it's defined by a beam break:<img width="316" alt="Screen Shot 2022-03-02 at 8 23 32 PM" src="https://user-images.githubusercontent.com/5659171/156495794-391d700b-501a-4951-b420-25fe5ddb262a.png">
While this example may seem clear, I was noticing that more complex examples were not. I can be persuaded to change this behavior.
- The issue also includes the following example in which the second tuplet _should not_ have a bracket:
![image](https://user-images.githubusercontent.com/5659171/156495837-539fac10-6ef9-4134-82ee-cbae974a972b.png)
In theory, this PR fixes this issue. However, I could not figure out how to beam over the rest so I could not verify it.

@oktophonie ready for your review