### PR TITLE
Fix MinGW/MSVC Compiler warnings

### DIFF
--- a/build/cmake/SetupCompileWarnings.cmake
+++ b/build/cmake/SetupCompileWarnings.cmake
@@ -48,6 +48,7 @@ function(target_no_warning TARGET WNAME)
     elseif(WNAME STREQUAL "-Wno-attributes")
     elseif(WNAME STREQUAL "-Wno-absolute-value")
     elseif(WNAME STREQUAL "-Wno-tautological-pointer-compare")
+    elseif(WNAME STREQUAL "-Wno-sign-compare")
 
     elseif(WNAME STREQUAL "-w")
         set(MSVC_Warning /w)

--- a/src/framework/audio/internal/encoders/flacencoder.cpp
+++ b/src/framework/audio/internal/encoders/flacencoder.cpp
@@ -97,7 +97,7 @@ size_t FlacEncoder::encode(samples_t samplesPerChannel, const float* input)
 
     size_t result = 0;
     size_t totalSamplesNumber = samplesPerChannel * m_format.audioChannelsNumber;
-    size_t frameSize = 1024;
+    uint32_t frameSize = 1024;
     size_t stepSize = frameSize * m_format.audioChannelsNumber;
 
     std::vector<FLAC__int32> buff(samplesPerChannel * sizeof(float));

--- a/src/framework/audio/internal/encoders/mp3encoder.cpp
+++ b/src/framework/audio/internal/encoders/mp3encoder.cpp
@@ -104,7 +104,7 @@ size_t Mp3Encoder::encode(samples_t samplesPerChannel, const float* input)
 
     int encodedBytes = lame_encode_buffer_interleaved_ieee_float(LameHandler::instance()->flags, input, samplesPerChannel,
                                                                  m_outputBuffer.data(),
-                                                                 m_outputBuffer.size());
+                                                                 static_cast<int>(m_outputBuffer.size()));
 
     return std::fwrite(m_outputBuffer.data(), sizeof(unsigned char), encodedBytes, m_fileStream);
 }
@@ -113,7 +113,7 @@ size_t Mp3Encoder::flush()
 {
     int encodedBytes = lame_encode_flush(LameHandler::instance()->flags,
                                          m_outputBuffer.data(),
-                                         m_outputBuffer.size());
+                                         static_cast<int>(m_outputBuffer.size()));
 
     return std::fwrite(m_outputBuffer.data(), sizeof(unsigned char), encodedBytes, m_fileStream);
 }

--- a/src/framework/global/serialization/xmlstreamreader.cpp
+++ b/src/framework/global/serialization/xmlstreamreader.cpp
@@ -60,7 +60,7 @@ void XmlStreamReader::setData(const QByteArray& data)
 void XmlStreamReader::setData(const io::ByteArray& data)
 {
     m_reader->clear();
-    QByteArray ba(reinterpret_cast<const char*>(data.constData()), data.size());
+    QByteArray ba(reinterpret_cast<const char*>(data.constData()), static_cast<int>(data.size()));
     m_reader->addData(ba);
 }
 

--- a/thirdparty/flac/flac-1.3.4/include/share/compat.h
+++ b/thirdparty/flac/flac-1.3.4/include/share/compat.h
@@ -54,6 +54,7 @@
 #define ftello _ftelli64
 #else /* MinGW */
 #if !defined(HAVE_FSEEKO)
+#define _off_t _off64_t
 #define fseeko fseeko64
 #define ftello ftello64
 #endif

--- a/thirdparty/flac/flac-1.3.4/include/share/compat.h
+++ b/thirdparty/flac/flac-1.3.4/include/share/compat.h
@@ -188,7 +188,7 @@
 #endif
 
 #ifndef M_LN2
-#define M_LN2 0.69314718055994530942
+#define M_LN2 0.693147180559945309417
 #endif
 #ifndef M_PI
 #define M_PI 3.14159265358979323846

--- a/thirdparty/flac/flac-1.3.4/src/libFLAC++/metadata.cpp
+++ b/thirdparty/flac/flac-1.3.4/src/libFLAC++/metadata.cpp
@@ -695,7 +695,11 @@ namespace FLAC {
 
 			clear_field_name();
 
+#if defined _MSC_VER || defined __MINGW32__
+			if(0 == (field_name_ = _strdup(field_name))) {
+#else
 			if(0 == (field_name_ = strdup(field_name))) {
+#endif
 				is_valid_ = false;
 			}
 			else {

--- a/thirdparty/flac/flac-1.3.4/src/libFLAC/format.c
+++ b/thirdparty/flac/flac-1.3.4/src/libFLAC/format.c
@@ -577,11 +577,11 @@ FLAC__bool FLAC__format_entropy_coding_method_partitioned_rice_contents_ensure_s
 	FLAC__ASSERT(object->capacity_by_order > 0 || (0 == object->parameters && 0 == object->raw_bits));
 
 	if(object->capacity_by_order < max_partition_order) {
-		if(0 == (object->parameters = safe_realloc_(object->parameters, sizeof(uint32_t)*(1 << max_partition_order))))
+		if(0 == (object->parameters = safe_realloc_(object->parameters, sizeof(uint32_t)*(size_t)(1 << max_partition_order))))
 			return false;
-		if(0 == (object->raw_bits = safe_realloc_(object->raw_bits, sizeof(uint32_t)*(1 << max_partition_order))))
+		if(0 == (object->raw_bits = safe_realloc_(object->raw_bits, sizeof(uint32_t)*(size_t)(1 << max_partition_order))))
 			return false;
-		memset(object->raw_bits, 0, sizeof(uint32_t)*(1 << max_partition_order));
+		memset(object->raw_bits, 0, sizeof(uint32_t)*(size_t)(1 << max_partition_order));
 		object->capacity_by_order = max_partition_order;
 	}
 

--- a/thirdparty/flac/flac-1.3.4/src/libFLAC/include/private/bitmath.h
+++ b/thirdparty/flac/flac-1.3.4/src/libFLAC/include/private/bitmath.h
@@ -82,7 +82,7 @@ static inline uint32_t FLAC__clz_uint32(FLAC__uint32 v)
 	return __builtin_clz(v);
 #elif defined(_MSC_VER)
 	{
-		uint32_t idx;
+		DWORD idx;
 		_BitScanReverse(&idx, v);
 		return idx ^ 31U;
 	}
@@ -106,7 +106,7 @@ static inline uint32_t FLAC__clz_uint64(FLAC__uint64 v)
 	return __builtin_clzll(v);
 #elif (defined(__INTEL_COMPILER) || defined(_MSC_VER)) && (defined(_M_IA64) || defined(_M_X64))
 	{
-		uint32_t idx;
+		DWORD idx;
 		_BitScanReverse64(&idx, v);
 		return idx ^ 63U;
 	}
@@ -160,7 +160,7 @@ static inline uint32_t FLAC__bitmath_ilog2(FLAC__uint32 v)
 	return _bit_scan_reverse(v);
 #elif defined(_MSC_VER)
 	{
-		uint32_t idx;
+		DWORD idx;
 		_BitScanReverse(&idx, v);
 		return idx;
 	}
@@ -177,7 +177,7 @@ static inline uint32_t FLAC__bitmath_ilog2_wide(FLAC__uint64 v)
 /* Sorry, only supported in x64/Itanium.. and both have fast FPU which makes integer-only encoder pointless */
 #elif (defined(__INTEL_COMPILER) || defined(_MSC_VER)) && (defined(_M_IA64) || defined(_M_X64))
 	{
-		uint32_t idx;
+		DWORD idx;
 		_BitScanReverse64(&idx, v);
 		return idx;
 	}

--- a/thirdparty/flac/flac-1.3.4/src/libFLAC/metadata_iterators.c
+++ b/thirdparty/flac/flac-1.3.4/src/libFLAC/metadata_iterators.c
@@ -489,11 +489,19 @@ FLAC_API FLAC__bool FLAC__metadata_simple_iterator_init(FLAC__Metadata_SimpleIte
 	if(!read_only && preserve_file_stats)
 		iterator->has_stats = get_file_stats_(filename, &iterator->stats);
 
+#if defined _MSC_VER || defined __MINGW32__
+	if(0 == (iterator->filename = _strdup(filename))) {
+#else
 	if(0 == (iterator->filename = strdup(filename))) {
+#endif
 		iterator->status = FLAC__METADATA_SIMPLE_ITERATOR_STATUS_MEMORY_ALLOCATION_ERROR;
 		return false;
 	}
+#if defined _MSC_VER || defined __MINGW32__
+	if(0 != tempfile_path_prefix && 0 == (iterator->tempfile_path_prefix = _strdup(tempfile_path_prefix))) {
+#else
 	if(0 != tempfile_path_prefix && 0 == (iterator->tempfile_path_prefix = strdup(tempfile_path_prefix))) {
+#endif
 		iterator->status = FLAC__METADATA_SIMPLE_ITERATOR_STATUS_MEMORY_ALLOCATION_ERROR;
 		return false;
 	}
@@ -1543,7 +1551,11 @@ static FLAC__bool chain_read_(FLAC__Metadata_Chain *chain, const char *filename,
 
 	chain_clear_(chain);
 
+#if defined _MSC_VER || defined __MINGW32__
+	if(0 == (chain->filename = _strdup(filename))) {
+#else
 	if(0 == (chain->filename = strdup(filename))) {
+#endif
 		chain->status = FLAC__METADATA_CHAIN_STATUS_MEMORY_ALLOCATION_ERROR;
 		return false;
 	}

--- a/thirdparty/flac/flac-1.3.4/src/libFLAC/metadata_object.c
+++ b/thirdparty/flac/flac-1.3.4/src/libFLAC/metadata_object.c
@@ -114,7 +114,11 @@ static FLAC__bool ensure_null_terminated_(FLAC__byte **entry, uint32_t length)
  */
 static FLAC__bool copy_cstring_(char **to, const char *from)
 {
+#if defined _MSC_VER || defined __MINGW32__
+	char *copy = _strdup(from);
+#else
 	char *copy = strdup(from);
+#endif
 	FLAC__ASSERT(to != NULL);
 	if (copy) {
 		free(*to);

--- a/thirdparty/flac/flac-1.3.4/src/libFLAC/stream_decoder.c
+++ b/thirdparty/flac/flac-1.3.4/src/libFLAC/stream_decoder.c
@@ -3433,7 +3433,11 @@ FLAC__StreamDecoderLengthStatus file_length_callback_(const FLAC__StreamDecoder 
 
 	if(decoder->private_->file == stdin)
 		return FLAC__STREAM_DECODER_LENGTH_STATUS_UNSUPPORTED;
+#if defined _MSC_VER || defined __MINGW32__
+	else if(flac_fstat(_fileno(decoder->private_->file), &filestats) != 0)
+#else
 	else if(flac_fstat(fileno(decoder->private_->file), &filestats) != 0)
+#endif
 		return FLAC__STREAM_DECODER_LENGTH_STATUS_ERROR;
 	else {
 		*stream_length = (FLAC__uint64)filestats.st_size;

--- a/thirdparty/flac/flac-1.3.4/src/libFLAC/stream_encoder.c
+++ b/thirdparty/flac/flac-1.3.4/src/libFLAC/stream_encoder.c
@@ -3971,9 +3971,9 @@ uint32_t find_best_partition_order_(
 
 		/* save best parameters and raw_bits */
 		FLAC__format_entropy_coding_method_partitioned_rice_contents_ensure_size(prc, flac_max(6u, best_partition_order));
-		memcpy(prc->parameters, private_->partitioned_rice_contents_extra[best_parameters_index].parameters, sizeof(uint32_t)*(1<<(best_partition_order)));
+		memcpy(prc->parameters, private_->partitioned_rice_contents_extra[best_parameters_index].parameters, sizeof(uint32_t)*(size_t)(1<<(best_partition_order)));
 		if(do_escape_coding)
-			memcpy(prc->raw_bits, private_->partitioned_rice_contents_extra[best_parameters_index].raw_bits, sizeof(uint32_t)*(1<<(best_partition_order)));
+			memcpy(prc->raw_bits, private_->partitioned_rice_contents_extra[best_parameters_index].raw_bits, sizeof(uint32_t)*(size_t)(1<<(best_partition_order)));
 		/*
 		 * Now need to check if the type should be changed to
 		 * FLAC__ENTROPY_CODING_METHOD_PARTITIONED_RICE2 based on the

--- a/thirdparty/opusenc/libopusenc-0.2.1/src/opusenc.c
+++ b/thirdparty/opusenc/libopusenc-0.2.1/src/opusenc.c
@@ -81,11 +81,9 @@ struct OggOpusComments {
 /* Create a new comments object. The vendor string is optional. */
 OggOpusComments *ope_comments_create() {
   OggOpusComments *c;
-  const char *libopus_str;
   char vendor_str[1024];
   c = malloc(sizeof(*c));
   if (c == NULL) return NULL;
-  libopus_str = opus_get_version_string();
   opeint_comment_init(&c->comment, &c->comment_length, vendor_str);
   c->seen_file_icons = 0;
   if (c->comment == NULL) {

--- a/thirdparty/opusenc/libopusenc-0.2.1/src/resample.c
+++ b/thirdparty/opusenc/libopusenc-0.2.1/src/resample.c
@@ -670,7 +670,7 @@ static int update_filter(SpeexResamplerState *st)
       spx_uint32_t i;
       for (i=0;i<st->den_rate;i++)
       {
-         spx_int32_t j;
+         spx_uint32_t j;
          for (j=0;j<st->filt_len;j++)
          {
             st->sinc_table[i*st->filt_len+j] = sinc(st->cutoff,((j-(spx_int32_t)st->filt_len/2+1)-((float)i)/st->den_rate), st->filt_len, quality_map[st->quality].window_func);
@@ -927,7 +927,7 @@ EXPORT int speex_resampler_process_int(SpeexResamplerState *st, spx_uint32_t cha
 EXPORT int speex_resampler_process_float(SpeexResamplerState *st, spx_uint32_t channel_index, const float *in, spx_uint32_t *in_len, float *out, spx_uint32_t *out_len)
 #endif
 {
-   int j;
+   spx_uint32_t j;
    spx_uint32_t ilen = *in_len;
    spx_uint32_t olen = *out_len;
    spx_word16_t *x = st->mem + channel_index * st->mem_alloc_size;
@@ -968,7 +968,7 @@ EXPORT int speex_resampler_process_float(SpeexResamplerState *st, spx_uint32_t c
 EXPORT int speex_resampler_process_int(SpeexResamplerState *st, spx_uint32_t channel_index, const spx_int16_t *in, spx_uint32_t *in_len, spx_int16_t *out, spx_uint32_t *out_len)
 #endif
 {
-   int j;
+   spx_uint32_t j;
    const int istride_save = st->in_stride;
    const int ostride_save = st->out_stride;
    spx_uint32_t ilen = *in_len;


### PR DESCRIPTION
after #11669

* reg. variable set but not used (-Wunused-but-set-variable)
* reg. 'unsigned long *' differs in indirection to slightly different base types from 'uint32_t *' (C4057)
* reg. 'argument': conversion from 'size_t' to 'uint32_t/int', possible loss of data (C4267)
* reg. '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)	(C4334)
* reg. 'M_LN2': macro redefinition (C4005)
* reg. '<': signed/unsigned mismatch (C4018)
* reg. the POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name (C4996)
* reg. unknown -Wno-sign-compare
* And fix MinGW build

after #11694

* reg. 'argument': conversion from 'size_t' to 'int', possible loss of data (C4267)