### PR TITLE
Fix #9984: Set appropriate staff size at score creation

### DIFF
--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -1254,6 +1254,8 @@ public:
     const PaddingTable& paddingTable() const { return _paddingTable; }
     double minimumPaddingUnit() const { return _minimumPaddingUnit; }
 
+    void autoUpdateSpatium();
+
     friend class ChangeSynthesizerState;
     friend class Chord;
 };

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -432,6 +432,7 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
     }
 
     score->setUpTempoMap();
+    score->autoUpdateSpatium();
 
     {
         mu::engraving::ScoreLoad sl;


### PR DESCRIPTION
Resolves: #9984 

When creating a new score, the staff size is reduced as necessary to make sure that the system can fit in one page, thus avoiding silly results as shown in the related issue. This change does not affect templates nor existing documents. @oktophonie @Tantacrul 