### PR TITLE
Fix #12074 prevent crash when dragging certain elements (e.g. brackets)

### DIFF
--- a/src/engraving/accessibility/accessibleroot.cpp
+++ b/src/engraving/accessibility/accessibleroot.cpp
@@ -119,7 +119,7 @@ void AccessibleRoot::updateStaffInfo(const AccessibleItem* newAccessibleItem, co
 
     if (newAccessibleItem && newAccessibleItem->element()->hasStaff()) {
         staff_idx_t newStaffIdx = newAccessibleItem->element()->staffIdx();
-        staff_idx_t oldStaffIdx = oldAccessibleItem ? oldAccessibleItem->element()->staffIdx() : nidx;
+        staff_idx_t oldStaffIdx = oldAccessibleItem && oldAccessibleItem->element() ? oldAccessibleItem->element()->staffIdx() : nidx;
 
         if (newStaffIdx != oldStaffIdx) {
             auto element = newAccessibleItem->element();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/12074

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
