### PR TITLE
Cross staff beams draft

### DIFF
--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -452,6 +452,9 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
 
     layoutSystemElements(options, ctx, score, system);
     system->layout2(ctx);     // compute staff distances
+    for (MeasureBase* mb : system->measures()) {
+        mb->layoutCrossStaff();
+    }
     // TODO: now that the code at the top of this function does this same backwards search,
     // we might be able to eliminate this block
     // but, lc might be used elsewhere so we need to be careful

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -431,6 +431,7 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
                 firstMeasure = false;
             }
             mb->setPos(pos);
+            mb->setParent(system);
             Measure* m = toMeasure(mb);
             m->layoutMeasureElements();
             m->layoutStaffLines();

--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -907,6 +907,10 @@ void Beam::offsetBeamToRemoveCollisions(std::vector<ChordRest*> chordRests, int&
     if (_cross) {
         return;
     }
+    if (endX == startX) {
+        // zero-length beams?
+        return;
+    }
     // tolerance eliminates all possibilities of floating point rounding errors
     qreal tolerance = score()->styleMM(Sid::beamWidth).val() * mag() * 0.25 * (_up ? -1 : 1);
     qreal startY = (isStartDictator ? dictator : pointer) * spatium() / 4 + tolerance;
@@ -917,8 +921,9 @@ void Beam::offsetBeamToRemoveCollisions(std::vector<ChordRest*> chordRests, int&
         }
         Chord* chord = toChord(chordRest);
         PointF anchor = chordBeamAnchor(chord);
+
         qreal proportionAlongX = (anchor.x() - startX) / (endX - startX);
-        while (true) {
+        while (true && proportionAlongX) {
             qreal desiredY = proportionAlongX * (endY - startY) + startY;
             bool beamClearsAnchor = (_up && desiredY <= anchor.y()) || (!_up && desiredY >= anchor.y());
             if (beamClearsAnchor) {

--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -64,6 +64,8 @@ class Beam final : public EngravingItem
     qreal _grow2            { 1.0f };
     qreal _beamDist         { 0.0f };
     int _beamSpacing        { 3 }; // how far apart beams are spaced in quarter spaces
+    mu::PointF _startAnchor;
+    mu::PointF _endAnchor;
 
     // for tabs
     bool _isBesideTabStaff  { false };
@@ -97,7 +99,7 @@ class Beam final : public EngravingItem
                                bool isAscending);
     void addMiddleLineSlant(int& dictator, int& pointer, int beamCount, int middleLine, int interval);
     void add8thSpaceSlant(mu::PointF& dictatorAnchor, int dictator, int pointer, int beamCount, int interval, int middleLine, bool Flat);
-    void extendStems(std::vector<ChordRest*> chordRests, mu::PointF start, mu::PointF end);
+    void extendStems(std::vector<ChordRest*> chordRests);
     mu::PointF chordBeamAnchor(Chord* chord) const;
     bool calcIsBeamletBefore(Chord* chord, int i, int level, bool isAfter32Break, bool isAfter64Break) const;
     void createBeamSegment(Chord* startChord, Chord* endChord, int level);
@@ -186,6 +188,9 @@ public:
     void setBeamPos(const mu::engraving::PairF& bp);
 
     qreal beamDist() const { return _beamDist; }
+
+    inline const mu::PointF startAnchor() const { return _startAnchor; }
+    inline const mu::PointF endAnchor() const { return _endAnchor; }
 
     mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;

--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -100,7 +100,6 @@ class Beam final : public EngravingItem
     void addMiddleLineSlant(int& dictator, int& pointer, int beamCount, int middleLine, int interval);
     void add8thSpaceSlant(mu::PointF& dictatorAnchor, int dictator, int pointer, int beamCount, int interval, int middleLine, bool Flat);
     void extendStems(std::vector<ChordRest*> chordRests);
-    mu::PointF chordBeamAnchor(Chord* chord) const;
     bool calcIsBeamletBefore(Chord* chord, int i, int level, bool isAfter32Break, bool isAfter64Break) const;
     void createBeamSegment(Chord* startChord, Chord* endChord, int level);
     void createBeamletSegment(Chord* chord, bool isBefore, int level);
@@ -143,6 +142,7 @@ public:
     void layout1();
     void layoutGraceNotes();
     void layout() override;
+    mu::PointF chordBeamAnchor(Chord* chord) const;
 
     const std::vector<ChordRest*>& elements() const { return _elements; }
     void clear() { _elements.clear(); }

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -983,13 +983,30 @@ void Chord::computeUp()
         return;
     }
 
-    if (_beam) {
-        _up = _beam->up();
+    if (_isUiItem) {
+        _up = true;
         return;
     }
 
-    if (_isUiItem) {
-        _up = true;
+    if (_beam) {
+        if (_beam->userModified() || _beam->cross()) {
+            double noteY = upNote()->pagePos().y();
+            PointF startAnchor = _beam->startAnchor();
+            PointF endAnchor = _beam->endAnchor();
+            if (this == _beam->elements().first()) {
+                _up = noteY > startAnchor.y();
+                // std::cout << "noteY: " << noteY << " startAnchor: " << startAnchor.y() << " up: " << _up << std::endl;
+            } else if (this == _beam->elements().last()) {
+                _up = noteY > endAnchor.y();
+            } else {
+                double noteX = stemPosX() + pagePos().x() + _beam->pagePos().x() + measure()->pos().x();
+                qreal proportionAlongX = (noteX - startAnchor.x()) / (endAnchor.x() - startAnchor.x());
+                qreal desiredY = proportionAlongX * (endAnchor.y() - startAnchor.y()) + startAnchor.y();
+                _up = noteY > desiredY;
+            }
+        } else {
+            _up = _beam->up();
+        }
         return;
     }
 

--- a/src/engraving/libmscore/chordrest.h
+++ b/src/engraving/libmscore/chordrest.h
@@ -78,8 +78,6 @@ protected:
     CrossMeasure _crossMeasure;           ///< 0: no cross-measure modification; 1: 1st note of a mod.; -1: 2nd note
     TDuration _crossMeasureTDur;          ///< the total Duration type of the combined notes
 
-    void setUp(bool val) { _up = val; }
-
 public:
     ChordRest(const ElementType& type, Segment* parent);
     ChordRest(const ChordRest&, bool link = false);
@@ -120,6 +118,7 @@ public:
     virtual mu::PointF stemPosBeam() const = 0;
     virtual qreal rightEdge() const = 0;
 
+    void setUp(bool val) { _up = val; }
     bool up() const { return _up; }
     bool usesAutoUp() const { return _usesAutoUp; }
 

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -3253,6 +3253,32 @@ void Measure::layoutMeasureElements()
 }
 
 //---------------------------------------------------
+//    layoutCrossStaff()
+//    layout all elements that require knowledge of staff
+//    distances (determined in System::layout2), such as cross-staff beams
+//---------------------------------------------------
+
+void Measure::layoutCrossStaff()
+{
+    for (Segment& s : m_segments) {
+        if (!s.enabled()) {
+            continue;
+        }
+        for (EngravingItem* e : s.elist()) {
+            if (!e) {
+                continue;
+            }
+            if (e->isChord()) {
+                Chord* c = toChord(e);
+                if (c->beam() && (c->beam()->cross() || c->beam()->userModified())) {
+                    c->computeUp(); // for cross-staff beams
+                }
+            }
+        }
+    }
+}
+
+//---------------------------------------------------
 //    computeTicks
 //    set ticks for all segments
 //       return minTick

--- a/src/engraving/libmscore/measure.h
+++ b/src/engraving/libmscore/measure.h
@@ -218,6 +218,7 @@ public:
     Fraction shortestChordRest() const;
     Fraction maxTicks() const;
     void layout2();
+    void layoutCrossStaff() override;
 
     bool showsMeasureNumber();
     bool showsMeasureNumberInAutoMode();

--- a/src/engraving/libmscore/measurebase.h
+++ b/src/engraving/libmscore/measurebase.h
@@ -122,6 +122,7 @@ public:
     virtual void write(XmlWriter&, int, bool, bool) const = 0;
 
     virtual void layout() override;
+    virtual void layoutCrossStaff() {}
 
     ElementList& el() { return _el; }
     const ElementList& el() const { return _el; }

--- a/src/engraving/libmscore/stem.cpp
+++ b/src/engraving/libmscore/stem.cpp
@@ -111,6 +111,10 @@ void Stem::layout()
         if (chord()->hook() && !chord()->beam()) {
             y2 += chord()->hook()->smuflAnchor().y();
         }
+
+        if (chord()->beam()) {
+            y2 -= _up * point(score()->styleS(Sid::beamWidth)) * .5 * chord()->beam()->mag();
+        }
     }
 
     double lineWidthCorrection = lineWidthMag() * 0.5;

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -215,6 +215,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::useWideBeams,            "useWideBeams",            false },
     { Sid::beamMinLen,              "beamMinLen",              Spatium(1.2) },
     { Sid::beamNoSlope,             "beamNoSlope",             false },
+    { Sid::snapCustomBeamsToGrid,   "snapCustomBeamsToGrid",   true },
 
     { Sid::dotMag,                  "dotMag",                  PropertyValue(1.0) },
     { Sid::dotNoteDistance,         "dotNoteDistance",         Spatium(0.5) },

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -226,6 +226,7 @@ enum class Sid {
     useWideBeams,
     beamMinLen,
     beamNoSlope,
+    snapCustomBeamsToGrid,
 
     dotMag,
     dotNoteDistance,


### PR DESCRIPTION
This is a draft PR for the purpose of code review.

In this branch, there is an issue in the block of code in `Chord::computeUp()` starting on line 973, where there seems to be a strange discrepancy in determining the up flag for cross-staff chords. The y-position of the note in question, whether determined through `canvasPos` or `pagePos`, don't seem to be taking the system spacing into account. This can be tested by:

1. Create a set of beamed notes
2. Send one of the notes cross-staff
3. Manually adjust the beam
4. Note how adjustments to other notes in the system seem to be pushing the computed y-value around:
![image](https://user-images.githubusercontent.com/89263931/160510020-4e5f8487-b623-475c-ad8e-09b49bd43686.png)
![image](https://user-images.githubusercontent.com/89263931/160510083-e9431f19-af88-4b16-9b94-f04c7cf802c8.png)

I've been trying to figure out what it is that I'm doing wrong here, and I've made some significant changes to the ordering of everything so that measures have assigned systems by the time cross-staff beams are dealt with, but at this point I've hit a brick wall. If anyone has any suggestions as to what to look at or wants to play around with this branch please let me know!