### PR TITLE
Fixes for non-unity build

### DIFF
--- a/src/framework/uicomponents/view/internal/popupviewclosecontroller.cpp
+++ b/src/framework/uicomponents/view/internal/popupviewclosecontroller.cpp
@@ -23,6 +23,7 @@
 #include "popupviewclosecontroller.h"
 
 #include <QApplication>
+#include <QWindow>
 
 using namespace mu::uicomponents;
 

--- a/src/framework/uicomponents/view/menuview.cpp
+++ b/src/framework/uicomponents/view/menuview.cpp
@@ -22,6 +22,8 @@
 
 #include "menuview.h"
 
+#include "log.h"
+
 using namespace mu::uicomponents;
 
 static const QString MENU_VIEW_CONTENT_OBJECT_NAME("_MenuViewContent");

--- a/src/notation/view/loopmarker.cpp
+++ b/src/notation/view/loopmarker.cpp
@@ -22,6 +22,7 @@
 
 #include "loopmarker.h"
 #include "draw/pen.h"
+#include "libmscore/scorefont.h"
 
 using namespace mu::notation;
 using namespace mu;

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -34,6 +34,7 @@
 #include "engraving/engravingerrors.h"
 #include "engraving/style/defaultstyle.h"
 
+#include "iprojectautosaver.h"
 #include "notation/notationerrors.h"
 #include "projectaudiosettings.h"
 #include "projectfileinfoprovider.h"


### PR DESCRIPTION
Resolves: 

These patches fixes compile error when building MuseScore with `-DBUILD_UNITY=OFF`


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
