### PR TITLE
fix: #11060; Extract leftover action codes into the shortcuts list

### DIFF
--- a/src/framework/shortcuts/view/shortcutsmodel.cpp
+++ b/src/framework/shortcuts/view/shortcutsmodel.cpp
@@ -25,6 +25,7 @@
 #include "ui/view/iconcodes.h"
 #include "translation.h"
 #include "log.h"
+#include <unordered_set>
 
 using namespace mu::shortcuts;
 using namespace mu::ui;
@@ -93,12 +94,25 @@ void ShortcutsModel::load()
     beginResetModel();
     m_shortcuts.clear();
 
+    std::unordered_set<std::string> actionsLeft;
+    for (const std::string& action : uiactionsRegister()->getKeys()) {
+        actionsLeft.insert(action);
+    }
+
     for (const Shortcut& shortcut : shortcutsRegister()->shortcuts()) {
         if (actionTitle(shortcut.action).isEmpty()) {
             continue;
         }
 
+        if (actionsLeft.find(shortcut.action) != actionsLeft.end()) {
+            actionsLeft.erase(shortcut.action);
+        }
+
         m_shortcuts << shortcut;
+    }
+
+    for (const std::string& action : actionsLeft) {
+        m_shortcuts << Shortcut(action);
     }
 
     shortcutsRegister()->shortcutsChanged().onNotify(this, [this]() {

--- a/src/framework/ui/internal/uiactionsregister.cpp
+++ b/src/framework/ui/internal/uiactionsregister.cpp
@@ -239,3 +239,12 @@ mu::async::Channel<ActionCodeList> UiActionsRegister::actionStateChanged() const
 {
     return m_actionStateChanged;
 }
+
+std::vector<std::string> mu::ui::UiActionsRegister::getKeys() const
+{
+    std::vector<std::string> key;
+    for (auto it = m_actions.begin(); it != m_actions.end(); ++it) {
+        key.push_back(it->first);
+    }
+    return key;
+}

--- a/src/framework/ui/internal/uiactionsregister.h
+++ b/src/framework/ui/internal/uiactionsregister.h
@@ -45,6 +45,7 @@ public:
     const UiAction& action(const actions::ActionCode& code) const override;
     UiActionState actionState(const actions::ActionCode& code) const override;
     async::Channel<actions::ActionCodeList> actionStateChanged() const override;
+    std::vector<std::string> getKeys() const override;
 
 private:
 

--- a/src/framework/ui/iuiactionsregister.h
+++ b/src/framework/ui/iuiactionsregister.h
@@ -41,6 +41,7 @@ public:
     virtual const UiAction& action(const actions::ActionCode& code) const = 0;
     virtual UiActionState actionState(const actions::ActionCode& code) const = 0;
     virtual async::Channel<actions::ActionCodeList> actionStateChanged() const = 0;
+    virtual std::vector<std::string> getKeys() const = 0;
 };
 }
 


### PR DESCRIPTION
Resolves: #11060 

It reads from a map object m_actions of the `uiactionsregister`, whose keys contain all the action codes as far as I can understand. Do let me know in case this is not the case.  

Secondly, there are a few null shortcut names

![image](https://user-images.githubusercontent.com/75690289/162762866-b316a179-3a61-4254-b610-6a4e852db47a.png)

Please let me know how to proceed with the same

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
