### PR TITLE
[MU4] Fix MSVC compiler warning

### DIFF
--- a/src/engraving/libmscore/instrtemplate.cpp
+++ b/src/engraving/libmscore/instrtemplate.cpp
@@ -45,7 +45,7 @@ using namespace mu::engraving;
 
 namespace mu::engraving {
 std::vector<InstrumentGroup*> instrumentGroups;
-std::vector<MidiArticulation> articulation;                 // global articulations
+std::vector<MidiArticulation> midiArticulations;            // global articulations
 std::vector<InstrumentGenre*> instrumentGenres;
 std::vector<InstrumentFamily*> instrumentFamilies;
 std::vector<ScoreOrder> instrumentOrders;
@@ -111,7 +111,7 @@ InstrumentGroup* searchInstrumentGroup(const QString& name)
 
 static MidiArticulation searchArticulation(const QString& name)
 {
-    for (MidiArticulation a : articulation) {
+    for (MidiArticulation a : midiArticulations) {
         if (a.name == name) {
             return a;
         }
@@ -163,7 +163,8 @@ void InstrumentGroup::read(XmlReader& e)
             InstrumentTemplate* t = searchTemplate(sid);
             if (t == 0) {
                 t = new InstrumentTemplate;
-                t->articulation.insert(t->articulation.end(), articulation.begin(), articulation.end());             // init with global articulation
+                // init with global articulation
+                t->midiArticulations.insert(t->midiArticulations.end(), midiArticulations.begin(), midiArticulations.end());
                 t->sequenceOrder = static_cast<int>(instrumentTemplates.size());
                 instrumentTemplates.push_back(t);
             }
@@ -395,9 +396,9 @@ void InstrumentTemplate::write(XmlWriter& xml) const
     for (const InstrChannel& a : channel) {
         a.write(xml, nullptr);
     }
-    for (const MidiArticulation& ma : articulation) {
+    for (const MidiArticulation& ma : midiArticulations) {
         bool isGlobal = false;
-        for (const MidiArticulation& ga : mu::engraving::articulation) {
+        for (const MidiArticulation& ga : mu::engraving::midiArticulations) {
             if (ma == ga) {
                 isGlobal = true;
                 break;
@@ -546,16 +547,16 @@ void InstrumentTemplate::read(XmlReader& e)
         } else if (tag == "Articulation") {
             MidiArticulation a;
             a.read(e);
-            size_t n = articulation.size();
+            size_t n = midiArticulations.size();
             size_t i;
             for (i = 0; i < n; ++i) {
-                if (articulation[i].name == a.name) {
-                    articulation[i] = a;
+                if (midiArticulations[i].name == a.name) {
+                    midiArticulations[i] = a;
                     break;
                 }
             }
             if (i == n) {
-                articulation.push_back(a);
+                midiArticulations.push_back(a);
             }
         } else if (tag == "stafftype") {
             int staffIdx = readStaffIdx(e);
@@ -657,7 +658,7 @@ void clearInstrumentTemplates()
     instrumentGenres.clear();
     qDeleteAll(instrumentFamilies);
     instrumentFamilies.clear();
-    articulation.clear();
+    midiArticulations.clear();
     instrumentOrders.clear();
 }
 
@@ -691,7 +692,7 @@ bool loadInstrumentTemplates(const QString& instrTemplates)
                     QString name(e.attribute("name"));
                     MidiArticulation a = searchArticulation(name);
                     a.read(e);
-                    articulation.push_back(a);
+                    midiArticulations.push_back(a);
                 } else if (tag == "Genre") {
                     QString idGenre(e.attribute("id"));
                     InstrumentGenre* genre = searchInstrumentGenre(idGenre);

--- a/src/engraving/libmscore/instrtemplate.h
+++ b/src/engraving/libmscore/instrtemplate.h
@@ -109,7 +109,7 @@ public:
     StringData stringData;
 
     std::list<NamedEventList> midiActions;
-    std::vector<MidiArticulation> articulation;
+    std::vector<MidiArticulation> midiArticulations;
     std::vector<InstrChannel> channel;
     std::list<InstrumentGenre*> genres;       //; list of genres this instrument belongs to
     InstrumentFamily* family = nullptr;   //; family the instrument belongs to
@@ -169,7 +169,7 @@ struct InstrumentIndex {
 
 extern std::vector<InstrumentGenre*> instrumentGenres;
 extern std::vector<InstrumentFamily*> instrumentFamilies;
-extern std::vector<MidiArticulation> articulation;
+extern std::vector<MidiArticulation> midiArticulations;
 extern std::vector<InstrumentGroup*> instrumentGroups;
 extern std::vector<ScoreOrder> instrumentOrders;
 extern void clearInstrumentTemplates();

--- a/src/engraving/libmscore/instrument.cpp
+++ b/src/engraving/libmscore/instrument.cpp
@@ -1706,7 +1706,7 @@ Instrument Instrument::fromTemplate(const InstrumentTemplate* templ)
     }
 
     instrument.setMidiActions(templ->midiActions);
-    instrument.setArticulation(templ->articulation);
+    instrument.setArticulation(templ->midiArticulations);
     instrument._channel.clear();
 
     for (const InstrChannel& c : templ->channel) {

--- a/src/engraving/playback/metaparsers/chordarticulationsparser.cpp
+++ b/src/engraving/playback/metaparsers/chordarticulationsparser.cpp
@@ -117,8 +117,8 @@ void ChordArticulationsParser::parseSpanners(const Chord* chord, const Rendering
 
 void ChordArticulationsParser::parseArticulationSymbols(const Chord* chord, const RenderingContext& ctx, mpe::ArticulationMap& result)
 {
-    for (const Articulation* artic : chord->articulations()) {
-        SymbolsMetaParser::parse(artic, ctx, result);
+    for (const Articulation* articulation : chord->articulations()) {
+        SymbolsMetaParser::parse(articulation, ctx, result);
     }
 }
 

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -494,7 +494,7 @@ static Instrument createInstrument(const MusicXMLInstrument& mxmlInstr, const In
         instr.setTranspose(Interval());
     } else {
         // set articulations to default (global articulations)
-        instr.setArticulation(articulation);
+        instr.setArticulation(midiArticulations);
         // set default program
         instr.channel(0)->setProgram(mxmlInstr.midiProgram >= 0 ? mxmlInstr.midiProgram : 0);
     }

--- a/src/inspector/models/notation/ornaments/ornamentsettingsmodel.cpp
+++ b/src/inspector/models/notation/ornaments/ornamentsettingsmodel.cpp
@@ -52,12 +52,12 @@ void OrnamentSettingsModel::requestElements()
             return false;
         }
 
-        const mu::engraving::Articulation* artic = mu::engraving::toArticulation(element);
-        IF_ASSERT_FAILED(artic) {
+        const mu::engraving::Articulation* articulation = mu::engraving::toArticulation(element);
+        IF_ASSERT_FAILED(articulation) {
             return false;
         }
 
-        return artic->isOrnament();
+        return articulation->isOrnament();
     });
 }
 

--- a/src/notation/view/noteinputbarmodel.cpp
+++ b/src/notation/view/noteinputbarmodel.cpp
@@ -436,8 +436,8 @@ std::set<SymbolId> NoteInputBarModel::resolveCurrentArticulations() const
 
     auto chordArticulations = [](const Chord* chord) {
         std::set<SymbolId> result;
-        for (Articulation* artic: chord->articulations()) {
-            result.insert(artic->symId());
+        for (Articulation* articulation: chord->articulations()) {
+            result.insert(articulation->symId());
         }
 
         result = mu::engraving::flipArticulations(result, mu::engraving::PlacementV::ABOVE);


### PR DESCRIPTION
reg.	declaration of 'articulation' hides global declaration (C4459), since #11865

Follow-up to #11868, apparently I missed to include it there, but now it reverts that PR and renames the conflicting global declaration instead.