### PR TITLE
Fix #11498 Unpredictable stem direction on middle line

### DIFF
--- a/share/templates/01-General/01-Treble_Clef/score_style.mss
+++ b/share/templates/01-General/01-Treble_Clef/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/01-General/02-Bass_Clef/score_style.mss
+++ b/share/templates/01-General/02-Bass_Clef/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/01-General/03-Grand_Staff/score_style.mss
+++ b/share/templates/01-General/03-Grand_Staff/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/02-Choral/01-SATB/score_style.mss
+++ b/share/templates/02-Choral/01-SATB/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/02-Choral/02-SATB_+_Organ/score_style.mss
+++ b/share/templates/02-Choral/02-SATB_+_Organ/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/02-Choral/03-SATB_+_Piano/score_style.mss
+++ b/share/templates/02-Choral/03-SATB_+_Piano/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/02-Choral/04-SATB_Closed_Score/score_style.mss
+++ b/share/templates/02-Choral/04-SATB_Closed_Score/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/02-Choral/05-SATB_Closed_Score_+_Organ/score_style.mss
+++ b/share/templates/02-Choral/05-SATB_Closed_Score_+_Organ/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/02-Choral/06-SATB_Closed_Score_+_Piano/score_style.mss
+++ b/share/templates/02-Choral/06-SATB_Closed_Score_+_Piano/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/02-Choral/07-Voice_+_Piano/score_style.mss
+++ b/share/templates/02-Choral/07-Voice_+_Piano/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/02-Choral/08-Barbershop_Quartet_(Men)/score_style.mss
+++ b/share/templates/02-Choral/08-Barbershop_Quartet_(Men)/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/02-Choral/09-Barbershop_Quartet_(Women)/score_style.mss
+++ b/share/templates/02-Choral/09-Barbershop_Quartet_(Women)/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/02-Choral/10-Liturgical_Unmetrical/score_style.mss
+++ b/share/templates/02-Choral/10-Liturgical_Unmetrical/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/02-Choral/11-Liturgical_Unmetrical_+_Organ/score_style.mss
+++ b/share/templates/02-Choral/11-Liturgical_Unmetrical_+_Organ/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.2</barNoteDistance>

--- a/share/templates/03-Chamber_Music/01-String_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/01-String_Quartet/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/03-Chamber_Music/02-Wind_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/02-Wind_Quartet/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/03-Chamber_Music/03-Wind_Quintet/score_style.mss
+++ b/share/templates/03-Chamber_Music/03-Wind_Quintet/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/03-Chamber_Music/04-Saxophone_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/04-Saxophone_Quartet/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/03-Chamber_Music/05-Brass_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/05-Brass_Quartet/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/03-Chamber_Music/06-Brass_Quintet/score_style.mss
+++ b/share/templates/03-Chamber_Music/06-Brass_Quintet/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/04-Solo/01-Guitar/score_style.mss
+++ b/share/templates/04-Solo/01-Guitar/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/04-Solo/02-Guitar_+_Tablature/score_style.mss
+++ b/share/templates/04-Solo/02-Guitar_+_Tablature/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/04-Solo/03-Guitar_Tablature/score_style.mss
+++ b/share/templates/04-Solo/03-Guitar_Tablature/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/04-Solo/04-Piano/score_style.mss
+++ b/share/templates/04-Solo/04-Piano/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/05-Jazz/01-Jazz_Lead_Sheet/score_style.mss
+++ b/share/templates/05-Jazz/01-Jazz_Lead_Sheet/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/05-Jazz/02-Big_Band/score_style.mss
+++ b/share/templates/05-Jazz/02-Big_Band/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/05-Jazz/03-Jazz_Combo/score_style.mss
+++ b/share/templates/05-Jazz/03-Jazz_Combo/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/06-Popular/01-Rock_Band/score_style.mss
+++ b/share/templates/06-Popular/01-Rock_Band/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/06-Popular/02-Bluegrass_Band/score_style.mss
+++ b/share/templates/06-Popular/02-Bluegrass_Band/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/07-Band_and_Percussion/01-Concert_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/01-Concert_Band/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/07-Band_and_Percussion/02-Small_Concert_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/02-Small_Concert_Band/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/07-Band_and_Percussion/03-Brass_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/03-Brass_Band/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/07-Band_and_Percussion/04-Marching_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/04-Marching_Band/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/07-Band_and_Percussion/05-Small_Marching_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/05-Small_Marching_Band/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/07-Band_and_Percussion/06-Battery_Percussion/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/06-Battery_Percussion/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/07-Band_and_Percussion/07-Large_Pit_Percussion/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/07-Large_Pit_Percussion/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/07-Band_and_Percussion/08-Small_Pit_Percussion/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/08-Small_Pit_Percussion/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/07-Band_and_Percussion/09-European_Concert_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/09-European_Concert_Band/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/08-Orchestral/01-Classical_Orchestra/score_style.mss
+++ b/share/templates/08-Orchestral/01-Classical_Orchestra/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/08-Orchestral/02-Symphony_Orchestra/score_style.mss
+++ b/share/templates/08-Orchestral/02-Symphony_Orchestra/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/share/templates/08-Orchestral/03-String_Orchestra/score_style.mss
+++ b/share/templates/08-Orchestral/03-String_Orchestra/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.6</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -1088,10 +1088,6 @@ void Chord::computeUp()
     int direction = Chord::computeAutoStemDirection(distances);
     _up = direction > 0;
     _usesAutoUp = direction == 0;
-
-    if (_usesAutoUp && score()->styleB(Sid::preferStemDirectionMatchContext)) {
-        _up = computeUpContext();
-    }
 }
 
 // return 1 means up, 0 means in the middle, -1 means down
@@ -1112,41 +1108,6 @@ int Chord::computeAutoStemDirection(const std::vector<int>& noteDistances)
         return netDirecting > 0 ? 1 : -1;
     }
     return 0;
-}
-
-bool Chord::computeUpContext()
-{
-    ChordRest* previous = prevChordRest(this);
-    bool previousIsChord = false;
-    bool previousIsUp = false;
-    if (previous) {
-        while (previous->isChord() && previous->usesAutoUp()) {
-            if (prevChordRest(previous)) {
-                previous = prevChordRest(previous);
-            } else {
-                break;
-            }
-        }
-        previousIsChord = previous->isChord();
-        previousIsUp = previous->isChord() && previous->up();
-    }
-
-    ChordRest* next = nextChordRest(this);
-    bool nextIsChord = false;
-    bool nextIsUp = false;
-    if (next) {
-        while (next->isChord() && next->usesAutoUp()) {
-            if (nextChordRest(next)) {
-                next = nextChordRest(next);
-            } else {
-                break;
-            }
-        }
-        nextIsChord = next->isChord();
-        nextIsUp = next->isChord() && next->up();
-    }
-
-    return (previousIsUp && nextIsUp) || (!previousIsChord && nextIsUp) || (!nextIsChord && previousIsUp);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/chord.h
+++ b/src/engraving/libmscore/chord.h
@@ -145,8 +145,6 @@ class Chord final : public ChordRest
     int calc4BeamsException(int stemLength) const;
     qreal calcDefaultStemLength();
 
-    bool computeUpContext();
-
 public:
 
     ~Chord();

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -187,7 +187,6 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::shortestStem,            "shortestStem",            PropertyValue(2.5) },
     { Sid::minStaffSizeForAutoStems, "minStaffSizeForAutoStems", 4 },
     { Sid::smallStaffStemDirection, "smallStaffStemDirection", DirectionV::UP },
-    { Sid::preferStemDirectionMatchContext, "preferStemDirectionMatchContext", false },
     { Sid::beginRepeatLeftMargin,   "beginRepeatLeftMargin",   Spatium(1.0) },
     { Sid::minNoteDistance,         "minNoteDistance",         Spatium(0.6) },
     { Sid::barNoteDistance,         "barNoteDistance",         Spatium(1.3) },     // was 1.2

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -199,7 +199,6 @@ enum class Sid {
     shortestStem,
     minStaffSizeForAutoStems,
     smallStaffStemDirection,
-    preferStemDirectionMatchContext,
     beginRepeatLeftMargin,
     minNoteDistance,
     barNoteDistance,

--- a/src/engraving/utests/playbackeventsrenderer_data/chord_arpeggio/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/chord_arpeggio/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/chord_arpeggio_bracket/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/chord_arpeggio_bracket/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/chord_arpeggio_down/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/chord_arpeggio_down/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/chord_arpeggio_straight_down/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/chord_arpeggio_straight_down/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/chord_arpeggio_straight_up/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/chord_arpeggio_straight_up/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/chord_arpeggio_up/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/chord_arpeggio_up/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/single_chord_tremolo/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/single_chord_tremolo/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/single_note_acciaccatura/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/single_note_acciaccatura/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/single_note_appoggiatura_post/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/single_note_appoggiatura_post/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/single_note_inverted_turn/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/single_note_inverted_turn/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/single_note_inverted_turn_slash_variation/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/single_note_inverted_turn_slash_variation/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/single_note_lower_mordent/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/single_note_lower_mordent/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/single_note_multi_acciaccatura/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/single_note_multi_acciaccatura/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/single_note_multi_appoggiatura_post/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/single_note_multi_appoggiatura_post/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/single_note_no_articulations/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/single_note_no_articulations/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/single_note_regular_turn/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/single_note_regular_turn/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/single_note_tenuto_accent/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/single_note_tenuto_accent/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/single_note_tremolo/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/single_note_tremolo/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/single_note_trill_baroque/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/single_note_trill_baroque/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.25</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.25</minNoteDistance>
     <barNoteDistance>1</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/single_note_trill_default_tempo/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/single_note_trill_default_tempo/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/single_note_unexpandable_trill/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/single_note_unexpandable_trill/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/single_note_upper_mordent/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/single_note_upper_mordent/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/two_chords_tremolo/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/two_chords_tremolo/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/two_notes_continuous_glissando/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/two_notes_continuous_glissando/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/two_notes_continuous_glissando_no_play/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/two_notes_continuous_glissando_no_play/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/two_notes_discrete_glissando/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/two_notes_discrete_glissando/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackeventsrenderer_data/whole_measure_rest/score_style.mss
+++ b/src/engraving/utests/playbackeventsrenderer_data/whole_measure_rest/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>1</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackmodel_data/da_capo_al_coda/score_style.mss
+++ b/src/engraving/utests/playbackmodel_data/da_capo_al_coda/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackmodel_data/da_capo_al_fine/score_style.mss
+++ b/src/engraving/utests/playbackmodel_data/da_capo_al_fine/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackmodel_data/dal_segno_al_coda/score_style.mss
+++ b/src/engraving/utests/playbackmodel_data/dal_segno_al_coda/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackmodel_data/dal_segno_al_fine/score_style.mss
+++ b/src/engraving/utests/playbackmodel_data/dal_segno_al_fine/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackmodel_data/metronome_4_4/score_style.mss
+++ b/src/engraving/utests/playbackmodel_data/metronome_4_4/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackmodel_data/metronome_6_4_with_repeat/score_style.mss
+++ b/src/engraving/utests/playbackmodel_data/metronome_6_4_with_repeat/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackmodel_data/note_entry_playback_chord/score_style.mss
+++ b/src/engraving/utests/playbackmodel_data/note_entry_playback_chord/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackmodel_data/note_entry_playback_note/score_style.mss
+++ b/src/engraving/utests/playbackmodel_data/note_entry_playback_note/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackmodel_data/pizz_to_arco/score_style.mss
+++ b/src/engraving/utests/playbackmodel_data/pizz_to_arco/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackmodel_data/playback_setup_instruments/score_style.mss
+++ b/src/engraving/utests/playbackmodel_data/playback_setup_instruments/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackmodel_data/repeat_last_measure/score_style.mss
+++ b/src/engraving/utests/playbackmodel_data/repeat_last_measure/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackmodel_data/repeat_range/score_style.mss
+++ b/src/engraving/utests/playbackmodel_data/repeat_range/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/playbackmodel_data/repeat_with_2_voltas/score_style.mss
+++ b/src/engraving/utests/playbackmodel_data/repeat_with_2_voltas/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/tempomap_data/absolute_tempo_80_to_120_bpm/score_style.mss
+++ b/src/engraving/utests/tempomap_data/absolute_tempo_80_to_120_bpm/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/tempomap_data/custom_tempo_80_bpm/score_style.mss
+++ b/src/engraving/utests/tempomap_data/custom_tempo_80_bpm/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/tempomap_data/default_tempo/score_style.mss
+++ b/src/engraving/utests/tempomap_data/default_tempo/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/tempomap_data/gradual_tempo_change_accelerando/score_style.mss
+++ b/src/engraving/utests/tempomap_data/gradual_tempo_change_accelerando/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>

--- a/src/engraving/utests/tempomap_data/gradual_tempo_change_rallentando/score_style.mss
+++ b/src/engraving/utests/tempomap_data/gradual_tempo_change_rallentando/score_style.mss
@@ -129,7 +129,6 @@
     <shortestStem>2.5</shortestStem>
     <minStaffSizeForAutoStems>4</minStaffSizeForAutoStems>
     <smallStaffStemDirection>1</smallStaffStemDirection>
-    <preferStemDirectionMatchContext>0</preferStemDirectionMatchContext>
     <beginRepeatLeftMargin>1</beginRepeatLeftMargin>
     <minNoteDistance>0.2</minNoteDistance>
     <barNoteDistance>1.3</barNoteDistance>


### PR DESCRIPTION
Resolves #11498 

No functional changes, just eliminating unused code and cleaning up the templates (which was the cause of the bug: the feature was partially implemented and then discarded but some templates still had the option in).