### PR TITLE
Fix storing list of recent files if a filename contains commas

### DIFF
--- a/src/project/internal/projectconfiguration.h
+++ b/src/project/internal/projectconfiguration.h
@@ -92,7 +92,7 @@ public:
     async::Channel<int> autoSaveIntervalChanged() const override;
 
 private:
-    io::paths parsePaths(const mu::Val& value) const;
+    io::paths parseRecentProjectsPaths(const mu::Val& value) const;
 
     io::path appTemplatesPath() const;
 


### PR DESCRIPTION
Store them as JSON, not as comma-separated list of unencoded paths. It might give a little bit more overhead (I'm not sure how much exactly), but at least it won't break :) (hopefully, otherwise it's QJsonDocument's fault)

Resolves: #11042 

**NOTE:** after this is merged, users' existing list of recent files will be lost. If you want to preserve your list of recent files, do the following _before opening the new build_:
- in the old build, go to DevTools > Settings and find the "project/recentList" key
- click the text field and press Cmd/Ctrl+A to select everything inside it
- paste it into a decent plain text editor
- replace every instance of `,` with `","` (including the quotation marks)
- add `["` at the beginning, and add `"]` at the end (including the quotation marks)
- copy all that
- in the new build, go to DevTools > Settings and find the "project/recentList" key
- click the text field and press Cmd/Ctrl+A to select everything inside it and delete the old content
- paste the new content