### PR TITLE
[MU4] Fix #9432: Ornaments options not displaying in the Inspector

### DIFF
--- a/src/engraving/libmscore/articulation.cpp
+++ b/src/engraving/libmscore/articulation.cpp
@@ -639,23 +639,34 @@ bool Articulation::isLuteFingering() const
 
 bool Articulation::isOrnament() const
 {
-    return _symId == SymId::ornamentTurn
-           || _symId == SymId::ornamentTurnInverted
-           || _symId == SymId::ornamentTurnSlash
-           || _symId == SymId::ornamentTrill
-           || _symId == SymId::brassMuteClosed
-           || _symId == SymId::ornamentMordent
-           || _symId == SymId::ornamentShortTrill
-           || _symId == SymId::ornamentTremblement
-           || _symId == SymId::ornamentPrallMordent
-           || _symId == SymId::ornamentLinePrall
-           || _symId == SymId::ornamentUpPrall
-           || _symId == SymId::ornamentUpMordent
-           || _symId == SymId::ornamentPrecompMordentUpperPrefix
-           || _symId == SymId::ornamentDownMordent
-           || _symId == SymId::ornamentPrallUp
-           || _symId == SymId::ornamentPrallDown
-           || _symId == SymId::ornamentPrecompSlide;
+    return isOrnament(subtype());
+}
+
+bool Articulation::isOrnament(int subtype)
+{
+    static const std::set<SymId> ornaments {
+        SymId::ornamentTurn,
+        SymId::ornamentTurnInverted,
+        SymId::ornamentTurnSlash,
+        SymId::ornamentTrill,
+        SymId::brassMuteClosed,
+        SymId::ornamentMordent,
+        SymId::ornamentShortTrill,
+        SymId::ornamentTremblement,
+        SymId::ornamentPrallMordent,
+        SymId::ornamentLinePrall,
+        SymId::ornamentUpPrall,
+        SymId::ornamentUpMordent,
+        SymId::ornamentPrecompMordentUpperPrefix,
+        SymId::ornamentDownMordent,
+        SymId::ornamentPrallUp,
+        SymId::ornamentPrallDown,
+        SymId::ornamentPrecompSlide
+    };
+
+    SymId symId = static_cast<SymId>(subtype);
+
+    return ornaments.find(symId) != ornaments.end();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/articulation.h
+++ b/src/engraving/libmscore/articulation.h
@@ -170,7 +170,9 @@ public:
     bool isAccent() const;
     bool isMarcato() const;
     bool isLuteFingering() const;
+
     bool isOrnament() const;
+    static bool isOrnament(int subtype);
 
     void doAutoplace();
 };

--- a/src/inspector/models/abstractinspectormodel.cpp
+++ b/src/inspector/models/abstractinspectormodel.cpp
@@ -23,8 +23,9 @@
 
 #include "libmscore/musescoreCore.h"
 
-#include "log.h"
 #include "types/texttypes.h"
+
+#include "log.h"
 
 using namespace mu::inspector;
 using namespace mu::notation;
@@ -175,6 +176,12 @@ InspectorModelType AbstractInspectorModel::modelTypeByElementKey(const ElementKe
     if (elementKey.type == Ms::ElementType::LAYOUT_BREAK) {
         return LAYOUT_BREAK_ELEMENT_MODEL_TYPES.value(static_cast<Ms::LayoutBreakType>(elementKey.subtype),
                                                       InspectorModelType::TYPE_UNDEFINED);
+    }
+
+    if (elementKey.type == Ms::ElementType::ARTICULATION) {
+        if (Ms::Articulation::isOrnament(elementKey.subtype)) {
+            return InspectorModelType::TYPE_ORNAMENT;
+        }
     }
 
     return NOTATION_ELEMENT_MODEL_TYPES.value(elementKey.type, InspectorModelType::TYPE_UNDEFINED);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9432