### PR TITLE
fix #12074 - prevent crash after certain operations that delete elements

### DIFF
--- a/src/engraving/accessibility/accessibleitem.cpp
+++ b/src/engraving/accessibility/accessibleitem.cpp
@@ -40,12 +40,11 @@ AccessibleItem::AccessibleItem(EngravingItem* e, Role role)
 
 AccessibleItem::~AccessibleItem()
 {
-    m_element = nullptr;
-
     AccessibleRoot* root = accessibleRoot();
     if (root && root->focusedElement() == this) {
         root->setFocusedElement(nullptr);
     }
+    m_element = nullptr;
 
     if (m_registred && accessibilityController()) {
         accessibilityController()->unreg(this);


### PR DESCRIPTION
Resolves:  https://github.com/musescore/MuseScore/issues/12074

Logic issue with destruction of AccessibleItem .

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
