### PR TITLE
New Score dialog: Update current template after selecting a different category

### DIFF
--- a/src/project/view/templatesmodel.cpp
+++ b/src/project/view/templatesmodel.cpp
@@ -227,6 +227,8 @@ void TemplatesModel::updateTemplatesAndCategoriesBySearch()
 
     setVisibleCategories(newVisibleCategories);
     setVisibleTemplates(newVisibleTemplates);
+
+    setCurrentCategory(m_currentTemplate.categoryTitle);
 }
 
 bool TemplatesModel::titleAccepted(const QString& title) const

--- a/src/project/view/templatesmodel.h
+++ b/src/project/view/templatesmodel.h
@@ -72,8 +72,8 @@ private:
     void setVisibleTemplates(const Templates& templates);
     void setVisibleCategories(const QStringList& titles);
 
-    void doSetCurrentTemplateIndex(int index);
-    void doSetCurrentCategoryIndex(int index);
+    void setCurrentTemplate(const Template& templ);
+    void setCurrentCategory(const QString& category);
 
     void updateTemplatesByCurrentCategory();
     void updateTemplatesAndCategoriesBySearch();
@@ -82,16 +82,14 @@ private:
 
     bool isSearching() const;
 
-    const Template& currentTemplate() const;
-
     Templates m_allTemplates;
     Templates m_visibleTemplates;
     QStringList m_visibleCategoriesTitles;
 
     QString m_searchText;
 
-    int m_currentCategoryIndex = -1;
-    int m_currentTemplateIndex = -1;
+    QString m_currentCategory;
+    Template m_currentTemplate;
 
     bool m_saveCurrentCategory = false;
 };


### PR DESCRIPTION
Resolves: #11374 
Closes: #11385 (I discussed it with @HemantAntony)

I also discovered another problem: when you start typing text to search, the first search result template will be selected, but the wrong category will be selected. When you click another template in the list with search results, the category gets updated correctly. With this change, the category will also be updated when just starting to search. 