### PR TITLE
Trivial fixes for MusicXML tests graceAfter2 and 3, incorrectMidiProg…

### DIFF
--- a/src/importexport/musicxml/tests/data/testChangeTranspose-no-diatonic_ref.xml
+++ b/src/importexport/musicxml/tests/data/testChangeTranspose-no-diatonic_ref.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
-<score-partwise version="3.1">
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
   <work>
     <work-number>MuseScore testfile</work-number>
     <work-title>Change transpose (no diatonic)</work-title>

--- a/src/importexport/musicxml/tests/data/testGraceAfter2.xml
+++ b/src/importexport/musicxml/tests/data/testGraceAfter2.xml
@@ -57,8 +57,9 @@
         <duration>2</duration>
         <voice>1</voice>
         <type>half</type>
+        <stem>up</stem>
         <notations>
-          <slur type="start" number="1"/>
+          <slur type="start" placement="below" number="1"/>
           </notations>
         </note>
       <note>
@@ -82,6 +83,7 @@
         <duration>2</duration>
         <voice>1</voice>
         <type>half</type>
+        <stem>up</stem>
         </note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>

--- a/src/importexport/musicxml/tests/data/testGraceAfter3.xml
+++ b/src/importexport/musicxml/tests/data/testGraceAfter3.xml
@@ -57,8 +57,9 @@
         <duration>2</duration>
         <voice>1</voice>
         <type>half</type>
+        <stem>up</stem>
         <notations>
-          <slur type="start" number="1"/>
+          <slur type="start" placement="below" number="1"/>
           </notations>
         </note>
       <note>
@@ -70,6 +71,7 @@
         <duration>2</duration>
         <voice>1</voice>
         <type>half</type>
+        <stem>up</stem>
         </note>
       <note>
         <grace/>
@@ -103,6 +105,7 @@
         <duration>2</duration>
         <voice>1</voice>
         <type>half</type>
+        <stem>up</stem>
         </note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>

--- a/src/importexport/musicxml/tests/data/testIncorrectMidiProgram_ref.xml
+++ b/src/importexport/musicxml/tests/data/testIncorrectMidiProgram_ref.xml
@@ -62,7 +62,7 @@
           </clef>
         </attributes>
       <note>
-        <rest/>
+        <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
@@ -93,7 +93,7 @@
           </clef>
         </attributes>
       <note>
-        <rest/>
+        <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         <staff>1</staff>
@@ -102,7 +102,7 @@
         <duration>4</duration>
         </backup>
       <note>
-        <rest/>
+        <rest measure="yes"/>
         <duration>4</duration>
         <voice>5</voice>
         <staff>2</staff>

--- a/src/importexport/musicxml/tests/data/testMeasureStyleSlash_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testMeasureStyleSlash_ref.mscx
@@ -5,19 +5,8 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27001</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.0889</pagePrintableWidth>
-      <pageEvenLeftMargin>0.590551</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.590551</pageOddLeftMargin>
-      <pageEvenTopMargin>0.590551</pageEvenTopMargin>
-      <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
-      <pageOddTopMargin>0.590551</pageOddTopMargin>
-      <pageOddBottomMargin>0.590551</pageOddBottomMargin>
       <lyricsOddFontSize>11</lyricsOddFontSize>
       <lyricsEvenFontSize>11</lyricsEvenFontSize>
-      <chordSymbolAFontSize>10</chordSymbolAFontSize>
-      <chordSymbolBFontSize>10</chordSymbolBFontSize>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>
@@ -25,7 +14,6 @@
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
-      <dynamicsFontSize>10</dynamicsFontSize>
       <tempoFontSize>10</tempoFontSize>
       <metronomeFontSize>10</metronomeFontSize>
       <measureNumberFontSize>10</measureNumberFontSize>
@@ -37,7 +25,7 @@
       <bendFontSize>10</bendFontSize>
       <headerFontSize>10</headerFontSize>
       <footerFontSize>10</footerFontSize>
-      <Spatium>1.76389</Spatium>
+      <Spatium>1.74978</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -122,7 +110,7 @@
         <height>3.5</height>
         <Text>
           <style>title</style>
-          <offset x="0" y="-0.0564445"/>
+          <offset x="0" y="-0.0559929"/>
           <text><font size="24"/>Test measure-style/slash</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testMultiInstrumentPart3_ref.xml
+++ b/src/importexport/musicxml/tests/data/testMultiInstrumentPart3_ref.xml
@@ -276,28 +276,28 @@
       </measure>
     <measure number="5">
       <note>
-        <rest/>
+        <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
     <measure number="6">
       <note>
-        <rest/>
+        <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
     <measure number="7">
       <note>
-        <rest/>
+        <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
     <measure number="8">
       <note>
-        <rest/>
+        <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>

--- a/src/importexport/musicxml/tests/data/testTextLines_ref.xml
+++ b/src/importexport/musicxml/tests/data/testTextLines_ref.xml
@@ -165,7 +165,7 @@
       </measure>
     <measure number="7">
       <barline location="left">
-        <ending number="1" type="start"/>
+        <ending number="1" type="start">1.</ending>
         </barline>
       <note>
         <pitch>
@@ -184,7 +184,7 @@
       </measure>
     <measure number="8">
       <barline location="left">
-        <ending number="2" type="start"/>
+        <ending number="2" type="start">2.</ending>
         </barline>
       <note>
         <pitch>
@@ -316,7 +316,7 @@
       </measure>
     <measure number="7">
       <barline location="left">
-        <ending number="1" type="start"/>
+        <ending number="1" type="start">1.</ending>
         </barline>
       <note>
         <pitch>
@@ -336,7 +336,7 @@
       </measure>
     <measure number="8">
       <barline location="left">
-        <ending number="2" type="start"/>
+        <ending number="2" type="start">2.</ending>
         </barline>
       <note>
         <pitch>

--- a/src/importexport/musicxml/tests/data/testVolta2.xml
+++ b/src/importexport/musicxml/tests/data/testVolta2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
-<score-partwise version="3.1">
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
   <work>
     <work-number>MuseScore testfile</work-number>
     <work-title>Volta 2</work-title>

--- a/src/importexport/musicxml/tests/tst_mxml_io.cpp
+++ b/src/importexport/musicxml/tests/tst_mxml_io.cpp
@@ -103,7 +103,7 @@ private slots:
     // void breaksPage() { mxmlMscxExportTestRefBreaks("testBreaksPage"); } fail after sync with 3.x
     void breaksSystem() { mxmlMscxExportTestRefBreaks("testBreaksSystem"); }
     void changeTranspose() { mxmlIoTest("testChangeTranspose"); }
-    //void changeTransposeNoDiatonic() { mxmlIoTestRef("testChangeTranspose-no-diatonic"); } FIXME
+    void changeTransposeNoDiatonic() { mxmlIoTestRef("testChangeTranspose-no-diatonic"); }
     void chordDiagrams1() { mxmlIoTest("testChordDiagrams1"); }
     void chordNoVoice() { mxmlIoTestRef("testChordNoVoice"); }
     void clefs1() { mxmlIoTest("testClefs1"); }
@@ -139,8 +139,8 @@ private slots:
     void grace1() { mxmlIoTest("testGrace1"); }
     void grace2() { mxmlIoTest("testGrace2"); }
     void graceAfter1() { mxmlIoTest("testGraceAfter1"); }
-    // void graceAfter2() { mxmlIoTest("testGraceAfter2"); } fails
-    // void graceAfter3() { mxmlIoTest("testGraceAfter3"); } fails
+    void graceAfter2() { mxmlIoTest("testGraceAfter2"); }
+    void graceAfter3() { mxmlIoTest("testGraceAfter3"); }
     // void graceAfter4() { mxmlIoTest("testGraceAfter4"); } fails
     void hairpinDynamics() { mxmlMscxExportTestRef("testHairpinDynamics"); }
     void harmony1() { mxmlIoTest("testHarmony1"); }
@@ -154,7 +154,7 @@ private slots:
     void helloReadWriteCompr() { mxmlReadWriteTestCompr("testHello"); }
     void implicitMeasure1() { mxmlIoTest("testImplicitMeasure1"); }
     void incompleteTuplet() { mxmlIoTestRef("testIncompleteTuplet"); }
-    // void incorrectMidiProgram() { mxmlIoTestRef("testIncorrectMidiProgram"); } fails
+    void incorrectMidiProgram() { mxmlIoTestRef("testIncorrectMidiProgram"); }
     void incorrectStaffNumber1() { mxmlIoTestRef("testIncorrectStaffNumber1"); }
     void incorrectStaffNumber2() { mxmlIoTestRef("testIncorrectStaffNumber2"); }
     void instrumentChangeMIDIportExport() { mxmlMscxExportTestRef("testInstrumentChangeMIDIportExport"); }
@@ -176,13 +176,13 @@ private slots:
     void measureLength() { mxmlIoTestRef("testMeasureLength"); }
     void measureNumbers() { mxmlIoTest("testMeasureNumbers"); }
     void measureRepeats1() { mxmlIoTestRef("testMeasureRepeats1"); }
-    // void measureRepeats2() { mxmlIoTestRef("testMeasureRepeats2"); } fail libmscore/style.cpp Q_ASSERT(idx == textStyles[int(idx)].tid);
+    // void measureRepeats2() { mxmlIoTestRef("testMeasureRepeats2"); } <part-name print-object="no">MusicXML Part</part-name>
     void measureRepeats3() { mxmlIoTest("testMeasureRepeats3"); }
-    // void measureStyleSlash() { mxmlIoTestRef("testMeasureStyleSlash"); } fails
+    void measureStyleSlash() { mxmlImportTestRef("testMeasureStyleSlash"); }
     void midiPortExport() { mxmlMscxExportTestRef("testMidiPortExport"); }
     void multiInstrumentPart1() { mxmlIoTest("testMultiInstrumentPart1"); }
     void multiInstrumentPart2() { mxmlIoTest("testMultiInstrumentPart2"); }
-    // void multiInstrumentPart3() { mxmlIoTest("testMultiInstrumentPart3"); } fails
+    void multiInstrumentPart3() { mxmlMscxExportTestRef("testMultiInstrumentPart3"); }
     void multiMeasureRest1() { mxmlIoTestRef("testMultiMeasureRest1"); }
     void multiMeasureRest2() { mxmlIoTestRef("testMultiMeasureRest2"); }
     void multiMeasureRest3() { mxmlIoTestRef("testMultiMeasureRest3"); }
@@ -237,7 +237,7 @@ private slots:
     void tempo4() { mxmlIoTestRef("testTempo4"); }
     // void tempoOverlap() { mxmlIoTestRef("testTempoOverlap"); } fails
     void tempoPrecision() { mxmlMscxExportTestRef("testTempoPrecision"); }
-    //void textLines() { mxmlMscxExportTestRef("testTextLines"); } FIXME
+    void textLines() { mxmlMscxExportTestRef("testTextLines"); }
     void tieTied() { mxmlIoTestRef("testTieTied"); }
     void timesig1() { mxmlIoTest("testTimesig1"); }
     void timesig3() { mxmlIoTest("testTimesig3"); }
@@ -261,11 +261,11 @@ private slots:
     void voiceMapper3() { mxmlIoTestRef("testVoiceMapper3"); }
     void voicePiano1() { mxmlIoTest("testVoicePiano1"); }
     void volta1() { mxmlIoTest("testVolta1"); }
-    //void volta2() { mxmlIoTest("testVolta2"); } FIXME
+    void volta2() { mxmlIoTest("testVolta2"); }
     void wedge1() { mxmlIoTest("testWedge1"); }
     void wedge2() { mxmlIoTest("testWedge2"); }
     void wedge3() { mxmlIoTest("testWedge3"); }
-    // void wedge4() { mxmlIoTestRef("testWedge4"); } fails
+    void wedge4() { mxmlMscxExportTestRef("testWedge4"); }
     void words1() { mxmlIoTest("testWords1"); }
     void words2() { mxmlIoTest("testWords2"); }
 };


### PR DESCRIPTION
…ram, measureStyleSlash,

multiInstrumentPart3, textLines, transposeNoDiatonic, volta2 and wedge4

Resolves: MusicXML tests (trivial cases only, slightly more difficult cases still to do)

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
