### PR TITLE
Fix #8512 support ALT+drag to make copy

### DIFF
--- a/src/appshell/view/navigableappmenumodel.cpp
+++ b/src/appshell/view/navigableappmenumodel.cpp
@@ -221,6 +221,9 @@ bool NavigableAppMenuModel::processEventForOpenedMenu(QEvent* event)
 
 bool NavigableAppMenuModel::processEventForAppMenu(QEvent* event)
 {
+    if (event->type() == QEvent::Type::MouseButtonPress) {
+        m_needActivateHighlight = false;
+    }
     QKeyEvent* keyEvent = dynamic_cast<QKeyEvent*>(event);
     if (!keyEvent) {
         return false;

--- a/src/engraving/libmscore/dynamic.cpp
+++ b/src/engraving/libmscore/dynamic.cpp
@@ -444,30 +444,7 @@ std::unique_ptr<ElementGroup> Dynamic::getDragGroup(std::function<bool(const Eng
 
 mu::RectF Dynamic::drag(EditData& ed)
 {
-    RectF f = EngravingItem::drag(ed);
-
-    //
-    // move anchor
-    //
-    KeyboardModifiers km = ed.modifiers;
-    if (km != (ShiftModifier | ControlModifier)) {
-        staff_idx_t si = staffIdx();
-        Segment* seg = segment();
-        score()->dragPosition(canvasPos(), &si, &seg);
-        if (seg != segment() || staffIdx() != si) {
-            const PointF oldOffset = offset();
-            PointF pos1(canvasPos());
-            score()->undo(new ChangeParent(this, seg, si));
-            setOffset(PointF());
-            layout();
-            PointF pos2(canvasPos());
-            const PointF newOffset = pos1 - pos2;
-            setOffset(newOffset);
-            ElementEditDataPtr eed = ed.getData(this);
-            eed->initOffset += newOffset - oldOffset;
-        }
-    }
-    return f;
+    return EngravingItem::drag(ed);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/line.h
+++ b/src/engraving/libmscore/line.h
@@ -84,6 +84,7 @@ private:
     static Fraction lastSegmentEndTick(const Segment* lastSeg, const Spanner* s);
     LineSegment* rebaseAnchor(Grip grip, Segment* newSeg);
     void rebaseAnchors(EditData&, Grip);
+    void handleStaffChange();
 };
 
 //---------------------------------------------------------

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -888,6 +888,16 @@ void NotationInteraction::startDrag(const std::vector<EngravingItem*>& elems,
     qreal proximity = configuration()->selectionProximity() * 0.5f / scaling;
     m_scoreCallbacks.setSelectionProximity(proximity);
 
+    if (elems.size() == 1 && (m_editData.modifiers & Qt::KeyboardModifier::AltModifier)) {
+        if (elems[0]->isSpannerSegment()) {
+            auto copy = toSpannerSegment(elems[0])->spanner()->clone();
+            score()->undoAddElement(copy);
+        } else {
+            auto copy = elems[0]->clone();
+            score()->undoAddElement(copy);
+        }
+    }
+
     if (isGripEditStarted()) {
         m_editData.element->startEditDrag(m_editData);
         return;

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -616,7 +616,9 @@ void NotationViewInputController::mouseMoveEvent(QMouseEvent* event)
 
             DragMode mode = DragMode::BothXY;
             if (keyState & Qt::ShiftModifier) {
-                mode = DragMode::OnlyY;
+                if (!(keyState & Qt::ControlModifier)) {
+                    mode = DragMode::OnlyY;
+                }
             } else if (keyState & Qt::ControlModifier) {
                 mode = DragMode::OnlyX;
             }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/8512

WIP - just for demonstration, need to confirm ALT+drag behaviour causing both copy and turning off auto-place

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
