### PR TITLE
[MU4] Fix compiler warnings

### DIFF
--- a/src/engraving/layout/layoutchords.cpp
+++ b/src/engraving/layout/layoutchords.cpp
@@ -275,7 +275,7 @@ void LayoutChords::layoutChords1(Score* score, Segment* segment, int staffIdx)
                 bool conflictSecondDownHigher = false;            // second found
                 int lastLine = 1000;
                 Note* p = overlapNotes[0];
-                for (int i = 0, count = overlapNotes.size(); i < count; ++i) {
+                for (size_t i = 0, count = overlapNotes.size(); i < count; ++i) {
                     Note* n = overlapNotes[i];
                     NoteHeadType nHeadType;
                     NoteHeadType pHeadType;
@@ -352,7 +352,7 @@ void LayoutChords::layoutChords1(Score* score, Segment* segment, int staffIdx)
 
                 // calculate offsets
                 if (shareHeads) {
-                    for (int i = overlapNotes.size() - 1; i >= 1; i -= 2) {
+                    for (int i = static_cast<int>(overlapNotes.size()) - 1; i >= 1; i -= 2) {
                         Note* previousNote = overlapNotes[i - 1];
                         Note* n = overlapNotes[i];
                         if (!(previousNote->chord()->isNudged() || n->chord()->isNudged())) {
@@ -718,8 +718,8 @@ static QPair<qreal, qreal> layoutAccidental(const MStyle& style, AcEl* me, AcEl*
     }
 
     // clear left notes
-    int lns = leftNotes.size();
-    for (int i = 0; i < lns; ++i) {
+    size_t lns = leftNotes.size();
+    for (size_t i = 0; i < lns; ++i) {
         Note* ln = leftNotes[i];
         int lnLine = ln->line();
         qreal lnTop = (lnLine - 1) * 0.5 * sp;
@@ -954,7 +954,7 @@ void LayoutChords::layoutChords3(const MStyle& style, std::vector<Note*>& notes,
 
     // if there are no non-mirrored notes in a downstem chord,
     // then use the stem X position as X origin for accidental layout
-    if (nNotes && leftNotes.size() == nNotes) {
+    if (nNotes && static_cast<int>(leftNotes.size()) == nNotes) {
         lx = notes.front()->chord()->stemPosX();
     }
 
@@ -1021,16 +1021,16 @@ void LayoutChords::layoutChords3(const MStyle& style, std::vector<Note*>& notes,
                 unmatched.push_back(n);
             }
         }
-        int nColumns = column.size();
-        int nUnmatched = unmatched.size();
+        size_t nColumns = column.size();
+        size_t nUnmatched = unmatched.size();
 
         // handle unmatched accidentals
-        for (int i = 0; i < nUnmatched; ++i) {
+        for (size_t i = 0; i < nUnmatched; ++i) {
             // first try to slot it into an existing column
             AcEl* me = &aclist[unmatched[i]];
             // find column
             bool found = false;
-            for (int j = 0; j < nColumns; ++j) {
+            for (size_t j = 0; j < nColumns; ++j) {
                 int pc = column[j];
                 int above = -1;
                 int below = -1;
@@ -1070,7 +1070,7 @@ void LayoutChords::layoutChords3(const MStyle& style, std::vector<Note*>& notes,
                 umi.push_back(unmatched[i]);
             }
         }
-        nAcc = umi.size();
+        nAcc = static_cast<int>(umi.size());
         if (nAcc > 1) {
             std::sort(umi.begin(), umi.end());
         }
@@ -1078,7 +1078,7 @@ void LayoutChords::layoutChords3(const MStyle& style, std::vector<Note*>& notes,
         bool alignLeft = style.styleB(Sid::alignAccidentalsLeft);
 
         // through columns
-        for (int i = 0; i < nColumns; ++i) {
+        for (size_t i = 0; i < nColumns; ++i) {
             // column index
             const int pc = column[i];
 

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -1183,6 +1183,8 @@ void LayoutSystem::layoutSystemElements(const LayoutOptions& options, LayoutCont
 
 void LayoutSystem::doLayoutTies(System* system, std::vector<Ms::Segment*> sl, const Fraction& stick, const Fraction& etick)
 {
+    Q_UNUSED(etick);
+
     for (Segment* s : sl) {
         for (EngravingItem* e : s->elist()) {
             if (!e || !e->isChord()) {

--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -504,7 +504,7 @@ void Beam::layout()
             if (fragments.size() < n) {
                 fragments.push_back(new BeamFragment);
             }
-            layout2(crl, st, n - 1);
+            layout2(crl, st, static_cast<int>(n) - 1);
             crl.clear();
             system = cr->measure()->system();
         }
@@ -521,7 +521,7 @@ void Beam::layout()
         if (fragments.size() < (n + 1)) {
             fragments.push_back(new BeamFragment);
         }
-        layout2(crl, st, n);
+        layout2(crl, st, static_cast<int>(n));
 
         qreal lw2 = point(score()->styleS(Sid::beamWidth)) * .5 * mag();
 
@@ -574,7 +574,7 @@ int Beam::computeDesiredSlant(int startNote, int endNote, int middleLine, int di
                 if (higherEnd > _notes[1]) {
                     return 0;
                 }
-                int chordCount = _elements.size();
+                size_t chordCount = _elements.size();
                 if (chordCount >= 3 && _notes.size() >= 3) {
                     bool middleNoteHigherThanHigherEnd = higherEnd >= _notes[2];
                     if (middleNoteHigherThanHigherEnd) {
@@ -600,7 +600,7 @@ int Beam::computeDesiredSlant(int startNote, int endNote, int middleLine, int di
                 if (lowerEnd < _notes[_notes.size() - 2]) {
                     return 0;
                 }
-                int chordCount = _elements.size();
+                size_t chordCount = _elements.size();
                 if (chordCount >= 3 && _notes.size() >= 3) {
                     bool middleNoteLowerThanLowerEnd = lowerEnd <= _notes[_notes.size() - 3];
                     if (middleNoteLowerThanLowerEnd) {
@@ -708,7 +708,7 @@ bool Beam::calcIsBeamletBefore(Chord* chord, int i, int level, bool isAfter32Bre
     // if first or last chord in beam group
     if (i == 0) {
         return false;
-    } else if (i == _elements.size() - 1) {
+    } else if (i == static_cast<int>(_elements.size()) - 1) {
         return true;
     }
     // if first or last chord in tuplet
@@ -749,7 +749,7 @@ bool Beam::calcIsBeamletBefore(Chord* chord, int i, int level, bool isAfter32Bre
     }
 
     int nextOffset = 1;
-    while (i + nextOffset < _elements.size()) {
+    while (i + nextOffset < static_cast<int>(_elements.size())) {
         ChordRest* next = _elements[i + nextOffset];
         if (next->isChord()) {
             nextChordLevel = toChord(next)->beams();
@@ -1370,13 +1370,13 @@ std::vector<PointF> Beam::gripsPositions(const EditData& ed) const
 
     ChordRest* c1 = nullptr;
     ChordRest* c2 = nullptr;
-    int n = _elements.size();
+    size_t n = _elements.size();
 
     if (n == 0) {
         return std::vector<PointF>();
     }
 
-    for (int i = 0; i < n; ++i) {
+    for (size_t i = 0; i < n; ++i) {
         if (_elements[i]->isChordRest()) {
             c1 = toChordRest(_elements[i]);
             break;
@@ -1385,7 +1385,7 @@ std::vector<PointF> Beam::gripsPositions(const EditData& ed) const
     if (!c1) { // no chord/rest found, no need to check again below
         return {}; // just ignore the requested operation
     }
-    for (int i = n - 1; i >= 0; --i) {
+    for (int i = static_cast<int>(n) - 1; i >= 0; --i) {
         if (_elements[i]->isChordRest()) {
             c2 = toChordRest(_elements[i]);
             break;

--- a/src/engraving/libmscore/bsp.cpp
+++ b/src/engraving/libmscore/bsp.cpp
@@ -103,7 +103,7 @@ void BspTree::initialize(const RectF& rec, int n)
     leafCnt    = 0;
 
     nodes.resize((1 << (depth + 1)) - 1);
-    leaves.resize(1 << depth);
+    leaves.resize(1LL << depth);
     std::fill(leaves.begin(), leaves.end(), QList<EngravingItem*>());
     initialize(rec, depth, 0);
 }

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -432,7 +432,7 @@ bool Chord::containsEqualArticulations(const Chord* other) const
         return false;
     }
 
-    for (int i = 0; i < _articulations.size(); ++i) {
+    for (size_t i = 0; i < _articulations.size(); ++i) {
         const Articulation* first = _articulations.at(i);
         const Articulation* second = other->_articulations.at(i);
 
@@ -1805,8 +1805,8 @@ void Chord::layout2()
                 ? score()->styleMM(Sid::noteBarDistance) * mag
                 : minNoteDist;
         // scan grace note list from the end
-        int n = gna.size();
-        for (int i = n - 1; i >= 0; i--) {
+        size_t n = gna.size();
+        for (int i = static_cast<int>(n) - 1; i >= 0; i--) {
             Chord* g = gna.at(i);
             xOff -= g->_spaceRw;                        // move to left by grace note left space (incl. grace own width)
             g->rxpos() = xOff;
@@ -2013,7 +2013,7 @@ void Chord::layoutPitched()
         }
     }
     const std::vector<Chord*> graceNotesBefore = Chord::graceNotesBefore();
-    const int gnb = graceNotesBefore.size();
+    const size_t gnb = graceNotesBefore.size();
 
     // lay out grace notes after separately so they are processed left to right
     // (they are normally stored right to left)
@@ -2239,7 +2239,7 @@ void Chord::layoutPitched()
 
     if (gnb) {
         qreal xl = -(_spaceLw + minNoteDistance) - chordX;
-        for (int i = gnb - 1; i >= 0; --i) {
+        for (int i = static_cast<int>(gnb) - 1; i >= 0; --i) {
             Chord* g = graceNotesBefore.at(i);
             xl -= g->_spaceRw /* * 1.2*/;
             g->setPos(xl, 0);
@@ -2251,8 +2251,8 @@ void Chord::layoutPitched()
     }
     if (!gna.empty()) {
         qreal xr = _spaceRw;
-        int n = gna.size();
-        for (int i = 0; i <= n - 1; i++) {
+        size_t n = gna.size();
+        for (int i = 0; i <= static_cast<int>(n) - 1; i++) {
             Chord* g = gna.at(i);
             xr += g->_spaceLw + g->_spaceRw + minNoteDistance * graceMag;
         }
@@ -2609,10 +2609,10 @@ void Chord::layoutTablature()
     qreal graceMag = score()->styleD(Sid::graceNoteMag);
 
     std::vector<Chord*> graceNotesBefore = Chord::graceNotesBefore();
-    int nb = graceNotesBefore.size();
+    size_t nb = graceNotesBefore.size();
     if (nb) {
         qreal xl = -(_spaceLw + minNoteDistance);
-        for (int i = nb - 1; i >= 0; --i) {
+        for (int i = static_cast<int>(nb) - 1; i >= 0; --i) {
             Chord* c = graceNotesBefore.at(i);
             xl -= c->_spaceRw /* * 1.2*/;
             c->setPos(xl, 0);
@@ -2623,7 +2623,7 @@ void Chord::layoutTablature()
         }
     }
     std::vector<Chord*> gna = graceNotesAfter();
-    int na = gna.size();
+    size_t na = gna.size();
     if (na) {
         // get factor for start distance after main note. Values found by testing.
         qreal fc;
@@ -2645,7 +2645,7 @@ void Chord::layoutTablature()
         default: fc = 1;
         }
         qreal xr = fc * (_spaceRw + minNoteDistance);
-        for (int i = 0; i <= na - 1; i++) {
+        for (int i = 0; i <= static_cast<int>(na) - 1; i++) {
             Chord* c = gna.at(i);
             xr += c->_spaceLw * (i == 0 ? 1.3 : 1);
             c->setPos(xr, 0);
@@ -3338,7 +3338,7 @@ std::vector<Chord*> Chord::graceNotesBefore() const
 std::vector<Chord*> Chord::graceNotesAfter() const
 {
     std::vector<Chord*> cl;
-    for (int i = _graceNotes.size() - 1; i >= 0; i--) {
+    for (int i = static_cast<int>(_graceNotes.size()) - 1; i >= 0; i--) {
         Chord* c = _graceNotes[i];
         Q_ASSERT(c->noteType() != NoteType::NORMAL && c->noteType() != NoteType::INVALID);
         if (c->noteType() & (NoteType::GRACE8_AFTER | NoteType::GRACE16_AFTER | NoteType::GRACE32_AFTER)) {

--- a/src/engraving/libmscore/chordrest.cpp
+++ b/src/engraving/libmscore/chordrest.cpp
@@ -1418,10 +1418,10 @@ bool ChordRest::isBefore(const ChordRest* o) const
         int oGraceIndex  = oGrace ? toChord(o)->graceIndex() + 1 : 0;
         int graceIndex   = grace ? toChord(this)->graceIndex() + 1 : 0;
         if (oGrace) {
-            oGraceIndex = toChord(o->explicitParent())->graceNotes().size() - oGraceIndex;
+            oGraceIndex = static_cast<int>(toChord(o->explicitParent())->graceNotes().size()) - oGraceIndex;
         }
         if (grace) {
-            graceIndex = toChord(explicitParent())->graceNotes().size() - graceIndex;
+            graceIndex = static_cast<int>(toChord(explicitParent())->graceNotes().size()) - graceIndex;
         }
         otick = otick + (oGraceAfter ? 1 : -1) * oGraceIndex;
         t     = t + (graceAfter ? 1 : -1) * graceIndex;

--- a/src/engraving/libmscore/engravingitem.cpp
+++ b/src/engraving/libmscore/engravingitem.cpp
@@ -1014,7 +1014,7 @@ bool EngravingItem::readProperties(XmlReader& e)
         _links = mu::value(e.linkIds(), id, nullptr);
         if (!_links) {
             if (!score()->isMaster()) {       // DEBUG
-                qDebug("---link %d not found (%d)", id, e.linkIds().size());
+                qDebug("---link %d not found (%zu)", id, e.linkIds().size());
             }
             _links = new LinkedObjects(score(), id);
             e.linkIds().insert({ id, _links });

--- a/src/engraving/libmscore/glissando.cpp
+++ b/src/engraving/libmscore/glissando.cpp
@@ -351,7 +351,7 @@ void Glissando::layout()
 
     // initial note dots / ledger line / notehead
     offs1 *= -1.0;            // discount changes already applied
-    int dots = anchor1->dots().size();
+    int dots = static_cast<int>(anchor1->dots().size());
     LedgerLine* ledLin = cr1->ledgerLines();
 
     // If TAB: completely zero first offset since it was already applied as right edge of first note

--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -2056,8 +2056,8 @@ void Note::setDotY(DirectionV pos)
 
     // apply to dots
 
-    int cdots = chord()->dots();
-    int ndots = _dots.size();
+    int cdots = static_cast<int>(chord()->dots());
+    int ndots = static_cast<int>(_dots.size());
 
     int n = cdots - ndots;
     for (int i = 0; i < n; ++i) {
@@ -3280,7 +3280,7 @@ NoteVal Note::noteVal() const
 
 int Note::qmlDotsCount()
 {
-    return _dots.size();
+    return static_cast<int>(_dots.size());
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/rendermidi.cpp
+++ b/src/engraving/libmscore/rendermidi.cpp
@@ -1674,11 +1674,11 @@ bool renderNoteArticulation(NoteEventList* events, Note* note, bool chromatic, i
     int sustain   = 0;
     int ontime    = 0;
 
-    int gnb = note->chord()->graceNotesBefore().size();
+    int gnb = int(note->chord()->graceNotesBefore().size());
     int p = int(prefix.size());
     int b = int(body.size());
     int s = int(suffix.size());
-    int gna = note->chord()->graceNotesAfter().size();
+    int gna = int(note->chord()->graceNotesAfter().size());
 
     int ticksPerNote = 0;
 
@@ -2218,8 +2218,8 @@ void Score::createGraceNotesPlayEvents(const Fraction& tick, Chord* chord, int& 
 {
     std::vector<Chord*> gnb = chord->graceNotesBefore();
     std::vector<Chord*> gna = chord->graceNotesAfter();
-    int nb = gnb.size();
-    int na = gna.size();
+    int nb = int(gnb.size());
+    int na = int(gna.size());
     if (0 == nb + na) {
         return;     // return immediately if no grace notes to deal with
     }

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -1524,8 +1524,8 @@ void Score::addElement(EngravingItem* element)
     case ElementType::BEAM:
     {
         Beam* b = toBeam(element);
-        int n = b->elements().size();
-        for (int i = 0; i < n; ++i) {
+        size_t n = b->elements().size();
+        for (size_t i = 0; i < n; ++i) {
             b->elements().at(i)->setBeam(b);
         }
     }

--- a/src/engraving/libmscore/scoretree.cpp
+++ b/src/engraving/libmscore/scoretree.cpp
@@ -547,11 +547,11 @@ EngravingObject* Chord::scanChild(int idx) const
     if (idx < int(graceNotes().size())) {
         return graceNotes()[idx];
     }
-    idx -= graceNotes().size();
+    idx -= int(graceNotes().size());
     if (idx < int(articulations().size())) {
         return articulations()[idx];
     }
-    idx -= articulations().size();
+    idx -= int(articulations().size());
     if (stem()) {
         if (idx == 0) {
             return stem();
@@ -658,7 +658,7 @@ EngravingObject* Note::scanChild(int idx) const
     if (idx < int(dots().size())) {
         return dots()[idx];
     }
-    idx -= dots().size();
+    idx -= int(dots().size());
     if (tieFor()) {
         if (idx == 0) {
             return tieFor();
@@ -672,7 +672,7 @@ EngravingObject* Note::scanChild(int idx) const
     if (idx < int(spannerFor().size())) {
         return spannerFor()[idx];
     }
-    idx -= spannerFor().size();
+    idx -= int(spannerFor().size());
     return nullptr;
 }
 

--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -98,6 +98,8 @@ void SlurSegment::draw(mu::draw::Painter* painter) const
         pen.setDashPattern(wideDashed);
         pen.setWidthF(score()->styleMM(Sid::SlurDottedWidth) * mag);
         break;
+    case SlurStyleType::Undefined:
+        break;
     }
     painter->setPen(pen);
     painter->drawPath(path);
@@ -520,9 +522,8 @@ void SlurSegment::layoutSegment(const PointF& p1, const PointF& p2)
         qreal midpointDist = 0.0;
         qreal end1Dist = 0.0;
         qreal end2Dist = 0.0;
-        qreal segRelativeX;
+        qreal segRelativeX = 0.0;
         bool intersection = false;
-        qreal minDistance = score()->styleS(Sid::SlurMinDistance).val() * spatium();
         bool adjusted[3] = { false, false, false };
         const qreal collisionMargin = 0.5 * spatium();
         for (int tries = 0; tries < 3; ++tries) {

--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -1839,7 +1839,6 @@ ChordRest* System::lastChordRest(int track)
 
 ChordRest* System::firstChordRest(int track)
 {
-    qreal margin = score()->spatium();
     for (const MeasureBase* mb : measures()) {
         if (!mb->isMeasure()) {
             continue;
@@ -1854,6 +1853,7 @@ ChordRest* System::firstChordRest(int track)
             }
         }
     }
+    return 0;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -2932,11 +2932,9 @@ mu::engraving::PropertyValue TextBase::propertyDefault(Pid id) const
                 return styleValue(id, p.sid);
             }
         }
-
-        return EngravingItem::propertyDefault(id);
     }
 
-    return PropertyValue();
+    return EngravingItem::propertyDefault(id);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/tie.cpp
+++ b/src/engraving/libmscore/tie.cpp
@@ -102,6 +102,8 @@ void TieSegment::draw(mu::draw::Painter* painter) const
         pen.setDashPattern(wideDashed);
         pen.setWidthF(score()->styleMM(Sid::SlurDottedWidth) * mag);
         break;
+    case SlurStyleType::Undefined:
+        break;
     }
     painter->setPen(pen);
     painter->drawPath(path);

--- a/src/engraving/playback/renderers/gracenotesrenderer.cpp
+++ b/src/engraving/playback/renderers/gracenotesrenderer.cpp
@@ -176,7 +176,7 @@ void GraceNotesRenderer::buildPrincipalNoteEvents(const Ms::Chord* chord, const 
 }
 
 duration_t GraceNotesRenderer::graceNotesMaxAvailableDuration(const ArticulationType type, const RenderingContext& ctx,
-                                                              const int graceNotesCount)
+                                                              const size_t graceNotesCount)
 {
     duration_t halfedDuration = 0.5 * ctx.nominalDuration;
     duration_t twoThirdsDuration = (2 * ctx.nominalDuration) / 3;
@@ -192,7 +192,7 @@ duration_t GraceNotesRenderer::graceNotesMaxAvailableDuration(const Articulation
 
     duration_t minAcciacaturaDuration = durationFromTicks(ctx.beatsPerSecond.val, DEMISEMIQUAVER_TICKS / 2);
 
-    return std::min(minAcciacaturaDuration * graceNotesCount, halfedDuration);
+    return std::min(minAcciacaturaDuration * static_cast<duration_t>(graceNotesCount), halfedDuration);
 }
 
 timestamp_t GraceNotesRenderer::graceNotesStartTimestamp(const mpe::ArticulationType type, const mpe::duration_t availableDuration,

--- a/src/engraving/playback/renderers/gracenotesrenderer.h
+++ b/src/engraving/playback/renderers/gracenotesrenderer.h
@@ -59,7 +59,7 @@ private:
                                          const mpe::duration_t duration, const mpe::timestamp_t timestamp, mpe::PlaybackEventList& result);
 
     static mpe::duration_t graceNotesMaxAvailableDuration(const mpe::ArticulationType type, const RenderingContext& ctx,
-                                                          const int graceNotesCount);
+                                                          const size_t graceNotesCount);
     static mpe::timestamp_t graceNotesStartTimestamp(const mpe::ArticulationType type, const mpe::duration_t availableDuration,
                                                      const mpe::timestamp_t& nominalTimestamp);
 

--- a/src/engraving/utests/playbackeventsrendering_tests.cpp
+++ b/src/engraving/utests/playbackeventsrendering_tests.cpp
@@ -398,7 +398,7 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_Turn_Regular)
 
             // [THEN] We expect that each sub-note in Regular Turn articulation will be equal to 0.25 of the principal note
             EXPECT_EQ(noteEvent.arrangementCtx().nominalDuration, expectedDuration);
-            EXPECT_EQ(noteEvent.arrangementCtx().nominalTimestamp, i * expectedDuration);
+            EXPECT_EQ(noteEvent.arrangementCtx().nominalTimestamp, static_cast<duration_t>(i) * expectedDuration);
 
             // [THEN] We expect that each note event will match expected pitch disclosure
             EXPECT_EQ(noteEvent.pitchCtx().nominalPitchLevel, expectedPitches.at(i));
@@ -457,7 +457,7 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_Turn_Inverted)
 
             // [THEN] We expect that each sub-note in Inverted Turn articulation will be equal to 0.25 of the principal note
             EXPECT_EQ(noteEvent.arrangementCtx().nominalDuration, expectedDuration);
-            EXPECT_EQ(noteEvent.arrangementCtx().nominalTimestamp, i * expectedDuration);
+            EXPECT_EQ(noteEvent.arrangementCtx().nominalTimestamp, static_cast<duration_t>(i) * expectedDuration);
 
             // [THEN] We expect that each note event will match expected pitch disclosure
             EXPECT_EQ(noteEvent.pitchCtx().nominalPitchLevel, expectedPitches.at(i));
@@ -518,7 +518,7 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_Turn_Inverted_Slash_Variation)
 
             // [THEN] We expect that each sub-note in Inverted Turn articulation will be equal to 0.25 of the principal note
             EXPECT_EQ(noteEvent.arrangementCtx().nominalDuration, expectedDuration);
-            EXPECT_EQ(noteEvent.arrangementCtx().nominalTimestamp, i * expectedDuration);
+            EXPECT_EQ(noteEvent.arrangementCtx().nominalTimestamp, static_cast<duration_t>(i) * expectedDuration);
 
             // [THEN] We expect that each note event will match expected pitch disclosure
             EXPECT_EQ(noteEvent.pitchCtx().nominalPitchLevel, expectedPitches.at(i));
@@ -783,7 +783,7 @@ TEST_F(PlaybackEventsRendererTests, TwoNotes_Continuous_Glissando)
 
             // [THEN] We expect that each sub-note has an expected duration
             EXPECT_EQ(noteEvent.arrangementCtx().nominalDuration, expectedDuration);
-            EXPECT_EQ(noteEvent.arrangementCtx().nominalTimestamp, i * expectedDuration);
+            EXPECT_EQ(noteEvent.arrangementCtx().nominalTimestamp, static_cast<duration_t>(i) * expectedDuration);
 
             // [THEN] We expect that each note event will match expected pitch disclosure
             EXPECT_EQ(noteEvent.pitchCtx().nominalPitchLevel, expectedPitches.at(i));
@@ -845,7 +845,7 @@ TEST_F(PlaybackEventsRendererTests, TwoNotes_Glissando_NoPlay)
 
             // [THEN] We expect that each sub-note has an expected duration
             EXPECT_EQ(noteEvent.arrangementCtx().nominalDuration, expectedDuration);
-            EXPECT_EQ(noteEvent.arrangementCtx().nominalTimestamp, i * expectedDuration);
+            EXPECT_EQ(noteEvent.arrangementCtx().nominalTimestamp, static_cast<duration_t>(i) * expectedDuration);
 
             // [THEN] We expect that each note event will match expected pitch disclosure
             EXPECT_EQ(noteEvent.pitchCtx().nominalPitchLevel, expectedPitches.at(i));

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
@@ -230,12 +230,12 @@ void FluidSynth::setupSound(const PlaybackSetupData& setupData)
 
     const Programs& programs = findPrograms(setupData);
     for (const Program& program : programs) {
-        m_channels.emplace(m_channels.size(), program);
+        m_channels.emplace(static_cast<int>(m_channels.size()), program);
     }
 
     m_articulationMapping = articulationSounds(setupData);
     for (const auto& pair : m_articulationMapping) {
-        m_channels.emplace(m_channels.size(), pair.second);
+        m_channels.emplace(static_cast<int>(m_channels.size()), pair.second);
     }
 
     fluid_synth_activate_octave_tuning(m_fluid->synth, 0, 0, "standard", FLUID_STANDARD_TUNING.data(), 0);

--- a/src/framework/global/containers.h
+++ b/src/framework/global/containers.h
@@ -86,7 +86,7 @@ inline auto value(const Map& m, const K& k) -> typename Map::mapped_type
     if (it != m.end()) {
         return it->second;
     }
-    typename Map::mapped_type def;
+    typename Map::mapped_type def {};
     return def;
 }
 

--- a/src/framework/global/log.h
+++ b/src/framework/global/log.h
@@ -31,7 +31,7 @@
 #include "thirdparty/haw_logger/logger/log_base.h"
 
 #define IF_ASSERT_FAILED_X(cond, msg) if (!(cond)) { \
-        LOGE() << "\"ASSERT FAILED!\":" << msg << __FILE__ << __LINE__; \
+        LOGE() << "\"ASSERT FAILED!\": " << msg << ", file: " << __FILE__ << ", line: " << __LINE__; \
         Q_ASSERT(cond); \
 } \
     if (!(cond)) \
@@ -39,14 +39,14 @@
 #define IF_ASSERT_FAILED(cond) IF_ASSERT_FAILED_X(cond, #cond)
 
 #define IF_FAILED(cond) if (!(cond)) { \
-        LOGE() << "\"FAILED!\":" << #cond << __FILE__ << __LINE__; \
+        LOGE() << "\"FAILED!\": " << #cond << ", file: " << __FILE__ << ", line: " << __LINE__; \
 } \
     if (!(cond)) \
 
 #define UNUSED(x) (void)x;
 
 #define UNREACHABLE \
-    LOGE() << "\"UNREACHABLE!\":" << __FILE__ << __LINE__; \
+    LOGE() << "\"UNREACHABLE!\": " << ", file: " << __FILE__ << ", line: " << __LINE__; \
     Q_ASSERT_X(false, "UNREACHABLE", "UNREACHABLE was reached"); \
 
 #endif // MU_FRAMEWORK_LOG_H

--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -1048,34 +1048,34 @@ bool GuitarPro5::readNoteEffects(Note* note)
     }
     if (modMask2 & EFFECT_SLIDE) {
         int slideKind = readUChar();
-        Slide* slide = nullptr;
-        ChordLineType slideType;
+        Slide* sld = nullptr;
+        ChordLineType slideType = ChordLineType::NOTYPE;
 
         if (slideKind & SLIDE_OUT_DOWN) {
             slideKind &= ~SLIDE_OUT_DOWN;
-            slide = Factory::createSlide(score->dummy()->chord());
+            sld = Factory::createSlide(score->dummy()->chord());
             slideType = ChordLineType::FALL;
         }
         // slide out upwards (doit)
         if (slideKind & SLIDE_OUT_UP) {
             slideKind &= ~SLIDE_OUT_UP;
-            slide = Factory::createSlide(score->dummy()->chord());
+            sld = Factory::createSlide(score->dummy()->chord());
             slideType = ChordLineType::DOIT;
         }
         // slide in from below (plop)
         if (slideKind & SLIDE_IN_BELOW) {
             slideKind &= ~SLIDE_IN_BELOW;
-            slide = Factory::createSlide(score->dummy()->chord());
+            sld = Factory::createSlide(score->dummy()->chord());
             slideType = ChordLineType::PLOP;
         }
         // slide in from above (scoop)
         if (slideKind & SLIDE_IN_ABOVE) {
             slideKind &= ~SLIDE_IN_ABOVE;
-            slide = Factory::createSlide(score->dummy()->chord());
+            sld = Factory::createSlide(score->dummy()->chord());
             slideType = ChordLineType::SCOOP;
         }
 
-        if (slide) {
+        if (sld) {
             auto convertSlideType = [](ChordLineType slideType) -> Note::SlideType {
                 if (slideType == ChordLineType::FALL) {
                     return Note::SlideType::Fall;
@@ -1091,9 +1091,9 @@ bool GuitarPro5::readNoteEffects(Note* note)
                 }
             };
 
-            slide->setChordLineType(slideType);
-            note->chord()->add(slide);
-            slide->setNote(note);
+            sld->setChordLineType(slideType);
+            note->chord()->add(sld);
+            sld->setNote(note);
             Note::Slide sl{ convertSlideType(slideType), nullptr };
             note->attachSlide(sl);
         }

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -2996,10 +2996,8 @@ Score::FileError importGTP(MasterScore* score, const QString& name)
     // create parts (excerpts)
     //
     std::vector<Part*> infoParts;
+#if 0 //! HACK Temporary disabled, something not corrected, so crashed
     for (Part* part : score->parts()) {
-        //! HACK Temporary disabled, something not corrected, so crashed
-        continue;
-
         const QString& longName = part->longName();
         if (!longName.isEmpty() && longName[0] == '@') {
             infoParts.push_back(part);
@@ -3080,6 +3078,7 @@ Score::FileError importGTP(MasterScore* score, const QString& name)
         pscore->addLayoutFlags(LayoutFlag::FIX_PITCH_VELO);
         //            pscore->doLayout();
     }
+#endif
 
     for (auto p : infoParts) {
         auto staff = p->staves()->back();

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -3192,7 +3192,7 @@ static void writeBeam(XmlWriter& xml, ChordRest* const cr, Beam* const b)
         blc = toChord(cr)->beams();
     }
     // find beam level next chord
-    for (int i = idx + 1; bln == -1 && i < elements.size(); ++i) {
+    for (int i = idx + 1; bln == -1 && i < static_cast<int>(elements.size()); ++i) {
         const auto crst = elements[i];
         if (crst->isChord()) {
             bln = toChord(crst)->beams();

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -1801,7 +1801,7 @@ static Measure* findMeasure(Score* score, const Fraction& tick)
 
 static void removeBeam(Beam*& beam)
 {
-    for (int i = 0; i < beam->elements().size(); ++i) {
+    for (size_t i = 0; i < beam->elements().size(); ++i) {
         beam->elements().at(i)->setBeamMode(BeamMode::NONE);
     }
     delete beam;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2706,7 +2706,7 @@ static int findGrip(const std::vector<mu::RectF>& grips, const mu::PointF& canva
     qreal align = grips[0].width() / 2;
     for (size_t i = 0; i < grips.size(); ++i) {
         if (grips[i].adjusted(-align, -align, align, align).contains(canvasPos)) {
-            return i;
+            return static_cast<int>(i);
         }
     }
     return -1;

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -907,6 +907,7 @@ ElementType NotationViewInputController::selectionType() const
         return ElementType::PAGE;
     }
 
+    UNREACHABLE;
     return type;
 }
 

--- a/thirdparty/freetype/src/autofit/afcjk.c
+++ b/thirdparty/freetype/src/autofit/afcjk.c
@@ -520,7 +520,7 @@
     /* digit `0' is 0x30 in all supported charmaps */
     for ( i = 0x30; i <= 0x39; i++ )
     {
-      FT_ULong  glyph_index;
+      FT_ULong  glyph_index = 0;
       FT_Long   y_offset;
 
 


### PR DESCRIPTION
Fixes two left-overs from https://github.com/musescore/MuseScore/pull/10711#issuecomment-1057045279 and a whole bunch of new ones, reg. size_t, some other comparisons between signed and unsigned and some unhandled cases. Also some unused variables and paremeters, unintilalized variables and a possible return without value, reported by MSVC and/or MinGW.