### PR TITLE
Fix (MSVC) compiler warning

### DIFF
--- a/src/engraving/libmscore/repeatlist.cpp
+++ b/src/engraving/libmscore/repeatlist.cpp
@@ -428,7 +428,7 @@ void RepeatList::collectRepeatListElements()
                 }
                 // Cross-section of the repeatList
                 std::vector<int> endings = remainder->endings();
-                std::remove_if(endings.begin(), endings.end(), [&volta](const int& ending) {
+                (void)std::remove_if(endings.begin(), endings.end(), [&volta](const int& ending) {
                     return !(volta->hasEnding(ending));
                 });
                 remainder->setEndings(endings);


### PR DESCRIPTION
reg. "discarding return value of function with 'nodiscard' attribute"

Fixes just one odd warning, still leaving some 1005 warnings C4267 "'return': conversion from 'size_t' to 'int', possible loss of data" (along with 4 long term warnings C4505 "'checkNotifySignalValidity_KDDockWidgets__DockWidgetQuick': unreferenced function with internal linkage has been removed" all of which are due to a 'moc' limitation, so can't get avoided as far as I can tell)