### PR TITLE
[MU4] Fix #10802: View>Toolbars: Playback Controls and Status bar items aren't checked when they are present in MU window

### DIFF
--- a/src/appshell/view/dockwindow/dockwindow.cpp
+++ b/src/appshell/view/dockwindow/dockwindow.cpp
@@ -612,12 +612,20 @@ void DockWindow::notifyAboutDocksOpenStatus()
 
     QStringList dockNames;
 
+    for (DockToolBarView* toolBar : page->mainToolBars()) {
+        dockNames << toolBar->objectName();
+    }
+
     for (DockToolBarView* toolBar : page->toolBars()) {
         dockNames << toolBar->objectName();
     }
 
     for (DockPanelView* panel : page->panels()) {
         dockNames << panel->objectName();
+    }
+
+    if (page->statusBar()) {
+        dockNames << page->statusBar()->objectName();
     }
 
     m_docksOpenStatusChanged.send(dockNames);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10802