### PR TITLE
[MU4] Fix incorrect beaming for tuplets

### DIFF
--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -43,6 +43,12 @@ enum class SpannerSegmentType;
 
 struct BeamFragment;
 
+struct BeamSegment {
+    mu::LineF line;
+    int level;
+    bool above; // above level 0 or below? (meaningless for level 0)
+};
+
 //---------------------------------------------------------
 //   @@ Beam
 //---------------------------------------------------------
@@ -50,7 +56,7 @@ struct BeamFragment;
 class Beam final : public EngravingItem
 {
     std::vector<ChordRest*> _elements;          // must be sorted by tick
-    std::vector<mu::LineF*> _beamSegments;
+    std::vector<BeamSegment*> _beamSegments;
     DirectionV _direction    { DirectionV::AUTO };
 
     bool _up                { true };
@@ -165,7 +171,7 @@ public:
     void setBeamDirection(DirectionV d);
     DirectionV beamDirection() const { return _direction; }
 
-    void calcBeamBreaks(const Chord* chord, int level, bool& isBroken32, bool& isBroken64) const;
+    void calcBeamBreaks(const ChordRest* chord, const ChordRest* prevChord, int level, bool& isBroken32, bool& isBroken64) const;
 
     //!Note Unfortunately we have no FEATHERED_BEAM_MODE for now int BeamMode enum, so we'll handle this locally
     void setAsFeathered(const bool slower);

--- a/src/engraving/libmscore/groups.cpp
+++ b/src/engraving/libmscore/groups.cpp
@@ -90,7 +90,7 @@ static std::vector<NoteGroup> noteGroups {
 //   endBeam
 //---------------------------------------------------------
 
-BeamMode Groups::endBeam(ChordRest* cr, ChordRest* prev)
+BeamMode Groups::endBeam(const ChordRest* cr, const ChordRest* prev)
 {
     if (cr->isGrace() || cr->beamMode() != BeamMode::AUTO) {
         return cr->beamMode();

--- a/src/engraving/libmscore/groups.h
+++ b/src/engraving/libmscore/groups.h
@@ -69,7 +69,7 @@ public:
     void dump(const char*) const;
 
     static const Groups& endings(const Fraction& f);
-    static BeamMode endBeam(ChordRest* cr, ChordRest* prev = 0);
+    static BeamMode endBeam(const ChordRest* cr, const ChordRest* prev = 0);
 
 private:
     GroupNodes m_nodes;

--- a/src/engraving/libmscore/tuplet.cpp
+++ b/src/engraving/libmscore/tuplet.cpp
@@ -714,7 +714,9 @@ bool Tuplet::calcHasBracket(const DurationElement* cr1, const DurationElement* c
     bool startChordBreaks32 = false;
     bool startChordBreaks64 = false;
     Chord* prevStartChord = c1->prev();
-    beamStart->calcBeamBreaks(c1, beamCount, startChordBreaks32, startChordBreaks64);
+    if (prevStartChord) {
+        beamStart->calcBeamBreaks(c1, prevStartChord, beamCount, startChordBreaks32, startChordBreaks64);
+    }
     bool startChordDefinesTuplet = startChordBreaks32 || startChordBreaks64 || tupletStartsBeam;
     if (prevStartChord) {
         startChordDefinesTuplet = startChordDefinesTuplet || prevStartChord->beams() < beamCount;
@@ -724,7 +726,7 @@ bool Tuplet::calcHasBracket(const DurationElement* cr1, const DurationElement* c
     bool endChordBreaks64 = false;
     Chord* nextEndChord = c2->next();
     if (nextEndChord) {
-        beamEnd->calcBeamBreaks(nextEndChord, beamCount, endChordBreaks32, endChordBreaks64);
+        beamEnd->calcBeamBreaks(nextEndChord, c2, beamCount, endChordBreaks32, endChordBreaks64);
     }
     bool endChordDefinesTuplet = endChordBreaks32 || endChordBreaks64 || tupletEndsBeam;
     if (nextEndChord) {


### PR DESCRIPTION
Tuplet sub-beams were not behaving like in 3.6, so this PR fixes them to work like the old ones. If we need to change them based on new design specs for 4.0 we can do that, but this one at least restores the original behavior.

There is also something to be gained from investigating how beamed-together tuplets determine whether brackets are necessary.

Before (example):
![image](https://user-images.githubusercontent.com/89263931/167954621-d2fa2ea0-85f0-4ea8-b282-2ac13ead340f.png)

After (different example):
![image](https://user-images.githubusercontent.com/89263931/167954785-233cf119-3a04-45ee-9750-f8e0f6915971.png)

edit: also, tuplet beams were weirdly askew, which I also fixed.