### PR TITLE
Fix #11374: No Preview for First Template

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/CreateFromTemplatePage.qml
+++ b/src/project/qml/MuseScore/Project/internal/CreateFromTemplatePage.qml
@@ -71,6 +71,7 @@ Item {
 
             onTitleClicked: function(index) {
                 model.currentCategoryIndex = index
+                templatePreview.load(model.currentTemplatePath)
 
                 if (templatesView.searching) {
                     model.saveCurrentCategory()


### PR DESCRIPTION
Resolves: #11374 

*(short description of the changes and the motivation to make the changes)*

This commit adds a preview for the first template when a category is changed


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
