### PR TITLE
Improvements to guitar slides and bends

### DIFF
--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -2193,6 +2193,10 @@ void Chord::layoutPitched()
     _spaceLw = lll;
     _spaceRw = rrr;
 
+    for (Note* note : _notes) {
+        note->layout2();
+    }
+
     for (EngravingItem* e : el()) {
         if (e->type() == ElementType::SLUR) {       // we cannot at this time as chordpositions are not fixed
             continue;
@@ -2209,10 +2213,6 @@ void Chord::layoutPitched()
                 _spaceRw = rx;
             }
         }
-    }
-
-    for (Note* note : _notes) {
-        note->layout2();
     }
 
     // align note-based fingerings

--- a/src/engraving/libmscore/chordline.h
+++ b/src/engraving/libmscore/chordline.h
@@ -49,12 +49,14 @@ protected:
     bool modified;
     qreal _lengthX;
     qreal _lengthY;
-    const int _initialLength = 2;
+    static constexpr double _baseLength = 1.0;
 
     friend class Factory;
 
     ChordLine(Chord* parent, const ElementType& type = ElementType::CHORDLINE);
     ChordLine(const ChordLine&);
+
+    bool sameVoiceKerningLimited() const override { return true; }
 
 public:
 
@@ -87,6 +89,9 @@ public:
     Grip initialEditModeGrip() const override { return Grip(gripsCount() - 1); }
     Grip defaultGrip() const override { return initialEditModeGrip(); }
     std::vector<mu::PointF> gripsPositions(const EditData&) const override;
+
+    bool isToTheLeft() const { return _chordLineType == ChordLineType::PLOP || _chordLineType == ChordLineType::SCOOP; }
+    bool isBelow() const { return _chordLineType == ChordLineType::SCOOP || _chordLineType == ChordLineType::FALL; }
 };
 
 extern const char* scorelineNames[];

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -5568,6 +5568,16 @@ void Score::createPaddingTable()
 
     // Temporary hack, because some padding is already constructed inside the lyrics themselves.
     _paddingTable[ElementType::BAR_LINE][ElementType::LYRICS] = 0.0 * spatium();
+
+    // Chordlines
+    for (auto& elem : _paddingTable[ElementType::CHORDLINE]) {
+        elem.second = 0.35 * spatium();
+    }
+    for (auto& elem: _paddingTable) {
+        elem.second[ElementType::CHORDLINE] = 0.35 * spatium();
+    }
+    _paddingTable[ElementType::BAR_LINE][ElementType::CHORDLINE] = 0.65 * spatium();
+    _paddingTable[ElementType::CHORDLINE][ElementType::BAR_LINE] = 0.65 * spatium();
 }
 
 //--------------------------------------------------------

--- a/src/engraving/libmscore/slide.cpp
+++ b/src/engraving/libmscore/slide.cpp
@@ -52,7 +52,7 @@ void Slide::layout()
     if (!modified) {
         qreal x2 = 0;
         qreal y2 = 0;
-        qreal halfLength = _initialLength / 2;
+        qreal halfLength = _baseLength / 2;
 
         if (_chordLineType != ChordLineType::NOTYPE) {
             path = PainterPath();


### PR DESCRIPTION
Resolves: #10316 

- Made all the marks smaller, as they were previously ridiculously large.
- Improved the positioning, which now also clears accidentals and augmentation dots.
- Added appropriate padding for horizontal spacing
- Prevent kerning over notes of the same voice.

Before:
![Screenshot from 2022-06-14 13-23-45](https://user-images.githubusercontent.com/93707756/173609217-6a42d7cf-0153-4d02-9e73-19e137a6339e.png)
After:
![Screenshot from 2022-06-14 13-25-39](https://user-images.githubusercontent.com/93707756/173609239-324cba0b-4424-456c-89a7-3330ad350fbc.png)

