### PR TITLE
Fix #10794 - ensure string sections are in "common" group

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -13210,7 +13210,7 @@
             </Instrument>
             <Instrument id="violins">
                   <family>orchestral-strings</family>
-                  <trackName>Violins</trackName>
+                  <trackName>Violins (section)</trackName>
                   <longName>Violins</longName>
                   <shortName>Vlns.</shortName>
                   <description>Violin section.</description>
@@ -13234,6 +13234,7 @@
                         <controller ctrl="32" value="21"/> <!--Bank LSB-->
                         <program value="44"/> <!--Tremolo Strings-->
                   </Channel>
+                  <genre>common</genre>
                   <genre>orchestra</genre>
             </Instrument>
             <Instrument id="viola">
@@ -13265,7 +13266,7 @@
             </Instrument>
             <Instrument id="violas">
                   <family>orchestral-strings</family>
-                  <trackName>Violas</trackName>
+                  <trackName>Violas (section)</trackName>
                   <longName>Violas</longName>
                   <shortName>Vlas.</shortName>
                   <description>Viola section.</description>
@@ -13289,6 +13290,7 @@
                         <controller ctrl="32" value="31"/> <!--Bank LSB-->
                         <program value="44"/> <!--Tremolo Strings-->
                   </Channel>
+                  <genre>common</genre>
                   <genre>orchestra</genre>
             </Instrument>
             <Instrument id="violoncello">
@@ -13321,7 +13323,7 @@
             </Instrument>
             <Instrument id="violoncellos">
                   <family>orchestral-strings</family>
-                  <trackName>Violoncellos</trackName>
+                  <trackName>Violoncellos (section)</trackName>
                   <longName>Violoncellos</longName>
                   <shortName>Vcs.</shortName>
                   <description>Violoncello section.</description>
@@ -13345,6 +13347,7 @@
                         <controller ctrl="32" value="41"/> <!--Bank LSB-->
                         <program value="44"/> <!--Tremolo Strings-->
                   </Channel>
+                  <genre>common</genre>
                   <genre>orchestra</genre>
             </Instrument>
             <Instrument id="contrabass">
@@ -13380,7 +13383,7 @@
             </Instrument>
             <Instrument id="contrabasses">
                   <family>orchestral-strings</family>
-                  <trackName>Contrabasses</trackName>
+                  <trackName>Contrabasses (section)</trackName>
                   <longName>Contrabasses</longName>
                   <shortName>Cbs.</shortName>
                   <description>Contrabass (double bass) section.</description>
@@ -13407,6 +13410,7 @@
                         <controller ctrl="32" value="51"/> <!--Bank LSB-->
                         <program value="44"/> <!--Tremolo Strings-->
                   </Channel>
+                  <genre>common</genre>
                   <genre>orchestra</genre>
             </Instrument>
             <Instrument id="treble-viol">


### PR DESCRIPTION
Resolves: [*(direct link to the issue)*](https://github.com/musescore/MuseScore/issues/10794)

String sections in common group

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [ x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x ] I made sure the code compiles on my machine
- [x ] I made sure there are no unnecessary changes in the code
- [x ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
