### PR TITLE
fix #10491: arpeggio direction and visibility on standard staff

### DIFF
--- a/src/engraving/libmscore/arpeggio.cpp
+++ b/src/engraving/libmscore/arpeggio.cpp
@@ -235,7 +235,7 @@ void Arpeggio::layout()
     if (score()->styleB(Sid::ArpeggioHiddenInStdIfTab)) {
         if (staff() && staff()->isPitchedStaff(tick())) {
             for (Staff* s : staff()->staffList()) {
-                if (s->score() == score() && s->isTabStaff(tick())) {
+                if (s->score() == score() && s->isTabStaff(tick()) && s->visible()) {
                     _hidden = true;
                     setbbox(RectF());
                     return;

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -2015,7 +2015,7 @@ void GPConverter::addArpeggio(const GPBeat* beat, ChordRest* cr)
         if (gpArp == GPBeat::Arpeggio::Up) {
             return ArpeggioType::DOWN;
         } else {
-            return ArpeggioType::NORMAL;
+            return ArpeggioType::UP;
         }
     };
 


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/10491*

*fixing arpeggio direction and visibility on standard staff*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
