### PR TITLE
[MU4] Fix #11883: Bracket / Brace can't be removed with [Delete]; no UNDO possible; leads to crash

### DIFF
--- a/src/notation/internal/notationaccessibility.cpp
+++ b/src/notation/internal/notationaccessibility.cpp
@@ -77,13 +77,25 @@ void NotationAccessibility::setMapToScreenFunc(const AccessibleMapToScreenFunc& 
 
 void NotationAccessibility::setEnabled(bool enabled)
 {
-    auto accessibleRootItem = score()->rootItem()->accessible()->accessibleRoot();
-    accessibleRootItem->setEnabled(enabled);
-    updateAccessibleState(accessibleRootItem);
+    std::vector<AccessibleRoot*> roots {
+        score()->rootItem()->accessible()->accessibleRoot(),
+        score()->dummy()->rootItem()->accessible()->accessibleRoot()
+    };
 
-    auto accessibleDummyItem = score()->dummy()->rootItem()->accessible()->accessibleRoot();
-    accessibleDummyItem->setEnabled(enabled);
-    updateAccessibleState(accessibleRootItem);
+    EngravingItem* selectedElement = selection()->element();
+
+    for (AccessibleRoot* root : roots) {
+        root->setEnabled(enabled);
+
+        if (!enabled) {
+            root->setFocusedElement(nullptr);
+            continue;
+        }
+
+        if (selectedElement && selectedElement->accessible()->accessibleRoot() == root) {
+            root->setFocusedElement(selectedElement->accessible());
+        }
+    }
 }
 
 void NotationAccessibility::updateAccessibilityInfo()
@@ -106,21 +118,6 @@ void NotationAccessibility::updateAccessibilityInfo()
     newAccessibilityInfo = newAccessibilityInfo.simplified();
 
     setAccessibilityInfo(newAccessibilityInfo);
-}
-
-void NotationAccessibility::updateAccessibleState(engraving::AccessibleRoot* root)
-{
-    if (!root->enabled()) {
-        root->setFocusedElement(nullptr);
-        return;
-    }
-
-    EngravingItem* element = selection()->element();
-    if (!element) {
-        return;
-    }
-
-    root->setFocusedElement(element->accessible());
 }
 
 void NotationAccessibility::setAccessibilityInfo(const QString& info)

--- a/src/notation/internal/notationaccessibility.h
+++ b/src/notation/internal/notationaccessibility.h
@@ -53,7 +53,6 @@ private:
     const engraving::Selection* selection() const;
 
     void updateAccessibilityInfo();
-    void updateAccessibleState(engraving::AccessibleRoot* root);
 
     void setAccessibilityInfo(const QString& info);
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11883#issuecomment-1148664808