### PR TITLE
fix #11539: fix positioning of tuplets in gp import

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -2154,7 +2154,7 @@ void GPConverter::addTuplet(const GPBeat* beat, ChordRest* cr)
         _lastTuplet = Factory::createTuplet(_score->dummy()->measure());
         _lastTuplet->setTrack(cr->track());
         _lastTuplet->setParent(cr->measure());
-        _lastTuplet->setTrack(cr->track());
+        _lastTuplet->setTick(cr->tick());
         _lastTuplet->setBaseLen(cr->actualDurationType());
         _lastTuplet->setRatio(Fraction(beat->tuplet().num, beat->tuplet().denom));
         _lastTuplet->setTicks(cr->actualDurationType().ticks() * beat->tuplet().denom);


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/11539*

*fix positioning of tuplets in gp import*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
