### PR TITLE
fix: #11665; Multi-Selection directory box doesn't return empty path on being crossed out anymore

### DIFF
--- a/src/framework/global/internal/interactive.cpp
+++ b/src/framework/global/internal/interactive.cpp
@@ -170,7 +170,7 @@ io::paths Interactive::selectMultipleDirectories(const QString& title, const io:
 
     RetVal<Val> paths = open("musescore://interactive/selectMultipleDirectories?" + params.join("&").toStdString());
     if (!paths.ret) {
-        return io::paths();
+        return selectedDirectories;
     }
 
     io::paths result;

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/SelectMultipleDirectoriesDialog.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/SelectMultipleDirectoriesDialog.qml
@@ -105,8 +105,7 @@ StyledDialogView {
             navigationPanel.order: 3
 
             onRejected: {
-                root.ret = { errcode: 0, value: directoriesModel.originDirectories() }
-                root.hide()
+                root.reject()
             }
 
             onAccepted: {

--- a/src/framework/uicomponents/view/selectmultipledirectoriesmodel.cpp
+++ b/src/framework/uicomponents/view/selectmultipledirectoriesmodel.cpp
@@ -85,7 +85,6 @@ void SelectMultipleDirectoriesModel::load(const QString& startDir, const QString
 {
     beginResetModel();
     m_directories = io::pathsFromString(directoriesStr.toStdString());
-    m_originDirectories = m_directories;
     m_dir = startDir.toStdString();
     endResetModel();
 }
@@ -139,16 +138,6 @@ void SelectMultipleDirectoriesModel::addDirectory()
 
     m_dir = path;
     emit directoryAdded(row);
-}
-
-QStringList SelectMultipleDirectoriesModel::originDirectories() const
-{
-    QStringList directories;
-    for (const io::path& directory : m_originDirectories) {
-        directories << directory.toQString();
-    }
-
-    return directories;
 }
 
 QStringList SelectMultipleDirectoriesModel::directories() const

--- a/src/framework/uicomponents/view/selectmultipledirectoriesmodel.h
+++ b/src/framework/uicomponents/view/selectmultipledirectoriesmodel.h
@@ -51,7 +51,6 @@ public:
     Q_INVOKABLE void removeSelectedDirectories();
     Q_INVOKABLE void addDirectory();
 
-    Q_INVOKABLE QStringList originDirectories() const;
     Q_INVOKABLE QStringList directories() const;
 
     bool isRemovingAvailable() const;
@@ -71,7 +70,6 @@ private:
 
     void doRemoveDirectory(int index);
 
-    io::paths m_originDirectories;
     io::paths m_directories;
     io::path m_dir;
 


### PR DESCRIPTION
Resolves: #11665 

Instead of returning an empty list of paths whenever the dialogue box returned an error, we now return the previous list, which prevents the deletion of directories as described in the issue.

This does not prevent you from emptying the list manually. You may still clear the list as usual but remember to use the OK button to confirm that.
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
