### PR TITLE
[MU4] Fix user dir default to "MuseScore4" or "MuseScore4Development"

### DIFF
--- a/src/framework/global/internal/globalconfiguration.cpp
+++ b/src/framework/global/internal/globalconfiguration.cpp
@@ -102,7 +102,7 @@ io::path GlobalConfiguration::userBackupPath() const
 
 io::path GlobalConfiguration::userDataPath() const
 {
-    static io::path p = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/MuseScore";
+    static io::path p = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/" + QCoreApplication::applicationName();
     return p;
 }
 


### PR DESCRIPTION
or whatever the `applicationName()` is going to be, for it to not collide with the default user dir of MuseScore 1.x