### PR TITLE
WidgetView: fix updating the size of the contained QWidget

### DIFF
--- a/src/framework/ui/view/widgetview.cpp
+++ b/src/framework/ui/view/widgetview.cpp
@@ -125,7 +125,7 @@ QWidget* WidgetView::qWidget() const
 void WidgetView::updateSizeConstraints()
 {
     if (qWidget()) {
-        qWidget()->setMinimumSize(width(), height());
+        qWidget()->setFixedSize(width(), height());
     }
 }
 


### PR DESCRIPTION
Resolves: #9948

(The scrollbars were just there, but the size of the Timeline widget was not updated properly, so the scrollbars ended up being out of view.)