### PR TITLE
[MU4] Fix strange beam placement inconsistencies

### DIFF
--- a/src/engraving/utests/chordsymbol_data/realize-triplet-ref.mscx
+++ b/src/engraving/utests/chordsymbol_data/realize-triplet-ref.mscx
@@ -749,7 +749,7 @@
             </Tuplet>
           <Beam>
             <l1>-8</l1>
-            <l2>-4</l2>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <durationType>16th</durationType>
@@ -1133,8 +1133,8 @@
               </Number>
             </Tuplet>
           <Beam>
-            <l1>-8</l1>
-            <l2>-10</l2>
+            <l1>-12</l1>
+            <l2>-14</l2>
             </Beam>
           <Chord>
             <durationType>32nd</durationType>

--- a/src/engraving/utests/exchangevoices_data/exchangevoices-slurs-ref.mscx
+++ b/src/engraving/utests/exchangevoices_data/exchangevoices-slurs-ref.mscx
@@ -129,7 +129,7 @@
             </Chord>
           <Beam>
             <l1>44</l1>
-            <l2>36</l2>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/implode_explode_data/implode1-ref.mscx
+++ b/src/engraving/utests/implode_explode_data/implode1-ref.mscx
@@ -1113,8 +1113,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-6</l1>
-            <l2>-2</l2>
+            <l1>-8</l1>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/implode_explode_data/implode1.mscx
+++ b/src/engraving/utests/implode_explode_data/implode1.mscx
@@ -698,8 +698,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-6</l1>
-            <l2>-2</l2>
+            <l1>-8</l1>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/implode_explode_data/undoExplode01-ref.mscx
+++ b/src/engraving/utests/implode_explode_data/undoExplode01-ref.mscx
@@ -372,8 +372,8 @@
               </Number>
             </Tuplet>
           <Beam>
-            <l1>16</l1>
-            <l2>22</l2>
+            <l1>22</l1>
+            <l2>24</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -552,7 +552,7 @@
               </Number>
             </Tuplet>
           <Beam>
-            <l1>28</l1>
+            <l1>30</l1>
             <l2>32</l2>
             </Beam>
           <Chord>

--- a/src/engraving/utests/implode_explode_data/undoExplode02-ref.mscx
+++ b/src/engraving/utests/implode_explode_data/undoExplode02-ref.mscx
@@ -526,8 +526,8 @@
               </Number>
             </Tuplet>
           <Beam>
-            <l1>16</l1>
-            <l2>22</l2>
+            <l1>22</l1>
+            <l2>24</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>


### PR DESCRIPTION
The beams would snap back and forth to weird locations after generating thumbnails (due to save and autosave, for example) since a layout, but importantly, _not_ an update, was triggered. During a layout not following an update, `explicitParent` was not set for systems, which accounted for the inconsistencies between the update and non-update layouts.

The incorrect beam locations, however, stemmed from the fact that when the systems _did_ have an explicit parent, the code to translate mm position to quarter-space locations was based on coordinates based on the page, which resulted in strange rounding errors when compared to coordinates based on the top of the staff. This PR fixes that by using system coordinates when the beams are not cross-staff. If they are cross-staff, they will still need to use page or canvas coordinates, because the relative location of each staff is important. However, for beamed groups that are all on the same staff, it's been fixed to use only system coordinates, where y=0 is the very top of the system we are using.