### PR TITLE
Support slides/bends on multiple notes of a chord

### DIFF
--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -1200,6 +1200,9 @@ void Chord::write(XmlWriter& xml) const
         _tremolo->write(xml);
     }
     for (EngravingItem* e : el()) {
+        if (e->isChordLine() && toChordLine(e)->note()) { // this is now written by Note
+            continue;
+        }
         e->write(xml);
     }
     xml.endElement();

--- a/src/engraving/libmscore/chordline.cpp
+++ b/src/engraving/libmscore/chordline.cpp
@@ -51,6 +51,7 @@ ChordLine::ChordLine(Chord* parent)
     _straight = false;
     _lengthX = 0.0;
     _lengthY = 0.0;
+    _note = nullptr;
 }
 
 ChordLine::ChordLine(const ChordLine& cl)
@@ -62,6 +63,7 @@ ChordLine::ChordLine(const ChordLine& cl)
     _straight = cl._straight;
     _lengthX = cl._lengthX;
     _lengthY = cl._lengthY;
+    _note = cl._note;
 }
 
 //---------------------------------------------------------
@@ -105,7 +107,7 @@ void ChordLine::layout()
 
     qreal _spatium = spatium();
     if (explicitParent()) {
-        Note* note = chord()->upNote();
+        Note* note = _note ? _note : chord()->upNote();
         double x = note->pos().x();
         double y = note->pos().y();
         double horOffset = 0.33 * spatium(); // one third of a space away from the note

--- a/src/engraving/libmscore/chordline.h
+++ b/src/engraving/libmscore/chordline.h
@@ -49,6 +49,7 @@ protected:
     bool modified;
     qreal _lengthX;
     qreal _lengthY;
+    Note* _note;
     static constexpr double _baseLength = 1.0;
 
     friend class Factory;
@@ -92,6 +93,9 @@ public:
 
     bool isToTheLeft() const { return _chordLineType == ChordLineType::PLOP || _chordLineType == ChordLineType::SCOOP; }
     bool isBelow() const { return _chordLineType == ChordLineType::SCOOP || _chordLineType == ChordLineType::FALL; }
+
+    void setNote(Note* note) { _note = note; }
+    Note* note() const { return _note; }
 };
 
 extern const char* scorelineNames[];

--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -1438,6 +1438,12 @@ void Note::write(XmlWriter& xml) const
         e->writeSpannerEnd(xml, this, track());
     }
 
+    for (EngravingItem* e : chord()->el()) {
+        if (e->isChordLine() && toChordLine(e)->note() && toChordLine(e)->note() == this) {
+            toChordLine(e)->write(xml);
+        }
+    }
+
     xml.endElement();
 }
 
@@ -1642,6 +1648,11 @@ bool Note::readProperties(XmlReader& e)
         }
     } else if (tag == "offset") {
         EngravingItem::readProperties(e);
+    } else if (tag == "ChordLine") {
+        ChordLine* cl = Factory::createChordLine(chord());
+        cl->setNote(this);
+        cl->read(e);
+        chord()->add(cl);
     } else if (EngravingItem::readProperties(e)) {
     } else {
         return false;

--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -43,6 +43,7 @@
 #include "bagpembell.h"
 #include "bend.h"
 #include "chord.h"
+#include "chordline.h"
 #include "clef.h"
 #include "drumset.h"
 #include "factory.h"
@@ -2049,6 +2050,10 @@ EngravingItem* Note::drop(EditData& data)
         delete e;
     }
     break;
+
+    case ElementType::CHORDLINE:
+        toChordLine(e)->setNote(this);
+        return ch->drop(data);
 
     default:
         Spanner* spanner;


### PR DESCRIPTION
Resolves: #10316 

Currently, Musescore does not support inserting slides and bends on multiple notes of a chord. This is particularly important in guitar notation, but there may be plenty of other applications, so we should support it, regardless of guitar.

The origin of the problem is that these type of marks are handled by the `ChordLine` class, whose `parent` item is `Chord`, so all the marks are attached to a Chord, not to an individual note. The "proper" solution would be to change the parent of ChordLine from `Chord` to `Note`, but this would require to modify almost every bit of code where this class is used. 

Instead, this is a simple temporary solution which allows to support the feature. A small modification to the read and write functions was also necessary to ensure that they are reloaded correctly upon reopening a file. Nothing changes when opening older files.

BEFORE:
![Screenshot from 2022-06-18 16-45-18](https://user-images.githubusercontent.com/93707756/174443641-d42c1784-63cc-4a5b-a049-de183c6f87f2.png)
![Screenshot from 2022-06-18 16-43-27](https://user-images.githubusercontent.com/93707756/174443642-5f18e394-d343-4652-9dde-5b28226e3073.png)

AFTER:
![Screenshot from 2022-06-18 16-45-03](https://user-images.githubusercontent.com/93707756/174443663-bd29bb84-f8e6-408d-942b-56ce071c3cbb.png)
![Screenshot from 2022-06-18 16-43-08](https://user-images.githubusercontent.com/93707756/174443666-7d5cd65d-364b-4532-a85b-6f38f9b2e4fa.png)

