### PR TITLE
Two minor bug fixes for EditStyle dialog

### DIFF
--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1418,8 +1418,6 @@ void EditStyle::buttonClicked(QAbstractButton* b)
         }
         break;
     }
-
-    globalContext()->currentNotation()->style()->styleChanged().notify();
 }
 
 //---------------------------------------------------------
@@ -1429,6 +1427,10 @@ void EditStyle::buttonClicked(QAbstractButton* b)
 void EditStyle::accept()
 {
     globalContext()->currentNotation()->undoStack()->commitChanges();
+    globalContext()->currentNotation()->style()->styleChanged().notify();
+
+    settings()->setSharedValue(STYLE_MENU_ORDER, Val(arrayToString(pageListMap)));
+
     QDialog::accept();
 }
 
@@ -1439,6 +1441,8 @@ void EditStyle::accept()
 void EditStyle::reject()
 {
     globalContext()->currentNotation()->undoStack()->rollbackChanges();
+    globalContext()->currentNotation()->style()->styleChanged().notify();
+
     QDialog::reject();
 }
 

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1321,7 +1321,12 @@ void EditStyle::setCurrentPageCode(const QString& code)
         return;
     }
 
-    pageList->setCurrentRow(index);
+    int* mappedPageIndex = std::find(pageListMap, pageListMap + numberOfPage, index);
+    IF_ASSERT_FAILED(mappedPageIndex != std::end(pageListMap)) {
+        return;
+    }
+
+    pageList->setCurrentRow(int(mappedPageIndex - pageListMap));
 
     m_currentPageCode = code;
     emit currentPageChanged();


### PR DESCRIPTION
- Bug 1: since PR #7997, users can customize the order of the pages in the Edit Style dialog (is that desired at all? anyway, that PR has been merged back then.)
  This was not taken into account when setting the current page code. Resulting bug: if you had customized the order of the pages and you would select an instrument name and click "Style settings" in the inspector, you might land on the wrong page.

- Bug 2: if you would change some style settings and then close the dialog using the 'X' button in the title bar or using the Esc key, the changes would technically be canceled as expected, but the score view would not be updated until zooming or scrolling a bit. 