### PR TITLE
Added connector lines for slurs

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1099,6 +1099,7 @@ bool NotationInteraction::isDropAccepted(const PointF& pos, Qt::KeyboardModifier
     case ElementType::TRILL:
     case ElementType::HAIRPIN:
     case ElementType::TEXTLINE:
+    case ElementType::SLUR:
         return dragTimeAnchorElement(pos);
     case ElementType::IMAGE:
     case ElementType::SYMBOL:
@@ -1136,7 +1137,6 @@ bool NotationInteraction::isDropAccepted(const PointF& pos, Qt::KeyboardModifier
     case ElementType::ACTION_ICON:
     case ElementType::CHORD:
     case ElementType::SPACER:
-    case ElementType::SLUR:
     case ElementType::HARMONY:
     case ElementType::BAGPIPE_EMBELLISHMENT:
     case ElementType::AMBITUS:
@@ -1330,10 +1330,21 @@ bool NotationInteraction::drop(const PointF& pos, Qt::KeyboardModifiers modifier
     break;
     case ElementType::SLUR:
     {
-        EngravingItem* el = dropTarget(m_dropData.ed);
+        Ms::staff_idx_t staffIdx = 0;
+        Ms::Segment* seg = nullptr;
+        score()->pos2measure(pos, &staffIdx, 0, &seg, 0);
+        Ms::track_idx_t track = staffIdx * Ms::VOICES;
+
+        EngravingItem* element = seg->elementAt(track);
+
+        if (!element->isChord()) {
+            break;
+        }
+
+        Chord* chord = toChord(element);
         Ms::Slur* dropElement = toSlur(m_dropData.ed.dropElement);
-        if (toNote(el)->chord()) {
-            doAddSlur(toNote(el)->chord(), nullptr, dropElement);
+        if (chord) {
+            doAddSlur(chord, nullptr, dropElement);
             accepted = true;
         }
     }


### PR DESCRIPTION
*(short description of the changes and the motivation to make the changes)*

This commit creates connector lines to the nearest object when you drag a slur from Palettes

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
