### PR TITLE
Remplementing minimum tie length and minimum glissando length

### DIFF
--- a/src/engraving/layout/layoutchords.h
+++ b/src/engraving/layout/layoutchords.h
@@ -46,6 +46,8 @@ public:
     static void updateGraceNotes(Measure* measure);
     static void repositionGraceNotesAfter(Segment* segment);
     static void appendGraceNotes(Chord* chord);
+    static void updateLineAttachPoints(Measure* measure);
+    static void doUpdateLineAttachPoints(Chord* chord);
 };
 }
 

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -96,9 +96,10 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
     Fraction prevMinTicks = Fraction(1, 1);
     bool changeMinSysTicks = false;
     qreal oldStretch = 1;
+    System* oldSystem = nullptr;
 
     while (ctx.curMeasure) {      // collect measure for system
-        System* oldSystem = ctx.curMeasure->system();
+        oldSystem = ctx.curMeasure->system();
         system->appendMeasure(ctx.curMeasure);
 
         qreal ww  = 0;          // width of current measure
@@ -455,6 +456,11 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
     system->setWidth(pos.x());
 
     layoutSystemElements(options, ctx, score, system);
+    if (oldSystem) {
+        // We may have previously processed some elements of the first measure of next system.
+        // This restores the correct state.
+        layoutSystemElements(options, ctx, score, oldSystem);
+    }
     system->layout2(ctx);     // compute staff distances
     for (MeasureBase* mb : system->measures()) {
         mb->layoutCrossStaff();

--- a/src/engraving/libmscore/glissando.cpp
+++ b/src/engraving/libmscore/glissando.cpp
@@ -404,6 +404,30 @@ void Glissando::layout()
     RectF r = RectF(anchor2SystPos - segm2->pos(), anchor2SystPos - segm2->pos() - segm2->pos2()).normalized();
     qreal lw = lineWidth() * .5;
     setbbox(r.adjusted(-lw, -lw, lw, lw));
+
+    addLineAttachPoints();
+}
+
+void Glissando::addLineAttachPoints()
+{
+    auto seg = toGlissandoSegment(frontSegment());
+    Note* startNote = nullptr;
+    Note* endNote = nullptr;
+    if (startElement() && startElement()->isNote()) {
+        startNote = toNote(startElement());
+    }
+    if (endElement() && endElement()->isNote()) {
+        endNote = toNote(endElement());
+    }
+    if (!seg || !startNote || !endNote || (startNote->findMeasure() != endNote->findMeasure())) {
+        return;
+    }
+    double startX = seg->ipos().x();
+    double endX = seg->pos2().x() + seg->ipos().x(); // because pos2 is relative to ipos
+    // Here we don't pass y() because its value is unreliable during the first stages of layout.
+    // The y() is irrelevant anyway for horizontal spacing.
+    startNote->addLineAttachPoint(PointF(startX, 0.0), this);
+    endNote->addLineAttachPoint(PointF(endX, 0.0), this);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/glissando.h
+++ b/src/engraving/libmscore/glissando.h
@@ -94,6 +94,7 @@ public:
     PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const PropertyValue&) override;
     PropertyValue propertyDefault(Pid) const override;
+    void addLineAttachPoints();
 };
 } // namespace mu::engraving
 

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -4362,6 +4362,7 @@ void Measure::computeWidth(Fraction minTicks, qreal stretchCoeff)
     }
 
     LayoutChords::updateGraceNotes(this);
+    LayoutChords::updateLineAttachPoints(this);
 
     x = computeFirstSegmentXPosition(s);
     bool isSystemHeader = s->header();

--- a/src/engraving/libmscore/note.h
+++ b/src/engraving/libmscore/note.h
@@ -58,6 +58,26 @@ enum class AccidentalType;
 
 static constexpr int MAX_DOTS = 4;
 
+//--------------------------------------------------------------------------------
+// LINE ATTACHMENT POINT
+// Represents the attachment point of any line (tie, slur, glissando...)
+// with respect to the note. Each note can hold a vector of line attach points, which
+// it may use to make spacing decision with the surrounding items.
+//--------------------------------------------------------------------------------
+class LineAttachPoint
+{
+private:
+    EngravingItem* _line = nullptr;
+    PointF _pos = PointF(0.0, 0.0);
+
+public:
+    LineAttachPoint(EngravingItem* l, double x, double y)
+        : _line(l), _pos(PointF(x, y)) {}
+
+    const EngravingItem* line() const { return _line; }
+    const PointF pos() const { return _pos; }
+};
+
 //---------------------------------------------------------
 //   @@ NoteHead
 //---------------------------------------------------------
@@ -251,6 +271,8 @@ private:
     static String tpcUserName(int tpc, int pitch, bool explicitAccidental);
 
     bool sameVoiceKerningLimited() const override { return true; }
+
+    std::vector<LineAttachPoint> _lineAttachPoints;
 
 public:
 
@@ -522,6 +544,12 @@ public:
     bool harmonic() const { return _harmonic; }
 
     bool isGrace() const { return noteType() != NoteType::NORMAL; }
+
+    void addLineAttachPoint(mu::PointF point, EngravingItem* line);
+    std::vector<LineAttachPoint>& lineAttachPoints() { return _lineAttachPoints; }
+    const std::vector<LineAttachPoint>& lineAttachPoints() const { return _lineAttachPoints; }
+
+    mu::PointF posInStaffCoordinates();
 };
 } // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/tie.h
+++ b/src/engraving/libmscore/tie.h
@@ -65,6 +65,7 @@ public:
     Tie* tie() const { return (Tie*)spanner(); }
 
     void computeBezier(mu::PointF so = mu::PointF()) override;
+    void addLineAttachPoints();
 };
 
 //---------------------------------------------------------


### PR DESCRIPTION
(also resolves #11823)

Minimum tie length and minimum glissando length are re-implemented, taking advantage of the new horizontal spacing system and the new tie positioning system. Additionally, minimum glissando length has a dedicated value and does not share the same as minimum tie length (as previously done in 3.6). 

Important note: this PR only affects the spacing. The positioning of the attachment points for ties and glissandi have not been touched.

@oktophonie 
