### PR TITLE
fix #11243: 2 scrollbars in font face menu, Preferences

### DIFF
--- a/src/engraving/libmscore/arpeggio.cpp
+++ b/src/engraving/libmscore/arpeggio.cpp
@@ -235,7 +235,7 @@ void Arpeggio::layout()
     if (score()->styleB(Sid::ArpeggioHiddenInStdIfTab)) {
         if (staff() && staff()->isPitchedStaff(tick())) {
             for (Staff* s : staff()->staffList()) {
-                if (s->score() == score() && s->isTabStaff(tick())) {
+                if (s->score() == score() && s->isTabStaff(tick()) && s->visible()) {
                     _hidden = true;
                     setbbox(RectF());
                     return;

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/Dropdown.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/Dropdown.qml
@@ -251,11 +251,7 @@ Item {
                     anchors.fill: parent
 
                     model: root.model
-
-                    ScrollBar.vertical: StyledScrollBar {
-                        thickness: 6
-                        policy: ScrollBar.AlwaysOn
-                    }
+                    scrollBarAlwaysOn: true
 
                     delegate: DropdownItem {
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledListView.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledListView.qml
@@ -30,6 +30,7 @@ ListView {
     id: root
 
     property bool arrowControlsAvailable: false
+    property bool scrollBarAlwaysOn: false
 
     clip: true
     boundsBehavior: Flickable.StopAtBounds
@@ -37,8 +38,13 @@ ListView {
 
     Component.onCompleted: {
         if (!root.arrowControlsAvailable) {
-            var scrollBarVerticalObj = scrollBarComp.createObject(root)
-            var scrollBarHorizontalObj = scrollBarComp.createObject(root)
+            var scrollChanges = {}
+            if (root.scrollBarAlwaysOn) {
+                scrollChanges.policy = ScrollBar.AlwaysOn
+            }
+
+            var scrollBarVerticalObj = scrollBarComp.createObject(root, scrollChanges)
+            var scrollBarHorizontalObj = scrollBarComp.createObject(root, scrollChanges)
 
             ScrollBar.vertical = scrollBarVerticalObj
             ScrollBar.horizontal = scrollBarHorizontalObj

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/ValueList.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/ValueList.qml
@@ -196,8 +196,6 @@ Item {
             }
         }
 
-        ScrollBar.vertical: StyledScrollBar {}
-
         delegate: ValueListItem {
             id: listItem
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/internal/DirectoriesView.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/internal/DirectoriesView.qml
@@ -117,8 +117,6 @@ Item {
             }
         }
 
-        ScrollBar.vertical: StyledScrollBar {}
-
         Connections {
             target: root.model
 

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -2015,7 +2015,7 @@ void GPConverter::addArpeggio(const GPBeat* beat, ChordRest* cr)
         if (gpArp == GPBeat::Arpeggio::Up) {
             return ArpeggioType::DOWN;
         } else {
-            return ArpeggioType::NORMAL;
+            return ArpeggioType::UP;
         }
     };
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/PartsView.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PartsView.qml
@@ -96,8 +96,6 @@ Item {
             }
         }
 
-        ScrollBar.vertical: StyledScrollBar {}
-
         Connections {
             target: root.model
 


### PR DESCRIPTION
Resolves: #11243

The problem is that Dropdown.qml uses StyledListView.qml, which *already* sets `ScrollBar.vertical` and `ScrollBar.horizontal`. Now in Dropdown, an always-on scroll bar is desired. Hence I created the boolean `scrollBarAlwaysOn` inside StyledListView.qml.

For the same reason as above, I suggest removing the `ScrollBar.vertical` of the following files:
* [ValueList.qml](https://github.com/musescore/MuseScore/blob/36d5a315df466e73aba4bbcf8684f6e4fd9cd8fe/src/framework/uicomponents/qml/MuseScore/UiComponents/ValueList.qml)
* [PartsView.qml](https://github.com/musescore/MuseScore/blob/36d5a315df466e73aba4bbcf8684f6e4fd9cd8fe/src/notation/qml/MuseScore/NotationScene/internal/PartsView.qml)
* [DirectoriesView.qml](https://github.com/musescore/MuseScore/blob/0ba0827cdaef2b5617f9af825bd5069bafd04dfe/src/framework/uicomponents/qml/MuseScore/UiComponents/internal/DirectoriesView.qml)

Although I am confident that the scroll bars remain, I didn't remove for now because I cannot test those extra changes.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
