### PR TITLE
[MU4] Fix #11727: Choosing 'No effect' in Audio FX should close VST effect window

### DIFF
--- a/src/playback/view/internal/abstractaudioresourceitem.cpp
+++ b/src/playback/view/internal/abstractaudioresourceitem.cpp
@@ -16,11 +16,32 @@ AbstractAudioResourceItem::AbstractAudioResourceItem(QObject* parent)
 {
 }
 
+AbstractAudioResourceItem::~AbstractAudioResourceItem()
+{
+    if (m_editorUri.isValid()) {
+        emit nativeEditorViewCloseRequested();
+    }
+}
+
 void AbstractAudioResourceItem::requestToLaunchNativeEditorView()
 {
     if (hasNativeEditorSupport()) {
-        QTimer::singleShot(EXPLICIT_DELAY_MSECS, this, &AbstractAudioResourceItem::nativeEditorViewLaunchRequested);
+        doRequestToLaunchNativeEditorView();
     }
+}
+
+void AbstractAudioResourceItem::updateNativeEditorView()
+{
+    if (hasNativeEditorSupport()) {
+        doRequestToLaunchNativeEditorView();
+    } else if (m_editorUri.isValid()) {
+        emit nativeEditorViewCloseRequested();
+    }
+}
+
+void AbstractAudioResourceItem::doRequestToLaunchNativeEditorView()
+{
+    QTimer::singleShot(EXPLICIT_DELAY_MSECS, this, &AbstractAudioResourceItem::nativeEditorViewLaunchRequested);
 }
 
 QString AbstractAudioResourceItem::title() const

--- a/src/playback/view/internal/abstractaudioresourceitem.h
+++ b/src/playback/view/internal/abstractaudioresourceitem.h
@@ -41,6 +41,7 @@ class AbstractAudioResourceItem : public QObject
 
 public:
     explicit AbstractAudioResourceItem(QObject* parent);
+    ~AbstractAudioResourceItem() override;
 
     virtual Q_INVOKABLE void requestAvailableResources() {}
     virtual Q_INVOKABLE void requestToLaunchNativeEditorView();
@@ -61,6 +62,7 @@ signals:
     void hasNativeEditorSupportChanged();
 
     void nativeEditorViewLaunchRequested();
+    void nativeEditorViewCloseRequested();
     void availableResourceListResolved(const QVariantList& resources);
 
 protected:
@@ -71,7 +73,11 @@ protected:
 
     void sortResourcesList(audio::AudioResourceMetaList& list);
 
+    void updateNativeEditorView();
+
 private:
+    void doRequestToLaunchNativeEditorView();
+
     UriQuery m_editorUri;
 };
 }

--- a/src/playback/view/internal/inputresourceitem.cpp
+++ b/src/playback/view/internal/inputresourceitem.cpp
@@ -191,7 +191,7 @@ void InputResourceItem::updateCurrentParams(const AudioResourceMeta& newMeta)
     emit isActiveChanged();
     emit inputParamsChanged();
 
-    requestToLaunchNativeEditorView();
+    updateNativeEditorView();
 }
 
 void InputResourceItem::updateAvailableResources(const AudioResourceMetaList& availableResources)

--- a/src/playback/view/internal/mixerchannelitem.cpp
+++ b/src/playback/view/internal/mixerchannelitem.cpp
@@ -327,6 +327,10 @@ InputResourceItem* MixerChannelItem::buildInputResourceItem()
         openEditor(newItem, uri);
     });
 
+    connect(newItem, &InputResourceItem::nativeEditorViewCloseRequested, this, [this, newItem]() {
+        closeEditor(newItem);
+    });
+
     return newItem;
 }
 
@@ -363,6 +367,10 @@ OutputResourceItem* MixerChannelItem::buildOutputResourceItem(const audio::Audio
         openEditor(newItem, uri);
     });
 
+    connect(newItem, &OutputResourceItem::nativeEditorViewCloseRequested, this, [this, newItem]() {
+        closeEditor(newItem);
+    });
+
     return newItem;
 }
 
@@ -378,6 +386,12 @@ void MixerChannelItem::openEditor(AbstractAudioResourceItem* item, const UriQuer
     } else {
         interactive()->open(editorUri);
     }
+}
+
+void MixerChannelItem::closeEditor(AbstractAudioResourceItem* item)
+{
+    interactive()->close(item->editorUri());
+    item->setEditorUri(UriQuery());
 }
 
 void MixerChannelItem::ensureBlankOutputResourceSlot()
@@ -423,6 +437,7 @@ void MixerChannelItem::removeRedundantEmptySlots()
 {
     for (OutputResourceItem* itemToRemove : emptySlotsToRemove()) {
         m_outputResourceItemList.removeOne(itemToRemove);
+        closeEditor(itemToRemove);
         itemToRemove->disconnect();
         itemToRemove->deleteLater();
     }

--- a/src/playback/view/internal/mixerchannelitem.h
+++ b/src/playback/view/internal/mixerchannelitem.h
@@ -147,6 +147,7 @@ private:
     void loadOutputResourceItemList(const audio::AudioFxChain& fxChain);
 
     void openEditor(AbstractAudioResourceItem* item, const UriQuery& editorUri);
+    void closeEditor(AbstractAudioResourceItem* item);
 
     audio::TrackId m_id = -1;
 

--- a/src/playback/view/internal/outputresourceitem.cpp
+++ b/src/playback/view/internal/outputresourceitem.cpp
@@ -141,7 +141,7 @@ void OutputResourceItem::updateCurrentFxParams(const AudioResourceMeta& newMeta)
     emit fxParamsChanged();
     emit isBlankChanged();
 
-    requestToLaunchNativeEditorView();
+    updateNativeEditorView();
 }
 
 void OutputResourceItem::updateAvailableFxVendorsMap(const audio::AudioResourceMetaList& availableFxResources)


### PR DESCRIPTION
Resolves: #11727
Resolves: #11726