### PR TITLE
[MU4] Fix #11874: New SoundFont notification dialog cannot accommodate entire text string

### DIFF
--- a/src/framework/audio/internal/soundfontrepository.cpp
+++ b/src/framework/audio/internal/soundfontrepository.cpp
@@ -86,10 +86,12 @@ mu::Ret SoundFontRepository::addSoundFont(const SoundFontPath& path)
     }
 
     if (fileSystem()->exists(newPath.val)) {
-        title = qtrc("audio", "File \"%1\" already exists.")
-                .arg(newPath.val.toQString()).toStdString();
+        title = trc("audio", "File already exists. Do you want to overwrite it?");
 
-        btn = interactive()->question(title, trc("audio", "Do you want to overwrite it?"), {
+        std::string body = qtrc("audio", "File path: %1")
+                           .arg(newPath.val.toQString()).toStdString();
+
+        btn = interactive()->question(title, body, {
             IInteractive::Button::No,
             IInteractive::Button::Yes
         }, IInteractive::Button::Yes, IInteractive::WithIcon).standardButton();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11874