### PR TITLE
fix #10638: fix barline types on different staves

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.h
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.h
@@ -85,7 +85,7 @@ private:
     void doAddVolta(const GPMasterBar* mB, Measure* measure);
     void addClef(const GPBar* bar, int curTrack);
     bool addSimileMark(const GPBar* bar, int curTrack);
-    void addBarline(const GPMasterBar* mB, Measure* measure, Context ctx);
+    void addBarline(const GPMasterBar* mB, Measure* measure);
 
     void addTie(const GPNote* gpnote, Note* note);
     void addFretDiagram(const GPBeat* gpnote, ChordRest* note, const Context& ctx);
@@ -164,6 +164,7 @@ private:
     Tuplet* _lastTuplet = nullptr;
     Hairpin* _lastHairpin = nullptr;
     Ottava* _lastOttava = nullptr;
+    Measure* _lastMeasure = nullptr;
 };
 } //end Ms namespace
 #endif // SCOREDOMBUILDER_H


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/10638*

*fixed appearance of barlines: adding same barline types on different staves of the same measure*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
