### PR TITLE
[MU4] Fix compiler warnings

### DIFF
--- a/src/engraving/CMakeLists.txt
+++ b/src/engraving/CMakeLists.txt
@@ -224,8 +224,5 @@ set_property(TARGET ${MODULE} APPEND PROPERTY AUTOMOC_MACRO_NAMES "BEGIN_QT_REGI
 
 if (MSVC)
     # temporarily disabled some warnings (int vs size_t)
-    target_compile_options(${MODULE} PUBLIC /wd4244)
     target_compile_options(${MODULE} PUBLIC /wd4267)
-    target_compile_options(${MODULE} PUBLIC /wd4310)
-    target_compile_options(${MODULE} PUBLIC /wd4701)
 endif()

--- a/src/engraving/utests/barline_tests.cpp
+++ b/src/engraving/utests/barline_tests.cpp
@@ -239,7 +239,7 @@ TEST_F(BarlineTests, barline05)
     // create and add a LineBreak element
     LayoutBreak* lb = Factory::createLayoutBreak(msr);
     lb->setLayoutBreakType(LayoutBreakType::LINE);
-    lb->setTrack(-1);               // system-level element
+    lb->setTrack(mu::nidx);               // system-level element
     lb->setParent(msr);
     score->undoAddElement(lb);
     score->doLayout();

--- a/src/framework/audio/internal/encoders/mp3encoder.cpp
+++ b/src/framework/audio/internal/encoders/mp3encoder.cpp
@@ -110,5 +110,5 @@ samples_t Mp3Encoder::doFlush(char* output, size_t outputSize)
 {
     return lame_encode_flush(LameHandler::instance()->flags,
                              reinterpret_cast<unsigned char*>(output),
-                             outputSize);
+                             static_cast<int>(outputSize));
 }

--- a/src/framework/audio/internal/synthesizers/fluidsynth/sfcachedloader.h
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/sfcachedloader.h
@@ -92,7 +92,7 @@ void* openSoundFont(const char* filename)
 
 int readSoundFont(void* buf, int count, void* handle)
 {
-    return std::fread(buf, count, 1, static_cast<std::FILE*>(handle));
+    return static_cast<int>(std::fread(buf, count, 1, static_cast<std::FILE*>(handle)));
 }
 
 int seekSoundFont(void* handle, long offset, int origin)

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -331,7 +331,7 @@ void NotationNoteInput::resetInputPosition()
 {
     Ms::InputState& inputState = score()->inputState();
 
-    inputState.setTrack(-1);
+    inputState.setTrack(mu::nidx);
     inputState.setString(-1);
     inputState.setSegment(nullptr);
 

--- a/thirdparty/opus/CMakeLists.txt
+++ b/thirdparty/opus/CMakeLists.txt
@@ -414,3 +414,7 @@ if(MSVC)
   target_compile_options(opus PUBLIC /wd4310)
   target_compile_options(opus PUBLIC /wd4701)
 endif()
+
+if(MINGW)
+  target_compile_options(opus PUBLIC -Wno-unused-parameter)
+endif()


### PR DESCRIPTION
* Disable MinGW warnings in thirdparty/opus reg. unused parameters (-Wunused-parameter).
* Fix MSVC compiler warnings, reg. signed/unsigned mismatch (C4245).
* Enable some of the previously (and apparently unnecessarily) disabled MSVC compiler warnings in src/engraving again.
* Fix MSVC compiler warnings reg. conversion from `size_t` to `int` (C4267), outside of engraving (so still showing, regardless being disabled).
 
There are 5 MinGW warnings about invalid PCH, which I believe to stem from thirdparty/flac, so also something we should probably not deal with other than to disable them, but I haven't (yet) found out how?
And there are 4 MSVC warnings reg. unreferenced function with internal linkage has been removed (C4505), those seem to be due to a MOC limitation (QT's Meta-Object Compiler). Not new, show since quite a while. Might be worth getting disabled too, somehow... I've seen it showing up in other and apparently legitimate cases too, not sure how to disable for MOC, but not for the rest?