### PR TITLE
Don't draw fretboard diagram harmony in Palettes

### DIFF
--- a/src/engraving/libmscore/fret.cpp
+++ b/src/engraving/libmscore/fret.cpp
@@ -1260,9 +1260,11 @@ EngravingItem* FretDiagram::drop(EditData& data)
 void FretDiagram::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
 {
     Q_UNUSED(all);
+
     func(data, this);
+
     // don't display harmony in palette
-    if (_harmony && !!parent()) {
+    if (_harmony && !score()->isPaletteScore()) {
         func(data, _harmony);
     }
 }


### PR DESCRIPTION
Resolves: #11380

(Restores MU3 behaviour)