### PR TITLE
Sync instruments.xml and Instrument Spreadsheet

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -7059,7 +7059,7 @@
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="36"> <!--Acoustic Bass Drum-->
+                  <Drum pitch="36"> <!--Electric Bass Drum-->
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
@@ -7491,7 +7491,7 @@
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="68">
+                  <Drum pitch="68"> <!--Low Agogô-->
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
@@ -8003,7 +8003,7 @@
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="52">
+                  <Drum pitch="52"> <!--Chinese Cymbal-->
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
@@ -8736,7 +8736,7 @@
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="62">
+                  <Drum pitch="62"> <!--Mute High Conga-->
                         <head>cross</head>
                         <line>-1</line>
                         <voice>0</voice>
@@ -8744,7 +8744,7 @@
                         <stem>1</stem>
                         <shortcut>B</shortcut>
                   </Drum>
-                  <Drum pitch="63">
+                  <Drum pitch="63"> <!--Open High Conga-->
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
@@ -8752,7 +8752,7 @@
                         <stem>1</stem>
                         <shortcut>C</shortcut>
                   </Drum>
-                  <Drum pitch="64">
+                  <Drum pitch="64"> <!--Low Conga-->
                         <head>normal</head>
                         <line>1</line>
                         <voice>0</voice>
@@ -8763,7 +8763,7 @@
                   <Channel>
                         <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
                         <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="48"/> <!-- Orchestra Kit-->
+                        <program value="48"/> <!--Orchestra Kit-->
                   </Channel>
                   <genre>world</genre>
             </Instrument>
@@ -8807,7 +8807,7 @@
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="52">
+                  <Drum pitch="52"> <!--Chinese Cymbal-->
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
@@ -8818,7 +8818,7 @@
                   <Channel>
                         <!--MIDI: Bank 128, Prog 56; MS General: Marching Snare-->
                         <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="56"/> <!--Marching Snare-->
+                        <program value="56"/> <!--SFX Kit-->
                   </Channel>
                   <genre>orchestra</genre>
                   <genre>concertband</genre>


### PR DESCRIPTION
The online spreadsheet was updated to include the semantic changes in instruments.xml made by PR #11355. This changed the comments in the spreadsheet so now update_instruments_xml.py is run to bring the XML comments up to date here too.

Comments in the online spreadsheet are generated automatically from MIDI data at https://en.wikipedia.org/wiki/General_MIDI#Percussion and similar pages.