### PR TITLE
[MU4] Fix #11097: Chord symbols incorrectly displayed in part scores

### DIFF
--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -349,6 +349,8 @@ Score::Score(MasterScore* parent, bool forcePartStyle /* = true */)
         // inherit most style settings from parent
         _style = parent->style();
 
+        checkChordList();
+
         static const Sid styles[] = {
             Sid::pageWidth,
             Sid::pageHeight,


### PR DESCRIPTION
Resolves: #11097 

Although I'm not quite sure what exactly caused the original issue to behave the way it did, I can confirm this change resolves the issue.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
