### PR TITLE
Fix double XML encoding of Palette (cell) names

### DIFF
--- a/src/palette/internal/palette.cpp
+++ b/src/palette/internal/palette.cpp
@@ -312,7 +312,7 @@ QByteArray Palette::toMimeData() const
 
 void Palette::write(XmlWriter& xml) const
 {
-    xml.startElement("Palette", { { "name", XmlWriter::xmlString(m_name) } });
+    xml.startElement("Palette", { { "name", m_name } });
     xml.tag("type", QMetaEnum::fromType<Type>().valueToKey(int(m_type)));
     xml.tag("gridWidth", m_gridSize.width());
     xml.tag("gridHeight", m_gridSize.height());

--- a/src/palette/internal/palettecell.cpp
+++ b/src/palette/internal/palettecell.cpp
@@ -239,7 +239,7 @@ void PaletteCell::write(XmlWriter& xml) const
     // for pre-3.3 version compatibility
     XmlWriter::Attributes cellAttrs;
     if (!name.isEmpty()) {
-        cellAttrs.push_back({ "name", XmlWriter::xmlString(name) });
+        cellAttrs.push_back({ "name", name });
     }
     if (custom) {
         cellAttrs.push_back({ "custom", "1" });


### PR DESCRIPTION
Resolves: #11978 

Escaping of attribute values is already done by the XmlStreamWriter itself, so no need to do it separately in Palette::write and PaletteCell::write.