### PR TITLE
[MU4] Fix #10779: Initiating 'Play' automatically scrolls the score to the top of the page. Vertical scrolling should be disabled

### DIFF
--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -33,6 +33,7 @@
 
 #include "libmscore/engravingitem.h"
 #include "libmscore/page.h"
+#include "libmscore/system.h"
 #include "libmscore/durationtype.h"
 #include "libmscore/mscore.h"
 #include "libmscore/masterscore.h"
@@ -58,6 +59,7 @@
 
 namespace mu::notation {
 using Page = Ms::Page;
+using System = Ms::System;
 using EngravingItem = Ms::EngravingItem;
 using ElementType = Ms::ElementType;
 using PropertyValue = engraving::PropertyValue;

--- a/src/notation/view/notationpaintview.h
+++ b/src/notation/view/notationpaintview.h
@@ -202,7 +202,7 @@ private:
     qreal horizontalScrollableSize() const;
     qreal verticalScrollableSize() const;
 
-    bool adjustCanvasPosition(const RectF& logicRect);
+    bool adjustCanvasPosition(const RectF& logicRect, bool adjustVertically = true);
 
     void onNoteInputStateChanged();
 
@@ -210,6 +210,7 @@ private:
 
     void onPlayingChanged();
     void movePlaybackCursor(midi::tick_t tick);
+    bool needAdjustCanvasVerticallyWhilePlayback(const RectF& cursorRect);
 
     void updateLoopMarkers(const LoopBoundaries& boundaries);
 

--- a/src/notation/view/notationpaintview.h
+++ b/src/notation/view/notationpaintview.h
@@ -23,6 +23,7 @@
 #define MU_NOTATION_NOTATIONPAINTVIEW_H
 
 #include <QQuickPaintedItem>
+#include <QTimer>
 
 #include "modularity/ioc.h"
 
@@ -178,6 +179,8 @@ private:
     void onCurrentNotationChanged();
     bool isInited() const;
 
+    bool doMoveCanvas(qreal dx, qreal dy);
+
     // Input
     void wheelEvent(QWheelEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
@@ -238,6 +241,9 @@ private:
     bool m_publishMode = false;
     int m_lastAcceptedKey = -1;
     bool m_accessibilityEnabled = false;
+
+    bool m_autoScrollEnabled = true;
+    QTimer m_enableAutoScrollTimer;
 };
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10779
Resolves: https://github.com/musescore/MuseScore/issues/11181
Closes: https://github.com/musescore/MuseScore/pull/10799