### PR TITLE
[MU4] Fix #11914: Crash after deleting initial time signatures and Undo

### DIFF
--- a/src/engraving/libmscore/part.cpp
+++ b/src/engraving/libmscore/part.cpp
@@ -645,7 +645,7 @@ void Part::insertTime(const Fraction& tick, const Fraction& len)
         Instrument* instrument = i->second;
         int t = i->first;
         _instruments.erase(i++);
-        _instruments[t + len.ticks()] = instrument;
+        il[t + len.ticks()] = instrument;
     }
     _instruments.insert(il.begin(), il.end());
 }

--- a/src/engraving/libmscore/undo.cpp
+++ b/src/engraving/libmscore/undo.cpp
@@ -2126,9 +2126,7 @@ void InsertRemoveMeasures::removeMeasures()
         // remember clefs at the end of previous measure
         const auto clefs = getCourtesyClefs(toMeasure(fm));
 
-        if (score->firstMeasure()) {
-            score->insertTime(tick1, -(tick2 - tick1));
-        }
+        score->insertTime(tick1, -(tick2 - tick1));
 
         // Restore clefs that were backed up. Events for them could be lost
         // as a result of the recent insertTime() call.


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11914