### PR TITLE
[MU4] Fix #10264: Bars are not highlighted when adding elements from Palettes (missing MU3 feature)

### DIFF
--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -75,6 +75,8 @@ public:
 
     virtual QColor selectionColor(engraving::voice_idx_t voiceIndex = 0) const = 0;
 
+    virtual QColor dropRectColor() const = 0;
+
     virtual int selectionProximity() const = 0;
     virtual void setSelectionProximity(int proximity) = 0;
 

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -96,6 +96,7 @@ public:
     virtual bool drop(const PointF& pos, Qt::KeyboardModifiers modifiers) = 0;
     virtual const EngravingItem* dropTarget() const = 0;
     virtual void setDropTarget(const EngravingItem* item, bool notify = true) = 0;
+    virtual void setDropRect(const RectF& rect) = 0;
     virtual void endDrop() = 0;
     virtual async::Notification dropChanged() const = 0;
 

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -94,7 +94,6 @@ public:
     virtual bool startDrop(const QUrl& url) = 0;
     virtual bool isDropAccepted(const PointF& pos, Qt::KeyboardModifiers modifiers) = 0; //! NOTE Also may set drop target
     virtual bool drop(const PointF& pos, Qt::KeyboardModifiers modifiers) = 0;
-    virtual const EngravingItem* dropTarget() const = 0;
     virtual void setDropTarget(const EngravingItem* item, bool notify = true) = 0;
     virtual void setDropRect(const RectF& rect) = 0;
     virtual void endDrop() = 0;

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -413,6 +413,11 @@ QColor NotationConfiguration::selectionColor(engraving::voice_idx_t voiceIndex) 
     return engravingConfiguration()->selectionColor(voiceIndex).toQColor();
 }
 
+QColor NotationConfiguration::dropRectColor() const
+{
+    return QColor(80, 0, 0, 80);
+}
+
 int NotationConfiguration::selectionProximity() const
 {
     return settings()->value(SELECTION_PROXIMITY).toInt();

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -81,6 +81,8 @@ public:
 
     QColor selectionColor(engraving::voice_idx_t voiceIndex = 0) const override;
 
+    QColor dropRectColor() const override;
+
     int selectionProximity() const override;
     void setSelectionProximity(int proximity) override;
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1974,11 +1974,6 @@ bool NotationInteraction::dragTimeAnchorElement(const PointF& pos)
     return false;
 }
 
-const EngravingItem* NotationInteraction::dropTarget() const
-{
-    return m_dropData.dropTarget;
-}
-
 //! NOTE Copied from ScoreView::setDropTarget
 void NotationInteraction::setDropTarget(const EngravingItem* item, bool notify)
 {

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -102,6 +102,7 @@ public:
     bool drop(const PointF& pos, Qt::KeyboardModifiers modifiers) override;
     const EngravingItem* dropTarget() const override;
     void setDropTarget(const EngravingItem* item, bool notify = true) override;
+    void setDropRect(const RectF& rect) override;
     void endDrop() override;
     async::Notification dropChanged() const override;
 
@@ -369,6 +370,7 @@ private:
     {
         Ms::EditData ed;
         const EngravingItem* dropTarget = nullptr;
+        RectF dropRect;
     };
 
     ScoreCallbacks m_scoreCallbacks;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -100,7 +100,6 @@ public:
     bool startDrop(const QUrl& url) override;
     bool isDropAccepted(const PointF& pos, Qt::KeyboardModifiers modifiers) override;
     bool drop(const PointF& pos, Qt::KeyboardModifiers modifiers) override;
-    const EngravingItem* dropTarget() const override;
     void setDropTarget(const EngravingItem* item, bool notify = true) override;
     void setDropRect(const RectF& rect) override;
     void endDrop() override;

--- a/src/notation/internal/scorecallbacks.cpp
+++ b/src/notation/internal/scorecallbacks.cpp
@@ -72,6 +72,15 @@ void ScoreCallbacks::setDropTarget(const Ms::EngravingItem* dropTarget)
     m_interaction->setDropTarget(dropTarget, false);
 }
 
+void ScoreCallbacks::setDropRectangle(const RectF& rect)
+{
+    IF_ASSERT_FAILED(m_interaction) {
+        return;
+    }
+
+    m_interaction->setDropRect(rect);
+}
+
 void ScoreCallbacks::changeEditElement(Ms::EngravingItem* newElement)
 {
     IF_ASSERT_FAILED(m_interaction) {

--- a/src/notation/internal/scorecallbacks.cpp
+++ b/src/notation/internal/scorecallbacks.cpp
@@ -99,15 +99,6 @@ void ScoreCallbacks::adjustCanvasPosition(const Ms::EngravingItem* el, int staff
     m_interaction->showItem(el, staffIndex);
 }
 
-const Ms::EngravingItem* ScoreCallbacks::dropTarget() const
-{
-    IF_ASSERT_FAILED(m_interaction) {
-        return nullptr;
-    }
-
-    return m_interaction->dropTarget();
-}
-
 void ScoreCallbacks::setNotationInteraction(INotationInteraction* interaction)
 {
     m_interaction = interaction;

--- a/src/notation/internal/scorecallbacks.h
+++ b/src/notation/internal/scorecallbacks.h
@@ -48,8 +48,6 @@ public:
     void adjustCanvasPosition(const Ms::EngravingItem*, int staffIdx = -1) override;
 
     void setSelectionProximity(qreal proximity);
-    const Ms::EngravingItem* dropTarget() const;
-
     void setNotationInteraction(INotationInteraction* interaction);
 
 private:

--- a/src/notation/internal/scorecallbacks.h
+++ b/src/notation/internal/scorecallbacks.h
@@ -43,6 +43,7 @@ public:
     const mu::Rect geometry() const override;
     qreal selectionProximity() const override;
     void setDropTarget(const Ms::EngravingItem* dropTarget) override;
+    void setDropRectangle(const RectF& rect) override;
     void changeEditElement(Ms::EngravingItem* newElement) override;
     void adjustCanvasPosition(const Ms::EngravingItem*, int staffIdx = -1) override;
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10264