### PR TITLE
[MU4] Fix more (MSVC) compiler warnings

### DIFF
--- a/src/converter/internal/compat/notationmeta.cpp
+++ b/src/converter/internal/compat/notationmeta.cpp
@@ -60,8 +60,8 @@ mu::RetVal<std::string> NotationMeta::metaJson(notation::INotationPtr notation)
     json["poet"] =  poet(score);
     json["mscoreVersion"] =  score->mscoreVersion();
     json["fileVersion"] =  score->mscVersion();
-    json["pages"] =  score->npages();
-    json["measures"] =  score->nmeasures();
+    json["pages"] =  static_cast<int>(score->npages()); // no = operator for size_t
+    json["measures"] = static_cast<int>(score->nmeasures()); // no = operator for size_t
     json["hasLyrics"] =  boolToString(score->hasLyrics());
     json["hasHarmonies"] =  boolToString(score->hasHarmonies());
     json["keysig"] =  score->keysig();

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -2067,7 +2067,7 @@ void Measure::readAddConnector(ConnectorInfoReader* info, bool pasteMode)
 bool Measure::visible(size_t staffIdx) const
 {
     if (staffIdx >= score()->staves().size()) {
-        qDebug("Measure::visible: bad staffIdx: %llu", staffIdx);
+        qDebug("Measure::visible: bad staffIdx: %zu", staffIdx);
         return false;
     }
     if (system() && (system()->staves()->empty() || !system()->staff(staffIdx)->show())) {

--- a/src/engraving/libmscore/range.cpp
+++ b/src/engraving/libmscore/range.cpp
@@ -824,7 +824,7 @@ Fraction ScoreRange::ticks() const
 
 void TrackList::dump() const
 {
-    qDebug("elements %llu, duration %d/%d", size(), _duration.numerator(), _duration.denominator());
+    qDebug("elements %zu, duration %d/%d", size(), _duration.numerator(), _duration.denominator());
     for (EngravingItem* e : *this) {
         if (e->isDurationElement()) {
             Fraction du = toDurationElement(e)->ticks();

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -4554,9 +4554,9 @@ EngravingItem* Score::getScoreElementOfMeasureBase(MeasureBase* mb) const
 //   nmeasure
 //---------------------------------------------------------
 
-int Score::nmeasures() const
+size_t Score::nmeasures() const
 {
-    int n = 0;
+    size_t n = 0;
     for (const Measure* m = firstMeasure(); m; m = m->nextMeasure()) {
         n++;
     }

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -2087,7 +2087,7 @@ void Score::removeAudio()
 bool Score::appendScore(Score* score, bool addPageBreak, bool addSectionBreak)
 {
     if (parts().size() < score->parts().size() || staves().size() < score->staves().size()) {
-        qDebug("Score to append has %llu parts and %llu staves, but this score only has %llu parts and %llu staves.",
+        qDebug("Score to append has %zu parts and %zu staves, but this score only has %zu parts and %zu staves.",
                score->parts().size(), score->staves().size(), parts().size(), staves().size());
         return false;
     }

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -651,7 +651,7 @@ public:
 
     const std::vector<Staff*>& staves() const { return _staves; }
     size_t nstaves() const { return _staves.size(); }
-    int ntracks() const { return _staves.size() * VOICES; }
+    size_t ntracks() const { return _staves.size() * VOICES; }
 
     size_t staffIdx(const Part*) const;
     Staff* staff(size_t n) const { return (n < _staves.size()) ? _staves.at(n) : nullptr; }
@@ -1011,7 +1011,7 @@ public:
     void nextInputPos(ChordRest* cr, bool);
     void cmdMirrorNoteHead();
 
-    virtual int npages() const { return _pages.size(); }
+    virtual size_t npages() const { return _pages.size(); }
     virtual int pageIdx(Page* page) const { return mu::indexOf(_pages, page); }
     virtual const std::vector<Page*>& pages() const { return _pages; }
     virtual std::vector<Page*>& pages() { return _pages; }
@@ -1190,7 +1190,7 @@ public:
     EngravingItem* firstElement(bool frame = true);
     EngravingItem* lastElement(bool frame = true);
 
-    int nmeasures() const;
+    size_t nmeasures() const;
     bool hasLyrics();
     bool hasHarmonies();
     int  lyricCount();

--- a/src/engraving/libmscore/stringdata.h
+++ b/src/engraving/libmscore/stringdata.h
@@ -72,7 +72,7 @@ public:
     void        fretChords(Chord* chord) const;
     int         getPitch(int string, int fret, Staff* staff) const;
     static int  pitchOffsetAt(Staff* staff);
-    int         strings() const { return stringTable.size(); }
+    size_t      strings() const { return stringTable.size(); }
     int         frettedStrings() const;
     const std::vector<instrString>& stringList() const { return stringTable; }
     std::vector<instrString>& stringList() { return stringTable; }

--- a/src/engraving/libmscore/textbase.h
+++ b/src/engraving/libmscore/textbase.h
@@ -446,7 +446,7 @@ public:
     const TextBlock& textBlock(int line) const { return _layout[line]; }
     TextBlock& textBlock(int line) { return _layout[line]; }
     std::vector<TextBlock>& textBlockList() { return _layout; }
-    int rows() const { return _layout.size(); }
+    size_t rows() const { return _layout.size(); }
 
     void setTextInvalid() { textInvalid = true; }
     bool isTextInvalid() const { return textInvalid; }

--- a/src/engraving/rw/compat/read114.cpp
+++ b/src/engraving/rw/compat/read114.cpp
@@ -2923,7 +2923,7 @@ Score::FileError Read114::read114(MasterScore* masterScore, XmlReader& e, ReadCo
 
         // check barLineSpan
         if (s->barLineSpan() > (masterScore->nstaves() - idx)) {
-            qDebug("read114: invalid barline span %d (max %llu)",
+            qDebug("read114: invalid barline span %d (max %zu)",
                    s->barLineSpan(), masterScore->nstaves() - idx);
             s->setBarLineSpan(masterScore->nstaves() - idx);
         }

--- a/src/engraving/rw/xmlwriter.cpp
+++ b/src/engraving/rw/xmlwriter.cpp
@@ -57,8 +57,8 @@ XmlWriter::XmlWriter(Score* s, QIODevice* device)
 
 void XmlWriter::putLevel()
 {
-    int level = stack.size();
-    for (int i = 0; i < level * 2; ++i) {
+    size_t level = stack.size();
+    for (size_t i = 0; i < level * 2; ++i) {
         *this << ' ';
     }
 }

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -6436,7 +6436,7 @@ static void partList(XmlWriter& xml, Score* score, MxmlInstrumentMap& instrMap)
                             }
                         } else {
                             // bracket in other staff not supported in MusicXML
-                            qDebug("bracket starting in staff %llu not supported", i + 1);
+                            qDebug("bracket starting in staff %zu not supported", i + 1);
                         }
                     }
                 }

--- a/src/notation/view/widgets/timeline.cpp
+++ b/src/notation/view/widgets/timeline.cpp
@@ -1762,7 +1762,7 @@ void Timeline::setMetaData(QGraphicsItem* gi, int staff, ElementType et, Measure
 int Timeline::getWidth() const
 {
     if (score()) {
-        return int(score()->nmeasures() * _gridWidth);
+        return score()->nmeasures() * _gridWidth;
     } else {
         return 0;
     }

--- a/src/plugins/api/score.h
+++ b/src/plugins/api/score.h
@@ -203,10 +203,10 @@ public:
 //      Q_INVOKABLE void updateRepeatList(bool expandRepeats) { score()->updateRepeatList(); } // TODO: needed?
 
     /// \cond MS_INTERNAL
-    int nmeasures() const { return score()->nmeasures(); }
-    int npages() const { return score()->npages(); }
-    int nstaves() const { return score()->nstaves(); }
-    int ntracks() const { return score()->ntracks(); }
+    int nmeasures() const { return static_cast<int>(score()->nmeasures()); }
+    int npages() const { return static_cast<int>(score()->npages()); }
+    int nstaves() const { return static_cast<int>(score()->nstaves()); }
+    int  ntracks() const { return static_cast<int>(score()->ntracks()); }
     /// \endcond
 
     /**


### PR DESCRIPTION
reg. `size_t` vs. `int`, still not all (and some of these changes result in new warnings elsewhere), but 496 less than before (still 452 left).