### PR TITLE
fix #10311: fixing the calculation of harmonic frets

### DIFF
--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -581,6 +581,8 @@ Note::Note(const Note& n, bool link)
     _subchannel        = n._subchannel;
     _line              = n._line;
     _fret              = n._fret;
+    m_harmonicFret     = n.m_harmonicFret;
+    m_displayFret      = n.m_displayFret;
     _string            = n._string;
     _fretConflict      = n._fretConflict;
     _ghost             = n._ghost;
@@ -1312,6 +1314,9 @@ void Note::draw(mu::draw::Painter* painter) const
 
     // tablature
     if (tablature) {
+        if (m_displayFret == DisplayFretOption::Hide) {
+            return;
+        }
         const Staff* st = staff();
         const StaffType* tab = st->staffTypeForElement(this);
         if (tieBack() && !tab->showBackTied()) {
@@ -2169,6 +2174,10 @@ void Note::layout()
 {
     bool useTablature = staff() && staff()->isTabStaff(chord()->tick());
     if (useTablature) {
+        if (m_displayFret == DisplayFretOption::Hide) {
+            return;
+        }
+
         const Staff* st = staff();
         const StaffType* tab = st->staffTypeForElement(this);
         qreal mags = magS();
@@ -2186,8 +2195,10 @@ void Note::layout()
             _fretString = "/";
         } else {
             _fretString = tab->fretString(_fret, _string, _deadNote);
-            if (_harmonic) {
-                _fretString = QString("<%1>").arg(_fretString);
+            if (m_displayFret == DisplayFretOption::ArtificialHarmonic) {
+                _fretString = QString("%1 <%2>").arg(_fretString, QString::number(m_harmonicFret));
+            } else if (m_displayFret == DisplayFretOption::NaturalHarmonic) {
+                _fretString = QString("<%1>").arg(QString::number(m_harmonicFret));
             }
         }
         if (parenthesis) {

--- a/src/engraving/libmscore/note.h
+++ b/src/engraving/libmscore/note.h
@@ -152,56 +152,65 @@ public:
         Note* endNote = nullptr;     // note to end slide (for 2 notes slides)
         bool isValid() const { return type != SlideType::Undefined; }
         bool is(SlideType t) const { return t == type; }
-        uint32_t slideToNoteLenght{ 40 };
+        uint32_t slideToNoteLenght = 40;
+    };
+
+    enum DisplayFretOption {
+        Hide = -1,
+        NoHarmonic,
+        NaturalHarmonic,
+        ArtificialHarmonic
     };
 
 private:
-    bool _ghost         { false };        ///< ghost note
-    bool _deadNote      { false };        ///< dead note
-    bool _hidden        { false };        ///< marks this note as the hidden one if there are
+    bool _ghost = false;        ///< ghost note
+    bool _deadNote = false;     ///< dead note
+    bool _hidden = false;                 ///< marks this note as the hidden one if there are
                                           ///< overlapping notes; hidden notes are not played
                                           ///< and heads + accidentals are not shown
-    bool _dotsHidden    { false };        ///< dots of hidden notes are hidden too
-                                          ///< except if only one note is dotted
-    bool _fretConflict  { false };        ///< used by TAB staves to mark a fretting conflict:
-                                          ///< two or more notes on the same string
-    bool dragMode       { false };
-    bool _mirror        { false };        ///< True if note is mirrored at stem.
-    bool m_isSmall      { false };
-    bool _play          { true };         // note is not played if false
-    mutable bool _mark  { false };        // for use in sequencer
-    bool _fixed         { false };        // for slash notation
+    bool _dotsHidden = false;        ///< dots of hidden notes are hidden too
+                                     ///< except if only one note is dotted
+    bool _fretConflict = false;      ///< used by TAB staves to mark a fretting conflict:
+                                     ///< two or more notes on the same string
+    bool dragMode = false;
+    bool _mirror = false;        ///< True if note is mirrored at stem.
+    bool m_isSmall = false;
+    bool _play = true;           ///< note is not played if false
+    mutable bool _mark = false;  ///< for use in sequencer
+    bool _fixed = false;         ///< for slash notation
 
-    DirectionH _userMirror { DirectionH::AUTO };        ///< user override of mirror
-    DirectionV _userDotPosition { DirectionV::AUTO };                 ///< user override of dot position
+    DirectionH _userMirror = DirectionH::AUTO;        ///< user override of mirror
+    DirectionV _userDotPosition = DirectionV::AUTO;   ///< user override of dot position
 
-    NoteHeadScheme _headScheme { NoteHeadScheme::HEAD_AUTO };
-    NoteHeadGroup _headGroup { NoteHeadGroup::HEAD_NORMAL };
-    NoteHeadType _headType  { NoteHeadType::HEAD_AUTO };
+    NoteHeadScheme _headScheme = NoteHeadScheme::HEAD_AUTO;
+    NoteHeadGroup _headGroup = NoteHeadGroup::HEAD_NORMAL;
+    NoteHeadType _headType = NoteHeadType::HEAD_AUTO;
 
-    VeloType _veloType { VeloType::OFFSET_VAL };
+    VeloType _veloType = VeloType::OFFSET_VAL;
 
-    int _offTimeType    { 0 };      // compatibility only 1 - user(absolute), 2 - offset (%)
-    int _onTimeType     { 0 };      // compatibility only 1 - user, 2 - offset
+    int _offTimeType = 0;     ///< compatibility only 1 - user(absolute), 2 - offset (%)
+    int _onTimeType = 0;      ///< compatibility only 1 - user, 2 - offset
 
-    int _subchannel     { 0 };      ///< articulation
-    int _line           { INVALID_LINE };      ///< y-Position; 0 - top line.
-    int _fret           { -1 };     ///< for tablature view
-    int _string         { -1 };
-    mutable int _tpc[2] { Tpc::TPC_INVALID, Tpc::TPC_INVALID };   ///< tonal pitch class  (concert/transposing)
-    mutable int _pitch  { 0 };      ///< Note pitch as midi value (0 - 127).
+    int _subchannel = 0;       ///< articulation
+    int _line = INVALID_LINE;  ///< y-Position; 0 - top line.
+    int _fret = -1;            ///< for tablature view
+    float m_harmonicFret = -1.0;
+    DisplayFretOption m_displayFret = DisplayFretOption::NoHarmonic;
+    int _string = -1;
+    mutable int _tpc[2] = { Tpc::TPC_INVALID, Tpc::TPC_INVALID };   ///< tonal pitch class  (concert/transposing)
+    mutable int _pitch = 0;      ///< Note pitch as midi value (0 - 127).
 
-    int _veloOffset     { 0 };      ///< velocity user offset in percent, or absolute velocity for this note
-    int _fixedLine      { 0 };      // fixed line number if _fixed == true
-    qreal _tuning       { 0.0 };    ///< pitch offset in cent, playable only by internal synthesizer
+    int _veloOffset = 0;    ///< velocity user offset in percent, or absolute velocity for this note
+    int _fixedLine = 0;     ///< fixed line number if _fixed == true
+    qreal _tuning = 0.0;    ///< pitch offset in cent, playable only by internal synthesizer
 
-    Accidental* _accidental { 0 };
+    Accidental* _accidental = nullptr;
 
-    Tie* _tieFor        { 0 };
-    Tie* _tieBack       { 0 };
+    Tie* _tieFor = nullptr;
+    Tie* _tieBack = nullptr;
 
-    Slide _attachedSlide; // slide which starts from note
-    Slide* _relatedSlide = nullptr; // slide which goes to note
+    Slide _attachedSlide;           ///< slide which starts from note
+    Slide* _relatedSlide = nullptr; ///< slide which goes to note
 
     Symbol* _leftParenthesis = nullptr;
     Symbol* _rightParenthesis = nullptr;
@@ -339,6 +348,10 @@ public:
 
     int fret() const { return _fret; }
     void setFret(int val) { _fret = val; }
+    float harmonicFret() const { return m_harmonicFret; }
+    void setHarmonicFret(float val) { m_harmonicFret = val; }
+    DisplayFretOption displayFret() const { return m_displayFret; }
+    void setDisplayFret(DisplayFretOption val) { m_displayFret = val; }
     int string() const { return _string; }
     void setString(int val);
     bool ghost() const { return _ghost; }

--- a/src/engraving/libmscore/stringdata.cpp
+++ b/src/engraving/libmscore/stringdata.cpp
@@ -219,7 +219,7 @@ void StringData::fretChords(Chord* chord) const
     maxFret = INT32_MIN;
     for (auto& p : sortedNotes) {
         Note* note = p.second;
-        if (note->string() != INVALID_STRING_INDEX) {
+        if (note->string() != INVALID_STRING_INDEX && note->displayFret() != Note::DisplayFretOption::Hide) {
             bUsed[note->string()]++;
         }
         if (note->fret() != INVALID_FRET_INDEX && note->fret() < minFret) {
@@ -259,7 +259,7 @@ void StringData::fretChords(Chord* chord) const
         }
 
         // if the note string (either original or newly assigned) is also used by another note
-        if (bUsed[nNewString] > 1) {
+        if (note->displayFret() == Note::DisplayFretOption::NoHarmonic && bUsed[nNewString] > 1) {
             // attempt to find a suitable string, from topmost
             for (nTempString=0; nTempString < static_cast<int>(strings()); nTempString++) {
                 if (bUsed[nTempString] < 1
@@ -470,15 +470,6 @@ void StringData::sortChordNotes(std::map<int, Note*>& sortedNotes, const Chord* 
     for (Note* note : chord->notes()) {
         int string = note->string();
         int fret = note->fret();
-
-        // if note not fretted yet or current fretting no longer valid,
-        // use most convenient string as key
-        if (string <= INVALID_STRING_INDEX || fret <= INVALID_FRET_INDEX
-            || getPitch(string, fret + capoFret, pitchOffset) != note->pitch()) {
-            note->setString(INVALID_STRING_INDEX);
-            note->setFret(INVALID_FRET_INDEX);
-            convertPitch(note->pitch(), pitchOffset, &string, &fret);
-        }
         int key = string * 100000;
         key += -(note->pitch() + pitchOffset) * 100 + *count;       // disambiguate notes of equal pitch
         sortedNotes.insert({ key, note });

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -2837,6 +2837,67 @@ void GuitarPro::createCrecDim(int staffIdx, int track, const Fraction& tick, boo
 }
 
 //---------------------------------------------------------
+//   addMetaInfo
+//---------------------------------------------------------
+
+static void addMetaInfo(MasterScore* score, GuitarPro* gp)
+{
+    std::vector<QString> fieldNames = { gp->title, gp->subtitle, gp->artist,
+                                        gp->album, gp->composer };
+
+    bool createTitleField
+        = std::any_of(fieldNames.begin(), fieldNames.end(), [](const QString& fieldName) { return !fieldName.isEmpty(); });
+
+    if (createTitleField) {
+        MeasureBase* m;
+        if (!score->measures()->first()) {
+            m = Factory::createVBox(score->dummy()->system());
+            m->setTick(Fraction(0, 1));
+            score->addMeasure(m, 0);
+        } else {
+            m = score->measures()->first();
+            if (!m->isVBox()) {
+                MeasureBase* mb = Factory::createVBox(score->dummy()->system());
+                mb->setTick(Fraction(0, 1));
+                score->addMeasure(mb, m);
+                m = mb;
+            }
+        }
+        if (!gp->title.isEmpty()) {
+            Text* s = Factory::createText(m, TextStyleType::TITLE);
+            s->setPlainText(gp->title);
+            m->add(s);
+        }
+        if (!gp->subtitle.isEmpty() || !gp->artist.isEmpty() || !gp->album.isEmpty()) {
+            Text* s = Factory::createText(m, TextStyleType::SUBTITLE);
+            QString str;
+            if (!gp->subtitle.isEmpty()) {
+                str.append(gp->subtitle);
+            }
+            if (!gp->artist.isEmpty()) {
+                if (!str.isEmpty()) {
+                    str.append("\n");
+                }
+                str.append(gp->artist);
+            }
+            if (!gp->album.isEmpty()) {
+                if (!str.isEmpty()) {
+                    str.append("\n");
+                }
+                str.append(gp->album);
+            }
+            s->setPlainText(str);
+            m->add(s);
+        }
+        if (!gp->composer.isEmpty()) {
+            Text* s = Factory::createText(m, TextStyleType::COMPOSER);
+            s->setPlainText(gp->composer);
+            m->add(s);
+        }
+    }
+}
+
+//---------------------------------------------------------
 //   importGTP
 //---------------------------------------------------------
 
@@ -2929,59 +2990,7 @@ Score::FileError importGTP(MasterScore* score, const QString& name)
 
     score->style().set(Sid::ArpeggioHiddenInStdIfTab, true);
 
-    std::vector<QString> fieldNames = { gp->title, gp->subtitle, gp->artist,
-                                        gp->album, gp->composer };
-
-    bool createTitleField
-        = std::any_of(fieldNames.begin(), fieldNames.end(), [](const QString& fieldName) { return !fieldName.isEmpty(); });
-
-    if (createTitleField) {
-        MeasureBase* m;
-        if (!score->measures()->first()) {
-            m = Factory::createVBox(score->dummy()->system());
-            m->setTick(Fraction(0, 1));
-            score->addMeasure(m, 0);
-        } else {
-            m = score->measures()->first();
-            if (!m->isVBox()) {
-                MeasureBase* mb = Factory::createVBox(score->dummy()->system());
-                mb->setTick(Fraction(0, 1));
-                score->addMeasure(mb, m);
-                m = mb;
-            }
-        }
-        if (!gp->title.isEmpty()) {
-            Text* s = Factory::createText(m, TextStyleType::TITLE);
-            s->setPlainText(gp->title);
-            m->add(s);
-        }
-        if (!gp->subtitle.isEmpty() || !gp->artist.isEmpty() || !gp->album.isEmpty()) {
-            Text* s = Factory::createText(m, TextStyleType::SUBTITLE);
-            QString str;
-            if (!gp->subtitle.isEmpty()) {
-                str.append(gp->subtitle);
-            }
-            if (!gp->artist.isEmpty()) {
-                if (!str.isEmpty()) {
-                    str.append("\n");
-                }
-                str.append(gp->artist);
-            }
-            if (!gp->album.isEmpty()) {
-                if (!str.isEmpty()) {
-                    str.append("\n");
-                }
-                str.append(gp->album);
-            }
-            s->setPlainText(str);
-            m->add(s);
-        }
-        if (!gp->composer.isEmpty()) {
-            Text* s = Factory::createText(m, TextStyleType::COMPOSER);
-            s->setPlainText(gp->composer);
-            m->add(s);
-        }
-    }
+    addMetaInfo(score, gp);
 
     int idx = 0;
 

--- a/src/importexport/guitarpro/internal/importgtp.h
+++ b/src/importexport/guitarpro/internal/importgtp.h
@@ -362,6 +362,7 @@ class GuitarPro5 : public GuitarPro
     void readMeasures(int startingTempo);
     Fraction readBeat(const Fraction& tick, int voice, Measure* measure, int staffIdx, Tuplet** tuplets, bool mixChange);
     bool readNoteEffects(Note*);
+    float naturalHarmonicFromFret(int fret);
 
 public:
     GuitarPro5(MasterScore* s, int v)


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/10311*

*fixing the calculation of harmonic frets*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
