### PR TITLE
Score properties dialog: fix/improve "Reveal in Finder"/"Reveal in Explorer"

### DIFF
--- a/src/autobot/internal/autobotinteractive.cpp
+++ b/src/autobot/internal/autobotinteractive.cpp
@@ -174,6 +174,11 @@ Ret AutobotInteractive::openUrl(const QUrl& url) const
     return m_real->openUrl(url);
 }
 
+Ret AutobotInteractive::revealInFileBrowser(const io::path& filePath) const
+{
+    return m_real->revealInFileBrowser(filePath);
+}
+
 io::path AutobotInteractive::selectedFilePath() const
 {
     return m_selectedFilePath;

--- a/src/autobot/internal/autobotinteractive.h
+++ b/src/autobot/internal/autobotinteractive.h
@@ -88,6 +88,8 @@ public:
     Ret openUrl(const std::string& url) const override;
     Ret openUrl(const QUrl& url) const override;
 
+    Ret revealInFileBrowser(const io::path& filePath) const override;
+
     // AutobotInteractive
     io::path selectedFilePath() const; // last selected file path
 

--- a/src/framework/global/CMakeLists.txt
+++ b/src/framework/global/CMakeLists.txt
@@ -93,6 +93,19 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/interactive.h
 )
 
+if (OS_IS_MAC)
+    set(MODULE_SRC ${MODULE_SRC}
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosinteractivehelper.mm
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosinteractivehelper.h
+    )
+    set_source_files_properties(
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosinteractivehelper.mm
+        PROPERTIES
+        SKIP_UNITY_BUILD_INCLUSION ON
+        SKIP_PRECOMPILE_HEADERS ON
+    )
+endif()
+
 set(FS_LIB )
 # The use of `filesystem` is disabled until
 # I figure out how to use it correctly for all platforms and compilers (including MinGW)

--- a/src/framework/global/iinteractive.h
+++ b/src/framework/global/iinteractive.h
@@ -174,6 +174,10 @@ public:
 
     virtual Ret openUrl(const std::string& url) const = 0;
     virtual Ret openUrl(const QUrl& url) const = 0;
+
+    /// Opens a file browser at the parent directory of filePath,
+    /// and selects the file at filePath on OSs that support it
+    virtual Ret revealInFileBrowser(const io::path& filePath) const = 0;
 };
 Q_DECLARE_OPERATORS_FOR_FLAGS(IInteractive::Options)
 }

--- a/src/framework/global/internal/interactive.cpp
+++ b/src/framework/global/internal/interactive.cpp
@@ -33,6 +33,9 @@
 
 #ifdef Q_OS_MAC
 #include "platform/macos/macosinteractivehelper.h"
+#elif defined(Q_OS_WIN)
+#include <QDir>
+#include <QProcess>
 #endif
 
 #include "log.h"
@@ -233,6 +236,11 @@ Ret Interactive::revealInFileBrowser(const io::path& filePath) const
 {
 #ifdef Q_OS_MACOS
     if (MacOSInteractiveHelper::revealInFinder(filePath)) {
+        return true;
+    }
+#elif defined(Q_OS_WIN)
+    QString command = QLatin1String("explorer /select,%1").arg(QDir::toNativeSeparators(filePath.toQString()));
+    if (QProcess::startDetached(command)) {
         return true;
     }
 #endif

--- a/src/framework/global/internal/interactive.cpp
+++ b/src/framework/global/internal/interactive.cpp
@@ -31,6 +31,10 @@
 #include <QGridLayout>
 #include <QDesktopServices>
 
+#ifdef Q_OS_MAC
+#include "platform/macos/macosinteractivehelper.h"
+#endif
+
 #include "log.h"
 #include "translation.h"
 #include "io/path.h"
@@ -223,6 +227,17 @@ Ret Interactive::openUrl(const std::string& url) const
 Ret Interactive::openUrl(const QUrl& url) const
 {
     return QDesktopServices::openUrl(url);
+}
+
+Ret Interactive::revealInFileBrowser(const io::path& filePath) const
+{
+#ifdef Q_OS_MACOS
+    if (MacOSInteractiveHelper::revealInFinder(filePath)) {
+        return true;
+    }
+#endif
+    io::path dirPath = io::dirpath(filePath);
+    return openUrl(QUrl::fromLocalFile(dirPath.toQString()));
 }
 
 IInteractive::ButtonDatas Interactive::buttonDataList(const Buttons& buttons) const

--- a/src/framework/global/internal/interactive.h
+++ b/src/framework/global/internal/interactive.h
@@ -88,6 +88,8 @@ public:
     Ret openUrl(const std::string& url) const override;
     Ret openUrl(const QUrl& url) const override;
 
+    Ret revealInFileBrowser(const io::path& filePath) const override;
+
 private:
     ButtonDatas buttonDataList(const Buttons& buttons) const;
 };

--- a/src/framework/global/internal/platform/macos/macosinteractivehelper.h
+++ b/src/framework/global/internal/platform/macos/macosinteractivehelper.h
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2022 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_FRAMEWORK_MACOSINTERACTIVEHELPER_H
+#define MU_FRAMEWORK_MACOSINTERACTIVEHELPER_H
+
+#include "io/path.h"
+
+namespace mu::framework {
+class MacOSInteractiveHelper
+{
+public:
+    static bool revealInFinder(const io::path& filePath);
+};
+}
+
+#endif // MU_FRAMEWORK_MACOSINTERACTIVEHELPER_H

--- a/src/framework/global/internal/platform/macos/macosinteractivehelper.mm
+++ b/src/framework/global/internal/platform/macos/macosinteractivehelper.mm
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2022 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "macosinteractivehelper.h"
+
+#include <QUrl>
+
+#include <Cocoa/Cocoa.h>
+
+using namespace mu::framework;
+
+bool MacOSInteractiveHelper::revealInFinder(const io::path& filePath)
+{
+    NSURL* fileUrl = QUrl::fromLocalFile(filePath.toQString()).toNSURL();
+
+    [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:@[fileUrl]];
+
+    return true;
+}

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -793,7 +793,7 @@ QVariant NotationViewInputController::inputMethodQuery(Qt::InputMethodQuery quer
     case Qt::ImHints:
         return Qt::ImhNone; // No hints for now, but maybe in future will give hints
     default:
-        return QVariant();
+        break;
     }
 
     return QVariant();

--- a/src/notation/view/widgets/scoreproperties.cpp
+++ b/src/notation/view/widgets/scoreproperties.cpp
@@ -237,12 +237,11 @@ void ScorePropertiesDialog::setDirty(const bool dirty)
 
 void ScorePropertiesDialog::openFileLocation()
 {
-    io::path dirPath = io::dirpath(filePath->text());
-    Ret ret = interactive()->openUrl(QUrl::fromLocalFile(dirPath.toQString()));
+    Ret ret = interactive()->revealInFileBrowser(filePath->text());
 
     if (!ret) {
         interactive()->warning(trc("notation", "Open Containing Folder Error"),
-                               trc("notation", "Could not open containing folder"));
+                               trc("notation", "Could not open containing folder."));
     }
 }
 

--- a/src/notation/view/widgets/scoreproperties.cpp
+++ b/src/notation/view/widgets/scoreproperties.cpp
@@ -238,7 +238,7 @@ void ScorePropertiesDialog::setDirty(const bool dirty)
 void ScorePropertiesDialog::openFileLocation()
 {
     io::path dirPath = io::dirpath(filePath->text());
-    Ret ret = interactive()->openUrl(dirPath.toStdString());
+    Ret ret = interactive()->openUrl(QUrl::fromLocalFile(dirPath.toQString()));
 
     if (!ret) {
         interactive()->warning(trc("notation", "Open Containing Folder Error"),


### PR DESCRIPTION
It was broken on macOS.

Now, not only the containing folder will be opened, but also the file will be selected inside that folder (on OSs that support it, so macOS and Windows)