### PR TITLE
[MU4] Fix #11906: Crash occurs when using Repeat command inside triplet (tuplet) group (and warning message like in MU3 doesn't appear)

### DIFF
--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -156,6 +156,7 @@ public:
     virtual void addBoxes(BoxType boxType, int count, int beforeBoxIndex) = 0;
 
     virtual void copySelection() = 0;
+    virtual mu::Ret repeatSelection() = 0;
     virtual void copyLyrics() = 0;
     virtual void pasteSelection(const Fraction& scale = Fraction(1, 1)) = 0;
     virtual void swapSelection() = 0;
@@ -210,7 +211,6 @@ public:
     virtual void fillSelectionWithSlashes() = 0;
     virtual void replaceSelectedNotesWithSlashes() = 0;
 
-    virtual void repeatSelection() = 0;
     virtual void changeEnharmonicSpelling(bool both) = 0;
     virtual void spellPitches() = 0;
     virtual void regroupNotesAndRests() = 0;

--- a/src/notation/inotationselection.h
+++ b/src/notation/inotationselection.h
@@ -23,11 +23,12 @@
 #define MU_NOTATION_INOTATIONSELECTION_H
 
 #include <vector>
-#include <QRectF>
-#include <QMimeData>
 
 #include "notationtypes.h"
 #include "internal/inotationselectionrange.h"
+#include "ret.h"
+
+class QMimeData;
 
 namespace mu::notation {
 class INotationSelection
@@ -39,7 +40,7 @@ public:
     virtual bool isRange() const = 0;
     virtual SelectionState state() const = 0;
 
-    virtual bool canCopy() const = 0;
+    virtual mu::Ret canCopy() const = 0;
     virtual QMimeData* mimeData() const = 0;
 
     virtual EngravingItem* element() const = 0;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -401,7 +401,7 @@ void NotationActionController::init()
     registerAction("pitch-up-diatonic", &Interaction::movePitch, MoveDirection::Up, PitchMode::DIATONIC, PlayMode::PlayNote);
     registerAction("pitch-down-diatonic", &Interaction::movePitch, MoveDirection::Down, PitchMode::DIATONIC, PlayMode::PlayNote);
 
-    registerAction("repeat-sel", &Interaction::repeatSelection);
+    registerAction("repeat-sel", &Controller::repeatSelection);
 
     registerAction("add-trill", &Interaction::toggleArticulation, mu::engraving::SymId::ornamentTrill);
     registerAction("add-up-bow", &Interaction::toggleArticulation, mu::engraving::SymId::stringsUpBow);
@@ -943,6 +943,20 @@ void NotationActionController::cutSelection()
     }
     interaction->copySelection();
     interaction->deleteSelection();
+}
+
+void NotationActionController::repeatSelection()
+{
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+
+    Ret ret = interaction->repeatSelection();
+
+    if (!ret && !ret.text().empty()) {
+        interactive()->error("", ret.text());
+    }
 }
 
 void NotationActionController::pasteSelection(PastingType type)

--- a/src/notation/internal/notationactioncontroller.h
+++ b/src/notation/internal/notationactioncontroller.h
@@ -97,6 +97,7 @@ private:
     void changeVoice(int voiceIndex);
 
     void cutSelection();
+    void repeatSelection();
     void addTie();
     void chordTie();
     void addSlur();

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -29,6 +29,7 @@
 #include <QClipboard>
 #include <QApplication>
 #include <QKeyEvent>
+#include <QMimeData>
 
 #include "defer.h"
 #include "ptrutils.h"
@@ -3242,6 +3243,56 @@ void NotationInteraction::copySelection()
     }
 }
 
+mu::Ret NotationInteraction::repeatSelection()
+{
+    const mu::engraving::Selection& selection = score()->selection();
+    if (score()->noteEntryMode() && selection.isSingle()) {
+        EngravingItem* el = selection.element();
+        if (el && el->type() == ElementType::NOTE && !score()->inputState().endOfScore()) {
+            startEdit();
+            Chord* c = toNote(el)->chord();
+            for (Note* note : c->notes()) {
+                mu::engraving::NoteVal nval = note->noteVal();
+                score()->addPitch(nval, note != c->notes()[0]);
+            }
+            apply();
+        }
+    }
+
+    if (!selection.isRange()) {
+        ChordRest* cr = score()->getSelectedChordRest();
+        if (!cr) {
+            return make_ret(Err::EmptySelection);
+        }
+        score()->select(cr, SelectType::RANGE);
+    }
+
+    Ret ret = m_selection->canCopy();
+    if (!ret) {
+        return ret;
+    }
+
+    mu::engraving::XmlReader xml(selection.mimeData());
+    xml.context()->setPasteMode(true);
+    track_idx_t dStaff = selection.staffStart();
+    mu::engraving::Segment* endSegment = selection.endSegment();
+
+    if (endSegment && endSegment->segmentType() != mu::engraving::SegmentType::ChordRest) {
+        endSegment = endSegment->next1(mu::engraving::SegmentType::ChordRest);
+    }
+    if (endSegment && endSegment->element(dStaff * mu::engraving::VOICES)) {
+        EngravingItem* e = endSegment->element(dStaff * mu::engraving::VOICES);
+        if (e) {
+            startEdit();
+            ChordRest* cr = toChordRest(e);
+            score()->pasteStaff(xml, cr->segment(), cr->staffIdx());
+            apply();
+        }
+    }
+
+    return ret;
+}
+
 void NotationInteraction::copyLyrics()
 {
     QString text = score()->extractLyrics();
@@ -3883,48 +3934,6 @@ void NotationInteraction::replaceSelectedNotesWithSlashes()
     startEdit();
     score()->cmdSlashRhythm();
     apply();
-}
-
-void NotationInteraction::repeatSelection()
-{
-    const mu::engraving::Selection& selection = score()->selection();
-    if (score()->noteEntryMode() && selection.isSingle()) {
-        EngravingItem* el = selection.element();
-        if (el && el->type() == ElementType::NOTE && !score()->inputState().endOfScore()) {
-            startEdit();
-            Chord* c = toNote(el)->chord();
-            for (Note* note : c->notes()) {
-                mu::engraving::NoteVal nval = note->noteVal();
-                score()->addPitch(nval, note != c->notes()[0]);
-            }
-            apply();
-        }
-        return;
-    }
-    if (!selection.isRange()) {
-        ChordRest* cr = score()->getSelectedChordRest();
-        if (!cr) {
-            return;
-        }
-        score()->select(cr, SelectType::RANGE);
-    }
-    mu::engraving::XmlReader xml(selection.mimeData());
-    xml.context()->setPasteMode(true);
-    track_idx_t dStaff = selection.staffStart();
-    mu::engraving::Segment* endSegment = selection.endSegment();
-
-    if (endSegment && endSegment->segmentType() != mu::engraving::SegmentType::ChordRest) {
-        endSegment = endSegment->next1(mu::engraving::SegmentType::ChordRest);
-    }
-    if (endSegment && endSegment->element(dStaff * mu::engraving::VOICES)) {
-        EngravingItem* e = endSegment->element(dStaff * mu::engraving::VOICES);
-        if (e) {
-            startEdit();
-            ChordRest* cr = toChordRest(e);
-            score()->pasteStaff(xml, cr->segment(), cr->staffIdx());
-            apply();
-        }
-    }
 }
 
 void NotationInteraction::changeEnharmonicSpelling(bool both)

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -159,6 +159,7 @@ public:
 
     void copySelection() override;
     void copyLyrics() override;
+    Ret repeatSelection() override;
     void pasteSelection(const Fraction& scale = Fraction(1, 1)) override;
     void swapSelection() override;
     void deleteSelection() override;
@@ -211,7 +212,6 @@ public:
 
     void fillSelectionWithSlashes() override;
     void replaceSelectedNotesWithSlashes() override;
-    void repeatSelection() override;
     void changeEnharmonicSpelling(bool) override;
     void spellPitches() override;
     void regroupNotesAndRests() override;

--- a/src/notation/internal/notationselection.cpp
+++ b/src/notation/internal/notationselection.cpp
@@ -21,11 +21,14 @@
  */
 #include "notationselection.h"
 
+#include <QMimeData>
+
 #include "libmscore/masterscore.h"
 #include "libmscore/segment.h"
 #include "libmscore/measure.h"
 
 #include "notationselectionrange.h"
+#include "notationerrors.h"
 
 #include "log.h"
 
@@ -52,9 +55,17 @@ SelectionState NotationSelection::state() const
     return score()->selection().state();
 }
 
-bool NotationSelection::canCopy() const
+mu::Ret NotationSelection::canCopy() const
 {
-    return score()->selection().canCopy();
+    if (isNone()) {
+        return make_ret(Err::EmptySelection);
+    }
+
+    if (!score()->selection().canCopy()) {
+        return make_ret(Err::SelectCompleteTupletOrTremolo);
+    }
+
+    return make_ok();
 }
 
 QMimeData* NotationSelection::mimeData() const

--- a/src/notation/internal/notationselection.h
+++ b/src/notation/internal/notationselection.h
@@ -40,7 +40,7 @@ public:
     bool isRange() const override;
     SelectionState state() const override;
 
-    bool canCopy() const override;
+    Ret canCopy() const override;
     QMimeData* mimeData() const override;
 
     EngravingItem* element() const override;

--- a/src/notation/notationerrors.h
+++ b/src/notation/notationerrors.h
@@ -35,6 +35,7 @@ enum class Err {
     NoteOrRestIsNotSelected = 1050,
     NoteOrFiguredBassIsNotSelected,
     MeasureIsNotSelected,
+    SelectCompleteTupletOrTremolo,
     EmptySelection,
 };
 
@@ -54,6 +55,9 @@ inline Ret make_ret(Err err)
         break;
     case Err::MeasureIsNotSelected:
         text = trc("notation", "No measure selected: Please select a measure and retry");
+        break;
+    case Err::SelectCompleteTupletOrTremolo:
+        text = trc("notation", "Please select the complete tuplet/tremolo and retry the command");
         break;
     case Err::EmptySelection:
         text = trc("notation", "The selection is empty");


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11906