### PR TITLE
Fix a build issue from slur PR

### DIFF
--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -913,7 +913,7 @@ void Slur::slurPos(SlurPos* sp)
         }
         // don't allow overlap with beam
         qreal yadj;
-        if (ec->beam() && ec->beam()->elements().first() != ec) {
+        if (ec->beam() && ec->beam()->elements().front() != ec) {
             yadj = 0.75;
         } else {
             yadj = -stemSideInset;


### PR DESCRIPTION
Due to an invisible merge issue, PR https://github.com/musescore/MuseScore/pull/10483 broke the build. This PR fixes it.