### PR TITLE
fix #10684: Added Heavy X and Heavy X with hat noteheads

### DIFF
--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -141,6 +141,11 @@ static const SymId noteHeads[2][int(NoteHeadGroup::HEAD_GROUPS) - 1][int(NoteHea
         { SymId::noteShapeTriangleRoundWhite, SymId::noteShapeTriangleRoundWhite, SymId::noteShapeTriangleRoundBlack,
           SymId::noteShapeTriangleRoundDoubleWhole },
 
+        { SymId::noteheadHeavyX,              SymId::noteheadHeavyX,              SymId::noteheadHeavyX,
+          SymId::noteheadHeavyX },
+        { SymId::noteheadHeavyXHat,           SymId::noteheadHeavyXHat,           SymId::noteheadHeavyXHat,
+          SymId::noteheadHeavyXHat },
+
         { SymId::noteShapeKeystoneWhite,          SymId::noteShapeKeystoneWhite,          SymId::noteShapeKeystoneBlack,
           SymId::noteShapeKeystoneDoubleWhole },
         { SymId::noteShapeQuarterMoonWhite,       SymId::noteShapeQuarterMoonWhite,       SymId::noteShapeQuarterMoonBlack,
@@ -238,6 +243,11 @@ static const SymId noteHeads[2][int(NoteHeadGroup::HEAD_GROUPS) - 1][int(NoteHea
           SymId::noteShapeMoonDoubleWhole },
         { SymId::noteShapeTriangleRoundWhite, SymId::noteShapeTriangleRoundWhite, SymId::noteShapeTriangleRoundBlack,
           SymId::noteShapeTriangleRoundDoubleWhole },
+
+        { SymId::noteheadHeavyX,              SymId::noteheadHeavyX,              SymId::noteheadHeavyX,
+          SymId::noteheadHeavyX },
+        { SymId::noteheadHeavyXHat,           SymId::noteheadHeavyXHat,           SymId::noteheadHeavyXHat,
+          SymId::noteheadHeavyXHat },
 
         { SymId::noteShapeKeystoneWhite,          SymId::noteShapeKeystoneWhite,          SymId::noteShapeKeystoneBlack,
           SymId::noteShapeKeystoneDoubleWhole },

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -259,6 +259,7 @@ enum class NoteHeadGroup : signed char {
 
     HEAD_HEAVY_CROSS,
     HEAD_HEAVY_CROSS_HAT,
+
     // not exposed from here
     HEAD_DO_WALKER,
     HEAD_RE_WALKER,

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -256,6 +256,9 @@ enum class NoteHeadGroup : signed char {
     HEAD_DO,
     HEAD_RE,
     HEAD_TI,
+
+    HEAD_HEAVY_CROSS,
+    HEAD_HEAVY_CROSS_HAT,
     // not exposed from here
     HEAD_DO_WALKER,
     HEAD_RE_WALKER,

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -287,6 +287,9 @@ static const std::vector<Item<NoteHeadGroup> > NOTEHEAD_GROUPS = {
 
     { NoteHeadGroup::HEAD_SLASH,            "slash",          QT_TRANSLATE_NOOP("engraving", "Slash") },
 
+    { NoteHeadGroup::HEAD_HEAVY_CROSS,      "heavy-cross",    QT_TRANSLATE_NOOP("engraving", "Heavy Cross") },
+    { NoteHeadGroup::HEAD_HEAVY_CROSS_HAT,  "heavy-cross-hat",    QT_TRANSLATE_NOOP("engraving", "Heavy Cross Hat") },
+
     // shape notes
     { NoteHeadGroup::HEAD_SOL,  "sol",       QT_TRANSLATE_NOOP("engraving", "Sol") },
     { NoteHeadGroup::HEAD_LA,   "la",        QT_TRANSLATE_NOOP("engraving", "La") },

--- a/src/framework/ui/view/musicalsymbolcodes.h
+++ b/src/framework/ui/view/musicalsymbolcodes.h
@@ -77,6 +77,9 @@ public:
         NOTEHEAD_RE = 0xE1BD,
         NOTEHEAD_TI = 0xE1BF,
 
+        NOTEHEAD_HEAVY_CROSS = 0xE0FA,
+        NOTEHEAD_HEAVY_CROSS_HAT = 0xE0F9,
+
         SEMIBREVE = 0xE1D2,
         MINIM = 0xE1D3,
         CROTCHET = 0xE1D5,

--- a/src/plugins/api/apitypes.h
+++ b/src/plugins/api/apitypes.h
@@ -152,7 +152,6 @@ enum class NoteHeadGroup {
     HEAD_BREVIS_ALT = int(mu::engraving::NoteHeadGroup::HEAD_BREVIS_ALT),
     HEAD_HEAVY_CROSS = int(mu::engraving::NoteHeadGroup::HEAD_HEAVY_CROSS),
     HEAD_HEAVY_CROSS_HAT = int(mu::engraving::NoteHeadGroup::HEAD_HEAVY_CROSS_HAT)
-
 };
 Q_ENUM_NS(NoteHeadGroup);
 

--- a/src/plugins/api/apitypes.h
+++ b/src/plugins/api/apitypes.h
@@ -149,7 +149,10 @@ enum class NoteHeadGroup {
     HEAD_CIRCLED = int(mu::engraving::NoteHeadGroup::HEAD_CIRCLED),
     HEAD_CIRCLED_LARGE = int(mu::engraving::NoteHeadGroup::HEAD_CIRCLED_LARGE),
     HEAD_LARGE_ARROW = int(mu::engraving::NoteHeadGroup::HEAD_LARGE_ARROW),
-    HEAD_BREVIS_ALT = int(mu::engraving::NoteHeadGroup::HEAD_BREVIS_ALT)
+    HEAD_BREVIS_ALT = int(mu::engraving::NoteHeadGroup::HEAD_BREVIS_ALT),
+    HEAD_HEAVY_CROSS = int(mu::engraving::NoteHeadGroup::HEAD_HEAVY_CROSS),
+    HEAD_HEAVY_CROSS_HAT = int(mu::engraving::NoteHeadGroup::HEAD_HEAVY_CROSS_HAT)
+
 };
 Q_ENUM_NS(NoteHeadGroup);
 


### PR DESCRIPTION
Resolves: [#10684](https://github.com/musescore/MuseScore/issues/10684)

Added U+E0F8 and U+E0F9 to the noteheads palette.

I'd like to work on the chromatic solfege noteheads, but these two were needed more urgently.  Should I open a new issue and PR for this?