### PR TITLE
[MU4] Change default for enableVerticalSpread to be in line with 3.6

### DIFF
--- a/src/engraving/data/styles/legacy-style-defaults-v302.mss
+++ b/src/engraving/data/styles/legacy-style-defaults-v302.mss
@@ -17,7 +17,7 @@
     <akkoladeDistance>6.5</akkoladeDistance>
     <minSystemDistance>8.5</minSystemDistance>
     <maxSystemDistance>15</maxSystemDistance>
-    <enableVerticalSpread>1</enableVerticalSpread>
+    <enableVerticalSpread>0</enableVerticalSpread>
     <spreadSystem>2.5</spreadSystem>
     <spreadSquareBracket>1.2</spreadSquareBracket>
     <spreadCurlyBracket>1.1</spreadCurlyBracket>


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11023

The 302 default for `enableVerticalSpread` was false, so the 302 defaults file had to be changed to be in line with it.