### PR TITLE
Allowing function keys while typing for calling shortcuts

### DIFF
--- a/src/engraving/libmscore/textedit.cpp
+++ b/src/engraving/libmscore/textedit.cpp
@@ -245,7 +245,45 @@ void TextBase::insertText(EditData& ed, const QString& s)
 
 bool TextBase::isEditAllowed(EditData& ed) const
 {
-    if (ed.key == Qt::Key_Shift || ed.key == Qt::Key_Escape) {
+    static QSet<int> functionKeys = {
+        Qt::Key_F1,
+        Qt::Key_F2,
+        Qt::Key_F3,
+        Qt::Key_F4,
+        Qt::Key_F5,
+        Qt::Key_F6,
+        Qt::Key_F7,
+        Qt::Key_F8,
+        Qt::Key_F9,
+        Qt::Key_F10,
+        Qt::Key_F11,
+        Qt::Key_F12,
+        Qt::Key_F13,
+        Qt::Key_F14,
+        Qt::Key_F15,
+        Qt::Key_F16,
+        Qt::Key_F17,
+        Qt::Key_F18,
+        Qt::Key_F19,
+        Qt::Key_F20,
+        Qt::Key_F21,
+        Qt::Key_F22,
+        Qt::Key_F23,
+        Qt::Key_F24,
+        Qt::Key_F25,
+        Qt::Key_F26,
+        Qt::Key_F27,
+        Qt::Key_F28,
+        Qt::Key_F29,
+        Qt::Key_F30,
+        Qt::Key_F31,
+        Qt::Key_F32,
+        Qt::Key_F33,
+        Qt::Key_F34,
+        Qt::Key_F35
+    };
+
+    if (ed.key == Qt::Key_Shift || ed.key == Qt::Key_Escape || functionKeys.contains(ed.key)) {
         return false;
     }
 


### PR DESCRIPTION
By-Product of: https://github.com/musescore/MuseScore/pull/11586
This PR intends to filter out function keys while text-editing as no shortcuts are picked up while typing. But they are required for shortcuts like `show-keys`. 

Thank you @cbjeukendrup for guidance!

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
