### PR TITLE
[MU4] Fix compiler warnings

### DIFF
--- a/share/icons/windows_icons.rc
+++ b/share/icons/windows_icons.rc
@@ -1,3 +1,3 @@
-IDI_ICON1   ICON  DISCARDABLE "AppIcon\MS4_AppIcon.ico"
-IDI_ICON2   ICON  DISCARDABLE "MsczIcon\MS4_MsczIcon.ico"
-IDI_ICON3   ICON  DISCARDABLE "MscxIcon\MS4_MscxIcon.ico"
+IDI_ICON1   ICON  DISCARDABLE "AppIcon\\MS4_AppIcon.ico"
+IDI_ICON2   ICON  DISCARDABLE "MsczIcon\\MS4_MsczIcon.ico"
+IDI_ICON3   ICON  DISCARDABLE "MscxIcon\\MS4_MscxIcon.ico"

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -250,9 +250,9 @@ void GPConverter::convertBars(const std::vector<std::unique_ptr<GPBar> >& bars, 
 
 void GPConverter::convertBar(const GPBar* bar, Context ctx)
 {
-    addClef(bar, ctx.curTrack);
+    addClef(bar, static_cast<int>(ctx.curTrack));
 
-    if (addSimileMark(bar, ctx.curTrack)) {
+    if (addSimileMark(bar, static_cast<int>(ctx.curTrack))) {
         return;
     }
     convertVoices(bar->voices(), ctx);
@@ -1937,7 +1937,7 @@ void GPConverter::addFretDiagram(const GPBeat* gpnote, ChordRest* cr, const Cont
 {
     static int last_idx = -1;
 
-    int GPTrackIdx = ctx.curTrack;
+    int GPTrackIdx = static_cast<int>(ctx.curTrack);
     int diaId = gpnote->diagramIdx(GPTrackIdx, ctx.masterBarIndex);
 
     if (last_idx == diaId) {

--- a/src/project/internal/projectaudiosettings.cpp
+++ b/src/project/internal/projectaudiosettings.cpp
@@ -366,7 +366,7 @@ QJsonObject ProjectAudioSettings::unitConfigToJson(const audio::AudioUnitConfig&
     QJsonObject result;
 
     for (const auto& pair : config) {
-        QByteArray byteArray = QByteArray::fromRawData(pair.second.c_str(), pair.second.size());
+        QByteArray byteArray = QByteArray::fromRawData(pair.second.c_str(), static_cast<int>(pair.second.size()));
         result.insert(QString::fromStdString(pair.first), QString(byteArray.toBase64()));
     }
 


### PR DESCRIPTION
* Fix QtCreator/MinGW compiler (?) warnings reg. unrecognized escape sequence (since #11556)
* Fix MSVC compiler warnings reg. conversion from 'size_t' to 'int', possible loss of data (C4267)
 (since #11822, #11825, #11849)