### PR TITLE
Tremolo stem direction fix

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -2091,6 +2091,12 @@ void Score::cmdFlip()
                 } else {
                     continue;
                 }
+            } else if (chord->tremolo()) {
+                if (!selection().isRange()) {
+                    e = chord->tremolo();
+                } else {
+                    continue;
+                }
             } else {
                 flipOnce(chord, [chord]() {
                     DirectionV dir = chord->up() ? DirectionV::DOWN : DirectionV::UP;
@@ -2104,6 +2110,12 @@ void Score::cmdFlip()
             flipOnce(beam, [beam]() {
                 DirectionV dir = beam->up() ? DirectionV::DOWN : DirectionV::UP;
                 beam->undoChangeProperty(Pid::STEM_DIRECTION, dir);
+            });
+        } else if (e->isTremolo()) {
+            auto tremolo = toTremolo(e);
+            flipOnce(tremolo, [tremolo]() {
+                DirectionV dir = tremolo->up() ? DirectionV::DOWN : DirectionV::UP;
+                tremolo->undoChangeProperty(Pid::STEM_DIRECTION, dir);
             });
         } else if (e->isSlurTieSegment()) {
             auto slurTieSegment = toSlurTieSegment(e)->slurTie();

--- a/src/engraving/libmscore/tremolo.cpp
+++ b/src/engraving/libmscore/tremolo.cpp
@@ -346,10 +346,14 @@ void Tremolo::layoutTwoNotesTremolo(double x, double y, double h, double spatium
             isUp = true;
         } else if (_chord1->measure()->hasVoices(_chord1->staffIdx(), _chord1->tick(), _chord2->rtick() - _chord1->tick())) {
             isUp = _chord1->track() % 2 == 0;
+        } else if (_chord1->stemDirection() != DirectionV::AUTO) {
+            isUp = _chord1->stemDirection() == DirectionV::UP;
+        } else if (_chord2->stemDirection() != DirectionV::AUTO) {
+            isUp = _chord2->stemDirection() == DirectionV::UP;
         }
         _up = isUp;
-        _chord1->setUp(isUp ^ (_chord1->staffMove() != 0)); // xor
-        _chord2->setUp(isUp ^ (_chord2->staffMove() != 0));
+        _chord1->setUp(_chord1->staffMove() == 0 ? isUp : !isUp); // if on a different staff, flip stem dir
+        _chord2->setUp(_chord2->staffMove() == 0 ? isUp : !isUp);
         _chord1->layoutStem();
         _chord2->layoutStem();
     }

--- a/src/engraving/libmscore/tremolo.cpp
+++ b/src/engraving/libmscore/tremolo.cpp
@@ -319,6 +319,40 @@ void Tremolo::layoutTwoNotesTremolo(double x, double y, double h, double spatium
     const bool defaultStyle = (!customStyleApplicable()) || (_style == TremoloStyle::DEFAULT);
     const bool isTraditionalAlternate = (_style == TremoloStyle::TRADITIONAL_ALTERNATE);
 
+    // make sure both stems are in the same direction
+    int up = 0;
+    bool isUp = _up;
+    if (_chord1->beam() && _chord1->beam() == _chord2->beam()) {
+        Beam* beam = _chord1->beam();
+        _up = beam->up();
+        _direction = beam->beamDirection();
+        // stem stuff is already taken care of by the beams
+    } else {
+        if (_chord1->stemDirection() == DirectionV::AUTO && _chord2->stemDirection() == DirectionV::AUTO
+            && _chord1->staffMove() == _chord2->staffMove()) {
+            std::vector<int> noteDistances;
+            for (int distance : _chord1->noteDistances()) {
+                noteDistances.push_back(distance);
+            }
+            for (int distance : _chord2->noteDistances()) {
+                noteDistances.push_back(distance);
+            }
+            std::sort(noteDistances.begin(), noteDistances.end());
+            up = Chord::computeAutoStemDirection(noteDistances);
+            isUp = up > 0;
+        } else if (_chord1->staffMove() > 0 || _chord2->staffMove() > 0) {
+            isUp = false;
+        } else if (_chord1->staffMove() < 0 || _chord2->staffMove() < 0) {
+            isUp = true;
+        } else if (_chord1->measure()->hasVoices(_chord1->staffIdx(), _chord1->tick(), _chord2->rtick() - _chord1->tick())) {
+            isUp = _chord1->track() % 2 == 0;
+        }
+        _up = isUp;
+        _chord1->setUp(isUp ^ (_chord1->staffMove() != 0)); // xor
+        _chord2->setUp(isUp ^ (_chord2->staffMove() != 0));
+        _chord1->layoutStem();
+        _chord2->layoutStem();
+    }
     //---------------------------------------------------
     //   Step 1: Calculate the position of the tremolo (x, y)
     //---------------------------------------------------
@@ -483,6 +517,26 @@ void Tremolo::layoutTwoNotesTremolo(double x, double y, double h, double spatium
 
     setbbox(path.boundingRect());
     setPos(x, y + beamYOffset);
+}
+
+//---------------------------------------------------------
+//   setBeamDirection
+//---------------------------------------------------------
+
+void Tremolo::setBeamDirection(DirectionV d)
+{
+    if (_direction == d) {
+        return;
+    }
+
+    _direction = d;
+
+    if (d != DirectionV::AUTO) {
+        _up = d == DirectionV::UP;
+    }
+
+    _chord1->setStemDirection(d);
+    _chord2->setStemDirection(d);
 }
 
 //---------------------------------------------------------
@@ -686,6 +740,9 @@ bool Tremolo::setProperty(Pid propertyId, const PropertyValue& val)
         if (customStyleApplicable()) {
             setStyle(TremoloStyle(val.toInt()));
         }
+        break;
+    case Pid::STEM_DIRECTION:
+        setBeamDirection(val.value<DirectionV>());
         break;
     default:
         return EngravingItem::setProperty(propertyId, val);

--- a/src/engraving/libmscore/tremolo.h
+++ b/src/engraving/libmscore/tremolo.h
@@ -47,7 +47,7 @@ class Tremolo final : public EngravingItem
     Chord* _chord2 { nullptr };
     TDuration _durationType;
     bool _up{ true };
-    Ms::DirectionV _direction;
+    DirectionV _direction;
     mu::PainterPath path;
 
     int _lines;         // derived from _subtype

--- a/src/engraving/libmscore/tremolo.h
+++ b/src/engraving/libmscore/tremolo.h
@@ -46,6 +46,8 @@ class Tremolo final : public EngravingItem
     Chord* _chord1 { nullptr };
     Chord* _chord2 { nullptr };
     TDuration _durationType;
+    bool _up{ true };
+    Ms::DirectionV _direction;
     mu::PainterPath path;
 
     int _lines;         // derived from _subtype
@@ -102,6 +104,7 @@ public:
     bool isBuzzRoll() const { return _tremoloType == TremoloType::BUZZ_ROLL; }
     bool twoNotes() const { return _tremoloType >= TremoloType::C8; }    // is it a two note tremolo?
     int lines() const { return _lines; }
+    bool up() const { return _up; }
 
     bool placeMidStem() const;
 
@@ -115,6 +118,7 @@ public:
 
     TremoloStyle style() const { return _style; }
     void setStyle(TremoloStyle v) { _style = v; }
+    void setBeamDirection(DirectionV v);
 
     bool customStyleApplicable() const;
 

--- a/src/engraving/utests/beam_data/flipTremoloStemDir.mscx
+++ b/src/engraving/utests/beam_data/flipTremoloStemDir.mscx
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.00">
+  <programVersion>4.0.0</programVersion>
+  <programRevision></programRevision>
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <Spatium>1.74978</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Composer / arranger</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="subtitle">Subtitle</metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Untitled Score</metaTag>
+    <Order id="orchestral">
+      <name>Orchestral</name>
+      <instrument id="piano">
+        <family id="keyboards">Keyboards</family>
+        </instrument>
+      <section id="woodwind" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>flutes</family>
+        <family>oboes</family>
+        <family>clarinets</family>
+        <family>saxophones</family>
+        <family>bassoons</family>
+        <unsorted group="woodwinds"/>
+        </section>
+      <section id="brass" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>horns</family>
+        <family>trumpets</family>
+        <family>cornets</family>
+        <family>flugelhorns</family>
+        <family>trombones</family>
+        <family>tubas</family>
+        </section>
+      <section id="timpani" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>timpani</family>
+        </section>
+      <section id="percussion" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>keyboard-percussion</family>
+        <family>drums</family>
+        <family>unpitched-metal-percussion</family>
+        <family>unpitched-wooden-percussion</family>
+        <family>other-percussion</family>
+        </section>
+      <family>keyboards</family>
+      <family>harps</family>
+      <family>organs</family>
+      <family>synths</family>
+      <soloists/>
+      <section id="voices" brackets="true" barLineSpan="false" thinBrackets="true">
+        <family>voices</family>
+        <family>voice-groups</family>
+        </section>
+      <section id="strings" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>orchestral-strings</family>
+        </section>
+      <unsorted/>
+      </Order>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="1" span="2" col="2"/>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument id="piano">
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <durationType>half</durationType>
+            <duration>1/4</duration>
+            <Note>
+              <pitch>69</pitch>
+              <tpc>17</tpc>
+              </Note>
+            <Tremolo>
+              <subtype>c32</subtype>
+              </Tremolo>
+            </Chord>
+          <Chord>
+            <durationType>half</durationType>
+            <duration>1/4</duration>
+            <Note>
+              <pitch>65</pitch>
+              <tpc>13</tpc>
+              </Note>
+            </Chord>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Chord>
+            <durationType>half</durationType>
+            <duration>1/4</duration>
+            <Note>
+              <pitch>64</pitch>
+              <tpc>18</tpc>
+              </Note>
+            <Tremolo>
+              <subtype>c64</subtype>
+              </Tremolo>
+            </Chord>
+          <Chord>
+            <durationType>half</durationType>
+            <duration>1/4</duration>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/utests/beam_tests.cpp
+++ b/src/engraving/utests/beam_tests.cpp
@@ -26,6 +26,7 @@
 #include "libmscore/measure.h"
 #include "libmscore/chordrest.h"
 #include "libmscore/chord.h"
+#include "libmscore/tremolo.h"
 
 #include "utils/scorerw.h"
 #include "utils/scorecomp.h"
@@ -223,6 +224,37 @@ TEST_F(BeamTests, flipBeamStemDir)
     score->doLayout();
 
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"flipBeamStemDir-01.mscx", BEAM_DATA_DIR + u"flipBeamStemDir-01-ref.mscx"));
+
+    delete score;
+}
+
+//---------------------------------------------------------
+//   flipTremoloStemDir
+//   This method tests if a tremolo's stem direction will be set to
+//   all its chords and will not affect other tremolos in score
+//   after using the flip command
+//---------------------------------------------------------
+
+TEST_F(BeamTests, flipTremoloStemDir)
+{
+    MasterScore* score = ScoreRW::readScore(BEAM_DATA_DIR + "flipTremoloStemDir.mscx");
+    EXPECT_TRUE(score);
+
+    Measure* m1 = score->firstMeasure();
+    ChordRest* cr = toChordRest(m1->findSegment(SegmentType::ChordRest, m1->tick())->element(0));
+    Tremolo* t = toChord(cr)->tremolo();
+    Chord* c1 = t->chord1();
+    Chord* c2 = t->chord2();
+    EXPECT_TRUE(t->up() && c1->up() && c2->up());
+
+    score->select(c1->upNote());
+    score->startCmd();
+    score->cmdFlip();
+    score->endCmd();
+
+    score->update();
+    score->doLayout();
+    EXPECT_FALSE(t->up() || c1->up() || c2->up());
 
     delete score;
 }

--- a/src/importexport/musicxml/tests/data/testTremolo.xml
+++ b/src/importexport/musicxml/tests/data/testTremolo.xml
@@ -293,7 +293,7 @@
           <actual-notes>2</actual-notes>
           <normal-notes>1</normal-notes>
           </time-modification>
-        <stem>down</stem>
+        <stem>up</stem>
         <notations>
           <ornaments>
             <tremolo type="start">2</tremolo>
@@ -312,7 +312,7 @@
           <actual-notes>2</actual-notes>
           <normal-notes>1</normal-notes>
           </time-modification>
-        <stem>down</stem>
+        <stem>up</stem>
         <notations>
           <ornaments>
             <tremolo type="stop">2</tremolo>
@@ -371,7 +371,7 @@
           <actual-notes>2</actual-notes>
           <normal-notes>1</normal-notes>
           </time-modification>
-        <stem>down</stem>
+        <stem>up</stem>
         <notations>
           <ornaments>
             <tremolo type="start">4</tremolo>
@@ -390,7 +390,7 @@
           <actual-notes>2</actual-notes>
           <normal-notes>1</normal-notes>
           </time-modification>
-        <stem>down</stem>
+        <stem>up</stem>
         <notations>
           <ornaments>
             <tremolo type="stop">4</tremolo>

--- a/src/importexport/musicxml/tests/data/testTremolo.xml
+++ b/src/importexport/musicxml/tests/data/testTremolo.xml
@@ -293,7 +293,7 @@
           <actual-notes>2</actual-notes>
           <normal-notes>1</normal-notes>
           </time-modification>
-        <stem>up</stem>
+        <stem>down</stem>
         <notations>
           <ornaments>
             <tremolo type="start">2</tremolo>
@@ -312,7 +312,7 @@
           <actual-notes>2</actual-notes>
           <normal-notes>1</normal-notes>
           </time-modification>
-        <stem>up</stem>
+        <stem>down</stem>
         <notations>
           <ornaments>
             <tremolo type="stop">2</tremolo>
@@ -371,7 +371,7 @@
           <actual-notes>2</actual-notes>
           <normal-notes>1</normal-notes>
           </time-modification>
-        <stem>up</stem>
+        <stem>down</stem>
         <notations>
           <ornaments>
             <tremolo type="start">4</tremolo>
@@ -390,7 +390,7 @@
           <actual-notes>2</actual-notes>
           <normal-notes>1</normal-notes>
           </time-modification>
-        <stem>up</stem>
+        <stem>down</stem>
         <notations>
           <ornaments>
             <tremolo type="stop">4</tremolo>

--- a/src/importexport/musicxml/tests/data/testTwoNoteTremoloTuplet.xml
+++ b/src/importexport/musicxml/tests/data/testTwoNoteTremoloTuplet.xml
@@ -98,7 +98,7 @@
           <actual-notes>2</actual-notes>
           <normal-notes>1</normal-notes>
           </time-modification>
-        <stem>up</stem>
+        <stem>down</stem>
         <notations>
           <ornaments>
             <tremolo type="start">1</tremolo>
@@ -117,7 +117,7 @@
           <actual-notes>2</actual-notes>
           <normal-notes>1</normal-notes>
           </time-modification>
-        <stem>up</stem>
+        <stem>down</stem>
         <notations>
           <ornaments>
             <tremolo type="stop">1</tremolo>
@@ -144,7 +144,7 @@
           <actual-notes>6</actual-notes>
           <normal-notes>2</normal-notes>
           </time-modification>
-        <stem>up</stem>
+        <stem>down</stem>
         <notations>
           <tuplet type="start" bracket="yes">
             <tuplet-actual>
@@ -173,7 +173,7 @@
           <actual-notes>6</actual-notes>
           <normal-notes>2</normal-notes>
           </time-modification>
-        <stem>up</stem>
+        <stem>down</stem>
         <notations>
           <ornaments>
             <tremolo type="stop">1</tremolo>

--- a/src/importexport/musicxml/tests/data/testTwoNoteTremoloTuplet.xml
+++ b/src/importexport/musicxml/tests/data/testTwoNoteTremoloTuplet.xml
@@ -79,7 +79,7 @@
           <actual-notes>2</actual-notes>
           <normal-notes>1</normal-notes>
           </time-modification>
-        <stem>down</stem>
+        <stem>up</stem>
         <notations>
           <ornaments>
             <tremolo type="stop">1</tremolo>
@@ -98,7 +98,7 @@
           <actual-notes>2</actual-notes>
           <normal-notes>1</normal-notes>
           </time-modification>
-        <stem>down</stem>
+        <stem>up</stem>
         <notations>
           <ornaments>
             <tremolo type="start">1</tremolo>
@@ -117,7 +117,7 @@
           <actual-notes>2</actual-notes>
           <normal-notes>1</normal-notes>
           </time-modification>
-        <stem>down</stem>
+        <stem>up</stem>
         <notations>
           <ornaments>
             <tremolo type="stop">1</tremolo>
@@ -144,7 +144,7 @@
           <actual-notes>6</actual-notes>
           <normal-notes>2</normal-notes>
           </time-modification>
-        <stem>down</stem>
+        <stem>up</stem>
         <notations>
           <tuplet type="start" bracket="yes">
             <tuplet-actual>
@@ -173,7 +173,7 @@
           <actual-notes>6</actual-notes>
           <normal-notes>2</normal-notes>
           </time-modification>
-        <stem>down</stem>
+        <stem>up</stem>
         <notations>
           <ornaments>
             <tremolo type="stop">1</tremolo>


### PR DESCRIPTION
Problem:
![tremolo-before](https://user-images.githubusercontent.com/20604032/171358423-f00662b4-f03b-4352-86eb-be8189098404.png)

Notes with tremolos with no beams should be made to keep consistent direction, similar to behavior from beams:
![tremolo-after](https://user-images.githubusercontent.com/20604032/171358461-8f326c3c-1994-4ed1-8f8d-ad058e6e79b2.png)

In the future (likely post-4.0), these tremolos will be moved in stem direction to be more consistent with where beams would normally be. However, we don't have enough time to do that at the moment as it will take a lot of engineering to factor out that behavior from the `Beam` class and be made to work for `Tremolo` as well, perhaps with a helper class of some kind. 