### PR TITLE
Enhance error message text on Learn Page

### DIFF
--- a/src/framework/global/CMakeLists.txt
+++ b/src/framework/global/CMakeLists.txt
@@ -93,19 +93,6 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/interactive.h
 )
 
-if (OS_IS_MAC)
-    set(MODULE_SRC ${MODULE_SRC}
-        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosinteractivehelper.mm
-        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosinteractivehelper.h
-    )
-    set_source_files_properties(
-        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosinteractivehelper.mm
-        PROPERTIES
-        SKIP_UNITY_BUILD_INCLUSION ON
-        SKIP_PRECOMPILE_HEADERS ON
-    )
-endif()
-
 set(FS_LIB )
 # The use of `filesystem` is disabled until
 # I figure out how to use it correctly for all platforms and compilers (including MinGW)
@@ -117,5 +104,20 @@ set(FS_LIB )
 set(MODULE_LINK
     ${FS_LIB}
 )
+
+if (OS_IS_MAC)
+    set(MODULE_SRC ${MODULE_SRC}
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosinteractivehelper.mm
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosinteractivehelper.h
+    )
+    set_source_files_properties(
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosinteractivehelper.mm
+        PROPERTIES
+        SKIP_UNITY_BUILD_INCLUSION ON
+        SKIP_PRECOMPILE_HEADERS ON
+    )
+    find_library(AppKit NAMES AppKit)
+    set(MODULE_LINK ${MODULE_LINK} ${AppKit})
+endif()
 
 include(${PROJECT_SOURCE_DIR}/build/module.cmake)

--- a/src/learn/qml/MuseScore/Learn/internal/Playlist.qml
+++ b/src/learn/qml/MuseScore/Learn/internal/Playlist.qml
@@ -147,12 +147,12 @@ FocusScope {
         StyledTextLabel {
             width: parent.width
             font: ui.theme.tabBoldFont
-            text: qsTrc("learn", "Sorry, but we can’t load these videos right now")
+            text: qsTrc("learn", "Sorry, we are unable to load these videos right now")
         }
 
         StyledTextLabel {
             width: parent.width
-            text: qsTrc("learn", "Please check your internet connection, or try again later.")
+            text: qsTrc("learn", "Please check your internet connection or try again later.")
         }
     }
 }


### PR DESCRIPTION
Resolves: #10736 (the part about the text)
<img width="871" alt="Schermafbeelding 2022-03-05 om 23 47 32" src="https://user-images.githubusercontent.com/48658420/156902239-f0d6f60e-185f-4367-ba93-37c570ff5315.png">
Also fixes macOS build (_sometimes_ it failed; the cause is that I forgot to link with Appkit in PR #10750.)