### PR TITLE
Fix #12069: Co-location of palette elements

### DIFF
--- a/src/engraving/libmscore/line.cpp
+++ b/src/engraving/libmscore/line.cpp
@@ -1188,12 +1188,13 @@ void SLine::layout()
         // tick and tick2 has no meaning so no layout is
         // possible and needed
         //
-        setLen(score()->spatium() * 7);
-        if (!spannerSegments().empty()) {
-            LineSegment* lineSegm = frontSegment();
-            lineSegm->layout();
-            setbbox(lineSegm->bbox());
+        if (spannerSegments().empty()) {
+            setLen(score()->spatium() * 7);
         }
+
+        LineSegment* lineSegm = frontSegment();
+        lineSegm->layout();
+        setbbox(lineSegm->bbox());
         return;
     }
 

--- a/src/palette/internal/palette.h
+++ b/src/palette/internal/palette.h
@@ -79,6 +79,9 @@ public:
         BagpipeEmbellishment,
         Layout,
         Beam,
+        Guitar,
+        Keyboard,
+        Pitch,
         Custom
     };
     Q_ENUM(Type)

--- a/src/palette/internal/palettecreator.h
+++ b/src/palette/internal/palettecreator.h
@@ -58,6 +58,9 @@ public:
     static PalettePtr newBarLinePalette(bool defaultPalette = false);
     static PalettePtr newLinesPalette(bool defaultPalette = false);
     static PalettePtr newFretboardDiagramPalette();
+    static PalettePtr newGuitarPalette();
+    static PalettePtr newKeyboardPalette();
+    static PalettePtr newPitchPalette(bool defaultPalette = false);
 
     static PaletteTreePtr newMasterPaletteTree();
     static PaletteTreePtr newDefaultPaletteTree();


### PR DESCRIPTION
Resolves: #12069 

*(short description of the changes and the motivation to make the changes)*

This commit adds already existing palette elements to other palettes. This commit also creates the Guitar, Keyboard and Pitch Palettes

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
