### PR TITLE
fix #11157: Checking that string is not empty before erasing

### DIFF
--- a/src/framework/global/io/path.cpp
+++ b/src/framework/global/io/path.cpp
@@ -246,6 +246,9 @@ std::string mu::io::pathsToString(const paths& ps, const std::string& delim)
     }
 
     for (size_t i = 0; i < delim.length(); ++i) {
+        if (result.empty()) {
+            break;
+        }
         result.pop_back();
     }
 


### PR DESCRIPTION
Resolves: #11157 

A simple check to ensure that `pop_back` is not called on an empty string.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
