### PR TITLE
Add missing operators to Char class

### DIFF
--- a/src/engraving/libmscore/actionicon.cpp
+++ b/src/engraving/libmscore/actionicon.cpp
@@ -102,7 +102,7 @@ void ActionIcon::read(XmlReader& e)
 void ActionIcon::layout()
 {
     FontMetrics fontMetrics(m_iconFont);
-    setbbox(fontMetrics.boundingRect(QChar(m_icon)));
+    setbbox(fontMetrics.boundingRect(Char(m_icon)));
 }
 
 void ActionIcon::draw(Painter* painter) const

--- a/src/engraving/libmscore/figuredbass.cpp
+++ b/src/engraving/libmscore/figuredbass.cpp
@@ -78,7 +78,7 @@ static std::vector<FiguredBassFont> g_FBFonts;
 
 // used for indexed access to parenthesis chars
 // (these is no normAccidToChar[], as accidentals may use mult. chars in normalized display):
-const QChar FiguredBassItem::normParenthToChar[int(FiguredBassItem::Parenthesis::NUMOF)] =
+const Char FiguredBassItem::normParenthToChar[int(FiguredBassItem::Parenthesis::NUMOF)] =
 { 0, '(', ')', '[', ']' };
 
 FiguredBassItem::FiguredBassItem(FiguredBass* parent, int l)
@@ -192,7 +192,7 @@ bool FiguredBassItem::parse(String& str)
 //    scans str to extract prefix or suffix properties. Stops at the first char which cannot fit.
 //    Fitting chars are removed from str. DOES NOT generate any display text
 //
-// returns the number of QChar's read from str or -1 if prefix / suffix has an illegal format
+// returns the number of Chars read from str or -1 if prefix / suffix has an illegal format
 // (no prefix / suffix at all IS legal)
 //---------------------------------------------------------
 
@@ -274,7 +274,7 @@ int FiguredBassItem::parsePrefixSuffix(String& str, bool bPrefix)
 //    scans str to extract digit properties. Stops at the first char which cannot belong to digit part.
 //    Fitting chars are removed from str. DOES NOT generate any display text
 //
-// returns the number of QChar's read from str or -1 if no legal digit can be constructed
+// returns the number of Chars read from str or -1 if no legal digit can be constructed
 // (no digit at all IS legal)
 //---------------------------------------------------------
 
@@ -309,7 +309,7 @@ int FiguredBassItem::parseDigit(String& str)
 //    scans str to extract a (possible) parenthesis, stores its code into parenth[parenthIdx]
 //    and removes it from str. Only looks at first str char.
 //
-// returns the number of QChar's read from str (actually 0 or 1).
+// returns the number of Chars read from str (actually 0 or 1).
 //---------------------------------------------------------
 
 int FiguredBassItem::parseParenthesis(String& str, int parenthIdx)

--- a/src/engraving/libmscore/figuredbass.h
+++ b/src/engraving/libmscore/figuredbass.h
@@ -132,7 +132,7 @@ public:
 
 private:
 
-    static const QChar normParenthToChar[int(Parenthesis::NUMOF)];
+    static const Char normParenthToChar[int(Parenthesis::NUMOF)];
 
     String _displayText;                        // the constructed display text (read-only)
     int ord;                                    // the line ordinal of this element in the FB stack

--- a/src/engraving/libmscore/fret.cpp
+++ b/src/engraving/libmscore/fret.cpp
@@ -142,7 +142,7 @@ std::shared_ptr<FretDiagram> FretDiagram::createFromString(Score* score, const S
     std::vector<std::pair<int, int> > dotsToAdd;
 
     for (int i = 0; i < strings; i++) {
-        QChar c = s.at(i);
+        Char c = s.at(i);
         if (c == 'X' || c == 'O') {
             FretMarkerType mt = (c == 'X' ? FretMarkerType::CROSS : FretMarkerType::CIRCLE);
             fd->setMarker(i, mt);

--- a/src/framework/global/types/string.h
+++ b/src/framework/global/types/string.h
@@ -96,6 +96,11 @@ public:
     inline bool operator <(Char c) const { return m_ch < c.m_ch; }
     inline bool operator <(char16_t c) const { return m_ch < c; }
 
+    inline bool operator >=(Char c) const { return m_ch >= c.m_ch; }
+    inline bool operator >=(char16_t c) const { return m_ch >= c; }
+    inline bool operator <=(Char c) const { return m_ch <= c.m_ch; }
+    inline bool operator <=(char16_t c) const { return m_ch <= c; }
+
     inline char16_t unicode() const { return m_ch; }
 
     inline bool isNull() const { return m_ch == 0; }
@@ -362,6 +367,12 @@ private:
 inline String operator+(char16_t s1, const String& s2) { String t(s1); t += s2; return t; }
 inline String operator+(const char16_t* s1, const String& s2) { String t(s1); t += s2; return t; }
 }
+
+// ============================
+// Char (UTF-16)
+// ============================
+inline bool operator ==(const char16_t c1, const mu::Char c2) { return c2 == c1; }
+inline bool operator !=(const char16_t c1, const mu::Char c2) { return c2 != c1; }
 
 // ============================
 // String (UTF-16)

--- a/src/framework/global/uri.cpp
+++ b/src/framework/global/uri.cpp
@@ -155,7 +155,7 @@ void UriQuery::extractQuotedStrings(const std::string& str, std::vector<std::str
 
     int bi = -1;
     for (size_t i = 0; i < str.size(); ++i) {
-        if (str.at(i) == QChar('\'')) {
+        if (str.at(i) == u'\'') {
             if (bi == -1) { // begin quotes string
                 bi = int(i);
             } else {  // end quotes string

--- a/src/importexport/ove/internal/ove.cpp
+++ b/src/importexport/ove/internal/ove.cpp
@@ -4187,7 +4187,7 @@ bool NameBlock::isEqual(const QString& name) const
     }
 
     for (int i = 0; i < size() && nsize; ++i) {
-        if (data()[i] != name[i]) {
+        if (name[i] != data()[i]) {
             return false;
         }
     }


### PR DESCRIPTION
Otherwise, sometimes the operators from `QChar` would be used due to implicit `Char` <-> `QChar` conversion. (The reason that I found this, is that it breaks the Qt 6 build.)

I also eliminated some implicit `Char` <-> `QChar` conversions, found by temporarily removing `Char::operator QChar()` and making `Char::Char(QChar)` explicit.