### PR TITLE
Fix #11427, #11429 - Project Properties Dialog Rearrangement

### DIFF
--- a/src/project/project.qrc
+++ b/src/project/project.qrc
@@ -41,7 +41,7 @@
         <file>qml/MuseScore/Project/internal/SaveToCloud/images/Cloud.png</file>
         <file>qml/MuseScore/Project/internal/SaveToCloud/images/Laptop.png</file>
         <file>qml/MuseScore/Project/ProjectPropertiesDialog.qml</file>
-        <file>qml/MuseScore/Project/internal/ProjectPropertiesTopPanel.qml</file>
+        <file>qml/MuseScore/Project/internal/ProjectPropertiesFileInfoPanel.qml</file>
         <file>qml/MuseScore/Project/internal/ProjectPropertiesBottomPanel.qml</file>
         <file>qml/MuseScore/Project/internal/ProjectPropertiesView.qml</file>
         <file>qml/MuseScore/Project/internal/PropertyItem.qml</file>

--- a/src/project/qml/MuseScore/Project/ProjectPropertiesDialog.qml
+++ b/src/project/qml/MuseScore/Project/ProjectPropertiesDialog.qml
@@ -34,7 +34,7 @@ StyledDialogView {
     title: qsTrc("project", "Project properties")
 
     contentWidth: 680
-    contentHeight: 400
+    contentHeight: 460
     margins: 16
 
     property int propertyNameWidth: 110
@@ -63,16 +63,6 @@ StyledDialogView {
 
         spacing: 8
 
-        ProjectPropertiesTopPanel {
-            id: propertiesTopPanel
-
-            propertyNameWidth: root.propertyNameWidth
-
-            navigationPanel: root.navigationPanel
-        }
-
-        SeparatorLine {}
-
         ProjectPropertiesView {
             id: propertiesListView
 
@@ -80,7 +70,7 @@ StyledDialogView {
             propertyNameWidth: root.propertyNameWidth
 
             navigationPanel: root.navigationPanel
-            navigationColumnStart: propertiesTopPanel.navigationColumnEnd + 1
+            navigationColumnStart: propertiesFileInfoPanel.navigationColumnEnd + 1
         }
 
         Connections {
@@ -93,6 +83,16 @@ StyledDialogView {
         }
 
         SeparatorLine {}
+
+        ProjectPropertiesFileInfoPanel {
+            id: propertiesFileInfoPanel
+
+            propertyNameWidth: root.propertyNameWidth
+            Layout.topMargin: 4
+            Layout.bottomMargin: 8
+
+            navigationPanel: root.navigationPanel
+        }
 
         ProjectPropertiesBottomPanel {
             model: projectPropertiesModel

--- a/src/project/qml/MuseScore/Project/internal/ProjectPropertiesFileInfoPanel.qml
+++ b/src/project/qml/MuseScore/Project/internal/ProjectPropertiesFileInfoPanel.qml
@@ -25,7 +25,7 @@ import QtQuick.Layouts 1.15
 import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
 
-Column {
+ColumnLayout {
     id: root
 
     Layout.fillWidth: true
@@ -38,9 +38,6 @@ Column {
     property int navigationColumnEnd: apiLevelProperty.navigationColumnEnd
 
     RowLayout {
-        anchors.left: parent.left
-        anchors.right: parent.right
-
         spacing: 8
 
         PropertyItem {
@@ -50,7 +47,8 @@ Column {
             index: 0
             propertyName: qsTrc("project", "File path:")
             propertyValue: projectPropertiesModel.filePath
-            isTopPanelProperty: true
+            isFileInfoPanelProperty: true
+            valueFillWidth: true
 
             navigationPanel: root.navigationPanel
         }
@@ -70,11 +68,12 @@ Column {
 
             onClicked: projectPropertiesModel.openFileLocation()
         }
+
+        Item { width: 8 }
     }
 
     RowLayout {
-        anchors.left: parent.left
-        anchors.right: parent.right
+        Layout.topMargin: 4
 
         spacing: 8
 
@@ -83,7 +82,7 @@ Column {
             index: 2
             propertyName: qsTrc("project", "MuseScore version:")
             propertyValue: projectPropertiesModel.version
-            isTopPanelProperty: true
+            isFileInfoPanelProperty: true
 
             navigationPanel: root.navigationPanel
         }
@@ -92,7 +91,10 @@ Column {
             index: 3
             propertyName: qsTrc("project", "Revision:")
             propertyValue: projectPropertiesModel.revision
-            isTopPanelProperty: true
+            isFileInfoPanelProperty: true
+
+            Layout.leftMargin: 32
+            Layout.rightMargin: 32
 
             navigationPanel: root.navigationPanel
         }
@@ -103,14 +105,9 @@ Column {
             index: 4
             propertyName: qsTrc("project", "API-Level:")
             propertyValue: projectPropertiesModel.apiLevel
-            isTopPanelProperty: true
+            isFileInfoPanelProperty: true
 
             navigationPanel: root.navigationPanel
-        }
-
-        Item {      // To mimic a flatbutton so that it aligns with the open folder button
-            Layout.preferredWidth: openFileLocation.width
-            Layout.preferredHeight: openFileLocation.height
         }
     }
 }

--- a/src/project/qml/MuseScore/Project/internal/ProjectPropertiesView.qml
+++ b/src/project/qml/MuseScore/Project/internal/ProjectPropertiesView.qml
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
 import MuseScore.Ui 1.0
@@ -38,34 +39,43 @@ StyledListView {
     property NavigationPanel navigationPanel: null
     property int navigationColumnStart: 0
 
+    scrollBarPolicy: ScrollBar.AlwaysOn
+
     model: projectPropertiesModel
 
-    delegate: PropertyItem {
-        width: root.width
+    delegate: RowLayout{
+        anchors.left: parent ? parent.left : undefined
+        anchors.right: parent ? parent.right : undefined
+        spacing: 0
+        PropertyItem {
+            width: root.width - 10
 
-        index: root.navigationColumnStart + model.index
-        propertyName: model.propertyName
-        propertyValue: model.propertyValue
-        isStandardProperty: model.isStandardProperty
-        isTopPanelProperty: false
-        propertyNameWidth: root.propertyNameWidth
+            index: root.navigationColumnStart + model.index
+            propertyName: model.propertyName
+            propertyValue: model.propertyValue
+            isStandardProperty: model.isStandardProperty
+            isFileInfoPanelProperty: false
+            propertyNameWidth: root.propertyNameWidth
 
-        navigationPanel: root.navigationPanel
+            navigationPanel: root.navigationPanel
 
-        onPropertyNameChanged: function() {
-            model.propertyName = propertyName
+            onPropertyNameChanged: function() {
+                model.propertyName = propertyName
+            }
+
+            onPropertyValueChanged: function() {
+                model.propertyValue = propertyValue
+            }
+
+            onChangePositionOfListIndex: function() {
+                root.positionViewAtIndex(model.index, ListView.Contain)
+            }
+
+            onDeleteProperty: function() {
+                projectPropertiesModel.deleteProperty(model.index)
+            }
         }
 
-        onPropertyValueChanged: function() {
-            model.propertyValue = propertyValue
-        }
-
-        onChangePositionOfListIndex: function() {
-            root.positionViewAtIndex(model.index, ListView.Contain)
-        }
-
-        onDeleteProperty: function() {
-            projectPropertiesModel.deleteProperty(model.index)
-        }
+        Item { Layout.preferredWidth: 16 }
     }
 }

--- a/src/project/qml/MuseScore/Project/internal/PropertyItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/PropertyItem.qml
@@ -32,7 +32,6 @@ RowLayout {
     spacing: 8
 
     property int propertyNameWidth: -1
-    property int propertyValueWidth: 100
     property NavigationPanel navigationPanel: null
     property int navigationColumnEnd: deletePropertyButton.navigation.column
 
@@ -40,7 +39,8 @@ RowLayout {
     property string propertyName: ""
     property string propertyValue: ""
     property bool isStandardProperty: true
-    property bool isTopPanelProperty: false
+    property bool isFileInfoPanelProperty: false
+    property bool valueFillWidth: false
 
     signal changePositionOfListIndex()
     signal deleteProperty()
@@ -86,14 +86,14 @@ RowLayout {
 
         currentText: root.propertyValue ? root.propertyValue : ""
         hint: root.isStandardProperty ? "" : qsTrc("project", "Value")
-        readOnly: root.isTopPanelProperty
+        visible: !root.isFileInfoPanelProperty
 
         navigation.name: root.propertyName + "PropertyValue"
         navigation.panel: root.navigationPanel
         navigation.column: prv.navigationStartIndex + 1
         accessible.name: root.propertyName + " " + currentText
         navigation.onActiveChanged: {
-            if (navigation.active && !root.isTopPanelProperty) {
+            if (navigation.active && !root.isFileInfoPanelProperty) {
                 root.changePositionOfListIndex()
             }
         }
@@ -103,13 +103,22 @@ RowLayout {
         }
     }
 
+    StyledTextLabel {
+        Layout.fillWidth: root.valueFillWidth
+
+        text: root.propertyValue ? root.propertyValue : ""
+        font: ui.theme.bodyBoldFont
+        horizontalAlignment: Qt.AlignLeft
+        visible: root.isFileInfoPanelProperty
+    }
+
     FlatButton {
         id: deletePropertyButton
 
         icon: IconCode.DELETE_TANK
         opacity: !root.isStandardProperty
         enabled: !root.isStandardProperty
-        visible: !root.isTopPanelProperty
+        visible: !root.isFileInfoPanelProperty
 
         navigation.name: root.propertyName + "Delete"
         navigation.panel: root.navigationPanel


### PR DESCRIPTION
Resolves: #11427
Resolves: #11429

*(short description of the changes and the motivation to make the changes)*

Rearranges Project Properties Dialog. This includes changing the Top Panel Properties to labels from text fields. This also changes the position of Top Panel Properties to below the List of Project Properties

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
