### PR TITLE
Remove unnecessary uses of `mu::engraving::` inside the Engraving module

### DIFF
--- a/src/engraving/accessibility/accessibleitem.cpp
+++ b/src/engraving/accessibility/accessibleitem.cpp
@@ -33,7 +33,7 @@ using namespace mu::engraving;
 
 bool AccessibleItem::enabled = true;
 
-AccessibleItem::AccessibleItem(mu::engraving::EngravingItem* e, Role role)
+AccessibleItem::AccessibleItem(EngravingItem* e, Role role)
     : m_element(e), m_role(role)
 {
 }
@@ -53,7 +53,7 @@ AccessibleItem::~AccessibleItem()
     m_element = nullptr;
 }
 
-AccessibleItem* AccessibleItem::clone(mu::engraving::EngravingItem* e) const
+AccessibleItem* AccessibleItem::clone(EngravingItem* e) const
 {
     return new AccessibleItem(e, m_role);
 }
@@ -78,7 +78,7 @@ AccessibleRoot* AccessibleItem::accessibleRoot() const
         return nullptr;
     }
 
-    mu::engraving::Score* score = m_element->score();
+    Score* score = m_element->score();
     if (!score) {
         return nullptr;
     }
@@ -87,7 +87,7 @@ AccessibleRoot* AccessibleItem::accessibleRoot() const
     return dynamic_cast<AccessibleRoot*>(rootItem->accessible());
 }
 
-const mu::engraving::EngravingItem* AccessibleItem::element() const
+const EngravingItem* AccessibleItem::element() const
 {
     return m_element;
 }
@@ -104,7 +104,7 @@ void AccessibleItem::notifyAboutFocus(bool focused)
 
 const IAccessible* AccessibleItem::accessibleParent() const
 {
-    mu::engraving::EngravingObject* p = m_element->parent();
+    EngravingObject* p = m_element->parent();
     if (!p || !p->isEngravingItem()) {
         return nullptr;
     }
@@ -118,7 +118,7 @@ size_t AccessibleItem::accessibleChildCount() const
     size_t count = 0;
     for (const EngravingObject* obj : m_element->children()) {
         if (obj->isEngravingItem()) {
-            AccessibleItem* access = mu::engraving::toEngravingItem(obj)->accessible();
+            AccessibleItem* access = toEngravingItem(obj)->accessible();
             if (access && access->registered()) {
                 ++count;
             }
@@ -133,7 +133,7 @@ const IAccessible* AccessibleItem::accessibleChild(size_t i) const
     size_t count = 0;
     for (const EngravingObject* obj : m_element->children()) {
         if (obj->isEngravingItem()) {
-            AccessibleItem* access = mu::engraving::toEngravingItem(obj)->accessible();
+            AccessibleItem* access = toEngravingItem(obj)->accessible();
             if (access && access->registered()) {
                 if (count == i) {
                     return access;
@@ -194,9 +194,9 @@ QVariant AccessibleItem::accessibleValueStepSize() const
 
 void AccessibleItem::accessibleSelection(int selectionIndex, int* startOffset, int* endOffset) const
 {
-    mu::engraving::TextCursor* textCursor = this->textCursor();
+    TextCursor* textCursor = this->textCursor();
     if (selectionIndex == 0 && textCursor && textCursor->hasSelection()) {
-        mu::engraving::TextCursor::Range selectionRange = textCursor->selectionRange();
+        TextCursor::Range selectionRange = textCursor->selectionRange();
         *startOffset = selectionRange.startPosition;
         *endOffset = selectionRange.endPosition;
     } else {
@@ -207,7 +207,7 @@ void AccessibleItem::accessibleSelection(int selectionIndex, int* startOffset, i
 
 int AccessibleItem::accessibleSelectionCount() const
 {
-    mu::engraving::TextCursor* textCursor = this->textCursor();
+    TextCursor* textCursor = this->textCursor();
     if (!textCursor) {
         return 0;
     }
@@ -217,7 +217,7 @@ int AccessibleItem::accessibleSelectionCount() const
 
 int AccessibleItem::accessibleCursorPosition() const
 {
-    mu::engraving::TextCursor* textCursor = this->textCursor();
+    TextCursor* textCursor = this->textCursor();
     if (!textCursor) {
         return 0;
     }
@@ -231,7 +231,7 @@ QString AccessibleItem::accessibleText(int startOffset, int endOffset) const
         return QString();
     }
 
-    mu::engraving::TextCursor* textCursor = new mu::engraving::TextCursor(mu::engraving::toTextBase(m_element));
+    TextCursor* textCursor = new TextCursor(toTextBase(m_element));
     auto startCoord = textCursor->positionToLocalCoord(startOffset);
     if (startCoord.first == mu::nidx || startCoord.second == mu::nidx) {
         return QString();
@@ -239,7 +239,7 @@ QString AccessibleItem::accessibleText(int startOffset, int endOffset) const
 
     textCursor->setRow(startCoord.first);
     textCursor->setColumn(startCoord.second);
-    textCursor->movePosition(mu::engraving::TextCursor::MoveOperation::Right, mu::engraving::TextCursor::MoveMode::KeepAnchor,
+    textCursor->movePosition(TextCursor::MoveOperation::Right, TextCursor::MoveMode::KeepAnchor,
                              endOffset - startOffset);
 
     textCursor->setSelectLine(startCoord.first);
@@ -259,7 +259,7 @@ QString AccessibleItem::accessibleTextAtOffset(int offset, TextBoundaryType boun
 
     QString result;
 
-    mu::engraving::TextCursor* textCursor = new mu::engraving::TextCursor(mu::engraving::toTextBase(m_element));
+    TextCursor* textCursor = new TextCursor(toTextBase(m_element));
     auto startCoord = textCursor->positionToLocalCoord(offset);
     if (startCoord.first == mu::nidx || startCoord.second == mu::nidx) {
         return QString();
@@ -271,21 +271,21 @@ QString AccessibleItem::accessibleTextAtOffset(int offset, TextBoundaryType boun
     switch (boundaryType) {
     case CharBoundary: {
         *startOffset = textCursor->currentPosition();
-        textCursor->movePosition(mu::engraving::TextCursor::MoveOperation::Right, mu::engraving::TextCursor::MoveMode::KeepAnchor);
+        textCursor->movePosition(TextCursor::MoveOperation::Right, TextCursor::MoveMode::KeepAnchor);
         *endOffset = textCursor->currentPosition();
         break;
     }
     case WordBoundary: {
-        textCursor->movePosition(mu::engraving::TextCursor::MoveOperation::WordLeft, mu::engraving::TextCursor::MoveMode::MoveAnchor);
+        textCursor->movePosition(TextCursor::MoveOperation::WordLeft, TextCursor::MoveMode::MoveAnchor);
         *startOffset = textCursor->currentPosition();
-        textCursor->movePosition(mu::engraving::TextCursor::MoveOperation::NextWord, mu::engraving::TextCursor::MoveMode::KeepAnchor);
+        textCursor->movePosition(TextCursor::MoveOperation::NextWord, TextCursor::MoveMode::KeepAnchor);
         *endOffset = textCursor->currentPosition();
         break;
     }
     case LineBoundary: {
-        textCursor->movePosition(mu::engraving::TextCursor::MoveOperation::StartOfLine, mu::engraving::TextCursor::MoveMode::MoveAnchor);
+        textCursor->movePosition(TextCursor::MoveOperation::StartOfLine, TextCursor::MoveMode::MoveAnchor);
         *startOffset = textCursor->currentPosition();
-        textCursor->movePosition(mu::engraving::TextCursor::MoveOperation::EndOfLine, mu::engraving::TextCursor::MoveMode::KeepAnchor);
+        textCursor->movePosition(TextCursor::MoveOperation::EndOfLine, TextCursor::MoveMode::KeepAnchor);
         *endOffset = textCursor->currentPosition();
         break;
     }
@@ -309,7 +309,7 @@ int AccessibleItem::accessibleCharacterCount() const
         return 0;
     }
 
-    mu::engraving::TextBase* text = mu::engraving::toTextBase(m_element);
+    TextBase* text = toTextBase(m_element);
     return text->plainText().length();
 }
 
@@ -375,6 +375,6 @@ TextCursor* AccessibleItem::textCursor() const
         return nullptr;
     }
 
-    mu::engraving::TextBase* text = mu::engraving::toTextBase(m_element);
+    TextBase* text = toTextBase(m_element);
     return text ? text->cursor() : nullptr;
 }

--- a/src/engraving/accessibility/accessibleitem.h
+++ b/src/engraving/accessibility/accessibleitem.h
@@ -38,15 +38,15 @@ class AccessibleItem : public accessibility::IAccessible
     INJECT_STATIC(engraving, accessibility::IAccessibilityController, accessibilityController)
 
 public:
-    AccessibleItem(mu::engraving::EngravingItem* e, Role role = Role::ElementOnScore);
+    AccessibleItem(EngravingItem* e, Role role = Role::ElementOnScore);
     virtual ~AccessibleItem();
-    virtual AccessibleItem* clone(mu::engraving::EngravingItem* e) const;
+    virtual AccessibleItem* clone(EngravingItem* e) const;
 
     virtual void setup();
 
     AccessibleRoot* accessibleRoot() const;
 
-    const mu::engraving::EngravingItem* element() const;
+    const EngravingItem* element() const;
 
     bool registered() const;
 
@@ -85,11 +85,11 @@ public:
     static bool enabled;
 
 private:
-    mu::engraving::TextCursor* textCursor() const;
+    TextCursor* textCursor() const;
 
 protected:
 
-    mu::engraving::EngravingItem* m_element = nullptr;
+    EngravingItem* m_element = nullptr;
     bool m_registred = false;
 
     Role m_role = Role::ElementOnScore;

--- a/src/engraving/accessibility/accessiblenote.cpp
+++ b/src/engraving/accessibility/accessiblenote.cpp
@@ -26,7 +26,7 @@
 using namespace mu::engraving;
 using namespace mu::accessibility;
 
-AccessibleNote::AccessibleNote(mu::engraving::EngravingItem* n)
+AccessibleNote::AccessibleNote(EngravingItem* n)
     : AccessibleItem(n)
 {
 }
@@ -35,7 +35,7 @@ AccessibleNote::~AccessibleNote()
 {
 }
 
-AccessibleItem* AccessibleNote::clone(mu::engraving::EngravingItem* e) const
+AccessibleItem* AccessibleNote::clone(EngravingItem* e) const
 {
     return new AccessibleNote(e);
 }

--- a/src/engraving/accessibility/accessiblenote.h
+++ b/src/engraving/accessibility/accessiblenote.h
@@ -30,10 +30,10 @@ namespace mu::engraving {
 class AccessibleNote : public AccessibleItem
 {
 public:
-    AccessibleNote(mu::engraving::EngravingItem* n = nullptr);
+    AccessibleNote(EngravingItem* n = nullptr);
     ~AccessibleNote();
 
-    AccessibleItem* clone(mu::engraving::EngravingItem* e) const override;
+    AccessibleItem* clone(EngravingItem* e) const override;
 };
 }
 

--- a/src/engraving/compat/dummyelement.cpp
+++ b/src/engraving/compat/dummyelement.cpp
@@ -36,7 +36,7 @@ using namespace mu::engraving;
 using namespace mu::engraving::compat;
 
 DummyElement::DummyElement(EngravingObject* parent)
-    : mu::engraving::EngravingItem(mu::engraving::ElementType::DUMMY, parent)
+    : EngravingItem(ElementType::DUMMY, parent)
 {
 }
 
@@ -82,42 +82,42 @@ RootItem* DummyElement::rootItem()
     return m_root;
 }
 
-mu::engraving::Page* DummyElement::page()
+Page* DummyElement::page()
 {
     return m_page;
 }
 
-mu::engraving::System* DummyElement::system()
+System* DummyElement::system()
 {
     return m_system;
 }
 
-mu::engraving::Measure* DummyElement::measure()
+Measure* DummyElement::measure()
 {
     return m_measure;
 }
 
-mu::engraving::Segment* DummyElement::segment()
+Segment* DummyElement::segment()
 {
     return m_segment;
 }
 
-mu::engraving::Chord* DummyElement::chord()
+Chord* DummyElement::chord()
 {
     return m_chord;
 }
 
-mu::engraving::Note* DummyElement::note()
+Note* DummyElement::note()
 {
     return m_note;
 }
 
-mu::engraving::EngravingItem* DummyElement::clone() const
+EngravingItem* DummyElement::clone() const
 {
     return nullptr;
 }
 
 AccessibleItem* DummyElement::createAccessible()
 {
-    return new mu::engraving::AccessibleItem(this, accessibility::IAccessible::Panel);
+    return new AccessibleItem(this, accessibility::IAccessible::Panel);
 }

--- a/src/engraving/compat/dummyelement.h
+++ b/src/engraving/compat/dummyelement.h
@@ -28,14 +28,12 @@
 
 namespace mu::engraving {
 enum class Pid : int;
-}
 
-namespace mu::engraving {
 class RootItem;
 }
 
 namespace mu::engraving::compat {
-class DummyElement : public mu::engraving::EngravingItem
+class DummyElement : public EngravingItem
 {
 public:
     DummyElement(EngravingObject* parent);
@@ -44,28 +42,28 @@ public:
     void init();
 
     RootItem* rootItem();
-    mu::engraving::Page* page();
-    mu::engraving::System* system();
-    mu::engraving::Measure* measure();
-    mu::engraving::Segment* segment();
-    mu::engraving::Chord* chord();
-    mu::engraving::Note* note();
+    Page* page();
+    System* system();
+    Measure* measure();
+    Segment* segment();
+    Chord* chord();
+    Note* note();
 
-    mu::engraving::EngravingItem* clone() const override;
+    EngravingItem* clone() const override;
 
-    mu::engraving::PropertyValue getProperty(mu::engraving::Pid) const override { return mu::engraving::PropertyValue(); }
-    bool setProperty(mu::engraving::Pid, const mu::engraving::PropertyValue&) override { return false; }
+    PropertyValue getProperty(Pid) const override { return PropertyValue(); }
+    bool setProperty(Pid, const PropertyValue&) override { return false; }
 
 private:
-    mu::engraving::AccessibleItem* createAccessible() override;
+    AccessibleItem* createAccessible() override;
 
     RootItem* m_root = nullptr;
-    mu::engraving::Page* m_page = nullptr;
-    mu::engraving::System* m_system = nullptr;
-    mu::engraving::Measure* m_measure = nullptr;
-    mu::engraving::Segment* m_segment = nullptr;
-    mu::engraving::Chord* m_chord = nullptr;
-    mu::engraving::Note* m_note = nullptr;
+    Page* m_page = nullptr;
+    System* m_system = nullptr;
+    Measure* m_measure = nullptr;
+    Segment* m_segment = nullptr;
+    Chord* m_chord = nullptr;
+    Note* m_note = nullptr;
 };
 }
 

--- a/src/engraving/compat/mscxcompat.cpp
+++ b/src/engraving/compat/mscxcompat.cpp
@@ -31,13 +31,14 @@
 #include "log.h"
 
 using namespace mu::io;
+using namespace mu::engraving;
 
-mu::engraving::Score::FileError mu::engraving::compat::mscxToMscz(const QString& mscxFilePath, ByteArray* msczData)
+Score::FileError mu::engraving::compat::mscxToMscz(const QString& mscxFilePath, ByteArray* msczData)
 {
     File mscxFile(mscxFilePath);
     if (!mscxFile.open(IODevice::ReadOnly)) {
         LOGE() << "failed open file: " << mscxFilePath;
-        return mu::engraving::Score::FileError::FILE_OPEN_ERROR;
+        return Score::FileError::FILE_OPEN_ERROR;
     }
 
     ByteArray mscxData = mscxFile.readAll();
@@ -51,31 +52,30 @@ mu::engraving::Score::FileError mu::engraving::compat::mscxToMscz(const QString&
     writer.open();
     writer.writeScoreFile(mscxData);
 
-    return mu::engraving::Score::FileError::FILE_NO_ERROR;
+    return Score::FileError::FILE_NO_ERROR;
 }
 
-mu::engraving::Score::FileError mu::engraving::compat::loadMsczOrMscx(mu::engraving::MasterScore* score, const QString& path,
-                                                                      bool ignoreVersionError)
+Score::FileError mu::engraving::compat::loadMsczOrMscx(MasterScore* score, const QString& path, bool ignoreVersionError)
 {
     ByteArray msczData;
     if (path.endsWith(".mscx", Qt::CaseInsensitive)) {
         //! NOTE Convert mscx -> mscz
 
-        mu::engraving::Score::FileError err = mscxToMscz(path, &msczData);
-        if (err != mu::engraving::Score::FileError::FILE_NO_ERROR) {
+        Score::FileError err = mscxToMscz(path, &msczData);
+        if (err != Score::FileError::FILE_NO_ERROR) {
             return err;
         }
     } else if (path.endsWith(".mscz", Qt::CaseInsensitive)) {
         File msczFile(path);
         if (!msczFile.open(IODevice::ReadOnly)) {
             LOGE() << "failed open file: " << path;
-            return mu::engraving::Score::FileError::FILE_OPEN_ERROR;
+            return Score::FileError::FILE_OPEN_ERROR;
         }
 
         msczData = msczFile.readAll();
     } else {
         LOGE() << "unknown type, path: " << path;
-        return mu::engraving::Score::FileError::FILE_UNKNOWN_TYPE;
+        return Score::FileError::FILE_UNKNOWN_TYPE;
     }
 
     score->setFileInfoProvider(std::make_shared<LocalFileInfoProvider>(path));
@@ -91,31 +91,31 @@ mu::engraving::Score::FileError mu::engraving::compat::loadMsczOrMscx(mu::engrav
 
     ScoreReader scoreReader;
     engraving::Err err = scoreReader.loadMscz(score, reader, ignoreVersionError);
-    return err == Err::NoError ? mu::engraving::Score::FileError::FILE_NO_ERROR : mu::engraving::Score::FileError::FILE_ERROR;
+    return err == Err::NoError ? Score::FileError::FILE_NO_ERROR : Score::FileError::FILE_ERROR;
 }
 
-mu::engraving::Err mu::engraving::compat::loadMsczOrMscx(EngravingProjectPtr project, const QString& path, bool ignoreVersionError)
+Err mu::engraving::compat::loadMsczOrMscx(EngravingProjectPtr project, const QString& path, bool ignoreVersionError)
 {
     ByteArray msczData;
     QString filePath = path;
     if (path.endsWith(".mscx", Qt::CaseInsensitive)) {
         //! NOTE Convert mscx -> mscz
 
-        mu::engraving::Score::FileError err = mscxToMscz(path, &msczData);
-        if (err != mu::engraving::Score::FileError::FILE_NO_ERROR) {
+        Score::FileError err = mscxToMscz(path, &msczData);
+        if (err != Score::FileError::FILE_NO_ERROR) {
             return scoreFileErrorToErr(err);
         }
     } else if (path.endsWith(".mscz", Qt::CaseInsensitive)) {
         File msczFile(path);
         if (!msczFile.open(IODevice::ReadOnly)) {
             LOGE() << "failed open file: " << path;
-            return scoreFileErrorToErr(mu::engraving::Score::FileError::FILE_OPEN_ERROR);
+            return scoreFileErrorToErr(Score::FileError::FILE_OPEN_ERROR);
         }
 
         msczData = msczFile.readAll();
     } else {
         LOGE() << "unknown type, path: " << path;
-        return scoreFileErrorToErr(mu::engraving::Score::FileError::FILE_UNKNOWN_TYPE);
+        return scoreFileErrorToErr(Score::FileError::FILE_UNKNOWN_TYPE);
     }
 
     project->setFileInfoProvider(std::make_shared<LocalFileInfoProvider>(path));

--- a/src/engraving/compat/mscxcompat.h
+++ b/src/engraving/compat/mscxcompat.h
@@ -27,8 +27,8 @@
 #include "engravingproject.h"
 
 namespace mu::engraving::compat {
-mu::engraving::Score::FileError mscxToMscz(const QString& mscxFilePath, ByteArray* msczData);
-mu::engraving::Score::FileError loadMsczOrMscx(mu::engraving::MasterScore* score, const QString& path, bool ignoreVersionError = false);
+Score::FileError mscxToMscz(const QString& mscxFilePath, ByteArray* msczData);
+Score::FileError loadMsczOrMscx(MasterScore* score, const QString& path, bool ignoreVersionError = false);
 Err loadMsczOrMscx(EngravingProjectPtr project, const QString& path, bool ignoreVersionError = false);
 }
 

--- a/src/engraving/compat/pageformat.h
+++ b/src/engraving/compat/pageformat.h
@@ -54,7 +54,7 @@ public:
     qreal height() const { return _size.height(); }
     void setSize(const SizeF& s) { _size = s; }
 
-    void read206(mu::engraving::XmlReader&);
+    void read206(XmlReader&);
 
     qreal evenLeftMargin() const { return _evenLeftMargin; }
     qreal oddLeftMargin() const { return _oddLeftMargin; }
@@ -80,6 +80,6 @@ public:
     qreal oddRightMargin() const { return _size.width() - _printableWidth - _oddLeftMargin; }
 };
 
-void readPageFormat206(mu::engraving::MStyle* style, mu::engraving::XmlReader& e);
+void readPageFormat206(MStyle* style, XmlReader& e);
 }
 #endif // MU_ENGRAVING_READPAGEFORMAT_H

--- a/src/engraving/compat/scoreaccess.cpp
+++ b/src/engraving/compat/scoreaccess.cpp
@@ -23,29 +23,30 @@
 #include "style/defaultstyle.h"
 #include "libmscore/masterscore.h"
 
+using namespace mu::engraving;
 using namespace mu::engraving::compat;
 
-mu::engraving::MasterScore* ScoreAccess::createMasterScore()
+MasterScore* ScoreAccess::createMasterScore()
 {
-    return new mu::engraving::MasterScore();
+    return new MasterScore();
 }
 
-mu::engraving::MasterScore* ScoreAccess::createMasterScoreWithBaseStyle()
+MasterScore* ScoreAccess::createMasterScoreWithBaseStyle()
 {
-    return new mu::engraving::MasterScore(DefaultStyle::baseStyle());
+    return new MasterScore(DefaultStyle::baseStyle());
 }
 
-mu::engraving::MasterScore* ScoreAccess::createMasterScoreWithDefaultStyle()
+MasterScore* ScoreAccess::createMasterScoreWithDefaultStyle()
 {
-    return new mu::engraving::MasterScore(DefaultStyle::defaultStyle());
+    return new MasterScore(DefaultStyle::defaultStyle());
 }
 
-mu::engraving::MasterScore* ScoreAccess::createMasterScore(const mu::engraving::MStyle& style)
+MasterScore* ScoreAccess::createMasterScore(const MStyle& style)
 {
-    return new mu::engraving::MasterScore(style);
+    return new MasterScore(style);
 }
 
-bool ScoreAccess::exportPart(mu::engraving::MscWriter& mscWriter, mu::engraving::Score* partScore)
+bool ScoreAccess::exportPart(MscWriter& mscWriter, Score* partScore)
 {
     return partScore->masterScore()->exportPart(mscWriter, partScore);
 }

--- a/src/engraving/compat/scoreaccess.h
+++ b/src/engraving/compat/scoreaccess.h
@@ -32,12 +32,12 @@ class ScoreAccess
 {
 public:
 
-    static mu::engraving::MasterScore* createMasterScore();
-    static mu::engraving::MasterScore* createMasterScoreWithBaseStyle();
-    static mu::engraving::MasterScore* createMasterScoreWithDefaultStyle();
-    static mu::engraving::MasterScore* createMasterScore(const mu::engraving::MStyle& style);
+    static MasterScore* createMasterScore();
+    static MasterScore* createMasterScoreWithBaseStyle();
+    static MasterScore* createMasterScoreWithDefaultStyle();
+    static MasterScore* createMasterScore(const MStyle& style);
 
-    static bool exportPart(mu::engraving::MscWriter& mscWriter, mu::engraving::Score* partScore);
+    static bool exportPart(MscWriter& mscWriter, Score* partScore);
 };
 }
 

--- a/src/engraving/compat/writescorehook.cpp
+++ b/src/engraving/compat/writescorehook.cpp
@@ -27,9 +27,10 @@
 
 #include "config.h"
 
+using namespace mu::engraving;
 using namespace mu::engraving::compat;
 
-void WriteScoreHook::onWriteStyle302(mu::engraving::Score* score, mu::engraving::XmlWriter& xml)
+void WriteScoreHook::onWriteStyle302(Score* score, XmlWriter& xml)
 {
     bool isWriteStyle = false;
     //! NOTE Write the style to the score file if the compatibility define is set
@@ -43,7 +44,7 @@ void WriteScoreHook::onWriteStyle302(mu::engraving::Score* score, mu::engraving:
     }
 
     //! NOTE If the test mode, because the tests have not yet been adapted to the new format
-    if (mu::engraving::MScore::testMode) {
+    if (MScore::testMode) {
         isWriteStyle = true;
     }
 
@@ -52,7 +53,7 @@ void WriteScoreHook::onWriteStyle302(mu::engraving::Score* score, mu::engraving:
     }
 }
 
-void WriteScoreHook::onWriteExcerpts302(mu::engraving::Score* score, mu::engraving::XmlWriter& xml, bool selectionOnly)
+void WriteScoreHook::onWriteExcerpts302(Score* score, XmlWriter& xml, bool selectionOnly)
 {
     bool isWriteExcerpts = false;
     //! NOTE Write the Excerpts to the score file if the compatibility define is set
@@ -63,8 +64,8 @@ void WriteScoreHook::onWriteExcerpts302(mu::engraving::Score* score, mu::engravi
     if (isWriteExcerpts) {
         if (score->isMaster()) {
             if (!selectionOnly) {
-                mu::engraving::MasterScore* mScore = static_cast<mu::engraving::MasterScore*>(score);
-                for (const mu::engraving::Excerpt* excerpt : mScore->excerpts()) {
+                MasterScore* mScore = static_cast<MasterScore*>(score);
+                for (const Excerpt* excerpt : mScore->excerpts()) {
                     if (excerpt->excerptScore() != score) {
                         excerpt->excerptScore()->write(xml, selectionOnly, *this); // recursion write
                     }

--- a/src/engraving/compat/writescorehook.h
+++ b/src/engraving/compat/writescorehook.h
@@ -33,8 +33,8 @@ class WriteScoreHook
 public:
     WriteScoreHook() = default;
 
-    void onWriteStyle302(mu::engraving::Score* score, mu::engraving::XmlWriter& xml);
-    void onWriteExcerpts302(mu::engraving::Score* score, mu::engraving::XmlWriter& xml, bool selectionOnly);
+    void onWriteStyle302(Score* score, XmlWriter& xml);
+    void onWriteExcerpts302(Score* score, XmlWriter& xml, bool selectionOnly);
 };
 }
 #endif // MU_ENGRAVING_WRITESCOREHOOK_H

--- a/src/engraving/engravingerrors.h
+++ b/src/engraving/engravingerrors.h
@@ -105,28 +105,28 @@ inline Ret make_ret(Err err, const io::path_t& filePath = "")
     return mu::Ret(static_cast<int>(err), text.toStdString());
 }
 
-inline Err scoreFileErrorToErr(mu::engraving::Score::FileError err)
+inline Err scoreFileErrorToErr(Score::FileError err)
 {
     switch (err) {
-    case mu::engraving::Score::FileError::FILE_NO_ERROR:       return Err::NoError;
-    case mu::engraving::Score::FileError::FILE_ERROR:          return Err::FileUnknownError;
-    case mu::engraving::Score::FileError::FILE_NOT_FOUND:      return Err::FileNotFound;
-    case mu::engraving::Score::FileError::FILE_OPEN_ERROR:     return Err::FileOpenError;
-    case mu::engraving::Score::FileError::FILE_BAD_FORMAT:     return Err::FileBadFormat;
-    case mu::engraving::Score::FileError::FILE_UNKNOWN_TYPE:   return Err::FileUnknownType;
-    case mu::engraving::Score::FileError::FILE_NO_ROOTFILE:    return Err::FileBadFormat;
-    case mu::engraving::Score::FileError::FILE_TOO_OLD:        return Err::FileTooOld;
-    case mu::engraving::Score::FileError::FILE_TOO_NEW:        return Err::FileTooNew;
-    case mu::engraving::Score::FileError::FILE_OLD_300_FORMAT: return Err::FileOld300Format;
-    case mu::engraving::Score::FileError::FILE_CORRUPTED:      return Err::FileCorrupted;
-    case mu::engraving::Score::FileError::FILE_CRITICALLY_CORRUPTED: return Err::FileCriticalCorrupted;
-    case mu::engraving::Score::FileError::FILE_USER_ABORT:      return Err::UserAbort;
-    case mu::engraving::Score::FileError::FILE_IGNORE_ERROR:    return Err::IgnoreError;
+    case Score::FileError::FILE_NO_ERROR:       return Err::NoError;
+    case Score::FileError::FILE_ERROR:          return Err::FileUnknownError;
+    case Score::FileError::FILE_NOT_FOUND:      return Err::FileNotFound;
+    case Score::FileError::FILE_OPEN_ERROR:     return Err::FileOpenError;
+    case Score::FileError::FILE_BAD_FORMAT:     return Err::FileBadFormat;
+    case Score::FileError::FILE_UNKNOWN_TYPE:   return Err::FileUnknownType;
+    case Score::FileError::FILE_NO_ROOTFILE:    return Err::FileBadFormat;
+    case Score::FileError::FILE_TOO_OLD:        return Err::FileTooOld;
+    case Score::FileError::FILE_TOO_NEW:        return Err::FileTooNew;
+    case Score::FileError::FILE_OLD_300_FORMAT: return Err::FileOld300Format;
+    case Score::FileError::FILE_CORRUPTED:      return Err::FileCorrupted;
+    case Score::FileError::FILE_CRITICALLY_CORRUPTED: return Err::FileCriticalCorrupted;
+    case Score::FileError::FILE_USER_ABORT:      return Err::UserAbort;
+    case Score::FileError::FILE_IGNORE_ERROR:    return Err::IgnoreError;
     }
     return Err::FileUnknownError;
 }
 
-inline Ret scoreFileErrorToRet(mu::engraving::Score::FileError err, const io::path_t& filePath)
+inline Ret scoreFileErrorToRet(Score::FileError err, const io::path_t& filePath)
 {
     return make_ret(scoreFileErrorToErr(err), filePath);
 }

--- a/src/engraving/engravingmodule.cpp
+++ b/src/engraving/engravingmodule.cpp
@@ -76,7 +76,7 @@ void EngravingModule::registerResources()
 
 void EngravingModule::registerUiTypes()
 {
-    mu::engraving::MScore::registerUiTypes();
+    MScore::registerUiTypes();
 }
 
 void EngravingModule::onInit(const framework::IApplication::RunMode&)
@@ -88,32 +88,31 @@ void EngravingModule::onInit(const framework::IApplication::RunMode&)
                                    s_configuration->partStyleFilePath());
 #endif
 
-    mu::engraving::MScore::init();     // initialize libmscore
+    MScore::init();     // initialize libmscore
 
-    mu::engraving::MScore::setNudgeStep(0.1); // cursor key (default 0.1)
-    mu::engraving::MScore::setNudgeStep10(1.0); // Ctrl + cursor key (default 1.0)
-    mu::engraving::MScore::setNudgeStep50(0.01); // Alt  + cursor key (default 0.01)
+    MScore::setNudgeStep(0.1); // cursor key (default 0.1)
+    MScore::setNudgeStep10(1.0); // Ctrl + cursor key (default 1.0)
+    MScore::setNudgeStep50(0.01); // Alt  + cursor key (default 0.01)
 
     AccessibleItem::enabled = false;
-    mu::engraving::gpaletteScore = compat::ScoreAccess::createMasterScore();
+    gpaletteScore = compat::ScoreAccess::createMasterScore();
     AccessibleItem::enabled = true;
-    if (mu::engraving::EngravingObject::elementsProvider()) {
-        mu::engraving::EngravingObject::elementsProvider()->unreg(mu::engraving::gpaletteScore);
+    if (EngravingObject::elementsProvider()) {
+        EngravingObject::elementsProvider()->unreg(gpaletteScore);
     }
 
-    mu::engraving::gpaletteScore->setStyle(DefaultStyle::baseStyle());
+    gpaletteScore->setStyle(DefaultStyle::baseStyle());
 
-    mu::engraving::gpaletteScore->style().set(mu::engraving::Sid::MusicalTextFont, QString("Leland Text"));
-    mu::engraving::ScoreFont* scoreFont = mu::engraving::ScoreFont::fontByName("Leland");
-    mu::engraving::gpaletteScore->setScoreFont(scoreFont);
-    mu::engraving::gpaletteScore->setNoteHeadWidth(scoreFont->width(mu::engraving::SymId::noteheadBlack,
-                                                                    mu::engraving::gpaletteScore->spatium()) / mu::engraving::SPATIUM20);
+    gpaletteScore->style().set(Sid::MusicalTextFont, QString("Leland Text"));
+    ScoreFont* scoreFont = ScoreFont::fontByName("Leland");
+    gpaletteScore->setScoreFont(scoreFont);
+    gpaletteScore->setNoteHeadWidth(scoreFont->width(SymId::noteheadBlack, gpaletteScore->spatium()) / SPATIUM20);
 
     //! NOTE And some initialization in the `Notation::init()`
 }
 
 void EngravingModule::onDestroy()
 {
-    delete mu::engraving::gpaletteScore;
-    mu::engraving::gpaletteScore = nullptr;
+    delete gpaletteScore;
+    gpaletteScore = nullptr;
 }

--- a/src/engraving/engravingproject.cpp
+++ b/src/engraving/engravingproject.cpp
@@ -38,7 +38,7 @@ std::shared_ptr<EngravingProject> EngravingProject::create()
     return p;
 }
 
-std::shared_ptr<EngravingProject> EngravingProject::create(const mu::engraving::MStyle& style)
+std::shared_ptr<EngravingProject> EngravingProject::create(const MStyle& style)
 {
     std::shared_ptr<EngravingProject> p = std::shared_ptr<EngravingProject>(new EngravingProject());
     p->init(style);
@@ -50,9 +50,9 @@ EngravingProject::~EngravingProject()
     delete m_masterScore;
 }
 
-void EngravingProject::init(const mu::engraving::MStyle& style)
+void EngravingProject::init(const MStyle& style)
 {
-    m_masterScore = new mu::engraving::MasterScore(style, weak_from_this());
+    m_masterScore = new MasterScore(style, weak_from_this());
 }
 
 IFileInfoProviderPtr EngravingProject::fileInfoProvider() const
@@ -90,23 +90,23 @@ Err EngravingProject::setupMasterScore(bool forceMode)
     return err;
 }
 
-Err EngravingProject::doSetupMasterScore(mu::engraving::MasterScore* score, bool forceMode)
+Err EngravingProject::doSetupMasterScore(MasterScore* score, bool forceMode)
 {
     TRACEFUNC;
 
     score->createPaddingTable();
     score->connectTies();
 
-    for (mu::engraving::Part* p : score->parts()) {
+    for (Part* p : score->parts()) {
         p->updateHarmonyChannels(false);
     }
 
     score->rebuildMidiMapping();
     score->setSoloMute();
 
-    for (mu::engraving::Score* s : score->scoreList()) {
+    for (Score* s : score->scoreList()) {
         s->setPlaylistDirty();
-        s->addLayoutFlags(mu::engraving::LayoutFlag::FIX_PITCH_VELO);
+        s->addLayoutFlags(LayoutFlag::FIX_PITCH_VELO);
         s->setLayoutAll();
     }
 
@@ -122,7 +122,7 @@ Err EngravingProject::doSetupMasterScore(mu::engraving::MasterScore* score, bool
     return Err::NoError;
 }
 
-mu::engraving::MasterScore* EngravingProject::masterScore() const
+MasterScore* EngravingProject::masterScore() const
 {
     return m_masterScore;
 }
@@ -132,14 +132,14 @@ Err EngravingProject::loadMscz(const MscReader& msc, bool ignoreVersionError)
     TRACEFUNC;
 
     engravingElementsProvider()->clearStatistic();
-    mu::engraving::MScore::setError(mu::engraving::MsError::MS_NO_ERROR);
+    MScore::setError(MsError::MS_NO_ERROR);
     ScoreReader scoreReader;
     Err err = scoreReader.loadMscz(m_masterScore, msc, ignoreVersionError);
     engravingElementsProvider()->printStatistic("=== Load ===");
     return err;
 }
 
-bool EngravingProject::writeMscz(mu::engraving::MscWriter& writer, bool onlySelection, bool createThumbnail)
+bool EngravingProject::writeMscz(MscWriter& writer, bool onlySelection, bool createThumbnail)
 {
     bool ok = m_masterScore->writeMscz(writer, onlySelection, createThumbnail);
     if (ok && !onlySelection) {

--- a/src/engraving/engravingproject.h
+++ b/src/engraving/engravingproject.h
@@ -45,9 +45,7 @@
 namespace mu::engraving {
 class MasterScore;
 class MStyle;
-}
 
-namespace mu::engraving {
 class EngravingProject : public std::enable_shared_from_this<EngravingProject>
 {
     INJECT(engraving, diagnostics::IEngravingElementsProvider, engravingElementsProvider)
@@ -56,7 +54,7 @@ public:
     ~EngravingProject();
 
     static std::shared_ptr<EngravingProject> create();
-    static std::shared_ptr<EngravingProject> create(const mu::engraving::MStyle& style);
+    static std::shared_ptr<EngravingProject> create(const MStyle& style);
 
     IFileInfoProviderPtr fileInfoProvider() const;
     void setFileInfoProvider(IFileInfoProviderPtr fileInfoProvider);
@@ -66,22 +64,22 @@ public:
 
     bool readOnly() const;
 
-    mu::engraving::MasterScore* masterScore() const;
+    MasterScore* masterScore() const;
     Err setupMasterScore(bool forceMode);
 
-    Err loadMscz(const mu::engraving::MscReader& msc, bool ignoreVersionError);
-    bool writeMscz(mu::engraving::MscWriter& writer, bool onlySelection, bool createThumbnail);
+    Err loadMscz(const MscReader& msc, bool ignoreVersionError);
+    bool writeMscz(MscWriter& writer, bool onlySelection, bool createThumbnail);
 
 private:
-    friend class mu::engraving::MasterScore;
+    friend class MasterScore;
 
     EngravingProject() = default;
 
-    void init(const mu::engraving::MStyle& style);
+    void init(const MStyle& style);
 
-    Err doSetupMasterScore(mu::engraving::MasterScore* score, bool forceMode);
+    Err doSetupMasterScore(MasterScore* score, bool forceMode);
 
-    mu::engraving::MasterScore* m_masterScore = nullptr;
+    MasterScore* m_masterScore = nullptr;
 };
 
 using EngravingProjectPtr = std::shared_ptr<EngravingProject>;

--- a/src/engraving/infrastructure/internal/engravingconfiguration.cpp
+++ b/src/engraving/infrastructure/internal/engravingconfiguration.cpp
@@ -41,11 +41,11 @@ struct VoiceColorKey {
     Color color;
 };
 
-static VoiceColorKey voiceColorKeys[mu::engraving::VOICES];
+static VoiceColorKey voiceColorKeys[VOICES];
 
 void EngravingConfiguration::init()
 {
-    Color defaultVoiceColors[mu::engraving::VOICES] {
+    Color defaultVoiceColors[VOICES] {
         "#0065BF",
         "#007F00",
         "#C53F00",
@@ -57,7 +57,7 @@ void EngravingConfiguration::init()
         m_scoreInversionChanged.notify();
     });
 
-    for (mu::engraving::voice_idx_t voice = 0; voice < mu::engraving::VOICES; ++voice) {
+    for (voice_idx_t voice = 0; voice < VOICES; ++voice) {
         Settings::Key key("engraving", "engraving/colors/voice" + std::to_string(voice + 1));
 
         settings()->setDefaultValue(key, Val(defaultVoiceColors[voice].toQColor()));

--- a/src/engraving/infrastructure/io/ifileinfoprovider.h
+++ b/src/engraving/infrastructure/io/ifileinfoprovider.h
@@ -45,9 +45,4 @@ public:
 using IFileInfoProviderPtr = std::shared_ptr<IFileInfoProvider>;
 }
 
-//! NOTE compat
-namespace mu::engraving {
-using IFileInfoProviderPtr = mu::engraving::IFileInfoProviderPtr;
-}
-
 #endif // MU_ENGRAVING_IFILEINFOPROVIDER_H

--- a/src/engraving/layout/layout.cpp
+++ b/src/engraving/layout/layout.cpp
@@ -72,7 +72,7 @@ public:
     ~CmdStateLocker() { m_score->cmdState().unlock(); }
 };
 
-Layout::Layout(mu::engraving::Score* score)
+Layout::Layout(Score* score)
     : m_score(score)
 {
 }

--- a/src/engraving/layout/layout.h
+++ b/src/engraving/layout/layout.h
@@ -28,16 +28,14 @@ namespace mu::engraving {
 class Score;
 class System;
 class Tremolo;
-}
 
-namespace mu::engraving {
 class LayoutContext;
 class Layout
 {
 public:
-    Layout(mu::engraving::Score* score);
+    Layout(Score* score);
 
-    void doLayoutRange(const LayoutOptions& options, const mu::engraving::Fraction&, const mu::engraving::Fraction&);
+    void doLayoutRange(const LayoutOptions& options, const Fraction&, const Fraction&);
 
 private:
 
@@ -48,7 +46,7 @@ private:
 
     void doLayout(const LayoutOptions& options, LayoutContext& lc);
 
-    mu::engraving::Score* m_score = nullptr;
+    Score* m_score = nullptr;
 };
 }
 

--- a/src/engraving/layout/layoutbeams.h
+++ b/src/engraving/layout/layoutbeams.h
@@ -29,23 +29,21 @@ class Score;
 class Measure;
 class Chord;
 class ChordRest;
-}
 
-namespace mu::engraving {
 class LayoutContext;
 class LayoutBeams
 {
 public:
 
-    static bool isTopBeam(mu::engraving::ChordRest* cr);
-    static bool notTopBeam(mu::engraving::ChordRest* cr);
-    static void createBeams(mu::engraving::Score* score, LayoutContext& lc, mu::engraving::Measure* measure);
-    static void restoreBeams(mu::engraving::Measure* m);
-    static void breakCrossMeasureBeams(const LayoutContext& ctx, mu::engraving::Measure* measure);
-    static void respace(const std::vector<mu::engraving::ChordRest*>& elements);
+    static bool isTopBeam(ChordRest* cr);
+    static bool notTopBeam(ChordRest* cr);
+    static void createBeams(Score* score, LayoutContext& lc, Measure* measure);
+    static void restoreBeams(Measure* m);
+    static void breakCrossMeasureBeams(const LayoutContext& ctx, Measure* measure);
+    static void respace(const std::vector<ChordRest*>& elements);
 
 private:
-    static void beamGraceNotes(mu::engraving::Score* score, mu::engraving::Chord* mainNote, bool after);
+    static void beamGraceNotes(Score* score, Chord* mainNote, bool after);
 };
 }
 

--- a/src/engraving/layout/layoutchords.h
+++ b/src/engraving/layout/layoutchords.h
@@ -35,20 +35,17 @@ class Staff;
 class MStyle;
 class Measure;
 class Chord;
-}
 
-namespace mu::engraving {
 class LayoutChords
 {
 public:
 
-    static void layoutChords1(mu::engraving::Score* score, mu::engraving::Segment* segment, staff_idx_t staffIdx);
-    static qreal layoutChords2(std::vector<mu::engraving::Note*>& notes, bool up);
-    static void layoutChords3(const mu::engraving::MStyle& style, std::vector<mu::engraving::Note*>&, const mu::engraving::Staff*,
-                              mu::engraving::Segment*);
-    static void updateGraceNotes(mu::engraving::Measure* measure);
-    static void repositionGraceNotesAfter(mu::engraving::Segment* segment);
-    static void appendGraceNotes(mu::engraving::Chord* chord);
+    static void layoutChords1(Score* score, Segment* segment, staff_idx_t staffIdx);
+    static qreal layoutChords2(std::vector<Note*>& notes, bool up);
+    static void layoutChords3(const MStyle& style, std::vector<Note*>&, const Staff*, Segment*);
+    static void updateGraceNotes(Measure* measure);
+    static void repositionGraceNotesAfter(Segment* segment);
+    static void appendGraceNotes(Chord* chord);
 };
 }
 

--- a/src/engraving/layout/layoutcontext.h
+++ b/src/engraving/layout/layoutcontext.h
@@ -34,45 +34,43 @@ class Page;
 class System;
 class Spanner;
 class MeasureBase;
-}
 
-namespace mu::engraving {
 class LayoutContext
 {
 public:
-    LayoutContext(mu::engraving::Score* s);
+    LayoutContext(Score* s);
     LayoutContext(const LayoutContext&) = delete;
     LayoutContext& operator=(const LayoutContext&) = delete;
     ~LayoutContext();
 
-    mu::engraving::Score* score() const { return m_score; }
+    Score* score() const { return m_score; }
 
     bool startWithLongNames = true;
     bool firstSystem = true;
     bool firstSystemIndent = true;
-    mu::engraving::Page* page = nullptr;
+    Page* page = nullptr;
     page_idx_t curPage = 0; // index in Score->page()s
-    mu::engraving::Fraction tick{ 0, 1 };
+    Fraction tick{ 0, 1 };
 
-    std::vector<mu::engraving::System*> systemList; // reusable systems
-    std::set<mu::engraving::Spanner*> processedSpanners;
+    std::vector<System*> systemList; // reusable systems
+    std::set<Spanner*> processedSpanners;
 
-    mu::engraving::System* prevSystem = nullptr; // used during page layout
-    mu::engraving::System* curSystem = nullptr;
+    System* prevSystem = nullptr; // used during page layout
+    System* curSystem = nullptr;
 
-    mu::engraving::MeasureBase* systemOldMeasure = nullptr;
-    mu::engraving::MeasureBase* pageOldMeasure = nullptr;
+    MeasureBase* systemOldMeasure = nullptr;
+    MeasureBase* pageOldMeasure = nullptr;
     bool rangeDone = false;
 
-    mu::engraving::MeasureBase* prevMeasure = nullptr;
-    mu::engraving::MeasureBase* curMeasure = nullptr;
-    mu::engraving::MeasureBase* nextMeasure = nullptr;
+    MeasureBase* prevMeasure = nullptr;
+    MeasureBase* curMeasure = nullptr;
+    MeasureBase* nextMeasure = nullptr;
     int measureNo = 0;
-    mu::engraving::Fraction startTick;
-    mu::engraving::Fraction endTick;
+    Fraction startTick;
+    Fraction endTick;
 
 private:
-    mu::engraving::Score* m_score = nullptr;
+    Score* m_score = nullptr;
 };
 }
 

--- a/src/engraving/layout/layoutharmonies.h
+++ b/src/engraving/layout/layoutharmonies.h
@@ -27,16 +27,14 @@
 namespace mu::engraving {
 class System;
 class Segment;
-}
 
-namespace mu::engraving {
 class LayoutHarmonies
 {
 public:
 
-    static void layoutHarmonies(const std::vector<mu::engraving::Segment*>& sl);
-    static void alignHarmonies(const mu::engraving::System* system, const std::vector<mu::engraving::Segment*>& sl, bool harmony,
-                               const double maxShiftAbove, const double maxShiftBelow);
+    static void layoutHarmonies(const std::vector<Segment*>& sl);
+    static void alignHarmonies(const System* system, const std::vector<Segment*>& sl, bool harmony, const double maxShiftAbove,
+                               const double maxShiftBelow);
 };
 }
 

--- a/src/engraving/layout/layoutlyrics.h
+++ b/src/engraving/layout/layoutlyrics.h
@@ -27,15 +27,13 @@
 namespace mu::engraving {
 class Score;
 class System;
-}
 
-namespace mu::engraving {
 class LayoutLyrics
 {
 public:
     LayoutLyrics() = default;
 
-    static void layoutLyrics(const LayoutOptions& options, const mu::engraving::Score* score, mu::engraving::System* system);
+    static void layoutLyrics(const LayoutOptions& options, const Score* score, System* system);
 };
 }
 #endif // MU_ENGRAVING_LAYOUTLYRICS_H

--- a/src/engraving/layout/layoutmeasure.cpp
+++ b/src/engraving/layout/layoutmeasure.cpp
@@ -578,7 +578,7 @@ static void layoutDrumsetChord(Chord* c, const Drumset* drumset, const StaffType
 
 void LayoutMeasure::getNextMeasure(const LayoutOptions& options, LayoutContext& ctx)
 {
-    mu::engraving::Score* score = ctx.score();
+    Score* score = ctx.score();
     ctx.prevMeasure = ctx.curMeasure;
     ctx.curMeasure  = ctx.nextMeasure;
     if (!ctx.curMeasure) {

--- a/src/engraving/layout/layoutmeasure.h
+++ b/src/engraving/layout/layoutmeasure.h
@@ -28,9 +28,7 @@ namespace mu::engraving {
 class Score;
 class Measure;
 class MeasureBase;
-}
 
-namespace mu::engraving {
 class LayoutContext;
 class LayoutContext;
 class LayoutMeasure
@@ -42,10 +40,9 @@ public:
 
 private:
 
-    static void createMMRest(const LayoutOptions& options, mu::engraving::Score* score, mu::engraving::Measure* firstMeasure,
-                             mu::engraving::Measure* lastMeasure, const mu::engraving::Fraction& len);
+    static void createMMRest(const LayoutOptions& options, Score* score, Measure* firstMeasure, Measure* lastMeasure, const Fraction& len);
 
-    static int adjustMeasureNo(LayoutContext& lc, mu::engraving::MeasureBase* m);
+    static int adjustMeasureNo(LayoutContext& lc, MeasureBase* m);
 };
 }
 

--- a/src/engraving/layout/layoutoptions.h
+++ b/src/engraving/layout/layoutoptions.h
@@ -53,22 +53,22 @@ struct LayoutOptions
     qreal maxFretShiftAbove = 0;
     qreal maxFretShiftBelow = 0;
 
-    mu::engraving::VerticalAlignRange verticalAlignRange = mu::engraving::VerticalAlignRange::SEGMENT;
+    VerticalAlignRange verticalAlignRange = VerticalAlignRange::SEGMENT;
 
     bool isMode(LayoutMode m) const { return mode == m; }
     bool isLinearMode() const { return mode == LayoutMode::LINE || mode == LayoutMode::HORIZONTAL_FIXED; }
 
-    void updateFromStyle(const mu::engraving::MStyle& style)
+    void updateFromStyle(const MStyle& style)
     {
-        loWidth = style.styleD(mu::engraving::Sid::pageWidth) * mu::engraving::DPI;
-        loHeight = style.styleD(mu::engraving::Sid::pageHeight) * mu::engraving::DPI;
+        loWidth = style.styleD(Sid::pageWidth) * DPI;
+        loHeight = style.styleD(Sid::pageHeight) * DPI;
 
-        firstSystemIndent = style.styleB(mu::engraving::Sid::enableIndentationOnFirstSystem);
+        firstSystemIndent = style.styleB(Sid::enableIndentationOnFirstSystem);
 
-        maxFretShiftAbove = style.styleMM(mu::engraving::Sid::maxFretShiftAbove);
-        maxFretShiftBelow = style.styleMM(mu::engraving::Sid::maxFretShiftBelow);
+        maxFretShiftAbove = style.styleMM(Sid::maxFretShiftAbove);
+        maxFretShiftBelow = style.styleMM(Sid::maxFretShiftBelow);
 
-        verticalAlignRange = mu::engraving::VerticalAlignRange(style.styleI(mu::engraving::Sid::autoplaceVerticalAlignRange));
+        verticalAlignRange = VerticalAlignRange(style.styleI(Sid::autoplaceVerticalAlignRange));
     }
 };
 }

--- a/src/engraving/layout/layoutpage.h
+++ b/src/engraving/layout/layoutpage.h
@@ -28,9 +28,7 @@
 namespace mu::engraving {
 class Page;
 class System;
-}
 
-namespace mu::engraving {
 class LayoutPage
 {
 public:
@@ -39,9 +37,9 @@ public:
     static void collectPage(const LayoutOptions& options, LayoutContext& lc);
 
 private:
-    static void layoutPage(const LayoutContext& ctx, mu::engraving::Page* page, qreal restHeight, qreal footerPadding);
-    static void checkDivider(const LayoutContext& ctx, bool left, mu::engraving::System* s, qreal yOffset, bool remove = false);
-    static void distributeStaves(const LayoutContext& ctx, mu::engraving::Page* page, qreal footerPadding);
+    static void layoutPage(const LayoutContext& ctx, Page* page, qreal restHeight, qreal footerPadding);
+    static void checkDivider(const LayoutContext& ctx, bool left, System* s, qreal yOffset, bool remove = false);
+    static void distributeStaves(const LayoutContext& ctx, Page* page, qreal footerPadding);
 };
 }
 

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -55,7 +55,7 @@ using namespace mu::engraving;
 //   collectSystem
 //---------------------------------------------------------
 
-System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext& ctx, mu::engraving::Score* score)
+System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext& ctx, Score* score)
 {
     TRACEFUNC;
 
@@ -484,7 +484,7 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
 
 System* LayoutSystem::getNextSystem(LayoutContext& ctx)
 {
-    mu::engraving::Score* score = ctx.score();
+    Score* score = ctx.score();
     bool isVBox = ctx.curMeasure->isVBox();
     System* system = nullptr;
     if (ctx.systemList.empty()) {
@@ -1201,7 +1201,7 @@ void LayoutSystem::layoutSystemElements(const LayoutOptions& options, LayoutCont
     }
 }
 
-void LayoutSystem::doLayoutTies(System* system, std::vector<mu::engraving::Segment*> sl, const Fraction& stick, const Fraction& etick)
+void LayoutSystem::doLayoutTies(System* system, std::vector<Segment*> sl, const Fraction& stick, const Fraction& etick)
 {
     Q_UNUSED(etick);
 

--- a/src/engraving/layout/layoutsystem.h
+++ b/src/engraving/layout/layoutsystem.h
@@ -34,25 +34,19 @@ class Score;
 class System;
 class Spanner;
 class Chord;
-}
 
-namespace mu::engraving {
 class LayoutSystem
 {
 public:
-
-    static mu::engraving::System* collectSystem(const LayoutOptions& options, LayoutContext& lc, mu::engraving::Score* score);
-    static void layoutSystemElements(const LayoutOptions& options, LayoutContext& lc, mu::engraving::Score* score,
-                                     mu::engraving::System* system);
+    static System* collectSystem(const LayoutOptions& options, LayoutContext& lc, Score* score);
+    static void layoutSystemElements(const LayoutOptions& options, LayoutContext& lc, Score* score, System* system);
 
 private:
-
-    static mu::engraving::System* getNextSystem(LayoutContext& lc);
-    static void hideEmptyStaves(mu::engraving::Score* score, mu::engraving::System* system, bool isFirstSystem);
-    static void processLines(mu::engraving::System* system, std::vector<mu::engraving::Spanner*> lines, bool align);
-    static void layoutTies(mu::engraving::Chord* ch, mu::engraving::System* system, const mu::engraving::Fraction& stick);
-    static void doLayoutTies(mu::engraving::System* system, std::vector<mu::engraving::Segment*> sl, const Fraction& stick,
-                             const Fraction& etick);
+    static System* getNextSystem(LayoutContext& lc);
+    static void hideEmptyStaves(Score* score, System* system, bool isFirstSystem);
+    static void processLines(System* system, std::vector<Spanner*> lines, bool align);
+    static void layoutTies(Chord* ch, System* system, const Fraction& stick);
+    static void doLayoutTies(System* system, std::vector<Segment*> sl, const Fraction& stick, const Fraction& etick);
 };
 }
 

--- a/src/engraving/layout/layouttremolo.h
+++ b/src/engraving/layout/layouttremolo.h
@@ -27,13 +27,11 @@
 
 namespace mu::engraving {
 class Tremolo;
-}
 
-namespace mu::engraving {
 class LayoutTremolo
 {
 public:
-    static std::pair<qreal, qreal> extendedStemLenWithTwoNoteTremolo(mu::engraving::Tremolo* tremolo, qreal stemLen1, qreal stemLen2);
+    static std::pair<qreal, qreal> extendedStemLenWithTwoNoteTremolo(Tremolo* tremolo, qreal stemLen1, qreal stemLen2);
 };
 }
 

--- a/src/engraving/layout/layouttuplets.h
+++ b/src/engraving/layout/layouttuplets.h
@@ -25,15 +25,13 @@
 namespace mu::engraving {
 class ChordRest;
 class DurationElement;
-}
 
-namespace mu::engraving {
 class LayoutTuplets
 {
 public:
-    static void layout(mu::engraving::DurationElement* de);
-    static bool isTopTuplet(mu::engraving::ChordRest* cr);
-    static bool notTopTuplet(mu::engraving::ChordRest* cr);
+    static void layout(DurationElement* de);
+    static bool isTopTuplet(ChordRest* cr);
+    static bool notTopTuplet(ChordRest* cr);
 };
 }
 

--- a/src/engraving/layout/verticalgapdata.h
+++ b/src/engraving/layout/verticalgapdata.h
@@ -31,9 +31,7 @@ class System;
 class SysStaff;
 class Staff;
 class Spacer;
-}
 
-namespace mu::engraving {
 //---------------------------------------------------------
 //   VerticalStretchData
 //    helper class for spreading staves over a page
@@ -53,13 +51,12 @@ private:
     void  updateFactor(qreal factor);
 
 public:
-    mu::engraving::MStyle* style { nullptr };
-    mu::engraving::System* system { nullptr };
-    mu::engraving::SysStaff* sysStaff { nullptr };
-    mu::engraving::Staff* staff { nullptr };
+    MStyle* style { nullptr };
+    System* system { nullptr };
+    SysStaff* sysStaff { nullptr };
+    Staff* staff { nullptr };
 
-    VerticalGapData(mu::engraving::MStyle* style, bool first, mu::engraving::System* sys, mu::engraving::Staff* st,
-                    mu::engraving::SysStaff* sst, mu::engraving::Spacer* nextSpacer, qreal y);
+    VerticalGapData(MStyle* style, bool first, System* sys, Staff* st, SysStaff* sst, Spacer* nextSpacer, qreal y);
 
     void addSpaceBetweenSections();
     void addSpaceAroundVBox(bool above);

--- a/src/engraving/libmscore/accidental.h
+++ b/src/engraving/libmscore/accidental.h
@@ -141,7 +141,7 @@ public:
 };
 
 extern AccidentalVal sym2accidentalVal(SymId id);
-}     // namespace Ms
+} // namespace mu::engraving
 
 Q_DECLARE_METATYPE(mu::engraving::AccidentalRole);
 

--- a/src/engraving/libmscore/accidental.h
+++ b/src/engraving/libmscore/accidental.h
@@ -37,9 +37,6 @@
 
 namespace mu::engraving {
 class Factory;
-}
-
-namespace mu::engraving {
 class Note;
 enum class AccidentalVal : signed char;
 
@@ -80,7 +77,7 @@ class Accidental final : public EngravingItem
     AccidentalBracket _bracket     { AccidentalBracket::NONE };
     AccidentalRole _role           { AccidentalRole::AUTO };
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
 
     Accidental(EngravingItem* parent);
 
@@ -125,9 +122,9 @@ public:
     void read(XmlReader&) override;
     void write(XmlWriter& xml) const override;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid propertyId) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid propertyId) const override;
     Pid propertyId(const QStringRef& xmlName) const override;
 
     static AccidentalVal subtype2value(AccidentalType);               // return effective pitch offset

--- a/src/engraving/libmscore/actionicon.h
+++ b/src/engraving/libmscore/actionicon.h
@@ -81,8 +81,8 @@ public:
     void draw(mu::draw::Painter*) const override;
     void layout() override;
 
-    mu::engraving::PropertyValue getProperty(Pid) const override;
-    bool setProperty(Pid, const mu::engraving::PropertyValue&) override;
+    PropertyValue getProperty(Pid) const override;
+    bool setProperty(Pid, const PropertyValue&) override;
 
     static constexpr qreal DEFAULT_FONT_SIZE = 16.0;
 

--- a/src/engraving/libmscore/ambitus.h
+++ b/src/engraving/libmscore/ambitus.h
@@ -29,9 +29,7 @@
 
 namespace mu::engraving {
 class Factory;
-}
 
-namespace mu::engraving {
 //---------------------------------------------------------
 //   @@ Ambitus
 //---------------------------------------------------------
@@ -53,7 +51,7 @@ class Ambitus final : public EngravingItem
     mu::PointF _bottomPos;    // position of bottom note symbol
     mu::LineF _line;          // the drawn line
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Ambitus(Segment* parent);
     Ambitus(const Ambitus& a);
 
@@ -114,9 +112,9 @@ public:
     void remove(EngravingItem*) override;
 
     // properties
-    mu::engraving::PropertyValue getProperty(Pid) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid id) const override;
 
     EngravingItem* nextSegmentElement() override;
     EngravingItem* prevSegmentElement() override;

--- a/src/engraving/libmscore/ambitus.h
+++ b/src/engraving/libmscore/ambitus.h
@@ -132,5 +132,5 @@ private:
 
     Ranges estimateRanges() const;                // scan staff up to next section break and update range pitches
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/arpeggio.h
+++ b/src/engraving/libmscore/arpeggio.h
@@ -127,5 +127,5 @@ public:
     Grip defaultGrip() const override { return Grip::START; }
     std::vector<mu::PointF> gripsPositions(const EditData& = EditData()) const override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/arpeggio.h
+++ b/src/engraving/libmscore/arpeggio.h
@@ -27,9 +27,6 @@
 
 namespace mu::engraving {
 class Factory;
-}
-
-namespace mu::engraving {
 class Chord;
 
 enum class ArpeggioType : char {
@@ -54,7 +51,7 @@ class Arpeggio final : public EngravingItem
 
     bool _hidden = false;   // set in layout, will skip draw if true
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Arpeggio(Chord* parent);
 
     void symbolLine(SymId start, SymId fill);
@@ -115,9 +112,9 @@ public:
     qreal Stretch() const { return _stretch; }
     void setStretch(qreal val) { _stretch = val; }
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid propertyId) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid propertyId) const override;
     Pid propertyId(const QStringRef& xmlName) const override;
 
     // TODO: add a grip for moving the entire arpeggio

--- a/src/engraving/libmscore/articulation.h
+++ b/src/engraving/libmscore/articulation.h
@@ -177,5 +177,5 @@ public:
 
     void doAutoplace();
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/articulation.h
+++ b/src/engraving/libmscore/articulation.h
@@ -30,9 +30,7 @@
 
 namespace mu::engraving {
 class Factory;
-}
 
-namespace mu::engraving {
 class ChordRest;
 class Segment;
 class Measure;
@@ -95,7 +93,7 @@ class Articulation final : public EngravingItem
     OrnamentStyle _ornamentStyle;       // for use in ornaments such as trill
     bool _playArticulation;
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Articulation(ChordRest* parent);
 
     void draw(mu::draw::Painter*) const override;
@@ -132,9 +130,9 @@ public:
 
     std::vector<mu::LineF> dragAnchorLines() const override;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
     void resetProperty(Pid id) override;
     Sid getPropertyStyle(Pid id) const override;
 

--- a/src/engraving/libmscore/audio.h
+++ b/src/engraving/libmscore/audio.h
@@ -50,5 +50,5 @@ public:
     void read(XmlReader&);
     void write(XmlWriter&) const;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/bagpembell.h
+++ b/src/engraving/libmscore/bagpembell.h
@@ -81,5 +81,5 @@ public:
     static BagpipeNoteInfo BagpipeNoteInfoList[];
     noteList getNoteList() const;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/barline.h
+++ b/src/engraving/libmscore/barline.h
@@ -172,6 +172,6 @@ public:
 
     static const std::vector<BarLineTableItem> barLineTable;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/barline.h
+++ b/src/engraving/libmscore/barline.h
@@ -28,10 +28,6 @@
 
 namespace mu::engraving {
 class Factory;
-}
-
-namespace mu::engraving {
-class MuseScoreView;
 class Segment;
 
 static const int MIN_BARLINE_FROMTO_DIST        = 2;
@@ -76,7 +72,7 @@ class BarLine final : public EngravingItem
     mutable qreal y2;
     ElementList _el;          ///< fermata or other articulations
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     BarLine(Segment* parent);
     BarLine(const BarLine&);
 
@@ -148,11 +144,11 @@ public:
 
     int subtype() const override { return int(_barLineType); }
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid propertyId) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid propertyId) const override;
     Pid propertyId(const QStringRef& xmlName) const override;
-    void undoChangeProperty(Pid id, const mu::engraving::PropertyValue&, PropertyFlags ps) override;
+    void undoChangeProperty(Pid id, const PropertyValue&, PropertyFlags ps) override;
     using EngravingObject::undoChangeProperty;
 
     static qreal layoutWidth(Score*, BarLineType);

--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -84,7 +84,7 @@ class Beam final : public EngravingItem
     qreal _slope             { 0.0 };
     std::vector<int> _notes;
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Beam(System* parent);
     Beam(const Beam&);
 
@@ -186,17 +186,17 @@ public:
     bool userModified() const;
     void setUserModified(bool val);
 
-    mu::engraving::PairF beamPos() const;
-    void setBeamPos(const mu::engraving::PairF& bp);
+    PairF beamPos() const;
+    void setBeamPos(const PairF& bp);
 
     qreal beamDist() const { return _beamDist; }
 
     inline const mu::PointF startAnchor() const { return _startAnchor; }
     inline const mu::PointF endAnchor() const { return _endAnchor; }
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid id) const override;
 
     bool isGrace() const { return _isGrace; }    // for debugger
     bool cross() const { return _cross; }

--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -222,5 +222,5 @@ private:
 
     static constexpr std::array _maxSlopes = { 1, 2, 3, 4, 5, 6, 7 };
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/bend.h
+++ b/src/engraving/libmscore/bend.h
@@ -31,9 +31,7 @@
 
 namespace mu::engraving {
 class Factory;
-}
 
-namespace mu::engraving {
 //---------------------------------------------------------
 //   @@ Bend
 //---------------------------------------------------------
@@ -68,12 +66,12 @@ public:
     void setPlayBend(bool v) { m_playBend = v; }
 
     // property methods
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
 
 private:
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Bend(Note* parent);
 
     mu::draw::Font font(qreal) const;

--- a/src/engraving/libmscore/bend.h
+++ b/src/engraving/libmscore/bend.h
@@ -86,5 +86,5 @@ private:
     mu::PointF m_notePos;
     qreal m_noteWidth;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/box.h
+++ b/src/engraving/libmscore/box.h
@@ -188,5 +188,5 @@ public:
     void layout() override;
     void add(EngravingItem*) override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/box.h
+++ b/src/engraving/libmscore/box.h
@@ -94,9 +94,9 @@ public:
     void setAutoSizeEnabled(const bool val) { _isAutoSizeEnabled = val; }
     void copyValues(Box* origin);
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
 
     QString accessibleExtraInfo() const override;
 
@@ -136,9 +136,9 @@ public:
     bool createSystemHeader() const { return _createSystemHeader; }
     void setCreateSystemHeader(bool val) { _createSystemHeader = val; }
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
 
     std::vector<mu::PointF> gripsPositions(const EditData&) const override;
 };
@@ -160,7 +160,7 @@ public:
     qreal minHeight() const;
     qreal maxHeight() const;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
     void layout() override;
 
     void startEditDrag(EditData&) override;

--- a/src/engraving/libmscore/bracket.h
+++ b/src/engraving/libmscore/bracket.h
@@ -29,10 +29,6 @@
 
 namespace mu::engraving {
 class Factory;
-}
-
-namespace mu::engraving {
-class MuseScoreView;
 class System;
 enum class BracketType : signed char;
 
@@ -58,7 +54,7 @@ class Bracket final : public EngravingItem
     qreal _magx;
     Measure* _measure = nullptr;
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Bracket(EngravingItem* parent);
 
 public:
@@ -115,11 +111,11 @@ public:
     bool acceptDrop(EditData&) const override;
     EngravingItem* drop(EditData&) override;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
 
-    void undoChangeProperty(Pid id, const mu::engraving::PropertyValue& v, PropertyFlags ps) override;
+    void undoChangeProperty(Pid id, const PropertyValue& v, PropertyFlags ps) override;
     using EngravingObject::undoChangeProperty;
 
     int gripsCount() const override { return 1; }

--- a/src/engraving/libmscore/bracket.h
+++ b/src/engraving/libmscore/bracket.h
@@ -129,5 +129,5 @@ public:
 
     void setSelected(bool f) override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/bracketItem.cpp
+++ b/src/engraving/libmscore/bracketItem.cpp
@@ -43,7 +43,7 @@ EngravingItem* BracketItem::clone() const
     return new BracketItem(*this);
 }
 
-mu::engraving::PropertyValue BracketItem::getProperty(Pid id) const
+PropertyValue BracketItem::getProperty(Pid id) const
 {
     switch (id) {
     case Pid::SYSTEM_BRACKET:
@@ -57,7 +57,7 @@ mu::engraving::PropertyValue BracketItem::getProperty(Pid id) const
     }
 }
 
-bool BracketItem::setProperty(Pid id, const engraving::PropertyValue& v)
+bool BracketItem::setProperty(Pid id, const PropertyValue& v)
 {
     switch (id) {
     case Pid::SYSTEM_BRACKET:
@@ -76,7 +76,7 @@ bool BracketItem::setProperty(Pid id, const engraving::PropertyValue& v)
     return true;
 }
 
-engraving::PropertyValue BracketItem::propertyDefault(Pid id) const
+PropertyValue BracketItem::propertyDefault(Pid id) const
 {
     switch (id) {
     case Pid::SYSTEM_BRACKET:

--- a/src/engraving/libmscore/bracketItem.h
+++ b/src/engraving/libmscore/bracketItem.h
@@ -28,9 +28,7 @@
 
 namespace mu::engraving {
 class Factory;
-}
 
-namespace mu::engraving {
 //---------------------------------------------------------
 //   BracketItem
 //---------------------------------------------------------
@@ -42,17 +40,17 @@ class BracketItem final : public EngravingItem
     size_t _bracketSpan = 0;
     Staff* _staff = nullptr;
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
 
     BracketItem(EngravingItem* parent);
     BracketItem(EngravingItem* parent, BracketType a, int b);
 
 public:
-    mu::engraving::EngravingItem* clone() const override;
+    EngravingItem* clone() const override;
 
-    mu::engraving::PropertyValue getProperty(Pid) const override;
-    bool setProperty(Pid, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid) const override;
+    bool setProperty(Pid, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid id) const override;
 
     size_t bracketSpan() const { return _bracketSpan; }
     BracketType bracketType() const { return _bracketType; }

--- a/src/engraving/libmscore/breath.h
+++ b/src/engraving/libmscore/breath.h
@@ -90,5 +90,5 @@ protected:
     void added() override;
     void removed() override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/breath.h
+++ b/src/engraving/libmscore/breath.h
@@ -27,9 +27,7 @@
 
 namespace mu::engraving {
 class Factory;
-}
 
-namespace mu::engraving {
 //---------------------------------------------------------
 //   BreathType
 //---------------------------------------------------------
@@ -50,7 +48,7 @@ class Breath final : public EngravingItem
     qreal _pause;
     SymId _symId;
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Breath(Segment* parent);
 
     bool sameVoiceKerningLimited() const override { return true; }
@@ -74,9 +72,9 @@ public:
     void read(XmlReader&) override;
     mu::PointF pagePos() const override;        ///< position in page coordinates
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
 
     EngravingItem* nextSegmentElement() override;
     EngravingItem* prevSegmentElement() override;

--- a/src/engraving/libmscore/bsp.h
+++ b/src/engraving/libmscore/bsp.h
@@ -103,5 +103,5 @@ public:
     virtual ~BspTreeVisitor() {}
     virtual void visit(std::list<EngravingItem*>* items) = 0;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/bsymbol.cpp
+++ b/src/engraving/libmscore/bsymbol.cpp
@@ -44,7 +44,7 @@ namespace mu::engraving {
 //   BSymbol
 //---------------------------------------------------------
 
-BSymbol::BSymbol(const mu::engraving::ElementType& type, mu::engraving::EngravingItem* parent, ElementFlags f)
+BSymbol::BSymbol(const ElementType& type, EngravingItem* parent, ElementFlags f)
     : EngravingItem(type, parent, f)
 {
     _align = { AlignH::LEFT, AlignV::BASELINE };

--- a/src/engraving/libmscore/bsymbol.h
+++ b/src/engraving/libmscore/bsymbol.h
@@ -74,5 +74,5 @@ private:
     std::vector<EngravingItem*> _leafs;
     Align _align;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/changeMap.h
+++ b/src/engraving/libmscore/changeMap.h
@@ -100,5 +100,5 @@ public:
 
     static int interpolate(Fraction& eventTick, ChangeEvent& event, Fraction& tick);
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/chord.h
+++ b/src/engraving/libmscore/chord.h
@@ -116,7 +116,7 @@ class Chord final : public ChordRest
 
     std::vector<Articulation*> _articulations;
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Chord(Segment* parent = 0);
     Chord(const Chord&, bool link = false);
 
@@ -243,9 +243,9 @@ public:
     Hook* hook() const { return _hook; }
 
     //@ add an element to the Chord
-    Q_INVOKABLE void add(mu::engraving::EngravingItem*) override;
+    Q_INVOKABLE void add(EngravingItem*) override;
     //@ remove the element from the Chord
-    Q_INVOKABLE void remove(mu::engraving::EngravingItem*) override;
+    Q_INVOKABLE void remove(EngravingItem*) override;
 
     Note* selectedNote() const;
     void layout() override;
@@ -290,9 +290,9 @@ public:
     void crossMeasureSetup(bool on) override;
 
     void localSpatiumChanged(qreal oldValue, qreal newValue) override;
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
 
     void reset() override;
 
@@ -311,8 +311,8 @@ public:
     QString accessibleExtraInfo() const override;
 
     Shape shape() const override;
-    void undoChangeProperty(Pid id, const mu::engraving::PropertyValue& newValue);
-    void undoChangeProperty(Pid id, const mu::engraving::PropertyValue& newValue, PropertyFlags ps) override;
+    void undoChangeProperty(Pid id, const PropertyValue& newValue);
+    void undoChangeProperty(Pid id, const PropertyValue& newValue, PropertyFlags ps) override;
 };
 } // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/chord.h
+++ b/src/engraving/libmscore/chord.h
@@ -314,5 +314,5 @@ public:
     void undoChangeProperty(Pid id, const mu::engraving::PropertyValue& newValue);
     void undoChangeProperty(Pid id, const mu::engraving::PropertyValue& newValue, PropertyFlags ps) override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/chordline.h
+++ b/src/engraving/libmscore/chordline.h
@@ -93,5 +93,5 @@ public:
 };
 
 extern const char* scorelineNames[];
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/chordline.h
+++ b/src/engraving/libmscore/chordline.h
@@ -30,9 +30,7 @@
 
 namespace mu::engraving {
 class Factory;
-}
 
-namespace mu::engraving {
 class Chord;
 
 //---------------------------------------------------------
@@ -53,7 +51,7 @@ protected:
     qreal _lengthY;
     const int _initialLength = 2;
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
 
     ChordLine(Chord* parent, const ElementType& type = ElementType::CHORDLINE);
     ChordLine(const ChordLine&);
@@ -80,9 +78,9 @@ public:
 
     QString accessibleInfo() const override;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
     Pid propertyId(const QStringRef& xmlName) const override;
 
     bool needStartEditingAfterSelecting() const override { return true; }

--- a/src/engraving/libmscore/chordlist.h
+++ b/src/engraving/libmscore/chordlist.h
@@ -301,7 +301,7 @@ public:
 
 private:
 
-    friend class mu::engraving::compat::ReadChordListHook;
+    friend class compat::ReadChordListHook;
 
     void read(XmlReader&);
     void write(XmlWriter& xml) const;

--- a/src/engraving/libmscore/chordlist.h
+++ b/src/engraving/libmscore/chordlist.h
@@ -306,5 +306,5 @@ private:
     void read(XmlReader&);
     void write(XmlWriter& xml) const;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/chordrest.cpp
+++ b/src/engraving/libmscore/chordrest.cpp
@@ -795,16 +795,16 @@ void ChordRest::replaceBeam(Beam* newBeam)
 Slur* ChordRest::slur(const ChordRest* secondChordRest) const
 {
     if (secondChordRest == nullptr) {
-        secondChordRest = mu::engraving::nextChordRest(const_cast<ChordRest*>(this));
+        secondChordRest = nextChordRest(const_cast<ChordRest*>(this));
     }
     int currentTick = tick().ticks();
-    mu::engraving::Slur* result = nullptr;
+    Slur* result = nullptr;
     for (auto it : score()->spannerMap().findOverlapping(currentTick, currentTick + 1)) {
-        mu::engraving::Spanner* spanner = it.value;
+        Spanner* spanner = it.value;
         if (!spanner->isSlur()) {
             continue;
         }
-        mu::engraving::Slur* slur = mu::engraving::toSlur(spanner);
+        Slur* slur = toSlur(spanner);
         if (slur->startElement() == this && slur->endElement() == secondChordRest) {
             if (slur->slurDirection() == DirectionV::AUTO) {
                 return slur;

--- a/src/engraving/libmscore/chordrest.h
+++ b/src/engraving/libmscore/chordrest.h
@@ -182,9 +182,9 @@ public:
     void setCrossMeasureDurationType(TDuration v) { _crossMeasureTDur = v; }
 
     void localSpatiumChanged(qreal oldValue, qreal newValue) override;
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
     bool isGrace() const;
     bool isGraceBefore() const;
     bool isGraceAfter() const;

--- a/src/engraving/libmscore/chordrest.h
+++ b/src/engraving/libmscore/chordrest.h
@@ -211,5 +211,5 @@ public:
 
     void undoAddAnnotation(EngravingItem*);
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/chordtextlinebase.h
+++ b/src/engraving/libmscore/chordtextlinebase.h
@@ -40,6 +40,6 @@ protected:
 public:
     ChordTextLineBase(const ElementType& type, EngravingItem* parent, ElementFlags = ElementFlag::NOTHING);
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/clef.h
+++ b/src/engraving/libmscore/clef.h
@@ -154,5 +154,5 @@ public:
     QString accessibleInfo() const override;
     void clear();
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/clef.h
+++ b/src/engraving/libmscore/clef.h
@@ -33,12 +33,8 @@
 
 namespace mu::engraving {
 class Factory;
-}
-
-namespace mu::engraving {
-class XmlWriter;
-class MuseScoreView;
 class Segment;
+class XmlWriter;
 
 static const int NO_CLEF = -1000;
 
@@ -101,7 +97,7 @@ class Clef final : public EngravingItem
 
     ClefTypeList _clefTypes { ClefType::INVALID };
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Clef(Segment* parent);
 
     bool neverKernable() const override { return true; }
@@ -145,9 +141,9 @@ public:
     void setClefType(const ClefTypeList& ctl) { _clefTypes = ctl; }
     void spatiumChanged(qreal oldValue, qreal newValue) override;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid id) const override;
 
     EngravingItem* nextSegmentElement() override;
     EngravingItem* prevSegmentElement() override;

--- a/src/engraving/libmscore/cleflist.h
+++ b/src/engraving/libmscore/cleflist.h
@@ -42,5 +42,5 @@ public:
     int nextClefTick(int tick) const;
     int currentClefTick(int tick) const;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -348,7 +348,7 @@ ElementTypeSet Score::changedTypes() const
         return empty;
     }
 
-    const mu::engraving::UndoMacro* actualMacro = undoStack()->current();
+    const UndoMacro* actualMacro = undoStack()->current();
 
     if (!actualMacro) {
         actualMacro = undoStack()->last();

--- a/src/engraving/libmscore/connector.h
+++ b/src/engraving/libmscore/connector.h
@@ -156,5 +156,5 @@ public:
 
     void write();
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/drumset.h
+++ b/src/engraving/libmscore/drumset.h
@@ -105,5 +105,5 @@ public:
 
 extern Drumset* smDrumset;
 extern void initDrumset();
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/duration.h
+++ b/src/engraving/libmscore/duration.h
@@ -74,5 +74,5 @@ private:
     Fraction _duration;
     Tuplet* _tuplet;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/duration.h
+++ b/src/engraving/libmscore/duration.h
@@ -63,8 +63,8 @@ public:
     Fraction globalTicks() const;
     void setTicks(const Fraction& f) { _duration = f; }
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
 
 protected:
     DurationElement(const ElementType& type, EngravingItem* parent = 0, ElementFlags = ElementFlag::MOVABLE | ElementFlag::ON_STAFF);

--- a/src/engraving/libmscore/durationtype.h
+++ b/src/engraving/libmscore/durationtype.h
@@ -103,7 +103,7 @@ void populateRhythmicList(std::vector<TDuration>* dList, const Fraction& l, bool
                           const TimeSigFrac& nominal, int maxDots);
 void splitCompoundBeatsForList(std::vector<TDuration>* dList, const Fraction& l, bool isRest, const Fraction& rtickStart,
                                const TimeSigFrac& nominal, int maxDots);
-}     // namespace Ms
+} // namespace mu::engraving
 
 Q_DECLARE_METATYPE(mu::engraving::TDuration);
 

--- a/src/engraving/libmscore/dynamic.cpp
+++ b/src/engraving/libmscore/dynamic.cpp
@@ -196,7 +196,7 @@ Fraction Dynamic::velocityChangeLength() const
         break;
     }
 
-    return Fraction::fromTicks(int(ratio * (speedMult * double(Constant::division))));
+    return Fraction::fromTicks(int(ratio * (speedMult * double(Constants::division))));
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/dynamic.h
+++ b/src/engraving/libmscore/dynamic.h
@@ -108,6 +108,6 @@ public:
 
     static QString dynamicText(DynamicType t);
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/dynamic.h
+++ b/src/engraving/libmscore/dynamic.h
@@ -95,9 +95,9 @@ public:
     DynamicSpeed velChangeSpeed() const { return _velChangeSpeed; }
     void setVelChangeSpeed(DynamicSpeed val) { _velChangeSpeed = val; }
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid id) const override;
     Pid propertyId(const QStringRef& xmlName) const override;
 
     std::unique_ptr<ElementGroup> getDragGroup(std::function<bool(const EngravingItem*)> isDragged) override;

--- a/src/engraving/libmscore/dynamichairpingroup.cpp
+++ b/src/engraving/libmscore/dynamichairpingroup.cpp
@@ -216,4 +216,4 @@ void DynamicNearHairpinsDragGroup::endDrag(EditData& ed)
     dynamic->endDrag(ed);
     dynamic->triggerLayout();
 }
-} // namespace Ms
+} // namespace mu::engraving

--- a/src/engraving/libmscore/dynamichairpingroup.h
+++ b/src/engraving/libmscore/dynamichairpingroup.h
@@ -77,6 +77,6 @@ public:
 
     static std::unique_ptr<ElementGroup> detectFor(Dynamic* d, std::function<bool(const EngravingItem*)> isDragged);
 };
-} // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/easeInOut.h
+++ b/src/engraving/libmscore/easeInOut.h
@@ -64,5 +64,5 @@ public:
     qreal XfromY(const qreal y) const { return EvalX(tFromY(y)); }
     void timeList(const int nbNotes, const int duration, std::vector<int>* times) const;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -270,10 +270,10 @@ Tuplet* Score::addTuplet(ChordRest* destinationChordRest, Fraction ratio, Tuplet
 
     cmdCreateTuplet(destinationChordRest, tuplet);
 
-    const std::vector<mu::engraving::DurationElement*>& elements = tuplet->elements();
-    mu::engraving::DurationElement* elementForSelect = nullptr;
+    const std::vector<DurationElement*>& elements = tuplet->elements();
+    DurationElement* elementForSelect = nullptr;
     if (!elements.empty()) {
-        mu::engraving::DurationElement* firstElement = elements.front();
+        DurationElement* firstElement = elements.front();
         if (firstElement->isRest()) {
             elementForSelect = firstElement;
         } else if (elements.size() > 1) {
@@ -4279,7 +4279,7 @@ void Score::cloneVoice(track_idx_t strack, track_idx_t dtrack, Segment* sf, cons
                             nn->setTpc2(on->tpc1());
                         } else {
                             v.flip();
-                            nn->setTpc2(mu::engraving::transposeTpc(nn->tpc1(), v, true));
+                            nn->setTpc2(transposeTpc(nn->tpc1(), v, true));
                         }
 
                         if (on->tieFor()) {

--- a/src/engraving/libmscore/elementgroup.cpp
+++ b/src/engraving/libmscore/elementgroup.cpp
@@ -39,4 +39,4 @@ void SingleElementGroup::endDrag(EditData& ed)
     e->endDrag(ed);
     e->triggerLayout();
 }
-} // namespace Ms
+} // namespace mu::engraving

--- a/src/engraving/libmscore/elementgroup.h
+++ b/src/engraving/libmscore/elementgroup.h
@@ -77,6 +77,6 @@ public:
     mu::RectF drag(EditData& ed) override;
     void endDrag(EditData& ed) override;
 };
-} // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/elementmap.h
+++ b/src/engraving/libmscore/elementmap.h
@@ -39,5 +39,5 @@ public:
     EngravingItem* findNew(EngravingItem* o) const;
     void add(EngravingItem* o, EngravingItem* n);
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/engravingitem.cpp
+++ b/src/engraving/libmscore/engravingitem.cpp
@@ -233,9 +233,9 @@ EngravingItemList EngravingItem::childrenItems() const
     return list;
 }
 
-mu::engraving::AccessibleItem* EngravingItem::createAccessible()
+AccessibleItem* EngravingItem::createAccessible()
 {
-    return new mu::engraving::AccessibleItem(this);
+    return new AccessibleItem(this);
 }
 
 //---------------------------------------------------------
@@ -1995,7 +1995,7 @@ EngravingItem* EngravingItem::prevSegmentElement()
     return score()->firstElement();
 }
 
-mu::engraving::AccessibleItem* EngravingItem::accessible() const
+AccessibleItem* EngravingItem::accessible() const
 {
     return m_accessible;
 }
@@ -2454,13 +2454,13 @@ std::pair<int, float> EngravingItem::barbeat() const
     int beat = 0;
     int ticks = 0;
 
-    const mu::engraving::TimeSigMap* timeSigMap = score()->sigmap();
-    int ticksB = mu::engraving::ticks_beat(timeSigMap->timesig(0).timesig().denominator());
+    const TimeSigMap* timeSigMap = score()->sigmap();
+    int ticksB = ticks_beat(timeSigMap->timesig(0).timesig().denominator());
 
     if (parent->type() == ElementType::SEGMENT) {
-        const mu::engraving::Segment* segment = static_cast<const mu::engraving::Segment*>(parent);
+        const Segment* segment = static_cast<const Segment*>(parent);
         timeSigMap->tickValues(segment->tick().ticks(), &bar, &beat, &ticks);
-        ticksB = mu::engraving::ticks_beat(timeSigMap->timesig(segment->tick().ticks()).timesig().denominator());
+        ticksB = ticks_beat(timeSigMap->timesig(segment->tick().ticks()).timesig().denominator());
     } else if (parent->type() == ElementType::MEASURE) {
         const Measure* measure = static_cast<const Measure*>(parent);
         bar = measure->no();

--- a/src/engraving/libmscore/engravingitem.h
+++ b/src/engraving/libmscore/engravingitem.h
@@ -206,7 +206,7 @@ public:
 
 class EngravingItem : public EngravingObject
 {
-    INJECT_STATIC(engraving, mu::engraving::IEngravingConfiguration, engravingConfiguration)
+    INJECT_STATIC(engraving, IEngravingConfiguration, engravingConfiguration)
 
     mutable mu::RectF _bbox;  ///< Bounding box relative to _pos + _offset
     qreal _mag;                     ///< standard magnification (derived value)
@@ -220,7 +220,7 @@ class EngravingItem : public EngravingObject
     ///< valid after call to layout()
     uint _tag;                    ///< tag bitmask
 
-    mu::engraving::AccessibleItem* m_accessible = nullptr;
+    AccessibleItem* m_accessible = nullptr;
     bool m_accessibleEnabled = false;
 
     bool m_colorsInversionEnabled = true;
@@ -235,10 +235,10 @@ protected:
     mu::draw::Color _color;                ///< element color attribute
     bool _skipDraw{ false };
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     EngravingItem(const ElementType& type, EngravingObject* se = 0, ElementFlags = ElementFlag::NOTHING);
     EngravingItem(const EngravingItem&);
-    virtual mu::engraving::AccessibleItem* createAccessible();
+    virtual AccessibleItem* createAccessible();
     virtual KerningType doComputeKerningType(const EngravingItem*) const { return KerningType::KERNING; }
 
 public:
@@ -254,7 +254,7 @@ public:
 
     EngravingItem& operator=(const EngravingItem&) = delete;
     //@ create a copy of the element
-    Q_INVOKABLE virtual mu::engraving::EngravingItem* clone() const = 0;
+    Q_INVOKABLE virtual EngravingItem* clone() const = 0;
     virtual EngravingItem* linkedClone();
 
     void deleteLater();
@@ -557,11 +557,11 @@ public:
     virtual void setAutoplace(bool v) { setFlag(ElementFlag::NO_AUTOPLACE, !v); }
     bool addToSkyline() const { return !(_flags & (ElementFlag::INVISIBLE | ElementFlag::NO_AUTOPLACE)); }
 
-    mu::engraving::PropertyValue getProperty(Pid) const override;
-    bool setProperty(Pid, const mu::engraving::PropertyValue&) override;
-    void undoChangeProperty(Pid id, const mu::engraving::PropertyValue&, PropertyFlags ps) override;
+    PropertyValue getProperty(Pid) const override;
+    bool setProperty(Pid, const PropertyValue&) override;
+    void undoChangeProperty(Pid id, const PropertyValue&, PropertyFlags ps) override;
     using EngravingObject::undoChangeProperty;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue propertyDefault(Pid) const override;
     Pid propertyId(const QStringRef& xmlName) const override;
     virtual EngravingItem* propertyDelegate(Pid) { return 0; }     // return Spanner for SpannerSegment for some properties
 
@@ -589,7 +589,7 @@ public:
     virtual EngravingItem* nextSegmentElement();    //< Used for navigation
     virtual EngravingItem* prevSegmentElement();    //< next-element and prev-element command
 
-    mu::engraving::AccessibleItem* accessible() const;
+    AccessibleItem* accessible() const;
     virtual QString accessibleInfo() const;           //< used to populate the status bar
     virtual QString screenReaderInfo() const          //< by default returns accessibleInfo, but can be overridden
     {
@@ -647,7 +647,7 @@ enum class EditDataType : signed char {
 
 struct PropertyData {
     Pid id;
-    mu::engraving::PropertyValue data;
+    PropertyValue data;
     PropertyFlags f;
 };
 
@@ -706,7 +706,7 @@ public:
 
 extern bool elementLessThan(const EngravingItem* const, const EngravingItem* const);
 extern void collectElements(void* data, EngravingItem* e);
-}     // namespace Ms
+} // mu::engraving
 
 Q_DECLARE_METATYPE(mu::engraving::ElementType);
 

--- a/src/engraving/libmscore/engravingobject.h
+++ b/src/engraving/libmscore/engravingobject.h
@@ -244,11 +244,11 @@ public:
     const MStyle* style() const;
     QString mscoreVersion() const;
 
-    virtual mu::engraving::PropertyValue getProperty(Pid) const = 0;
-    virtual bool setProperty(Pid, const mu::engraving::PropertyValue&) = 0;
-    virtual mu::engraving::PropertyValue propertyDefault(Pid) const;
+    virtual PropertyValue getProperty(Pid) const = 0;
+    virtual bool setProperty(Pid, const PropertyValue&) = 0;
+    virtual PropertyValue propertyDefault(Pid) const;
     virtual void resetProperty(Pid id);
-    mu::engraving::PropertyValue propertyDefault(Pid pid, TextStyleType tid) const;
+    PropertyValue propertyDefault(Pid pid, TextStyleType tid) const;
     virtual bool sizeIsSpatiumDependent() const { return true; }
     virtual bool offsetIsSpatiumDependent() const { return true; }
 
@@ -262,7 +262,7 @@ public:
     virtual PropertyFlags* propertyFlagsList() const { return _propertyFlagsList; }
     virtual PropertyFlags propertyFlags(Pid) const;
     bool isStyled(Pid pid) const;
-    mu::engraving::PropertyValue styleValue(Pid, Sid) const;
+    PropertyValue styleValue(Pid, Sid) const;
 
     void setPropertyFlags(Pid, PropertyFlags);
 
@@ -275,8 +275,8 @@ public:
 
     virtual void styleChanged();
 
-    virtual void undoChangeProperty(Pid id, const mu::engraving::PropertyValue&, PropertyFlags ps);
-    void undoChangeProperty(Pid id, const mu::engraving::PropertyValue&);
+    virtual void undoChangeProperty(Pid id, const PropertyValue&, PropertyFlags ps);
+    void undoChangeProperty(Pid id, const PropertyValue&);
     void undoResetProperty(Pid id);
 
     void undoPushProperty(Pid);

--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -184,8 +184,8 @@ void Excerpt::setVoiceVisible(Staff* staff, int voiceIndex, bool visible)
     }
 
     staff_idx_t staffIndex = staff->idx();
-    mu::engraving::Fraction startTick = staff->score()->firstMeasure()->tick();
-    mu::engraving::Fraction endTick = staff->score()->lastMeasure()->tick();
+    Fraction startTick = staff->score()->firstMeasure()->tick();
+    Fraction endTick = staff->score()->lastMeasure()->tick();
 
     // update tracks
     staff->setVoiceVisible(voiceIndex, visible);
@@ -575,12 +575,11 @@ static void processLinkedClone(EngravingItem* ne, Score* score, track_idx_t stra
     ne->setScore(score);
 }
 
-static mu::engraving::MeasureBase* cloneMeasure(mu::engraving::MeasureBase* mb, mu::engraving::Score* score,
-                                                const mu::engraving::Score* oscore,
-                                                const std::vector<staff_idx_t>& sourceStavesIndexes,
-                                                const TracksMap& trackList, TieMap& tieMap)
+static MeasureBase* cloneMeasure(MeasureBase* mb, Score* score, const Score* oscore,
+                                 const std::vector<staff_idx_t>& sourceStavesIndexes,
+                                 const TracksMap& trackList, TieMap& tieMap)
 {
-    mu::engraving::MeasureBase* nmb = nullptr;
+    MeasureBase* nmb = nullptr;
 
     if (mb->isHBox()) {
         nmb = Factory::createHBox(score->dummy()->system());

--- a/src/engraving/libmscore/factory.cpp
+++ b/src/engraving/libmscore/factory.cpp
@@ -411,7 +411,7 @@ const char* Factory::name(ElementType type)
     return elementNames[int(type)].name.ascii();
 }
 
-const char* Factory::userName(mu::engraving::ElementType type)
+const char* Factory::userName(ElementType type)
 {
     return elementNames[int(type)].userName;
 }
@@ -488,7 +488,7 @@ MAKE_ITEM_IMPL(Breath, Segment)
 
 CREATE_ITEM_IMPL(Chord, ElementType::CHORD, Segment, isAccessibleEnabled)
 
-mu::engraving::Chord* Factory::copyChord(const mu::engraving::Chord& src, bool link)
+Chord* Factory::copyChord(const Chord& src, bool link)
 {
     Chord* copy = new Chord(src, link);
     copy->setAccessibleEnabled(src.accessibleEnabled());
@@ -546,7 +546,7 @@ CREATE_ITEM_IMPL(NoteDot, ElementType::NOTEDOT, Note, isAccessibleEnabled)
 CREATE_ITEM_IMPL(NoteDot, ElementType::NOTEDOT, Rest, isAccessibleEnabled)
 COPY_ITEM_IMPL(NoteDot)
 
-mu::engraving::Page* Factory::createPage(RootItem * parent, bool isAccessibleEnabled)
+Page* Factory::createPage(RootItem * parent, bool isAccessibleEnabled)
 {
     Page* page = new Page(parent);
     page->setAccessibleEnabled(isAccessibleEnabled);
@@ -554,7 +554,7 @@ mu::engraving::Page* Factory::createPage(RootItem * parent, bool isAccessibleEna
     return page;
 }
 
-mu::engraving::Rest* Factory::createRest(mu::engraving::Segment* parent, bool isAccessibleEnabled)
+Rest* Factory::createRest(Segment* parent, bool isAccessibleEnabled)
 {
     Rest* r = new Rest(parent);
     r->setAccessibleEnabled(isAccessibleEnabled);
@@ -562,7 +562,7 @@ mu::engraving::Rest* Factory::createRest(mu::engraving::Segment* parent, bool is
     return r;
 }
 
-mu::engraving::Rest* Factory::createRest(mu::engraving::Segment* parent, const mu::engraving::TDuration& t, bool isAccessibleEnabled)
+Rest* Factory::createRest(Segment* parent, const TDuration& t, bool isAccessibleEnabled)
 {
     Rest* r = new Rest(parent, t);
     r->setAccessibleEnabled(isAccessibleEnabled);
@@ -570,7 +570,7 @@ mu::engraving::Rest* Factory::createRest(mu::engraving::Segment* parent, const m
     return r;
 }
 
-mu::engraving::Rest* Factory::copyRest(const mu::engraving::Rest& src, bool link)
+Rest* Factory::copyRest(const Rest& src, bool link)
 {
     Rest* copy = new Rest(src, link);
     copy->setAccessibleEnabled(src.accessibleEnabled());
@@ -578,7 +578,7 @@ mu::engraving::Rest* Factory::copyRest(const mu::engraving::Rest& src, bool link
     return copy;
 }
 
-mu::engraving::Segment* Factory::createSegment(mu::engraving::Measure* parent, bool isAccessibleEnabled)
+Segment* Factory::createSegment(Measure* parent, bool isAccessibleEnabled)
 {
     Segment* s = new Segment(parent);
     s->setAccessibleEnabled(isAccessibleEnabled);
@@ -586,8 +586,7 @@ mu::engraving::Segment* Factory::createSegment(mu::engraving::Measure* parent, b
     return s;
 }
 
-mu::engraving::Segment* Factory::createSegment(mu::engraving::Measure* parent, mu::engraving::SegmentType type,
-                                               const mu::engraving::Fraction& t, bool isAccessibleEnabled)
+Segment* Factory::createSegment(Measure* parent, SegmentType type, const Fraction& t, bool isAccessibleEnabled)
 {
     Segment* s = new Segment(parent, type, t);
     s->setAccessibleEnabled(isAccessibleEnabled);
@@ -627,7 +626,7 @@ CREATE_ITEM_IMPL(StaffState, ElementType::STAFF_STATE, EngravingItem, isAccessib
 CREATE_ITEM_IMPL(StaffTypeChange, ElementType::STAFFTYPE_CHANGE, MeasureBase, isAccessibleEnabled)
 MAKE_ITEM_IMPL(StaffTypeChange, MeasureBase)
 
-StaffText* Factory::createStaffText(Segment * parent, mu::engraving::TextStyleType textStyleType, bool isAccessibleEnabled)
+StaffText* Factory::createStaffText(Segment * parent, TextStyleType textStyleType, bool isAccessibleEnabled)
 {
     StaffText* staffText = new StaffText(parent, textStyleType);
     staffText->setAccessibleEnabled(isAccessibleEnabled);
@@ -640,7 +639,7 @@ CREATE_ITEM_IMPL(RehearsalMark, ElementType::REHEARSAL_MARK, Segment, isAccessib
 CREATE_ITEM_IMPL(Stem, ElementType::STEM, Chord, isAccessibleEnabled)
 COPY_ITEM_IMPL(Stem)
 
-mu::engraving::StemSlash* Factory::createStemSlash(mu::engraving::Chord * parent, bool isAccessibleEnabled)
+StemSlash* Factory::createStemSlash(Chord * parent, bool isAccessibleEnabled)
 {
     StemSlash* s = new StemSlash(parent);
     s->setAccessibleEnabled(isAccessibleEnabled);
@@ -650,7 +649,7 @@ mu::engraving::StemSlash* Factory::createStemSlash(mu::engraving::Chord * parent
 
 COPY_ITEM_IMPL(StemSlash)
 
-mu::engraving::System* Factory::createSystem(mu::engraving::Page * parent, bool isAccessibleEnabled)
+System* Factory::createSystem(Page * parent, bool isAccessibleEnabled)
 {
     System* s = new System(parent);
     s->setAccessibleEnabled(isAccessibleEnabled);
@@ -658,8 +657,7 @@ mu::engraving::System* Factory::createSystem(mu::engraving::Page * parent, bool 
     return s;
 }
 
-mu::engraving::SystemText* Factory::createSystemText(mu::engraving::Segment* parent, mu::engraving::TextStyleType textStyleType,
-                                                     bool isAccessibleEnabled)
+SystemText* Factory::createSystemText(Segment* parent, TextStyleType textStyleType, bool isAccessibleEnabled)
 {
     SystemText* systemText = new SystemText(parent, textStyleType);
     systemText->setAccessibleEnabled(isAccessibleEnabled);
@@ -669,8 +667,8 @@ mu::engraving::SystemText* Factory::createSystemText(mu::engraving::Segment* par
 
 CREATE_ITEM_IMPL(InstrumentChange, ElementType::INSTRUMENT_CHANGE, Segment, isAccessibleEnabled)
 
-mu::engraving::InstrumentChange* Factory::createInstrumentChange(mu::engraving::Segment * parent, const Instrument& instrument,
-                                                                 bool isAccessibleEnabled)
+InstrumentChange* Factory::createInstrumentChange(Segment * parent, const Instrument& instrument,
+                                                  bool isAccessibleEnabled)
 {
     InstrumentChange* instrumentChange = new InstrumentChange(instrument, parent);
     instrumentChange->setAccessibleEnabled(isAccessibleEnabled);
@@ -682,8 +680,8 @@ CREATE_ITEM_IMPL(Sticking, ElementType::STICKING, Segment, isAccessibleEnabled)
 
 CREATE_ITEM_IMPL(Fingering, ElementType::FINGERING, Note, isAccessibleEnabled)
 
-mu::engraving::Fingering* Factory::createFingering(mu::engraving::Note * parent, mu::engraving::TextStyleType textStyleType,
-                                                   bool isAccessibleEnabled)
+Fingering* Factory::createFingering(Note * parent, TextStyleType textStyleType,
+                                    bool isAccessibleEnabled)
 {
     Fingering* fingering = new Fingering(parent, textStyleType);
     fingering->setAccessibleEnabled(isAccessibleEnabled);
@@ -695,7 +693,7 @@ CREATE_ITEM_IMPL(Harmony, ElementType::HARMONY, Segment, isAccessibleEnabled)
 
 CREATE_ITEM_IMPL(TempoText, ElementType::TEMPO_TEXT, Segment, isAccessibleEnabled)
 
-mu::engraving::Text* Factory::createText(mu::engraving::EngravingItem * parent, TextStyleType tid, bool isAccessibleEnabled)
+Text* Factory::createText(EngravingItem * parent, TextStyleType tid, bool isAccessibleEnabled)
 {
     Text* t = new Text(parent, tid);
     t->setAccessibleEnabled(isAccessibleEnabled);
@@ -742,7 +740,7 @@ CREATE_ITEM_IMPL(LetRing, ElementType::LET_RING, EngravingItem, isAccessibleEnab
 
 CREATE_ITEM_IMPL(Marker, ElementType::MARKER, EngravingItem, isAccessibleEnabled)
 
-mu::engraving::Marker* Factory::createMarker(mu::engraving::EngravingItem * parent, TextStyleType tid, bool isAccessibleEnabled)
+Marker* Factory::createMarker(EngravingItem * parent, TextStyleType tid, bool isAccessibleEnabled)
 {
     Marker* m = new Marker(parent, tid);
     m->setAccessibleEnabled(isAccessibleEnabled);
@@ -772,7 +770,7 @@ CREATE_ITEM_IMPL(MMRest, ElementType::MMREST, EngravingItem, isAccessibleEnabled
 
 CREATE_ITEM_IMPL(VBox, ElementType::VBOX, System, isAccessibleEnabled)
 
-mu::engraving::VBox* Factory::createVBox(const ElementType& type, System * parent, bool isAccessibleEnabled)
+VBox* Factory::createVBox(const ElementType& type, System * parent, bool isAccessibleEnabled)
 {
     VBox* b = new VBox(type, parent);
     b->setAccessibleEnabled(isAccessibleEnabled);

--- a/src/engraving/libmscore/factory.h
+++ b/src/engraving/libmscore/factory.h
@@ -41,231 +41,218 @@ class Factory
 {
 public:
 
-    static mu::engraving::ElementType name2type(const AsciiString& name, bool silent = false);
-    static const char* name(mu::engraving::ElementType type);
-    static const char* userName(mu::engraving::ElementType type);
+    static ElementType name2type(const AsciiString& name, bool silent = false);
+    static const char* name(ElementType type);
+    static const char* userName(ElementType type);
 
-    static mu::engraving::EngravingItem* createItem(mu::engraving::ElementType type, mu::engraving::EngravingItem* parent,
-                                                    bool isAccessibleEnabled = true);
-    static mu::engraving::EngravingItem* createItemByName(const AsciiString& name, mu::engraving::EngravingItem* parent,
-                                                          bool isAccessibleEnabled = true);
+    static EngravingItem* createItem(ElementType type, EngravingItem* parent, bool isAccessibleEnabled = true);
+    static EngravingItem* createItemByName(const AsciiString& name, EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::Accidental* createAccidental(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<mu::engraving::Accidental> makeAccidental(mu::engraving::EngravingItem* parent);
+    static Accidental* createAccidental(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Accidental> makeAccidental(EngravingItem* parent);
 
-    static mu::engraving::Ambitus* createAmbitus(mu::engraving::Segment* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<mu::engraving::Ambitus> makeAmbitus(mu::engraving::Segment* parent);
+    static Ambitus* createAmbitus(Segment* parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Ambitus> makeAmbitus(Segment* parent);
 
-    static mu::engraving::Arpeggio* createArpeggio(mu::engraving::Chord* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<mu::engraving::Arpeggio> makeArpeggio(mu::engraving::Chord* parent);
+    static Arpeggio* createArpeggio(Chord* parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Arpeggio> makeArpeggio(Chord* parent);
 
-    static mu::engraving::Articulation* createArticulation(mu::engraving::ChordRest* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<mu::engraving::Articulation> makeArticulation(mu::engraving::ChordRest* parent);
+    static Articulation* createArticulation(ChordRest* parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Articulation> makeArticulation(ChordRest* parent);
 
-    static mu::engraving::BarLine* createBarLine(mu::engraving::Segment* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::BarLine* copyBarLine(const mu::engraving::BarLine& src);
-    static std::shared_ptr<mu::engraving::BarLine> makeBarLine(mu::engraving::Segment* parent);
+    static BarLine* createBarLine(Segment* parent, bool isAccessibleEnabled = true);
+    static BarLine* copyBarLine(const BarLine& src);
+    static std::shared_ptr<BarLine> makeBarLine(Segment* parent);
 
-    static mu::engraving::Beam* createBeam(mu::engraving::System* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<mu::engraving::Beam> makeBeam(mu::engraving::System* parent);
+    static Beam* createBeam(System* parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Beam> makeBeam(System* parent);
 
-    static mu::engraving::Bend* createBend(mu::engraving::Note* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<mu::engraving::Bend> makeBend(mu::engraving::Note* parent);
+    static Bend* createBend(Note* parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Bend> makeBend(Note* parent);
 
-    static mu::engraving::Bracket* createBracket(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<mu::engraving::Bracket> makeBracket(mu::engraving::EngravingItem* parent);
-    static mu::engraving::BracketItem* createBracketItem(mu::engraving::EngravingItem* parent);
-    static mu::engraving::BracketItem* createBracketItem(mu::engraving::EngravingItem* parent, mu::engraving::BracketType a, int b);
+    static Bracket* createBracket(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Bracket> makeBracket(EngravingItem* parent);
+    static BracketItem* createBracketItem(EngravingItem* parent);
+    static BracketItem* createBracketItem(EngravingItem* parent, BracketType a, int b);
 
-    static mu::engraving::Breath* createBreath(mu::engraving::Segment* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<mu::engraving::Breath> makeBreath(mu::engraving::Segment* parent);
+    static Breath* createBreath(Segment* parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Breath> makeBreath(Segment* parent);
 
-    static mu::engraving::Chord* createChord(mu::engraving::Segment* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::Chord* copyChord(const mu::engraving::Chord& src, bool link = false);
-    static std::shared_ptr<mu::engraving::Chord> makeChord(mu::engraving::Segment* parent);
+    static Chord* createChord(Segment* parent, bool isAccessibleEnabled = true);
+    static Chord* copyChord(const Chord& src, bool link = false);
+    static std::shared_ptr<Chord> makeChord(Segment* parent);
 
-    static mu::engraving::ChordLine* createChordLine(mu::engraving::Chord* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::ChordLine* copyChordLine(const mu::engraving::ChordLine& src);
-    static std::shared_ptr<mu::engraving::ChordLine> makeChordLine(mu::engraving::Chord* parent);
+    static ChordLine* createChordLine(Chord* parent, bool isAccessibleEnabled = true);
+    static ChordLine* copyChordLine(const ChordLine& src);
+    static std::shared_ptr<ChordLine> makeChordLine(Chord* parent);
 
-    static mu::engraving::Slide* createSlide(mu::engraving::Chord* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::Slide* copySlide(const mu::engraving::Slide& src);
-    static std::shared_ptr<mu::engraving::Slide> makeSlide(mu::engraving::Chord* parent);
+    static Slide* createSlide(Chord* parent, bool isAccessibleEnabled = true);
+    static Slide* copySlide(const Slide& src);
+    static std::shared_ptr<Slide> makeSlide(Chord* parent);
 
-    static mu::engraving::Clef* createClef(mu::engraving::Segment* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::Clef* copyClef(const mu::engraving::Clef& src);
-    static std::shared_ptr<mu::engraving::Clef> makeClef(mu::engraving::Segment* parent);
+    static Clef* createClef(Segment* parent, bool isAccessibleEnabled = true);
+    static Clef* copyClef(const Clef& src);
+    static std::shared_ptr<Clef> makeClef(Segment* parent);
 
-    static mu::engraving::Fermata* createFermata(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<mu::engraving::Fermata> makeFermata(mu::engraving::EngravingItem* parent);
+    static Fermata* createFermata(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Fermata> makeFermata(EngravingItem* parent);
 
-    static mu::engraving::FiguredBass* createFiguredBass(mu::engraving::Segment* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<mu::engraving::FiguredBass> makeFiguredBass(mu::engraving::Segment* parent);
+    static FiguredBass* createFiguredBass(Segment* parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<FiguredBass> makeFiguredBass(Segment* parent);
 
-    static mu::engraving::FretDiagram* createFretDiagram(mu::engraving::Segment* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::FretDiagram* copyFretDiagram(const mu::engraving::FretDiagram& src);
-    static std::shared_ptr<mu::engraving::FretDiagram> makeFretDiagram(mu::engraving::Segment* parent);
+    static FretDiagram* createFretDiagram(Segment* parent, bool isAccessibleEnabled = true);
+    static FretDiagram* copyFretDiagram(const FretDiagram& src);
+    static std::shared_ptr<FretDiagram> makeFretDiagram(Segment* parent);
 
-    static mu::engraving::KeySig* createKeySig(mu::engraving::Segment* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::KeySig* copyKeySig(const mu::engraving::KeySig& src);
-    static std::shared_ptr<mu::engraving::KeySig> makeKeySig(mu::engraving::Segment* parent);
+    static KeySig* createKeySig(Segment* parent, bool isAccessibleEnabled = true);
+    static KeySig* copyKeySig(const KeySig& src);
+    static std::shared_ptr<KeySig> makeKeySig(Segment* parent);
 
-    static mu::engraving::LayoutBreak* createLayoutBreak(mu::engraving::MeasureBase* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::LayoutBreak* copyLayoutBreak(const mu::engraving::LayoutBreak& src);
-    static std::shared_ptr<mu::engraving::LayoutBreak> makeLayoutBreak(mu::engraving::MeasureBase* parent);
+    static LayoutBreak* createLayoutBreak(MeasureBase* parent, bool isAccessibleEnabled = true);
+    static LayoutBreak* copyLayoutBreak(const LayoutBreak& src);
+    static std::shared_ptr<LayoutBreak> makeLayoutBreak(MeasureBase* parent);
 
-    static mu::engraving::Lyrics* createLyrics(mu::engraving::ChordRest* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::Lyrics* copyLyrics(const mu::engraving::Lyrics& src);
+    static Lyrics* createLyrics(ChordRest* parent, bool isAccessibleEnabled = true);
+    static Lyrics* copyLyrics(const Lyrics& src);
 
-    static mu::engraving::Measure* createMeasure(mu::engraving::System* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::Measure* copyMeasure(const mu::engraving::Measure& src);
+    static Measure* createMeasure(System* parent, bool isAccessibleEnabled = true);
+    static Measure* copyMeasure(const Measure& src);
 
-    static mu::engraving::MeasureRepeat* createMeasureRepeat(mu::engraving::Segment* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::MeasureRepeat* copyMeasureRepeat(const mu::engraving::MeasureRepeat& src);
+    static MeasureRepeat* createMeasureRepeat(Segment* parent, bool isAccessibleEnabled = true);
+    static MeasureRepeat* copyMeasureRepeat(const MeasureRepeat& src);
 
-    static mu::engraving::Note* createNote(mu::engraving::Chord* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::Note* copyNote(const mu::engraving::Note& src, bool link = false);
-    static std::shared_ptr<mu::engraving::Note> makeNote(mu::engraving::Chord* parent);
+    static Note* createNote(Chord* parent, bool isAccessibleEnabled = true);
+    static Note* copyNote(const Note& src, bool link = false);
+    static std::shared_ptr<Note> makeNote(Chord* parent);
 
-    static mu::engraving::NoteDot* createNoteDot(mu::engraving::Note* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::NoteDot* createNoteDot(mu::engraving::Rest* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::NoteDot* copyNoteDot(const mu::engraving::NoteDot& src);
+    static NoteDot* createNoteDot(Note* parent, bool isAccessibleEnabled = true);
+    static NoteDot* createNoteDot(Rest* parent, bool isAccessibleEnabled = true);
+    static NoteDot* copyNoteDot(const NoteDot& src);
 
-    static mu::engraving::Page* createPage(RootItem* parent, bool isAccessibleEnabled = true);
+    static Page* createPage(RootItem* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::Rest* createRest(mu::engraving::Segment* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::Rest* createRest(mu::engraving::Segment* parent, const mu::engraving::TDuration& t,
-                                           bool isAccessibleEnabled = true);
-    static mu::engraving::Rest* copyRest(const mu::engraving::Rest& src, bool link = false);
-    static mu::engraving::MMRest* createMMRest(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Rest* createRest(Segment* parent, bool isAccessibleEnabled = true);
+    static Rest* createRest(Segment* parent, const TDuration& t, bool isAccessibleEnabled = true);
+    static Rest* copyRest(const Rest& src, bool link = false);
+    static MMRest* createMMRest(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::Segment* createSegment(mu::engraving::Measure* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::Segment* createSegment(mu::engraving::Measure* parent, mu::engraving::SegmentType type,
-                                                 const mu::engraving::Fraction& t, bool isAccessibleEnabled = true);
+    static Segment* createSegment(Measure* parent, bool isAccessibleEnabled = true);
+    static Segment* createSegment(Measure* parent, SegmentType type, const Fraction& t, bool isAccessibleEnabled = true);
 
-    static mu::engraving::Slur* createSlur(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<mu::engraving::Slur> makeSlur(mu::engraving::EngravingItem* parent);
+    static Slur* createSlur(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Slur> makeSlur(EngravingItem* parent);
 
-    static mu::engraving::Spacer* createSpacer(mu::engraving::Measure* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<mu::engraving::Spacer> makeSpacer(mu::engraving::Measure* parent);
+    static Spacer* createSpacer(Measure* parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Spacer> makeSpacer(Measure* parent);
 
-    static mu::engraving::Staff* createStaff(mu::engraving::Part* parent);
+    static Staff* createStaff(Part* parent);
 
-    static mu::engraving::StaffLines* createStaffLines(mu::engraving::Measure* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::StaffLines* copyStaffLines(const mu::engraving::StaffLines& src);
+    static StaffLines* createStaffLines(Measure* parent, bool isAccessibleEnabled = true);
+    static StaffLines* copyStaffLines(const StaffLines& src);
 
-    static mu::engraving::StaffState* createStaffState(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
+    static StaffState* createStaffState(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::StaffTypeChange* createStaffTypeChange(mu::engraving::MeasureBase* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<mu::engraving::StaffTypeChange> makeStaffTypeChange(mu::engraving::MeasureBase* parent);
+    static StaffTypeChange* createStaffTypeChange(MeasureBase* parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<StaffTypeChange> makeStaffTypeChange(MeasureBase* parent);
 
-    static mu::engraving::StaffText* createStaffText(mu::engraving::Segment* parent,
-                                                     mu::engraving::TextStyleType textStyleType = TextStyleType::STAFF,
-                                                     bool isAccessibleEnabled = true);
+    static StaffText* createStaffText(Segment* parent, TextStyleType textStyleType = TextStyleType::STAFF, bool isAccessibleEnabled = true);
 
-    static mu::engraving::RehearsalMark* createRehearsalMark(mu::engraving::Segment* parent, bool isAccessibleEnabled = true);
+    static RehearsalMark* createRehearsalMark(Segment* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::Stem* createStem(mu::engraving::Chord* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::Stem* copyStem(const mu::engraving::Stem& src);
+    static Stem* createStem(Chord* parent, bool isAccessibleEnabled = true);
+    static Stem* copyStem(const Stem& src);
 
-    static mu::engraving::StemSlash* createStemSlash(mu::engraving::Chord* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::StemSlash* copyStemSlash(const mu::engraving::StemSlash& src);
+    static StemSlash* createStemSlash(Chord* parent, bool isAccessibleEnabled = true);
+    static StemSlash* copyStemSlash(const StemSlash& src);
 
-    static mu::engraving::System* createSystem(mu::engraving::Page* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::SystemText* createSystemText(mu::engraving::Segment* parent,
-                                                       mu::engraving::TextStyleType textStyleType = mu::engraving::TextStyleType::SYSTEM,
-                                                       bool isAccessibleEnabled = true);
+    static System* createSystem(Page* parent, bool isAccessibleEnabled = true);
+    static SystemText* createSystemText(Segment* parent, TextStyleType textStyleType = TextStyleType::SYSTEM,
+                                        bool isAccessibleEnabled = true);
 
-    static mu::engraving::InstrumentChange* createInstrumentChange(mu::engraving::Segment* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::InstrumentChange* createInstrumentChange(mu::engraving::Segment* parent,
-                                                                   const mu::engraving::Instrument& instrument,
-                                                                   bool isAccessibleEnabled = true);
+    static InstrumentChange* createInstrumentChange(Segment* parent, bool isAccessibleEnabled = true);
+    static InstrumentChange* createInstrumentChange(Segment* parent, const Instrument& instrument, bool isAccessibleEnabled = true);
 
-    static mu::engraving::Sticking* createSticking(mu::engraving::Segment* parent, bool isAccessibleEnabled = true);
+    static Sticking* createSticking(Segment* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::Fingering* createFingering(mu::engraving::Note* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::Fingering* createFingering(mu::engraving::Note* parent, mu::engraving::TextStyleType textStyleType,
-                                                     bool isAccessibleEnabled = true);
+    static Fingering* createFingering(Note* parent, bool isAccessibleEnabled = true);
+    static Fingering* createFingering(Note* parent, TextStyleType textStyleType, bool isAccessibleEnabled = true);
 
-    static mu::engraving::Harmony* createHarmony(mu::engraving::Segment* parent, bool isAccessibleEnabled = true);
+    static Harmony* createHarmony(Segment* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::TempoText* createTempoText(mu::engraving::Segment* parent, bool isAccessibleEnabled = true);
+    static TempoText* createTempoText(Segment* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::Text* createText(mu::engraving::EngravingItem* parent,
-                                           mu::engraving::TextStyleType tid = mu::engraving::TextStyleType::DEFAULT,
-                                           bool isAccessibleEnabled = true);
-    static mu::engraving::Text* copyText(const mu::engraving::Text& src);
+    static Text* createText(EngravingItem* parent, TextStyleType tid = TextStyleType::DEFAULT, bool isAccessibleEnabled = true);
+    static Text* copyText(const Text& src);
 
-    static mu::engraving::Tie* createTie(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::Tie* copyTie(const mu::engraving::Tie& src);
+    static Tie* createTie(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Tie* copyTie(const Tie& src);
 
-    static mu::engraving::TimeSig* createTimeSig(mu::engraving::Segment* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::TimeSig* copyTimeSig(const mu::engraving::TimeSig& src);
-    static std::shared_ptr<mu::engraving::TimeSig> makeTimeSig(mu::engraving::Segment* parent);
+    static TimeSig* createTimeSig(Segment* parent, bool isAccessibleEnabled = true);
+    static TimeSig* copyTimeSig(const TimeSig& src);
+    static std::shared_ptr<TimeSig> makeTimeSig(Segment* parent);
 
-    static mu::engraving::Tremolo* createTremolo(mu::engraving::Chord* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::Tremolo* copyTremolo(const mu::engraving::Tremolo& src);
-    static std::shared_ptr<mu::engraving::Tremolo> makeTremolo(mu::engraving::Chord* parent);
+    static Tremolo* createTremolo(Chord* parent, bool isAccessibleEnabled = true);
+    static Tremolo* copyTremolo(const Tremolo& src);
+    static std::shared_ptr<Tremolo> makeTremolo(Chord* parent);
 
-    static mu::engraving::TremoloBar* createTremoloBar(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<mu::engraving::TremoloBar> makeTremoloBar(mu::engraving::EngravingItem* parent);
+    static TremoloBar* createTremoloBar(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<TremoloBar> makeTremoloBar(EngravingItem* parent);
 
-    static mu::engraving::Tuplet* createTuplet(mu::engraving::Measure* parent, bool isAccessibleEnabled = true);
-    static mu::engraving::Tuplet* copyTuplet(const mu::engraving::Tuplet& src);
+    static Tuplet* createTuplet(Measure* parent, bool isAccessibleEnabled = true);
+    static Tuplet* copyTuplet(const Tuplet& src);
 
-    static mu::engraving::Hairpin* createHairpin(mu::engraving::Segment* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<mu::engraving::Hairpin> makeHairpin(mu::engraving::Segment* parent);
+    static Hairpin* createHairpin(Segment* parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Hairpin> makeHairpin(Segment* parent);
 
-    static mu::engraving::Glissando* createGlissando(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<mu::engraving::Glissando> makeGlissando(mu::engraving::EngravingItem* parent);
+    static Glissando* createGlissando(EngravingItem* parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Glissando> makeGlissando(EngravingItem* parent);
 
-    static mu::engraving::Jump* createJump(mu::engraving::Measure* parent, bool isAccessibleEnabled = true);
+    static Jump* createJump(Measure* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::Trill* createTrill(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Trill* createTrill(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::Vibrato* createVibrato(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Vibrato* createVibrato(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::TextLine* createTextLine(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
+    static TextLine* createTextLine(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::Ottava* createOttava(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Ottava* createOttava(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::LetRing* createLetRing(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
+    static LetRing* createLetRing(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::Marker* createMarker(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Marker* createMarker(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::Marker* createMarker(mu::engraving::EngravingItem* parent, TextStyleType tid, bool isAccessibleEnabled = true);
+    static Marker* createMarker(EngravingItem* parent, TextStyleType tid, bool isAccessibleEnabled = true);
 
-    static mu::engraving::TempoChangeRanged* createTempoChangeRanged(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
+    static TempoChangeRanged* createTempoChangeRanged(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::PalmMute* createPalmMute(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
+    static PalmMute* createPalmMute(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::WhammyBar* createWhammyBar(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
+    static WhammyBar* createWhammyBar(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::Rasgueado* createRasgueado(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Rasgueado* createRasgueado(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::HarmonicMark* createHarmonicMark(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
+    static HarmonicMark* createHarmonicMark(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::Volta* createVolta(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Volta* createVolta(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::Pedal* createPedal(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Pedal* createPedal(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::Dynamic* createDynamic(mu::engraving::Segment* parent, bool isAccessibleEnabled = true);
+    static Dynamic* createDynamic(Segment* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::Harmony* createHarmony(mu::engraving::EngravingItem* parent, bool isAccessibleEnabled = true);
+    static Harmony* createHarmony(EngravingItem* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::VBox* createVBox(mu::engraving::System* parent, bool isAccessibleEnabled = true);
+    static VBox* createVBox(System* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::VBox* createVBox(const mu::engraving::ElementType& type, mu::engraving::System* parent,
-                                           bool isAccessibleEnabled = true);
+    static VBox* createVBox(const ElementType& type, System* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::HBox* createHBox(mu::engraving::System* parent, bool isAccessibleEnabled = true);
+    static HBox* createHBox(System* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::TBox* createTBox(mu::engraving::System* parent, bool isAccessibleEnabled = true);
+    static TBox* createTBox(System* parent, bool isAccessibleEnabled = true);
 
-    static mu::engraving::FBox* createFBox(mu::engraving::System* parent, bool isAccessibleEnabled = true);
+    static FBox* createFBox(System* parent, bool isAccessibleEnabled = true);
 
 private:
-    static mu::engraving::EngravingItem* doCreateItem(mu::engraving::ElementType type, mu::engraving::EngravingItem* parent);
+    static EngravingItem* doCreateItem(ElementType type, EngravingItem* parent);
 };
 }
 

--- a/src/engraving/libmscore/fermata.cpp
+++ b/src/engraving/libmscore/fermata.cpp
@@ -386,20 +386,20 @@ qreal Fermata::mag() const
 FermataType Fermata::fermataType() const
 {
     static const std::unordered_map<SymId, FermataType> FERMATA_TYPES = {
-        { mu::engraving::SymId::fermataAbove, FermataType::Normal },
-        { mu::engraving::SymId::fermataBelow, FermataType::Normal },
-        { mu::engraving::SymId::fermataLongAbove, FermataType::Long },
-        { mu::engraving::SymId::fermataLongBelow, FermataType::Long },
-        { mu::engraving::SymId::fermataLongHenzeAbove, FermataType::LongHenze },
-        { mu::engraving::SymId::fermataLongHenzeBelow, FermataType::LongHenze },
-        { mu::engraving::SymId::fermataVeryLongAbove, FermataType::VeryLong },
-        { mu::engraving::SymId::fermataVeryLongBelow, FermataType::VeryLong },
-        { mu::engraving::SymId::fermataShortHenzeAbove, FermataType::ShortHenze },
-        { mu::engraving::SymId::fermataShortHenzeBelow, FermataType::ShortHenze },
-        { mu::engraving::SymId::fermataVeryShortAbove, FermataType::VeryShort },
-        { mu::engraving::SymId::fermataVeryShortBelow, FermataType::VeryShort },
-        { mu::engraving::SymId::fermataShortAbove, FermataType::Short },
-        { mu::engraving::SymId::fermataShortBelow, FermataType::Short },
+        { SymId::fermataAbove, FermataType::Normal },
+        { SymId::fermataBelow, FermataType::Normal },
+        { SymId::fermataLongAbove, FermataType::Long },
+        { SymId::fermataLongBelow, FermataType::Long },
+        { SymId::fermataLongHenzeAbove, FermataType::LongHenze },
+        { SymId::fermataLongHenzeBelow, FermataType::LongHenze },
+        { SymId::fermataVeryLongAbove, FermataType::VeryLong },
+        { SymId::fermataVeryLongBelow, FermataType::VeryLong },
+        { SymId::fermataShortHenzeAbove, FermataType::ShortHenze },
+        { SymId::fermataShortHenzeBelow, FermataType::ShortHenze },
+        { SymId::fermataVeryShortAbove, FermataType::VeryShort },
+        { SymId::fermataVeryShortBelow, FermataType::VeryShort },
+        { SymId::fermataShortAbove, FermataType::Short },
+        { SymId::fermataShortBelow, FermataType::Short },
     };
 
     auto search = FERMATA_TYPES.find(symId());

--- a/src/engraving/libmscore/fermata.h
+++ b/src/engraving/libmscore/fermata.h
@@ -103,5 +103,5 @@ protected:
     void added() override;
     void removed() override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/fermata.h
+++ b/src/engraving/libmscore/fermata.h
@@ -49,7 +49,7 @@ class Fermata final : public EngravingItem
     qreal _timeStretch;
     bool _play;
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Fermata(EngravingItem* parent);
 
     void draw(mu::draw::Painter*) const override;
@@ -78,9 +78,9 @@ public:
 
     std::vector<mu::LineF> dragAnchorLines() const override;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
     void resetProperty(Pid id) override;
 
     Pid propertyId(const QStringRef& xmlName) const override;

--- a/src/engraving/libmscore/figuredbass.h
+++ b/src/engraving/libmscore/figuredbass.h
@@ -320,7 +320,7 @@ public:
 
     void appendItem(FiguredBassItem* item) { items.push_back(item); }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 Q_DECLARE_METATYPE(mu::engraving::FiguredBassItem::Modifier);
 Q_DECLARE_METATYPE(mu::engraving::FiguredBassItem::Parenthesis);

--- a/src/engraving/libmscore/figuredbass.h
+++ b/src/engraving/libmscore/figuredbass.h
@@ -27,9 +27,6 @@
 
 namespace mu::engraving {
 class Factory;
-}
-
-namespace mu::engraving {
 class Segment;
 
 /*---------------------------------------------------------
@@ -217,9 +214,9 @@ public:
     QString           normalizedText() const;
     QString           displayText() const { return _displayText; }
 
-    mu::engraving::PropertyValue  getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue  propertyDefault(Pid) const override;
+    PropertyValue  getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue  propertyDefault(Pid) const override;
 };
 
 //---------------------------------------------------------
@@ -255,7 +252,7 @@ class FiguredBass final : public TextBase
                                                 // under the same note)
     qreal _printedLineLength;                   // the length of lines actually printed (i.e. continuation lines)
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     FiguredBass(Segment* parent = 0);
     FiguredBass(const FiguredBass&);
 
@@ -314,9 +311,9 @@ public:
     qreal             additionalContLineX(qreal pagePosY) const;  // returns the X coord (in page coord) of cont. line at pagePosY, if any
     FiguredBass* nextFiguredBass() const;                         // returns next *adjacent* f.b. item, if any
 
-    mu::engraving::PropertyValue  getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue  propertyDefault(Pid) const override;
+    PropertyValue  getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue  propertyDefault(Pid) const override;
 
     void appendItem(FiguredBassItem* item) { items.push_back(item); }
 };

--- a/src/engraving/libmscore/fingering.h
+++ b/src/engraving/libmscore/fingering.h
@@ -48,7 +48,7 @@ public:
     bool isEditAllowed(EditData&) const override;
     bool edit(EditData&) override;
 
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue propertyDefault(Pid id) const override;
 
     QString accessibleInfo() const override;
 };

--- a/src/engraving/libmscore/fingering.h
+++ b/src/engraving/libmscore/fingering.h
@@ -52,5 +52,5 @@ public:
 
     QString accessibleInfo() const override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/fret.h
+++ b/src/engraving/libmscore/fret.h
@@ -30,9 +30,6 @@
 
 namespace mu::engraving {
 class Factory;
-}
-
-namespace mu::engraving {
 class StringData;
 class Chord;
 
@@ -164,7 +161,7 @@ class FretDiagram final : public EngravingItem
     qreal markerSize;
     int _numPos;
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     FretDiagram(Segment* parent = nullptr);
     FretDiagram(const FretDiagram&);
 
@@ -239,7 +236,7 @@ public:
 
     Harmony* harmony() const { return _harmony; }
 
-    void init(mu::engraving::StringData*, Chord*);
+    void init(StringData*, Chord*);
     void add(EngravingItem*) override;
     void remove(EngravingItem*) override;
 
@@ -249,9 +246,9 @@ public:
     void endEditDrag(EditData& editData) override;
     void scanElements(void* data, void (* func)(void*, EngravingItem*), bool all=true) override;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
 
     qreal userMag() const { return _userMag; }
     void setUserMag(qreal m) { _userMag = m; }

--- a/src/engraving/libmscore/fret.h
+++ b/src/engraving/libmscore/fret.h
@@ -261,7 +261,7 @@ public:
 
     friend class FretUndoData;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 Q_DECLARE_METATYPE(mu::engraving::FretDiagram*)
 

--- a/src/engraving/libmscore/glissando.h
+++ b/src/engraving/libmscore/glissando.h
@@ -91,9 +91,9 @@ public:
     void read(XmlReader&) override;
 
     // property/style methods
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
     Pid propertyId(const QStringRef& xmlName) const override;
 };
 } // namespace mu::engraving

--- a/src/engraving/libmscore/glissando.h
+++ b/src/engraving/libmscore/glissando.h
@@ -96,6 +96,6 @@ public:
     mu::engraving::PropertyValue propertyDefault(Pid) const override;
     Pid propertyId(const QStringRef& xmlName) const override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/groups.cpp
+++ b/src/engraving/libmscore/groups.cpp
@@ -146,7 +146,7 @@ BeamMode Groups::beamMode(int tick, DurationType d) const
     default:
         return BeamMode::AUTO;
     }
-    const int dm = Constant::division / 8;
+    const int dm = Constants::division / 8;
     for (const GroupNode& e : m_nodes) {
         if (e.pos * dm < tick) {
             continue;

--- a/src/engraving/libmscore/groups.h
+++ b/src/engraving/libmscore/groups.h
@@ -83,6 +83,6 @@ struct NoteGroup {
     Fraction timeSig;
     Groups endings;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/hairpin.h
+++ b/src/engraving/libmscore/hairpin.h
@@ -152,9 +152,9 @@ public:
     void write(XmlWriter&) const override;
     void read(XmlReader&) override;
 
-    mu::engraving::PropertyValue getProperty(Pid id) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid id) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid id) const override;
     Pid propertyId(const QStringRef& xmlName) const override;
 
     QString accessibleInfo() const override;

--- a/src/engraving/libmscore/hairpin.h
+++ b/src/engraving/libmscore/hairpin.h
@@ -163,7 +163,7 @@ public:
         return _hairpinType == HairpinType::CRESC_LINE || _hairpinType == HairpinType::DECRESC_LINE;
     }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 Q_DECLARE_METATYPE(mu::engraving::HairpinType);
 

--- a/src/engraving/libmscore/harmonicmark.cpp
+++ b/src/engraving/libmscore/harmonicmark.cpp
@@ -86,7 +86,7 @@ HarmonicMark::HarmonicMark(EngravingItem* parent)
     resetProperty(Pid::END_TEXT);
 }
 
-bool HarmonicMark::setProperty(Pid propertyId, const mu::engraving::PropertyValue& value)
+bool HarmonicMark::setProperty(Pid propertyId, const PropertyValue& value)
 {
     if (propertyId == Pid::BEGIN_TEXT) {
         m_text = value.toString();

--- a/src/engraving/libmscore/harmonicmark.h
+++ b/src/engraving/libmscore/harmonicmark.h
@@ -59,9 +59,9 @@ public:
 
     LineSegment* createLineSegment(System* parent) override;
 
-    mu::engraving::PropertyValue propertyDefault(Pid propertyId) const override;
+    PropertyValue propertyDefault(Pid propertyId) const override;
     Sid getPropertyStyle(Pid) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue& value) override;
+    bool setProperty(Pid propertyId, const PropertyValue& value) override;
 
 private:
 

--- a/src/engraving/libmscore/harmonicmark.h
+++ b/src/engraving/libmscore/harmonicmark.h
@@ -67,5 +67,5 @@ private:
 
     QString m_text;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/harmony.h
+++ b/src/engraving/libmscore/harmony.h
@@ -235,5 +235,5 @@ public:
     bool setProperty(Pid propertyId, const mu::engraving::PropertyValue& v) override;
     mu::engraving::PropertyValue propertyDefault(Pid id) const override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/harmony.h
+++ b/src/engraving/libmscore/harmony.h
@@ -231,9 +231,9 @@ public:
     bool acceptDrop(EditData&) const override;
     EngravingItem* drop(EditData&) override;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue& v) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue& v) override;
+    PropertyValue propertyDefault(Pid id) const override;
 };
 } // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/hook.h
+++ b/src/engraving/libmscore/hook.h
@@ -50,5 +50,5 @@ public:
     //! @p straight: whether to use straight flags
     static SymId symIdForHookIndex(int index, bool straight);
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/image.h
+++ b/src/engraving/libmscore/image.h
@@ -120,5 +120,5 @@ private:
 
     ImageType imageType = ImageType::NONE;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/image.h
+++ b/src/engraving/libmscore/image.h
@@ -78,9 +78,9 @@ public:
     bool sizeIsSpatium() const { return _sizeIsSpatium; }
     void setSizeIsSpatium(bool val) { _sizeIsSpatium = val; }
 
-    mu::engraving::PropertyValue getProperty(Pid) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid id) const override;
 
     mu::SizeF imageSize() const;
 

--- a/src/engraving/libmscore/imageStore.h
+++ b/src/engraving/libmscore/imageStore.h
@@ -90,5 +90,5 @@ public:
 };
 
 extern ImageStore imageStore;       // this is the global imageStore
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/input.cpp
+++ b/src/engraving/libmscore/input.cpp
@@ -169,7 +169,7 @@ void InputState::update(Selection& selection)
                 }
 
                 articulationsIds = mu::engraving::splitArticulations(articulationsIds);
-                articulationsIds = mu::engraving::flipArticulations(articulationsIds, mu::engraving::PlacementV::ABOVE);
+                articulationsIds = mu::engraving::flipArticulations(articulationsIds, PlacementV::ABOVE);
                 for (const SymId& articulationSymbolId: articulationsIds) {
                     if (std::find(articulationSymbolIds.begin(), articulationSymbolIds.end(),
                                   articulationSymbolId) == articulationSymbolIds.end()) {
@@ -183,7 +183,7 @@ void InputState::update(Selection& selection)
                 for (Articulation* artic: n->chord()->articulations()) {
                     articulationsIds.insert(artic->symId());
                 }
-                articulationSymbolIds = mu::engraving::flipArticulations(articulationsIds, mu::engraving::PlacementV::ABOVE);
+                articulationSymbolIds = mu::engraving::flipArticulations(articulationsIds, PlacementV::ABOVE);
 
                 n1 = n;
             }

--- a/src/engraving/libmscore/input.h
+++ b/src/engraving/libmscore/input.h
@@ -147,5 +147,5 @@ public:
     static Note* note(EngravingItem*);
     static ChordRest* chordRest(EngravingItem*);
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/instrchange.h
+++ b/src/engraving/libmscore/instrchange.h
@@ -67,7 +67,7 @@ public:
 
     Segment* segment() const { return toSegment(explicitParent()); }
 
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue propertyDefault(Pid) const override;
 
     bool placeMultiple() const override { return false; }
 };

--- a/src/engraving/libmscore/instrchange.h
+++ b/src/engraving/libmscore/instrchange.h
@@ -71,5 +71,5 @@ public:
 
     bool placeMultiple() const override { return false; }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/instrtemplate.h
+++ b/src/engraving/libmscore/instrtemplate.h
@@ -183,5 +183,5 @@ extern InstrumentTemplate* searchTemplateForMidiProgram(int midiProgram, const b
 extern InstrumentTemplate* guessTemplateByNameData(const std::list<QString>& nameDataList);
 extern InstrumentGroup* searchInstrumentGroup(const QString& name);
 extern ClefType defaultClef(int patch);
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/instrument.cpp
+++ b/src/engraving/libmscore/instrument.cpp
@@ -269,7 +269,7 @@ void StaffName::read(XmlReader& e)
     _name = e.readXml();
     if (_name.startsWith("<html>")) {
         // compatibility to old html implementation:
-        _name = mu::engraving::HtmlParser::parse(_name);
+        _name = HtmlParser::parse(_name);
     }
 }
 

--- a/src/engraving/libmscore/instrument.h
+++ b/src/engraving/libmscore/instrument.h
@@ -449,5 +449,5 @@ public:
     void setInstrument(Instrument*, int tick);
     bool contains(const std::string& instrumentId) const;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/instrumentname.h
+++ b/src/engraving/libmscore/instrumentname.h
@@ -63,9 +63,9 @@ public:
 
     Fraction playTick() const override;
     bool isEditable() const override { return false; }
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
 };
 } // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/instrumentname.h
+++ b/src/engraving/libmscore/instrumentname.h
@@ -67,5 +67,5 @@ public:
     bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
     mu::engraving::PropertyValue propertyDefault(Pid) const override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/interval.h
+++ b/src/engraving/libmscore/interval.h
@@ -42,5 +42,5 @@ struct Interval {
     bool operator!=(const Interval& a) const { return diatonic != a.diatonic || chromatic != a.chromatic; }
     bool operator==(const Interval& a) const { return diatonic == a.diatonic && chromatic == a.chromatic; }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/jump.h
+++ b/src/engraving/libmscore/jump.h
@@ -111,7 +111,7 @@ struct JumpTypeTableItem {
 };
 
 extern const std::vector<JumpTypeTableItem> jumpTypeTable;
-} // namespace Ms
+} // namespace mu::engraving
 
 Q_DECLARE_METATYPE(mu::engraving::Jump::Type);
 

--- a/src/engraving/libmscore/jump.h
+++ b/src/engraving/libmscore/jump.h
@@ -92,9 +92,9 @@ public:
     bool playRepeats() const { return _playRepeats; }
     void setPlayRepeats(bool val) { _playRepeats = val; }
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
 
     EngravingItem* nextSegmentElement() override;
     EngravingItem* prevSegmentElement() override;

--- a/src/engraving/libmscore/key.h
+++ b/src/engraving/libmscore/key.h
@@ -163,5 +163,5 @@ struct Interval;
 enum class PreferSharpFlat : char;
 extern Key transposeKey(Key oldKey, const Interval&, PreferSharpFlat prefer = PreferSharpFlat(0));
 extern Interval calculateInterval(Key key1, Key key2);
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/keylist.h
+++ b/src/engraving/libmscore/keylist.h
@@ -29,9 +29,6 @@
 
 namespace mu::engraving {
 class ReadContext;
-}
-
-namespace mu::engraving {
 class XmlReader;
 
 //---------------------------------------------------------
@@ -49,7 +46,7 @@ public:
     void setKey(int tick, KeySigEvent);
     int nextKeyTick(int tick) const;
     int currentKeyTick(int tick) const;
-    void read(XmlReader&, const mu::engraving::ReadContext& ctx);
+    void read(XmlReader&, const ReadContext& ctx);
 };
 }
 

--- a/src/engraving/libmscore/keysig.h
+++ b/src/engraving/libmscore/keysig.h
@@ -106,5 +106,5 @@ public:
 };
 
 extern const char* keyNames[];
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/keysig.h
+++ b/src/engraving/libmscore/keysig.h
@@ -28,9 +28,6 @@
 
 namespace mu::engraving {
 class Factory;
-}
-
-namespace mu::engraving {
 class Segment;
 
 //---------------------------------------------------------------------------------------
@@ -46,7 +43,7 @@ class KeySig final : public EngravingItem
     bool _hideNaturals;       // used in layout to override score style (needed for the Continuous panel)
     KeySigEvent _sig;
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     KeySig(Segment* = 0);
     KeySig(const KeySig&);
 
@@ -94,9 +91,9 @@ public:
     void setForInstrumentChange(bool forInstrumentChange) { _sig.setForInstrumentChange(forInstrumentChange); }
     bool forInstrumentChange() const { return _sig.forInstrumentChange(); }
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid id) const override;
 
     EngravingItem* nextSegmentElement() override;
     EngravingItem* prevSegmentElement() override;

--- a/src/engraving/libmscore/lasso.h
+++ b/src/engraving/libmscore/lasso.h
@@ -53,5 +53,5 @@ public:
     Grip defaultGrip() const override { return Grip(7); }
     std::vector<mu::PointF> gripsPositions(const EditData&) const override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/lasso.h
+++ b/src/engraving/libmscore/lasso.h
@@ -35,7 +35,7 @@ namespace mu::engraving {
 
 class Lasso : public EngravingItem
 {
-    INJECT(engraving, mu::engraving::IEngravingConfiguration, engravingConfiguration)
+    INJECT(engraving, IEngravingConfiguration, engravingConfiguration)
 
 public:
     Lasso(Score*);

--- a/src/engraving/libmscore/layoutbreak.h
+++ b/src/engraving/libmscore/layoutbreak.h
@@ -28,9 +28,7 @@
 
 namespace mu::engraving {
 class Factory;
-}
 
-namespace mu::engraving {
 //---------------------------------------------------------
 //   @@ LayoutBreak
 ///    symbols for line break, page break etc.
@@ -67,9 +65,9 @@ public:
     bool isSectionBreak() const { return _layoutBreakType == LayoutBreakType::SECTION; }
     bool isNoBreak() const { return _layoutBreakType == LayoutBreakType::NOBREAK; }
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
     Pid propertyId(const QStringRef& xmlName) const override;
 
 protected:
@@ -78,7 +76,7 @@ protected:
 
 private:
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     LayoutBreak(MeasureBase* parent = 0);
     LayoutBreak(const LayoutBreak&);
 

--- a/src/engraving/libmscore/layoutbreak.h
+++ b/src/engraving/libmscore/layoutbreak.h
@@ -95,6 +95,6 @@ private:
     bool _firstSystemIndentation;
     LayoutBreakType _layoutBreakType;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/ledgerline.h
+++ b/src/engraving/libmscore/ledgerline.h
@@ -70,5 +70,5 @@ public:
     bool readProperties(XmlReader&) override;
     void spatiumChanged(qreal /*oldValue*/, qreal /*newValue*/) override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/letring.h
+++ b/src/engraving/libmscore/letring.h
@@ -61,7 +61,7 @@ public:
 //      virtual void write(XmlWriter& xml) const override;
     LineSegment* createLineSegment(System* parent) override;
 
-    mu::engraving::PropertyValue propertyDefault(Pid propertyId) const override;
+    PropertyValue propertyDefault(Pid propertyId) const override;
     Sid getPropertyStyle(Pid) const override;
 };
 } // namespace mu::engraving

--- a/src/engraving/libmscore/letring.h
+++ b/src/engraving/libmscore/letring.h
@@ -64,5 +64,5 @@ public:
     mu::engraving::PropertyValue propertyDefault(Pid propertyId) const override;
     Sid getPropertyStyle(Pid) const override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/line.h
+++ b/src/engraving/libmscore/line.h
@@ -142,9 +142,9 @@ public:
     LineSegment* segmentAt(int n) { return toLineSegment(Spanner::segmentAt(n)); }
     const LineSegment* segmentAt(int n) const { return toLineSegment(Spanner::segmentAt(n)); }
 
-    mu::engraving::PropertyValue getProperty(Pid id) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid id) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid id) const override;
 
     friend class LineSegment;
 };

--- a/src/engraving/libmscore/line.h
+++ b/src/engraving/libmscore/line.h
@@ -148,5 +148,5 @@ public:
 
     friend class LineSegment;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/location.h
+++ b/src/engraving/libmscore/location.h
@@ -94,7 +94,7 @@ public:
     void fillPositionForElement(const EngravingItem* e, bool absfrac = true);
     static Location forElement(const EngravingItem* e, bool absfrac = true);
     static Location positionForElement(const EngravingItem* e, bool absfrac = true);
-    static mu::engraving::PropertyValue getLocationProperty(Pid pid, const EngravingItem* start, const EngravingItem* end);
+    static PropertyValue getLocationProperty(Pid pid, const EngravingItem* start, const EngravingItem* end);
 
     bool operator==(const Location& other) const;
     bool operator!=(const Location& other) const { return !(*this == other); }

--- a/src/engraving/libmscore/location.h
+++ b/src/engraving/libmscore/location.h
@@ -99,5 +99,5 @@ public:
     bool operator==(const Location& other) const;
     bool operator!=(const Location& other) const { return !(*this == other); }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/lyrics.h
+++ b/src/engraving/libmscore/lyrics.h
@@ -59,12 +59,12 @@ private:
     Syllabic _syllabic;
     LyricsLine* _separator;
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Lyrics(ChordRest* parent);
     Lyrics(const Lyrics&);
 
     bool isMelisma() const;
-    void undoChangeProperty(Pid id, const mu::engraving::PropertyValue&, PropertyFlags ps) override;
+    void undoChangeProperty(Pid id, const PropertyValue&, PropertyFlags ps) override;
 
     bool alwaysKernable() const override { return true; }
 
@@ -114,9 +114,9 @@ public:
     using EngravingObject::undoChangeProperty;
     void paste(EditData& ed, const QString& txt) override;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid id) const override;
 };
 
 //---------------------------------------------------------
@@ -143,7 +143,7 @@ public:
     Lyrics* nextLyrics() const { return _nextLyrics; }
     bool isEndMelisma() const { return lyrics()->ticks().isNotZero(); }
     bool isDash() const { return !isEndMelisma(); }
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue& v) override;
+    bool setProperty(Pid propertyId, const PropertyValue& v) override;
     SpannerSegment* layoutSystem(System*) override;
 };
 

--- a/src/engraving/libmscore/lyrics.h
+++ b/src/engraving/libmscore/lyrics.h
@@ -168,5 +168,5 @@ public:
     LyricsLine* lyricsLine() const { return toLyricsLine(spanner()); }
     Lyrics* lyrics() const { return lyricsLine()->lyrics(); }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/marker.h
+++ b/src/engraving/libmscore/marker.h
@@ -97,7 +97,7 @@ struct MarkerTypeItem {
 };
 
 extern const std::vector<MarkerTypeItem> markerTypeTable;
-}     // namespace Ms
+} // namespace mu::engraving
 
 Q_DECLARE_METATYPE(mu::engraving::Marker::Type);
 

--- a/src/engraving/libmscore/marker.h
+++ b/src/engraving/libmscore/marker.h
@@ -78,9 +78,9 @@ public:
 
     void styleChanged() override;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
 
     EngravingItem* nextSegmentElement() override;
     EngravingItem* prevSegmentElement() override;

--- a/src/engraving/libmscore/masterscore.cpp
+++ b/src/engraving/libmscore/masterscore.cpp
@@ -328,7 +328,7 @@ bool MasterScore::writeMscz(MscWriter& mscWriter, bool onlySelection, bool doCre
     return true;
 }
 
-bool MasterScore::exportPart(mu::engraving::MscWriter& mscWriter, Score* partScore)
+bool MasterScore::exportPart(MscWriter& mscWriter, Score* partScore)
 {
     // Write excerpt style as main
     {

--- a/src/engraving/libmscore/masterscore.h
+++ b/src/engraving/libmscore/masterscore.h
@@ -105,7 +105,7 @@ class MasterScore : public Score
 
     qreal m_widthOfSegmentCell = 3;
 
-    std::weak_ptr<mu::engraving::EngravingProject> m_project;
+    std::weak_ptr<EngravingProject> m_project;
 
     // FIXME: Move to EngravingProject
     // We can't yet, because m_project is not set on every MasterScore
@@ -119,18 +119,18 @@ class MasterScore : public Score
     void removeDeletedMidiMapping();
     int updateMidiMapping();
 
-    friend class mu::engraving::EngravingProject;
-    friend class mu::engraving::compat::ScoreAccess;
-    friend class mu::engraving::compat::Read114;
-    friend class mu::engraving::compat::Read206;
-    friend class mu::engraving::compat::Read302;
-    friend class mu::engraving::Read400;
+    friend class EngravingProject;
+    friend class compat::ScoreAccess;
+    friend class compat::Read114;
+    friend class compat::Read206;
+    friend class compat::Read302;
+    friend class Read400;
 
-    MasterScore(std::weak_ptr<mu::engraving::EngravingProject> project  = std::weak_ptr<mu::engraving::EngravingProject>());
-    MasterScore(const MStyle&, std::weak_ptr<mu::engraving::EngravingProject> project  = std::weak_ptr<mu::engraving::EngravingProject>());
+    MasterScore(std::weak_ptr<EngravingProject> project  = std::weak_ptr<EngravingProject>());
+    MasterScore(const MStyle&, std::weak_ptr<EngravingProject> project  = std::weak_ptr<EngravingProject>());
 
-    bool writeMscz(mu::engraving::MscWriter& mscWriter, bool onlySelection = false, bool createThumbnail = true);
-    bool exportPart(mu::engraving::MscWriter& mscWriter, Score* partScore);
+    bool writeMscz(MscWriter& mscWriter, bool onlySelection = false, bool createThumbnail = true);
+    bool exportPart(MscWriter& mscWriter, Score* partScore);
 
 public:
 
@@ -140,7 +140,7 @@ public:
     Score* createScore();
     Score* createScore(const MStyle& s);
 
-    std::weak_ptr<mu::engraving::EngravingProject> project() const { return m_project; }
+    std::weak_ptr<EngravingProject> project() const { return m_project; }
 
     bool isMaster() const override { return true; }
     bool readOnly() const override { return _readOnly; }
@@ -236,7 +236,7 @@ public:
     qreal widthOfSegmentCell() const { return m_widthOfSegmentCell; }
 };
 
-extern mu::engraving::MasterScore* gpaletteScore;
+extern MasterScore* gpaletteScore;
 }
 
 #endif // MU_ENGRAVING_MASTERSCORE_H

--- a/src/engraving/libmscore/mcursor.cpp
+++ b/src/engraving/libmscore/mcursor.cpp
@@ -150,7 +150,7 @@ TimeSig* MCursor::addTimeSig(const Fraction& f)
 void MCursor::createScore(const QString& /*name*/)
 {
     delete _score;
-    _score = mu::engraving::compat::ScoreAccess::createMasterScoreWithBaseStyle();
+    _score = compat::ScoreAccess::createMasterScoreWithBaseStyle();
     // TODO: set path/filename
     NOT_IMPLEMENTED;
     move(0, Fraction(0, 1));

--- a/src/engraving/libmscore/mcursor.h
+++ b/src/engraving/libmscore/mcursor.h
@@ -60,5 +60,5 @@ public:
     void setScore(MasterScore* s) { _score = s; }
     void setTimeSig(Fraction f) { _sig = f; }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -2014,13 +2014,13 @@ void Measure::adjustToLen(Fraction nf, bool appendRestsIfNecessary)
 
 void Measure::write(XmlWriter& xml, staff_idx_t staff, bool writeSystemElements, bool forceTimeSig) const
 {
-    mu::engraving::rw::MeasureRW::MeasureRW::writeMeasure(this, xml, staff, writeSystemElements, forceTimeSig);
+    rw::MeasureRW::writeMeasure(this, xml, staff, writeSystemElements, forceTimeSig);
 }
 
 void Measure::read(XmlReader& xml)
 {
     ReadContext ctx(score());
-    mu::engraving::rw::MeasureRW::readMeasure(this, xml, ctx, 0);
+    rw::MeasureRW::readMeasure(this, xml, ctx, 0);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/measure.h
+++ b/src/engraving/libmscore/measure.h
@@ -407,5 +407,5 @@ private:
     double m_layoutStretch = 1.0;
     bool _isWidthLocked = false;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/measure.h
+++ b/src/engraving/libmscore/measure.h
@@ -197,11 +197,11 @@ public:
     bool isIrregular() const { return m_timesig != _len; }
 
     int size() const { return m_segments.size(); }
-    mu::engraving::Segment* first() const { return m_segments.first(); }
+    Segment* first() const { return m_segments.first(); }
     Segment* first(SegmentType t) const { return m_segments.first(t); }
     Segment* firstEnabled() const { return m_segments.first(ElementFlag::ENABLED); }
 
-    mu::engraving::Segment* last() const { return m_segments.last(); }
+    Segment* last() const { return m_segments.last(); }
     Segment* lastEnabled() const { return m_segments.last(ElementFlag::ENABLED); }
     SegmentList& segments() { return m_segments; }
     const SegmentList& segments() const { return m_segments; }
@@ -299,9 +299,9 @@ public:
     void setPlaybackCount(int val) { m_playbackCount = val; }
     mu::RectF staffabbox(staff_idx_t staffIdx) const;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
 
     bool hasMMRest() const { return m_mmRest != 0; }
     bool isMMRest() const { return m_mmRestCount > 0; }
@@ -367,8 +367,8 @@ public:
 
 private:
     double _squeezableSpace = 0;
-    friend class mu::engraving::Factory;
-    friend class mu::engraving::rw::MeasureRW;
+    friend class Factory;
+    friend class rw::MeasureRW;
 
     Measure(System* parent = 0);
     Measure(const Measure&);

--- a/src/engraving/libmscore/measurebase.h
+++ b/src/engraving/libmscore/measurebase.h
@@ -112,10 +112,10 @@ public:
     void setPrev(MeasureBase* e) { _prev = e; }
     MeasureBase* top() const;
 
-    mu::engraving::Measure* nextMeasure() const;
-    mu::engraving::Measure* prevMeasure() const;
-    mu::engraving::Measure* nextMeasureMM() const;
-    mu::engraving::Measure* prevMeasureMM() const;
+    Measure* nextMeasure() const;
+    Measure* prevMeasure() const;
+    Measure* nextMeasureMM() const;
+    Measure* prevMeasureMM() const;
 
     virtual void write(XmlWriter&) const override = 0;
     virtual void write(XmlWriter&, staff_idx_t, bool, bool) const = 0;
@@ -154,9 +154,9 @@ public:
 
     qreal pause() const;
 
-    mu::engraving::PropertyValue getProperty(Pid) const override;
-    bool setProperty(Pid, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid) const override;
+    bool setProperty(Pid, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
 
     void clearElements();
     ElementList takeElements();

--- a/src/engraving/libmscore/measurebase.h
+++ b/src/engraving/libmscore/measurebase.h
@@ -201,5 +201,5 @@ public:
     void setOldWidth(qreal n) { m_oldWidth = n; }
     qreal oldWidth() const { return m_oldWidth; }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/measurenumber.h
+++ b/src/engraving/libmscore/measurenumber.h
@@ -38,7 +38,7 @@ public:
 
     virtual MeasureNumber* clone() const override { return new MeasureNumber(*this); }
 
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue propertyDefault(Pid id) const override;
 };
 } // namespace mu::engraving
 

--- a/src/engraving/libmscore/measurenumber.h
+++ b/src/engraving/libmscore/measurenumber.h
@@ -40,6 +40,6 @@ public:
 
     mu::engraving::PropertyValue propertyDefault(Pid id) const override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/measurenumberbase.h
+++ b/src/engraving/libmscore/measurenumberbase.h
@@ -55,6 +55,6 @@ public:
 private:
     PlacementH m_placementH = PlacementH::LEFT;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/measurenumberbase.h
+++ b/src/engraving/libmscore/measurenumberbase.h
@@ -38,9 +38,9 @@ public:
     MeasureNumberBase(const ElementType& type, Measure* parent = nullptr, TextStyleType = TextStyleType::DEFAULT);
     MeasureNumberBase(const MeasureNumberBase& other);
 
-    mu::engraving::PropertyValue getProperty(Pid id) const override;
-    bool setProperty(Pid id, const mu::engraving::PropertyValue& val) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid id) const override;
+    bool setProperty(Pid id, const PropertyValue& val) override;
+    PropertyValue propertyDefault(Pid id) const override;
 
     bool readProperties(XmlReader&) override;
 

--- a/src/engraving/libmscore/measurerepeat.h
+++ b/src/engraving/libmscore/measurerepeat.h
@@ -80,5 +80,5 @@ private:
     qreal m_numberPos;
     SymId m_symId;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/measurerepeat.h
+++ b/src/engraving/libmscore/measurerepeat.h
@@ -59,9 +59,9 @@ public:
     void read(XmlReader&) override;
     void write(XmlWriter& xml) const override;
 
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
-    bool setProperty(Pid, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue getProperty(Pid) const override;
+    PropertyValue propertyDefault(Pid) const override;
+    bool setProperty(Pid, const PropertyValue&) override;
+    PropertyValue getProperty(Pid) const override;
 
     Shape shape() const override;
 

--- a/src/engraving/libmscore/midimapping.cpp
+++ b/src/engraving/libmscore/midimapping.cpp
@@ -375,4 +375,4 @@ void MasterScore::updateMidiMapping(InstrChannel* channel, Part* part, int midiP
         mm._part = part->masterPart();
     }
 }
-} // namespace Ms
+} // namespace mu::engraving

--- a/src/engraving/libmscore/mmrest.h
+++ b/src/engraving/libmscore/mmrest.h
@@ -63,5 +63,5 @@ private:
     SymIdList m_restSyms; // stores symbols when using old-style rests
     qreal m_symsWidth;    // width of symbols with spacing when using old-style
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/mmrest.h
+++ b/src/engraving/libmscore/mmrest.h
@@ -43,9 +43,9 @@ public:
 
     void write(XmlWriter&) const override;
 
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
-    bool setProperty(Pid, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue getProperty(Pid) const override;
+    PropertyValue propertyDefault(Pid) const override;
+    bool setProperty(Pid, const PropertyValue&) override;
+    PropertyValue getProperty(Pid) const override;
 
     Shape shape() const override;
 

--- a/src/engraving/libmscore/mmrestrange.h
+++ b/src/engraving/libmscore/mmrestrange.h
@@ -50,6 +50,6 @@ public:
 
     void setXmlText(const QString&) override;
 };
-} // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/mmrestrange.h
+++ b/src/engraving/libmscore/mmrestrange.h
@@ -42,9 +42,9 @@ public:
 
     MMRestRange* clone() const override { return new MMRestRange(*this); }
 
-    mu::engraving::PropertyValue getProperty(Pid id) const override;
-    bool setProperty(Pid id, const mu::engraving::PropertyValue& val) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid id) const override;
+    bool setProperty(Pid id, const PropertyValue& val) override;
+    PropertyValue propertyDefault(Pid id) const override;
 
     bool readProperties(XmlReader&) override;
 

--- a/src/engraving/libmscore/mscore.h
+++ b/src/engraving/libmscore/mscore.h
@@ -348,6 +348,6 @@ static constexpr int limit(int val, int min, int max)
     }
     return val;
 }
-} // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/mscoreview.h
+++ b/src/engraving/libmscore/mscoreview.h
@@ -84,6 +84,6 @@ private:
     EngravingItem* elementAt(const mu::PointF& p) const;
     const std::vector<EngravingItem*> elementsNear(const mu::PointF& pos) const;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/musescoreCore.h
+++ b/src/engraving/libmscore/musescoreCore.h
@@ -57,5 +57,5 @@ public:
                                    const QString& /*withFilename*/ = "") { Q_UNUSED(considerInCurrentSession); return 0; }
     std::vector<MasterScore*>& scores() { return scoreList; }
 };
-} // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/navigate.h
+++ b/src/engraving/libmscore/navigate.h
@@ -29,5 +29,5 @@ class ChordRest;
 extern int pitch2y(int pitch, int enh, int clefOffset, int key, int& prefix, const char* tversatz);
 extern ChordRest* nextChordRest(ChordRest* cr, bool skipGrace = false, bool skipMeasureRepeatRests = true);
 extern ChordRest* prevChordRest(ChordRest* cr, bool skipGrace = false, bool skipMeasureRepeatRests = true);
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -1912,28 +1912,28 @@ EngravingItem* Note::drop(EditData& data)
     {
         switch (toActionIcon(e)->actionType()) {
         case ActionIconType::ACCIACCATURA:
-            score()->setGraceNote(ch, pitch(), NoteType::ACCIACCATURA, Constant::division / 2);
+            score()->setGraceNote(ch, pitch(), NoteType::ACCIACCATURA, Constants::division / 2);
             break;
         case ActionIconType::APPOGGIATURA:
-            score()->setGraceNote(ch, pitch(), NoteType::APPOGGIATURA, Constant::division / 2);
+            score()->setGraceNote(ch, pitch(), NoteType::APPOGGIATURA, Constants::division / 2);
             break;
         case ActionIconType::GRACE4:
-            score()->setGraceNote(ch, pitch(), NoteType::GRACE4, Constant::division);
+            score()->setGraceNote(ch, pitch(), NoteType::GRACE4, Constants::division);
             break;
         case ActionIconType::GRACE16:
-            score()->setGraceNote(ch, pitch(), NoteType::GRACE16,  Constant::division / 4);
+            score()->setGraceNote(ch, pitch(), NoteType::GRACE16,  Constants::division / 4);
             break;
         case ActionIconType::GRACE32:
-            score()->setGraceNote(ch, pitch(), NoteType::GRACE32, Constant::division / 8);
+            score()->setGraceNote(ch, pitch(), NoteType::GRACE32, Constants::division / 8);
             break;
         case ActionIconType::GRACE8_AFTER:
-            score()->setGraceNote(ch, pitch(), NoteType::GRACE8_AFTER, Constant::division / 2);
+            score()->setGraceNote(ch, pitch(), NoteType::GRACE8_AFTER, Constants::division / 2);
             break;
         case ActionIconType::GRACE16_AFTER:
-            score()->setGraceNote(ch, pitch(), NoteType::GRACE16_AFTER, Constant::division / 4);
+            score()->setGraceNote(ch, pitch(), NoteType::GRACE16_AFTER, Constants::division / 4);
             break;
         case ActionIconType::GRACE32_AFTER:
-            score()->setGraceNote(ch, pitch(), NoteType::GRACE32_AFTER, Constant::division / 8);
+            score()->setGraceNote(ch, pitch(), NoteType::GRACE32_AFTER, Constants::division / 8);
             break;
         case ActionIconType::BEAM_START:
         case ActionIconType::BEAM_MID:
@@ -1961,7 +1961,7 @@ EngravingItem* Note::drop(EditData& data)
         // before the current note
         for (int i = static_cast<int>(nl.size()) - 1; i >= 0; --i) {
             int p = BagpipeEmbellishment::BagpipeNoteInfoList[nl.at(i)].pitch;
-            score()->setGraceNote(ch, p, NoteType::GRACE32, Constant::division / 8);
+            score()->setGraceNote(ch, p, NoteType::GRACE32, Constants::division / 8);
         }
     }
         delete e;

--- a/src/engraving/libmscore/note.h
+++ b/src/engraving/libmscore/note.h
@@ -41,9 +41,6 @@
 
 namespace mu::engraving {
 class Factory;
-}
-
-namespace mu::engraving {
 class Tie;
 class Chord;
 class NoteEvent;
@@ -230,7 +227,7 @@ private:
 
     QString _fretString;
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Note(Chord* ch = 0);
     Note(const Note&, bool link = false);
 
@@ -378,8 +375,8 @@ public:
     bool play() const { return _play; }
     void setPlay(bool val) { _play = val; }
 
-    mu::engraving::Tie* tieFor() const { return _tieFor; }
-    mu::engraving::Tie* tieBack() const { return _tieBack; }
+    Tie* tieFor() const { return _tieFor; }
+    Tie* tieBack() const { return _tieBack; }
     void setTieFor(Tie* t) { _tieFor = t; }
     void setTieBack(Tie* t) { _tieBack = t; }
     Note* firstTiedNote() const;
@@ -467,9 +464,9 @@ public:
     void transposeDiatonic(int interval, bool keepAlterations, bool useDoubleAccidentals);
 
     void localSpatiumChanged(qreal oldValue, qreal newValue) override;
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
 
     bool mark() const { return _mark; }
     void setMark(bool v) const { _mark = v; }

--- a/src/engraving/libmscore/note.h
+++ b/src/engraving/libmscore/note.h
@@ -526,5 +526,5 @@ public:
 
     bool isGrace() const { return noteType() != NoteType::NORMAL; }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/notedot.h
+++ b/src/engraving/libmscore/notedot.h
@@ -27,9 +27,6 @@
 
 namespace mu::engraving {
 class Factory;
-}
-
-namespace mu::engraving {
 class Note;
 class Rest;
 
@@ -53,7 +50,7 @@ public:
     EngravingItem* elementBase() const override;
 
 private:
-    friend class mu::engraving::Factory;
+    friend class Factory;
     NoteDot(Note* parent);
     NoteDot(Rest* parent);
 };

--- a/src/engraving/libmscore/notedot.h
+++ b/src/engraving/libmscore/notedot.h
@@ -57,5 +57,5 @@ private:
     NoteDot(Note* parent);
     NoteDot(Rest* parent);
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/noteentry.cpp
+++ b/src/engraving/libmscore/noteentry.cpp
@@ -814,4 +814,4 @@ void Score::globalInsertChord(const Position& pos)
         }
     }
 }
-} // namespace Ms
+} // namespace mu::engraving

--- a/src/engraving/libmscore/noteevent.h
+++ b/src/engraving/libmscore/noteevent.h
@@ -77,5 +77,5 @@ public:
         })->offtime();
     }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/noteline.cpp
+++ b/src/engraving/libmscore/noteline.cpp
@@ -45,4 +45,4 @@ LineSegment* NoteLine::createLineSegment(System* parent)
     seg->setTrack(track());
     return seg;
 }
-}     // namespace Ms
+} // namespace mu::engraving

--- a/src/engraving/libmscore/noteline.h
+++ b/src/engraving/libmscore/noteline.h
@@ -50,5 +50,5 @@ public:
     Note* endNote() const { return _endNote; }
     LineSegment* createLineSegment(System* parent) override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/notifier.hpp
+++ b/src/engraving/libmscore/notifier.hpp
@@ -161,5 +161,5 @@ void swap(Listener<Data>& l1, Listener<Data>& l2)
     l1.setNotifier(n2);
     l2.setNotifier(n1);
 }
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/ottava.h
+++ b/src/engraving/libmscore/ottava.h
@@ -136,6 +136,6 @@ public:
     QString accessibleInfo() const override;
     static const char* ottavaTypeName(OttavaType type);
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/ottava.h
+++ b/src/engraving/libmscore/ottava.h
@@ -78,7 +78,7 @@ class Ottava;
 
 class OttavaSegment final : public TextLineBaseSegment
 {
-    void undoChangeProperty(Pid id, const mu::engraving::PropertyValue&, PropertyFlags ps) override;
+    void undoChangeProperty(Pid id, const PropertyValue&, PropertyFlags ps) override;
     Sid getPropertyStyle(Pid) const override;
 
 public:
@@ -102,7 +102,7 @@ class Ottava final : public TextLineBase
 
     void updateStyledProperties();
     Sid getPropertyStyle(Pid) const override;
-    void undoChangeProperty(Pid id, const mu::engraving::PropertyValue&, PropertyFlags ps) override;
+    void undoChangeProperty(Pid id, const PropertyValue&, PropertyFlags ps) override;
 
 protected:
     friend class OttavaSegment;
@@ -128,9 +128,9 @@ public:
     void read(XmlReader& de) override;
     bool readProperties(XmlReader& e) override;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
     Pid propertyId(const QStringRef& xmlName) const override;
 
     QString accessibleInfo() const override;

--- a/src/engraving/libmscore/page.h
+++ b/src/engraving/libmscore/page.h
@@ -101,5 +101,5 @@ public:
     mu::RectF tbbox();                             // tight bounding box, excluding white space
     Fraction endTick() const;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/page.h
+++ b/src/engraving/libmscore/page.h
@@ -32,9 +32,6 @@
 namespace mu::engraving {
 class RootItem;
 class Factory;
-}
-
-namespace mu::engraving {
 class System;
 class Text;
 class Measure;
@@ -57,8 +54,8 @@ class Page final : public EngravingItem
 
     void doRebuildBspTree();
 
-    friend class mu::engraving::Factory;
-    Page(mu::engraving::RootItem* parent);
+    friend class Factory;
+    Page(RootItem* parent);
 
     QString replaceTextMacros(const QString&) const;
     void drawHeaderFooter(mu::draw::Painter*, int area, const QString&) const;

--- a/src/engraving/libmscore/palmmute.h
+++ b/src/engraving/libmscore/palmmute.h
@@ -65,7 +65,7 @@ public:
 //      virtual void write(XmlWriter& xml) const override;
 
     LineSegment* createLineSegment(System* parent) override;
-    mu::engraving::PropertyValue propertyDefault(Pid propertyId) const override;
+    PropertyValue propertyDefault(Pid propertyId) const override;
 
     friend class PalmMuteLine;
 };

--- a/src/engraving/libmscore/palmmute.h
+++ b/src/engraving/libmscore/palmmute.h
@@ -69,5 +69,5 @@ public:
 
     friend class PalmMuteLine;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/part.h
+++ b/src/engraving/libmscore/part.h
@@ -189,5 +189,5 @@ public:
     // TODO: do we need instruments info in parts at all?
     friend void readPart206(Part*, XmlReader&);
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/part.h
+++ b/src/engraving/libmscore/part.h
@@ -83,7 +83,7 @@ class Part final : public EngravingObject
 
     PreferSharpFlat _preferSharpFlat = PreferSharpFlat::DEFAULT;
 
-    friend class mu::engraving::compat::Read206;
+    friend class compat::Read206;
 
 public:
     Part(Score* score = nullptr);
@@ -167,8 +167,8 @@ public:
 
     bool isVisible() const;
 
-    mu::engraving::PropertyValue getProperty(Pid) const override;
-    bool setProperty(Pid, const mu::engraving::PropertyValue&) override;
+    PropertyValue getProperty(Pid) const override;
+    bool setProperty(Pid, const PropertyValue&) override;
 
     int lyricCount() const;
     int harmonyCount() const;

--- a/src/engraving/libmscore/pedal.h
+++ b/src/engraving/libmscore/pedal.h
@@ -69,7 +69,7 @@ public:
     void write(XmlWriter& xml) const override;
 
     LineSegment* createLineSegment(System* parent) override;
-    mu::engraving::PropertyValue propertyDefault(Pid propertyId) const override;
+    PropertyValue propertyDefault(Pid propertyId) const override;
 
     friend class PedalLine;
 };

--- a/src/engraving/libmscore/pedal.h
+++ b/src/engraving/libmscore/pedal.h
@@ -73,5 +73,5 @@ public:
 
     friend class PedalLine;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/pitch.h
+++ b/src/engraving/libmscore/pitch.h
@@ -38,5 +38,5 @@ public:
     int pitchOffset(int tick) const;
     void setPitchOffset(int tick, int offset) { insert_or_assign(tick, offset); }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/pitchspelling.h
+++ b/src/engraving/libmscore/pitchspelling.h
@@ -107,5 +107,5 @@ inline static AccidentalVal tpc2alter(int tpc)
 extern QString tpc2stepName(int tpc);
 extern bool tpcIsValid(int val);
 inline bool pitchIsValid(int pitch) { return pitch >= 0 && pitch <= 127; }
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/playtechannotation.cpp
+++ b/src/engraving/libmscore/playtechannotation.cpp
@@ -95,7 +95,7 @@ PropertyValue PlayTechAnnotation::getProperty(Pid id) const
     }
 }
 
-bool PlayTechAnnotation::setProperty(Pid propertyId, const mu::engraving::PropertyValue& val)
+bool PlayTechAnnotation::setProperty(Pid propertyId, const PropertyValue& val)
 {
     switch (propertyId) {
     case Pid::PLAY_TECH_TYPE:

--- a/src/engraving/libmscore/playtechannotation.h
+++ b/src/engraving/libmscore/playtechannotation.h
@@ -43,9 +43,9 @@ private:
     void write(XmlWriter& writer) const override;
     void read(XmlReader& reader) override;
 
-    mu::engraving::PropertyValue getProperty(Pid id) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue& val) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid id) const override;
+    bool setProperty(Pid propertyId, const PropertyValue& val) override;
+    PropertyValue propertyDefault(Pid id) const override;
 
     PlayingTechniqueType m_techniqueType = PlayingTechniqueType::Undefined;
 };

--- a/src/engraving/libmscore/pos.h
+++ b/src/engraving/libmscore/pos.h
@@ -138,5 +138,5 @@ public:
 
     bool operator==(const PosLen& s) const;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/property.cpp
+++ b/src/engraving/libmscore/property.cpp
@@ -464,7 +464,7 @@ QString propertyUserName(Pid id)
 //    propertyFromString
 //---------------------------------------------------------
 
-PropertyValue propertyFromString(mu::engraving::P_TYPE type, QString)
+PropertyValue propertyFromString(P_TYPE type, QString)
 {
     switch (type) {
     case P_TYPE::BEAM_MODE:

--- a/src/engraving/libmscore/property.h
+++ b/src/engraving/libmscore/property.h
@@ -405,6 +405,6 @@ extern bool propertyLink(Pid id);
 extern Pid propertyId(const QString& name);
 extern Pid propertyId(const QStringRef& name);
 extern QString propertyUserName(Pid);
-}     // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/property.h
+++ b/src/engraving/libmscore/property.h
@@ -396,10 +396,10 @@ enum class Pid {
     END
 };
 
-extern mu::engraving::PropertyValue readProperty(Pid type, XmlReader& e);
-extern mu::engraving::PropertyValue propertyFromString(mu::engraving::P_TYPE type, QString value);
-extern QString propertyToString(Pid, const mu::engraving::PropertyValue& value, bool mscx);
-extern mu::engraving::P_TYPE propertyType(Pid);
+extern PropertyValue readProperty(Pid type, XmlReader& e);
+extern PropertyValue propertyFromString(P_TYPE type, QString value);
+extern QString propertyToString(Pid, const PropertyValue& value, bool mscx);
+extern P_TYPE propertyType(Pid);
 extern const char* propertyName(Pid);
 extern bool propertyLink(Pid id);
 extern Pid propertyId(const QString& name);

--- a/src/engraving/libmscore/range.h
+++ b/src/engraving/libmscore/range.h
@@ -108,5 +108,5 @@ public:
 
     friend class TrackList;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/range.h
+++ b/src/engraving/libmscore/range.h
@@ -67,7 +67,7 @@ public:
     void read(const Segment* fs, const Segment* ls);
     bool write(Score*, const Fraction&) const;
 
-    void appendGap(const Fraction&, mu::engraving::Score* score);
+    void appendGap(const Fraction&, Score* score);
     bool truncate(const Fraction&);
     void dump() const;
 };

--- a/src/engraving/libmscore/rasgueado.h
+++ b/src/engraving/libmscore/rasgueado.h
@@ -59,7 +59,7 @@ public:
 
     LineSegment* createLineSegment(System* parent) override;
 
-    mu::engraving::PropertyValue propertyDefault(Pid propertyId) const override;
+    PropertyValue propertyDefault(Pid propertyId) const override;
     Sid getPropertyStyle(Pid) const override;
 };
 } // namespace mu::engraving

--- a/src/engraving/libmscore/rasgueado.h
+++ b/src/engraving/libmscore/rasgueado.h
@@ -62,5 +62,5 @@ public:
     mu::engraving::PropertyValue propertyDefault(Pid propertyId) const override;
     Sid getPropertyStyle(Pid) const override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/rehearsalmark.cpp
+++ b/src/engraving/libmscore/rehearsalmark.cpp
@@ -135,4 +135,4 @@ engraving::PropertyValue RehearsalMark::propertyDefault(Pid id) const
         return TextBase::propertyDefault(id);
     }
 }
-} // namespace Ms
+} // namespace mu::engraving

--- a/src/engraving/libmscore/rehearsalmark.h
+++ b/src/engraving/libmscore/rehearsalmark.h
@@ -52,5 +52,5 @@ public:
 private:
     Type _type = Type::Main;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/rehearsalmark.h
+++ b/src/engraving/libmscore/rehearsalmark.h
@@ -44,7 +44,7 @@ public:
 
     Segment* segment() const { return (Segment*)explicitParent(); }
     void layout() override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue propertyDefault(Pid id) const override;
 
     void setType(Type type);
     Type type() const { return _type; }

--- a/src/engraving/libmscore/rendermidi.cpp
+++ b/src/engraving/libmscore/rendermidi.cpp
@@ -251,7 +251,7 @@ void Score::updateChannel()
 //---------------------------------------------------------
 int toMilliseconds(float tempo, float midiTime)
 {
-    float ticksPerSecond = (float)Constant::division * tempo;
+    float ticksPerSecond = (float)Constants::division * tempo;
     int time = (int)((midiTime / ticksPerSecond) * 1000.0f);
     if (time > 0x7fff) { //maximum possible value
         time = 0x7fff;
@@ -1230,7 +1230,7 @@ void MidiRenderer::renderSpanners(const Chunk& chunk, EventMap* events)
             }
 
             int j = 0;
-            int delta = Constant::division / 8;       // 1/8 note
+            int delta = Constants::division / 8;       // 1/8 note
             int lastPointTick = stick;
             while (lastPointTick < etick) {
                 int pitch = (j % 4 < 2) ? spitch : epitch;
@@ -1365,7 +1365,7 @@ void renderTremolo(Chord* chord, std::vector<NoteEventList>& ell)
 
     // render tremolo with multiple events
     if (chord->tremoloChordType() == TremoloChordType::TremoloFirstNote) {
-        int t = Constant::division / (1 << (tremolo->lines() + chord->durationType().hooks()));
+        int t = Constants::division / (1 << (tremolo->lines() + chord->durationType().hooks()));
         if (t == 0) {   // avoid crash on very short tremolo
             t = 1;
         }
@@ -1441,7 +1441,7 @@ void renderTremolo(Chord* chord, std::vector<NoteEventList>& ell)
             events->clear();
         }
     } else if (chord->tremoloChordType() == TremoloChordType::TremoloSingle) {
-        int t = Constant::division / (1 << (tremolo->lines() + chord->durationType().hooks()));
+        int t = Constants::division / (1 << (tremolo->lines() + chord->durationType().hooks()));
         if (t == 0) {   // avoid crash on very short tremolo
             t = 1;
         }
@@ -1639,7 +1639,7 @@ int totalTiedNoteTicks(Note* note)
 //   renderNoteArticulation
 // prefix, vector of int, normally something like {0,-1,0,1} modeling the prefix of tremblement relative to the base note
 // body, vector of int, normally something like {0,-1,0,1} modeling the possibly repeated tremblement relative to the base note
-// tickspernote, number of ticks, either _16h or _32nd, i.e., Constant::division/4 or Constant::division/8
+// tickspernote, number of ticks, either _16h or _32nd, i.e., Constants::division/4 or Constants::division/8
 // repeatp, true means repeat the body as many times as possible to fill the time slice.
 // sustainp, true means the last note of the body is sustained to fill remaining time slice
 //---------------------------------------------------------
@@ -1672,7 +1672,7 @@ bool renderNoteArticulation(NoteEventList* events, Note* note, bool chromatic, i
 
     Fraction tick = chord->tick();
     BeatsPerSecond tempo = chord->score()->tempo(tick);
-    int ticksPerSecond = tempo.val * Constant::division;
+    int ticksPerSecond = tempo.val * Constants::division;
 
     int minTicksPerNote = int(ticksPerSecond / fastestFreq);
     int maxTicksPerNote = (0 == slowestFreq) ? 0 : int(ticksPerSecond / slowestFreq);
@@ -1869,7 +1869,7 @@ struct OrnamentExcursion {
 std::set<OrnamentStyle> baroque  = { OrnamentStyle::BAROQUE };
 std::set<OrnamentStyle> defstyle = { OrnamentStyle::DEFAULT };
 std::set<OrnamentStyle> any; // empty set has the special meaning of any-style, rather than no-styles.
-int _16th = Constant::division / 4;
+int _16th = Constants::division / 4;
 int _32nd = _16th / 2;
 
 std::vector<OrnamentExcursion> excursions = {
@@ -2031,7 +2031,7 @@ void renderGlissando(NoteEventList* events, Note* notestart)
         if (spanner->type() == ElementType::GLISSANDO
             && toGlissando(spanner)->playGlissando()
             && glissandoPitchOffsets(spanner, body)) {
-            renderNoteArticulation(events, notestart, true, Constant::division, empty, body, false, true, empty, 16, 0);
+            renderNoteArticulation(events, notestart, true, Constants::division, empty, body, false, true, empty, 16, 0);
         }
     }
 }
@@ -2223,7 +2223,7 @@ void Score::createGraceNotesPlayEvents(const Fraction& tick, Chord* chord, int& 
 
     int graceDuration = 0;
     bool drumset = (getDrumset(chord) != nullptr);
-    const qreal ticksPerSecond = tempo(tick).val * Constant::division;
+    const qreal ticksPerSecond = tempo(tick).val * Constants::division;
     const qreal chordTimeMS = (chord->actualTicks().ticks() / ticksPerSecond) * 1000;
     if (drumset) {
         int flamDuration = 15;     //ms

--- a/src/engraving/libmscore/rendermidi.h
+++ b/src/engraving/libmscore/rendermidi.h
@@ -147,6 +147,6 @@ public:
 
 class Spanner;
 extern bool glissandoPitchOffsets(const Spanner* spanner, std::vector<int>& pitchOffsets);
-} // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/rendermidi.h
+++ b/src/engraving/libmscore/rendermidi.h
@@ -127,7 +127,7 @@ public:
 
     struct Context
     {
-        mu::engraving::SynthesizerState synthState;
+        SynthesizerState synthState;
         bool metronome{ true };
         bool renderHarmony{ false };
 

--- a/src/engraving/libmscore/repeatlist.h
+++ b/src/engraving/libmscore/repeatlist.h
@@ -113,5 +113,5 @@ public:
 
     std::vector<RepeatSegment*>::const_iterator findRepeatSegmentFromUTick(int utick) const;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/rest.h
+++ b/src/engraving/libmscore/rest.h
@@ -132,5 +132,5 @@ private:
 
     bool sameVoiceKerningLimited() const override { return true; }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/rest.h
+++ b/src/engraving/libmscore/rest.h
@@ -90,10 +90,10 @@ public:
     qreal rightEdge() const override;
 
     void localSpatiumChanged(qreal oldValue, qreal newValue) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue propertyDefault(Pid) const override;
     void resetProperty(Pid id) override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue& v) override;
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue& v) override;
+    PropertyValue getProperty(Pid propertyId) const override;
     void undoChangeDotsVisible(bool v);
 
     EngravingItem* nextElement() override;
@@ -115,7 +115,7 @@ protected:
 
 private:
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Rest(Segment* parent);
     Rest(Segment* parent, const TDuration&);
 

--- a/src/engraving/libmscore/revisions.h
+++ b/src/engraving/libmscore/revisions.h
@@ -75,5 +75,5 @@ public:
     Revision* trunk() { return _trunk; }
     void write(XmlWriter&) const;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/rootitem.cpp
+++ b/src/engraving/libmscore/rootitem.cpp
@@ -55,7 +55,7 @@ EngravingObject* RootItem::scanParent() const
     return m_score->scanParent();
 }
 
-mu::engraving::AccessibleItem* RootItem::createAccessible()
+AccessibleItem* RootItem::createAccessible()
 {
     return new AccessibleRoot(this);
 }

--- a/src/engraving/libmscore/rootitem.h
+++ b/src/engraving/libmscore/rootitem.h
@@ -28,13 +28,11 @@
 
 namespace mu::engraving {
 class Score;
-}
 
-namespace mu::engraving {
-class RootItem : public mu::engraving::EngravingItem
+class RootItem : public EngravingItem
 {
 public:
-    RootItem(mu::engraving::Score* score);
+    RootItem(Score* score);
     ~RootItem() override;
 
     compat::DummyElement* dummy() const;
@@ -42,15 +40,15 @@ public:
 
     EngravingObject* scanParent() const override;
 
-    mu::engraving::EngravingItem* clone() const override { return nullptr; }
-    mu::engraving::PropertyValue getProperty(mu::engraving::Pid) const override { return mu::engraving::PropertyValue(); }
-    bool setProperty(mu::engraving::Pid, const mu::engraving::PropertyValue&) override { return false; }
+    EngravingItem* clone() const override { return nullptr; }
+    PropertyValue getProperty(Pid) const override { return PropertyValue(); }
+    bool setProperty(Pid, const PropertyValue&) override { return false; }
 
 private:
 
-    mu::engraving::AccessibleItem* createAccessible() override;
+    AccessibleItem* createAccessible() override;
 
-    mu::engraving::Score* m_score = nullptr;
+    Score* m_score = nullptr;
     compat::DummyElement* m_dummy = nullptr;
 };
 }

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -328,10 +328,10 @@ Score::Score()
 
     _scoreFont = ScoreFont::fontByName("Leland");
 
-    _fileDivision           = Constant::division;
+    _fileDivision           = Constants::division;
     _style  = DefaultStyle::defaultStyle();
 
-    m_rootItem = new mu::engraving::RootItem(this);
+    m_rootItem = new RootItem(this);
     m_rootItem->init();
     createPaddingTable();
 
@@ -475,12 +475,12 @@ Score* Score::clone()
 
 Score* Score::paletteScore()
 {
-    return mu::engraving::gpaletteScore;
+    return gpaletteScore;
 }
 
 bool Score::isPaletteScore() const
 {
-    return this == mu::engraving::gpaletteScore;
+    return this == gpaletteScore;
 }
 
 //---------------------------------------------------------
@@ -1096,8 +1096,8 @@ void Score::spell(Note* note)
     nn = prevNote(nn);
     notes.insert(notes.begin(), nn);
 
-    int opt = mu::engraving::computeWindow(notes, 0, 7);
-    note->setTpc(mu::engraving::tpc(3, note->pitch(), opt));
+    int opt = computeWindow(notes, 0, 7);
+    note->setTpc(tpc(3, note->pitch(), opt));
 }
 
 //---------------------------------------------------------
@@ -2763,7 +2763,7 @@ KeyList Score::keyList() const
 
     Key normalizedC = Key::C;
     // normalize the keyevents to concert pitch if necessary
-    if (firstStaff && !masterScore()->styleB(mu::engraving::Sid::concertPitch) && firstStaff->part()->instrument()->transpose().chromatic) {
+    if (firstStaff && !masterScore()->styleB(Sid::concertPitch) && firstStaff->part()->instrument()->transpose().chromatic) {
         int interval = firstStaff->part()->instrument()->transpose().chromatic;
         normalizedC = transposeKey(normalizedC, interval);
         for (auto i = tmpKeymap.begin(); i != tmpKeymap.end(); ++i) {
@@ -2966,7 +2966,7 @@ void Score::mapExcerptTracks(const std::vector<staff_idx_t>& dst)
 
 void Score::cmdConcertPitchChanged(bool flag)
 {
-    if (flag == styleB(mu::engraving::Sid::concertPitch)) {
+    if (flag == styleB(Sid::concertPitch)) {
         return;
     }
 

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -1287,6 +1287,6 @@ public:
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(LayoutFlags)
-}     // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -392,9 +392,9 @@ public:
 
 private:
 
-    friend class mu::engraving::compat::Read302;
-    friend class mu::engraving::Read400;
-    friend class mu::engraving::Layout;
+    friend class compat::Read302;
+    friend class Read400;
+    friend class Layout;
 
     static std::set<Score*> validScores;
     int _linkId { 0 };
@@ -461,9 +461,9 @@ private:
 
     qreal _noteHeadWidth { 0.0 };         // cached value
 
-    mu::engraving::RootItem* m_rootItem = nullptr;
-    mu::engraving::Layout m_layout;
-    mu::engraving::LayoutOptions m_layoutOptions;
+    RootItem* m_rootItem = nullptr;
+    Layout m_layout;
+    LayoutOptions m_layoutOptions;
 
     mu::async::Channel<EngravingItem*> m_elementDestroyed;
 
@@ -559,8 +559,8 @@ public:
 
     void dumpScoreTree();  // for debugging purposes
 
-    mu::engraving::RootItem* rootItem() const { return m_rootItem; }
-    mu::engraving::compat::DummyElement* dummy() const { return m_rootItem->dummy(); }
+    RootItem* rootItem() const { return m_rootItem; }
+    compat::DummyElement* dummy() const { return m_rootItem->dummy(); }
 
     ShadowNote& shadowNote() const;
 
@@ -600,7 +600,7 @@ public:
     void cmdToggleTie();
     static std::vector<Note*> cmdTieNoteList(const Selection& selection, bool noteEntryMode);
     void cmdAddOttava(OttavaType);
-    std::vector<mu::engraving::Hairpin*> addHairpins(HairpinType);
+    std::vector<Hairpin*> addHairpins(HairpinType);
     void addNoteLine();
     void padToggle(Pad p, const EditData& ed);
     void cmdAddPitch(const EditData&, int note, bool addFlag, bool insert);
@@ -646,10 +646,9 @@ public:
     bool appendMeasuresFromScore(Score* score, const Fraction& startTick, const Fraction& endTick);
     bool appendScore(Score*, bool addPageBreak = false, bool addSectionBreak = true);
 
-    void write(XmlWriter&, bool onlySelection, mu::engraving::compat::WriteScoreHook& hook);
-    bool writeScore(mu::io::IODevice* f, bool msczFormat, bool onlySelection, mu::engraving::compat::WriteScoreHook& hook);
-    bool writeScore(mu::io::IODevice* f, bool msczFormat, bool onlySelection, mu::engraving::compat::WriteScoreHook& hook,
-                    mu::engraving::WriteContext& ctx);
+    void write(XmlWriter&, bool onlySelection, compat::WriteScoreHook& hook);
+    bool writeScore(mu::io::IODevice* f, bool msczFormat, bool onlySelection, compat::WriteScoreHook& hook);
+    bool writeScore(mu::io::IODevice* f, bool msczFormat, bool onlySelection, compat::WriteScoreHook& hook, WriteContext& ctx);
 
     bool read400(XmlReader& e);
     bool readScore400(XmlReader& e);
@@ -691,8 +690,8 @@ public:
     void undoChangeUserMirror(Note*, DirectionH);
     void undoChangeKeySig(Staff* ostaff, const Fraction& tick, KeySigEvent);
     void undoChangeClef(Staff* ostaff, EngravingItem*, ClefType st, bool forInstrumentChange = false);
-    bool undoPropertyChanged(EngravingItem* e, Pid t, const mu::engraving::PropertyValue& st, PropertyFlags ps = PropertyFlags::NOSTYLE);
-    void undoPropertyChanged(EngravingObject*, Pid, const mu::engraving::PropertyValue& v, PropertyFlags ps = PropertyFlags::NOSTYLE);
+    bool undoPropertyChanged(EngravingItem* e, Pid t, const PropertyValue& st, PropertyFlags ps = PropertyFlags::NOSTYLE);
+    void undoPropertyChanged(EngravingObject*, Pid, const PropertyValue& v, PropertyFlags ps = PropertyFlags::NOSTYLE);
     virtual UndoStack* undoStack() const;
     void undo(UndoCommand*, EditData* = 0) const;
     void undoRemoveMeasures(Measure*, Measure*, bool preserveTies = false);
@@ -700,11 +699,10 @@ public:
     void undoAddBracket(Staff* staff, int level, BracketType type, size_t span);
     void undoRemoveBracket(Bracket*);
     void undoInsertTime(const Fraction& tick, const Fraction& len);
-    void undoChangeStyleVal(Sid idx, const mu::engraving::PropertyValue& v);
+    void undoChangeStyleVal(Sid idx, const PropertyValue& v);
     void undoChangePageNumberOffset(int po);
 
-    void updateInstrumentChangeTranspositions(mu::engraving::KeySigEvent& key, mu::engraving::Staff* staff,
-                                              const mu::engraving::Fraction& tick);
+    void updateInstrumentChangeTranspositions(KeySigEvent& key, Staff* staff, const Fraction& tick);
 
     Note* setGraceNote(Chord*,  int pitch, NoteType type, int len);
 
@@ -739,7 +737,7 @@ public:
     bool toggleArticulation(EngravingItem*, Articulation* atr);
     void toggleAccidental(AccidentalType, const EditData& ed);
     void changeAccidental(AccidentalType);
-    void changeAccidental(Note* oNote, mu::engraving::AccidentalType);
+    void changeAccidental(Note* oNote, AccidentalType);
 
     void addElement(EngravingItem*);
     void removeElement(EngravingItem*);
@@ -870,7 +868,7 @@ public:
     MeasureBase* getNextPrevSectionBreak(MeasureBase*, bool) const;
     EngravingItem* getScoreElementOfMeasureBase(MeasureBase*) const;
 
-    int fileDivision(int t) const { return static_cast<int>(((qint64)t * Constant::division + _fileDivision / 2) / _fileDivision); }
+    int fileDivision(int t) const { return static_cast<int>(((qint64)t * Constants::division + _fileDivision / 2) / _fileDivision); }
     void setFileDivision(int t) { _fileDivision = t; }
 
     bool dirty() const;
@@ -905,7 +903,7 @@ public:
     bool loadStyle(const QString&, bool ign = false, const bool overlap = false);
     bool saveStyle(const QString&);
 
-    const mu::engraving::PropertyValue& styleV(Sid idx) const { return style().styleV(idx); }
+    const PropertyValue& styleV(Sid idx) const { return style().styleV(idx); }
     Spatium  styleS(Sid idx) const { return style().styleS(idx); }
     Millimetre styleMM(Sid idx) const { return style().styleMM(idx); }
     QString styleSt(Sid idx) const { return style().styleSt(idx); }
@@ -913,7 +911,7 @@ public:
     qreal styleD(Sid idx) const { return style().styleD(idx); }
     int styleI(Sid idx) const { return style().styleI(idx); }
 
-    void setStyleValue(Sid sid, const mu::engraving::PropertyValue& value) { style().set(sid, value); }
+    void setStyleValue(Sid sid, const PropertyValue& value) { style().set(sid, value); }
     QString getTextStyleUserName(TextStyleType tid);
     qreal spatium() const { return styleD(Sid::spatium); }
     void setSpatium(qreal v) { setStyleValue(Sid::spatium, v); }
@@ -1029,10 +1027,10 @@ public:
     MeasureBase* first() const;
     MeasureBase* firstMM() const;
     MeasureBase* last()  const;
-    mu::engraving::Measure* firstMeasure() const;
-    mu::engraving::Measure* firstMeasureMM() const;
-    mu::engraving::Measure* lastMeasure() const;
-    mu::engraving::Measure* lastMeasureMM() const;
+    Measure* firstMeasure() const;
+    Measure* firstMeasureMM() const;
+    Measure* lastMeasure() const;
+    Measure* lastMeasureMM() const;
     MeasureBase* measure(int idx) const;
     Measure* crMeasure(int idx) const;
 
@@ -1111,18 +1109,18 @@ public:
     const std::list<MuseScoreView*>& getViewer() const { return viewer; }
 
     //! NOTE Layout
-    const mu::engraving::LayoutOptions& layoutOptions() const { return m_layoutOptions; }
-    void setLayoutMode(mu::engraving::LayoutMode lm) { m_layoutOptions.mode = lm; }
+    const LayoutOptions& layoutOptions() const { return m_layoutOptions; }
+    void setLayoutMode(LayoutMode lm) { m_layoutOptions.mode = lm; }
     void setShowVBox(bool v) { m_layoutOptions.showVBox = v; }
 
     // temporary methods
-    bool isLayoutMode(mu::engraving::LayoutMode lm) const { return m_layoutOptions.isMode(lm); }
-    mu::engraving::LayoutMode layoutMode() const { return m_layoutOptions.mode; }
-    bool floatMode() const { return m_layoutOptions.isMode(mu::engraving::LayoutMode::FLOAT); }
-    bool pageMode() const { return m_layoutOptions.isMode(mu::engraving::LayoutMode::PAGE); }
-    bool lineMode() const { return m_layoutOptions.isMode(mu::engraving::LayoutMode::LINE); }
-    bool systemMode() const { return m_layoutOptions.isMode(mu::engraving::LayoutMode::SYSTEM); }
-    bool horizontalFixedMode() const { return m_layoutOptions.isMode(mu::engraving::LayoutMode::HORIZONTAL_FIXED); }
+    bool isLayoutMode(LayoutMode lm) const { return m_layoutOptions.isMode(lm); }
+    LayoutMode layoutMode() const { return m_layoutOptions.mode; }
+    bool floatMode() const { return m_layoutOptions.isMode(LayoutMode::FLOAT); }
+    bool pageMode() const { return m_layoutOptions.isMode(LayoutMode::PAGE); }
+    bool lineMode() const { return m_layoutOptions.isMode(LayoutMode::LINE); }
+    bool systemMode() const { return m_layoutOptions.isMode(LayoutMode::SYSTEM); }
+    bool horizontalFixedMode() const { return m_layoutOptions.isMode(LayoutMode::HORIZONTAL_FIXED); }
     bool linearMode() const { return lineMode() || horizontalFixedMode(); }
     // ----
 
@@ -1140,8 +1138,8 @@ public:
         bool addToAllScores = true;
     };
 
-    mu::engraving::MeasureBase* insertMeasure(ElementType type, MeasureBase* beforeMeasure = nullptr,
-                                              const InsertMeasureOptions& options = InsertMeasureOptions());
+    MeasureBase* insertMeasure(ElementType type, MeasureBase* beforeMeasure = nullptr,
+                               const InsertMeasureOptions& options = InsertMeasureOptions());
 
     Audio* audio() const { return _audio; }
     void setAudio(Audio* a) { _audio = a; }
@@ -1229,9 +1227,9 @@ public:
 
     void switchToPageMode();
 
-    mu::engraving::PropertyValue getProperty(Pid) const override;
-    bool setProperty(Pid, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid) const override;
+    bool setProperty(Pid, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
 
     virtual QQueue<MidiInputEvent>* midiInputQueue();
     virtual std::list<MidiInputEvent>& activeMidiPitches();

--- a/src/engraving/libmscore/scorediff.h
+++ b/src/engraving/libmscore/scorediff.h
@@ -177,5 +177,5 @@ public:
     QString rawDiff(bool skipEqual = true) const;
     QString userDiff() const;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/scorefile.cpp
+++ b/src/engraving/libmscore/scorefile.cpp
@@ -151,7 +151,7 @@ void Score::write(XmlWriter& xml, bool selectionOnly, compat::WriteScoreHook& ho
     if (pageNumberOffset()) {
         xml.tag("page-offset", pageNumberOffset());
     }
-    xml.tag("Division", Constant::division);
+    xml.tag("Division", Constants::division);
     xml.context()->setCurTrack(mu::nidx);
 
     hook.onWriteStyle302(this, xml);
@@ -373,7 +373,7 @@ bool Score::saveStyle(const QString& name)
 //extern QString revision;
 static QString revision;
 
-bool Score::writeScore(io::IODevice* f, bool msczFormat, bool onlySelection, mu::engraving::compat::WriteScoreHook& hook)
+bool Score::writeScore(io::IODevice* f, bool msczFormat, bool onlySelection, compat::WriteScoreHook& hook)
 {
     WriteContext ctx;
     return writeScore(f, msczFormat, onlySelection, hook, ctx);

--- a/src/engraving/libmscore/scoreorder.cpp
+++ b/src/engraving/libmscore/scoreorder.cpp
@@ -84,7 +84,7 @@ bool ScoreOrder::operator!=(const ScoreOrder& order) const
     return !(*this == order);
 }
 
-bool ScoreOrder::readBoolAttribute(mu::engraving::XmlReader& reader, const char* attrName, bool defvalue)
+bool ScoreOrder::readBoolAttribute(XmlReader& reader, const char* attrName, bool defvalue)
 {
     if (!reader.hasAttribute(attrName)) {
         return defvalue;
@@ -103,7 +103,7 @@ bool ScoreOrder::readBoolAttribute(mu::engraving::XmlReader& reader, const char*
 //   readInstrument
 //---------------------------------------------------------
 
-void ScoreOrder::readInstrument(mu::engraving::XmlReader& reader)
+void ScoreOrder::readInstrument(XmlReader& reader)
 {
     QString instrumentId { reader.attribute("id") };
     if (!mu::engraving::searchTemplate(instrumentId)) {
@@ -127,7 +127,7 @@ void ScoreOrder::readInstrument(mu::engraving::XmlReader& reader)
 //   readSoloists
 //---------------------------------------------------------
 
-void ScoreOrder::readSoloists(mu::engraving::XmlReader& reader, const QString section)
+void ScoreOrder::readSoloists(XmlReader& reader, const QString section)
 {
     reader.skipCurrentElement();
     if (hasGroup(SOLOISTS_ID)) {
@@ -143,7 +143,7 @@ void ScoreOrder::readSoloists(mu::engraving::XmlReader& reader, const QString se
 //   readSection
 //---------------------------------------------------------
 
-void ScoreOrder::readSection(mu::engraving::XmlReader& reader)
+void ScoreOrder::readSection(XmlReader& reader)
 {
     QString sectionId { reader.attribute("id") };
     bool barLineSpan = readBoolAttribute(reader, "barLineSpan", true);
@@ -473,7 +473,7 @@ void ScoreOrder::setBracketsAndBarlines(Score* score)
 //   read
 //---------------------------------------------------------
 
-void ScoreOrder::read(mu::engraving::XmlReader& reader)
+void ScoreOrder::read(XmlReader& reader)
 {
     id = reader.attribute("id");
     const QString sectionId { "" };
@@ -517,7 +517,7 @@ void ScoreOrder::read(mu::engraving::XmlReader& reader)
 //   write
 //---------------------------------------------------------
 
-void ScoreOrder::write(mu::engraving::XmlWriter& xml) const
+void ScoreOrder::write(XmlWriter& xml) const
 {
     if (!isValid()) {
         return;

--- a/src/engraving/libmscore/scoreorder.h
+++ b/src/engraving/libmscore/scoreorder.h
@@ -72,10 +72,10 @@ struct ScoreOrder
     bool operator==(const ScoreOrder& order) const;
     bool operator!=(const ScoreOrder& order) const;
 
-    bool readBoolAttribute(mu::engraving::XmlReader& reader, const char* name, bool defValue);
-    void readInstrument(mu::engraving::XmlReader& reader);
-    void readSoloists(mu::engraving::XmlReader& reader, const QString section);
-    void readSection(mu::engraving::XmlReader& reader);
+    bool readBoolAttribute(XmlReader& reader, const char* name, bool defValue);
+    void readInstrument(XmlReader& reader);
+    void readSoloists(XmlReader& reader, const QString section);
+    void readSection(XmlReader& reader);
     bool hasGroup(const QString& id, const QString& group=QString()) const;
 
     bool isValid() const;
@@ -90,8 +90,8 @@ struct ScoreOrder
 
     void setBracketsAndBarlines(Score* score);
 
-    void read(mu::engraving::XmlReader& reader);
-    void write(mu::engraving::XmlWriter& xml) const;
+    void read(XmlReader& reader);
+    void write(XmlWriter& xml) const;
 
     void updateInstruments(const Score* score);
 };

--- a/src/engraving/libmscore/scoreorder.h
+++ b/src/engraving/libmscore/scoreorder.h
@@ -95,6 +95,6 @@ struct ScoreOrder
 
     void updateInstruments(const Score* score);
 };
-} // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/scoretree.cpp
+++ b/src/engraving/libmscore/scoretree.cpp
@@ -703,4 +703,4 @@ void Score::dumpScoreTree()
 {
     _dumpScoreTree(this, 0);
 }
-}  // namespace Ms
+} // namespace mu::engraving

--- a/src/engraving/libmscore/scoretree.cpp
+++ b/src/engraving/libmscore/scoretree.cpp
@@ -226,7 +226,7 @@ EngravingObjectList Measure::scanChildren() const
         }
     }
 
-    const std::multimap<int, mu::engraving::Spanner*>& spannerMap = score()->spanner();
+    const std::multimap<int, Spanner*>& spannerMap = score()->spanner();
     int start_tick = tick().ticks();
     for (auto i = spannerMap.lower_bound(start_tick); i != spannerMap.upper_bound(start_tick); ++i) {
         Spanner* s = i->second;
@@ -273,7 +273,7 @@ EngravingObjectList Segment::scanChildren() const
     }
 
     if (segmentType() == SegmentType::ChordRest) {
-        const std::multimap<int, mu::engraving::Spanner*>& spannerMap = score()->spanner();
+        const std::multimap<int, Spanner*>& spannerMap = score()->spanner();
         int start_tick = tick().ticks();
         for (auto i = spannerMap.lower_bound(start_tick); i != spannerMap.upper_bound(start_tick); ++i) {
             Spanner* s = i->second;
@@ -333,7 +333,7 @@ EngravingObjectList ChordRest::scanChildren() const
         children.push_back(element);
     }
 
-    const std::multimap<int, mu::engraving::Spanner*>& spannerMap = score()->spanner();
+    const std::multimap<int, Spanner*>& spannerMap = score()->spanner();
     int start_tick = tick().ticks();
     for (auto i = spannerMap.lower_bound(start_tick); i != spannerMap.upper_bound(start_tick); ++i) {
         Spanner* s = i->second;

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -1266,7 +1266,7 @@ void Segment::clearAnnotations()
 //    specifically intended to be called from QML plugins
 //---------------------------------------------------------
 
-mu::engraving::EngravingItem* Segment::elementAt(track_idx_t track) const
+EngravingItem* Segment::elementAt(track_idx_t track) const
 {
     EngravingItem* e = track < _elist.size() ? _elist[track] : 0;
     return e;
@@ -2508,9 +2508,9 @@ qreal Segment::elementsTopOffsetFromSkyline(staff_idx_t staffIndex) const
         return 0;
     }
 
-    mu::engraving::SkylineLine north = staffSystem->skyline().north();
+    SkylineLine north = staffSystem->skyline().north();
     int topOffset = INT_MAX;
-    for (mu::engraving::SkylineSegment segment: north) {
+    for (SkylineSegment segment: north) {
         Segment* seg = prev1enabled();
         if (!seg) {
             continue;
@@ -2541,9 +2541,9 @@ qreal Segment::elementsBottomOffsetFromSkyline(staff_idx_t staffIndex) const
         return 0;
     }
 
-    mu::engraving::SkylineLine south = staffSystem->skyline().south();
+    SkylineLine south = staffSystem->skyline().south();
     int bottomOffset = INT_MIN;
-    for (mu::engraving::SkylineSegment segment: south) {
+    for (SkylineSegment segment: south) {
         Segment* seg = prev1enabled();
         if (!seg) {
             continue;

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -2651,4 +2651,4 @@ Fraction Segment::shortestChordRest() const
     }
     return shortest;
 }
-}           // namespace Ms
+} // namespace mu::engraving

--- a/src/engraving/libmscore/segment.h
+++ b/src/engraving/libmscore/segment.h
@@ -29,9 +29,6 @@
 
 namespace mu::engraving {
 class Factory;
-}
-
-namespace mu::engraving {
 class Measure;
 class Segment;
 class ChordRest;
@@ -78,7 +75,7 @@ class Segment final : public EngravingItem
     std::vector<qreal> _dotPosX;          // size = staves
     qreal m_spacing{ 0 };
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Segment(Measure* m = 0);
     Segment(Measure*, SegmentType, const Fraction&);
     Segment(const Segment&);
@@ -141,7 +138,7 @@ public:
 
     // a variant of the above function, specifically designed to be called from QML
     //@ returns the element at track 'track' (null if none)
-    mu::engraving::EngravingItem* elementAt(track_idx_t track) const;
+    EngravingItem* elementAt(track_idx_t track) const;
 
     const std::vector<EngravingItem*>& elist() const { return _elist; }
     std::vector<EngravingItem*>& elist() { return _elist; }
@@ -213,9 +210,9 @@ public:
     void write(XmlWriter&) const override;
     void read(XmlReader&) override;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
 
     bool operator<(const Segment&) const;
     bool operator>(const Segment&) const;

--- a/src/engraving/libmscore/segment.h
+++ b/src/engraving/libmscore/segment.h
@@ -350,7 +350,7 @@ inline Segment* Segment::prevEnabled() const
     }
     return ps;
 }
-}     // namespace Ms
+} // namespace mu::engraving
 
 Q_DECLARE_METATYPE(mu::engraving::SegmentType);
 

--- a/src/engraving/libmscore/segmentlist.h
+++ b/src/engraving/libmscore/segmentlist.h
@@ -88,5 +88,5 @@ public:
 
 // Segment* begin(SegmentList& l) { return l.first(); }
 // Segment* end(SegmentList&) { return 0; }
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/select.h
+++ b/src/engraving/libmscore/select.h
@@ -248,5 +248,5 @@ public:
     void extendRangeSelection(ChordRest* cr);
     void extendRangeSelection(Segment* seg, Segment* segAfter, staff_idx_t staffIdx, const Fraction& tick, const Fraction& etick);
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/shadownote.h
+++ b/src/engraving/libmscore/shadownote.h
@@ -41,7 +41,7 @@ namespace mu::engraving {
 
 class ShadowNote final : public EngravingItem
 {
-    INJECT(notation, mu::engraving::IEngravingConfiguration, engravingConfiguration)
+    INJECT(notation, IEngravingConfiguration, engravingConfiguration)
 
     Fraction m_tick;
     int m_lineIndex;

--- a/src/engraving/libmscore/shadownote.h
+++ b/src/engraving/libmscore/shadownote.h
@@ -80,5 +80,5 @@ public:
     bool hasFlag() const;
     SymId flagSym() const;
 };
-} // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/shape.cpp
+++ b/src/engraving/libmscore/shape.cpp
@@ -359,4 +359,4 @@ void ShapeElement::dump() const
 }
 
 #endif
-} // namespace Ms
+} // namespace mu::engraving

--- a/src/engraving/libmscore/shape.h
+++ b/src/engraving/libmscore/shape.h
@@ -119,6 +119,6 @@ inline static bool intersects(qreal a, qreal b, qreal c, qreal d, qreal vertical
     }
     return (b + verticalClearance > c) && (a < d + verticalClearance);
 }
-} // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/sig.cpp
+++ b/src/engraving/libmscore/sig.cpp
@@ -34,8 +34,8 @@ namespace mu::engraving {
 
 int ticks_beat(int n)
 {
-    int m = (Constant::division * 4) / n;
-    if ((Constant::division* 4) % n) {
+    int m = (Constants::division * 4) / n;
+    if ((Constants::division* 4) % n) {
         ASSERT_X(QString::asprintf("Mscore: ticks_beat(): bad divisor %d", n));
     }
     return m;
@@ -47,7 +47,7 @@ int ticks_beat(int n)
 
 static int ticks_measure(const Fraction& f)
 {
-    return (Constant::division * 4 * f.numerator()) / f.denominator();
+    return (Constants::division * 4 * f.numerator()) / f.denominator();
 }
 
 //---------------------------------------------------------
@@ -439,7 +439,7 @@ void SigEvent::write(XmlWriter& xml, int tick) const
 int SigEvent::read(XmlReader& e, int fileDivision)
 {
     int tick  = e.intAttribute("tick", 0);
-    tick      = tick * Constant::division / fileDivision;
+    tick      = tick * Constants::division / fileDivision;
 
     int numerator = 1;
     int denominator = 1;
@@ -578,6 +578,6 @@ void TimeSigMap::dump() const
 
 int TimeSigFrac::dUnitTicks() const
 {
-    return (4 * Constant::division) / denominator();
+    return (4 * Constants::division) / denominator();
 }
 }

--- a/src/engraving/libmscore/sig.h
+++ b/src/engraving/libmscore/sig.h
@@ -167,5 +167,5 @@ public:
     unsigned raster2(unsigned tick, int raster) const;      // round up
     int rasterStep(unsigned tick, int raster) const;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/skyline.cpp
+++ b/src/engraving/libmscore/skyline.cpp
@@ -354,4 +354,4 @@ qreal SkylineLine::max() const
     }
     return val;
 }
-} // namespace Ms
+} // namespace mu::engraving

--- a/src/engraving/libmscore/skyline.h
+++ b/src/engraving/libmscore/skyline.h
@@ -112,6 +112,6 @@ public:
     void paint(mu::draw::Painter& painter, qreal lineWidth) const;
     void dump(const char*, bool north = false) const;
 };
-} // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/slide.h
+++ b/src/engraving/libmscore/slide.h
@@ -28,9 +28,6 @@
 
 namespace mu::engraving {
 class Factory;
-}
-
-namespace mu::engraving {
 class Chord;
 
 //---------------------------------------------------------
@@ -53,7 +50,7 @@ class Slide final : public ChordLine
 
 public:
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
 
     Slide* clone() const override { return new Slide(*this); }
 

--- a/src/engraving/libmscore/slide.h
+++ b/src/engraving/libmscore/slide.h
@@ -62,5 +62,5 @@ public:
     void setNote(Note* note) { _note = note; }
     Note* note() const { return _note; }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -1296,8 +1296,8 @@ SpannerSegment* Slur::layoutSystem(System* system)
             if (_sourceStemArrangement != -1) {
                 if (_sourceStemArrangement != calcStemArrangement(c1, c2)) {
                     // copy & paste from incompatible stem arrangement, so reset bezier points
-                    for (int g = 0; g < (int)mu::engraving::Grip::GRIPS; ++g) {
-                        slurSegment->ups((mu::engraving::Grip)g) = UP();
+                    for (int g = 0; g < (int)Grip::GRIPS; ++g) {
+                        slurSegment->ups((Grip)g) = UP();
                     }
                 }
             }

--- a/src/engraving/libmscore/slur.h
+++ b/src/engraving/libmscore/slur.h
@@ -90,5 +90,5 @@ public:
 
     SlurTieSegment* newSlurTieSegment(System* parent) override { return new SlurSegment(parent); }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/slur.h
+++ b/src/engraving/libmscore/slur.h
@@ -65,7 +65,7 @@ class Slur final : public SlurTie
     void slurPosChord(SlurPos*);
     int _sourceStemArrangement = -1;
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Slur(EngravingItem* parent);
     Slur(const Slur&);
 

--- a/src/engraving/libmscore/slurtie.h
+++ b/src/engraving/libmscore/slurtie.h
@@ -112,11 +112,11 @@ public:
     void endEditDrag(EditData& ed) override;
     void editDrag(EditData&) override;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid id) const override;
     void reset() override;
-    void undoChangeProperty(Pid id, const mu::engraving::PropertyValue&, PropertyFlags ps) override;
+    void undoChangeProperty(Pid id, const PropertyValue&, PropertyFlags ps) override;
     void move(const mu::PointF& s) override;
     bool isEditable() const override { return true; }
 
@@ -180,9 +180,9 @@ public:
     virtual void slurPos(SlurPos*) = 0;
     virtual SlurTieSegment* newSlurTieSegment(System* parent) = 0;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid id) const override;
 };
 }
 

--- a/src/engraving/libmscore/spacer.h
+++ b/src/engraving/libmscore/spacer.h
@@ -88,5 +88,5 @@ public:
     bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
     mu::engraving::PropertyValue propertyDefault(Pid id) const override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/spacer.h
+++ b/src/engraving/libmscore/spacer.h
@@ -28,9 +28,7 @@
 
 namespace mu::engraving {
 class Factory;
-}
 
-namespace mu::engraving {
 //---------------------------------------------------------
 //   SpacerType
 //---------------------------------------------------------
@@ -51,7 +49,7 @@ class Spacer final : public EngravingItem
 
     mu::PainterPath path;
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Spacer(Measure* parent);
     Spacer(const Spacer&);
 
@@ -84,9 +82,9 @@ public:
     Grip defaultGrip() const override { return Grip::START; }
     std::vector<mu::PointF> gripsPositions(const EditData&) const override;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid id) const override;
 };
 } // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/spanner.cpp
+++ b/src/engraving/libmscore/spanner.cpp
@@ -1641,22 +1641,22 @@ void SpannerSegment::autoplaceSpannerSegment()
 
 QString SpannerSegment::formatBarsAndBeats() const
 {
-    const mu::engraving::Spanner* spanner = this->spanner();
+    const Spanner* spanner = this->spanner();
 
     if (!spanner) {
         return EngravingItem::formatBarsAndBeats();
     }
 
-    const mu::engraving::Segment* endSegment = spanner->endSegment();
+    const Segment* endSegment = spanner->endSegment();
 
     if (!endSegment) {
-        endSegment = score()->lastSegment()->prev1MM(mu::engraving::SegmentType::ChordRest);
+        endSegment = score()->lastSegment()->prev1MM(SegmentType::ChordRest);
     }
 
-    if (endSegment->tick() != score()->lastSegment()->prev1MM(mu::engraving::SegmentType::ChordRest)->tick()
+    if (endSegment->tick() != score()->lastSegment()->prev1MM(SegmentType::ChordRest)->tick()
         && spanner->type() != ElementType::SLUR
         && spanner->type() != ElementType::TIE) {
-        endSegment = endSegment->prev1MM(mu::engraving::SegmentType::ChordRest);
+        endSegment = endSegment->prev1MM(SegmentType::ChordRest);
     }
 
     return formatStartBarsAndBeats(spanner->startSegment()) + " " + formatEndBarsAndBeats(endSegment);

--- a/src/engraving/libmscore/spanner.h
+++ b/src/engraving/libmscore/spanner.h
@@ -101,11 +101,11 @@ public:
 
     void spatiumChanged(qreal ov, qreal nv) override;
 
-    mu::engraving::PropertyValue getProperty(Pid id) const override;
-    bool setProperty(Pid id, const mu::engraving::PropertyValue& v) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid id) const override;
+    bool setProperty(Pid id, const PropertyValue& v) override;
+    PropertyValue propertyDefault(Pid id) const override;
     virtual EngravingItem* propertyDelegate(Pid) override;
-    void undoChangeProperty(Pid id, const mu::engraving::PropertyValue&, PropertyFlags ps) override;
+    void undoChangeProperty(Pid id, const PropertyValue&, PropertyFlags ps) override;
     using EngravingObject::undoChangeProperty;
 
     Sid getPropertyStyle(Pid id) const override;
@@ -247,10 +247,10 @@ public:
     virtual void removeUnmanaged();
     virtual void insertTimeUnmanaged(const Fraction& tick, const Fraction& len);
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue& v) override;
-    mu::engraving::PropertyValue propertyDefault(Pid propertyId) const override;
-    virtual void undoChangeProperty(Pid id, const mu::engraving::PropertyValue&, PropertyFlags ps) override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue& v) override;
+    PropertyValue propertyDefault(Pid propertyId) const override;
+    virtual void undoChangeProperty(Pid id, const PropertyValue&, PropertyFlags ps) override;
 
     void computeStartElement();
     void computeEndElement();

--- a/src/engraving/libmscore/spanner.h
+++ b/src/engraving/libmscore/spanner.h
@@ -294,5 +294,5 @@ public:
     friend class SpannerSegment;
     using EngravingObject::undoChangeProperty;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/spannermap.cpp
+++ b/src/engraving/libmscore/spannermap.cpp
@@ -122,4 +122,4 @@ void SpannerMap::dump() const
 }
 
 #endif
-}     // namespace Ms
+} // namespace mu::engraving

--- a/src/engraving/libmscore/spannermap.h
+++ b/src/engraving/libmscore/spannermap.h
@@ -57,6 +57,6 @@ public:
     void dump() const;
 #endif
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/staff.cpp
+++ b/src/engraving/libmscore/staff.cpp
@@ -1000,9 +1000,9 @@ SwingParameters Staff::swing(const Fraction& tick) const
     DurationType unit = TConv::fromXml(ba.constData(), DurationType::V_INVALID);
     int swingRatio = score()->styleI(Sid::swingRatio);
     if (unit == DurationType::V_EIGHTH) {
-        swingUnit = Constant::division / 2;
+        swingUnit = Constants::division / 2;
     } else if (unit == DurationType::V_16TH) {
-        swingUnit = Constant::division / 4;
+        swingUnit = Constants::division / 4;
     } else if (unit == DurationType::V_ZERO) {
         swingUnit = 0;
     }
@@ -1504,7 +1504,7 @@ std::list<Staff*> Staff::staffList() const
 
 Staff* Staff::primaryStaff() const
 {
-    const mu::engraving::LinkedObjects* linkedElements = links();
+    const LinkedObjects* linkedElements = links();
     if (!linkedElements) {
         return nullptr;
     }

--- a/src/engraving/libmscore/staff.h
+++ b/src/engraving/libmscore/staff.h
@@ -37,9 +37,6 @@
 
 namespace mu::engraving {
 class Factory;
-}
-
-namespace mu::engraving {
 class InstrumentTemplate;
 class XmlWriter;
 class Part;
@@ -114,7 +111,7 @@ private:
     ChangeMap _velocityMultiplications;         ///< cached value
     PitchList _pitchOffsets;        ///< cached value
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Staff(Part* parent);
     Staff(const Staff& staff);
 
@@ -290,9 +287,9 @@ public:
     void undoSetColor(const mu::draw::Color& val);
     void insertTime(const Fraction&, const Fraction& len);
 
-    mu::engraving::PropertyValue getProperty(Pid) const override;
-    bool setProperty(Pid, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid) const override;
+    bool setProperty(Pid, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
 
     BracketType innerBracket() const;
 

--- a/src/engraving/libmscore/staff.h
+++ b/src/engraving/libmscore/staff.h
@@ -318,5 +318,5 @@ public:
     void triggerLayout() const override;
     void triggerLayout(const Fraction& tick);
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/stafflines.h
+++ b/src/engraving/libmscore/stafflines.h
@@ -39,7 +39,7 @@ class StaffLines final : public EngravingItem
     qreal lw { 0.0 };
     std::vector<mu::LineF> lines;
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     StaffLines(Measure* parent);
 
 public:

--- a/src/engraving/libmscore/staffstate.h
+++ b/src/engraving/libmscore/staffstate.h
@@ -47,7 +47,7 @@ class StaffState final : public EngravingItem
 
     Instrument* _instrument { nullptr };
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     StaffState(EngravingItem* parent);
     StaffState(const StaffState&);
 

--- a/src/engraving/libmscore/staffstate.h
+++ b/src/engraving/libmscore/staffstate.h
@@ -76,5 +76,5 @@ public:
     void setInstrument(const Instrument&& i) { *_instrument = i; }
     Segment* segment() { return (Segment*)explicitParent(); }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/stafftext.h
+++ b/src/engraving/libmscore/stafftext.h
@@ -43,5 +43,5 @@ public:
     StaffText* clone() const override { return new StaffText(*this); }
     void layout() override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/stafftext.h
+++ b/src/engraving/libmscore/stafftext.h
@@ -35,7 +35,7 @@ namespace mu::engraving {
 
 class StaffText final : public StaffTextBase
 {
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue propertyDefault(Pid id) const override;
 
 public:
     StaffText(Segment* parent = 0, TextStyleType = TextStyleType::STAFF);

--- a/src/engraving/libmscore/stafftextbase.cpp
+++ b/src/engraving/libmscore/stafftextbase.cpp
@@ -42,7 +42,7 @@ namespace mu::engraving {
 StaffTextBase::StaffTextBase(const ElementType& type, Segment* parent, TextStyleType tid, ElementFlags flags)
     : TextBase(type, parent, tid, flags)
 {
-    setSwingParameters(Constant::division / 2, 60);
+    setSwingParameters(Constants::division / 2, 60);
 }
 
 //---------------------------------------------------------
@@ -74,9 +74,9 @@ void StaffTextBase::write(XmlWriter& xml) const
     }
     if (swing()) {
         DurationType swingUnit;
-        if (swingParameters().swingUnit == Constant::division / 2) {
+        if (swingParameters().swingUnit == Constants::division / 2) {
             swingUnit = DurationType::V_EIGHTH;
-        } else if (swingParameters().swingUnit == Constant::division / 4) {
+        } else if (swingParameters().swingUnit == Constants::division / 4) {
             swingUnit = DurationType::V_16TH;
         } else {
             swingUnit = DurationType::V_ZERO;
@@ -161,9 +161,9 @@ bool StaffTextBase::readProperties(XmlReader& e)
         DurationType swingUnit = TConv::fromXml(e.asciiAttribute("unit"), DurationType::V_INVALID);
         int unit = 0;
         if (swingUnit == DurationType::V_EIGHTH) {
-            unit = Constant::division / 2;
+            unit = Constants::division / 2;
         } else if (swingUnit == DurationType::V_16TH) {
-            unit = Constant::division / 4;
+            unit = Constants::division / 4;
         } else if (swingUnit == DurationType::V_ZERO) {
             unit = 0;
         }

--- a/src/engraving/libmscore/stafftextbase.h
+++ b/src/engraving/libmscore/stafftextbase.h
@@ -80,5 +80,5 @@ public:
     bool swing() const { return _swing; }
     int capo() const { return _capo; }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/stafftype.cpp
+++ b/src/engraving/libmscore/stafftype.cpp
@@ -1439,4 +1439,4 @@ qreal StaffType::spatium(Score* score) const
 {
     return score->spatium() * (isSmall() ? score->styleD(Sid::smallStaffMag) : 1.0) * userMag();
 }
-} // namespace Ms
+} // namespace mu::engraving

--- a/src/engraving/libmscore/stafftype.h
+++ b/src/engraving/libmscore/stafftype.h
@@ -185,7 +185,7 @@ static const int STAFF_GROUP_NAME_MAX_LENGTH   = 32;
 
 class StaffType
 {
-    INJECT_STATIC(engraving, mu::engraving::IEngravingConfiguration, engravingConfiguration)
+    INJECT_STATIC(engraving, IEngravingConfiguration, engravingConfiguration)
 
     friend class TabDurationSymbol;
 

--- a/src/engraving/libmscore/stafftype.h
+++ b/src/engraving/libmscore/stafftype.h
@@ -469,5 +469,5 @@ public:
     bool isRepeat() const { return _repeat; }
     void setRepeat(bool val) { _repeat = val; }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/stafftypechange.h
+++ b/src/engraving/libmscore/stafftypechange.h
@@ -63,6 +63,6 @@ public:
     bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
     mu::engraving::PropertyValue propertyDefault(Pid) const override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/stafftypechange.h
+++ b/src/engraving/libmscore/stafftypechange.h
@@ -38,7 +38,7 @@ class StaffTypeChange final : public EngravingItem
     bool m_ownsStaffType = false;
     qreal lw;
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     StaffTypeChange(MeasureBase* parent = 0);
     StaffTypeChange(const StaffTypeChange&);
 
@@ -59,9 +59,9 @@ public:
 
     Measure* measure() const { return toMeasure(explicitParent()); }
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
 };
 } // namespace mu::engraving
 

--- a/src/engraving/libmscore/stem.h
+++ b/src/engraving/libmscore/stem.h
@@ -54,9 +54,9 @@ public:
     bool readProperties(XmlReader&) override;
 
     void reset() override;
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid id) const override;
 
     staff_idx_t vStaffIdx() const override;
 
@@ -84,7 +84,7 @@ public:
     std::vector<mu::PointF> gripsPositions(const EditData&) const override;
 
 private:
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Stem(Chord* parent = 0);
 
     mu::LineF m_line;

--- a/src/engraving/libmscore/stemslash.h
+++ b/src/engraving/libmscore/stemslash.h
@@ -36,7 +36,7 @@ class StemSlash final : public EngravingItem
 {
     mu::LineF line;
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     StemSlash(Chord* parent = 0);
 
 public:

--- a/src/engraving/libmscore/stemslash.h
+++ b/src/engraving/libmscore/stemslash.h
@@ -49,5 +49,5 @@ public:
     void layout() override;
     Chord* chord() const { return (Chord*)explicitParent(); }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/sticking.h
+++ b/src/engraving/libmscore/sticking.h
@@ -50,5 +50,5 @@ public:
     bool isEditAllowed(EditData&) const override;
     bool edit(EditData&) override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/sticking.h
+++ b/src/engraving/libmscore/sticking.h
@@ -33,7 +33,7 @@ namespace mu::engraving {
 
 class Sticking final : public TextBase
 {
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue propertyDefault(Pid id) const override;
 
 public:
     Sticking(Segment* parent);

--- a/src/engraving/libmscore/stringdata.h
+++ b/src/engraving/libmscore/stringdata.h
@@ -86,5 +86,5 @@ public:
     int         adjustBanjo5thFret(int fret) const;
     bool        isFiveStringBanjo() const;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/symbol.h
+++ b/src/engraving/libmscore/symbol.h
@@ -99,5 +99,5 @@ public:
     void setFont(const mu::draw::Font& f);
     void setCode(int val) { _code = val; }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/symbol.h
+++ b/src/engraving/libmscore/symbol.h
@@ -64,8 +64,8 @@ public:
     void read(XmlReader&) override;
     void layout() override;
 
-    mu::engraving::PropertyValue getProperty(Pid) const override;
-    bool setProperty(Pid, const mu::engraving::PropertyValue&) override;
+    PropertyValue getProperty(Pid) const override;
+    bool setProperty(Pid, const PropertyValue&) override;
 
     qreal baseLine() const override { return 0.0; }
     virtual Segment* segment() const { return (Segment*)explicitParent(); }

--- a/src/engraving/libmscore/synthesizerstate.h
+++ b/src/engraving/libmscore/synthesizerstate.h
@@ -110,5 +110,5 @@ static SynthesizerState defaultState = {
       },
     }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -633,8 +633,8 @@ void System::addBrackets(const LayoutContext& ctx, Measure* measure)
 //   Returns the bracket if it got created, else NULL
 //---------------------------------------------------------
 
-Bracket* System::createBracket(const LayoutContext& ctx, mu::engraving::BracketItem* bi, size_t column, staff_idx_t staffIdx,
-                               std::vector<mu::engraving::Bracket*>& bl,
+Bracket* System::createBracket(const LayoutContext& ctx, BracketItem* bi, size_t column, staff_idx_t staffIdx,
+                               std::vector<Bracket*>& bl,
                                Measure* measure)
 {
     size_t nstaves = _staves.size();

--- a/src/engraving/libmscore/system.h
+++ b/src/engraving/libmscore/system.h
@@ -34,9 +34,6 @@
 
 namespace mu::engraving {
 class LayoutContext;
-}
-
-namespace mu::engraving {
 class Staff;
 class StaffLines;
 class Clef;
@@ -115,7 +112,7 @@ class System final : public EngravingItem
     qreal _distance                { 0.0 };     /// temp. variable used during layout
     qreal _systemHeight            { 0.0 };
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     System(Page* parent);
 
     staff_idx_t firstVisibleSysStaff() const;
@@ -125,12 +122,12 @@ class System final : public EngravingItem
 
     size_t getBracketsColumnsCount();
     void setBracketsXPosition(const qreal xOffset);
-    Bracket* createBracket(const mu::engraving::LayoutContext& ctx, mu::engraving::BracketItem* bi, size_t column, staff_idx_t staffIdx,
-                           std::vector<Bracket*>& bl, Measure* measure);
+    Bracket* createBracket(const LayoutContext& ctx, BracketItem* bi, size_t column, staff_idx_t staffIdx, std::vector<Bracket*>& bl,
+                           Measure* measure);
 
     qreal systemNamesWidth();
-    qreal layoutBrackets(const mu::engraving::LayoutContext& ctx);
-    qreal totalBracketOffset(const mu::engraving::LayoutContext& ctx);
+    qreal layoutBrackets(const LayoutContext& ctx);
+    qreal totalBracketOffset(const LayoutContext& ctx);
 
 public:
 
@@ -158,17 +155,17 @@ public:
 
     Page* page() const { return (Page*)explicitParent(); }
 
-    void layoutSystem(const mu::engraving::LayoutContext& ctx, qreal xo1, const bool isFirstSystem = false, bool firstSystemIndent = false);
+    void layoutSystem(const LayoutContext& ctx, qreal xo1, const bool isFirstSystem = false, bool firstSystemIndent = false);
 
     void setMeasureHeight(qreal height);
     void layoutBracketsVertical();
     void layoutInstrumentNames();
 
-    void addBrackets(const mu::engraving::LayoutContext& ctx, Measure* measure);
+    void addBrackets(const LayoutContext& ctx, Measure* measure);
 
-    void layout2(const mu::engraving::LayoutContext& ctx);                       ///< Called after Measure layout.
+    void layout2(const LayoutContext& ctx); ///< Called after Measure layout.
     void restoreLayout2();
-    void clear();                         ///< Clear measure list.
+    void clear(); ///< Clear measure list.
 
     mu::RectF bboxStaff(int staff) const { return _staves[staff]->bbox(); }
     std::vector<SysStaff*>& staves() { return _staves; }
@@ -185,7 +182,7 @@ public:
 
     int y2staff(qreal y) const;
     staff_idx_t searchStaff(qreal y, staff_idx_t preferredStaff = mu::nidx, qreal spacingFactor = 0.5) const;
-    void setInstrumentNames(const mu::engraving::LayoutContext& ctx, bool longName, Fraction tick = { 0, 1 });
+    void setInstrumentNames(const LayoutContext& ctx, bool longName, Fraction tick = { 0, 1 });
     Fraction snap(const Fraction& tick, const mu::PointF p) const;
     Fraction snapNote(const Fraction& tick, const mu::PointF p, int staff) const;
 

--- a/src/engraving/libmscore/system.h
+++ b/src/engraving/libmscore/system.h
@@ -245,5 +245,5 @@ public:
 
 typedef std::vector<System*>::iterator iSystem;
 typedef std::vector<System*>::const_iterator ciSystem;
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/systemdivider.cpp
+++ b/src/engraving/libmscore/systemdivider.cpp
@@ -127,4 +127,4 @@ void SystemDivider::read(XmlReader& e)
     }
     Symbol::read(e);
 }
-}  // namespace Ms
+} // namespace mu::engraving

--- a/src/engraving/libmscore/systemdivider.h
+++ b/src/engraving/libmscore/systemdivider.h
@@ -59,6 +59,6 @@ public:
     Segment* segment() const override { return nullptr; }
     System* system() const { return (System*)explicitParent(); }
 };
-} // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/systemtext.cpp
+++ b/src/engraving/libmscore/systemtext.cpp
@@ -67,4 +67,4 @@ void SystemText::layout()
     TextBase::layout();
     autoplaceSegmentElement();
 }
-} // namespace Ms
+} // namespace mu::engraving

--- a/src/engraving/libmscore/systemtext.h
+++ b/src/engraving/libmscore/systemtext.h
@@ -41,5 +41,5 @@ public:
     SystemText* clone() const override { return new SystemText(*this); }
     Segment* segment() const { return (Segment*)explicitParent(); }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/systemtext.h
+++ b/src/engraving/libmscore/systemtext.h
@@ -33,7 +33,7 @@ namespace mu::engraving {
 class SystemText final : public StaffTextBase
 {
     void layout() override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue propertyDefault(Pid id) const override;
 
 public:
     SystemText(Segment* parent, TextStyleType = TextStyleType::SYSTEM);

--- a/src/engraving/libmscore/tempo.cpp
+++ b/src/engraving/libmscore/tempo.cpp
@@ -124,7 +124,7 @@ void TempoMap::normalize()
             e->second.tempo = tempo;
         }
         int delta = e->first - tick;
-        time += qreal(delta) / (Constant::division * tempo.val * _relTempo.val);
+        time += qreal(delta) / (Constants::division * tempo.val * _relTempo.val);
         time += e->second.pause;
         e->second.time = time;
         tick  = e->first;
@@ -294,7 +294,7 @@ qreal TempoMap::tick2time(int tick, int* sn) const
     if (sn) {
         *sn = _tempoSN;
     }
-    time += delta / (Constant::division * tempo.val * _relTempo.val);
+    time += delta / (Constants::division * tempo.val * _relTempo.val);
     return time;
 }
 
@@ -324,7 +324,7 @@ int TempoMap::time2tick(qreal time, int* sn) const
         tempo = e->second.tempo;
     }
     delta = time - delta;
-    tick += lrint(delta * _relTempo.val * Constant::division * tempo.val);
+    tick += lrint(delta * _relTempo.val * Constants::division * tempo.val);
     if (sn) {
         *sn = _tempoSN;
     }

--- a/src/engraving/libmscore/tempo.h
+++ b/src/engraving/libmscore/tempo.h
@@ -98,5 +98,5 @@ public:
     void setRelTempo(BeatsPerSecond val);
     BeatsPerSecond relTempo() const { return _relTempo; }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/tempochangeranged.cpp
+++ b/src/engraving/libmscore/tempochangeranged.cpp
@@ -179,7 +179,7 @@ PropertyValue TempoChangeRanged::getProperty(Pid id) const
     }
 }
 
-bool TempoChangeRanged::setProperty(Pid id, const mu::engraving::PropertyValue& val)
+bool TempoChangeRanged::setProperty(Pid id, const PropertyValue& val)
 {
     switch (id) {
     case Pid::TEMPO_CHANGE_TYPE:

--- a/src/engraving/libmscore/tempochangeranged.h
+++ b/src/engraving/libmscore/tempochangeranged.h
@@ -46,9 +46,9 @@ public:
 
     float tempoChangeFactor() const;
 
-    mu::engraving::PropertyValue getProperty(Pid id) const override;
-    bool setProperty(Pid id, const mu::engraving::PropertyValue& val) override;
-    mu::engraving::PropertyValue propertyDefault(Pid propertyId) const override;
+    PropertyValue getProperty(Pid id) const override;
+    bool setProperty(Pid id, const PropertyValue& val) override;
+    PropertyValue propertyDefault(Pid propertyId) const override;
     Sid getPropertyStyle(Pid id) const override;
 
 protected:

--- a/src/engraving/libmscore/tempotext.h
+++ b/src/engraving/libmscore/tempotext.h
@@ -88,5 +88,5 @@ protected:
     qreal _relative;
     bool _isRelative;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/tempotext.h
+++ b/src/engraving/libmscore/tempotext.h
@@ -68,9 +68,9 @@ public:
     static QString duration2tempoTextString(const TDuration dur);
     static QString duration2userName(const TDuration t);
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid id) const override;
     QString accessibleInfo() const override;
 
 protected:
@@ -78,7 +78,7 @@ protected:
     void removed() override;
     void commitText() override;
 
-    void undoChangeProperty(Pid id, const mu::engraving::PropertyValue&, PropertyFlags ps) override;
+    void undoChangeProperty(Pid id, const PropertyValue&, PropertyFlags ps) override;
 
     void updateScore();
     void updateTempo();

--- a/src/engraving/libmscore/text.h
+++ b/src/engraving/libmscore/text.h
@@ -44,6 +44,6 @@ private:
     friend class mu::engraving::Factory;
     Text(EngravingItem* parent, TextStyleType tid = TextStyleType::DEFAULT);
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/text.h
+++ b/src/engraving/libmscore/text.h
@@ -36,12 +36,12 @@ public:
 
     Text* clone() const override { return new Text(*this); }
     void read(XmlReader&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue propertyDefault(Pid id) const override;
 
     static QString readXmlText(XmlReader& r, Score* score);
 
 private:
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Text(EngravingItem* parent, TextStyleType tid = TextStyleType::DEFAULT);
 };
 } // namespace mu::engraving

--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -974,7 +974,7 @@ void TextBlock::layout(TextBase* t)
 //   fragmentsWithoutEmpty
 //---------------------------------------------------------
 
-std::list<mu::engraving::TextFragment> TextBlock::fragmentsWithoutEmpty()
+std::list<TextFragment> TextBlock::fragmentsWithoutEmpty()
 {
     std::list<TextFragment> list;
     for (const auto& x : qAsConst(_fragments)) {
@@ -1425,7 +1425,7 @@ void TextFragment::changeFormat(FormatId id, QVariant data)
 //   split
 //---------------------------------------------------------
 
-TextBlock TextBlock::split(int column, mu::engraving::TextCursor* cursor)
+TextBlock TextBlock::split(int column, TextCursor* cursor)
 {
     TextBlock tl;
 
@@ -1517,7 +1517,7 @@ QString TextBlock::text(int col1, int len, bool withFormat) const
 //   Text
 //---------------------------------------------------------
 
-TextBase::TextBase(const mu::engraving::ElementType& type, mu::engraving::EngravingItem* parent, TextStyleType tid, ElementFlags f)
+TextBase::TextBase(const ElementType& type, EngravingItem* parent, TextStyleType tid, ElementFlags f)
     : EngravingItem(type, parent, f | ElementFlag::MOVABLE)
 {
     _textLineSpacing        = 1.0;
@@ -1534,7 +1534,7 @@ TextBase::TextBase(const mu::engraving::ElementType& type, mu::engraving::Engrav
     _cursor->init();
 }
 
-TextBase::TextBase(const ElementType& type, mu::engraving::EngravingItem* parent, ElementFlags f)
+TextBase::TextBase(const ElementType& type, EngravingItem* parent, ElementFlags f)
     : TextBase(type, parent, TextStyleType::DEFAULT, f)
 {
 }
@@ -1770,7 +1770,7 @@ void TextBase::createLayout()
 //---------------------------------------------------------
 //   prepareFormat - used when reading from XML and when pasting from clipboard
 //---------------------------------------------------------
-bool TextBase::prepareFormat(const QString& token, mu::engraving::CharFormat& format)
+bool TextBase::prepareFormat(const QString& token, CharFormat& format)
 {
     if (token == "b") {
         format.setBold(true);
@@ -1821,7 +1821,7 @@ bool TextBase::prepareFormat(const QString& token, mu::engraving::CharFormat& fo
 //---------------------------------------------------------
 //   prepareFormat - used when reading from XML
 //---------------------------------------------------------
-void TextBase::prepareFormat(const QString& token, mu::engraving::TextCursor& cursor)
+void TextBase::prepareFormat(const QString& token, TextCursor& cursor)
 {
     if (prepareFormat(token, *cursor.format())) {
         setPropertyFlags(Pid::FONT_FACE, PropertyFlags::UNSTYLED);
@@ -2094,7 +2094,7 @@ void TextBase::genText() const
     CharFormat fmt;
     fmt.setFontFamily(propertyDefault(Pid::FONT_FACE).toString());
     fmt.setFontSize(propertyDefault(Pid::FONT_SIZE).toReal());
-    fmt.setStyle(static_cast<mu::engraving::FontStyle>(propertyDefault(Pid::FONT_STYLE).toInt()));
+    fmt.setStyle(static_cast<FontStyle>(propertyDefault(Pid::FONT_STYLE).toInt()));
 
     for (const TextBlock& block : _layout) {
         for (const TextFragment& f : block.fragments()) {
@@ -2511,7 +2511,7 @@ void TextBase::resetFormatting()
     // reset any formatting properties that can be changed per-character (doesn't change existing text)
     cursor()->format()->setFontFamily(propertyDefault(Pid::FONT_FACE).toString());
     cursor()->format()->setFontSize(propertyDefault(Pid::FONT_SIZE).toReal());
-    cursor()->format()->setStyle(static_cast<mu::engraving::FontStyle>(propertyDefault(Pid::FONT_STYLE).toInt()));
+    cursor()->format()->setStyle(static_cast<FontStyle>(propertyDefault(Pid::FONT_STYLE).toInt()));
     cursor()->format()->setValign(VerticalAlignment::AlignNormal);
 }
 
@@ -2675,7 +2675,7 @@ QString TextBase::subtypeName() const
  Used by the MusicXML formatted export to avoid parsing the xml text format
  */
 
-std::list<mu::engraving::TextFragment> TextBase::fragmentList() const
+std::list<TextFragment> TextBase::fragmentList() const
 {
     std::list<TextFragment> res;
     for (const TextBlock& block : _layout) {
@@ -2836,7 +2836,7 @@ PropertyValue TextBase::getProperty(Pid propertyId) const
 //   setProperty
 //---------------------------------------------------------
 
-bool TextBase::setProperty(Pid pid, const mu::engraving::PropertyValue& v)
+bool TextBase::setProperty(Pid pid, const PropertyValue& v)
 {
     if (textInvalid) {
         genText();
@@ -2900,7 +2900,7 @@ bool TextBase::setProperty(Pid pid, const mu::engraving::PropertyValue& v)
 //   propertyDefault
 //---------------------------------------------------------
 
-mu::engraving::PropertyValue TextBase::propertyDefault(Pid id) const
+PropertyValue TextBase::propertyDefault(Pid id) const
 {
     if (id == Pid::Z) {
         return EngravingItem::propertyDefault(id);
@@ -2998,9 +2998,8 @@ Sid TextBase::offsetSid() const
 //---------------------------------------------------------
 //   getHtmlStartTag - helper function for extractText with withFormat = true
 //---------------------------------------------------------
-QString TextBase::getHtmlStartTag(qreal newSize, qreal& curSize, const QString& newFamily, QString& curFamily,
-                                  mu::engraving::FontStyle style,
-                                  mu::engraving::VerticalAlignment vAlign)
+QString TextBase::getHtmlStartTag(qreal newSize, qreal& curSize, const QString& newFamily, QString& curFamily, FontStyle style,
+                                  VerticalAlignment vAlign)
 {
     QString s;
     if (fabs(newSize - curSize) > 0.1) {
@@ -3011,21 +3010,21 @@ QString TextBase::getHtmlStartTag(qreal newSize, qreal& curSize, const QString& 
         curFamily = newFamily;
         s += QString("<font face=\"%1\"/>").arg(newFamily);
     }
-    if (style & mu::engraving::FontStyle::Bold) {
+    if (style & FontStyle::Bold) {
         s += "<b>";
     }
-    if (style & mu::engraving::FontStyle::Italic) {
+    if (style & FontStyle::Italic) {
         s += "<i>";
     }
-    if (style & mu::engraving::FontStyle::Underline) {
+    if (style & FontStyle::Underline) {
         s += "<u>";
     }
     if (style & mu::engraving::FontStyle::Strike) {
         s += "<s>";
     }
-    if (vAlign == mu::engraving::VerticalAlignment::AlignSubScript) {
+    if (vAlign == VerticalAlignment::AlignSubScript) {
         s += "<sub>";
-    } else if (vAlign == mu::engraving::VerticalAlignment::AlignSuperScript) {
+    } else if (vAlign == VerticalAlignment::AlignSuperScript) {
         s += "<sup>";
     }
     return s;
@@ -3034,24 +3033,24 @@ QString TextBase::getHtmlStartTag(qreal newSize, qreal& curSize, const QString& 
 //---------------------------------------------------------
 //   getHtmlEndTag - helper function for extractText with withFormat = true
 //---------------------------------------------------------
-QString TextBase::getHtmlEndTag(mu::engraving::FontStyle style, mu::engraving::VerticalAlignment vAlign)
+QString TextBase::getHtmlEndTag(FontStyle style, VerticalAlignment vAlign)
 {
     QString s;
-    if (vAlign == mu::engraving::VerticalAlignment::AlignSubScript) {
+    if (vAlign == VerticalAlignment::AlignSubScript) {
         s += "</sub>";
-    } else if (vAlign == mu::engraving::VerticalAlignment::AlignSuperScript) {
+    } else if (vAlign == VerticalAlignment::AlignSuperScript) {
         s += "</sup>";
     }
-    if (style & mu::engraving::FontStyle::Strike) {
+    if (style & FontStyle::Strike) {
         s += "</s>";
     }
-    if (style & mu::engraving::FontStyle::Underline) {
+    if (style & FontStyle::Underline) {
         s += "</u>";
     }
-    if (style & mu::engraving::FontStyle::Italic) {
+    if (style & FontStyle::Italic) {
         s += "</i>";
     }
-    if (style & mu::engraving::FontStyle::Bold) {
+    if (style & FontStyle::Bold) {
         s += "</b>";
     }
     return s;

--- a/src/engraving/libmscore/textbase.h
+++ b/src/engraving/libmscore/textbase.h
@@ -508,6 +508,6 @@ inline bool isTextNavigationKey(int key, Qt::KeyboardModifiers modifiers)
 
     return navigationKeys.find(key) != navigationKeys.end();
 }
-}     // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/textbase.h
+++ b/src/engraving/libmscore/textbase.h
@@ -308,10 +308,10 @@ class TextBase : public EngravingItem
     QString stripText(bool, bool, bool) const;
     Sid offsetSid() const;
 
-    static QString getHtmlStartTag(qreal, qreal&, const QString&, QString&, mu::engraving::FontStyle, mu::engraving::VerticalAlignment);
-    static QString getHtmlEndTag(mu::engraving::FontStyle, mu::engraving::VerticalAlignment);
+    static QString getHtmlStartTag(qreal, qreal&, const QString&, QString&, FontStyle, VerticalAlignment);
+    static QString getHtmlEndTag(FontStyle, VerticalAlignment);
 
-    mu::engraving::AccessibleItem* createAccessible() override;
+    AccessibleItem* createAccessible() override;
 
     void notifyAboutTextCursorChanged();
     void notifyAboutTextInserted(int startPosition, int endPosition, const QString& text);
@@ -329,8 +329,8 @@ protected:
     void layoutEdit();
     void createLayout();
     void insertSym(EditData& ed, SymId id);
-    void prepareFormat(const QString& token, mu::engraving::TextCursor& cursor);
-    bool prepareFormat(const QString& token, mu::engraving::CharFormat& format);
+    void prepareFormat(const QString& token, TextCursor& cursor);
+    bool prepareFormat(const QString& token, CharFormat& format);
 
     virtual void commitText();
 
@@ -432,10 +432,10 @@ public:
     mu::draw::Font font() const;
     mu::draw::FontMetrics fontMetrics() const;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue& v) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
-    void undoChangeProperty(Pid id, const mu::engraving::PropertyValue& v, PropertyFlags ps) override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue& v) override;
+    PropertyValue propertyDefault(Pid id) const override;
+    void undoChangeProperty(Pid id, const PropertyValue& v, PropertyFlags ps) override;
     Pid propertyId(const QStringRef& xmlName) const override;
     Sid getPropertyStyle(Pid) const override;
     void styleChanged() override;

--- a/src/engraving/libmscore/textedit.cpp
+++ b/src/engraving/libmscore/textedit.cpp
@@ -753,7 +753,7 @@ void TextBase::paste(EditData& ed, const QString& txt)
     QString token;
     QString sym;
     bool symState = false;
-    mu::engraving::CharFormat format = *static_cast<TextEditData*>(ed.getData(this).get())->cursor()->format();
+    CharFormat format = *static_cast<TextEditData*>(ed.getData(this).get())->cursor()->format();
 
     score()->startCmd();
     for (int i = 0; i < txt.length(); i++) {
@@ -894,7 +894,7 @@ bool TextBase::deleteSelectedText(EditData& ed)
             if (!_cursor->movePosition(TextCursor::MoveOperation::Left)) {
                 break;
             }
-            mu::engraving::TextCursor undoCursor(*_cursor);
+            TextCursor undoCursor(*_cursor);
             // can't rely on the cursor's current format as it doesn't preserve the special font "ScoreText"
             undoCursor.setFormat(*_layout[_cursor->row()].formatAt(static_cast<int>(_cursor->column())));
             score()->undo(new RemoveText(&undoCursor, QString(_cursor->currentCharacter())), &ed);
@@ -916,8 +916,7 @@ void ChangeTextProperties::restoreSelection()
     tc.text()->cursor()->setColumn(tc.column());
 }
 
-ChangeTextProperties::ChangeTextProperties(const TextCursor* tc, mu::engraving::Pid propId, const PropertyValue& propVal,
-                                           PropertyFlags flags_)
+ChangeTextProperties::ChangeTextProperties(const TextCursor* tc, Pid propId, const PropertyValue& propVal, PropertyFlags flags_)
     : TextEditUndoCommand(*tc)
 {
     propertyId = propId;

--- a/src/engraving/libmscore/textedit.cpp
+++ b/src/engraving/libmscore/textedit.cpp
@@ -963,4 +963,4 @@ void ChangeTextProperties::redo(EditData*)
         cursor().text()->setProperty(propertyId, propertyVal);
     }
 }
-}  // namespace Ms
+} // namespace mu::engraving

--- a/src/engraving/libmscore/textedit.h
+++ b/src/engraving/libmscore/textedit.h
@@ -80,14 +80,14 @@ class ChangeTextProperties : public TextEditUndoCommand
 {
     QString xmlText;
     Pid propertyId;
-    mu::engraving::PropertyValue propertyVal;
+    PropertyValue propertyVal;
     FontStyle existingStyle;
     PropertyFlags flags;
 
     void restoreSelection();
 
 public:
-    ChangeTextProperties(const TextCursor* tc, mu::engraving::Pid propId, const mu::engraving::PropertyValue& propVal, PropertyFlags flags);
+    ChangeTextProperties(const TextCursor* tc, Pid propId, const PropertyValue& propVal, PropertyFlags flags);
     void undo(EditData*) override;
     void redo(EditData*) override;
 };

--- a/src/engraving/libmscore/textedit.h
+++ b/src/engraving/libmscore/textedit.h
@@ -184,6 +184,6 @@ public:
         : SplitJoinText(tc) {}
     UNDO_NAME("JoinText");
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/textframe.h
+++ b/src/engraving/libmscore/textframe.h
@@ -68,5 +68,5 @@ public:
 private:
     Text* m_text = nullptr;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/textline.cpp
+++ b/src/engraving/libmscore/textline.cpp
@@ -380,4 +380,4 @@ SpannerSegment* TextLine::layoutSystem(System* system)
 
     return tls;
 }
-}     // namespace Ms
+} // namespace mu::engraving

--- a/src/engraving/libmscore/textline.h
+++ b/src/engraving/libmscore/textline.h
@@ -62,7 +62,7 @@ public:
     TextLine(const TextLine&);
     ~TextLine() {}
 
-    void undoChangeProperty(Pid id, const mu::engraving::PropertyValue&, PropertyFlags ps) override;
+    void undoChangeProperty(Pid id, const PropertyValue&, PropertyFlags ps) override;
     SpannerSegment* layoutSystem(System*) override;
 
     TextLine* clone() const override { return new TextLine(*this); }
@@ -73,8 +73,8 @@ public:
     void initStyle();
 
     LineSegment* createLineSegment(System* parent) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
 };
 } // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/textline.h
+++ b/src/engraving/libmscore/textline.h
@@ -76,5 +76,5 @@ public:
     mu::engraving::PropertyValue propertyDefault(Pid) const override;
     bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/textlinebase.h
+++ b/src/engraving/libmscore/textlinebase.h
@@ -65,7 +65,7 @@ public:
 
     Shape shape() const override;
 
-    bool setProperty(Pid id, const mu::engraving::PropertyValue& v) override;
+    bool setProperty(Pid id, const PropertyValue& v) override;
 };
 
 //---------------------------------------------------------
@@ -118,8 +118,8 @@ public:
 
     void spatiumChanged(qreal /*oldValue*/, qreal /*newValue*/) override;
 
-    mu::engraving::PropertyValue getProperty(Pid id) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
+    PropertyValue getProperty(Pid id) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
     Pid propertyId(const QStringRef& xmlName) const override;
 };
 } // namespace mu::engraving

--- a/src/engraving/libmscore/textlinebase.h
+++ b/src/engraving/libmscore/textlinebase.h
@@ -122,6 +122,6 @@ public:
     bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
     Pid propertyId(const QStringRef& xmlName) const override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/tie.h
+++ b/src/engraving/libmscore/tie.h
@@ -110,5 +110,5 @@ public:
 
     SlurTieSegment* newSlurTieSegment(System* parent) override { return new TieSegment(parent); }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/tiemap.h
+++ b/src/engraving/libmscore/tiemap.h
@@ -39,5 +39,5 @@ public:
     Tie* findNew(Tie* o) const { return (Tie*)(ElementMap::findNew((EngravingItem*)o)); }
     void add(Tie* _o, Tie* _n) { ElementMap::add((EngravingItem*)_o, (EngravingItem*)_n); }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/timesig.h
+++ b/src/engraving/libmscore/timesig.h
@@ -70,7 +70,7 @@ class TimeSig final : public EngravingItem
     bool _showCourtesySig;
     bool _largeParentheses;
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     TimeSig(Segment* parent = 0);
 
     bool neverKernable() const override { return true; }
@@ -126,9 +126,9 @@ public:
 
     void setFrom(const TimeSig*);
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid id) const override;
     Pid propertyId(const QStringRef& xmlName) const override;
 
     const Groups& groups() const { return _groups; }

--- a/src/engraving/libmscore/timesig.h
+++ b/src/engraving/libmscore/timesig.h
@@ -147,5 +147,5 @@ protected:
     void added() override;
     void removed() override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/tremolo.cpp
+++ b/src/engraving/libmscore/tremolo.cpp
@@ -338,8 +338,7 @@ void Tremolo::layoutTwoNotesTremolo(qreal x, qreal y, qreal h, qreal spatium)
     } else {
         firstChordStaffY = _chord1->pagePos().y() - _chord1->y();      // y coordinate of the staff of the first chord
         const std::pair<qreal, qreal> extendedLen
-            = mu::engraving::LayoutTremolo::extendedStemLenWithTwoNoteTremolo(this, _chord1->defaultStemLength(),
-                                                                              _chord2->defaultStemLength());
+            = LayoutTremolo::extendedStemLenWithTwoNoteTremolo(this, _chord1->defaultStemLength(), _chord2->defaultStemLength());
         y1 = _chord1->stemPos().y() - firstChordStaffY + extendedLen.first;
         y2 = _chord2->stemPos().y() - firstChordStaffY + extendedLen.second;
     }

--- a/src/engraving/libmscore/tremolo.h
+++ b/src/engraving/libmscore/tremolo.h
@@ -134,5 +134,5 @@ public:
     mu::engraving::PropertyValue propertyDefault(Pid propertyId) const override;
     Pid propertyId(const QStringRef& xmlName) const override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/tremolo.h
+++ b/src/engraving/libmscore/tremolo.h
@@ -57,7 +57,7 @@ class Tremolo final : public EngravingItem
     int _lines;         // derived from _subtype
     TremoloStyle _style { TremoloStyle::DEFAULT };
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     Tremolo(Chord* parent);
     Tremolo(const Tremolo&);
 
@@ -129,9 +129,9 @@ public:
 
     bool customStyleApplicable() const;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid propertyId) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid propertyId) const override;
     Pid propertyId(const QStringRef& xmlName) const override;
 };
 } // namespace mu::engraving

--- a/src/engraving/libmscore/tremolobar.h
+++ b/src/engraving/libmscore/tremolobar.h
@@ -89,5 +89,5 @@ private:
 
     mu::PolygonF m_polygon;                    // computed by layout
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/tremolobar.h
+++ b/src/engraving/libmscore/tremolobar.h
@@ -60,9 +60,9 @@ public:
     const PitchValues& points() const { return m_points; }
     void setPoints(const PitchValues& p) { m_points = p; }
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
 
     qreal userMag() const { return m_userMag; }
     void setUserMag(qreal m) { m_userMag = m; }
@@ -75,7 +75,7 @@ public:
 
 private:
 
-    friend class mu::engraving::Factory;
+    friend class Factory;
     TremoloBar(EngravingItem* parent);
 
     TremoloBarType parseTremoloBarTypeFromCurve(const PitchValues& curve) const;

--- a/src/engraving/libmscore/trill.h
+++ b/src/engraving/libmscore/trill.h
@@ -116,9 +116,9 @@ public:
 
     Segment* segment() const { return (Segment*)explicitParent(); }
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
     Pid propertyId(const QStringRef& xmlName) const override;
 
     QString accessibleInfo() const override;

--- a/src/engraving/libmscore/trill.h
+++ b/src/engraving/libmscore/trill.h
@@ -131,7 +131,7 @@ struct TrillTableItem {
 };
 
 extern const std::vector<TrillTableItem> trillTable;
-}     // namespace Ms
+} // namespace mu::engraving
 
 Q_DECLARE_METATYPE(mu::engraving::Trill::Type);
 

--- a/src/engraving/libmscore/tuplet.cpp
+++ b/src/engraving/libmscore/tuplet.cpp
@@ -1445,4 +1445,4 @@ void Tuplet::addMissingElements()
              missingElementsDuration.numerator(), missingElementsDuration.denominator());
     }
 }
-}  // namespace Ms
+} // namespace mu::engraving

--- a/src/engraving/libmscore/tuplet.h
+++ b/src/engraving/libmscore/tuplet.h
@@ -150,9 +150,9 @@ public:
 
     void setVisible(bool f) override;
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue& v) override;
-    mu::engraving::PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue& v) override;
+    PropertyValue propertyDefault(Pid id) const override;
 
     Shape shape() const override;
 

--- a/src/engraving/libmscore/tuplet.h
+++ b/src/engraving/libmscore/tuplet.h
@@ -165,5 +165,5 @@ public:
     void sanitizeTuplet();
     void addMissingElements();
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/tupletmap.h
+++ b/src/engraving/libmscore/tupletmap.h
@@ -52,5 +52,5 @@ public:
     Tuplet* findNew(Tuplet* o);
     void add(Tuplet* _o, Tuplet* _n) { map.push_back(Tuplet2(_o, _n)); }
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/types.h
+++ b/src/engraving/libmscore/types.h
@@ -557,7 +557,7 @@ Q_ENUM_NS(PlayEventType);
 Q_ENUM_NS(AccidentalType);
 Q_ENUM_NS(HarmonyType);
 #endif
-} // namespace Ms
+} // namespace mu::engraving
 
 Q_DECLARE_METATYPE(mu::engraving::NoteType);
 

--- a/src/engraving/libmscore/undo.h
+++ b/src/engraving/libmscore/undo.h
@@ -1679,5 +1679,5 @@ public:
     UNDO_NAME("ChangeScoreOrder")
     UNDO_CHANGED_OBJECTS({ score });
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/undo.h
+++ b/src/engraving/libmscore/undo.h
@@ -821,12 +821,12 @@ class ChangeStyleVal : public UndoCommand
 {
     Score* score;
     Sid idx;
-    mu::engraving::PropertyValue value;
+    PropertyValue value;
 
     void flip(EditData*) override;
 
 public:
-    ChangeStyleVal(Score* s, Sid i, const mu::engraving::PropertyValue& v)
+    ChangeStyleVal(Score* s, Sid i, const PropertyValue& v)
         : score(s), idx(i), value(v) {}
     UNDO_NAME("ChangeStyleVal")
     UNDO_CHANGED_OBJECTS({ score });
@@ -1085,14 +1085,14 @@ public:
 
 class ChangeNoteEventList : public UndoCommand
 {
-    mu::engraving::Note* note;
+    Note* note;
     NoteEventList newEvents;
     PlayEventType newPetype;
 
     void flip(EditData*) override;
 
 public:
-    ChangeNoteEventList(mu::engraving::Note* n, NoteEventList& ne)
+    ChangeNoteEventList(Note* n, NoteEventList& ne)
         : note(n), newEvents(ne), newPetype(PlayEventType::User) {}
     UNDO_NAME("ChangeNoteEventList")
     UNDO_CHANGED_OBJECTS({ note });
@@ -1104,14 +1104,14 @@ public:
 
 class ChangeChordPlayEventType : public UndoCommand
 {
-    mu::engraving::Chord* chord;
-    mu::engraving::PlayEventType petype;
+    Chord* chord;
+    PlayEventType petype;
     std::vector<NoteEventList> events;
 
     void flip(EditData*) override;
 
 public:
-    ChangeChordPlayEventType(Chord* c, mu::engraving::PlayEventType pet)
+    ChangeChordPlayEventType(Chord* c, PlayEventType pet)
         : chord(c), petype(pet)
     {
         events = c->getNoteEventLists();
@@ -1140,7 +1140,7 @@ public:
     UNDO_CHANGED_OBJECTS({ is });
 };
 
-extern void updateNoteLines(Segment*, mu::engraving::track_idx_t track);
+extern void updateNoteLines(Segment*, track_idx_t track);
 
 //---------------------------------------------------------
 //   SwapCR
@@ -1186,17 +1186,17 @@ class ChangeProperty : public UndoCommand
 protected:
     EngravingObject* element;
     Pid id;
-    mu::engraving::PropertyValue property;
+    PropertyValue property;
     PropertyFlags flags;
 
     void flip(EditData*) override;
 
 public:
-    ChangeProperty(EngravingObject* e, Pid i, const mu::engraving::PropertyValue& v, PropertyFlags ps = PropertyFlags::NOSTYLE)
+    ChangeProperty(EngravingObject* e, Pid i, const PropertyValue& v, PropertyFlags ps = PropertyFlags::NOSTYLE)
         : element(e), id(i), property(v), flags(ps) {}
     Pid getId() const { return id; }
     EngravingObject* getElement() const { return element; }
-    mu::engraving::PropertyValue data() const { return property; }
+    PropertyValue data() const { return property; }
     UNDO_NAME("ChangeProperty")
     UNDO_CHANGED_OBJECTS({ element });
 
@@ -1218,7 +1218,7 @@ class ChangeBracketProperty : public ChangeProperty
     void flip(EditData*) override;
 
 public:
-    ChangeBracketProperty(Staff* s, size_t l, Pid i, const mu::engraving::PropertyValue& v, PropertyFlags ps = PropertyFlags::NOSTYLE)
+    ChangeBracketProperty(Staff* s, size_t l, Pid i, const PropertyValue& v, PropertyFlags ps = PropertyFlags::NOSTYLE)
         : ChangeProperty(nullptr, i, v, ps), staff(s), level(l) {}
     UNDO_NAME("ChangeBracketProperty")
     UNDO_CHANGED_OBJECTS({ staff });
@@ -1233,7 +1233,7 @@ class ChangeTextLineProperty : public ChangeProperty
     void flip(EditData*) override;
 
 public:
-    ChangeTextLineProperty(EngravingObject* e, mu::engraving::PropertyValue v)
+    ChangeTextLineProperty(EngravingObject* e, PropertyValue v)
         : ChangeProperty(e, Pid::SYSTEM_FLAG, v, PropertyFlags::NOSTYLE) {}
     UNDO_NAME("ChangeTextLineProperty")
 };

--- a/src/engraving/libmscore/utils.h
+++ b/src/engraving/libmscore/utils.h
@@ -95,5 +95,5 @@ extern int step2pitch(int step);
 extern Segment* skipTuplet(Tuplet* tuplet);
 extern SymIdList timeSigSymIdsFromString(const QString&);
 extern Fraction actualTicks(Fraction duration, Tuplet* tuplet, Fraction timeStretch);
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/vibrato.h
+++ b/src/engraving/libmscore/vibrato.h
@@ -98,9 +98,9 @@ public:
 
     Segment* segment() const { return (Segment*)explicitParent(); }
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
     Pid propertyId(const QStringRef& xmlName) const override;
     QString accessibleInfo() const override;
 };

--- a/src/engraving/libmscore/vibrato.h
+++ b/src/engraving/libmscore/vibrato.h
@@ -116,7 +116,7 @@ struct VibratoTableItem {
 };
 
 extern const std::vector<VibratoTableItem> vibratoTable;
-}     // namespace Ms
+} // namespace mu::engraving
 
 Q_DECLARE_METATYPE(mu::engraving::Vibrato::Type);
 

--- a/src/engraving/libmscore/volta.h
+++ b/src/engraving/libmscore/volta.h
@@ -100,7 +100,7 @@ public:
 
     QString accessibleInfo() const override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 Q_DECLARE_METATYPE(mu::engraving::Volta::Type);
 

--- a/src/engraving/libmscore/volta.h
+++ b/src/engraving/libmscore/volta.h
@@ -94,9 +94,9 @@ public:
     void setVoltaType(Volta::Type);       // deprecated
     Type voltaType() const;               // deprecated
 
-    mu::engraving::PropertyValue getProperty(Pid propertyId) const override;
-    bool setProperty(Pid propertyId, const mu::engraving::PropertyValue&) override;
-    mu::engraving::PropertyValue propertyDefault(Pid) const override;
+    PropertyValue getProperty(Pid propertyId) const override;
+    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    PropertyValue propertyDefault(Pid) const override;
 
     QString accessibleInfo() const override;
 };

--- a/src/engraving/libmscore/whammybar.h
+++ b/src/engraving/libmscore/whammybar.h
@@ -59,7 +59,7 @@ public:
 
     LineSegment* createLineSegment(System* parent) override;
 
-    mu::engraving::PropertyValue propertyDefault(Pid propertyId) const override;
+    PropertyValue propertyDefault(Pid propertyId) const override;
     Sid getPropertyStyle(Pid) const override;
 };
 } // namespace mu::engraving

--- a/src/engraving/libmscore/whammybar.h
+++ b/src/engraving/libmscore/whammybar.h
@@ -62,5 +62,5 @@ public:
     mu::engraving::PropertyValue propertyDefault(Pid propertyId) const override;
     Sid getPropertyStyle(Pid) const override;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 #endif

--- a/src/engraving/paint/debugpaint.cpp
+++ b/src/engraving/paint/debugpaint.cpp
@@ -38,7 +38,7 @@ using namespace mu::engraving;
 
 static const mu::draw::Color DEBUG_ELTREE_SELECTED_COLOR(164, 0, 0);
 
-void DebugPaint::paintElementDebug(mu::draw::Painter& painter, const mu::engraving::EngravingItem* item,
+void DebugPaint::paintElementDebug(mu::draw::Painter& painter, const EngravingItem* item,
                                    std::shared_ptr<PaintDebugger>& debugger)
 {
     // Elements tree
@@ -67,7 +67,7 @@ void DebugPaint::paintElementDebug(mu::draw::Painter& painter, const mu::engravi
     debugger->restorePenColor();
 }
 
-void DebugPaint::paintElementsDebug(mu::draw::Painter& painter, const std::vector<mu::engraving::EngravingItem*>& elements)
+void DebugPaint::paintElementsDebug(mu::draw::Painter& painter, const std::vector<EngravingItem*>& elements)
 {
     // Setup debug provider
     auto originalProvider = painter.provider();

--- a/src/engraving/paint/debugpaint.h
+++ b/src/engraving/paint/debugpaint.h
@@ -32,9 +32,7 @@
 namespace mu::engraving {
 class EngravingItem;
 class Page;
-}
 
-namespace mu::engraving {
 class PaintDebugger;
 class DebugPaint
 {
@@ -42,11 +40,10 @@ class DebugPaint
     INJECT_STATIC(engraving, diagnostics::IEngravingElementsProvider, elementsProvider)
 
 public:
-    static void paintElementDebug(mu::draw::Painter& painter, const mu::engraving::EngravingItem* element,
-                                  std::shared_ptr<PaintDebugger>& debugger);
-    static void paintElementsDebug(mu::draw::Painter& painter, const std::vector<mu::engraving::EngravingItem*>& elements);
+    static void paintElementDebug(mu::draw::Painter& painter, const EngravingItem* element, std::shared_ptr<PaintDebugger>& debugger);
+    static void paintElementsDebug(mu::draw::Painter& painter, const std::vector<EngravingItem*>& elements);
 
-    static void paintPageDebug(mu::draw::Painter& painter, const mu::engraving::Page* page);
+    static void paintPageDebug(mu::draw::Painter& painter, const Page* page);
 };
 }
 

--- a/src/engraving/paint/paint.cpp
+++ b/src/engraving/paint/paint.cpp
@@ -33,7 +33,7 @@
 
 using namespace mu::engraving;
 
-void Paint::paintElement(mu::draw::Painter& painter, const mu::engraving::EngravingItem* element)
+void Paint::paintElement(mu::draw::Painter& painter, const EngravingItem* element)
 {
     if (element->skipDraw()) {
         return;
@@ -48,7 +48,7 @@ void Paint::paintElement(mu::draw::Painter& painter, const mu::engraving::Engrav
 
 void Paint::paintElements(mu::draw::Painter& painter, const std::vector<EngravingItem*>& elements, bool isPrinting)
 {
-    std::vector<mu::engraving::EngravingItem*> sortedElements(elements.begin(), elements.end());
+    std::vector<EngravingItem*> sortedElements(elements.begin(), elements.end());
 
     std::sort(sortedElements.begin(), sortedElements.end(), mu::engraving::elementLessThan);
 

--- a/src/engraving/paint/paint.h
+++ b/src/engraving/paint/paint.h
@@ -31,14 +31,12 @@
 
 namespace mu::engraving {
 class EngravingItem;
-}
 
-namespace mu::engraving {
 class Paint
 {
 public:
-    static void paintElement(mu::draw::Painter& painter, const mu::engraving::EngravingItem* element);
-    static void paintElements(mu::draw::Painter& painter, const std::vector<mu::engraving::EngravingItem*>& elements, bool isPrinting);
+    static void paintElement(mu::draw::Painter& painter, const EngravingItem* element);
+    static void paintElements(mu::draw::Painter& painter, const std::vector<EngravingItem*>& elements, bool isPrinting);
 };
 }
 

--- a/src/engraving/playback/mapping/keyboardssetupdataresolver.cpp
+++ b/src/engraving/playback/mapping/keyboardssetupdataresolver.cpp
@@ -27,7 +27,7 @@
 using namespace mu::engraving;
 using namespace mu::mpe;
 
-bool KeyboardsSetupDataResolver::supportsInstrument(const mu::engraving::Instrument* instrument)
+bool KeyboardsSetupDataResolver::supportsInstrument(const Instrument* instrument)
 {
     static const std::unordered_set<std::string> KEYBOARDS_FAMILY_SET = {
         "keyboards", "organs", "synths",
@@ -36,7 +36,7 @@ bool KeyboardsSetupDataResolver::supportsInstrument(const mu::engraving::Instrum
     return KEYBOARDS_FAMILY_SET.find(instrument->family().toStdString()) != KEYBOARDS_FAMILY_SET.cend();
 }
 
-const PlaybackSetupData& KeyboardsSetupDataResolver::doResolve(const mu::engraving::Instrument* instrument)
+const PlaybackSetupData& KeyboardsSetupDataResolver::doResolve(const Instrument* instrument)
 {
     static std::unordered_map<std::string, mpe::PlaybackSetupData> SETUP_DATA_MAP = {
         { "celesta", { SoundId::Celesta, SoundCategory::Keyboards, {}, {} } },

--- a/src/engraving/playback/mapping/keyboardssetupdataresolver.h
+++ b/src/engraving/playback/mapping/keyboardssetupdataresolver.h
@@ -29,9 +29,9 @@ namespace mu::engraving {
 class KeyboardsSetupDataResolver : public SetupDataResolverBase<KeyboardsSetupDataResolver>
 {
 public:
-    static bool supportsInstrument(const mu::engraving::Instrument* instrument);
+    static bool supportsInstrument(const Instrument* instrument);
 
-    static const mpe::PlaybackSetupData& doResolve(const mu::engraving::Instrument* instrument);
+    static const mpe::PlaybackSetupData& doResolve(const Instrument* instrument);
 };
 }
 

--- a/src/engraving/playback/mapping/percussionssetupdataresolver.cpp
+++ b/src/engraving/playback/mapping/percussionssetupdataresolver.cpp
@@ -25,7 +25,7 @@
 using namespace mu::engraving;
 using namespace mu::mpe;
 
-bool PercussionsSetupDataResolver::supportsInstrument(const mu::engraving::Instrument* instrument)
+bool PercussionsSetupDataResolver::supportsInstrument(const Instrument* instrument)
 {
     static const std::unordered_set<std::string> PERCUSSION_FAMILY_SET = {
         "timpani", "roto-toms", "tubaphones", "steel-drums",
@@ -39,7 +39,7 @@ bool PercussionsSetupDataResolver::supportsInstrument(const mu::engraving::Instr
     return PERCUSSION_FAMILY_SET.find(instrument->family().toStdString()) != PERCUSSION_FAMILY_SET.cend();
 }
 
-const PlaybackSetupData& PercussionsSetupDataResolver::doResolve(const mu::engraving::Instrument* instrument)
+const PlaybackSetupData& PercussionsSetupDataResolver::doResolve(const Instrument* instrument)
 {
     static std::unordered_map<std::string, mpe::PlaybackSetupData> SETUP_DATA_MAP = {
         { "timpani", { SoundId::Timpani, SoundCategory::Percussions, {}, {} } },

--- a/src/engraving/playback/mapping/percussionssetupdataresolver.h
+++ b/src/engraving/playback/mapping/percussionssetupdataresolver.h
@@ -29,9 +29,9 @@ namespace mu::engraving {
 class PercussionsSetupDataResolver : public SetupDataResolverBase<PercussionsSetupDataResolver>
 {
 public:
-    static bool supportsInstrument(const mu::engraving::Instrument* instrument);
+    static bool supportsInstrument(const Instrument* instrument);
 
-    static const mpe::PlaybackSetupData& doResolve(const mu::engraving::Instrument* instrument);
+    static const mpe::PlaybackSetupData& doResolve(const Instrument* instrument);
 };
 }
 

--- a/src/engraving/playback/mapping/setupresolverbase.h
+++ b/src/engraving/playback/mapping/setupresolverbase.h
@@ -32,7 +32,7 @@ template<class T>
 class SetupDataResolverBase
 {
 public:
-    static bool isAbleToResolve(const mu::engraving::Instrument* instrument)
+    static bool isAbleToResolve(const Instrument* instrument)
     {
         IF_ASSERT_FAILED(instrument) {
             return false;
@@ -41,7 +41,7 @@ public:
         return T::supportsInstrument(instrument);
     }
 
-    static void resolve(const mu::engraving::Instrument* instrument, mpe::PlaybackSetupData& result)
+    static void resolve(const Instrument* instrument, mpe::PlaybackSetupData& result)
     {
         IF_ASSERT_FAILED(instrument) {
             return;

--- a/src/engraving/playback/mapping/stringssetupdataresolver.cpp
+++ b/src/engraving/playback/mapping/stringssetupdataresolver.cpp
@@ -25,7 +25,7 @@
 using namespace mu::engraving;
 using namespace mu::mpe;
 
-bool StringsSetupDataResolver::supportsInstrument(const mu::engraving::Instrument* instrument)
+bool StringsSetupDataResolver::supportsInstrument(const Instrument* instrument)
 {
     static const std::unordered_set<std::string> STRINGS_FAMILY_SET = {
         "harps", "guitars", "bass-guitars", "banjos",
@@ -39,7 +39,7 @@ bool StringsSetupDataResolver::supportsInstrument(const mu::engraving::Instrumen
     return STRINGS_FAMILY_SET.find(instrument->family().toStdString()) != STRINGS_FAMILY_SET.cend();
 }
 
-const PlaybackSetupData& StringsSetupDataResolver::doResolve(const mu::engraving::Instrument* instrument)
+const PlaybackSetupData& StringsSetupDataResolver::doResolve(const Instrument* instrument)
 {
     static std::unordered_map<std::string, mpe::PlaybackSetupData> SETUP_DATA_MAP = {
         { "harp", { SoundId::Harp, SoundCategory::Strings, {}, {} } },

--- a/src/engraving/playback/mapping/stringssetupdataresolver.h
+++ b/src/engraving/playback/mapping/stringssetupdataresolver.h
@@ -29,9 +29,9 @@ namespace mu::engraving {
 class StringsSetupDataResolver : public SetupDataResolverBase<StringsSetupDataResolver>
 {
 public:
-    static bool supportsInstrument(const mu::engraving::Instrument* instrument);
+    static bool supportsInstrument(const Instrument* instrument);
 
-    static const mpe::PlaybackSetupData& doResolve(const mu::engraving::Instrument* instrument);
+    static const mpe::PlaybackSetupData& doResolve(const Instrument* instrument);
 };
 }
 

--- a/src/engraving/playback/mapping/voicessetupdataresolver.cpp
+++ b/src/engraving/playback/mapping/voicessetupdataresolver.cpp
@@ -25,7 +25,7 @@
 using namespace mu::engraving;
 using namespace mu::mpe;
 
-bool VoicesSetupDataResolver::supportsInstrument(const mu::engraving::Instrument* instrument)
+bool VoicesSetupDataResolver::supportsInstrument(const Instrument* instrument)
 {
     static const std::unordered_set<std::string> VOICE_FAMILY_SET = {
         "voices", "voice-groups"
@@ -34,7 +34,7 @@ bool VoicesSetupDataResolver::supportsInstrument(const mu::engraving::Instrument
     return VOICE_FAMILY_SET.find(instrument->family().toStdString()) != VOICE_FAMILY_SET.cend();
 }
 
-const PlaybackSetupData& VoicesSetupDataResolver::doResolve(const mu::engraving::Instrument* instrument)
+const PlaybackSetupData& VoicesSetupDataResolver::doResolve(const Instrument* instrument)
 {
     static std::unordered_map<std::string, mpe::PlaybackSetupData> SETUP_DATA_MAP = {
         { "boy-soprano", { SoundId::Choir, SoundCategory::Voices, { SoundSubCategory::Soprano,

--- a/src/engraving/playback/mapping/voicessetupdataresolver.h
+++ b/src/engraving/playback/mapping/voicessetupdataresolver.h
@@ -29,9 +29,9 @@ namespace mu::engraving {
 class VoicesSetupDataResolver : public SetupDataResolverBase<VoicesSetupDataResolver>
 {
 public:
-    static bool supportsInstrument(const mu::engraving::Instrument* instrument);
+    static bool supportsInstrument(const Instrument* instrument);
 
-    static const mpe::PlaybackSetupData& doResolve(const mu::engraving::Instrument* instrument);
+    static const mpe::PlaybackSetupData& doResolve(const Instrument* instrument);
 };
 }
 

--- a/src/engraving/playback/mapping/windssetupdataresolver.cpp
+++ b/src/engraving/playback/mapping/windssetupdataresolver.cpp
@@ -25,7 +25,7 @@
 using namespace mu::engraving;
 using namespace mu::mpe;
 
-bool WindsSetupDataResolver::supportsInstrument(const mu::engraving::Instrument* instrument)
+bool WindsSetupDataResolver::supportsInstrument(const Instrument* instrument)
 {
     static const std::unordered_set<std::string> WINDS_FAMILY_SET = {
         "winds", "flutes", "dizis", "shakuhachis",
@@ -50,7 +50,7 @@ bool WindsSetupDataResolver::supportsInstrument(const mu::engraving::Instrument*
     return WINDS_FAMILY_SET.find(instrument->family().toStdString()) != WINDS_FAMILY_SET.cend();
 }
 
-const PlaybackSetupData& WindsSetupDataResolver::doResolve(const mu::engraving::Instrument* instrument)
+const PlaybackSetupData& WindsSetupDataResolver::doResolve(const Instrument* instrument)
 {
     static std::unordered_map<std::string, mpe::PlaybackSetupData> SETUP_DATA_MAP = {
         { "winds", { SoundId::WindsGroup, SoundCategory::Winds, {}, {} } },

--- a/src/engraving/playback/mapping/windssetupdataresolver.h
+++ b/src/engraving/playback/mapping/windssetupdataresolver.h
@@ -29,9 +29,9 @@ namespace mu::engraving {
 class WindsSetupDataResolver : public SetupDataResolverBase<WindsSetupDataResolver>
 {
 public:
-    static bool supportsInstrument(const mu::engraving::Instrument* instrument);
+    static bool supportsInstrument(const Instrument* instrument);
 
-    static const mpe::PlaybackSetupData& doResolve(const mu::engraving::Instrument* instrument);
+    static const mpe::PlaybackSetupData& doResolve(const Instrument* instrument);
 };
 }
 

--- a/src/engraving/playback/metaparsers/chordarticulationsparser.cpp
+++ b/src/engraving/playback/metaparsers/chordarticulationsparser.cpp
@@ -41,8 +41,7 @@
 using namespace mu::engraving;
 using namespace mu::mpe;
 
-void ChordArticulationsParser::buildChordArticulationMap(const mu::engraving::Chord* chord, const RenderingContext& ctx,
-                                                         mpe::ArticulationMap& result)
+void ChordArticulationsParser::buildChordArticulationMap(const Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
     if (!chord || !ctx.isValid()) {
         LOGE() << "Unable to render playback events of invalid chord";
@@ -67,14 +66,13 @@ void ChordArticulationsParser::buildChordArticulationMap(const mu::engraving::Ch
     result.preCalculateAverageData();
 }
 
-void ChordArticulationsParser::doParse(const mu::engraving::EngravingItem* item, const RenderingContext& ctx,
-                                       mpe::ArticulationMap& result)
+void ChordArticulationsParser::doParse(const EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
-    IF_ASSERT_FAILED(item->type() == mu::engraving::ElementType::CHORD) {
+    IF_ASSERT_FAILED(item->type() == ElementType::CHORD) {
         return;
     }
 
-    const mu::engraving::Chord* chord = mu::engraving::toChord(item);
+    const Chord* chord = toChord(item);
 
     parseSpanners(chord, ctx, result);
     parseArticulationSymbols(chord, ctx, result);
@@ -85,16 +83,15 @@ void ChordArticulationsParser::doParse(const mu::engraving::EngravingItem* item,
     parseChordLine(chord, ctx, result);
 }
 
-void ChordArticulationsParser::parseSpanners(const mu::engraving::Chord* chord, const RenderingContext& ctx,
-                                             mpe::ArticulationMap& result)
+void ChordArticulationsParser::parseSpanners(const Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
-    const mu::engraving::Score* score = chord->score();
+    const Score* score = chord->score();
 
-    const std::multimap<int, mu::engraving::Spanner*>& spannerMap = score->spanner();
+    const std::multimap<int, Spanner*>& spannerMap = score->spanner();
     auto startIt = spannerMap.lower_bound(ctx.nominalPositionStartTick);
     auto endIt = spannerMap.upper_bound(ctx.nominalPositionEndTick);
     for (auto it = startIt; it != endIt; ++it) {
-        mu::engraving::Spanner* spanner = it->second;
+        Spanner* spanner = it->second;
 
         if (spanner->staffIdx() != chord->staffIdx()) {
             continue;
@@ -118,18 +115,16 @@ void ChordArticulationsParser::parseSpanners(const mu::engraving::Chord* chord, 
     }
 }
 
-void ChordArticulationsParser::parseArticulationSymbols(const mu::engraving::Chord* chord, const RenderingContext& ctx,
-                                                        mpe::ArticulationMap& result)
+void ChordArticulationsParser::parseArticulationSymbols(const Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
-    for (const mu::engraving::Articulation* artic : chord->articulations()) {
+    for (const Articulation* artic : chord->articulations()) {
         SymbolsMetaParser::parse(artic, ctx, result);
     }
 }
 
-void ChordArticulationsParser::parseAnnotations(const mu::engraving::Chord* chord, const RenderingContext& ctx,
-                                                mpe::ArticulationMap& result)
+void ChordArticulationsParser::parseAnnotations(const Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
-    for (const mu::engraving::EngravingItem* annotation : chord->segment()->annotations()) {
+    for (const EngravingItem* annotation : chord->segment()->annotations()) {
         if (annotation->staffIdx() != chord->staffIdx()) {
             continue;
         }
@@ -138,10 +133,9 @@ void ChordArticulationsParser::parseAnnotations(const mu::engraving::Chord* chor
     }
 }
 
-void ChordArticulationsParser::parseTremolo(const mu::engraving::Chord* chord, const RenderingContext& ctx,
-                                            mpe::ArticulationMap& result)
+void ChordArticulationsParser::parseTremolo(const Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
-    const mu::engraving::Tremolo* tremolo = chord->tremolo();
+    const Tremolo* tremolo = chord->tremolo();
 
     if (!tremolo) {
         return;
@@ -150,10 +144,9 @@ void ChordArticulationsParser::parseTremolo(const mu::engraving::Chord* chord, c
     TremoloMetaParser::parse(tremolo, ctx, result);
 }
 
-void ChordArticulationsParser::parseArpeggio(const mu::engraving::Chord* chord, const RenderingContext& ctx,
-                                             mpe::ArticulationMap& result)
+void ChordArticulationsParser::parseArpeggio(const Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
-    const mu::engraving::Arpeggio* arpeggio = chord->arpeggio();
+    const Arpeggio* arpeggio = chord->arpeggio();
 
     if (!arpeggio) {
         return;
@@ -166,17 +159,16 @@ void ChordArticulationsParser::parseArpeggio(const mu::engraving::Chord* chord, 
     ArpeggioMetaParser::parse(arpeggio, ctx, result);
 }
 
-void ChordArticulationsParser::parseGraceNotes(const mu::engraving::Chord* chord, const RenderingContext& ctx,
-                                               mpe::ArticulationMap& result)
+void ChordArticulationsParser::parseGraceNotes(const Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
-    for (const mu::engraving::Chord* graceChord : chord->graceNotes()) {
+    for (const Chord* graceChord : chord->graceNotes()) {
         GraceNotesMetaParser::parse(graceChord, ctx, result);
     }
 }
 
-void ChordArticulationsParser::parseChordLine(const mu::engraving::Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result)
+void ChordArticulationsParser::parseChordLine(const Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
-    const mu::engraving::ChordLine* chordLine = chord->chordLine();
+    const ChordLine* chordLine = chord->chordLine();
 
     if (!chordLine) {
         return;

--- a/src/engraving/playback/metaparsers/chordarticulationsparser.h
+++ b/src/engraving/playback/metaparsers/chordarticulationsparser.h
@@ -27,27 +27,25 @@
 
 namespace mu::engraving {
 class Chord;
-}
 
-namespace mu::engraving {
 class ChordArticulationsParser : public MetaParserBase<ChordArticulationsParser>
 {
 public:
-    static void buildChordArticulationMap(const mu::engraving::Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void buildChordArticulationMap(const Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result);
 
 protected:
     friend MetaParserBase;
 
-    static void doParse(const mu::engraving::EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void doParse(const EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result);
 
 private:
-    static void parseSpanners(const mu::engraving::Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result);
-    static void parseArticulationSymbols(const mu::engraving::Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result);
-    static void parseAnnotations(const mu::engraving::Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result);
-    static void parseTremolo(const mu::engraving::Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result);
-    static void parseArpeggio(const mu::engraving::Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result);
-    static void parseGraceNotes(const mu::engraving::Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result);
-    static void parseChordLine(const mu::engraving::Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void parseSpanners(const Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void parseArticulationSymbols(const Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void parseAnnotations(const Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void parseTremolo(const Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void parseArpeggio(const Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void parseGraceNotes(const Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void parseChordLine(const Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result);
 };
 }
 

--- a/src/engraving/playback/metaparsers/internal/annotationsmetaparser.cpp
+++ b/src/engraving/playback/metaparsers/internal/annotationsmetaparser.cpp
@@ -27,8 +27,7 @@
 using namespace mu::engraving;
 using namespace mu::mpe;
 
-void AnnotationsMetaParser::doParse(const mu::engraving::EngravingItem* item, const RenderingContext& ctx,
-                                    mpe::ArticulationMap& result)
+void AnnotationsMetaParser::doParse(const EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
     IF_ASSERT_FAILED(item) {
         return;
@@ -37,16 +36,16 @@ void AnnotationsMetaParser::doParse(const mu::engraving::EngravingItem* item, co
     mpe::ArticulationType type = mpe::ArticulationType::Undefined;
 
     if (item->isDynamic()) {
-        const mu::engraving::Dynamic* dynamic = mu::engraving::toDynamic(item);
-        const mu::engraving::DynamicType dynamicType = dynamic->dynamicType();
+        const Dynamic* dynamic = toDynamic(item);
+        const DynamicType dynamicType = dynamic->dynamicType();
 
-        if (dynamicType == mu::engraving::DynamicType::S
-            || dynamicType == mu::engraving::DynamicType::SF
-            || dynamicType == mu::engraving::DynamicType::SFF
-            || dynamicType == mu::engraving::DynamicType::SFFZ
-            || dynamicType == mu::engraving::DynamicType::SFP
-            || dynamicType == mu::engraving::DynamicType::SFPP
-            || dynamicType == mu::engraving::DynamicType::SFZ) {
+        if (dynamicType == DynamicType::S
+            || dynamicType == DynamicType::SF
+            || dynamicType == DynamicType::SFF
+            || dynamicType == DynamicType::SFFZ
+            || dynamicType == DynamicType::SFP
+            || dynamicType == DynamicType::SFPP
+            || dynamicType == DynamicType::SFZ) {
             type = mpe::ArticulationType::Subito;
         }
     }

--- a/src/engraving/playback/metaparsers/internal/annotationsmetaparser.h
+++ b/src/engraving/playback/metaparsers/internal/annotationsmetaparser.h
@@ -31,7 +31,7 @@ class AnnotationsMetaParser : public MetaParserBase<AnnotationsMetaParser>
 protected:
     friend MetaParserBase;
 
-    static void doParse(const mu::engraving::EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void doParse(const EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result);
 };
 }
 

--- a/src/engraving/playback/metaparsers/internal/arpeggiometaparser.cpp
+++ b/src/engraving/playback/metaparsers/internal/arpeggiometaparser.cpp
@@ -26,13 +26,13 @@
 
 using namespace mu::engraving;
 
-void ArpeggioMetaParser::doParse(const mu::engraving::EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result)
+void ArpeggioMetaParser::doParse(const EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
-    IF_ASSERT_FAILED(item->type() == mu::engraving::ElementType::ARPEGGIO) {
+    IF_ASSERT_FAILED(item->type() == ElementType::ARPEGGIO) {
         return;
     }
 
-    const mu::engraving::Arpeggio* arpeggio = mu::engraving::toArpeggio(item);
+    const Arpeggio* arpeggio = toArpeggio(item);
 
     if (!arpeggio->playArpeggio()) {
         return;
@@ -41,19 +41,19 @@ void ArpeggioMetaParser::doParse(const mu::engraving::EngravingItem* item, const
     mpe::ArticulationType type = mpe::ArticulationType::Undefined;
 
     switch (arpeggio->arpeggioType()) {
-    case mu::engraving::ArpeggioType::NORMAL:
+    case ArpeggioType::NORMAL:
         type = mpe::ArticulationType::Arpeggio;
         break;
-    case mu::engraving::ArpeggioType::UP:
+    case ArpeggioType::UP:
         type = mpe::ArticulationType::ArpeggioUp;
         break;
-    case mu::engraving::ArpeggioType::DOWN:
+    case ArpeggioType::DOWN:
         type = mpe::ArticulationType::ArpeggioDown;
         break;
-    case mu::engraving::ArpeggioType::DOWN_STRAIGHT:
+    case ArpeggioType::DOWN_STRAIGHT:
         type = mpe::ArticulationType::ArpeggioStraightDown;
         break;
-    case mu::engraving::ArpeggioType::UP_STRAIGHT:
+    case ArpeggioType::UP_STRAIGHT:
         type = mpe::ArticulationType::ArpeggioStraightUp;
         break;
     default:

--- a/src/engraving/playback/metaparsers/internal/arpeggiometaparser.h
+++ b/src/engraving/playback/metaparsers/internal/arpeggiometaparser.h
@@ -31,7 +31,7 @@ class ArpeggioMetaParser : public MetaParserBase<ArpeggioMetaParser>
 protected:
     friend MetaParserBase;
 
-    static void doParse(const mu::engraving::EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void doParse(const EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result);
 };
 }
 

--- a/src/engraving/playback/metaparsers/internal/chordlinemetaparser.cpp
+++ b/src/engraving/playback/metaparsers/internal/chordlinemetaparser.cpp
@@ -27,7 +27,7 @@
 using namespace mu::engraving;
 using namespace mu::mpe;
 
-void ChordLineMetaParser::doParse(const mu::engraving::EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result)
+void ChordLineMetaParser::doParse(const EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
     IF_ASSERT_FAILED(item) {
         return;
@@ -37,7 +37,7 @@ void ChordLineMetaParser::doParse(const mu::engraving::EngravingItem* item, cons
         return;
     }
 
-    const mu::engraving::ChordLine* chordLine = mu::engraving::toChordLine(item);
+    const ChordLine* chordLine = toChordLine(item);
 
     ArticulationType type = chordLineArticulationType(chordLine->chordLineType());
 

--- a/src/engraving/playback/metaparsers/internal/chordlinemetaparser.h
+++ b/src/engraving/playback/metaparsers/internal/chordlinemetaparser.h
@@ -31,7 +31,7 @@ class ChordLineMetaParser : public MetaParserBase<ChordLineMetaParser>
 protected:
     friend MetaParserBase;
 
-    static void doParse(const mu::engraving::EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void doParse(const EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result);
 
     static mpe::ArticulationType chordLineArticulationType(const ChordLineType chordLineType);
 };

--- a/src/engraving/playback/metaparsers/internal/gracenotesmetaparser.cpp
+++ b/src/engraving/playback/metaparsers/internal/gracenotesmetaparser.cpp
@@ -26,35 +26,35 @@
 
 using namespace mu::engraving;
 
-void GraceNotesMetaParser::doParse(const mu::engraving::EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result)
+void GraceNotesMetaParser::doParse(const EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
-    IF_ASSERT_FAILED(item->type() == mu::engraving::ElementType::CHORD) {
+    IF_ASSERT_FAILED(item->type() == ElementType::CHORD) {
         return;
     }
 
     mpe::ArticulationType type = mpe::ArticulationType::Undefined;
 
-    const mu::engraving::Chord* graceChord = mu::engraving::toChord(item);
+    const Chord* graceChord = toChord(item);
 
     if (!graceChord->isChordPlayable()) {
         return;
     }
 
     switch (graceChord->noteType()) {
-    case mu::engraving::NoteType::ACCIACCATURA:
+    case NoteType::ACCIACCATURA:
         type = mpe::ArticulationType::Acciaccatura;
         break;
 
-    case mu::engraving::NoteType::APPOGGIATURA:
-    case mu::engraving::NoteType::GRACE4:
-    case mu::engraving::NoteType::GRACE16:
-    case mu::engraving::NoteType::GRACE32:
+    case NoteType::APPOGGIATURA:
+    case NoteType::GRACE4:
+    case NoteType::GRACE16:
+    case NoteType::GRACE32:
         type = mpe::ArticulationType::PreAppoggiatura;
         break;
 
-    case mu::engraving::NoteType::GRACE8_AFTER:
-    case mu::engraving::NoteType::GRACE16_AFTER:
-    case mu::engraving::NoteType::GRACE32_AFTER:
+    case NoteType::GRACE8_AFTER:
+    case NoteType::GRACE16_AFTER:
+    case NoteType::GRACE32_AFTER:
         type = mpe::ArticulationType::PostAppoggiatura;
         break;
     default:

--- a/src/engraving/playback/metaparsers/internal/gracenotesmetaparser.h
+++ b/src/engraving/playback/metaparsers/internal/gracenotesmetaparser.h
@@ -31,7 +31,7 @@ class GraceNotesMetaParser : public MetaParserBase<GraceNotesMetaParser>
 protected:
     friend MetaParserBase;
 
-    static void doParse(const mu::engraving::EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void doParse(const EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result);
 };
 }
 

--- a/src/engraving/playback/metaparsers/internal/spannersmetaparser.cpp
+++ b/src/engraving/playback/metaparsers/internal/spannersmetaparser.cpp
@@ -32,14 +32,13 @@
 
 using namespace mu::engraving;
 
-void SpannersMetaParser::doParse(const mu::engraving::EngravingItem* item, const RenderingContext& ctx,
-                                 mpe::ArticulationMap& result)
+void SpannersMetaParser::doParse(const EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
     IF_ASSERT_FAILED(item->isSpanner()) {
         return;
     }
 
-    const mu::engraving::Spanner* spanner = mu::engraving::toSpanner(item);
+    const Spanner* spanner = toSpanner(item);
 
     mpe::ArticulationType type = mpe::ArticulationType::Undefined;
 
@@ -48,52 +47,52 @@ void SpannersMetaParser::doParse(const mu::engraving::EngravingItem* item, const
     int overallDurationTicks = spanner->ticks().ticks();
 
     switch (spanner->type()) {
-    case mu::engraving::ElementType::SLUR:
+    case ElementType::SLUR:
         type = mpe::ArticulationType::Legato;
         break;
-    case mu::engraving::ElementType::PEDAL:
+    case ElementType::PEDAL:
         type = mpe::ArticulationType::Pedal;
         break;
-    case mu::engraving::ElementType::LET_RING:
+    case ElementType::LET_RING:
         type = mpe::ArticulationType::LaissezVibrer;
         break;
-    case mu::engraving::ElementType::PALM_MUTE: {
+    case ElementType::PALM_MUTE: {
         type = mpe::ArticulationType::Mute;
         break;
     }
-    case mu::engraving::ElementType::TRILL: {
-        const mu::engraving::Trill* trill = mu::engraving::toTrill(spanner);
+    case ElementType::TRILL: {
+        const Trill* trill = toTrill(spanner);
 
         if (!trill->playArticulation()) {
             return;
         }
 
-        if (trill->trillType() == mu::engraving::Trill::Type::TRILL_LINE) {
+        if (trill->trillType() == Trill::Type::TRILL_LINE) {
             type = mpe::ArticulationType::Trill;
-        } else if (trill->trillType() == mu::engraving::Trill::Type::UPPRALL_LINE) {
+        } else if (trill->trillType() == Trill::Type::UPPRALL_LINE) {
             type = mpe::ArticulationType::UpPrall;
-        } else if (trill->trillType() == mu::engraving::Trill::Type::DOWNPRALL_LINE) {
+        } else if (trill->trillType() == Trill::Type::DOWNPRALL_LINE) {
             type = mpe::ArticulationType::PrallDown;
-        } else if (trill->trillType() == mu::engraving::Trill::Type::PRALLPRALL_LINE) {
+        } else if (trill->trillType() == Trill::Type::PRALLPRALL_LINE) {
             type = mpe::ArticulationType::LinePrall;
         }
         overallDurationTicks = ctx.nominalDurationTicks;
         break;
     }
-    case mu::engraving::ElementType::GLISSANDO: {
-        const mu::engraving::Glissando* glissando = mu::engraving::toGlissando(spanner);
+    case ElementType::GLISSANDO: {
+        const Glissando* glissando = toGlissando(spanner);
         if (!glissando->playGlissando()) {
             break;
         }
 
-        mu::engraving::Note* startNote = mu::engraving::toNote(glissando->startElement());
-        mu::engraving::Note* endNote = mu::engraving::toNote(glissando->endElement());
+        Note* startNote = toNote(glissando->startElement());
+        Note* endNote = toNote(glissando->endElement());
 
         if (!startNote || !endNote) {
             break;
         }
 
-        if (glissando->glissandoStyle() == mu::engraving::GlissandoStyle::PORTAMENTO) {
+        if (glissando->glissandoStyle() == GlissandoStyle::PORTAMENTO) {
             type = mpe::ArticulationType::ContinuousGlissando;
         } else {
             type = mpe::ArticulationType::DiscreteGlissando;
@@ -105,9 +104,8 @@ void SpannersMetaParser::doParse(const mu::engraving::EngravingItem* item, const
         mpe::PitchClass startNotePitchClass = pitchClassFromTpc(startNoteTpc);
         mpe::PitchClass endNotePitchClass = pitchClassFromTpc(endNoteTpc);
 
-        mpe::octave_t startNoteOctave
-            = actualOctave(startNote->playingOctave(), startNotePitchClass, mu::engraving::tpc2alter(startNoteTpc));
-        mpe::octave_t endNoteOctave = actualOctave(endNote->playingOctave(), endNotePitchClass, mu::engraving::tpc2alter(endNoteTpc));
+        mpe::octave_t startNoteOctave = actualOctave(startNote->playingOctave(), startNotePitchClass, tpc2alter(startNoteTpc));
+        mpe::octave_t endNoteOctave = actualOctave(endNote->playingOctave(), endNotePitchClass, tpc2alter(endNoteTpc));
 
         overallPitchRange = mpe::pitchLevelDiff(endNotePitchClass, endNoteOctave, startNotePitchClass, startNoteOctave);
 

--- a/src/engraving/playback/metaparsers/internal/spannersmetaparser.h
+++ b/src/engraving/playback/metaparsers/internal/spannersmetaparser.h
@@ -31,7 +31,7 @@ class SpannersMetaParser : public MetaParserBase<SpannersMetaParser>
 protected:
     friend MetaParserBase;
 
-    static void doParse(const mu::engraving::EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void doParse(const EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result);
 };
 }
 

--- a/src/engraving/playback/metaparsers/internal/symbolsmetaparser.cpp
+++ b/src/engraving/playback/metaparsers/internal/symbolsmetaparser.cpp
@@ -26,14 +26,13 @@
 
 using namespace mu::engraving;
 
-void SymbolsMetaParser::doParse(const mu::engraving::EngravingItem* item, const RenderingContext& ctx,
-                                mpe::ArticulationMap& result)
+void SymbolsMetaParser::doParse(const EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
-    IF_ASSERT_FAILED(item->type() == mu::engraving::ElementType::ARTICULATION) {
+    IF_ASSERT_FAILED(item->type() == ElementType::ARTICULATION) {
         return;
     }
 
-    const mu::engraving::Articulation* articulationSymbol = mu::engraving::toArticulation(item);
+    const Articulation* articulationSymbol = toArticulation(item);
 
     if (!articulationSymbol->playArticulation()) {
         return;
@@ -42,338 +41,338 @@ void SymbolsMetaParser::doParse(const mu::engraving::EngravingItem* item, const 
     mpe::ArticulationTypeSet types;
 
     switch (articulationSymbol->symId()) {
-    case mu::engraving::SymId::articAccentAbove:
-    case mu::engraving::SymId::articAccentBelow:
+    case SymId::articAccentAbove:
+    case SymId::articAccentBelow:
         types.emplace(mpe::ArticulationType::Accent);
         break;
-    case mu::engraving::SymId::articAccentStaccatoAbove:
-    case mu::engraving::SymId::articAccentStaccatoBelow:
+    case SymId::articAccentStaccatoAbove:
+    case SymId::articAccentStaccatoBelow:
         types.emplace(mpe::ArticulationType::Accent);
         types.emplace(mpe::ArticulationType::Staccato);
         break;
-    case mu::engraving::SymId::articLaissezVibrerAbove:
-    case mu::engraving::SymId::articLaissezVibrerBelow:
+    case SymId::articLaissezVibrerAbove:
+    case SymId::articLaissezVibrerBelow:
         types.emplace(mpe::ArticulationType::LaissezVibrer);
         break;
-    case mu::engraving::SymId::articMarcatoAbove:
-    case mu::engraving::SymId::articMarcatoBelow:
+    case SymId::articMarcatoAbove:
+    case SymId::articMarcatoBelow:
         types.emplace(mpe::ArticulationType::Marcato);
         break;
-    case mu::engraving::SymId::articMarcatoStaccatoAbove:
-    case mu::engraving::SymId::articMarcatoStaccatoBelow:
+    case SymId::articMarcatoStaccatoAbove:
+    case SymId::articMarcatoStaccatoBelow:
         types.emplace(mpe::ArticulationType::Marcato);
         types.emplace(mpe::ArticulationType::Staccato);
         break;
-    case mu::engraving::SymId::articMarcatoTenutoAbove:
-    case mu::engraving::SymId::articMarcatoTenutoBelow:
+    case SymId::articMarcatoTenutoAbove:
+    case SymId::articMarcatoTenutoBelow:
         types.emplace(mpe::ArticulationType::Marcato);
         types.emplace(mpe::ArticulationType::Tenuto);
         break;
-    case mu::engraving::SymId::articSoftAccentAbove:
-    case mu::engraving::SymId::articSoftAccentBelow:
+    case SymId::articSoftAccentAbove:
+    case SymId::articSoftAccentBelow:
         types.emplace(mpe::ArticulationType::SoftAccent);
         break;
-    case mu::engraving::SymId::articSoftAccentStaccatoAbove:
-    case mu::engraving::SymId::articSoftAccentStaccatoBelow:
+    case SymId::articSoftAccentStaccatoAbove:
+    case SymId::articSoftAccentStaccatoBelow:
         types.emplace(mpe::ArticulationType::SoftAccent);
         types.emplace(mpe::ArticulationType::Staccato);
         break;
-    case mu::engraving::SymId::articSoftAccentTenutoAbove:
-    case mu::engraving::SymId::articSoftAccentTenutoBelow:
+    case SymId::articSoftAccentTenutoAbove:
+    case SymId::articSoftAccentTenutoBelow:
         types.emplace(mpe::ArticulationType::SoftAccent);
         types.emplace(mpe::ArticulationType::Tenuto);
         break;
-    case mu::engraving::SymId::articSoftAccentTenutoStaccatoAbove:
-    case mu::engraving::SymId::articSoftAccentTenutoStaccatoBelow:
+    case SymId::articSoftAccentTenutoStaccatoAbove:
+    case SymId::articSoftAccentTenutoStaccatoBelow:
         types.emplace(mpe::ArticulationType::SoftAccent);
         types.emplace(mpe::ArticulationType::Tenuto);
         types.emplace(mpe::ArticulationType::Staccato);
         break;
-    case mu::engraving::SymId::articStaccatissimoAbove:
-    case mu::engraving::SymId::articStaccatissimoBelow:
-    case mu::engraving::SymId::articStaccatissimoStrokeAbove:
-    case mu::engraving::SymId::articStaccatissimoStrokeBelow:
-    case mu::engraving::SymId::articStaccatissimoWedgeAbove:
-    case mu::engraving::SymId::articStaccatissimoWedgeBelow:
+    case SymId::articStaccatissimoAbove:
+    case SymId::articStaccatissimoBelow:
+    case SymId::articStaccatissimoStrokeAbove:
+    case SymId::articStaccatissimoStrokeBelow:
+    case SymId::articStaccatissimoWedgeAbove:
+    case SymId::articStaccatissimoWedgeBelow:
         types.emplace(mpe::ArticulationType::Staccatissimo);
         break;
-    case mu::engraving::SymId::articStaccatoAbove:
-    case mu::engraving::SymId::articStaccatoBelow:
+    case SymId::articStaccatoAbove:
+    case SymId::articStaccatoBelow:
         types.emplace(mpe::ArticulationType::Staccato);
         break;
-    case mu::engraving::SymId::articTenutoAbove:
-    case mu::engraving::SymId::articTenutoBelow:
+    case SymId::articTenutoAbove:
+    case SymId::articTenutoBelow:
         types.emplace(mpe::ArticulationType::Tenuto);
         break;
-    case mu::engraving::SymId::articTenutoStaccatoAbove:
-    case mu::engraving::SymId::articTenutoStaccatoBelow:
+    case SymId::articTenutoStaccatoAbove:
+    case SymId::articTenutoStaccatoBelow:
         types.emplace(mpe::ArticulationType::Tenuto);
         types.emplace(mpe::ArticulationType::Staccato);
         break;
-    case mu::engraving::SymId::articTenutoAccentAbove:
-    case mu::engraving::SymId::articTenutoAccentBelow:
+    case SymId::articTenutoAccentAbove:
+    case SymId::articTenutoAccentBelow:
         types.emplace(mpe::ArticulationType::Tenuto);
         types.emplace(mpe::ArticulationType::Accent);
         break;
-    case mu::engraving::SymId::dynamicSforzando:
-    case mu::engraving::SymId::dynamicSforzando1:
-    case mu::engraving::SymId::dynamicSforzandoPianissimo:
-    case mu::engraving::SymId::dynamicSforzandoPiano:
-    case mu::engraving::SymId::dynamicSforzato:
-    case mu::engraving::SymId::dynamicSforzatoFF:
-    case mu::engraving::SymId::dynamicSforzatoPiano:
+    case SymId::dynamicSforzando:
+    case SymId::dynamicSforzando1:
+    case SymId::dynamicSforzandoPianissimo:
+    case SymId::dynamicSforzandoPiano:
+    case SymId::dynamicSforzato:
+    case SymId::dynamicSforzatoFF:
+    case SymId::dynamicSforzatoPiano:
         types.emplace(mpe::ArticulationType::Subito);
         break;
-    case mu::engraving::SymId::guitarFadeIn:
+    case SymId::guitarFadeIn:
         types.emplace(mpe::ArticulationType::FadeIn);
         break;
-    case mu::engraving::SymId::guitarVolumeSwell:
+    case SymId::guitarVolumeSwell:
         types.emplace(mpe::ArticulationType::VolumeSwell);
         break;
-    case mu::engraving::SymId::guitarFadeOut:
+    case SymId::guitarFadeOut:
         types.emplace(mpe::ArticulationType::FadeOut);
         break;
-    case mu::engraving::SymId::stringsHalfHarmonic:
-    case mu::engraving::SymId::stringsHarmonic:
+    case SymId::stringsHalfHarmonic:
+    case SymId::stringsHarmonic:
         types.emplace(mpe::ArticulationType::Harmonic);
         break;
-    case mu::engraving::SymId::stringsMuteOn:
-    case mu::engraving::SymId::elecMute:
-    case mu::engraving::SymId::handbellsMutedMartellato:
-    case mu::engraving::SymId::brassMuteHalfClosed:
-    case mu::engraving::SymId::brassMuteClosed:
-    case mu::engraving::SymId::brassHarmonMuteStemHalfRight:
-    case mu::engraving::SymId::brassHarmonMuteStemHalfLeft:
-    case mu::engraving::SymId::brassHarmonMuteClosed:
+    case SymId::stringsMuteOn:
+    case SymId::elecMute:
+    case SymId::handbellsMutedMartellato:
+    case SymId::brassMuteHalfClosed:
+    case SymId::brassMuteClosed:
+    case SymId::brassHarmonMuteStemHalfRight:
+    case SymId::brassHarmonMuteStemHalfLeft:
+    case SymId::brassHarmonMuteClosed:
         types.emplace(mpe::ArticulationType::Mute);
         break;
-    case mu::engraving::SymId::brassHarmonMuteStemOpen:
-    case mu::engraving::SymId::brassMuteOpen:
-    case mu::engraving::SymId::guitarHalfOpenPedal:
-    case mu::engraving::SymId::guitarOpenPedal:
-    case mu::engraving::SymId::vocalMouthOpen:
-    case mu::engraving::SymId::vocalMouthSlightlyOpen:
-    case mu::engraving::SymId::vocalMouthWideOpen:
-    case mu::engraving::SymId::windOpenHole:
-    case mu::engraving::SymId::elecUnmute:
-    case mu::engraving::SymId::stringsMuteOff:
+    case SymId::brassHarmonMuteStemOpen:
+    case SymId::brassMuteOpen:
+    case SymId::guitarHalfOpenPedal:
+    case SymId::guitarOpenPedal:
+    case SymId::vocalMouthOpen:
+    case SymId::vocalMouthSlightlyOpen:
+    case SymId::vocalMouthWideOpen:
+    case SymId::windOpenHole:
+    case SymId::elecUnmute:
+    case SymId::stringsMuteOff:
         types.emplace(mpe::ArticulationType::Open);
         break;
 
-    case mu::engraving::SymId::pluckedLeftHandPizzicato:
+    case SymId::pluckedLeftHandPizzicato:
         types.emplace(mpe::ArticulationType::Pizzicato);
         break;
-    case mu::engraving::SymId::pluckedSnapPizzicatoAbove:
-    case mu::engraving::SymId::pluckedSnapPizzicatoBelow:
+    case SymId::pluckedSnapPizzicatoAbove:
+    case SymId::pluckedSnapPizzicatoBelow:
         types.emplace(mpe::ArticulationType::SnapPizzicato);
         break;
-    case mu::engraving::SymId::stringsUpBow:
+    case SymId::stringsUpBow:
         types.emplace(mpe::ArticulationType::UpBow);
         break;
-    case mu::engraving::SymId::stringsDownBow:
+    case SymId::stringsDownBow:
         types.emplace(mpe::ArticulationType::DownBow);
         break;
-    case mu::engraving::SymId::stringsJeteAbove:
-    case mu::engraving::SymId::stringsJeteBelow:
+    case SymId::stringsJeteAbove:
+    case SymId::stringsJeteBelow:
         types.emplace(mpe::ArticulationType::Jete);
         break;
-    case mu::engraving::SymId::noteheadXWhole:
-    case mu::engraving::SymId::noteheadXOrnate:
-    case mu::engraving::SymId::noteheadXBlack:
-    case mu::engraving::SymId::noteheadXDoubleWhole:
-    case mu::engraving::SymId::noteheadWholeWithX:
-    case mu::engraving::SymId::noteheadVoidWithX:
+    case SymId::noteheadXWhole:
+    case SymId::noteheadXOrnate:
+    case SymId::noteheadXBlack:
+    case SymId::noteheadXDoubleWhole:
+    case SymId::noteheadWholeWithX:
+    case SymId::noteheadVoidWithX:
         types.emplace(mpe::ArticulationType::CrossNote);
         break;
-    case mu::engraving::SymId::noteheadCircleSlash:
-    case mu::engraving::SymId::noteheadCircledBlack:
-    case mu::engraving::SymId::noteheadCircledHalf:
-    case mu::engraving::SymId::noteheadCircledBlackLarge:
-    case mu::engraving::SymId::noteheadCircledDoubleWhole:
-    case mu::engraving::SymId::noteheadCircledDoubleWholeLarge:
-    case mu::engraving::SymId::noteheadCircledHalfLarge:
-    case mu::engraving::SymId::noteheadCircledWhole:
-    case mu::engraving::SymId::noteheadCircledWholeLarge:
+    case SymId::noteheadCircleSlash:
+    case SymId::noteheadCircledBlack:
+    case SymId::noteheadCircledHalf:
+    case SymId::noteheadCircledBlackLarge:
+    case SymId::noteheadCircledDoubleWhole:
+    case SymId::noteheadCircledDoubleWholeLarge:
+    case SymId::noteheadCircledHalfLarge:
+    case SymId::noteheadCircledWhole:
+    case SymId::noteheadCircledWholeLarge:
         types.emplace(mpe::ArticulationType::CircleNote);
         break;
-    case mu::engraving::SymId::noteheadDiamondBlack:
-    case mu::engraving::SymId::noteheadDiamondBlackOld:
-    case mu::engraving::SymId::noteheadDiamondBlackWide:
-    case mu::engraving::SymId::noteheadDiamondDoubleWhole:
-    case mu::engraving::SymId::noteheadDiamondHalfWide:
-    case mu::engraving::SymId::noteheadDiamondDoubleWholeOld:
-    case mu::engraving::SymId::noteheadDiamondWhole:
-    case mu::engraving::SymId::noteheadDiamondWholeOld:
-    case mu::engraving::SymId::noteheadDiamondHalf:
-    case mu::engraving::SymId::noteheadDiamondHalfFilled:
-    case mu::engraving::SymId::noteheadDiamondHalfOld:
+    case SymId::noteheadDiamondBlack:
+    case SymId::noteheadDiamondBlackOld:
+    case SymId::noteheadDiamondBlackWide:
+    case SymId::noteheadDiamondDoubleWhole:
+    case SymId::noteheadDiamondHalfWide:
+    case SymId::noteheadDiamondDoubleWholeOld:
+    case SymId::noteheadDiamondWhole:
+    case SymId::noteheadDiamondWholeOld:
+    case SymId::noteheadDiamondHalf:
+    case SymId::noteheadDiamondHalfFilled:
+    case SymId::noteheadDiamondHalfOld:
         types.emplace(mpe::ArticulationType::DiamondNote);
         break;
-    case mu::engraving::SymId::noteheadTriangleDownBlack:
-    case mu::engraving::SymId::noteheadTriangleDownDoubleWhole:
-    case mu::engraving::SymId::noteheadTriangleDownHalf:
-    case mu::engraving::SymId::noteheadTriangleDownWhite:
-    case mu::engraving::SymId::noteheadTriangleDownWhole:
-    case mu::engraving::SymId::noteheadTriangleLeftBlack:
-    case mu::engraving::SymId::noteheadTriangleLeftWhite:
-    case mu::engraving::SymId::noteheadTriangleRightBlack:
-    case mu::engraving::SymId::noteheadTriangleRightWhite:
-    case mu::engraving::SymId::noteheadTriangleRoundDownBlack:
-    case mu::engraving::SymId::noteheadTriangleRoundDownWhite:
-    case mu::engraving::SymId::noteheadTriangleUpBlack:
-    case mu::engraving::SymId::noteheadTriangleUpDoubleWhole:
-    case mu::engraving::SymId::noteheadTriangleUpHalf:
-    case mu::engraving::SymId::noteheadTriangleUpRightBlack:
-    case mu::engraving::SymId::noteheadTriangleUpRightWhite:
-    case mu::engraving::SymId::noteheadTriangleUpWhite:
-    case mu::engraving::SymId::noteheadTriangleUpWhole:
+    case SymId::noteheadTriangleDownBlack:
+    case SymId::noteheadTriangleDownDoubleWhole:
+    case SymId::noteheadTriangleDownHalf:
+    case SymId::noteheadTriangleDownWhite:
+    case SymId::noteheadTriangleDownWhole:
+    case SymId::noteheadTriangleLeftBlack:
+    case SymId::noteheadTriangleLeftWhite:
+    case SymId::noteheadTriangleRightBlack:
+    case SymId::noteheadTriangleRightWhite:
+    case SymId::noteheadTriangleRoundDownBlack:
+    case SymId::noteheadTriangleRoundDownWhite:
+    case SymId::noteheadTriangleUpBlack:
+    case SymId::noteheadTriangleUpDoubleWhole:
+    case SymId::noteheadTriangleUpHalf:
+    case SymId::noteheadTriangleUpRightBlack:
+    case SymId::noteheadTriangleUpRightWhite:
+    case SymId::noteheadTriangleUpWhite:
+    case SymId::noteheadTriangleUpWhole:
         types.emplace(mpe::ArticulationType::TriangleNote);
         break;
-    case mu::engraving::SymId::brassScoop:
+    case SymId::brassScoop:
         types.emplace(mpe::ArticulationType::Scoop);
         break;
-    case mu::engraving::SymId::brassPlop:
+    case SymId::brassPlop:
         types.emplace(mpe::ArticulationType::Plop);
         break;
-    case mu::engraving::SymId::brassFallLipLong:
-    case mu::engraving::SymId::brassFallLipMedium:
-    case mu::engraving::SymId::brassFallLipShort:
-    case mu::engraving::SymId::brassFallRoughLong:
-    case mu::engraving::SymId::brassFallRoughMedium:
-    case mu::engraving::SymId::brassFallRoughShort:
+    case SymId::brassFallLipLong:
+    case SymId::brassFallLipMedium:
+    case SymId::brassFallLipShort:
+    case SymId::brassFallRoughLong:
+    case SymId::brassFallRoughMedium:
+    case SymId::brassFallRoughShort:
         types.emplace(mpe::ArticulationType::QuickFall);
         break;
-    case mu::engraving::SymId::brassFallSmoothLong:
-    case mu::engraving::SymId::brassFallSmoothMedium:
-    case mu::engraving::SymId::brassFallSmoothShort:
+    case SymId::brassFallSmoothLong:
+    case SymId::brassFallSmoothMedium:
+    case SymId::brassFallSmoothShort:
         types.emplace(mpe::ArticulationType::Fall);
         break;
-    case mu::engraving::SymId::brassDoitLong:
-    case mu::engraving::SymId::brassDoitMedium:
-    case mu::engraving::SymId::brassDoitShort:
+    case SymId::brassDoitLong:
+    case SymId::brassDoitMedium:
+    case SymId::brassDoitShort:
         types.emplace(mpe::ArticulationType::Doit);
         break;
-    case mu::engraving::SymId::brassBend:
+    case SymId::brassBend:
         types.emplace(mpe::ArticulationType::Bend);
         break;
-    case mu::engraving::SymId::dynamicCrescendoHairpin:
+    case SymId::dynamicCrescendoHairpin:
         types.emplace(mpe::ArticulationType::Crescendo);
         break;
-    case mu::engraving::SymId::dynamicDiminuendoHairpin:
+    case SymId::dynamicDiminuendoHairpin:
         types.emplace(mpe::ArticulationType::Decrescendo);
         break;
-    case mu::engraving::SymId::ornamentUpPrall:
+    case SymId::ornamentUpPrall:
         types.emplace(mpe::ArticulationType::UpPrall);
         break;
-    case mu::engraving::SymId::ornamentPrallDown:
+    case SymId::ornamentPrallDown:
         types.emplace(mpe::ArticulationType::PrallDown);
         break;
-    case mu::engraving::SymId::ornamentPrallUp:
+    case SymId::ornamentPrallUp:
         types.emplace(mpe::ArticulationType::PrallUp);
         break;
-    case mu::engraving::SymId::ornamentLinePrall:
+    case SymId::ornamentLinePrall:
         types.emplace(mpe::ArticulationType::LinePrall);
         break;
-    case mu::engraving::SymId::ornamentPrallMordent:
+    case SymId::ornamentPrallMordent:
         types.emplace(mpe::ArticulationType::PrallMordent);
         break;
-    case mu::engraving::SymId::ornamentUpMordent:
+    case SymId::ornamentUpMordent:
         types.emplace(mpe::ArticulationType::UpMordent);
         break;
-    case mu::engraving::SymId::ornamentMordent:
+    case SymId::ornamentMordent:
         types.emplace(mpe::ArticulationType::LowerMordent);
         break;
-    case mu::engraving::SymId::ornamentDownMordent:
+    case SymId::ornamentDownMordent:
         types.emplace(mpe::ArticulationType::DownMordent);
         break;
-    case mu::engraving::SymId::ornamentTurn:
-    case mu::engraving::SymId::brassJazzTurn:
+    case SymId::ornamentTurn:
+    case SymId::brassJazzTurn:
         types.emplace(mpe::ArticulationType::Turn);
         break;
-    case mu::engraving::SymId::ornamentTurnInverted:
-    case mu::engraving::SymId::ornamentTurnSlash:
+    case SymId::ornamentTurnInverted:
+    case SymId::ornamentTurnSlash:
         types.emplace(mpe::ArticulationType::InvertedTurn);
         break;
-    case mu::engraving::SymId::ornamentTrill:
-        if (articulationSymbol->ornamentStyle() == mu::engraving::OrnamentStyle::DEFAULT) {
+    case SymId::ornamentTrill:
+        if (articulationSymbol->ornamentStyle() == OrnamentStyle::DEFAULT) {
             types.emplace(mpe::ArticulationType::Trill);
         } else {
             types.emplace(mpe::ArticulationType::TrillBaroque);
         }
         break;
-    case mu::engraving::SymId::ornamentShortTrill:
+    case SymId::ornamentShortTrill:
         types.emplace(mpe::ArticulationType::UpperMordent);
         break;
-    case mu::engraving::SymId::ornamentTremblement:
-    case mu::engraving::SymId::ornamentTremblementCouperin:
+    case SymId::ornamentTremblement:
+    case SymId::ornamentTremblementCouperin:
         types.emplace(mpe::ArticulationType::Tremblement);
         break;
-    case mu::engraving::SymId::graceNoteAcciaccaturaStemDown:
-    case mu::engraving::SymId::graceNoteAcciaccaturaStemUp:
-    case mu::engraving::SymId::graceNoteSlashStemDown:
-    case mu::engraving::SymId::graceNoteSlashStemUp:
+    case SymId::graceNoteAcciaccaturaStemDown:
+    case SymId::graceNoteAcciaccaturaStemUp:
+    case SymId::graceNoteSlashStemDown:
+    case SymId::graceNoteSlashStemUp:
         types.emplace(mpe::ArticulationType::Acciaccatura);
         break;
-    case mu::engraving::SymId::graceNoteAppoggiaturaStemDown:
-    case mu::engraving::SymId::graceNoteAppoggiaturaStemUp:
+    case SymId::graceNoteAppoggiaturaStemDown:
+    case SymId::graceNoteAppoggiaturaStemUp:
         types.emplace(mpe::ArticulationType::PreAppoggiatura);
         break;
-    case mu::engraving::SymId::glissandoUp:
-    case mu::engraving::SymId::glissandoDown:
+    case SymId::glissandoUp:
+    case SymId::glissandoDown:
         types.emplace(mpe::ArticulationType::DiscreteGlissando);
         break;
-    case mu::engraving::SymId::wiggleArpeggiatoDown:
-    case mu::engraving::SymId::wiggleArpeggiatoDownArrow:
+    case SymId::wiggleArpeggiatoDown:
+    case SymId::wiggleArpeggiatoDownArrow:
         types.emplace(mpe::ArticulationType::ArpeggioDown);
         break;
-    case mu::engraving::SymId::wiggleArpeggiatoUp:
-    case mu::engraving::SymId::wiggleArpeggiatoUpArrow:
+    case SymId::wiggleArpeggiatoUp:
+    case SymId::wiggleArpeggiatoUpArrow:
         types.emplace(mpe::ArticulationType::ArpeggioUp);
         break;
-    case mu::engraving::SymId::wiggleArpeggiatoDownSwash:
+    case SymId::wiggleArpeggiatoDownSwash:
         types.emplace(mpe::ArticulationType::ArpeggioStraightDown);
         break;
-    case mu::engraving::SymId::wiggleArpeggiatoUpSwash:
+    case SymId::wiggleArpeggiatoUpSwash:
         types.emplace(mpe::ArticulationType::ArpeggioStraightUp);
         break;
-    case mu::engraving::SymId::wiggleVibratoLargeFaster:
-    case mu::engraving::SymId::wiggleVibratoLargeFasterStill:
-    case mu::engraving::SymId::wiggleVibratoLargeFastest:
-    case mu::engraving::SymId::wiggleVibratoLargeSlow:
-    case mu::engraving::SymId::wiggleVibratoLargeSlower:
-    case mu::engraving::SymId::wiggleVibratoLargeSlowest:
-    case mu::engraving::SymId::wiggleVibratoLargestFast:
-    case mu::engraving::SymId::wiggleVibratoLargestFaster:
-    case mu::engraving::SymId::wiggleVibratoLargestFasterStill:
-    case mu::engraving::SymId::wiggleVibratoLargestFastest:
-    case mu::engraving::SymId::wiggleVibratoLargestSlow:
-    case mu::engraving::SymId::wiggleVibratoLargestSlowest:
-    case mu::engraving::SymId::wiggleVibratoMediumFast:
-    case mu::engraving::SymId::wiggleVibratoMediumFaster:
-    case mu::engraving::SymId::wiggleVibratoMediumFasterStill:
-    case mu::engraving::SymId::wiggleVibratoMediumFastest:
-    case mu::engraving::SymId::wiggleVibratoMediumSlow:
-    case mu::engraving::SymId::wiggleVibratoMediumSlowest:
-    case mu::engraving::SymId::wiggleVibratoSmallFast:
-    case mu::engraving::SymId::wiggleVibratoSmallFaster:
-    case mu::engraving::SymId::wiggleVibratoSmallFasterStill:
-    case mu::engraving::SymId::wiggleVibratoSmallFastest:
-    case mu::engraving::SymId::wiggleVibratoSmallSlow:
-    case mu::engraving::SymId::wiggleVibratoSmallSlower:
-    case mu::engraving::SymId::wiggleVibratoSmallSlowest:
-    case mu::engraving::SymId::wiggleVibratoSmallestFast:
-    case mu::engraving::SymId::wiggleVibratoSmallestFaster:
-    case mu::engraving::SymId::wiggleVibratoSmallestFasterStill:
-    case mu::engraving::SymId::wiggleVibratoSmallestFastest:
-    case mu::engraving::SymId::wiggleVibratoSmallestSlow:
-    case mu::engraving::SymId::wiggleVibratoSmallestSlower:
-    case mu::engraving::SymId::wiggleVibratoSmallestSlowest:
-    case mu::engraving::SymId::wiggleVibratoStart:
-    case mu::engraving::SymId::wiggleVibratoLargeFast:
-    case mu::engraving::SymId::wiggleVibrato:
+    case SymId::wiggleVibratoLargeFaster:
+    case SymId::wiggleVibratoLargeFasterStill:
+    case SymId::wiggleVibratoLargeFastest:
+    case SymId::wiggleVibratoLargeSlow:
+    case SymId::wiggleVibratoLargeSlower:
+    case SymId::wiggleVibratoLargeSlowest:
+    case SymId::wiggleVibratoLargestFast:
+    case SymId::wiggleVibratoLargestFaster:
+    case SymId::wiggleVibratoLargestFasterStill:
+    case SymId::wiggleVibratoLargestFastest:
+    case SymId::wiggleVibratoLargestSlow:
+    case SymId::wiggleVibratoLargestSlowest:
+    case SymId::wiggleVibratoMediumFast:
+    case SymId::wiggleVibratoMediumFaster:
+    case SymId::wiggleVibratoMediumFasterStill:
+    case SymId::wiggleVibratoMediumFastest:
+    case SymId::wiggleVibratoMediumSlow:
+    case SymId::wiggleVibratoMediumSlowest:
+    case SymId::wiggleVibratoSmallFast:
+    case SymId::wiggleVibratoSmallFaster:
+    case SymId::wiggleVibratoSmallFasterStill:
+    case SymId::wiggleVibratoSmallFastest:
+    case SymId::wiggleVibratoSmallSlow:
+    case SymId::wiggleVibratoSmallSlower:
+    case SymId::wiggleVibratoSmallSlowest:
+    case SymId::wiggleVibratoSmallestFast:
+    case SymId::wiggleVibratoSmallestFaster:
+    case SymId::wiggleVibratoSmallestFasterStill:
+    case SymId::wiggleVibratoSmallestFastest:
+    case SymId::wiggleVibratoSmallestSlow:
+    case SymId::wiggleVibratoSmallestSlower:
+    case SymId::wiggleVibratoSmallestSlowest:
+    case SymId::wiggleVibratoStart:
+    case SymId::wiggleVibratoLargeFast:
+    case SymId::wiggleVibrato:
         types.emplace(mpe::ArticulationType::Vibrato);
         break;
-    case mu::engraving::SymId::wiggleVibratoWide:
+    case SymId::wiggleVibratoWide:
         types.emplace(mpe::ArticulationType::WideVibrato);
         break;
     default:

--- a/src/engraving/playback/metaparsers/internal/symbolsmetaparser.h
+++ b/src/engraving/playback/metaparsers/internal/symbolsmetaparser.h
@@ -31,7 +31,7 @@ class SymbolsMetaParser : public MetaParserBase<SymbolsMetaParser>
 protected:
     friend MetaParserBase;
 
-    static void doParse(const mu::engraving::EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void doParse(const EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result);
 };
 }
 

--- a/src/engraving/playback/metaparsers/internal/tremolometaparser.cpp
+++ b/src/engraving/playback/metaparsers/internal/tremolometaparser.cpp
@@ -27,34 +27,34 @@
 
 using namespace mu::engraving;
 
-void TremoloMetaParser::doParse(const mu::engraving::EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result)
+void TremoloMetaParser::doParse(const EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
-    IF_ASSERT_FAILED(item->type() == mu::engraving::ElementType::TREMOLO) {
+    IF_ASSERT_FAILED(item->type() == ElementType::TREMOLO) {
         return;
     }
 
-    const mu::engraving::Tremolo* tremolo = mu::engraving::toTremolo(item);
+    const Tremolo* tremolo = toTremolo(item);
 
     mpe::ArticulationType type = mpe::ArticulationType::Undefined;
 
     switch (tremolo->tremoloType()) {
-    case mu::engraving::TremoloType::R8:
-    case mu::engraving::TremoloType::C8:
+    case TremoloType::R8:
+    case TremoloType::C8:
         type = mpe::ArticulationType::Tremolo8th;
         break;
 
-    case mu::engraving::TremoloType::R16:
-    case mu::engraving::TremoloType::C16:
+    case TremoloType::R16:
+    case TremoloType::C16:
         type = mpe::ArticulationType::Tremolo16th;
         break;
 
-    case mu::engraving::TremoloType::R32:
-    case mu::engraving::TremoloType::C32:
+    case TremoloType::R32:
+    case TremoloType::C32:
         type = mpe::ArticulationType::Tremolo32nd;
         break;
 
-    case mu::engraving::TremoloType::R64:
-    case mu::engraving::TremoloType::C64:
+    case TremoloType::R64:
+    case TremoloType::C64:
         type = mpe::ArticulationType::Tremolo64th;
         break;
 

--- a/src/engraving/playback/metaparsers/internal/tremolometaparser.h
+++ b/src/engraving/playback/metaparsers/internal/tremolometaparser.h
@@ -31,7 +31,7 @@ class TremoloMetaParser : public MetaParserBase<TremoloMetaParser>
 protected:
     friend MetaParserBase;
 
-    static void doParse(const mu::engraving::EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void doParse(const EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result);
 };
 }
 

--- a/src/engraving/playback/metaparsers/metaparserbase.h
+++ b/src/engraving/playback/metaparsers/metaparserbase.h
@@ -30,14 +30,12 @@
 
 namespace mu::engraving {
 class EngravingItem;
-}
 
-namespace mu::engraving {
 template<class T>
 class MetaParserBase
 {
 public:
-    static void parse(const mu::engraving::EngravingItem* item, const RenderingContext& context, mpe::ArticulationMap& result)
+    static void parse(const EngravingItem* item, const RenderingContext& context, mpe::ArticulationMap& result)
     {
         IF_ASSERT_FAILED(item) {
             return;

--- a/src/engraving/playback/metaparsers/notearticulationsparser.cpp
+++ b/src/engraving/playback/metaparsers/notearticulationsparser.cpp
@@ -31,8 +31,7 @@
 using namespace mu::engraving;
 using namespace mu::mpe;
 
-void NoteArticulationsParser::buildNoteArticulationMap(const mu::engraving::Note* note, const RenderingContext& ctx,
-                                                       mpe::ArticulationMap& result)
+void NoteArticulationsParser::buildNoteArticulationMap(const Note* note, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
     if (!note || !ctx.isValid()) {
         LOGE() << "Unable to render playback events of invalid note";
@@ -53,14 +52,13 @@ void NoteArticulationsParser::buildNoteArticulationMap(const mu::engraving::Note
     result.preCalculateAverageData();
 }
 
-void NoteArticulationsParser::doParse(const mu::engraving::EngravingItem* item, const RenderingContext& ctx,
-                                      mpe::ArticulationMap& result)
+void NoteArticulationsParser::doParse(const EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
-    IF_ASSERT_FAILED(item->type() == mu::engraving::ElementType::NOTE) {
+    IF_ASSERT_FAILED(item->type() == ElementType::NOTE) {
         return;
     }
 
-    const mu::engraving::Note* note = mu::engraving::toNote(item);
+    const Note* note = toNote(item);
 
     if (!note || !note->play()) {
         return;
@@ -110,8 +108,7 @@ void NoteArticulationsParser::parsePersistentMeta(const RenderingContext& ctx, m
                              0 }, result);
 }
 
-void NoteArticulationsParser::parseGhostNote(const mu::engraving::Note* note, const RenderingContext& ctx,
-                                             mpe::ArticulationMap& result)
+void NoteArticulationsParser::parseGhostNote(const Note* note, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
     if (!note->ghost()) {
         return;
@@ -123,8 +120,7 @@ void NoteArticulationsParser::parseGhostNote(const mu::engraving::Note* note, co
                                                  ctx.nominalDuration), result);
 }
 
-void NoteArticulationsParser::parseNoteHead(const mu::engraving::Note* note, const RenderingContext& ctx,
-                                            mpe::ArticulationMap& result)
+void NoteArticulationsParser::parseNoteHead(const Note* note, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
     mpe::ArticulationType typeByNoteHead = articulationTypeByNotehead(note->headGroup());
 
@@ -138,10 +134,9 @@ void NoteArticulationsParser::parseNoteHead(const mu::engraving::Note* note, con
                                                  ctx.nominalDuration), result);
 }
 
-void NoteArticulationsParser::parseSpanners(const mu::engraving::Note* note, const RenderingContext& ctx,
-                                            mpe::ArticulationMap& result)
+void NoteArticulationsParser::parseSpanners(const Note* note, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
-    for (const mu::engraving::Spanner* spanner : note->spannerFor()) {
+    for (const Spanner* spanner : note->spannerFor()) {
         int spannerFrom = spanner->tick().ticks();
         int spannerTo = spanner->tick().ticks() + std::abs(spanner->ticks().ticks());
         int spannerDurationTicks = spannerTo - spannerFrom;

--- a/src/engraving/playback/metaparsers/notearticulationsparser.h
+++ b/src/engraving/playback/metaparsers/notearticulationsparser.h
@@ -28,26 +28,24 @@
 
 namespace mu::engraving {
 class Note;
-}
 
-namespace mu::engraving {
 class NoteArticulationsParser : public MetaParserBase<NoteArticulationsParser>
 {
 public:
-    static void buildNoteArticulationMap(const mu::engraving::Note* note, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void buildNoteArticulationMap(const Note* note, const RenderingContext& ctx, mpe::ArticulationMap& result);
 
 protected:
     friend MetaParserBase;
 
-    static void doParse(const mu::engraving::EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void doParse(const EngravingItem* item, const RenderingContext& ctx, mpe::ArticulationMap& result);
 
 private:
     static mpe::ArticulationType articulationTypeByNotehead(const NoteHeadGroup noteheadGroup);
 
     static void parsePersistentMeta(const RenderingContext& ctx, mpe::ArticulationMap& result);
-    static void parseGhostNote(const mu::engraving::Note* note, const RenderingContext& ctx, mpe::ArticulationMap& result);
-    static void parseNoteHead(const mu::engraving::Note* note, const RenderingContext& ctx, mpe::ArticulationMap& result);
-    static void parseSpanners(const mu::engraving::Note* note, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void parseGhostNote(const Note* note, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void parseNoteHead(const Note* note, const RenderingContext& ctx, mpe::ArticulationMap& result);
+    static void parseSpanners(const Note* note, const RenderingContext& ctx, mpe::ArticulationMap& result);
 };
 }
 

--- a/src/engraving/playback/playbackcontext.cpp
+++ b/src/engraving/playback/playbackcontext.cpp
@@ -61,13 +61,13 @@ ArticulationType PlaybackContext::persistentArticulationType(const int nominalPo
     return mpe::ArticulationType::Standard;
 }
 
-void PlaybackContext::update(const ID partId, const mu::engraving::Score* score)
+void PlaybackContext::update(const ID partId, const Score* score)
 {
-    for (const mu::engraving::RepeatSegment* repeatSegment : score->repeatList()) {
+    for (const RepeatSegment* repeatSegment : score->repeatList()) {
         int tickPositionOffset = repeatSegment->utick - repeatSegment->tick;
 
-        for (const mu::engraving::Measure* measure : repeatSegment->measureList()) {
-            for (mu::engraving::Segment* segment = measure->first(); segment; segment = segment->next()) {
+        for (const Measure* measure : repeatSegment->measureList()) {
+            for (Segment* segment = measure->first(); segment; segment = segment->next()) {
                 int segmentStartTick = segment->tick().ticks() + tickPositionOffset;
 
                 handleAnnotations(partId, segment, segmentStartTick);
@@ -84,7 +84,7 @@ void PlaybackContext::clear()
     m_playTechniquesMap.clear();
 }
 
-DynamicLevelMap PlaybackContext::dynamicLevelMap(const mu::engraving::Score* score) const
+DynamicLevelMap PlaybackContext::dynamicLevelMap(const Score* score) const
 {
     DynamicLevelMap result;
 
@@ -110,10 +110,9 @@ dynamic_level_t PlaybackContext::nominalDynamicLevel(const int positionTick) con
     return search->second;
 }
 
-void PlaybackContext::updateDynamicMap(const mu::engraving::Dynamic* dynamic, const mu::engraving::Segment* segment,
-                                       const int segmentPositionTick)
+void PlaybackContext::updateDynamicMap(const Dynamic* dynamic, const Segment* segment, const int segmentPositionTick)
 {
-    const mu::engraving::DynamicType type = dynamic->dynamicType();
+    const DynamicType type = dynamic->dynamicType();
     if (isOrdinaryDynamicType(type)) {
         m_dynamicsMap[segmentPositionTick] = dynamicLevelFromType(type);
         return;
@@ -137,18 +136,18 @@ void PlaybackContext::updateDynamicMap(const mu::engraving::Dynamic* dynamic, co
     applyDynamicToNextSegment(segment, dynamicLevelFromType(transition.to));
 }
 
-void PlaybackContext::updatePlayTechMap(const mu::engraving::PlayTechAnnotation* annotation, const int segmentPositionTick)
+void PlaybackContext::updatePlayTechMap(const PlayTechAnnotation* annotation, const int segmentPositionTick)
 {
-    const mu::engraving::PlayingTechniqueType type = annotation->techniqueType();
+    const PlayingTechniqueType type = annotation->techniqueType();
 
-    if (type == mu::engraving::PlayingTechniqueType::Undefined) {
+    if (type == PlayingTechniqueType::Undefined) {
         return;
     }
 
     m_playTechniquesMap[segmentPositionTick] = articulationFromPlayTechType(type);
 }
 
-void PlaybackContext::applyDynamicToNextSegment(const mu::engraving::Segment* currentSegment, const mpe::dynamic_level_t dynamicLevel)
+void PlaybackContext::applyDynamicToNextSegment(const Segment* currentSegment, const mpe::dynamic_level_t dynamicLevel)
 {
     if (!currentSegment->next()) {
         return;
@@ -158,10 +157,10 @@ void PlaybackContext::applyDynamicToNextSegment(const mu::engraving::Segment* cu
     m_dynamicsMap[nextSegmentPositionTick] = dynamicLevel;
 }
 
-void PlaybackContext::handleSpanners(const ID partId, const mu::engraving::Score* score)
+void PlaybackContext::handleSpanners(const ID partId, const Score* score)
 {
     for (const auto& pair : score->spanner()) {
-        const mu::engraving::Spanner* spanner = pair.second;
+        const Spanner* spanner = pair.second;
 
         if (!spanner->isHairpin()) {
             continue;
@@ -180,10 +179,10 @@ void PlaybackContext::handleSpanners(const ID partId, const mu::engraving::Score
             continue;
         }
 
-        const mu::engraving::Hairpin* hairpin = mu::engraving::toHairpin(spanner);
+        const Hairpin* hairpin = toHairpin(spanner);
 
-        mu::engraving::DynamicType dynamicTypeFrom = hairpin->dynamicTypeFrom();
-        mu::engraving::DynamicType dynamicTypeTo = hairpin->dynamicTypeTo();
+        DynamicType dynamicTypeFrom = hairpin->dynamicTypeFrom();
+        DynamicType dynamicTypeTo = hairpin->dynamicTypeTo();
 
         dynamic_level_t nominalLevelFrom = dynamicLevelFromType(dynamicTypeFrom, appliableDynamicLevel(spannerFrom));
         dynamic_level_t nominalLevelTo = dynamicLevelFromType(dynamicTypeTo, nominalDynamicLevel(spannerTo));
@@ -205,9 +204,9 @@ void PlaybackContext::handleSpanners(const ID partId, const mu::engraving::Score
     }
 }
 
-void PlaybackContext::handleAnnotations(const ID partId, const mu::engraving::Segment* segment, const int segmentPositionTick)
+void PlaybackContext::handleAnnotations(const ID partId, const Segment* segment, const int segmentPositionTick)
 {
-    for (const mu::engraving::EngravingItem* annotation : segment->annotations()) {
+    for (const EngravingItem* annotation : segment->annotations()) {
         if (!annotation || !annotation->part()) {
             continue;
         }
@@ -217,12 +216,12 @@ void PlaybackContext::handleAnnotations(const ID partId, const mu::engraving::Se
         }
 
         if (annotation->isDynamic()) {
-            updateDynamicMap(mu::engraving::toDynamic(annotation), segment, segmentPositionTick);
+            updateDynamicMap(toDynamic(annotation), segment, segmentPositionTick);
             return;
         }
 
         if (annotation->isPlayTechAnnotation()) {
-            updatePlayTechMap(mu::engraving::toPlayTechAnnotation(annotation), segmentPositionTick);
+            updatePlayTechMap(toPlayTechAnnotation(annotation), segmentPositionTick);
             return;
         }
     }

--- a/src/engraving/playback/playbackcontext.h
+++ b/src/engraving/playback/playbackcontext.h
@@ -32,9 +32,7 @@ class Segment;
 class Dynamic;
 class PlayTechAnnotation;
 class Score;
-}
 
-namespace mu::engraving {
 using DynamicMap = std::map<int /*nominalPositionTick*/, mpe::dynamic_level_t>;
 using PlayTechniquesMap = std::map<int /*nominalPositionTick*/, mpe::ArticulationType>;
 
@@ -44,20 +42,20 @@ public:
     mpe::dynamic_level_t appliableDynamicLevel(const int nominalPositionTick) const;
     mpe::ArticulationType persistentArticulationType(const int nominalPositionTick) const;
 
-    void update(const ID partId, const mu::engraving::Score* score);
+    void update(const ID partId, const Score* score);
     void clear();
 
-    mpe::DynamicLevelMap dynamicLevelMap(const mu::engraving::Score* score) const;
+    mpe::DynamicLevelMap dynamicLevelMap(const Score* score) const;
 
 private:
     mpe::dynamic_level_t nominalDynamicLevel(const int positionTick) const;
 
-    void updateDynamicMap(const mu::engraving::Dynamic* dynamic, const mu::engraving::Segment* segment, const int segmentPositionTick);
-    void updatePlayTechMap(const mu::engraving::PlayTechAnnotation* annotation, const int segmentPositionTick);
-    void applyDynamicToNextSegment(const mu::engraving::Segment* currentSegment, const mpe::dynamic_level_t dynamicLevel);
+    void updateDynamicMap(const Dynamic* dynamic, const Segment* segment, const int segmentPositionTick);
+    void updatePlayTechMap(const PlayTechAnnotation* annotation, const int segmentPositionTick);
+    void applyDynamicToNextSegment(const Segment* currentSegment, const mpe::dynamic_level_t dynamicLevel);
 
-    void handleSpanners(const ID partId, const mu::engraving::Score* score);
-    void handleAnnotations(const ID partId, const mu::engraving::Segment* segment, const int segmentPositionTick);
+    void handleSpanners(const ID partId, const Score* score);
+    void handleAnnotations(const ID partId, const Segment* segment, const int segmentPositionTick);
 
     void removeDynamicData(const int from, const int to);
     void removePlayTechniqueData(const int from, const int to);

--- a/src/engraving/playback/playbackeventsrenderer.cpp
+++ b/src/engraving/playback/playbackeventsrenderer.cpp
@@ -41,7 +41,7 @@
 using namespace mu::engraving;
 using namespace mu::mpe;
 
-void PlaybackEventsRenderer::render(const mu::engraving::EngravingItem* item, const dynamic_level_t nominalDynamicLevel,
+void PlaybackEventsRenderer::render(const EngravingItem* item, const dynamic_level_t nominalDynamicLevel,
                                     const ArticulationType persistentArticulationApplied,
                                     const ArticulationsProfilePtr profile,
                                     PlaybackEventsMap& result) const
@@ -49,7 +49,7 @@ void PlaybackEventsRenderer::render(const mu::engraving::EngravingItem* item, co
     render(item, 0, nominalDynamicLevel, persistentArticulationApplied, profile, result);
 }
 
-void PlaybackEventsRenderer::render(const mu::engraving::EngravingItem* item, const int tickPositionOffset,
+void PlaybackEventsRenderer::render(const EngravingItem* item, const int tickPositionOffset,
                                     const dynamic_level_t nominalDynamicLevel,
                                     const ArticulationType persistentArticulationApplied, const ArticulationsProfilePtr profile,
                                     PlaybackEventsMap& result) const
@@ -60,15 +60,15 @@ void PlaybackEventsRenderer::render(const mu::engraving::EngravingItem* item, co
         return;
     }
 
-    if (item->type() == mu::engraving::ElementType::CHORD) {
-        renderNoteEvents(mu::engraving::toChord(
+    if (item->type() == ElementType::CHORD) {
+        renderNoteEvents(toChord(
                              item), tickPositionOffset, nominalDynamicLevel, persistentArticulationApplied, profile, result);
-    } else if (item->type() == mu::engraving::ElementType::REST) {
-        renderRestEvents(mu::engraving::toRest(item), tickPositionOffset, result);
+    } else if (item->type() == ElementType::REST) {
+        renderRestEvents(toRest(item), tickPositionOffset, result);
     }
 }
 
-void PlaybackEventsRenderer::render(const mu::engraving::EngravingItem* item, const mpe::timestamp_t actualTimestamp,
+void PlaybackEventsRenderer::render(const EngravingItem* item, const mpe::timestamp_t actualTimestamp,
                                     const mpe::duration_t actualDuration, const mpe::dynamic_level_t actualDynamicLevel,
                                     const ArticulationType persistentArticulationApplied, const ArticulationsProfilePtr profile,
                                     PlaybackEventsMap& result) const
@@ -79,35 +79,35 @@ void PlaybackEventsRenderer::render(const mu::engraving::EngravingItem* item, co
         return;
     }
 
-    if (item->type() == mu::engraving::ElementType::CHORD) {
-        const mu::engraving::Chord* chord = mu::engraving::toChord(item);
+    if (item->type() == ElementType::CHORD) {
+        const Chord* chord = toChord(item);
 
-        for (const mu::engraving::Note* note : chord->notes()) {
+        for (const Note* note : chord->notes()) {
             renderFixedNoteEvent(note, actualTimestamp, actualDuration,
                                  actualDynamicLevel, persistentArticulationApplied, profile, result[actualTimestamp]);
         }
-    } else if (item->type() == mu::engraving::ElementType::NOTE) {
-        renderFixedNoteEvent(mu::engraving::toNote(item), actualTimestamp, actualDuration,
+    } else if (item->type() == ElementType::NOTE) {
+        renderFixedNoteEvent(toNote(item), actualTimestamp, actualDuration,
                              actualDynamicLevel, persistentArticulationApplied, profile, result[actualTimestamp]);
-    } else if (item->type() == mu::engraving::ElementType::REST) {
-        renderRestEvents(mu::engraving::toRest(item), 0, result);
+    } else if (item->type() == ElementType::REST) {
+        renderRestEvents(toRest(item), 0, result);
     }
 }
 
-void PlaybackEventsRenderer::renderMetronome(const mu::engraving::Score* score, const int positionTick, const int durationTicks,
+void PlaybackEventsRenderer::renderMetronome(const Score* score, const int positionTick, const int durationTicks,
                                              const int ticksPositionOffset, mpe::PlaybackEventsMap& result) const
 {
     IF_ASSERT_FAILED(score) {
         return;
     }
 
-    mu::engraving::BeatType beatType = score->tick2beatType(mu::engraving::Fraction::fromTicks(positionTick));
+    BeatType beatType = score->tick2beatType(Fraction::fromTicks(positionTick));
 
-    if (beatType == mu::engraving::BeatType::SUBBEAT) {
+    if (beatType == BeatType::SUBBEAT) {
         return;
     }
 
-    mu::engraving::TimeSigFrac timeSignatureFraction = score->sigmap()->timesig(positionTick).timesig();
+    TimeSigFrac timeSignatureFraction = score->sigmap()->timesig(positionTick).timesig();
     int ticksPerBeat = timeSignatureFraction.ticks() / timeSignatureFraction.numerator();
 
     BeatsPerSecond bps = score->tempomap()->tempo(positionTick);
@@ -120,7 +120,7 @@ void PlaybackEventsRenderer::renderMetronome(const mu::engraving::Score* score, 
         timestamp_t eventTimestamp = timestampFromTicks(score, positionTick + ticksPositionOffset + i * ticksPerBeat);
 
         pitch_level_t eventPitchLevel = pitchLevel(PitchClass::A, 4);
-        if (beatType == mu::engraving::BeatType::DOWNBEAT && i == 0) {
+        if (beatType == BeatType::DOWNBEAT && i == 0) {
             eventPitchLevel = pitchLevel(PitchClass::B, 4);
         }
 
@@ -133,7 +133,7 @@ void PlaybackEventsRenderer::renderMetronome(const mu::engraving::Score* score, 
     }
 }
 
-void PlaybackEventsRenderer::renderNoteEvents(const mu::engraving::Chord* chord, const int tickPositionOffset,
+void PlaybackEventsRenderer::renderNoteEvents(const Chord* chord, const int tickPositionOffset,
                                               const mpe::dynamic_level_t nominalDynamicLevel,
                                               const ArticulationType persistentArticulationApplied,
                                               const mpe::ArticulationsProfilePtr profile, PlaybackEventsMap& result) const
@@ -145,10 +145,10 @@ void PlaybackEventsRenderer::renderNoteEvents(const mu::engraving::Chord* chord,
     int chordPosTick = chord->tick().ticks() + tickPositionOffset;
     int chordDurationTicks = chord->durationTypeTicks().ticks();
 
-    const mu::engraving::Score* score = chord->score();
+    const Score* score = chord->score();
 
     BeatsPerSecond bps = score->tempomap()->tempo(chordPosTick);
-    mu::engraving::TimeSigFrac timeSignatureFraction = score->sigmap()->timesig(chordPosTick).timesig();
+    TimeSigFrac timeSignatureFraction = score->sigmap()->timesig(chordPosTick).timesig();
 
     static ArticulationMap articulations;
 
@@ -168,7 +168,7 @@ void PlaybackEventsRenderer::renderNoteEvents(const mu::engraving::Chord* chord,
     renderArticulations(chord, ctx, result[ctx.nominalTimestamp]);
 }
 
-void PlaybackEventsRenderer::renderFixedNoteEvent(const mu::engraving::Note* note, const mpe::timestamp_t actualTimestamp,
+void PlaybackEventsRenderer::renderFixedNoteEvent(const Note* note, const mpe::timestamp_t actualTimestamp,
                                                   const mpe::duration_t actualDuration,
                                                   const mpe::dynamic_level_t actualDynamicLevel,
                                                   const mpe::ArticulationType persistentArticulationApplied,
@@ -188,8 +188,7 @@ void PlaybackEventsRenderer::renderFixedNoteEvent(const mu::engraving::Note* not
     result.emplace_back(buildFixedNoteEvent(note, actualTimestamp, actualDuration, actualDynamicLevel, articulations));
 }
 
-void PlaybackEventsRenderer::renderRestEvents(const mu::engraving::Rest* rest, const int tickPositionOffset,
-                                              mpe::PlaybackEventsMap& result) const
+void PlaybackEventsRenderer::renderRestEvents(const Rest* rest, const int tickPositionOffset, mpe::PlaybackEventsMap& result) const
 {
     IF_ASSERT_FAILED(rest) {
         return;
@@ -205,8 +204,7 @@ void PlaybackEventsRenderer::renderRestEvents(const mu::engraving::Rest* rest, c
     result[nominalTimestamp].emplace_back(mpe::RestEvent(nominalTimestamp, nominalDuration, static_cast<voice_layer_idx_t>(rest->voice())));
 }
 
-void PlaybackEventsRenderer::renderArticulations(const mu::engraving::Chord* chord, const RenderingContext& ctx,
-                                                 mpe::PlaybackEventList& result) const
+void PlaybackEventsRenderer::renderArticulations(const Chord* chord, const RenderingContext& ctx, mpe::PlaybackEventList& result) const
 {
     if (renderChordArticulations(chord, ctx, result)) {
         return;
@@ -215,8 +213,7 @@ void PlaybackEventsRenderer::renderArticulations(const mu::engraving::Chord* cho
     renderNoteArticulations(chord, ctx, result);
 }
 
-bool PlaybackEventsRenderer::renderChordArticulations(const mu::engraving::Chord* chord, const RenderingContext& ctx,
-                                                      mpe::PlaybackEventList& result) const
+bool PlaybackEventsRenderer::renderChordArticulations(const Chord* chord, const RenderingContext& ctx, mpe::PlaybackEventList& result) const
 {
     for (const auto& pair : ctx.commonArticulations) {
         const ArticulationType type = pair.first;
@@ -245,10 +242,9 @@ bool PlaybackEventsRenderer::renderChordArticulations(const mu::engraving::Chord
     return false;
 }
 
-void PlaybackEventsRenderer::renderNoteArticulations(const mu::engraving::Chord* chord, const RenderingContext& ctx,
-                                                     mpe::PlaybackEventList& result) const
+void PlaybackEventsRenderer::renderNoteArticulations(const Chord* chord, const RenderingContext& ctx, mpe::PlaybackEventList& result) const
 {
-    for (const mu::engraving::Note* note : chord->notes()) {
+    for (const Note* note : chord->notes()) {
         if (!isNotePlayable(note)) {
             continue;
         }

--- a/src/engraving/playback/playbackeventsrenderer.h
+++ b/src/engraving/playback/playbackeventsrenderer.h
@@ -31,43 +31,41 @@ namespace mu::engraving {
 class Chord;
 class Rest;
 class Score;
-}
 
-namespace mu::engraving {
 class PlaybackEventsRenderer
 {
 public:
     PlaybackEventsRenderer() = default;
 
-    void render(const mu::engraving::EngravingItem* item, const mpe::dynamic_level_t nominalDynamicLevel,
+    void render(const EngravingItem* item, const mpe::dynamic_level_t nominalDynamicLevel,
                 const mpe::ArticulationType persistentArticulationApplied, const mpe::ArticulationsProfilePtr profile,
                 mpe::PlaybackEventsMap& result) const;
 
-    void render(const mu::engraving::EngravingItem* item, const int tickPositionOffset, const mpe::dynamic_level_t nominalDynamicLevel,
+    void render(const EngravingItem* item, const int tickPositionOffset, const mpe::dynamic_level_t nominalDynamicLevel,
                 const mpe::ArticulationType persistentArticulationApplied, const mpe::ArticulationsProfilePtr profile,
                 mpe::PlaybackEventsMap& result) const;
 
-    void render(const mu::engraving::EngravingItem* item, const mpe::timestamp_t actualTimestamp, const mpe::duration_t actualDuration,
+    void render(const EngravingItem* item, const mpe::timestamp_t actualTimestamp, const mpe::duration_t actualDuration,
                 const mpe::dynamic_level_t actualDynamicLevel, const mpe::ArticulationType persistentArticulationApplied,
                 const mpe::ArticulationsProfilePtr profile, mpe::PlaybackEventsMap& result) const;
 
-    void renderMetronome(const mu::engraving::Score* score, const int positionTick, const int durationTicks, const int ticksPositionOffset,
+    void renderMetronome(const Score* score, const int positionTick, const int durationTicks, const int ticksPositionOffset,
                          mpe::PlaybackEventsMap& result) const;
 
 private:
-    void renderNoteEvents(const mu::engraving::Chord* chord, const int tickPositionOffset, const mpe::dynamic_level_t nominalDynamicLevel,
+    void renderNoteEvents(const Chord* chord, const int tickPositionOffset, const mpe::dynamic_level_t nominalDynamicLevel,
                           const mpe::ArticulationType persistentArticulationApplied, const mpe::ArticulationsProfilePtr profile,
                           mpe::PlaybackEventsMap& result) const;
 
-    void renderFixedNoteEvent(const mu::engraving::Note* note, const mpe::timestamp_t actualTimestamp, const mpe::duration_t actualDuration,
+    void renderFixedNoteEvent(const Note* note, const mpe::timestamp_t actualTimestamp, const mpe::duration_t actualDuration,
                               const mpe::dynamic_level_t actualDynamicLevel, const mpe::ArticulationType persistentArticulationApplied,
                               const mpe::ArticulationsProfilePtr profile, mpe::PlaybackEventList& result) const;
 
-    void renderRestEvents(const mu::engraving::Rest* rest, const int tickPositionOffset, mpe::PlaybackEventsMap& result) const;
+    void renderRestEvents(const Rest* rest, const int tickPositionOffset, mpe::PlaybackEventsMap& result) const;
 
-    void renderArticulations(const mu::engraving::Chord* chord, const RenderingContext& ctx, mpe::PlaybackEventList& result) const;
-    bool renderChordArticulations(const mu::engraving::Chord* chord, const RenderingContext& ctx, mpe::PlaybackEventList& result) const;
-    void renderNoteArticulations(const mu::engraving::Chord* chord, const RenderingContext& ctx, mpe::PlaybackEventList& result) const;
+    void renderArticulations(const Chord* chord, const RenderingContext& ctx, mpe::PlaybackEventList& result) const;
+    bool renderChordArticulations(const Chord* chord, const RenderingContext& ctx, mpe::PlaybackEventList& result) const;
+    void renderNoteArticulations(const Chord* chord, const RenderingContext& ctx, mpe::PlaybackEventList& result) const;
 };
 }
 

--- a/src/engraving/playback/playbackmodel.h
+++ b/src/engraving/playback/playbackmodel.h
@@ -47,15 +47,13 @@ class EngravingItem;
 class Segment;
 class Instrument;
 class RepeatList;
-}
 
-namespace mu::engraving {
 class PlaybackModel : public async::Asyncable
 {
     INJECT(engraving, mpe::IArticulationProfilesRepository, profilesRepository)
 
 public:
-    void load(mu::engraving::Score* score);
+    void load(Score* score);
     void reload();
 
     async::Notification dataChanged() const;
@@ -67,7 +65,7 @@ public:
 
     const mpe::PlaybackData& resolveTrackPlaybackData(const InstrumentTrackId& trackId);
     const mpe::PlaybackData& resolveTrackPlaybackData(const ID& partId, const std::string& instrumentId);
-    void triggerEventsForItem(const mu::engraving::EngravingItem* item);
+    void triggerEventsForItem(const EngravingItem* item);
 
     async::Channel<InstrumentTrackId> trackAdded() const;
     async::Channel<InstrumentTrackId> trackRemoved() const;
@@ -89,7 +87,7 @@ private:
         track_idx_t trackTo = mu::nidx;
     };
 
-    InstrumentTrackId idKey(const mu::engraving::EngravingItem* item) const;
+    InstrumentTrackId idKey(const EngravingItem* item) const;
     InstrumentTrackId idKey(const ID& partId, const std::string& instrumentId) const;
     InstrumentTrackIdSet existingTrackIdSet() const;
 
@@ -100,8 +98,8 @@ private:
     void updateEvents(const int tickFrom, const int tickTo, const track_idx_t trackFrom, const track_idx_t trackTo,
                       ChangedTrackIdSet* trackChanges = nullptr);
 
-    bool hasToReloadTracks(const std::unordered_set<mu::engraving::ElementType>& changedTypes) const;
-    bool hasToReloadScore(const std::unordered_set<mu::engraving::ElementType>& changedTypes) const;
+    bool hasToReloadTracks(const std::unordered_set<ElementType>& changedTypes) const;
+    bool hasToReloadScore(const std::unordered_set<ElementType>& changedTypes) const;
 
     bool containsTrack(const InstrumentTrackId& trackId) const;
     void clearExpiredTracks();
@@ -112,12 +110,12 @@ private:
 
     void removeEvents(const InstrumentTrackId& trackId, const mpe::timestamp_t timestampFrom, const mpe::timestamp_t timestampTo);
 
-    TrackBoundaries trackBoundaries(const mu::engraving::ScoreChangesRange& changesRange) const;
-    TickBoundaries tickBoundaries(const mu::engraving::ScoreChangesRange& changesRange) const;
+    TrackBoundaries trackBoundaries(const ScoreChangesRange& changesRange) const;
+    TickBoundaries tickBoundaries(const ScoreChangesRange& changesRange) const;
 
-    const mu::engraving::RepeatList& repeatList() const;
+    const RepeatList& repeatList() const;
 
-    mu::engraving::Score* m_score = nullptr;
+    Score* m_score = nullptr;
     bool m_expandRepeats = true;
 
     PlaybackEventsRenderer m_renderer;

--- a/src/engraving/playback/playbacksetupdataresolver.cpp
+++ b/src/engraving/playback/playbacksetupdataresolver.cpp
@@ -31,7 +31,7 @@
 using namespace mu::engraving;
 using namespace mu::mpe;
 
-void PlaybackSetupDataResolver::resolveSetupData(const mu::engraving::Instrument* instrument, mpe::PlaybackSetupData& result) const
+void PlaybackSetupDataResolver::resolveSetupData(const Instrument* instrument, mpe::PlaybackSetupData& result) const
 {
     if (KeyboardsSetupDataResolver::isAbleToResolve(instrument)) {
         KeyboardsSetupDataResolver::resolve(instrument, result);

--- a/src/engraving/playback/playbacksetupdataresolver.h
+++ b/src/engraving/playback/playbacksetupdataresolver.h
@@ -27,13 +27,11 @@
 
 namespace mu::engraving {
 class Instrument;
-}
 
-namespace mu::engraving {
 class PlaybackSetupDataResolver
 {
 public:
-    void resolveSetupData(const mu::engraving::Instrument* instrument, mpe::PlaybackSetupData& result) const;
+    void resolveSetupData(const Instrument* instrument, mpe::PlaybackSetupData& result) const;
     void resolveMetronomeSetupData(mpe::PlaybackSetupData& result) const;
 };
 }

--- a/src/engraving/playback/renderers/arpeggiorenderer.cpp
+++ b/src/engraving/playback/renderers/arpeggiorenderer.cpp
@@ -38,11 +38,11 @@ const ArticulationTypeSet& ArpeggioRenderer::supportedTypes()
     return types;
 }
 
-void ArpeggioRenderer::doRender(const mu::engraving::EngravingItem* item, const mpe::ArticulationType preferredType,
+void ArpeggioRenderer::doRender(const EngravingItem* item, const mpe::ArticulationType preferredType,
                                 const RenderingContext& context,
                                 mpe::PlaybackEventList& result)
 {
-    const mu::engraving::Chord* chord = mu::engraving::toChord(item);
+    const Chord* chord = toChord(item);
 
     IF_ASSERT_FAILED(chord) {
         return;
@@ -105,11 +105,11 @@ msecs_t ArpeggioRenderer::timestampOffsetStep(const RenderingContext& ctx)
     return MINIMAL_TIMESTAMP_OFFSET_STEP;
 }
 
-std::map<pitch_level_t, NominalNoteCtx> ArpeggioRenderer::arpeggioNotes(const mu::engraving::Chord* chord, const RenderingContext& ctx)
+std::map<pitch_level_t, NominalNoteCtx> ArpeggioRenderer::arpeggioNotes(const Chord* chord, const RenderingContext& ctx)
 {
     std::map<pitch_level_t, NominalNoteCtx> result;
 
-    for (const mu::engraving::Note* note : chord->notes()) {
+    for (const Note* note : chord->notes()) {
         if (!isNotePlayable(note)) {
             continue;
         }

--- a/src/engraving/playback/renderers/arpeggiorenderer.h
+++ b/src/engraving/playback/renderers/arpeggiorenderer.h
@@ -27,21 +27,19 @@
 
 namespace mu::engraving {
 class Chord;
-}
 
-namespace mu::engraving {
 class ArpeggioRenderer : public RenderBase<ArpeggioRenderer>
 {
 public:
     static const mpe::ArticulationTypeSet& supportedTypes();
 
-    static void doRender(const mu::engraving::EngravingItem* item, const mpe::ArticulationType preferredType,
-                         const RenderingContext& context, mpe::PlaybackEventList& result);
+    static void doRender(const EngravingItem* item, const mpe::ArticulationType preferredType, const RenderingContext& context,
+                         mpe::PlaybackEventList& result);
 
 private:
     static bool isDirectionUp(const mpe::ArticulationType type);
     static mpe::msecs_t timestampOffsetStep(const RenderingContext& context);
-    static std::map<mpe::pitch_level_t, NominalNoteCtx> arpeggioNotes(const mu::engraving::Chord* chord, const RenderingContext& ctx);
+    static std::map<mpe::pitch_level_t, NominalNoteCtx> arpeggioNotes(const Chord* chord, const RenderingContext& ctx);
 };
 }
 

--- a/src/engraving/playback/renderers/glissandosrenderer.cpp
+++ b/src/engraving/playback/renderers/glissandosrenderer.cpp
@@ -34,11 +34,11 @@ const ArticulationTypeSet& GlissandosRenderer::supportedTypes()
     return types;
 }
 
-void GlissandosRenderer::doRender(const mu::engraving::EngravingItem* item, const mpe::ArticulationType type,
+void GlissandosRenderer::doRender(const EngravingItem* item, const mpe::ArticulationType type,
                                   const RenderingContext& context,
                                   mpe::PlaybackEventList& result)
 {
-    const mu::engraving::Note* note = mu::engraving::toNote(item);
+    const Note* note = toNote(item);
 
     IF_ASSERT_FAILED(note) {
         return;
@@ -51,8 +51,7 @@ void GlissandosRenderer::doRender(const mu::engraving::EngravingItem* item, cons
     }
 }
 
-void GlissandosRenderer::renderDiscreteGlissando(const mu::engraving::Note* note, const RenderingContext& context,
-                                                 mpe::PlaybackEventList& result)
+void GlissandosRenderer::renderDiscreteGlissando(const Note* note, const RenderingContext& context, mpe::PlaybackEventList& result)
 {
     const mpe::ArticulationAppliedData& articulationData = context.commonArticulations.at(ArticulationType::DiscreteGlissando);
     int stepsCount = pitchStepsCount(articulationData.meta.overallPitchChangesRange);
@@ -77,8 +76,7 @@ void GlissandosRenderer::renderDiscreteGlissando(const mu::engraving::Note* note
     }
 }
 
-void GlissandosRenderer::renderContinuousGlissando(const mu::engraving::Note* note, const RenderingContext& context,
-                                                   mpe::PlaybackEventList& result)
+void GlissandosRenderer::renderContinuousGlissando(const Note* note, const RenderingContext& context, mpe::PlaybackEventList& result)
 {
     if (!isNotePlayable(note)) {
         return;

--- a/src/engraving/playback/renderers/glissandosrenderer.h
+++ b/src/engraving/playback/renderers/glissandosrenderer.h
@@ -27,20 +27,18 @@
 
 namespace mu::engraving {
 class Note;
-}
 
-namespace mu::engraving {
 class GlissandosRenderer : public RenderBase<GlissandosRenderer>
 {
 public:
     static const mpe::ArticulationTypeSet& supportedTypes();
 
-    static void doRender(const mu::engraving::EngravingItem* item, const mpe::ArticulationType type, const RenderingContext& context,
+    static void doRender(const EngravingItem* item, const mpe::ArticulationType type, const RenderingContext& context,
                          mpe::PlaybackEventList& result);
 
 private:
-    static void renderDiscreteGlissando(const mu::engraving::Note* note, const RenderingContext& context, mpe::PlaybackEventList& result);
-    static void renderContinuousGlissando(const mu::engraving::Note* note, const RenderingContext& context, mpe::PlaybackEventList& result);
+    static void renderDiscreteGlissando(const Note* note, const RenderingContext& context, mpe::PlaybackEventList& result);
+    static void renderContinuousGlissando(const Note* note, const RenderingContext& context, mpe::PlaybackEventList& result);
 };
 }
 

--- a/src/engraving/playback/renderers/gracenotesrenderer.cpp
+++ b/src/engraving/playback/renderers/gracenotesrenderer.cpp
@@ -37,11 +37,11 @@ const ArticulationTypeSet& GraceNotesRenderer::supportedTypes()
     return types;
 }
 
-void GraceNotesRenderer::doRender(const mu::engraving::EngravingItem* item, const mpe::ArticulationType type,
+void GraceNotesRenderer::doRender(const EngravingItem* item, const mpe::ArticulationType type,
                                   const RenderingContext& context,
                                   mpe::PlaybackEventList& result)
 {
-    const mu::engraving::Chord* chord = mu::engraving::toChord(item);
+    const Chord* chord = toChord(item);
 
     IF_ASSERT_FAILED(chord) {
         return;
@@ -63,7 +63,7 @@ bool GraceNotesRenderer::isPlacedBeforePrincipalNote(const mpe::ArticulationType
     return false;
 }
 
-void GraceNotesRenderer::renderPrependedGraceNotes(const mu::engraving::Chord* chord, const RenderingContext& context,
+void GraceNotesRenderer::renderPrependedGraceNotes(const Chord* chord, const RenderingContext& context,
                                                    const mpe::ArticulationType type,
                                                    mpe::PlaybackEventList& result)
 {
@@ -81,7 +81,7 @@ void GraceNotesRenderer::renderPrependedGraceNotes(const mu::engraving::Chord* c
     buildPrincipalNoteEvents(chord, context, type, totalPrincipalNotesDuration, principalNotesTimestampFrom, result);
 }
 
-void GraceNotesRenderer::renderAppendedGraceNotes(const mu::engraving::Chord* chord, const RenderingContext& context,
+void GraceNotesRenderer::renderAppendedGraceNotes(const Chord* chord, const RenderingContext& context,
                                                   const mpe::ArticulationType type,
                                                   mpe::PlaybackEventList& result)
 {
@@ -122,13 +122,12 @@ float GraceNotesRenderer::graceNotesDurationRatio(const mpe::duration_t totalDur
     return result;
 }
 
-std::vector<NominalNoteCtx> GraceNotesRenderer::graceNotesCtxList(const std::vector<mu::engraving::Chord*>& graceChords,
-                                                                  const RenderingContext& context)
+std::vector<NominalNoteCtx> GraceNotesRenderer::graceNotesCtxList(const std::vector<Chord*>& graceChords, const RenderingContext& context)
 {
     std::vector<NominalNoteCtx> result;
 
-    for (const mu::engraving::Chord* graceChord : graceChords) {
-        for (const mu::engraving::Note* graceNote : graceChord->notes()) {
+    for (const Chord* graceChord : graceChords) {
+        for (const Note* graceNote : graceChord->notes()) {
             if (!isNotePlayable(graceNote)) {
                 continue;
             }
@@ -157,13 +156,13 @@ void GraceNotesRenderer::buildGraceNoteEvents(std::vector<NominalNoteCtx>&& note
     }
 }
 
-void GraceNotesRenderer::buildPrincipalNoteEvents(const mu::engraving::Chord* chord, const RenderingContext& context,
+void GraceNotesRenderer::buildPrincipalNoteEvents(const Chord* chord, const RenderingContext& context,
                                                   const ArticulationType type,
                                                   const mpe::duration_t duration,
                                                   const mpe::timestamp_t timestamp,
                                                   mpe::PlaybackEventList& result)
 {
-    for (const mu::engraving::Note* note : chord->notes()) {
+    for (const Note* note : chord->notes()) {
         if (!isNotePlayable(note)) {
             continue;
         }

--- a/src/engraving/playback/renderers/gracenotesrenderer.h
+++ b/src/engraving/playback/renderers/gracenotesrenderer.h
@@ -29,36 +29,32 @@
 
 namespace mu::engraving {
 class Chord;
-}
 
-namespace mu::engraving {
 class GraceNotesRenderer : public RenderBase<GraceNotesRenderer>
 {
 public:
     static const mpe::ArticulationTypeSet& supportedTypes();
 
-    static void doRender(const mu::engraving::EngravingItem* item, const mpe::ArticulationType type, const RenderingContext& context,
+    static void doRender(const EngravingItem* item, const mpe::ArticulationType type, const RenderingContext& context,
                          mpe::PlaybackEventList& result);
 private:
     static bool isPlacedBeforePrincipalNote(const mpe::ArticulationType type);
 
-    static void renderPrependedGraceNotes(const mu::engraving::Chord* chord, const RenderingContext& context,
-                                          const mpe::ArticulationType type, mpe::PlaybackEventList& result);
-    static void renderAppendedGraceNotes(const mu::engraving::Chord* chord, const RenderingContext& context,
-                                         const mpe::ArticulationType type, mpe::PlaybackEventList& result);
+    static void renderPrependedGraceNotes(const Chord* chord, const RenderingContext& context, const mpe::ArticulationType type,
+                                          mpe::PlaybackEventList& result);
+    static void renderAppendedGraceNotes(const Chord* chord, const RenderingContext& context, const mpe::ArticulationType type,
+                                         mpe::PlaybackEventList& result);
 
     static mpe::duration_t graceNotesTotalDuration(const std::vector<NominalNoteCtx>& noteCtxList);
     static float graceNotesDurationRatio(const mpe::duration_t totalDuration, const mpe::duration_t maxAvailableDuration);
-    static std::vector<NominalNoteCtx> graceNotesCtxList(const std::vector<mu::engraving::Chord*>& graceChords,
-                                                         const RenderingContext& context);
+    static std::vector<NominalNoteCtx> graceNotesCtxList(const std::vector<Chord*>& graceChords, const RenderingContext& context);
 
     static void buildGraceNoteEvents(std::vector<NominalNoteCtx>&& noteCtxList, const mpe::timestamp_t timestampFrom,
                                      const mpe::ArticulationType type, const mpe::duration_t availableDuration,
                                      mpe::PlaybackEventList& result);
 
-    static void buildPrincipalNoteEvents(const mu::engraving::Chord* chord, const RenderingContext& context,
-                                         const mpe::ArticulationType type, const mpe::duration_t duration, const mpe::timestamp_t timestamp,
-                                         mpe::PlaybackEventList& result);
+    static void buildPrincipalNoteEvents(const Chord* chord, const RenderingContext& context, const mpe::ArticulationType type,
+                                         const mpe::duration_t duration, const mpe::timestamp_t timestamp, mpe::PlaybackEventList& result);
 
     static mpe::duration_t graceNotesMaxAvailableDuration(const mpe::ArticulationType type, const RenderingContext& ctx,
                                                           const size_t graceNotesCount);

--- a/src/engraving/playback/renderers/ornamentsrenderer.cpp
+++ b/src/engraving/playback/renderers/ornamentsrenderer.cpp
@@ -204,17 +204,17 @@ const ArticulationTypeSet& OrnamentsRenderer::supportedTypes()
     return types;
 }
 
-void OrnamentsRenderer::doRender(const mu::engraving::EngravingItem* item, const ArticulationType preferredType,
+void OrnamentsRenderer::doRender(const EngravingItem* item, const ArticulationType preferredType,
                                  const RenderingContext& context,
                                  mpe::PlaybackEventList& result)
 {
-    const mu::engraving::Chord* chord = mu::engraving::toChord(item);
+    const Chord* chord = toChord(item);
 
     IF_ASSERT_FAILED(chord) {
         return;
     }
 
-    for (const mu::engraving::Note* note : chord->notes()) {
+    for (const Note* note : chord->notes()) {
         if (!isNotePlayable(note)) {
             continue;
         }

--- a/src/engraving/playback/renderers/ornamentsrenderer.h
+++ b/src/engraving/playback/renderers/ornamentsrenderer.h
@@ -44,8 +44,8 @@ class OrnamentsRenderer : public RenderBase<OrnamentsRenderer>
 public:
     static const mpe::ArticulationTypeSet& supportedTypes();
 
-    static void doRender(const mu::engraving::EngravingItem* item, const mpe::ArticulationType preferredType,
-                         const RenderingContext& context, mpe::PlaybackEventList& result);
+    static void doRender(const EngravingItem* item, const mpe::ArticulationType preferredType, const RenderingContext& context,
+                         mpe::PlaybackEventList& result);
 
 private:
     static void convert(const mpe::ArticulationType type, NominalNoteCtx&& noteCtx, mpe::PlaybackEventList& result);

--- a/src/engraving/playback/renderers/renderbase.h
+++ b/src/engraving/playback/renderers/renderbase.h
@@ -39,7 +39,7 @@ public:
         return supportedTypes.find(type) != supportedTypes.cend();
     }
 
-    static void render(const mu::engraving::EngravingItem* item, const mpe::ArticulationType preferredType, const RenderingContext& context,
+    static void render(const EngravingItem* item, const mpe::ArticulationType preferredType, const RenderingContext& context,
                        mpe::PlaybackEventList& result)
     {
         IF_ASSERT_FAILED(item) {

--- a/src/engraving/playback/renderers/tremolorenderer.cpp
+++ b/src/engraving/playback/renderers/tremolorenderer.cpp
@@ -38,16 +38,16 @@ const ArticulationTypeSet& TremoloRenderer::supportedTypes()
     return types;
 }
 
-void TremoloRenderer::doRender(const mu::engraving::EngravingItem* item, const mpe::ArticulationType preferredType,
+void TremoloRenderer::doRender(const EngravingItem* item, const mpe::ArticulationType preferredType,
                                const RenderingContext& context,
                                mpe::PlaybackEventList& result)
 {
-    const mu::engraving::Chord* chord = mu::engraving::toChord(item);
+    const Chord* chord = toChord(item);
     IF_ASSERT_FAILED(chord) {
         return;
     }
 
-    const mu::engraving::Tremolo* tremolo = chord->tremolo();
+    const Tremolo* tremolo = chord->tremolo();
     IF_ASSERT_FAILED(tremolo) {
         return;
     }
@@ -64,15 +64,15 @@ void TremoloRenderer::doRender(const mu::engraving::EngravingItem* item, const m
     int stepsCount = articulationData.meta.overallDuration / stepDuration;
 
     if (tremolo->twoNotes()) {
-        const mu::engraving::Chord* firstTremoloChord = tremolo->chord1();
-        const mu::engraving::Chord* secondTremoloChord = tremolo->chord2();
+        const Chord* firstTremoloChord = tremolo->chord1();
+        const Chord* secondTremoloChord = tremolo->chord2();
 
         IF_ASSERT_FAILED(firstTremoloChord && secondTremoloChord) {
             return;
         }
 
         for (int i = 0; i < stepsCount; ++i) {
-            const mu::engraving::Chord* currentChord = firstTremoloChord;
+            const Chord* currentChord = firstTremoloChord;
 
             if (i % 2 == 0) {
                 currentChord = secondTremoloChord;
@@ -105,13 +105,13 @@ int TremoloRenderer::stepDurationTicksByType(const mpe::ArticulationType& type)
     }
 }
 
-void TremoloRenderer::buildAndAppendEvents(const mu::engraving::Chord* chord, const ArticulationType type,
+void TremoloRenderer::buildAndAppendEvents(const Chord* chord, const ArticulationType type,
                                            const mpe::duration_t stepDuration,
                                            const mpe::timestamp_t timestampOffset, const RenderingContext& context,
                                            mpe::PlaybackEventList& result)
 {
     for (size_t noteIdx = 0; noteIdx < chord->notes().size(); ++noteIdx) {
-        const mu::engraving::Note* note = chord->notes().at(noteIdx);
+        const Note* note = chord->notes().at(noteIdx);
 
         if (!isNotePlayable(note)) {
             continue;

--- a/src/engraving/playback/renderers/tremolorenderer.h
+++ b/src/engraving/playback/renderers/tremolorenderer.h
@@ -31,14 +31,14 @@ class TremoloRenderer : public RenderBase<TremoloRenderer>
 public:
     static const mpe::ArticulationTypeSet& supportedTypes();
 
-    static void doRender(const mu::engraving::EngravingItem* item, const mpe::ArticulationType preferredType,
-                         const RenderingContext& context, mpe::PlaybackEventList& result);
+    static void doRender(const EngravingItem* item, const mpe::ArticulationType preferredType, const RenderingContext& context,
+                         mpe::PlaybackEventList& result);
 
 private:
     static int stepDurationTicksByType(const mpe::ArticulationType& type);
-    static void buildAndAppendEvents(const mu::engraving::Chord* chord, const mpe::ArticulationType type,
-                                     const mpe::duration_t stepDuration, const mpe::timestamp_t timestampOffset,
-                                     const RenderingContext& context, mpe::PlaybackEventList& result);
+    static void buildAndAppendEvents(const Chord* chord, const mpe::ArticulationType type, const mpe::duration_t stepDuration,
+                                     const mpe::timestamp_t timestampOffset, const RenderingContext& context,
+                                     mpe::PlaybackEventList& result);
 };
 }
 

--- a/src/engraving/playback/renderingcontext.h
+++ b/src/engraving/playback/renderingcontext.h
@@ -43,7 +43,7 @@ struct RenderingContext {
     int nominalDurationTicks = 0;
 
     BeatsPerSecond beatsPerSecond = 0;
-    mu::engraving::TimeSigFrac timeSignatureFraction;
+    TimeSigFrac timeSignatureFraction;
 
     mpe::ArticulationType persistentArticulation = mpe::ArticulationType::Undefined;
     mpe::ArticulationMap commonArticulations;
@@ -57,7 +57,7 @@ struct RenderingContext {
                               const int posTick,
                               const int durationTicks,
                               const BeatsPerSecond& bps,
-                              const mu::engraving::TimeSigFrac& timeSig,
+                              const TimeSigFrac& timeSig,
                               const mpe::ArticulationType persistentArticulationType,
                               const mpe::ArticulationMap& articulations,
                               const mpe::ArticulationsProfilePtr profilePtr)
@@ -83,21 +83,21 @@ struct RenderingContext {
     }
 };
 
-inline bool isNotePlayable(const mu::engraving::Note* note)
+inline bool isNotePlayable(const Note* note)
 {
     if (!note->play()) {
         return false;
     }
 
-    const mu::engraving::Tie* tie = note->tieBack();
+    const Tie* tie = note->tieBack();
 
     if (tie) {
         if (!tie->startNote() || !tie->endNote()) {
             return false;
         }
 
-        const mu::engraving::Chord* firstChord = tie->startNote()->chord();
-        const mu::engraving::Chord* lastChord = tie->endNote()->chord();
+        const Chord* firstChord = tie->startNote()->chord();
+        const Chord* lastChord = tie->endNote()->chord();
 
         return !firstChord->containsEqualArticulations(lastChord)
                || !firstChord->containsEqualTremolo(lastChord);
@@ -106,7 +106,7 @@ inline bool isNotePlayable(const mu::engraving::Note* note)
     return true;
 }
 
-inline mpe::duration_t noteNominalDuration(const mu::engraving::Note* note, const RenderingContext& ctx)
+inline mpe::duration_t noteNominalDuration(const Note* note, const RenderingContext& ctx)
 {
     return durationFromTicks(ctx.beatsPerSecond.val, note->playTicks());
 }
@@ -120,7 +120,7 @@ struct NominalNoteCtx {
 
     RenderingContext chordCtx;
 
-    explicit NominalNoteCtx(const mu::engraving::Note* note, const RenderingContext& ctx)
+    explicit NominalNoteCtx(const Note* note, const RenderingContext& ctx)
         : voiceIdx(note->voice()),
         timestamp(ctx.nominalTimestamp),
         duration(noteNominalDuration(note, ctx)),
@@ -139,7 +139,7 @@ inline mpe::NoteEvent buildNoteEvent(NominalNoteCtx&& ctx)
                           ctx.chordCtx.commonArticulations);
 }
 
-inline mpe::NoteEvent buildNoteEvent(const mu::engraving::Note* note, const RenderingContext& ctx)
+inline mpe::NoteEvent buildNoteEvent(const Note* note, const RenderingContext& ctx)
 {
     return mpe::NoteEvent(ctx.nominalTimestamp,
                           noteNominalDuration(note, ctx),
@@ -161,7 +161,7 @@ inline mpe::NoteEvent buildNoteEvent(NominalNoteCtx&& ctx, const mpe::duration_t
                           ctx.chordCtx.commonArticulations);
 }
 
-inline mpe::NoteEvent buildFixedNoteEvent(const mu::engraving::Note* note, const mpe::timestamp_t actualTimestamp,
+inline mpe::NoteEvent buildFixedNoteEvent(const Note* note, const mpe::timestamp_t actualTimestamp,
                                           const mpe::duration_t actualDuration, const mpe::dynamic_level_t actualDynamicLevel,
                                           const mpe::ArticulationMap& articulations)
 {

--- a/src/engraving/playback/utils/arrangementutils.h
+++ b/src/engraving/playback/utils/arrangementutils.h
@@ -31,7 +31,7 @@
 #include "types/constants.h"
 
 namespace mu::engraving {
-inline mpe::timestamp_t timestampFromTicks(const mu::engraving::Score* score, const int tick)
+inline mpe::timestamp_t timestampFromTicks(const Score* score, const int tick)
 {
     return score->repeatList().utick2utime(tick) * 1000;
 }
@@ -43,10 +43,10 @@ inline mpe::duration_t durationFromTicks(const qreal beatsPerSecond, const int d
     return (beatsNumber / beatsPerSecond) * 1000;
 }
 
-static constexpr int CROTCHET_TICKS = mu::engraving::Constant::division;
-static constexpr int QUAVER_TICKS = mu::engraving::Constant::division / 2;
-static constexpr int SEMIQUAVER_TICKS = mu::engraving::Constant::division / 4;
-static constexpr int DEMISEMIQUAVER_TICKS = mu::engraving::Constant::division / 8;
+static constexpr int CROTCHET_TICKS = Constants::division;
+static constexpr int QUAVER_TICKS = Constants::division / 2;
+static constexpr int SEMIQUAVER_TICKS = Constants::division / 4;
+static constexpr int DEMISEMIQUAVER_TICKS = Constants::division / 8;
 
 static constexpr qreal PRESTISSIMO_BPS_BOUND = 200 /*bpm*/ / 60.f /*secs*/;
 static constexpr qreal PRESTO_BPS_BOUND = 168 /*bpm*/ / 60.f /*secs*/;

--- a/src/engraving/playback/utils/expressionutils.h
+++ b/src/engraving/playback/utils/expressionutils.h
@@ -29,41 +29,41 @@
 
 namespace mu::engraving {
 struct DynamicTransition {
-    mu::engraving::DynamicType from = mu::engraving::DynamicType::OTHER;
-    mu::engraving::DynamicType to = mu::engraving::DynamicType::OTHER;
+    DynamicType from = DynamicType::OTHER;
+    DynamicType to = DynamicType::OTHER;
 
     bool isValid() const
     {
-        return from != mu::engraving::DynamicType::OTHER && to != mu::engraving::DynamicType::OTHER;
+        return from != DynamicType::OTHER && to != DynamicType::OTHER;
     }
 };
 
-inline mpe::dynamic_level_t dynamicLevelFromType(const mu::engraving::DynamicType type,
+inline mpe::dynamic_level_t dynamicLevelFromType(const DynamicType type,
                                                  const mpe::dynamic_level_t defLevel = mpe::dynamicLevelFromType(mpe::DynamicType::Natural))
 {
-    static const std::unordered_map<mu::engraving::DynamicType, mpe::dynamic_level_t> DYNAMIC_LEVELS = {
-        { mu::engraving::DynamicType::PPPPPP, mpe::dynamicLevelFromType(mpe::DynamicType::pppppp) },
-        { mu::engraving::DynamicType::PPPPP, mpe::dynamicLevelFromType(mpe::DynamicType::ppppp) },
-        { mu::engraving::DynamicType::PPPP, mpe::dynamicLevelFromType(mpe::DynamicType::pppp) },
-        { mu::engraving::DynamicType::PPP, mpe::dynamicLevelFromType(mpe::DynamicType::ppp) },
-        { mu::engraving::DynamicType::PP, mpe::dynamicLevelFromType(mpe::DynamicType::pp) },
-        { mu::engraving::DynamicType::P, mpe::dynamicLevelFromType(mpe::DynamicType::p) },
-        { mu::engraving::DynamicType::MP, mpe::dynamicLevelFromType(mpe::DynamicType::mp) },
-        { mu::engraving::DynamicType::MF, mpe::dynamicLevelFromType(mpe::DynamicType::mf) },
-        { mu::engraving::DynamicType::F, mpe::dynamicLevelFromType(mpe::DynamicType::f) },
-        { mu::engraving::DynamicType::FF, mpe::dynamicLevelFromType(mpe::DynamicType::ff) },
-        { mu::engraving::DynamicType::FFF, mpe::dynamicLevelFromType(mpe::DynamicType::fff) },
-        { mu::engraving::DynamicType::FFFF, mpe::dynamicLevelFromType(mpe::DynamicType::ffff) },
-        { mu::engraving::DynamicType::FFFFF, mpe::dynamicLevelFromType(mpe::DynamicType::fffff) },
-        { mu::engraving::DynamicType::FFFFFF, mpe::dynamicLevelFromType(mpe::DynamicType::ffffff) },
-        { mu::engraving::DynamicType::SF, mpe::dynamicLevelFromType(mpe::DynamicType::f) },
-        { mu::engraving::DynamicType::SFZ, mpe::dynamicLevelFromType(mpe::DynamicType::f) },
-        { mu::engraving::DynamicType::SFF, mpe::dynamicLevelFromType(mpe::DynamicType::ff) },
-        { mu::engraving::DynamicType::SFFZ, mpe::dynamicLevelFromType(mpe::DynamicType::ff) },
-        { mu::engraving::DynamicType::RFZ, mpe::dynamicLevelFromType(mpe::DynamicType::f) },
-        { mu::engraving::DynamicType::RF, mpe::dynamicLevelFromType(mpe::DynamicType::f) },
-        { mu::engraving::DynamicType::FZ, mpe::dynamicLevelFromType(mpe::DynamicType::f) },
-        { mu::engraving::DynamicType::N, mpe::dynamicLevelFromType(mpe::DynamicType::ppppppppp) }
+    static const std::unordered_map<DynamicType, mpe::dynamic_level_t> DYNAMIC_LEVELS = {
+        { DynamicType::PPPPPP, mpe::dynamicLevelFromType(mpe::DynamicType::pppppp) },
+        { DynamicType::PPPPP, mpe::dynamicLevelFromType(mpe::DynamicType::ppppp) },
+        { DynamicType::PPPP, mpe::dynamicLevelFromType(mpe::DynamicType::pppp) },
+        { DynamicType::PPP, mpe::dynamicLevelFromType(mpe::DynamicType::ppp) },
+        { DynamicType::PP, mpe::dynamicLevelFromType(mpe::DynamicType::pp) },
+        { DynamicType::P, mpe::dynamicLevelFromType(mpe::DynamicType::p) },
+        { DynamicType::MP, mpe::dynamicLevelFromType(mpe::DynamicType::mp) },
+        { DynamicType::MF, mpe::dynamicLevelFromType(mpe::DynamicType::mf) },
+        { DynamicType::F, mpe::dynamicLevelFromType(mpe::DynamicType::f) },
+        { DynamicType::FF, mpe::dynamicLevelFromType(mpe::DynamicType::ff) },
+        { DynamicType::FFF, mpe::dynamicLevelFromType(mpe::DynamicType::fff) },
+        { DynamicType::FFFF, mpe::dynamicLevelFromType(mpe::DynamicType::ffff) },
+        { DynamicType::FFFFF, mpe::dynamicLevelFromType(mpe::DynamicType::fffff) },
+        { DynamicType::FFFFFF, mpe::dynamicLevelFromType(mpe::DynamicType::ffffff) },
+        { DynamicType::SF, mpe::dynamicLevelFromType(mpe::DynamicType::f) },
+        { DynamicType::SFZ, mpe::dynamicLevelFromType(mpe::DynamicType::f) },
+        { DynamicType::SFF, mpe::dynamicLevelFromType(mpe::DynamicType::ff) },
+        { DynamicType::SFFZ, mpe::dynamicLevelFromType(mpe::DynamicType::ff) },
+        { DynamicType::RFZ, mpe::dynamicLevelFromType(mpe::DynamicType::f) },
+        { DynamicType::RF, mpe::dynamicLevelFromType(mpe::DynamicType::f) },
+        { DynamicType::FZ, mpe::dynamicLevelFromType(mpe::DynamicType::f) },
+        { DynamicType::N, mpe::dynamicLevelFromType(mpe::DynamicType::ppppppppp) }
     };
 
     auto search = DYNAMIC_LEVELS.find(type);
@@ -75,8 +75,8 @@ inline mpe::dynamic_level_t dynamicLevelFromType(const mu::engraving::DynamicTyp
     return defLevel;
 }
 
-inline mpe::dynamic_level_t dynamicLevelRangeByTypes(const mu::engraving::DynamicType dynamicTypeFrom,
-                                                     const mu::engraving::DynamicType dynamicTypeTo,
+inline mpe::dynamic_level_t dynamicLevelRangeByTypes(const DynamicType dynamicTypeFrom,
+                                                     const DynamicType dynamicTypeTo,
                                                      const mpe::dynamic_level_t nominalDynamicLevelFrom,
                                                      const mpe::dynamic_level_t nominalDynamicLevelTo, const bool isCrescendo)
 {
@@ -99,48 +99,48 @@ inline mpe::dynamic_level_t dynamicLevelRangeByTypes(const mu::engraving::Dynami
     return dynamicLevelTo - dynamicLevelFrom;
 }
 
-inline bool isOrdinaryDynamicType(const mu::engraving::DynamicType type)
+inline bool isOrdinaryDynamicType(const DynamicType type)
 {
-    static const std::set<mu::engraving::DynamicType> ORDINARY_DYNAMIC_TYPES = {
-        mu::engraving::DynamicType::PPPPPP,
-        mu::engraving::DynamicType::PPPPP,
-        mu::engraving::DynamicType::PPPP,
-        mu::engraving::DynamicType::PPP,
-        mu::engraving::DynamicType::PP,
-        mu::engraving::DynamicType::P,
-        mu::engraving::DynamicType::MP,
-        mu::engraving::DynamicType::MF,
-        mu::engraving::DynamicType::F,
-        mu::engraving::DynamicType::FF,
-        mu::engraving::DynamicType::FFF,
-        mu::engraving::DynamicType::FFFF,
-        mu::engraving::DynamicType::FFFFF,
-        mu::engraving::DynamicType::FFFFFF
+    static const std::set<DynamicType> ORDINARY_DYNAMIC_TYPES = {
+        DynamicType::PPPPPP,
+        DynamicType::PPPPP,
+        DynamicType::PPPP,
+        DynamicType::PPP,
+        DynamicType::PP,
+        DynamicType::P,
+        DynamicType::MP,
+        DynamicType::MF,
+        DynamicType::F,
+        DynamicType::FF,
+        DynamicType::FFF,
+        DynamicType::FFFF,
+        DynamicType::FFFFF,
+        DynamicType::FFFFFF
     };
 
     return ORDINARY_DYNAMIC_TYPES.find(type) != ORDINARY_DYNAMIC_TYPES.cend();
 }
 
-inline bool isSingleNoteDynamicType(const mu::engraving::DynamicType type)
+inline bool isSingleNoteDynamicType(const DynamicType type)
 {
-    static const std::set<mu::engraving::DynamicType> SINGLE_NOTE_DYNAMIC_TYPES = {
-        mu::engraving::DynamicType::SF,
-        mu::engraving::DynamicType::SFZ,
-        mu::engraving::DynamicType::SFFZ,
-        mu::engraving::DynamicType::RFZ,
-        mu::engraving::DynamicType::RF
+    static const std::set<DynamicType> SINGLE_NOTE_DYNAMIC_TYPES = {
+        DynamicType::SF,
+        DynamicType::SFZ,
+        DynamicType::SFFZ,
+        DynamicType::RFZ,
+        DynamicType::RF
     };
 
     return SINGLE_NOTE_DYNAMIC_TYPES.find(type) != SINGLE_NOTE_DYNAMIC_TYPES.cend();
 }
 
-inline const DynamicTransition& dynamicTransitionFromType(const mu::engraving::DynamicType type)
+inline const DynamicTransition& dynamicTransitionFromType(const DynamicType type)
 {
-    static const std::unordered_map<mu::engraving::DynamicType, DynamicTransition> DYNAMIC_TRANSITIONS = {
-        { mu::engraving::DynamicType::FP, { mu::engraving::DynamicType::F, mu::engraving::DynamicType::P } },
-        { mu::engraving::DynamicType::PF, { mu::engraving::DynamicType::P, mu::engraving::DynamicType::F } },
-        { mu::engraving::DynamicType::SFP, { mu::engraving::DynamicType::F, mu::engraving::DynamicType::P } },
-        { mu::engraving::DynamicType::SFPP, { mu::engraving::DynamicType::F, mu::engraving::DynamicType::PP } }
+    static const std::unordered_map<DynamicType, DynamicTransition> DYNAMIC_TRANSITIONS = {
+        { DynamicType::FP, { DynamicType::F, DynamicType::P } },
+        { DynamicType::PF, { DynamicType::P, DynamicType::F } },
+        { DynamicType::SFP, { DynamicType::F, DynamicType::P } },
+        { DynamicType::SFPP, { DynamicType::F, DynamicType::PP } }
     };
 
     auto search = DYNAMIC_TRANSITIONS.find(type);
@@ -152,22 +152,22 @@ inline const DynamicTransition& dynamicTransitionFromType(const mu::engraving::D
     return empty;
 }
 
-inline mpe::ArticulationType articulationFromPlayTechType(const mu::engraving::PlayingTechniqueType technique)
+inline mpe::ArticulationType articulationFromPlayTechType(const PlayingTechniqueType technique)
 {
-    static const std::unordered_map<mu::engraving::PlayingTechniqueType, mpe::ArticulationType> PLAYING_TECH_TYPES = {
-        { mu::engraving::PlayingTechniqueType::Undefined, mpe::ArticulationType::Undefined },
-        { mu::engraving::PlayingTechniqueType::Natural, mpe::ArticulationType::Standard },
-        { mu::engraving::PlayingTechniqueType::Pizzicato, mpe::ArticulationType::Pizzicato },
-        { mu::engraving::PlayingTechniqueType::Open, mpe::ArticulationType::Open },
-        { mu::engraving::PlayingTechniqueType::Mute, mpe::ArticulationType::Mute },
-        { mu::engraving::PlayingTechniqueType::Tremolo, mpe::ArticulationType::Tremolo64th },
-        { mu::engraving::PlayingTechniqueType::Detache, mpe::ArticulationType::Detache },
-        { mu::engraving::PlayingTechniqueType::Martele, mpe::ArticulationType::Martele },
-        { mu::engraving::PlayingTechniqueType::ColLegno, mpe::ArticulationType::ColLegno },
-        { mu::engraving::PlayingTechniqueType::SulPonticello, mpe::ArticulationType::SulPont },
-        { mu::engraving::PlayingTechniqueType::SulTasto, mpe::ArticulationType::SulTasto },
-        { mu::engraving::PlayingTechniqueType::Distortion, mpe::ArticulationType::Distortion },
-        { mu::engraving::PlayingTechniqueType::Overdrive, mpe::ArticulationType::Overdrive }
+    static const std::unordered_map<PlayingTechniqueType, mpe::ArticulationType> PLAYING_TECH_TYPES = {
+        { PlayingTechniqueType::Undefined, mpe::ArticulationType::Undefined },
+        { PlayingTechniqueType::Natural, mpe::ArticulationType::Standard },
+        { PlayingTechniqueType::Pizzicato, mpe::ArticulationType::Pizzicato },
+        { PlayingTechniqueType::Open, mpe::ArticulationType::Open },
+        { PlayingTechniqueType::Mute, mpe::ArticulationType::Mute },
+        { PlayingTechniqueType::Tremolo, mpe::ArticulationType::Tremolo64th },
+        { PlayingTechniqueType::Detache, mpe::ArticulationType::Detache },
+        { PlayingTechniqueType::Martele, mpe::ArticulationType::Martele },
+        { PlayingTechniqueType::ColLegno, mpe::ArticulationType::ColLegno },
+        { PlayingTechniqueType::SulPonticello, mpe::ArticulationType::SulPont },
+        { PlayingTechniqueType::SulTasto, mpe::ArticulationType::SulTasto },
+        { PlayingTechniqueType::Distortion, mpe::ArticulationType::Distortion },
+        { PlayingTechniqueType::Overdrive, mpe::ArticulationType::Overdrive }
     };
 
     auto search = PLAYING_TECH_TYPES.find(technique);

--- a/src/engraving/playback/utils/pitchutils.h
+++ b/src/engraving/playback/utils/pitchutils.h
@@ -32,78 +32,78 @@ inline mpe::PitchClass pitchClassFromTpc(const int tpc)
 {
     switch (tpc) {
     // C
-    case mu::engraving::TPC_D_BB:
-    case mu::engraving::TPC_C:
-    case mu::engraving::TPC_B_S:
-    case mu::engraving::TPC_A_SSS:
+    case TPC_D_BB:
+    case TPC_C:
+    case TPC_B_S:
+    case TPC_A_SSS:
         return mpe::PitchClass::C;
-    case mu::engraving::TPC_E_BBB:
-    case mu::engraving::TPC_D_B:
-    case mu::engraving::TPC_C_S:
-    case mu::engraving::TPC_B_SS:
+    case TPC_E_BBB:
+    case TPC_D_B:
+    case TPC_C_S:
+    case TPC_B_SS:
         return mpe::PitchClass::C_sharp;
 
     // D
-    case mu::engraving::TPC_F_BBB:
-    case mu::engraving::TPC_E_BB:
-    case mu::engraving::TPC_D:
-    case mu::engraving::TPC_C_SS:
-    case mu::engraving::TPC_B_SSS:
+    case TPC_F_BBB:
+    case TPC_E_BB:
+    case TPC_D:
+    case TPC_C_SS:
+    case TPC_B_SSS:
         return mpe::PitchClass::D;
-    case mu::engraving::TPC_F_BB:
-    case mu::engraving::TPC_E_B:
-    case mu::engraving::TPC_D_S:
-    case mu::engraving::TPC_C_SSS:
+    case TPC_F_BB:
+    case TPC_E_B:
+    case TPC_D_S:
+    case TPC_C_SSS:
         return mpe::PitchClass::D_sharp;
 
     // E
-    case mu::engraving::TPC_G_BBB:
-    case mu::engraving::TPC_F_B:
-    case mu::engraving::TPC_E:
-    case mu::engraving::TPC_D_SS:
+    case TPC_G_BBB:
+    case TPC_F_B:
+    case TPC_E:
+    case TPC_D_SS:
         return mpe::PitchClass::E;
 
     // F
-    case mu::engraving::TPC_G_BB:
-    case mu::engraving::TPC_F:
-    case mu::engraving::TPC_E_S:
-    case mu::engraving::TPC_D_SSS:
+    case TPC_G_BB:
+    case TPC_F:
+    case TPC_E_S:
+    case TPC_D_SSS:
         return mpe::PitchClass::F;
-    case mu::engraving::TPC_A_BBB:
-    case mu::engraving::TPC_G_B:
-    case mu::engraving::TPC_F_S:
-    case mu::engraving::TPC_E_SS:
+    case TPC_A_BBB:
+    case TPC_G_B:
+    case TPC_F_S:
+    case TPC_E_SS:
         return mpe::PitchClass::F_sharp;
 
     // G
-    case mu::engraving::TPC_A_BB:
-    case mu::engraving::TPC_G:
-    case mu::engraving::TPC_F_SS:
-    case mu::engraving::TPC_E_SSS:
+    case TPC_A_BB:
+    case TPC_G:
+    case TPC_F_SS:
+    case TPC_E_SSS:
         return mpe::PitchClass::G;
-    case mu::engraving::TPC_B_BBB:
-    case mu::engraving::TPC_A_B:
-    case mu::engraving::TPC_G_S:
-    case mu::engraving::TPC_F_SSS:
+    case TPC_B_BBB:
+    case TPC_A_B:
+    case TPC_G_S:
+    case TPC_F_SSS:
         return mpe::PitchClass::G_sharp;
 
     // A
-    case mu::engraving::TPC_C_BBB:
-    case mu::engraving::TPC_B_BB:
-    case mu::engraving::TPC_A:
-    case mu::engraving::TPC_G_SS:
+    case TPC_C_BBB:
+    case TPC_B_BB:
+    case TPC_A:
+    case TPC_G_SS:
         return mpe::PitchClass::A;
-    case mu::engraving::TPC_C_BB:
-    case mu::engraving::TPC_B_B:
-    case mu::engraving::TPC_A_S:
-    case mu::engraving::TPC_G_SSS:
+    case TPC_C_BB:
+    case TPC_B_B:
+    case TPC_A_S:
+    case TPC_G_SSS:
         return mpe::PitchClass::A_sharp;
 
     // B
-    case mu::engraving::TPC_D_BBB:
-    case mu::engraving::TPC_C_B:
-    case mu::engraving::TPC_B:
-    case mu::engraving::TPC_A_SS:
+    case TPC_D_BBB:
+    case TPC_C_B:
+    case TPC_B:
+    case TPC_A_SS:
         return mpe::PitchClass::B;
 
     default:
@@ -112,7 +112,7 @@ inline mpe::PitchClass pitchClassFromTpc(const int tpc)
 }
 
 inline mpe::octave_t actualOctave(const int nominalOctave, const mpe::PitchClass nominalPitchClass,
-                                  const mu::engraving::AccidentalVal accidental)
+                                  const AccidentalVal accidental)
 {
     int shift = static_cast<int>(nominalPitchClass) - static_cast<int>(accidental);
 
@@ -134,7 +134,7 @@ inline mpe::pitch_level_t notePitchLevel(const int noteTpc, const int noteOctave
 {
     mpe::PitchClass pitchClass = pitchClassFromTpc(noteTpc);
 
-    return mpe::pitchLevel(pitchClass, actualOctave(noteOctave, pitchClass, mu::engraving::tpc2alter(noteTpc)));
+    return mpe::pitchLevel(pitchClass, actualOctave(noteOctave, pitchClass, tpc2alter(noteTpc)));
 }
 }
 

--- a/src/engraving/property/propertyvalue.cpp
+++ b/src/engraving/property/propertyvalue.cpp
@@ -155,7 +155,7 @@ QVariant PropertyValue::toQVariant() const
     case P_TYPE::KEY_MODE:         return static_cast<int>(value<KeyMode>());
     case P_TYPE::TEXT_STYLE:       return static_cast<int>(value<TextStyleType>());
     case P_TYPE::PLAYTECH_TYPE:    return static_cast<int>(value<PlayingTechniqueType>());
-    case P_TYPE::TEMPOCHANGE_TYPE: return static_cast<int>(value<TempoTechniqueType>());
+    case P_TYPE::TEMPOCHANGE_TYPE: return static_cast<int>(value<TempoChangeType>());
     case P_TYPE::SLUR_STYLE_TYPE:  return static_cast<int>(value<SlurStyleType>());
 
     // Other
@@ -245,7 +245,7 @@ PropertyValue PropertyValue::fromQVariant(const QVariant& v, P_TYPE type)
     case P_TYPE::KEY_MODE:         return PropertyValue(KeyMode(v.toInt()));
     case P_TYPE::TEXT_STYLE:       return PropertyValue(TextStyleType(v.toInt()));
     case P_TYPE::PLAYTECH_TYPE:    return PropertyValue(PlayingTechniqueType(v.toInt()));
-    case P_TYPE::TEMPOCHANGE_TYPE: return PropertyValue(TempoTechniqueType(v.toInt()));
+    case P_TYPE::TEMPOCHANGE_TYPE: return PropertyValue(TempoChangeType(v.toInt()));
     case P_TYPE::SLUR_STYLE_TYPE:  return PropertyValue(SlurStyleType(v.toInt()));
 
     // Other

--- a/src/engraving/property/propertyvalue.h
+++ b/src/engraving/property/propertyvalue.h
@@ -37,9 +37,7 @@
 namespace mu::engraving {
 class Groups;
 class TDuration;
-}
 
-namespace mu::engraving {
 enum class P_TYPE {
     UNDEFINED = 0,
     // Base
@@ -244,8 +242,8 @@ public:
     PropertyValue(PlayingTechniqueType v)
         : m_type(P_TYPE::PLAYTECH_TYPE), m_data(make_data<PlayingTechniqueType>(v)) {}
 
-    PropertyValue(TempoTechniqueType v)
-        : m_type(P_TYPE::TEMPOCHANGE_TYPE), m_data(make_data<TempoTechniqueType>(v)) {}
+    PropertyValue(TempoChangeType v)
+        : m_type(P_TYPE::TEMPOCHANGE_TYPE), m_data(make_data<TempoChangeType>(v)) {}
 
     PropertyValue(SlurStyleType v)
         : m_type(P_TYPE::SLUR_STYLE_TYPE), m_data(make_data<SlurStyleType>(v)) {}

--- a/src/engraving/rw/compat/read114.cpp
+++ b/src/engraving/rw/compat/read114.cpp
@@ -600,7 +600,7 @@ static void readFingering114(XmlReader& e, Fingering* fing)
         const AsciiString tag(e.name());
 
         if (tag == "html-data") {
-            auto htmlDdata = mu::engraving::HtmlParser::parse(e.readXml());
+            auto htmlDdata = HtmlParser::parse(e.readXml());
             htmlDdata.replace(" ", "");
             fing->setPlainText(htmlDdata);
         } else if (tag == "subtype") {

--- a/src/engraving/rw/compat/read114.h
+++ b/src/engraving/rw/compat/read114.h
@@ -37,7 +37,7 @@ public:
     //   read114
     //    import old version <= 1.3 files
     //---------------------------------------------------------
-    static mu::engraving::Score::FileError read114(mu::engraving::MasterScore* masterScore, mu::engraving::XmlReader& e, ReadContext& ctx);
+    static Score::FileError read114(MasterScore* masterScore, XmlReader& e, ReadContext& ctx);
 };
 }
 

--- a/src/engraving/rw/compat/read206.h
+++ b/src/engraving/rw/compat/read206.h
@@ -55,31 +55,31 @@ public:
     //   read206
     //    import old version > 1.3  and < 3.x files
     //---------------------------------------------------------
-    static mu::engraving::Score::FileError read206(mu::engraving::MasterScore* masterScore, mu::engraving::XmlReader& e, ReadContext& ctx);
+    static Score::FileError read206(MasterScore* masterScore, XmlReader& e, ReadContext& ctx);
 
-    static mu::engraving::EngravingItem* readArticulation(mu::engraving::EngravingItem*, mu::engraving::XmlReader&, const ReadContext& ctx);
-    static void readAccidental206(mu::engraving::Accidental*, mu::engraving::XmlReader&);
-    static void readTextStyle206(mu::engraving::MStyle* style, mu::engraving::XmlReader& e, std::map<QString, std::map<mu::engraving::Sid,
-                                                                                                                       PropertyValue> >& excessStyles);
-    static void readTextLine206(mu::engraving::XmlReader& e, const ReadContext& ctx, mu::engraving::TextLineBase* tlb);
-    static void readTrill206(mu::engraving::XmlReader& e, mu::engraving::Trill* t);
-    static void readHairpin206(mu::engraving::XmlReader& e, const ReadContext& ctx, mu::engraving::Hairpin* h);
-    static void readSlur206(mu::engraving::XmlReader& e, ReadContext& ctx, mu::engraving::Slur* s);
-    static void readTie206(mu::engraving::XmlReader& e, ReadContext& ctx, mu::engraving::Tie* t);
+    static EngravingItem* readArticulation(EngravingItem*, XmlReader&, const ReadContext& ctx);
+    static void readAccidental206(Accidental*, XmlReader&);
+    static void readTextStyle206(MStyle* style, XmlReader& e, std::map<QString, std::map<Sid,
+                                                                                         PropertyValue> >& excessStyles);
+    static void readTextLine206(XmlReader& e, const ReadContext& ctx, TextLineBase* tlb);
+    static void readTrill206(XmlReader& e, Trill* t);
+    static void readHairpin206(XmlReader& e, const ReadContext& ctx, Hairpin* h);
+    static void readSlur206(XmlReader& e, ReadContext& ctx, Slur* s);
+    static void readTie206(XmlReader& e, ReadContext& ctx, Tie* t);
 
-    static bool readNoteProperties206(mu::engraving::Note* note, mu::engraving::XmlReader& e, ReadContext& ctx);
-    static bool readDurationProperties206(mu::engraving::XmlReader& e, const ReadContext& ctx, mu::engraving::DurationElement* de);
-    static bool readTupletProperties206(mu::engraving::XmlReader& e, const ReadContext& ctx, mu::engraving::Tuplet* t);
-    static bool readChordRestProperties206(mu::engraving::XmlReader& e, ReadContext& ctx, mu::engraving::ChordRest* cr);
-    static bool readChordProperties206(mu::engraving::XmlReader& e, ReadContext& ctx, mu::engraving::Chord* ch);
+    static bool readNoteProperties206(Note* note, XmlReader& e, ReadContext& ctx);
+    static bool readDurationProperties206(XmlReader& e, const ReadContext& ctx, DurationElement* de);
+    static bool readTupletProperties206(XmlReader& e, const ReadContext& ctx, Tuplet* t);
+    static bool readChordRestProperties206(XmlReader& e, ReadContext& ctx, ChordRest* cr);
+    static bool readChordProperties206(XmlReader& e, ReadContext& ctx, Chord* ch);
 
-    static mu::engraving::SymId articulationNames2SymId206(const AsciiString& s);
+    static SymId articulationNames2SymId206(const AsciiString& s);
 
-    static mu::engraving::NoteHeadGroup convertHeadGroup(int i);
+    static NoteHeadGroup convertHeadGroup(int i);
 
 private:
-    static bool readScore206(mu::engraving::Score* score, mu::engraving::XmlReader& e, ReadContext& ctx);
-    static void readPart206(mu::engraving::Part* part, mu::engraving::XmlReader& e, ReadContext& ctx);
+    static bool readScore206(Score* score, XmlReader& e, ReadContext& ctx);
+    static void readPart206(Part* part, XmlReader& e, ReadContext& ctx);
 };
 }
 

--- a/src/engraving/rw/compat/read302.cpp
+++ b/src/engraving/rw/compat/read302.cpp
@@ -52,7 +52,7 @@ using namespace mu::engraving;
 using namespace mu::engraving::rw;
 using namespace mu::engraving::compat;
 
-bool Read302::readScore302(mu::engraving::Score* score, XmlReader& e, ReadContext& ctx)
+bool Read302::readScore302(Score* score, XmlReader& e, ReadContext& ctx)
 {
     // HACK
     // style setting compatibility settings for minor versions
@@ -265,7 +265,7 @@ bool Read302::readScore302(mu::engraving::Score* score, XmlReader& e, ReadContex
     return true;
 }
 
-Score::FileError Read302::read302(mu::engraving::MasterScore* masterScore, XmlReader& e, ReadContext& ctx)
+Score::FileError Read302::read302(MasterScore* masterScore, XmlReader& e, ReadContext& ctx)
 {
     while (e.readNextStartElement()) {
         const AsciiString tag(e.name());

--- a/src/engraving/rw/compat/read302.h
+++ b/src/engraving/rw/compat/read302.h
@@ -33,10 +33,10 @@ class Read302
 {
 public:
 
-    static mu::engraving::Score::FileError read302(mu::engraving::MasterScore* masterScore, mu::engraving::XmlReader& e, ReadContext& ctx);
+    static Score::FileError read302(MasterScore* masterScore, XmlReader& e, ReadContext& ctx);
 
 private:
-    static bool readScore302(mu::engraving::Score* score, mu::engraving::XmlReader& e, ReadContext& ctx);
+    static bool readScore302(Score* score, XmlReader& e, ReadContext& ctx);
 };
 }
 

--- a/src/engraving/rw/compat/readchordlisthook.cpp
+++ b/src/engraving/rw/compat/readchordlisthook.cpp
@@ -30,7 +30,7 @@
 using namespace mu::engraving::compat;
 using namespace mu::engraving;
 
-ReadChordListHook::ReadChordListHook(mu::engraving::Score* score)
+ReadChordListHook::ReadChordListHook(Score* score)
     : m_score(score)
 {
     if (m_score) {
@@ -38,7 +38,7 @@ ReadChordListHook::ReadChordListHook(mu::engraving::Score* score)
     }
 }
 
-void ReadChordListHook::read(mu::engraving::XmlReader& e)
+void ReadChordListHook::read(XmlReader& e)
 {
     if (!m_score) {
         return;

--- a/src/engraving/rw/compat/readchordlisthook.h
+++ b/src/engraving/rw/compat/readchordlisthook.h
@@ -34,13 +34,13 @@ namespace mu::engraving::compat {
 class ReadChordListHook
 {
 public:
-    ReadChordListHook(mu::engraving::Score* score);
+    ReadChordListHook(Score* score);
 
-    void read(mu::engraving::XmlReader& e);
+    void read(XmlReader& e);
     void validate();
 
 private:
-    mu::engraving::Score* m_score = nullptr;
+    Score* m_score = nullptr;
     bool m_chordListTag = false;
     QString m_oldChordDescriptionFile;
 };

--- a/src/engraving/rw/compat/readstyle.cpp
+++ b/src/engraving/rw/compat/readstyle.cpp
@@ -50,7 +50,7 @@ static int readStyleDefaultsVersion(MasterScore* score, const ByteArray& scoreDa
     return ReadStyleHook::styleDefaultByMscVersion(score->mscVersion());
 }
 
-ReadStyleHook::ReadStyleHook(mu::engraving::Score* score, const ByteArray& scoreData, const QString& completeBaseName)
+ReadStyleHook::ReadStyleHook(Score* score, const ByteArray& scoreData, const QString& completeBaseName)
     : m_score(score), m_scoreData(scoreData), m_completeBaseName(completeBaseName)
 {
 }
@@ -97,7 +97,7 @@ void ReadStyleHook::setupDefaultStyle()
     m_score->style().setDefaultStyleVersion(defaultsVersion);
 }
 
-void ReadStyleHook::setupDefaultStyle(mu::engraving::Score* score)
+void ReadStyleHook::setupDefaultStyle(Score* score)
 {
     IF_ASSERT_FAILED(!score->isMaster()) {
         return;
@@ -108,18 +108,18 @@ void ReadStyleHook::setupDefaultStyle(mu::engraving::Score* score)
     score->style().setDefaultStyleVersion(defaultsVersion);
 }
 
-void ReadStyleHook::readStyleTag(mu::engraving::XmlReader& e)
+void ReadStyleHook::readStyleTag(XmlReader& e)
 {
     readStyleTag(m_score, e);
 }
 
-void ReadStyleHook::readStyleTag(mu::engraving::Score* score, mu::engraving::XmlReader& e)
+void ReadStyleHook::readStyleTag(Score* score, XmlReader& e)
 {
     ReadChordListHook clhook(score);
     score->style().read(e, &clhook);
 }
 
-bool ReadStyleHook::readStyleProperties(mu::engraving::MStyle* style, mu::engraving::XmlReader& e)
+bool ReadStyleHook::readStyleProperties(MStyle* style, XmlReader& e)
 {
     return style->readProperties(e);
 }

--- a/src/engraving/rw/compat/readstyle.h
+++ b/src/engraving/rw/compat/readstyle.h
@@ -36,19 +36,19 @@ namespace mu::engraving::compat {
 class ReadStyleHook
 {
 public:
-    ReadStyleHook(mu::engraving::Score* score, const ByteArray& scoreData, const QString& completeBaseName);
+    ReadStyleHook(Score* score, const ByteArray& scoreData, const QString& completeBaseName);
 
     void setupDefaultStyle();
 
-    void readStyleTag(mu::engraving::XmlReader& e);
+    void readStyleTag(XmlReader& e);
 
     static int styleDefaultByMscVersion(const int mscVer);
-    static void setupDefaultStyle(mu::engraving::Score* score);
-    static void readStyleTag(mu::engraving::Score* score, mu::engraving::XmlReader& e);
-    static bool readStyleProperties(mu::engraving::MStyle* style, mu::engraving::XmlReader& e);
+    static void setupDefaultStyle(Score* score);
+    static void readStyleTag(Score* score, XmlReader& e);
+    static bool readStyleProperties(MStyle* style, XmlReader& e);
 
 private:
-    mu::engraving::Score* m_score = nullptr;
+    Score* m_score = nullptr;
     const ByteArray& m_scoreData;
     const QString& m_completeBaseName;
 };

--- a/src/engraving/rw/measurerw.cpp
+++ b/src/engraving/rw/measurerw.cpp
@@ -546,8 +546,7 @@ void MeasureRW::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, int 
     }
 }
 
-void MeasureRW::writeMeasure(const mu::engraving::Measure* measure, XmlWriter& xml, staff_idx_t staff, bool writeSystemElements,
-                             bool forceTimeSig)
+void MeasureRW::writeMeasure(const Measure* measure, XmlWriter& xml, staff_idx_t staff, bool writeSystemElements, bool forceTimeSig)
 {
     if (MScore::debugMode) {
         const int mno = measure->no() + 1;

--- a/src/engraving/rw/measurerw.h
+++ b/src/engraving/rw/measurerw.h
@@ -29,12 +29,11 @@ class MeasureRW
 {
 public:
 
-    static void readMeasure(mu::engraving::Measure* measure, mu::engraving::XmlReader& xml, ReadContext& ctx, int staffIdx);
-    static void writeMeasure(const mu::engraving::Measure* measure, mu::engraving::XmlWriter& xml, staff_idx_t staff,
-                             bool writeSystemElements, bool forceTimeSig);
+    static void readMeasure(Measure* measure, XmlReader& xml, ReadContext& ctx, int staffIdx);
+    static void writeMeasure(const Measure* measure, XmlWriter& xml, staff_idx_t staff, bool writeSystemElements, bool forceTimeSig);
 
 private:
-    static void readVoice(mu::engraving::Measure* measure, mu::engraving::XmlReader& e, ReadContext& ctx, int staffIdx, bool irregular);
+    static void readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, int staffIdx, bool irregular);
 };
 }
 

--- a/src/engraving/rw/read400.cpp
+++ b/src/engraving/rw/read400.cpp
@@ -40,7 +40,7 @@
 using namespace mu::engraving;
 using namespace mu::engraving::rw;
 
-bool Read400::read400(mu::engraving::Score* score, XmlReader& e, ReadContext& ctx)
+bool Read400::read400(Score* score, XmlReader& e, ReadContext& ctx)
 {
     if (!e.readNextStartElement()) {
         LOGD("%s: xml file is empty", qPrintable(e.getDocName()));
@@ -72,7 +72,7 @@ bool Read400::read400(mu::engraving::Score* score, XmlReader& e, ReadContext& ct
     return true;
 }
 
-bool Read400::readScore400(mu::engraving::Score* score, XmlReader& e, ReadContext& ctx)
+bool Read400::readScore400(Score* score, XmlReader& e, ReadContext& ctx)
 {
     // HACK
     // style setting compatibility settings for minor versions

--- a/src/engraving/rw/read400.h
+++ b/src/engraving/rw/read400.h
@@ -27,15 +27,13 @@
 
 namespace mu::engraving {
 class XmlReader;
-}
 
-namespace mu::engraving {
 class Read400
 {
 public:
 
-    static bool read400(mu::engraving::Score* score, mu::engraving::XmlReader& e, ReadContext& ctx);
-    static bool readScore400(mu::engraving::Score* score, mu::engraving::XmlReader& e, ReadContext& ctx);
+    static bool read400(Score* score, XmlReader& e, ReadContext& ctx);
+    static bool readScore400(Score* score, XmlReader& e, ReadContext& ctx);
 };
 }
 

--- a/src/engraving/rw/readcontext.cpp
+++ b/src/engraving/rw/readcontext.cpp
@@ -31,7 +31,7 @@
 
 using namespace mu::engraving;
 
-ReadContext::ReadContext(mu::engraving::Score* score)
+ReadContext::ReadContext(Score* score)
     : m_score(score)
 {
 }
@@ -52,12 +52,12 @@ ReadContext::~ReadContext()
     }
 }
 
-void ReadContext::setScore(mu::engraving::Score* score)
+void ReadContext::setScore(Score* score)
 {
     m_score = score;
 }
 
-mu::engraving::Score* ReadContext::score() const
+Score* ReadContext::score() const
 {
     return m_score;
 }
@@ -97,27 +97,27 @@ qreal ReadContext::spatium() const
     return m_score->spatium();
 }
 
-mu::engraving::compat::DummyElement* ReadContext::dummy() const
+compat::DummyElement* ReadContext::dummy() const
 {
     return m_score->dummy();
 }
 
-mu::engraving::TimeSigMap* ReadContext::sigmap()
+TimeSigMap* ReadContext::sigmap()
 {
     return m_score->sigmap();
 }
 
-mu::engraving::Staff* ReadContext::staff(int n)
+Staff* ReadContext::staff(int n)
 {
     return m_score->staff(n);
 }
 
-void ReadContext::appendStaff(mu::engraving::Staff* staff)
+void ReadContext::appendStaff(Staff* staff)
 {
     m_score->appendStaff(staff);
 }
 
-void ReadContext::addSpanner(mu::engraving::Spanner* s)
+void ReadContext::addSpanner(Spanner* s)
 {
     m_score->addSpanner(s);
 }
@@ -127,7 +127,7 @@ bool ReadContext::undoStackActive() const
     return m_score->undoStack()->active();
 }
 
-bool ReadContext::isSameScore(const mu::engraving::EngravingObject* obj) const
+bool ReadContext::isSameScore(const EngravingObject* obj) const
 {
     return obj->score() == m_score;
 }
@@ -138,7 +138,7 @@ void ReadContext::initLinks(const ReadContext& ctx)
     m_staffLinkedElements = ctx.m_staffLinkedElements;
 }
 
-void ReadContext::addLink(mu::engraving::Staff* staff, mu::engraving::LinkedObjects* link, const mu::engraving::Location& location)
+void ReadContext::addLink(Staff* staff, LinkedObjects* link, const Location& location)
 {
     int staffIndex = static_cast<int>(staff->idx());
     const bool isMasterScore = staff->score()->isMaster();
@@ -146,7 +146,7 @@ void ReadContext::addLink(mu::engraving::Staff* staff, mu::engraving::LinkedObje
         staffIndex *= -1;
     }
 
-    std::vector<std::pair<mu::engraving::LinkedObjects*, mu::engraving::Location> >& staffLinks = m_staffLinkedElements[staffIndex];
+    std::vector<std::pair<LinkedObjects*, Location> >& staffLinks = m_staffLinkedElements[staffIndex];
     if (!isMasterScore) {
         if (!staffLinks.empty()
             && (link->mainElement()->score() != staffLinks.front().first->mainElement()->score())
@@ -159,7 +159,7 @@ void ReadContext::addLink(mu::engraving::Staff* staff, mu::engraving::LinkedObje
     staffLinks.push_back(std::make_pair(link, location));
 }
 
-mu::engraving::LinkedObjects* ReadContext::getLink(bool isMasterScore, const mu::engraving::Location& location, int localIndexDiff)
+LinkedObjects* ReadContext::getLink(bool isMasterScore, const Location& location, int localIndexDiff)
 {
     int staffIndex = location.staff();
     if (!isMasterScore) {
@@ -167,7 +167,7 @@ mu::engraving::LinkedObjects* ReadContext::getLink(bool isMasterScore, const mu:
     }
 
     const int localIndex = m_linksIndexer.assignLocalIndex(location) + localIndexDiff;
-    std::vector<std::pair<mu::engraving::LinkedObjects*, mu::engraving::Location> >& staffLinks = m_staffLinkedElements[staffIndex];
+    std::vector<std::pair<LinkedObjects*, Location> >& staffLinks = m_staffLinkedElements[staffIndex];
 
     if (!staffLinks.empty() && staffLinks.back().second == location) {
         // This element potentially affects local index for "main"
@@ -198,7 +198,7 @@ mu::engraving::LinkedObjects* ReadContext::getLink(bool isMasterScore, const mu:
     return nullptr;
 }
 
-std::map<int, std::vector<std::pair<mu::engraving::LinkedObjects*, mu::engraving::Location> > >& ReadContext::staffLinkedElements()
+std::map<int, std::vector<std::pair<LinkedObjects*, Location> > >& ReadContext::staffLinkedElements()
 {
     return m_staffLinkedElements;
 }

--- a/src/engraving/rw/readcontext.h
+++ b/src/engraving/rw/readcontext.h
@@ -52,18 +52,16 @@ struct TextStyleMap {
     QString name;
     TextStyleType ss;
 };
-}
 
-namespace mu::engraving {
 class ReadContext
 {
 public:
 
-    ReadContext(mu::engraving::Score* score);
+    ReadContext(Score* score);
     ~ReadContext();
 
-    void setScore(mu::engraving::Score* score);
-    mu::engraving::Score* score() const;
+    void setScore(Score* score);
+    Score* score() const;
 
     bool pasteMode() const { return _pasteMode; }
     void setPasteMode(bool v) { _pasteMode = v; }
@@ -79,22 +77,22 @@ public:
 
     qreal spatium() const;
 
-    mu::engraving::compat::DummyElement* dummy() const;
+    compat::DummyElement* dummy() const;
 
-    mu::engraving::TimeSigMap* sigmap();
-    mu::engraving::Staff* staff(int n);
+    TimeSigMap* sigmap();
+    Staff* staff(int n);
 
-    void appendStaff(mu::engraving::Staff* staff);
-    void addSpanner(mu::engraving::Spanner* s);
+    void appendStaff(Staff* staff);
+    void addSpanner(Spanner* s);
 
     bool undoStackActive() const;
 
-    bool isSameScore(const mu::engraving::EngravingObject* obj) const;
+    bool isSameScore(const EngravingObject* obj) const;
 
     void initLinks(const ReadContext& ctx);
-    void addLink(mu::engraving::Staff* staff, mu::engraving::LinkedObjects* link, const mu::engraving::Location& location);
-    mu::engraving::LinkedObjects* getLink(bool isMasterScore, const mu::engraving::Location& location, int localIndexDiff);
-    std::map<int, std::vector<std::pair<mu::engraving::LinkedObjects*, mu::engraving::Location> > >& staffLinkedElements();
+    void addLink(Staff* staff, LinkedObjects* link, const Location& location);
+    LinkedObjects* getLink(bool isMasterScore, const Location& location, int localIndexDiff);
+    std::map<int, std::vector<std::pair<LinkedObjects*, Location> > >& staffLinkedElements();
 
     bool hasAccidental = false; // used for userAccidental backward compatibility
 
@@ -110,64 +108,64 @@ public:
     int trackOffset() const { return _trackOffset; }
     void setTrack(track_idx_t val) { _track = val; }
 
-    mu::engraving::Location location(bool forceAbsFrac = false) const;
-    void fillLocation(mu::engraving::Location&, bool forceAbsFrac = false) const;
-    void setLocation(const mu::engraving::Location&);   // sets a new reading point, taking into account its type (absolute or relative).
+    Location location(bool forceAbsFrac = false) const;
+    void fillLocation(Location&, bool forceAbsFrac = false) const;
+    void setLocation(const Location&);   // sets a new reading point, taking into account its type (absolute or relative).
 
-    void setCurrentMeasure(mu::engraving::Measure* m) { _curMeasure = m; }
-    mu::engraving::Measure* currentMeasure() const { return _curMeasure; }
-    void setLastMeasure(mu::engraving::Measure* m) { _lastMeasure = m; }
-    mu::engraving::Measure* lastMeasure() const { return _lastMeasure; }
+    void setCurrentMeasure(Measure* m) { _curMeasure = m; }
+    Measure* currentMeasure() const { return _curMeasure; }
+    void setLastMeasure(Measure* m) { _lastMeasure = m; }
+    Measure* lastMeasure() const { return _lastMeasure; }
     void setCurrentMeasureIndex(int idx) { _curMeasureIdx = idx; }
     int currentMeasureIndex() const { return _curMeasureIdx; }
 
-    void addBeam(mu::engraving::Beam* s);
-    mu::engraving::Beam* findBeam(int id) const { return mu::value(_beams, id, nullptr); }
+    void addBeam(Beam* s);
+    Beam* findBeam(int id) const { return mu::value(_beams, id, nullptr); }
 
-    void addTuplet(mu::engraving::Tuplet* s);
-    mu::engraving::Tuplet* findTuplet(int id) const { return mu::value(_tuplets, id, nullptr); }
-    std::unordered_map<int, mu::engraving::Tuplet*>& tuplets() { return _tuplets; }
+    void addTuplet(Tuplet* s);
+    Tuplet* findTuplet(int id) const { return mu::value(_tuplets, id, nullptr); }
+    std::unordered_map<int, Tuplet*>& tuplets() { return _tuplets; }
     void checkTuplets();
 
-    void removeSpanner(const mu::engraving::Spanner*);
-    void addSpanner(int id, mu::engraving::Spanner*);
-    mu::engraving::Spanner* findSpanner(int id);
+    void removeSpanner(const Spanner*);
+    void addSpanner(int id, Spanner*);
+    Spanner* findSpanner(int id);
 
-    int spannerId(const mu::engraving::Spanner*);        // returns spanner id, allocates new one if none exists
+    int spannerId(const Spanner*);        // returns spanner id, allocates new one if none exists
 
-    void addSpannerValues(const mu::engraving::SpannerValues& sv) { _spannerValues.push_back(sv); }
-    const mu::engraving::SpannerValues* spannerValues(int id) const;
+    void addSpannerValues(const SpannerValues& sv) { _spannerValues.push_back(sv); }
+    const SpannerValues* spannerValues(int id) const;
 
-    void addConnectorInfoLater(std::unique_ptr<mu::engraving::ConnectorInfoReader> c) { _pendingConnectors.push_back(std::move(c)); }   // add connector info to be checked after calling checkConnectors()
+    void addConnectorInfoLater(std::unique_ptr<ConnectorInfoReader> c) { _pendingConnectors.push_back(std::move(c)); }   // add connector info to be checked after calling checkConnectors()
     void checkConnectors();
     void reconnectBrokenConnectors();
 
-    mu::engraving::Interval transpose() const { return _transpose; }
+    Interval transpose() const { return _transpose; }
     void setTransposeChromatic(int8_t v) { _transpose.chromatic = v; }
     void setTransposeDiatonic(int8_t v) { _transpose.diatonic = v; }
 
-    std::map<int, mu::engraving::LinkedObjects*>& linkIds() { return _elinks; }
+    std::map<int, LinkedObjects*>& linkIds() { return _elinks; }
     TracksMap& tracks() { return _tracks; }
 
     TextStyleType addUserTextStyle(const QString& name);
     TextStyleType lookupUserTextStyle(const QString& name) const;
     void clearUserTextStyles() { userTextStyles.clear(); }
 
-    std::list<std::pair<mu::engraving::EngravingItem*, mu::PointF> >& fixOffsets() { return _fixOffsets; }
+    std::list<std::pair<EngravingItem*, mu::PointF> >& fixOffsets() { return _fixOffsets; }
 
 private:
 
-    void addConnectorInfo(std::unique_ptr<mu::engraving::ConnectorInfoReader>);
-    void removeConnector(const mu::engraving::ConnectorInfoReader*);   // Removes the whole ConnectorInfo chain from the connectors list.
+    void addConnectorInfo(std::unique_ptr<ConnectorInfoReader>);
+    void removeConnector(const ConnectorInfoReader*);   // Removes the whole ConnectorInfo chain from the connectors list.
 
-    mu::engraving::Score* m_score = nullptr;
+    Score* m_score = nullptr;
 
     bool _pasteMode = false;  // modifies read behaviour on paste operation
 
     bool m_ignoreVersionError = false;
 
-    std::map<int /*staffIndex*/, std::vector<std::pair<mu::engraving::LinkedObjects*, mu::engraving::Location> > > m_staffLinkedElements; // one list per staff
-    mu::engraving::LinksIndexer m_linksIndexer;
+    std::map<int /*staffIndex*/, std::vector<std::pair<LinkedObjects*, Location> > > m_staffLinkedElements; // one list per staff
+    LinksIndexer m_linksIndexer;
 
     Fraction _tick             { Fraction(0, 1) };
     Fraction _tickOffset       { Fraction(0, 1) };
@@ -176,27 +174,27 @@ private:
     track_idx_t _track = 0;
     int _trackOffset = 0;
 
-    mu::engraving::Measure* _curMeasure = nullptr;
-    mu::engraving::Measure* _lastMeasure = nullptr;
+    Measure* _curMeasure = nullptr;
+    Measure* _lastMeasure = nullptr;
     int _curMeasureIdx = 0;
 
-    std::unordered_map<int, mu::engraving::Beam*> _beams;
-    std::unordered_map<int, mu::engraving::Tuplet*> _tuplets;
+    std::unordered_map<int, Beam*> _beams;
+    std::unordered_map<int, Tuplet*> _tuplets;
 
-    std::list<mu::engraving::SpannerValues> _spannerValues;
-    std::list<std::pair<int, mu::engraving::Spanner*> > _spanner;
+    std::list<SpannerValues> _spannerValues;
+    std::list<std::pair<int, Spanner*> > _spanner;
 
-    std::vector<std::unique_ptr<mu::engraving::ConnectorInfoReader> > _connectors;
-    std::vector<std::unique_ptr<mu::engraving::ConnectorInfoReader> > _pendingConnectors;  // connectors that are pending to be updated and added to _connectors. That will happen when checkConnectors() is called.
+    std::vector<std::unique_ptr<ConnectorInfoReader> > _connectors;
+    std::vector<std::unique_ptr<ConnectorInfoReader> > _pendingConnectors;  // connectors that are pending to be updated and added to _connectors. That will happen when checkConnectors() is called.
 
-    mu::engraving::Interval _transpose;
+    Interval _transpose;
 
-    std::map<int, mu::engraving::LinkedObjects*> _elinks;   // for reading old files (< 3.01)
+    std::map<int, LinkedObjects*> _elinks;   // for reading old files (< 3.01)
     TracksMap _tracks;
 
-    std::list<mu::engraving::TextStyleMap> userTextStyles;
+    std::list<TextStyleMap> userTextStyles;
 
-    std::list<std::pair<mu::engraving::EngravingItem*, mu::PointF> > _fixOffsets;
+    std::list<std::pair<EngravingItem*, mu::PointF> > _fixOffsets;
 };
 }
 

--- a/src/engraving/rw/scorereader.cpp
+++ b/src/engraving/rw/scorereader.cpp
@@ -39,7 +39,7 @@
 using namespace mu::io;
 using namespace mu::engraving;
 
-Err ScoreReader::loadMscz(mu::engraving::MasterScore* masterScore, const mu::engraving::MscReader& mscReader, bool ignoreVersionError)
+Err ScoreReader::loadMscz(MasterScore* masterScore, const MscReader& mscReader, bool ignoreVersionError)
 {
     TRACEFUNC;
 

--- a/src/engraving/rw/scorereader.h
+++ b/src/engraving/rw/scorereader.h
@@ -34,14 +34,14 @@ class ScoreReader
 public:
     ScoreReader() = default;
 
-    Err loadMscz(mu::engraving::MasterScore* score, const mu::engraving::MscReader& mscReader, bool ignoreVersionError);
+    Err loadMscz(MasterScore* score, const MscReader& mscReader, bool ignoreVersionError);
 
 private:
 
-    friend class mu::engraving::MasterScore;
+    friend class MasterScore;
 
-    Err read(mu::engraving::MasterScore* score, mu::engraving::XmlReader&, ReadContext& ctx, compat::ReadStyleHook* styleHook = nullptr);
-    Err doRead(mu::engraving::MasterScore* score, mu::engraving::XmlReader& e, ReadContext& ctx);
+    Err read(MasterScore* score, XmlReader&, ReadContext& ctx, compat::ReadStyleHook* styleHook = nullptr);
+    Err doRead(MasterScore* score, XmlReader& e, ReadContext& ctx);
 };
 }
 

--- a/src/engraving/rw/staffrw.cpp
+++ b/src/engraving/rw/staffrw.cpp
@@ -36,7 +36,7 @@
 using namespace mu::engraving::rw;
 using namespace mu::engraving;
 
-void StaffRW::readStaff(mu::engraving::Score* score, mu::engraving::XmlReader& e, ReadContext& ctx)
+void StaffRW::readStaff(Score* score, XmlReader& e, ReadContext& ctx)
 {
     int staff = e.intAttribute("id", 1) - 1;
     int measureIdx = 0;
@@ -138,8 +138,8 @@ static void writeMeasure(XmlWriter& xml, MeasureBase* m, staff_idx_t staffIdx, b
     xml.context()->setCurTick(m->endTick());
 }
 
-void StaffRW::writeStaff(const mu::engraving::Staff* staff, mu::engraving::XmlWriter& xml,
-                         mu::engraving::MeasureBase* measureStart, mu::engraving::MeasureBase* measureEnd,
+void StaffRW::writeStaff(const Staff* staff, XmlWriter& xml,
+                         MeasureBase* measureStart, MeasureBase* measureEnd,
                          staff_idx_t staffStart, staff_idx_t staffIdx,
                          bool selectionOnly)
 {

--- a/src/engraving/rw/staffrw.h
+++ b/src/engraving/rw/staffrw.h
@@ -29,9 +29,9 @@ class StaffRW
 {
 public:
 
-    static void readStaff(mu::engraving::Score* score, mu::engraving::XmlReader&, ReadContext& ctx);
-    static void writeStaff(const mu::engraving::Staff* staff, mu::engraving::XmlWriter& xml, mu::engraving::MeasureBase* measureStart,
-                           mu::engraving::MeasureBase* measureEnd, staff_idx_t staffStart, staff_idx_t staffIdx, bool selectionOnly);
+    static void readStaff(Score* score, XmlReader&, ReadContext& ctx);
+    static void writeStaff(const Staff* staff, XmlWriter& xml, MeasureBase* measureStart, MeasureBase* measureEnd, staff_idx_t staffStart,
+                           staff_idx_t staffIdx, bool selectionOnly);
 };
 }
 

--- a/src/engraving/rw/writecontext.cpp
+++ b/src/engraving/rw/writecontext.cpp
@@ -25,7 +25,7 @@
 
 using namespace mu::engraving;
 
-int WriteContext::assignLocalIndex(const mu::engraving::Location& mainElementLocation)
+int WriteContext::assignLocalIndex(const Location& mainElementLocation)
 {
     return m_linksIndexer.assignLocalIndex(mainElementLocation);
 }
@@ -40,7 +40,7 @@ int WriteContext::lidLocalIndex(int lid) const
     return mu::value(m_lidLocalIndices, lid, 0);
 }
 
-bool WriteContext::canWrite(const mu::engraving::EngravingItem* e) const
+bool WriteContext::canWrite(const EngravingItem* e) const
 {
     if (!_clipboardmode) {
         return true;

--- a/src/engraving/rw/writecontext.h
+++ b/src/engraving/rw/writecontext.h
@@ -32,7 +32,7 @@ namespace mu::engraving {
 class WriteContext
 {
 public:
-    int assignLocalIndex(const mu::engraving::Location& mainElementLocation);
+    int assignLocalIndex(const Location& mainElementLocation);
     void setLidLocalIndex(int lid, int localIndex);
     int lidLocalIndex(int lid) const;
 
@@ -60,12 +60,12 @@ public:
     void setWriteTrack(bool v) { _writeTrack= v; }
     void setWritePosition(bool v) { _writePosition = v; }
 
-    void setFilter(mu::engraving::SelectionFilter f) { _filter = f; }
-    bool canWrite(const mu::engraving::EngravingItem*) const;
+    void setFilter(SelectionFilter f) { _filter = f; }
+    bool canWrite(const EngravingItem*) const;
     bool canWriteVoice(track_idx_t track) const;
 
 private:
-    mu::engraving::LinksIndexer m_linksIndexer;
+    LinksIndexer m_linksIndexer;
     std::map<int, int> m_lidLocalIndices;
 
     Fraction _curTick    { 0, 1 };           // used to optimize output
@@ -79,7 +79,7 @@ private:
     bool _writeTrack     { false };
     bool _writePosition  { false };
 
-    mu::engraving::SelectionFilter _filter;
+    SelectionFilter _filter;
 };
 }
 

--- a/src/engraving/rw/xmlreader.cpp
+++ b/src/engraving/rw/xmlreader.cpp
@@ -339,7 +339,7 @@ engraving::ReadContext* XmlReader::context() const
     return m_context;
 }
 
-void XmlReader::setContext(mu::engraving::ReadContext* context)
+void XmlReader::setContext(ReadContext* context)
 {
     if (m_context && m_selfContext) {
         delete m_context;

--- a/src/engraving/rw/xmlreader.h
+++ b/src/engraving/rw/xmlreader.h
@@ -33,9 +33,7 @@
 
 namespace mu::engraving {
 class ReadContext;
-}
 
-namespace mu::engraving {
 class XmlReader : public mu::XmlStreamReader
 {
 public:
@@ -88,8 +86,8 @@ public:
     // for reading old files (< 3.01)
     void setOffsetLines(qint64 val) { _offsetLines = val; }
 
-    mu::engraving::ReadContext* context() const;
-    void setContext(mu::engraving::ReadContext* context);
+    ReadContext* context() const;
+    void setContext(ReadContext* context);
 
 private:
     QString docName;    // used for error reporting
@@ -98,7 +96,7 @@ private:
 
     void htmlToString(int level, QString*);
 
-    mutable mu::engraving::ReadContext* m_context = nullptr;
+    mutable ReadContext* m_context = nullptr;
     mutable bool m_selfContext = false;
 };
 }

--- a/src/engraving/rw/xmlwriter.cpp
+++ b/src/engraving/rw/xmlwriter.cpp
@@ -404,7 +404,7 @@ void XmlWriter::writeXml(const QString& name, QString s)
     writeElement(name, s);
 }
 
-mu::engraving::WriteContext* XmlWriter::context() const
+WriteContext* XmlWriter::context() const
 {
     if (!m_context) {
         m_context = new engraving::WriteContext();

--- a/src/engraving/rw/xmlwriter.h
+++ b/src/engraving/rw/xmlwriter.h
@@ -38,9 +38,7 @@
 
 namespace mu::engraving {
 class WriteContext;
-}
 
-namespace mu::engraving {
 class XmlWriter : public mu::XmlStreamWriter
 {
 public:
@@ -58,10 +56,9 @@ public:
 
     void tagE(const QString&);
 
-    void tag(Pid id, const mu::engraving::PropertyValue& data, const mu::engraving::PropertyValue& def = mu::engraving::PropertyValue());
-    void tagProperty(const mu::AsciiString&, const mu::engraving::PropertyValue& data,
-                     const mu::engraving::PropertyValue& def = mu::engraving::PropertyValue());
-    void tagProperty(const mu::AsciiString& name, mu::engraving::P_TYPE type, const mu::engraving::PropertyValue& data);
+    void tag(Pid id, const PropertyValue& data, const PropertyValue& def = PropertyValue());
+    void tagProperty(const mu::AsciiString&, const PropertyValue& data, const PropertyValue& def = PropertyValue());
+    void tagProperty(const mu::AsciiString& name, P_TYPE type, const PropertyValue& data);
 
     void tag(const mu::AsciiString& name, const mu::AsciiString& v);
     void tag(const mu::AsciiString& name, const QString& v);
@@ -101,8 +98,8 @@ public:
 
     void writeXml(const QString&, QString s);
 
-    mu::engraving::WriteContext* context() const;
-    void setContext(mu::engraving::WriteContext* context);
+    WriteContext* context() const;
+    void setContext(WriteContext* context);
 
     static QString xmlString(const QString&);
     static QString xmlString(ushort c);
@@ -111,7 +108,7 @@ private:
     std::vector<std::pair<const EngravingObject*, AsciiString> > _elements;
     bool _recordElements = false;
 
-    mutable mu::engraving::WriteContext* m_context = nullptr;
+    mutable WriteContext* m_context = nullptr;
     mutable bool m_selfContext = false;
 };
 }

--- a/src/engraving/style/defaultstyle.cpp
+++ b/src/engraving/style/defaultstyle.cpp
@@ -71,7 +71,7 @@ void DefaultStyle::init(const QString& defaultStyleFilePath, const QString& part
     }
 }
 
-bool DefaultStyle::doLoadStyle(mu::engraving::MStyle* style, const QString& filePath)
+bool DefaultStyle::doLoadStyle(MStyle* style, const QString& filePath)
 {
     File file(filePath);
     if (!file.open(IODevice::ReadOnly)) {
@@ -84,7 +84,7 @@ bool DefaultStyle::doLoadStyle(mu::engraving::MStyle* style, const QString& file
 
 // Static
 
-const mu::engraving::MStyle& DefaultStyle::baseStyle()
+const MStyle& DefaultStyle::baseStyle()
 {
     return instance()->m_baseStyle;
 }
@@ -97,7 +97,7 @@ bool DefaultStyle::isHasDefaultStyle()
     return false;
 }
 
-const mu::engraving::MStyle& DefaultStyle::defaultStyle()
+const MStyle& DefaultStyle::defaultStyle()
 {
     if (instance()->m_defaultStyle) {
         return *instance()->m_defaultStyle;

--- a/src/engraving/style/defaultstyle.h
+++ b/src/engraving/style/defaultstyle.h
@@ -33,23 +33,23 @@ public:
 
     void init(const QString& defaultStyleFilePath, const QString& partStyleFilePath);
 
-    static const mu::engraving::MStyle& baseStyle();
+    static const MStyle& baseStyle();
 
     static bool isHasDefaultStyle();
-    static const mu::engraving::MStyle& defaultStyle();
+    static const MStyle& defaultStyle();
 
-    static const mu::engraving::MStyle* defaultStyleForParts();
+    static const MStyle* defaultStyleForParts();
 
-    static const mu::engraving::MStyle& resolveStyleDefaults(const int defaultsVersion);
+    static const MStyle& resolveStyleDefaults(const int defaultsVersion);
 
 private:
     DefaultStyle() = default;
 
-    static bool doLoadStyle(mu::engraving::MStyle* style, const QString& filePath);
+    static bool doLoadStyle(MStyle* style, const QString& filePath);
 
-    mu::engraving::MStyle m_baseStyle; // builtin initial style
-    mu::engraving::MStyle* m_defaultStyle; // builtin modified by preferences
-    mu::engraving::MStyle* m_defaultStyleForParts = nullptr;
+    MStyle m_baseStyle; // builtin initial style
+    MStyle* m_defaultStyle; // builtin modified by preferences
+    MStyle* m_defaultStyleForParts = nullptr;
 };
 }
 

--- a/src/engraving/style/style.cpp
+++ b/src/engraving/style/style.cpp
@@ -44,7 +44,7 @@ const PropertyValue& MStyle::value(Sid idx) const
         return dummy;
     }
 
-    const mu::engraving::PropertyValue& val = m_values[size_t(idx)];
+    const PropertyValue& val = m_values[size_t(idx)];
     if (val.isValid()) {
         return val;
     }
@@ -151,11 +151,11 @@ bool MStyle::readProperties(XmlReader& e)
                 set(idx, c);
                 e.readElementText();
             } else if (P_TYPE::PLACEMENT_V == type) {
-                set(idx, mu::engraving::PlacementV(e.readElementText().toInt()));
+                set(idx, PlacementV(e.readElementText().toInt()));
             } else if (P_TYPE::PLACEMENT_H == type) {
-                set(idx, mu::engraving::PlacementH(e.readElementText().toInt()));
+                set(idx, PlacementH(e.readElementText().toInt()));
             } else if (P_TYPE::HOOK_TYPE == type) {
-                set(idx, mu::engraving::HookType(e.readElementText().toInt()));
+                set(idx, HookType(e.readElementText().toInt()));
             } else {
                 ASSERT_X("unhandled type " + QString::number(int(type)));
             }

--- a/src/engraving/style/style.h
+++ b/src/engraving/style/style.h
@@ -97,6 +97,6 @@ private:
     std::array<mu::engraving::PropertyValue, size_t(Sid::STYLES)> m_values;
     std::array<Millimetre, size_t(Sid::STYLES)> m_precomputedValues;
 };
-}     // namespace Ms
+} // namespace mu::engraving
 
 #endif // MU_ENGRAVING_STYLE_H

--- a/src/engraving/style/style.h
+++ b/src/engraving/style/style.h
@@ -51,23 +51,23 @@ class MStyle
 public:
     MStyle() = default;
 
-    const mu::engraving::PropertyValue& styleV(Sid idx) const { return value(idx); }
+    const PropertyValue& styleV(Sid idx) const { return value(idx); }
     Spatium styleS(Sid idx) const
     {
-        Q_ASSERT(MStyle::valueType(idx) == mu::engraving::P_TYPE::SPATIUM);
+        Q_ASSERT(MStyle::valueType(idx) == P_TYPE::SPATIUM);
         return value(idx).value<Spatium>();
     }
 
-    Millimetre styleMM(Sid idx) const { Q_ASSERT(MStyle::valueType(idx) == mu::engraving::P_TYPE::SPATIUM); return valueMM(idx); }
-    QString  styleSt(Sid idx) const { Q_ASSERT(MStyle::valueType(idx) == mu::engraving::P_TYPE::STRING); return value(idx).toString(); }
-    bool     styleB(Sid idx) const { Q_ASSERT(MStyle::valueType(idx) == mu::engraving::P_TYPE::BOOL); return value(idx).toBool(); }
-    qreal    styleD(Sid idx) const { Q_ASSERT(MStyle::valueType(idx) == mu::engraving::P_TYPE::REAL); return value(idx).toReal(); }
+    Millimetre styleMM(Sid idx) const { Q_ASSERT(MStyle::valueType(idx) == P_TYPE::SPATIUM); return valueMM(idx); }
+    QString  styleSt(Sid idx) const { Q_ASSERT(MStyle::valueType(idx) == P_TYPE::STRING); return value(idx).toString(); }
+    bool     styleB(Sid idx) const { Q_ASSERT(MStyle::valueType(idx) == P_TYPE::BOOL); return value(idx).toBool(); }
+    qreal    styleD(Sid idx) const { Q_ASSERT(MStyle::valueType(idx) == P_TYPE::REAL); return value(idx).toReal(); }
     int      styleI(Sid idx) const { /* can be int or enum, so no assert */ return value(idx).toInt(); }
 
-    const mu::engraving::PropertyValue& value(Sid idx) const;
+    const PropertyValue& value(Sid idx) const;
     Millimetre valueMM(Sid idx) const;
 
-    void set(Sid idx, const mu::engraving::PropertyValue& v);
+    void set(Sid idx, const PropertyValue& v);
 
     bool isDefault(Sid idx) const;
     void setDefaultStyleVersion(const int defaultsVersion);
@@ -80,21 +80,21 @@ public:
 
     void precomputeValues();
 
-    static mu::engraving::P_TYPE valueType(const Sid);
+    static P_TYPE valueType(const Sid);
     static const char* valueName(const Sid);
     static Sid styleIdx(const QString& name);
 
 private:
 
-    friend class mu::engraving::compat::ReadStyleHook;
+    friend class compat::ReadStyleHook;
 
-    void read(XmlReader& e, mu::engraving::compat::ReadChordListHook* readChordListHook);
+    void read(XmlReader& e, compat::ReadChordListHook* readChordListHook);
 
     bool readProperties(XmlReader&);
     bool readStyleValCompat(XmlReader&);
     bool readTextStyleValCompat(XmlReader&);
 
-    std::array<mu::engraving::PropertyValue, size_t(Sid::STYLES)> m_values;
+    std::array<PropertyValue, size_t(Sid::STYLES)> m_values;
     std::array<Millimetre, size_t(Sid::STYLES)> m_precomputedValues;
 };
 } // namespace mu::engraving

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -1456,5 +1456,5 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::tupletMinDistance,             "tupletMinDistance",             Spatium(0.5) },
 
     { Sid::autoplaceEnabled,              "autoplaceEnabled",              true },
-    { Sid::defaultsVersion,               "defaultsVersion",               mu::engraving::MSCVERSION }
+    { Sid::defaultsVersion,               "defaultsVersion",               MSCVERSION }
 } };

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -1506,14 +1506,14 @@ private:
     struct StyleValue {
         Sid _idx;
         mu::AsciiString _name;         // xml name for read()/write()
-        mu::engraving::PropertyValue _defaultValue;
+        PropertyValue _defaultValue;
 
     public:
         Sid  styleIdx() const { return _idx; }
         int idx() const { return int(_idx); }
         const mu::AsciiString& name() const { return _name; }
-        mu::engraving::P_TYPE valueType() const { return _defaultValue.type(); }
-        const mu::engraving::PropertyValue& defaultValue() const { return _defaultValue; }
+        P_TYPE valueType() const { return _defaultValue.type(); }
+        const PropertyValue& defaultValue() const { return _defaultValue; }
     };
 
     static const std::array<StyleValue, size_t(Sid::STYLES)> styleValues;

--- a/src/engraving/types/bps.h
+++ b/src/engraving/types/bps.h
@@ -63,10 +63,4 @@ struct BeatsPerSecond // beats per second
 };
 }
 
-//! NOTE compat
-namespace mu::engraving {
-using BeatsPerMinute = mu::engraving::BeatsPerMinute;
-using BeatsPerSecond = mu::engraving::BeatsPerSecond;
-}
-
 #endif // MU_ENGRAVING_BPS_H

--- a/src/engraving/types/constants.h
+++ b/src/engraving/types/constants.h
@@ -33,9 +33,4 @@ struct Constants
 };
 }
 
-//! NOTE compat
-namespace mu::engraving {
-using Constant = mu::engraving::Constants;
-}
-
 #endif // MU_ENGRAVING_CONSTANTS_H

--- a/src/engraving/types/dimension.h
+++ b/src/engraving/types/dimension.h
@@ -262,10 +262,4 @@ inline Spatium operator*(qreal a, const Spatium& b)
 }
 }
 
-//! NOTE compat
-namespace mu::engraving {
-using Spatium = mu::engraving::Spatium;
-using Millimetre = mu::engraving::Millimetre;
-}
-
 #endif //MU_ENGRAVING_DIMENSION_H

--- a/src/engraving/types/fraction.h
+++ b/src/engraving/types/fraction.h
@@ -233,9 +233,9 @@ public:
             return -1;
         }
 
-        // Constant::division     - ticks per quarter note
-        // Constant::division * 4 - ticks per whole note
-        // result: rounded (Constant::division * 4 * m_numerator * 1.0 / m_denominator) value
+        // Constants::division     - ticks per quarter note
+        // Constants::division * 4 - ticks per whole note
+        // result: rounded (Constants::division * 4 * m_numerator * 1.0 / m_denominator) value
         const int sgn = (m_numerator < 0) ? -1 : 1;
         const auto result = sgn * (static_cast<int_least64_t>(sgn * m_numerator) * Constants::division * 4 + (m_denominator / 2))
                             / m_denominator;
@@ -263,11 +263,6 @@ public:
 
 inline Fraction operator*(const Fraction& f, int v) { return Fraction(f) *= v; }
 inline Fraction operator*(int v, const Fraction& f) { return Fraction(f) *= v; }
-}
-
-//! NOTE compat
-namespace mu::engraving {
-using Fraction = mu::engraving::Fraction;
 }
 
 #endif // MU_ENGRAVING_FRACTION_H

--- a/src/engraving/types/groupnode.h
+++ b/src/engraving/types/groupnode.h
@@ -39,10 +39,4 @@ struct GroupNode {
 using GroupNodes = std::vector<GroupNode>;
 }
 
-//! NOTE compat
-namespace mu::engraving {
-using GroupNode = mu::engraving::GroupNode;
-using GroupNodes = mu::engraving::GroupNodes;
-}
-
 #endif // MU_ENGRAVING_GROUPNODE_H

--- a/src/engraving/types/pitchvalue.h
+++ b/src/engraving/types/pitchvalue.h
@@ -102,10 +102,4 @@ inline PitchValues pitchValuesFromQVariant(const QVariant& var)
 #endif
 }
 
-//! NOTE compat
-namespace mu::engraving {
-using PitchValue = mu::engraving::PitchValue;
-using PitchValues = mu::engraving::PitchValues;
-}
-
 #endif // MU_ENGRAVING_PITCHVALUE_H

--- a/src/engraving/types/symid.h
+++ b/src/engraving/types/symid.h
@@ -39,11 +39,4 @@ enum class SmuflAnchorId {
 #include "symid_p.h"
 }
 
-//! NOTE compat
-namespace mu::engraving {
-using SymId = mu::engraving::SymId;
-using SymIdList = mu::engraving::SymIdList;
-using SmuflAnchorId = mu::engraving::SmuflAnchorId;
-}
-
 #endif // MU_ENGRAVING_SYMID_H

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -532,7 +532,7 @@ enum class PlayingTechniqueType {
     Overdrive
 };
 
-enum class TempoTechniqueType {
+enum class TempoChangeType {
     Undefined = -1,
     Accelerando,
     Allargando,
@@ -639,53 +639,5 @@ struct std::hash<mu::engraving::InstrumentTrackId>
         return h1 ^ (h2 << 1);
     }
 };
-
-//! NOTE compat
-namespace mu::engraving {
-using OrnamentStyle = mu::engraving::OrnamentStyle;
-using AlignV = mu::engraving::AlignV;
-using AlignH = mu::engraving::AlignH;
-using Align = mu::engraving::Align;
-using PlacementV = mu::engraving::PlacementV;
-using PlacementH = mu::engraving::PlacementH;
-using DirectionV = mu::engraving::DirectionV;
-using DirectionH = mu::engraving::DirectionH;
-using Orientation = mu::engraving::Orientation;
-using LayoutBreakType = mu::engraving::LayoutBreakType;
-using VeloType = mu::engraving::VeloType;
-using BeamMode = mu::engraving::BeamMode;
-using TextPlace = mu::engraving::TextPlace;
-using GlissandoStyle = mu::engraving::GlissandoStyle;
-using BarLineType = mu::engraving::BarLineType;
-using NoteHeadType = mu::engraving::NoteHeadType;
-using NoteHeadScheme = mu::engraving::NoteHeadScheme;
-using NoteHeadGroup = mu::engraving::NoteHeadGroup;
-using ClefType = mu::engraving::ClefType;
-using DynamicType = mu::engraving::DynamicType;
-using DynamicRange = mu::engraving::DynamicRange;
-using DynamicSpeed = mu::engraving::DynamicSpeed;
-using HookType = mu::engraving::HookType;
-using KeyMode = mu::engraving::KeyMode;
-using TextStyleType = mu::engraving::TextStyleType;
-using ChangeMethod = mu::engraving::ChangeMethod;
-using ChangeDirection = mu::engraving::ChangeDirection;
-using AccidentalRole = mu::engraving::AccidentalRole;
-using DurationType = mu::engraving::DurationType;
-using DurationTypeWithDots = mu::engraving::DurationTypeWithDots;
-using PlayingTechniqueType = mu::engraving::PlayingTechniqueType;
-using TempoChangeType = mu::engraving::TempoTechniqueType;
-using InstrumentTrackId = mu::engraving::InstrumentTrackId;
-using InstrumentTrackIdSet = mu::engraving::InstrumentTrackIdSet;
-using FermataType = mu::engraving::FermataType;
-using ChordLineType = mu::engraving::ChordLineType;
-using SlurStyleType = mu::engraving::SlurStyleType;
-using staff_idx_t = mu::engraving::staff_idx_t;
-using track_idx_t = mu::engraving::track_idx_t;
-using TracksMap = mu::engraving::TracksMap;
-using voice_idx_t = mu::engraving::voice_idx_t;
-using system_idx_t = mu::engraving::system_idx_t;
-using part_idx_t = mu::engraving::part_idx_t;
-using page_idx_t = mu::engraving::page_idx_t;
-}
 
 #endif // MU_ENGRAVING_TYPES_H

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -1043,29 +1043,29 @@ PlayingTechniqueType TConv::fromXml(const AsciiString& tag, PlayingTechniqueType
     return findTypeByXmlTag<PlayingTechniqueType>(PLAY_TECH_TYPES, tag, def);
 }
 
-static const std::vector<Item<TempoTechniqueType> > TEMPO_CHANGE_TYPES = {
-    { TempoTechniqueType::Undefined, "undefined" },
-    { TempoTechniqueType::Accelerando, "accelerando" },
-    { TempoTechniqueType::Allargando, "allargando" },
-    { TempoTechniqueType::Calando, "calando" },
-    { TempoTechniqueType::Lentando, "lentando" },
-    { TempoTechniqueType::Morendo, "morendo" },
-    { TempoTechniqueType::Precipitando, "precipitando" },
-    { TempoTechniqueType::Rallentando, "rallentando" },
-    { TempoTechniqueType::Ritardando, "ritardando" },
-    { TempoTechniqueType::Smorzando, "smorzando" },
-    { TempoTechniqueType::Sostenuto, "sostenuto" },
-    { TempoTechniqueType::Stringendo, "stringendo" }
+static const std::vector<Item<TempoChangeType> > TEMPO_CHANGE_TYPES = {
+    { TempoChangeType::Undefined, "undefined" },
+    { TempoChangeType::Accelerando, "accelerando" },
+    { TempoChangeType::Allargando, "allargando" },
+    { TempoChangeType::Calando, "calando" },
+    { TempoChangeType::Lentando, "lentando" },
+    { TempoChangeType::Morendo, "morendo" },
+    { TempoChangeType::Precipitando, "precipitando" },
+    { TempoChangeType::Rallentando, "rallentando" },
+    { TempoChangeType::Ritardando, "ritardando" },
+    { TempoChangeType::Smorzando, "smorzando" },
+    { TempoChangeType::Sostenuto, "sostenuto" },
+    { TempoChangeType::Stringendo, "stringendo" }
 };
 
-QString TConv::toXml(TempoTechniqueType v)
+QString TConv::toXml(TempoChangeType v)
 {
-    return findXmlTagByType<TempoTechniqueType>(TEMPO_CHANGE_TYPES, v);
+    return findXmlTagByType<TempoChangeType>(TEMPO_CHANGE_TYPES, v);
 }
 
-TempoTechniqueType TConv::fromXml(const AsciiString& tag, TempoTechniqueType def)
+TempoChangeType TConv::fromXml(const AsciiString& tag, TempoChangeType def)
 {
-    return findTypeByXmlTag<TempoTechniqueType>(TEMPO_CHANGE_TYPES, tag, def);
+    return findTypeByXmlTag<TempoChangeType>(TEMPO_CHANGE_TYPES, tag, def);
 }
 
 static const std::vector<Item<OrnamentStyle> > ORNAMENTSTYLE_TYPES = {

--- a/src/engraving/types/typesconv.h
+++ b/src/engraving/types/typesconv.h
@@ -64,7 +64,7 @@ public:
     static ClefType fromXml(const AsciiString& tag, ClefType def);
 
     static QString toUserName(DynamicType v);
-    static mu::engraving::SymId symId(DynamicType v);
+    static SymId symId(DynamicType v);
     static DynamicType dynamicType(SymId v);
     static DynamicType dynamicType(const AsciiString& string);
     static QString toXml(DynamicType v);
@@ -111,8 +111,8 @@ public:
     static QString toXml(PlayingTechniqueType v);
     static PlayingTechniqueType fromXml(const AsciiString& tag, PlayingTechniqueType def);
 
-    static QString toXml(TempoTechniqueType v);
-    static TempoTechniqueType fromXml(const AsciiString& tag, TempoTechniqueType def);
+    static QString toXml(TempoChangeType v);
+    static TempoChangeType fromXml(const AsciiString& tag, TempoChangeType def);
 
     static QString toXml(OrnamentStyle v);
     static OrnamentStyle fromXml(const AsciiString& str, OrnamentStyle def);

--- a/src/engraving/utests/copypaste_tests.cpp
+++ b/src/engraving/utests/copypaste_tests.cpp
@@ -201,7 +201,7 @@ void CopyPasteTests::copypastevoice(const char* idx, int voice)
     // create a range selection on 2 and 3 beat of first measure
     SegmentType segTypeCR = SegmentType::ChordRest;
     Segment* s = m1->first(segTypeCR)->next1(segTypeCR);
-    score->select(static_cast<mu::engraving::Chord*>(s->element(voice))->notes().at(0));
+    score->select(toChord(s->element(voice))->notes().at(0));
     s = s->next(SegmentType::ChordRest);
     score->select(s->element(voice), SelectType::RANGE);
 
@@ -237,7 +237,7 @@ TEST_F(CopyPasteTests, copypaste2Voice)
 
     // select 2 chord rests at the start of the first measure
     Segment* s = m1->first(SegmentType::ChordRest);
-    score->select(static_cast<mu::engraving::Chord*>(s->element(0))->notes().at(0));
+    score->select(toChord(s->element(0))->notes().at(0));
     s = s->next(SegmentType::ChordRest);
     score->select(s->element(0), SelectType::RANGE);
 
@@ -272,7 +272,7 @@ TEST_F(CopyPasteTests, copypaste2Voice5)
     // create a range selection from 2 eighth note to the end of first measure
     SegmentType segTypeCR = SegmentType::ChordRest;
     Segment* s = m1->first(segTypeCR)->next1(segTypeCR);
-    score->select(static_cast<mu::engraving::Chord*>(s->element(0))->notes().at(0));
+    score->select(toChord(s->element(0))->notes().at(0));
 
     s = m1->last()->prev(SegmentType::ChordRest);
     score->select(s->element(0), SelectType::RANGE);
@@ -312,7 +312,7 @@ TEST_F(CopyPasteTests, copypaste2Voice6)
     // create a range selection from 2nd eighth note to the end of first measure
     SegmentType segTypeCR = SegmentType::ChordRest;
     Segment* s = m1->first(segTypeCR)->next1(segTypeCR);
-    score->select(static_cast<mu::engraving::Chord*>(s->element(0))->notes().at(0));
+    score->select(toChord(s->element(0))->notes().at(0));
 
     s = m1->last()->prev(SegmentType::ChordRest);
     score->select(s->element(1), SelectType::RANGE);
@@ -592,7 +592,7 @@ TEST_F(CopyPasteTests, DISABLED_copypastetremolo)
     // create a range selection on 2nd to 3rd beat (voice 1) of first measure
     SegmentType segTypeCR = SegmentType::ChordRest;
     Segment* s = m1->first(segTypeCR)->next1(segTypeCR);
-    score->select(static_cast<mu::engraving::Chord*>(s->element(1))->notes().at(0));
+    score->select(toChord(s->element(1))->notes().at(0));
     s = s->next1(segTypeCR);
     score->select(s->element(1), SelectType::RANGE);
 
@@ -612,7 +612,7 @@ TEST_F(CopyPasteTests, DISABLED_copypastetremolo)
 
     // create a range selection on 2nd to 4th beat (voice 0) of first measure
     s = m1->first(segTypeCR)->next1(segTypeCR);
-    score->select(static_cast<mu::engraving::Chord*>(s->element(0))->notes().at(0));
+    score->select(toChord(s->element(0))->notes().at(0));
     s = s->next1(segTypeCR)->next1(segTypeCR);
     score->select(s->element(0), SelectType::RANGE);
 

--- a/src/engraving/utests/durationtype_tests.cpp
+++ b/src/engraving/utests/durationtype_tests.cpp
@@ -67,7 +67,7 @@ TEST_F(DurationTypeTests, halfDuration)
 
     score->startCmd();
     score->cmdAddPitch(42, false, false);
-    mu::engraving::Chord* c = score->firstMeasure()->findChord(Fraction(0, 1), 0);
+    Chord* c = score->firstMeasure()->findChord(Fraction(0, 1), 0);
     EXPECT_EQ(c->ticks(), Fraction(1, 1));
     score->endCmd();
 
@@ -76,7 +76,7 @@ TEST_F(DurationTypeTests, halfDuration)
         score->startCmd();
         score->cmdHalfDuration();
         score->endCmd();
-        mu::engraving::Chord* c2 = score->firstMeasure()->findChord(Fraction(0, 1), 0);
+        Chord* c2 = score->firstMeasure()->findChord(Fraction(0, 1), 0);
         EXPECT_EQ(c2->ticks(), Fraction(i / 2, 128));
     }
 }
@@ -103,7 +103,7 @@ TEST_F(DurationTypeTests, doubleDuration)
     // repeatedly double-duration from V_128 to V_WHOLE
     for (int i = 1; i < 128; i *= 2) {
         score->cmdDoubleDuration();
-        mu::engraving::Chord* c = score->firstMeasure()->findChord(Fraction(0, 1), 0);
+        Chord* c = score->firstMeasure()->findChord(Fraction(0, 1), 0);
         EXPECT_EQ(c->ticks(), Fraction(2 * i, 128));
     }
     score->endCmd();
@@ -126,13 +126,13 @@ TEST_F(DurationTypeTests, decDurationDotted)
 
     score->startCmd();
     score->cmdAddPitch(42, false, false);
-    mu::engraving::Chord* c = score->firstMeasure()->findChord(Fraction(0, 1), 0);
+    Chord* c = score->firstMeasure()->findChord(Fraction(0, 1), 0);
     EXPECT_EQ(c->ticks(), Fraction(1, 1));
 
     // repeatedly dec-duration-dotted from V_WHOLE to V_128
     for (int i = 128; i > 1; i /= 2) {
         score->cmdDecDurationDotted();
-        mu::engraving::Chord* c2 = score->firstMeasure()->findChord(Fraction(0, 1), 0);
+        Chord* c2 = score->firstMeasure()->findChord(Fraction(0, 1), 0);
         EXPECT_EQ(c2->ticks(), Fraction(i + i / 2, 256));
 
         score->cmdDecDurationDotted();

--- a/src/engraving/utests/earlymusic_tests.cpp
+++ b/src/engraving/utests/earlymusic_tests.cpp
@@ -54,7 +54,7 @@ TEST_F(EarlymusicTests, earlymusic01)
     EXPECT_TRUE(msr);
     Segment* seg   = msr->findSegment(SegmentType::ChordRest, Fraction(0, 1));
     EXPECT_TRUE(seg);
-    mu::engraving::Chord* chord = static_cast<mu::engraving::Chord*>(seg->element(0));
+    Chord* chord = toChord(seg->element(0));
     EXPECT_TRUE(chord);
     EXPECT_EQ(chord->type(), ElementType::CHORD);
     EXPECT_EQ(chord->crossMeasure(), CrossMeasure::UNKNOWN);

--- a/src/engraving/utests/exchangevoices_tests.cpp
+++ b/src/engraving/utests/exchangevoices_tests.cpp
@@ -96,7 +96,7 @@ TEST_F(ExchangevoicesTests, undoChangeVoice)
     for (Segment* s = score->firstSegment(SegmentType::ChordRest); s; s = s->next1()) {
         ChordRest* cr = static_cast<ChordRest*>(s->element(0));
         if (cr && cr->type() == ElementType::CHORD) {
-            mu::engraving::Chord* c = static_cast<mu::engraving::Chord*>(cr);
+            Chord* c = toChord(cr);
             score->select(c->downNote(), SelectType::ADD);
         }
     }

--- a/src/engraving/utests/join_tests.cpp
+++ b/src/engraving/utests/join_tests.cpp
@@ -84,7 +84,7 @@ void JoinTests::join1(const char* p1)
     Segment* s = score->firstSegment(SegmentType::ChordRest);
 
     for (int i = 0; i < 8; ++i) {
-        Note* note = static_cast<mu::engraving::Chord*>(s->element(0))->upNote();
+        Note* note = toChord(s->element(0))->upNote();
         EXPECT_EQ(note->line(), 6);
         s = s->next1(SegmentType::ChordRest);
     }

--- a/src/engraving/utests/note_tests.cpp
+++ b/src/engraving/utests/note_tests.cpp
@@ -57,70 +57,70 @@ class NoteTests : public ::testing::Test
 TEST_F(NoteTests, note)
 {
     MasterScore* score = compat::ScoreAccess::createMasterScore();
-    mu::engraving::Chord* chord = Factory::createChord(score->dummy()->segment());
+    Chord* chord = Factory::createChord(score->dummy()->segment());
     Note* note = Factory::createNote(chord);
     chord->add(note);
 
     // pitch
     note->setPitch(33);
     note->setTpcFromPitch();
-    Note* n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    Note* n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->pitch(), 33);
     delete n;
 
     // tpc
     note->setTpc1(22);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->tpc1(), 22);
     delete n;
 
     note->setTpc1(23);
     note->setTpc2(23);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->tpc2(), 23);
     delete n;
 
     // small
     note->setSmall(true);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_TRUE(n->isSmall());
     delete n;
 
     // mirror
     note->setUserMirror(DirectionH::LEFT);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->userMirror(), DirectionH::LEFT);
     delete n;
 
     note->setUserMirror(DirectionH::RIGHT);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->userMirror(), DirectionH::RIGHT);
     delete n;
 
     note->setUserMirror(DirectionH::AUTO);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->userMirror(), DirectionH::AUTO);
     delete n;
 
     // dot position
     note->setUserDotPosition(DirectionV::UP);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(int(n->userDotPosition()), int(DirectionV::UP));
     delete n;
 
     note->setUserDotPosition(DirectionV::DOWN);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(int(n->userDotPosition()), int(DirectionV::DOWN));
     delete n;
 
     note->setUserDotPosition(DirectionV::AUTO);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(int(n->userDotPosition()), int(DirectionV::AUTO));
     delete n;
     // headGroup
     for (int i = 0; i < int(NoteHeadGroup::HEAD_GROUPS); ++i) {
         note->setHeadGroup(NoteHeadGroup(i));
-        n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+        n = toNote(ScoreRW::writeReadElement(note));
         EXPECT_EQ(int(n->headGroup()), i);
         delete n;
     }
@@ -128,49 +128,49 @@ TEST_F(NoteTests, note)
     // headType
     for (int i = 0; i < int(NoteHeadType::HEAD_TYPES); ++i) {
         note->setHeadType(NoteHeadType(i));
-        n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+        n = toNote(ScoreRW::writeReadElement(note));
         EXPECT_EQ(int(n->headType()), i);
         delete n;
     }
 
     // velo offset
     note->setVeloOffset(71);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->veloOffset(), 71);
     delete n;
 
     // tuning
     note->setTuning(1.3);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->tuning(), 1.3);
     delete n;
 
     // fret
     note->setFret(9);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->fret(), 9);
     delete n;
 
     // string
     note->setString(3);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->string(), 3);
     delete n;
 
     // ghost
     note->setGhost(true);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_TRUE(n->ghost());
     delete n;
 
     // velo type
     note->setVeloType(VeloType::USER_VAL);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->veloType(), VeloType::USER_VAL);
     delete n;
 
     note->setVeloType(VeloType::OFFSET_VAL);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->veloType(), VeloType::OFFSET_VAL);
     delete n;
 
@@ -180,69 +180,69 @@ TEST_F(NoteTests, note)
 
     // pitch
     note->setProperty(Pid::PITCH, 32);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->pitch(), 32);
     delete n;
 
     // tpc
     note->setProperty(Pid::TPC1, 21);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->tpc1(), 21);
     delete n;
 
     note->setProperty(Pid::TPC1, 22);
     note->setProperty(Pid::TPC2, 22);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->tpc2(), 22);
     delete n;
 
     // small
     note->setProperty(Pid::SMALL, false);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_TRUE(!n->isSmall());
     delete n;
 
     note->setProperty(Pid::SMALL, true);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_TRUE(n->isSmall());
     delete n;
 
     // mirror
     note->setProperty(Pid::MIRROR_HEAD, int(DirectionH::LEFT));
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->userMirror(), DirectionH::LEFT);
     delete n;
 
     note->setProperty(Pid::MIRROR_HEAD, int(DirectionH::RIGHT));
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->userMirror(), DirectionH::RIGHT);
     delete n;
 
     note->setProperty(Pid::MIRROR_HEAD, int(DirectionH::AUTO));
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->userMirror(), DirectionH::AUTO);
     delete n;
 
     // dot position
     note->setProperty(Pid::DOT_POSITION, PropertyValue::fromValue(DirectionV(DirectionV::UP)));
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(int(n->userDotPosition()), int(DirectionV::UP));
     delete n;
 
     note->setProperty(Pid::DOT_POSITION, PropertyValue::fromValue(DirectionV(DirectionV::DOWN)));
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(int(n->userDotPosition()), int(DirectionV::DOWN));
     delete n;
 
     note->setProperty(Pid::DOT_POSITION, PropertyValue::fromValue(DirectionV(DirectionV::AUTO)));
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(int(n->userDotPosition()), int(DirectionV::AUTO));
     delete n;
 
     // headGroup
     for (int i = 0; i < int(NoteHeadGroup::HEAD_GROUPS); ++i) {
         note->setProperty(Pid::HEAD_GROUP, i);
-        n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+        n = toNote(ScoreRW::writeReadElement(note));
         EXPECT_EQ(int(n->headGroup()), i);
         delete n;
     }
@@ -250,54 +250,54 @@ TEST_F(NoteTests, note)
     // headType
     for (int i = 0; i < int(NoteHeadType::HEAD_TYPES); ++i) {
         note->setProperty(Pid::HEAD_TYPE, i);
-        n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+        n = toNote(ScoreRW::writeReadElement(note));
         EXPECT_EQ(int(n->headType()), i);
         delete n;
     }
 
     // velo offset
     note->setProperty(Pid::VELO_OFFSET, 38);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->veloOffset(), 38);
     delete n;
 
     // tuning
     note->setProperty(Pid::TUNING, 2.4);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->tuning(), 2.4);
     delete n;
 
     // fret
     note->setProperty(Pid::FRET, 7);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->fret(), 7);
     delete n;
 
     // string
     note->setProperty(Pid::STRING, 4);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->string(), 4);
     delete n;
 
     // ghost
     note->setProperty(Pid::GHOST, false);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_TRUE(!n->ghost());
     delete n;
 
     note->setProperty(Pid::GHOST, true);
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_TRUE(n->ghost());
     delete n;
 
     // velo type
     note->setProperty(Pid::VELO_TYPE, int(VeloType::USER_VAL));
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->veloType(), VeloType::USER_VAL);
     delete n;
 
     note->setProperty(Pid::VELO_TYPE, int(VeloType::OFFSET_VAL));
-    n = static_cast<Note*>(ScoreRW::writeReadElement(note));
+    n = toNote(ScoreRW::writeReadElement(note));
     EXPECT_EQ(n->veloType(), VeloType::OFFSET_VAL);
     delete n;
 
@@ -315,21 +315,21 @@ TEST_F(NoteTests, grace)
 {
     MasterScore* score = ScoreRW::readScore(NOTE_DATA_DIR + "grace.mscx");
     score->doLayout();
-    mu::engraving::Chord* chord = score->firstMeasure()->findChord(Fraction(0, 1), 0);
+    Chord* chord = score->firstMeasure()->findChord(Fraction(0, 1), 0);
     Note* note = chord->upNote();
 
     // create
     score->setGraceNote(chord, note->pitch(), NoteType::APPOGGIATURA, Constants::division / 2);
-    mu::engraving::Chord* gc = chord->graceNotes().front();
+    Chord* gc = chord->graceNotes().front();
     Note* gn = gc->notes().front();
-//      Note* n = static_cast<Note*>(ScoreRW::writeReadElement(gn));
+//      Note* n = toNote(ScoreRW::writeReadElement(gn));
 //      QCOMPARE(n->noteType(), NoteType::APPOGGIATURA);
 //      delete n;
 
     // tie
     score->select(gn);
     score->cmdAddTie();
-//      n = static_cast<Note*>(ScoreRW::writeReadElement(gn));
+//      n = toNote(ScoreRW::writeReadElement(gn));
 //      QVERIFY(n->tieFor() != 0);
 //      delete n;
 
@@ -341,7 +341,7 @@ TEST_F(NoteTests, grace)
     tr->setTrack(gc->track());
     score->undoAddElement(tr);
     score->endCmd();
-//      mu::engraving::Chord* c = static_cast<mu::engraving::Chord*>(ScoreRW::writeReadElement(gc));
+//      Chord* c = static_cast<Chord*>(ScoreRW::writeReadElement(gc));
 //      QVERIFY(c->tremolo() != 0);
 //      delete c;
 
@@ -353,7 +353,7 @@ TEST_F(NoteTests, grace)
     ar->setTrack(gc->track());
     score->undoAddElement(ar);
     score->endCmd();
-//      c = static_cast<mu::engraving::Chord*>(ScoreRW::writeReadElement(gc));
+//      c = static_cast<Chord*>(ScoreRW::writeReadElement(gc));
 //      QVERIFY(c->articulations().size() == 1);
 //      delete c;
 
@@ -501,11 +501,11 @@ TEST_F(NoteTests, alteredUnison)
     MasterScore* score = ScoreRW::readScore(NOTE_DATA_DIR + "altered-unison.mscx");
     Measure* m = score->firstMeasure();
     Chord* c = m->findChord(Fraction(0, 1), 0);
-    EXPECT_TRUE(c->downNote()->accidental() && c->downNote()->accidental()->accidentalType() == mu::engraving::AccidentalType::FLAT);
-    EXPECT_TRUE(c->upNote()->accidental() && c->upNote()->accidental()->accidentalType() == mu::engraving::AccidentalType::NATURAL);
+    EXPECT_TRUE(c->downNote()->accidental() && c->downNote()->accidental()->accidentalType() == AccidentalType::FLAT);
+    EXPECT_TRUE(c->upNote()->accidental() && c->upNote()->accidental()->accidentalType() == AccidentalType::NATURAL);
     c = m->findChord(Fraction(1, 4), 0);
-    EXPECT_TRUE(c->downNote()->accidental() && c->downNote()->accidental()->accidentalType() == mu::engraving::AccidentalType::NATURAL);
-    EXPECT_TRUE(c->upNote()->accidental() && c->upNote()->accidental()->accidentalType() == mu::engraving::AccidentalType::SHARP);
+    EXPECT_TRUE(c->downNote()->accidental() && c->downNote()->accidental()->accidentalType() == AccidentalType::NATURAL);
+    EXPECT_TRUE(c->upNote()->accidental() && c->upNote()->accidental()->accidentalType() == AccidentalType::SHARP);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/utests/playbackeventsrendering_tests.cpp
+++ b/src/engraving/utests/playbackeventsrendering_tests.cpp
@@ -69,15 +69,15 @@ protected:
 TEST_F(PlaybackEventsRendererTests, SingleNote_TenutoAccent)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "single_note_tenuto_accent/tenuto_accent.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "single_note_tenuto_accent/tenuto_accent.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Fulfill articulations profile with dummy patterns
@@ -116,15 +116,15 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_TenutoAccent)
 TEST_F(PlaybackEventsRendererTests, SingleNote_NoArticulations)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "single_note_no_articulations/no_articulations.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "single_note_no_articulations/no_articulations.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Fulfill articulations profile with dummy patterns
@@ -161,15 +161,15 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_NoArticulations)
 TEST_F(PlaybackEventsRendererTests, Rest)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "whole_measure_rest/whole_measure_rest.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "whole_measure_rest/whole_measure_rest.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* rest = firstSegment->nextChordRest(0);
+    ChordRest* rest = firstSegment->nextChordRest(0);
     ASSERT_TRUE(rest);
 
     // [WHEN] Request to render the rest
@@ -195,16 +195,16 @@ TEST_F(PlaybackEventsRendererTests, Rest)
 TEST_F(PlaybackEventsRendererTests, SingleNote_Trill_Modern)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         PLAYBACK_EVENTS_RENDERING_DIR + "single_note_trill_default_tempo/single_note_trill_default_tempo.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected trill disclosure
@@ -253,16 +253,16 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_Trill_Modern)
 TEST_F(PlaybackEventsRendererTests, SingleNote_Unexpandable_Trill)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         PLAYBACK_EVENTS_RENDERING_DIR + "single_note_unexpandable_trill/single_note_unexpandable_trill.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected trill disclosure
@@ -289,16 +289,16 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_Unexpandable_Trill)
 TEST_F(PlaybackEventsRendererTests, SingleNote_Trill_Baroque)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         PLAYBACK_EVENTS_RENDERING_DIR + "single_note_trill_baroque/single_note_trill_baroque.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected trill disclosure
@@ -356,16 +356,16 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_Trill_Baroque)
 TEST_F(PlaybackEventsRendererTests, SingleNote_Turn_Regular)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         PLAYBACK_EVENTS_RENDERING_DIR + "single_note_regular_turn/single_note_regular_turn.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected disclosure
@@ -416,16 +416,16 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_Turn_Regular)
 TEST_F(PlaybackEventsRendererTests, SingleNote_Turn_Inverted)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         PLAYBACK_EVENTS_RENDERING_DIR + "single_note_inverted_turn/single_note_inverted_turn.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected disclosure
@@ -477,16 +477,16 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_Turn_Inverted)
 TEST_F(PlaybackEventsRendererTests, SingleNote_Turn_Inverted_Slash_Variation)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         PLAYBACK_EVENTS_RENDERING_DIR + "single_note_inverted_turn_slash_variation/single_note_inverted_turn_slash_variation.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected disclosure
@@ -537,16 +537,16 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_Turn_Inverted_Slash_Variation)
 TEST_F(PlaybackEventsRendererTests, SingleNote_Upper_Mordent)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         PLAYBACK_EVENTS_RENDERING_DIR + "single_note_upper_mordent/single_note_upper_mordent.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected disclosure
@@ -610,16 +610,16 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_Upper_Mordent)
 TEST_F(PlaybackEventsRendererTests, SingleNote_Lower_Mordent)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         PLAYBACK_EVENTS_RENDERING_DIR + "single_note_lower_mordent/single_note_lower_mordent.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected disclosure
@@ -683,16 +683,16 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_Lower_Mordent)
 TEST_F(PlaybackEventsRendererTests, TwoNotes_Discrete_Glissando)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         PLAYBACK_EVENTS_RENDERING_DIR + "two_notes_discrete_glissando/two_notes_discrete_glissando.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected glissando disclosure
@@ -744,16 +744,16 @@ TEST_F(PlaybackEventsRendererTests, TwoNotes_Discrete_Glissando)
 TEST_F(PlaybackEventsRendererTests, TwoNotes_Continuous_Glissando)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score
+    Score* score
         = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "two_notes_continuous_glissando/two_notes_continuous_glissando.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected glissando disclosure
@@ -806,16 +806,16 @@ TEST_F(PlaybackEventsRendererTests, TwoNotes_Continuous_Glissando)
 TEST_F(PlaybackEventsRendererTests, TwoNotes_Glissando_NoPlay)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         PLAYBACK_EVENTS_RENDERING_DIR + "two_notes_continuous_glissando_no_play/two_notes_continuous_glissando_no_play.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected glissando disclosure
@@ -867,16 +867,16 @@ TEST_F(PlaybackEventsRendererTests, TwoNotes_Glissando_NoPlay)
 TEST_F(PlaybackEventsRendererTests, SingleNote_Acciaccatura)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         PLAYBACK_EVENTS_RENDERING_DIR + "single_note_acciaccatura/single_note_acciaccatura.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected disclosure
@@ -934,16 +934,16 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_Acciaccatura)
 TEST_F(PlaybackEventsRendererTests, SingleNote_MultiAcciaccatura)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         PLAYBACK_EVENTS_RENDERING_DIR + "single_note_multi_acciaccatura/single_note_multi_acciaccatura.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected disclosure
@@ -1004,16 +1004,16 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_MultiAcciaccatura)
 TEST_F(PlaybackEventsRendererTests, SingleNote_Appoggiatura_Post)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score
+    Score* score
         = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "single_note_appoggiatura_post/single_note_appoggiatura_post.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected disclosure
@@ -1071,16 +1071,16 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_Appoggiatura_Post)
 TEST_F(PlaybackEventsRendererTests, SingleNote_MultiAppoggiatura_Post)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         PLAYBACK_EVENTS_RENDERING_DIR + "single_note_multi_appoggiatura_post/single_note_multi_appoggiatura_post.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected disclosure
@@ -1141,15 +1141,15 @@ TEST_F(PlaybackEventsRendererTests, SingleNote_MultiAppoggiatura_Post)
 TEST_F(PlaybackEventsRendererTests, Chord_Arpeggio)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "chord_arpeggio/chord_arpeggio.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "chord_arpeggio/chord_arpeggio.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected disclosure
@@ -1203,15 +1203,15 @@ TEST_F(PlaybackEventsRendererTests, Chord_Arpeggio)
 TEST_F(PlaybackEventsRendererTests, Chord_Arpeggio_Up)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "chord_arpeggio_up/chord_arpeggio_up.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "chord_arpeggio_up/chord_arpeggio_up.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected disclosure
@@ -1265,15 +1265,15 @@ TEST_F(PlaybackEventsRendererTests, Chord_Arpeggio_Up)
 TEST_F(PlaybackEventsRendererTests, Chord_Arpeggio_Down)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "chord_arpeggio_down/chord_arpeggio_down.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "chord_arpeggio_down/chord_arpeggio_down.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected disclosure
@@ -1327,16 +1327,16 @@ TEST_F(PlaybackEventsRendererTests, Chord_Arpeggio_Down)
 TEST_F(PlaybackEventsRendererTests, Chord_Arpeggio_Straight_Down)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         PLAYBACK_EVENTS_RENDERING_DIR + "chord_arpeggio_straight_down/chord_arpeggio_straight_down.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected disclosure
@@ -1390,16 +1390,16 @@ TEST_F(PlaybackEventsRendererTests, Chord_Arpeggio_Straight_Down)
 TEST_F(PlaybackEventsRendererTests, Chord_Arpeggio_Straight_Up)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         PLAYBACK_EVENTS_RENDERING_DIR + "chord_arpeggio_straight_up/chord_arpeggio_straight_up.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected disclosure
@@ -1454,15 +1454,15 @@ TEST_F(PlaybackEventsRendererTests, Chord_Arpeggio_Straight_Up)
 TEST_F(PlaybackEventsRendererTests, Chord_Arpeggio_Bracket)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "chord_arpeggio_bracket/chord_arpeggio_bracket.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "chord_arpeggio_bracket/chord_arpeggio_bracket.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected disclosure
@@ -1516,15 +1516,15 @@ TEST_F(PlaybackEventsRendererTests, Chord_Arpeggio_Bracket)
 TEST_F(PlaybackEventsRendererTests, Single_Note_Tremolo)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "single_note_tremolo/single_note_tremolo.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "single_note_tremolo/single_note_tremolo.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected disclosure
@@ -1580,15 +1580,15 @@ TEST_F(PlaybackEventsRendererTests, Single_Note_Tremolo)
 TEST_F(PlaybackEventsRendererTests, Single_Chord_Tremolo)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "single_chord_tremolo/single_chord_tremolo.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "single_chord_tremolo/single_chord_tremolo.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected disclosure
@@ -1646,15 +1646,15 @@ TEST_F(PlaybackEventsRendererTests, Single_Chord_Tremolo)
 TEST_F(PlaybackEventsRendererTests, Two_Chords_Tremolo)
 {
     // [GIVEN] Simple piece of score (piano, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "two_chords_tremolo/two_chords_tremolo.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_EVENTS_RENDERING_DIR + "two_chords_tremolo/two_chords_tremolo.mscx");
 
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    mu::engraving::ChordRest* chord = firstSegment->nextChordRest(0);
+    ChordRest* chord = firstSegment->nextChordRest(0);
     ASSERT_TRUE(chord);
 
     // [GIVEN] Expected disclosure

--- a/src/engraving/utests/playbackmodel_tests.cpp
+++ b/src/engraving/utests/playbackmodel_tests.cpp
@@ -78,12 +78,12 @@ protected:
 TEST_F(PlaybackModelTests, SimpleRepeat)
 {
     // [GIVEN] Simple piece of score (Violin, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "repeat_range/repeat_range.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "repeat_range/repeat_range.mscx");
 
     ASSERT_TRUE(score);
     ASSERT_EQ(score->parts().size(), 1);
 
-    const mu::engraving::Part* part = score->parts().at(0);
+    const Part* part = score->parts().at(0);
     ASSERT_TRUE(part);
     ASSERT_EQ(part->instruments().size(), 1);
 
@@ -113,12 +113,12 @@ TEST_F(PlaybackModelTests, SimpleRepeat)
 TEST_F(PlaybackModelTests, Two_Ending_Repeat)
 {
     // [GIVEN] Simple piece of score (Violin, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "repeat_with_2_voltas/repeat_with_2_voltas.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "repeat_with_2_voltas/repeat_with_2_voltas.mscx");
 
     ASSERT_TRUE(score);
     ASSERT_EQ(score->parts().size(), 1);
 
-    const mu::engraving::Part* part = score->parts().at(0);
+    const Part* part = score->parts().at(0);
     ASSERT_TRUE(part);
     ASSERT_EQ(part->instruments().size(), 1);
 
@@ -148,12 +148,12 @@ TEST_F(PlaybackModelTests, Two_Ending_Repeat)
 TEST_F(PlaybackModelTests, Da_Capo_Al_Fine)
 {
     // [GIVEN] Simple piece of score (Violin, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "da_capo_al_fine/da_capo_al_fine.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "da_capo_al_fine/da_capo_al_fine.mscx");
 
     ASSERT_TRUE(score);
     ASSERT_EQ(score->parts().size(), 1);
 
-    const mu::engraving::Part* part = score->parts().at(0);
+    const Part* part = score->parts().at(0);
     ASSERT_TRUE(part);
     ASSERT_EQ(part->instruments().size(), 1);
 
@@ -184,12 +184,12 @@ TEST_F(PlaybackModelTests, Da_Capo_Al_Fine)
 TEST_F(PlaybackModelTests, Dal_Segno_Al_Coda)
 {
     // [GIVEN] Simple piece of score (Violin, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "dal_segno_al_coda/dal_segno_al_coda.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "dal_segno_al_coda/dal_segno_al_coda.mscx");
 
     ASSERT_TRUE(score);
     ASSERT_EQ(score->parts().size(), 1);
 
-    const mu::engraving::Part* part = score->parts().at(0);
+    const Part* part = score->parts().at(0);
     ASSERT_TRUE(part);
     ASSERT_EQ(part->instruments().size(), 1);
 
@@ -219,12 +219,12 @@ TEST_F(PlaybackModelTests, Dal_Segno_Al_Coda)
 TEST_F(PlaybackModelTests, Dal_Segno_Al_Fine)
 {
     // [GIVEN] Simple piece of score (Violin, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "dal_segno_al_fine/dal_segno_al_fine.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "dal_segno_al_fine/dal_segno_al_fine.mscx");
 
     ASSERT_TRUE(score);
     ASSERT_EQ(score->parts().size(), 1);
 
-    const mu::engraving::Part* part = score->parts().at(0);
+    const Part* part = score->parts().at(0);
     ASSERT_TRUE(part);
     ASSERT_EQ(part->instruments().size(), 1);
 
@@ -254,12 +254,12 @@ TEST_F(PlaybackModelTests, Dal_Segno_Al_Fine)
 TEST_F(PlaybackModelTests, Da_Capo_Al_Coda)
 {
     // [GIVEN] Simple piece of score (Violin, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "da_capo_al_coda/da_capo_al_coda.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "da_capo_al_coda/da_capo_al_coda.mscx");
 
     ASSERT_TRUE(score);
     ASSERT_EQ(score->parts().size(), 1);
 
-    const mu::engraving::Part* part = score->parts().at(0);
+    const Part* part = score->parts().at(0);
     ASSERT_TRUE(part);
     ASSERT_EQ(part->instruments().size(), 1);
 
@@ -289,12 +289,12 @@ TEST_F(PlaybackModelTests, Da_Capo_Al_Coda)
 TEST_F(PlaybackModelTests, Pizz_To_Arco_Technique)
 {
     // [GIVEN] Simple piece of score (Violin, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "pizz_to_arco/pizz_to_arco.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "pizz_to_arco/pizz_to_arco.mscx");
 
     ASSERT_TRUE(score);
     ASSERT_EQ(score->parts().size(), 1);
 
-    const mu::engraving::Part* part = score->parts().at(0);
+    const Part* part = score->parts().at(0);
     ASSERT_TRUE(part);
     ASSERT_EQ(part->instruments().size(), 1);
 
@@ -348,12 +348,12 @@ TEST_F(PlaybackModelTests, Pizz_To_Arco_Technique)
 TEST_F(PlaybackModelTests, DISABLED_Repeat_Last_Measure)
 {
     // [GIVEN] Simple piece of score (Violin, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "repeat_last_measure/repeat_last_measure.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "repeat_last_measure/repeat_last_measure.mscx");
 
     ASSERT_TRUE(score);
     ASSERT_EQ(score->parts().size(), 1);
 
-    const mu::engraving::Part* part = score->parts().at(0);
+    const Part* part = score->parts().at(0);
     ASSERT_TRUE(part);
     ASSERT_EQ(part->instruments().size(), 1);
 
@@ -385,12 +385,12 @@ TEST_F(PlaybackModelTests, DISABLED_Repeat_Last_Measure)
 TEST_F(PlaybackModelTests, SimpleRepeat_Changes_Notification)
 {
     // [GIVEN] Simple piece of score (Violin, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "repeat_range/repeat_range.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "repeat_range/repeat_range.mscx");
 
     ASSERT_TRUE(score);
     ASSERT_EQ(score->parts().size(), 1);
 
-    const mu::engraving::Part* part = score->parts().at(0);
+    const Part* part = score->parts().at(0);
     ASSERT_TRUE(part);
     ASSERT_EQ(part->instruments().size(), 1);
 
@@ -413,12 +413,12 @@ TEST_F(PlaybackModelTests, SimpleRepeat_Changes_Notification)
     });
 
     // [WHEN] Notation has been changed on the 2-nd measure
-    mu::engraving::ScoreChangesRange range;
+    ScoreChangesRange range;
     range.tickFrom = 1920;
     range.tickTo = 3840;
     range.staffIdxFrom = 0;
     range.staffIdxTo = 0;
-    range.changedTypes = { mu::engraving::ElementType::NOTE };
+    range.changedTypes = { ElementType::NOTE };
 
     score->changesChannel().send(range);
 }
@@ -432,12 +432,12 @@ TEST_F(PlaybackModelTests, SimpleRepeat_Changes_Notification)
 TEST_F(PlaybackModelTests, Metronome_4_4)
 {
     // [GIVEN] Simple piece of score (Violin, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "metronome_4_4/metronome_4_4.mscx");
+    Score* score = ScoreRW::readScore(PLAYBACK_MODEL_TEST_FILES_DIR + "metronome_4_4/metronome_4_4.mscx");
 
     ASSERT_TRUE(score);
     ASSERT_EQ(score->parts().size(), 1);
 
-    const mu::engraving::Part* part = score->parts().at(0);
+    const Part* part = score->parts().at(0);
     ASSERT_TRUE(part);
     ASSERT_EQ(part->instruments().size(), 1);
 
@@ -466,13 +466,13 @@ TEST_F(PlaybackModelTests, Metronome_4_4)
 TEST_F(PlaybackModelTests, Metronome_6_4_Repeat)
 {
     // [GIVEN] Simple piece of score (Violin, 6/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         PLAYBACK_MODEL_TEST_FILES_DIR + "metronome_6_4_with_repeat/metronome_6_4_with_repeat.mscx");
 
     ASSERT_TRUE(score);
     ASSERT_EQ(score->parts().size(), 1);
 
-    const mu::engraving::Part* part = score->parts().at(0);
+    const Part* part = score->parts().at(0);
     ASSERT_TRUE(part);
     ASSERT_EQ(part->instruments().size(), 1);
 
@@ -502,13 +502,13 @@ TEST_F(PlaybackModelTests, Metronome_6_4_Repeat)
 TEST_F(PlaybackModelTests, Note_Entry_Playback_Note)
 {
     // [GIVEN] Simple piece of score (Violin, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         PLAYBACK_MODEL_TEST_FILES_DIR + "note_entry_playback_note/note_entry_playback_note.mscx");
 
     ASSERT_TRUE(score);
     ASSERT_EQ(score->parts().size(), 1);
 
-    const mu::engraving::Part* part = score->parts().at(0);
+    const Part* part = score->parts().at(0);
     ASSERT_TRUE(part);
     ASSERT_EQ(part->instruments().size(), 1);
 
@@ -516,17 +516,17 @@ TEST_F(PlaybackModelTests, Note_Entry_Playback_Note)
     ON_CALL(*m_repositoryMock, defaultProfile(_)).WillByDefault(Return(m_defaultProfile));
 
     // [GIVEN] The very first note of the score
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
-    mu::engraving::Segment* firstSegment = firstMeasure->segments().firstCRSegment();
+    Segment* firstSegment = firstMeasure->segments().firstCRSegment();
     ASSERT_TRUE(firstSegment);
 
-    const mu::engraving::Chord* chord = mu::engraving::toChord(firstSegment->nextChordRest(0));
+    const Chord* chord = toChord(firstSegment->nextChordRest(0));
     ASSERT_TRUE(chord);
     ASSERT_TRUE(chord->notes().size() == 1);
 
-    const mu::engraving::Note* firstNote = chord->notes().front();
+    const Note* firstNote = chord->notes().front();
     mpe::timestamp_t firstNoteTimestamp = 0;
 
     // [GIVEN] The playback model requested to be loaded
@@ -568,13 +568,13 @@ TEST_F(PlaybackModelTests, Note_Entry_Playback_Note)
 TEST_F(PlaybackModelTests, Note_Entry_Playback_Chord)
 {
     // [GIVEN] Simple piece of score (Violin, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         PLAYBACK_MODEL_TEST_FILES_DIR + "note_entry_playback_chord/note_entry_playback_chord.mscx");
 
     ASSERT_TRUE(score);
     ASSERT_EQ(score->parts().size(), 1);
 
-    const mu::engraving::Part* part = score->parts().at(0);
+    const Part* part = score->parts().at(0);
     ASSERT_TRUE(part);
     ASSERT_EQ(part->instruments().size(), 1);
 
@@ -582,14 +582,14 @@ TEST_F(PlaybackModelTests, Note_Entry_Playback_Chord)
     ON_CALL(*m_repositoryMock, defaultProfile(_)).WillByDefault(Return(m_defaultProfile));
 
     // [GIVEN] The third chord of the score
-    mu::engraving::Measure* firstMeasure = score->firstMeasure();
+    Measure* firstMeasure = score->firstMeasure();
     ASSERT_TRUE(firstMeasure);
 
     size_t expectedNoteCount = 3;
     int thirdChordPositionTick = 480 * 2;
     timestamp_t thirdChordTimestamp = 500 * 2;
 
-    const mu::engraving::Chord* thirdChord = firstMeasure->findChord(mu::engraving::Fraction::fromTicks(thirdChordPositionTick), 0);
+    const Chord* thirdChord = firstMeasure->findChord(Fraction::fromTicks(thirdChordPositionTick), 0);
     ASSERT_TRUE(thirdChord);
     ASSERT_TRUE(thirdChord->notes().size() == expectedNoteCount);
 
@@ -644,7 +644,7 @@ TEST_F(PlaybackModelTests, Note_Entry_Playback_Chord)
 TEST_F(PlaybackModelTests, Playback_Setup_Data_MultiInstrument)
 {
     // [GIVEN] Score with 12 instruments
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         PLAYBACK_MODEL_TEST_FILES_DIR + "playback_setup_instruments/playback_setup_instruments.mscx");
 
     ASSERT_TRUE(score);
@@ -683,7 +683,7 @@ TEST_F(PlaybackModelTests, Playback_Setup_Data_MultiInstrument)
     model.load(score);
 
     // [THEN] Result matches with our expectations
-    for (const mu::engraving::Part* part : score->parts()) {
+    for (const Part* part : score->parts()) {
         for (const auto& pair : part->instruments()) {
             const std::string& instrumentId = pair.second->id().toStdString();
             const PlaybackData& result = model.resolveTrackPlaybackData(part->id(), instrumentId);

--- a/src/engraving/utests/remove_tests.cpp
+++ b/src/engraving/utests/remove_tests.cpp
@@ -44,7 +44,7 @@ class RemoveTests : public ::testing::Test
 //---------------------------------------------------------
 
 struct StaffCheckData {
-    mu::engraving::staff_idx_t staffIdx;
+    staff_idx_t staffIdx;
     bool staffHasElements;
 };
 
@@ -62,7 +62,7 @@ static void inStaff(void* staffCheckData, EngravingItem* e)
     }
 }
 
-static bool staffHasElements(Score* score, mu::engraving::staff_idx_t staffIdx)
+static bool staffHasElements(Score* score, staff_idx_t staffIdx)
 {
     for (auto i = score->spannerMap().cbegin(); i != score->spannerMap().cend(); ++i) {
         Spanner* s = i->second;

--- a/src/engraving/utests/spanners_tests.cpp
+++ b/src/engraving/utests/spanners_tests.cpp
@@ -65,7 +65,7 @@ TEST_F(SpannersTests, spanners01)
     EXPECT_TRUE(msr);
     Segment* seg   = msr->findSegment(SegmentType::ChordRest, Fraction(0, 1));
     EXPECT_TRUE(seg);
-    mu::engraving::Chord* chord = static_cast<mu::engraving::Chord*>(seg->element(0));
+    Chord* chord = static_cast<Chord*>(seg->element(0));
     EXPECT_TRUE(chord);
     EXPECT_EQ(chord->type(), ElementType::CHORD);
     Note* note  = chord->upNote();
@@ -82,7 +82,7 @@ TEST_F(SpannersTests, spanners01)
     EXPECT_TRUE(msr);
     seg   = msr->first();
     EXPECT_TRUE(seg);
-    chord = static_cast<mu::engraving::Chord*>(seg->element(0));     // voice 0 of staff 0
+    chord = static_cast<Chord*>(seg->element(0));     // voice 0 of staff 0
     EXPECT_TRUE(chord);
     EXPECT_EQ(chord->type(), ElementType::CHORD);
     note  = chord->upNote();
@@ -99,7 +99,7 @@ TEST_F(SpannersTests, spanners01)
     EXPECT_TRUE(msr);
     seg   = msr->first();
     EXPECT_TRUE(seg);
-    chord = static_cast<mu::engraving::Chord*>(seg->element(4));     // voice 0 of staff 1
+    chord = static_cast<Chord*>(seg->element(4));     // voice 0 of staff 1
     EXPECT_TRUE(chord);
     EXPECT_EQ(chord->type(), ElementType::CHORD);
     note  = chord->upNote();
@@ -116,7 +116,7 @@ TEST_F(SpannersTests, spanners01)
     EXPECT_TRUE(msr);
     seg   = msr->first();
     EXPECT_TRUE(seg);
-    chord = static_cast<mu::engraving::Chord*>(seg->element(0));     // voice 0 of staff 0
+    chord = static_cast<Chord*>(seg->element(0));     // voice 0 of staff 0
     EXPECT_TRUE(chord);
     EXPECT_EQ(chord->type(), ElementType::CHORD);
     note  = chord->upNote();
@@ -133,7 +133,7 @@ TEST_F(SpannersTests, spanners01)
     EXPECT_TRUE(msr);
     seg   = msr->first();
     EXPECT_TRUE(seg);
-    chord = static_cast<mu::engraving::Chord*>(seg->element(0));     // voice 0 of staff 0
+    chord = static_cast<Chord*>(seg->element(0));     // voice 0 of staff 0
     EXPECT_TRUE(chord);
     EXPECT_EQ(chord->type(), ElementType::CHORD);
     note  = chord->upNote();
@@ -181,7 +181,7 @@ TEST_F(SpannersTests, spanners03)
     EXPECT_TRUE(msr);
     Segment* seg   = msr->findSegment(SegmentType::ChordRest, Fraction(0, 1));
     EXPECT_TRUE(seg);
-    mu::engraving::Chord* chord = static_cast<mu::engraving::Chord*>(seg->element(0));
+    Chord* chord = static_cast<Chord*>(seg->element(0));
     EXPECT_TRUE(chord);
     EXPECT_EQ(chord->type(), ElementType::CHORD);
     Note* note  = chord->upNote();
@@ -194,7 +194,7 @@ TEST_F(SpannersTests, spanners03)
 
     // GLISSANDO FROM AFTER-GRACE TO BEFORE-GRACE OF NEXT CHORD
     // go to last after-grace of chord and drop a glissando on it
-    mu::engraving::Chord* grace = chord->graceNotesAfter().back();
+    Chord* grace = chord->graceNotesAfter().back();
     EXPECT_TRUE(grace);
     EXPECT_EQ(grace->type(), ElementType::CHORD);
     note              = grace->upNote();
@@ -208,7 +208,7 @@ TEST_F(SpannersTests, spanners03)
     // go to next chord
     seg               = seg->nextCR(0);
     EXPECT_TRUE(seg);
-    chord             = static_cast<mu::engraving::Chord*>(seg->element(0));
+    chord             = static_cast<Chord*>(seg->element(0));
     EXPECT_TRUE(chord);
     EXPECT_EQ(chord->type(), ElementType::CHORD);
     note              = chord->upNote();
@@ -222,7 +222,7 @@ TEST_F(SpannersTests, spanners03)
     // go to next chord
     seg               = seg->nextCR(0);
     EXPECT_TRUE(seg);
-    chord             = static_cast<mu::engraving::Chord*>(seg->element(0));
+    chord             = static_cast<Chord*>(seg->element(0));
     EXPECT_TRUE(chord && chord->type() == ElementType::CHORD);
     // go to its last before-grace note
     grace             = chord->graceNotesBefore().back();
@@ -312,7 +312,7 @@ TEST_F(SpannersTests, spanners06)
     EXPECT_TRUE(msr);
     Segment* seg   = msr->findSegment(SegmentType::ChordRest, Fraction(0, 1));
     EXPECT_TRUE(seg);
-    mu::engraving::Chord* chord = static_cast<mu::engraving::Chord*>(seg->element(0));
+    Chord* chord = static_cast<Chord*>(seg->element(0));
     EXPECT_TRUE(chord && chord->type() == ElementType::CHORD);
     Note* note  = chord->upNote();
     EXPECT_TRUE(note);
@@ -344,7 +344,7 @@ TEST_F(SpannersTests, spanners07)
     EXPECT_TRUE(msr);
     Segment* seg   = msr->findSegment(SegmentType::ChordRest, Fraction(0, 1));
     EXPECT_TRUE(seg);
-    mu::engraving::Chord* chord = static_cast<mu::engraving::Chord*>(seg->element(0));
+    Chord* chord = static_cast<Chord*>(seg->element(0));
     EXPECT_TRUE(chord && chord->type() == ElementType::CHORD);
     Note* note  = chord->upNote();
     EXPECT_TRUE(note);

--- a/src/engraving/utests/tempomap_tests.cpp
+++ b/src/engraving/utests/tempomap_tests.cpp
@@ -46,7 +46,7 @@ protected:
 TEST_F(TempoMapTests, DEFAULT_TEMPO)
 {
     // [GIVEN] Simple piece of score (Violin, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(TEMPOMAP_TEST_FILES_DIR + "default_tempo/default_tempo.mscx");
+    Score* score = ScoreRW::readScore(TEMPOMAP_TEST_FILES_DIR + "default_tempo/default_tempo.mscx");
 
     ASSERT_TRUE(score);
 
@@ -54,7 +54,7 @@ TEST_F(TempoMapTests, DEFAULT_TEMPO)
     BeatsPerSecond expectedTempo = Constants::defaultTempo;
 
     // [WHEN] We request score's tempomap it should contain only 1 value, which is our expected tempo
-    const mu::engraving::TempoMap* tempoMap = score->tempomap();
+    const TempoMap* tempoMap = score->tempomap();
     EXPECT_EQ(tempoMap->size(), 1);
 
     // [THEN] Applied tempo matches our expectations
@@ -71,7 +71,7 @@ TEST_F(TempoMapTests, DEFAULT_TEMPO)
 TEST_F(TempoMapTests, ABSOLUTE_TEMPO_80_BPM)
 {
     // [GIVEN] Simple piece of score (Violin, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(TEMPOMAP_TEST_FILES_DIR + "custom_tempo_80_bpm/custom_tempo_80_bpm.mscx");
+    Score* score = ScoreRW::readScore(TEMPOMAP_TEST_FILES_DIR + "custom_tempo_80_bpm/custom_tempo_80_bpm.mscx");
 
     ASSERT_TRUE(score);
 
@@ -79,7 +79,7 @@ TEST_F(TempoMapTests, ABSOLUTE_TEMPO_80_BPM)
     BeatsPerSecond expectedTempo = BeatsPerSecond::fromBPM(BeatsPerMinute(80.f));
 
     // [WHEN] We request score's tempomap it should contain only 1 value, which is our expected tempo
-    const mu::engraving::TempoMap* tempoMap = score->tempomap();
+    const TempoMap* tempoMap = score->tempomap();
     EXPECT_EQ(tempoMap->size(), 1);
 
     // [THEN] Applied tempo matches with our expectations
@@ -96,7 +96,7 @@ TEST_F(TempoMapTests, ABSOLUTE_TEMPO_80_BPM)
 TEST_F(TempoMapTests, ABSOLUTE_TEMPO_FROM_80_TO_120_BPM)
 {
     // [GIVEN] Simple piece of score (Violin, 4/4, 80 bpm, Treble Cleff)
-    mu::engraving::Score* score = ScoreRW::readScore(
+    Score* score = ScoreRW::readScore(
         TEMPOMAP_TEST_FILES_DIR + "absolute_tempo_80_to_120_bpm/absolute_tempo_80_to_120_bpm.mscx");
 
     ASSERT_TRUE(score);
@@ -108,7 +108,7 @@ TEST_F(TempoMapTests, ABSOLUTE_TEMPO_FROM_80_TO_120_BPM)
     };
 
     // [WHEN] We request score's tempomap its size matches with our expectations
-    const mu::engraving::TempoMap* tempoMap = score->tempomap();
+    const TempoMap* tempoMap = score->tempomap();
     EXPECT_EQ(tempoMap->size(), expectedTempoMap.size());
 
     // [THEN] Applied tempo matches with our expectations
@@ -126,7 +126,7 @@ TEST_F(TempoMapTests, ABSOLUTE_TEMPO_FROM_80_TO_120_BPM)
 TEST_F(TempoMapTests, GRADUAL_TEMPO_CHANGE_ACCELERANDO)
 {
     // [GIVEN] Simple piece of score (Violin, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score
+    Score* score
         = ScoreRW::readScore(TEMPOMAP_TEST_FILES_DIR + "gradual_tempo_change_accelerando/gradual_tempo_change_accelerando.mscx");
 
     ASSERT_TRUE(score);
@@ -138,7 +138,7 @@ TEST_F(TempoMapTests, GRADUAL_TEMPO_CHANGE_ACCELERANDO)
     };
 
     // [WHEN] We request score's tempomap its size matches with our expectations
-    const mu::engraving::TempoMap* tempoMap = score->tempomap();
+    const TempoMap* tempoMap = score->tempomap();
     EXPECT_FALSE(tempoMap->empty());
 
     // [THEN] Applied tempo matches with our expectations
@@ -156,8 +156,7 @@ TEST_F(TempoMapTests, GRADUAL_TEMPO_CHANGE_ACCELERANDO)
 TEST_F(TempoMapTests, GRADUAL_TEMPO_CHANGE_RALLENTANDO)
 {
     // [GIVEN] Simple piece of score (Violin, 4/4, 120 bpm, Treble Cleff)
-    mu::engraving::Score* score
-        = ScoreRW::readScore(TEMPOMAP_TEST_FILES_DIR + "gradual_tempo_change_rallentando/gradual_tempo_change_rallentando.mscx");
+    Score* score = ScoreRW::readScore(TEMPOMAP_TEST_FILES_DIR + "gradual_tempo_change_rallentando/gradual_tempo_change_rallentando.mscx");
 
     ASSERT_TRUE(score);
 
@@ -168,7 +167,7 @@ TEST_F(TempoMapTests, GRADUAL_TEMPO_CHANGE_RALLENTANDO)
     };
 
     // [WHEN] We request score's tempomap its size matches with our expectations
-    const mu::engraving::TempoMap* tempoMap = score->tempomap();
+    const TempoMap* tempoMap = score->tempomap();
     EXPECT_FALSE(tempoMap->empty());
 
     // [THEN] Applied tempo matches with our expectations

--- a/src/engraving/utests/textbase_tests.cpp
+++ b/src/engraving/utests/textbase_tests.cpp
@@ -94,7 +94,7 @@ TEST_F(TextBaseTests, dynamicAddTextNoItalic)
     Dynamic* dynamic = addDynamic(score);
     EditData ed;
     dynamic->startEdit(ed);
-    dynamic->setProperty(mu::engraving::Pid::FONT_STYLE, PropertyValue::fromValue(0));
+    dynamic->setProperty(Pid::FONT_STYLE, PropertyValue::fromValue(0));
     score->undo(new InsertText(dynamic->cursor(), QString("moderately ")), &ed);
     dynamic->endEdit(ed);
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, "dynamicAddTextNoItalic.mscx", TEXTBASE_DATA_DIR + "dynamicAddTextNoItalic-ref.mscx"));
@@ -117,20 +117,20 @@ TEST_F(TextBaseTests, getFontStyleProperty)
     EditData ed;
     staffText->startEdit(ed);
     score->undo(new InsertText(staffText->cursor(), QString("normal ")), &ed);
-    staffText->setProperty(mu::engraving::Pid::FONT_STYLE, PropertyValue::fromValue(static_cast<int>(FontStyle::Bold)));
+    staffText->setProperty(Pid::FONT_STYLE, PropertyValue::fromValue(static_cast<int>(FontStyle::Bold)));
     score->undo(new InsertText(staffText->cursor(), QString("bold")), &ed);
     staffText->cursor()->moveCursorToStart();
-    EXPECT_EQ(staffText->getProperty(mu::engraving::Pid::FONT_STYLE), PropertyValue::fromValue(0));
+    EXPECT_EQ(staffText->getProperty(Pid::FONT_STYLE), PropertyValue::fromValue(0));
     staffText->cursor()->movePosition(TextCursor::MoveOperation::NextWord, TextCursor::MoveMode::KeepAnchor);
-    EXPECT_EQ(staffText->getProperty(mu::engraving::Pid::FONT_STYLE), PropertyValue::fromValue(0));
+    EXPECT_EQ(staffText->getProperty(Pid::FONT_STYLE), PropertyValue::fromValue(0));
     staffText->cursor()->movePosition(TextCursor::MoveOperation::End, TextCursor::MoveMode::KeepAnchor);
-    EXPECT_EQ(staffText->getProperty(mu::engraving::Pid::FONT_STYLE), PropertyValue::fromValue(0));
+    EXPECT_EQ(staffText->getProperty(Pid::FONT_STYLE), PropertyValue::fromValue(0));
     staffText->cursor()->movePosition(TextCursor::MoveOperation::WordLeft, TextCursor::MoveMode::MoveAnchor);
-    EXPECT_EQ(staffText->getProperty(mu::engraving::Pid::FONT_STYLE), PropertyValue::fromValue(static_cast<int>(FontStyle::Bold)));
+    EXPECT_EQ(staffText->getProperty(Pid::FONT_STYLE), PropertyValue::fromValue(static_cast<int>(FontStyle::Bold)));
     staffText->cursor()->movePosition(TextCursor::MoveOperation::NextWord, TextCursor::MoveMode::KeepAnchor);
-    EXPECT_EQ(staffText->getProperty(mu::engraving::Pid::FONT_STYLE), PropertyValue::fromValue(static_cast<int>(FontStyle::Bold)));
+    EXPECT_EQ(staffText->getProperty(Pid::FONT_STYLE), PropertyValue::fromValue(static_cast<int>(FontStyle::Bold)));
     staffText->endEdit(ed);
-    EXPECT_EQ(staffText->getProperty(mu::engraving::Pid::FONT_STYLE), PropertyValue::fromValue(0));
+    EXPECT_EQ(staffText->getProperty(Pid::FONT_STYLE), PropertyValue::fromValue(0));
 }
 
 TEST_F(TextBaseTests, undoChangeFontStyleProperty)
@@ -140,11 +140,11 @@ TEST_F(TextBaseTests, undoChangeFontStyleProperty)
     staffText->setXmlText("normal <b>bold</b> <u>underline</u> <i>italic</i>");
     staffText->layout();
     score->startCmd();
-    staffText->undoChangeProperty(mu::engraving::Pid::FONT_STYLE, PropertyValue::fromValue(0), PropertyFlags::UNSTYLED);
+    staffText->undoChangeProperty(Pid::FONT_STYLE, PropertyValue::fromValue(0), PropertyFlags::UNSTYLED);
     score->endCmd();
     EXPECT_EQ(staffText->xmlText(), "normal <b>bold</b> <u>underline</u> <i>italic</i>");
     score->startCmd();
-    staffText->undoChangeProperty(mu::engraving::Pid::FONT_STYLE, PropertyValue::fromValue(static_cast<int>(FontStyle::Bold)),
+    staffText->undoChangeProperty(Pid::FONT_STYLE, PropertyValue::fromValue(static_cast<int>(FontStyle::Bold)),
                                   PropertyFlags::UNSTYLED);
     score->endCmd();
     EXPECT_EQ(staffText->xmlText(), "<b>normal bold <u>underline</u> <i>italic</i></b>");
@@ -154,19 +154,19 @@ TEST_F(TextBaseTests, undoChangeFontStyleProperty)
     score->undoStack()->redo(&ed);
     EXPECT_EQ(staffText->xmlText(), "<b>normal bold <u>underline</u> <i>italic</i></b>");
     score->startCmd();
-    staffText->undoChangeProperty(mu::engraving::Pid::FONT_STYLE, PropertyValue::fromValue(
+    staffText->undoChangeProperty(Pid::FONT_STYLE, PropertyValue::fromValue(
                                       static_cast<int>(FontStyle::Italic + FontStyle::Bold)), PropertyFlags::UNSTYLED);
     score->endCmd();
     EXPECT_EQ(staffText->xmlText(), "<b><i>normal bold <u>underline</u> italic</i></b>");
     score->startCmd();
-    staffText->undoChangeProperty(mu::engraving::Pid::FONT_STYLE,
+    staffText->undoChangeProperty(Pid::FONT_STYLE,
                                   PropertyValue::fromValue(
                                       static_cast<int>(FontStyle::Italic + FontStyle::Bold + FontStyle::Underline)),
                                   PropertyFlags::UNSTYLED);
     score->endCmd();
     EXPECT_EQ(staffText->xmlText(), "<b><i><u>normal bold underline italic</u></i></b>");
     score->startCmd();
-    staffText->undoChangeProperty(mu::engraving::Pid::FONT_STYLE, PropertyValue::fromValue(0), PropertyFlags::UNSTYLED);
+    staffText->undoChangeProperty(Pid::FONT_STYLE, PropertyValue::fromValue(0), PropertyFlags::UNSTYLED);
     score->endCmd();
     EXPECT_EQ(staffText->xmlText(), "normal bold underline italic");
 }

--- a/src/engraving/utests/tuplet_tests.cpp
+++ b/src/engraving/utests/tuplet_tests.cpp
@@ -105,7 +105,7 @@ void TupletTests::tuplet(const char* p1, const char* p2)
 
     Segment* s = m2->first(SegmentType::ChordRest);
     EXPECT_TRUE(s != 0);
-    mu::engraving::Chord* c = toChord(s->element(0));
+    Chord* c = toChord(s->element(0));
     EXPECT_TRUE(c != 0);
 
     EXPECT_TRUE(createTuplet(3, c));

--- a/src/engraving/utests/utils/scorecomp.cpp
+++ b/src/engraving/utests/utils/scorecomp.cpp
@@ -30,7 +30,7 @@
 using namespace mu::io;
 using namespace mu::engraving;
 
-bool ScoreComp::saveCompareScore(mu::engraving::Score* score, const QString& saveName, const QString& compareWithLocalPath)
+bool ScoreComp::saveCompareScore(Score* score, const QString& saveName, const QString& compareWithLocalPath)
 {
     if (!ScoreRW::saveScore(score, saveName)) {
         return false;

--- a/src/engraving/utests/utils/scorecomp.h
+++ b/src/engraving/utests/utils/scorecomp.h
@@ -30,7 +30,7 @@ class ScoreComp
 {
 public:
 
-    static bool saveCompareScore(mu::engraving::Score*, const QString& saveName, const QString& compareWithLocalPath);
+    static bool saveCompareScore(Score*, const QString& saveName, const QString& compareWithLocalPath);
     static bool saveCompareMimeData(mu::ByteArray mimeData, const QString& saveName, const QString& compareWithLocalPath);
     static bool compareFiles(const QString& fullPath1, const QString& fullPath2);
 };

--- a/src/engraving/utests/utils/scorerw.cpp
+++ b/src/engraving/utests/utils/scorerw.cpp
@@ -45,7 +45,7 @@ QString ScoreRW::rootPath()
 MasterScore* ScoreRW::readScore(const QString& name, bool isAbsolutePath)
 {
     io::path_t path = isAbsolutePath ? name : (rootPath() + "/" + name);
-    MasterScore* score = mu::engraving::compat::ScoreAccess::createMasterScoreWithBaseStyle();
+    MasterScore* score = compat::ScoreAccess::createMasterScoreWithBaseStyle();
     score->setFileInfoProvider(std::make_shared<LocalFileInfoProvider>(path));
     std::string suffix = io::suffix(path);
 
@@ -70,7 +70,7 @@ MasterScore* ScoreRW::readScore(const QString& name, bool isAbsolutePath)
     return score;
 }
 
-bool ScoreRW::saveScore(mu::engraving::Score* score, const QString& name)
+bool ScoreRW::saveScore(Score* score, const QString& name)
 {
     File file(name);
     if (file.exists()) {

--- a/src/engraving/utests/utils/scorerw.h
+++ b/src/engraving/utests/utils/scorerw.h
@@ -35,9 +35,9 @@ public:
 
     static QString rootPath();
 
-    static mu::engraving::MasterScore* readScore(const QString& path, bool isAbsolutePath = false);
-    static bool saveScore(mu::engraving::Score* score, const QString& name);
-    static mu::engraving::EngravingItem* writeReadElement(mu::engraving::EngravingItem* element);
+    static MasterScore* readScore(const QString& path, bool isAbsolutePath = false);
+    static bool saveScore(Score* score, const QString& name);
+    static EngravingItem* writeReadElement(EngravingItem* element);
     static bool saveMimeData(ByteArray mimeData, const QString& saveName);
 };
 }

--- a/src/importexport/bb/internal/bb.cpp
+++ b/src/importexport/bb/internal/bb.cpp
@@ -356,7 +356,7 @@ bool BBFile::read(const QString& name)
                     continue;
                 }
                 Event note(ME_NOTE);
-                note.setOntime((tick.ticks() * Constant::division) / bbDivision);
+                note.setOntime((tick.ticks() * Constants::division) / bbDivision);
                 note.setPitch(a[idx + 5]);
                 note.setVelo(a[idx + 6]);
                 note.setChannel(channel);
@@ -369,7 +369,7 @@ bool BBFile::read(const QString& name)
                     len1 = lastLen;
                 }
                 lastLen = len1;
-                note.setDuration((len1* Constant::division) / bbDivision);
+                note.setDuration((len1* Constants::division) / bbDivision);
                 track->append(note);
             } else if (type == 0xb0 || type == 0xc0) {
                 // ignore controller
@@ -499,7 +499,7 @@ Score::FileError importBB(MasterScore* score, const QString& name)
         14, 9, 16, 11, 18, 13, 8, 15, 10, 17, 12, 19, 21, 23, 20, 22, 24
     };
     foreach (const BBChord& c, bb.chords()) {
-        Fraction tick = Fraction(c.beat, 4);          // c.beat  * Constant::division;
+        Fraction tick = Fraction(c.beat, 4);          // c.beat  * Constants::division;
 // LOGD("CHORD %d %d", c.beat, tick);
         Measure* m = score->tick2measure(tick);
         if (m == 0) {
@@ -791,7 +791,7 @@ void BBFile::convertTrack(Score* score, BBTrack* track, int staffIdx)
 
 void BBTrack::quantize(int startTick, int endTick, EventList* dst)
 {
-    int mintick = Constant::division * 64;
+    int mintick = Constants::division * 64;
     iEvent i = _events.begin();
     for (; i != _events.end(); ++i) {
         if (i->ontime() >= startTick) {
@@ -808,26 +808,26 @@ void BBTrack::quantize(int startTick, int endTick, EventList* dst)
             mintick = e.duration();
         }
     }
-    if (mintick <= Constant::division / 16) {        // minimum duration is 1/64
-        mintick = Constant::division / 16;
-    } else if (mintick <= Constant::division / 8) {
-        mintick = Constant::division / 8;
-    } else if (mintick <= Constant::division / 4) {
-        mintick = Constant::division / 4;
-    } else if (mintick <= Constant::division / 2) {
-        mintick = Constant::division / 2;
-    } else if (mintick <= Constant::division) {
-        mintick = Constant::division;
-    } else if (mintick <= Constant::division* 2) {
-        mintick = Constant::division * 2;
-    } else if (mintick <= Constant::division* 4) {
-        mintick = Constant::division * 4;
-    } else if (mintick <= Constant::division* 8) {
-        mintick = Constant::division * 8;
+    if (mintick <= Constants::division / 16) {        // minimum duration is 1/64
+        mintick = Constants::division / 16;
+    } else if (mintick <= Constants::division / 8) {
+        mintick = Constants::division / 8;
+    } else if (mintick <= Constants::division / 4) {
+        mintick = Constants::division / 4;
+    } else if (mintick <= Constants::division / 2) {
+        mintick = Constants::division / 2;
+    } else if (mintick <= Constants::division) {
+        mintick = Constants::division;
+    } else if (mintick <= Constants::division* 2) {
+        mintick = Constants::division * 2;
+    } else if (mintick <= Constants::division* 4) {
+        mintick = Constants::division * 4;
+    } else if (mintick <= Constants::division* 8) {
+        mintick = Constants::division * 8;
     }
     int raster;
-    if (mintick > Constant::division) {
-        raster = Constant::division;
+    if (mintick > Constants::division) {
+        raster = Constants::division;
     } else {
         raster = mintick;
     }

--- a/src/importexport/bww/internal/bww/importbww.cpp
+++ b/src/importexport/bww/internal/bww/importbww.cpp
@@ -342,7 +342,7 @@ void MsScWriter::note(const QString pitch, const QVector<Bww::BeamType> beamList
     }
     StepAlterOct sao = stepAlterOctMap.value(pitch);
 
-    int ticks = 4 * mu::engraving::Constant::division / type.toInt();
+    int ticks = 4 * mu::engraving::Constants::division / type.toInt();
     if (dots) {
         ticks = 3 * ticks / 2;
     }

--- a/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
@@ -957,7 +957,7 @@ void GP67DomBuilder::readBeatXProperties(const QDomNode& propertiesNode, GPBeat*
 
         if (propertyId == 687931393 || propertyId == 687935489) {
             // arpeggio/brush ticks
-            beat->setArpeggioStretch(propertyNode.firstChild().toElement().text().toDouble() / mu::engraving::Constant::division);
+            beat->setArpeggioStretch(propertyNode.firstChild().toElement().text().toDouble() / mu::engraving::Constants::division);
         }
 
         propertyNode = propertyNode.nextSibling();

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1017,7 +1017,7 @@ void GPConverter::addFermatas()
     for (const auto& fr : _fermatas) {
         const auto& measure = fr.first;
         const auto& gpFermata = fr.second;
-        Fraction tick = Fraction::fromTicks(mu::engraving::Constant::division * gpFermata.offsetNum / gpFermata.offsetDenom);
+        Fraction tick = Fraction::fromTicks(mu::engraving::Constants::division * gpFermata.offsetNum / gpFermata.offsetDenom);
         // bellow how gtp fermata timeStretch converting to MU timeStretch
         float convertingLength = 1.5f - gpFermata.length * 0.5f + gpFermata.length * gpFermata.length * 3;
         Segment* seg = measure->getSegmentR(SegmentType::ChordRest, tick);
@@ -1064,7 +1064,7 @@ void GPConverter::addTempoMap()
         measureIdx++;
         for (auto tempIt = range.first; tempIt != range.second; tempIt++) {
             Fraction tick = m->tick() + Fraction::fromTicks(
-                tempIt->second.position * Constant::division * 4 * m->ticks().numerator() / m->ticks().denominator());
+                tempIt->second.position * Constants::division * 4 * m->ticks().numerator() / m->ticks().denominator());
             Segment* segment = m->getSegment(SegmentType::ChordRest, tick);
             int realTemp = realTempo(tempIt->second);
             TempoText* tt = Factory::createTempoText(segment);
@@ -1077,10 +1077,10 @@ void GPConverter::addTempoMap()
             if (_lastTempoChangeRanged) {
                 _lastTempoChangeRanged->setTick2(tick);
                 if (realTemp > previousTempo) {
-                    _lastTempoChangeRanged->setTempoChangeType(TempoTechniqueType::Accelerando);
+                    _lastTempoChangeRanged->setTempoChangeType(TempoChangeType::Accelerando);
                     _lastTempoChangeRanged->setBeginText("accel");
                 } else {
-                    _lastTempoChangeRanged->setTempoChangeType(TempoTechniqueType::Rallentando);
+                    _lastTempoChangeRanged->setTempoChangeType(TempoChangeType::Rallentando);
                     _lastTempoChangeRanged->setBeginText("rall");
                 }
 

--- a/src/importexport/guitarpro/internal/importgtp-gp4.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp4.cpp
@@ -311,13 +311,13 @@ bool GuitarPro4::readNote(int string, int staffIdx, Note* note)
             int transition = readUChar();             // grace transition
             int duration = readUChar();               // grace duration
 
-            int grace_len = Constant::division / 8;
+            int grace_len = Constants::division / 8;
             if (duration == 1) {
-                grace_len = Constant::division / 8;       //32nd
+                grace_len = Constants::division / 8;       //32nd
             } else if (duration == 2) {
-                grace_len = Constant::division / 6;       //24th
+                grace_len = Constants::division / 6;       //24th
             } else if (duration == 3) {
-                grace_len = Constant::division / 4;       //16th
+                grace_len = Constants::division / 4;       //16th
             }
             Note* gn = Factory::createNote(score->dummy()->chord());
 
@@ -341,7 +341,7 @@ bool GuitarPro4::readNote(int string, int staffIdx, Note* note)
 
             TDuration d;
             d.setVal(grace_len);
-            if (grace_len == Constant::division / 6) {
+            if (grace_len == Constants::division / 6) {
                 d.setDots(1);
             }
             gc->setDurationType(d);

--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -991,7 +991,7 @@ bool GuitarPro5::readNoteEffects(Note* note)
         }
 
         int grace_pitch = note->staff()->part()->instrument()->stringData()->getPitch(note->string(), fret, nullptr);
-        auto gnote = score->setGraceNote(note->chord(), grace_pitch, note_type, Constant::division / 2);
+        auto gnote = score->setGraceNote(note->chord(), grace_pitch, note_type, Constants::division / 2);
         gnote->setString(note->string());
         auto sd = note->part()->instrument()->stringData();
         gnote->setFret(grace_pitch - sd->stringList().at(sd->stringList().size() - note->string() - 1).pitch);

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -1960,13 +1960,13 @@ bool GuitarPro1::readNote(int string, Note* note)
             int transition = readUChar();                  // grace transition
             int duration = readUChar();                  // grace duration
 
-            int grace_len = Constant::division / 8;
+            int grace_len = Constants::division / 8;
             if (duration == 1) {
-                grace_len = Constant::division / 8;       //32nd
+                grace_len = Constants::division / 8;       //32nd
             } else if (duration == 2) {
-                grace_len = Constant::division / 6;       //24th
+                grace_len = Constants::division / 6;       //24th
             } else if (duration == 3) {
-                grace_len = Constant::division / 4;       //16th
+                grace_len = Constants::division / 4;       //16th
             }
             Note* gn = Factory::createNote(score->dummy()->chord());
 
@@ -1991,7 +1991,7 @@ bool GuitarPro1::readNote(int string, Note* note)
                 gc = Factory::createChord(score->dummy()->segment());
                 TDuration d;
                 d.setVal(grace_len);
-                if (grace_len == Constant::division / 6) {
+                if (grace_len == Constants::division / 6) {
                     d.setDots(1);
                 }
                 gc->setDurationType(d);

--- a/src/importexport/midi/internal/midiconfiguration.cpp
+++ b/src/importexport/midi/internal/midiconfiguration.cpp
@@ -35,7 +35,7 @@ static const Settings::Key EXPORTRPNS_KEY("iex_midi", "io/midi/exportRPNs");
 
 void MidiConfiguration::init()
 {
-    settings()->setDefaultValue(SHORTEST_NOTE_KEY, Val(mu::engraving::Constant::division / 4));
+    settings()->setDefaultValue(SHORTEST_NOTE_KEY, Val(mu::engraving::Constants::division / 4));
     settings()->setDefaultValue(EXPORTRPNS_KEY, Val(false));
 }
 

--- a/src/importexport/midi/internal/midiexport/exportmidi.cpp
+++ b/src/importexport/midi/internal/midiexport/exportmidi.cpp
@@ -217,7 +217,7 @@ void ExportMidi::writeHeader()
 
 bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPNs, const SynthesizerState& synthState)
 {
-    m_midiFile.setDivision(Constant::division);
+    m_midiFile.setDivision(Constants::division);
     m_midiFile.setFormat(1);
     std::vector<MidiTrack>& tracks = m_midiFile.tracks();
 
@@ -409,7 +409,7 @@ void ExportMidi::PauseMap::calculate(const Score* s)
                 if (tick != startTick) {
                     Fraction timeSig(sigmap->timesig(tick).timesig());
                     qreal quarterNotesPerMeasure = (4.0 * timeSig.numerator()) / timeSig.denominator();
-                    int ticksPerMeasure =  quarterNotesPerMeasure * Constant::division;           // store a full measure of ticks to keep barlines in same places
+                    int ticksPerMeasure =  quarterNotesPerMeasure * Constants::division;           // store a full measure of ticks to keep barlines in same places
                     tempomapWithPauses->setTempo(this->addPauseTicks(utick), quarterNotesPerMeasure / it->second.pause);           // new tempo for pause
                     this->insert(std::pair<const int, int>(utick, ticksPerMeasure + this->offsetAtUTick(utick)));            // store running total of extra ticks
                     tempomapWithPauses->setTempo(this->addPauseTicks(utick), it->second.tempo);           // restore previous tempo

--- a/src/importexport/midi/internal/midiimport/importmidi_beat.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_beat.cpp
@@ -423,7 +423,7 @@ void adjustChordsToBeats(std::multimap<int, MTrack>& tracks)
 
         Q_ASSERT_X(beats.size() > 1, "MidiBeat::adjustChordsToBeats", "Human beat count < 2");
 
-        const auto newBeatLen = ReducedFraction::fromTicks(Constant::division);
+        const auto newBeatLen = ReducedFraction::fromTicks(Constants::division);
 
         for (auto trackIt = tracks.begin(); trackIt != tracks.end(); ++trackIt) {
             auto& chords = trackIt->second.chords;

--- a/src/importexport/midi/internal/midiimport/importmidi_chord.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_chord.cpp
@@ -86,7 +86,7 @@ findFirstChordInRange(const std::multimap<ReducedFraction, MidiChord>& chords,
 
 const ReducedFraction& minAllowedDuration()
 {
-    const static auto minDuration = ReducedFraction::fromTicks(Constant::division) / 32;
+    const static auto minDuration = ReducedFraction::fromTicks(Constants::division) / 32;
     return minDuration;
 }
 

--- a/src/importexport/midi/internal/midiimport/importmidi_fraction.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_fraction.cpp
@@ -134,7 +134,7 @@ ReducedFraction::ReducedFraction(const Fraction& fraction)
 
 ReducedFraction ReducedFraction::fromTicks(int ticks)
 {
-    return ReducedFraction(ticks, Constant::division * 4).reduced();
+    return ReducedFraction(ticks, Constants::division * 4).reduced();
 }
 
 ReducedFraction ReducedFraction::reduced() const
@@ -155,7 +155,7 @@ int ReducedFraction::ticks() const
 {
     int integral = numerator_ / denominator_;
     int newNumerator = numerator_ % denominator_;
-    int division = Constant::division * 4;
+    int division = Constants::division * 4;
 
 #ifdef QT_DEBUG
     Q_ASSERT_X(!isMultiplicationOverflow(newNumerator, division),
@@ -361,20 +361,20 @@ ReducedFraction toMuseScoreTicks(int tick, int oldDivision, bool isDivisionInTps
     const int integral = tick / oldDivision;
     const int remainder = tick % oldDivision;
 #ifdef QT_DEBUG
-    Q_ASSERT_X(!isMultiplicationOverflow(remainder, Constant::division),
+    Q_ASSERT_X(!isMultiplicationOverflow(remainder, Constants::division),
                "ReducedFraction::toMuseScoreTicks", "Multiplication overflow");
-    Q_ASSERT_X(!isAdditionOverflow(remainder * Constant::division, oldDivision / 2),
+    Q_ASSERT_X(!isAdditionOverflow(remainder * Constants::division, oldDivision / 2),
                "ReducedFraction::toMuseScoreTicks", "Addition overflow");
 #endif
-    const int tmp = remainder * Constant::division + oldDivision / 2;
+    const int tmp = remainder * Constants::division + oldDivision / 2;
 #ifdef QT_DEBUG
     Q_ASSERT_X(!isDivisionOverflow(tmp, oldDivision),
                "ReducedFraction::toMuseScoreTicks", "Division overflow");
-    Q_ASSERT_X(!isMultiplicationOverflow(integral, Constant::division),
+    Q_ASSERT_X(!isMultiplicationOverflow(integral, Constants::division),
                "ReducedFraction::toMuseScoreTicks", "Multiplication overflow");
-    Q_ASSERT_X(!isAdditionOverflow(tmp / oldDivision, integral * Constant::division),
+    Q_ASSERT_X(!isAdditionOverflow(tmp / oldDivision, integral * Constants::division),
                "ReducedFraction::toMuseScoreTicks", "Addition overflow");
 #endif
-    return ReducedFraction::fromTicks(tmp / oldDivision + integral * Constant::division);
+    return ReducedFraction::fromTicks(tmp / oldDivision + integral * Constants::division);
 }
 } // namespace Ms

--- a/src/importexport/midi/internal/midiimport/importmidi_meter.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_meter.cpp
@@ -313,7 +313,7 @@ bool isPowerOfTwo(unsigned int x)
 
 bool isSimpleNoteDuration(const ReducedFraction& duration)
 {
-    const auto division = ReducedFraction::fromTicks(Constant::division);
+    const auto division = ReducedFraction::fromTicks(Constants::division);
     auto div = (duration > division) ? duration / division : division / duration;
     if (div > ReducedFraction(0, 1)) {
         div.reduce();

--- a/src/importexport/midi/internal/midiimport/importmidi_quant.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_quant.cpp
@@ -45,7 +45,7 @@ namespace mu::engraving {
 namespace Quantize {
 ReducedFraction quantValueToFraction(MidiOperations::QuantValue quantValue)
 {
-    const auto division = ReducedFraction::fromTicks(Constant::division);
+    const auto division = ReducedFraction::fromTicks(Constants::division);
     ReducedFraction fraction;
 
     switch (quantValue) {
@@ -86,7 +86,7 @@ ReducedFraction quantValueToFraction(MidiOperations::QuantValue quantValue)
 
 MidiOperations::QuantValue fractionToQuantValue(const ReducedFraction& fraction)
 {
-    const auto division = ReducedFraction::fromTicks(Constant::division);
+    const auto division = ReducedFraction::fromTicks(Constants::division);
     MidiOperations::QuantValue quantValue = MidiOperations::QuantValue::Q_4;
 
     if (fraction == division) {
@@ -120,7 +120,7 @@ MidiOperations::QuantValue fractionToQuantValue(const ReducedFraction& fraction)
 MidiOperations::QuantValue defaultQuantValueFromPreferences()
 {
     auto conf = mu::modularity::ioc()->resolve<mu::iex::midi::IMidiImportExportConfiguration>("iex_midi");
-    int ticks = conf ? conf->midiShortestNote() : (Constant::division / 4);
+    int ticks = conf ? conf->midiShortestNote() : (Constants::division / 4);
     const auto fraction = ReducedFraction::fromTicks(ticks);
     MidiOperations::QuantValue quantValue = fractionToQuantValue(fraction);
     if (quantValue == MidiOperations::QuantValue::Q_INVALID) {
@@ -134,7 +134,7 @@ ReducedFraction shortestQuantizedNoteInRange(
     const std::multimap<ReducedFraction, MidiChord>::const_iterator& beg,
     const std::multimap<ReducedFraction, MidiChord>::const_iterator& end)
 {
-    const auto division = ReducedFraction::fromTicks(Constant::division);
+    const auto division = ReducedFraction::fromTicks(Constants::division);
     auto minDuration = division;
     for (auto it = beg; it != end; ++it) {
         for (const auto& note: it->second.notes) {
@@ -402,7 +402,7 @@ bool isHumanPerformance(
         return false;
     }
 
-    const auto basicQuant = ReducedFraction::fromTicks(Constant::division) / 4;      // 1/16
+    const auto basicQuant = ReducedFraction::fromTicks(Constants::division) / 4;      // 1/16
     int matches = 0;
     int count = 0;
 
@@ -474,7 +474,7 @@ void setIfHumanPerformance(
         if (opers.maxVoiceCount.canRedefineDefaultLater()) {
             opers.maxVoiceCount.setDefaultValue(MidiOperations::VoiceCount::V_2);
         }
-        const double ticksPerSec = MidiTempo::findBasicTempo(tracks, true) * Constant::division;
+        const double ticksPerSec = MidiTempo::findBasicTempo(tracks, true) * Constants::division;
         MidiBeat::findBeatLocations(allChords, sigmap, ticksPerSec);          // and set time sig
     }
 }

--- a/src/importexport/midi/internal/midiimport/importmidi_simplify.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_simplify.cpp
@@ -189,7 +189,7 @@ void shortenDrumNote(
         }
         if (next != chords.end()) {
             const auto len = ReducedFraction::fromTicks(
-                Constant::division) / 8;                             // 1/32
+                Constants::division) / 8;                             // 1/32
             auto newOffTime = it->first + len;
             if (next->second.isInTuplet) {
                 const auto& tuplet = next->second.tuplet->second;

--- a/src/importexport/midi/internal/midiimport/importmidi_swing.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_swing.cpp
@@ -68,7 +68,7 @@ void SwingDetector::add(ChordRest* cr)
             return;
         }
         const int tickInBar = (cr->tick() - cr->measure()->tick()).ticks();
-        if (tickInBar % Constant::division == 0) {
+        if (tickInBar % Constants::division == 0) {
             append(cr);
         }
     } else {
@@ -170,7 +170,7 @@ void SwingDetector::applySwing()
     const int startTick = first->segment()->tick().ticks();
     ChordRest* last = elements.back();
     last->segment()->remove(last);
-    Segment* s = last->measure()->getSegment(SegmentType::ChordRest, Fraction::fromTicks(startTick + Constant::division / 2));
+    Segment* s = last->measure()->getSegment(SegmentType::ChordRest, Fraction::fromTicks(startTick + Constants::division / 2));
     s->add(last);
 
     if (elements.size() == 3) {

--- a/src/importexport/midi/internal/midiimport/importmidi_tempo.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_tempo.cpp
@@ -107,7 +107,7 @@ void applyAllTempoEvents(const std::multimap<int, MTrack>& tracks, Score* score)
 {
     for (const auto& track: tracks) {
         if (track.second.isDivisionInTps) {         // ticks per second
-            const double ticksPerBeat = Constant::division;
+            const double ticksPerBeat = Constants::division;
             const double beatsPerSecond = roundToBpm(track.second.division / ticksPerBeat);
             setTempoToScore(score, 0, beatsPerSecond);
         } else {        // beats per second
@@ -147,7 +147,7 @@ void setTempo(const std::multimap<int, MTrack>& tracks, Score* score)
         int counter = 0;
         auto it = beats.begin();
         auto beatStart = *it;
-        const auto newBeatLen = ReducedFraction::fromTicks(Constant::division);
+        const auto newBeatLen = ReducedFraction::fromTicks(Constants::division);
 
         for (++it; it != beats.end(); ++it) {
             const auto& beatEnd = *it;

--- a/src/importexport/musedata/internal/musedata.cpp
+++ b/src/importexport/musedata/internal/musedata.cpp
@@ -279,7 +279,7 @@ void MuseData::readNote(Part* part, const QString& s)
     if (pitch > 127) {
         pitch = 127;
     }
-    Fraction ticks = Fraction::fromTicks((s.midRef(5, 3).toInt() * Constant::division + _division / 2) / _division);
+    Fraction ticks = Fraction::fromTicks((s.midRef(5, 3).toInt() * Constants::division + _division / 2) / _division);
     Fraction tick  = curTick;
     curTick  += ticks;
 
@@ -479,7 +479,7 @@ QString MuseData::diacritical(QString s)
 
 void MuseData::readRest(Part* part, const QString& s)
 {
-    Fraction ticks = Fraction::fromTicks((s.midRef(5, 3).toInt() * Constant::division + _division / 2) / _division);
+    Fraction ticks = Fraction::fromTicks((s.midRef(5, 3).toInt() * Constants::division + _division / 2) / _division);
 
     Fraction tick  = curTick;
     curTick  += ticks;
@@ -523,7 +523,7 @@ void MuseData::readRest(Part* part, const QString& s)
 
 void MuseData::readBackup(const QString& s)
 {
-    Fraction ticks = Fraction::fromTicks((s.midRef(5, 3).toInt() * Constant::division + _division / 2) / _division);
+    Fraction ticks = Fraction::fromTicks((s.midRef(5, 3).toInt() * Constants::division + _division / 2) / _division);
     if (s[0] == 'b') {
         curTick  -= ticks;
     } else {

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -1191,7 +1191,7 @@ void ExportMusicXml::calcDivisions()
     // init
     integers.clear();
     primes.clear();
-    integers.append(Constant::division);
+    integers.append(Constants::division);
     primes.append(2);
     primes.append(3);
     primes.append(5);
@@ -1265,7 +1265,7 @@ void ExportMusicXml::calcDivisions()
         }
     }
 
-    div = Constant::division / integers[0];
+    div = Constants::division / integers[0];
 #ifdef DEBUG_TICK
     LOGD("divisions=%d div=%d", integers[0], div);
 #endif
@@ -7087,7 +7087,7 @@ void ExportMusicXml::writeMeasure(const Measure* const m,
     // output attributes with the first actual measure (pickup or regular)
     if (isFirstActualMeasure) {
         _attr.doAttr(_xml, true);
-        _xml.tag("divisions", Constant::division / div);
+        _xml.tag("divisions", Constants::division / div);
     }
 
     // output attributes at start of measure: key, time

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -284,8 +284,8 @@ static void fillGap(Measure* measure, track_idx_t track, const Fraction& tstart,
     Fraction restLen = tend - tstart;
     // LOGD("\nfillGIFV     fillGap(measure %p track %d tstart %d tend %d) restLen %d len",
     //        measure, track, tstart, tend, restLen);
-    // note: as Constant::division (#ticks in a quarter note) equals 480
-    // Constant::division / 64 (#ticks in a 256th note) equals 7.5 but is rounded down to 7
+    // note: as Constants::division (#ticks in a quarter note) equals 480
+    // Constants::division / 64 (#ticks in a 256th note) equals 7.5 but is rounded down to 7
     while (restLen > Fraction(1, 256)) {
         Fraction len = restLen;
         TDuration d(DurationType::V_INVALID);

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -594,7 +594,7 @@ std::string NotationConfiguration::notationRevision() const
 
 int NotationConfiguration::notationDivision() const
 {
-    return mu::engraving::Constant::division;
+    return mu::engraving::Constants::division;
 }
 
 ValCh<framework::Orientation> NotationConfiguration::canvasOrientation() const

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3514,7 +3514,7 @@ void NotationInteraction::addGraceNotesToSelectedNotes(GraceNoteType type)
     }
 
     startEdit();
-    score()->cmdAddGrace(type, mu::engraving::Constant::division / denominator);
+    score()->cmdAddGrace(type, mu::engraving::Constants::division / denominator);
     apply();
 }
 

--- a/src/notation/view/widgets/stafftextpropertiesdialog.cpp
+++ b/src/notation/view/widgets/stafftextpropertiesdialog.cpp
@@ -188,11 +188,11 @@ StaffTextPropertiesDialog::StaffTextPropertiesDialog(QWidget* parent)
 
     if (m_staffText->swing()) {
         setSwingBox->setChecked(true);
-        if (m_staffText->swingParameters().swingUnit == Constant::division / 2) {
+        if (m_staffText->swingParameters().swingUnit == Constants::division / 2) {
             swingBox->setEnabled(true);
             swingEighth->setChecked(true);
             swingBox->setValue(m_staffText->swingParameters().swingRatio);
-        } else if (m_staffText->swingParameters().swingUnit == Constant::division / 4) {
+        } else if (m_staffText->swingParameters().swingUnit == Constants::division / 4) {
             swingBox->setEnabled(true);
             swingSixteenth->setChecked(true);
             swingBox->setValue(m_staffText->swingParameters().swingRatio);
@@ -534,10 +534,10 @@ void StaffTextPropertiesDialog::saveValues()
             m_staffText->setSwingParameters(0, swingBox->value());
             swingBox->setEnabled(false);
         } else if (swingEighth->isChecked()) {
-            m_staffText->setSwingParameters(Constant::division / 2, swingBox->value());
+            m_staffText->setSwingParameters(Constants::division / 2, swingBox->value());
             swingBox->setEnabled(true);
         } else if (swingSixteenth->isChecked()) {
-            m_staffText->setSwingParameters(Constant::division / 4, swingBox->value());
+            m_staffText->setSwingParameters(Constants::division / 4, swingBox->value());
             swingBox->setEnabled(true);
         }
     }

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -1313,25 +1313,25 @@ PalettePtr PaletteCreator::newTempoPalette(bool defaultPalette)
         }
     }
 
-    static const std::map<TempoTechniqueType, const char*> DEFAULT_TEMPO_CHANGE = {
-        { TempoTechniqueType::Accelerando, QT_TRANSLATE_NOOP("palette", "accel.") },
-        { TempoTechniqueType::Allargando, QT_TRANSLATE_NOOP("palette", "allarg.") },
-        { TempoTechniqueType::Rallentando, QT_TRANSLATE_NOOP("palette", "rall.") },
-        { TempoTechniqueType::Ritardando, QT_TRANSLATE_NOOP("palette", "rit.") },
+    static const std::map<TempoChangeType, const char*> DEFAULT_TEMPO_CHANGE = {
+        { TempoChangeType::Accelerando, QT_TRANSLATE_NOOP("palette", "accel.") },
+        { TempoChangeType::Allargando, QT_TRANSLATE_NOOP("palette", "allarg.") },
+        { TempoChangeType::Rallentando, QT_TRANSLATE_NOOP("palette", "rall.") },
+        { TempoChangeType::Ritardando, QT_TRANSLATE_NOOP("palette", "rit.") },
     };
 
-    static const std::map<TempoTechniqueType, const char*> MASTER_TEMPO_CHANGE = {
-        { TempoTechniqueType::Accelerando, QT_TRANSLATE_NOOP("palette", "accel.") },
-        { TempoTechniqueType::Allargando, QT_TRANSLATE_NOOP("palette", "allarg.") },
-        { TempoTechniqueType::Calando, QT_TRANSLATE_NOOP("palette", "calando") },
-        { TempoTechniqueType::Lentando, QT_TRANSLATE_NOOP("palette", "lentando") },
-        { TempoTechniqueType::Morendo, QT_TRANSLATE_NOOP("palette", "morendo") },
-        { TempoTechniqueType::Precipitando, QT_TRANSLATE_NOOP("palette", "precipitando") },
-        { TempoTechniqueType::Rallentando, QT_TRANSLATE_NOOP("palette", "rall.") },
-        { TempoTechniqueType::Ritardando, QT_TRANSLATE_NOOP("palette", "rit.") },
-        { TempoTechniqueType::Smorzando, QT_TRANSLATE_NOOP("palette", "smorz.") },
-        { TempoTechniqueType::Sostenuto, QT_TRANSLATE_NOOP("palette", "sost.") },
-        { TempoTechniqueType::Stringendo, QT_TRANSLATE_NOOP("palette", "string.") }
+    static const std::map<TempoChangeType, const char*> MASTER_TEMPO_CHANGE = {
+        { TempoChangeType::Accelerando, QT_TRANSLATE_NOOP("palette", "accel.") },
+        { TempoChangeType::Allargando, QT_TRANSLATE_NOOP("palette", "allarg.") },
+        { TempoChangeType::Calando, QT_TRANSLATE_NOOP("palette", "calando") },
+        { TempoChangeType::Lentando, QT_TRANSLATE_NOOP("palette", "lentando") },
+        { TempoChangeType::Morendo, QT_TRANSLATE_NOOP("palette", "morendo") },
+        { TempoChangeType::Precipitando, QT_TRANSLATE_NOOP("palette", "precipitando") },
+        { TempoChangeType::Rallentando, QT_TRANSLATE_NOOP("palette", "rall.") },
+        { TempoChangeType::Ritardando, QT_TRANSLATE_NOOP("palette", "rit.") },
+        { TempoChangeType::Smorzando, QT_TRANSLATE_NOOP("palette", "smorz.") },
+        { TempoChangeType::Sostenuto, QT_TRANSLATE_NOOP("palette", "sost.") },
+        { TempoChangeType::Stringendo, QT_TRANSLATE_NOOP("palette", "string.") }
     };
 
     for (const auto& pair : defaultPalette ? DEFAULT_TEMPO_CHANGE : MASTER_TEMPO_CHANGE) {

--- a/src/plugins/api/qmlplugin.cpp
+++ b/src/plugins/api/qmlplugin.cpp
@@ -137,7 +137,7 @@ bool QmlPlugin::requiresScore() const
 
 int QmlPlugin::division() const
 {
-    return Constant::division;
+    return Constants::division;
 }
 
 int QmlPlugin::mscoreVersion() const


### PR DESCRIPTION
Also removed some type aliases that existed for compatibility reasons, and fixed some problems that arose from that. 