### PR TITLE
fix #12076: fix regression of pitch and ties import

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -2010,12 +2010,21 @@ void GPConverter::addOttava(const GPBeat* gpb, ChordRest* cr)
     addLineElement(cr, m_ottavas[gpb->ottavaType()], ElementType::OTTAVA, ottavaToImportType(gpb->ottavaType()),
                    gpb->ottavaType() != GPBeat::OttavaType::None);
 
-    if (!cr->isChord()) {
+    if (!cr->isChord() || gpb->ottavaType() == GPBeat::OttavaType::None) {
         return;
     }
 
     const Chord* chord = toChord(cr);
     mu::engraving::OttavaType type = ottavaType(gpb->ottavaType());
+
+    TextLineBase* textLineElem = m_ottavas[gpb->ottavaType()].back();
+    Ottava* ottava = dynamic_cast<Ottava*>(textLineElem);
+
+    if (!ottava) {
+        return;
+    }
+
+    ottava->setOttavaType(type);
 
     for (mu::engraving::Note* note : chord->notes()) {
         int pitch = note->pitch();


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/12076*

*fix of regression after #12095*
*Regression happened because "no octave" was treated as "8va" while importing from GP*
<img width="309" alt="Screenshot 2022-06-21 at 19 44 55" src="https://user-images.githubusercontent.com/24373905/174853798-6916ace5-468f-4ef6-80d8-67ffe1544b5c.png">

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
