### PR TITLE
Fix AppleClang 13.1 compiler warnings

### DIFF
--- a/src/engraving/infrastructure/draw/geometry.h
+++ b/src/engraving/infrastructure/draw/geometry.h
@@ -377,7 +377,6 @@ class PolygonX : public std::vector<PointX<T> >
 public:
 
     inline PolygonX<T>() = default;
-    inline PolygonX<T>(const PolygonX<T>& p) = default;
     inline PolygonX<T>(const std::vector<PointX<T> >& v) : std::vector<PointX<T> >(v) {
     }
     inline PolygonX<T>(size_t size) : std::vector<PointX<T> >(size) {

--- a/src/engraving/libmscore/articulation.h
+++ b/src/engraving/libmscore/articulation.h
@@ -109,6 +109,7 @@ class Articulation final : public EngravingItem
 
 public:
 
+    Articulation(const Articulation&) = default;
     Articulation& operator=(const Articulation&) = delete;
 
     Articulation* clone() const override { return new Articulation(*this); }

--- a/src/engraving/libmscore/fermata.h
+++ b/src/engraving/libmscore/fermata.h
@@ -57,6 +57,7 @@ class Fermata final : public EngravingItem
 
 public:
 
+    Fermata(const Fermata&) = default;
     Fermata& operator=(const Fermata&) = delete;
 
     Fermata* clone() const override { return new Fermata(*this); }

--- a/src/engraving/libmscore/key.h
+++ b/src/engraving/libmscore/key.h
@@ -96,8 +96,7 @@ class KeySigEvent
     void enforceLimits();
 
 public:
-    KeySigEvent() {}
-    KeySigEvent(const KeySigEvent&) = default;
+    KeySigEvent() = default;
 
     bool operator==(const KeySigEvent& e) const;
     bool operator!=(const KeySigEvent& e) const { return !(*this == e); }

--- a/src/engraving/libmscore/measurerepeat.h
+++ b/src/engraving/libmscore/measurerepeat.h
@@ -34,6 +34,7 @@ class MeasureRepeat final : public Rest
 {
 public:
     MeasureRepeat(Segment* parent);
+    MeasureRepeat(const MeasureRepeat&) = default;
     MeasureRepeat& operator=(const MeasureRepeat&) = delete;
 
     MeasureRepeat* clone() const override { return new MeasureRepeat(*this); }

--- a/src/engraving/libmscore/note.h
+++ b/src/engraving/libmscore/note.h
@@ -70,6 +70,7 @@ class NoteHead final : public Symbol
 public:
 
     NoteHead(Note* parent = 0);
+    NoteHead(const NoteHead&) = default;
     NoteHead& operator=(const NoteHead&) = delete;
     NoteHead* clone() const override { return new NoteHead(*this); }
 

--- a/src/engraving/libmscore/sig.h
+++ b/src/engraving/libmscore/sig.h
@@ -57,7 +57,6 @@ public:
         : Fraction(n, d) {}
     TimeSigFrac(const Fraction& f)
         : TimeSigFrac(f.numerator(), f.denominator()) {}
-    TimeSigFrac(const TimeSigFrac&) = default;
 
     // isCompound? Note: 3/8, 3/16, ... are NOT considered compound.
     bool isCompound() const { return numerator() > 3 /*&& denominator() >= 8*/ && numerator() % 3 == 0; }
@@ -121,7 +120,6 @@ public:
         : _timesig(s), _nominal(s), _bar(bar) {}
     SigEvent(const Fraction& s, const Fraction& ss, int bar = 0)
         : _timesig(s), _nominal(ss), _bar(bar) {}
-    SigEvent(const SigEvent&) = default;
 
     bool operator==(const SigEvent& e) const;
     bool valid() const { return _timesig.isValid(); }

--- a/src/engraving/libmscore/stem.h
+++ b/src/engraving/libmscore/stem.h
@@ -32,6 +32,7 @@ class Stem final : public EngravingItem
 {
 public:
 
+    Stem(const Stem&) = default;
     Stem& operator=(const Stem&) = delete;
 
     Stem* clone() const override { return new Stem(*this); }

--- a/src/framework/global/io/path.h
+++ b/src/framework/global/io/path.h
@@ -30,7 +30,6 @@ struct path;
 using paths = std::vector<path>;
 struct path {
     path() = default;
-    path(const path&) = default;
     path(const QByteArray& s);
     path(const QString& s);
     path(const std::string& s);

--- a/src/importexport/musedata/internal/musedata.cpp
+++ b/src/importexport/musedata/internal/musedata.cpp
@@ -44,6 +44,8 @@
 #include "libmscore/timesig.h"
 #include "libmscore/segment.h"
 
+#include "log.h"
+
 using namespace mu::engraving;
 
 namespace Ms {
@@ -53,7 +55,7 @@ namespace Ms {
 
 void MuseData::musicalAttribute(QString s, Part* part)
 {
-    QStringList al = s.mid(3).split(" ", Qt::SkipEmptyParts);
+    QStringList al = s.mid(2).split(" ", Qt::SkipEmptyParts);
     foreach (QString item, al) {
         if (item.startsWith("K:")) {
             int key = item.midRef(2).toInt();
@@ -67,23 +69,22 @@ void MuseData::musicalAttribute(QString s, Part* part)
         } else if (item.startsWith("T:")) {
             QStringList tl = item.mid(2).split("/");
             if (tl.size() != 2) {
-                qDebug("bad time sig <%s>", qPrintable(item));
+                LOGD() << "bad time sig: " << item;
                 continue;
             }
             int z = tl[0].toInt();
             int n = tl[1].toInt();
             if ((z > 0) && (n > 0)) {
-//TODO                        score->sigmap()->add(curTick, Fraction(z, n));
                 Measure* mes = score->tick2measure(curTick);
                 Segment* seg = mes->getSegment(SegmentType::TimeSig, curTick);
                 TimeSig* ts = Factory::createTimeSig(seg);
                 Staff* staff = part->staff(0);
                 ts->setTrack(staff->idx() * VOICES);
+                ts->setSig(Fraction(z, n));
                 seg->add(ts);
             }
         } else if (item.startsWith("X:")) {
         } else if (item[0] == 'C') {
-#if 0 // TODO
             int staffIdx = 1;
             int col = 2;
             if (item[1].isDigit()) {
@@ -91,29 +92,65 @@ void MuseData::musicalAttribute(QString s, Part* part)
                 col = 3;
             }
             staffIdx -= 1;
-            int clef = item.mid(col).toInt();
-            ClefType mscoreClef = ClefType::G;
-            switch (clef) {
-            case 4:  mscoreClef = ClefType::G;
+            int clefCode = item.mid(col).toInt();
+            ClefType clefType = ClefType::G;
+            switch (clefCode) {
+            // G clef
+            case 04: clefType = ClefType::G;
                 break;
-            case 22: mscoreClef = ClefType::F;
+            case 05: clefType = ClefType::G_1;
                 break;
-            case 13: mscoreClef = ClefType::C3;
+
+            // C clef
+            case 11: clefType = ClefType::C5;
                 break;
-            case 14: mscoreClef = ClefType::C2;
+            case 12: clefType = ClefType::C4;
                 break;
-            case 15: mscoreClef = ClefType::C1;
+            case 13: clefType = ClefType::C3;
                 break;
+            case 14: clefType = ClefType::C2;
+                break;
+            case 15: clefType = ClefType::C1;
+                break;
+
+            // F clef
+            case 21: clefType = ClefType::F_C;
+                break;
+            case 22: clefType = ClefType::F;
+                break;
+            case 23: clefType = ClefType::F_B;
+                break;
+
+            // G clef 8vb
+            case 34: clefType = ClefType::G8_VB;
+                break;
+
+            // F clef 8vb
+            case 52: clefType = ClefType::F8_VB;
+                break;
+
+            // G clef 8va
+            case 64: clefType = ClefType::G8_VA;
+                break;
+
+            // F clef 8va
+            case 82: clefType = ClefType::F_8VA;
+                break;
+
             default:
-                qDebug("unknown clef %d", clef);
+                LOGD() << "unknown clef code: " << clefCode;
                 break;
             }
 
+            Measure* mes = score->tick2measure(curTick);
+            Segment* seg = mes->getSegment(SegmentType::Clef, curTick);
             Staff* staff = part->staff(staffIdx);
-            staff->setClef(curTick, mscoreClef);
-#endif
+            Clef* clef = Factory::createClef(seg);
+            clef->setTrack(staff->idx() * VOICES);
+            clef->setClefType(clefType);
+            seg->add(clef);
         } else {
-            qDebug("unknown $key <%s>", qPrintable(item));
+            LOGD() << "unknown $key: " << item;
         }
     }
 }

--- a/src/importexport/musedata/internal/musedata.cpp
+++ b/src/importexport/musedata/internal/musedata.cpp
@@ -83,28 +83,35 @@ void MuseData::musicalAttribute(QString s, Part* part)
             }
         } else if (item.startsWith("X:")) {
         } else if (item[0] == 'C') {
+#if 0 // TODO
             int staffIdx = 1;
-//                  int col = 2;
+            int col = 2;
             if (item[1].isDigit()) {
                 staffIdx = item.midRef(1, 1).toInt();
-//                        col = 3;
+                col = 3;
             }
             staffIdx -= 1;
-/*                  int clef = item.mid(col).toInt();
-                  ClefType mscoreClef = ClefType::G;
-                  switch(clef) {
-                        case 4:  mscoreClef = ClefType::G; break;
-                        case 22: mscoreClef = ClefType::F; break;
-                        case 13: mscoreClef = ClefType::C3; break;
-                        case 14: mscoreClef = ClefType::C2; break;
-                        case 15: mscoreClef = ClefType::C1; break;
-                        default:
-                              qDebug("unknown clef %d", clef);
-                              break;
-                        }
-                  */
-//                  Staff* staff = part->staff(staffIdx);
-//                  staff->setClef(curTick, mscoreClef);
+            int clef = item.mid(col).toInt();
+            ClefType mscoreClef = ClefType::G;
+            switch (clef) {
+            case 4:  mscoreClef = ClefType::G;
+                break;
+            case 22: mscoreClef = ClefType::F;
+                break;
+            case 13: mscoreClef = ClefType::C3;
+                break;
+            case 14: mscoreClef = ClefType::C2;
+                break;
+            case 15: mscoreClef = ClefType::C1;
+                break;
+            default:
+                qDebug("unknown clef %d", clef);
+                break;
+            }
+
+            Staff* staff = part->staff(staffIdx);
+            staff->setClef(curTick, mscoreClef);
+#endif
         } else {
             qDebug("unknown $key <%s>", qPrintable(item));
         }

--- a/src/importexport/musedata/musedatamodule.cpp
+++ b/src/importexport/musedata/musedatamodule.cpp
@@ -35,7 +35,7 @@ std::string MuseDataModule::moduleName() const
     return "iex_musedata";
 }
 
-void MuseDataModule::registerResources()
+void MuseDataModule::resolveImports()
 {
     auto readers = modularity::ioc()->resolve<INotationReadersRegister>(moduleName());
     if (readers) {

--- a/src/importexport/musedata/musedatamodule.h
+++ b/src/importexport/musedata/musedatamodule.h
@@ -30,7 +30,7 @@ class MuseDataModule : public modularity::IModuleSetup
 public:
 
     std::string moduleName() const override;
-    void registerResources() override;
+    void resolveImports() override;
 };
 }
 

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -1202,14 +1202,6 @@ void ExportMusicXml::calcDivisions()
             Measure* m = (Measure*)mb;
 
             for (int st = strack; st < etrack; ++st) {
-                // sstaff - xml staff number, counting from 1 for this
-                // instrument
-                // special number 0 -> don’t show staff number in
-                // xml output (because there is only one staff)
-
-                int sstaff = (staves > 1) ? st - strack + VOICES : 0;
-                sstaff /= VOICES;
-
                 for (Segment* seg = m->first(); seg; seg = seg->next()) {
                     EngravingItem* el = seg->element(st);
                     if (!el) {

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -80,6 +80,7 @@
 #include "importexport/capella/capellamodule.h"
 #include "importexport/guitarpro/guitarpromodule.h"
 #include "importexport/midi/midimodule.h"
+#include "importexport/musedata/musedatamodule.h"
 #include "importexport/ove/ovemodule.h"
 #include "importexport/audioexport/audioexportmodule.h"
 #include "importexport/imagesexport/imagesexportmodule.h"
@@ -244,6 +245,7 @@ int main(int argc, char** argv)
     app.addModule(new mu::iex::capella::CapellaModule());
     app.addModule(new mu::iex::guitarpro::GuitarProModule());
     app.addModule(new mu::iex::midi::MidiModule());
+    app.addModule(new mu::iex::musedata::MuseDataModule());
     app.addModule(new mu::iex::ove::OveModule());
     app.addModule(new mu::iex::audioexport::AudioExportModule());
     app.addModule(new mu::iex::imagesexport::ImagesExportModule());

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -1044,7 +1044,6 @@ void NotationParts::sortParts(const PartInstrumentList& parts, const QList<Ms::S
     QList<int> staffMapping;
     QList<int> trackMapping;
     int runningStaffIndex = 0;
-    bool sortingNeeded = false;
 
     int partIndex = 0;
     for (const PartInstrument& pi: parts) {
@@ -1055,15 +1054,12 @@ void NotationParts::sortParts(const PartInstrumentList& parts, const QList<Ms::S
 
             trackMapping.append(originalStaves.indexOf(staff));
             staffMapping.append(actualStaffIndex);
-            sortingNeeded |= actualStaffIndex != runningStaffIndex;
             ++runningStaffIndex;
         }
         ++partIndex;
     }
 
-    //if (sortingNeeded) {
     score()->undo(new Ms::SortStaves(score(), staffMapping));
-    //}
 
     score()->undo(new Ms::MapExcerptTracks(score(), trackMapping));
 }

--- a/thirdparty/beatroot/Induction.cpp
+++ b/thirdparty/beatroot/Induction.cpp
@@ -160,7 +160,6 @@ AgentList Induction::beatInduction(const AgentParameters &params,
             b = bestn[index];
                               // Adjust it, using the size of super- and sub-intervals
             double newSum = clusterMean[b] * clusterScore[b];
-            int newCount = clusterSize[b];
             int newWeight = clusterScore[b];
 
             for (i = 0; i < intervals; i++) {
@@ -173,7 +172,6 @@ AgentList Induction::beatInduction(const AgentParameters &params,
                               err = std::fabs(clusterMean[b] * degree - clusterMean[i]);
                               if (err < clusterWidth) {
                                     newSum += clusterMean[i] / degree * clusterScore[i];
-                                    newCount += clusterSize[i];
                                     newWeight += clusterScore[i];
                                     }
                               }
@@ -184,7 +182,6 @@ AgentList Induction::beatInduction(const AgentParameters &params,
                               err = std::fabs(clusterMean[b] - degree * clusterMean[i]);
                               if (err < clusterWidth * degree) {
                                     newSum += clusterMean[i] * degree * clusterScore[i];
-                                    newCount += clusterSize[i];
                                     newWeight += clusterScore[i];
                                     }
                               }


### PR DESCRIPTION
The update to Xcode 13.3 includes AppleClang 13.1, which gives some new compiler warnings (actually, a lot of them, almost 600, but only a few _unique_ ones).

- It got stricter about the "rule of three": even if you declare a copy constructor or copy assignment operator with `= default` or `= delete`, it treats it as "user declared", and wants you to explicitly declare the other too. In some cases, I just removed the `= default` declaration, because it's redundant, and sometimes, I added a copy constructor with `= default`.

- It got smarter about "unused variables": it now warns about variables that are assigned to but never read (before, these warnings only appeared in "deep analysis" mode). This reveals some strange situations, and I was not always sure how to handle them. You'd say that someone must have added those variables with a reason, but it's not easy to track down which reason (Git blame often shows the famous "Changed code style" commit, or even worse, "Initial commit").