### PR TITLE
fix #11008 - various mouse selection issues

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -536,14 +536,9 @@ bool NotationViewInputController::needSelect(const ClickContext& ctx) const
     if (!ctx.hitElement) {
         return false;
     }
-
-    bool result = true;
-
-    if (ctx.event->button() == Qt::MouseButton::RightButton) {
-        result = !viewInteraction()->selection()->range()->containsPoint(ctx.logicClickPos);
-    }
-
-    return result;
+    return !(ctx.event->modifiers() & Qt::ControlModifier)
+           && !viewInteraction()->selection()->range()->containsPoint(ctx.logicClickPos)
+           && !ctx.hitElement->selected();
 }
 
 void NotationViewInputController::handleLeftClick(const ClickContext& ctx)
@@ -682,7 +677,7 @@ void NotationViewInputController::startDragElements(ElementType elementsType, co
     viewInteraction()->startDrag(elements, elementsOffset, isDraggable);
 }
 
-void NotationViewInputController::mouseReleaseEvent(QMouseEvent*)
+void NotationViewInputController::mouseReleaseEvent(QMouseEvent* event)
 {
     INotationInteractionPtr interaction = viewInteraction();
     INotationNoteInputPtr noteInput = interaction->noteInput();
@@ -690,6 +685,10 @@ void NotationViewInputController::mouseReleaseEvent(QMouseEvent*)
     if (!hitElement() && !m_isCanvasDragged && !interaction->isGripEditStarted()
         && !interaction->isDragStarted() && !noteInput->isNoteInputMode()) {
         interaction->clearSelection();
+    }
+    if (event->button() == Qt::MouseButton::LeftButton && m_view->toLogical(event->pos()) == m_beginPoint
+        && !(event->modifiers() & Qt::KeyboardModifier::ControlModifier) && hitElement()) {
+        interaction->select({ hitElement() });
     }
 
     m_isCanvasDragged = false;


### PR DESCRIPTION
Resolves: [*(direct link to the issue)*](https://github.com/musescore/MuseScore/issues/11008)

Fixes not being able to secondary click an element while retaining a list selection 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
