### PR TITLE
fix #11589: displaying tab key when tab notation is shown

### DIFF
--- a/src/engraving/libmscore/staff.cpp
+++ b/src/engraving/libmscore/staff.cpp
@@ -424,10 +424,15 @@ String Staff::partName() const
 
 ClefTypeList Staff::clefType(const Fraction& tick) const
 {
+    StaffGroup staffGroup = staffType(tick)->group();
     ClefTypeList ct = clefs.clef(tick.ticks());
+
+    if (ClefInfo::staffGroup(ct._concertClef) != staffGroup) {
+        ct._concertClef = ClefType::INVALID;
+    }
+
     if (ct._concertClef == ClefType::INVALID) {
         // Clef compatibility based on instrument (override StaffGroup)
-        StaffGroup staffGroup = staffType(tick)->group();
         if (staffGroup != StaffGroup::TAB) {
             staffGroup = part()->instrument(tick)->useDrumset() ? StaffGroup::PERCUSSION : StaffGroup::STANDARD;
         }


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/11589*

*fixed the bug: standard clef was displayed after changing standard staff type to tab staff for a non-linked staff*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
