### PR TITLE
fix: #11483; Instrument comparison fix

### DIFF
--- a/src/engraving/libmscore/instrument.cpp
+++ b/src/engraving/libmscore/instrument.cpp
@@ -1346,21 +1346,33 @@ void Instrument::switchExpressive(MasterScore* score, Synthesizer* synth, bool e
 
 bool Instrument::operator==(const Instrument& i) const
 {
-    return i._longNames == _longNames
-           && i._shortNames == _shortNames
-           && i._channel == _channel
-           && i._minPitchA == _minPitchA
-           && i._maxPitchA == _maxPitchA
-           && i._minPitchP == _minPitchP
-           && i._maxPitchP == _maxPitchP
-           && i._useDrumset == _useDrumset
-           && i._midiActions == _midiActions
-           && i._articulation == _articulation
-           && i._transpose.diatonic == _transpose.diatonic
-           && i._transpose.chromatic == _transpose.chromatic
-           && i._trackName == _trackName
-           && *i.stringData() == *stringData()
-           && i._singleNoteDynamics == _singleNoteDynamics;
+    bool equal = i._longNames == _longNames;
+    equal &= i._shortNames == _shortNames;
+
+    if (i._channel.size() == _channel.size()) {
+        for (int cur = 0; cur < _channel.size(); cur++) {
+            if (*i._channel[cur] != *_channel[cur]) {
+                return false;
+            }
+        }
+    } else {
+        return false;
+    }
+
+    equal &= i._minPitchA == _minPitchA;
+    equal &= i._maxPitchA == _maxPitchA;
+    equal &= i._minPitchP == _minPitchP;
+    equal &= i._maxPitchP == _maxPitchP;
+    equal &= i._useDrumset == _useDrumset;
+    equal &= i._midiActions == _midiActions;
+    equal &= i._articulation == _articulation;
+    equal &= i._transpose.diatonic == _transpose.diatonic;
+    equal &= i._transpose.chromatic == _transpose.chromatic;
+    equal &= i._trackName == _trackName;
+    equal &= *i.stringData() == *stringData();
+    equal &= i._singleNoteDynamics == _singleNoteDynamics;
+
+    return equal;
 }
 
 bool Instrument::operator!=(const Instrument& i) const

--- a/src/engraving/libmscore/instrument.h
+++ b/src/engraving/libmscore/instrument.h
@@ -217,6 +217,7 @@ public:
     void read(XmlReader&, Part* part);
     void updateInitList() const;
     bool operator==(const Channel& c) const { return (_name == c._name) && (_channel == c._channel); }
+    bool operator!=(const Channel& c) const { return !(*this == c); }
 
     void addListener(ChannelListener* l);
     void removeListener(ChannelListener* l);


### PR DESCRIPTION
Resolves: #11483 

Fixed comparison of instrument objects by comparing the channel objects inside the instrument rather than comparing their memory addresses.
This was needed because beforehand, when you clicked apply, and the program checked whether values were still same, it always resulted in it thinking that instruments were changed whereas they weren't. 

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
