### PR TITLE
Disable clearing the OS recent files list on Windows

### DIFF
--- a/src/project/internal/platform/windows/windowsrecentfilescontroller.cpp
+++ b/src/project/internal/platform/windows/windowsrecentfilescontroller.cpp
@@ -34,7 +34,4 @@ void WindowsRecentFilesController::addRecentFile(const io::path& path)
 
 void WindowsRecentFilesController::clearRecentFiles()
 {
-    // The "docs" seem to say that this should clear the recent files list
-    // But in practice it's not sure if that's the case
-    SHAddToRecentDocs(0, NULL);
 }


### PR DESCRIPTION
Turns out it clears ALL recent files of the whole OS, not only those of MuseScore.

Resolves: #11404 