### PR TITLE
fix: 11533; Title is also checked when checking equality of meta struct

### DIFF
--- a/src/project/projecttypes.h
+++ b/src/project/projecttypes.h
@@ -168,6 +168,7 @@ struct ProjectMeta
     bool operator==(const ProjectMeta& other) const
     {
         bool equal = filePath == other.filePath;
+        equal &= title == other.title;
         equal &= subtitle == other.subtitle;
         equal &= composer == other.composer;
         equal &= lyricist == other.lyricist;


### PR DESCRIPTION
Part of #11533 

When checking the equality of meta info struct, the title attribute was not considered. I have added that now.

The date issue mentioned was because of the wrong format of date inputted. To make it clear, should I add the format in brackets after "Creation date"?

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
