### PR TITLE
fix #10779 - avoid panning score vertically if current system is visible

### DIFF
--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -1088,8 +1088,10 @@ void NotationPaintView::movePlaybackCursor(uint32_t tick)
     }
 
     if (configuration()->isAutomaticallyPanEnabled()) {
-        if (adjustCanvasPosition(cursorRect)) {
-            return;
+        if (!viewport().intersects(cursorRect)) {
+            if (adjustCanvasPosition(cursorRect)) {
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10779

When starting playback, avoid panning score if current system is visible

- [ x] I signed [CLA](https://musescore.org/en/cla)
- [ x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x] I made sure the code compiles on my machine
- [ x] I made sure there are no unnecessary changes in the code
- [ x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
