### PR TITLE
Correctly center jump markers in Palettes

### DIFF
--- a/src/engraving/libmscore/barline.cpp
+++ b/src/engraving/libmscore/barline.cpp
@@ -262,18 +262,6 @@ const std::vector<BarLineTableItem> BarLine::barLineTable {
 };
 
 //---------------------------------------------------------
-//   barLineTableItem
-//---------------------------------------------------------
-
-const BarLineTableItem* BarLine::barLineTableItem(unsigned i)
-{
-    if (i >= barLineTable.size()) {
-        return 0;
-    }
-    return &barLineTable[i];
-}
-
-//---------------------------------------------------------
 //   userTypeName
 //---------------------------------------------------------
 

--- a/src/engraving/libmscore/barline.h
+++ b/src/engraving/libmscore/barline.h
@@ -138,7 +138,6 @@ public:
     const ElementList* el() const { return &_el; }
 
     static QString userTypeName(BarLineType);
-    static const BarLineTableItem* barLineTableItem(unsigned);
 
     void setBarLineType(BarLineType i) { _barLineType = i; }
     BarLineType barLineType() const { return _barLineType; }

--- a/src/engraving/libmscore/jump.cpp
+++ b/src/engraving/libmscore/jump.cpp
@@ -45,7 +45,7 @@ static const ElementStyle jumpStyle {
 //   JumpTypeTable
 //---------------------------------------------------------
 
-const JumpTypeTable jumpTypeTable[] = {
+const std::vector<JumpTypeTableItem> jumpTypeTable {
     { Jump::Type::DC,         "D.C.",         "start", "end",  "",      QT_TRANSLATE_NOOP("jumpType", "Da Capo") },
     { Jump::Type::DC_AL_FINE, "D.C. al Fine", "start", "fine", "",      QT_TRANSLATE_NOOP("jumpType", "Da Capo al Fine") },
     { Jump::Type::DC_AL_CODA, "D.C. al Coda", "start", "coda", "codab", QT_TRANSLATE_NOOP("jumpType", "Da Capo al Coda") },
@@ -53,25 +53,23 @@ const JumpTypeTable jumpTypeTable[] = {
     { Jump::Type::DS_AL_FINE, "D.S. al Fine", "segno", "fine", "",      QT_TRANSLATE_NOOP("jumpType", "D.S. al Fine") },
     { Jump::Type::DS,         "D.S.",         "segno", "end",  "",      QT_TRANSLATE_NOOP("jumpType", "D.S.") },
 
-    { Jump::Type::DC_AL_DBLCODA,  "D.C. al Double Coda",   "start", "varcoda",  "codab", QT_TRANSLATE_NOOP("jumpType",
-                                                                                                           "Da Capo al Double Coda") },
-    { Jump::Type::DS_AL_DBLCODA,  "D.S. al Double Coda",   "segno", "varcoda",  "codab", QT_TRANSLATE_NOOP("jumpType",
-                                                                                                           "Da Segno al Double Coda") },
-    { Jump::Type::DSS,            "Dal Segno Segno",       "varsegno", "end",  "", QT_TRANSLATE_NOOP("jumpType", "Dal Segno Segno") },
-    { Jump::Type::DSS_AL_CODA,    "D.S.S. al Coda",        "varsegno", "coda",  "codab", QT_TRANSLATE_NOOP("jumpType",
-                                                                                                           "Dal Segno Segno al Coda") },
-    { Jump::Type::DSS_AL_DBLCODA, "D.S.S. al Double Coda", "varsegno", "varcoda", "codab", QT_TRANSLATE_NOOP("jumpType",
-                                                                                                             "Dal Segno Segno al Double Coda") },
+    { Jump::Type::DC_AL_DBLCODA,  "D.C. al Double Coda",   "start", "varcoda",  "codab",
+      QT_TRANSLATE_NOOP("jumpType", "Da Capo al Double Coda") },
+    { Jump::Type::DS_AL_DBLCODA,  "D.S. al Double Coda",   "segno", "varcoda",  "codab",
+      QT_TRANSLATE_NOOP("jumpType", "Da Segno al Double Coda") },
+    { Jump::Type::DSS,            "Dal Segno Segno",       "varsegno", "end",  "",
+      QT_TRANSLATE_NOOP("jumpType", "Dal Segno Segno") },
+    { Jump::Type::DSS_AL_CODA,    "D.S.S. al Coda",        "varsegno", "coda",  "codab",
+      QT_TRANSLATE_NOOP("jumpType", "Dal Segno Segno al Coda") },
+    { Jump::Type::DSS_AL_DBLCODA, "D.S.S. al Double Coda", "varsegno", "varcoda", "codab",
+      QT_TRANSLATE_NOOP("jumpType", "Dal Segno Segno al Double Coda") },
     { Jump::Type::DSS_AL_FINE,    "D.S.S. al Fine",        "varsegno", "fine",  "",
       QT_TRANSLATE_NOOP("jumpType", "Dal Segno Segno al Fine") },
-    { Jump::Type::DCODA,          "Da Coda",               "coda", "end",  "", QT_TRANSLATE_NOOP("jumpType", "Da Coda") },
-    { Jump::Type::DDBLCODA,       "Da Double Coda",        "varcoda", "end",  "", QT_TRANSLATE_NOOP("jumpType", "Da Double Coda") }
+    { Jump::Type::DCODA,          "Da Coda",               "coda", "end",  "",
+      QT_TRANSLATE_NOOP("jumpType", "Da Coda") },
+    { Jump::Type::DDBLCODA,       "Da Double Coda",        "varcoda", "end",  "",
+      QT_TRANSLATE_NOOP("jumpType", "Da Double Coda") }
 };
-
-int jumpTypeTableSize()
-{
-    return sizeof(jumpTypeTable) / sizeof(JumpTypeTable);
-}
 
 //---------------------------------------------------------
 //   Jump
@@ -91,7 +89,7 @@ Jump::Jump(Measure* parent)
 
 void Jump::setJumpType(Type t)
 {
-    for (const JumpTypeTable& p : jumpTypeTable) {
+    for (const JumpTypeTableItem& p : jumpTypeTable) {
         if (p.type == t) {
             setXmlText(p.text);
             setJumpTo(p.jumpTo);
@@ -109,7 +107,7 @@ void Jump::setJumpType(Type t)
 
 Jump::Type Jump::jumpType() const
 {
-    for (const JumpTypeTable& t : jumpTypeTable) {
+    for (const JumpTypeTableItem& t : jumpTypeTable) {
         if (_jumpTo == t.jumpTo && _playUntil == t.playUntil && _continueAt == t.continueAt) {
             return t.type;
         }
@@ -119,8 +117,8 @@ Jump::Type Jump::jumpType() const
 
 QString Jump::jumpTypeUserName() const
 {
-    int idx = static_cast<int>(this->jumpType());
-    if (idx < jumpTypeTableSize()) {
+    size_t idx = static_cast<size_t>(jumpType());
+    if (idx < jumpTypeTable.size()) {
         return qtrc("jumpType", jumpTypeTable[idx].userText.toUtf8().constData());
     }
     return QObject::tr("Custom");

--- a/src/engraving/libmscore/jump.h
+++ b/src/engraving/libmscore/jump.h
@@ -101,11 +101,7 @@ public:
     QString accessibleInfo() const override;
 };
 
-//---------------------------------------------------------
-//   JumpTypeTable
-//---------------------------------------------------------
-
-struct JumpTypeTable {
+struct JumpTypeTableItem {
     Jump::Type type;
     const char* text;
     const char* jumpTo;
@@ -114,9 +110,8 @@ struct JumpTypeTable {
     QString userText;
 };
 
-extern const JumpTypeTable jumpTypeTable[];
-int jumpTypeTableSize();
-}     // namespace Ms
+extern const std::vector<JumpTypeTableItem> jumpTypeTable;
+} // namespace Ms
 
 Q_DECLARE_METATYPE(Ms::Jump::Type);
 

--- a/src/engraving/libmscore/marker.cpp
+++ b/src/engraving/libmscore/marker.cpp
@@ -190,7 +190,7 @@ void Marker::layout()
     // although normally laid out to parent (measure) width,
     // force to center over barline if left-aligned
 
-    if (layoutToParentWidth() && align() == AlignH::LEFT) {
+    if (!score()->isPaletteScore() && layoutToParentWidth() && align() == AlignH::LEFT) {
         rxpos() -= width() * 0.5;
     }
 

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -337,8 +337,8 @@ PalettePtr PaletteCreator::newRepeatsPalette(bool defaultPalette)
 {
     PalettePtr sp = std::make_shared<Palette>(Palette::Type::Repeat);
     sp->setName(QT_TRANSLATE_NOOP("palette", "Repeats & jumps"));
-    sp->setMag(0.85);
-    sp->setGridSize(75, 28);
+    sp->setMag(0.75);
+    sp->setGridSize(100, 28);
     sp->setDrawGrid(true);
 
     struct MeasureRepeatInfo

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -382,10 +382,10 @@ PalettePtr PaletteCreator::newRepeatsPalette(bool defaultPalette)
         sp->appendElement(mk, markerTypeItem.name);
     }
 
-    for (int i = 0; i < jumpTypeTableSize(); i++) {
+    for (const JumpTypeTableItem& item : jumpTypeTable) {
         auto jp = makeElement<Jump>(gpaletteScore);
-        jp->setJumpType(jumpTypeTable[i].type);
-        sp->appendElement(jp, jumpTypeTable[i].userText);
+        jp->setJumpType(item.type);
+        sp->appendElement(jp, item.userText);
     }
 
     for (unsigned i = 0;; ++i) {

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -301,14 +301,10 @@ PalettePtr PaletteCreator::newBarLinePalette(bool defaultPalette)
     sp->setDrawGrid(true);
 
     // bar line styles
-    for (unsigned i = 0;; ++i) {
-        const BarLineTableItem* bti = BarLine::barLineTableItem(i);
-        if (!bti) {
-            break;
-        }
+    for (const BarLineTableItem& bti : BarLine::barLineTable) {
         auto b = Factory::makeBarLine(gpaletteScore->dummy()->segment());
-        b->setBarLineType(bti->type);
-        sp->appendElement(b, BarLine::userTypeName(bti->type));
+        b->setBarLineType(bti.type);
+        sp->appendElement(b, BarLine::userTypeName(bti.type));
     }
 
     // bar line spans
@@ -388,12 +384,8 @@ PalettePtr PaletteCreator::newRepeatsPalette(bool defaultPalette)
         sp->appendElement(jp, item.userText);
     }
 
-    for (unsigned i = 0;; ++i) {
-        const BarLineTableItem* bti = BarLine::barLineTableItem(i);
-        if (!bti) {
-            break;
-        }
-        switch (bti->type) {
+    for (const BarLineTableItem& bti : BarLine::barLineTable) {
+        switch (bti.type) {
         case BarLineType::START_REPEAT:
         case BarLineType::END_REPEAT:
         case BarLineType::END_START_REPEAT:
@@ -403,8 +395,8 @@ PalettePtr PaletteCreator::newRepeatsPalette(bool defaultPalette)
         }
 
         auto b = Factory::makeBarLine(gpaletteScore->dummy()->segment());
-        b->setBarLineType(bti->type);
-        PaletteCellPtr cell = sp->appendElement(b, BarLine::userTypeName(bti->type));
+        b->setBarLineType(bti.type);
+        PaletteCellPtr cell = sp->appendElement(b, BarLine::userTypeName(bti.type));
         cell->drawStaff = false;
     }
 


### PR DESCRIPTION
Also increase cell width and decrease scaling, to make jumps with text fit.
And another tiny refactoring in libmscore.

Note: you may need to reset your "Repeats and jumps" palette in order to see the effect of this PR. 

Resolves: #11383