### PR TITLE
Fix #10791: focus search field when loading instruments page or templates pages in New Score dialog

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledDialogView.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledDialogView.qml
@@ -41,6 +41,8 @@ DialogView {
     property int contentWidth: 240
     property int contentHeight: contentBody.childrenRect.height
 
+    property bool isDoActiveFirstControlOnOpen: true
+
     property bool isDoActiveParentOnClose: true
     property NavigationSection navigationSection: NavigationSection {
         id: navSec
@@ -63,7 +65,9 @@ DialogView {
     }
 
     onOpened: {
-        Qt.callLater(navSec.requestActive)
+        if (root.isDoActiveFirstControlOnOpen) {
+            Qt.callLater(navSec.requestActive)
+        }
     }
 
     onClosed: {

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/ChooseInstrumentsPage.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/ChooseInstrumentsPage.qml
@@ -59,6 +59,10 @@ Rectangle {
         familyView.focusOnFirst()
     }
 
+    function focusOnFirstSearchField() {
+        instrumentsView.focusSearchField() // templatesView in CreateFromTemplatePage.qml
+    }
+
     color: ui.theme.backgroundPrimaryColor
 
     InstrumentListModel {

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/InstrumentsDialog.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/InstrumentsDialog.qml
@@ -32,6 +32,8 @@ StyledDialogView {
     property bool canSelectMultipleInstruments: true
     property string currentInstrumentId: ""
 
+    isDoActiveFirstControlOnOpen: false
+
     contentHeight: 500
     contentWidth: root.canSelectMultipleInstruments ? 900 : 600
     margins: 12

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsView.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsView.qml
@@ -45,6 +45,10 @@ Item {
         instrumentsView.positionViewAtIndex(instrumentIndex, ListView.Beginning)
     }
 
+    function focusSearchField() {
+        searchField.navigation.requestActive()
+    }
+
     NavigationPanel {
         id: navPanel
         name: "InstrumentsView"

--- a/src/project/qml/MuseScore/Project/NewScoreDialog.qml
+++ b/src/project/qml/MuseScore/Project/NewScoreDialog.qml
@@ -37,6 +37,8 @@ StyledDialogView {
     contentWidth: 1024
     resizable: true
 
+    isDoActiveFirstControlOnOpen: false
+
     objectName: "NewScoreDialog"
 
     function onDone() {
@@ -59,7 +61,8 @@ StyledDialogView {
     }
 
     onOpened: {
-        Qt.callLater(chooseInstrumentsAndTemplatePage.focusOnSelected)
+        chooseInstrumentsAndTemplatePage.focusOnSelected
+//        Qt.callLater(chooseInstrumentsAndTemplatePage.focusOnSelected)
     }
 
     NewScoreModel {

--- a/src/project/qml/MuseScore/Project/NewScoreDialog.qml
+++ b/src/project/qml/MuseScore/Project/NewScoreDialog.qml
@@ -62,7 +62,6 @@ StyledDialogView {
 
     onOpened: {
         chooseInstrumentsAndTemplatePage.focusOnSelected
-//        Qt.callLater(chooseInstrumentsAndTemplatePage.focusOnSelected)
     }
 
     NewScoreModel {

--- a/src/project/qml/MuseScore/Project/internal/ChooseInstrumentsAndTemplatesPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/ChooseInstrumentsAndTemplatesPage.qml
@@ -155,6 +155,12 @@ Item {
         anchors.right: parent.right
         anchors.bottom: parent.bottom
 
+        onLoaded: {
+            if(item && item.focusOnFirstSearchField){
+                Qt.callLater(item.focusOnFirstSearchField)
+            }
+        }
+
         sourceComponent: {
             if (!bar.complited) {
                 return null

--- a/src/project/qml/MuseScore/Project/internal/CreateFromTemplatePage.qml
+++ b/src/project/qml/MuseScore/Project/internal/CreateFromTemplatePage.qml
@@ -35,6 +35,10 @@ Item {
 
     property NavigationSection navigationSection: null
 
+    function focusOnFirstSearchField() {
+        instrumentsView.focusSearchField() // templatesView in CreateFromTemplatePage.qml
+    }
+
     signal done
 
     TemplatesModel {

--- a/src/project/qml/MuseScore/Project/internal/TitleListView.qml
+++ b/src/project/qml/MuseScore/Project/internal/TitleListView.qml
@@ -46,6 +46,10 @@ Item {
         searchField.clear()
     }
 
+    function focusSearchField() {
+        searchField.navigation.requestActive()
+    }
+
     QtObject {
         id: prv
 


### PR DESCRIPTION
Resolves: *[(direct link to the issue)](https://github.com/musescore/MuseScore/issues/10791)*

*I followed [here](https://github.com/musescore/MuseScore/pull/10920), with small changes because of naming conficts*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
