### PR TITLE
Fix FileInfo tests on Windows

### DIFF
--- a/src/framework/global/io/fileinfo.cpp
+++ b/src/framework/global/io/fileinfo.cpp
@@ -145,26 +145,6 @@ QDateTime FileInfo::lastModified() const
     return fileSystem()->lastModified(m_filePath);
 }
 
-#if defined(Q_OS_WIN)
-bool FileInfo::isRelative() const
-{
-    return m_filePath.isEmpty()
-           || (m_filePath.at(0) != '/'
-               && !(m_filePath.length() >= 2 && m_filePath.at(1) == ':'));
-}
-
-bool FileInfo::isAbsolute() const
-{
-    return (m_filePath.length() >= 3
-            && m_filePath.at(0).isLetter()
-            && m_filePath.at(1) == ':'
-            && m_filePath.at(2) == '/')
-           || (m_filePath.length() >= 2
-               && m_filePath.at(0) == '/'
-               && m_filePath.at(1) == '/');
-}
-
-#else
 bool FileInfo::isRelative() const
 {
     return !isAbsolute();
@@ -172,10 +152,18 @@ bool FileInfo::isRelative() const
 
 bool FileInfo::isAbsolute() const
 {
+#ifdef Q_OS_WIN
+    return (m_filePath.length() >= 3
+            && m_filePath.at(0).isLetter()
+            && m_filePath.at(1) == ':'
+            && m_filePath.at(2) == '/')
+           || (!m_filePath.isEmpty()
+               && (m_filePath.at(0) == '/'
+                   || m_filePath.at(0) == ':'));
+#else
     return !m_filePath.isEmpty() && (m_filePath.at(0) == '/' || m_filePath.at(0) == ':');
-}
-
 #endif
+}
 
 bool FileInfo::exists() const
 {

--- a/src/framework/global/tests/iodevice_tests.cpp
+++ b/src/framework/global/tests/iodevice_tests.cpp
@@ -57,7 +57,7 @@ TEST_F(Global_IO_IODeviceTests, Open_ReadOnly)
     EXPECT_DEATH({
         size_t size = buf.write(wrba);
         EXPECT_EQ(size, 0);
-    }, ".*isOpenModeWriteable().*");
+    }, ".*isOpenModeWriteable\\(\\).*");
 }
 
 TEST_F(Global_IO_IODeviceTests, Open_WriteOnly)
@@ -82,18 +82,18 @@ TEST_F(Global_IO_IODeviceTests, Open_WriteOnly)
     EXPECT_DEATH({
         ByteArray rba = buf.readAll();
         EXPECT_TRUE(rba.empty());
-    }, ".*isOpenModeReadable().*");
+    }, ".*isOpenModeReadable\\(\\).*");
 
     EXPECT_DEATH({
         ByteArray rba = buf.read(4);
         EXPECT_TRUE(rba.empty());
-    }, ".*isOpenModeReadable().*");
+    }, ".*isOpenModeReadable\\(\\).*");
 
     EXPECT_DEATH({
         uint8_t d = 0;
         size_t s = buf.read(&d, 1);
         EXPECT_EQ(s, 0);
-    }, ".*isOpenModeReadable().*");
+    }, ".*isOpenModeReadable\\(\\).*");
 }
 
 TEST_F(Global_IO_IODeviceTests, Open_ReadWrite)


### PR DESCRIPTION
- fix unsupported unescaped () in regex
- fix FileInfo::relative and FileInfo::absolute

Note: these changes fix the tests, but I'm not sure if they are 'universally correct' for Windows.

Resolves: #12047 