### PR TITLE
Fixes and simplifications for the Score Properties dialog

### DIFF
--- a/src/converter/internal/compat/backendapi.cpp
+++ b/src/converter/internal/compat/backendapi.cpp
@@ -721,7 +721,7 @@ Ret BackendApi::updateSource(const io::path& in, const std::string& newSource, b
     ProjectMeta meta = project.val->metaInfo();
     meta.source = QString::fromStdString(newSource);
 
-    project.val->setMetaInfo(meta);
+    project.val->setMetaInfo(meta, false);
 
     return project.val->save();
 }

--- a/src/notation/qml/MuseScore/NotationScene/internal/NotationSwitchButton.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/NotationSwitchButton.qml
@@ -87,7 +87,7 @@ FlatRadioButton {
 
             visible: false
             color: "white"
-            opacity: 0.1
+            opacity: 0.05
         }
 
         NavigationFocusBorder {

--- a/src/notation/view/widgets/scoreproperties.cpp
+++ b/src/notation/view/widgets/scoreproperties.cpp
@@ -423,7 +423,7 @@ void ScorePropertiesDialog::saveMetaTags(const QVariantMap& tagsMap)
         meta.additionalTags[key] = tagsMap[key];
     }
 
-    project()->setMetaInfo(meta);
+    project()->setMetaInfo(meta, true);
 }
 
 void ScorePropertiesDialog::updateTabOrders(const TagItem& lastTagItem)

--- a/src/notation/view/widgets/scoreproperties.h
+++ b/src/notation/view/widgets/scoreproperties.h
@@ -57,8 +57,10 @@ public:
     ScorePropertiesDialog(const ScorePropertiesDialog& dialog);
 
 private:
-    virtual void closeEvent(QCloseEvent*) override;
     void accept() override;
+
+    void buttonClicked(QAbstractButton* button);
+    void newClicked();
 
     struct TagItem {
         QWidget* titleWidget = nullptr;
@@ -69,20 +71,17 @@ private:
     bool isStandardTag(const QString& tag) const;
     TagItem addTag(const QString& key, const QString& value);
 
-    bool save();
-    void newClicked();
-    void setDirty(const bool dirty = true);
     void openFileLocation();
+    bool save();
 
     project::INotationProjectPtr project() const;
 
     void initTags();
     void saveMetaTags(const QVariantMap& tagsMap);
 
-    void updateTabOrders(const TagItem& lastTagItem);
+    void updateTabOrders();
 
-private:
-    bool m_dirty = false;     /// whether the editor has unsaved changes or not
+    QPushButton* newButton = nullptr;
 };
 }
 

--- a/src/notation/view/widgets/scoreproperties.ui
+++ b/src/notation/view/widgets/scoreproperties.ui
@@ -196,8 +196,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>662</width>
-        <height>283</height>
+        <width>656</width>
+        <height>271</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="scrollAreaLayout">
@@ -209,70 +209,11 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="buttonLayout">
-     <item>
-      <widget class="QPushButton" name="newButton">
-       <property name="cursor">
-        <cursorShape>PointingHandCursor</cursorShape>
-       </property>
-       <property name="toolTip">
-        <string>Add a tag to this score.</string>
-       </property>
-       <property name="text">
-        <string>New</string>
-       </property>
-       <property name="autoRepeat">
-        <bool>true</bool>
-       </property>
-       <property name="autoRepeatDelay">
-        <number>500</number>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="okButton">
-       <property name="text">
-        <string>Ok</string>
-       </property>
-       <property name="default">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="cancelButton">
-       <property name="text">
-        <string>Cancel</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="saveButton">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="cursor">
-        <cursorShape>PointingHandCursor</cursorShape>
-       </property>
-       <property name="text">
-        <string>Save</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -283,44 +224,7 @@
   <tabstop>revision</tabstop>
   <tabstop>level</tabstop>
   <tabstop>scrollArea</tabstop>
-  <tabstop>newButton</tabstop>
-  <tabstop>okButton</tabstop>
-  <tabstop>cancelButton</tabstop>
-  <tabstop>saveButton</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>okButton</sender>
-   <signal>clicked()</signal>
-   <receiver>ScorePropertiesDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>499</x>
-     <y>395</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>435</x>
-     <y>389</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>cancelButton</sender>
-   <signal>clicked()</signal>
-   <receiver>ScorePropertiesDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>585</x>
-     <y>395</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>546</x>
-     <y>405</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/project/inotationproject.h
+++ b/src/project/inotationproject.h
@@ -55,7 +55,7 @@ public:
     virtual Ret writeToDevice(io::Device* device) = 0;
 
     virtual ProjectMeta metaInfo() const = 0;
-    virtual void setMetaInfo(const ProjectMeta& meta) = 0;
+    virtual void setMetaInfo(const ProjectMeta& meta, bool undoable) = 0;
 
     virtual notation::IMasterNotationPtr masterNotation() const = 0;
     virtual IProjectAudioSettingsPtr audioSettings() const = 0;

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -77,7 +77,7 @@ public:
     Ret writeToDevice(io::Device* device) override;
 
     ProjectMeta metaInfo() const override;
-    void setMetaInfo(const ProjectMeta& meta) override;
+    void setMetaInfo(const ProjectMeta& meta, bool undoable) override;
 
     notation::IMasterNotationPtr masterNotation() const override;
     IProjectAudioSettingsPtr audioSettings() const override;

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -483,7 +483,7 @@ bool ProjectActionsController::saveProjectToCloud(const SaveLocation::CloudInfo&
         }
 
         meta.source = newSource;
-        project->setMetaInfo(meta);
+        project->setMetaInfo(meta, false);
 
         if (!project->isNewlyCreated()) {
             project->save();


### PR DESCRIPTION
- Resolves: #10522

- Simplifies the dialog, by eliminating the concept of the dialog being "dirty" and having a "save" button. It made the dialog unnecessarily complicated for the user, and could cause confusion about closing the dialog vs closing the score. Removing it brings this dialog in line with other dialogs throughout the app. 

- Replaces the buttons at the bottom of the dialog with a QDialogButtonBox, fixing a problem with the order of the buttons on some platforms. 
(I had to fight a bit to get the Tab order right; finally, I decided to go the hard way of setting the tab order for every widget, because anything more elegant didn't work, probably due to bugs in Qt.)

- (Also includes a tiny color fix proposed by Jessica.)