### PR TITLE
fix #10311: fixed red frets of harmonics

### DIFF
--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -554,6 +554,7 @@ Note::Note(const Note& n, bool link)
     _fixedLine         = n._fixedLine;
     _accidental        = 0;
     _harmonic          = n._harmonic;
+    _harmonicFret      = n._harmonicFret;
     _cachedNoteheadSym = n._cachedNoteheadSym;
     _cachedSymNull     = n._cachedSymNull;
 

--- a/src/engraving/libmscore/note.h
+++ b/src/engraving/libmscore/note.h
@@ -205,6 +205,7 @@ private:
 
     bool _isHammerOn = false;
     bool _harmonic = false;
+    int _harmonicFret = 0;
 
     ElementList _el;          ///< fingering, other text, symbols or images
     std::vector<NoteDot*> _dots;
@@ -503,6 +504,9 @@ public:
 
     void setHarmonic(bool val) { _harmonic = val; }
     bool harmonic() const { return _harmonic; }
+
+    void setHarmonicFret(int val) { _harmonicFret = val; }
+    int harmonicFret() const { return _harmonicFret; }
 };
 }     // namespace Ms
 #endif

--- a/src/engraving/libmscore/stringdata.cpp
+++ b/src/engraving/libmscore/stringdata.cpp
@@ -470,6 +470,9 @@ void StringData::sortChordNotes(std::map<int, Note*>& sortedNotes, const Chord* 
     for (Note* note : chord->notes()) {
         int string = note->string();
         int fret = note->fret();
+        if (note->harmonic()) {
+            fret = note->harmonicFret();
+        }
 
         // if note not fretted yet or current fretting no longer valid,
         // use most convenient string as key

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1340,6 +1340,7 @@ void GPConverter::addHarmonic(const GPNote* gpnote, Note* note)
     note->setPitch(harmonicPitch);
     note->setTpcFromPitch();
     note->setHarmonic(true);
+    note->setHarmonicFret(harmonicFret);
 
     auto harmonicText = [](const GPNote::Harmonic::Type& h) {
         if (h == GPNote::Harmonic::Type::Artificial) {


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/10311*

*fixed red frets of harmonics*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
