### PR TITLE
fix #10375: add parenthesis on tied note over the measure

### DIFF
--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -2090,7 +2090,7 @@ void Note::layout()
         const StaffType* tab = st->staffTypeForElement(this);
         qreal mags = magS();
         bool parenthesis = false;
-        if (tieBack() && !tab->showBackTied()) {
+        if (tieBack()) {
             if (chord()->measure() != tieBack()->startNote()->chord()->measure() || !el().empty()) {
                 parenthesis = true;
             }


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/10375*

*Added parenthesis on tied note over the measure*
The problem was solved already only for "hidden" notes:
https://github.com/musescore/MuseScore/commit/36b38751082ccfa4063ff47150919ba77da4277c

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
