### PR TITLE
Change slur beam anchor to account for new beam placement w/r/t stem

### DIFF
--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -965,8 +965,8 @@ void Slur::slurPos(SlurPos* sp)
                 // and slur direction is same as start chord (stem side)
 
                 // in these cases, layout start of slur to stem
-
-                qreal sh = stem1->height() + (beamClearance * _spatium);
+                qreal beamWidthSp = score()->styleS(Sid::beamWidth).val() * beam1->mag();
+                qreal sh = stem1->height() + ((beamWidthSp / 2 + beamClearance) * _spatium);
                 if (_up) {
                     po.ry() = sc->downNote()->pos().y() - sh;
                 } else {
@@ -1082,8 +1082,8 @@ void Slur::slurPos(SlurPos* sp)
                     // and start chordrest is not a grace chord
 
                     // in these cases, layout end of slur to stem
-
-                    qreal sh = stem2->height() + (beamClearance * _spatium);
+                    qreal beamWidthSp = beam2 ? score()->styleS(Sid::beamWidth).val() * beam2->mag() : 0;
+                    qreal sh = stem2->height() + ((beamClearance + (beamWidthSp / 2)) * _spatium);
                     if (_up) {
                         po.ry() = ec->downNote()->pos().y() - sh;
                     } else {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/89263931/170517068-b21c9c38-2d62-4ea7-91ca-dfa71cc7e9c4.png)
The stems used to extend to the bottom of the beams, and now that they end in the middle of the beam, the slurs have to account for some extra space the beam creates.