### PR TITLE
[MU4] Fix #330595: Crash on selecting entire score after XML import

### DIFF
--- a/src/engraving/libmscore/select.cpp
+++ b/src/engraving/libmscore/select.cpp
@@ -508,7 +508,7 @@ void Selection::appendChord(Chord* chord)
             if (note->tieFor()->endElement()->isNote()) {
                 Note* endNote = toNote(note->tieFor()->endElement());
                 Segment* s = endNote->chord()->segment();
-                if (s->tick() < tickEnd()) {
+                if (!s || s->tick() < tickEnd()) {
                     _el.push_back(note->tieFor());
                 }
             }
@@ -517,7 +517,7 @@ void Selection::appendChord(Chord* chord)
             if (sp->endElement()->isNote()) {
                 Note* endNote = toNote(sp->endElement());
                 Segment* s = endNote->chord()->segment();
-                if (s->tick() < tickEnd()) {
+                if (!s || s->tick() < tickEnd()) {
                     _el.push_back(sp);
                 }
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/330595 (the 2nd part, the first part is not an issue with master, looking at its fix for 3.x seems to indicate that this is because #8530 hasn't been ported to master yet? For 3.x and master that crash had been fixed in #8199 resp. #8200, we'd need to make sure it doesn't break again when porting those backend fixes to master)
Applies to 3.x too.
Strange enough: There is no crash when saving the imported XML as an MSCZ, closing and reopening it and doing that "select all" then.