### PR TITLE
fix:#11844; Changed toggle insert action functionality

### DIFF
--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -424,7 +424,7 @@ void NotationActionController::init()
     registerAction("add-down-bow", &Interaction::toggleArticulation, mu::engraving::SymId::stringsDownBow);
     registerAction("transpose-up", &Interaction::transposeSemitone, 1, PlayMode::PlayNote);
     registerAction("transpose-down", &Interaction::transposeSemitone, -1, PlayMode::PlayNote);
-    //registerAction("toggle-insert-mode", );
+    registerAction("toggle-insert-mode", [this]() { toggleNoteInputInsert(); }, &NotationActionController::isNotEditingElement);
 
     registerAction("get-location", &Interaction::getLocation, &Controller::isNotationPage);
     registerAction("toggle-mmrest", &Interaction::execute, &mu::engraving::Score::cmdToggleMmrest);
@@ -684,6 +684,15 @@ void NotationActionController::toggleNoteInputMethod(NoteInputMethod method)
     }
 
     noteInput->toggleNoteInputMethod(method);
+}
+
+void NotationActionController::toggleNoteInputInsert()
+{
+    if (currentNotationNoteInput()->state().method != NoteInputMethod::TIMEWISE) {
+        toggleNoteInputMethod(NoteInputMethod::TIMEWISE);
+    } else {
+        toggleNoteInputMethod(NoteInputMethod::STEPTIME);
+    }
 }
 
 void NotationActionController::addNote(NoteName note, NoteAddingMode addingMode)

--- a/src/notation/internal/notationactioncontroller.h
+++ b/src/notation/internal/notationactioncontroller.h
@@ -80,6 +80,7 @@ private:
 
     void toggleNoteInput();
     void toggleNoteInputMethod(NoteInputMethod method);
+    void toggleNoteInputInsert();
     void addNote(NoteName note, NoteAddingMode addingMode);
     void padNote(const Pad& pad);
     void putNote(const actions::ActionData& args);


### PR DESCRIPTION
Resolves: #11844 

~I have added a new action code that replaces the old one (I have not deleted the previous one). Now the toggle insert action does exactly as desired in the issue. 
The old one will not appear in the shortcuts list right now to avoid any confusion to the user as I have removed it from the xml as well and assigned its shortcut to the newly generated action.~

The PR changes the functionality of `toggle-insert-mode` to what is desired in the issue. Though this does make the function associated with it previously to be removed from this command.

Please let me know if any changes are required!

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
