### PR TITLE
Remove "Images" field from Preferences > Folders

### DIFF
--- a/src/appshell/view/preferences/folderspreferencesmodel.cpp
+++ b/src/appshell/view/preferences/folderspreferencesmodel.cpp
@@ -21,7 +21,6 @@
  */
 #include "folderspreferencesmodel.h"
 
-#include "log.h"
 #include "translation.h"
 
 using namespace mu::appshell;

--- a/src/appshell/view/preferences/folderspreferencesmodel.cpp
+++ b/src/appshell/view/preferences/folderspreferencesmodel.cpp
@@ -109,11 +109,8 @@ void FoldersPreferencesModel::load()
         {
             FolderType::VST3, qtrc("appshell", "VST3"), pathsToString(vstConfiguration()->userVstDirectories()),
             configuration()->userDataPath().toQString(), FolderValueType::MultiDirectories
-        },
+        }
 #endif
-        {
-            FolderType::Images, qtrc("appshell", "Images"), "", ""
-        }  // todo: need implement
     };
 
     endResetModel();
@@ -180,9 +177,6 @@ void FoldersPreferencesModel::saveFolderPaths(FoldersPreferencesModel::FolderTyp
         vstConfiguration()->setUserVstDirectories(pathsFromString(paths));
         break;
     }
-    case FolderType::Images:
-        NOT_IMPLEMENTED;
-        break;
     case FolderType::Undefined:
         break;
     }

--- a/src/appshell/view/preferences/folderspreferencesmodel.h
+++ b/src/appshell/view/preferences/folderspreferencesmodel.h
@@ -72,8 +72,7 @@ private:
         Templates,
         Plugins,
         SoundFonts,
-        VST3,
-        Images
+        VST3
     };
 
     enum class FolderValueType {


### PR DESCRIPTION
In MU3, as far as I can see, this field was only used by the Image Capture feature, to choose where captured images would be saved. This feature is delayed for MuseScore 4.0, and when we reimplement it, I'm pretty sure that the UX will be totally different, and most probably won't involve a field in Preferences.