### PR TITLE
[MU4] Tie staff line avoidance fix

### DIFF
--- a/src/engraving/libmscore/tie.cpp
+++ b/src/engraving/libmscore/tie.cpp
@@ -555,17 +555,24 @@ void TieSegment::adjustY(const PointF& p1, const PointF& p2)
             }
         }
         shoulderHeightMax = 4 / 3; // at max ties will be 1sp tall
-        // are the endpoints within the staff?
-        if (line > 0 && line < (lines - 1) * 2) {
-            // ENDPOINTS ////////////////////////////////
-            // Each line position in the staff has a set endpoint Y location
-            qreal newAnchor;
-            if (isUp) {
-                newAnchor = floor(line / 2) + ((line & 1) ? staffLineOffset : -staffLineOffset);
-            } else {
-                newAnchor = floor((line + 1) / 2) + ((line & 1) ? -staffLineOffset : staffLineOffset);
-            }
 
+        // ENDPOINTS ////////////////////////////////
+        // Each line position in the staff has a set endpoint Y location
+        qreal newAnchor;
+        if (isUp) {
+            newAnchor = floor(line / 2.0) + ((line & 1) ? staffLineOffset : -staffLineOffset);
+        } else {
+            newAnchor = floor((line + 1) / 2.0) + ((line & 1) ? -staffLineOffset : staffLineOffset);
+        }
+
+        // are the endpoints within the staff?
+        bool endpointsInStaff = endpointYsp >= -staffLineOffset && endpointYsp <= (lines - 1) + staffLineOffset;
+        // are the endpoints outside, but still close enough to need height adjustment?
+        int lastLine = (lines - 1) * 2;
+        bool downTieAbove = !isUp && line >= -2 && line < 0;
+        bool upTieBelow = isUp && line > lastLine && line <= lastLine + 2;
+
+        if (endpointsInStaff || downTieAbove || upTieBelow) {
             // TIE APOGEE ///////////////////////////////
             // Constrain tie height to avoid staff line collisions
             if (line & 1) {
@@ -586,9 +593,8 @@ void TieSegment::adjustY(const PointF& p1, const PointF& p2)
                 shoulderHeightMax = 4 * (1 - (staffLineOffset * 2) - (tieThicknessSp / 2)) / 3;
                 shoulderHeightMax *= (ld / spatium());
             }
-
-            setAutoAdjust(PointF(0, (newAnchor - endpointYsp) * ld));
         }
+        setAutoAdjust(PointF(0, (newAnchor - endpointYsp) * ld));
     }
 }
 


### PR DESCRIPTION
Issue: 
![image](https://user-images.githubusercontent.com/89263931/172168221-34d77fad-71b3-4b4c-a2f7-f251e09378a4.png)

Notes on the bottom line with inside ties laid out the tie assuming that the endpoints would be outside the staff. Obviously this works for down-ties but not for up-ties. This has been changed to compare the actual endpoint locations to see if they are inside the staff or not. This way we don't have to worry about whether the tie is up or down when we determine whether to adjust them for staff lines or not.
![image](https://user-images.githubusercontent.com/89263931/172168681-fcbd5e31-b41a-4497-842c-bd55b416aadf.png)

