### PR TITLE
[MU4] Fix #313977: avoid adding a palette element twice on double-click

### DIFF
--- a/src/palette/qml/MuseScore/Palette/internal/Palette.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/Palette.qml
@@ -541,9 +541,7 @@ StyledGridView {
             }
 
             onDoubleClicked: {
-                const index = paletteCell.modelIndex;
-                paletteView.selectionModel.setCurrentIndex(index, ItemSelectionModel.Current);
-                paletteView.paletteController.applyPaletteElement(index, ui.keyboardModifiers());
+                // Empty handler to avoid onClicked being triggered twice on double-click.
             }
 
             onRemoveSelectionRequested: {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/313977

The issue doesn't happen in MuseScore 3.4.2 but happens in the 3.5 version (and later). The possible reason is that #5474 has occasionally reverted the previous commit which had fixed this issue, 77e4347. This pull request returns the empty double-click handler back. Removing the handler entirely causes two `onClicked` events being triggered and results in identical elements being added as well, so we have to put an empty handler there to prevent this.

Port of #7590 (for 3.x) to master