### PR TITLE
Fix and clarify vertical text offset for lines

### DIFF
--- a/src/inspector/models/notation/lines/textlinesettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/textlinesettingsmodel.cpp
@@ -93,7 +93,8 @@ void TextLineSettingsModel::createProperties()
         m_continiousText = buildPropertyItem(Ms::Pid::CONTINUE_TEXT);
 
         m_continiousTextVerticalOffset = buildPropertyItem(Ms::Pid::CONTINUE_TEXT_OFFSET, [this](const Ms::Pid pid, const QVariant& newValue) {
-            onPropertyValueChanged(pid, QPointF(0, newValue.toDouble()));
+            onPropertyValueChanged(pid, QPointF(0,
+                                                newValue.toDouble()));
         });
     }
 

--- a/src/inspector/models/notation/lines/textlinesettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/textlinesettingsmodel.cpp
@@ -85,7 +85,7 @@ void TextLineSettingsModel::createProperties()
         m_beginingText = buildPropertyItem(Ms::Pid::BEGIN_TEXT);
 
         m_beginingTextVerticalOffset = buildPropertyItem(Ms::Pid::BEGIN_TEXT_OFFSET, [this](const Ms::Pid pid, const QVariant& newValue) {
-            onPropertyValueChanged(pid, QPointF(m_beginingTextVerticalOffset->value().toDouble(), newValue.toDouble()));
+            onPropertyValueChanged(pid, QPointF(0, newValue.toDouble()));
         });
     }
 
@@ -94,7 +94,7 @@ void TextLineSettingsModel::createProperties()
 
         m_continiousTextVerticalOffset = buildPropertyItem(Ms::Pid::CONTINUE_TEXT_OFFSET, [this](const Ms::Pid pid,
                                                                                                  const QVariant& newValue) {
-            onPropertyValueChanged(pid, QPointF(m_continiousTextVerticalOffset->value().toDouble(), newValue.toDouble()));
+            onPropertyValueChanged(pid, QPointF(0, newValue.toDouble()));
         });
     }
 
@@ -102,7 +102,7 @@ void TextLineSettingsModel::createProperties()
         m_endText = buildPropertyItem(Ms::Pid::END_TEXT);
 
         m_endTextVerticalOffset = buildPropertyItem(Ms::Pid::END_TEXT_OFFSET, [this](const Ms::Pid pid, const QVariant& newValue) {
-            onPropertyValueChanged(pid, QPointF(m_endTextVerticalOffset->value().toDouble(), newValue.toDouble()));
+            onPropertyValueChanged(pid, QPointF(0, newValue.toDouble()));
         });
     }
 }

--- a/src/inspector/models/notation/lines/textlinesettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/textlinesettingsmodel.cpp
@@ -92,8 +92,7 @@ void TextLineSettingsModel::createProperties()
     if (isTextVisible(ContiniousText)) {
         m_continiousText = buildPropertyItem(Ms::Pid::CONTINUE_TEXT);
 
-        m_continiousTextVerticalOffset = buildPropertyItem(Ms::Pid::CONTINUE_TEXT_OFFSET, [this](const Ms::Pid pid,
-                                                                                                 const QVariant& newValue) {
+        m_continiousTextVerticalOffset = buildPropertyItem(Ms::Pid::CONTINUE_TEXT_OFFSET, [this](const Ms::Pid pid, const QVariant& newValue) {
             onPropertyValueChanged(pid, QPointF(0, newValue.toDouble()));
         });
     }

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/LineTextSettingsTab.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/LineTextSettingsTab.qml
@@ -58,6 +58,7 @@ FocusableItem {
 
         OffsetSection {
             id: beginningTextOffsetSection
+            titleText: qsTrc("inspector", "Vertical offset")
             verticalOffset: root.model ? root.model.beginingTextVerticalOffset : null
 
             navigationPanel: root.navigationPanel
@@ -77,6 +78,7 @@ FocusableItem {
 
         OffsetSection {
             id: continiousTextOffsetSection
+            titleText: qsTrc("inspector", "Vertical offset")
             verticalOffset: root.model ? root.model.continiousTextVerticalOffset : null
 
             navigationPanel: root.navigationPanel
@@ -87,7 +89,6 @@ FocusableItem {
 
         TextSection {
             id: endTextSection
-
             titleText:  qsTrc("inspector", "End text")
             propertyItem: root.model ? root.model.endText : null
 
@@ -97,7 +98,7 @@ FocusableItem {
 
         OffsetSection {
             id: endTextOffsetSection
-
+            titleText: qsTrc("inspector", "Vertical offset")
             verticalOffset: root.model ? root.model.endTextVerticalOffset : null
 
             navigationPanel: root.navigationPanel


### PR DESCRIPTION
Resolves  #11266, tangential to #11264.

Vertical text offset would incorrectly update both the X- and Y-positions, so I fixed the X-positions to `0` when updating. Also clarified the title from "Offset" to "Vertical offset."

Re. #11264: We were considering adding a horizontal offset option that purely moved the text (and largely ignored the line, e.g. allowing the text to overlap the line), but that feels pointless. Should further decide on what options to (not) include for line text.

Final result with example:
<img width="550" alt="image" src="https://user-images.githubusercontent.com/90884224/166128739-9b32de4b-c80a-4cb8-b763-b2075a20ff36.png">

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
