### PR TITLE
fix #11791: Multiple brackets added if more then one measure is selected horizontally

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1523,7 +1523,7 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
                 PointF pt(r.x() + r.width() * .5, r.y() + r.height() * .5);
                 pt += m->system()->page()->pos();
                 applyDropPaletteElement(score, m, element, modifiers, pt);
-                if (m == last) {
+                if ((m == last) || (element->type() == ElementType::BRACKET)) {
                     break;
                 }
             }


### PR DESCRIPTION
Resolves #11791

Add brackets for only one measure in case multiple measures are selected because the bracket is actually added to the staff instead of the measure.

The changes applies to brackets only and not to other elements handled by the same part of the code because these elements are to the selected measure itself while, when adding a bracket, the measure just defines the staves which should be grouped by the measure, the measure itself isn't used at all.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
