### PR TITLE
[MU4] Fix some more compiler warnings

### DIFF
--- a/src/engraving/libmscore/bend.cpp
+++ b/src/engraving/libmscore/bend.cpp
@@ -184,7 +184,7 @@ void Bend::layout()
 
     mu::draw::FontMetrics fm(font(_spatium));
 
-    int n   = m_points.size();
+    size_t n   = m_points.size();
     qreal x = m_noteWidth;
     qreal y = -_spatium * .8;
     qreal x2, y2;
@@ -195,7 +195,7 @@ void Bend::layout()
     PolygonF arrowDown;
     arrowDown << PointF(0, 0) << PointF(aw * .5, -aw) << PointF(-aw * .5, -aw);
 
-    for (int pt = 0; pt < n; ++pt) {
+    for (size_t pt = 0; pt < n; ++pt) {
         if (pt == (n - 1)) {
             break;
         }
@@ -287,8 +287,8 @@ void Bend::draw(mu::draw::Painter* painter) const
     PolygonF arrowDown;
     arrowDown << PointF(0, 0) << PointF(aw * .5, -aw) << PointF(-aw * .5, -aw);
 
-    int n = m_points.size();
-    for (int pt = 0; pt < n - 1; ++pt) {
+    size_t n = m_points.size();
+    for (size_t pt = 0; pt < n - 1; ++pt) {
         int pitch = m_points[pt].pitch;
         if (pt == 0 && pitch) {
             y2 = -m_notePos.y() - _spatium * 2;

--- a/src/engraving/libmscore/instrument.cpp
+++ b/src/engraving/libmscore/instrument.cpp
@@ -1498,7 +1498,7 @@ void Instrument::addShortName(const StaffName& f)
     _shortNames.push_back(f);
 }
 
-int Instrument::cleffTypeCount() const
+size_t Instrument::cleffTypeCount() const
 {
     return _clefType.size();
 }

--- a/src/engraving/libmscore/instrument.h
+++ b/src/engraving/libmscore/instrument.h
@@ -381,7 +381,7 @@ public:
     const Channel* channel(int idx) const { return _channel.at(idx); }
     Channel* playbackChannel(int idx, MasterScore*);
     const Channel* playbackChannel(int idx, const MasterScore*) const;
-    int cleffTypeCount() const;
+    size_t cleffTypeCount() const;
     ClefTypeList clefType(size_t staffIdx) const;
     void setClefType(size_t staffIdx, const ClefTypeList& c);
 

--- a/src/engraving/libmscore/undo.h
+++ b/src/engraving/libmscore/undo.h
@@ -224,7 +224,7 @@ public:
     void pop();
     void setClean();
     bool canUndo() const { return curIdx > 0; }
-    bool canRedo() const { return curIdx < list.size(); }
+    bool canRedo() const { return curIdx < static_cast<int>(list.size()); }
     int state() const { return stateList[curIdx]; }
     bool isClean() const { return cleanState == state(); }
     int getCurIdx() const { return curIdx; }

--- a/src/engraving/libmscore/undo.h
+++ b/src/engraving/libmscore/undo.h
@@ -134,7 +134,7 @@ public:
     virtual void redo(EditData*);
     void appendChild(UndoCommand* cmd) { childList.push_back(cmd); }
     UndoCommand* removeChild() { return mu::takeLast(childList); }
-    int childCount() const { return childList.size(); }
+    size_t childCount() const { return childList.size(); }
     void unwind();
     const std::list<UndoCommand*>& commands() const { return childList; }
     virtual std::vector<const EngravingObject*> objectItems() const { return {}; }

--- a/src/importexport/braille/internal/exportbraille.cpp
+++ b/src/importexport/braille/internal/exportbraille.cpp
@@ -624,7 +624,7 @@ bool ExportBrailleImpl::write(io::Device& device)
 {
     credits(device);
     instruments(device);
-    int nrStaves = score->staves().size();
+    size_t nrStaves = score->staves().size();
     std::vector<QString> measureBraille(nrStaves);
     std::vector<QString> line(nrStaves + 1);
     int currentLineLenght = 0;
@@ -644,7 +644,7 @@ bool ExportBrailleImpl::write(io::Device& device)
             QString measureNumber = textToBraille.braille(QString::number(m->no() + 1)).remove(0, 1) + " ";
             int measureNumberLen = measureNumber.size();
             line[0] += measureNumber;
-            for (int i = 1; i < nrStaves; i++) {
+            for (size_t i = 1; i < nrStaves; i++) {
                 line[i] += QString("").leftJustified(measureNumberLen);
             }
             currentLineLenght += measureNumberLen;
@@ -654,7 +654,7 @@ bool ExportBrailleImpl::write(io::Device& device)
             mb = m = m->mmRest();
         }
 
-        for (int i = 0; i < nrStaves; ++i) {
+        for (size_t i = 0; i < nrStaves; ++i) {
             qDebug() << "Measure " << mb->no() + 1 << " Staff " << i;
 
             measureBraille[i] = brailleMeasure(m, i).toUtf8();
@@ -670,7 +670,7 @@ bool ExportBrailleImpl::write(io::Device& device)
         // have to be split on multiple lines based on specific rules
         if ((currentMeasureMaxLength + currentLineLenght > MAX_CHARS_PER_LINE) && !measureAboveMax) {
             QTextStream out(&device);
-            for (int i = 0; i < nrStaves; ++i) {
+            for (size_t i = 0; i < nrStaves; ++i) {
                 out << line[i].toUtf8() << Qt::endl;
                 line[i] = QString();
             }
@@ -689,14 +689,14 @@ bool ExportBrailleImpl::write(io::Device& device)
         }
 
         currentLineLenght += currentMeasureMaxLength;
-        for (int i = 0; i < nrStaves; ++i) {
+        for (size_t i = 0; i < nrStaves; ++i) {
             line[i] += measureBraille[i].leftJustified(currentMeasureMaxLength);
             measureBraille[i] = QString();
         }
 
         if (measureAboveMax || m->sectionBreak()) {
             QTextStream out(&device);
-            for (int i = 0; i < nrStaves; ++i) {
+            for (size_t i = 0; i < nrStaves; ++i) {
                 out << line[i].toUtf8() << Qt::endl;
                 line[i] = QString();
             }
@@ -714,7 +714,7 @@ bool ExportBrailleImpl::write(io::Device& device)
 
     // Write the last measures
     QTextStream out(&device);
-    for (int i = 0; i < nrStaves; ++i) {
+    for (size_t i = 0; i < nrStaves; ++i) {
         out << line[i].toUtf8() << Qt::endl;
         line[i] = QString();
     }

--- a/src/inspector/view/widgets/gridcanvas.cpp
+++ b/src/inspector/view/widgets/gridcanvas.cpp
@@ -289,9 +289,9 @@ void GridCanvas::mousePressEvent(QMouseEvent* ev)
     const int time = column * 60 / (m_columns - 1);
     const int pitch = row * 100 / m_primaryRowsInterval;
 
-    const int numberOfPoints = m_points.size();
+    const size_t numberOfPoints = m_points.size();
     bool found = false;
-    for (int i = 0; i < numberOfPoints; ++i) {
+    for (size_t i = 0; i < numberOfPoints; ++i) {
         if (round(qreal(m_points[i].time) / 60 * (m_columns - 1)) > column) {
             m_points.insert(m_points.begin() + i, Ms::PitchValue(time, pitch, false));
             found = true;


### PR DESCRIPTION
* MinGW: reg. "comparison of integer expressions of different signedness: 'int' and 'size_t' {aka 'long long unsigned int'}", this one-line change fixes 51 of 94.
As `curIdx` being `-1` is used elsewhere to detect whether an operation is (not) undoable, that cast is unavoidable as far as I can tell
* MSVC: `size_t` vs. `int`, fixes 271 warnings of 1005