### PR TITLE
Fix #11356: Unopened parts not in Export Dialog

### DIFF
--- a/src/project/view/exportdialogmodel.cpp
+++ b/src/project/view/exportdialogmodel.cpp
@@ -122,6 +122,10 @@ void ExportDialogModel::load()
         m_notations << excerpt->notation();
     }
 
+    for (IExcerptNotationPtr excerpt : masterNotation->potentialExcerpts()) {
+        m_notations << excerpt->notation();
+    }
+
     endResetModel();
 
     selectCurrentNotation();


### PR DESCRIPTION
Resolves: #11356 

*(short description of the changes and the motivation to make the changes)*

This commit fixes the bug where parts are not displayed in Export Dialog without opening them first

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
