### PR TITLE
Fix 10859: Score tab is always bold if it has an opened score

### DIFF
--- a/src/appshell/qml/MainToolBar.qml
+++ b/src/appshell/qml/MainToolBar.qml
@@ -32,6 +32,8 @@ Item {
     height: radioButtonList.height
 
     property alias navigation: navPanel
+    property alias navigation: navCtrl
+    property bool isNotationOpened: false
 
     property string currentUri: "musescore://home"
     property var items: [
@@ -96,6 +98,7 @@ Item {
 
             checked: modelData["uri"] === root.currentUri
             title: modelData["title"]
+            isBoldOnly: (modelData["title"] === qsTrc("appshell", "Score")) && !checked && isNotationOpened
 
             onToggled: {
                 root.selected(modelData["uri"])

--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -90,6 +90,9 @@ DockPage {
         Qt.callLater(pageModel.init)
     }
 
+
+    property bool isNotationOpened:pageModel.isNotationOpened
+
     readonly property int verticalPanelDefaultWidth: 300
 
     readonly property int horizontalPanelMinHeight: 100

--- a/src/appshell/qml/WindowContent.qml
+++ b/src/appshell/qml/WindowContent.qml
@@ -69,6 +69,7 @@ DockWindow {
                 id: toolBar
                 navigation.section: root.topToolKeyNavSec
                 navigation.order: 1
+                isNotationOpened: notationPage.isNotationOpened
 
                 currentUri: root.currentPageUri
 
@@ -93,6 +94,7 @@ DockWindow {
         HomePage {},
 
         NotationPage {
+            id: notationPage
             topToolKeyNavSec: root.topToolKeyNavSec
         },
 

--- a/src/appshell/view/notationpagemodel.cpp
+++ b/src/appshell/view/notationpagemodel.cpp
@@ -40,6 +40,11 @@ bool NotationPageModel::isNavigatorVisible() const
     return configuration()->isNotationNavigatorVisible();
 }
 
+bool NotationPageModel::isNotationOpened() const
+{
+    return m_isNotationOpened;
+}
+
 void NotationPageModel::init()
 {
     TRACEFUNC;
@@ -131,7 +136,17 @@ void NotationPageModel::onNotationChanged()
 {
     INotationPtr notation = globalContext()->currentNotation();
     if (!notation) {
+        if (m_isNotationOpened) {
+            m_isNotationOpened = false;
+            emit isNotationOpenedChanged();
+        }
+
         return;
+    }
+
+    if (!m_isNotationOpened) {
+        m_isNotationOpened = true;
+        emit isNotationOpenedChanged();
     }
 
     INotationNoteInputPtr noteInput = notation->interaction()->noteInput();

--- a/src/appshell/view/notationpagemodel.h
+++ b/src/appshell/view/notationpagemodel.h
@@ -43,11 +43,13 @@ class NotationPageModel : public QObject, public async::Asyncable, public action
     INJECT(appshell, dock::IDockWindowProvider, dockWindowProvider)
 
     Q_PROPERTY(bool isNavigatorVisible READ isNavigatorVisible NOTIFY isNavigatorVisibleChanged)
+    Q_PROPERTY(bool isNotationOpened READ isNotationOpened NOTIFY isNotationOpenedChanged)
 
 public:
     explicit NotationPageModel(QObject* parent = nullptr);
 
     bool isNavigatorVisible() const;
+    bool isNotationOpened() const;
 
     Q_INVOKABLE void init();
 
@@ -71,6 +73,7 @@ public:
 
 signals:
     void isNavigatorVisibleChanged();
+    void isNotationOpenedChanged();
 
 private:
     void onNotationChanged();
@@ -78,6 +81,8 @@ private:
     void toggleDock(const QString& name);
 
     void updateDrumsetPanelVisibility();
+
+    bool m_isNotationOpened = false;
 };
 }
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/PageTabButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/PageTabButton.qml
@@ -38,6 +38,7 @@ RadioDelegate {
     property var selectedStateFont: ui.theme.largeBodyBoldFont
 
     property alias navigation: navCtrl
+    property bool isBoldOnly: false
 
     height: isVertical ? 36 : 44
 
@@ -188,6 +189,15 @@ RadioDelegate {
                 visible: true
             }
 
+            PropertyChanges {
+                target: textLabel
+                font: root.selectedStateFont
+            }
+        },
+
+        State {
+            name: "BOLDONLY"
+            when: root.isBoldOnly
             PropertyChanges {
                 target: textLabel
                 font: root.selectedStateFont


### PR DESCRIPTION
Resolves: [#10859](https://github.com/musescore/MuseScore/issues/10859)

Score tab is always bold if it has an opened score.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
