### PR TITLE
[MU4] Fix Compiler warnings

### DIFF
--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -2452,7 +2452,7 @@ EngravingItem* Score::move(const QString& cmd)
                 }
             }
             // segment for sure contains chords/rests,
-            int size = int(seg->elist().size());
+            size_t size = seg->elist().size();
             // if segment has a chord/rest in original element track, use it
             if (track < size && seg->element(track)) {
                 trg  = seg->element(track);
@@ -2460,7 +2460,7 @@ EngravingItem* Score::move(const QString& cmd)
                 break;
             }
             // if not, get topmost chord/rest
-            for (int i = 0; i < size; i++) {
+            for (size_t i = 0; i < size; i++) {
                 if (seg->element(i)) {
                     trg  = seg->element(i);
                     cr = toChordRest(trg);

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -2973,7 +2973,7 @@ int Measure::measureRepeatCount(staff_idx_t staffIdx) const
     return m_mstaves[staffIdx]->measureRepeatCount();
 }
 
-void Measure::setMeasureRepeatCount(int n, int staffIdx)
+void Measure::setMeasureRepeatCount(int n, staff_idx_t staffIdx)
 {
     if (staffIdx >= m_mstaves.size()) {
         return;

--- a/src/engraving/libmscore/measure.h
+++ b/src/engraving/libmscore/measure.h
@@ -313,7 +313,7 @@ public:
     Measure* mmRestLast() const;
 
     int measureRepeatCount(staff_idx_t staffIdx) const;
-    void setMeasureRepeatCount(int n, int staffIdx);
+    void setMeasureRepeatCount(int n, staff_idx_t staffIdx);
     bool isMeasureRepeatGroup(staff_idx_t staffIdx) const;
     bool isMeasureRepeatGroupWithNextM(int staffIdx) const;
     bool isMeasureRepeatGroupWithPrevM(int staffIdx) const;

--- a/src/engraving/libmscore/measurebase.cpp
+++ b/src/engraving/libmscore/measurebase.cpp
@@ -356,7 +356,7 @@ void MeasureBase::triggerLayout() const
     const MeasureBase* mb = top();
     // avoid triggering layout before getting added to a score
     if (mb->prev() || mb->next()) {
-        score()->setLayout(mb->tick(), -1, mb);
+        score()->setLayout(mb->tick(), mu::nidx, mb);
     }
 }
 

--- a/src/engraving/libmscore/scoretree.cpp
+++ b/src/engraving/libmscore/scoretree.cpp
@@ -310,9 +310,9 @@ EngravingObjectList ChordRest::scanChildren() const
 {
     EngravingObjectList children;
 
-    Beam* _beam = beam();
-    if (_beam && _beam->scanParent() == this) {
-        children.push_back(_beam);
+    Beam* _b = beam();
+    if (_b && _b->scanParent() == this) {
+        children.push_back(_b);
     }
 
     for (Lyrics* lyrics : _lyrics) {
@@ -380,8 +380,8 @@ EngravingObjectList Chord::scanChildren() const
         children.push_back(chord);
     }
 
-    for (Articulation* articulation : articulations()) {
-        children.push_back(articulation);
+    for (Articulation* art : articulations()) {
+        children.push_back(art);
     }
 
     if (_stem) {

--- a/src/engraving/rw/compat/read114.cpp
+++ b/src/engraving/rw/compat/read114.cpp
@@ -2752,7 +2752,7 @@ Score::FileError Read114::read114(MasterScore* masterScore, XmlReader& e, ReadCo
 {
     TempoMap tm;
     while (e.readNextStartElement()) {
-        e.setTrack(-1);
+        e.setTrack(mu::nidx);
         const QStringRef& tag(e.name());
         if (tag == "Staff") {
             readStaffContent(masterScore, e, ctx);

--- a/src/engraving/rw/compat/read206.cpp
+++ b/src/engraving/rw/compat/read206.cpp
@@ -3196,7 +3196,7 @@ static void readStyle206(MStyle* style, XmlReader& e, ReadChordListHook& readCho
 bool Read206::readScore206(Score* score, XmlReader& e, ReadContext& ctx)
 {
     while (e.readNextStartElement()) {
-        e.setTrack(-1);
+        e.setTrack(mu::nidx);
         const QStringRef& tag(e.name());
         if (tag == "Staff") {
             readStaffContent206(score, e, ctx);

--- a/src/engraving/rw/compat/read302.cpp
+++ b/src/engraving/rw/compat/read302.cpp
@@ -66,7 +66,7 @@ bool Read302::readScore302(Ms::Score* score, XmlReader& e, ReadContext& ctx)
     }
 
     while (e.readNextStartElement()) {
-        e.setTrack(-1);
+        e.setTrack(mu::nidx);
         const QStringRef& tag(e.name());
         if (tag == "Staff") {
             StaffRW::readStaff(score, e, ctx);

--- a/src/engraving/rw/read400.cpp
+++ b/src/engraving/rw/read400.cpp
@@ -87,7 +87,7 @@ bool Read400::readScore400(Ms::Score* score, XmlReader& e, ReadContext& ctx)
 
     std::vector<int> sysStaves;
     while (e.readNextStartElement()) {
-        e.setTrack(-1);
+        e.setTrack(mu::nidx);
         const QStringRef& tag(e.name());
         if (tag == "Staff") {
             StaffRW::readStaff(score, e, ctx);

--- a/src/engraving/utests/layoutelements_tests.cpp
+++ b/src/engraving/utests/layoutelements_tests.cpp
@@ -81,7 +81,7 @@ static void isLayoutDone(void* data, EngravingItem* e)
         (*result) = false;
         // Print some info about the element to make test more useful...
         if (Measure* m = toMeasure(e->findMeasure())) {
-            qDebug("Layout of %s is not done (page %d, measure %d)", e->typeName(), m->system()->page()->no() + 1,
+            qDebug("Layout of %s is not done (page %zu, measure %d)", e->typeName(), m->system()->page()->no() + 1,
                    m->no() + 1);
         } else {
             qDebug("Layout of %s is not done", e->typeName());


### PR DESCRIPTION
* Fix MSVC compiler warnings reg. conversion from `size_t` to `int` (C4245)
* Fix MinGW compiler warning reg. wrong format specifier
* Fix MinGW compiler warnings reg. comparison of integer expressions of different signdedness (-Wsign-compare)
* Fix MSVC compiler warnings reg. variable declarations hiding global declarations (C4459) resp.  class members (C4458)
 
Yes, @igorkorsukov, I know patience and all that ;-)
But these show in MSVC even with C4267 being disabled and also in MinGW