### PR TITLE
fix #10332: hiding vertical frame when there is no meta info

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -674,6 +674,16 @@ void GPConverter::addKeySig(const GPMasterBar* mB, Measure* measure)
 
 void GPConverter::setUpGPScore(const GPScore* gpscore)
 {
+    std::vector<QString> fieldNames = { gpscore->title(), gpscore->subTitle(), gpscore->artist(),
+                                        gpscore->album(), gpscore->composer(), gpscore->poet() };
+
+    bool createTitleField
+        = std::any_of(fieldNames.begin(), fieldNames.end(), [](const QString& fieldName) { return !fieldName.isEmpty(); });
+
+    if (!createTitleField) {
+        return;
+    }
+
     MeasureBase* m = nullptr;
     if (!_score->measures()->first()) {
         m = Factory::createVBox(_score->dummy()->system());

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -2929,51 +2929,60 @@ Score::FileError importGTP(MasterScore* score, const QString& name)
 
     score->style().set(Sid::ArpeggioHiddenInStdIfTab, true);
 
-    MeasureBase* m;
-    if (!score->measures()->first()) {
-        m = Factory::createVBox(score->dummy()->system());
-        m->setTick(Fraction(0, 1));
-        score->addMeasure(m, 0);
-    } else {
-        m = score->measures()->first();
-        if (!m->isVBox()) {
-            MeasureBase* mb = Factory::createVBox(score->dummy()->system());
-            mb->setTick(Fraction(0, 1));
-            score->addMeasure(mb, m);
-            m = mb;
-        }
-    }
-    if (!gp->title.isEmpty()) {
-        Text* s = Factory::createText(m, TextStyleType::TITLE);
-        s->setPlainText(gp->title);
-        m->add(s);
-    }
-    if (!gp->subtitle.isEmpty() || !gp->artist.isEmpty() || !gp->album.isEmpty()) {
-        Text* s = Factory::createText(m, TextStyleType::SUBTITLE);
-        QString str;
-        if (!gp->subtitle.isEmpty()) {
-            str.append(gp->subtitle);
-        }
-        if (!gp->artist.isEmpty()) {
-            if (!str.isEmpty()) {
-                str.append("\n");
+    std::vector<QString> fieldNames = { gp->title, gp->subtitle, gp->artist,
+                                        gp->album, gp->composer };
+
+    bool createTitleField
+        = std::any_of(fieldNames.begin(), fieldNames.end(), [](const QString& fieldName) { return !fieldName.isEmpty(); });
+
+    if (createTitleField) {
+        MeasureBase* m;
+        if (!score->measures()->first()) {
+            m = Factory::createVBox(score->dummy()->system());
+            m->setTick(Fraction(0, 1));
+            score->addMeasure(m, 0);
+        } else {
+            m = score->measures()->first();
+            if (!m->isVBox()) {
+                MeasureBase* mb = Factory::createVBox(score->dummy()->system());
+                mb->setTick(Fraction(0, 1));
+                score->addMeasure(mb, m);
+                m = mb;
             }
-            str.append(gp->artist);
         }
-        if (!gp->album.isEmpty()) {
-            if (!str.isEmpty()) {
-                str.append("\n");
+        if (!gp->title.isEmpty()) {
+            Text* s = Factory::createText(m, TextStyleType::TITLE);
+            s->setPlainText(gp->title);
+            m->add(s);
+        }
+        if (!gp->subtitle.isEmpty() || !gp->artist.isEmpty() || !gp->album.isEmpty()) {
+            Text* s = Factory::createText(m, TextStyleType::SUBTITLE);
+            QString str;
+            if (!gp->subtitle.isEmpty()) {
+                str.append(gp->subtitle);
             }
-            str.append(gp->album);
+            if (!gp->artist.isEmpty()) {
+                if (!str.isEmpty()) {
+                    str.append("\n");
+                }
+                str.append(gp->artist);
+            }
+            if (!gp->album.isEmpty()) {
+                if (!str.isEmpty()) {
+                    str.append("\n");
+                }
+                str.append(gp->album);
+            }
+            s->setPlainText(str);
+            m->add(s);
         }
-        s->setPlainText(str);
-        m->add(s);
+        if (!gp->composer.isEmpty()) {
+            Text* s = Factory::createText(m, TextStyleType::COMPOSER);
+            s->setPlainText(gp->composer);
+            m->add(s);
+        }
     }
-    if (!gp->composer.isEmpty()) {
-        Text* s = Factory::createText(m, TextStyleType::COMPOSER);
-        s->setPlainText(gp->composer);
-        m->add(s);
-    }
+
     int idx = 0;
 
     for (Measure* m1 = score->firstMeasure(); m1; m1 = m1->nextMeasure(), ++idx) {


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/10332*

*hiding vertical frame when there is no meta info*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
