### PR TITLE
fix #11515: fixed import of tuplets in gp

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.h
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.h
@@ -143,6 +143,8 @@ private:
     void fillUncompletedMeasure(const Context& ctx);
     void fillHarmonicMarksMap();
     int getStringNumberFor(Note* pNote, int pitch) const;
+    void fillTuplet();
+    bool tupletParamsChanged(const GPBeat* beat, const ChordRest* cr);
 
     Score* _score;
     std::unique_ptr<GPDomModel> _gpDom;
@@ -170,7 +172,18 @@ private:
     std::vector<Vibrato*> _vibratos;
     std::vector<Ottava*> _ottavas;
     Volta* _lastVolta = nullptr;
-    Tuplet* _lastTuplet = nullptr;
+
+    struct NextTupletInfo {
+        Fraction ratio;
+        Fraction duration;                // duration of all current elements
+        std::vector<ChordRest*> elements; // elements that will be added to tuplet
+        track_idx_t track;
+        Tuplet* tuplet = nullptr;
+        Measure* measure = nullptr;
+        int lowestBase = LOWEST_BASE;     // expected denominator
+        static constexpr int LOWEST_BASE = 1024;
+    } m_nextTupletInfo;
+
     Hairpin* _lastHairpin = nullptr;
     Ottava* _lastOttava = nullptr;
     Measure* _lastMeasure = nullptr;


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/11515*

*fixed import of tuplets*

- tuplet was positioned too far from notes
- too many notes were added to tuplet
- separate consecutive notes of different tuplet duration would be shown as the same tuplet duration (3, 3, 3 instead of 3, 4:3, 3)
- "4:6" type of tuplet is change to "4"

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
