### PR TITLE
fix #9429 - various bugs editing barline properties

### DIFF
--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -3463,6 +3463,12 @@ void Measure::barLinesSetSpan(Segment* seg)
             bl->setSpanTo(staff->barLineTo());
             bl->layout();
             score()->addElement(bl);
+            if (score()->selection().element() && score()->selection().element()->isBarLine()) {
+                BarLine* existing = toBarLine(score()->selection().element());
+                if (existing->track() == track) {
+                    score()->select(bl);
+                }
+            }
         }
         track += VOICES;
     }

--- a/src/engraving/utests/barline_tests.cpp
+++ b/src/engraving/utests/barline_tests.cpp
@@ -344,33 +344,43 @@ TEST_F(BarlineTests, barline179726)
     Measure* m = score->firstMeasure();
 
     // drop NORMAL onto initial START_REPEAT barline will remove that START_REPEAT
-    dropNormalBarline(m->findSegment(SegmentType::StartRepeatBarLine, m->tick())->elementAt(0));
+    Segment* seg = m->findSegment(SegmentType::StartRepeatBarLine, m->tick());
+    EXPECT_TRUE(seg);
+    dropNormalBarline(seg->elementAt(0));
     EXPECT_EQ(m->findSegment(SegmentType::StartRepeatBarLine, Fraction(0, 1)), nullptr);
 
     // drop NORMAL onto END_START_REPEAT will turn into NORMAL
-    dropNormalBarline(m->findSegment(SegmentType::EndBarLine, m->endTick())->elementAt(0));
-    BarLine* bar = static_cast<BarLine*>(m->findSegment(SegmentType::EndBarLine, m->endTick())->elementAt(0));
+    seg = m->findSegment(SegmentType::EndBarLine, m->endTick());
+    EXPECT_TRUE(seg);
+    dropNormalBarline(seg->elementAt(0));
+    seg = m->findSegment(SegmentType::EndBarLine, m->endTick());
+    EXPECT_TRUE(seg);
+    BarLine* bar = static_cast<BarLine*>(seg->elementAt(0));
     EXPECT_TRUE(bar);
     EXPECT_EQ(bar->barLineType(), BarLineType::NORMAL);
 
     m = m->nextMeasure();
 
     // drop NORMAL onto the END_REPEAT part of an END_START_REPEAT straddling a newline will turn into NORMAL at the end of this meas
-    dropNormalBarline(m->findSegment(SegmentType::EndBarLine, m->endTick())->elementAt(0));
-    bar = static_cast<BarLine*>(m->findSegment(SegmentType::EndBarLine, m->endTick())->elementAt(0));
+    seg = m->findSegment(SegmentType::EndBarLine, m->endTick());
+    EXPECT_TRUE(seg);
+    dropNormalBarline(seg->elementAt(0));
+    bar = static_cast<BarLine*>(seg->elementAt(0));
     EXPECT_TRUE(bar);
     EXPECT_EQ(bar->barLineType(), BarLineType::NORMAL);
 
     m = m->nextMeasure();
 
     // but leave START_REPEAT at the beginning of the newline
-    bar = static_cast<BarLine*>(m->findSegment(SegmentType::StartRepeatBarLine, m->tick())->elementAt(0));
+    seg = m->findSegment(SegmentType::StartRepeatBarLine, m->tick());
+    bar = static_cast<BarLine*>(seg->elementAt(0));
     EXPECT_TRUE(bar);
 
     // drop NORMAL onto the meas ending with an END_START_REPEAT straddling a newline will turn into NORMAL at the end of this meas
     // but note I'm not verifying what happens to the START_REPEAT at the beginning of the newline...I'm not sure that behavior is well-defined yet
     dropNormalBarline(m);
-    bar = static_cast<BarLine*>(m->findSegment(SegmentType::EndBarLine, m->endTick())->elementAt(0));
+    seg = m->findSegment(SegmentType::EndBarLine, m->endTick());
+    bar = static_cast<BarLine*>(seg->elementAt(0));
     EXPECT_TRUE(bar);
     EXPECT_EQ(bar->barLineType(), BarLineType::NORMAL);
 
@@ -378,18 +388,23 @@ TEST_F(BarlineTests, barline179726)
     m = m->nextMeasure();
 
     // drop NORMAL onto the START_REPEAT part of an END_START_REPEAT straddling a newline will remove the START_REPEAT at the beginning of this measure
-    dropNormalBarline(m->findSegment(SegmentType::StartRepeatBarLine, m->tick())->elementAt(0));
+    seg = m->findSegment(SegmentType::StartRepeatBarLine, m->tick());
+    dropNormalBarline(seg->elementAt(0));
     EXPECT_EQ(m->findSegment(SegmentType::StartRepeatBarLine, m->tick()), nullptr);
 
     // but leave END_REPEAT at the end of previous line
-    bar = static_cast<BarLine*>(m->prevMeasure()->findSegment(SegmentType::EndBarLine, m->tick())->elementAt(0));
+    seg = m->prevMeasure()->findSegment(SegmentType::EndBarLine, m->tick());
+    EXPECT_TRUE(seg);
+    bar = static_cast<BarLine*>(seg->elementAt(0));
     EXPECT_TRUE(bar);
     EXPECT_EQ(bar->barLineType(), BarLineType::END_REPEAT);
 
     for (int i = 0; i < 4; i++, m = m->nextMeasure()) {
         // drop NORMAL onto END_REPEAT, BROKEN, DOTTED, DOUBLE at the end of this meas will turn into NORMAL
-        dropNormalBarline(m->findSegment(SegmentType::EndBarLine, m->endTick())->elementAt(0));
-        bar = static_cast<BarLine*>(m->findSegment(SegmentType::EndBarLine, m->endTick())->elementAt(0));
+        seg = m->findSegment(SegmentType::EndBarLine, m->endTick());
+        EXPECT_TRUE(seg);
+        dropNormalBarline(seg->elementAt(0));
+        bar = static_cast<BarLine*>(seg->elementAt(0));
         EXPECT_TRUE(bar);
         EXPECT_EQ(bar->barLineType(), BarLineType::NORMAL);
     }
@@ -397,12 +412,15 @@ TEST_F(BarlineTests, barline179726)
     m = m->nextMeasure();
 
     // drop NORMAL onto a START_REPEAT in middle of a line will remove the START_REPEAT at the beginning of this measure
-    dropNormalBarline(m->findSegment(SegmentType::StartRepeatBarLine, m->tick())->elementAt(0));
+    seg = m->findSegment(SegmentType::StartRepeatBarLine, m->tick());
+    dropNormalBarline(seg->elementAt(0));
     EXPECT_EQ(m->findSegment(SegmentType::StartRepeatBarLine, m->tick()), nullptr);
 
     // drop NORMAL onto final END_REPEAT at end of score will turn into NORMAL
-    dropNormalBarline(m->findSegment(SegmentType::EndBarLine, m->endTick())->elementAt(0));
-    bar = static_cast<BarLine*>(m->findSegment(SegmentType::EndBarLine, m->endTick())->elementAt(0));
+    seg = m->findSegment(SegmentType::EndBarLine, m->endTick());
+    EXPECT_TRUE(seg);
+    dropNormalBarline(seg->elementAt(0));
+    bar = static_cast<BarLine*>(seg->elementAt(0));
     EXPECT_TRUE(bar);
     EXPECT_EQ(bar->barLineType(), BarLineType::NORMAL);
 

--- a/src/inspector/models/notation/barlines/barlinesettingsmodel.h
+++ b/src/inspector/models/notation/barlines/barlinesettingsmodel.h
@@ -35,12 +35,14 @@ class BarlineSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(PropertyItem * spanTo READ spanTo CONSTANT)
     Q_PROPERTY(PropertyItem * hasToShowTips READ hasToShowTips CONSTANT)
     Q_PROPERTY(bool isRepeatStyleChangingAllowed READ isRepeatStyleChangingAllowed NOTIFY isRepeatStyleChangingAllowedChanged)
+    Q_PROPERTY(bool isStyleChangingAllowed READ isStyleChangingAllowed NOTIFY isStyleChangingAllowedChanged)
 
 public:
     explicit BarlineSettingsModel(QObject* parent, IElementRepositoryService* repository);
 
     Q_INVOKABLE void applySpanPreset(const int presetType);
     Q_INVOKABLE void setSpanIntervalAsStaffDefault();
+    Q_INVOKABLE bool shouldShowType(const int type) const;
 
     void createProperties() override;
     void requestElements() override;
@@ -54,9 +56,12 @@ public:
     PropertyItem* hasToShowTips() const;
 
     bool isRepeatStyleChangingAllowed() const;
+    bool isStyleChangingAllowed() const;
 
 signals:
     void isRepeatStyleChangingAllowedChanged();
+    void isStyleChangingAllowedChanged();
+    void isFinalBarlineChanged();
 
 private:
     PropertyItem* m_type = nullptr;

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/barlines/BarlineSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/barlines/BarlineSettings.qml
@@ -56,19 +56,27 @@ Column {
         navigationPanel: root.navigationPanel
         navigationRowStart: root.navigationRowStart
 
-        model: [
-            { text: qsTrc("symUserNames", "Single barline"), value: BarlineTypes.TYPE_NORMAL },
-            { text: qsTrc("symUserNames", "Double barline"), value: BarlineTypes.TYPE_DOUBLE },
-            { text: qsTrc("symUserNames", "Left (start) repeat sign"), value: BarlineTypes.TYPE_START_REPEAT },
-            { text: qsTrc("symUserNames", "Right (end) repeat sign"), value: BarlineTypes.TYPE_END_REPEAT },
-            { text: qsTrc("symUserNames", "Right and left repeat sign"), value: BarlineTypes.TYPE_END_START_REPEAT },
-            { text: qsTrc("symUserNames", "Dashed barline"), value: BarlineTypes.TYPE_DASHED },
-            { text: qsTrc("symUserNames", "Final barline"), value: BarlineTypes.TYPE_FINAL },
-            { text: qsTrc("symUserNames", "Dotted barline"), value: BarlineTypes.TYPE_DOTTED },
-            { text: qsTrc("symUserNames", "Reverse final barline"), value: BarlineTypes.TYPE_REVERSE_END },
-            { text: qsTrc("symUserNames", "Heavy barline"), value: BarlineTypes.TYPE_HEAVY },
-            { text: qsTrc("symUserNames", "Heavy double barline"), value: BarlineTypes.TYPE_DOUBLE_HEAVY },
-        ]
+        visible: root.barlineSettingsModel && root.barlineSettingsModel.isStyleChangingAllowed
+
+        function getModel() {
+            let model = [
+                        { text: qsTrc("symUserNames", "Single barline"), value: BarlineTypes.TYPE_NORMAL },
+                        { text: qsTrc("symUserNames", "Double barline"), value: BarlineTypes.TYPE_DOUBLE },
+                        { text: qsTrc("symUserNames", "Left (start) repeat sign"), value: BarlineTypes.TYPE_START_REPEAT },
+                        { text: qsTrc("symUserNames", "Right (end) repeat sign"), value: BarlineTypes.TYPE_END_REPEAT },
+                        { text: qsTrc("symUserNames", "Right and left repeat sign"), value: BarlineTypes.TYPE_END_START_REPEAT },
+                        { text: qsTrc("symUserNames", "Dashed barline"), value: BarlineTypes.TYPE_DASHED },
+                        { text: qsTrc("symUserNames", "Final barline"), value: BarlineTypes.TYPE_FINAL },
+                        { text: qsTrc("symUserNames", "Dotted barline"), value: BarlineTypes.TYPE_DOTTED },
+                        { text: qsTrc("symUserNames", "Reverse final barline"), value: BarlineTypes.TYPE_REVERSE_END },
+                        { text: qsTrc("symUserNames", "Heavy barline"), value: BarlineTypes.TYPE_HEAVY },
+                        { text: qsTrc("symUserNames", "Heavy double barline"), value: BarlineTypes.TYPE_DOUBLE_HEAVY },
+                    ]
+            return model.filter(function(item) { return root.barlineSettingsModel && root.barlineSettingsModel.isStyleChangingAllowed 
+                && root.barlineSettingsModel.shouldShowType(item.value) })
+        }
+
+        model: getModel()
     }
 
     FlatRadioButtonGroupPropertyView {


### PR DESCRIPTION
Resolves: #9429

Fixes a number of bugs with barline properties:

a) when changing a barline to "start repeat", it was changing the barline *after* the one selected
b) for a "start repeat" barline added at the beginning of the system, it was allowing changing the type, despite this not being meaningful. The controls are now hidden for such barlines
c) for a final measure barline (end of section) it was allowing changing the type to "start repeat" or "start & end repeat", neither of which worked. Those options are now hidden for final measure barlines.
d) when changing from "start repeat" or "start & end repeat" to any other sort of barline, the start repeat barline was not getting removed as expected, even if the new barline type was correctly drawn in the same location, and the barline was not selected after doing so (under the hood it's actually now a different barline...)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
