### PR TITLE
[MU4] Fix #10672: 'Hide stem' option should also hide note flags

### DIFF
--- a/src/inspector/models/notation/notes/stems/stemsettingsmodel.cpp
+++ b/src/inspector/models/notation/notes/stems/stemsettingsmodel.cpp
@@ -40,8 +40,8 @@ StemSettingsModel::StemSettingsModel(QObject* parent, IElementRepositoryService*
 
 void StemSettingsModel::createProperties()
 {
-    m_isStemHidden = buildPropertyItem(Ms::Pid::VISIBLE, [this](const Ms::Pid pid, const QVariant& isStemHidden) {
-        onPropertyValueChanged(pid, !isStemHidden.toBool());
+    m_isStemHidden = buildPropertyItem(Ms::Pid::NO_STEM, [this](const Ms::Pid pid, const QVariant& isStemHidden) {
+        onPropertyValueChanged(pid, isStemHidden.toBool());
     });
 
     m_thickness = buildPropertyItem(Ms::Pid::LINE_WIDTH);
@@ -71,8 +71,8 @@ void StemSettingsModel::requestElements()
 
 void StemSettingsModel::loadProperties()
 {
-    loadPropertyItem(m_isStemHidden, [](const QVariant& isVisible) -> QVariant {
-        return !isVisible.toBool();
+    loadPropertyItem(m_isStemHidden, [](const QVariant& isHidden) -> QVariant {
+        return isHidden.toBool();
     });
 
     loadPropertyItem(m_thickness, [](const QVariant& elementPropertyValue) -> QVariant {

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/notes/StemSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/notes/StemSettings.qml
@@ -51,21 +51,13 @@ FocusableItem {
 
         spacing: 12
 
-        CheckBox {
-            width: parent.width
-            isIndeterminate: root.stemModel && root.beamModel ? root.stemModel.isStemHidden.isUndefined || root.beamModel.isBeamHidden.isUndefined : false
-            checked: root.stemModel && !isIndeterminate && root.beamModel ? root.stemModel.isStemHidden.value && root.beamModel.isBeamHidden.value : false
+        CheckBoxPropertyView {
             text: qsTrc("inspector", "Hide stem (also hides beam)")
+            propertyItem: root.stemModel ? root.stemModel.isStemHidden : null
 
             navigation.name: "HideStem"
             navigation.panel: root.navigationPanel
             navigation.row: root.navigationRowStart + 1
-
-            onClicked: {
-                var isHidden = !checked
-                root.stemModel.isStemHidden.value = isHidden
-                root.beamModel.isBeamHidden.value = isHidden
-            }
         }
 
         FlatRadioButtonGroupPropertyView {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10672