### PR TITLE
Fixes for "Follow system theme" checkboxes - again

### DIFF
--- a/src/appshell/qml/FirstLaunchSetup/ThemesPage.qml
+++ b/src/appshell/qml/FirstLaunchSetup/ThemesPage.qml
@@ -32,7 +32,7 @@ Page {
     title: qsTrc("appshell", "Welcome to MuseScore 4")
     explanation: qsTrc("appshell", "Let's get started by choosing a theme.")
 
-    titleContentSpacing: 28
+    titleContentSpacing: model.isFollowSystemThemeAvailable ? 24 : 28
 
     ThemesPageModel {
         id: model
@@ -45,7 +45,30 @@ Page {
     ColumnLayout {
         anchors.top: parent.top
         anchors.horizontalCenter: parent.horizontalCenter
-        spacing: 28
+        spacing: model.isFollowSystemThemeAvailable ? 20 : 28
+
+        CheckBox {
+            visible: model.isFollowSystemThemeAvailable
+            Layout.alignment: Qt.AlignCenter
+
+            text: qsTrc("appshell", "Follow system theme")
+
+            checked: model.isFollowSystemTheme
+
+            navigation.name: "FollowSystemThemeBox"
+            navigation.order: 1
+            navigation.panel: NavigationPanel {
+                name: "FollowSystemThemeBox"
+                enabled: parent.enabled && parent.visible
+                section: root.navigationSection
+                order: 1
+                direction: NavigationPanel.Horizontal
+            }
+
+            onClicked: {
+                model.isFollowSystemTheme = !checked
+            }
+        }
 
         ThemeSamplesList {
             id: themeSamplesList
@@ -54,10 +77,10 @@ Page {
             themes: model.highContrastEnabled ? model.highContrastThemes : model.generalThemes
             currentThemeCode: model.currentThemeCode
 
-            spacing: 64
+            spacing: 48
 
             navigationPanel.section: root.navigationSection
-            navigationPanel.order: 1
+            navigationPanel.order: 2
 
             onThemeChangeRequested: function(newThemeCode) {
                 model.currentThemeCode = newThemeCode
@@ -77,7 +100,7 @@ Page {
             spacing: 4
 
             navigationPanel.section: root.navigationSection
-            navigationPanel.order: 2
+            navigationPanel.order: 3
 
             onAccentColorChangeRequested: function(newColorIndex) {
                 model.currentAccentColorIndex = newColorIndex
@@ -104,7 +127,7 @@ Page {
                 name: "EnableHighContrast"
                 enabled: parent.enabled && parent.visible
                 section: root.navigationSection
-                order: 3
+                order: 4
                 direction: NavigationPanel.Horizontal
             }
             navigation.accessible.description: highContrastPreferencesHintLabel.text

--- a/src/appshell/qml/Preferences/internal/ThemesSection.qml
+++ b/src/appshell/qml/Preferences/internal/ThemesSection.qml
@@ -50,49 +50,59 @@ BaseSection {
 
     signal ensureContentVisibleRequested(var contentRect)
 
-    ThemeSamplesList {
-        id: themeSamplesList
+    Column {
         width: parent.width
-        spacing: root.columnWidth + root.columnSpacing - sampleWidth
+        spacing: 24
 
-        navigationPanel: root.navigation
-        navigationRow: 0
+        ThemeSamplesList {
+            id: themeSamplesList
+            width: parent.width
+            spacing: root.columnWidth + root.columnSpacing - sampleWidth
 
-        onThemeChangeRequested: function(newThemeCode) {
-            root.themeChangeRequested(newThemeCode)
+            navigationPanel: root.navigation
+            navigationRow: 0
+
+            onThemeChangeRequested: function(newThemeCode) {
+                root.themeChangeRequested(newThemeCode)
+            }
         }
-    }
 
-    CheckBox {
-        id: followSystemThemeCheckBox
-        width: parent.width
+        Column {
+            width: parent.width
+            spacing: 12
 
-        text: qsTrc("appshell", "Follow system theme")
+            CheckBox {
+                id: followSystemThemeCheckBox
+                width: parent.width
 
-        navigation.name: "FollowSystemThemeBox"
-        navigation.panel: root.navigation
-        navigation.row: 1
-        navigation.column: 0
+                text: qsTrc("appshell", "Follow system theme")
 
-        onClicked: {
-            root.setFollowSystemThemeRequested(!checked)
-        }
-    }
+                navigation.name: "FollowSystemThemeBox"
+                navigation.panel: root.navigation
+                navigation.row: 1
+                navigation.column: 0
 
-    CheckBox {
-        width: parent.height
+                onClicked: {
+                    root.setFollowSystemThemeRequested(!checked)
+                }
+            }
 
-        text: qsTrc("appshell", "Enable high-contrast")
+            CheckBox {
+                width: parent.width
 
-        checked: root.highContrastEnabled
+                text: qsTrc("appshell", "Enable high-contrast")
 
-        navigation.name: "EnableHighContrastBox"
-        navigation.panel: root.navigation
-        navigation.row: 2
-        navigation.column: 0
+                checked: root.highContrastEnabled
 
-        onClicked: {
-            root.highContrastChangeRequested(!checked)
+                navigation.name: "EnableHighContrastBox"
+                navigation.panel: root.navigation
+                navigation.row: 2
+                navigation.column: 0
+
+                onClicked: {
+                    root.highContrastChangeRequested(!checked)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fix spacing in Preferences dialog and bring back the one in the Getting Started dialog, also with slightly improved spacing

Resolves: #10941
<img width="728" alt="Schermafbeelding 2022-03-29 om 19 43 16" src="https://user-images.githubusercontent.com/48658420/160672896-d5b947a9-b5b8-4a6b-b944-4b4cf7d72953.png">