### PR TITLE
Custom keysig - count symbols width

### DIFF
--- a/src/engraving/libmscore/key.cpp
+++ b/src/engraving/libmscore/key.cpp
@@ -46,6 +46,21 @@ const SymId accTable[] = {
     SymId::accidentalDoubleSharp,
     SymId::accidentalTripleSharp,
     SymId::noSym,
+    //  natural sharp
+    SymId::accidentalNatural,
+    SymId::accidentalNaturalSharp,
+    SymId::accidentalSharp,
+    SymId::noSym,
+    //  natural flat
+    SymId::accidentalDoubleFlat,
+    SymId::accidentalNaturalFlat,
+    SymId::accidentalNatural,
+    SymId::noSym,
+    //  natural sharp sharp
+    SymId::accidentalSharp,
+    SymId::accidentalSharpSharp,
+    SymId::accidentalTripleSharp,
+    SymId::noSym,
     // Gould quarter tone
     //  arrow down
     SymId::accidentalFiveQuarterTonesFlatArrowDown,

--- a/src/engraving/libmscore/key.h
+++ b/src/engraving/libmscore/key.h
@@ -105,7 +105,6 @@ class KeySigEvent
     bool _forInstrumentChange{ false };
     std::vector<CustDef> _customKeyDefs;
     std::vector<KeySym> _keySymbols;
-    double _xstep       { 1.4 };
 
     void enforceLimits();
 
@@ -125,7 +124,6 @@ public:
     void setCustom(bool val) { _custom = val; _key = (_key == Key::INVALID ? Key::C : _key); }
     bool isValid() const { return _key != Key::INVALID; }
     bool isAtonal() const { return _mode == KeyMode::NONE; }
-    double xstep() const { return _xstep; }
     void setForInstrumentChange(bool forInstrumentChange) { _forInstrumentChange = forInstrumentChange; }
     bool forInstrumentChange() const { return _forInstrumentChange; }
     void initFromSubtype(int);      // for backward compatibility

--- a/src/palette/view/widgets/keyedit.cpp
+++ b/src/palette/view/widgets/keyedit.cpp
@@ -275,11 +275,23 @@ void KeyCanvas::dropEvent(QDropEvent*)
 
 void KeyCanvas::snap(Accidental* a)
 {
-    double y        = a->ipos().y();
-    double spatium2 = gpaletteScore->spatium() * .5;
-    int line        = int((y + spatium2 * .5) / spatium2);
-    y               = line * spatium2;
-    a->rypos()      = y;
+    double _spatium = gpaletteScore->spatium();
+    double spatium2 = _spatium * .5;
+    double y = a->ipos().y();
+    int line = round(y / spatium2);
+    y = line * spatium2;
+    a->rypos() = y;
+    // take default xposition unless Control is pressed
+    int i = accidentals.indexOf(a);
+    if (i > 0) {
+        qreal accidentalGap = DefaultStyle::baseStyle().styleS(Sid::keysigAccidentalDistance).val();
+        Accidental* prev = accidentals[i - 1];
+        double prevX = prev->ipos().x();
+        qreal prevWidth = prev->symWidth(prev->symbol());
+        if (!QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
+            a->rxpos() = prevX + prevWidth + accidentalGap * _spatium;
+        }
+    }
 }
 
 //---------------------------------------------------------

--- a/src/palette/view/widgets/keyedit.cpp
+++ b/src/palette/view/widgets/keyedit.cpp
@@ -376,19 +376,25 @@ void KeyEditor::addClicked()
 
     KeySigEvent e;
     e.setCustom(true);
-    for (Accidental* a : al) {
+    qreal accidentalGap = DefaultStyle::baseStyle().styleS(Sid::keysigAccidentalDistance).val();
+    for (int i = 0; i < al.size(); ++i) {
+        Accidental* a = al[i];
         CustDef c;
-        c.sym       = a->symbol();
-        size_t idx  = e.customKeyDefs().size();
-        PointF pos  = a->ipos();
-        pos.rx()   -= xoff;
-        c.xAlt      = pos.x() / spatium - idx * e.xstep();
-        int line    = static_cast<int>(round((pos.y() / spatium) * 2));
-        bool flat   = QString(SymNames::nameForSymId(c.sym)).contains("Flat");
-        c.degree    = (3 - line) % 7;
-        c.degree   += (c.degree < 0) ? 7 : 0;
-        line       += flat ? -1 : 1; // top accidentals in treble clef are gis (#), or es (b)
-        c.octAlt    = static_cast<int>((line - (line >= 0 ? 0 : 6)) / 7);
+        c.sym = a->symbol();
+        PointF pos = a->ipos();
+        c.xAlt = (pos.x() - xoff) / spatium;
+        if (i > 0) {
+            Accidental* prev = al[i - 1];
+            PointF prevPos = prev->ipos();
+            qreal prevWidth = prev->symWidth(prev->symbol());
+            c.xAlt -= (prevPos.x() - xoff + prevWidth) / spatium + accidentalGap;
+        }
+        int line = static_cast<int>(round((pos.y() / spatium) * 2));
+        bool flat = std::string(SymNames::nameForSymId(c.sym)).find("Flat") != std::string::npos;
+        c.degree = (3 - line) % 7;
+        c.degree += (c.degree < 0) ? 7 : 0;
+        line += flat ? -1 : 1; // top accidentals in treble clef are gis (#), or es (b)
+        c.octAlt = static_cast<int>((line - (line >= 0 ? 0 : 6)) / 7);
         e.customKeyDefs().push_back(c);
     }
     auto ks = Factory::makeKeySig(gpaletteScore->dummy()->segment());

--- a/vtest/scores/custom-keysig-1.mscx
+++ b/vtest/scores/custom-keysig-1.mscx
@@ -1,25 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="3.02">
-  <programVersion>3.6.2</programVersion>
-  <programRevision>3224f34</programRevision>
+<museScore version="4.00">
+  <programVersion>4.0.0</programVersion>
+  <programRevision></programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>
     <currentLayer>0</currentLayer>
     <Division>480</Division>
-    <Style>
-      <pageWidth>3.93701</pageWidth>
-      <pageHeight>1.1811</pageHeight>
-      <pagePrintableWidth>3.77953</pagePrintableWidth>
-      <pageEvenLeftMargin>0.0787402</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.0787402</pageOddLeftMargin>
-      <pageEvenTopMargin>0</pageEvenTopMargin>
-      <pageEvenBottomMargin>0</pageEvenBottomMargin>
-      <pageOddTopMargin>0</pageOddTopMargin>
-      <pageOddBottomMargin>0</pageOddBottomMargin>
-      <enableVerticalSpread>1</enableVerticalSpread>
-      <useStandardNoteNames>0</useStandardNoteNames>
-      <Spatium>1.75</Spatium>
-      </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
     <showFrames>1</showFrames>
@@ -31,13 +17,14 @@
     <metaTag name="lyricist"></metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
+    <metaTag name="mscVersion">4.00</metaTag>
     <metaTag name="platform">Linux</metaTag>
     <metaTag name="poet"></metaTag>
     <metaTag name="source"></metaTag>
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Order id="orchestral" customized="1">
+    <Order id="orchestral">
       <name>Orchestral</name>
       <instrument id="piano">
         <family id="keyboards">Keyboards</family>
@@ -152,19 +139,24 @@
       <Measure>
         <voice>
           <KeySig>
+            <accidental>0</accidental>
             <custom>1</custom>
-            <KeySym>
+            <CustDef>
               <sym>accidentalSharp</sym>
-              <pos x="0" y="0"/>
-              </KeySym>
-            <KeySym>
+              <def degree="3" xAlt="0" octAlt="0"/>
+              </CustDef>
+            <CustDef>
               <sym>accidentalFlat</sym>
-              <pos x="1" y="3"/>
-              </KeySym>
-            <KeySym>
+              <def degree="4" xAlt="0" octAlt="0"/>
+              </CustDef>
+            <CustDef>
+              <sym>accidentalTripleSharp</sym>
+              <def degree="0" xAlt="0" octAlt="0"/>
+              </CustDef>
+            <CustDef>
               <sym>accidentalNatural</sym>
-              <pos x="2" y="1.5"/>
-              </KeySym>
+              <def degree="2" xAlt="0" octAlt="0"/>
+              </CustDef>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>


### PR DESCRIPTION
Custom Key Signature - default accidental positions by symbol width, not fixed xstep

Accidentals have various widths (natural is thin, triple flat is fat). If default xstep were fixed, unwanted gaps, or overlays are produced.
Test file - accidentals on default positions (`xAlt = 0`)
before (xStep = 1.4 sp):
![Width-before](https://user-images.githubusercontent.com/1646034/167490981-acb0015f-9f48-4907-8c3c-3abb8a9eb7b8.png)

after (xstep depends od symbol width):
![Width-after](https://user-images.githubusercontent.com/1646034/167490956-dd51a2a9-c516-4060-8046-c40eb86f0561.png)


other minor tweaks:
- add more transposable symbols (`Sharp Sharp`, `Natural Sharp`, `Natural Flat`)
- replaced `QString` by `std::string` on some places
- replaced `score()->spatium() / mag()` by `spatium()` (which already has mag calculation included)


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
