### PR TITLE
Fix sizes of icons in QWidgets

### DIFF
--- a/src/framework/ui/view/widgetutils.h
+++ b/src/framework/ui/view/widgetutils.h
@@ -29,6 +29,7 @@
 #include "modularity/ioc.h"
 #include "ui/iuiconfiguration.h"
 
+class QToolButton;
 class QWidget;
 
 namespace mu::ui {
@@ -38,15 +39,19 @@ class WidgetUtils
 
 public:
     template<class W>
-    static inline std::enable_if_t<std::is_base_of<QWidget, W>::value, void>
+    static inline std::enable_if_t<std::is_base_of_v<QWidget, W>, void>
     setWidgetIcon(W* widget, IconCode::Code iconCode)
     {
         QChar icon = iconCodeToChar(iconCode);
-        QString styleSheet = QString("font-family: %1; font-size: %2")
+        QString styleSheet = QString("font-family: %1; font-size: %2px")
                              .arg(QString::fromStdString(uiConfiguration()->iconsFontFamily()))
                              .arg(uiConfiguration()->iconsFontSize(IconSizeType::Regular));
         widget->setStyleSheet(styleSheet);
         widget->setText(icon);
+
+        if constexpr (std::is_same_v<W, QToolButton>) {
+            widget->setFixedSize(30, 30);
+        }
     }
 };
 }

--- a/src/palette/view/widgets/timesignaturepropertiesdialog.cpp
+++ b/src/palette/view/widgets/timesignaturepropertiesdialog.cpp
@@ -56,7 +56,7 @@ TimeSignaturePropertiesDialog::TimeSignaturePropertiesDialog(QWidget* parent)
     QString musicalFontFamily = QString::fromStdString(uiConfiguration()->musicalFontFamily());
     int musicalFontSize = uiConfiguration()->musicalFontSize();
 
-    QString radioButtonStyle = QString("QRadioButton { font-family: %1; font-size: %2pt }")
+    QString radioButtonStyle = QString("QRadioButton { font-family: %1; font-size: %2px }")
                                .arg(musicalFontFamily)
                                .arg(musicalFontSize);
 
@@ -137,7 +137,7 @@ TimeSignaturePropertiesDialog::TimeSignaturePropertiesDialog(QWidget* parent)
     ScoreFont* scoreFont = gpaletteScore->scoreFont();
 
     otherCombo->clear();
-    otherCombo->setStyleSheet(QString("QComboBox { font-family: \"%1 Text\"; font-size: %2pt; max-height: 30px } ")
+    otherCombo->setStyleSheet(QString("QComboBox { font-family: \"%1 Text\"; font-size: %2px; max-height: 30px } ")
                               .arg(scoreFont->family()).arg(musicalFontSize));
 
     int idx = 0;


### PR DESCRIPTION
Use pixel size instead of point size

Before: too small
<img width="40" alt="Schermafbeelding 2022-06-10 om 23 45 23" src="https://user-images.githubusercontent.com/48658420/173155167-d37d0f9e-ed4a-44bb-ba32-26384fb1941e.png">

After: similar to QML
<img width="40" alt="Schermafbeelding 2022-06-10 om 23 43 41" src="https://user-images.githubusercontent.com/48658420/173155037-f644e0f6-ea23-4156-bbd0-79491306eece.png">

QML, for comparison:
<img width="40" alt="Schermafbeelding 2022-06-10 om 23 50 21" src="https://user-images.githubusercontent.com/48658420/173155617-cbc6793d-6af5-4921-b3af-4b962da1b207.png">

Note: due to the different rendering engine, all icons and text look a bit bolder in QWidgets than in QML.