### PR TITLE
Added keyboard navigation for the Save to cloud dialogs

### DIFF
--- a/src/framework/global/defer.h
+++ b/src/framework/global/defer.h
@@ -27,18 +27,24 @@
 namespace mu {
 struct Defer
 {
-    Defer(const std::function<void()>& f)
-        : f(f) {}
+    template<class F>
+    Defer(F f)
+        : m_f(f) {}
 
     ~Defer()
     {
-        if (f) {
-            f();
+        if (m_f) {
+            m_f();
         }
     }
 
-    std::function<void()> f;
+    std::function<void()> m_f;
 };
 }
+
+#define CONCAT_IMPL(x, y) x##y
+#define MACRO_CONCAT(x, y) CONCAT_IMPL(x, y)
+
+#define DEFER const Defer MACRO_CONCAT(defer_, __LINE__) = [&]()
 
 #endif // MU_GLOBAL_DEFER_H

--- a/src/framework/ui/internal/navigationcontroller.cpp
+++ b/src/framework/ui/internal/navigationcontroller.cpp
@@ -1200,11 +1200,11 @@ void NavigationController::onActiveRequested(INavigationSection* sect, INavigati
 
     bool isChanged = false;
 
-    Defer defer([&]() {
+    DEFER {
         if (isChanged) {
             m_navigationChanged.notify();
         }
-    });
+    };
 
     INavigationSection* activeSec = findActive(m_sections);
     if (activeSec && activeSec != sect) {

--- a/src/framework/ui/internal/navigationcontroller.cpp
+++ b/src/framework/ui/internal/navigationcontroller.cpp
@@ -30,6 +30,7 @@
 
 #include "diagnostics/diagnosticutils.h"
 #include "async/async.h"
+#include "defer.h"
 #include "log.h"
 
 #include "config.h"
@@ -1197,10 +1198,15 @@ void NavigationController::onActiveRequested(INavigationSection* sect, INavigati
         return;
     }
 
-    INavigationSection* activeSec = findActive(m_sections);
-
     bool isChanged = false;
 
+    Defer defer([&]() {
+        if (isChanged) {
+            m_navigationChanged.notify();
+        }
+    });
+
+    INavigationSection* activeSec = findActive(m_sections);
     if (activeSec && activeSec != sect) {
         doDeactivateSection(activeSec);
     }
@@ -1211,30 +1217,42 @@ void NavigationController::onActiveRequested(INavigationSection* sect, INavigati
         MYLOG() << "activated section: " << sect->name() << ", order: " << sect->index().order();
     }
 
+    if (!panel) {
+        panel = firstEnabled(sect->panels());
+    }
+
     INavigationPanel* activePanel = findActive(sect->panels());
     if (activePanel && activePanel != panel) {
         doDeactivatePanel(activePanel);
     }
 
-    if (panel && !panel->active()) {
+    if (!panel) {
+        return;
+    }
+
+    if (!panel->active()) {
         panel->setActive(true);
         isChanged = true;
         MYLOG() << "activated panel: " << panel->name() << ", order: " << panel->index().order();
     }
 
-    INavigationControl* activeCtrl = panel ? findActive(panel->controls()) : nullptr;
+    if (!ctrl) {
+        ctrl = firstEnabled(panel->controls());
+    }
+
+    INavigationControl* activeCtrl = findActive(panel->controls());
     if (activeCtrl && activeCtrl != ctrl) {
         activeCtrl->setActive(false);
     }
 
-    if (ctrl && !ctrl->active()) {
+    if (!ctrl) {
+        return;
+    }
+
+    if (!ctrl->active()) {
         ctrl->setActive(true);
         isChanged = true;
         MYLOG() << "activated control: " << ctrl->name() << ", row: " << ctrl->index().row << ", column: " << ctrl->index().column;
-    }
-
-    if (isChanged) {
-        m_navigationChanged.notify();
     }
 }
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledDialogView.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledDialogView.qml
@@ -63,7 +63,7 @@ DialogView {
     }
 
     onOpened: {
-        navSec.requestActive()
+        Qt.callLater(navSec.requestActive)
     }
 
     onClosed: {

--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -183,6 +183,10 @@ void PopupView::open()
         //! NOTE At the moment we have only qml navigation controls
         QObject* qmlCtrl = dynamic_cast<QObject*>(ctrl);
         setNavigationParentControl(qmlCtrl);
+
+        connect(qmlCtrl, &QObject::destroyed, this, [this]() {
+            setNavigationParentControl(nullptr);
+        });
     }
 
     qApp->installEventFilter(this);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3852,9 +3852,9 @@ void NotationInteraction::resetShapesAndPosition()
 
     startEdit();
 
-    Defer defer([this] {
+    DEFER {
         apply();
-    });
+    };
 
     if (selection()->element()) {
         resetItem(selection()->element());

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -235,10 +235,10 @@ void PlaybackController::onNotationChanged()
     m_masterNotation = globalContext()->currentMasterNotation();
     m_notation = globalContext()->currentNotation();
 
-    Defer defer([this] {
+    DEFER {
         m_isPlayAllowedChanged.notify();
         m_totalPlayTimeChanged.notify();
-    });
+    };
 
     if (!m_notation || !m_masterNotation) {
         return;

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -126,9 +126,9 @@ Ret ProjectActionsController::openProject(const io::path& projectPath_)
     }
     m_isProjectProcessing = true;
 
-    Defer defer([this]() {
+    DEFER {
         m_isProjectProcessing = false;
-    });
+    };
 
     //! Step 1. If no path is specified, ask the user to select a project
     io::path projectPath = projectPath_;
@@ -238,9 +238,9 @@ void ProjectActionsController::newProject()
     }
     m_isProjectProcessing = true;
 
-    Defer defer([this]() {
+    DEFER {
         m_isProjectProcessing = false;
-    });
+    };
 
     if (globalContext()->currentProject()) {
         //! Check, if any project is already open in the current window

--- a/src/project/qml/MuseScore/Project/AskSaveLocationTypeDialog.qml
+++ b/src/project/qml/MuseScore/Project/AskSaveLocationTypeDialog.qml
@@ -64,6 +64,15 @@ StyledDialogView {
         RowLayout {
             spacing: 24
 
+            NavigationPanel {
+                id: optionsNavPanel
+                name: "SaveLocationOptionsButtons"
+                enabled: parent.enabled && parent.visible
+                direction: NavigationPanel.Horizontal
+                section: root.navigationSection
+                order: 1
+            }
+
             SaveLocationOption {
                 title: qsTrc("project", "To the Cloud (free)")
                 description: qsTrc("project", "Files are saved privately on your own personal account. \
@@ -71,6 +80,11 @@ You can share drafts with others and publish your finished scores publicly too."
                 buttonText: qsTrc("project", "Save to the cloud")
 
                 imageSource: "internal/SaveToCloud/images/Cloud.png"
+
+                navigation.panel: optionsNavPanel
+                navigation.column: 1
+                navigation.accessible.name: qsTrc("project", "Save to the cloud (free)")
+                navigation.accessible.description: description
 
                 onButtonClicked: {
                     root.done(SaveLocationType.Cloud)
@@ -84,6 +98,11 @@ You can share drafts with others and publish your finished scores publicly too."
 
                 imageSource: "internal/SaveToCloud/images/Laptop.png"
 
+                navigation.panel: optionsNavPanel
+                navigation.column: 2
+                navigation.accessible.name: qsTrc("project", "Save on your computer")
+                navigation.accessible.description: description
+
                 onButtonClicked: {
                     root.done(SaveLocationType.Local)
                 }
@@ -92,11 +111,24 @@ You can share drafts with others and publish your finished scores publicly too."
 
         SeparatorLine { Layout.margins: -24 }
 
+        NavigationPanel {
+            id: dontAskAgainPanel
+            name: "DontAskAgain"
+            enabled: dontAskAgainCheckbox.enabled && dontAskAgainCheckbox.visible
+            section: root.navigationSection
+            order: 2
+            accessible.name: dontAskAgainCheckbox.text
+        }
+
         CheckBox {
             id: dontAskAgainCheckbox
+
             width: parent.width
             text: qsTrc("project", "Don’t show again")
             checked: !root.askAgain
+
+            navigation.panel: dontAskAgainPanel
+            navigation.order: 1
 
             onClicked: {
                 root.askAgain = !root.askAgain

--- a/src/project/qml/MuseScore/Project/SaveToCloudDialog.qml
+++ b/src/project/qml/MuseScore/Project/SaveToCloudDialog.qml
@@ -78,15 +78,27 @@ StyledDialogView {
             spacing: 20
 
             StyledTextLabel {
+                id: titleLabel
                 text: root.visibility === CloudVisibility.Public
-                ? qsTrc("project", "Publish to MuseScore.com")
-                : qsTrc("project", "Save to cloud")
+                      ? qsTrc("project", "Publish to MuseScore.com")
+                      : qsTrc("project", "Save to cloud")
                 font: ui.theme.largeBodyBoldFont
                 horizontalAlignment: Text.AlignLeft
             }
 
             ColumnLayout {
+                id: optionsColumn
                 spacing: 16
+
+                NavigationPanel {
+                    id: optionsNavPanel
+                    name: "SaveToCloudOptions"
+                    enabled: optionsColumn.enabled && optionsColumn.visible
+                    direction: NavigationPanel.Vertical
+                    section: root.navigationSection
+                    order: 1
+                    accessible.name: qsTrc("project", "Options")
+                }
 
                 ColumnLayout {
                     spacing: 8
@@ -100,6 +112,10 @@ StyledDialogView {
                     TextInputField {
                         Layout.fillWidth: true
                         currentText: root.name
+
+                        navigation.panel: optionsNavPanel
+                        navigation.row: 1
+                        accessible.name: titleLabel.text + ". " + qsTrc("project", "Name") + ": " + currentText
 
                         onCurrentTextEdited: function(newTextValue) {
                             root.name = newTextValue
@@ -118,12 +134,18 @@ StyledDialogView {
 
                     Dropdown {
                         Layout.fillWidth: true
+
                         model: [
                             { value: CloudVisibility.Private, text: qsTrc("project", "Private") },
                             { value: CloudVisibility.Public, text: qsTrc("project", "Public") }
                         ]
 
                         currentIndex: indexOfValue(root.visibility)
+
+                        navigation.panel: optionsNavPanel
+                        navigation.row: 2
+                        navigation.accessible.name: qsTrc("project", "Visibility") + ": " + currentText
+
                         onCurrentValueChanged: {
                             root.visibility = currentValue
                         }
@@ -132,12 +154,25 @@ StyledDialogView {
             }
 
             RowLayout {
+                id: buttonsRow
                 Layout.alignment: Qt.AlignRight
                 spacing: 12
+
+                NavigationPanel {
+                    id: buttonsNavPanel
+                    name: "SaveToCloudButtons"
+                    enabled: buttonsRow.enabled && buttonsRow.visible
+                    direction: NavigationPanel.Horizontal
+                    section: root.navigationSection
+                    order: 2
+                }
 
                 FlatButton {
                     text: qsTrc("project", "Save to computer")
                     visible: root.canSaveToComputer
+
+                    navigation.panel: buttonsNavPanel
+                    navigation.column: 2
 
                     onClicked: {
                         root.done(SaveToCloudResponse.SaveLocallyInstead)
@@ -147,15 +182,22 @@ StyledDialogView {
                 FlatButton {
                     text: qsTrc("global", "Cancel")
 
+                    navigation.panel: buttonsNavPanel
+                    navigation.column: 3
+
                     onClicked: {
                         root.done(SaveToCloudResponse.Cancel)
                     }
                 }
 
                 FlatButton {
+                    id: saveButton
                     text: qsTrc("project", "Save")
                     accentButton: enabled
                     enabled: Boolean(root.name)
+
+                    navigation.panel: buttonsNavPanel
+                    navigation.column: 1
 
                     onClicked: {
                         root.done(SaveToCloudResponse.Ok, {

--- a/src/project/qml/MuseScore/Project/internal/SaveToCloud/SaveLocationOption.qml
+++ b/src/project/qml/MuseScore/Project/internal/SaveToCloud/SaveLocationOption.qml
@@ -34,6 +34,8 @@ ColumnLayout {
 
     property alias imageSource: image.source
 
+    property alias navigation: button.navigation
+
     signal buttonClicked
 
     readonly property int radius: 6
@@ -92,6 +94,7 @@ ColumnLayout {
             FlatButton {
                 id: button
                 accentButton: true
+
                 onClicked: {
                     root.buttonClicked()
                 }


### PR DESCRIPTION
Added keyboard navigation for two dialogs:
- "How would you like to save?"
- "Save to cloud"

And fixed some problems with requesting focus when the "Save to cloud" dialog is opened from the "How would you like to save?" dialog. 

Also added a nice macro for the "Defer" struct, so that we can use it like this:
```c++
DEFER {
   doSomethingOnScopeExit();
   // It almost looks like a built-in language feature
}; // Except for that semicolon there
```

Inspired by what I've seen at the Swift project, but slightly simpler under the hood.