### PR TITLE
fix #10674 - ensure "select similar in range" and "select dialog" menu options work as expected

### DIFF
--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -3359,7 +3359,7 @@ void Score::selectAdd(EngravingItem* e)
     SelState selState = _selection.state();
 
     if (_selection.isRange()) {
-        select(0, SelectType::SINGLE, 0);
+        select(e, SelectType::SINGLE, 0);
         return;
     }
 

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -269,6 +269,8 @@ public:
 };
 
 using INotationInteractionPtr = std::shared_ptr<INotationInteraction>;
+
+EngravingItem* contextItem(INotationInteractionPtr);
 }
 
 #endif // MU_NOTATION_INOTATIONINTERACTION_H

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -216,12 +216,10 @@ void NotationActionController::init()
                    &Controller::isNotNoteInputMode);
     registerAction("select-prev-chord", &Interaction::addToSelection, MoveDirection::Left, MoveSelectionType::Chord, PlayMode::NoPlay,
                    &Controller::isNotNoteInputMode);
-
     registerAction("select-similar", &Controller::selectAllSimilarElements, &Controller::hasSelection);
     registerAction("select-similar-staff", &Controller::selectAllSimilarElementsInStaff, &Controller::hasSelection);
     registerAction("select-similar-range", &Controller::selectAllSimilarElementsInRange, &Controller::hasSelection);
     registerAction("select-dialog", &Controller::openSelectionMoreOptions, &Controller::hasSelection);
-
     registerAction("notation-select-all", &Interaction::selectAll);
     registerAction("notation-select-section", &Interaction::selectSection);
     registerAction("first-element", &Interaction::selectFirstElement, false, PlayMode::PlayChord);
@@ -1169,12 +1167,12 @@ void NotationActionController::openSelectionMoreOptions()
         return;
     }
 
-    auto selection = interaction->selection();
-    if (!selection) {
+    auto item = contextItem(interaction);
+    if (!item) {
         return;
     }
 
-    bool noteSelected = selection->element() && selection->element()->isNote();
+    bool noteSelected = item->isNote();
 
     if (noteSelected) {
         interactive()->open("musescore://notation/selectnote");

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5152,3 +5152,14 @@ mu::async::Channel<NotationInteraction::ShowItemRequest> NotationInteraction::sh
 {
     return m_showItemRequested;
 }
+
+namespace mu::notation {
+EngravingItem* contextItem(INotationInteractionPtr interaction)
+{
+    EngravingItem* item = interaction->selection()->element();
+    if (item == nullptr) {
+        return interaction->hitElementContext().element;
+    }
+    return item;
+}
+}

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -256,22 +256,22 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("select-similar",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Select: similar"),
+             QT_TRANSLATE_NOOP("action", "Similar"),
              QT_TRANSLATE_NOOP("action", "Select all similar elements")
              ),
     UiAction("select-similar-staff",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Select: similar in same staff"),
-             QT_TRANSLATE_NOOP("action", "Select all similar elements in same staff")
+             QT_TRANSLATE_NOOP("action", "Similar on this staff"),
+             QT_TRANSLATE_NOOP("action", "Select all similar elements on the same staff")
              ),
     UiAction("select-similar-range",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Select: similar in the range"),
+             QT_TRANSLATE_NOOP("action", "Similar in this range"),
              QT_TRANSLATE_NOOP("action", "Select all similar elements in the range selection")
              ),
     UiAction("select-dialog",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Select dialog"),
+             QT_TRANSLATE_NOOP("action", "More..."),
              QT_TRANSLATE_NOOP("action", "Select all similar elements with more options")
              ),
     UiAction("notation-delete",

--- a/src/notation/view/notationcontextmenumodel.h
+++ b/src/notation/view/notationcontextmenumodel.h
@@ -54,6 +54,8 @@ private:
     uicomponents::MenuItemList makeInsertMeasuresItems();
 
     bool isSingleSelection() const;
+    bool canSelectSimilarInRange() const;
+    bool canSelectSimilar() const;
     bool isDrumsetStaff() const;
 };
 }

--- a/src/notation/view/widgets/selectdialog.ui
+++ b/src/notation/view/widgets/selectdialog.ui
@@ -128,7 +128,7 @@
         </item>
         <item row="1" column="0">
          <widget class="QRadioButton" name="fromSelection">
-          <property name="enabled">
+          <property name="visible">
            <bool>false</bool>
           </property>
           <property name="text">

--- a/src/notation/view/widgets/selectnotedialog.ui
+++ b/src/notation/view/widgets/selectnotedialog.ui
@@ -188,7 +188,7 @@
         </item>
         <item row="1" column="0">
          <widget class="QRadioButton" name="fromSelection">
-          <property name="enabled">
+          <property name="visible">
            <bool>false</bool>
           </property>
           <property name="text">


### PR DESCRIPTION

Resolves: [*(direct link to the issue)*](https://github.com/musescore/MuseScore/issues/10674)

A number of behaviours around "select similar in range" and the "select dialog" weren't correct.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
