### PR TITLE
Fix #10694: Hidden staves become visible on reopen

### DIFF
--- a/src/engraving/libmscore/staff.cpp
+++ b/src/engraving/libmscore/staff.cpp
@@ -816,6 +816,9 @@ void Staff::write(XmlWriter& xml) const
     if (_mergeMatchingRests) {
         xml.tag("mergeMatchingRests", _mergeMatchingRests);
     }
+    if (!visible()) {
+        xml.tag("isStaffVisible", visible());
+    }
 
     for (const BracketItem* i : _brackets) {
         BracketType a = i->bracketType();
@@ -883,6 +886,8 @@ bool Staff::readProperties(XmlReader& e)
         _hideSystemBarLine = e.readInt();
     } else if (tag == "mergeMatchingRests") {
         _mergeMatchingRests = e.readInt();
+    } else if (tag == "isStaffVisible") {
+        setVisible(e.readBool());
     } else if (tag == "keylist") {
         _keys.read(e, score());
     } else if (tag == "bracket") {


### PR DESCRIPTION
Resolves: #10694

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
