### PR TITLE
Fix #10780 - irrelevant staff types shown for all instruments

### DIFF
--- a/src/engraving/libmscore/staff.cpp
+++ b/src/engraving/libmscore/staff.cpp
@@ -493,7 +493,7 @@ Fraction Staff::currentClefTick(const Fraction& tick) const
 
 QString Staff::staffName() const
 {
-    return TConv::toUserName(defaultClefType()._transposingClef);
+    return TConv::toUserName(clefType(Fraction())._transposingClef);
 }
 
 #ifndef NDEBUG

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/StaffSettingsPopup.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/StaffSettingsPopup.qml
@@ -75,7 +75,9 @@ StyledPopupView {
             navigation.row: 1
             navigation.accessible.name: typeLabel.text + " " + currentValue
 
-            model: settingsModel.allStaffTypes()
+            model: settingsModel.allStaffTypes
+            currentIndex: indexOfValue(settingsModel.staffType)
+            enabled: count > 1
 
             onCurrentValueChanged: {
                 settingsModel.setStaffType(staffTypesComboBox.currentValue)

--- a/src/instrumentsscene/view/staffsettingsmodel.cpp
+++ b/src/instrumentsscene/view/staffsettingsmodel.cpp
@@ -44,6 +44,13 @@ void StaffSettingsModel::load(const QString& staffId)
     m_config = notationParts()->staffConfig(m_staffId);
 
     m_type = staff->staffType()->type();
+    auto presets = Ms::StaffType::presets();
+    auto match = std::find_if(presets.begin(), presets.end(), [staff](const Ms::StaffType& t) {
+        return t.isSameStructure(*staff->staffType());
+    });
+    if (match != presets.end()) {
+        m_type = match->type();
+    }
 
     m_voicesVisibility.clear();
     for (const QVariant& voice: staff->visibilityVoices()) {
@@ -53,27 +60,44 @@ void StaffSettingsModel::load(const QString& staffId)
     emit voicesChanged();
     emit cutawayEnabledChanged();
     emit isSmallStaffChanged();
+    emit allStaffTypesChanged();
+    emit staffTypeChanged();
 }
 
 QVariantList StaffSettingsModel::allStaffTypes() const
 {
     QVariantList result;
+    auto staff = notationParts()->staff(m_staffId);
+    if (staff == nullptr) {
+        return result;
+    }
+    int maxLines = 0;
+    bool isPercussion = false;
+    if (staff->part() && staff->part()->instrument()) {
+        if (staff->part()->instrument()->stringData()) {
+            maxLines = staff->part()->instrument()->stringData()->frettedStrings();
+        }
+        isPercussion = staff->part()->instrument()->useDrumset();
+    }
 
-    for (notation::StaffType type: notation::allStaffTypes()) {
-        QVariantMap obj;
+    for (const Ms::StaffType& type : Ms::StaffType::presets()) {
+        if (isPercussion ? type.group() == Ms::StaffGroup::PERCUSSION
+            : type.group() == Ms::StaffGroup::STANDARD || type.group() == Ms::StaffGroup::TAB && type.lines() <= maxLines) {
+            QVariantMap obj;
 
-        obj["text"] = staffTypeToString(type);
-        obj["value"] = static_cast<int>(type);
+            obj["text"] = staffTypeToString(type.type());
+            obj["value"] = static_cast<int>(type.type());
 
-        result << obj;
+            result << obj;
+        }
     }
 
     return result;
 }
 
-QString StaffSettingsModel::staffType() const
+int StaffSettingsModel::staffType() const
 {
-    return staffTypeToString(m_type);
+    return static_cast<int>(m_type);
 }
 
 void StaffSettingsModel::setStaffType(int type)

--- a/src/instrumentsscene/view/staffsettingsmodel.h
+++ b/src/instrumentsscene/view/staffsettingsmodel.h
@@ -35,24 +35,24 @@ class StaffSettingsModel : public QObject
 
     INJECT(instruments, context::IGlobalContext, context)
 
-    Q_PROPERTY(QString staffType READ staffType NOTIFY staffTypeChanged)
+    Q_PROPERTY(int staffType READ staffType NOTIFY staffTypeChanged)
     Q_PROPERTY(QVariantList voices READ voices NOTIFY voicesChanged)
     Q_PROPERTY(bool isSmallStaff READ isSmallStaff NOTIFY isSmallStaffChanged)
     Q_PROPERTY(bool cutawayEnabled READ cutawayEnabled NOTIFY cutawayEnabledChanged)
-
     Q_PROPERTY(bool isMainScore READ isMainScore NOTIFY isMainScoreChanged)
+    Q_PROPERTY(QVariantList allStaffTypes READ allStaffTypes NOTIFY allStaffTypesChanged)
 
 public:
     explicit StaffSettingsModel(QObject* parent = nullptr);
 
-    QString staffType() const;
+    int staffType() const;
     QVariantList voices() const;
     bool isSmallStaff() const;
     bool cutawayEnabled() const;
+    QVariantList allStaffTypes() const;
 
     Q_INVOKABLE void load(const QString& staffId);
 
-    Q_INVOKABLE QVariantList allStaffTypes() const;
     Q_INVOKABLE void createLinkedStaff();
 
     Q_INVOKABLE void setStaffType(int type);
@@ -68,6 +68,7 @@ signals:
     void voiceVisibilityChanged(int voiceIndex, bool visible);
     void isSmallStaffChanged();
     void cutawayEnabledChanged();
+    void allStaffTypesChanged();
 
     void isMainScoreChanged(bool isMainScore);
 


### PR DESCRIPTION
Resolves: [*(direct link to the issue)*](https://github.com/musescore/MuseScore/issues/10780)

Full list of all staff types was being shown for all instruments, rather than those matching the instrument's staff type group.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
