### PR TITLE
fix #11377: Template and instruments search: show hint when no results are found

### DIFF
--- a/src/instrumentsscene/view/instrumentlistmodel.cpp
+++ b/src/instrumentsscene/view/instrumentlistmodel.cpp
@@ -152,8 +152,13 @@ QStringList InstrumentListModel::groups() const
 {
     QStringList result;
 
-    for (const InstrumentGroup* group: m_groups) {
-        result << group->name;
+    if (m_groups.isEmpty()) {
+        std::string title = mu::trc("mscore", "No results found.");
+        result << QString::fromStdString(title);
+    } else {
+        for (const InstrumentGroup* group: m_groups) {
+            result << group->name;
+        }
     }
 
     return result;

--- a/src/project/view/templatesmodel.cpp
+++ b/src/project/view/templatesmodel.cpp
@@ -143,7 +143,13 @@ void TemplatesModel::setVisibleCategories(const QStringList& titles)
         currentCategory = m_currentCategory;
     }
 
-    m_visibleCategoriesTitles = titles;
+    if (titles.isEmpty()) {
+        std::string title = mu::trc("mscore", "No results found.");
+        m_visibleCategoriesTitles = QStringList { QString::fromStdString(title) };
+    } else {
+        m_visibleCategoriesTitles = titles;
+    }
+
     emit categoriesChanged();
 
     setCurrentCategory(currentCategory);


### PR DESCRIPTION
Template and instruments search: show hint when no results are found

Resolves: [[MU4 Issue] New Score - Templates - Search - No context on results not found](https://github.com/musescore/MuseScore/issues/11377)

No hint was shown when there were no search results. This change shows the text „No results found.“ in the template category list or the instrument group list.

The text is clickable since it is technically a dummy category/group. When clicked, it resets the search. Is this behaviour acceptable? It is a side effect of trying to implement the change with minimal changes. It was not intended but I sticked with it since it felt logical to me.

Also, I was not sure how localization works in MuseScore. So please let me know if I did it incorrectly.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
