### PR TITLE
Fix alignment of instrument names with multiple lines

### DIFF
--- a/src/engraving/libmscore/system.h
+++ b/src/engraving/libmscore/system.h
@@ -125,7 +125,7 @@ class System final : public EngravingItem
     Bracket* createBracket(const LayoutContext& ctx, BracketItem* bi, size_t column, staff_idx_t staffIdx, std::vector<Bracket*>& bl,
                            Measure* measure);
 
-    qreal systemNamesWidth();
+    qreal instrumentNamesWidth();
     qreal layoutBrackets(const LayoutContext& ctx);
     qreal totalBracketOffset(const LayoutContext& ctx);
 

--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -956,13 +956,18 @@ void TextBlock::layout(TextBase* t)
     _lineSpacing *= t->textLineSpacing();
 
     qreal rx = 0;
-    if (t->align() == AlignH::RIGHT) {
-        rx = layoutWidth - _bbox.right();
-    } else if (t->align() == AlignH::HCENTER) {
-        rx = (layoutWidth - (_bbox.left() + _bbox.right())) * .5;
-    } else { // Align::LEFT
+    switch (t->align().horizontal) {
+    case AlignH::LEFT:
         rx = -_bbox.left();
+        break;
+    case AlignH::HCENTER:
+        rx = (layoutWidth - (_bbox.left() + _bbox.right())) * .5;
+        break;
+    case AlignH::RIGHT:
+        rx = layoutWidth - _bbox.right();
+        break;
     }
+
     rx += lm;
     for (TextFragment& f : _fragments) {
         f.pos.rx() += rx;


### PR DESCRIPTION
- The multiple lines are now correctly aligned relative to each other again
- Instead of counting `Sid::instrumentNameOffset` twice, correctly take the brackets width into account for determining the system left margin if instrument names are present
- Fix a possible bug where bracket width was counted using integers instead of qreals
- Added a comment that the `System::totalBracketOffset` method does not work (fixing it is a separate job...)
- And a tiny optimization / code style improvement in TextBlock::layout().

Resolves: #11044 