### PR TITLE
[MU4] Fix #329485: Large diamond noteheads in slash notation

### DIFF
--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -119,6 +119,8 @@ static const SymId noteHeads[2][int(NoteHeadGroup::HEAD_GROUPS) - 1][int(NoteHea
 
         { SymId::noteheadSlashWhiteWhole,     SymId::noteheadSlashWhiteHalf,      SymId::noteheadSlashHorizontalEnds,
           SymId::noteheadSlashWhiteWhole },
+        { SymId::noteheadSlashDiamondWhite,   SymId::noteheadSlashDiamondWhite,   SymId::noteheadSlashHorizontalEnds,
+          SymId::noteheadSlashWhiteWhole },
 
         { SymId::noteShapeRoundWhite,         SymId::noteShapeRoundWhite,         SymId::noteShapeRoundBlack,
           SymId::noteShapeRoundDoubleWhole },
@@ -229,6 +231,8 @@ static const SymId noteHeads[2][int(NoteHeadGroup::HEAD_GROUPS) - 1][int(NoteHea
           SymId::noteheadDoubleWholeSquare },
 
         { SymId::noteheadSlashWhiteWhole,     SymId::noteheadSlashWhiteHalf,      SymId::noteheadSlashHorizontalEnds,
+          SymId::noteheadSlashWhiteDoubleWhole },
+        { SymId::noteheadSlashDiamondWhite,   SymId::noteheadSlashDiamondWhite,   SymId::noteheadSlashHorizontalEnds,
           SymId::noteheadSlashWhiteDoubleWhole },
 
         { SymId::noteShapeRoundWhite,         SymId::noteShapeRoundWhite,         SymId::noteShapeRoundBlack,

--- a/src/engraving/libmscore/note.h
+++ b/src/engraving/libmscore/note.h
@@ -125,7 +125,7 @@ static const int INVALID_LINE = -10000;
 //   @P fret             int              fret number in tablature
 //   @P ghost            bool             ghost note (guitar: death note)
 //   @P headScheme       enum (NoteHeadScheme.HEAD_AUTO, .HEAD_NORMAL, .HEAD_PITCHNAME, .HEAD_PITCHNAME_GERMAN, .HEAD_SHAPE_NOTE_4, .HEAD_SHAPE_NOTE_7_AIKIN, .HEAD_SHAPE_NOTE_7_FUNK, .HEAD_SHAPE_NOTE_7_WALKER, .HEAD_SOLFEGE, .HEAD_SOLFEGE_FIXED)
-//   @P headGroup        enum (NoteHeadGroup.HEAD_NORMAL, .HEAD_BREVIS_ALT, .HEAD_CROSS, .HEAD_DIAMOND, .HEAD_DO, .HEAD_FA, .HEAD_LA, .HEAD_MI, .HEAD_RE, .HEAD_SLASH, .HEAD_SOL, .HEAD_TI, .HEAD_XCIRCLE, .HEAD_TRIANGLE)
+//   @P headGroup        enum (NoteHeadGroup.HEAD_NORMAL, .HEAD_BREVIS_ALT, .HEAD_CROSS, .HEAD_DIAMOND, .HEAD_DO, .HEAD_FA, .HEAD_LA, .HEAD_MI, .HEAD_RE, .HEAD_SLASH, .HEAD_LARGE_DIAMOND, .HEAD_SOL, .HEAD_TI, .HEAD_XCIRCLE, .HEAD_TRIANGLE)
 //   @P headType         enum (NoteHeadType.HEAD_AUTO, .HEAD_BREVIS, .HEAD_HALF, .HEAD_QUARTER, .HEAD_WHOLE)
 //   @P hidden           bool             hidden, not played note (read only)
 //   @P line             int              notehead position (read only)

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -408,6 +408,7 @@ enum class NoteHeadGroup : signed char {
     HEAD_BREVIS_ALT,
 
     HEAD_SLASH,
+    HEAD_LARGE_DIAMOND,
 
     HEAD_SOL,
     HEAD_LA,

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -424,6 +424,7 @@ static const std::vector<Item<NoteHeadGroup> > NOTEHEAD_GROUPS = {
     { NoteHeadGroup::HEAD_BREVIS_ALT,       "altbrevis",      TranslatableString("engraving/noteheadgroup", "Alt. brevis") },
 
     { NoteHeadGroup::HEAD_SLASH,            "slash",          TranslatableString("engraving/noteheadgroup", "Slash") },
+    { NoteHeadGroup::HEAD_LARGE_DIAMOND,    "large-diamond",  TranslatableString("engraving/noteheadgroup", "Large diamond") },
 
     { NoteHeadGroup::HEAD_HEAVY_CROSS,      "heavy-cross",    TranslatableString("engraving/noteheadgroup", "Heavy cross") },
     { NoteHeadGroup::HEAD_HEAVY_CROSS_HAT,  "heavy-cross-hat",    TranslatableString("engraving/noteheadgroup", "Heavy cross hat") },

--- a/src/framework/ui/view/musicalsymbolcodes.h
+++ b/src/framework/ui/view/musicalsymbolcodes.h
@@ -69,6 +69,7 @@ public:
         NOTEHEAD_LARGE_ARROW = 0xE0F0,
 
         NOTEHEAD_SLASH = 0xE101,
+        NOTEHEAD_LARGE_DIAMOND = 0xE104,
         NOTEHEAD_SOL = 0xE1B1,
         NOTEHEAD_LA = 0xE1B3,
         NOTEHEAD_FA = 0xE1B5,

--- a/src/inspector/types/noteheadtypes.h
+++ b/src/inspector/types/noteheadtypes.h
@@ -48,6 +48,7 @@ public:
         HEAD_BREVIS_ALT,
 
         HEAD_SLASH,
+        HEAD_LARGE_DIAMOND,
 
         HEAD_SOL,
         HEAD_LA,

--- a/src/plugins/api/apitypes.h
+++ b/src/plugins/api/apitypes.h
@@ -150,6 +150,8 @@ enum class NoteHeadGroup {
     HEAD_CIRCLED_LARGE = int(mu::engraving::NoteHeadGroup::HEAD_CIRCLED_LARGE),
     HEAD_LARGE_ARROW = int(mu::engraving::NoteHeadGroup::HEAD_LARGE_ARROW),
     HEAD_BREVIS_ALT = int(mu::engraving::NoteHeadGroup::HEAD_BREVIS_ALT),
+    HEAD_SLASH = int(mu::engraving::NoteHeadGroup::HEAD_SLASH),
+    HEAD_LARGE_DIAMOND = int(mu::engraving::NoteHeadGroup::HEAD_LARGE_DIAMOND),
     HEAD_HEAVY_CROSS = int(mu::engraving::NoteHeadGroup::HEAD_HEAVY_CROSS),
     HEAD_HEAVY_CROSS_HAT = int(mu::engraving::NoteHeadGroup::HEAD_HEAVY_CROSS_HAT)
 };


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/329485

ToDo:
* Doesn't (yet) show a proper image in 'Inspector', instead duplicates the one from the 'regular' slash. Not sure why that is the case though, my guess is that it is the fault of the icon font, the icon for `0xE104`?
* Doesn't (yet) im- or export from/to MusicXML. (Should it? How?)