### PR TITLE
Fix #10848: Onboarding process no longer starts in the main 'Score' tab. Rewording of Tutorial description needed. App should start maximised.

### DIFF
--- a/src/appshell/qml/FirstLaunchSetup/TutorialsPage.qml
+++ b/src/appshell/qml/FirstLaunchSetup/TutorialsPage.qml
@@ -29,7 +29,7 @@ import MuseScore.AppShell 1.0
 
 Page {
     title: qsTrc("appshell", "Video tutorials")
-    explanation: qsTrc("appshell", "This is the ‘Learn’ section, where you’ll find tutorials to get you started\n(Video tutorials require an internet connection)")
+    explanation: qsTrc("appshell", "Behind this dialog is the ‘Learn’ section, where you’ll find tutorials to get you started\n(Video tutorials require an internet connection)")
 
     titleContentSpacing: 12
 

--- a/src/appshell/qml/platform/linux/Main.qml
+++ b/src/appshell/qml/platform/linux/Main.qml
@@ -51,9 +51,5 @@ AppWindow {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: parent.bottom
-
-        onWindowLoaded: {
-            root.visible = true
-        }
     }
 }

--- a/src/appshell/qml/platform/mac/Main.qml
+++ b/src/appshell/qml/platform/mac/Main.qml
@@ -141,9 +141,5 @@ AppWindow {
         id: window
 
         anchors.fill: parent
-
-        onWindowLoaded: {
-            root.visible = true
-        }
     }
 }

--- a/src/appshell/qml/platform/win/Main.qml
+++ b/src/appshell/qml/platform/win/Main.qml
@@ -83,9 +83,5 @@ AppWindow {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: parent.bottom
-
-        onWindowLoaded: {
-            root.visible = true
-        }
     }
 }

--- a/src/appshell/view/dockwindow/dockwindow.h
+++ b/src/appshell/view/dockwindow/dockwindow.h
@@ -90,7 +90,6 @@ public:
     void restoreDefaultLayout() override;
 
 signals:
-    void windowLoaded();
     void pageLoaded();
     void currentPageUriChanged(const QString& uri);
 
@@ -137,6 +136,7 @@ private:
     uicomponents::QmlListProperty<DockPageView> m_pages;
     async::Channel<QStringList> m_docksOpenStatusChanged;
 
+    bool m_hasGeometryBeenRestored = false;
     bool m_quiting = false;
     bool m_workspaceChanging = false;
 };

--- a/src/appshell/view/firstlaunchsetup/firstlaunchsetupmodel.cpp
+++ b/src/appshell/view/firstlaunchsetup/firstlaunchsetupmodel.cpp
@@ -31,8 +31,8 @@ FirstLaunchSetupModel::FirstLaunchSetupModel(QObject* parent)
     : QObject(parent)
 {
     m_pages = {
-        Page { "ThemesPage.qml", "musescore://home" },
-        Page { "PlaybackPage.qml", "musescore://home" },
+        Page { "ThemesPage.qml", "musescore://notation" },
+        Page { "PlaybackPage.qml", "musescore://notation" },
         Page { "TutorialsPage.qml", "musescore://home?section=learn" }
     };
 }


### PR DESCRIPTION
Resolves: #10848