### PR TITLE
Fix MSVC/MinGW Compiler warnings

### DIFF
--- a/src/converter/internal/compat/backendapi.cpp
+++ b/src/converter/internal/compat/backendapi.cpp
@@ -617,7 +617,7 @@ RetVal<QByteArray> BackendApi::scorePartJson(Ms::Score* score, const std::string
     }
     mscWriter.close();
 
-    QByteArray ba = QByteArray::fromRawData(reinterpret_cast<const char*>(scoreData.constData()), scoreData.size());
+    QByteArray ba = QByteArray::fromRawData(reinterpret_cast<const char*>(scoreData.constData()), static_cast<int>(scoreData.size()));
 
     RetVal<QByteArray> result;
     result.ret = ok ? make_ret(Ret::Code::Ok) : make_ret(Ret::Code::InternalError);

--- a/src/engraving/infrastructure/internal/fontengineft.cpp
+++ b/src/engraving/infrastructure/internal/fontengineft.cpp
@@ -86,7 +86,7 @@ bool FontEngineFT::load(const QString& path)
 
     m_data->fontData = f.readAll();
 
-    int rval = FT_New_Memory_Face(ftlib, (FT_Byte*)m_data->fontData.constData(), m_data->fontData.size(), 0, &m_data->face);
+    int rval = FT_New_Memory_Face(ftlib, (FT_Byte*)m_data->fontData.constData(), (FT_Long)m_data->fontData.size(), 0, &m_data->face);
     if (rval) {
         LOGE() << "freetype: cannot create face: " << path << ", rval: " << rval;
         return false;

--- a/src/engraving/infrastructure/io/mscwriter.cpp
+++ b/src/engraving/infrastructure/io/mscwriter.cpp
@@ -113,7 +113,7 @@ MscWriter::IWriter* MscWriter::writer() const
 
 bool MscWriter::addFileData(const QString& fileName, const ByteArray& data)
 {
-    QByteArray ba = QByteArray::fromRawData(reinterpret_cast<const char*>(data.constData()), data.size());
+    QByteArray ba = QByteArray::fromRawData(reinterpret_cast<const char*>(data.constData()), static_cast<int>(data.size()));
     return addFileData(fileName, ba);
 }
 

--- a/src/engraving/tests/testbase.cpp
+++ b/src/engraving/tests/testbase.cpp
@@ -207,7 +207,7 @@ bool MTest::saveMimeData(QByteArray mimeData, const QString& saveName)
     }
 
     size_t size = f.write(mimeData);
-    return size == mimeData.size();
+    return size == static_cast<size_t>(mimeData.size());
 }
 
 //---------------------------------------------------------

--- a/src/engraving/utests/utils/scorerw.cpp
+++ b/src/engraving/utests/utils/scorerw.cpp
@@ -117,5 +117,5 @@ bool ScoreRW::saveMimeData(QByteArray mimeData, const QString& saveName)
     }
 
     size_t size = f.write(mimeData);
-    return size == mimeData.size();
+    return size == static_cast<size_t>(mimeData.size());
 }

--- a/src/framework/global/io/bytearray.h
+++ b/src/framework/global/io/bytearray.h
@@ -73,12 +73,12 @@ public:
 
     QByteArray toQByteArray() const
     {
-        return QByteArray(reinterpret_cast<const char*>(constData()), size());
+        return QByteArray(reinterpret_cast<const char*>(constData()), static_cast<int>(size()));
     }
 
     QByteArray toQByteArrayNoCopy() const
     {
-        return QByteArray::fromRawData(reinterpret_cast<const char*>(constData()), size());
+        return QByteArray::fromRawData(reinterpret_cast<const char*>(constData()), static_cast<int>(size()));
     }
 
 #endif


### PR DESCRIPTION
Introduced by #11700

* reg. 'argument': conversion from 'size_t' to 'int', possible loss of data (C4267)
* reg. comparison of integer expressions of different signedness: 'size_t' {aka 'long long unsigned int'} and 'int' (-Wsign-compare)