### PR TITLE
[MU4] Manual Beam Adjustments

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -369,10 +369,8 @@ void Beam::layout1()
     //
     if (_direction != DirectionV::AUTO) {
         _up = _direction == DirectionV::UP;
-    } else if (_maxMove > 0) {
+    } else if (_maxMove > 0 || _minMove < 0) {
         _up = true;
-    } else if (_minMove < 0) {
-        _up = false;
     } else if (_notes.size()) {
         ChordRest* firstNote = _elements.first();
         Measure* measure = firstNote->measure();
@@ -657,10 +655,10 @@ int Beam::getBeamCount(std::vector<ChordRest*> chordRests) const
 
 PointF Beam::chordBeamAnchor(Chord* chord) const
 {
-    Note* note = _up ? chord->downNote() : chord->upNote();
-    PointF position = note->pos() + chord->segment()->pos() + chord->measure()->pos();
+    Note* note = chord->up() ? chord->downNote() : chord->upNote();
+    PointF position = note->pagePos();
 
-    int upValue = _up ? -1 : 1;
+    int upValue = chord->up() ? -1 : 1;
     qreal beamWidth = score()->styleMM(Sid::beamWidth).val() * chord->mag();
     qreal beamOffset = beamWidth / 2 * upValue;
 
@@ -680,19 +678,19 @@ void Beam::createBeamSegment(Chord* startChord, Chord* endChord, int level)
 {
     PointF posStart = chordBeamAnchor(startChord);
     PointF posEnd = chordBeamAnchor(endChord);
-    qreal y2 = _slope * (posEnd.x() - posStart.x()) + posStart.y();
+    qreal y1 = _slope * (posStart.x() - _startAnchor.x()) + _startAnchor.y() - pagePos().y();
+    qreal y2 = _slope * (posEnd.x() - _startAnchor.x()) + _startAnchor.y() - pagePos().y();
 
     int upValue = _up ? -1 : 1;
     qreal verticalOffset = _beamDist * level * upValue;
-    qreal stemWidth = score()->styleMM(Sid::stemWidth).val() * startChord->mag();
 
-    qreal startOffsetX = _up && !_tab ? -stemWidth : 0.0;
-    qreal endOffsetX = _up || _tab ? 0.0 : stemWidth;
+    qreal startOffsetX = startChord->up() && !_tab ? -(startChord->stem()->lineWidth().val() * startChord->mag()) : 0.0;
+    qreal endOffsetX = endChord->up() || _tab ? 0.0 : endChord->stem()->lineWidth().val() * endChord->mag();
 
     _beamSegments.push_back(
         new LineF(
             posStart.x() + startOffsetX,
-            posStart.y() - verticalOffset,
+            y1 - verticalOffset,
             posEnd.x() + endOffsetX,
             y2 - verticalOffset
             )
@@ -788,16 +786,17 @@ void Beam::createBeamletSegment(Chord* chord, bool isBefore, int level)
                           * mag()
                           * chord->staff()->staffMag(chord);
     qreal x2 = chordPos.x() + (isBefore ? -beamletLength : beamletLength);
-    qreal y2 = chordPos.y() + _slope * (x2 - chordPos.x());
+    qreal y1 = _slope * (chordPos.x() - _startAnchor.x()) + _startAnchor.y() - pagePos().y();
+    qreal y2 = _slope * (x2 - chordPos.x()) + y1;
 
     int upValue = _up ? -1 : 1;
     qreal verticalOffset = _beamDist * level * upValue;
-    qreal stemWidth = score()->styleMM(Sid::stemWidth).val() * chord->mag();
+    qreal stemWidth = chord->stem()->lineWidth().val() * chord->mag();
     qreal startOffsetX = 0;
     if (!_tab) {
-        if (isBefore && !_up) {
+        if (isBefore && !chord->up()) {
             startOffsetX = stemWidth;
-        } else if (!isBefore && _up) {
+        } else if (!isBefore && chord->up()) {
             startOffsetX = -stemWidth;
         }
     }
@@ -805,7 +804,7 @@ void Beam::createBeamletSegment(Chord* chord, bool isBefore, int level)
     _beamSegments.push_back(
         new LineF(
             chordPos.x() + startOffsetX,
-            chordPos.y() - verticalOffset,
+            y1 - verticalOffset,
             x2,
             y2 - verticalOffset
             )
@@ -930,7 +929,7 @@ void Beam::offsetBeamToRemoveCollisions(std::vector<ChordRest*> chordRests, int&
     }
 }
 
-void Beam::extendStems(std::vector<ChordRest*> chordRests, PointF start, PointF end)
+void Beam::extendStems(std::vector<ChordRest*> chordRests)
 {
     for (ChordRest* chordRest : chordRests) {
         if (!chordRest->isChord()) {
@@ -938,12 +937,13 @@ void Beam::extendStems(std::vector<ChordRest*> chordRests, PointF start, PointF 
         }
         Chord* chord = toChord(chordRest);
         PointF anchor = chordBeamAnchor(chord);
-        qreal proportionAlongX = (anchor.x() - start.x()) / (end.x() - start.x());
-        qreal desiredY = proportionAlongX * (end.y() - start.y()) + start.y();
-        if (_up) {
-            chord->setBeamExtension(anchor.y() - desiredY);
+        qreal proportionAlongX = (anchor.x() - _startAnchor.x()) / (_endAnchor.x() - _startAnchor.x());
+        qreal desiredY = proportionAlongX * (_endAnchor.y() - _startAnchor.y()) + _startAnchor.y();
+        qreal beamsAddition = chord->up() != _up ? (chord->beams() - 1) * _beamDist : 0;
+        if (chord->up()) {
+            chord->setBeamExtension(anchor.y() - desiredY + beamsAddition);
         } else {
-            chord->setBeamExtension(desiredY - anchor.y());
+            chord->setBeamExtension(desiredY - anchor.y() + beamsAddition);
         }
         if (chord->tremolo()) {
             chord->tremolo()->layout();
@@ -1119,9 +1119,6 @@ void Beam::layout2(std::vector<ChordRest*> chordRests, SpannerSegmentType, int f
         LayoutBeams::respace(&chordRests);
     }
 
-    _beamSpacing = score()->styleB(Sid::useWideBeams) ? 4 : 3;
-    _beamDist = (_beamSpacing / 4.0) * spatium() * mag();
-
     if (!chordRests.front()->isChord() || !chordRests.back()->isChord()) {
         NOT_IMPL_RETURN;
     }
@@ -1129,16 +1126,37 @@ void Beam::layout2(std::vector<ChordRest*> chordRests, SpannerSegmentType, int f
     // todo: add edge case for when a beam starts or ends on a rest
     Chord* startChord = toChord(chordRests.front());
     Chord* endChord = toChord(chordRests.back());
+    _startAnchor = chordBeamAnchor(startChord);
+    _endAnchor = chordBeamAnchor(endChord);
+    _beamSpacing = score()->styleB(Sid::useWideBeams) ? 4 : 3;
+    _beamDist = (_beamSpacing / 4.0) * spatium() * mag();
 
     const Staff* staffItem = staff();
     const StaffType* staffType = staffItem ? staffItem->staffTypeForElement(this) : nullptr;
     _tab = (staffType && staffType->isTabStaff()) ? staffType : nullptr;
     _isBesideTabStaff = _tab && !_tab->stemless() && !_tab->stemThrough();
 
+    int fragmentIndex = (_direction == DirectionV::AUTO || _direction == DirectionV::DOWN) ? 0 : 1;
+    if (_userModified[fragmentIndex]) {
+        qreal startY = fragments[frag]->py1[fragmentIndex] + pagePos().y();
+        qreal endY = fragments[frag]->py2[fragmentIndex] + pagePos().y();
+        if (score()->styleB(Sid::snapCustomBeamsToGrid)) {
+            const qreal quarterSpace = spatium() / 4;
+            startY = round(startY / quarterSpace) * quarterSpace;
+            endY = round(endY / quarterSpace) * quarterSpace;
+        }
+        _startAnchor.setY(startY);
+        _endAnchor.setY(endY);
+        _slope = (_endAnchor.y() - _startAnchor.y()) / (_endAnchor.x() - _startAnchor.x());
+        extendStems(chordRests);
+        createBeamSegments(chordRests);
+        return;
+    }
+
     // anchor represents the middle of the beam, not the tip of the stem
     // location depends on _isBesideTabStaff
-    PointF startAnchor = chordBeamAnchor(startChord);
-    PointF endAnchor = chordBeamAnchor(endChord);
+    _startAnchor = chordBeamAnchor(startChord);
+    _endAnchor = chordBeamAnchor(endChord);
 
     if (!_isBesideTabStaff) {
         int startNote = _up ? startChord->upNote()->line() : startChord->downNote()->line();
@@ -1150,8 +1168,8 @@ void Beam::layout2(std::vector<ChordRest*> chordRests, SpannerSegmentType, int f
         const int interval = qAbs(startNote - endNote);
         const bool isStartDictator = _up ? startNote < endNote : startNote > endNote;
         const qreal quarterSpace = spatium() / 4;
-        int dictator = round((isStartDictator ? startAnchor.y() : endAnchor.y()) / quarterSpace);
-        int pointer = round((isStartDictator ? endAnchor.y() : startAnchor.y()) / quarterSpace);
+        int dictator = round((isStartDictator ? _startAnchor.y() : _endAnchor.y()) / quarterSpace);
+        int pointer = round((isStartDictator ? _endAnchor.y() : _startAnchor.y()) / quarterSpace);
 
         const int staffLines = startChord->staff()->lines(tick());
         const int middleLine = getMiddleStaffLine(startChord, endChord, staffLines);
@@ -1162,27 +1180,27 @@ void Beam::layout2(std::vector<ChordRest*> chordRests, SpannerSegmentType, int f
         bool isAscending = startNote > endNote;
         int beamCount = getBeamCount(chordRests);
 
-        offsetBeamToRemoveCollisions(chordRests, dictator, pointer, startAnchor.x(), endAnchor.x(), isFlat, isStartDictator);
+        offsetBeamToRemoveCollisions(chordRests, dictator, pointer, _startAnchor.x(), _endAnchor.x(), isFlat, isStartDictator);
         if (!_tab) {
             setValidBeamPositions(dictator, pointer, beamCount, staffLines, isStartDictator, isFlat, isAscending);
             addMiddleLineSlant(dictator, pointer, beamCount, middleLine, interval);
         }
 
-        startAnchor.setY(quarterSpace * (isStartDictator ? dictator : pointer));
-        endAnchor.setY(quarterSpace * (isStartDictator ? pointer : dictator));
+        _startAnchor.setY(quarterSpace * (isStartDictator ? dictator : pointer));
+        _endAnchor.setY(quarterSpace * (isStartDictator ? pointer : dictator));
+        add8thSpaceSlant(isStartDictator ? _startAnchor : _endAnchor, dictator, pointer, beamCount, interval, middleLine, isFlat);
 
         if (!_tab) {
-            add8thSpaceSlant(isStartDictator ? startAnchor : endAnchor, dictator, pointer, beamCount, interval, middleLine, isFlat);
+            add8thSpaceSlant(isStartDictator ? _startAnchor : _endAnchor, dictator, pointer, beamCount, interval, middleLine, isFlat);
         }
-        _slope = (endAnchor.y() - startAnchor.y()) / (endAnchor.x() - startAnchor.x());
-        extendStems(chordRests, startAnchor, endAnchor);
+        _slope = (_endAnchor.y() - _startAnchor.y()) / (_endAnchor.x() - _startAnchor.x());
+        extendStems(chordRests);
     } else {
         _slope = 0;
     }
 
-    int fragmentIndex = (_direction == DirectionV::AUTO || _direction == DirectionV::DOWN) ? 0 : 1;
-    fragments[frag]->py1[fragmentIndex] = startAnchor.y();
-    fragments[frag]->py2[fragmentIndex] = endAnchor.y();
+    fragments[frag]->py1[fragmentIndex] = _startAnchor.y() - pagePos().y();
+    fragments[frag]->py2[fragmentIndex] = _endAnchor.y() - pagePos().y();
 
     createBeamSegments(chordRests);
 }

--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -64,6 +64,8 @@ class Beam final : public EngravingItem
     qreal _grow2            { 1.0f };
     qreal _beamDist         { 0.0f };
     int _beamSpacing        { 3 }; // how far apart beams are spaced in quarter spaces
+    mu::PointF _startAnchor;
+    mu::PointF _endAnchor;
 
     // for tabs
     bool _isBesideTabStaff  { false };
@@ -97,7 +99,7 @@ class Beam final : public EngravingItem
                                bool isAscending);
     void addMiddleLineSlant(int& dictator, int& pointer, int beamCount, int middleLine, int interval);
     void add8thSpaceSlant(mu::PointF& dictatorAnchor, int dictator, int pointer, int beamCount, int interval, int middleLine, bool Flat);
-    void extendStems(std::vector<ChordRest*> chordRests, mu::PointF start, mu::PointF end);
+    void extendStems(std::vector<ChordRest*> chordRests);
     mu::PointF chordBeamAnchor(Chord* chord) const;
     bool calcIsBeamletBefore(Chord* chord, int i, int level, bool isAfter32Break, bool isAfter64Break) const;
     void createBeamSegment(Chord* startChord, Chord* endChord, int level);
@@ -185,6 +187,9 @@ public:
     void setBeamPos(const mu::engraving::PairF& bp);
 
     qreal beamDist() const { return _beamDist; }
+
+    inline const mu::PointF startAnchor() const { return _startAnchor; }
+    inline const mu::PointF endAnchor() const { return _endAnchor; }
 
     mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -936,16 +936,15 @@ void Chord::computeUp()
 
     if (_beam) {
         if (_beam->userModified() || _beam->cross()) {
-            double noteY = upNote()->pagePos().y();
-            PointF startAnchor = _beam->startAnchor();
-            PointF endAnchor = _beam->endAnchor();
+            qreal noteY = (_up ? downNote()->pagePos().y() : upNote()->pagePos().y()) - pagePos().y();
+            qreal noteX = stemPosX() + pagePos().x() - _beam->canvasPos().x() - pagePos().x();
+            PointF startAnchor = _beam->startAnchor() - pagePos();
+            PointF endAnchor = _beam->endAnchor() - pagePos();
             if (this == _beam->elements().first()) {
                 _up = noteY > startAnchor.y();
-                // std::cout << "noteY: " << noteY << " startAnchor: " << startAnchor.y() << " up: " << _up << std::endl;
             } else if (this == _beam->elements().last()) {
                 _up = noteY > endAnchor.y();
             } else {
-                double noteX = stemPosX() + pagePos().x() + _beam->pagePos().x() + measure()->pos().x();
                 qreal proportionAlongX = (noteX - startAnchor.x()) / (endAnchor.x() - startAnchor.x());
                 qreal desiredY = proportionAlongX * (endAnchor.y() - startAnchor.y()) + startAnchor.y();
                 _up = noteY > desiredY;

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -929,13 +929,30 @@ void Chord::computeUp()
         return;
     }
 
-    if (_beam) {
-        _up = _beam->up();
+    if (_isUiItem) {
+        _up = true;
         return;
     }
 
-    if (_isUiItem) {
-        _up = true;
+    if (_beam) {
+        if (_beam->userModified() || _beam->cross()) {
+            double noteY = upNote()->pagePos().y();
+            PointF startAnchor = _beam->startAnchor();
+            PointF endAnchor = _beam->endAnchor();
+            if (this == _beam->elements().first()) {
+                _up = noteY > startAnchor.y();
+                // std::cout << "noteY: " << noteY << " startAnchor: " << startAnchor.y() << " up: " << _up << std::endl;
+            } else if (this == _beam->elements().last()) {
+                _up = noteY > endAnchor.y();
+            } else {
+                double noteX = stemPosX() + pagePos().x() + _beam->pagePos().x() + measure()->pos().x();
+                qreal proportionAlongX = (noteX - startAnchor.x()) / (endAnchor.x() - startAnchor.x());
+                qreal desiredY = proportionAlongX * (endAnchor.y() - startAnchor.y()) + startAnchor.y();
+                _up = noteY > desiredY;
+            }
+        } else {
+            _up = _beam->up();
+        }
         return;
     }
 

--- a/src/engraving/libmscore/stem.cpp
+++ b/src/engraving/libmscore/stem.cpp
@@ -111,6 +111,10 @@ void Stem::layout()
         if (chord()->hook() && !chord()->beam()) {
             y2 += chord()->hook()->smuflAnchor().y();
         }
+
+        if (chord()->beam()) {
+            y2 -= _up * point(score()->styleS(Sid::beamWidth)) * .5 * chord()->beam()->mag();
+        }
     }
 
     double lineWidthCorrection = lineWidthMag() * 0.5;

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -215,6 +215,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::useWideBeams,            "useWideBeams",            false },
     { Sid::beamMinLen,              "beamMinLen",              Spatium(1.2) },
     { Sid::beamNoSlope,             "beamNoSlope",             false },
+    { Sid::snapCustomBeamsToGrid,   "snapCustomBeamsToGrid",   true },
 
     { Sid::dotMag,                  "dotMag",                  PropertyValue(1.0) },
     { Sid::dotNoteDistance,         "dotNoteDistance",         Spatium(0.5) },

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -226,6 +226,7 @@ enum class Sid {
     useWideBeams,
     beamMinLen,
     beamNoSlope,
+    snapCustomBeamsToGrid,
 
     dotMag,
     dotNoteDistance,


### PR DESCRIPTION
A merge / fix of https://github.com/musescore/MuseScore/pull/10130

Manual adjustments to beams are now possible. However, there were a few bugs to fix:
- Stem direction would sometimes be incorrect
- Thumbnail generation would launch layout() with different values that would move everything around
- Changing direction of stems within a beam would cause graphical problems
- A small 8th space slant, which is necessary for unmodified 32nd note beams, was still present when the beams were adjusted manually

This PR fixes all of those issues!