### PR TITLE
[MU4] Fix #11310: Selection filter should not be enabled by default when users first launch MuseScore 4

### DIFF
--- a/src/appshell/view/dockwindow/dockwindow.cpp
+++ b/src/appshell/view/dockwindow/dockwindow.cpp
@@ -349,7 +349,7 @@ void DockWindow::loadPanels(const DockPageView* page)
 
     auto addPanel = [this, page](DockPanelView* panel, Location location) {
         for (DockPanelView* destinationPanel : page->panels()) {
-            if (destinationPanel->isTabAllowed(panel)) {
+            if (panel->isVisible() && destinationPanel->isTabAllowed(panel)) {
                 registerDock(panel);
 
                 destinationPanel->addPanelAsTab(panel);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11310