### PR TITLE
Fix mouse selection issues

### DIFF
--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -3345,7 +3345,7 @@ void Score::selectAdd(EngravingItem* e)
     SelState selState = _selection.state();
 
     if (_selection.isRange()) {
-        select(0, SelectType::SINGLE, 0);
+        select(e, SelectType::SINGLE, 0);
         return;
     }
 

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -268,6 +268,8 @@ public:
 };
 
 using INotationInteractionPtr = std::shared_ptr<INotationInteraction>;
+
+EngravingItem* contextItem(INotationInteractionPtr);
 }
 
 #endif // MU_NOTATION_INOTATIONINTERACTION_H

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -1150,12 +1150,12 @@ void NotationActionController::openSelectionMoreOptions()
         return;
     }
 
-    auto selection = interaction->selection();
-    if (!selection) {
+    auto item = contextItem(interaction);
+    if (!item) {
         return;
     }
 
-    bool noteSelected = selection->element() && selection->element()->isNote();
+    bool noteSelected = item->isNote();
 
     if (noteSelected) {
         interactive()->open("musescore://notation/selectnote");

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5066,3 +5066,14 @@ mu::async::Channel<NotationInteraction::ShowItemRequest> NotationInteraction::sh
 {
     return m_showItemRequested;
 }
+
+namespace mu::notation {
+EngravingItem* contextItem(INotationInteractionPtr interaction)
+{
+    EngravingItem* item = interaction->selection()->element();
+    if (item == nullptr) {
+        return interaction->hitElementContext().element;
+    }
+    return item;
+}
+}

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -256,22 +256,22 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("select-similar",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Select: similar"),
+             QT_TRANSLATE_NOOP("action", "Similar"),
              QT_TRANSLATE_NOOP("action", "Select all similar elements")
              ),
     UiAction("select-similar-staff",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Select: similar in same staff"),
+             QT_TRANSLATE_NOOP("action", "Similar in same staff"),
              QT_TRANSLATE_NOOP("action", "Select all similar elements in same staff")
              ),
     UiAction("select-similar-range",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Select: similar in the range"),
+             QT_TRANSLATE_NOOP("action", "Similar in the range"),
              QT_TRANSLATE_NOOP("action", "Select all similar elements in the range selection")
              ),
     UiAction("select-dialog",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Select dialog"),
+             QT_TRANSLATE_NOOP("action", "More..."),
              QT_TRANSLATE_NOOP("action", "Select all similar elements with more options")
              ),
     UiAction("notation-delete",

--- a/src/notation/view/notationcontextmenumodel.cpp
+++ b/src/notation/view/notationcontextmenumodel.cpp
@@ -150,24 +150,25 @@ MenuItemList NotationContextMenuModel::makeHarmonyItems()
 
 MenuItemList NotationContextMenuModel::makeSelectItems()
 {
-    MenuItemList items {
-        makeMenuItem("select-similar"),
-        makeMenuItem("select-similar-staff"),
-        makeMenuItem("select-similar-range"),
-        makeMenuItem("select-dialog"),
-    };
-
-    return items;
+    if (isSingleSelection()) {
+        return MenuItemList { makeMenuItem("select-similar"), makeMenuItem("select-similar-staff"), makeMenuItem("select-dialog") };
+    }
+    else if (canSelectSimilarInRange()) {
+        return MenuItemList { makeMenuItem("select-similar-range"), makeMenuItem("select-dialog") };
+    }
+    else if (canSelectSimilar()) {
+        return MenuItemList{ makeMenuItem("select-dialog") };
+    }
+    return MenuItemList();
 }
 
 MenuItemList NotationContextMenuModel::makeElementItems()
 {
     MenuItemList items = makeDefaultCopyPasteItems();
-
-    if (isSingleSelection()) {
-        items << makeMenu(qtrc("notation", "Select"), makeSelectItems());
+    MenuItemList selectItems = makeSelectItems();
+    if (!selectItems.isEmpty()) {
+        items << makeMenu(qtrc("notation", "Select"), selectItems);
     }
-
     return items;
 }
 
@@ -198,6 +199,27 @@ bool NotationContextMenuModel::isSingleSelection() const
 
     auto selection = interaction->selection();
     return selection ? selection->element() != nullptr : false;
+}
+
+bool NotationContextMenuModel::canSelectSimilar() const
+{
+    auto notation = globalContext()->currentNotation();
+    if (!notation) {
+        return false;
+    }
+
+    auto interaction = notation->interaction();
+    if (!interaction) {
+        return false;
+    }
+
+    return interaction->hitElementContext().element != nullptr;
+}
+
+
+bool NotationContextMenuModel::canSelectSimilarInRange() const
+{
+    return canSelectSimilar() && globalContext()->currentNotation()->interaction()->selection()->isRange();
 }
 
 bool NotationContextMenuModel::isDrumsetStaff() const

--- a/src/notation/view/notationcontextmenumodel.h
+++ b/src/notation/view/notationcontextmenumodel.h
@@ -53,6 +53,8 @@ private:
     uicomponents::MenuItemList makeInsertMeasuresItems();
 
     bool isSingleSelection() const;
+    bool canSelectSimilarInRange() const;
+    bool canSelectSimilar() const;
     bool isDrumsetStaff() const;
 };
 }

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -536,14 +536,9 @@ bool NotationViewInputController::needSelect(const ClickContext& ctx) const
     if (!ctx.hitElement) {
         return false;
     }
-
-    bool result = true;
-
-    if (ctx.event->button() == Qt::MouseButton::RightButton) {
-        result = !viewInteraction()->selection()->range()->containsPoint(ctx.logicClickPos);
-    }
-
-    return result;
+    return !(ctx.event->modifiers() & Qt::ControlModifier)
+           && !viewInteraction()->selection()->range()->containsPoint(ctx.logicClickPos)
+           && !ctx.hitElement->selected();
 }
 
 void NotationViewInputController::handleLeftClick(const ClickContext& ctx)
@@ -682,7 +677,7 @@ void NotationViewInputController::startDragElements(ElementType elementsType, co
     viewInteraction()->startDrag(elements, elementsOffset, isDraggable);
 }
 
-void NotationViewInputController::mouseReleaseEvent(QMouseEvent*)
+void NotationViewInputController::mouseReleaseEvent(QMouseEvent* event)
 {
     INotationInteractionPtr interaction = viewInteraction();
     INotationNoteInputPtr noteInput = interaction->noteInput();
@@ -690,6 +685,10 @@ void NotationViewInputController::mouseReleaseEvent(QMouseEvent*)
     if (!hitElement() && !m_isCanvasDragged && !interaction->isGripEditStarted()
         && !interaction->isDragStarted() && !noteInput->isNoteInputMode()) {
         interaction->clearSelection();
+    }
+    if (event->button() == Qt::MouseButton::LeftButton && m_view->toLogical(event->pos()) == m_beginPoint
+        && !(event->modifiers() & Qt::KeyboardModifier::ControlModifier) && hitElement()) {
+        interaction->select({ hitElement() });
     }
 
     m_isCanvasDragged = false;

--- a/src/notation/view/widgets/selectdialog.ui
+++ b/src/notation/view/widgets/selectdialog.ui
@@ -128,7 +128,7 @@
         </item>
         <item row="1" column="0">
          <widget class="QRadioButton" name="fromSelection">
-          <property name="enabled">
+          <property name="visible">
            <bool>false</bool>
           </property>
           <property name="text">

--- a/src/notation/view/widgets/selectnotedialog.ui
+++ b/src/notation/view/widgets/selectnotedialog.ui
@@ -188,7 +188,7 @@
         </item>
         <item row="1" column="0">
          <widget class="QRadioButton" name="fromSelection">
-          <property name="enabled">
+          <property name="visible">
            <bool>false</bool>
           </property>
           <property name="text">


### PR DESCRIPTION
Resolves: [*(direct link to the issue)*](https://github.com/musescore/MuseScore/issues/11008)

Main issue was that your existing list selection was lost when right-clicking on a selected element.
However the logic for how to adjust the current selection depending on what button and keyboard modifiers used on mouse press and mouse release wasn't right in quite a few cases, e.g. preventing dragging of a list selection.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://musescore.org/en/cla)
- [ x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x] I made sure the code compiles on my machine
- [ x] I made sure there are no unnecessary changes in the code
- [ x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
