### PR TITLE
Fix initializing the EditStaffType dialog

### DIFF
--- a/src/engraving/libmscore/stafftype.cpp
+++ b/src/engraving/libmscore/stafftype.cpp
@@ -183,7 +183,7 @@ bool StaffType::operator==(const StaffType& st) const
     equal &= (_stepOffset == st._stepOffset);
     equal &= (_lineDistance == st._lineDistance);
     equal &= (_showBarlines == st._showBarlines);
-    equal &= (_showLedgerLines == st._showBarlines);
+    equal &= (_showLedgerLines == st._showLedgerLines);
     equal &= (_stemless == st._stemless);
     equal &= (_genClef == st._genClef);
     equal &= (_genTimesig == st._genTimesig);

--- a/src/notation/view/widgets/editstafftype.cpp
+++ b/src/notation/view/widgets/editstafftype.cpp
@@ -501,35 +501,52 @@ void EditStaffType::blockSignals(bool block)
 //      groupCombo->blockSignals(block);
     lines->blockSignals(block);
     lineDistance->blockSignals(block);
-    showBarlines->blockSignals(block);
     genClef->blockSignals(block);
+    showBarlines->blockSignals(block);
     genTimesig->blockSignals(block);
-    noteValuesSymb->blockSignals(block);
-    noteValuesStems->blockSignals(block);
-    durFontName->blockSignals(block);
-    durFontSize->blockSignals(block);
-    durY->blockSignals(block);
+
+    genKeysigPitched->blockSignals(block);
+    showLedgerLinesPitched->blockSignals(block);
+    stemlessPitched->blockSignals(block);
+    noteHeadScheme->blockSignals(block);
+
+    upsideDown->blockSignals(block);
+    showTabFingering->blockSignals(block);
+
     fretFontName->blockSignals(block);
     fretFontSize->blockSignals(block);
     fretY->blockSignals(block);
 
     numbersRadio->blockSignals(block);
-    linesThroughRadio->blockSignals(block);
+    lettersRadio->blockSignals(block);
     onLinesRadio->blockSignals(block);
+    aboveLinesRadio->blockSignals(block);
+    linesThroughRadio->blockSignals(block);
+    linesBrokenRadio->blockSignals(block);
     showBackTied->blockSignals(block);
 
-    upsideDown->blockSignals(block);
-    showTabFingering->blockSignals(block);
-    valuesRepeatNever->blockSignals(block);
-    valuesRepeatSystem->blockSignals(block);
-    valuesRepeatMeasure->blockSignals(block);
-    valuesRepeatAlways->blockSignals(block);
+    durFontName->blockSignals(block);
+    durFontSize->blockSignals(block);
+    durY->blockSignals(block);
+
     stemAboveRadio->blockSignals(block);
     stemBelowRadio->blockSignals(block);
     stemBesideRadio->blockSignals(block);
     stemThroughRadio->blockSignals(block);
+
+    minimNoneRadio->blockSignals(block);
     minimShortRadio->blockSignals(block);
     minimSlashedRadio->blockSignals(block);
+
+    valuesRepeatNever->blockSignals(block);
+    valuesRepeatSystem->blockSignals(block);
+    valuesRepeatMeasure->blockSignals(block);
+    valuesRepeatAlways->blockSignals(block);
+
+    noteValuesNone->blockSignals(block);
+    noteValuesSymb->blockSignals(block);
+    noteValuesStems->blockSignals(block);
+
     showRests->blockSignals(block);
 
     showLedgerLinesPercussion->blockSignals(block);


### PR DESCRIPTION
Resolves: #11286

For some properties, the signals of the corresponding widgets were not properly blocked, causing the value of the property to be wrong when opening the dialog. 

Also fixed a mistake in `StaffType::operator==`, but that does not seem to be the cause of this issue. 