### PR TITLE
[MU4] Fix #9753: When replacing a VSTi, current VSTi should be closed

### DIFF
--- a/src/autobot/internal/autobotinteractive.cpp
+++ b/src/autobot/internal/autobotinteractive.cpp
@@ -154,6 +154,11 @@ void AutobotInteractive::close(const Uri& uri)
     m_real->close(uri);
 }
 
+void AutobotInteractive::close(const UriQuery& uri)
+{
+    m_real->close(uri);
+}
+
 ValCh<Uri> AutobotInteractive::currentUri() const
 {
     return m_real->currentUri();

--- a/src/autobot/internal/autobotinteractive.h
+++ b/src/autobot/internal/autobotinteractive.h
@@ -81,6 +81,7 @@ public:
 
     void close(const std::string& uri) override;
     void close(const Uri& uri) override;
+    void close(const UriQuery& uri) override;
 
     ValCh<Uri> currentUri() const override;
     std::vector<Uri> stack() const override;

--- a/src/framework/audio/audiotypes.h
+++ b/src/framework/audio/audiotypes.h
@@ -145,6 +145,11 @@ struct AudioFxParams {
                && configuration == other.configuration;
     }
 
+    bool operator !=(const AudioFxParams& other) const
+    {
+        return !(*this == other);
+    }
+
     bool operator<(const AudioFxParams& other) const
     {
         return resourceMeta < other.resourceMeta

--- a/src/framework/global/iinteractive.h
+++ b/src/framework/global/iinteractive.h
@@ -168,6 +168,7 @@ public:
 
     virtual void close(const std::string& uri) = 0;
     virtual void close(const Uri& uri) = 0;
+    virtual void close(const UriQuery& uri) = 0;
 
     virtual ValCh<Uri> currentUri() const = 0;
     virtual std::vector<Uri> stack() const = 0;

--- a/src/framework/global/internal/interactive.cpp
+++ b/src/framework/global/internal/interactive.cpp
@@ -214,6 +214,11 @@ void Interactive::close(const Uri& uri)
     provider()->close(uri);
 }
 
+void Interactive::close(const UriQuery& uri)
+{
+    provider()->close(uri);
+}
+
 ValCh<Uri> Interactive::currentUri() const
 {
     return provider()->currentUri();

--- a/src/framework/global/internal/interactive.h
+++ b/src/framework/global/internal/interactive.h
@@ -81,6 +81,7 @@ public:
 
     void close(const std::string& uri) override;
     void close(const Uri& uri) override;
+    void close(const UriQuery& uri) override;
 
     ValCh<Uri> currentUri() const override;
     std::vector<Uri> stack() const override;

--- a/src/framework/ui/iinteractiveprovider.h
+++ b/src/framework/ui/iinteractiveprovider.h
@@ -63,6 +63,7 @@ public:
     virtual void raise(const UriQuery& uri) = 0;
 
     virtual void close(const Uri& uri) = 0;
+    virtual void close(const UriQuery& uri) = 0;
 
     virtual ValCh<Uri> currentUri() const = 0;
     virtual std::vector<Uri> stack() const = 0;

--- a/src/framework/ui/view/interactiveprovider.cpp
+++ b/src/framework/ui/view/interactiveprovider.cpp
@@ -213,25 +213,37 @@ void InteractiveProvider::raise(const UriQuery& uri)
 
 void InteractiveProvider::close(const Uri& uri)
 {
-    for (const ObjectInfo& objectInfo : m_stack) {
-        if (objectInfo.uriQuery.uri() != uri) {
-            continue;
+    for (const ObjectInfo& obj : m_stack) {
+        if (obj.uriQuery.uri() == uri) {
+            closeObject(obj);
         }
+    }
+}
 
-        ContainerMeta openMeta = uriRegister()->meta(objectInfo.uriQuery.uri());
-        switch (openMeta.type) {
-        case ContainerType::QWidgetDialog: {
-            if (auto window = dynamic_cast<QWidget*>(objectInfo.window)) {
-                window->close();
-            }
-        } break;
-        case ContainerType::QmlDialog:
-            closeQml(objectInfo.objectId);
-            break;
-        case ContainerType::PrimaryPage:
-        case ContainerType::Undefined:
-            break;
+void InteractiveProvider::close(const UriQuery& uri)
+{
+    for (const ObjectInfo& obj : m_stack) {
+        if (obj.uriQuery == uri) {
+            closeObject(obj);
         }
+    }
+}
+
+void InteractiveProvider::closeObject(const ObjectInfo& obj)
+{
+    ContainerMeta openMeta = uriRegister()->meta(obj.uriQuery.uri());
+    switch (openMeta.type) {
+    case ContainerType::QWidgetDialog: {
+        if (auto window = dynamic_cast<QWidget*>(obj.window)) {
+            window->close();
+        }
+    } break;
+    case ContainerType::QmlDialog:
+        closeQml(obj.objectId);
+        break;
+    case ContainerType::PrimaryPage:
+    case ContainerType::Undefined:
+        break;
     }
 }
 

--- a/src/framework/ui/view/interactiveprovider.h
+++ b/src/framework/ui/view/interactiveprovider.h
@@ -80,6 +80,7 @@ public:
     void raise(const UriQuery& uri) override;
 
     void close(const Uri& uri) override;
+    void close(const UriQuery& uri) override;
 
     ValCh<Uri> currentUri() const override;
     std::vector<Uri> stack() const override;
@@ -130,6 +131,8 @@ private:
                                    const framework::IInteractive::ButtonDatas& buttons,
                                    int defBtn = int(framework::IInteractive::Button::NoButton),
                                    const framework::IInteractive::Options& options = {});
+
+    void closeObject(const ObjectInfo& obj);
 
     void closeQml(const QVariant& objectId);
     void raiseQml(const QVariant& objectId);

--- a/src/framework/vst/internal/fx/vstfxresolver.cpp
+++ b/src/framework/vst/internal/fx/vstfxresolver.cpp
@@ -28,12 +28,6 @@ using namespace mu::vst;
 using namespace mu::audio;
 using namespace mu::audio::fx;
 
-bool filterFxParams(const std::pair<AudioFxChainOrder, AudioFxParams>& f,
-                    const std::pair<AudioFxChainOrder, AudioFxParams>& s)
-{
-    return (f.first == s.first) && !(f.second == s.second);
-}
-
 std::vector<IFxProcessorPtr> VstFxResolver::resolveFxList(const audio::TrackId trackId, const AudioFxChain& fxChain)
 {
     if (fxChain.empty()) {
@@ -128,15 +122,16 @@ void VstFxResolver::updateTrackFxMap(FxMap& fxMap, const audio::TrackId trackId,
     }
 
     audio::AudioFxChain fxToRemove;
-    fxChainToRemove(newFxChain, currentFxChain, fxToRemove);
+    fxChainToRemove(currentFxChain, newFxChain, fxToRemove);
 
     for (const auto& pair : fxToRemove) {
         pluginsRegister()->unregisterFxPlugin(trackId, pair.second.resourceMeta.id, pair.second.chainOrder);
+        currentFxChain.erase(pair.second.chainOrder);
         fxMap.erase(pair.second.chainOrder);
     }
 
     audio::AudioFxChain fxToCreate;
-    fxChainToCreate(newFxChain, currentFxChain, fxToCreate);
+    fxChainToCreate(currentFxChain, newFxChain, fxToCreate);
 
     for (const auto& pair : fxToCreate) {
         if (!pair.second.isValid()) {
@@ -163,6 +158,7 @@ void VstFxResolver::updateMasterFxMap(const AudioFxChain& newFxChain)
 
     for (const auto& pair : fxToRemove) {
         pluginsRegister()->unregisterMasterFxPlugin(pair.second.resourceMeta.id, pair.second.chainOrder);
+        currentFxChain.erase(pair.second.chainOrder);
         m_masterFxMap.erase(pair.second.chainOrder);
     }
 
@@ -170,9 +166,6 @@ void VstFxResolver::updateMasterFxMap(const AudioFxChain& newFxChain)
     fxChainToCreate(newFxChain, currentFxChain, fxToCreate);
 
     for (const auto& pair : fxToCreate) {
-        if (!pair.second.isValid()) {
-            continue;
-        }
         m_masterFxMap.emplace(pair.first, createMasterFx(pair.second));
     }
 }
@@ -181,18 +174,31 @@ void VstFxResolver::fxChainToRemove(const AudioFxChain& currentFxChain,
                                     const AudioFxChain& newFxChain,
                                     AudioFxChain& resultChain)
 {
-    std::set_difference(newFxChain.begin(), newFxChain.end(),
-                        currentFxChain.begin(), currentFxChain.end(),
-                        std::inserter(resultChain, resultChain.begin()),
-                        filterFxParams);
+    for (auto it = currentFxChain.cbegin(); it != currentFxChain.cend(); ++it) {
+        auto newIt = newFxChain.find(it->first);
+
+        if (newIt == newFxChain.cend()) {
+            resultChain.insert({ it->first, it->second });
+            continue;
+        }
+
+        if (it->second != newIt->second) {
+            resultChain.insert({ it->first, it->second });
+        }
+    }
 }
 
 void VstFxResolver::fxChainToCreate(const AudioFxChain& currentFxChain,
                                     const AudioFxChain& newFxChain,
                                     AudioFxChain& resultChain)
 {
-    std::set_difference(currentFxChain.begin(), currentFxChain.end(),
-                        newFxChain.begin(), newFxChain.end(),
-                        std::inserter(resultChain, resultChain.begin()),
-                        filterFxParams);
+    for (auto it = newFxChain.cbegin(); it != newFxChain.cend(); ++it) {
+        if (currentFxChain.find(it->first) != currentFxChain.cend()) {
+            continue;
+        }
+
+        if (it->second.isValid()) {
+            resultChain.insert({ it->first, it->second });
+        }
+    }
 }

--- a/src/framework/vst/internal/synth/vstiresolver.cpp
+++ b/src/framework/vst/internal/synth/vstiresolver.cpp
@@ -40,6 +40,7 @@ ISynthesizerPtr VstiResolver::resolveSynth(const audio::TrackId trackId, const a
         pluginsRegister()->unregisterInstrPlugin(trackId, pair.first);
     }
 
+    pair.first = params.resourceMeta.id;
     pair.second = createSynth(trackId, params);
 
     return pair.second;

--- a/src/framework/vst/internal/vstpluginsregister.cpp
+++ b/src/framework/vst/internal/vstpluginsregister.cpp
@@ -121,7 +121,7 @@ VstPluginPtr VstPluginsRegister::masterFxPlugin(const audio::AudioResourceId& re
 
     auto pluginSearch = m_masterPluginsMap.find({ resourceId, chainOrder });
     if (pluginSearch == m_masterPluginsMap.end()) {
-        LOGE() << "Unable to find master plugin, resourceId: " << resourceId;
+        LOGE() << "Unable to find master plugin, resourceId: " << resourceId << ", chainOrder: " << chainOrder;
 
         return nullptr;
     }

--- a/src/playback/view/internal/abstractaudioresourceitem.cpp
+++ b/src/playback/view/internal/abstractaudioresourceitem.cpp
@@ -62,3 +62,13 @@ bool AbstractAudioResourceItem::hasNativeEditorSupport() const
 {
     return false;
 }
+
+const mu::UriQuery& AbstractAudioResourceItem::editorUri() const
+{
+    return m_editorUri;
+}
+
+void AbstractAudioResourceItem::setEditorUri(const UriQuery& uri)
+{
+    m_editorUri = uri;
+}

--- a/src/playback/view/internal/abstractaudioresourceitem.h
+++ b/src/playback/view/internal/abstractaudioresourceitem.h
@@ -25,6 +25,8 @@
 
 #include <QObject>
 
+#include "uri.h"
+
 namespace mu::playback {
 class AbstractAudioResourceItem : public QObject
 {
@@ -47,6 +49,9 @@ public:
     virtual bool isActive() const;
     virtual bool hasNativeEditorSupport() const;
 
+    const UriQuery& editorUri() const;
+    void setEditorUri(const UriQuery& uri);
+
 signals:
     void titleChanged();
     void isBlankChanged();
@@ -61,6 +66,9 @@ protected:
                               const QVariantList& subItems = QVariantList()) const;
 
     QVariantMap buildSeparator() const;
+
+private:
+    UriQuery m_editorUri;
 };
 }
 

--- a/src/playback/view/internal/mixerchannelitem.cpp
+++ b/src/playback/view/internal/mixerchannelitem.cpp
@@ -34,8 +34,8 @@ static constexpr float BALANCE_SCALING_FACTOR = 100.f;
 
 static constexpr int OUTPUT_RESOURCE_COUNT_LIMIT = 4;
 
-static const std::string VSTFX_EDITOR_URI("musescore://vstfx/editor?sync=false&floating=true&modal=false");
-static const std::string VSTI_EDITOR_URI("musescore://vsti/editor?sync=false&floating=true&modal=false");
+static const std::string VSTFX_EDITOR_URI("musescore://vstfx/editor?sync=false&modal=false");
+static const std::string VSTI_EDITOR_URI("musescore://vsti/editor?sync=false&modal=false");
 
 static const std::string TRACK_ID_KEY("trackId");
 static const std::string RESOURCE_ID_KEY("resourceId");

--- a/src/playback/view/internal/mixerchannelitem.cpp
+++ b/src/playback/view/internal/mixerchannelitem.cpp
@@ -334,7 +334,7 @@ InputResourceItem* MixerChannelItem::buildInputResourceItem()
         uri.addParam(TRACK_ID_KEY, Val(m_id));
         uri.addParam(RESOURCE_ID_KEY, Val(newItem->params().resourceMeta.id));
 
-        openEditor(uri);
+        openEditor(newItem, uri);
     });
 
     return newItem;
@@ -370,18 +370,23 @@ OutputResourceItem* MixerChannelItem::buildOutputResourceItem(const audio::Audio
         uri.addParam(RESOURCE_ID_KEY, Val(newItem->params().resourceMeta.id));
         uri.addParam(CHAIN_ORDER_KEY, Val(newItem->params().chainOrder));
 
-        openEditor(uri);
+        openEditor(newItem, uri);
     });
 
     return newItem;
 }
 
-void MixerChannelItem::openEditor(const UriQuery& uri)
+void MixerChannelItem::openEditor(AbstractAudioResourceItem* item, const UriQuery& editorUri)
 {
-    if (interactive()->isOpened(uri).val) {
-        interactive()->raise(uri);
+    if (item->editorUri() != editorUri) {
+        interactive()->close(item->editorUri());
+        item->setEditorUri(editorUri);
+    }
+
+    if (interactive()->isOpened(editorUri).val) {
+        interactive()->raise(editorUri);
     } else {
-        interactive()->open(uri);
+        interactive()->open(editorUri);
     }
 }
 

--- a/src/playback/view/internal/mixerchannelitem.h
+++ b/src/playback/view/internal/mixerchannelitem.h
@@ -143,7 +143,7 @@ private:
 
     void loadOutputResourceItemList(const audio::AudioFxChain& fxChain);
 
-    void openEditor(const UriQuery& uri);
+    void openEditor(AbstractAudioResourceItem* item, const UriQuery& editorUri);
 
     audio::TrackId m_id = -1;
 

--- a/src/playback/view/internal/mixerchannelitem.h
+++ b/src/playback/view/internal/mixerchannelitem.h
@@ -141,6 +141,8 @@ private:
     QList<OutputResourceItem*> emptySlotsToRemove() const;
     void removeRedundantEmptySlots();
 
+    void loadOutputResourceItemList(const audio::AudioFxChain& fxChain);
+
     void openEditor(const UriQuery& uri);
 
     audio::TrackId m_id = -1;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9753
Resolves: https://github.com/musescore/MuseScore/issues/9755
Resolves: https://github.com/musescore/MuseScore/issues/10450