### PR TITLE
Fix #11635 Clarify kerning behaviour of text based items

### DIFF
--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -3668,7 +3668,7 @@ Shape Chord::shape() const
                 continue;
             }
             if (e->isFingering() && toFingering(e)->layoutType() == ElementType::CHORD && e->bbox().isValid()) {
-                shape.add(e->bbox().translated(e->pos() + note->pos()));
+                shape.add(e->bbox().translated(e->pos() + note->pos()), e);
             }
         }
     }

--- a/src/engraving/libmscore/harmony.h
+++ b/src/engraving/libmscore/harmony.h
@@ -121,8 +121,6 @@ class Harmony final : public TextBase
 
     Harmony* findInSeg(Segment* seg) const;
 
-    bool alwaysKernable() const override { return true; }
-
 public:
     Harmony(Segment* parent = 0);
     Harmony(const Harmony&);

--- a/src/engraving/libmscore/lyrics.h
+++ b/src/engraving/libmscore/lyrics.h
@@ -66,8 +66,6 @@ private:
     bool isMelisma() const;
     void undoChangeProperty(Pid id, const mu::engraving::PropertyValue&, PropertyFlags ps) override;
 
-    bool alwaysKernable() const override { return true; }
-
 protected:
     int _no;                  ///< row index
     bool _even;

--- a/src/engraving/libmscore/shape.cpp
+++ b/src/engraving/libmscore/shape.cpp
@@ -174,8 +174,8 @@ qreal Shape::minVerticalDistance(const Shape& a) const
 qreal Shape::left() const
 {
     qreal dist = 0.0;
-    for (const RectF& r : *this) {
-        if (r.height() != 0.0 && r.left() < dist) {
+    for (const ShapeElement& r : *this) {
+        if (r.height() != 0.0 && !(r.toItem && r.toItem->isTextBase()) && r.left() < dist) {
             // if (r.left() < dist)
             dist = r.left();
         }

--- a/src/engraving/libmscore/textbase.h
+++ b/src/engraving/libmscore/textbase.h
@@ -317,6 +317,8 @@ class TextBase : public EngravingItem
     void notifyAboutTextInserted(int startPosition, int endPosition, const QString& text);
     void notifyAboutTextRemoved(int startPosition, int endPosition, const QString& text);
 
+    virtual bool alwaysKernable() const override { return true; }
+
 protected:
     TextBase(const ElementType& type, EngravingItem* parent = 0, TextStyleType tid = TextStyleType::DEFAULT,
              ElementFlags = ElementFlag::NOTHING);


### PR DESCRIPTION
Resolves: #11635 

The issue in itself is nothing big, but it did highlight some inconsistencies in the kerning properties of text based items. This is now fixed.
