### PR TITLE
Correct layout at score loading

### DIFF
--- a/src/engraving/layout/layoutmeasure.cpp
+++ b/src/engraving/layout/layoutmeasure.cpp
@@ -784,8 +784,6 @@ void LayoutMeasure::getNextMeasure(const LayoutOptions& options, LayoutContext& 
         }
     }
 
-    measure->computeTicks();
-
     for (Segment& segment : measure->segments()) {
         if (segment.isBreathType()) {
             for (EngravingItem* e : segment.elist()) {
@@ -825,6 +823,9 @@ void LayoutMeasure::getNextMeasure(const LayoutOptions& options, LayoutContext& 
         }
         s.createShapes();
     }
+
+    measure->computeTicks(); // Must be called *after* Segment::createShapes() because it relies on the
+    // Segment::visible() property, which is determined by Segment::createShapes().
 
     ctx.tick += measure->ticks();
 }

--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -1059,8 +1059,13 @@ void Beam::offsetBeamToRemoveCollisions(const std::vector<ChordRest*> chordRests
 void Beam::extendStem(Chord* chord, int extraBeamAdjust)
 {
     PointF anchor = chordBeamAnchor(chord);
-    qreal proportionAlongX = (anchor.x() - _startAnchor.x()) / (_endAnchor.x() - _startAnchor.x());
-    qreal desiredY = proportionAlongX * (_endAnchor.y() - _startAnchor.y()) + _startAnchor.y();
+    qreal desiredY;
+    if (_endAnchor.x() > _startAnchor.x()) {
+        qreal proportionAlongX = (anchor.x() - _startAnchor.x()) / (_endAnchor.x() - _startAnchor.x());
+        desiredY = proportionAlongX * (_endAnchor.y() - _startAnchor.y()) + _startAnchor.y();
+    } else {
+        desiredY = std::max(_endAnchor.y(), _startAnchor.y());
+    }
     qreal beamsAddition = extraBeamAdjust * _beamDist;
 
     if (chord->up()) {

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -4211,7 +4211,7 @@ void Measure::computeWidth(Segment* s, qreal x, bool isSystemHeader, Fraction mi
                     } else { // The following calculations are key to correct spacing of polyrythms
                         Fraction curTicks = s->shortestChordRest();
                         Fraction prevTicks = ps ? ps->shortestChordRest() : Fraction(0, 1);
-                        if (!prevHasAdjacent && prevTicks < curTicks) {
+                        if (ps && !prevHasAdjacent && prevTicks < curTicks) {
                             durStretch = durationStretch(prevTicks, minTicks) * (double(s->ticks().ticks()) / double(prevTicks.ticks()));
                         } else {
                             durStretch = durationStretch(curTicks, minTicks) * (double(s->ticks().ticks()) / double(curTicks.ticks()));


### PR DESCRIPTION
Fixes a couple of bugs that cause incorrect layout when first opening a score.
1. Collisions with stems are not correctly avoided.
2. Some bars can have incorrect width in the presence of hidden staves.

Both errors correct themselves as soon as a re-layout is triggered. Now they are both fixed from the start.
Before:
![Screenshot from 2022-05-04 12-20-52](https://user-images.githubusercontent.com/93707756/166677349-5e70c865-89a6-4b68-8565-e955778b8200.png)
After:
![Screenshot from 2022-05-04 12-22-28](https://user-images.githubusercontent.com/93707756/166677374-1e6df4b8-22d3-4196-ac62-fcdc1c7ad419.png)

@oktophonie 