### PR TITLE
Add Staff/part properties to Instrument right-click menu

### DIFF
--- a/src/notation/view/notationcontextmenumodel.cpp
+++ b/src/notation/view/notationcontextmenumodel.cpp
@@ -47,6 +47,8 @@ MenuItemList NotationContextMenuModel::makeItemsByElementType(ElementType elemen
         return makeSystemTextItems();
     case ElementType::TIMESIG:
         return makeTimeSignatureItems();
+    case ElementType::INSTRUMENT_NAME:
+        return makeInstrumentNameItems();
     case ElementType::HARMONY:
         return makeHarmonyItems();
     default:
@@ -135,6 +137,15 @@ MenuItemList NotationContextMenuModel::makeTimeSignatureItems()
     MenuItemList items = makeElementItems();
     items << makeSeparator();
     items << makeMenuItem("time-signature-properties");
+
+    return items;
+}
+
+MenuItemList NotationContextMenuModel::makeInstrumentNameItems()
+{
+    MenuItemList items = makeElementItems();
+    items << makeSeparator();
+    items << makeMenuItem("staff-properties");
 
     return items;
 }

--- a/src/notation/view/notationcontextmenumodel.h
+++ b/src/notation/view/notationcontextmenumodel.h
@@ -47,6 +47,7 @@ private:
     uicomponents::MenuItemList makeStaffTextItems();
     uicomponents::MenuItemList makeSystemTextItems();
     uicomponents::MenuItemList makeTimeSignatureItems();
+    uicomponents::MenuItemList makeInstrumentNameItems();
     uicomponents::MenuItemList makeHarmonyItems();
     uicomponents::MenuItemList makeSelectItems();
     uicomponents::MenuItemList makeElementItems();


### PR DESCRIPTION
Resolves #11130

Define a function that creates a specialized right-click menu for instrument names, which contains the default right-click menu options as well as "Staff/part properties" after a separator.
This implements convenient functionality from MU3 and is useful for end-users.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
