### PR TITLE
Check the mode of clipboard usage while copying depending on the platform

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3089,7 +3089,12 @@ void NotationInteraction::copySelection()
         m_editData.element->editCopy(m_editData);
         Ms::TextEditData* ted = static_cast<Ms::TextEditData*>(m_editData.getData(m_editData.element).get());
         if (!ted->selectedText.isEmpty()) {
-            QGuiApplication::clipboard()->setText(ted->selectedText, QClipboard::Clipboard);
+            #if defined(Q_OS_MAC) || defined(Q_OS_WIN)
+            QClipboard::Mode mode = QClipboard::Clipboard;
+            #else
+            QClipboard::Mode mode = QClipboard::Selection;
+            #endif
+            QGuiApplication::clipboard()->setText(ted->selectedText, mode);
         }
     } else {
         QMimeData* mimeData = selection()->mimeData();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10742

Add platform dependant check while copying the selection to determine whether to use the global clipboard or global mouse selection and use the enum type corresponding to the part of the system clipboard used by setText().

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://musescore.org/en/cla)
- [X] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [X] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made

https://user-images.githubusercontent.com/73242397/156912069-8ab1b6c6-32dc-40d5-8f44-c9783032cb5c.mp4


