### PR TITLE
[MU4] fixed #11478: keyboard navigation breaks at key and time signatures if >1 staff

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2468,7 +2468,7 @@ void NotationInteraction::moveElementSelection(MoveDirection d)
         endEditElement();
     }
 
-    select({ toEl }, SelectType::SINGLE);
+    select({ toEl }, SelectType::REPLACE);
     resetHitElementContext();
     showItem(toEl);
 


### PR DESCRIPTION
Resolves: #11478