### PR TITLE
[MU4] Fix #331840: Crash on creating a 4-or-higher tuplet on a 512th or an 8-or-higher tuplet on a 256th

### DIFF
--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -180,7 +180,7 @@ public:
     virtual void addBracketsToSelection(BracketsType type) = 0;
     virtual void changeSelectedNotesArticulation(SymbolId articulationSymbolId) = 0;
     virtual void addGraceNotesToSelectedNotes(GraceNoteType type) = 0;
-    virtual bool canAddTupletToSelectedChordRests() const = 0;
+    virtual bool canAddTupletToSelectedChordRests(int numerator) const = 0;
     virtual void addTupletToSelectedChordRests(const TupletOptions& options) = 0;
     virtual void addBeamToSelectedChordRests(BeamMode mode) = 0;
 

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -828,7 +828,7 @@ void NotationActionController::putTuplet(const TupletOptions& options)
         return;
     }
 
-    if (!interaction->canAddTupletToSelectedChordRests()) {
+    if (!interaction->canAddTupletToSelectedChordRests(options.ratio.numerator())) {
         interactive()->error(trc("notation", "Cannot create tuplet"), trc("notation", "Note value is too short"));
         return;
     }

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3904,15 +3904,18 @@ void NotationInteraction::addGraceNotesToSelectedNotes(GraceNoteType type)
     apply();
 }
 
-bool NotationInteraction::canAddTupletToSelectedChordRests() const
+bool NotationInteraction::canAddTupletToSelectedChordRests(int n) const
 {
     for (ChordRest* chordRest : score()->getSelectedChordRests()) {
         if (chordRest->isGrace()) {
             continue;
         }
 
-        if (chordRest->durationType() < mu::engraving::TDuration(mu::engraving::DurationType::V_512TH)
-            && chordRest->durationType() != mu::engraving::TDuration(mu::engraving::DurationType::V_MEASURE)) {
+        if ((chordRest->durationType() < mu::engraving::TDuration(mu::engraving::DurationType::V_512TH)
+             && chordRest->durationType() != mu::engraving::TDuration(mu::engraving::DurationType::V_MEASURE))
+            || (chordRest->durationType() < mu::engraving::TDuration(mu::engraving::DurationType::V_256TH) && n > 3)
+            || (chordRest->durationType() < mu::engraving::TDuration(mu::engraving::DurationType::V_128TH) && n > 7)
+            ) {
             return false;
         }
     }

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -186,7 +186,7 @@ public:
     void addBracketsToSelection(BracketsType type) override;
     void changeSelectedNotesArticulation(SymbolId articulationSymbolId) override;
     void addGraceNotesToSelectedNotes(GraceNoteType type) override;
-    bool canAddTupletToSelectedChordRests() const override;
+    bool canAddTupletToSelectedChordRests(int numerator) const override;
     void addTupletToSelectedChordRests(const TupletOptions& options) override;
     void addBeamToSelectedChordRests(BeamMode mode) override;
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/331840

Applies to 3.x too.