### PR TITLE
[MU4] Fix #11926: Crash on inserting special character in heading or sub-heading

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1416,8 +1416,8 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
 
         auto isEntryDrumStaff = [score]() {
             const mu::engraving::InputState& is = score->inputState();
-            mu::engraving::Staff* staff = score->staff(is.track() / mu::engraving::VOICES);
-            return staff->staffType(is.tick())->group() == mu::engraving::StaffGroup::PERCUSSION;
+            const mu::engraving::Staff* staff = score->staff(is.track() / mu::engraving::VOICES);
+            return staff ? staff->staffType(is.tick())->group() == mu::engraving::StaffGroup::PERCUSSION : false;
         };
 
         if (isEntryDrumStaff() && element->isChord()) {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11926