### PR TITLE
fix #9919 - prevent "resize" cursor showing for edges of non-resizable dockable widgets

### DIFF
--- a/src/appshell/qml/dockwindow/DockSeparator.qml
+++ b/src/appshell/qml/dockwindow/DockSeparator.qml
@@ -39,8 +39,8 @@ Rectangle {
         anchors.fill: parent
         anchors.margins: -5 //! NOTE: extra space for user convenience
 
-        cursorShape: separatorCpp ? (separatorCpp.isVertical ? Qt.SizeVerCursor : Qt.SizeHorCursor)
-                                   : Qt.SizeHorCursor
+        cursorShape: (separatorCpp && separatorCpp.showResizeCursor) ? (separatorCpp.isVertical ? Qt.SizeVerCursor : Qt.SizeHorCursor)
+                                   : Qt.ArrowCursor
         onPressed: {
             separatorCpp.onMousePressed()
         }

--- a/src/appshell/view/dockwindow/internal/dockseparator.cpp
+++ b/src/appshell/view/dockwindow/internal/dockseparator.cpp
@@ -76,6 +76,7 @@ DockSeparator::DockSeparator(Layouting::Widget* parent)
 
     // Only set on Separator::init(), so single-shot
     QTimer::singleShot(0, this, &DockSeparator::isVerticalChanged);
+    QTimer::singleShot(0, this, &DockSeparator::showResizeCursorChanged);
     QTimer::singleShot(0, this, [this]() {
         initAvailability();
     });
@@ -89,6 +90,7 @@ void DockSeparator::initAvailability()
     if (properties.isValid()) {
         m_isSeparatorVisible = properties.separatorsVisible;
         emit isSeparatorVisibleChanged();
+        emit showResizeCursorChanged();
     }
 }
 
@@ -100,6 +102,13 @@ bool DockSeparator::isVertical() const
 bool DockSeparator::isSeparatorVisible() const
 {
     return m_isSeparatorVisible;
+}
+
+bool DockSeparator::showResizeCursor() const
+{
+    return parentContainer()
+           && (parentContainer()->minPosForSeparator_global(const_cast<DockSeparator*>(this))
+               != parentContainer()->maxPosForSeparator_global(const_cast<DockSeparator*>(this)));
 }
 
 Layouting::Widget* DockSeparator::createRubberBand(Layouting::Widget* parent)

--- a/src/appshell/view/dockwindow/internal/dockseparator.h
+++ b/src/appshell/view/dockwindow/internal/dockseparator.h
@@ -35,12 +35,14 @@ class DockSeparator : public QQuickItem, public Layouting::Separator, public Lay
 
     Q_PROPERTY(bool isVertical READ isVertical NOTIFY isVerticalChanged)
     Q_PROPERTY(bool isSeparatorVisible READ isSeparatorVisible NOTIFY isSeparatorVisibleChanged)
+    Q_PROPERTY(bool showResizeCursor READ showResizeCursor NOTIFY showResizeCursorChanged)
 
 public:
     explicit DockSeparator(Layouting::Widget* parent = nullptr);
 
     bool isVertical() const;
     bool isSeparatorVisible() const;
+    bool showResizeCursor() const;
 
     Q_INVOKABLE void onMousePressed();
     Q_INVOKABLE void onMouseMoved(QPointF localPos);
@@ -50,6 +52,7 @@ public:
 signals:
     void isVerticalChanged();
     void isSeparatorVisibleChanged();
+    void showResizeCursorChanged();
 
 private:
     void initAvailability();


### PR DESCRIPTION
Resolves: [*(direct link to the issue)*](https://github.com/musescore/MuseScore/issues/9919)

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
