### PR TITLE
Fix crash when pressing arrow key with bracket in Edit Mode

### DIFF
--- a/src/engraving/libmscore/mscoreview.h
+++ b/src/engraving/libmscore/mscoreview.h
@@ -55,7 +55,7 @@ public:
 
     virtual void moveCursor() {}
 
-    virtual void adjustCanvasPosition(const EngravingItem*, int /*staffIdx*/ = -1) {}
+    virtual Score* score() const { return m_score; }
     virtual void setScore(Score* s) { m_score = s; }
     virtual void removeScore() {}
 
@@ -70,13 +70,11 @@ public:
     virtual void lyricsMinus() {}
     virtual void lyricsUnderscore() {}
 
-    virtual void onElementDestruction(EngravingItem*) {}
-
     virtual const mu::Rect geometry() const = 0;
 
     const std::vector<EngravingItem*> elementsAt(const mu::PointF&) const;
     EngravingItem* elementNear(const mu::PointF& pos) const;
-    Score* score() const { return m_score; }
+    virtual void adjustCanvasPosition(const EngravingItem*, int /*staffIdx*/ = -1) {}
 
 protected:
     Score* m_score = nullptr;

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -441,6 +441,11 @@ void Score::notifyPosChanged(POS pos, unsigned ticks)
     m_posChanged.send(pos, ticks);
 }
 
+mu::async::Channel<EngravingItem*> Score::elementDestroyed()
+{
+    return m_elementDestroyed;
+}
+
 //---------------------------------------------------------
 //   Score::clone
 //         To create excerpt clone to show when changing PageSettings
@@ -487,15 +492,15 @@ bool Score::isPaletteScore() const
 void Score::onElementDestruction(EngravingItem* e)
 {
     Score* score = e->EngravingObject::score();
+
     if (!score || Score::validScores.find(score) == Score::validScores.end()) {
         // No score or the score is already deleted
         return;
     }
+
     score->selection().remove(e);
     score->cmdState().unsetElement(e);
-    for (MuseScoreView* v : score->viewer) {
-        v->onElementDestruction(e);
-    }
+    score->elementDestroyed().send(e);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -465,6 +465,8 @@ private:
     mu::engraving::Layout m_layout;
     mu::engraving::LayoutOptions m_layoutOptions;
 
+    mu::async::Channel<EngravingItem*> m_elementDestroyed;
+
     mu::async::Channel<ScoreChangesRange> m_changesRangeChannel;
 
     ShadowNote* m_shadowNote = nullptr;
@@ -564,6 +566,8 @@ public:
 
     mu::async::Channel<POS, unsigned> posChanged() const;
     void notifyPosChanged(POS pos, unsigned ticks);
+
+    mu::async::Channel<EngravingItem*> elementDestroyed();
 
     void rebuildBspTree();
     bool noStaves() const { return _staves.empty(); }

--- a/src/notation/internal/igetscore.h
+++ b/src/notation/internal/igetscore.h
@@ -22,6 +22,8 @@
 #ifndef MU_NOTATION_IGETSCORE_H
 #define MU_NOTATION_IGETSCORE_H
 
+#include "async/notification.h"
+
 namespace Ms {
 class Score;
 }
@@ -33,6 +35,7 @@ public:
     virtual ~IGetScore() = default;
 
     virtual Ms::Score* score() const = 0;
+    virtual async::Notification scoreInited() const = 0;
 };
 }
 

--- a/src/notation/internal/notation.cpp
+++ b/src/notation/internal/notation.cpp
@@ -127,7 +127,17 @@ void Notation::init()
 
 void Notation::setScore(Ms::Score* score)
 {
+    if (m_score == score) {
+        return;
+    }
+
     m_score = score;
+    m_scoreInited.notify();
+}
+
+mu::async::Notification Notation::scoreInited() const
+{
+    return m_scoreInited;
 }
 
 QString Notation::name() const

--- a/src/notation/internal/notation.h
+++ b/src/notation/internal/notation.h
@@ -78,6 +78,8 @@ public:
 protected:
     Ms::Score* score() const override;
     void setScore(Ms::Score* score);
+    async::Notification scoreInited() const override;
+
     void notifyAboutNotationChanged();
 
     INotationPartsPtr m_parts = nullptr;
@@ -89,6 +91,8 @@ private:
     friend class NotationPainting;
 
     Ms::Score* m_score = nullptr;
+    async::Notification m_scoreInited;
+
     async::Notification m_openChanged;
 
     INotationPaintingPtr m_painting = nullptr;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -264,6 +264,7 @@ public:
 
 private:
     Ms::Score* score() const;
+    void onScoreInited();
 
     void startEdit();
     void apply();
@@ -273,6 +274,8 @@ private:
 
     void doEndEditElement();
     void doEndDrag();
+
+    void onElementDestroyed(EngravingItem* element);
 
     void doSelect(const std::vector<EngravingItem*>& elements, SelectType type, engraving::staff_idx_t staffIndex = 0);
     void selectElementsWithSameTypeOnSegment(Ms::ElementType elementType, Ms::Segment* segment);


### PR DESCRIPTION
Resolves: #11294

Again the same type of problem: during the edit, the brackets get deleted and replaced during re-layout, but somewhere we still try to use the old bracket which causes the crash. 

I had to do some refactoring in order to get the ScoreCallbacks object consistently registered as a "viewer" of the score, so that we can use the `onElementDestruction` callback in order to be able to remove references to the deleted object. After that, we attempt to select the newly created bracket. 