### PR TITLE
[MU4] Fix broken pitch classes

### DIFF
--- a/src/engraving/playback/utils/pitchutils.h
+++ b/src/engraving/playback/utils/pitchutils.h
@@ -113,17 +113,17 @@ inline mpe::PitchClass pitchClassFromTpc(const int tpc)
 
 inline mpe::octave_t actualOctave(const int nominalOctave, const mpe::PitchClass nominalPitchClass, const Ms::AccidentalVal accidental)
 {
-    int shift = static_cast<int>(nominalPitchClass) + static_cast<int>(accidental);
+    int shift = static_cast<int>(nominalPitchClass) - static_cast<int>(accidental);
 
     constexpr int lowerBound = 0;
     constexpr int upperBound = static_cast<int>(mpe::PitchClass::Last) - 1;
 
     if (shift < lowerBound) {
-        return nominalOctave - 1;
+        return nominalOctave + 1;
     }
 
     if (shift > upperBound) {
-        return nominalOctave + 1;
+        return nominalOctave - 1;
     }
 
     return nominalOctave;

--- a/src/engraving/playback/utils/pitchutils.h
+++ b/src/engraving/playback/utils/pitchutils.h
@@ -53,7 +53,6 @@ inline mpe::PitchClass pitchClassFromTpc(const int tpc)
     case Ms::TPC_F_BB:
     case Ms::TPC_E_B:
     case Ms::TPC_D_S:
-    case Ms::TPC_F_SS:
     case Ms::TPC_C_SSS:
         return mpe::PitchClass::D_sharp;
 
@@ -79,6 +78,7 @@ inline mpe::PitchClass pitchClassFromTpc(const int tpc)
     // G
     case Ms::TPC_A_BB:
     case Ms::TPC_G:
+    case Ms::TPC_F_SS:
     case Ms::TPC_E_SSS:
         return mpe::PitchClass::G;
     case Ms::TPC_B_BBB:


### PR DESCRIPTION
Resolves: #10756

- The first commit fixes the actual issue. The `actualOctave()` function was shifting in the wrong direction, but actually we had to reverse apply the accidental (not apply again like before this patch) to get back to the original note.
- The second commit fixes a wrong pitch class mapping

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made (Does this apply here?)
