### PR TITLE
StyledTextLabel: only create MouseArea if really necessary

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledTextLabel.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledTextLabel.qml
@@ -43,9 +43,21 @@ Text {
         Qt.openUrlExternally(link)
     }
 
-    MouseArea {
+    onHoveredLinkChanged: {
+        if (Boolean(hoveredLink)) {
+            mouseAreaLoader.active = true
+        }
+    }
+
+    Loader {
+        id: mouseAreaLoader
         anchors.fill: parent
-        acceptedButtons: Qt.NoButton
-        cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
+        active: false
+
+        sourceComponent: MouseArea {
+            anchors.fill: parent
+            acceptedButtons: Qt.NoButton
+            cursorShape: root.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
+        }
     }
 }


### PR DESCRIPTION
Only needed when a link is hovered

Resolves: #8543