### PR TITLE
Fix spacing in continuous view

### DIFF
--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -4291,9 +4291,6 @@ void Measure::computeWidth(Fraction minTicks, qreal stretchCoeff)
     } else {
         setWidthLocked(false);
     }
-    if (width() > maxWidth) {
-        setWidthToTargetValue(s, x, isSystemHeader, minTicks, stretchCoeff, maxWidth);
-    }
 }
 
 void Measure::setWidthToTargetValue(Segment* s, qreal x, bool isSystemHeader, Fraction minTicks, qreal stretchCoeff, qreal targetWidth)
@@ -4555,7 +4552,7 @@ Fraction Measure::maxTicks() const
     Segment* s = first();
     Fraction maxticks = Fraction(0, 1);
     while (s) {
-        if (s->enabled()) {
+        if (s->enabled() && s->isChordRestType() && !s->isMMRestSegment()) {
             maxticks = std::max(maxticks, s->ticks());
         }
         s = s->next();


### PR DESCRIPTION
Resolves: [10955](https://github.com/musescore/MuseScore/issues/10955)
[10973](https://github.com/musescore/MuseScore/issues/10973)
[11024](https://github.com/musescore/MuseScore/issues/11024)

Completes the initial solution from PR [10980](https://github.com/musescore/MuseScore/pull/10980) by @RomanPudashkin.

The deleted lines were originally done to help with an edge case in page view but that isn't necessary anymore. 
Additionally, MM rests need to be disregarded when computing the longest note of a system, otherwise they introduce "fake" long notes and cause additional wrong layouts.

The two things together should fix the issue @DmitryArefiev 
