### PR TITLE
MusicXML: Export invisible noteheads as "none"

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -3273,7 +3273,11 @@ static void writeNotehead(XmlWriter& xml, const Note* const note)
     } else if ((note->headType() == NoteHeadType::HEAD_HALF) || (note->headType() == NoteHeadType::HEAD_WHOLE)) {
         noteheadTagname += " filled=\"no\"";
     }
-    if (note->headGroup() == NoteHeadGroup::HEAD_SLASH) {
+    if (!note->visible()) {
+        // The notehead is invisible but other parts of the note might
+        // still be visible so don't export <note print-object="no">.
+        xml.tag(noteheadTagname, "none");
+    } else if (note->headGroup() == NoteHeadGroup::HEAD_SLASH) {
         xml.tag(noteheadTagname, "slash");
     } else if (note->headGroup() == NoteHeadGroup::HEAD_TRIANGLE_UP) {
         xml.tag(noteheadTagname, "triangle");
@@ -3642,9 +3646,6 @@ void ExportMusicXml::chord(Chord* chord, staff_idx_t staff, const std::vector<Ly
 
         noteTag += notePosition(this, note);
 
-        if (!note->visible()) {
-            noteTag += QString(" print-object=\"no\"");
-        }
         //TODO support for OFFSET_VAL
         if (note->veloType() == VeloType::USER_VAL) {
             int velo = note->veloOffset();

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -4441,6 +4441,7 @@ Note* MusicXMLParserPass2::note(const QString& partId,
     QString voice;
     DirectionV stemDir = DirectionV::AUTO;
     bool noStem = false;
+    bool hasHead = true;
     NoteHeadGroup headGroup = NoteHeadGroup::HEAD_NORMAL;
     QColor noteColor = QColor::Invalid;
     noteColor.setNamedColor(_e.attributes().value("color").toString());
@@ -4494,7 +4495,12 @@ Note* MusicXMLParserPass2::note(const QString& partId,
             noteheadColor.setNamedColor(_e.attributes().value("color").toString());
             noteheadParentheses = _e.attributes().value("parentheses") == "yes";
             noteheadFilled = _e.attributes().value("filled").toString();
-            headGroup = convertNotehead(_e.readElementText());
+            auto noteheadValue = _e.readElementText();
+            if (noteheadValue == "none") {
+                hasHead = false;
+            } else {
+                headGroup = convertNotehead(noteheadValue);
+            }
         } else if (_e.name() == "rest") {
             rest = true;
             mnp.displayStepOctave(_e);
@@ -4696,7 +4702,7 @@ Note* MusicXMLParserPass2::note(const QString& partId,
             note->setColor(noteColor);
         }
         setNoteHead(note, noteheadColor, noteheadParentheses, noteheadFilled);
-        note->setVisible(printObject);     // TODO also set the stem to invisible
+        note->setVisible(hasHead && printObject);     // TODO also set the stem to invisible
 
         if (velocity > 0) {
             note->setVeloType(VeloType::USER_VAL);

--- a/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_invisible_ref.xml
+++ b/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_invisible_ref.xml
@@ -260,7 +260,7 @@
         <type>quarter</type>
         <stem>up</stem>
         </note>
-      <note print-object="no">
+      <note>
         <pitch>
           <step>C</step>
           <octave>4</octave>
@@ -269,6 +269,7 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notehead>none</notehead>
         </note>
       </measure>
     <measure number="5">

--- a/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_noinvisible_ref.xml
+++ b/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_noinvisible_ref.xml
@@ -233,7 +233,7 @@
         <type>quarter</type>
         <stem>up</stem>
         </note>
-      <note print-object="no">
+      <note>
         <pitch>
           <step>C</step>
           <octave>4</octave>
@@ -242,6 +242,7 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notehead>none</notehead>
         </note>
       </measure>
     <measure number="5">

--- a/src/importexport/musicxml/tests/data/testInvisibleElements.xml
+++ b/src/importexport/musicxml/tests/data/testInvisibleElements.xml
@@ -122,7 +122,7 @@
         <type>quarter</type>
         <stem>down</stem>
         </note>
-      <note print-object="no">
+      <note>
         <pitch>
           <step>A</step>
           <octave>4</octave>
@@ -131,6 +131,7 @@
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
+        <notehead>none</notehead>
         </note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>


### PR DESCRIPTION
Avoid setting `<note print-object="none">` because that hides other parts of the note in addition to the head, which causes problems for some MusicXML importers and Braille conversion tools. Use `<notehead>none</notehead>` instead.

Resolves: https://musescore.org/en/node/327118

MusicXML documentation for:
- [`<note print-object="no">`](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/note/)
- [`<notehead>`](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/notehead/) and its ["none" value](
https://www.w3.org/2021/06/musicxml40/musicxml-reference/data-types/notehead-value/).