### PR TITLE
fix #10326: hiding ottava signs on tab staff

### DIFF
--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -973,6 +973,10 @@ void LayoutSystem::layoutSystemElements(const LayoutOptions& options, LayoutCont
         Spanner* sp = interval.value;
         if (sp->tick() < etick && sp->tick2() > stick) {
             if (sp->isOttava()) {
+                if (sp->staff()->staffType()->isTabStaff()) {
+                    continue;
+                }
+
                 ottavas.push_back(sp);
             } else if (sp->isPedal()) {
                 pedal.push_back(sp);


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/10326*

*hiding ottava signs on tab staff*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
