### PR TITLE
[MU4] Fix #11018: Number inputs can't be scrolled

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/IncrementalPropertyControl.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/IncrementalPropertyControl.qml
@@ -112,6 +112,8 @@ Item {
     TextInputField {
         id: textInputField
 
+        property int scrolled: 0
+
         anchors.top: parent.top
         anchors.bottom: parent.bottom
 
@@ -147,6 +149,39 @@ Item {
 
             onIncreaseButtonClicked: { root.increment() }
             onDecreaseButtonClicked: { root.decrement() }
+        }
+
+        mouseArea.onWheel: function(wheel) {
+            if (textInputField.activeFocus == true) {
+                let pixelY = wheel.pixelDelta.y
+                let angleY = wheel.angleDelta.y
+
+                // This is set below. For angleY, make sure it is <= 120,
+                // because in many actual mouse wheels, one scroll sets
+                // angleY to +/- 120.
+                let oneScroll = 0
+
+                if (pixelY != 0) {
+                    scrolled += pixelY
+                    oneScroll = 60
+                } else if (angleY != 0) {
+                    scrolled += angleY
+                    oneScroll = 120
+                }
+                if (scrolled >= oneScroll) {
+                    root.increment()
+                    scrolled = 0
+                } else if (scrolled <= -oneScroll) {
+                    root.decrement()
+                    scrolled = 0
+                }
+            } else {
+                wheel.accepted = false
+            }
+        }
+
+        mouseArea.onExited: {
+            scrolled = 0
         }
 
         onCurrentTextEdited: function(newTextValue) {


### PR DESCRIPTION
Resolves: #11018

Docs:
https://doc.qt.io/qt-5/qml-qtquick-mousearea.html
https://doc.qt.io/qt-6/qml-qtquick-mousearea.html

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla) ([Ameer Lubang](https://musescore.org/en/user/3060033))
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
