### PR TITLE
Resolve #11253 - Add 'To Back' and 'To Front' buttons to 'Arrange'

### DIFF
--- a/src/inspector/models/general/appearance/appearancesettingsmodel.cpp
+++ b/src/inspector/models/general/appearance/appearancesettingsmodel.cpp
@@ -111,12 +111,12 @@ std::vector<Ms::EngravingItem*> AppearanceSettingsModel::getAllElementsInPage()
     return page->elements();
 }
 
-void AppearanceSettingsModel::pushBackInOrder()
+void AppearanceSettingsModel::pushBackwardsInOrder()
 {
     m_arrangeOrder->setValue(m_arrangeOrder->value().toInt() - REARRANGE_ORDER_STEP);
 }
 
-void AppearanceSettingsModel::pushFrontInOrder()
+void AppearanceSettingsModel::pushForwardsInOrder()
 {
     m_arrangeOrder->setValue(m_arrangeOrder->value().toInt() + REARRANGE_ORDER_STEP);
 }

--- a/src/inspector/models/general/appearance/appearancesettingsmodel.cpp
+++ b/src/inspector/models/general/appearance/appearancesettingsmodel.cpp
@@ -103,6 +103,14 @@ void AppearanceSettingsModel::loadOffsets()
     });
 }
 
+std::vector<Ms::EngravingItem*> AppearanceSettingsModel::getAllElementsInPage()
+{
+    requestElements();
+    Ms::EngravingItem* element = m_elementList.first();
+    Ms::Page* page = toPage(element->findAncestor(Ms::ElementType::PAGE));
+    return page->elements();
+}
+
 void AppearanceSettingsModel::pushBackInOrder()
 {
     m_arrangeOrder->setValue(m_arrangeOrder->value().toInt() - REARRANGE_ORDER_STEP);
@@ -111,6 +119,30 @@ void AppearanceSettingsModel::pushBackInOrder()
 void AppearanceSettingsModel::pushFrontInOrder()
 {
     m_arrangeOrder->setValue(m_arrangeOrder->value().toInt() + REARRANGE_ORDER_STEP);
+}
+
+void AppearanceSettingsModel::pushToBackInOrder()
+{
+    std::vector<Ms::EngravingItem*> elementsInPage = getAllElementsInPage();
+    EngravingItem* min_element = *std::min_element(elementsInPage.begin(), elementsInPage.end(), Ms::elementLessThan);
+
+    if (m_elementList.contains(min_element)) {
+        m_arrangeOrder->setValue(min_element->z());
+    } else {
+        m_arrangeOrder->setValue(min_element->z() - REARRANGE_ORDER_STEP / 2);
+    }
+}
+
+void AppearanceSettingsModel::pushToFrontInOrder()
+{
+    std::vector<Ms::EngravingItem*> elementsInPage = getAllElementsInPage();
+    EngravingItem* max_element = *std::max_element(elementsInPage.begin(), elementsInPage.end(), Ms::elementLessThan);
+
+    if (m_elementList.contains(max_element)) {
+        m_arrangeOrder->setValue(max_element->z());
+    } else {
+        m_arrangeOrder->setValue(max_element->z() + REARRANGE_ORDER_STEP / 2);
+    }
 }
 
 void AppearanceSettingsModel::configureGrid()

--- a/src/inspector/models/general/appearance/appearancesettingsmodel.h
+++ b/src/inspector/models/general/appearance/appearancesettingsmodel.h
@@ -47,6 +47,8 @@ public:
 
     Q_INVOKABLE void pushBackInOrder();
     Q_INVOKABLE void pushFrontInOrder();
+    Q_INVOKABLE void pushToBackInOrder();
+    Q_INVOKABLE void pushToFrontInOrder();
 
     Q_INVOKABLE void configureGrid();
 
@@ -75,6 +77,7 @@ private:
     void updatePropertiesOnNotationChanged() override;
 
     void loadOffsets();
+    std::vector<Ms::EngravingItem*> getAllElementsInPage();
 
     PropertyItem* m_leadingSpace = nullptr;
     PropertyItem* m_barWidth = nullptr;

--- a/src/inspector/models/general/appearance/appearancesettingsmodel.h
+++ b/src/inspector/models/general/appearance/appearancesettingsmodel.h
@@ -77,7 +77,9 @@ private:
     void updatePropertiesOnNotationChanged() override;
 
     void loadOffsets();
-    std::vector<Ms::EngravingItem*> getAllElementsInPage();
+    mu::engraving::Page* getPage();
+    std::vector<mu::engraving::EngravingItem*> getAllElementsInPage();
+    std::vector<mu::engraving::EngravingItem*> getAllOverlappingElements();
 
     PropertyItem* m_leadingSpace = nullptr;
     PropertyItem* m_barWidth = nullptr;

--- a/src/inspector/models/general/appearance/appearancesettingsmodel.h
+++ b/src/inspector/models/general/appearance/appearancesettingsmodel.h
@@ -45,8 +45,8 @@ class AppearanceSettingsModel : public AbstractInspectorModel
 public:
     explicit AppearanceSettingsModel(QObject* parent, IElementRepositoryService* repository);
 
-    Q_INVOKABLE void pushBackInOrder();
-    Q_INVOKABLE void pushFrontInOrder();
+    Q_INVOKABLE void pushBackwardsInOrder();
+    Q_INVOKABLE void pushForwardsInOrder();
     Q_INVOKABLE void pushToBackInOrder();
     Q_INVOKABLE void pushToFrontInOrder();
 

--- a/src/inspector/view/qml/MuseScore/Inspector/general/appearance/AppearanceSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/general/appearance/AppearanceSettings.qml
@@ -107,6 +107,18 @@ Column {
                 root.model.pushFrontInOrder()
             }
         }
+
+        onPushToBackRequested: {
+            if (root.model) {
+                root.model.pushToBackInOrder()
+            }
+        }
+
+        onPushToFrontRequested: {
+            if (root.model) {
+                root.model.pushToFrontInOrder()
+            }
+        }
     }
 
     SeparatorLine { anchors.margins: -12 }

--- a/src/inspector/view/qml/MuseScore/Inspector/general/appearance/AppearanceSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/general/appearance/AppearanceSettings.qml
@@ -96,15 +96,15 @@ Column {
         navigationPanel: root.navigationPanel
         navigationRowStart: offsetSection.navigationRowEnd
 
-        onPushBackRequested: {
+        onPushBackwardsRequested: {
             if (root.model) {
-                root.model.pushBackInOrder()
+                root.model.pushBackwardsInOrder()
             }
         }
 
-        onPushFrontRequested: {
+        onPushForwardsRequested: {
             if (root.model) {
-                root.model.pushFrontInOrder()
+                root.model.pushForwardsInOrder()
             }
         }
 

--- a/src/inspector/view/qml/MuseScore/Inspector/general/appearance/internal/ArrangeSection.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/general/appearance/internal/ArrangeSection.qml
@@ -33,6 +33,8 @@ Column {
 
     signal pushBackRequested()
     signal pushFrontRequested()
+    signal pushToBackRequested()
+    signal pushToFrontRequested()
 
     height: implicitHeight
     width: parent.width
@@ -84,6 +86,45 @@ Column {
 
                 onClicked: {
                     root.pushFrontRequested()
+                }
+            }
+        }
+
+        Item {
+            height: childrenRect.height
+            width: parent.width
+
+            FlatButton {
+                id: toBackButton
+                anchors.left: parent.left
+                anchors.right: parent.horizontalCenter
+                anchors.rightMargin: 4
+
+                navigation.name: "To Back"
+                navigation.panel: root.navigationPanel
+                navigation.row: root.navigationRowStart + 1
+
+                text: qsTrc("inspector", "To Back")
+
+                onClicked: {
+                    root.pushToBackRequested()
+                }
+            }
+
+            FlatButton {
+                id: toFrontButton
+                anchors.left: parent.horizontalCenter
+                anchors.leftMargin: 4
+                anchors.right: parent.right
+
+                navigation.name: "To Front"
+                navigation.panel: root.navigationPanel
+                navigation.row: root.navigationRowStart + 2
+
+                text: qsTrc("inspector", "To Front")
+
+                onClicked: {
+                    root.pushToFrontRequested()
                 }
             }
         }

--- a/src/inspector/view/qml/MuseScore/Inspector/general/appearance/internal/ArrangeSection.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/general/appearance/internal/ArrangeSection.qml
@@ -31,8 +31,8 @@ Column {
     property int navigationRowStart: 0
     property int navigationRowEnd: forwardsButton.navigation.row
 
-    signal pushBackRequested()
-    signal pushFrontRequested()
+    signal pushBackwardsRequested()
+    signal pushForwardsRequested()
     signal pushToBackRequested()
     signal pushToFrontRequested()
 
@@ -68,7 +68,7 @@ Column {
                 text: qsTrc("inspector", "Backwards")
 
                 onClicked: {
-                    root.pushBackRequested()
+                    root.pushBackwardsRequested()
                 }
             }
 
@@ -85,7 +85,7 @@ Column {
                 text: qsTrc("inspector", "Forwards")
 
                 onClicked: {
-                    root.pushFrontRequested()
+                    root.pushForwardsRequested()
                 }
             }
         }


### PR DESCRIPTION
Resolves: [#11253](https://github.com/musescore/MuseScore/issues/11253)

*I've added a "To Back" and "To Front" buttons to the "Arrange" section of an item's "Appearance" settings. These would immediately push the selected items to the front or back of the score (in the z-axis).*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
