### PR TITLE
Fix 9381: set correct color for brackets in dark mode

### DIFF
--- a/src/engraving/libmscore/bracket.h
+++ b/src/engraving/libmscore/bracket.h
@@ -109,6 +109,8 @@ public:
     void editDrag(EditData&) override;
     void endEditDrag(EditData&) override;
 
+    mu::draw::Color color() const override { return _bi->color(); }
+
     bool acceptDrop(EditData&) const override;
     EngravingItem* drop(EditData&) override;
 


### PR DESCRIPTION
Resolves: #9381 

This issue occurs because class `Bracket` uses `BrackItem` to store some properties, which is different from many other `EngravingItem`.
When we set the color of the bracket in `PaletteCellIconEngine::paintPaletteElement` through `element->setProperty`, we actually set it for `BrackItem` instead of `Bracket` itself. So when the `draw` function ask for color it only gets the default color for light mode.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
