### PR TITLE
fix #12033: adding text for articulation, fixing slap, pop in GP

### DIFF
--- a/src/engraving/libmscore/articulation.h
+++ b/src/engraving/libmscore/articulation.h
@@ -83,9 +83,27 @@ std::set<SymId> flipArticulations(const std::set<SymId>& articulationSymbolIds, 
 
 class Articulation final : public EngravingItem
 {
+public:
+
+    enum TextType {
+        NO_TEXT,
+        SLAP,
+        POP
+    };
+
+    struct TextTypeMapping {
+        String text;
+        String name;
+    };
+
+private:
+
     SymId _symId;
     DirectionV _direction;
     String _channelName;
+
+    TextType m_textType;
+    mu::draw::Font m_font; // used for drawing text type articulations
 
     ArticulationAnchor _anchor;
 
@@ -121,6 +139,7 @@ public:
     SymId symId() const { return _symId; }
     void setSymId(SymId id);
     int subtype() const override;
+    void setTextType(TextType textType);
     String typeUserName() const override;
     String articulationName() const;    // type-name of articulation; used for midi rendering
     static String symId2ArticulationName(SymId symId);

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1518,7 +1518,11 @@ void GPConverter::addTapping(const GPNote* gpnote, Note* note)
         return;
     }
 
-    addTextToNote("T", note);
+    Articulation* art = Factory::createArticulation(note->score()->dummy()->chord());
+    art->setSymId(SymId::guitarRightHandTapping);
+    if (!note->score()->toggleArticulation(note, art)) {
+        delete art;
+    }
 }
 
 void GPConverter::addSlide(const GPNote* gpnote, Note* note)
@@ -2028,8 +2032,9 @@ void GPConverter::addSlapped(const GPBeat* beat, ChordRest* cr)
         return;
     }
 
-    auto ch = static_cast<Chord*>(cr);
-    addTextToNote("S", ch->upNote());
+    Articulation* art = mu::engraving::Factory::createArticulation(_score->dummy()->chord());
+    art->setTextType(Articulation::TextType::SLAP);
+    cr->add(art);
 }
 
 void GPConverter::addPopped(const GPBeat* beat, ChordRest* cr)
@@ -2038,8 +2043,9 @@ void GPConverter::addPopped(const GPBeat* beat, ChordRest* cr)
         return;
     }
 
-    auto ch = static_cast<Chord*>(cr);
-    addTextToNote("P", ch->upNote());
+    Articulation* art = mu::engraving::Factory::createArticulation(_score->dummy()->chord());
+    art->setTextType(Articulation::TextType::POP);
+    cr->add(art);
 }
 
 void GPConverter::addBrush(const GPBeat* beat, ChordRest* cr)


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/12033*

*added possibility to have a text instead of symbol for articulation*
*fixed the behaviour of "Tap", "Slap", "Pop", imported from guitar pro (tap has a symid, slap & pop - text articulations)*

*fixed state (see difference with staff text (H, P)*
<img width="789" alt="Screenshot 2022-06-16 at 12 49 31" src="https://user-images.githubusercontent.com/24373905/174300805-940bd794-339e-4928-b392-f5d61285f5a7.png">



<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
