### PR TITLE
Fix MIDI input on macOS 11.0 and higher

### DIFF
--- a/src/appshell/qml/Preferences/IOPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/IOPreferencesPage.qml
@@ -41,6 +41,8 @@ PreferencesPage {
         width: parent.width
         spacing: root.sectionsSpacing
 
+        /*
+         * TODO: https://github.com/musescore/MuseScore/issues/9807
         AudioApiSection {
             currentAudioApiIndex: ioModel.currentAudioApiIndex
             audioApiList: ioModel.audioApiList()
@@ -54,6 +56,7 @@ PreferencesPage {
         }
 
         SeparatorLine {}
+         */
 
         MidiDevicesSection {
             currentInputDeviceIndex: ioModel.currentMidiInputDeviceIndex
@@ -73,6 +76,8 @@ PreferencesPage {
             }
         }
 
+        /*
+         * TODO: https://github.com/musescore/MuseScore/issues/9807
         SeparatorLine {}
 
         AudioEngineSection {
@@ -83,5 +88,6 @@ PreferencesPage {
                 ioModel.restartAudioAndMidiDevices()
             }
         }
+         */
     }
 }

--- a/src/appshell/view/preferences/preferencesmodel.cpp
+++ b/src/appshell/view/preferences/preferencesmodel.cpp
@@ -172,11 +172,8 @@ void PreferencesModel::load(const QString& currentPageId)
         makeItem("score", QT_TRANSLATE_NOOP("appshell", "Score"), IconCode::Code::SCORE,
                  "Preferences/ScorePreferencesPage.qml"),
 
-        /*
-         * TODO: https://github.com/musescore/MuseScore/issues/9807
         makeItem("io", QT_TRANSLATE_NOOP("appshell", "I/O"), IconCode::Code::AUDIO,
                  "Preferences/IOPreferencesPage.qml"),
-        */
 
         makeItem("import", QT_TRANSLATE_NOOP("appshell", "Import"), IconCode::Code::IMPORT,
                  "Preferences/ImportPreferencesPage.qml"),

--- a/src/framework/audio/qml/MuseScore/Audio/DevTools/MidiPorts.qml
+++ b/src/framework/audio/qml/MuseScore/Audio/DevTools/MidiPorts.qml
@@ -19,211 +19,126 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2.7
-import QtQuick.Controls 2.2
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
 import MuseScore.UiComponents 1.0
 import MuseScore.Midi 1.0
 
-Item {
+ColumnLayout {
+    anchors.fill: parent
+    anchors.margins: 12
+    spacing: 12
 
     MidiPortDevModel {
         id: midiModel
+    }
 
-        onOutputDevicesChanged: {
-            outputDevicesRepeater.model = 0
-            outputDevicesRepeater.model = midiModel.outputDevices()
+    Column {
+        Layout.fillWidth: true
+        spacing: 12
+
+        StyledTextLabel {
+            width: parent.width
+            horizontalAlignment: Text.AlignLeft
+            font: ui.theme.bodyBoldFont
+            text: "MIDI output devices:"
         }
 
-        onInputDevicesChanged: {
-            inputDevicesRepeater.model = 0
-            inputDevicesRepeater.model = midiModel.inputDevices()
-        }
+        StyledListView {
+            width: parent.width
+            height: contentHeight
 
-        onInputEventsChanged: {
-            inputEventsRepeator.model = 0
-            inputEventsRepeator.model = midiModel.inputEvents()
+            model: midiModel.outputDevices
+
+            delegate: RowLayout {
+                width: ListView.view.width
+                height: 40
+                spacing: 12
+
+                StyledTextLabel {
+                    Layout.minimumWidth: 240
+                    horizontalAlignment: Text.AlignLeft
+                    text: modelData.id + " " + modelData.name
+                }
+
+                FlatButton {
+                    text: modelData.action
+                    onClicked: {
+                        midiModel.outputDeviceAction(modelData.id, modelData.action)
+                    }
+                }
+
+                StyledTextLabel {
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignLeft
+                    text: modelData.error
+                }
+            }
         }
     }
 
-    Flickable {
-        anchors.fill: parent
-        contentWidth: parent.width
-        contentHeight: childrenRect.height
+    Column {
+        Layout.fillWidth: true
+        spacing: 12
 
-        Column {
-            id: outputPanel
-            anchors.left: parent.left
-            anchors.right: parent.right
-            height: childrenRect.height
+        StyledTextLabel {
+            width: parent.width
+            horizontalAlignment: Text.AlignLeft
+            font: ui.theme.bodyBoldFont
+            text: "MIDI input devices:"
+        }
 
-            StyledTextLabel {
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.leftMargin: 8
+        StyledListView {
+            width: parent.width
+            height: contentHeight
+
+            model: midiModel.inputDevices
+
+            delegate: RowLayout {
+                width: ListView.view.width
                 height: 40
-                font: ui.theme.bodyBoldFont
-                text: "MIDI output"
-            }
+                spacing: 12
 
-            StyledTextLabel {
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.leftMargin: 8
-                height: 40
-                horizontalAlignment: Text.AlignLeft
-                font: ui.theme.bodyBoldFont
-                text: "Devices:"
-            }
+                StyledTextLabel {
+                    Layout.minimumWidth: 240
+                    horizontalAlignment: Text.AlignLeft
+                    text: modelData.id + " " + modelData.name
+                }
 
-            Column {
-                anchors.left: parent.left
-                anchors.right: parent.right
-                height: childrenRect.height
-
-                Repeater {
-                    id: outputDevicesRepeater
-                    model: midiModel.outputDevices()
-                    delegate: Item {
-
-                        anchors.left: parent.left
-                        anchors.right: parent.right
-                        anchors.leftMargin: 8
-                        anchors.rightMargin: 8
-                        height: 40
-
-                        StyledTextLabel {
-                            id: label
-                            anchors.top: parent.top
-                            anchors.bottom: parent.bottom
-                            anchors.left: parent.left
-                            width: 240
-                            horizontalAlignment: Text.AlignLeft
-                            text: modelData.id + " " + modelData.name
-                        }
-
-                        FlatButton {
-                            id: connBtn
-                            anchors.left: label.right
-                            anchors.verticalCenter: parent.verticalCenter
-                            height: 30
-                            text: modelData.action
-                            onClicked: midiModel.outputDeviceAction(modelData.id, modelData.action)
-                        }
-
-                        StyledTextLabel {
-                            anchors.top: parent.top
-                            anchors.bottom: parent.bottom
-                            anchors.left: connBtn.right
-                            anchors.right: parent.right
-                            anchors.leftMargin: 8
-                            horizontalAlignment: Text.AlignLeft
-                            text: modelData.error
-                        }
+                FlatButton {
+                    text: modelData.action
+                    onClicked: {
+                        midiModel.inputDeviceAction(modelData.id, modelData.action)
                     }
+                }
+
+                StyledTextLabel {
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignLeft
+                    text: modelData.error
                 }
             }
         }
+    }
 
-        Column {
-            id: inputPanel
-            anchors.top: outputPanel.bottom
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.topMargin: 16
-            height: childrenRect.height
+    FlatButton {
+        text: "Generate MIDI2.0"
+        onClicked: midiModel.generateMIDI20();
+    }
 
-            StyledTextLabel {
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.leftMargin: 8
-                height: 40
-                font: ui.theme.bodyBoldFont
-                text: "MIDI input"
-            }
+    StyledListView {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
 
-            StyledTextLabel {
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.leftMargin: 8
-                height: 40
-                horizontalAlignment: Text.AlignLeft
-                font: ui.theme.bodyBoldFont
-                text: "Devices:"
-            }
+        model: midiModel.inputEvents
 
-            Column {
-                anchors.left: parent.left
-                anchors.right: parent.right
-                height: childrenRect.height
-
-                Repeater {
-                    id: inputDevicesRepeater
-                    model: midiModel.inputDevices()
-                    delegate: Item {
-
-                        anchors.left: parent.left
-                        anchors.right: parent.right
-                        anchors.leftMargin: 8
-                        anchors.rightMargin: 8
-                        height: 40
-
-                        StyledTextLabel {
-                            id: ilabel
-                            anchors.top: parent.top
-                            anchors.bottom: parent.bottom
-                            anchors.left: parent.left
-                            width: 240
-                            horizontalAlignment: Text.AlignLeft
-                            text: modelData.id + " " + modelData.name
-                        }
-
-                        FlatButton {
-                            id: iconnBtn
-                            anchors.left: ilabel.right
-                            anchors.verticalCenter: parent.verticalCenter
-                            height: 30
-                            text: modelData.action
-                            onClicked: midiModel.inputDeviceAction(modelData.id, modelData.action)
-                        }
-
-                        StyledTextLabel {
-                            anchors.top: parent.top
-                            anchors.bottom: parent.bottom
-                            anchors.left: iconnBtn.right
-                            anchors.right: parent.right
-                            anchors.leftMargin: 8
-                            horizontalAlignment: Text.AlignLeft
-                            text: modelData.error
-                        }
-                    }
-                }
-            }
-        }
-
-        Column {
-            anchors.top: inputPanel.bottom
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.topMargin: 16
-            height: childrenRect.height
-
-            FlatButton {
-                text: "generate MIDI2.0"
-                onClicked: midiModel.generateMIDI20();
-            }
-
-            Repeater {
-                id: inputEventsRepeator
-                model: midiModel.inputEvents()
-                delegate: StyledTextLabel {
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    anchors.leftMargin: 8
-                    anchors.rightMargin: 8
-                    height: 20
-                    text: modelData
-                }
-            }
+        delegate: StyledTextLabel {
+            width: ListView.view.width
+            height: 20
+            horizontalAlignment: Text.AlignLeft
+            text: modelData
         }
     }
 }

--- a/src/framework/midi/midievent.h
+++ b/src/framework/midi/midievent.h
@@ -136,7 +136,8 @@ struct Event {
     static Event fromRawData(const uint32_t* data, size_t count)
     {
         Event e;
-        memcpy(e.m_data.data(), data, std::min(count, e.m_data.size()));
+        size_t numBytes = std::min(count, e.m_data.size()) * sizeof(uint32_t);
+        memcpy(e.m_data.data(), data, numBytes);
         return e;
     }
 

--- a/src/framework/midi/view/devtools/midiportdevmodel.cpp
+++ b/src/framework/midi/view/devtools/midiportdevmodel.cpp
@@ -35,6 +35,14 @@ MidiPortDevModel::MidiPortDevModel(QObject* parent)
         m_inputEvents.prepend(str);
         emit inputEventsChanged();
     });
+
+    midiInPort()->devicesChanged().onNotify(this, [this]() {
+        emit inputDevicesChanged();
+    });
+
+    midiOutPort()->devicesChanged().onNotify(this, [this]() {
+        emit outputDevicesChanged();
+    });
 }
 
 QVariantList MidiPortDevModel::outputDevices() const
@@ -201,9 +209,4 @@ void MidiPortDevModel::generateMIDI20()
         m_inputEvents.prepend(str);
     }
     emit inputEventsChanged();
-}
-
-bool MidiPortDevModel::isInputConnected() const
-{
-    return midiInPort()->isConnected();
 }

--- a/src/framework/midi/view/devtools/midiportdevmodel.h
+++ b/src/framework/midi/view/devtools/midiportdevmodel.h
@@ -38,27 +38,26 @@ class MidiPortDevModel : public QObject, public async::Asyncable
     INJECT(midi, IMidiOutPort, midiOutPort)
     INJECT(midi, IMidiInPort, midiInPort)
 
-    Q_PROPERTY(bool isInputConnected READ isInputConnected NOTIFY isInputConnectedChanged)
+    Q_PROPERTY(QVariantList outputDevices READ outputDevices NOTIFY outputDevicesChanged)
+    Q_PROPERTY(QVariantList inputDevices READ inputDevices NOTIFY inputDevicesChanged)
+    Q_PROPERTY(QVariantList inputEvents READ inputEvents NOTIFY inputEventsChanged)
 
 public:
     explicit MidiPortDevModel(QObject* parent = nullptr);
 
-    bool isInputConnected() const;
-
-    Q_INVOKABLE QVariantList outputDevices() const;
+    QVariantList outputDevices() const;
     Q_INVOKABLE void outputDeviceAction(const QString& deviceID, const QString& action);
 
-    Q_INVOKABLE QVariantList inputDevices() const;
+    QVariantList inputDevices() const;
     Q_INVOKABLE void inputDeviceAction(const QString& deviceID, const QString& action);
 
-    Q_INVOKABLE QVariantList inputEvents() const;
+    QVariantList inputEvents() const;
     Q_INVOKABLE void generateMIDI20();
 
 signals:
     void outputDevicesChanged();
     void inputDevicesChanged();
     void inputEventsChanged();
-    void isInputConnectedChanged();
 
 private:
     QMap<QString, QString> m_connectionErrors;


### PR DESCRIPTION
Resolves: #9860

The culprit was bad use of memcpy in Event::fromRawData: I forgot to multiply the number of "words" (a.k.a. `uint32_t`) with the number of bytes per word (i.e. `sizeof(uint32_t)`).