### PR TITLE
Fix stem direction in drum staff beams

### DIFF
--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -1012,6 +1012,9 @@ void Chord::computeUp()
             }
         }
         Measure* measure = findMeasure();
+        if (!cross && !_beam->userModified()) {
+            _up = _beam->up();
+        }
         if (!measure->explicitParent()) {
             // this method will be called later (from Measure::layoutCrossStaff) after the
             // system is completely laid out.


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11747

The stem direction needs to be set properly in `Chord::computeUp()` whether or not an explicit parent is set.