### PR TITLE
Fix clang compiler warnings

### DIFF
--- a/src/engraving/libmscore/scorefont.cpp
+++ b/src/engraving/libmscore/scorefont.cpp
@@ -267,7 +267,7 @@ void ScoreFont::load()
 
 void ScoreFont::loadGlyphsWithAnchors(const QJsonObject& glyphsWithAnchors)
 {
-    for (const String& symName : glyphsWithAnchors.keys()) {
+    for (const QString& symName : glyphsWithAnchors.keys()) {
         SymId symId = SymNames::symIdByName(symName);
         if (symId == SymId::noSym) {
             //! NOTE currently, Bravura contains a bunch of entries in glyphsWithAnchors
@@ -551,7 +551,7 @@ void ScoreFont::loadEngravingDefaults(const QJsonObject& engravingDefaultsObject
         { u"tupletBracketThickness",        Sid::tupletBracketWidth }
     };
 
-    for (const String& key : engravingDefaultsObject.keys()) {
+    for (const QString& key : engravingDefaultsObject.keys()) {
         if (key == "textEnclosureThickness") {
             m_textEnclosureThickness = engravingDefaultsObject.value(key).toDouble();
             continue;

--- a/src/engraving/libmscore/scorefont.cpp
+++ b/src/engraving/libmscore/scorefont.cpp
@@ -94,7 +94,7 @@ const String& ScoreFont::fontPath() const
     return m_fontPath;
 }
 
-std::list<std::pair<Sid, QVariant> > ScoreFont::engravingDefaults()
+std::unordered_map<Sid, PropertyValue> ScoreFont::engravingDefaults()
 {
     return m_engravingDefaults;
 }
@@ -117,7 +117,7 @@ void ScoreFont::initScoreFonts()
     }
 
     for (size_t i = 0; i < s_symIdCodes.size(); ++i) {
-        String name(SymNames::nameForSymId(static_cast<SymId>(i)).toQLatin1String());
+        QString name(SymNames::nameForSymId(static_cast<SymId>(i)).toQLatin1String());
 
         bool ok;
         uint code = glyphNamesJson.value(name).toObject().value("codepoint").toString().midRef(2).toUInt(&ok, 16);
@@ -278,16 +278,16 @@ void ScoreFont::loadGlyphsWithAnchors(const QJsonObject& glyphsWithAnchors)
         Sym& sym = this->sym(symId);
         QJsonObject anchors = glyphsWithAnchors.value(symName).toObject();
 
-        static const std::map<String, SmuflAnchorId> smuflAnchorIdNames {
-            { u"stemDownNW", SmuflAnchorId::stemDownNW },
-            { u"stemUpSE", SmuflAnchorId::stemUpSE },
-            { u"stemDownSW", SmuflAnchorId::stemDownSW },
-            { u"stemUpNW", SmuflAnchorId::stemUpNW },
-            { u"cutOutNE", SmuflAnchorId::cutOutNE },
-            { u"cutOutNW", SmuflAnchorId::cutOutNW },
-            { u"cutOutSE", SmuflAnchorId::cutOutSE },
-            { u"cutOutSW", SmuflAnchorId::cutOutSW },
-            { u"opticalCenter", SmuflAnchorId::opticalCenter },
+        static const std::unordered_map<QString, SmuflAnchorId> smuflAnchorIdNames {
+            { "stemDownNW", SmuflAnchorId::stemDownNW },
+            { "stemUpSE", SmuflAnchorId::stemUpSE },
+            { "stemDownSW", SmuflAnchorId::stemDownSW },
+            { "stemUpNW", SmuflAnchorId::stemUpNW },
+            { "cutOutNE", SmuflAnchorId::cutOutNE },
+            { "cutOutNW", SmuflAnchorId::cutOutNW },
+            { "cutOutSE", SmuflAnchorId::cutOutSE },
+            { "cutOutSW", SmuflAnchorId::cutOutSW },
+            { "opticalCenter", SmuflAnchorId::opticalCenter },
         };
 
         for (const QString& anchorId : anchors.keys()) {
@@ -526,29 +526,28 @@ void ScoreFont::loadStylisticAlternates(const QJsonObject& glyphsWithAlternatesO
 
 void ScoreFont::loadEngravingDefaults(const QJsonObject& engravingDefaultsObject)
 {
-    static const std::list<std::pair<String, Sid> > engravingDefaultsMapping = {
-        { u"staffLineThickness",            Sid::staffLineWidth },
-        { u"stemThickness",                 Sid::stemWidth },
-        { u"beamThickness",                 Sid::beamWidth },
-        { u"beamSpacing",                   Sid::useWideBeams },
-        { u"legerLineThickness",            Sid::ledgerLineWidth },
-        { u"legerLineExtension",            Sid::ledgerLineLength },
-        { u"slurEndpointThickness",         Sid::SlurEndWidth },
-        { u"slurMidpointThickness",         Sid::SlurMidWidth },
-        { u"thinBarlineThickness",          Sid::barWidth },
-        { u"thinBarlineThickness",          Sid::doubleBarWidth },
-        { u"thickBarlineThickness",         Sid::endBarWidth },
-        { u"dashedBarlineThickness",        Sid::barWidth },
-        { u"barlineSeparation",             Sid::doubleBarDistance },
-        { u"barlineSeparation",             Sid::endBarDistance },
-        { u"repeatBarlineDotSeparation",    Sid::repeatBarlineDotSeparation },
-        { u"bracketThickness",              Sid::bracketWidth },
-        { u"hairpinThickness",              Sid::hairpinLineWidth },
-        { u"octaveLineThickness",           Sid::ottavaLineWidth },
-        { u"pedalLineThickness",            Sid::pedalLineWidth },
-        { u"repeatEndingLineThickness",     Sid::voltaLineWidth },
-        { u"lyricLineThickness",            Sid::lyricsLineThickness },
-        { u"tupletBracketThickness",        Sid::tupletBracketWidth }
+    static const std::unordered_map<QString, Sid> engravingDefaultsMapping = {
+        { "staffLineThickness",            Sid::staffLineWidth },
+        { "stemThickness",                 Sid::stemWidth },
+        { "beamThickness",                 Sid::beamWidth },
+        { "legerLineThickness",            Sid::ledgerLineWidth },
+        { "legerLineExtension",            Sid::ledgerLineLength },
+        { "slurEndpointThickness",         Sid::SlurEndWidth },
+        { "slurMidpointThickness",         Sid::SlurMidWidth },
+        { "thinBarlineThickness",          Sid::barWidth },
+        { "thinBarlineThickness",          Sid::doubleBarWidth },
+        { "thickBarlineThickness",         Sid::endBarWidth },
+        { "dashedBarlineThickness",        Sid::barWidth },
+        { "barlineSeparation",             Sid::doubleBarDistance },
+        { "barlineSeparation",             Sid::endBarDistance },
+        { "repeatBarlineDotSeparation",    Sid::repeatBarlineDotSeparation },
+        { "bracketThickness",              Sid::bracketWidth },
+        { "hairpinThickness",              Sid::hairpinLineWidth },
+        { "octaveLineThickness",           Sid::ottavaLineWidth },
+        { "pedalLineThickness",            Sid::pedalLineWidth },
+        { "repeatEndingLineThickness",     Sid::voltaLineWidth },
+        { "lyricLineThickness",            Sid::lyricsLineThickness },
+        { "tupletBracketThickness",        Sid::tupletBracketWidth }
     };
 
     for (const QString& key : engravingDefaultsObject.keys()) {
@@ -557,20 +556,20 @@ void ScoreFont::loadEngravingDefaults(const QJsonObject& engravingDefaultsObject
             continue;
         }
 
-        for (auto mapping : engravingDefaultsMapping) {
-            if (key == mapping.first) {
-                qreal value = engravingDefaultsObject.value(key).toDouble();
+        if (key == "beamSpacing") {
+            bool value = engravingDefaultsObject.value(key).toDouble() > 0.75;
+            m_engravingDefaults.insert({ Sid::useWideBeams, value });
+            continue;
+        }
 
-                if (key == "beamSpacing") {
-                    value = value > 0.75;
-                }
-
-                m_engravingDefaults.push_back({ mapping.second, value });
-            }
+        auto search = engravingDefaultsMapping.find(key);
+        if (search != engravingDefaultsMapping.cend()) {
+            qreal value = engravingDefaultsObject.value(key).toDouble();
+            m_engravingDefaults.insert({ search->second, value });
         }
     }
 
-    m_engravingDefaults.push_back({ Sid::MusicalTextFont, QString("%1 Text").arg(m_family.toQString()) });
+    m_engravingDefaults.insert({ Sid::MusicalTextFont, String("%1 Text").arg(m_family) });
 }
 
 void ScoreFont::computeMetrics(ScoreFont::Sym& sym, uint code)

--- a/src/engraving/libmscore/scorefont.h
+++ b/src/engraving/libmscore/scorefont.h
@@ -22,6 +22,8 @@
 #ifndef MS_SCOREFONT_H
 #define MS_SCOREFONT_H
 
+#include <unordered_map>
+
 #include "style/style.h"
 
 #include "infrastructure/draw/geometry.h"
@@ -46,7 +48,7 @@ public:
     const String& family() const;
     const String& fontPath() const;
 
-    std::list<std::pair<Sid, QVariant> > engravingDefaults();
+    std::unordered_map<Sid, PropertyValue> engravingDefaults();
     double textEnclosureThickness();
 
     static void initScoreFonts();
@@ -121,7 +123,7 @@ private:
     String m_fontPath;
     String m_filename;
 
-    std::list<std::pair<Sid, QVariant> > m_engravingDefaults;
+    std::unordered_map<Sid, PropertyValue> m_engravingDefaults;
     double m_textEnclosureThickness = 0;
 
     static std::vector<ScoreFont> s_scoreFonts;

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1985,7 +1985,7 @@ void EditStyle::valueChanged(int i)
         mu::engraving::ScoreFont* scoreFont = mu::engraving::ScoreFont::fontByName(val.value<String>());
         if (scoreFont) {
             for (auto j : scoreFont->engravingDefaults()) {
-                setStyleQVariantValue(j.first, j.second);
+                setStyleValue(j.first, j.second);
             }
 
             // fix values, the distances are defined different in MuseScore


### PR DESCRIPTION
In a few places, I reverted String back to QString, because we are using it in combination with QJsonObject etc. In those places, it doesn't make sense to use String (until we invent our own Json reading mechanism), and it can even be harmful, for example here:
```
for (const String& symName : glyphsWithAnchors.keys()) {
```
We are iterating over a collection of QStrings, but use `const String&` as the type of the loop variable. As Clang says in a warning: in order to convert from from QString to String, a temporary copy is created, and we try to bind the reference to that temporary copy. So, either we must make the copying explicit by using just `String` as the type, or we must use `const QString&`. In this case, I think the latter makes more sense for now, since we are not using it for anything else than reading the JSON. 

I also optimized/cleaned things a bit by using `std::unordered_map<Sid, PropertyValue>` instead of `std::list<std::pair<Sid, QVariant> >`.