### PR TITLE
fix #11816: placement of capo fret text

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.h
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.h
@@ -50,7 +50,7 @@ private:
 
     struct Context {
         int32_t masterBarIndex{ 0 };
-        int curTrack{ 0 };
+        track_idx_t curTrack{ 0 };
         Fraction curTick;
     };
 
@@ -157,6 +157,7 @@ private:
     std::unordered_multimap<int, GPMasterTracks::Automation> _tempoMap;
     std::unordered_map<track_idx_t, GPBar::Clef> _clefs;
     std::unordered_map<track_idx_t, GPBeat::DynamicType> _dynamics;
+    std::unordered_map<track_idx_t, bool> m_hasCapo;
     std::unordered_multimap<track_idx_t, Tie*> _ties; // map(track, tie)
     std::unordered_map<track_idx_t, Slur*> _slurs; // map(track, slur)
     std::vector<TextLineBase*> m_palmMutes;
@@ -169,6 +170,7 @@ private:
     Hairpin* _lastHairpin = nullptr;
     Ottava* _lastOttava = nullptr;
     Measure* _lastMeasure = nullptr;
+    bool m_showCapo = true; // TODO-gp : settings
 };
 } //end Ms namespace
 #endif // SCOREDOMBUILDER_H


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/11816*

*fixed capo fret text placement in guitar pro imported files*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
