### PR TITLE
[MU4] Fix more compiler warnings, as seen in MinGW and MSVC

### DIFF
--- a/src/engraving/accessibility/accessibleitem.cpp
+++ b/src/engraving/accessibility/accessibleitem.cpp
@@ -226,7 +226,7 @@ QString AccessibleItem::accessibleText(int startOffset, int endOffset) const
 
     Ms::TextCursor* textCursor = new Ms::TextCursor(Ms::toTextBase(m_element));
     auto startCoord = textCursor->positionToLocalCoord(startOffset);
-    if (startCoord.first == -1 || startCoord.second == -1) {
+    if (startCoord.first == mu::nidx || startCoord.second == mu::nidx) {
         return QString();
     }
 
@@ -253,7 +253,7 @@ QString AccessibleItem::accessibleTextAtOffset(int offset, TextBoundaryType boun
 
     Ms::TextCursor* textCursor = new Ms::TextCursor(Ms::toTextBase(m_element));
     auto startCoord = textCursor->positionToLocalCoord(offset);
-    if (startCoord.first == -1 || startCoord.second == -1) {
+    if (startCoord.first == mu::nidx || startCoord.second == mu::nidx) {
         return QString();
     }
 

--- a/src/engraving/layout/layoutlyrics.cpp
+++ b/src/engraving/layout/layoutlyrics.cpp
@@ -263,7 +263,7 @@ void LayoutLyrics::layoutLyrics(const LayoutOptions& options, const Score* score
                         ChordRest* cr = s.cr(staffIdx * VOICES + voice);
                         if (cr) {
                             for (Lyrics* l : cr->lyrics()) {
-                                l->layout2(VnAbove[staffIdx]);
+                                l->layout2(static_cast<int>(VnAbove[staffIdx]));
                             }
                         }
                     }

--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -3104,8 +3104,8 @@ void Score::cmdExplode()
         const QByteArray mimeData(selection().mimeData());
         // copy to all destination staves
         Segment* firstCRSegment = startMeasure->tick2segment(startMeasure->tick());
-        for (int i = 1; srcStaff + i < lastStaff; ++i) {
-            int track = (srcStaff + i) * VOICES;
+        for (size_t i = 1; srcStaff + i < lastStaff; ++i) {
+            track_idx_t track = (srcStaff + i) * VOICES;
             ChordRest* cr = toChordRest(firstCRSegment->element(track));
             if (cr) {
                 XmlReader e(mimeData);
@@ -3115,8 +3115,8 @@ void Score::cmdExplode()
         }
 
         // loop through each staff removing all but one note from each chord
-        for (int i = 0; srcStaff + i < lastStaff; ++i) {
-            int track = (srcStaff + i) * VOICES;
+        for (size_t i = 0; srcStaff + i < lastStaff; ++i) {
+            track_idx_t track = (srcStaff + i) * VOICES;
             for (Segment* s = startSegment; s && s != endSegment; s = s->next1()) {
                 EngravingItem* e = s->element(track);
                 if (e && e->type() == ElementType::CHORD) {
@@ -3125,10 +3125,10 @@ void Score::cmdExplode()
                     size_t nnotes = notes.size();
                     // keep note "i" from top, which is backwards from nnotes - 1
                     // reuse notes if there are more instruments than notes
-                    size_t stavesPerNote = qMax((lastStaff - srcStaff) / nnotes, size_t(1));
-                    size_t keepIndex = qMax(nnotes - 1 - (i / stavesPerNote), size_t(0));
+                    size_t stavesPerNote = qMax((lastStaff - srcStaff) / nnotes, static_cast<size_t>(1));
+                    size_t keepIndex = qMax(nnotes - 1 - (i / stavesPerNote), static_cast<size_t>(0));
                     Note* keepNote = c->notes()[keepIndex];
-                    foreach (Note* n, notes) {
+                    for (Note* n : notes) {
                         if (n != keepNote) {
                             undoRemoveElement(n);
                         }

--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -868,7 +868,7 @@ bool Score::rewriteMeasures(Measure* fm, Measure* lm, const Fraction& ns, staff_
     bool fmr     = true;
 
     // Format: chord 1 tick, chord 2 tick, tremolo, track
-    std::vector<std::tuple<Fraction, Fraction, Tremolo*, int> > tremoloChordTicks;
+    std::vector<std::tuple<Fraction, Fraction, Tremolo*, track_idx_t> > tremoloChordTicks;
 
     track_idx_t strack, etrack;
     if (staffIdx == mu::nidx) {
@@ -897,7 +897,8 @@ bool Score::rewriteMeasures(Measure* fm, Measure* lm, const Fraction& ns, staff_
                             continue;
                         }
                         auto newP
-                            = std::tuple<Fraction, Fraction, Tremolo*, int>(cr->tick(), trem->chord2()->segment()->tick(), trem, track);
+                            = std::tuple<Fraction, Fraction, Tremolo*, track_idx_t>(cr->tick(),
+                                                                                    trem->chord2()->segment()->tick(), trem, track);
                         tremoloChordTicks.push_back(newP);
                     }
                 }
@@ -3789,7 +3790,7 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
 
         // add rest to all staves and to all the staves linked to it
         for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
-            int track = staffIdx * VOICES;
+            size_t track = staffIdx * VOICES;
             Rest* rest = Factory::createRest(score->dummy()->segment(), TDuration(DurationType::V_MEASURE));
             Fraction timeStretch(score->staff(staffIdx)->timeStretch(om->tick()));
             rest->setTicks(om->ticks() * timeStretch);

--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -933,7 +933,7 @@ void Excerpt::cloneStaves(Score* sourceScore, Score* dstScore, const std::vector
                 }
             }
             if (dstStaffIdx + span > n) {
-                span = n - dstStaffIdx - 1;
+                span = static_cast<int>(n - dstStaffIdx - 1);
             }
             dstStaff->setBarLineSpan(span);
             int idx = 0;

--- a/src/engraving/libmscore/instrtemplate.cpp
+++ b/src/engraving/libmscore/instrtemplate.cpp
@@ -163,7 +163,7 @@ void InstrumentGroup::read(XmlReader& e)
             if (t == 0) {
                 t = new InstrumentTemplate;
                 t->articulation.insert(t->articulation.end(), articulation.begin(), articulation.end());             // init with global articulation
-                t->sequenceOrder = instrumentTemplates.size();
+                t->sequenceOrder = static_cast<int>(instrumentTemplates.size());
                 instrumentTemplates.push_back(t);
             }
             t->read(e);
@@ -475,7 +475,7 @@ void InstrumentTemplate::read(XmlReader& e)
             extended = e.readInt();
         } else if (tag == "staves") {
             staffCount = e.readInt();
-            bracketSpan[0] = staffCount;
+            bracketSpan[0] = static_cast<int>(staffCount);
 //                  for (int i = 0; i < staves-1; ++i)
 //                        barlineSpan[i] = true;
         } else if (tag == "clef") {             // sets both transposing and concert clef
@@ -557,8 +557,8 @@ void InstrumentTemplate::read(XmlReader& e)
         } else if (tag == "Articulation") {
             MidiArticulation a;
             a.read(e);
-            int n = articulation.size();
-            int i;
+            size_t n = articulation.size();
+            size_t i;
             for (i = 0; i < n; ++i) {
                 if (articulation[i].name == a.name) {
                     articulation[i] = a;

--- a/src/engraving/libmscore/instrtemplate.h
+++ b/src/engraving/libmscore/instrtemplate.h
@@ -161,7 +161,7 @@ struct InstrumentGroup {
 struct InstrumentIndex {
     int groupIndex = 0;
     int instrIndex = 0;
-    int templateCount = 0;
+    size_t templateCount = 0;
     InstrumentTemplate* instrTemplate = nullptr;
 
     InstrumentIndex(int g, int i, InstrumentTemplate* it);

--- a/src/engraving/libmscore/instrument.cpp
+++ b/src/engraving/libmscore/instrument.cpp
@@ -1350,7 +1350,7 @@ bool Instrument::operator==(const Instrument& i) const
     equal &= i._shortNames == _shortNames;
 
     if (i._channel.size() == _channel.size()) {
-        for (int cur = 0; cur < _channel.size(); cur++) {
+        for (size_t cur = 0; cur < _channel.size(); cur++) {
             if (*i._channel[cur] != *_channel[cur]) {
                 return false;
             }

--- a/src/engraving/libmscore/page.cpp
+++ b/src/engraving/libmscore/page.cpp
@@ -417,7 +417,7 @@ QString Page::replaceTextMacros(const QString& s) const
             // FALLTHROUGH
             case 'P': // on all pages
             {
-                int no = _no + 1 + score()->pageNumberOffset();
+                int no = static_cast<int>(_no) + 1 + score()->pageNumberOffset();
                 if (no > 0) {
                     d += QString("%1").arg(no);
                 }

--- a/src/engraving/libmscore/rendermidi.cpp
+++ b/src/engraving/libmscore/rendermidi.cpp
@@ -239,7 +239,7 @@ void Score::updateChannel()
                     if (note->hidden()) {
                         continue;
                     }
-                    note->setSubchannel(channel);
+                    note->setSubchannel(static_cast<int>(channel));
                 }
             }
         }
@@ -382,7 +382,7 @@ static void collectNote(EventMap* events, int channel, const Note* note, qreal v
     bool tieBack = note->tieBack();
 
     NoteEventList nel = note->playEvents();
-    int nels = nel.size();
+    size_t nels = nel.size();
     for (int i = 0, pitch = note->ppitch(); i < nels; ++i) {
         const NoteEvent& e = nel[i];     // we make an explicit const ref, not a const copy.  no need to copy as we won't change the original object.
 

--- a/src/engraving/libmscore/rendermidi.cpp
+++ b/src/engraving/libmscore/rendermidi.cpp
@@ -383,7 +383,7 @@ static void collectNote(EventMap* events, int channel, const Note* note, qreal v
 
     NoteEventList nel = note->playEvents();
     size_t nels = nel.size();
-    for (int i = 0, pitch = note->ppitch(); i < nels; ++i) {
+    for (int i = 0, pitch = note->ppitch(); i < static_cast<int>(nels); ++i) {
         const NoteEvent& e = nel[i];     // we make an explicit const ref, not a const copy.  no need to copy as we won't change the original object.
 
         // skip if note has a tie into it and only one NoteEvent
@@ -401,7 +401,7 @@ static void collectNote(EventMap* events, int channel, const Note* note, qreal v
         }
         int on  = tick1 + (ticks * e.ontime()) / 1000;
         int off = on + (ticks * e.len()) / 1000 - 1;
-        if (tieFor && i == nels - 1) {
+        if (tieFor && i == static_cast<int>(nels) - 1) {
             off += tieLen;
         }
 

--- a/src/engraving/libmscore/repeatlist.cpp
+++ b/src/engraving/libmscore/repeatlist.cpp
@@ -192,7 +192,7 @@ void RepeatList::updateTempo()
 
 int RepeatList::utick2tick(int tick) const
 {
-    unsigned n = size();
+    size_t n = size();
     if (n == 0) {
         return tick;
     }
@@ -234,7 +234,7 @@ int RepeatList::tick2utick(int tick) const
 
 qreal RepeatList::utick2utime(int tick) const
 {
-    unsigned n = size();
+    size_t n = size();
     unsigned ii = (idx1 < n) && (tick >= at(idx1)->utick) ? idx1 : 0;
     for (unsigned i = ii; i < n; ++i) {
         if ((tick >= at(i)->utick) && ((i + 1 == n) || (tick < at(i + 1)->utick))) {
@@ -252,7 +252,7 @@ qreal RepeatList::utick2utime(int tick) const
 
 int RepeatList::utime2utick(qreal secs) const
 {
-    unsigned repeatSegmentsCount = size();
+    size_t repeatSegmentsCount = size();
     unsigned ii = (idx2 < repeatSegmentsCount) && (secs >= at(idx2)->utime) ? idx2 : 0;
     for (unsigned i = ii; i < repeatSegmentsCount; ++i) {
         if ((secs >= at(i)->utime) && ((i + 1 == repeatSegmentsCount) || (secs < at(i + 1)->utime))) {

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -4155,8 +4155,8 @@ void Score::appendPart(const InstrumentTemplate* t)
         }
         undoInsertStaff(staff, i);
     }
-    part->staves().front()->setBarLineSpan(part->nstaves());
-    undoInsertPart(part, n);
+    part->staves().front()->setBarLineSpan(static_cast<int>(part->nstaves()));
+    undoInsertPart(part, static_cast<int>(n));
     setUpTempoMap();
     masterScore()->rebuildMidiMapping();
 }

--- a/src/engraving/libmscore/scoreorder.cpp
+++ b/src/engraving/libmscore/scoreorder.cpp
@@ -319,7 +319,7 @@ int ScoreOrder::instrumentSortingIndex(const QString& instrumentId, bool isSoloi
 
     size_t index = groups.size();
 
-    auto calculateIndex = [instrumentId, &ii](int index) {
+    auto calculateIndex = [instrumentId, &ii](size_t index) {
         return index * ii.templateCount + ii.instrTemplate->sequenceOrder;
     };
 
@@ -329,7 +329,7 @@ int ScoreOrder::instrumentSortingIndex(const QString& instrumentId, bool isSoloi
         const ScoreGroup& sg = groups.at(i);
 
         if ((sg.family == SoloistsGroup) && isSoloist) {
-            return calculateIndex(i);
+            return static_cast<int>(calculateIndex(i));
         } else if ((priority < Priority::Family) && (sg.family == family)) {
             index = i;
             priority = Priority::Family;
@@ -343,7 +343,7 @@ int ScoreOrder::instrumentSortingIndex(const QString& instrumentId, bool isSoloi
         }
     }
 
-    return calculateIndex(index);
+    return static_cast<int>(calculateIndex(index));
 }
 
 //---------------------------------------------------------
@@ -424,7 +424,7 @@ void ScoreOrder::setBracketsAndBarlines(Score* score)
                 }
             }
             if (sg.bracket && !staffIdx) {
-                thkBracketSpan += part->nstaves();
+                thkBracketSpan += static_cast<int>(part->nstaves());
             }
 
             if (!staffIdx || (ii.instrIndex != prvInstrument)) {
@@ -449,7 +449,7 @@ void ScoreOrder::setBracketsAndBarlines(Score* score)
                 prvStaff = nullptr;
             } else {
                 if (sg.thinBracket && !staffIdx) {
-                    thnBracketSpan += part->nstaves();
+                    thnBracketSpan += static_cast<int>(part->nstaves());
                 }
                 if (prvStaff) {
                     prvStaff->undoChangeProperty(Pid::STAFF_BARLINE_SPAN,

--- a/src/engraving/libmscore/staff.cpp
+++ b/src/engraving/libmscore/staff.cpp
@@ -889,7 +889,7 @@ bool Staff::readProperties(XmlReader& e)
     } else if (tag == "bracket") {
         int col = e.intAttribute("col", -1);
         if (col == -1) {
-            col = _brackets.size();
+            col = static_cast<int>(_brackets.size());
         }
         setBracketType(col, BracketType(e.intAttribute("type", -1)));
         setBracketSpan(col, e.intAttribute("span", 0));

--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -73,7 +73,7 @@ static const qreal superScriptOffset = -.9;      // of x-height
 /// return true if (r1,c1) is at or before (r2,c2)
 //---------------------------------------------------------
 
-static bool isSorted(int r1, int c1, int r2, int c2)
+static bool isSorted(size_t r1, size_t c1, size_t r2, size_t c2)
 {
     if (r1 < r2) {
         return true;

--- a/src/engraving/libmscore/textbase.h
+++ b/src/engraving/libmscore/textbase.h
@@ -171,7 +171,7 @@ public:
         QString text;
     };
 
-    std::pair<int, int> positionToLocalCoord(int position) const;
+    std::pair<size_t, size_t> positionToLocalCoord(int position) const;
 
     int currentPosition() const;
     Range selectionRange() const;

--- a/src/engraving/libmscore/textedit.cpp
+++ b/src/engraving/libmscore/textedit.cpp
@@ -851,7 +851,7 @@ void TextBase::endHexState(EditData& ed)
             if (ok) {
                 editInsertText(cursor, QString(code));
             } else {
-                LOGD("cannot convert hex string <%s>, state %d (%d-%d)",
+                LOGD("cannot convert hex string <%s>, state %d (%zu-%zu)",
                      qPrintable(ss.mid(1)), hexState, c1, c2);
             }
         }

--- a/src/engraving/libmscore/textedit.cpp
+++ b/src/engraving/libmscore/textedit.cpp
@@ -629,10 +629,10 @@ void ChangeText::removeText(EditData* ed)
 {
     TextCursor tc = _cursor;
     TextBlock& l  = _cursor.curLine();
-    int column    = _cursor.column();
+    size_t column = _cursor.column();
 
     for (int n = 0; n < s.size(); ++n) {
-        l.remove(column, &_cursor);
+        l.remove(static_cast<int>(column), &_cursor);
     }
     _cursor.text()->triggerLayout();
     if (ed) {
@@ -648,19 +648,19 @@ void ChangeText::removeText(EditData* ed)
 void SplitJoinText::join(EditData* ed)
 {
     TextBase* t   = _cursor.text();
-    int line      = _cursor.row();
+    size_t line   = _cursor.row();
     t->setTextInvalid();
     t->triggerLayout();
 
     CharFormat* charFmt = _cursor.format();         // take current format
-    int col             = t->textBlock(line - 1).columns();
-    int eol             = t->textBlock(line).eol();
-    auto fragmentsList = t->textBlock(line).fragmentsWithoutEmpty();
+    size_t col          = t->textBlock(static_cast<int>(line) - 1).columns();
+    int eol             = t->textBlock(static_cast<int>(line)).eol();
+    auto fragmentsList = t->textBlock(static_cast<int>(line)).fragmentsWithoutEmpty();
 
     if (fragmentsList.size() > 0) {
-        t->textBlock(line - 1).removeEmptyFragment();
+        t->textBlock(static_cast<int>(line) - 1).removeEmptyFragment();
     }
-    mu::join(t->textBlock(line - 1).fragments(), fragmentsList);
+    mu::join(t->textBlock(static_cast<int>(line) - 1).fragments(), fragmentsList);
 
     t->textBlockList().erase(t->textBlockList().begin() + line);
 
@@ -679,13 +679,14 @@ void SplitJoinText::join(EditData* ed)
 void SplitJoinText::split(EditData* ed)
 {
     TextBase* t   = _cursor.text();
-    int line      = _cursor.row();
+    size_t line   = _cursor.row();
     bool eol      = _cursor.curLine().eol();
     t->setTextInvalid();
     t->triggerLayout();
 
     CharFormat* charFmt = _cursor.format();           // take current format
-    t->textBlockList().insert(t->textBlockList().begin() + line + 1, _cursor.curLine().split(_cursor.column(), t->cursorFromEditData(*ed)));
+    t->textBlockList().insert(t->textBlockList().begin() + line + 1,
+                              _cursor.curLine().split(static_cast<int>(_cursor.column()), t->cursorFromEditData(*ed)));
     _cursor.curLine().setEol(true);
 
     _cursor.setRow(line + 1);
@@ -838,11 +839,11 @@ void TextBase::endHexState(EditData& ed)
 
     if (hexState >= 0) {
         if (hexState > 0) {
-            int c2 = cursor->column();
-            int c1 = c2 - (hexState + 1);
+            size_t c2 = cursor->column();
+            size_t c1 = c2 - (hexState + 1);
 
             TextBlock& t = _layout[cursor->row()];
-            QString ss   = t.remove(c1, hexState + 1, cursor);
+            QString ss   = t.remove(static_cast<int>(c1), hexState + 1, cursor);
             bool ok;
             int code     = ss.mid(1).toInt(&ok, 16);
             cursor->setColumn(c1);
@@ -895,7 +896,7 @@ bool TextBase::deleteSelectedText(EditData& ed)
             }
             Ms::TextCursor undoCursor(*_cursor);
             // can't rely on the cursor's current format as it doesn't preserve the special font "ScoreText"
-            undoCursor.setFormat(*_layout[_cursor->row()].formatAt(_cursor->column()));
+            undoCursor.setFormat(*_layout[_cursor->row()].formatAt(static_cast<int>(_cursor->column())));
             score()->undo(new RemoveText(&undoCursor, QString(_cursor->currentCharacter())), &ed);
         }
     }

--- a/src/engraving/libmscore/undo.h
+++ b/src/engraving/libmscore/undo.h
@@ -1218,7 +1218,7 @@ class ChangeBracketProperty : public ChangeProperty
     void flip(EditData*) override;
 
 public:
-    ChangeBracketProperty(Staff* s, int l, Pid i, const mu::engraving::PropertyValue& v, PropertyFlags ps = PropertyFlags::NOSTYLE)
+    ChangeBracketProperty(Staff* s, size_t l, Pid i, const mu::engraving::PropertyValue& v, PropertyFlags ps = PropertyFlags::NOSTYLE)
         : ChangeProperty(nullptr, i, v, ps), staff(s), level(l) {}
     UNDO_NAME("ChangeBracketProperty")
     UNDO_CHANGED_OBJECTS({ staff });
@@ -1284,13 +1284,13 @@ class RemoveBracket : public UndoCommand
     Staff* staff;
     size_t level;
     BracketType type;
-    int span;
+    size_t span;
 
     virtual void undo(EditData*) override;
     virtual void redo(EditData*) override;
 
 public:
-    RemoveBracket(Staff* s, size_t l, BracketType t, int sp)
+    RemoveBracket(Staff* s, size_t l, BracketType t, size_t sp)
         : staff(s), level(l), type(t), span(sp) {}
     UNDO_NAME("RemoveBracket")
     UNDO_CHANGED_OBJECTS({ staff });

--- a/src/engraving/rw/compat/read114.cpp
+++ b/src/engraving/rw/compat/read114.cpp
@@ -2927,7 +2927,7 @@ Score::FileError Read114::read114(MasterScore* masterScore, XmlReader& e, ReadCo
         if (s->barLineSpan() > static_cast<int>(masterScore->nstaves() - idx)) {
             LOGD("read114: invalid barline span %d (max %zu)",
                  s->barLineSpan(), masterScore->nstaves() - idx);
-            s->setBarLineSpan(masterScore->nstaves() - idx);
+            s->setBarLineSpan(static_cast<int>(masterScore->nstaves() - idx));
         }
         for (auto i : s->clefList()) {
             Fraction tick   = Fraction::fromTicks(i.first);
@@ -3083,7 +3083,7 @@ Score::FileError Read114::read114(MasterScore* masterScore, XmlReader& e, ReadCo
         size_t n = masterScore->nstaves();
         if (idx + barLineSpan > n) {
             LOGD("bad span: idx %zu  span %d staves %zu", idx, barLineSpan, n);
-            staff->setBarLineSpan(n - idx);
+            staff->setBarLineSpan(static_cast<int>(n - idx));
         }
         staff->updateOttava();
     }

--- a/src/engraving/rw/compat/read206.cpp
+++ b/src/engraving/rw/compat/read206.cpp
@@ -1795,7 +1795,7 @@ bool Read206::readChordProperties206(XmlReader& e, ReadContext& ctx, Chord* ch)
         gliss->setStartElement(nullptr);
         gliss->setEndElement(nullptr);
         // in TAB, use straight line with no text
-        if (ctx.staff(ctx.track() >> 2)->isTabStaff(ch->tick())) {
+        if (ctx.staff(static_cast<int>(ctx.track()) >> 2)->isTabStaff(ch->tick())) {
             gliss->setGlissandoType(GlissandoType::STRAIGHT);
             gliss->setShowText(false);
         }

--- a/src/engraving/rw/readcontext.cpp
+++ b/src/engraving/rw/readcontext.cpp
@@ -243,7 +243,7 @@ void ReadContext::fillLocation(Location& l, bool forceAbsFrac) const
     constexpr Location defaults = Location::absolute();
     const bool absFrac = (pasteMode() || forceAbsFrac);
     if (l.track() == defaults.track()) {
-        l.setTrack(track());
+        l.setTrack(static_cast<int>(track()));
     }
     if (l.frac() == defaults.frac()) {
         l.setFrac(absFrac ? tick() : rtick());

--- a/src/importexport/braille/internal/exportbraille.cpp
+++ b/src/importexport/braille/internal/exportbraille.cpp
@@ -1113,10 +1113,10 @@ QString ExportBrailleImpl::brailleMeasure(Measure* measure, int staffCount)
             score->select(measure, SelectType::RANGE, staffCount);
             score->update();
             score->startCmd();
-            score->cmdExchangeVoice(0, i);
+            score->cmdExchangeVoice(0, static_cast<int>(i));
             score->endCmd();
             score->startCmd();
-            score->cmdExchangeVoice(0, i);
+            score->cmdExchangeVoice(0, static_cast<int>(i));
             score->endCmd();
 
             resetOctave(staffCount);

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1663,7 +1663,7 @@ void GPConverter::setPitch(Note* note, const GPNote::MidiPitch& midiPitch)
     int32_t fret = midiPitch.fret;
     int32_t musescoreString{ -1 };
     if (midiPitch.string != -1) {
-        musescoreString = note->part()->instrument()->stringData()->strings() - 1 - midiPitch.string;
+        musescoreString = static_cast<int32_t>(note->part()->instrument()->stringData()->strings()) - 1 - midiPitch.string;
     }
 
     int pitch = 0;

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.h
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.h
@@ -149,7 +149,7 @@ private:
 
     GPMasterBar::TimeSig _lastTimeSig;
     GPMasterBar::TripletFeelType _lastTripletFeel = GPMasterBar::TripletFeelType::None;
-    std::unordered_map<int, GPMasterBar::KeySig> _lastKeySigs;
+    std::unordered_map<size_t, GPMasterBar::KeySig> _lastKeySigs;
     std::list<std::pair<Measure*, GPMasterBar::Fermata> > _fermatas;
     std::unordered_multimap<int, GPMasterTracks::Automation> _tempoMap;
     std::unordered_map<track_idx_t, GPBar::Clef> _clefs;

--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -1180,13 +1180,13 @@ bool GuitarPro5::readNoteEffects(Note* note)
                 harmonicFret = 4;
                 break;
             case 23:
-                harmonicFret = 3.2;
+                harmonicFret = 3.2f;
                 break;
             case 25:
-                harmonicFret = 2.7;
+                harmonicFret = 2.7f;
                 break;
             case 28:
-                harmonicFret = 2.4;
+                harmonicFret = 2.4f;
                 break;
             default:
                 harmonicFret = 12;
@@ -1474,9 +1474,9 @@ float GuitarPro5::naturalHarmonicFromFret(int fret)
 {
     switch (fret) {
     case 2:
-        return 2.4;
+        return 2.4f;
     case 3:
-        return 3.2;
+        return 3.2f;
     case 4:
     case 5:
     case 7:
@@ -1488,22 +1488,20 @@ float GuitarPro5::naturalHarmonicFromFret(int fret)
     case 24:
         return fret;
     case 8:
-        return 8.2;
+        return 8.2f;
     case 10:
-        return 9.6;
+        return 9.6f;
     case 14:
-        return 14.7;
+        return 14.7f;
     case 15:
-        return 14.7;
+        return 14.7f;
     case 21:
-        return 21.7;
+        return 21.7f;
     case 22:
-        return 21.7;
+        return 21.7f;
     default:
-        return 12.0;
+        return 12.0f;
     }
-
-    return 0;
 }
 
 //---------------------------------------------------------

--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -1368,7 +1368,7 @@ bool GuitarPro5::readNote(int string, Note* note)
 
     if (tieNote) {
         auto staffIdx = note->staffIdx();
-        if (dead_end[{ staffIdx, string }]) {
+        if (dead_end[{ static_cast<int>(staffIdx), string }]) {
             note->setFret(-20);
             return false;
         }
@@ -1461,7 +1461,7 @@ bool GuitarPro5::readNote(int string, Note* note)
         }
         if (!found) {
             note->setFret(-20);
-            dead_end[{ staffIdx, string }] = true;
+            dead_end[{ static_cast<int>(staffIdx), string }] = true;
             LOGD("tied note not found, pitch %d fret %d string %d", note->pitch(), note->fret(), note->string());
             return false;
         }

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -1242,7 +1242,7 @@ bool GuitarPro1::read(QFile* fp)
                 }
                 Segment* segment = measure->getSegment(SegmentType::ChordRest, fraction);
                 if (beatBits & BEAT_CHORD) {
-                    int numStrings = score->staff(staffIdx)->part()->instrument()->stringData()->strings();
+                    int numStrings = static_cast<int>(score->staff(staffIdx)->part()->instrument()->stringData()->strings());
                     int header = readUChar();
                     QString name;
                     if ((header & 1) == 0) {
@@ -1310,7 +1310,7 @@ bool GuitarPro1::read(QFile* fp)
                 cr->setDurationType(d);
                 segment->add(cr);
                 Staff* staff = cr->staff();
-                int numStrings = staff->part()->instrument()->stringData()->strings();
+                int numStrings = static_cast<int>(staff->part()->instrument()->stringData()->strings());
                 for (int i = 6; i >= 0; --i) {
                     if (strings & (1 << i) && ((6 - i) < numStrings)) {
                         Note* note = Factory::createNote(static_cast<Chord*>(cr));
@@ -1777,7 +1777,7 @@ bool GuitarPro2::read(QFile* fp)
                 }
                 Segment* segment = measure->getSegment(SegmentType::ChordRest, fraction);
                 if (beatBits & BEAT_CHORD) {
-                    int numStrings = score->staff(staffIdx)->part()->instrument()->stringData()->strings();
+                    int numStrings = static_cast<int>(score->staff(staffIdx)->part()->instrument()->stringData()->strings());
                     int header = readUChar();
                     QString name;
                     if ((header & 1) == 0) {
@@ -1847,7 +1847,7 @@ bool GuitarPro2::read(QFile* fp)
                 cr->setDurationType(d);
                 segment->add(cr);
                 Staff* staff = cr->staff();
-                int numStrings = staff->part()->instrument()->stringData()->strings();
+                int numStrings = static_cast<int>(staff->part()->instrument()->stringData()->strings());
                 for (int i = 6; i >= 0; --i) {
                     if (strings & (1 << i) && ((6 - i) < numStrings)) {
                         Note* note = Factory::createNote(static_cast<Chord*>(cr));
@@ -2503,7 +2503,7 @@ bool GuitarPro3::read(QFile* fp)
 
                 Segment* segment = measure->getSegment(SegmentType::ChordRest, fraction);
                 if (beatBits & BEAT_CHORD) {
-                    int numStrings = score->staff(staffIdx)->part()->instrument()->stringData()->strings();
+                    int numStrings = static_cast<int>(score->staff(staffIdx)->part()->instrument()->stringData()->strings());
                     int header = readUChar();
                     QString name;
                     if ((header & 1) == 0) {
@@ -2597,7 +2597,7 @@ bool GuitarPro3::read(QFile* fp)
                 }
 
                 Staff* staff = cr->staff();
-                int numStrings = staff->part()->instrument()->stringData()->strings();
+                int numStrings = static_cast<int>(staff->part()->instrument()->stringData()->strings());
                 bool hasSlur = false;
                 for (int i = 6; i >= 0; --i) {
                     if (strings & (1 << i) && ((6 - i) < numStrings)) {

--- a/src/importexport/midi/internal/midiimport/importmidi_instrument.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_instrument.cpp
@@ -483,7 +483,7 @@ void createInstruments(Score* score, QList<MTrack>& tracks)
         if (instr) {
             for (size_t i = 0; i != part->nstaves(); ++i) {
                 if (instr->staffTypePreset) {
-                    part->staff(i)->init(instr, nullptr, i);
+                    part->staff(i)->init(instr, nullptr, static_cast<int>(i));
                     part->staff(i)->setStaffType(Fraction(0, 1), *(instr->staffTypePreset));
                 }
 //                        part->staff(i)->setLines(0, instr->staffLines[i]);

--- a/src/importexport/midi/internal/midiimport/importmidi_tuplet_voice.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_tuplet_voice.cpp
@@ -43,7 +43,7 @@ int tupletVoiceLimit()
                "Allowed voice count exceeds MuseScore voice limit");
 
     // for multiple voices: one voice is reserved for non-tuplet chords
-    return (allowedVoices == 1) ? 1 : allowedVoices - 1;
+    return (allowedVoices == 1) ? 1 : static_cast<int>(allowedVoices) - 1;
 }
 
 std::pair<ReducedFraction, ReducedFraction>

--- a/src/importexport/midi/internal/midiimport/importmidi_voice.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_voice.cpp
@@ -61,7 +61,7 @@ int voiceLimit()
                "MidiVoice::voiceLimit",
                "Allowed voice count exceeds MuseScore voice limit");
 
-    return allowedVoiceCount;
+    return static_cast<int>(allowedVoiceCount);
 }
 
 #ifdef QT_DEBUG
@@ -1074,7 +1074,7 @@ bool separateVoices(std::multimap<int, MTrack>& tracks, const TimeSigMap* sigmap
         if (chords.empty()) {
             continue;
         }
-        const int userVoiceCount = toIntVoiceCount(
+        const auto userVoiceCount = toIntVoiceCount(
             opers.data()->trackOpers.maxVoiceCount.value(mtrack.indexOfOperation));
         // pass current track index through MidiImportOperations
         // for further usage

--- a/src/importexport/midi/internal/midiimport/importmidi_voice.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_voice.cpp
@@ -1080,7 +1080,7 @@ bool separateVoices(std::multimap<int, MTrack>& tracks, const TimeSigMap* sigmap
         // for further usage
         MidiOperations::CurrentTrackSetter setCurrentTrack{ opers, mtrack.indexOfOperation };
 
-        if (userVoiceCount > 1 && userVoiceCount <= voiceLimit()) {
+        if (userVoiceCount > 1 && static_cast<int>(userVoiceCount) <= voiceLimit()) {
 #ifdef QT_DEBUG
             Q_ASSERT_X(MidiTuplet::areAllTupletsReferenced(mtrack.chords, mtrack.tuplets),
                        "MidiVoice::separateVoices",

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -6523,7 +6523,7 @@ static void partList(XmlWriter& xml, Score* score, MxmlInstrumentMap& instrMap)
         for (int i = MAX_PART_GROUPS - 1; i >= 0; i--) {
             int end = partGroupEnd[i];
             if (end >= 0) {
-                if (staffCount >= end) {
+                if (static_cast<int>(staffCount) >= end) {
                     xml.tagE(QString("part-group type=\"stop\" number=\"%1\"").arg(i + 1));
                     partGroupEnd[i] = -1;
                 }

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -459,7 +459,7 @@ track_idx_t MusicXMLParserPass1::trackForPart(const QString& id) const
 {
     Part* part = _partMap.value(id);
     IF_ASSERT_FAILED(part) {
-        return -1;
+        return mu::nidx;
     }
     staff_idx_t scoreRelStaff = _score->staffIdx(part);   // zero-based number of parts first staff in the score
     return scoreRelStaff * VOICES;

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -1085,7 +1085,7 @@ void MusicXMLParserPass1::scorePartwise()
             partSet << il.at(pg->start);
         }
         // determine span in staves
-        int stavesSpan = 0;
+        size_t stavesSpan = 0;
         for (int j = 0; j < pg->span; j++) {
             stavesSpan += il.at(pg->start + j)->nstaves();
         }
@@ -1110,7 +1110,7 @@ void MusicXMLParserPass1::scorePartwise()
             p->staff(0)->setBracketSpan(column, p->nstaves());
             if (allStaffGroupsIdentical(p)) {
                 // span only if the same types
-                p->staff(0)->setBarLineSpan(p->nstaves());
+                p->staff(0)->setBarLineSpan(static_cast<int>(p->nstaves()));
             }
         }
     }
@@ -2044,7 +2044,7 @@ static void setNumberOfStavesForPart(Part* const part, const size_t staves)
     }
 
     if (staves > part->nstaves()) {
-        part->setStaves(staves);
+        part->setStaves(static_cast<int>(staves));
     }
 }
 
@@ -2566,7 +2566,7 @@ void MusicXMLParserPass1::direction(const QString& partId, const Fraction cTime)
         if (_e.name() == "direction-type") {
             directionType(cTime, starts, stops);
         } else if (_e.name() == "staff") {
-            int nstaves = getPart(partId)->nstaves();
+            int nstaves = static_cast<int>(getPart(partId)->nstaves());
             QString strStaff = _e.readElementText();
             staff = strStaff.toInt() - 1;
             if (0 <= staff && staff < nstaves) {

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -437,7 +437,7 @@ void NotationActionController::init()
     }
 
     for (size_t i = 0; i < Ms::VOICES; ++i) {
-        registerAction("voice-" + std::to_string(i + 1), [this, i]() { changeVoice(i); });
+        registerAction("voice-" + std::to_string(i + 1), [this, i]() { changeVoice(static_cast<int>(i)); });
     }
 
     // TAB

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2463,7 +2463,7 @@ void NotationInteraction::moveStringSelection(MoveDirection d)
 {
     Ms::InputState& is = score()->inputState();
     Ms::Staff* staff = score()->staff(is.track() / Ms::VOICES);
-    int instrStrgs = staff->part()->instrument(is.tick())->stringData()->strings();
+    int instrStrgs = static_cast<int>(staff->part()->instrument(is.tick())->stringData()->strings());
     int delta = (staff->staffType(is.tick())->upsideDown() ? -1 : 1);
 
     if (MoveDirection::Up == d) {
@@ -2618,7 +2618,7 @@ void NotationInteraction::editText(QInputMethodEvent* event)
     while (n--) {
         if (cursor->movePosition(Ms::TextCursor::MoveOperation::Left)) {
             Ms::TextBlock& curLine = cursor->curLine();
-            curLine.remove(cursor->column(), cursor);
+            curLine.remove(static_cast<int>(cursor->column()), cursor);
             text->triggerLayout();
             text->setTextInvalid();
         }

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -398,7 +398,7 @@ mu::RectF NotationNoteInput::cursorRect() const
     int lines = staffType->lines();
     int inputStateStringsCount = inputState.string();
 
-    int instrumentStringsCount = staff->part()->instrument()->stringData()->strings();
+    int instrumentStringsCount = static_cast<int>(staff->part()->instrument()->stringData()->strings());
     if (staff->isTabStaff(inputState.tick()) && inputStateStringsCount >= 0 && inputStateStringsCount <= instrumentStringsCount) {
         h = lineDist;
         y += staffType->physStringToYOffset(inputStateStringsCount) * spatium;

--- a/src/notation/internal/notationpainting.cpp
+++ b/src/notation/internal/notationpainting.cpp
@@ -78,7 +78,7 @@ int NotationPainting::pageCount() const
         return 0;
     }
 
-    return score()->npages();
+    return static_cast<int>(score()->npages());
 }
 
 SizeF NotationPainting::pageSizeInch() const

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -1026,7 +1026,7 @@ void NotationParts::appendNewParts(const PartInstrumentList& parts)
         part->setLongName(formattedLongName);
         part->setShortName(formattedShortName);
 
-        score()->undo(new Ms::InsertPart(part, staffCount));
+        score()->undo(new Ms::InsertPart(part, static_cast<int>(staffCount)));
         appendStaves(part, pi.instrumentTemplate, keyList);
         staffCount += part->nstaves();
 

--- a/src/notation/view/widgets/editstringdata.cpp
+++ b/src/notation/view/widgets/editstringdata.cpp
@@ -47,7 +47,7 @@ EditStringData::EditStringData(QWidget* parent, std::vector<Ms::instrString>* st
     setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
     _strings = strings;
     QStringList hdrLabels;
-    int numOfStrings = _strings->size();
+    int numOfStrings = static_cast<int>(_strings->size());
     hdrLabels << tr("Open", "string data") << tr("Pitch", "string data");
     stringList->setHorizontalHeaderLabels(hdrLabels);
     stringList->setRowCount(numOfStrings);
@@ -247,7 +247,7 @@ void EditStringData::accept()
     // string tunings are copied in reversed order (from lowest to highest)
     if (_modified) {
         _strings->clear();
-        for (int i = _stringsLoc.size() - 1; i >= 0; i--) {
+        for (int i = static_cast<int>(_stringsLoc.size()) - 1; i >= 0; i--) {
             _strings->push_back(_stringsLoc[i]);
         }
     }

--- a/src/notation/view/widgets/measureproperties.cpp
+++ b/src/notation/view/widgets/measureproperties.cpp
@@ -205,8 +205,8 @@ void MeasurePropertiesDialog::setMeasure(Ms::Measure* measure)
     measureNumberOffset->setValue(m_measure->noOffset());
 
     Ms::Score* score = m_measure->score();
-    int rows = score->nstaves();
-    staves->setRowCount(rows);
+    size_t rows = score->nstaves();
+    staves->setRowCount(static_cast<int>(rows));
     staves->setColumnCount(3);
 
     auto itemAccessibleText = [](const QTableWidgetItem* item){
@@ -215,9 +215,9 @@ void MeasurePropertiesDialog::setMeasure(Ms::Measure* measure)
         return accessibleText;
     };
 
-    for (int staffIdx = 0; staffIdx < rows; ++staffIdx) {
+    for (size_t staffIdx = 0; staffIdx < rows; ++staffIdx) {
         QTableWidgetItem* item = new QTableWidgetItem(QString("%1").arg(staffIdx + 1));
-        staves->setItem(staffIdx, 0, item);
+        staves->setItem(static_cast<int>(staffIdx), 0, item);
 
         item = new QTableWidgetItem();
         item->setFlags(item->flags() | Qt::ItemIsUserCheckable | Qt::ItemIsEnabled);
@@ -227,14 +227,14 @@ void MeasurePropertiesDialog::setMeasure(Ms::Measure* measure)
         }
         item->setData(ITEM_ACCESSIBLE_TITLE_ROLE, qtrc("notation", "Visible"));
         item->setData(Qt::AccessibleTextRole, itemAccessibleText(item));
-        staves->setItem(staffIdx, 1, item);
+        staves->setItem(static_cast<int>(staffIdx), 1, item);
 
         item = new QTableWidgetItem();
         item->setFlags(item->flags() | Qt::ItemIsUserCheckable | Qt::ItemIsEnabled);
         item->setCheckState(m_measure->stemless(staffIdx) ? Qt::Checked : Qt::Unchecked);
         item->setData(ITEM_ACCESSIBLE_TITLE_ROLE, qtrc("notation", "Stemless"));
         item->setData(Qt::AccessibleTextRole, itemAccessibleText(item));
-        staves->setItem(staffIdx, 2, item);
+        staves->setItem(static_cast<int>(staffIdx), 2, item);
     }
 
     connect(staves, &QTableWidget::itemChanged, this, [&itemAccessibleText](QTableWidgetItem* item){
@@ -320,10 +320,10 @@ void MeasurePropertiesDialog::apply()
     m_notation->undoStack()->prepareChanges();
     bool propertiesChanged = false;
     for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
-        bool v = visible(staffIdx);
-        bool s = stemless(staffIdx);
+        bool v = visible(static_cast<int>(staffIdx));
+        bool s = stemless(static_cast<int>(staffIdx));
         if (m_measure->visible(staffIdx) != v || m_measure->stemless(staffIdx) != s) {
-            score->undo(new Ms::ChangeMStaffProperties(m_measure, staffIdx, v, s));
+            score->undo(new Ms::ChangeMStaffProperties(m_measure, static_cast<int>(staffIdx), v, s));
             propertiesChanged = true;
         }
     }

--- a/src/notation/view/widgets/stafftextpropertiesdialog.cpp
+++ b/src/notation/view/widgets/stafftextpropertiesdialog.cpp
@@ -149,7 +149,7 @@ StaffTextPropertiesDialog::StaffTextPropertiesDialog(QWidget* parent)
             }
             if (row == rows) {
                 m_vb[voice][rows]->setChecked(true);
-                m_channelCombo[row]->setCurrentIndex(i);
+                m_channelCombo[row]->setCurrentIndex(static_cast<int>(i));
                 ++rows;
             }
             break;
@@ -172,13 +172,13 @@ StaffTextPropertiesDialog::StaffTextPropertiesDialog(QWidget* parent)
         for (size_t col = 0; col < VOICES; ++col) {
             auto button = m_vb[col][row];
 
-            mapper->setMapping(button, (col << 8) + row);
+            mapper->setMapping(button, static_cast<int>((col << 8) + row));
             button->setAccessibleName(voiceLabel->text() + button->text());
 
             connect(button, SIGNAL(clicked()), mapper, SLOT(map()));
 
             connect(button, &QToolButton::toggled, this, [=](){
-                QColor color = button->isChecked() ? voicesColors[col] : voiceUncheckedColor;
+                QColor color = button->isChecked() ? voicesColors[static_cast<int>(col)] : voiceUncheckedColor;
                 QPalette palette;
                 palette.setColor(QPalette::Button, color);
                 button->setPalette(palette);
@@ -226,7 +226,7 @@ StaffTextPropertiesDialog::StaffTextPropertiesDialog(QWidget* parent)
 
     QTreeWidgetItem* selectedItem = 0;
     for (size_t i = 0; i < n; ++i) {
-        const Channel* a = part->instrument(tick)->channel(i);
+        const Channel* a = part->instrument(tick)->channel(static_cast<int>(i));
         QTreeWidgetItem* item = new QTreeWidgetItem(channelList);
         item->setData(0, Qt::UserRole, static_cast<int>(i));
         QString name = a->name();

--- a/src/notation/view/widgets/timeline.cpp
+++ b/src/notation/view/widgets/timeline.cpp
@@ -1212,9 +1212,9 @@ void Timeline::timeMeta(Segment* seg, int* stagger, int pos)
     }
 
     // Check if same across all staves
-    const int nrows = score()->staves().size();
+    const size_t nrows = score()->staves().size();
     bool same = true;
-    for (int track = 0; track < nrows; track++) {
+    for (size_t track = 0; track < nrows; track++) {
         const TimeSig* currTimeSig = toTimeSig(seg->element(track * VOICES));
         if (!currTimeSig) {
             same = false;
@@ -1762,7 +1762,7 @@ void Timeline::setMetaData(QGraphicsItem* gi, int staff, ElementType et, Measure
 int Timeline::getWidth() const
 {
     if (score()) {
-        return score()->nmeasures() * _gridWidth;
+        return static_cast<int>(score()->nmeasures()) * _gridWidth;
     } else {
         return 0;
     }
@@ -1775,7 +1775,7 @@ int Timeline::getWidth() const
 int Timeline::getHeight() const
 {
     if (score()) {
-        return int((nstaves() + nmetas()) * _gridHeight + 3);
+        return (nstaves() + static_cast<int>(nmetas())) * _gridHeight + 3;
     } else {
         return 0;
     }
@@ -2562,7 +2562,7 @@ void Timeline::updateGrid(int startMeasure, int endMeasure)
     TRACEFUNC;
 
     if (score() && score()->firstMeasure()) {
-        drawGrid(nstaves(), score()->nmeasures(), startMeasure, endMeasure);
+        drawGrid(static_cast<int>(nstaves()), static_cast<int>(score()->nmeasures()), startMeasure, endMeasure);
         updateView();
         drawSelection();
         mouseOver(mapToScene(mapFromGlobal(QCursor::pos())));
@@ -2597,7 +2597,7 @@ void Timeline::updateGridFromCmdState()
     const int startMeasureIndex = startMeasure ? startMeasure->measureIndex() : 0;
 
     const Measure* endMeasure = layoutAll ? nullptr : score()->tick2measure(cState.endTick());
-    const int endMeasureIndex = endMeasure ? (endMeasure->measureIndex() + 1) : score()->nmeasures();
+    const int endMeasureIndex = endMeasure ? (endMeasure->measureIndex() + 1) : static_cast<int>(score()->nmeasures());
 
     updateGrid(startMeasureIndex, endMeasureIndex);
 }
@@ -2613,7 +2613,7 @@ void Timeline::setNotation(mu::notation::INotationPtr notation)
     clearScene();
 
     if (m_notation) {
-        drawGrid(nstaves(), score()->nmeasures());
+        drawGrid(nstaves(), static_cast<int>(score()->nmeasures()));
         drawSelection();
         changeSelection(SelState::NONE);
         _rowNames->updateLabels(getLabels(), _gridHeight);
@@ -2677,7 +2677,7 @@ void Timeline::updateView()
                     mu::RectF showRect = mmrestMeasure->canvasBoundingRect().intersected(staveRect);
 
                     if (canvas.intersects(showRect)) {
-                        visiblePainterPath.addRect(getMeasureRect(measureIndex, staff, numMetas));
+                        visiblePainterPath.addRect(getMeasureRect(measureIndex, static_cast<int>(staff), numMetas));
                     }
                 }
             }
@@ -2694,7 +2694,7 @@ void Timeline::updateView()
                 mu::RectF showRect = mmrestMeasure->canvasBoundingRect().intersected(staveRect);
 
                 if (canvas.intersects(showRect)) {
-                    visiblePainterPath.addRect(getMeasureRect(measureIndex, staff, numMetas));
+                    visiblePainterPath.addRect(getMeasureRect(measureIndex, static_cast<int>(staff), numMetas));
                 }
             }
             continue;
@@ -2715,7 +2715,7 @@ void Timeline::updateView()
             mu::RectF showRect = currMeasure->canvasBoundingRect().intersected(staveRect);
 
             if (canvas.intersects(showRect)) {
-                visiblePainterPath.addRect(getMeasureRect(measureIndex, staff, numMetas));
+                visiblePainterPath.addRect(getMeasureRect(measureIndex, static_cast<int>(staff), numMetas));
             }
         }
     }
@@ -2762,7 +2762,7 @@ void Timeline::updateView()
 
 int Timeline::nstaves() const
 {
-    return score()->staves().size();
+    return static_cast<int>(score()->staves().size());
 }
 
 //---------------------------------------------------------

--- a/src/palette/view/widgets/keyedit.cpp
+++ b/src/palette/view/widgets/keyedit.cpp
@@ -379,7 +379,7 @@ void KeyEditor::addClicked()
     for (Accidental* a : al) {
         CustDef c;
         c.sym       = a->symbol();
-        int idx     = e.customKeyDefs().size();
+        size_t idx  = e.customKeyDefs().size();
         PointF pos  = a->ipos();
         pos.rx()   -= xoff;
         c.xAlt      = pos.x() / spatium - idx * e.xstep();

--- a/src/plugins/api/cursor.cpp
+++ b/src/plugins/api/cursor.cpp
@@ -644,7 +644,7 @@ void Cursor::setStaffIdx(int v)
 {
     track_idx_t _track = v * VOICES + track() % VOICES;
     size_t tracks = _score->nstaves() * VOICES;
-    if (_track < 0) {
+    if (_track == mu::nidx) {
         _track = 0;
     } else if (_track >= tracks) {
         _track = tracks - 1;
@@ -660,7 +660,7 @@ void Cursor::setVoice(int v)
 {
     track_idx_t _track = (track() / VOICES) * VOICES + v;
     size_t tracks = _score->nstaves() * VOICES;
-    if (_track < 0) {
+    if (_track == mu::nidx) {
         _track = 0;
     } else if (_track >= tracks) {
         _track = tracks - 1;

--- a/src/plugins/api/cursor.cpp
+++ b/src/plugins/api/cursor.cpp
@@ -642,8 +642,8 @@ void Cursor::setTrack(int _track)
 
 void Cursor::setStaffIdx(int v)
 {
-    int _track = v * VOICES + track() % VOICES;
-    int tracks = _score->nstaves() * VOICES;
+    track_idx_t _track = v * VOICES + track() % VOICES;
+    size_t tracks = _score->nstaves() * VOICES;
     if (_track < 0) {
         _track = 0;
     } else if (_track >= tracks) {
@@ -658,8 +658,8 @@ void Cursor::setStaffIdx(int v)
 
 void Cursor::setVoice(int v)
 {
-    int _track = (track() / VOICES) * VOICES + v;
-    int tracks = _score->nstaves() * VOICES;
+    track_idx_t _track = (track() / VOICES) * VOICES + v;
+    size_t tracks = _score->nstaves() * VOICES;
     if (_track < 0) {
         _track = 0;
     } else if (_track >= tracks) {

--- a/src/plugins/api/elements.cpp
+++ b/src/plugins/api/elements.cpp
@@ -261,9 +261,9 @@ void Chord::addInternal(Ms::Chord* chord, Ms::EngravingItem* s)
 //   Page::pagenumber
 //---------------------------------------------------------
 
-size_t Page::pagenumber() const
+int Page::pagenumber() const
 {
-    return page()->no();
+    return static_cast<int>(page()->no());
 }
 
 //---------------------------------------------------------

--- a/src/plugins/api/elements.h
+++ b/src/plugins/api/elements.h
@@ -887,7 +887,7 @@ public:
     Ms::Page* page() { return toPage(e); }
     const Ms::Page* page() const { return toPage(e); }
 
-    size_t pagenumber() const;
+    int pagenumber() const;
     /// \endcond
 };
 

--- a/src/plugins/api/selection.cpp
+++ b/src/plugins/api/selection.cpp
@@ -118,7 +118,7 @@ bool Selection::selectRange(int startTick, int endTick, int startStaff, int endS
         return false;
     }
 
-    const int nstaves = _select->score()->nstaves();
+    const int nstaves = static_cast<int>(_select->score()->nstaves());
 
     startStaff = qBound(0, startStaff, nstaves - 1);
     endStaff = qBound(1, endStaff, nstaves);


### PR DESCRIPTION
* Fix MSVC compiler warning reg. signed/unsigned mismatch, C4245
* Fix MSVC compiler warnings reg. conversion from `size` to `int`, possible loss of data, C4267
* Fix MinGW compiler warnings reg. -Wtype-limits, -Wsign-compare and -Wformat= caused by the above change
* Fix MSVC compiler warnings reg. truncation from `double` to `float`, C4305 and reg. unreachable code, C4702