### PR TITLE
Make async::Promise safer (and slightly simpler)

### DIFF
--- a/src/framework/audio/internal/worker/audiooutputhandler.cpp
+++ b/src/framework/audio/internal/worker/audiooutputhandler.cpp
@@ -45,8 +45,7 @@ AudioOutputHandler::AudioOutputHandler(IGetTrackSequence* getSequence)
 
 Promise<AudioOutputParams> AudioOutputHandler::outputParams(const TrackSequenceId sequenceId, const TrackId trackId) const
 {
-    return Promise<AudioOutputParams>([this, sequenceId, trackId](Promise<AudioOutputParams>::Resolve resolve,
-                                                                  Promise<AudioOutputParams>::Reject reject) {
+    return Promise<AudioOutputParams>([this, sequenceId, trackId](auto resolve, auto reject) {
         ONLY_AUDIO_WORKER_THREAD;
 
         ITrackSequencePtr s = sequence(sequenceId);
@@ -87,8 +86,7 @@ Channel<TrackSequenceId, TrackId, AudioOutputParams> AudioOutputHandler::outputP
 
 Promise<AudioOutputParams> AudioOutputHandler::masterOutputParams() const
 {
-    return Promise<AudioOutputParams>([this](Promise<AudioOutputParams>::Resolve resolve,
-                                             Promise<AudioOutputParams>::Reject reject) {
+    return Promise<AudioOutputParams>([this](auto resolve, auto reject) {
         ONLY_AUDIO_WORKER_THREAD;
 
         IF_ASSERT_FAILED(mixer()) {
@@ -121,8 +119,7 @@ Channel<AudioOutputParams> AudioOutputHandler::masterOutputParamsChanged() const
 
 Promise<AudioResourceMetaList> AudioOutputHandler::availableOutputResources() const
 {
-    return Promise<AudioResourceMetaList>([this](Promise<AudioResourceMetaList>::Resolve resolve,
-                                                 Promise<AudioResourceMetaList>::Reject /*reject*/) {
+    return Promise<AudioResourceMetaList>([this](auto resolve, auto /*reject*/) {
         ONLY_AUDIO_WORKER_THREAD;
 
         return resolve(fxResolver()->resolveAvailableResources());
@@ -131,8 +128,7 @@ Promise<AudioResourceMetaList> AudioOutputHandler::availableOutputResources() co
 
 Promise<AudioSignalChanges> AudioOutputHandler::signalChanges(const TrackSequenceId sequenceId, const TrackId trackId) const
 {
-    return Promise<AudioSignalChanges>([this, sequenceId, trackId](Promise<AudioSignalChanges>::Resolve resolve,
-                                                                   Promise<AudioSignalChanges>::Reject reject) {
+    return Promise<AudioSignalChanges>([this, sequenceId, trackId](auto resolve, auto reject) {
         ONLY_AUDIO_WORKER_THREAD;
 
         ITrackSequencePtr s = sequence(sequenceId);
@@ -151,8 +147,7 @@ Promise<AudioSignalChanges> AudioOutputHandler::signalChanges(const TrackSequenc
 
 Promise<AudioSignalChanges> AudioOutputHandler::masterSignalChanges() const
 {
-    return Promise<AudioSignalChanges>([this](Promise<AudioSignalChanges>::Resolve resolve,
-                                              Promise<AudioSignalChanges>::Reject reject) {
+    return Promise<AudioSignalChanges>([this](auto resolve, auto reject) {
         ONLY_AUDIO_WORKER_THREAD;
 
         IF_ASSERT_FAILED(mixer()) {

--- a/src/framework/audio/internal/worker/audiooutputhandler.cpp
+++ b/src/framework/audio/internal/worker/audiooutputhandler.cpp
@@ -52,16 +52,16 @@ Promise<AudioOutputParams> AudioOutputHandler::outputParams(const TrackSequenceI
         ITrackSequencePtr s = sequence(sequenceId);
 
         if (!s) {
-            reject(static_cast<int>(Err::InvalidSequenceId), "invalid sequence id");
+            return reject(static_cast<int>(Err::InvalidSequenceId), "invalid sequence id");
         }
 
         RetVal<AudioOutputParams> result = s->audioIO()->outputParams(trackId);
 
         if (!result.ret) {
-            reject(result.ret.code(), result.ret.text());
+            return reject(result.ret.code(), result.ret.text());
         }
 
-        resolve(result.val);
+        return resolve(result.val);
     }, AudioThread::ID);
 }
 
@@ -92,10 +92,10 @@ Promise<AudioOutputParams> AudioOutputHandler::masterOutputParams() const
         ONLY_AUDIO_WORKER_THREAD;
 
         IF_ASSERT_FAILED(mixer()) {
-            reject(static_cast<int>(Err::Undefined), "undefined reference to a mixer");
+            return reject(static_cast<int>(Err::Undefined), "undefined reference to a mixer");
         }
 
-        resolve(mixer()->masterOutputParams());
+        return resolve(mixer()->masterOutputParams());
     }, AudioThread::ID);
 }
 
@@ -125,7 +125,7 @@ Promise<AudioResourceMetaList> AudioOutputHandler::availableOutputResources() co
                                                  Promise<AudioResourceMetaList>::Reject /*reject*/) {
         ONLY_AUDIO_WORKER_THREAD;
 
-        resolve(fxResolver()->resolveAvailableResources());
+        return resolve(fxResolver()->resolveAvailableResources());
     }, AudioThread::ID);
 }
 
@@ -138,16 +138,14 @@ Promise<AudioSignalChanges> AudioOutputHandler::signalChanges(const TrackSequenc
         ITrackSequencePtr s = sequence(sequenceId);
 
         if (!s) {
-            reject(static_cast<int>(Err::InvalidSequenceId), "invalid sequence id");
-            return;
+            return reject(static_cast<int>(Err::InvalidSequenceId), "invalid sequence id");
         }
 
         if (!s->audioIO()->isHasTrack(trackId)) {
-            reject(static_cast<int>(Err::InvalidTrackId), "no track");
-            return;
+            return reject(static_cast<int>(Err::InvalidTrackId), "no track");
         }
 
-        resolve(s->audioIO()->audioSignalChanges(trackId));
+        return resolve(s->audioIO()->audioSignalChanges(trackId));
     }, AudioThread::ID);
 }
 
@@ -158,10 +156,10 @@ Promise<AudioSignalChanges> AudioOutputHandler::masterSignalChanges() const
         ONLY_AUDIO_WORKER_THREAD;
 
         IF_ASSERT_FAILED(mixer()) {
-            reject(static_cast<int>(Err::Undefined), "undefined reference to a mixer");
+            return reject(static_cast<int>(Err::Undefined), "undefined reference to a mixer");
         }
 
-        resolve(mixer()->masterAudioSignalChanges());
+        return resolve(mixer()->masterAudioSignalChanges());
     }, AudioThread::ID);
 }
 

--- a/src/framework/audio/internal/worker/playback.cpp
+++ b/src/framework/audio/internal/worker/playback.cpp
@@ -49,7 +49,7 @@ void Playback::init()
 
 Promise<TrackSequenceId> Playback::addSequence()
 {
-    return Promise<TrackSequenceId>([this](Promise<TrackSequenceId>::Resolve resolve, Promise<TrackSequenceId>::Reject /*reject*/) {
+    return Promise<TrackSequenceId>([this](auto resolve, auto /*reject*/) {
         ONLY_AUDIO_WORKER_THREAD;
 
         TrackSequenceId newId = static_cast<TrackSequenceId>(m_sequences.size());
@@ -63,8 +63,7 @@ Promise<TrackSequenceId> Playback::addSequence()
 
 Promise<TrackSequenceIdList> Playback::sequenceIdList() const
 {
-    return Promise<TrackSequenceIdList>([this](Promise<TrackSequenceIdList>::Resolve resolve,
-                                               Promise<TrackSequenceIdList>::Reject /*reject*/) {
+    return Promise<TrackSequenceIdList>([this](auto resolve, auto /*reject*/) {
         ONLY_AUDIO_WORKER_THREAD;
 
         TrackSequenceIdList result(m_sequences.size());

--- a/src/framework/audio/internal/worker/playback.cpp
+++ b/src/framework/audio/internal/worker/playback.cpp
@@ -57,7 +57,7 @@ Promise<TrackSequenceId> Playback::addSequence()
         m_sequences.emplace(newId, std::make_shared<TrackSequence>(newId));
         m_sequenceAdded.send(newId);
 
-        resolve(std::move(newId));
+        return resolve(std::move(newId));
     }, AudioThread::ID);
 }
 
@@ -73,7 +73,7 @@ Promise<TrackSequenceIdList> Playback::sequenceIdList() const
             result.push_back(pair.first);
         }
 
-        resolve(std::move(result));
+        return resolve(std::move(result));
     }, AudioThread::ID);
 }
 

--- a/src/framework/audio/internal/worker/playerhandler.cpp
+++ b/src/framework/audio/internal/worker/playerhandler.cpp
@@ -116,7 +116,7 @@ void PlayerHandler::setDuration(const TrackSequenceId sequenceId, const msecs_t 
 
 Promise<bool> PlayerHandler::setLoop(const TrackSequenceId sequenceId, const msecs_t fromMsec, const msecs_t toMsec)
 {
-    return Promise<bool>([this, sequenceId, fromMsec, toMsec](Promise<bool>::Resolve resolve, Promise<bool>::Reject reject) {
+    return Promise<bool>([this, sequenceId, fromMsec, toMsec](auto resolve, auto reject) {
         ONLY_AUDIO_WORKER_THREAD;
 
         ITrackSequencePtr s = sequence(sequenceId);

--- a/src/framework/audio/internal/worker/playerhandler.cpp
+++ b/src/framework/audio/internal/worker/playerhandler.cpp
@@ -122,16 +122,16 @@ Promise<bool> PlayerHandler::setLoop(const TrackSequenceId sequenceId, const mse
         ITrackSequencePtr s = sequence(sequenceId);
 
         if (!s) {
-            reject(static_cast<int>(Err::InvalidSequenceId), "invalid sequence id");
+            return reject(static_cast<int>(Err::InvalidSequenceId), "invalid sequence id");
         }
 
         Ret result = s->player()->setLoop(fromMsec, toMsec);
 
         if (!result) {
-            reject(result.code(), result.text());
+            return reject(result.code(), result.text());
         }
 
-        resolve(result);
+        return resolve(result);
     }, AudioThread::ID);
 }
 

--- a/src/framework/audio/internal/worker/trackshandler.cpp
+++ b/src/framework/audio/internal/worker/trackshandler.cpp
@@ -45,7 +45,7 @@ TracksHandler::~TracksHandler()
 
 Promise<TrackIdList> TracksHandler::trackIdList(const TrackSequenceId sequenceId) const
 {
-    return Promise<TrackIdList>([this, sequenceId](Promise<TrackIdList>::Resolve resolve, Promise<TrackIdList>::Reject reject) {
+    return Promise<TrackIdList>([this, sequenceId](auto resolve, auto reject) {
         ONLY_AUDIO_WORKER_THREAD;
 
         ITrackSequencePtr s = sequence(sequenceId);
@@ -60,7 +60,7 @@ Promise<TrackIdList> TracksHandler::trackIdList(const TrackSequenceId sequenceId
 
 Promise<TrackName> TracksHandler::trackName(const TrackSequenceId sequenceId, const TrackId trackId) const
 {
-    return Promise<TrackName>([this, sequenceId, trackId](Promise<TrackName>::Resolve resolve, Promise<TrackName>::Reject reject) {
+    return Promise<TrackName>([this, sequenceId, trackId](auto resolve, auto reject) {
         ONLY_AUDIO_WORKER_THREAD;
 
         ITrackSequencePtr s = sequence(sequenceId);
@@ -77,8 +77,7 @@ Promise<TrackId, AudioParams> TracksHandler::addTrack(const TrackSequenceId sequ
                                                       io::Device* playbackData,
                                                       AudioParams&& params)
 {
-    return Promise<TrackId, AudioParams>([this, sequenceId, trackName, playbackData, params](Promise<TrackId, AudioParams>::Resolve resolve,
-                                                                                             Promise<TrackId, AudioParams>::Reject reject) {
+    return Promise<TrackId, AudioParams>([this, sequenceId, trackName, playbackData, params](auto resolve, auto reject) {
         ONLY_AUDIO_WORKER_THREAD;
 
         ITrackSequencePtr s = sequence(sequenceId);
@@ -100,8 +99,7 @@ Promise<TrackId, AudioParams> TracksHandler::addTrack(const TrackSequenceId sequ
 Promise<TrackId, AudioParams> TracksHandler::addTrack(const TrackSequenceId sequenceId, const std::string& trackName,
                                                       const mpe::PlaybackData& playbackData, AudioParams&& params)
 {
-    return Promise<TrackId, AudioParams>([this, sequenceId, trackName, playbackData, params](Promise<TrackId, AudioParams>::Resolve resolve,
-                                                                                             Promise<TrackId, AudioParams>::Reject reject) {
+    return Promise<TrackId, AudioParams>([this, sequenceId, trackName, playbackData, params](auto resolve, auto reject) {
         ONLY_AUDIO_WORKER_THREAD;
 
         ITrackSequencePtr s = sequence(sequenceId);
@@ -168,8 +166,7 @@ Channel<TrackSequenceId, TrackId> TracksHandler::trackRemoved() const
 
 Promise<AudioResourceMetaList> TracksHandler::availableInputResources() const
 {
-    return Promise<AudioResourceMetaList>([this](Promise<AudioResourceMetaList>::Resolve resolve,
-                                                 Promise<AudioResourceMetaList>::Reject /*reject*/) {
+    return Promise<AudioResourceMetaList>([this](auto resolve, auto /*reject*/) {
         ONLY_AUDIO_WORKER_THREAD;
 
         return resolve(resolver()->resolveAvailableResources());
@@ -178,8 +175,7 @@ Promise<AudioResourceMetaList> TracksHandler::availableInputResources() const
 
 Promise<AudioInputParams> TracksHandler::inputParams(const TrackSequenceId sequenceId, const TrackId trackId) const
 {
-    return Promise<AudioInputParams>([this, sequenceId, trackId](Promise<AudioInputParams>::Resolve resolve,
-                                                                 Promise<AudioInputParams>::Reject reject) {
+    return Promise<AudioInputParams>([this, sequenceId, trackId](auto resolve, auto reject) {
         ONLY_AUDIO_WORKER_THREAD;
 
         ITrackSequencePtr s = sequence(sequenceId);

--- a/src/framework/audio/internal/worker/trackshandler.cpp
+++ b/src/framework/audio/internal/worker/trackshandler.cpp
@@ -51,9 +51,9 @@ Promise<TrackIdList> TracksHandler::trackIdList(const TrackSequenceId sequenceId
         ITrackSequencePtr s = sequence(sequenceId);
 
         if (s) {
-            resolve(s->trackIdList());
+            return resolve(s->trackIdList());
         } else {
-            reject(static_cast<int>(Err::InvalidSequenceId), "invalid sequence id");
+            return reject(static_cast<int>(Err::InvalidSequenceId), "invalid sequence id");
         }
     }, AudioThread::ID);
 }
@@ -66,9 +66,9 @@ Promise<TrackName> TracksHandler::trackName(const TrackSequenceId sequenceId, co
         ITrackSequencePtr s = sequence(sequenceId);
 
         if (s) {
-            resolve(s->trackName(trackId));
+            return resolve(s->trackName(trackId));
         } else {
-            reject(static_cast<int>(Err::InvalidSequenceId), "invalid sequence id");
+            return reject(static_cast<int>(Err::InvalidSequenceId), "invalid sequence id");
         }
     }, AudioThread::ID);
 }
@@ -84,18 +84,16 @@ Promise<TrackId, AudioParams> TracksHandler::addTrack(const TrackSequenceId sequ
         ITrackSequencePtr s = sequence(sequenceId);
 
         if (!s) {
-            reject(static_cast<int>(Err::InvalidSequenceId), "invalid sequence id");
-            return;
+            return reject(static_cast<int>(Err::InvalidSequenceId), "invalid sequence id");
         }
 
         RetVal2<TrackId, AudioParams> result = s->addTrack(trackName, playbackData, params);
 
         if (!result.ret) {
-            reject(result.ret.code(), result.ret.text());
-            return;
+            return reject(result.ret.code(), result.ret.text());
         }
 
-        resolve(result.val1, result.val2);
+        return resolve(result.val1, result.val2);
     }, AudioThread::ID);
 }
 
@@ -109,17 +107,16 @@ Promise<TrackId, AudioParams> TracksHandler::addTrack(const TrackSequenceId sequ
         ITrackSequencePtr s = sequence(sequenceId);
 
         if (!s) {
-            reject(static_cast<int>(Err::InvalidSequenceId), "invalid sequence id");
-            return;
+            return reject(static_cast<int>(Err::InvalidSequenceId), "invalid sequence id");
         }
 
         RetVal2<TrackId, AudioParams> result = s->addTrack(trackName, playbackData, params);
 
         if (!result.ret) {
-            reject(result.ret.code(), result.ret.text());
+            return reject(result.ret.code(), result.ret.text());
         }
 
-        resolve(result.val1, result.val2);
+        return resolve(result.val1, result.val2);
     }, AudioThread::ID);
 }
 
@@ -175,7 +172,7 @@ Promise<AudioResourceMetaList> TracksHandler::availableInputResources() const
                                                  Promise<AudioResourceMetaList>::Reject /*reject*/) {
         ONLY_AUDIO_WORKER_THREAD;
 
-        resolve(resolver()->resolveAvailableResources());
+        return resolve(resolver()->resolveAvailableResources());
     }, AudioThread::ID);
 }
 
@@ -188,18 +185,16 @@ Promise<AudioInputParams> TracksHandler::inputParams(const TrackSequenceId seque
         ITrackSequencePtr s = sequence(sequenceId);
 
         if (!s) {
-            reject(static_cast<int>(Err::InvalidSequenceId), "invalid sequence id");
-            return;
+            return reject(static_cast<int>(Err::InvalidSequenceId), "invalid sequence id");
         }
 
         RetVal<AudioInputParams> result = s->audioIO()->inputParams(trackId);
 
         if (!result.ret) {
-            reject(result.ret.code(), result.ret.text());
-            return;
+            return reject(result.ret.code(), result.ret.text());
         }
 
-        resolve(result.val);
+        return resolve(result.val);
     }, AudioThread::ID);
 }
 

--- a/thirdparty/deto_async/async/changednotify.h
+++ b/thirdparty/deto_async/async/changednotify.h
@@ -106,7 +106,7 @@ private:
         Call f;
         ItemChangedCallT(Call _f)
             : f(_f) {}
-        void itemChanged(const NotifyData& item) { std::apply(f, item.arg<Arg>()); }
+        void itemChanged(const NotifyData& item) { f(item.arg<Arg>()); }
     };
 
     struct IItemAdded {
@@ -119,7 +119,7 @@ private:
         Call f;
         ItemAddedCallT(Call _f)
             : f(_f) {}
-        void itemAdded(const NotifyData& item) { std::apply(f, item.arg<Arg>()); }
+        void itemAdded(const NotifyData& item) { f(item.arg<Arg>()); }
     };
 
     struct IItemRemoved {
@@ -132,7 +132,7 @@ private:
         Call f;
         ItemRemovedCallT(Call _f)
             : f(_f) {}
-        void itemRemoved(const NotifyData& item) { std::apply(f, item.arg<Arg>()); }
+        void itemRemoved(const NotifyData& item) { f(item.arg<Arg>()); }
     };
 
     struct IItemReplaced {
@@ -145,7 +145,7 @@ private:
         Call f;
         ItemReplacedCallT(Call _f)
             : f(_f) {}
-        void itemReplaced(const NotifyData& item) { f(std::get<0>(item.arg<Arg>(0)), std::get<0>(item.arg<Arg>(1))); }
+        void itemReplaced(const NotifyData& item) { f(item.arg<Arg>(0), item.arg<Arg>(1)); }
     };
 
     struct ChangedInvoker : public AbstractInvoker
@@ -220,10 +220,10 @@ class ChangedNotifier
 {
 public:
     ChangedNotifier()
-        : m_notify(std::make_shared<ChangedNotify<T>>()) {}
+        : m_notify(std::make_shared<ChangedNotify<T> >()) {}
     ~ChangedNotifier() {}
 
-    std::shared_ptr<ChangedNotify<T>> notify() const
+    std::shared_ptr<ChangedNotify<T> > notify() const
     {
         return m_notify;
     }
@@ -267,7 +267,7 @@ public:
     }
 
 private:
-    std::shared_ptr<ChangedNotify<T>> m_notify;
+    std::shared_ptr<ChangedNotify<T> > m_notify;
 };
 }
 

--- a/thirdparty/deto_async/async/channel.h
+++ b/thirdparty/deto_async/async/channel.h
@@ -77,7 +77,7 @@ private:
         Call f;
         ReceiveCall(Call _f)
             : f(_f) {}
-        void received(const NotifyData& d) { std::apply(f, d.arg<Arg...>()); }
+        void received(const NotifyData& d) { std::apply(f, d.args<Arg...>()); }
     };
 
     struct IClose {

--- a/thirdparty/deto_async/async/internal/abstractinvoker.h
+++ b/thirdparty/deto_async/async/internal/abstractinvoker.h
@@ -26,8 +26,19 @@ public:
         m_args.insert(m_args.begin() + i, std::shared_ptr<IArg>(p));
     }
 
+    template<typename T>
+    T arg(int i = 0) const
+    {
+        IArg* p = m_args.at(i).get();
+        if (!p) {
+            return {};
+        }
+        Arg<T>* d = reinterpret_cast<Arg<T>*>(p);
+        return std::get<0>(d->val);
+    }
+
     template<typename ... T>
-    std::tuple<T...> arg(int i = 0) const
+    std::tuple<T...> args(int i = 0) const
     {
         IArg* p = m_args.at(i).get();
         if (!p) {

--- a/thirdparty/deto_async/async/promise.h
+++ b/thirdparty/deto_async/async/promise.h
@@ -123,7 +123,7 @@ private:
         Call f;
         ResolveCall(Call _f)
             : f(_f) {}
-        void resolved(const NotifyData& e) { std::apply(f, e.arg<Arg...>()); }
+        void resolved(const NotifyData& e) { std::apply(f, e.args<Arg...>()); }
     };
 
     struct IReject {
@@ -136,7 +136,7 @@ private:
         Call f;
         RejectCall(Call _f)
             : f(_f) {}
-        void rejected(const NotifyData& e) { f(std::get<0>(e.arg<int>(0)), std::get<0>(e.arg<std::string>(1))); }
+        void rejected(const NotifyData& e) { f(e.arg<int>(0), e.arg<std::string>(1)); }
     };
 
     struct PromiseInvoker : public AbstractInvoker


### PR DESCRIPTION
With these changes, it is more-or-less enforced _at compile time_ that you resolve _or_ reject exactly once in the body of a Promise. It works like this:

We now enforce that the body of a promise returns a "Result" struct. Such a struct can only be obtained by calling "resolve" or "reject".
Additionally, if you call "resolve" or "reject" without using its result, `Q_REQUIRED_RESULT` will kick in and give you a compiler warning. So you either have to return it (which you should do), or use it in another way, which is impossible to do unconsciously.

The only disadvantage is that you now have to write `return resolve` etc. instead of just `resolve`, but the advantages are bigger.

Now that we're telling the compiler more about the type of the promise body anyway, it becomes more tempting to use `auto` in its parameter list. So, 
```c++
(Promise<AudioOutputParams>::Resolve resolve, Promise<AudioOutputParams>::Reject reject)
```
becomes
```
(auto resolve, auto reject)
```
Less work to type and to read.

This does give you a bigger chance to accidentally swap resolve and reject. However... when testing your code, you'll find out soon enough if you did that. 