### PR TITLE
fix #11826 fix fixed spacer on last staff of system.

### DIFF
--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -1707,7 +1707,7 @@ EngravingItem* Measure::drop(EditData& data)
             qreal gap = spatium() * 10;
             System* s = system();
             const staff_idx_t nextVisStaffIdx = s->nextVisibleStaff(staffIdx);
-            const bool systemEnd = (nextVisStaffIdx == score()->nstaves());
+            const bool systemEnd = (nextVisStaffIdx == mu::nidx);
             if (systemEnd) {
                 System* ns = 0;
                 for (System* ts : score()->systems()) {


### PR DESCRIPTION
Resolves: #11826

In case there is no next visible staff, `System::nextVisibleStaff()` now returns `mu::nidx` instead of number of staves in the system.
So the test for a system end must check for `mu::nidx`.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
