### PR TITLE
fix #11167: Default instrument genre set to 'common'

### DIFF
--- a/src/instrumentsscene/view/instrumentlistmodel.cpp
+++ b/src/instrumentsscene/view/instrumentlistmodel.cpp
@@ -132,7 +132,7 @@ void InstrumentListModel::load(bool canSelectMultipleInstruments, const QString&
     if (currentInstrumentId.isEmpty()) {
         init(COMMON_GENRE_ID, NONE_GROUP_ID);
     } else {
-        init(ALL_INSTRUMENTS_GENRE_ID, resolveInstrumentGroupId(currentInstrumentId));
+        init(COMMON_GENRE_ID, resolveInstrumentGroupId(currentInstrumentId));
         focusOnInstrument(currentInstrumentId);
     }
 }


### PR DESCRIPTION
Resolves: #11167 

Now the common set is displayed first in the Replace instrument dialog

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
