### PR TITLE
Fix #9056: Tooltips are not displayed fast enough

### DIFF
--- a/src/framework/ui/view/qmltooltip.cpp
+++ b/src/framework/ui/view/qmltooltip.cpp
@@ -35,8 +35,6 @@ using namespace mu::ui;
 QmlToolTip::QmlToolTip(QObject* parent)
     : QObject(parent)
 {
-    m_timer.setSingleShot(true);
-    connect(&m_timer, &QTimer::timeout, this, &QmlToolTip::doShow);
 }
 
 void QmlToolTip::show(QQuickItem* item, const QString& title, const QString& description, const QString& shortcut)
@@ -55,8 +53,7 @@ void QmlToolTip::show(QQuickItem* item, const QString& title, const QString& des
     if (m_item) {
         connect(m_item, &QObject::destroyed, this, &QmlToolTip::doHide);
 
-        const int interval = item ? qApp->styleHints()->mousePressAndHoldInterval() : 100;
-        m_timer.start(interval);
+        doShow();
     } else {
         doHide();
     }
@@ -86,7 +83,6 @@ void QmlToolTip::doHide()
         disconnect(m_item, &QObject::destroyed, this, &QmlToolTip::doHide);
     }
 
-    m_timer.stop();
     m_item = nullptr;
     m_title = QString();
     m_description = QString();

--- a/src/framework/ui/view/qmltooltip.h
+++ b/src/framework/ui/view/qmltooltip.h
@@ -49,7 +49,6 @@ private:
     QString m_title;
     QString m_description;
     QString m_shortcut;
-    QTimer m_timer;
 };
 }
 


### PR DESCRIPTION
Resolves: #9056 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
