### PR TITLE
Palette staff tonedown#10797

### DIFF
--- a/src/palette/internal/palettecelliconengine.cpp
+++ b/src/palette/internal/palettecelliconengine.cpp
@@ -130,9 +130,9 @@ void PaletteCellIconEngine::paintActionIcon(Painter& painter, const RectF& rect,
 qreal PaletteCellIconEngine::paintStaff(Painter& painter, const RectF& rect, qreal spatium) const
 {
     painter.save();
-    Color lighterpen(configuration()->elementsColor());
-    lighterpen.setAlpha(int(lighterpen.alpha()*0.5));
-    Pen pen(lighterpen);//reduce alpha by half
+    Color lighterStaffCol(configuration()->elementsColor());
+    lighterStaffCol.setAlpha(int(lighterStaffCol.alpha() * 0.5));
+    Pen pen(lighterStaffCol);//reduce alpha by half
     pen.setWidthF(engraving::DefaultStyle::defaultStyle().styleS(Sid::staffLineWidth).val() * spatium);
     painter.setPen(pen);
 

--- a/src/palette/internal/palettecelliconengine.cpp
+++ b/src/palette/internal/palettecelliconengine.cpp
@@ -130,9 +130,9 @@ void PaletteCellIconEngine::paintActionIcon(Painter& painter, const RectF& rect,
 qreal PaletteCellIconEngine::paintStaff(Painter& painter, const RectF& rect, qreal spatium) const
 {
     painter.save();
-    Color lighterStaffCol(configuration()->elementsColor());
-    lighterStaffCol.setAlpha(int(lighterStaffCol.alpha() * 0.5));
-    Pen pen(lighterStaffCol);//reduce alpha by half
+    Color staffLinesColor(configuration()->elementsColor());
+    staffLinesColor.setAlpha(127);//reduce alpha to half
+    Pen pen(staffLinesColor);
     pen.setWidthF(engraving::DefaultStyle::defaultStyle().styleS(Sid::staffLineWidth).val() * spatium);
     painter.setPen(pen);
 

--- a/src/palette/internal/palettecelliconengine.cpp
+++ b/src/palette/internal/palettecelliconengine.cpp
@@ -130,8 +130,9 @@ void PaletteCellIconEngine::paintActionIcon(Painter& painter, const RectF& rect,
 qreal PaletteCellIconEngine::paintStaff(Painter& painter, const RectF& rect, qreal spatium) const
 {
     painter.save();
-
-    Pen pen(configuration()->elementsColor());
+    Color lighterpen(configuration()->elementsColor());
+    lighterpen.setAlpha(int(lighterpen.alpha()*0.5));
+    Pen pen(lighterpen);//reduce alpha by half
     pen.setWidthF(engraving::DefaultStyle::defaultStyle().styleS(Sid::staffLineWidth).val() * spatium);
     painter.setPen(pen);
 


### PR DESCRIPTION
Resolves: [**](https://github.com/musescore/MuseScore/issues/10797)

Palette staff lines set to half transparency (alpha channel), as suggested in the issue post. Elements stand out more from the staff lines now.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
