### PR TITLE
fix #11038: A small underline stays under unselected styled buttons

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledTabButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledTabButton.qml
@@ -95,12 +95,13 @@ TabButton {
             id: selectedUnderline
 
             anchors.left: parent.left
+            anchors.leftMargin: isCurrent ? 0 : 3 * parent.width / 8
+            anchors.rightMargin: isCurrent ? 0 : 3 * parent.width / 8
             anchors.right: parent.right
             anchors.bottom: parent.bottom
 
             height: 2
 
-            visible: isCurrent
             color: ui.theme.accentColor
         }
     }


### PR DESCRIPTION
Resolves: #11038 

It simply puts a smaller underline below unselected buttons to ensure that the user knows they are selectable
![image](https://user-images.githubusercontent.com/75690289/161599432-4612bbc1-7eb0-47cd-a4c9-65d44bd77540.png)
I apologize for the commit message not having the issue number, please let me know if this requires a recommit
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
