### PR TITLE
Fix #10774: Play notes checkbox cannot be disabled

### DIFF
--- a/src/appshell/qml/Preferences/NoteInputPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/NoteInputPreferencesPage.qml
@@ -71,7 +71,7 @@ PreferencesPage {
             navigation.order: root.navigationOrderStart + 2
 
             onPlayNotesWhenEditingChangeRequested: function(play) {
-                noteInputModel.playChordWhenEditing = play
+                noteInputModel.playNotesWhenEditing = play
             }
 
             onPlayChordWhenEditingChangeRequested: function(play) {

--- a/src/appshell/qml/Preferences/internal/NoteInputPlaySection.qml
+++ b/src/appshell/qml/Preferences/internal/NoteInputPlaySection.qml
@@ -58,6 +58,8 @@ BaseSection {
 
         title: qsTrc("appshell", "Default duration:")
 
+        enabled: root.playNotesWhenEditing
+
         columnWidth: root.columnWidth
         spacing: root.columnSpacing
 


### PR DESCRIPTION
Resolves: #10774 

*(short description of the changes and the motivation to make the changes)*

Prior to this commit, 'Play notes while editing' checkbox in Note Input in Preferences could not be unselected

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
