### PR TITLE
[MU4] Fix #332925: Half duration shortcut crashes musescore when time signature is 5/4

### DIFF
--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -2900,9 +2900,18 @@ void Score::cmdIncDecDuration(int nSteps, bool stepDotted)
 
     // if measure rest is selected as input, then the correct initialDuration will be the
     // duration of the measure's time signature, else is just the input state's duration
-    TDuration initialDuration
-        = (cr->durationType() == DurationType::V_MEASURE) ? TDuration(cr->measure()->timesig()) : _is.duration();
-    TDuration d = initialDuration.shiftRetainDots(nSteps, stepDotted);
+    TDuration initialDuration;
+    if (cr->durationType() == DurationType::V_MEASURE) {
+        initialDuration = TDuration(cr->measure()->timesig(), true);
+
+        if (initialDuration.fraction() < cr->measure()->timesig() && nSteps > 0) {
+            // Duration already shortened by truncation; shorten one step less
+            --nSteps;
+        }
+    } else {
+        initialDuration = _is.duration();
+    }
+    TDuration d = (nSteps != 0) ? initialDuration.shiftRetainDots(nSteps, stepDotted) : initialDuration;
     if (!d.isValid()) {
         return;
     }


### PR DESCRIPTION
Crash happens only with Debug builds, not with Release or RelWithDebInfo builds, as those have asserts disabled.
Probably happens on any time sig, where the full measure rest is not having the same duration as a whole rest, and also does happen on "half dotted duration" as well as "double duration" and "double dotted duration".

Resolves: https://musescore.org/en/node/332925

Same issue and fix for MU3