### PR TITLE
Fix #11712: Crash when dragging note leftwards if preceding note has ledger lines and beam

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -1078,7 +1078,6 @@ void Beam::extendStem(Chord* chord, int extraBeamAdjust)
     if (chord->tremolo()) {
         chord->tremolo()->layout();
     }
-    chord->layout();
 }
 
 bool Beam::isBeamInsideStaff(int yPos, int staffLines) const


### PR DESCRIPTION
Resolves: #11712

By looking at the stack traces from Address Sanitizer, I found out what's going on exactly. 
It is crucial that the chord at the left of the note being dragged is under a beam. 
To summarize, the order of things is like this:
- Layout chords, and delete and replace ledger lines, as part of the standard layout process
- Segment::createShapes is called, to update the segment shapes
- layoutSystemElements is called
  - layout beams
    - layout chords again, and again delete and replace ledger lines
      But this time, segment shapes are _not_ recreated anymore, so the cached shapes will still contain pointers to the just-deleted ledger lines.

Solution: don't re-layout chords, since that should have any effect anyway. Only the stem needs to be re-laid out, which happens directly when calling chord->setBeamExtension.