### PR TITLE
fix #11675: importing graces note from gp as 1/8

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -436,25 +436,7 @@ void GPConverter::configureGraceChord(const GPBeat* beat, ChordRest* cr)
 {
     convertNotes(beat->notes(), cr);
 
-    auto rhythm = [](GPRhythm::RhytmType rhythm) {
-        if (rhythm == GPRhythm::RhytmType::Whole) {
-            return 1;
-        } else if (rhythm == GPRhythm::RhytmType::Half) {
-            return 2;
-        } else if (rhythm == GPRhythm::RhytmType::Quarter) {
-            return 4;
-        } else if (rhythm == GPRhythm::RhytmType::Eighth) {
-            return 8;
-        } else if (rhythm == GPRhythm::RhytmType::Sixteenth) {
-            return 16;
-        } else if (rhythm == GPRhythm::RhytmType::ThirtySecond) {
-            return 32;
-        } else {
-            return 64;
-        }
-    };
-
-    Fraction fr(1, rhythm(beat->lenth().second));
+    Fraction fr(1, 8);
     cr->setDurationType(TDuration(fr));
 
     if (cr->type() == ElementType::CHORD) {


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/11675*

*importing graces note from gp as 1/8*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
