### PR TITLE
[MU4] Slurs only adjust for slurs on their staff, and endpoint adjustment fix

### DIFF
--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -1245,32 +1245,34 @@ void LayoutSystem::processLines(System* system, std::vector<Spanner*> lines, boo
             }
             SlurSegment* slur1 = toSlurSegment(seg1);
             for (SpannerSegment* seg2 : segments) {
-                if (!seg2->isSlurSegment()) {
+                if (!seg2->isSlurTieSegment()) {
                     continue;
                 }
-                SlurSegment* slur2 = toSlurSegment(seg2);
+
+                SlurTieSegment* slurTie2 = toSlurTieSegment(seg2);
+
                 // slurs don't collide with themselves or slurs on other staves
-                if (slur1 == slur2 || slur1->vStaffIdx() != slur2->vStaffIdx()) {
+                if (slur1 == slurTie2 || slur1->vStaffIdx() != slurTie2->vStaffIdx()) {
                     continue;
                 }
                 // slurs which don't overlap don't need to be checked
-                if (slur1->ups(Grip::END).p.x() < slur2->ups(Grip::START).p.x()
-                    || slur2->ups(Grip::END).p.x() < slur1->ups(Grip::START).p.x()
-                    || slur1->slur()->up() != slur2->slur()->up()) {
+                if (slur1->ups(Grip::END).p.x() < slurTie2->ups(Grip::START).p.x()
+                    || slurTie2->ups(Grip::END).p.x() < slur1->ups(Grip::START).p.x()
+                    || slur1->slur()->up() != slurTie2->slurTie()->up()) {
                     continue;
                 }
                 // START POINT
-                if (compare(slur1->ups(Grip::START).p.x(), slur2->ups(Grip::START).p.x())) {
-                    if (slur1->ups(Grip::END).p.x() > slur2->ups(Grip::END).p.x()) {
+                if (compare(slur1->ups(Grip::START).p.x(), slurTie2->ups(Grip::START).p.x())) {
+                    if (slur1->ups(Grip::END).p.x() > slurTie2->ups(Grip::END).p.x() || slurTie2->isTieSegment()) {
                         // slur1 is the "outside" slur
                         slur1->ups(Grip::START).p.ry() += slurCollisionVertOffset * (slur1->slur()->up() ? -1 : 1);
                         slur1->computeBezier();
                     }
                 }
                 // END POINT
-                if (compare(slur1->ups(Grip::END).p.x(), slur2->ups(Grip::END).p.x())) {
+                if (compare(slur1->ups(Grip::END).p.x(), slurTie2->ups(Grip::END).p.x())) {
                     // slurs have the same endpoint
-                    if (slur1->ups(Grip::START).p.x() < slur2->ups(Grip::START).p.x()) {
+                    if (slur1->ups(Grip::START).p.x() < slurTie2->ups(Grip::START).p.x() || slurTie2->isTieSegment()) {
                         // slur1 is the "outside" slur
                         slur1->ups(Grip::END).p.ry() += slurCollisionVertOffset * (slur1->slur()->up() ? -1 : 1);
                         slur1->computeBezier();

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -1249,8 +1249,8 @@ void LayoutSystem::processLines(System* system, std::vector<Spanner*> lines, boo
                     continue;
                 }
                 SlurSegment* slur2 = toSlurSegment(seg2);
-                // slurs don't collide with themselves
-                if (slur1 == slur2) {
+                // slurs don't collide with themselves or slurs on other staves
+                if (slur1 == slur2 || slur1->vStaffIdx() != slur2->vStaffIdx()) {
                     continue;
                 }
                 // slurs which don't overlap don't need to be checked

--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -313,7 +313,7 @@ void SlurSegment::adjustEndpoints()
     // point 1
     int lines = staff()->lines(tick());
     auto adjustPoint = [staffLineMargin](bool up, qreal ysp) {
-        qreal y1offset = ysp - round(ysp);
+        qreal y1offset = ysp - floor(ysp);
         qreal adjust = 0;
         if (up) {
             if (y1offset < staffLineMargin) {
@@ -353,6 +353,9 @@ void SlurSegment::computeBezier(mu::PointF p6o)
     qreal _spatium  = spatium();
     qreal shoulderW;                // height as fraction of slur-length
     qreal shoulderH;
+    if (autoplace()) {
+        adjustEndpoints();
+    }
     //
     // pp1 and pp2 are the end points of the slur
     //
@@ -367,9 +370,6 @@ void SlurSegment::computeBezier(mu::PointF p6o)
                m1->tick().ticks(), tick().ticks(), track(), m1->no(), m2->no(), slur()->tick().ticks(), slur()->ticks().ticks());
         slur()->setBroken(true);
         return;
-    }
-    if (autoplace()) {
-        adjustEndpoints();
     }
     pp1 = ups(Grip::START).p + ups(Grip::START).off;
     pp2 = ups(Grip::END).p + ups(Grip::END).off;
@@ -1431,10 +1431,6 @@ SpannerSegment* Slur::layoutSystem(System* system)
                 tie = c->notes()[0]->tieFor();
                 endPoint = tie->segmentAt(0)->ups(Grip::START).pos();
             }
-            /*if (c->notes()[0]->tieBack() && !c->notes()[0]->tieBack()->isInside() && c->notes()[0]->tieBack()->up() == _up) {
-                // there is a tie that ends on this chordrest
-                p1.rx() += horizontalTieClearance;
-            }*/
             if (tie) {
                 if (_up && tie->up()) {
                     if (endPoint.y() - p1.y() < tieClearance) {

--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -1426,10 +1426,10 @@ SpannerSegment* Slur::layoutSystem(System* system)
             Chord* c = toChord(cr);
             Tie* tie = nullptr;
             PointF endPoint;
-            if (c->notes()[0]->tieFor() && !c->notes()[0]->tieFor()->isInside() && c->notes()[0]->tieFor()->up() == _up) {
-                // there is a tie that starts on this chordrest
-                tie = c->notes()[0]->tieFor();
-                endPoint = tie->segmentAt(0)->ups(Grip::START).pos();
+            if (c->notes()[0]->tieBack() && !c->notes()[0]->tieBack()->isInside() && c->notes()[0]->tieBack()->up() == _up) {
+                // there is a tie that ends on this chordrest
+                tie = c->notes()[0]->tieBack();
+                endPoint = tie->backSegment()->ups(Grip::START).pos();
             }
             if (tie) {
                 if (_up && tie->up()) {
@@ -1474,8 +1474,6 @@ SpannerSegment* Slur::layoutSystem(System* system)
             if (!adjustedVertically && ec->notes()[0]->tieFor() && !ec->notes()[0]->tieFor()->isInside()
                 && ec->notes()[0]->tieFor()->up() == up()) {
                 // there is a tie that starts on this chordrest
-                //tie = ec->notes()[0]->tieFor();
-                //endPoint = tie->segmentAt(0)->ups(Grip::START).pos();
                 p2.rx() -= horizontalTieClearance;
             }
         }
@@ -1521,10 +1519,10 @@ SpannerSegment* Slur::layoutSystem(System* system)
             Chord* c = toChord(cr);
             Tie* tie = nullptr;
             PointF endPoint;
-            if (c->notes()[0]->tieBack() && !c->notes()[0]->tieBack()->isInside() && c->notes()[0]->tieBack()->up() == up()) {
-                // there is a tie that ends on this chordrest
-                tie = c->notes()[0]->tieBack();
-                endPoint = tie->backSegment()->ups(Grip::END).pos();
+            if (c->notes()[0]->tieFor() && !c->notes()[0]->tieFor()->isInside() && c->notes()[0]->tieFor()->up() == up()) {
+                // there is a tie that starts on this chordrest
+                tie = c->notes()[0]->tieFor();
+                endPoint = tie->segmentAt(0)->ups(Grip::END).pos();
             }
             if (tie) {
                 if (_up && tie->up()) {

--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -1426,9 +1426,10 @@ SpannerSegment* Slur::layoutSystem(System* system)
             Chord* c = toChord(cr);
             Tie* tie = nullptr;
             PointF endPoint;
-            if (c->notes()[0]->tieBack() && !c->notes()[0]->tieBack()->isInside() && c->notes()[0]->tieBack()->up() == _up) {
+            Tie* tieBack = c->notes()[0]->tieBack();
+            if (tieBack && !tieBack->isInside() && tieBack->up() == _up) {
                 // there is a tie that ends on this chordrest
-                tie = c->notes()[0]->tieBack();
+                tie = tieBack;
                 endPoint = tie->backSegment()->ups(Grip::START).pos();
             }
             if (tie) {
@@ -1519,9 +1520,10 @@ SpannerSegment* Slur::layoutSystem(System* system)
             Chord* c = toChord(cr);
             Tie* tie = nullptr;
             PointF endPoint;
-            if (c->notes()[0]->tieFor() && !c->notes()[0]->tieFor()->isInside() && c->notes()[0]->tieFor()->up() == up()) {
+            Tie* tieFor = c->notes()[0]->tieFor();
+            if (tieFor && !tieFor->isInside() && tieFor->up() == up()) {
                 // there is a tie that starts on this chordrest
-                tie = c->notes()[0]->tieFor();
+                tie = tieFor;
                 endPoint = tie->segmentAt(0)->ups(Grip::END).pos();
             }
             if (tie) {


### PR DESCRIPTION
There were a few bugs in the slur adjustment code that caused slurs to adjust for slurs not on their system. This has been fixed. There was also a bit of a bug in the slur endpoint avoidance code which has been fixed now as well.

There still seems to be a strange issue with accidentals not being taken into account in the collision detection code (which this PR or the previous slur PR never touched), and I can't help but think that this issue didn't exist when the last slur revamp was written. So the shapewise collision stuff for accidentals still needs to be looked at a bit closelier in the future. This PR won't deal with that however!