### PR TITLE
[MU4] Fix #10954: Can't use first six volume or pan sliders when mixer(F10) is undocked (Windows only)

### DIFF
--- a/src/framework/audio/qml/MuseScore/Audio/KnobControl.qml
+++ b/src/framework/audio/qml/MuseScore/Audio/KnobControl.qml
@@ -64,6 +64,10 @@ Dial {
         readonly property color outerArcColor: Utils.colorWithAlpha(ui.theme.buttonColor, 0.7)
         readonly property color innerArcColor: Utils.colorWithAlpha(ui.theme.fontPrimaryColor, 0.5)
 
+        property int initialValue: 0
+        property real dragStartX: 0
+        property real dragStartY: 0
+
         onValueArcColorChanged: { backgroundCanvas.requestPaint() }
         onOuterArcColorChanged: { backgroundCanvas.requestPaint() }
         onInnerArcColorChanged: { backgroundCanvas.requestPaint() }
@@ -181,20 +185,18 @@ Dial {
 
         preventStealing: true // Don't let a Flickable steal the mouse
 
-        property int initialValue: 0
-        property real dragStartX: 0
-        property real dragStartY: 0
-
         onPressed: function(mouse) {
-            initialValue = root.value
-            dragStartX = mouse.x; dragStartY = mouse.y
+            prv.initialValue = root.value
+            prv.dragStartX = mouse.x
+            prv.dragStartY = mouse.y
         }
 
         onPositionChanged: function(mouse)  {
-            let dx = mouse.x - dragStartX; let dy = mouse.y - dragStartY
+            let dx = mouse.x - prv.dragStartX
+            let dy = mouse.y - prv.dragStartY
             let dist = Math.sqrt(dx * dx + dy * dy)
             let sgn = (dy < dx) ? 1 : -1
-            let newValue = initialValue + dist * sgn
+            let newValue = prv.initialValue + dist * sgn
             let bounded = Math.max(root.from, Math.min(newValue, root.to))
             root.newValueRequested(bounded)
         }

--- a/src/framework/audio/qml/MuseScore/Audio/VolumeSlider.qml
+++ b/src/framework/audio/qml/MuseScore/Audio/VolumeSlider.qml
@@ -125,6 +125,8 @@ Slider {
 
         readonly property real handleWidth: 16
         readonly property real handleHeight: 32
+
+        property real dragStartOffset: 0.0
     }
 
     NavigationControl {
@@ -254,6 +256,7 @@ Slider {
 
         MouseArea {
             anchors.fill: parent
+
             onDoubleClicked: {
                 // Double click resets the volume
                 root.volumeLevelMoved(0.0)
@@ -267,14 +270,12 @@ Slider {
 
             preventStealing: true // Don't let a Flickable steal the mouse
 
-            property real dragStartOffset: 0.0
-
             onPressed: function(mouse) {
-                dragStartOffset = mouse.y
+                prv.dragStartOffset = mouse.y
             }
 
             onPositionChanged: function(mouse)  {
-                let mousePosInRoot = mapToItem(root, 0, mouse.y - dragStartOffset).y
+                let mousePosInRoot = mapToItem(root, 0, mouse.y - prv.dragStartOffset).y
                 let newPosZeroToOne = 1 - mousePosInRoot / prv.rulerLineHeight
                 let newPosClamped = Math.max(0.0, Math.min(newPosZeroToOne, 1.0))
                 let localNewValue = root.valueAt(newPosClamped)

--- a/src/playback/qml/MuseScore/Playback/internal/AudioResourceControl.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/AudioResourceControl.qml
@@ -63,6 +63,16 @@ Item {
     height: 24
     width: 96
 
+    QtObject {
+        id: prv
+
+        // We can't just check the containsMouse property of the mouseAreas of the buttons themselves,
+        // because that property will always be false because this MouseArea is (and must be) on top
+        readonly property bool isActivityButtonHovered: rootMouseArea.containsMouse && activityLoader.visible && rootMouseArea.mouseX < root.height // activityLoader.visible && activityLoader.contains(rootMouseArea.mapToItem(activityLoader, rootMouseArea.mouseX, rootMouseArea.mouseY))
+        readonly property bool isTitleButtonHovered: rootMouseArea.containsMouse && titleLoader.visible && titleLoader.contains(rootMouseArea.mapToItem(titleLoader, rootMouseArea.mouseX, rootMouseArea.mouseY))
+        readonly property bool isSelectorButtonHovered: rootMouseArea.containsMouse && selectorLoader.visible && selectorLoader.contains(rootMouseArea.mapToItem(selectorLoader, rootMouseArea.mouseX, rootMouseArea.mouseY))
+    }
+
     RowLayout {
         anchors.fill: parent
 
@@ -121,7 +131,7 @@ Item {
 
                         State {
                             name: "HOVERED"
-                            when: !activityButton.mouseArea.pressed && rootMouseArea.isActivityButtonHovered
+                            when: !activityButton.mouseArea.pressed && prv.isActivityButtonHovered
 
                             PropertyChanges {
                                 target: activityButtonBackground
@@ -209,7 +219,7 @@ Item {
 
                         State {
                             name: "HOVERED"
-                            when: !titleButton.mouseArea.pressed && rootMouseArea.isTitleButtonHovered
+                            when: !titleButton.mouseArea.pressed && prv.isTitleButtonHovered
 
                             PropertyChanges {
                                 target: titleButtonBackground
@@ -296,7 +306,7 @@ Item {
 
                         State {
                             name: "HOVERED"
-                            when: !menuButton.mouseArea.pressed && rootMouseArea.isSelectorButtonHovered
+                            when: !menuButton.mouseArea.pressed && prv.isSelectorButtonHovered
 
                             PropertyChanges {
                                 target: menuButtonBackground
@@ -363,11 +373,5 @@ Item {
         anchors.fill: parent
         acceptedButtons: Qt.NoButton
         hoverEnabled: true
-
-        // We can't just check the containsMouse property of the mouseAreas of the buttons themselves,
-        // because that property will always be false because this MouseArea is (and must be) on top
-        readonly property bool isActivityButtonHovered: containsMouse && activityLoader.visible && mouseX < root.height// activityLoader.visible && activityLoader.contains(mapToItem(activityLoader, mouseX, mouseY))
-        readonly property bool isTitleButtonHovered: containsMouse && titleLoader.visible && titleLoader.contains(mapToItem(titleLoader, mouseX, mouseY))
-        readonly property bool isSelectorButtonHovered: containsMouse && selectorLoader.visible && selectorLoader.contains(mapToItem(selectorLoader, mouseX, mouseY))
     }
 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10954