### PR TITLE
fix #11928: octave import in gp

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.h
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.h
@@ -170,7 +170,6 @@ private:
     std::vector<TextLineBase*> m_rasgueados;
     std::map<GPNote::Harmonic::Type, std::vector<TextLineBase*> > m_harmonicMarks;
     std::vector<Vibrato*> _vibratos;
-    std::vector<Ottava*> _ottavas;
     Volta* _lastVolta = nullptr;
 
     struct NextTupletInfo {
@@ -185,7 +184,7 @@ private:
     } m_nextTupletInfo;
 
     Hairpin* _lastHairpin = nullptr;
-    Ottava* _lastOttava = nullptr;
+    std::vector<Ottava*> m_lastOttavas;
     Measure* _lastMeasure = nullptr;
     bool m_showCapo = true; // TODO-gp : settings
 };


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/11928*

*Octaves were imported wrong from multi-instrumental guitar pro file*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
