### PR TITLE
fix #10334: displaying chord names or fret diagrams

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1932,6 +1932,16 @@ void GPConverter::addFretDiagram(const GPBeat* gpnote, ChordRest* cr, const Cont
 
     GPTrack::Diagram diagram = _gpDom->tracks().at(GPTrackIdx)->diagram().at(diaId);
 
+    // TODO-gp: implement choosing the way to display fret: chord names or fret diagrams
+    //          also to show fret diagrams above the score or not
+    if (_chordNamesInsteadFretDiagrams) {
+        StaffText* staffText = Factory::createStaffText(cr->segment());
+        staffText->setTrack(cr->track());
+        staffText->setPlainText(diagram.name);
+        cr->segment()->add(staffText);
+        return;
+    }
+
     FretDiagram* fretDiagram = mu::engraving::Factory::createFretDiagram(_score->dummy()->segment());
     fretDiagram->setTrack(cr->track());
     //TODO-ws      fretDiagram->setChordName(name);

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.h
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.h
@@ -164,6 +164,7 @@ private:
     Tuplet* _lastTuplet = nullptr;
     Hairpin* _lastHairpin = nullptr;
     Ottava* _lastOttava = nullptr;
+    bool _chordNamesInsteadFretDiagrams = false; // TODO-gp: temporarly
 };
 } //end Ms namespace
 #endif // SCOREDOMBUILDER_H


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/10334*

*Displaying chord names or fret diagrams above the chords. some things which can be done now, the rest will be done after design*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
