### PR TITLE
Fixes for Edit Style dialog

### DIFF
--- a/src/notation/view/widgets/editstyle.h
+++ b/src/notation/view/widgets/editstyle.h
@@ -102,9 +102,6 @@ private:
     void setStyleQVariantValue(StyleId id, const QVariant& value);
     void setStyleValue(StyleId id, const PropertyValue& value);
 
-    int numberOfPage;
-    int pageListMap[50];
-
 private slots:
     void selectChordDescriptionFile();
     void setChordStyle(bool);
@@ -131,12 +128,6 @@ private slots:
     void editUserStyleName();
     void endEditUserStyleName();
     void resetUserStyleName();
-    void pageListRowChanged(int);
-    void pageListResetOrder();
-    void pageListMoved(QModelIndex, int, int, QModelIndex, int);
-    void stringToArray(std::string, int*);
-    std::string arrayToString(int*);
-    std::string ConsecutiveStr(int);
 
 private:
     QString m_currentPageCode;

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -32,15 +32,6 @@
         <height>0</height>
        </size>
       </property>
-      <property name="dragEnabled">
-       <bool>true</bool>
-      </property>
-      <property name="dragDropMode">
-       <enum>QAbstractItemView::DragDrop</enum>
-      </property>
-      <property name="defaultDropAction">
-       <enum>Qt::MoveAction</enum>
-      </property>
       <property name="alternatingRowColors">
        <bool>true</bool>
       </property>


### PR DESCRIPTION
Resolves: #10755 
Resolves: #10992 

Someone once made a feature in the EditStyle dialog that you can put the pages in a custom order. Motivation was that the list is quite long and you might want to put the mostly used pages at the top. 
However, this feature was not implemented reliably, causing issue #10992. I also wonder if it wouldn't be just confusing for many users. 