### PR TITLE
Fix #11488 Add condition for endNote returning null.

### DIFF
--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -2109,7 +2109,7 @@ void Chord::layoutPitched()
         // but the allocation of space needs to be performed here
         Tie* tie;
         tie = note->tieBack();
-        if (tie) {
+        if (tie && tie->endNote()) {
             tie->calculateDirection();
             qreal overlap = 0.0;
             bool shortStart = false;


### PR DESCRIPTION
Resolves: *([#11488 ](https://github.com/musescore/MuseScore/issues/11488))*

In some conditions, for example undoing split measure, endNote in tie class returns nullptr and tie condition is false positive. After adding the condition to if (tie) block this operation runs with no crash.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://musescore.org/en/cla)
- [X] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [X] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
