### PR TITLE
[MU4] Allow for newer libsndfile

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -350,7 +350,12 @@ if (OS_IS_WIN)
             )
 
     if (SNDFILE_LIB)
-        install(FILES ${DEPENDENCIES_DIR}/libsndfile-1.dll DESTINATION bin)
+        if (CC_IS_MINGW)
+            install(FILES ${SNDFILE_LIB} DESTINATION bin)
+        else()
+            find_library(dll_sndfile NAMES "sndfile" "libsndfile-1" PATHS ${DEPENDENCIES_DIR} NO_DEFAULT_PATH)
+            install(FILES ${dll_sndfile} DESTINATION bin)
+        endif()
     endif()
 
     # Install ssl


### PR DESCRIPTION
Was part of #6483 (as a port of https://github.com/musescore/MuseScore/pull/6489), see c615ba3, but apparently broke again later.

For a newer libsndfile version to get used on GitHub CI too, the dependencies.7z needs to get updated, see https://github.com/musescore/MuseScore/pull/6489#issuecomment-679888471, which pointe at libsndfile1.0.30, but actually meanwhile we should be taking it from https://github.com/libsndfile/libsndfile/releases/tag/1.1.0, the currently latest.