### PR TITLE
[MU3 backend] Fix #325825, fix #331098: Crash on MP3 export and playback with an open volta before a section break on a frame

### DIFF
--- a/libmscore/repeatlist.cpp
+++ b/libmscore/repeatlist.cpp
@@ -545,7 +545,7 @@ void RepeatList::collectRepeatListElements()
                         if (volta != nullptr) {
                               //if (volta->endMeasure()->tick() < mb->tick()) {
                                     // The previous volta was supposed to end before us (open volta case) -> insert the end
-                                    sectionRLElements->push_back(new RepeatListElement(RepeatListElementType::VOLTA_END, volta, toMeasure(mb)));
+                                    sectionRLElements->push_back(new RepeatListElement(RepeatListElementType::VOLTA_END, volta, toMeasure(sectionEndMeasureBase)));
                                     volta = nullptr;
                               //      }
                               //else { // Volta is spanning over this section break, consider splitting the volta and adding it again at the start of the next section }


### PR DESCRIPTION
 which affects "Save online" too.

Resolves: https://musescore.org/en/node/325825 and https://musescore.org/en/node/331098, backport of #9574