### PR TITLE
[MU4] Fix #330270: 1.x score using Pedal line with a `continueSymbol` imports empty in 3.x, crashes in master

### DIFF
--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -138,7 +138,7 @@ const PlaybackData& PlaybackModel::resolveTrackPlaybackData(const InstrumentTrac
         return search->second;
     }
 
-    const Ms::Part* part = m_score->partById(trackId.partId.toUint64());
+    const Ms::Part* part = m_score ? m_score->partById(trackId.partId.toUint64()) : nullptr;
 
     if (!part) {
         static PlaybackData empty;

--- a/src/engraving/rw/compat/read114.cpp
+++ b/src/engraving/rw/compat/read114.cpp
@@ -1356,12 +1356,7 @@ static void readPedal114(XmlReader& e, const ReadContext& ctx, Pedal* pedal)
 {
     while (e.readNextStartElement()) {
         const QStringRef& tag(e.name());
-        if (tag == "beginSymbol"
-            || tag == "beginSymbolOffset"
-            || tag == "endSymbol"
-            || tag == "endSymbolOffset"
-            || tag == "subtype"
-            ) {
+        if (tag == "subtype") {
             e.skipCurrentElement();
         } else if (tag == "endHookHeight" || tag == "hookHeight") {   // hookHeight is obsolete
             pedal->setEndHookHeight(Spatium(e.readDouble()));
@@ -1372,11 +1367,34 @@ static void readPedal114(XmlReader& e, const ReadContext& ctx, Pedal* pedal)
         } else if (tag == "lineStyle") {
             pedal->setLineStyle(mu::draw::PenStyle(e.readInt()));
             pedal->setPropertyFlags(Pid::LINE_STYLE, PropertyFlags::UNSTYLED);
+        } else if (tag == "beginSymbol" || tag == "symbol") {   // "symbol" is obsolete
+            QString text(e.readElementText());
+            pedal->setBeginText(QString("<sym>%1</sym>").arg(
+                                    text[0].isNumber()
+                                    ? resolveSymCompatibility(SymId(text.toInt()), ctx.mscoreVersion())
+                                    : text));
+        } else if (tag == "continueSymbol") {
+            QString text(e.readElementText());
+            pedal->setContinueText(QString("<sym>%1</sym>").arg(
+                                       text[0].isNumber()
+                                       ? resolveSymCompatibility(SymId(text.toInt()), ctx.mscoreVersion())
+                                       : text));
+        } else if (tag == "endSymbol") {
+            QString text(e.readElementText());
+            pedal->setEndText(QString("<sym>%1</sym>").arg(
+                                  text[0].isNumber()
+                                  ? resolveSymCompatibility(SymId(text.toInt()), ctx.mscoreVersion())
+                                  : text));
+        } else if (tag == "beginSymbolOffset") { // obsolete
+            e.readPoint();
+        } else if (tag == "continueSymbolOffset") { // obsolete
+            e.readPoint();
+        } else if (tag == "endSymbolOffset") { // obsolete
+            e.readPoint();
         } else if (!readTextLineProperties114(e, ctx, pedal)) {
             e.unknown();
         }
     }
-    pedal->setBeginText(Pedal::PEDAL_SYMBOL);
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
a score that that even 3.x imports as being entirely empty, but 1.x and 2.x just open cleanly.

Resolves: https://musescore.org/en/node/330270, 

* Commit 1 resolves only the crash, not the empty import.
* Commit 2 resolves the empty import (and applies to 3.x too)