### PR TITLE
[MU4] Fix #11756: Crash when starting to drag text line while there is a range selection

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -853,7 +853,13 @@ void NotationInteraction::startDrag(const std::vector<EngravingItem*>& elems,
     m_editData.modifiers = QGuiApplication::keyboardModifiers();
 
     for (EngravingItem* e : m_dragData.elements) {
-        if (!isDraggable(e)) {
+        bool draggable = isDraggable(e);
+
+        if (!draggable && e->isSpanner()) {
+            draggable = isDraggable(toSpanner(e)->frontSegment());
+        }
+
+        if (!draggable) {
             continue;
         }
 

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -542,10 +542,8 @@ bool NotationViewInputController::needSelect(const ClickContext& ctx) const
         return false;
     }
 
-    bool hitElementSelected = ctx.hitElement->selected();
-
-    if (ctx.event->modifiers() & Qt::ControlModifier) {
-        return !hitElementSelected;
+    if (!ctx.hitElement->selected()) {
+        return true;
     }
 
     INotationSelectionPtr selection = viewInteraction()->selection();
@@ -554,7 +552,7 @@ bool NotationViewInputController::needSelect(const ClickContext& ctx) const
         return !selection->range()->containsPoint(ctx.logicClickPos);
     }
 
-    return !hitElementSelected;
+    return false;
 }
 
 void NotationViewInputController::handleLeftClick(const ClickContext& ctx)
@@ -635,8 +633,9 @@ void NotationViewInputController::mouseMoveEvent(QMouseEvent* event)
             }
 
             if (viewInteraction()->isGripEditStarted() && !viewInteraction()->isDragStarted()) {
-                EngravingItem* selectedElement = viewInteraction()->selection()->element();
-                startDragElements(selectedElement->type(), selectedElement->offset());
+                const EngravingItem* selectedElement = viewInteraction()->selection()->element();
+                ElementType type = selectedElement ? selectedElement->type() : ElementType::INVALID;
+                startDragElements(type, selectedElement->offset());
             }
 
             DragMode mode = DragMode::BothXY;
@@ -668,6 +667,10 @@ void NotationViewInputController::mouseMoveEvent(QMouseEvent* event)
 
 void NotationViewInputController::startDragElements(ElementType elementsType, const PointF& elementsOffset)
 {
+    if (elementsType == ElementType::INVALID) {
+        return;
+    }
+
     std::vector<EngravingItem*> elements = viewInteraction()->selection()->elements();
     if (elements.empty()) {
         return;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11756