### PR TITLE
[MU4] Fix incorrect placement of system objects and add checking on load

### DIFF
--- a/src/engraving/libmscore/engravingitem.cpp
+++ b/src/engraving/libmscore/engravingitem.cpp
@@ -462,8 +462,7 @@ int EngravingItem::staffIdxOrNextVisible() const
         return si;
     }
     int firstVis = m->system()->firstVisibleStaff();
-    if (!isLinked() || (track() == 0 && (_links->mainElement()->score() != score()
-                                         || !toEngravingItem(_links->mainElement())->enabled()))) {
+    if (isTopSystemObject()) {
         // original, put on the top of the score
         return firstVis;
     }
@@ -498,6 +497,20 @@ int EngravingItem::staffIdxOrNextVisible() const
         foundStaff = true;
     }
     return foundStaff ? si : -1;
+}
+
+bool EngravingItem::isTopSystemObject() const
+{
+    if (!systemFlag()) {
+        return false; // non system object
+    }
+    if (!_links) {
+        return true; // a system object, but not one with any linked clones
+    }
+    // this is part of a link ecosystem, see if we're the main one
+    EngravingObject* mainElement = _links->mainElement();
+    return track() == 0
+           && (mainElement->score() != score() || !toEngravingItem(mainElement)->enabled());
 }
 
 int EngravingItem::vStaffIdx() const

--- a/src/engraving/libmscore/engravingitem.h
+++ b/src/engraving/libmscore/engravingitem.h
@@ -427,6 +427,7 @@ public:
     int staffIdx() const;
     void setStaffIdx(int val);
     int staffIdxOrNextVisible() const; // for system objects migrating
+    bool isTopSystemObject() const;
     virtual int vStaffIdx() const;
     int voice() const;
     void setVoice(int v);

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -496,7 +496,7 @@ void Segment::insertStaff(int staff)
 
     for (EngravingItem* e : _annotations) {
         int staffIdx = e->staffIdx();
-        if (staffIdx >= staff) {
+        if (staffIdx >= staff && !e->isTopSystemObject()) {
             e->setTrack(e->track() + VOICES);
         }
     }
@@ -516,7 +516,7 @@ void Segment::removeStaff(int staff)
 
     for (EngravingItem* e : _annotations) {
         int staffIdx = e->staffIdx();
-        if (staffIdx > staff && !e->systemFlag()) {
+        if (staffIdx > staff && !e->isTopSystemObject()) {
             e->setTrack(e->track() - VOICES);
         }
     }

--- a/src/engraving/rw/measurerw.cpp
+++ b/src/engraving/rw/measurerw.cpp
@@ -105,6 +105,9 @@ void MeasureRW::readMeasure(Measure* measure, XmlReader& e, ReadContext& ctx, in
             EngravingItem* el = Factory::createItemByName(tag, measure);
             el->setTrack(e.track());
             el->read(e);
+            if (el->systemFlag() && el->isTopSystemObject()) {
+                el->setTrack(0); // original system object always goes on top
+            }
             measure->add(el);
         } else if (tag == "stretch") {
             double val = e.readDouble();
@@ -443,12 +446,16 @@ void MeasureRW::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, int 
                    || tag == "StaffState"
                    || tag == "FiguredBass"
                    ) {
+            // hack - getSegment needed because tick tags are unreliable in 1.3 scores
+            // for symbols attached to anything but a measure
             segment = measure->getSegment(SegmentType::ChordRest, e.tick());
             EngravingItem* el = Factory::createItemByName(tag, segment);
-            // hack - needed because tick tags are unreliable in 1.3 scores
-            // for symbols attached to anything but a measure
+
             el->setTrack(e.track());
             el->read(e);
+            if (el->systemFlag() && el->isTopSystemObject()) {
+                el->setTrack(0); // original system object always goes on top
+            }
             segment->add(el);
         } else if (tag == "Fermata") {
             fermata = Factory::createFermata(ctx.dummy());


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10823

The issue was that there was a bug in the system object code that didn't produce any graphical errors (so the vtests still passed) but saved the system object to the incorrect staff in XML. That's been fixed now, and also some code has been added to the loading process to make sure that if we have invalid system objects in the xml the program won't crash anymore.