### PR TITLE
Update accessibilitycontroller_tests on Linux for Qt 6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ option(TRY_USE_CCACHE "Try use ccache" ON)
 option(BUILD_PCH "Build using precompiled headers." ON)
 option(BUILD_UNITY "Build using unity build." ON)
 option(TRY_BUILD_SHARED_LIBS_IN_DEBUG "Build shared libs if possible in debug" OFF)
+option(BUILD_ASAN "Enable Address Sanitizer" OFF)
 option(QML_LOAD_FROM_SOURCE "Load qml files from source (not resource)" OFF)
 option(TRACE_DRAW_OBJ_ENABLED "Trace draw objects" OFF)
 

--- a/build/cmake/SetupBuildEnvironment.cmake
+++ b/build/cmake/SetupBuildEnvironment.cmake
@@ -24,6 +24,10 @@ if (CC_IS_GCC)
         set(BUILD_SHARED_LIBS ON)
     endif()
 
+    if (BUILD_ASAN)
+        string(APPEND CMAKE_CXX_FLAGS_DEBUG " -fsanitize=address -fno-omit-frame-pointer")
+    endif()
+
 elseif(CC_IS_MSVC)
     message(STATUS "Using Compiler MSVC ${CMAKE_CXX_COMPILER_VERSION}")
 
@@ -68,6 +72,10 @@ elseif(CC_IS_CLANG)
 
     set(CMAKE_CXX_FLAGS_DEBUG   "-g")
     set(CMAKE_CXX_FLAGS_RELEASE "-O2")
+
+    if (BUILD_ASAN)
+        string(APPEND CMAKE_CXX_FLAGS_DEBUG " -fsanitize=address -fno-omit-frame-pointer")
+    endif()
 
 elseif(CC_IS_EMSCRIPTEN)
     message(STATUS "Using Compiler Emscripten ${CMAKE_CXX_COMPILER_VERSION}")


### PR DESCRIPTION
In Qt 6, we can't copy or move QEvents anymore. We will have to use pointers instead. 

Also: I think it's more or less a matter of luck that the previous version of these tests does not crash. We are relying on the fact that the QEvent in `expectDispatchEventOnFocus()` would have the same address as the 'copy' of the event in `SendEventOnFocusChanged` (the caller). In practice, this is the case, because of an optimization made by the compiler, namely that the event is not copied but created in-place, so the address will be the same. However, I don't know if we should rely on such optimizations. Basically, we are passing a pointer to stack memory to GMock which stores that pointer after the stack has been popped.

This PR fixes that. Now, because we can't copy the QEvent anymore, we rely on the fact that the event is not deleted. That is indeed the case, since this event is in practice not really handled by Qt (because of the ApplicationMock) and we also don't delete it ourselves. 