### PR TITLE
fix #10365: removed multiple accents on same chord

### DIFF
--- a/src/engraving/libmscore/articulation.cpp
+++ b/src/engraving/libmscore/articulation.cpp
@@ -291,6 +291,11 @@ void Articulation::layout()
 
 bool Articulation::layoutCloseToNote() const
 {
+    Staff* s = staff();
+    if (s && s->staffType()->isTabStaff() && isStaccato()) {
+        return false;
+    }
+
     return (isStaccato() || isTenuto()) && !isDouble();
 }
 

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1403,6 +1403,8 @@ void GPConverter::addAccent(const GPNote* gpnote, Note* note)
         return;
     }
 
+    auto symbolsIds = note->chord()->articulationSymbolIds();
+
     auto accentType = [](size_t flagIdx) {
         if (flagIdx == 0) {
             return SymId::articStaccatoAbove;
@@ -1416,7 +1418,7 @@ void GPConverter::addAccent(const GPNote* gpnote, Note* note)
     };
 
     for (size_t flagIdx = 0; flagIdx < gpnote->accents().size(); flagIdx++) {
-        if (gpnote->accents()[flagIdx]) {
+        if (gpnote->accents()[flagIdx] && symbolsIds.find(accentType(flagIdx)) == symbolsIds.end()) {
             Articulation* art = mu::engraving::Factory::createArticulation(_score->dummy()->chord());
             art->setSymId(accentType(flagIdx));
             note->chord()->add(art);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11514

*if there is several accents of the same type on the different notes of chord (accent, heavy accent, staccato), they should not appear several times like shown on the picture below*
<img width="178" alt="Screenshot 2022-05-04 at 13 18 31" src="https://user-images.githubusercontent.com/24373905/166663556-f64a9de2-872a-4503-bda6-7ffbdbf76694.png">

*Also placed staccato outside the tab notation*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
