### PR TITLE
Fix 10953: add asterisk at the beginning of the name

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/internal/NotationSwitchButton.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/NotationSwitchButton.qml
@@ -53,7 +53,7 @@ FlatRadioButton {
 
             horizontalAlignment: Text.AlignLeft
 
-            text: root.text + (root.needSave ? "*" : "")
+            text: (root.needSave ? "*" : "") + root.text
         }
 
         FlatButton {


### PR DESCRIPTION
Resolves:  #10953 

add asterisk at the beginning of the name

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
