### PR TITLE
Fix keyboard shortcut for full screen

### DIFF
--- a/src/framework/shortcuts/data/shortcuts-Mac.xml
+++ b/src/framework/shortcuts/data/shortcuts-Mac.xml
@@ -886,8 +886,8 @@
     </SC>
   <SC>
     <key>fullscreen</key>
-    <seq>F11</seq>
     <seq>Meta+Ctrl+F</seq>
+    <seq>F11</seq>
     </SC>
   <SC>
     <key>toggle-piano</key>

--- a/src/framework/shortcuts/data/shortcuts.xml
+++ b/src/framework/shortcuts/data/shortcuts.xml
@@ -883,7 +883,6 @@
   <SC>
     <key>fullscreen</key>
     <seq>F11</seq>
-    <seq>Meta+Ctrl+F</seq>
     </SC>
   <SC>
     <key>toggle-piano</key>

--- a/src/framework/shortcuts/data/shortcuts_AZERTY.xml
+++ b/src/framework/shortcuts/data/shortcuts_AZERTY.xml
@@ -909,7 +909,6 @@
   <SC>
     <key>fullscreen</key>
     <seq>F11</seq>
-    <seq>Meta+Ctrl+F</seq>
     </SC>
   <SC>
     <key>toggle-piano</key>


### PR DESCRIPTION
- Remove "Meta+Ctrl+F" for non-macOS platforms, where it is not common*
- Make it the primary shortcut on macOS, where it is standard

\* At least, on Windows, it is not common. It would be great if Linux users could comment about popular "full screen" keyboard shortcuts. 