### PR TITLE
Fix opening style settings for instrument names

### DIFF
--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -87,6 +87,7 @@ static const QStringList ALL_PAGE_CODES {
     "figured-bass",
     "chord-symbols",
     "fretboard-diagrams",
+    "tablature-styles",
     "text-styles"
 };
 


### PR DESCRIPTION
The new tablature styles page was added, but it was not added to the list of page _codes_. Therefore the index for the text styles page became wrong, and when opening style settings for instrument names, you would see the tablature page. 