### PR TITLE
Fix #11499 prevent division by zero

### DIFF
--- a/src/engraving/types/fraction.h
+++ b/src/engraving/types/fraction.h
@@ -199,7 +199,7 @@ public:
     {
         m_numerator *= val.m_numerator;
         m_denominator *= val.m_denominator;
-        if (val.m_denominator != 1) {
+        if (abs(val.m_denominator) > 1) {
             reduce();                            // We should be free to fully reduce here
         }
         return *this;


### PR DESCRIPTION
Resolves (partially): *[#11499](https://github.com/musescore/MuseScore/issues/11499)*

In some conditions is a danger to cause division by zero, so this commit should prevent of this problem. Issue #11499 was partially caused by division by zero. 

### TODO
* Resolve signal SIGABRT while pasting entire score
* Resolve division per zero while pasting measure rest.



<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://musescore.org/en/cla)
- [X] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [X] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
