### PR TITLE
[MU4] Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/layout/layoutchords.cpp
+++ b/src/engraving/layout/layoutchords.cpp
@@ -1196,8 +1196,8 @@ void LayoutChords::appendGraceNotes(Chord* chord)
 {
     Segment* segment = chord->segment();
     Measure* measure = chord->measure();
-    int track = chord->track();
-    int staffIdx = chord->staffIdx();
+    track_idx_t track = chord->track();
+    staff_idx_t staffIdx = chord->staffIdx();
     GraceNotesGroup& gnb = chord->graceNotesBefore();
     GraceNotesGroup& gna = chord->graceNotesAfter();
 
@@ -1205,12 +1205,12 @@ void LayoutChords::appendGraceNotes(Chord* chord)
     if (!gnb.empty()) {
         // If this segment already contains grace notes in the same voice (could happen if a
         // previous chord has appended grace-notes-after here) put them in the same vector.
-        EngravingItem* item = segment->preAppendedItem(track);
+        EngravingItem* item = segment->preAppendedItem(static_cast<int>(track));
         if (item && item->isGraceNotesGroup()) {
             GraceNotesGroup* gng = toGraceNotesGroup(item);
             gng->insert(gng->end(), gnb.begin(), gnb.end());
         } else {
-            segment->preAppend(&gnb, track);
+            segment->preAppend(&gnb, static_cast<int>(track));
         }
         segment->createShape(staffIdx);
     }
@@ -1223,7 +1223,7 @@ void LayoutChords::appendGraceNotes(Chord* chord)
             followingSeg = followingSeg->next();
         }
         if (followingSeg) {
-            followingSeg->preAppend(&gna, track);
+            followingSeg->preAppend(&gna, static_cast<int>(track));
             followingSeg->createShape(staffIdx);
         }
     }
@@ -1234,9 +1234,9 @@ void LayoutChords::appendGraceNotes(Chord* chord)
 *  is needed and must be called AFTER horizontal spacing is calculated. */
 void LayoutChords::repositionGraceNotesAfter(Segment* segment)
 {
-    int tracks = segment->score()->staves().size() * VOICES;
-    for (int track = 0; track < tracks; track++) {
-        EngravingItem* item = segment->preAppendedItem(track);
+    size_t tracks = segment->score()->staves().size() * VOICES;
+    for (size_t track = 0; track < tracks; track++) {
+        EngravingItem* item = segment->preAppendedItem(static_cast<int>(track));
         if (!item || !item->isGraceNotesGroup()) {
             continue;
         }

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -4108,7 +4108,7 @@ GraceNotesGroup::GraceNotesGroup(Chord* c)
 void GraceNotesGroup::layout()
 {
     _shape.clear();
-    for (int i = this->size() - 1; i >= 0; --i) {
+    for (size_t i = this->size() - 1; i != mu::nidx; --i) {
         Chord* chord = this->at(i);
         Shape chordShape = chord->shape();
         double offset;

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -2236,7 +2236,7 @@ void Segment::createShape(staff_idx_t staffIdx)
             s.add(r.translated(bl->pos()), bl);
         }
         s.addHorizontalSpacing(bl, 0, 0);
-        addPreAppendedToShape(staffIdx, s);
+        addPreAppendedToShape(static_cast<int>(staffIdx), s);
         //s.addHorizontalSpacing(Shape::SPACING_LYRICS, 0, 0);
         return;
     }
@@ -2296,7 +2296,7 @@ void Segment::createShape(staff_idx_t staffIdx)
         }
     }
 
-    addPreAppendedToShape(staffIdx, s);
+    addPreAppendedToShape(static_cast<int>(staffIdx), s);
 }
 
 void Segment::addPreAppendedToShape(int staffIdx, Shape& s)


### PR DESCRIPTION
reg. conversion from 'size_t' to 'int', possible loss of data (C4267), introduced by #11394