### PR TITLE
Improvements to grace notes spacing

### DIFF
--- a/src/engraving/layout/layoutchords.h
+++ b/src/engraving/layout/layoutchords.h
@@ -33,6 +33,7 @@ class Segment;
 class Note;
 class Staff;
 class MStyle;
+class Measure;
 }
 
 namespace mu::engraving {
@@ -43,6 +44,8 @@ public:
     static void layoutChords1(Ms::Score* score, Ms::Segment* segment, staff_idx_t staffIdx);
     static qreal layoutChords2(std::vector<Ms::Note*>& notes, bool up);
     static void layoutChords3(const Ms::MStyle& style, std::vector<Ms::Note*>&, const Ms::Staff*, Ms::Segment*);
+    static void updateGraceNotes(Ms::Measure* measure);
+    static void layoutGraceNotes(Ms::Segment* seg, int staffIdx);
 };
 }
 

--- a/src/engraving/layout/layoutchords.h
+++ b/src/engraving/layout/layoutchords.h
@@ -34,6 +34,7 @@ class Note;
 class Staff;
 class MStyle;
 class Measure;
+class Chord;
 }
 
 namespace mu::engraving {
@@ -45,7 +46,8 @@ public:
     static qreal layoutChords2(std::vector<Ms::Note*>& notes, bool up);
     static void layoutChords3(const Ms::MStyle& style, std::vector<Ms::Note*>&, const Ms::Staff*, Ms::Segment*);
     static void updateGraceNotes(Ms::Measure* measure);
-    static void layoutGraceNotes(Ms::Segment* seg, int staffIdx);
+    static void repositionGraceNotesAfter(Ms::Segment* segment);
+    static void appendGraceNotes(Ms::Chord* chord);
 };
 }
 

--- a/src/engraving/libmscore/barline.h
+++ b/src/engraving/libmscore/barline.h
@@ -87,9 +87,13 @@ class BarLine final : public EngravingItem
     bool isBottom() const;
     void drawEditMode(mu::draw::Painter* painter, EditData& editData, qreal currentViewScaling) override;
 
+    bool neverKernable() const override { return true; }
+
 public:
 
     virtual ~BarLine();
+
+    KerningType doComputeKerningType(const EngravingItem*) const override { return KerningType::NON_KERNING; }
 
     BarLine& operator=(const BarLine&) = delete;
 

--- a/src/engraving/libmscore/breath.h
+++ b/src/engraving/libmscore/breath.h
@@ -53,6 +53,8 @@ class Breath final : public EngravingItem
     friend class mu::engraving::Factory;
     Breath(Segment* parent);
 
+    bool sameVoiceKerningLimited() const override { return true; }
+
 public:
 
     Breath* clone() const override { return new Breath(*this); }

--- a/src/engraving/libmscore/chord.h
+++ b/src/engraving/libmscore/chord.h
@@ -53,6 +53,22 @@ enum class TremoloChordType : char {
     TremoloSingle, TremoloFirstNote, TremoloSecondNote
 };
 
+class GraceNotesGroup final : public std::vector<Chord*>, public EngravingItem
+{
+public:
+    GraceNotesGroup* clone() const override { return new GraceNotesGroup(*this); }
+    GraceNotesGroup(Chord* c);
+
+    Chord* parent() const { return _parent; }
+    Shape shape() const { return _shape; }
+    void layout() override;
+    void setPos(qreal x, qreal y) override;
+
+private:
+    Chord* _parent = nullptr;
+    Shape _shape;
+};
+
 //---------------------------------------------------------
 //   @@ Chord
 ///    Graphic representation of a chord.
@@ -80,7 +96,9 @@ class Chord final : public ChordRest
     Arpeggio* _arpeggio = nullptr;
     Tremolo* _tremolo = nullptr;
     bool _endsGlissando;                 ///< true if this chord is the ending point of a glissando (needed for layout)
-    std::vector<Chord*> _graceNotes;
+    std::vector<Chord*> _graceNotes; // storage for all grace notes
+    mutable GraceNotesGroup _graceNotesBefore = GraceNotesGroup(this); // will store before-chord grace notes
+    mutable GraceNotesGroup _graceNotesAfter = GraceNotesGroup(this); // will store after-chord grace notes
     size_t _graceIndex;                     ///< if this is a grace note, index in parent list
 
     DirectionV _stemDirection;
@@ -210,12 +228,11 @@ public:
     const std::vector<Chord*>& graceNotes() const { return _graceNotes; }
     std::vector<Chord*>& graceNotes() { return _graceNotes; }
 
-    std::vector<Chord*> graceNotesBefore() const;
-    std::vector<Chord*> graceNotesAfter() const;
+    GraceNotesGroup& graceNotesBefore() const;
+    GraceNotesGroup& graceNotesAfter() const;
 
     size_t graceIndex() const { return _graceIndex; }
     void setGraceIndex(size_t val) { _graceIndex = val; }
-    void attachGraceNotes();
 
     int upLine() const override;
     int downLine() const override;

--- a/src/engraving/libmscore/chord.h
+++ b/src/engraving/libmscore/chord.h
@@ -215,6 +215,7 @@ public:
 
     size_t graceIndex() const { return _graceIndex; }
     void setGraceIndex(size_t val) { _graceIndex = val; }
+    void attachGraceNotes();
 
     int upLine() const override;
     int downLine() const override;
@@ -234,7 +235,6 @@ public:
     Note* selectedNote() const;
     void layout() override;
     mu::PointF pagePos() const override;        ///< position in page coordinates
-    void layout2();
     void cmdUpdateNotes(AccidentalState*);
 
     NoteType noteType() const { return _noteType; }

--- a/src/engraving/libmscore/clef.h
+++ b/src/engraving/libmscore/clef.h
@@ -104,6 +104,8 @@ class Clef final : public EngravingItem
     friend class mu::engraving::Factory;
     Clef(Segment* parent);
 
+    bool neverKernable() const override { return true; }
+
 public:
 
     Clef* clone() const override { return new Clef(*this); }

--- a/src/engraving/libmscore/engravingitem.cpp
+++ b/src/engraving/libmscore/engravingitem.cpp
@@ -2746,4 +2746,27 @@ void EngravingItem::initAccessibleIfNeed()
 
     setupAccessible();
 }
+
+KerningType EngravingItem::computeKerningType(const EngravingItem* nextItem) const
+{
+    if (_userSetKerning != KerningType::NOT_SET) {
+        return _userSetKerning;
+    }
+    if (sameVoiceKerningLimited() && nextItem->sameVoiceKerningLimited() && track() == nextItem->track()) {
+        return KerningType::NON_KERNING;
+    }
+    if ((neverKernable() || nextItem->neverKernable())
+        && !(alwaysKernable() || nextItem->alwaysKernable())) {
+        return KerningType::NON_KERNING;
+    }
+    return doComputeKerningType(nextItem);
+}
+
+double EngravingItem::computePadding(const EngravingItem* nextItem) const
+{
+    double scaling = (mag() + nextItem->mag()) / 2;
+    double padding = score()->paddingTable().at(type()).at(nextItem->type());
+    padding *= scaling;
+    return padding;
+}
 }

--- a/src/engraving/libmscore/engravingitem.h
+++ b/src/engraving/libmscore/engravingitem.h
@@ -328,8 +328,8 @@ public:
     virtual const mu::PointF pos() const { return _pos + _offset; }
     virtual qreal x() const { return _pos.x() + _offset.x(); }
     virtual qreal y() const { return _pos.y() + _offset.y(); }
-    void setPos(qreal x, qreal y) { _pos.setX(x), _pos.setY(y); }
-    void setPos(const mu::PointF& p) { _pos = p; }
+    virtual void setPos(qreal x, qreal y) { _pos.setX(x), _pos.setY(y); }
+    virtual void setPos(const mu::PointF& p) { _pos = p; }
     mu::PointF& rpos() { return _pos; }
     qreal& rxpos() { return _pos.rx(); }
     qreal& rypos() { return _pos.ry(); }

--- a/src/engraving/libmscore/engravingitem.h
+++ b/src/engraving/libmscore/engravingitem.h
@@ -123,6 +123,16 @@ enum class ElementFlag {
 typedef QFlags<ElementFlag> ElementFlags;
 Q_DECLARE_OPERATORS_FOR_FLAGS(ElementFlags);
 
+enum class KerningType
+{
+    KERNING,
+    NON_KERNING,
+    LIMITED_KERNING,
+    SAME_VOICE_LIMIT,
+    KERNING_UNTIL_ORIGIN,
+    NOT_SET,
+};
+
 class ElementEditData;
 
 //---------------------------------------------------------
@@ -215,9 +225,10 @@ class EngravingItem : public EngravingObject
 
     bool m_colorsInversionEnabled = true;
 
-    // TODO: expose these as an option in item property panel.
-    bool _isKernable = true;
-    bool _isKernableUntilOrigin = false;
+    virtual bool sameVoiceKerningLimited() const { return false; }
+    virtual bool neverKernable() const { return false; }
+    virtual bool alwaysKernable() const { return false; }
+    KerningType _userSetKerning = KerningType::NOT_SET;
 
 protected:
     mutable int _z;
@@ -228,11 +239,14 @@ protected:
     EngravingItem(const ElementType& type, EngravingObject* se = 0, ElementFlags = ElementFlag::NOTHING);
     EngravingItem(const EngravingItem&);
     virtual mu::engraving::AccessibleItem* createAccessible();
+    virtual KerningType doComputeKerningType(const EngravingItem*) const { return KerningType::KERNING; }
 
 public:
-    bool isKernable() const { return _isKernable; }
-    bool isKernableUntilOrigin() const { return _isKernableUntilOrigin; }
+
     virtual ~EngravingItem();
+
+    KerningType computeKerningType(const EngravingItem* nextItem) const;
+    virtual double computePadding(const EngravingItem* nextItem) const;
 
     virtual void setupAccessible();
     bool accessibleEnabled() const;

--- a/src/engraving/libmscore/engravingobject.h
+++ b/src/engraving/libmscore/engravingobject.h
@@ -76,6 +76,7 @@ class StaffText;
 class Ottava;
 class Note;
 class Chord;
+class GraceNotesGroup;
 class Rest;
 class MMRest;
 class LayoutBreak;
@@ -401,6 +402,7 @@ public:
     CONVERT(BagpipeEmbellishment, BAGPIPE_EMBELLISHMENT)
     CONVERT(Lasso,         LASSO)
     CONVERT(Sticking,      STICKING)
+    CONVERT(GraceNotesGroup, GRACE_NOTES_GROUP)
 #undef CONVERT
 
     virtual bool isEngravingItem() const { return false; }   // overridden in element.h
@@ -716,6 +718,7 @@ CONVERT(Part)
 CONVERT(Lasso)
 CONVERT(BagpipeEmbellishment)
 CONVERT(Sticking)
+CONVERT(GraceNotesGroup)
 #undef CONVERT
 }
 

--- a/src/engraving/libmscore/factory.cpp
+++ b/src/engraving/libmscore/factory.cpp
@@ -222,6 +222,7 @@ static const ElementName elementNames[] = {
     { ElementType::OSSIA,                "Ossia",                QT_TRANSLATE_NOOP("elementName", "Ossia") },
     { ElementType::BAGPIPE_EMBELLISHMENT,"BagpipeEmbellishment", QT_TRANSLATE_NOOP("elementName", "Bagpipe embellishment") },
     { ElementType::STICKING,             "Sticking",             QT_TRANSLATE_NOOP("elementName", "Sticking") },
+    { ElementType::GRACE_NOTES_GROUP,    "GraceNotesGroup",      QT_TRANSLATE_NOOP("elementName", "Grace notes group")},
     { ElementType::ROOT_ITEM,            "RootItem",             QT_TRANSLATE_NOOP("elementName", "Root item") },
     { ElementType::DUMMY,                "Dummy",                QT_TRANSLATE_NOOP("elementName", "Dummy") },
 };
@@ -363,6 +364,7 @@ EngravingItem* Factory::doCreateItem(ElementType type, EngravingItem* parent)
     case ElementType::SCORE:
     case ElementType::BRACKET_ITEM:
     case ElementType::OSSIA:
+    case ElementType::GRACE_NOTES_GROUP:
     case ElementType::ROOT_ITEM:
     case ElementType::DUMMY:
         break;

--- a/src/engraving/libmscore/harmony.cpp
+++ b/src/engraving/libmscore/harmony.cpp
@@ -2367,4 +2367,12 @@ Sid Harmony::getPropertyStyle(Pid pid) const
     }
     return TextBase::getPropertyStyle(pid);
 }
+
+KerningType Harmony::doComputeKerningType(const EngravingItem* nextItem) const
+{
+    if (nextItem->isHarmony()) {
+        return KerningType::NON_KERNING;
+    }
+    return KerningType::KERNING;
+}
 }

--- a/src/engraving/libmscore/harmony.h
+++ b/src/engraving/libmscore/harmony.h
@@ -121,10 +121,14 @@ class Harmony final : public TextBase
 
     Harmony* findInSeg(Segment* seg) const;
 
+    bool alwaysKernable() const override { return true; }
+
 public:
     Harmony(Segment* parent = 0);
     Harmony(const Harmony&);
     ~Harmony();
+
+    KerningType doComputeKerningType(const EngravingItem* nextItem) const override;
 
     Harmony* clone() const override { return new Harmony(*this); }
 

--- a/src/engraving/libmscore/keysig.h
+++ b/src/engraving/libmscore/keysig.h
@@ -52,6 +52,8 @@ class KeySig final : public EngravingItem
 
     void addLayout(SymId sym, int line);
 
+    bool neverKernable() const override { return true; }
+
 public:
 
     KeySig* clone() const override { return new KeySig(*this); }

--- a/src/engraving/libmscore/lyrics.cpp
+++ b/src/engraving/libmscore/lyrics.cpp
@@ -733,4 +733,12 @@ void Lyrics::undoChangeProperty(Pid id, const PropertyValue& v, PropertyFlags ps
 
     TextBase::undoChangeProperty(id, v, ps);
 }
+
+KerningType Lyrics::doComputeKerningType(const EngravingItem* nextItem) const
+{
+    if (nextItem->isLyrics() || nextItem->isBarLine()) {
+        return KerningType::NON_KERNING;
+    }
+    return KerningType::KERNING;
+}
 }

--- a/src/engraving/libmscore/lyrics.h
+++ b/src/engraving/libmscore/lyrics.h
@@ -66,12 +66,16 @@ private:
     bool isMelisma() const;
     void undoChangeProperty(Pid id, const mu::engraving::PropertyValue&, PropertyFlags ps) override;
 
+    bool alwaysKernable() const override { return true; }
+
 protected:
     int _no;                  ///< row index
     bool _even;
 
 public:
     ~Lyrics();
+
+    KerningType doComputeKerningType(const EngravingItem* nextItem) const override;
 
     Lyrics* clone() const override { return new Lyrics(*this); }
     bool acceptDrop(EditData&) const override;

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -3220,7 +3220,7 @@ void Measure::layoutMeasureElements()
         }
 
         // After the rest of the spacing is calculated we position grace-notes-after.
-        s.positionGraceNotesAfter();
+        LayoutChords::repositionGraceNotesAfter(&s);
 
         for (EngravingItem* e : s.elist()) {
             if (!e) {
@@ -3640,11 +3640,6 @@ qreal Measure::createEndBarLines(bool isLastMeasureInSystem)
                 m_segments.insert(s1, s2);
             }
         }
-    }
-
-    // May have grace notes attached to it so we need to lay them out
-    for (unsigned stfIdx = 0; stfIdx < score()->staves().size(); ++stfIdx) {
-        LayoutChords::layoutGraceNotes(seg, stfIdx);
     }
 
     // fix segment layout
@@ -4572,7 +4567,7 @@ void Measure::stretchMeasureInPracticeMode(qreal targetWidth)
             continue;
         }
         // After the rest of the spacing is calculated we position grace-notes-after.
-        s.positionGraceNotesAfter();
+        LayoutChords::repositionGraceNotesAfter(&s);
         for (EngravingItem* e : s.elist()) {
             if (!e) {
                 continue;

--- a/src/engraving/libmscore/note.h
+++ b/src/engraving/libmscore/note.h
@@ -253,9 +253,13 @@ private:
 
     static QString tpcUserName(int tpc, int pitch, bool explicitAccidental);
 
+    bool sameVoiceKerningLimited() const override { return true; }
+
 public:
 
     ~Note();
+
+    double computePadding(const EngravingItem* nextItem) const override;
 
     Note& operator=(const Note&) = delete;
     virtual Note* clone() const override { return new Note(*this, false); }
@@ -519,6 +523,8 @@ public:
 
     void setHarmonic(bool val) { _harmonic = val; }
     bool harmonic() const { return _harmonic; }
+
+    bool isGrace() const { return noteType() != NoteType::NORMAL; }
 };
 }     // namespace Ms
 #endif

--- a/src/engraving/libmscore/rest.h
+++ b/src/engraving/libmscore/rest.h
@@ -129,6 +129,8 @@ private:
     qreal upPos() const override;
     qreal downPos() const override;
     void setOffset(const mu::PointF& o) override;
+
+    bool sameVoiceKerningLimited() const override { return true; }
 };
 }     // namespace Ms
 #endif

--- a/src/engraving/libmscore/segment.h
+++ b/src/engraving/libmscore/segment.h
@@ -73,10 +73,9 @@ class Segment final : public EngravingItem
 
     std::vector<EngravingItem*> _annotations;
     std::vector<EngravingItem*> _elist;         // EngravingItem storage, size = staves * VOICES.
+    std::vector<EngravingItem*> _preAppendedItems; // Container for items appended to the left of this segment (example: grace notes), size = staves * VOICES.
     std::vector<Shape> _shapes;           // size = staves
     std::vector<qreal> _dotPosX;          // size = staves
-    std::vector<std::vector<Chord*> > _graceNotesBefore; // We prepare an (initially empty) vector of grace notes for each voice
-    std::vector<std::vector<Chord*> > _graceNotesAfter; // This will be filled with the grace-notes-after of a *previous* segment.
     qreal m_spacing{ 0 };
 
     friend class mu::engraving::Factory;
@@ -290,13 +289,12 @@ public:
     bool isTimeSigAnnounceType() const { return _segmentType == SegmentType::TimeSigAnnounce; }
     bool isMMRestSegment() const;
 
-    void attachGraceNotesBefore(std::vector<Chord*> graceNotes, int track) { _graceNotesBefore[track] = graceNotes; }
-    void attachGraceNotesAfter(std::vector<Chord*> graceNotes, int track) { _graceNotesAfter[track] = graceNotes; }
-    std::vector<Chord*>& graceNotesBefore(int track) { return _graceNotesBefore[track]; }
-    std::vector<Chord*>& graceNotesAfter(int track) { return _graceNotesAfter[track]; }
-    void positionGraceNotesAfter();
-
     Fraction shortestChordRest() const;
+
+    EngravingItem* preAppendedItem(int track) { return _preAppendedItems[track]; }
+    void preAppend(EngravingItem* item, int track) { _preAppendedItems[track] = item; }
+    void clearPreAppended(int track) { _preAppendedItems[track] = nullptr; }
+    void addPreAppendedToShape(int staffIdx, Shape& s);
 
     static constexpr SegmentType durationSegmentsMask = SegmentType::ChordRest;   // segment types which may have non-zero tick length
 };

--- a/src/engraving/libmscore/segment.h
+++ b/src/engraving/libmscore/segment.h
@@ -75,6 +75,8 @@ class Segment final : public EngravingItem
     std::vector<EngravingItem*> _elist;         // EngravingItem storage, size = staves * VOICES.
     std::vector<Shape> _shapes;           // size = staves
     std::vector<qreal> _dotPosX;          // size = staves
+    std::vector<std::vector<Chord*> > _graceNotesBefore; // We prepare an (initially empty) vector of grace notes for each voice
+    std::vector<std::vector<Chord*> > _graceNotesAfter; // This will be filled with the grace-notes-after of a *previous* segment.
     qreal m_spacing{ 0 };
 
     friend class mu::engraving::Factory;
@@ -287,6 +289,12 @@ public:
     bool isKeySigAnnounceType() const { return _segmentType == SegmentType::KeySigAnnounce; }
     bool isTimeSigAnnounceType() const { return _segmentType == SegmentType::TimeSigAnnounce; }
     bool isMMRestSegment() const;
+
+    void attachGraceNotesBefore(std::vector<Chord*> graceNotes, int track) { _graceNotesBefore[track] = graceNotes; }
+    void attachGraceNotesAfter(std::vector<Chord*> graceNotes, int track) { _graceNotesAfter[track] = graceNotes; }
+    std::vector<Chord*>& graceNotesBefore(int track) { return _graceNotesBefore[track]; }
+    std::vector<Chord*>& graceNotesAfter(int track) { return _graceNotesAfter[track]; }
+    void positionGraceNotesAfter();
 
     Fraction shortestChordRest() const;
 

--- a/src/engraving/libmscore/shape.h
+++ b/src/engraving/libmscore/shape.h
@@ -82,11 +82,6 @@ public:
     void translateY(qreal);
     Shape translated(const mu::PointF&) const;
 
-    bool sameVoiceExceptions(const EngravingItem* item1, const EngravingItem* item2) const;
-    bool graceToMainExceptions(const EngravingItem* item1, const EngravingItem* item2) const;
-    bool graceToGraceExceptions(const EngravingItem* item1, const EngravingItem* item2) const;
-    bool nonKerningExceptions(const ShapeElement& r1, const ShapeElement& r2) const;
-    bool limitedKerningExceptions(const EngravingItem* item1, const EngravingItem* item2) const;
     qreal minHorizontalDistance(const Shape&, Score* score) const;
     qreal minVerticalDistance(const Shape&) const;
     qreal topDistance(const mu::PointF&) const;

--- a/src/engraving/libmscore/shape.h
+++ b/src/engraving/libmscore/shape.h
@@ -83,6 +83,8 @@ public:
     Shape translated(const mu::PointF&) const;
 
     bool sameVoiceExceptions(const EngravingItem* item1, const EngravingItem* item2) const;
+    bool graceToMainExceptions(const EngravingItem* item1, const EngravingItem* item2) const;
+    bool graceToGraceExceptions(const EngravingItem* item1, const EngravingItem* item2) const;
     bool nonKerningExceptions(const ShapeElement& r1, const ShapeElement& r2) const;
     bool limitedKerningExceptions(const EngravingItem* item1, const EngravingItem* item2) const;
     qreal minHorizontalDistance(const Shape&, Score* score) const;

--- a/src/engraving/libmscore/stem.h
+++ b/src/engraving/libmscore/stem.h
@@ -93,6 +93,8 @@ private:
     Millimetre m_userLength = Millimetre(0.0);
 
     Millimetre m_lineWidth = Millimetre(0.0);
+
+    bool sameVoiceKerningLimited() const override { return true; }
 };
 }
 #endif

--- a/src/engraving/libmscore/timesig.h
+++ b/src/engraving/libmscore/timesig.h
@@ -73,6 +73,8 @@ class TimeSig final : public EngravingItem
     friend class mu::engraving::Factory;
     TimeSig(Segment* parent = 0);
 
+    bool neverKernable() const override { return true; }
+
 public:
 
     void setParent(Segment* parent);

--- a/src/engraving/libmscore/types.h
+++ b/src/engraving/libmscore/types.h
@@ -164,6 +164,7 @@ enum class ElementType {
     OSSIA,
     BAGPIPE_EMBELLISHMENT,
     STICKING,
+    GRACE_NOTES_GROUP,
 
     ROOT_ITEM,
     DUMMY,

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -399,6 +399,8 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::measureNumberAllStaves,  "measureNumberAllStaffs",  false }, // need to keep staffs and not staves here for backward compatibility
     { Sid::smallNoteMag,            "smallNoteMag",            PropertyValue(.7) },
     { Sid::graceNoteMag,            "graceNoteMag",            PropertyValue(0.7) },
+    { Sid::graceToMainNoteDist,     "graceToMainNoteDist",     Spatium(0.6) },
+    { Sid::graceToGraceNoteDist,    "graceToGraceNoteDist",    Spatium(0.3) },
     { Sid::smallStaffMag,           "smallStaffMag",           PropertyValue(0.7) },
     { Sid::smallClefMag,            "smallClefMag",            PropertyValue(0.8) },
 

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -410,6 +410,8 @@ enum class Sid {
 
     smallNoteMag,
     graceNoteMag,
+    graceToMainNoteDist,
+    graceToGraceNoteDist,
     smallStaffMag,
     smallClefMag,
     genClef,


### PR DESCRIPTION
Grace notes are currently handled very primitively in Musescore. My previous horizontal spacing PR fixed some of the most outstanding issues, namely the fact that grace notes were tucking above time- and key signatures (and they shouldn't) but were not tucking above notes from a different voice (and they should).

This PR fixes most of the remaining problems with grace notes spacing:
- Grace notes are too close to each other
- Grace notes are _way_ too close to the main note
- Accidentals cause unnecessary wide gaps
- Grace-notes-after cause a totally pointless space gap in the second voice which is quite funny.
- Grace-notes-after have no collision checks with the other voices.

I order to achieve this, the code for grace notes layout needed to be substantially scrapped and rewritten. Most notably: there aren't anymore separate methods for the layout of grace-notes-before and grace-notes-after. Grace-notes-after are "attached" to the following segment and spaced as if they were grace-notes-before of that segment. This is quite elegant, as now all grace notes share one, very simple, layout function. The only delicate part is making sure that this operation of "attaching" grace notes to the appropriate segment is performed at the right moment in the code and updated correctly upon every user interaction.

Needs review and testing by @oktophonie.

Before:
![MU3GraceNotes](https://user-images.githubusercontent.com/93707756/165303048-0d394fbb-4ad1-467f-b705-07088c13302e.png)
After:
![Screenshot from 2022-04-26 14-17-05](https://user-images.githubusercontent.com/93707756/165303278-57ef85fb-ec62-45d7-94b2-7491aa18692f.png)
