### PR TITLE
fix #10318: hiding fermatas on tab staff when standard staff is shown

### DIFF
--- a/src/engraving/libmscore/fermata.h
+++ b/src/engraving/libmscore/fermata.h
@@ -45,9 +45,10 @@ class Page;
 
 class Fermata final : public EngravingItem
 {
-    SymId _symId;
-    qreal _timeStretch;
-    bool _play;
+    SymId m_symId;
+    qreal m_timeStretch = 0;
+    bool m_play = false;
+    bool m_hidden = false;
 
     friend class mu::engraving::Factory;
     Fermata(EngravingItem* parent);
@@ -64,8 +65,8 @@ public:
 
     qreal mag() const override;
 
-    SymId symId() const { return _symId; }
-    void setSymId(SymId id) { _symId  = id; }
+    SymId symId() const { return m_symId; }
+    void setSymId(SymId id) { m_symId  = id; }
     FermataType fermataType() const;
     int subtype() const override;
     QString typeUserName() const override;
@@ -91,11 +92,11 @@ public:
     System* system() const;
     Page* page() const;
 
-    qreal timeStretch() const { return _timeStretch; }
-    void setTimeStretch(qreal val) { _timeStretch = val; }
+    qreal timeStretch() const { return m_timeStretch; }
+    void setTimeStretch(qreal val) { m_timeStretch = val; }
 
-    bool play() const { return _play; }
-    void setPlay(bool val) { _play = val; }
+    bool play() const { return m_play; }
+    void setPlay(bool val) { m_play = val; }
 
     QString accessibleInfo() const override;
 


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/10318*

*hiding fermatas on tab staff when standard staff is shown*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
