### PR TITLE
Enable press and hold for notation tabs scroll buttons

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/IncrementalPropertyControl.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/IncrementalPropertyControl.qml
@@ -49,7 +49,7 @@ Item {
     implicitHeight: 30
     implicitWidth: parent.width
 
-    navigation.name: root.objectName != "" ? root.objectName : "IncrementalControl"
+    navigation.name: Boolean(root.objectName) ? root.objectName : "IncrementalControl"
 
     function increment() {
         var value = root.isIndeterminate ? 0.0 : currentValue
@@ -154,31 +154,33 @@ Item {
         }
 
         mouseArea.onWheel: function(wheel) {
-            if (textInputField.activeFocus == true) {
-                let pixelY = wheel.pixelDelta.y
-                let angleY = wheel.angleDelta.y
-
-                // This is set below. For angleY, make sure it is <= 120,
-                // because in many actual mouse wheels, one scroll sets
-                // angleY to +/- 120.
-                let oneScroll = 0
-
-                if (pixelY != 0) {
-                    scrolled += pixelY
-                    oneScroll = 60
-                } else if (angleY != 0) {
-                    scrolled += angleY
-                    oneScroll = 120
-                }
-                if (scrolled >= oneScroll) {
-                    root.increment()
-                    scrolled = 0
-                } else if (scrolled <= -oneScroll) {
-                    root.decrement()
-                    scrolled = 0
-                }
-            } else {
+            if (!textInputField.activeFocus) {
                 wheel.accepted = false
+                return
+            }
+
+            let pixelY = wheel.pixelDelta.y
+            let angleY = wheel.angleDelta.y
+
+            // This is set below. For angleY, make sure it is <= 120,
+            // because in many actual mouse wheels, one scroll sets
+            // angleY to +/- 120.
+            let oneScroll = 0
+
+            if (pixelY !== 0) {
+                scrolled += pixelY
+                oneScroll = 60
+            } else if (angleY !== 0) {
+                scrolled += angleY
+                oneScroll = 120
+            }
+
+            if (scrolled >= oneScroll) {
+                root.increment()
+                scrolled = 0
+            } else if (scrolled <= -oneScroll) {
+                root.decrement()
+                scrolled = 0
             }
         }
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/NotationSwitchPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/NotationSwitchPanel.qml
@@ -147,7 +147,7 @@ Rectangle {
 
                 icon: IconCode.CHEVRON_LEFT
 
-                onClicked: {
+                onScrollRequested: {
                     notationsView.scrollLeft()
                 }
             }
@@ -164,7 +164,7 @@ Rectangle {
 
                 icon: IconCode.CHEVRON_RIGHT
 
-                onClicked: {
+                onScrollRequested: {
                     notationsView.scrollRight()
                 }
             }

--- a/src/notation/qml/MuseScore/NotationScene/internal/NotationSwitchScrollArrowButton.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/NotationSwitchScrollArrowButton.qml
@@ -26,6 +26,8 @@ import MuseScore.UiComponents 1.0
 FlatButton {
     id: root
 
+    signal scrollRequested()
+
     width: 22
     height: parent.height
 
@@ -63,5 +65,29 @@ FlatButton {
             navigationCtrl: root.navigation
             drawOutsideParent: false
         }
+    }
+
+    mouseArea.preventStealing: true
+    mouseArea.pressAndHoldInterval: 200
+
+    mouseArea.onClicked: { root.scrollRequested() }
+    mouseArea.onPressAndHold: { timer.running = true }
+    mouseArea.onReleased: { timer.running = false }
+
+    onEnabledChanged: {
+        // If the button becomes disabled, the mouse area does not emit the
+        // `released` signal anymore, so we'll stop the repeat timer here.
+        if (!enabled) {
+            timer.running = false
+        }
+    }
+
+    Timer {
+        id: timer
+
+        interval: 100
+        repeat: true
+
+        onTriggered: { root.scrollRequested() }
     }
 }


### PR DESCRIPTION
Resolves: #11864

(While looking at IncrementalPropertyControl.qml for a quick reference, I found that there were some QML warnings in that file so I quickly fixed those too.)