### PR TITLE
Remove SND options from Staff/Part Properties and hairpin playback popup

### DIFF
--- a/src/inspector/models/general/playback/internal_models/hairpinplaybackmodel.cpp
+++ b/src/inspector/models/general/playback/internal_models/hairpinplaybackmodel.cpp
@@ -44,11 +44,6 @@ PropertyItem* HairpinPlaybackModel::velocityChange() const
     return m_velocityChange;
 }
 
-PropertyItem* HairpinPlaybackModel::useSingleNoteDynamics() const
-{
-    return m_useSingleNoteDynamics;
-}
-
 PropertyItem* HairpinPlaybackModel::velocityChangeType() const
 {
     return m_velocityChangeType;
@@ -58,7 +53,6 @@ void HairpinPlaybackModel::createProperties()
 {
     m_scopeType = buildPropertyItem(Ms::Pid::DYNAMIC_RANGE);
     m_velocityChange = buildPropertyItem(Ms::Pid::VELO_CHANGE);
-    m_useSingleNoteDynamics = buildPropertyItem(Ms::Pid::SINGLE_NOTE_DYNAMICS);
     m_velocityChangeType = buildPropertyItem(Ms::Pid::VELO_CHANGE_METHOD);
 }
 
@@ -66,7 +60,6 @@ void HairpinPlaybackModel::loadProperties()
 {
     loadPropertyItem(m_scopeType);
     loadPropertyItem(m_velocityChange);
-    loadPropertyItem(m_useSingleNoteDynamics);
     loadPropertyItem(m_velocityChangeType);
 }
 
@@ -74,6 +67,5 @@ void HairpinPlaybackModel::resetProperties()
 {
     m_scopeType->resetToDefault();
     m_velocityChange->resetToDefault();
-    m_useSingleNoteDynamics->resetToDefault();
     m_velocityChangeType->resetToDefault();
 }

--- a/src/inspector/models/general/playback/internal_models/hairpinplaybackmodel.h
+++ b/src/inspector/models/general/playback/internal_models/hairpinplaybackmodel.h
@@ -31,7 +31,6 @@ class HairpinPlaybackModel : public AbstractInspectorModel
 
     Q_PROPERTY(PropertyItem * scopeType READ scopeType CONSTANT)
     Q_PROPERTY(PropertyItem * velocityChange READ velocityChange CONSTANT)
-    Q_PROPERTY(PropertyItem * useSingleNoteDynamics READ useSingleNoteDynamics CONSTANT)
     Q_PROPERTY(PropertyItem * velocityChangeType READ velocityChangeType CONSTANT)
 
 public:
@@ -39,7 +38,6 @@ public:
 
     PropertyItem* scopeType() const;
     PropertyItem* velocityChange() const;
-    PropertyItem* useSingleNoteDynamics() const;
     PropertyItem* velocityChangeType() const;
 
 private:
@@ -49,7 +47,6 @@ private:
 
     PropertyItem* m_scopeType = nullptr;
     PropertyItem* m_velocityChange = nullptr;
-    PropertyItem* m_useSingleNoteDynamics = nullptr;
     PropertyItem* m_velocityChangeType = nullptr;
 };
 }

--- a/src/inspector/view/qml/MuseScore/Inspector/general/playback/internal/HairpinsExpandableBlank.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/general/playback/internal/HairpinsExpandableBlank.qml
@@ -79,23 +79,12 @@ ExpandableBlank {
             minValue: 0
         }
 
-        CheckBoxPropertyView {
-            id: singleNoteCheckBox
-
-            navigation.name: "Use single note dynamics"
-            navigation.panel: root.navigation.panel
-            navigation.row: velocityChangeSection.navigationRowEnd + 1
-
-            text: qsTrc("inspector", "Use single note dynamics")
-            propertyItem: root.model ? root.model.useSingleNoteDynamics : null
-        }
-
         DropdownPropertyView {
             id: velocityChangeTypeSection
 
             navigationName: "Changes in dynamics range"
             navigationPanel: root.navigation.panel
-            navigationRowStart: singleNoteCheckBox.navigation.row + 1
+            navigationRowStart: velocityChangeSection.navigationRowEnd + 1
 
             titleText: qsTrc("inspector", "Changes in dynamics range")
             propertyItem: root.model ? root.model.velocityChangeType : null

--- a/src/notation/view/widgets/editstaff.cpp
+++ b/src/notation/view/widgets/editstaff.cpp
@@ -232,7 +232,6 @@ void EditStaff::updateInstrument()
     maxPitchA->setText(midiCodeToStr(m_maxPitchA));
     minPitchP->setText(midiCodeToStr(m_minPitchP));
     maxPitchP->setText(midiCodeToStr(m_maxPitchP));
-    singleNoteDynamics->setChecked(m_instrument.singleNoteDynamics());
 
     // only show string data controls if instrument has strings
     size_t numStr = m_instrument.stringData()->strings();
@@ -545,8 +544,6 @@ void EditStaff::applyPartProperties()
     if (ln.length() > 0) {
         m_instrument.longNames().push_back(Ms::StaffName(ln, 0));
     }
-
-    m_instrument.setSingleNoteDynamics(singleNoteDynamics->isChecked());
 
     QString newPartName = partName->text().simplified();
 

--- a/src/notation/view/widgets/editstaff.ui
+++ b/src/notation/view/widgets/editstaff.ui
@@ -986,16 +986,6 @@
         </layout>
        </widget>
       </item>
-      <item>
-       <widget class="QCheckBox" name="singleNoteDynamics">
-        <property name="accessibleName">
-         <string>Use single note dynamics</string>
-        </property>
-        <property name="text">
-         <string>Use single note dynamics</string>
-        </property>
-       </widget>
-      </item>
      </layout>
     </widget>
    </item>
@@ -1109,7 +1099,6 @@
   <tabstop>down</tabstop>
   <tabstop>preferSharpFlat</tabstop>
   <tabstop>editStringData</tabstop>
-  <tabstop>singleNoteDynamics</tabstop>
   <tabstop>previousButton</tabstop>
   <tabstop>nextButton</tabstop>
  </tabstops>


### PR DESCRIPTION
Resolves #11417 

Title. Removed relevant XML from `editstaff.ui` and legacy code from `editstaff.cpp`. Also removed from `hairpinplaybackmodel`.

Noticed quite a bit of non-UI/functionality code surrounding SND, but I don't know if those are still necessary so I let them be.

## Staff/Part Properties
| Before | After |
| ------------- | ------------- |
| <img width="225" alt="image" src="https://user-images.githubusercontent.com/90884224/166157089-6c1d4205-b3ad-4027-a464-51f0558fd10e.png">  | <img width="229" alt="image" src="https://user-images.githubusercontent.com/90884224/166157054-b48a3dc8-ae94-447b-bbb2-8ee16f985413.png">  |

## Hairpin Playback Popup
| Before | After |
| ------------- | ------------- |
| <img width="278" alt="image" src="https://user-images.githubusercontent.com/90884224/166159104-b72b15a7-9187-4cf9-9837-2ebb2718fb5d.png">  | <img width="281" alt="image" src="https://user-images.githubusercontent.com/90884224/166159046-1091f6b9-db48-4dd7-9661-953eca2ad9dc.png">  |

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
