### PR TITLE
added handling alternativealternateCodepoint in glyphnames

### DIFF
--- a/src/engraving/libmscore/scorefont.h
+++ b/src/engraving/libmscore/scorefont.h
@@ -83,8 +83,14 @@ public:
     void draw(const SymIdList&, mu::draw::Painter*, const mu::SizeF& mag, const mu::PointF& pos) const;
 
 private:
+
+    struct Code {
+        uint smuflCode = 0;
+        uint musicSymBlockCode = 0;
+    };
+
     struct Sym {
-        uint code = 0;
+        uint code;
         mu::RectF bbox;
         qreal advance = 0.0;
 
@@ -109,7 +115,7 @@ private:
     void loadComposedGlyphs();
     void loadStylisticAlternates(const QJsonObject& glyphsWithAlternatesObject);
     void loadEngravingDefaults(const QJsonObject& engravingDefaultsObject);
-    void computeMetrics(Sym& sym, uint code);
+    void computeMetrics(Sym& sym, const Code& code);
 
     Sym& sym(SymId id);
     const Sym& sym(SymId id) const;
@@ -127,7 +133,7 @@ private:
     double m_textEnclosureThickness = 0;
 
     static std::vector<ScoreFont> s_scoreFonts;
-    static std::array<uint, size_t(SymId::lastSym) + 1> s_symIdCodes;
+    static std::array<Code, size_t(SymId::lastSym) + 1> s_symIdCodes;
 };
 }
 


### PR DESCRIPTION

Resolves: *(direct link to the issue)*

I've noticed that following symbols are not present in Bravura.otf
U+e31a
U+e31b
U+e3de
U+e3df
U+e07f
U+e8e0
U+e8e6
U+e8e4
U+e8e2
U+e8e1
U+e8e7
U+e8e5
U+e8e3
U+e548
U+e0a5
U+eb98
U+eb99
U+eb9a
U+eb9b
U+eb9c
U+eb9d
U+eb9e
U+eb9f
U+eb90
U+eb91
U+eb92
U+eb93
U+eb94
U+eb95
U+eb96
U+eb97
U+e09f
U+e09e

Some of that symbols are not present in Bravura but some symbols are present but dont have associated glyphs. Added handling these cases via QFontProvider. I've also noticed that QFontProvider::symBox() method which works with freetype ignores font substitutions. Although the  other methods of that class which works with QFontMetrics dont ignore substitutions. Fixed it

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://musescore.org/en/cla)
- [ ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ ] I made sure the code compiles on my machine
- [ ] I made sure there are no unnecessary changes in the code
- [ ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
