### PR TITLE
Fix #9345: KeySig in hidden staves cause additional space

### DIFF
--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -605,6 +605,14 @@ void LayoutSystem::hideEmptyStaves(Score* score, System* system, bool isFirstSys
         SysStaff* ss = system->staff(staff->idx());
         ss->setShow(true);
     }
+    // Re-create the shapes to account for newly hidden or un-hidden staves
+    for (auto mb : system->measures()) {
+        if (mb->isMeasure()) {
+            for (auto& seg : toMeasure(mb)->segments()) {
+                seg.createShapes();
+            }
+        }
+    }
 }
 
 void LayoutSystem::layoutSystemElements(const LayoutOptions& options, LayoutContext& lc, Score* score, System* system)

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -2221,6 +2221,9 @@ void Segment::createShape(staff_idx_t staffIdx)
 {
     Shape& s = _shapes[staffIdx];
     s.clear();
+    if (system() && !system()->staves().at(staffIdx)->show()) {
+        return;
+    }
 
     if (segmentType() & (SegmentType::BarLine | SegmentType::EndBarLine | SegmentType::StartRepeatBarLine | SegmentType::BeginBarLine)) {
         setVisible(true);


### PR DESCRIPTION
Fix #9345. A simple but effective solution. As a side benefit, we now avoid creating the shapes for hidden staves and thus save unnecessary operations.