### PR TITLE
Dynamically calculate the minimum size of the dock window

### DIFF
--- a/src/appshell/qml/AppWindow.qml
+++ b/src/appshell/qml/AppWindow.qml
@@ -35,11 +35,14 @@ ApplicationWindow {
 
     title: titleProvider.title
 
-    width: 1150
-    height: 800
+    // Minimum width and height are set in Main.qml files
+    onMinimumWidthChanged: {
+        width = Math.max(width, minimumWidth)
+    }
 
-    minimumWidth: 1150
-    minimumHeight: 600
+    onMinimumHeightChanged: {
+        height = Math.max(height, minimumHeight)
+    }
 
     visible: false
 

--- a/src/appshell/qml/platform/AppMenuBar.qml
+++ b/src/appshell/qml/platform/AppMenuBar.qml
@@ -30,6 +30,7 @@ ListView {
 
     height: contentItem.childrenRect.height
     width: contentWidth
+    implicitWidth: contentWidth
 
     property alias appWindow: appMenuModel.appWindow
 

--- a/src/appshell/qml/platform/linux/Main.qml
+++ b/src/appshell/qml/platform/linux/Main.qml
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
 import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
@@ -30,26 +31,35 @@ import "../../"
 AppWindow {
     id: root
 
-    AppMenuBar {
-        id: appMenuBar
-
-        anchors.top: parent.top
-        anchors.left: parent.left
-        anchors.right: parent.right
-
-        appWindow: root
-    }
+    minimumWidth: Math.max(400, contentColumn.implicitWidth)
+    minimumHeight: Math.max(400, contentColumn.implicitHeight)
 
     Component.onCompleted: {
         window.init()
     }
 
-    WindowContent {
-        id: window
+    ColumnLayout {
+        id: contentColumn
 
-        anchors.top: appMenuBar.bottom
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.bottom: parent.bottom
+        anchors.fill: parent
+        spacing: 0
+
+        AppMenuBar {
+            id: appMenuBar
+
+            Layout.fillWidth: true
+
+            appWindow: root
+        }
+
+        WindowContent {
+            id: window
+
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            Layout.minimumWidth: minimumSize.width
+            Layout.minimumHeight: minimumSize.height
+        }
     }
 }

--- a/src/appshell/qml/platform/mac/Main.qml
+++ b/src/appshell/qml/platform/mac/Main.qml
@@ -37,6 +37,9 @@ AppWindow {
         id: menuModel
     }
 
+    minimumWidth: Math.max(400, window.minimumSize.width)
+    minimumHeight: Math.max(400, window.minimumSize.height)
+
     Component.onCompleted: {
         menuModel.load()
 

--- a/src/appshell/qml/platform/win/AppTitleBar.qml
+++ b/src/appshell/qml/platform/win/AppTitleBar.qml
@@ -34,6 +34,9 @@ Rectangle {
 
     color: ui.theme.backgroundPrimaryColor
 
+    implicitHeight: 32
+    implicitWidth: contentRow.implicitWidth
+
     property alias title: titleTextmetrics.text
     property rect titleMoveAreaRect: Qt.rect(titleMoveArea.x, titleMoveArea.y, titleMoveArea.width, titleMoveArea.height)
 
@@ -46,6 +49,7 @@ Rectangle {
     signal closeWindowRequested()
 
     RowLayout {
+        id: contentRow
         anchors.fill: parent
 
         spacing: 8

--- a/src/appshell/qml/platform/win/Main.qml
+++ b/src/appshell/qml/platform/win/Main.qml
@@ -21,6 +21,7 @@
  */
 import QtQuick 2.15
 import QtQuick.Window 2.15
+import QtQuick.Layouts 1.15
 
 import MuseScore.UiComponents 1.0
 import MuseScore.AppShell 1.0
@@ -29,6 +30,9 @@ import "../../"
 
 AppWindow {
     id: root
+
+    minimumWidth: Math.max(400, contentColumn.implicitWidth)
+    minimumHeight: Math.max(400, contentColumn.implicitHeight)
 
     function toggleMaximized() {
         if (root.visibility === Window.Maximized) {
@@ -49,39 +53,44 @@ AppWindow {
         window.init()
     }
 
-    AppTitleBar {
-        id: appTitleBar
+    ColumnLayout {
+        id: contentColumn
 
-        anchors.top: parent.top
-        anchors.left: parent.left
-        anchors.right: parent.right
+        anchors.fill: parent
+        spacing: 0
 
-        height: 32
-        title: root.title
+        AppTitleBar {
+            id: appTitleBar
 
-        windowVisibility: root.visibility
+            Layout.fillWidth: true
 
-        appWindow: root
+            title: root.title
 
-        onShowWindowMinimizedRequested: {
-            root.showMinimized()
+            windowVisibility: root.visibility
+
+            appWindow: root
+
+            onShowWindowMinimizedRequested: {
+                root.showMinimized()
+            }
+
+            onToggleWindowMaximizedRequested: {
+                root.toggleMaximized()
+            }
+
+            onCloseWindowRequested: {
+                root.close()
+            }
         }
 
-        onToggleWindowMaximizedRequested: {
-            root.toggleMaximized()
+        WindowContent {
+            id: window
+
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            Layout.minimumWidth: minimumSize.width
+            Layout.minimumHeight: minimumSize.height
         }
-
-        onCloseWindowRequested: {
-            root.close()
-        }
-    }
-
-    WindowContent {
-        id: window
-
-        anchors.top: appTitleBar.bottom
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.bottom: parent.bottom
     }
 }

--- a/src/appshell/view/dockwindow/dockwindow.cpp
+++ b/src/appshell/view/dockwindow/dockwindow.cpp
@@ -90,6 +90,15 @@ DockWindow::~DockWindow()
     dockWindowProvider()->deinit();
 }
 
+QSize DockWindow::minimumSize() const
+{
+    if (!m_mainWindow) {
+        return {};
+    }
+
+    return m_mainWindow->minimumSize();
+}
+
 void DockWindow::componentComplete()
 {
     TRACEFUNC;
@@ -99,6 +108,8 @@ void DockWindow::componentComplete()
     m_mainWindow = new KDDockWidgets::MainWindowQuick("mainWindow",
                                                       KDDockWidgets::MainWindowOption_None,
                                                       this);
+
+    connect(m_mainWindow, &KDDockWidgets::MainWindowBase::geometryUpdated, this, &DockWindow::minimumSizeChanged);
 
     connect(qApp, &QCoreApplication::aboutToQuit, this, &DockWindow::onQuit);
 }
@@ -423,8 +434,13 @@ void DockWindow::alignToolBars(const DockPageView* page)
         deltaForLastCentralToolBar = 0;
     }
 
+    // Temporarily setting the minimum width to force a size update
     lastLeftToolBar->setMinimumWidth(lastLeftToolBar->contentWidth() + deltaForLastLeftToolbar);
     lastCentralToolBar->setMinimumWidth(lastCentralToolBar->contentWidth() + deltaForLastCentralToolBar);
+
+    // Restoring, to allow the window to be resized down
+    lastLeftToolBar->setMinimumWidth(lastLeftToolBar->contentWidth());
+    lastCentralToolBar->setMinimumWidth(lastCentralToolBar->contentWidth());
 }
 
 void DockWindow::addDock(DockBase* dock, Location location, const DockBase* relativeTo)

--- a/src/appshell/view/dockwindow/dockwindow.h
+++ b/src/appshell/view/dockwindow/dockwindow.h
@@ -52,6 +52,8 @@ class DockWindow : public QQuickItem, public IDockWindow, public async::Asyncabl
 {
     Q_OBJECT
 
+    Q_PROPERTY(QSize minimumSize READ minimumSize NOTIFY minimumSizeChanged)
+
     Q_PROPERTY(QString currentPageUri READ currentPageUri NOTIFY currentPageUriChanged)
 
     Q_PROPERTY(QQmlListProperty<mu::dock::DockToolBarView> toolBars READ toolBarsProperty)
@@ -65,6 +67,8 @@ class DockWindow : public QQuickItem, public IDockWindow, public async::Asyncabl
 public:
     explicit DockWindow(QQuickItem* parent = nullptr);
     ~DockWindow() override;
+
+    QSize minimumSize() const;
 
     QString currentPageUri() const;
 
@@ -92,6 +96,8 @@ public:
 signals:
     void pageLoaded();
     void currentPageUriChanged(const QString& uri);
+
+    void minimumSizeChanged();
 
 private slots:
     void onQuit();


### PR DESCRIPTION
Resolves: #10965 (kind of)

This makes sure that the minimum size of the window is always as low as it can be according to the calculations made by the docking system, based on the current minimum sizes of all docked dock widgets. For example, if you undock the note input toolbar, which has a large minimum width, then the minimum width of the window becomes lower. If you re-dock it, then the window will adjust its size. By undocking both the note input bar and the playback toolbar, you can get a pretty low minimum width. I'd say that counts as a solution for #10965, at least for the time being.

The advantage is that this eliminates some problems that arise when users use different text sizes or when translated strings take more space. For example, this causes the "Home/Score/Publish" toolbar to become wider, which might make the required minimum width larger than a hard-coded minimum width, so that the docking system gets crazy. We avoid this situation by letting the dock system determine the minimum size.

This PR also solves the problems that arose in PR #10207, so after merging this, we can just set the minimum height of the dock panels to 200px and it will be fine. 