### PR TITLE
fix #8601: displaying cross noteheads correctly on tab

### DIFF
--- a/src/engraving/libmscore/property.cpp
+++ b/src/engraving/libmscore/property.cpp
@@ -106,6 +106,7 @@ static constexpr PropertyMetaData propertyList[] = {
     { Pid::FRET,                    true,  "fret",                  P_TYPE::INT,            DUMMY_QT_TR_NOOP("propertyName", "fret") },
     { Pid::STRING,                  true,  "string",                P_TYPE::INT,            DUMMY_QT_TR_NOOP("propertyName", "string") },
     { Pid::GHOST,                   true,  "ghost",                 P_TYPE::BOOL,           DUMMY_QT_TR_NOOP("propertyName", "ghost") },
+    { Pid::DEAD,                    true,  "dead",                  P_TYPE::BOOL,           DUMMY_QT_TR_NOOP("propertyName", "dead") },
     { Pid::PLAY,                    false, "play",                  P_TYPE::BOOL,           DUMMY_QT_TR_NOOP("propertyName", "played") },
     { Pid::TIMESIG_NOMINAL,         false, 0,                       P_TYPE::FRACTION,       DUMMY_QT_TR_NOOP("propertyName", "nominal time signature") },
     { Pid::TIMESIG_ACTUAL,          true,  0,                       P_TYPE::FRACTION,       DUMMY_QT_TR_NOOP("propertyName", "actual time signature") },

--- a/src/engraving/libmscore/property.h
+++ b/src/engraving/libmscore/property.h
@@ -116,6 +116,7 @@ enum class Pid {
     FRET,
     STRING,
     GHOST,
+    DEAD,
     PLAY,
     TIMESIG_NOMINAL,
 

--- a/src/importexport/guitarpro/tests/data/all-percussion.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/all-percussion.gp-ref.mscx
@@ -578,6 +578,7 @@
               <head>cross</head>
               <fret>31</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -601,6 +602,7 @@
               <head>cross</head>
               <fret>33</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -646,6 +648,7 @@
               <head>cross</head>
               <fret>37</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -700,6 +703,7 @@
               <head>cross</head>
               <fret>42</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           </voice>
@@ -723,6 +727,7 @@
               <head>cross</head>
               <fret>44</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           </voice>
@@ -782,6 +787,7 @@
               <head>cross</head>
               <fret>49</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -805,6 +811,7 @@
               <head>cross</head>
               <fret>51</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -839,6 +846,7 @@
               <head>cross</head>
               <fret>54</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           </voice>
@@ -853,6 +861,7 @@
               <head>cross</head>
               <fret>55</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -876,6 +885,7 @@
               <head>cross</head>
               <fret>57</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -899,6 +909,7 @@
               <head>cross</head>
               <fret>59</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -931,6 +942,7 @@
               <head>cross</head>
               <fret>62</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           </voice>
@@ -945,6 +957,7 @@
               <head>cross</head>
               <fret>63</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -955,6 +968,7 @@
               <head>cross</head>
               <fret>64</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           </voice>
@@ -969,6 +983,7 @@
               <head>cross</head>
               <fret>65</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -979,6 +994,7 @@
               <head>cross</head>
               <fret>66</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/guitarpro/tests/data/all-percussion.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/all-percussion.gp5-ref.mscx
@@ -575,6 +575,7 @@
               <head>cross</head>
               <fret>31</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -598,6 +599,7 @@
               <head>cross</head>
               <fret>33</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -643,6 +645,7 @@
               <head>cross</head>
               <fret>37</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -697,6 +700,7 @@
               <head>cross</head>
               <fret>42</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           </voice>
@@ -720,6 +724,7 @@
               <head>cross</head>
               <fret>44</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           </voice>
@@ -779,6 +784,7 @@
               <head>cross</head>
               <fret>49</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -802,6 +808,7 @@
               <head>cross</head>
               <fret>51</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -836,6 +843,7 @@
               <head>cross</head>
               <fret>54</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           </voice>
@@ -850,6 +858,7 @@
               <head>cross</head>
               <fret>55</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -873,6 +882,7 @@
               <head>cross</head>
               <fret>57</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -896,6 +906,7 @@
               <head>cross</head>
               <fret>59</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -928,6 +939,7 @@
               <head>cross</head>
               <fret>62</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           </voice>
@@ -942,6 +954,7 @@
               <head>cross</head>
               <fret>63</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -952,6 +965,7 @@
               <head>cross</head>
               <fret>64</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           </voice>
@@ -966,6 +980,7 @@
               <head>cross</head>
               <fret>65</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -976,6 +991,7 @@
               <head>cross</head>
               <fret>66</fret>
               <string>0</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/guitarpro/tests/data/all-percussion.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/all-percussion.gpx-ref.mscx
@@ -10758,6 +10758,7 @@
               <pitch>37</pitch>
               <tpc>21</tpc>
               <head>cross</head>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -13358,6 +13359,7 @@
               <head>cross</head>
               <fret>4</fret>
               <string>3</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           </voice>
@@ -16878,6 +16880,7 @@
               <pitch>37</pitch>
               <tpc>21</tpc>
               <head>cross</head>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Rest>
@@ -16893,6 +16896,7 @@
               <pitch>37</pitch>
               <tpc>21</tpc>
               <head>cross</head>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Rest>
@@ -16926,6 +16930,7 @@
               <pitch>37</pitch>
               <tpc>21</tpc>
               <head>cross</head>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -16974,6 +16979,7 @@
               <head>cross</head>
               <fret>2</fret>
               <string>5</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           </voice>
@@ -16997,6 +17003,7 @@
               <head>cross</head>
               <fret>4</fret>
               <string>5</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           </voice>
@@ -17056,6 +17063,7 @@
               <head>cross</head>
               <fret>4</fret>
               <string>4</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -17079,6 +17087,7 @@
               <head>cross</head>
               <fret>1</fret>
               <string>3</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -17103,6 +17112,7 @@
               <head>cross</head>
               <fret>0</fret>
               <string>1</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Rest>
@@ -17120,6 +17130,7 @@
               <head>cross</head>
               <fret>0</fret>
               <string>2</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -17143,6 +17154,7 @@
               <head>cross</head>
               <fret>2</fret>
               <string>2</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Rest>
@@ -17160,6 +17172,7 @@
               <head>cross</head>
               <fret>0</fret>
               <string>1</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Rest>

--- a/src/importexport/guitarpro/tests/data/dead-note.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dead-note.gp-ref.mscx
@@ -75,6 +75,7 @@
               <head>cross</head>
               <fret>7</fret>
               <string>2</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>

--- a/src/importexport/guitarpro/tests/data/dead-note.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dead-note.gpx-ref.mscx
@@ -75,6 +75,7 @@
               <head>cross</head>
               <fret>7</fret>
               <string>2</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>

--- a/src/importexport/guitarpro/tests/data/ghost_note.gp3-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ghost_note.gp3-ref.mscx
@@ -83,6 +83,7 @@
               <head>cross</head>
               <fret>0</fret>
               <string>2</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -102,6 +103,7 @@
               <head>cross</head>
               <fret>0</fret>
               <string>2</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Beam>
@@ -134,6 +136,7 @@
               <head>cross</head>
               <fret>3</fret>
               <string>1</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>

--- a/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gp-ref.mscx
@@ -199,6 +199,7 @@
               <head>cross</head>
               <fret>0</fret>
               <string>1</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -221,6 +222,7 @@
               <head>cross</head>
               <fret>0</fret>
               <string>2</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Rest>
@@ -241,6 +243,7 @@
               <head>cross</head>
               <fret>0</fret>
               <string>2</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -266,6 +269,7 @@
               <head>cross</head>
               <fret>0</fret>
               <string>2</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <BarLine>

--- a/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gp5-ref.mscx
@@ -161,6 +161,7 @@
               <head>cross</head>
               <fret>0</fret>
               <string>1</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <StaffText>
@@ -183,6 +184,7 @@
               <head>cross</head>
               <fret>0</fret>
               <string>2</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Rest>
@@ -203,6 +205,7 @@
               <head>cross</head>
               <fret>0</fret>
               <string>2</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <StaffText>
@@ -228,6 +231,7 @@
               <head>cross</head>
               <fret>0</fret>
               <string>2</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <StaffText>

--- a/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gpx-ref.mscx
@@ -199,6 +199,7 @@
               <head>cross</head>
               <fret>0</fret>
               <string>1</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -221,6 +222,7 @@
               <head>cross</head>
               <fret>0</fret>
               <string>2</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Rest>
@@ -241,6 +243,7 @@
               <head>cross</head>
               <fret>0</fret>
               <string>2</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <Chord>
@@ -266,6 +269,7 @@
               <head>cross</head>
               <fret>0</fret>
               <string>2</string>
+              <dead>1</dead>
               </Note>
             </Chord>
           <BarLine>


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/8601*

*Fixed the following bugs:*

- Not possible to change cross notehead after opening gp file
- Parenthesis instead of cross in tab notation

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
