### PR TITLE
Fix #11382: Inconsistent text sizes

### DIFF
--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -787,11 +787,11 @@ mu::draw::Font TextFragment::font(const TextBase* t) const
 
     QString family;
     if (format.fontFamily() == "ScoreText") {
-        if (t->explicitParent() && t->isDynamic()) {
+        if (t->isDynamic()) {
             family = t->score()->scoreFont()->fontByName(t->score()->styleSt(Sid::MusicalSymbolFont))->family();
             // to keep desired size ratio (based on 20pt symbol size to 10pt text size)
             m *= 2;
-        } else if (t->explicitParent() && t->isTempoText()) {
+        } else if (t->isTempoText()) {
             family = t->score()->styleSt(Sid::MusicalTextFont);
             // to keep desired size ratio (based on 20pt symbol size to 12pt text size)
             m *= 5.0 / 3.0;

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -1345,14 +1345,16 @@ PalettePtr PaletteCreator::newTempoPalette(bool defaultPalette)
         auto item = makeElement<TempoChangeRanged>(gpaletteScore);
         item->setTempoChangeType(pair.first);
         item->setBeginText(pair.second);
-        sp->appendElement(item, pair.second);
+        sp->appendElement(item, pair.second, 1.3)->yoffset = 0.4;
     }
 
     auto stxt = makeElement<SystemText>(gpaletteScore);
     stxt->setTextStyleType(TextStyleType::TEMPO);
     stxt->setXmlText(QT_TRANSLATE_NOOP("palette", "Swing"));
     stxt->setSwing(true);
-    sp->appendElement(stxt, QT_TRANSLATE_NOOP("palette", "Swing"))->setElementTranslated(true);
+    PaletteCellPtr cell = sp->appendElement(stxt, QT_TRANSLATE_NOOP("palette", "Swing"), 1.3);
+    cell->yoffset = 0.4;
+    cell->setElementTranslated(true);
 
     stxt = makeElement<SystemText>(gpaletteScore);
     stxt->setTextStyleType(TextStyleType::TEMPO);
@@ -1363,7 +1365,9 @@ PalettePtr PaletteCreator::newTempoPalette(bool defaultPalette)
     // 0 (swingUnit) turns of swing; swingRatio is set to default
     stxt->setSwingParameters(0, stxt->score()->styleI(Sid::swingRatio));
     /*: System text to switch from swing rhythm back to straight rhythm */
-    sp->appendElement(stxt, QT_TRANSLATE_NOOP("palette", "Straight"))->setElementTranslated(true);
+    cell = sp->appendElement(stxt, QT_TRANSLATE_NOOP("palette", "Straight"), 1.3);
+    cell->yoffset = 0.4;
+    cell->setElementTranslated(true);
     return sp;
 }
 


### PR DESCRIPTION
Resolves: #11382 

*(short description of the changes and the motivation to make the changes)*

This commit fixes the differences in the size of certain palette cells of the Tempo Palette by increasing magnification. This also fixes the differences in size of the note symbol and the text in Tempo Palette

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
