### PR TITLE
[MU4] Use `std::gcd()`

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -3375,6 +3375,10 @@ void Score::cmdCreateTuplet(ChordRest* ocr, Tuplet* tuplet)
     track_idx_t track = ocr->track();
     Measure* measure = ocr->measure();
     Fraction tick = ocr->tick();
+    Fraction an = (tuplet->ticks() * tuplet->ratio()) / tuplet->baseLen().fraction();
+    if (!an.denominator()) {
+        return;
+    }
 
     if (ocr->tuplet()) {
         tuplet->setTuplet(ocr->tuplet());
@@ -3395,7 +3399,6 @@ void Score::cmdCreateTuplet(ChordRest* ocr, Tuplet* tuplet)
         cr = Factory::createRest(this->dummy()->segment());
     }
 
-    Fraction an     = (tuplet->ticks() * tuplet->ratio()) / tuplet->baseLen().fraction();
     int actualNotes = an.numerator() / an.denominator();
 
     tuplet->setTrack(track);

--- a/src/engraving/types/fraction.h
+++ b/src/engraving/types/fraction.h
@@ -24,6 +24,7 @@
 #define MU_ENGRAVING_FRACTION_H
 
 #include <cstdint>
+#include <numeric>
 
 #include <QString>
 
@@ -32,30 +33,6 @@
 // everything contained in .h file for performance reasons
 
 namespace mu::engraving {
-//---------------------------------------------------------
-//   gcd
-//    greatest common divisor. always returns a positive val
-//    however, since int / uint = uint by C++ rules,
-//    return int to avoid accidental implicit unsigned cast
-//---------------------------------------------------------
-
-inline int64_t gcd(int64_t a, int64_t b)
-{
-    int64_t bp;
-    if (b > a) {
-        bp = b;
-        b = a;
-        a = bp;
-    }                                       // Saves one % if true
-    while (b != 0) {
-        bp = b;
-        b = a % b;
-        a = bp;
-    }
-
-    return a >= 0 ? a : -a;
-}
-
 class Fraction
 {
     // ensure 64 bit to avoid overflows in comparisons
@@ -124,14 +101,14 @@ public:
 
     void reduce()
     {
-        const int64_t g = gcd(m_numerator, m_denominator);
+        const int64_t g = std::gcd(m_numerator, m_denominator);
         m_numerator /= g;
         m_denominator /= g;
     }
 
     Fraction reduced() const
     {
-        const int64_t g = gcd(m_numerator, m_denominator);
+        const int64_t g = std::gcd(m_numerator, m_denominator);
         return Fraction(static_cast<int>(m_numerator / g), static_cast<int>(m_denominator / g));
     }
 
@@ -174,7 +151,7 @@ public:
         if (m_denominator == val.m_denominator) {
             m_numerator += val.m_numerator;        // Common enough use case to be handled separately for efficiency
         } else {
-            const int64_t g = gcd(m_denominator, val.m_denominator);
+            const int64_t g = std::gcd(m_denominator, val.m_denominator);
             const int64_t m1 = val.m_denominator / g;       // This saves one division over straight lcm
             m_numerator = m_numerator * m1 + val.m_numerator * (m_denominator / g);
             m_denominator = m1 * m_denominator;
@@ -187,7 +164,7 @@ public:
         if (m_denominator == val.m_denominator) {
             m_numerator -= val.m_numerator;       // Common enough use case to be handled separately for efficiency
         } else {
-            const int64_t g = gcd(m_denominator, val.m_denominator);
+            const int64_t g = std::gcd(m_denominator, val.m_denominator);
             const int64_t m1 = val.m_denominator / g;       // This saves one division over straight lcm
             m_numerator = m_numerator * m1 - val.m_numerator * (m_denominator / g);
             m_denominator = m1 * m_denominator;

--- a/src/engraving/types/fraction.h
+++ b/src/engraving/types/fraction.h
@@ -102,14 +102,19 @@ public:
     void reduce()
     {
         const int64_t g = std::gcd(m_numerator, m_denominator);
-        m_numerator /= g;
-        m_denominator /= g;
+        if (g) {
+            m_numerator /= g;
+            m_denominator /= g;
+        }
     }
 
     Fraction reduced() const
     {
         const int64_t g = std::gcd(m_numerator, m_denominator);
-        return Fraction(static_cast<int>(m_numerator / g), static_cast<int>(m_denominator / g));
+        if (g) {
+            return Fraction(static_cast<int>(m_numerator / g), static_cast<int>(m_denominator / g));
+        }
+        return Fraction(m_numerator, m_denominator);
     }
 
     // comparison
@@ -152,9 +157,11 @@ public:
             m_numerator += val.m_numerator;        // Common enough use case to be handled separately for efficiency
         } else {
             const int64_t g = std::gcd(m_denominator, val.m_denominator);
-            const int64_t m1 = val.m_denominator / g;       // This saves one division over straight lcm
-            m_numerator = m_numerator * m1 + val.m_numerator * (m_denominator / g);
-            m_denominator = m1 * m_denominator;
+            if (g) {
+                const int64_t m1 = val.m_denominator / g;       // This saves one division over straight lcm
+                m_numerator = m_numerator * m1 + val.m_numerator * (m_denominator / g);
+                m_denominator = m1 * m_denominator;
+            }
         }
         return *this;
     }
@@ -165,9 +172,11 @@ public:
             m_numerator -= val.m_numerator;       // Common enough use case to be handled separately for efficiency
         } else {
             const int64_t g = std::gcd(m_denominator, val.m_denominator);
-            const int64_t m1 = val.m_denominator / g;       // This saves one division over straight lcm
-            m_numerator = m_numerator * m1 - val.m_numerator * (m_denominator / g);
-            m_denominator = m1 * m_denominator;
+            if (g) {
+                const int64_t m1 = val.m_denominator / g;       // This saves one division over straight lcm
+                m_numerator = m_numerator * m1 - val.m_numerator * (m_denominator / g);
+                m_denominator = m1 * m_denominator;
+            }
         }
         return *this;
     }

--- a/src/importexport/midi/internal/midiimport/importmidi_fraction.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_fraction.cpp
@@ -98,7 +98,7 @@ namespace {
 
 static unsigned lcm(int a, int b)
 {
-    const int g =  mu::engraving::gcd(a, b);
+    const int g =  std::gcd(a, b);
 
 #ifdef QT_DEBUG
     Q_ASSERT_X(!isDivisionOverflow(a, g),
@@ -139,7 +139,7 @@ ReducedFraction ReducedFraction::fromTicks(int ticks)
 
 ReducedFraction ReducedFraction::reduced() const
 {
-    const int tmp = mu::engraving::gcd(numerator_, denominator_);
+    const int tmp = std::gcd(numerator_, denominator_);
 
 #ifdef QT_DEBUG
     Q_ASSERT_X(!isDivisionOverflow(numerator_, tmp),
@@ -184,7 +184,7 @@ void ReducedFraction::reduce()
         denominator_ = 1;
         return;
     }
-    const int tmp = mu::engraving::gcd(numerator_, denominator_);
+    const int tmp = std::gcd(numerator_, denominator_);
 
 #ifdef QT_DEBUG
     Q_ASSERT_X(!isDivisionOverflow(numerator_, tmp),


### PR DESCRIPTION
Use C++17's `std::gcd()` rather than our own implementation.