### PR TITLE
Fix default zoom, and scaling in ExampleView

### DIFF
--- a/src/commonscene/exampleview.cpp
+++ b/src/commonscene/exampleview.cpp
@@ -84,7 +84,7 @@ ExampleView::ExampleView(QWidget* parent)
 
     m_stateMachine->start();
 
-    m_defaultScaling = 0.8 * notationConfiguration()->guiScaling() * notationConfiguration()->notationScaling();
+    m_defaultScaling = 0.9 * notationConfiguration()->notationScaling();
 }
 
 ExampleView::~ExampleView()

--- a/src/framework/ui/internal/uiconfiguration.h
+++ b/src/framework/ui/internal/uiconfiguration.h
@@ -82,7 +82,8 @@ public:
     int defaultFontSize() const override;
 
     double guiScaling() const override;
-    double dpi() const override;
+    double physicalDpi() const override;
+    double logicalDpi() const override;
 
     void setPhysicalDotsPerInch(std::optional<double> dpi) override;
 

--- a/src/framework/ui/iuiconfiguration.h
+++ b/src/framework/ui/iuiconfiguration.h
@@ -81,7 +81,8 @@ public:
     virtual int defaultFontSize() const = 0;
 
     virtual double guiScaling() const = 0;
-    virtual double dpi() const = 0;
+    virtual double physicalDpi() const = 0;
+    virtual double logicalDpi() const = 0;
 
     //! NOTE Maybe set from command line
     virtual void setPhysicalDotsPerInch(std::optional<double> dpi) = 0;

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -579,7 +579,7 @@ double NotationConfiguration::guiScaling() const
 
 double NotationConfiguration::notationScaling() const
 {
-    return uiConfiguration()->dpi() / Ms::DPI;
+    return uiConfiguration()->physicalDpi() / Ms::DPI;
 }
 
 std::string NotationConfiguration::notationRevision() const

--- a/src/notation/internal/notationpainting.cpp
+++ b/src/notation/internal/notationpainting.cpp
@@ -279,7 +279,7 @@ void NotationPainting::paintView(Painter* painter, const RectF& frameRect, bool 
     opt.isSetViewport = false;
     opt.isMultiPage = true;
     opt.frameRect = frameRect;
-    opt.deviceDpi = uiConfiguration()->dpi();
+    opt.deviceDpi = uiConfiguration()->logicalDpi();
     opt.isPrinting = isPrinting;
     doPaint(painter, opt);
 }

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -280,7 +280,7 @@ void NotationViewInputController::setZoom(int zoomPercentage, const PointF& pos)
         configuration()->setCurrentZoom(correctedZoom);
     }
 
-    qreal scaling = static_cast<qreal>(correctedZoom) / 100.0 * configuration()->notationScaling();
+    qreal scaling = scalingFromZoomPercentage(correctedZoom);
     m_view->setScaling(scaling, pos);
 }
 

--- a/src/palette/internal/palettecelliconengine.cpp
+++ b/src/palette/internal/palettecelliconengine.cpp
@@ -164,7 +164,7 @@ void PaletteCellIconEngine::paintScoreElement(Painter& painter, EngravingItem* e
 
     painter.save();
 
-    Ms::MScore::pixelRatio = Ms::DPI / uiConfiguration()->dpi();
+    Ms::MScore::pixelRatio = Ms::DPI / uiConfiguration()->logicalDpi();
 
     const qreal sizeRatio = spatium / gpaletteScore->spatium();
     painter.scale(sizeRatio, sizeRatio); // scale coordinates so element is drawn at correct size


### PR DESCRIPTION
(the latter is used in the TimeSigProperties dialog and Staff/Part Properties > Advanced)

Inspired by MuseScore 3.

Tested on multiple resolutions on M1 MacBook Pro built-in display with macOS and Windows via Parallels. 

Resolves: #10686 