### PR TITLE
Implemented updating ToolConfigs stored in workspace

### DIFF
--- a/src/framework/ui/internal/uiconfiguration.h
+++ b/src/framework/ui/internal/uiconfiguration.h
@@ -99,7 +99,7 @@ public:
     void setIsVisible(const QString& key, bool val) override;
     async::Notification isVisibleChanged(const QString& key) const override;
 
-    ToolConfig toolConfig(const QString& toolName) const override;
+    ToolConfig toolConfig(const QString& toolName, const ToolConfig& defaultConfig) const override;
     void setToolConfig(const QString& toolName, const ToolConfig& config) override;
     async::Notification toolConfigChanged(const QString& toolName) const override;
 
@@ -122,6 +122,8 @@ private:
 
     ThemeList readThemes() const;
     void writeThemes(const ThemeList& themes);
+
+    void updateToolConfig(const QString& toolName, ToolConfig& userConfig, const ToolConfig& defaultConfig) const;
 
     UiArrangement m_uiArrangement;
 

--- a/src/framework/ui/iuiconfiguration.h
+++ b/src/framework/ui/iuiconfiguration.h
@@ -99,7 +99,7 @@ public:
     virtual void setIsVisible(const QString& key, bool val) = 0;
     virtual async::Notification isVisibleChanged(const QString& key) const = 0;
 
-    virtual ToolConfig toolConfig(const QString& toolName) const = 0;
+    virtual ToolConfig toolConfig(const QString& toolName, const ToolConfig& defaultConfig) const = 0;
     virtual void setToolConfig(const QString& toolName, const ToolConfig& config) = 0;
     virtual async::Notification toolConfigChanged(const QString& toolName) const = 0;
 

--- a/src/framework/ui/uitypes.h
+++ b/src/framework/ui/uitypes.h
@@ -315,6 +315,17 @@ struct ToolConfig
         Item() = default;
         Item(const actions::ActionCode& a, bool sh)
             : action(a), show(sh) {}
+
+        bool isSeparator() const
+        {
+            return action.empty();
+        }
+
+        bool operator ==(const Item& other) const
+        {
+            return action == other.action
+                   && show == other.show;
+        }
     };
 
     QList<Item> items;

--- a/src/notation/view/noteinputbarcustomisemodel.cpp
+++ b/src/notation/view/noteinputbarcustomisemodel.cpp
@@ -49,10 +49,7 @@ void NoteInputBarCustomiseModel::load()
 
     QList<Item*> items;
 
-    ToolConfig toolConfig = uiConfiguration()->toolConfig(NOTE_INPUT_TOOLBAR_NAME);
-    if (!toolConfig.isValid()) {
-        toolConfig = NotationUiActions::defaultNoteInputBarConfig();
-    }
+    ToolConfig toolConfig = uiConfiguration()->toolConfig(NOTE_INPUT_TOOLBAR_NAME, NotationUiActions::defaultNoteInputBarConfig());
 
     for (const ToolConfig::Item& item : toolConfig.items) {
         UiAction action = actionsRegister()->action(item.action);

--- a/src/notation/view/noteinputbarmodel.cpp
+++ b/src/notation/view/noteinputbarmodel.cpp
@@ -119,10 +119,7 @@ void NoteInputBarModel::load()
 {
     MenuItemList items;
 
-    ToolConfig noteInputConfig = uiConfiguration()->toolConfig(TOOLBAR_NAME);
-    if (!noteInputConfig.isValid()) {
-        noteInputConfig = NotationUiActions::defaultNoteInputBarConfig();
-    }
+    ToolConfig noteInputConfig = uiConfiguration()->toolConfig(TOOLBAR_NAME, NotationUiActions::defaultNoteInputBarConfig());
 
     int section = 0;
     for (const ToolConfig::Item& citem : noteInputConfig.items) {


### PR DESCRIPTION
When new items are added to MuseScore's default items, those items will now also be added to the user's workspace. An attempt is made to insert the new item at a sensible index, even if the user has customized the order of their items.

(Without this, the user would have to delete their workspace file in order to see any new items we add to the default toolbar configurations.)