### PR TITLE
Hidden notes spacing fix

### DIFF
--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -2631,8 +2631,8 @@ qreal Segment::minHorizontalDistance(Segment* ns, bool systemHeaderGap) const
 //------------------------------------------------------
 Fraction Segment::shortestChordRest() const
 {
-    Fraction shortest = Fraction::max(); // Initializing at arbitrary high value
-    Fraction cur = Fraction::max();
+    Fraction shortest = measure()->ticks(); // Initializing at the highest possible value ( = time signature of the measure)
+    Fraction cur = measure()->ticks();
     for (auto elem : elist()) {
         if (!elem || !elem->staff()->show() || !elem->isChordRest() || !elem->visible()) {
             if (!(elem && elem->isRest() && toRest(elem)->isFullMeasureRest())) {


### PR DESCRIPTION
A tiny fix to improve the spacing of hidden notes, which is currently incorrect (see pics). A more comprehensive solution will be done for future releases.
Before:
![photo_2022-05-25_09-56-01](https://user-images.githubusercontent.com/93707756/170211184-69220d7f-12d4-4260-ad5c-8dff2a013b00.jpg)
After:
![Screenshot from 2022-05-25 09-56-41](https://user-images.githubusercontent.com/93707756/170211285-50043392-5f80-4b19-a3f5-e3edc248849a.png)

