### PR TITLE
Fix #11440 -user preference description

### DIFF
--- a/src/engraving/infrastructure/internal/engravingconfiguration.cpp
+++ b/src/engraving/infrastructure/internal/engravingconfiguration.cpp
@@ -58,7 +58,7 @@ void EngravingConfiguration::init()
     });
 
     for (Ms::voice_idx_t voice = 0; voice < Ms::VOICES; ++voice) {
-        Settings::Key key("engraving", "engraving/colors/voice" + std::to_string(voice + 1));
+        Settings::Key key("engraving", "Voice " + std::to_string(voice + 1) + " color");
 
         settings()->setDefaultValue(key, Val(defaultVoiceColors[voice].toQColor()));
         settings()->setCanBeMannualyEdited(key, true);

--- a/src/palette/internal/paletteconfiguration.cpp
+++ b/src/palette/internal/paletteconfiguration.cpp
@@ -31,9 +31,9 @@ using namespace mu::framework;
 using namespace mu::ui;
 
 static const std::string MODULE_NAME("palette");
-static const Settings::Key PALETTE_SCALE(MODULE_NAME, "application/paletteScale");
-static const Settings::Key PALETTE_USE_SINGLE(MODULE_NAME, "application/useSinglePalette");
-static const Settings::Key IS_SINGLE_CLICK_TO_OPEN_PALETTE(MODULE_NAME, "application/singleClickToOpenPalette");
+static const Settings::Key PALETTE_SCALE(MODULE_NAME, "Palette scale");
+static const Settings::Key PALETTE_USE_SINGLE(MODULE_NAME, "Use a single palette");
+static const Settings::Key IS_SINGLE_CLICK_TO_OPEN_PALETTE(MODULE_NAME, "Single-click to open a palette");
 
 void PaletteConfiguration::init()
 {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11440

Made the preferences descriptions more clear and user friendly in order to be immediately understood and less intimidating.

Example:
engraving/colors/voice1

becomes....

Voice 1 color

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://musescore.org/en/cla)
- [ x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x] I made sure the code compiles on my machine
- [ x] I made sure there are no unnecessary changes in the code
- [ x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
