### PR TITLE
[MU4] Fix #11842: Crash when un-hiding an instrument in a part

### DIFF
--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -2224,8 +2224,13 @@ void Segment::createShape(staff_idx_t staffIdx)
 {
     Shape& s = _shapes[staffIdx];
     s.clear();
-    if (system() && !system()->staves().at(staffIdx)->show()) {
-        return;
+
+    if (const System* system = this->system()) {
+        const std::vector<SysStaff*>& staves = system->staves();
+
+        if (staffIdx < staves.size() && !staves[staffIdx]->show()) {
+            return;
+        }
     }
 
     if (segmentType() & (SegmentType::BarLine | SegmentType::EndBarLine | SegmentType::StartRepeatBarLine | SegmentType::BeginBarLine)) {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11842

@mike-spa FYI