### PR TITLE
[MU4] Fix #11283: Crash after applying Remove empty trailing measures in a new score without notes

### DIFF
--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -488,8 +488,9 @@ PlaybackModel::TickBoundaries PlaybackModel::tickBoundaries(const Ms::ScoreChang
     if (hasToReloadTracks(changesRange.changedTypes)
         || hasToReloadScore(changesRange.changedTypes)
         || !changesRange.isValidBoundary()) {
+        const Ms::Measure* lastMeasure = m_score->lastMeasure();
         result.tickFrom = 0;
-        result.tickTo = m_score->lastMeasure()->endTick().ticks();
+        result.tickTo = lastMeasure ? lastMeasure->endTick().ticks() : 0;
     }
 
     return result;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11283