### PR TITLE
[MU4] Get git to ignore thirdparty/lame/config.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ dependencies
 VERSION
 /mscore/data/mscore.aps
 /msvc.*
+
+# Files created during build process
+/thirdparty/lame/config.h


### PR DESCRIPTION
which apparently does get generated during build, on both, MinGW and MSVC (at least).

Introduced with #11184