### PR TITLE
Fix #11461 - don't remove custom key signatures from begining of the score.

### DIFF
--- a/src/engraving/libmscore/transpose.cpp
+++ b/src/engraving/libmscore/transpose.cpp
@@ -611,7 +611,7 @@ void Score::transposeKeys(staff_idx_t staffStart, staff_idx_t staffEnd, const Fr
                 //      }
                 Key nKey = transposeKey(ke.key(), segmentInterval, pref);
                 // remove initial C major key signatures
-                if (nKey == Key::C && s->tick().isZero()) {
+                if (nKey == Key::C && s->tick().isZero() && !ks->isCustom()) {
                     undo(new RemoveElement(ks));
                     if (s->empty()) {
                         undo(new RemoveElement(s));


### PR DESCRIPTION
Resolves: #11461

Custom key signature dissapeared sometimes from begining of score.
Fixed.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
