### PR TITLE
Fix mouse cursor shape in TextInputField

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/TextInputField.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/TextInputField.qml
@@ -283,6 +283,7 @@ FocusScope {
 
         propagateComposedEvents: true
         hoverEnabled: true
+        cursorShape: root.readOnly ? Qt.ArrowCursor : Qt.IBeamCursor
 
         onPressed: function(mouse) {
             root.ensureActiveFocus()


### PR DESCRIPTION
Should be IBeamCursor, unless readonly (same behaviour as standard QML TextField)

Resolves: #10890