### PR TITLE
Nothing should be selected on the score when a new score is created, or an existing score opened

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatRadioButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatRadioButton.qml
@@ -44,6 +44,7 @@ RadioDelegate {
     property color checkedColor: ui.theme.accentColor
 
     property alias navigation: navCtrl
+    property alias navigationFocusBorder: navigationFocusBorder
 
     ButtonGroup.group: ListView.view && ListView.view instanceof RadioButtonGroup ? ListView.view.radioButtonGroup : null
 
@@ -76,7 +77,10 @@ RadioDelegate {
         id: backgroundRect
         anchors.fill: parent
 
-        NavigationFocusBorder { navigationCtrl: navCtrl }
+        NavigationFocusBorder {
+            id: navigationFocusBorder
+            navigationCtrl: navCtrl
+        }
 
         color: root.checked ? root.checkedColor : root.normalColor
         opacity: ui.theme.buttonOpacityNormal

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -283,19 +283,6 @@ void MasterNotation::applyOptions(Ms::MasterScore* score, const ScoreCreateOptio
 
     createMeasures(score, scoreOptions);
 
-    //
-    // select first rest
-    //
-    Measure* m = score->firstMeasure();
-    for (Ms::Segment* s = m->first(); s; s = s->next()) {
-        if (s->segmentType() == Ms::SegmentType::ChordRest) {
-            if (s->element(0)) {
-                score->select(s->element(0), SelectType::SINGLE, 0);
-                break;
-            }
-        }
-    }
-
     {
         QString title = score->metaTag("workTitle");
         QString subtitle = score->metaTag("subtitle");

--- a/src/notation/qml/MuseScore/NotationScene/NotationView.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NotationView.qml
@@ -116,6 +116,11 @@ FocusScope {
                         }
                     }
 
+                    NavigationFocusBorder {
+                        navigationCtrl: fakeNavCtrl
+                        drawOutsideParent: false
+                    }
+
                     onActiveFocusRequested: {
                         fakeNavCtrl.requestActive()
                     }

--- a/src/notation/qml/MuseScore/NotationScene/NotationView.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NotationView.qml
@@ -110,7 +110,6 @@ FocusScope {
                         onActiveChanged: {
                             if (fakeNavCtrl.active) {
                                 notationView.forceFocusIn()
-                                notationView.selectOnNavigationActive()
                             } else {
                                 notationView.focus = false
                             }

--- a/src/notation/qml/MuseScore/NotationScene/internal/NotationSwitchButton.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/NotationSwitchButton.qml
@@ -37,6 +37,9 @@ FlatRadioButton {
 
     checkedColor: ui.theme.backgroundPrimaryColor
 
+    navigationFocusBorder.drawOutsideParent: false
+    navigationFocusBorder.anchors.rightMargin: 1 // for separator
+
     RowLayout {
         id: contentRow
         anchors.fill: parent

--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -158,21 +158,6 @@ void NotationPaintView::zoomOut()
     m_inputController->zoomOut();
 }
 
-void NotationPaintView::selectOnNavigationActive()
-{
-    TRACEFUNC;
-    if (!notation()) {
-        return;
-    }
-
-    auto interaction = notation()->interaction();
-    if (!interaction->selection()->isNone()) {
-        return;
-    }
-
-    interaction->selectFirstElement(false);
-}
-
 bool NotationPaintView::canReceiveAction(const actions::ActionCode& actionCode) const
 {
     if (actionCode == "diagnostic-notationview-redraw") {

--- a/src/notation/view/notationpaintview.h
+++ b/src/notation/view/notationpaintview.h
@@ -82,8 +82,6 @@ public:
     Q_INVOKABLE void zoomIn();
     Q_INVOKABLE void zoomOut();
 
-    Q_INVOKABLE void selectOnNavigationActive();
-
     Q_INVOKABLE void forceFocusIn();
 
     qreal width() const override;


### PR DESCRIPTION
Resolves: #10428

Also:
- adds navigation focus border to the Notation view when it is focused (otherwise, there would not be any visual indication)
- fixes the navigation focus border in the notation parts tab bar (they should be drawn _inside_ the tabs, otherwise it looks bad)