### PR TITLE
[MU4 Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/playback/metaparsers/chordarticulationsparser.cpp
+++ b/src/engraving/playback/metaparsers/chordarticulationsparser.cpp
@@ -121,8 +121,8 @@ void ChordArticulationsParser::parseSpanners(const mu::engraving::Chord* chord, 
 void ChordArticulationsParser::parseArticulationSymbols(const mu::engraving::Chord* chord, const RenderingContext& ctx,
                                                         mpe::ArticulationMap& result)
 {
-    for (const mu::engraving::Articulation* articulation : chord->articulations()) {
-        SymbolsMetaParser::parse(articulation, ctx, result);
+    for (const mu::engraving::Articulation* artic : chord->articulations()) {
+        SymbolsMetaParser::parse(artic, ctx, result);
     }
 }
 

--- a/src/inspector/models/notation/ornaments/ornamentsettingsmodel.cpp
+++ b/src/inspector/models/notation/ornaments/ornamentsettingsmodel.cpp
@@ -52,12 +52,12 @@ void OrnamentSettingsModel::requestElements()
             return false;
         }
 
-        const mu::engraving::Articulation* articulation = mu::engraving::toArticulation(element);
-        IF_ASSERT_FAILED(articulation) {
+        const mu::engraving::Articulation* artic = mu::engraving::toArticulation(element);
+        IF_ASSERT_FAILED(artic) {
             return false;
         }
 
-        return articulation->isOrnament();
+        return artic->isOrnament();
     });
 }
 

--- a/src/notation/view/noteinputbarmodel.cpp
+++ b/src/notation/view/noteinputbarmodel.cpp
@@ -436,8 +436,8 @@ std::set<SymbolId> NoteInputBarModel::resolveCurrentArticulations() const
 
     auto chordArticulations = [](const Chord* chord) {
         std::set<SymbolId> result;
-        for (Articulation* articulation: chord->articulations()) {
-            result.insert(articulation->symId());
+        for (Articulation* artic: chord->articulations()) {
+            result.insert(artic->symId());
         }
 
         result = mu::engraving::flipArticulations(result, mu::engraving::PlacementV::ABOVE);


### PR DESCRIPTION
reg. declaration of 'articulation' hides global declaration (C4459) (since #11865)