### PR TITLE
Set default SoundFonts folder and path in Preferences

### DIFF
--- a/src/framework/audio/internal/audioconfiguration.cpp
+++ b/src/framework/audio/internal/audioconfiguration.cpp
@@ -60,10 +60,14 @@ void AudioConfiguration::init()
 
     settings()->setDefaultValue(AUDIO_API_KEY, Val("Core Audio"));
 
-    settings()->setDefaultValue(USER_SOUNDFONTS_PATHS, Val(""));
+    settings()->setDefaultValue(USER_SOUNDFONTS_PATHS, Val(globalConfiguration()->userDataPath() + "/SoundFonts"));
     settings()->valueChanged(USER_SOUNDFONTS_PATHS).onReceive(nullptr, [this](const Val&) {
         m_soundFontDirsChanged.send(soundFontDirectories());
     });
+
+    for (const auto& path : userSoundFontDirectories()) {
+        fileSystem()->makePath(path);
+    }
 }
 
 std::vector<std::string> AudioConfiguration::availableAudioApiList() const

--- a/src/framework/audio/internal/audioconfiguration.h
+++ b/src/framework/audio/internal/audioconfiguration.h
@@ -23,6 +23,7 @@
 #define MU_AUDIO_AUDIOCONFIGURATION_H
 
 #include "../iaudioconfiguration.h"
+#include "system/ifilesystem.h"
 #include "modularity/ioc.h"
 #include "iglobalconfiguration.h"
 
@@ -30,6 +31,7 @@ namespace mu::audio {
 class AudioConfiguration : public IAudioConfiguration
 {
     INJECT(audio, framework::IGlobalConfiguration, globalConfiguration)
+    INJECT(audio, system::IFileSystem, fileSystem)
 public:
     AudioConfiguration() = default;
 


### PR DESCRIPTION
Resolves: #11426 and one task from #9807

**Note:** I'm very unfamiliar with MuseScore's audio system so please guide my fix, if necessary.

Title. Note that we've configured MuseScore to allow multiple SoundFont directories. I'm particularly unsure on how to test this beyond verifying that the folder exists and the path shows.

If I have (mostly) correctly implemented this, then I could attempt to implement the defaults for Scores, VST3, and Images.

<img width="665" alt="image" src="https://user-images.githubusercontent.com/90884224/166827757-7298bb76-1d6d-458a-aa56-833f339ef994.png">

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [ ] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
