### PR TITLE
fix #12097 - ensure new/changed notes/rests are always scrolled into view

### DIFF
--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -254,10 +254,6 @@ void NotationNoteInput::putNote(const PointF& pos, bool replace, bool insert)
 
     notifyNoteAddedChanged();
     notifyAboutStateChanged();
-
-    if (mu::engraving::ChordRest* chordRest = score()->inputState().cr()) {
-        m_interaction->showItem(chordRest);
-    }
 }
 
 void NotationNoteInput::removeNote(const PointF& pos)
@@ -483,6 +479,10 @@ void NotationNoteInput::startEdit()
 void NotationNoteInput::apply()
 {
     m_undoStack->commitChanges();
+
+    if (mu::engraving::ChordRest* chordRest = score()->inputState().cr()) {
+        m_interaction->showItem(chordRest);
+    }
 }
 
 void NotationNoteInput::updateInputState()


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/12097

Ensure newly added or changed notes/rests are always kept in view

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
