### PR TITLE
Fix audio initialization failure

### DIFF
--- a/src/framework/audio/iaudiodriver.h
+++ b/src/framework/audio/iaudiodriver.h
@@ -48,7 +48,7 @@ public:
 
     struct Spec
     {
-        int sampleRate;               // frequency -- samples per second
+        unsigned int sampleRate;      // frequency -- samples per second
         Format format;                // Audio data format
         uint8_t channels;             // Number of channels: 1 mono, 2 stereo
         uint16_t samples;             // Audio buffer size in sample FRAMES (total samples divided by channel count)

--- a/src/framework/audio/internal/platform/lin/linuxaudiodriver.cpp
+++ b/src/framework/audio/internal/platform/lin/linuxaudiodriver.cpp
@@ -40,7 +40,7 @@ struct ALSAData
 {
     float* buffer = nullptr;
     snd_pcm_t* alsaDeviceHandle = nullptr;
-    int samples = 0;
+    unsigned long samples = 0;
     int channels = 0;
     bool audioProcessingDone = false;
     pthread_t threadHandle = 0;
@@ -133,7 +133,6 @@ bool LinuxAudioDriver::open(const Spec& spec, Spec* activeSpec)
     snd_pcm_hw_params_set_access(handle, params, SND_PCM_ACCESS_RW_INTERLEAVED);
     snd_pcm_hw_params_set_format(handle, params, SND_PCM_FORMAT_FLOAT_LE);
     snd_pcm_hw_params_set_channels(handle, params, spec.channels);
-    snd_pcm_hw_params_set_buffer_size(handle, params, spec.samples);
 
     unsigned int aSamplerate = spec.sampleRate;
     unsigned int val = aSamplerate;
@@ -142,6 +141,8 @@ bool LinuxAudioDriver::open(const Spec& spec, Spec* activeSpec)
     if (rc < 0) {
         return false;
     }
+
+    snd_pcm_hw_params_set_buffer_size_near(handle, params, &_alsaData->samples);
 
     rc = snd_pcm_hw_params(handle, params);
     if (rc < 0) {


### PR DESCRIPTION
Musescore was failing to play audio for me, with a log message printed about failing to initialize alsa. I poked around in the code a bit and found that the parameters were a bit unnecessarily restrictive, leaving out my hardware/software configuration (a pipewire-alsa bridge with an external sound card). A few minor tweaks to the alsa initialization code should fix this.

Commit message copypasted below:
This fix has two parts: firstly, snd_pcm_hw_params_set_buffer_size_near is used instead of snd_pcm_hw_params_set_buffer_size. We don't strictly /need/ whatever default buffer size we pick, so this allows for a wider range of hardware/software configurations. Secondly, we move the buffer size constraint after the set_rate_near call. This is required to avoid overconstraining, and it's the order aplay does things in.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
