### PR TITLE
fix:#11455: Double clicking instrument automatically submits

### DIFF
--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/ChooseInstrumentsPage.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/ChooseInstrumentsPage.qml
@@ -39,6 +39,8 @@ Rectangle {
 
     property NavigationSection navigationSection: null
 
+    signal submitRequested()
+
     function instruments() {
         if (root.canSelectMultipleInstruments) {
             return instrumentsOnScoreView.instruments()
@@ -142,6 +144,10 @@ Rectangle {
 
             onAddSelectedInstrumentsToScoreRequested: {
                 prv.addSelectedInstrumentsToScore()
+
+                if (!root.canSelectMultipleInstruments) {
+                    root.submitRequested()
+                }
             }
         }
 

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/InstrumentsDialog.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/InstrumentsDialog.qml
@@ -43,6 +43,15 @@ StyledDialogView {
         instrumentsPage.focusOnFirst()
     }
 
+    function submit() {
+        var result = {}
+        result["instruments"] = instrumentsPage.instruments()
+        result["scoreOrder"] = instrumentsPage.currentOrder()
+
+        root.ret = { errcode: 0, value: result }
+        root.hide()
+    }
+
     ColumnLayout {
         anchors.fill: parent
         spacing: 20
@@ -57,6 +66,10 @@ StyledDialogView {
             currentInstrumentId: root.currentInstrumentId
 
             navigationSection: root.navigationSection
+
+            onSubmitRequested: {
+                root.submit()
+            }
         }
 
         RowLayout {
@@ -106,12 +119,7 @@ StyledDialogView {
                 navigation.column: 2
 
                 onClicked: {
-                    var result = {}
-                    result["instruments"] = instrumentsPage.instruments()
-                    result["scoreOrder"] = instrumentsPage.currentOrder()
-
-                    root.ret = { errcode: 0, value: result }
-                    root.hide()
+                    root.submit()
                 }
             }
         }


### PR DESCRIPTION
Resolves: #11455 

A simple feature that allows double-clicking on an instrument in the "Replace Instrument" dialogue to select it rather than having to click the OK button.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
