### PR TITLE
Update spacing settings when loading up new scores

### DIFF
--- a/src/engraving/engravingproject.cpp
+++ b/src/engraving/engravingproject.cpp
@@ -96,6 +96,7 @@ Err EngravingProject::doSetupMasterScore(Ms::MasterScore* score)
 {
     TRACEFUNC;
 
+    score->createPaddingTable();
     score->connectTies();
 
     for (Ms::Part* p : score->parts()) {

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -516,7 +516,6 @@ private:
 
     PaddingTable _paddingTable;
     double _minimumPaddingUnit = 0.1 * spatium(); // Maybe style setting in future
-    void createPaddingTable();
 
 protected:
     int _fileDivision;   ///< division of current loading *.msc file
@@ -1246,6 +1245,7 @@ public:
     void cmdAddPitch(int note, bool addFlag, bool insert);
     void forAllLyrics(std::function<void(Lyrics*)> f);
 
+    void createPaddingTable();
     const PaddingTable& paddingTable() const { return _paddingTable; }
     double minimumPaddingUnit() const { return _minimumPaddingUnit; }
 


### PR DESCRIPTION
PR #11298 has eliminated a couple of time consuming function calls. This is now needed in order to load the correct spacing settings, otherwise many scores will load with wrong spacing.