### PR TITLE
Revive the "Follow system theme" feature

### DIFF
--- a/src/appshell/qml/FirstLaunchSetup/ThemesPage.qml
+++ b/src/appshell/qml/FirstLaunchSetup/ThemesPage.qml
@@ -30,9 +30,9 @@ import "../shared"
 
 Page {
     title: qsTrc("appshell", "Welcome to MuseScore 4")
-    explanation: qsTrc("appshell", "Let's get started by choosing a theme")
+    explanation: qsTrc("appshell", "Let's get started by choosing a theme.")
 
-    titleContentSpacing: 28
+    titleContentSpacing: model.isFollowSystemThemeAvailable ? 20 : 28
 
     ThemesPageModel {
         id: model
@@ -45,7 +45,30 @@ Page {
     ColumnLayout {
         anchors.top: parent.top
         anchors.horizontalCenter: parent.horizontalCenter
-        spacing: 28
+        spacing: model.isFollowSystemThemeAvailable ? 20 : 28
+
+        CheckBox {
+            visible: model.isFollowSystemThemeAvailable
+            Layout.alignment: Qt.AlignCenter
+
+            text: qsTrc("appshell", "Follow system theme")
+
+            checked: model.isFollowSystemTheme
+
+            navigation.name: "FollowSystemThemeBox"
+            navigation.order: 1
+            navigation.panel: NavigationPanel {
+                name: "FollowSystemThemeBox"
+                enabled: parent.enabled && parent.visible
+                section: root.navigationSection
+                order: 1
+                direction: NavigationPanel.Horizontal
+            }
+
+            onClicked: {
+                model.isFollowSystemTheme = !checked
+            }
+        }
 
         ThemeSamplesList {
             id: themeSamplesList
@@ -57,7 +80,7 @@ Page {
             spacing: 64
 
             navigationPanel.section: root.navigationSection
-            navigationPanel.order: 1
+            navigationPanel.order: 2
 
             onThemeChangeRequested: function(newThemeCode) {
                 model.currentThemeCode = newThemeCode
@@ -77,7 +100,7 @@ Page {
             spacing: 4
 
             navigationPanel.section: root.navigationSection
-            navigationPanel.order: 2
+            navigationPanel.order: 3
 
             onAccentColorChangeRequested: function(newColorIndex) {
                 model.currentAccentColorIndex = newColorIndex
@@ -104,9 +127,10 @@ Page {
                 name: "EnableHighContrast"
                 enabled: parent.enabled && parent.visible
                 section: root.navigationSection
-                order: 3
+                order: 4
                 direction: NavigationPanel.Horizontal
             }
+            navigation.accessible.description: highContrastPreferencesHintLabel.text
 
             onClicked: {
                 model.highContrastEnabled = !checked

--- a/src/appshell/qml/Preferences/AppearancePreferencesPage.qml
+++ b/src/appshell/qml/Preferences/AppearancePreferencesPage.qml
@@ -48,6 +48,8 @@ PreferencesPage {
             themes: appearanceModel.highContrastEnabled ? appearanceModel.highContrastThemes : appearanceModel.generalThemes
             currentThemeCode: appearanceModel.currentThemeCode
             highContrastEnabled: appearanceModel.highContrastEnabled
+            isFollowSystemThemeAvailable: appearanceModel.isFollowSystemThemeAvailable
+            isFollowSystemTheme: appearanceModel.isFollowSystemTheme
             accentColors: appearanceModel.accentColors
             currentAccentColorIndex: appearanceModel.currentAccentColorIndex
 
@@ -60,6 +62,10 @@ PreferencesPage {
 
             onHighContrastChangeRequested: function(enabled) {
                 appearanceModel.highContrastEnabled = enabled
+            }
+
+            onSetFollowSystemThemeRequested: function(enabled) {
+                appearanceModel.isFollowSystemTheme = enabled
             }
 
             onAccentColorChangeRequested: function(newColorIndex) {

--- a/src/appshell/qml/Preferences/internal/ThemesSection.qml
+++ b/src/appshell/qml/Preferences/internal/ThemesSection.qml
@@ -34,6 +34,9 @@ BaseSection {
 
     property bool highContrastEnabled: false
 
+    property alias isFollowSystemThemeAvailable: followSystemThemeCheckBox.visible
+    property alias isFollowSystemTheme: followSystemThemeCheckBox.checked
+
     property alias themes: themeSamplesList.themes
     property alias currentThemeCode: themeSamplesList.currentThemeCode
 
@@ -42,6 +45,7 @@ BaseSection {
 
     signal themeChangeRequested(var newThemeCode)
     signal highContrastChangeRequested(bool enabled)
+    signal setFollowSystemThemeRequested(bool enabled)
     signal accentColorChangeRequested(var newColorIndex)
 
     signal ensureContentVisibleRequested(var contentRect)
@@ -63,13 +67,29 @@ BaseSection {
         }
     }
 
+    CheckBox {
+        id: followSystemThemeCheckBox
+        width: parent.width
+
+        text: qsTrc("appshell", "Follow system theme")
+
+        navigation.name: "FollowSystemThemeBox"
+        navigation.panel: root.navigation
+        navigation.row: 1
+        navigation.column: 0
+
+        onClicked: {
+            root.setFollowSystemThemeRequested(!checked)
+        }
+    }
+
     ThemeSamplesList {
         id: themeSamplesList
         width: parent.width
         spacing: root.columnWidth + root.columnSpacing - sampleWidth
 
         navigationPanel: root.navigation
-        navigationRow: 1
+        navigationRow: 2
 
         onThemeChangeRequested: function(newThemeCode) {
             root.themeChangeRequested(newThemeCode)

--- a/src/appshell/view/firstlaunchsetup/themespagemodel.cpp
+++ b/src/appshell/view/firstlaunchsetup/themespagemodel.cpp
@@ -33,9 +33,32 @@ ThemesPageModel::ThemesPageModel(QObject* parent)
 
 void ThemesPageModel::load()
 {
+    uiConfiguration()->isFollowSystemTheme().notification.onNotify(this, [this]() {
+        emit isFollowSystemThemeChanged();
+    });
+
     uiConfiguration()->currentThemeChanged().onNotify(this, [this]() {
         emit themesChanged();
     });
+}
+
+bool ThemesPageModel::isFollowSystemThemeAvailable() const
+{
+    return uiConfiguration()->isFollowSystemThemeAvailable();
+}
+
+bool ThemesPageModel::isFollowSystemTheme() const
+{
+    return uiConfiguration()->isFollowSystemTheme().val;
+}
+
+void ThemesPageModel::setFollowSystemTheme(bool enabled)
+{
+    if (enabled == isFollowSystemTheme()) {
+        return;
+    }
+
+    uiConfiguration()->setFollowSystemTheme(enabled);
 }
 
 ThemeList ThemesPageModel::allThemes() const
@@ -96,9 +119,11 @@ QString ThemesPageModel::currentThemeCode() const
 
 void ThemesPageModel::setCurrentThemeCode(const QString& themeCode)
 {
-    if (themeCode == currentThemeCode()) {
+    if (themeCode == currentThemeCode() && !isFollowSystemTheme()) {
         return;
     }
+
+    setFollowSystemTheme(false);
 
     for (const ThemeInfo& theme : allThemes()) {
         if (themeCode == QString::fromStdString(theme.codeKey)) {
@@ -106,7 +131,6 @@ void ThemesPageModel::setCurrentThemeCode(const QString& themeCode)
             break;
         }
     }
-    emit themesChanged();
 }
 
 QStringList ThemesPageModel::accentColors() const
@@ -140,5 +164,4 @@ void ThemesPageModel::setCurrentAccentColorIndex(int index)
 
     QColor color = accentColors()[index];
     uiConfiguration()->setCurrentThemeStyleValue(ThemeStyleKey::ACCENT_COLOR, Val(color));
-    emit themesChanged();
 }

--- a/src/appshell/view/firstlaunchsetup/themespagemodel.cpp
+++ b/src/appshell/view/firstlaunchsetup/themespagemodel.cpp
@@ -123,14 +123,7 @@ void ThemesPageModel::setCurrentThemeCode(const QString& themeCode)
         return;
     }
 
-    setFollowSystemTheme(false);
-
-    for (const ThemeInfo& theme : allThemes()) {
-        if (themeCode == QString::fromStdString(theme.codeKey)) {
-            uiConfiguration()->setCurrentTheme(theme.codeKey);
-            break;
-        }
-    }
+    uiConfiguration()->setCurrentTheme(themeCodeFromString(themeCode));
 }
 
 QStringList ThemesPageModel::accentColors() const

--- a/src/appshell/view/firstlaunchsetup/themespagemodel.h
+++ b/src/appshell/view/firstlaunchsetup/themespagemodel.h
@@ -34,6 +34,9 @@ class ThemesPageModel : public QObject, public async::Asyncable
 {
     Q_OBJECT
 
+    Q_PROPERTY(bool isFollowSystemThemeAvailable READ isFollowSystemThemeAvailable CONSTANT)
+    Q_PROPERTY(bool isFollowSystemTheme READ isFollowSystemTheme WRITE setFollowSystemTheme NOTIFY isFollowSystemThemeChanged)
+
     Q_PROPERTY(bool highContrastEnabled READ highContrastEnabled WRITE setHighContrastEnabled NOTIFY highContrastEnabledChanged)
     Q_PROPERTY(QVariantList generalThemes READ generalThemes NOTIFY themesChanged)
     Q_PROPERTY(QVariantList highContrastThemes READ highContrastThemes NOTIFY themesChanged)
@@ -49,6 +52,9 @@ public:
 
     Q_INVOKABLE void load();
 
+    bool isFollowSystemThemeAvailable() const;
+    bool isFollowSystemTheme() const;
+
     QVariantList generalThemes() const;
     QVariantList highContrastThemes() const;
     bool highContrastEnabled() const;
@@ -58,11 +64,13 @@ public:
     int currentAccentColorIndex() const;
 
 public slots:
+    void setFollowSystemTheme(bool enabled);
     void setHighContrastEnabled(bool enabled);
     void setCurrentThemeCode(const QString& themeCode);
     void setCurrentAccentColorIndex(int index);
 
 signals:
+    void isFollowSystemThemeChanged();
     void highContrastEnabledChanged();
     void themesChanged();
 

--- a/src/appshell/view/preferences/appearancepreferencesmodel.cpp
+++ b/src/appshell/view/preferences/appearancepreferencesmodel.cpp
@@ -40,6 +40,10 @@ AppearancePreferencesModel::AppearancePreferencesModel(QObject* parent)
 
 void AppearancePreferencesModel::init()
 {
+    uiConfiguration()->isFollowSystemTheme().notification.onNotify(this, [this]() {
+        emit isFollowSystemThemeChanged();
+    });
+
     uiConfiguration()->currentThemeChanged().onNotify(this, [this]() {
         emit themesChanged();
         emit foregroundColorChanged();
@@ -66,6 +70,25 @@ void AppearancePreferencesModel::init()
         emit foregroundUseColorChanged();
         emit foregroundWallpaperPathChanged();
     });
+}
+
+bool AppearancePreferencesModel::isFollowSystemThemeAvailable() const
+{
+    return uiConfiguration()->isFollowSystemThemeAvailable();
+}
+
+bool AppearancePreferencesModel::isFollowSystemTheme() const
+{
+    return uiConfiguration()->isFollowSystemTheme().val;
+}
+
+void AppearancePreferencesModel::setFollowSystemTheme(bool enabled)
+{
+    if (enabled == isFollowSystemTheme()) {
+        return;
+    }
+
+    uiConfiguration()->setFollowSystemTheme(enabled);
 }
 
 bool AppearancePreferencesModel::highContrastEnabled() const
@@ -234,9 +257,11 @@ bool AppearancePreferencesModel::scoreInversionEnabled() const
 
 void AppearancePreferencesModel::setCurrentThemeCode(const QString& themeCode)
 {
-    if (themeCode == currentThemeCode()) {
+    if (themeCode == currentThemeCode() && !isFollowSystemTheme()) {
         return;
     }
+
+    setFollowSystemTheme(false);
 
     for (const ThemeInfo& theme : allThemes()) {
         if (themeCode == QString::fromStdString(theme.codeKey)) {
@@ -244,7 +269,6 @@ void AppearancePreferencesModel::setCurrentThemeCode(const QString& themeCode)
             break;
         }
     }
-    emit themesChanged();
 }
 
 void AppearancePreferencesModel::setCurrentAccentColorIndex(int index)
@@ -259,7 +283,6 @@ void AppearancePreferencesModel::setCurrentAccentColorIndex(int index)
 
     QColor color = accentColors()[index];
     uiConfiguration()->setCurrentThemeStyleValue(ThemeStyleKey::ACCENT_COLOR, Val(color));
-    emit themesChanged();
 }
 
 void AppearancePreferencesModel::setCurrentFontIndex(int index)

--- a/src/appshell/view/preferences/appearancepreferencesmodel.cpp
+++ b/src/appshell/view/preferences/appearancepreferencesmodel.cpp
@@ -261,14 +261,7 @@ void AppearancePreferencesModel::setCurrentThemeCode(const QString& themeCode)
         return;
     }
 
-    setFollowSystemTheme(false);
-
-    for (const ThemeInfo& theme : allThemes()) {
-        if (themeCode == QString::fromStdString(theme.codeKey)) {
-            uiConfiguration()->setCurrentTheme(theme.codeKey);
-            break;
-        }
-    }
+    uiConfiguration()->setCurrentTheme(themeCodeFromString(themeCode));
 }
 
 void AppearancePreferencesModel::setCurrentAccentColorIndex(int index)

--- a/src/appshell/view/preferences/appearancepreferencesmodel.h
+++ b/src/appshell/view/preferences/appearancepreferencesmodel.h
@@ -38,6 +38,9 @@ class AppearancePreferencesModel : public QObject, public async::Asyncable
     INJECT(appshell, notation::INotationConfiguration, notationConfiguration)
     INJECT(appshell, engraving::IEngravingConfiguration, engravingConfiguration)
 
+    Q_PROPERTY(bool isFollowSystemThemeAvailable READ isFollowSystemThemeAvailable CONSTANT)
+    Q_PROPERTY(bool isFollowSystemTheme READ isFollowSystemTheme WRITE setFollowSystemTheme NOTIFY isFollowSystemThemeChanged)
+
     Q_PROPERTY(bool highContrastEnabled READ highContrastEnabled WRITE setHighContrastEnabled NOTIFY highContrastEnabledChanged)
     Q_PROPERTY(QVariantList generalThemes READ generalThemes NOTIFY themesChanged)
     Q_PROPERTY(QVariantList highContrastThemes READ highContrastThemes NOTIFY themesChanged)
@@ -74,6 +77,9 @@ public:
     };
     Q_ENUM(ColorType)
 
+    bool isFollowSystemThemeAvailable() const;
+    bool isFollowSystemTheme() const;
+
     bool highContrastEnabled() const;
     QVariantList generalThemes() const;
     QVariantList highContrastThemes() const;
@@ -103,6 +109,7 @@ public:
     Q_INVOKABLE QString wallpapersDir() const;
 
 public slots:
+    void setFollowSystemTheme(bool enabled);
     void setHighContrastEnabled(bool enabled);
     void setCurrentThemeCode(const QString& themeCode);
     void setCurrentAccentColorIndex(int index);
@@ -117,6 +124,7 @@ public slots:
     void setScoreInversionEnabled(bool value);
 
 signals:
+    void isFollowSystemThemeChanged();
     void highContrastEnabledChanged();
     void themesChanged();
     void currentFontIndexChanged();

--- a/src/framework/ui/internal/iplatformtheme.h
+++ b/src/framework/ui/internal/iplatformtheme.h
@@ -5,7 +5,7 @@
  * MuseScore
  * Music Composition & Notation
  *
- * Copyright (C) 2021 MuseScore BVBA and others
+ * Copyright (C) 2022 MuseScore BVBA and others
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -24,7 +24,7 @@
 #define MU_UI_IPLATFORMTHEME_H
 
 #include "modularity/imoduleexport.h"
-#include "async/channel.h"
+#include "async/notification.h"
 #include "uitypes.h"
 
 class QWindow;
@@ -42,11 +42,11 @@ public:
 
     virtual bool isFollowSystemThemeAvailable() const = 0;
 
-    virtual ThemeCode themeCode() const = 0;
-    virtual async::Channel<ThemeCode> themeCodeChanged() const = 0;
+    virtual ThemeCode platformThemeCode() const = 0;
+    virtual async::Notification platformThemeChanged() const = 0;
 
-    virtual void applyPlatformStyleOnAppForTheme(ThemeCode themeCode) = 0;
-    virtual void applyPlatformStyleOnWindowForTheme(QWindow* window, ThemeCode themeCode) = 0;
+    virtual void applyPlatformStyleOnAppForTheme(const ThemeCode& themeCode) = 0;
+    virtual void applyPlatformStyleOnWindowForTheme(QWindow* window, const ThemeCode& themeCode) = 0;
 };
 }
 

--- a/src/framework/ui/internal/iplatformtheme.h
+++ b/src/framework/ui/internal/iplatformtheme.h
@@ -42,7 +42,7 @@ public:
 
     virtual bool isFollowSystemThemeAvailable() const = 0;
 
-    virtual ThemeCode platformThemeCode() const = 0;
+    virtual bool isSystemThemeDark() const = 0;
     virtual async::Notification platformThemeChanged() const = 0;
 
     virtual void applyPlatformStyleOnAppForTheme(const ThemeCode& themeCode) = 0;

--- a/src/framework/ui/internal/platform/macos/macosplatformtheme.h
+++ b/src/framework/ui/internal/platform/macos/macosplatformtheme.h
@@ -34,16 +34,13 @@ public:
 
     bool isFollowSystemThemeAvailable() const override;
 
-    ThemeCode platformThemeCode() const override;
+    bool isSystemThemeDark() const override;
     async::Notification platformThemeChanged() const override;
 
     void applyPlatformStyleOnAppForTheme(const ThemeCode& themeCode) override;
     void applyPlatformStyleOnWindowForTheme(QWindow* window, const ThemeCode& themeCode) override;
 
 private:
-    bool isSystemDarkMode() const;
-    bool isSystemHighContrast() const;
-
     async::Notification m_platformThemeChanged;
 };
 }

--- a/src/framework/ui/internal/platform/macos/macosplatformtheme.h
+++ b/src/framework/ui/internal/platform/macos/macosplatformtheme.h
@@ -5,7 +5,7 @@
  * MuseScore
  * Music Composition & Notation
  *
- * Copyright (C) 2021 MuseScore BVBA and others
+ * Copyright (C) 2022 MuseScore BVBA and others
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -34,17 +34,17 @@ public:
 
     bool isFollowSystemThemeAvailable() const override;
 
-    ThemeCode themeCode() const override;
-    async::Channel<ThemeCode> themeCodeChanged() const override;
+    ThemeCode platformThemeCode() const override;
+    async::Notification platformThemeChanged() const override;
 
-    void applyPlatformStyleOnAppForTheme(ThemeCode themeCode) override;
-    void applyPlatformStyleOnWindowForTheme(QWindow* window, ThemeCode themeCode) override;
+    void applyPlatformStyleOnAppForTheme(const ThemeCode& themeCode) override;
+    void applyPlatformStyleOnWindowForTheme(QWindow* window, const ThemeCode& themeCode) override;
 
 private:
     bool isSystemDarkMode() const;
     bool isSystemHighContrast() const;
 
-    async::Channel<ThemeCode> m_channel;
+    async::Notification m_platformThemeChanged;
 };
 }
 

--- a/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
+++ b/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
@@ -94,8 +94,8 @@ void MacOSPlatformTheme::applyPlatformStyleOnWindowForTheme(QWindow* window, con
     if (nsWindow) {
         [nsWindow setTitlebarAppearsTransparent:YES];
         [nsWindow setBackgroundColor:[NSColor colorWithRed:backgroundColor.red() / 255.0
-                                                     green:backgroundColor.green() / 255.0
-                                                      blue:backgroundColor.blue() / 255.0
-                                                     alpha:backgroundColor.alpha() / 255.0]];
+                                      green:backgroundColor.green() / 255.0
+                                      blue:backgroundColor.blue() / 255.0
+                                      alpha:backgroundColor.alpha() / 255.0]];
     }
 }

--- a/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
+++ b/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
@@ -1,21 +1,24 @@
-//=============================================================================
-//  MuseScore
-//  Music Composition & Notation
-//
-//  Copyright (C) 2021 MuseScore BVBA and others
-//
-//  This program is free software; you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License version 2.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-//  GNU General Public License for more details.
-//
-//  You should have received a copy of the GNU General Public License
-//  along with this program; if not, write to the Free Software
-//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-//=============================================================================
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2022 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 #include "macosplatformtheme.h"
 #include "log.h"
@@ -39,8 +42,8 @@ void MacOSPlatformTheme::startListening()
                                  object:nil
                                  queue:nil
                                  usingBlock:^(NSNotification*) {
-            m_channel.send(themeCode());
-        }];
+                                     m_platformThemeChanged.notify();
+                                 }];
     }
 
     if (!contrastObserverToken) {
@@ -49,8 +52,8 @@ void MacOSPlatformTheme::startListening()
                                  object:nil
                                  queue:nil
                                  usingBlock:^(NSNotification*) {
-            m_channel.send(themeCode());
-        }];
+                                     m_platformThemeChanged.notify();
+                                 }];
     }
 }
 
@@ -73,12 +76,13 @@ bool MacOSPlatformTheme::isFollowSystemThemeAvailable() const
     return true;
 }
 
-ThemeCode MacOSPlatformTheme::themeCode() const
+ThemeCode MacOSPlatformTheme::platformThemeCode() const
 {
     if (isSystemHighContrast()) {
         if (isSystemDarkMode()) {
             return HIGH_CONTRAST_BLACK_THEME_CODE;
         }
+
         return HIGH_CONTRAST_WHITE_THEME_CODE;
     }
 
@@ -86,15 +90,12 @@ ThemeCode MacOSPlatformTheme::themeCode() const
         return DARK_THEME_CODE;
     }
 
-    //! NOTE When system is in light mode, don't automatically use
-    //! high contrast theme, because it is too dark.
-    //! Light high contrast theme would be nice.
     return LIGHT_THEME_CODE;
 }
 
-Channel<ThemeCode> MacOSPlatformTheme::themeCodeChanged() const
+Notification MacOSPlatformTheme::platformThemeChanged() const
 {
-    return m_channel;
+    return m_platformThemeChanged;
 }
 
 bool MacOSPlatformTheme::isSystemDarkMode() const
@@ -108,18 +109,18 @@ bool MacOSPlatformTheme::isSystemHighContrast() const
     return [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldIncreaseContrast];
 }
 
-void MacOSPlatformTheme::applyPlatformStyleOnAppForTheme(ThemeCode themeCode)
+void MacOSPlatformTheme::applyPlatformStyleOnAppForTheme(const ThemeCode& themeCode)
 {
     // The system will turn these appearance names into their high contrast
     // counterparts automatically if system high contrast is enabled
-    if (themeCode == LIGHT_THEME_CODE) {
+    if (isLightTheme(themeCode)) {
         [NSApp setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameAqua]];
     } else {
         [NSApp setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameDarkAqua]];
     }
 }
 
-void MacOSPlatformTheme::applyPlatformStyleOnWindowForTheme(QWindow* window, ThemeCode)
+void MacOSPlatformTheme::applyPlatformStyleOnWindowForTheme(QWindow* window, const ThemeCode&)
 {
     if (!window) {
         return;

--- a/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
@@ -38,9 +38,9 @@ bool StubPlatformTheme::isFollowSystemThemeAvailable() const
     return false;
 }
 
-ThemeCode StubPlatformTheme::platformThemeCode() const
+bool StubPlatformTheme::isSystemThemeDark() const
 {
-    return LIGHT_THEME_CODE;
+    return false;
 }
 
 Notification StubPlatformTheme::platformThemeChanged() const

--- a/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
@@ -5,7 +5,7 @@
  * MuseScore
  * Music Composition & Notation
  *
- * Copyright (C) 2021 MuseScore BVBA and others
+ * Copyright (C) 2022 MuseScore BVBA and others
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -38,20 +38,20 @@ bool StubPlatformTheme::isFollowSystemThemeAvailable() const
     return false;
 }
 
-ThemeCode StubPlatformTheme::themeCode() const
+ThemeCode StubPlatformTheme::platformThemeCode() const
 {
     return LIGHT_THEME_CODE;
 }
 
-Channel<ThemeCode> StubPlatformTheme::themeCodeChanged() const
+Notification StubPlatformTheme::platformThemeChanged() const
 {
-    return m_channel;
+    return m_platformThemeChanged;
 }
 
-void StubPlatformTheme::applyPlatformStyleOnAppForTheme(ThemeCode)
+void StubPlatformTheme::applyPlatformStyleOnAppForTheme(const ThemeCode&)
 {
 }
 
-void StubPlatformTheme::applyPlatformStyleOnWindowForTheme(QWindow*, ThemeCode)
+void StubPlatformTheme::applyPlatformStyleOnWindowForTheme(QWindow*, const ThemeCode&)
 {
 }

--- a/src/framework/ui/internal/platform/stub/stubplatformtheme.h
+++ b/src/framework/ui/internal/platform/stub/stubplatformtheme.h
@@ -34,7 +34,7 @@ public:
 
     bool isFollowSystemThemeAvailable() const override;
 
-    ThemeCode platformThemeCode() const override;
+    bool isSystemThemeDark() const override;
     async::Notification platformThemeChanged() const override;
 
     void applyPlatformStyleOnAppForTheme(const ThemeCode& themeCode) override;

--- a/src/framework/ui/internal/platform/stub/stubplatformtheme.h
+++ b/src/framework/ui/internal/platform/stub/stubplatformtheme.h
@@ -5,7 +5,7 @@
  * MuseScore
  * Music Composition & Notation
  *
- * Copyright (C) 2021 MuseScore BVBA and others
+ * Copyright (C) 2022 MuseScore BVBA and others
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -34,14 +34,14 @@ public:
 
     bool isFollowSystemThemeAvailable() const override;
 
-    ThemeCode themeCode() const override;
-    async::Channel<ThemeCode> themeCodeChanged() const override;
+    ThemeCode platformThemeCode() const override;
+    async::Notification platformThemeChanged() const override;
 
-    void applyPlatformStyleOnAppForTheme(ThemeCode themeCode) override;
-    void applyPlatformStyleOnWindowForTheme(QWindow* window, ThemeCode themeCode) override;
+    void applyPlatformStyleOnAppForTheme(const ThemeCode& themeCode) override;
+    void applyPlatformStyleOnWindowForTheme(QWindow* window, const ThemeCode& themeCode) override;
 
 private:
-    async::Channel<ThemeCode> m_channel;
+    async::Notification m_platformThemeChanged;
 };
 }
 

--- a/src/framework/ui/internal/platform/windows/windowsplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/windows/windowsplatformtheme.cpp
@@ -5,7 +5,7 @@
  * MuseScore
  * Music Composition & Notation
  *
- * Copyright (C) 2021 MuseScore BVBA and others
+ * Copyright (C) 2022 MuseScore BVBA and others
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -51,6 +51,8 @@ WindowsPlatformTheme::WindowsPlatformTheme()
     } else {
         LOGE() << "Could not get Windows build number";
     }
+
+    m_platformThemeCode.val = bestSuitedThemeCode();
 }
 
 void WindowsPlatformTheme::startListening()
@@ -58,7 +60,9 @@ void WindowsPlatformTheme::startListening()
     if (m_isListening) {
         return;
     }
+
     m_isListening = true;
+
     if (RegOpenKeyExW(HKEY_CURRENT_USER, windowsThemesKey.c_str(), 0,
                       KEY_NOTIFY | KEY_CREATE_SUB_KEY | KEY_ENUMERATE_SUB_KEYS | KEY_QUERY_VALUE | KEY_WOW64_64KEY,
                       &hKey) == ERROR_SUCCESS) {
@@ -73,7 +77,9 @@ void WindowsPlatformTheme::stopListening()
     if (!m_isListening) {
         return;
     }
+
     m_isListening = false;
+
     // The following _might_ fail; in that case, the app won't respond
     // for max. 4000 ms (or whatever value is specified in th_listen()).
     SetEvent(hStopListeningEvent);
@@ -85,35 +91,26 @@ bool WindowsPlatformTheme::isFollowSystemThemeAvailable() const
     return m_buildNumber >= 17763; // Dark theme was introduced in Windows 1809
 }
 
-ThemeCode WindowsPlatformTheme::themeCode() const
+ThemeCode WindowsPlatformTheme::platformThemeCode() const
 {
-    if (isSystemHighContrast()) {
-        return HIGH_CONTRAST_BLACK_THEME_CODE;
-    }
-
-    if (isSystemDarkMode()) {
-        return DARK_THEME_CODE;
-    }
-
-    //! NOTE When system is in light mode, don't automatically use
-    //! high contrast theme, because it is too dark.
-    //! Light high contrast theme would be nice.
-    return LIGHT_THEME_CODE;
+    return m_platformThemeCode.val;
 }
 
-Channel<ThemeCode> WindowsPlatformTheme::themeCodeChanged() const
+Notification WindowsPlatformTheme::platformThemeChanged() const
 {
-    return m_channel;
+    return m_platformThemeCode.notification;
 }
 
 bool WindowsPlatformTheme::isSystemDarkMode() const
 {
     DWORD data {};
     DWORD datasize = sizeof(data);
+
     if (RegGetValue(HKEY_CURRENT_USER, windowsThemesPersonalizeKey.c_str(), windowsThemesPersonalizeSubkey.c_str(),
                     RRF_RT_REG_DWORD, nullptr, &data, &datasize) == ERROR_SUCCESS) {
         return data == 0;
     }
+
     return false;
 }
 
@@ -121,10 +118,29 @@ bool WindowsPlatformTheme::isSystemHighContrast() const
 {
     HIGHCONTRAST info;
     info.cbSize = sizeof(HIGHCONTRAST);
+
     if (SystemParametersInfoW(SPI_GETHIGHCONTRAST, 0, &info, 0)) {
         return info.dwFlags & HCF_HIGHCONTRASTON;
     }
+
     return false;
+}
+
+ThemeCode WindowsPlatformTheme::bestSuitedThemeCode() const
+{
+    if (isSystemHighContrast()) {
+        if (isSystemDarkMode()) {
+            return HIGH_CONTRAST_BLACK_THEME_CODE;
+        }
+
+        return HIGH_CONTRAST_WHITE_THEME_CODE;
+    }
+
+    if (isSystemDarkMode()) {
+        return DARK_THEME_CODE;
+    }
+
+    return LIGHT_THEME_CODE;
 }
 
 void WindowsPlatformTheme::th_listen()
@@ -137,17 +153,19 @@ void WindowsPlatformTheme::th_listen()
     while (m_isListening) {
         hStopListeningEvent = CreateEvent(NULL, FALSE, TRUE, TEXT("StopListening"));
         hThemeChangeEvent = CreateEvent(NULL, FALSE, TRUE, TEXT("ThemeSettingChange"));
+
         if (RegNotifyChangeKeyValue(hKey, TRUE, dwFilter, hThemeChangeEvent, TRUE) == ERROR_SUCCESS) {
-            ThemeCode oldBestSuited = themeCode();
             HANDLE handles[2] = { hStopListeningEvent, hThemeChangeEvent };
             DWORD dwRet = WaitForMultipleObjects(2, handles, FALSE, 4000);
+
             if (dwRet != WAIT_TIMEOUT && dwRet != WAIT_FAILED) {
                 if (m_isListening) {
                     //! NOTE There might be some delay before `isSystemHighContrast` returns the correct value
                     Sleep(100);
-                    ThemeCode newBestSuited = themeCode();
-                    if (newBestSuited != oldBestSuited) {
-                        m_channel.send(newBestSuited);
+
+                    ThemeCode newThemeCode = bestSuitedThemeCode();
+                    if (newThemeCode != m_platformThemeCode.val) {
+                        m_platformThemeCode.set(newThemeCode);
                     }
                 }
                 // Else, the received event must have been a stop event
@@ -156,13 +174,14 @@ void WindowsPlatformTheme::th_listen()
             LOGD() << "Failed registering for dark theme change notifications.";
         }
     }
+
     RegCloseKey(hKey);
 }
 
-void WindowsPlatformTheme::applyPlatformStyleOnAppForTheme(ThemeCode)
+void WindowsPlatformTheme::applyPlatformStyleOnAppForTheme(const ThemeCode&)
 {
 }
 
-void WindowsPlatformTheme::applyPlatformStyleOnWindowForTheme(QWindow*, ThemeCode)
+void WindowsPlatformTheme::applyPlatformStyleOnWindowForTheme(QWindow*, const ThemeCode&)
 {
 }

--- a/src/framework/ui/internal/platform/windows/windowsplatformtheme.h
+++ b/src/framework/ui/internal/platform/windows/windowsplatformtheme.h
@@ -38,17 +38,14 @@ public:
 
     bool isFollowSystemThemeAvailable() const override;
 
-    ThemeCode platformThemeCode() const override;
+    bool isSystemThemeDark() const override;
     async::Notification platformThemeChanged() const override;
 
     void applyPlatformStyleOnAppForTheme(const ThemeCode& themeCode) override;
     void applyPlatformStyleOnWindowForTheme(QWindow* window, const ThemeCode& themeCode) override;
 
 private:
-    bool isSystemDarkMode() const;
-    bool isSystemHighContrast() const;
-
-    ThemeCode bestSuitedThemeCode() const;
+    bool isSystemThemeCurrentlyDark() const;
 
     void th_listen();
 
@@ -57,7 +54,7 @@ private:
     std::atomic<bool> m_isListening = false;
     std::thread m_listenThread;
 
-    ValNt<ThemeCode> m_platformThemeCode;
+    ValNt<bool> m_isSystemThemeDark;
 };
 }
 

--- a/src/framework/ui/internal/platform/windows/windowsplatformtheme.h
+++ b/src/framework/ui/internal/platform/windows/windowsplatformtheme.h
@@ -5,7 +5,7 @@
  * MuseScore
  * Music Composition & Notation
  *
- * Copyright (C) 2021 MuseScore BVBA and others
+ * Copyright (C) 2022 MuseScore BVBA and others
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -25,6 +25,8 @@
 
 #include "internal/iplatformtheme.h"
 
+#include "retval.h"
+
 namespace mu::ui {
 class WindowsPlatformTheme : public IPlatformTheme
 {
@@ -36,23 +38,26 @@ public:
 
     bool isFollowSystemThemeAvailable() const override;
 
-    ThemeCode themeCode() const override;
-    async::Channel<ThemeCode> themeCodeChanged() const override;
+    ThemeCode platformThemeCode() const override;
+    async::Notification platformThemeChanged() const override;
 
-    void applyPlatformStyleOnAppForTheme(ThemeCode themeCode) override;
-    void applyPlatformStyleOnWindowForTheme(QWindow* window, ThemeCode themeCode) override;
+    void applyPlatformStyleOnAppForTheme(const ThemeCode& themeCode) override;
+    void applyPlatformStyleOnWindowForTheme(QWindow* window, const ThemeCode& themeCode) override;
 
 private:
-    int m_buildNumber = 0;
+    bool isSystemDarkMode() const;
+    bool isSystemHighContrast() const;
 
-    async::Channel<ThemeCode> m_channel;
-    std::atomic<bool> m_isListening = false;
-    std::thread m_listenThread;
+    ThemeCode bestSuitedThemeCode() const;
 
     void th_listen();
 
-    bool isSystemDarkMode() const;
-    bool isSystemHighContrast() const;
+    int m_buildNumber = 0;
+
+    std::atomic<bool> m_isListening = false;
+    std::thread m_listenThread;
+
+    ValNt<ThemeCode> m_platformThemeCode;
 };
 }
 

--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -309,7 +309,7 @@ void UiConfiguration::synchThemeWithSystemIfNecessary()
         return;
     }
 
-    setIsDarkMode(platformTheme()->isSystemThemeDark());
+    doSetIsDarkMode(platformTheme()->isSystemThemeDark());
 }
 
 void UiConfiguration::notifyAboutCurrentThemeChanged()
@@ -463,10 +463,17 @@ bool UiConfiguration::isDarkMode() const
 
 void UiConfiguration::setIsDarkMode(bool dark)
 {
+    setFollowSystemTheme(false);
+
+    doSetIsDarkMode(dark);
+}
+
+void UiConfiguration::doSetIsDarkMode(bool dark)
+{
     if (isHighContrast()) {
-        setCurrentTheme(dark ? HIGH_CONTRAST_BLACK_THEME_CODE : HIGH_CONTRAST_WHITE_THEME_CODE);
+        doSetCurrentTheme(dark ? HIGH_CONTRAST_BLACK_THEME_CODE : HIGH_CONTRAST_WHITE_THEME_CODE);
     } else {
-        setCurrentTheme(dark ? DARK_THEME_CODE : LIGHT_THEME_CODE);
+        doSetCurrentTheme(dark ? DARK_THEME_CODE : LIGHT_THEME_CODE);
     }
 }
 
@@ -478,15 +485,22 @@ bool UiConfiguration::isHighContrast() const
 void UiConfiguration::setIsHighContrast(bool highContrast)
 {
     if (isDarkMode()) {
-        setCurrentTheme(highContrast ? HIGH_CONTRAST_BLACK_THEME_CODE : DARK_THEME_CODE);
+        doSetCurrentTheme(highContrast ? HIGH_CONTRAST_BLACK_THEME_CODE : DARK_THEME_CODE);
     } else {
-        setCurrentTheme(highContrast ? HIGH_CONTRAST_WHITE_THEME_CODE : LIGHT_THEME_CODE);
+        doSetCurrentTheme(highContrast ? HIGH_CONTRAST_WHITE_THEME_CODE : LIGHT_THEME_CODE);
     }
 }
 
-void UiConfiguration::setCurrentTheme(const ThemeCode& codeKey)
+void UiConfiguration::setCurrentTheme(const ThemeCode& themeCode)
 {
-    settings()->setSharedValue(UI_CURRENT_THEME_CODE_KEY, Val(codeKey));
+    setFollowSystemTheme(false);
+
+    doSetCurrentTheme(themeCode);
+}
+
+void UiConfiguration::doSetCurrentTheme(const ThemeCode& themeCode)
+{
+    settings()->setSharedValue(UI_CURRENT_THEME_CODE_KEY, Val(themeCode));
 }
 
 void UiConfiguration::setCurrentThemeStyleValue(ThemeStyleKey key, const Val& val)

--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -221,7 +221,7 @@ bool UiConfiguration::needFollowSystemTheme() const
 
 void UiConfiguration::initThemes()
 {
-    platformTheme()->themeCodeChanged().onReceive(nullptr, [this](ThemeCode) {
+    platformTheme()->platformThemeChanged().onNotify(this, [this]() {
         notifyAboutCurrentThemeChanged();
     });
 
@@ -419,7 +419,7 @@ const ThemeInfo& UiConfiguration::currentTheme() const
 ThemeCode UiConfiguration::currentThemeCodeKey() const
 {
     if (needFollowSystemTheme()) {
-        return platformTheme()->themeCode();
+        return platformTheme()->platformThemeCode();
     }
 
     ThemeCode preferredThemeCode = settings()->value(UI_CURRENT_THEME_CODE_KEY).toString();

--- a/src/framework/ui/internal/uiconfiguration.h
+++ b/src/framework/ui/internal/uiconfiguration.h
@@ -48,15 +48,21 @@ public:
     QStringList possibleFontFamilies() const override;
     QStringList possibleAccentColors() const override;
 
+    bool isDarkMode() const override;
+    void setIsDarkMode(bool dark) override;
+
     bool isHighContrast() const override;
     void setIsHighContrast(bool highContrast) override;
 
-    void resetCurrentThemeToDefault(const ThemeCode& codeKey) override;
-
     const ThemeInfo& currentTheme() const override;
+    async::Notification currentThemeChanged() const override;
     void setCurrentTheme(const ThemeCode& codeKey) override;
     void setCurrentThemeStyleValue(ThemeStyleKey key, const Val& val) override;
-    async::Notification currentThemeChanged() const override;
+    void resetCurrentThemeToDefault(const ThemeCode& codeKey) override;
+
+    bool isFollowSystemThemeAvailable() const override;
+    ValNt<bool> isFollowSystemTheme() const override;
+    void setFollowSystemTheme(bool follow) override;
 
     std::string fontFamily() const override;
     void setFontFamily(const std::string& family) override;
@@ -100,12 +106,13 @@ public:
     int flickableMaxVelocity() const override;
 
 private:
-    bool needFollowSystemTheme() const;
-
     void initThemes();
     void notifyAboutCurrentThemeChanged();
     void updateCurrentTheme();
     void updateThemes();
+
+    void updateSystemThemeListeningStatus();
+    void synchThemeWithSystemIfNecessary();
 
     ThemeCode currentThemeCodeKey() const;
     ThemeInfo makeStandardTheme(const ThemeCode& codeKey) const;
@@ -120,6 +127,8 @@ private:
     async::Notification m_musicalFontChanged;
     async::Notification m_iconsFontChanged;
     async::Notification m_windowGeometryChanged;
+
+    ValNt<bool> m_isFollowSystemTheme;
 
     ThemeList m_themes;
     size_t m_currentThemeIndex = 0;

--- a/src/framework/ui/internal/uiconfiguration.h
+++ b/src/framework/ui/internal/uiconfiguration.h
@@ -114,6 +114,9 @@ private:
     void updateSystemThemeListeningStatus();
     void synchThemeWithSystemIfNecessary();
 
+    void doSetIsDarkMode(bool dark);
+    void doSetCurrentTheme(const ThemeCode& themeCode);
+
     ThemeCode currentThemeCodeKey() const;
     ThemeInfo makeStandardTheme(const ThemeCode& codeKey) const;
 

--- a/src/framework/ui/iuiconfiguration.h
+++ b/src/framework/ui/iuiconfiguration.h
@@ -27,8 +27,6 @@
 
 #include "retval.h"
 #include "async/notification.h"
-#include "async/channel.h"
-#include "actions/actiontypes.h"
 
 #include "modularity/imoduleexport.h"
 
@@ -49,15 +47,21 @@ public:
     virtual QStringList possibleFontFamilies() const = 0;
     virtual QStringList possibleAccentColors() const = 0;
 
+    virtual bool isDarkMode() const = 0;
+    virtual void setIsDarkMode(bool dark) = 0;
+
     virtual bool isHighContrast() const = 0;
     virtual void setIsHighContrast(bool highContrast) = 0;
 
-    virtual void resetCurrentThemeToDefault(const ThemeCode& codeKey) = 0;
-
     virtual const ThemeInfo& currentTheme() const = 0;
+    virtual async::Notification currentThemeChanged() const = 0;
     virtual void setCurrentTheme(const ThemeCode& codeKey) = 0;
     virtual void setCurrentThemeStyleValue(ThemeStyleKey key, const Val& val) = 0;
-    virtual async::Notification currentThemeChanged() const = 0;
+    virtual void resetCurrentThemeToDefault(const ThemeCode& codeKey) = 0;
+
+    virtual bool isFollowSystemThemeAvailable() const = 0;
+    virtual ValNt<bool> isFollowSystemTheme() const = 0;
+    virtual void setFollowSystemTheme(bool follow) = 0;
 
     virtual std::string fontFamily() const = 0;
     virtual void setFontFamily(const std::string& family) = 0;

--- a/src/framework/ui/uitypes.h
+++ b/src/framework/ui/uitypes.h
@@ -37,6 +37,11 @@
 namespace mu::ui {
 using ThemeCode = std::string;
 
+inline ThemeCode themeCodeFromString(const QString& str)
+{
+    return str.toStdString();
+}
+
 static const ThemeCode LIGHT_THEME_CODE("light");
 static const ThemeCode DARK_THEME_CODE("dark");
 static const ThemeCode HIGH_CONTRAST_WHITE_THEME_CODE("high_contrast_white");

--- a/src/framework/ui/uitypes.h
+++ b/src/framework/ui/uitypes.h
@@ -37,8 +37,8 @@
 namespace mu::ui {
 using ThemeCode = std::string;
 
-static const ThemeCode DARK_THEME_CODE("dark");
 static const ThemeCode LIGHT_THEME_CODE("light");
+static const ThemeCode DARK_THEME_CODE("dark");
 static const ThemeCode HIGH_CONTRAST_WHITE_THEME_CODE("high_contrast_white");
 static const ThemeCode HIGH_CONTRAST_BLACK_THEME_CODE("high_contrast_black");
 
@@ -52,10 +52,16 @@ inline std::vector<ThemeCode> allStandardThemeCodes()
     };
 }
 
-inline bool isLightTheme(ThemeCode themeCode)
+inline bool isDarkTheme(const ThemeCode& themeCode)
 {
-    return themeCode == LIGHT_THEME_CODE
-           || themeCode == HIGH_CONTRAST_WHITE_THEME_CODE;
+    return themeCode == DARK_THEME_CODE
+           || themeCode == HIGH_CONTRAST_BLACK_THEME_CODE;
+}
+
+inline bool isHighContrastTheme(const ThemeCode& themeCode)
+{
+    return themeCode == HIGH_CONTRAST_WHITE_THEME_CODE
+           || themeCode == HIGH_CONTRAST_BLACK_THEME_CODE;
 }
 
 enum ThemeStyleKey

--- a/src/framework/ui/view/uitheme.cpp
+++ b/src/framework/ui/view/uitheme.cpp
@@ -144,9 +144,9 @@ void UiTheme::update()
     notifyAboutThemeChanged();
 }
 
-bool UiTheme::isLight() const
+bool UiTheme::isDark() const
 {
-    return isLightTheme(configuration()->currentTheme().codeKey);
+    return configuration()->isDarkMode();
 }
 
 QColor UiTheme::backgroundPrimaryColor() const

--- a/src/framework/ui/view/uitheme.h
+++ b/src/framework/ui/view/uitheme.h
@@ -37,7 +37,7 @@ class UiTheme : public QProxyStyle, public async::Asyncable
 
     INJECT(ui, IUiConfiguration, configuration)
 
-    Q_PROPERTY(bool isLight READ isLight NOTIFY themeChanged)
+    Q_PROPERTY(bool isDark READ isDark NOTIFY themeChanged)
 
     Q_PROPERTY(QColor backgroundPrimaryColor READ backgroundPrimaryColor NOTIFY themeChanged)
     Q_PROPERTY(QColor backgroundSecondaryColor READ backgroundSecondaryColor NOTIFY themeChanged)
@@ -89,7 +89,7 @@ public:
     void init();
     void update();
 
-    bool isLight() const;
+    bool isDark() const;
 
     QColor backgroundPrimaryColor() const;
     QColor backgroundSecondaryColor() const;

--- a/src/project/qml/MuseScore/Project/internal/SaveToCloud/SaveLocationOption.qml
+++ b/src/project/qml/MuseScore/Project/internal/SaveToCloud/SaveLocationOption.qml
@@ -46,7 +46,7 @@ ColumnLayout {
         Layout.fillWidth: true
         implicitHeight: 208
 
-        color: ui.theme.isLight ? "#D7DEE5" : "#44495A"
+        color: ui.theme.isDark ? "#44495A" : "#D7DEE5"
 
         topLeftRadius: root.radius
         topRightRadius: root.radius

--- a/tools/codestyle/uncrustify_run_dir.sh
+++ b/tools/codestyle/uncrustify_run_dir.sh
@@ -26,6 +26,8 @@ START_TIME=$(date +%s)
 
 find $DIR -type f -regex '.*\.\(cpp\|h\|hpp\|cc\)$' | xargs -n 1 -P 16 \
     uncrustify -c "${HERE}/uncrustify_musescore.cfg" --no-backup -l CPP
+find $DIR -type f -regex '.*\.\(mm\)$' | xargs -n 1 -P 16 \
+    uncrustify -c "${HERE}/uncrustify_musescore.cfg" --no-backup -l OC+
 
 END_TIME=$(date +%s)
 DIFF_TIME=$(( $END_TIME - $START_TIME ))


### PR DESCRIPTION
There is now an opt-in feature that lets MuseScore follow the OS theme regarding light vs dark. This also works if high contrast is enabled. 
On some OSs, it would also be possible to let MuseScore follow the OS regarding high contrast. That seems less useful to me though, so I've removed the code for it for now.