### PR TITLE
Improve consistency of UI string capitalization

### DIFF
--- a/src/appshell/internal/applicationuiactions.cpp
+++ b/src/appshell/internal/applicationuiactions.cpp
@@ -42,7 +42,7 @@ const UiActionList ApplicationUiActions::m_actions = {
              ),
     UiAction("fullscreen",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Enter Full screen"),
+             QT_TRANSLATE_NOOP("action", "Enter full screen"),
              QT_TRANSLATE_NOOP("action", "Enter full screen"),
              Checkable::Yes
              ),
@@ -92,14 +92,14 @@ const UiActionList ApplicationUiActions::m_actions = {
     // Toolbars
     UiAction("toggle-transport",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Playback Controls"),
-             QT_TRANSLATE_NOOP("action", "Toggle Playback Controls toolbar"),
+             QT_TRANSLATE_NOOP("action", "Playback controls"),
+             QT_TRANSLATE_NOOP("action", "Toggle 'Playback controls' toolbar"),
              Checkable::Yes
              ),
     UiAction("toggle-noteinput",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Note Input"),
-             QT_TRANSLATE_NOOP("action", "Toggle 'Note Input' toolbar"),
+             QT_TRANSLATE_NOOP("action", "Note input"),
+             QT_TRANSLATE_NOOP("action", "Toggle 'Note input' toolbar"),
              Checkable::Yes
              ),
 

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -366,7 +366,7 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("view-mode-page",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Page View"),
+             QT_TRANSLATE_NOOP("action", "Page view"),
              IconCode::Code::PAGE_VIEW
              ),
     UiAction("view-mode-continuous",
@@ -390,7 +390,7 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("staff-text-properties",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Staff text Properties…"),
+             QT_TRANSLATE_NOOP("action", "Staff text properties…"),
              QT_TRANSLATE_NOOP("action", "Staff text properties")
              ),
     UiAction("system-text-properties",
@@ -996,7 +996,7 @@ const UiActionList NotationUiActions::m_actions = {
     UiAction("roman-numeral-text",
              mu::context::UiCtxNotationOpened,
              QT_TRANSLATE_NOOP("action", "Roman numeral analysis"),
-             QT_TRANSLATE_NOOP("action", "Add roman numeral analysis")
+             QT_TRANSLATE_NOOP("action", "Add Roman numeral analysis")
              ),
     UiAction("nashville-number-text",
              mu::context::UiCtxNotationOpened,
@@ -1111,7 +1111,7 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("get-location",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Accessibility: get location")
+             QT_TRANSLATE_NOOP("action", "Accessibility: Get location")
              ),
     UiAction("edit-element",
              mu::context::UiCtxNotationOpened,
@@ -1228,57 +1228,57 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("next-beat-TEXT",
              mu::context::UiCtxNotationFocused,
-             QT_TRANSLATE_NOOP("action", "Next Beat (Chord Symbol)"),
+             QT_TRANSLATE_NOOP("action", "Next beat (Chord symbol)"),
              QT_TRANSLATE_NOOP("action", "Next beat (Chord symbol)")
              ),
     UiAction("prev-beat-TEXT",
              mu::context::UiCtxNotationFocused,
-             QT_TRANSLATE_NOOP("action", "Previous Beat (Chord Symbol)"),
+             QT_TRANSLATE_NOOP("action", "Previous beat (Chord symbol)"),
              QT_TRANSLATE_NOOP("action", "Previous beat (Chord symbol)")
              ),
     UiAction("advance-longa",
              mu::context::UiCtxNotationFocused,
-             QT_TRANSLATE_NOOP("action", "Longa Advance (F.B./Chord Symbol)"),
+             QT_TRANSLATE_NOOP("action", "Longa advance (F.B./Chord symbol)"),
              QT_TRANSLATE_NOOP("action", "Advance of a longa (Figured bass/Chord symbol only)")
              ),
     UiAction("advance-breve",
              mu::context::UiCtxNotationFocused,
-             QT_TRANSLATE_NOOP("action", "Breve Advance (F.B./Chord Symbol)"),
+             QT_TRANSLATE_NOOP("action", "Breve advance (F.B./Chord symbol)"),
              QT_TRANSLATE_NOOP("action", "Advance of a double whole note (Figured bass/Chord symbol only)")
              ),
     UiAction("advance-1",
              mu::context::UiCtxNotationFocused,
-             QT_TRANSLATE_NOOP("action", "Whole Note Advance (F.B./Chord Symbol)"),
+             QT_TRANSLATE_NOOP("action", "Whole note advance (F.B./Chord symbol)"),
              QT_TRANSLATE_NOOP("action", "Advance of a whole note (Figured bass/Chord symbol only)")
              ),
     UiAction("advance-2",
              mu::context::UiCtxNotationFocused,
-             QT_TRANSLATE_NOOP("action", "Half Note Advance (F.B./Chord Symbol)"),
+             QT_TRANSLATE_NOOP("action", "Half note advance (F.B./Chord symbol)"),
              QT_TRANSLATE_NOOP("action", "Advance of a half note (Figured bass/Chord symbol only)")
              ),
     UiAction("advance-4",
              mu::context::UiCtxNotationFocused,
-             QT_TRANSLATE_NOOP("action", "Quarter Note Advance (F.B./Chord Symbol)"),
+             QT_TRANSLATE_NOOP("action", "Quarter note advance (F.B./Chord symbol)"),
              QT_TRANSLATE_NOOP("action", "Advance of a quarter note (Figured bass/Chord symbol only)")
              ),
     UiAction("advance-8",
              mu::context::UiCtxNotationFocused,
-             QT_TRANSLATE_NOOP("action", "Eighth Note Advance (F.B./Chord Symbol)"),
+             QT_TRANSLATE_NOOP("action", "Eighth note advance (F.B./Chord symbol)"),
              QT_TRANSLATE_NOOP("action", "Advance of an eighth note (Figured bass/Chord symbol only)")
              ),
     UiAction("advance-16",
              mu::context::UiCtxNotationFocused,
-             QT_TRANSLATE_NOOP("action", "16th Note Advance (F.B./Chord Symbol)"),
+             QT_TRANSLATE_NOOP("action", "16th note advance (F.B./Chord symbol)"),
              QT_TRANSLATE_NOOP("action", "Advance of a 16th note (Figured bass/Chord symbol only)")
              ),
     UiAction("advance-32",
              mu::context::UiCtxNotationFocused,
-             QT_TRANSLATE_NOOP("action", "32nd Note Advance (F.B./Chord Symbol)"),
+             QT_TRANSLATE_NOOP("action", "32nd note advance (F.B./Chord symbol)"),
              QT_TRANSLATE_NOOP("action", "Advance of a 32nd note (Figured bass/Chord symbol only)")
              ),
     UiAction("advance-64",
              mu::context::UiCtxNotationFocused,
-             QT_TRANSLATE_NOOP("action", "64th Note Advance (F.B./Chord Symbol)"),
+             QT_TRANSLATE_NOOP("action", "64th note advance (F.B./Chord symbol)"),
              QT_TRANSLATE_NOOP("action", "Advance of a 64th note (Figured bass/Chord symbol only)")
              ),
     UiAction("next-lyric-verse",
@@ -1569,7 +1569,7 @@ const UiActionList NotationUiActions::m_noteInputActions = {
     UiAction("note-longa",
              mu::context::UiCtxNotationOpened,
              QT_TRANSLATE_NOOP("action", "Longa"),
-             QT_TRANSLATE_NOOP("action", "Note duration: Longa"),
+             QT_TRANSLATE_NOOP("action", "Note duration: longa"),
              IconCode::Code::LONGO
              ),
     UiAction("note-breve",


### PR DESCRIPTION
This commit fixes some inconsistencies in the capitalization of various
strings in the UI. For example, 'Page view' now uses a lower case 'v' as
was already the case in 'Continuous view'. This commit also capitalizes
the word 'Roman' in 'Add Roman numeral analysis' as it is a proper noun.

**Complete list of string changes**
In src/appshell/internal/applicationuiactions.cpp:
- Replaced "Enter Full screen" with "Enter full screen" to make the title match the description
- Replaced "Playback Controls" with "Playback controls" to match the capitalization of "Status bar" in the same menu (View>Toolbars)
- Replaced "Note Input" with "Note input" to match the capitalization of "Status bar" in the same menu (View>Toolbars)
- Replaced "Toggle Playback Controls toolbar" with "Toggle 'Playback controls' toolbar" to match the quotation marks and capitalization used in "Toggle 'Status bar'"
- Replaced "Toggle 'Note Input' toolbar" with "Toggle 'Note input' toolbar" to match the capitalization used in "Toggle 'Status bar'"

In src/notation/internal/notationuiactions.cpp:
- Replaced "Page View" with "Page view" to match the capitalization of "Continuous view"
- Replaced "Staff text Properties…" with "Staff text properties…" to match the capitalization of "Staff/part properties…"
- Replaced "Add roman numeral analysis" with "Add Roman numeral analysis" because Roman is a proper noun
- Replaced "Accessibility: get location" with "Accessibility: Get location" to match the capitalization of other accessibility strings such as "Accessibility: Next segment element"
- Replaced "Next Beat (Chord Symbol)" with "Next beat (Chord symbol)" to match its description
- Same as above for "Previous Beat (Chord Symbol)"
- Replaced "Longa Advance (F.B./Chord Symbol)" with "Longa advance (F.B./Chord symbol)" to match sentence case used elsewhere
- Same for all other advance strings
- Replaced "Note duration: Longa" with "Note duration: longa" to match strings such as "Note duration: whole note"


- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
