### PR TITLE
fix #11082: Changed file open/save dialog's default path

### DIFF
--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -614,7 +614,19 @@ io::path ProjectActionsController::selectScoreOpeningFile()
            << QObject::tr("MuseScore Dev Files") + " (*.mscs)"
            << QObject::tr("MuseScore Backup Files") + " (*.mscz~)";
 
-    return interactive()->selectOpeningFile(qtrc("project", "Score"), configuration()->userProjectsPath(), filter.join(";;"));
+    io::path defaultDir = configuration()->lastOpenedProjectsPath();
+
+    if (defaultDir.empty()) {
+        defaultDir = configuration()->defaultProjectsPath();
+    }
+
+    io::path filePath = interactive()->selectOpeningFile(qtrc("project", "Score"), defaultDir, filter.join(";;"));
+
+    if (!filePath.empty()) {
+        configuration()->setLastOpenedProjectsPath(io::dirpath(filePath));
+    }
+
+    return filePath;
 }
 
 void ProjectActionsController::prependToRecentScoreList(const io::path& filePath)

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -39,6 +39,9 @@ static const std::string module_name("project");
 
 static const Settings::Key RECENT_PROJECTS_PATHS(module_name, "project/recentList");
 static const Settings::Key USER_TEMPLATES_PATH(module_name, "application/paths/myTemplates");
+static const Settings::Key DEFAULT_PROJECTS_PATH(module_name, "application/paths/defaultProjectsPath");
+static const Settings::Key LAST_OPENED_PROJECTS_PATH(module_name, "application/paths/lastOpenedProjectsPath");
+static const Settings::Key LAST_SAVED_PROJECTS_PATH(module_name, "application/paths/lastSavedProjectsPath");
 static const Settings::Key USER_PROJECTS_PATH(module_name, "application/paths/myScores");
 static const Settings::Key SHOULD_ASK_SAVE_LOCATION_TYPE(module_name, "project/shouldAskSaveLocationType");
 static const Settings::Key LAST_USED_SAVE_LOCATION_TYPE(module_name, "project/lastUsedSaveLocationType");
@@ -58,11 +61,12 @@ void ProjectConfiguration::init()
     });
     fileSystem()->makePath(userTemplatesPath());
 
-    settings()->setDefaultValue(USER_PROJECTS_PATH, Val(globalConfiguration()->userDataPath() + "/Scores"));
+    settings()->setDefaultValue(DEFAULT_PROJECTS_PATH, Val(globalConfiguration()->userDataPath() + "/Scores"));
+    fileSystem()->makePath(defaultProjectsPath());
+
     settings()->valueChanged(USER_PROJECTS_PATH).onReceive(nullptr, [this](const Val& val) {
         m_userScoresPathChanged.send(val.toPath());
     });
-    fileSystem()->makePath(userProjectsPath());
 
     settings()->valueChanged(RECENT_PROJECTS_PATHS).onReceive(nullptr, [this](const Val& val) {
         io::paths paths = parseRecentProjectsPaths(val);
@@ -208,6 +212,36 @@ async::Channel<io::path> ProjectConfiguration::userTemplatesPathChanged() const
     return m_userTemplatesPathChanged;
 }
 
+io::path ProjectConfiguration::defaultProjectsPath() const
+{
+    return settings()->value(DEFAULT_PROJECTS_PATH).toPath();
+}
+
+void ProjectConfiguration::setDefaultProjectsPath(const io::path& path)
+{
+    settings()->setSharedValue(DEFAULT_PROJECTS_PATH, Val(path));
+}
+
+io::path ProjectConfiguration::lastOpenedProjectsPath() const
+{
+    return settings()->value(LAST_OPENED_PROJECTS_PATH).toPath();
+}
+
+void ProjectConfiguration::setLastOpenedProjectsPath(const io::path& path)
+{
+    settings()->setSharedValue(LAST_OPENED_PROJECTS_PATH, Val(path));
+}
+
+io::path ProjectConfiguration::lastSavedProjectsPath() const
+{
+    return settings()->value(LAST_SAVED_PROJECTS_PATH).toPath();
+}
+
+void ProjectConfiguration::setLastSavedProjectsPath(const io::path& path)
+{
+    settings()->setSharedValue(LAST_SAVED_PROJECTS_PATH, Val(path));
+}
+
 io::path ProjectConfiguration::userProjectsPath() const
 {
     return settings()->value(USER_PROJECTS_PATH).toPath();
@@ -261,6 +295,14 @@ io::path ProjectConfiguration::defaultSavingFilePath(INotationProjectPtr project
 
     if (folderPath.empty()) {
         folderPath = userProjectsPath();
+    }
+
+    if (folderPath.empty()) {
+        folderPath = lastSavedProjectsPath();
+    }
+
+    if (folderPath.empty()) {
+        folderPath = defaultProjectsPath();
     }
 
     if (filename.empty()) {

--- a/src/project/internal/projectconfiguration.h
+++ b/src/project/internal/projectconfiguration.h
@@ -59,6 +59,15 @@ public:
     void setUserTemplatesPath(const io::path& path) override;
     async::Channel<io::path> userTemplatesPathChanged() const override;
 
+    io::path defaultProjectsPath() const override;
+    void setDefaultProjectsPath(const io::path& path) override;
+
+    io::path lastOpenedProjectsPath() const override;
+    void setLastOpenedProjectsPath(const io::path& path) override;
+
+    io::path lastSavedProjectsPath() const override;
+    void setLastSavedProjectsPath(const io::path& path) override;
+
     io::path userProjectsPath() const override;
     void setUserProjectsPath(const io::path& path) override;
     async::Channel<io::path> userProjectsPathChanged() const override;

--- a/src/project/internal/saveprojectscenario.cpp
+++ b/src/project/internal/saveprojectscenario.cpp
@@ -110,6 +110,8 @@ RetVal<io::path> SaveProjectScenario::askLocalPath(INotationProjectPtr project, 
         return make_ret(Ret::Code::Cancel);
     }
 
+    configuration()->setLastSavedProjectsPath(io::dirpath(selectedPath));
+
     return RetVal<io::path>::make_ok(selectedPath);
 }
 

--- a/src/project/iprojectconfiguration.h
+++ b/src/project/iprojectconfiguration.h
@@ -53,6 +53,15 @@ public:
     virtual void setUserTemplatesPath(const io::path& path) = 0;
     virtual async::Channel<io::path> userTemplatesPathChanged() const = 0;
 
+    virtual io::path defaultProjectsPath() const = 0;
+    virtual void setDefaultProjectsPath(const io::path& path) = 0;
+
+    virtual io::path lastOpenedProjectsPath() const = 0;
+    virtual void setLastOpenedProjectsPath(const io::path& path) = 0;
+
+    virtual io::path lastSavedProjectsPath() const = 0;
+    virtual void setLastSavedProjectsPath(const io::path& path) = 0;
+
     virtual io::path userProjectsPath() const = 0;
     virtual void setUserProjectsPath(const io::path& path) = 0;
     virtual async::Channel<io::path> userProjectsPathChanged() const = 0;

--- a/src/project/tests/mocks/projectconfigurationmock.h
+++ b/src/project/tests/mocks/projectconfigurationmock.h
@@ -43,6 +43,15 @@ public:
     MOCK_METHOD(void, setUserTemplatesPath, (const io::path&), (override));
     MOCK_METHOD(async::Channel<io::path>, userTemplatesPathChanged, (), (const, override));
 
+    MOCK_METHOD(io::path, defaultProjectsPath, (), (const, override));
+    MOCK_METHOD(void, setDefaultProjectsPath, (const io::path&), (override));
+
+    MOCK_METHOD(io::path, lastOpenedProjectsPath, (), (const, override));
+    MOCK_METHOD(void, setLastOpenedProjectsPath, (const io::path&), (override));
+
+    MOCK_METHOD(io::path, lastSavedProjectsPath, (), (const, override));
+    MOCK_METHOD(void, setLastSavedProjectsPath, (const io::path&), (override));
+
     MOCK_METHOD(io::path, userProjectsPath, (), (const, override));
     MOCK_METHOD(void, setUserProjectsPath, (const io::path&), (override));
     MOCK_METHOD(async::Channel<io::path>, userProjectsPathChanged, (), (const, override));


### PR DESCRIPTION
User projects path is empty by default

Open: Use path of last opened file
Save new file: Use user projects path if set; otherwise use path of last
saved file
Save existing file: Use last save path of this specific file

If no file has ever been opened or saved, use MuseScore's default path

Resolves: [([MU4 Issue] MS4 does not remember last folder when opening file (defaults to option in Preferences > Folders))](https://github.com/musescore/MuseScore/issues/11082)

This is my first pull request. I tried to implement the behaviour [as described by @Tantacrul](https://github.com/musescore/MuseScore/issues/11082#issuecomment-1096824509). I have not created a test since I am unsure about how to do that. If a test or any other change is required for this pull request, please let me know.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
