### PR TITLE
fix #11924: keep gp import preferences

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
@@ -66,6 +66,16 @@ void GP67DomBuilder::buildGPDomModel(QDomElement* qdomElem)
     buildGPTracks(&eachTrack);
 }
 
+void GP67DomBuilder::setProperties(const IGPDomBuilder::GPProperties& properties)
+{
+    _gpDom->setProperties(properties);
+}
+
+IGPDomBuilder::GPProperties GP67DomBuilder::properties() const
+{
+    return _gpDom->properties();
+}
+
 std::unique_ptr<GPDomModel> GP67DomBuilder::getGPDomModel()
 {
     return std::move(_gpDom);

--- a/src/importexport/guitarpro/internal/gtp/gp67dombuilder.h
+++ b/src/importexport/guitarpro/internal/gtp/gp67dombuilder.h
@@ -17,6 +17,9 @@ public:
     void buildGPDomModel(QDomElement* qdomElem) override;
     std::unique_ptr<GPDomModel> getGPDomModel() override;
 
+    void setProperties(const GPProperties& properties) override;
+    GPProperties properties() const override;
+
 protected:
 
     void buildGPScore(QDomNode* scoreNode);

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.h
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.h
@@ -94,6 +94,8 @@ private:
     void setUpTrack(const std::unique_ptr<GPTrack>& tracks);
     void collectTempoMap(const GPMasterTracks* mTr);
     void collectFermatas(const GPMasterBar* mB, Measure* measure);
+    void fixPercussion();
+    void setupTabDisplayStyle();
 
     Measure* addMeasure(const GPMasterBar* mB);
     void addTimeSig(const GPMasterBar* mB, Measure* measure);

--- a/src/importexport/guitarpro/internal/gtp/gpdommodel.h
+++ b/src/importexport/guitarpro/internal/gtp/gpdommodel.h
@@ -22,11 +22,26 @@ namespace mu::engraving {
 class GPDomModel
 {
 public:
+
+    enum class TabImportOption {
+        STANDARD = 1,
+        TAB      = 2,
+        BOTH     = 3
+    };
+
+    struct GPProperties {
+        std::vector<TabImportOption> partsImportOptions;
+        bool createLinkedTabForce = false;
+    };
+
     GPDomModel() = default;
     virtual ~GPDomModel() = default;
 
     GPDomModel(const GPDomModel& gp) = delete;
     GPDomModel& operator=(const GPDomModel&) = delete;
+
+    void setProperties(const GPProperties& properties) { _properties = properties; }
+    GPProperties properties() const { return _properties; }
 
     void addGPScore(std::unique_ptr<GPScore>&& score) { _score = std::move(score); }
 
@@ -46,6 +61,7 @@ private:
     std::map<int, std::unique_ptr<GPAudioTrack> > _audiotracks;
     std::map<int, std::unique_ptr<GPTrack> > _tracks;
     std::vector<std::unique_ptr<GPMasterBar> > _masterBars;
+    GPProperties _properties;
 };
 } // end Ms namespace
 #endif // GPDOMMODEL_H

--- a/src/importexport/guitarpro/internal/gtp/igpdombuilder.h
+++ b/src/importexport/guitarpro/internal/gtp/igpdombuilder.h
@@ -14,9 +14,15 @@ namespace mu::engraving {
 class IGPDomBuilder
 {
 public:
+
+    using TabImportOption = GPDomModel::TabImportOption;
+    using GPProperties = GPDomModel::GPProperties;
+
     virtual ~IGPDomBuilder() = default;
     virtual void buildGPDomModel(QDomElement* qdomElem) = 0;
     virtual std::unique_ptr<GPDomModel> getGPDomModel() = 0;
+    virtual void setProperties(const GPProperties& properties) = 0;
+    virtual GPProperties properties() const = 0;
 };
 } // end MSTab namespace
 #endif // IGPDOMBUILDER_H

--- a/src/importexport/guitarpro/internal/guitarproreader.cpp
+++ b/src/importexport/guitarpro/internal/guitarproreader.cpp
@@ -27,7 +27,7 @@
 #include "engraving/engravingerrors.h"
 
 namespace mu::engraving {
-extern Score::FileError importGTP(MasterScore*, mu::io::IODevice* io);
+extern Score::FileError importGTP(MasterScore*, mu::io::IODevice* io, bool createLinkedTabForce = false);
 }
 
 using namespace mu::iex::guitarpro;

--- a/src/importexport/guitarpro/internal/importgtp-gp4.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp4.cpp
@@ -622,7 +622,7 @@ int GuitarPro4::convertGP4SlideNum(int sl)
 //   read
 //---------------------------------------------------------
 
-bool GuitarPro4::read(IODevice* io)
+bool GuitarPro4::read(IODevice* io, bool /*createLinkedTabForce*/)
 {
     f      = io;
     curPos = 30;

--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -727,7 +727,7 @@ void GuitarPro5::readMeasures(int /*startingTempo*/)
 //   read
 //---------------------------------------------------------
 
-bool GuitarPro5::read(IODevice* io)
+bool GuitarPro5::read(IODevice* io, bool createLinkedTabForce)
 {
     f = io;
 
@@ -953,6 +953,33 @@ bool GuitarPro5::read(IODevice* io)
             }
         }
     }
+
+    /// сopied from gpconverter.cpp
+    /// creating linked TAB staff
+    if (createLinkedTabForce) {
+        for (int i = 0; i < score->parts().size(); i++) {
+            Part* part = score->parts()[i];
+            Fraction fr = Fraction(0, 1);
+            int lines = part->instrument()->stringData()->strings();
+
+            part->setStaves(2);
+
+            Staff* s = part->staff(0);
+            Staff* s1 = part->staff(1);
+
+            StaffTypes tabType = StaffTypes::TAB_6SIMPLE;
+            if (lines == 4) {
+                tabType = StaffTypes::TAB_4SIMPLE;
+            } else if (lines == 5) {
+                tabType = StaffTypes::TAB_5SIMPLE;
+            }
+
+            s1->setStaffType(fr, *StaffType::preset(tabType));
+            s1->setLines(fr, lines);
+            Excerpt::cloneStaff(s, s1);
+        }
+    }
+
     return true;
 }
 

--- a/src/importexport/guitarpro/internal/importgtp-gp6.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp6.cpp
@@ -369,7 +369,7 @@ QDomNode GuitarPro6::getNode(const QString& id, QDomNode currentDomNode)
 //   readGpif
 //---------------------------------------------------------
 
-void GuitarPro6::readGpif(QByteArray* data)
+void GuitarPro6::readGpif(QByteArray* data, const IGPDomBuilder::GPProperties& properties)
 {
     QDomDocument qdomDoc;
     qdomDoc.setContent(*data);
@@ -377,6 +377,7 @@ void GuitarPro6::readGpif(QByteArray* data)
 
     auto builder = createGPDomBuilder();
     builder->buildGPDomModel(&qdomElem);
+    builder->setProperties(properties);
 
     GPConverter scoreBuilder(score, builder->getGPDomModel());
     scoreBuilder.convertGP();
@@ -386,11 +387,11 @@ void GuitarPro6::readGpif(QByteArray* data)
 //   parseFile
 //---------------------------------------------------------
 
-void GuitarPro6::parseFile(const char* filename, QByteArray* data)
+void GuitarPro6::parseFile(const char* filename, QByteArray* data, const IGPDomBuilder::GPProperties& properties)
 {
     // test to check if we are dealing with the score
     if (!strcmp(filename, "score.gpif")) {
-        readGpif(data);
+        readGpif(data, properties);
     }
 }
 
@@ -398,7 +399,7 @@ void GuitarPro6::parseFile(const char* filename, QByteArray* data)
 //   readGPX
 //---------------------------------------------------------
 
-void GuitarPro6::readGPX(QByteArray* buffer)
+void GuitarPro6::readGPX(QByteArray* buffer, const IGPDomBuilder::GPProperties& gpProperties)
 {
     // start by reading the file header. It will tell us if the byte array is compressed.
     int fileHeader = readInteger(buffer, 0);
@@ -458,7 +459,7 @@ void GuitarPro6::readGPX(QByteArray* buffer)
                     QByteArray filenameBytes = readString(buffer, indexFileName, 127);
                     char* filename           = filenameBytes.data();
                     QByteArray data          = getBytes(fileBytes, 0, fileSize);
-                    parseFile(filename, &data);
+                    parseFile(filename, &data, gpProperties);
                 }
                 delete fileBytes;
             }
@@ -470,7 +471,7 @@ void GuitarPro6::readGPX(QByteArray* buffer)
 //   read
 //---------------------------------------------------------
 
-bool GuitarPro6::read(IODevice* io)
+bool GuitarPro6::read(IODevice* io, bool createLinkedTabForce)
 {
     f = io;
     previousTempo = -1;
@@ -478,7 +479,10 @@ bool GuitarPro6::read(IODevice* io)
 
     // decompress and read files contained within GPX file
     QByteArray ba = buffer.toQByteArrayNoCopy();
-    readGPX(&ba);
+    IGPDomBuilder::GPProperties gpProperties;
+    gpProperties.createLinkedTabForce = createLinkedTabForce;
+
+    readGPX(&ba, gpProperties);
 
     return true;
 }

--- a/src/importexport/guitarpro/internal/importgtp-gp7.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp7.cpp
@@ -39,17 +39,53 @@ namespace mu::engraving {
 //   read
 //---------------------------------------------------------
 
-bool GuitarPro7::read(IODevice* io)
+bool GuitarPro7::read(IODevice* io, bool createLinkedTabForce)
 {
     f = io;
     previousTempo = -1;
 
     mu::ZipReader zip(io);
     mu::ByteArray fileData = zip.fileData("Content/score.gpif");
+    mu::ByteArray partsData = zip.fileData("Content/PartConfiguration");
     zip.close();
+
+    QByteArray partsArray = partsData.toQByteArrayNoCopy();
+    IGPDomBuilder::GPProperties properties = readProperties(&partsArray);
+    properties.createLinkedTabForce = createLinkedTabForce;
+
     QByteArray ba = fileData.toQByteArrayNoCopy();
-    readGpif(&ba);
+    readGpif(&ba, properties);
     return true;
+}
+
+//---------------------------------------------------------
+//   readProperties
+//---------------------------------------------------------
+
+IGPDomBuilder::GPProperties GuitarPro7::readProperties(QByteArray* data)
+{
+    IGPDomBuilder::GPProperties properties;
+    size_t partsInfoSize = data->size();
+    const int numInstrOffset = 8;
+    if (partsInfoSize <= numInstrOffset) {
+        LOGE() << "failed to read gp properties";
+        return properties;
+    }
+
+    int numberOfInstruments = static_cast<int>(data->at(numInstrOffset));
+    if (partsInfoSize <= numInstrOffset + numberOfInstruments) {
+        LOGE() << "failed to read gp properties";
+        return properties;
+    }
+
+    using import_option_t = IGPDomBuilder::TabImportOption;
+    std::vector<import_option_t>& partsImportOpts = properties.partsImportOptions;
+
+    for (int i = numInstrOffset + 1; i <= numInstrOffset + numberOfInstruments; i++) {
+        partsImportOpts.push_back(static_cast<import_option_t>(data->at(i)));
+    }
+
+    return properties;
 }
 
 std::unique_ptr<IGPDomBuilder> GuitarPro7::createGPDomBuilder() const

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -1115,7 +1115,7 @@ void GuitarPro::applyBeatEffects(Chord* chord, int beatEffect)
 //   read
 //---------------------------------------------------------
 
-bool GuitarPro1::read(IODevice* io)
+bool GuitarPro1::read(IODevice* io, bool /*createLinkedTabForce*/)
 {
     f      = io;
     curPos = 30;
@@ -1530,7 +1530,7 @@ void GuitarPro::createOttava(bool hasOttava, int track, ChordRest* cr, QString v
 //   read
 //---------------------------------------------------------
 
-bool GuitarPro2::read(IODevice* io)
+bool GuitarPro2::read(IODevice* io, bool /*createLinkedTabForce*/)
 {
     f      = io;
     curPos = 30;
@@ -2205,7 +2205,7 @@ int GuitarPro1::readBeatEffects(int, Segment*)
 //   read
 //---------------------------------------------------------
 
-bool GuitarPro3::read(IODevice* io)
+bool GuitarPro3::read(IODevice* io, bool /*createLinkedTabForce*/)
 {
     f      = io;
     curPos = 30;
@@ -2900,7 +2900,7 @@ static void addMetaInfo(MasterScore* score, GuitarPro* gp)
 //   importGTP
 //---------------------------------------------------------
 
-Score::FileError importGTP(MasterScore* score, mu::io::IODevice* io)
+Score::FileError importGTP(MasterScore* score, mu::io::IODevice* io, bool createLinkedTabForce)
 {
     if (!io->open(IODevice::ReadOnly)) {
         return Score::FileError::FILE_OPEN_ERROR;
@@ -2921,14 +2921,14 @@ Score::FileError importGTP(MasterScore* score, mu::io::IODevice* io)
     if (strcmp(header, "PK\x3\x4") == 0) {
         gp = new GuitarPro7(score);
         gp->initGuitarProDrumset();
-        readResult = gp->read(io);
+        readResult = gp->read(io, createLinkedTabForce);
         gp->setTempo(0, 0);
     }
     // check to see if we are dealing with a GPX file via the extension
     else if (strcmp(header, "BCFZ") == 0) {
         gp = new GuitarPro6(score);
         gp->initGuitarProDrumset();
-        readResult = gp->read(io);
+        readResult = gp->read(io, createLinkedTabForce);
         gp->setTempo(0, 0);
     }
     // otherwise it's an older version - check the header
@@ -2965,7 +2965,7 @@ Score::FileError importGTP(MasterScore* score, mu::io::IODevice* io)
             return Score::FileError::FILE_BAD_FORMAT;
         }
         gp->initGuitarProDrumset();
-        readResult = gp->read(io);
+        readResult = gp->read(io, createLinkedTabForce);
         gp->setTempo(0, 0);
     } else {
         return Score::FileError::FILE_BAD_FORMAT;

--- a/src/importexport/guitarpro/internal/importgtp.h
+++ b/src/importexport/guitarpro/internal/importgtp.h
@@ -279,7 +279,7 @@ public:
 
     GuitarPro(MasterScore*, int v);
     virtual ~GuitarPro();
-    virtual bool read(mu::io::IODevice*) = 0;
+    virtual bool read(mu::io::IODevice*, bool createLinkedTabForce) = 0;
     QString error(GuitarProError n) const { return QString(errmsg[int(n)]); }
 };
 
@@ -296,7 +296,7 @@ protected:
 public:
     GuitarPro1(MasterScore* s, int v)
         : GuitarPro(s, v) {}
-    virtual bool read(mu::io::IODevice*);
+    virtual bool read(mu::io::IODevice*, bool);
 };
 
 //---------------------------------------------------------
@@ -308,7 +308,7 @@ class GuitarPro2 : public GuitarPro1
 public:
     GuitarPro2(MasterScore* s, int v)
         : GuitarPro1(s, v) {}
-    virtual bool read(mu::io::IODevice*);
+    virtual bool read(mu::io::IODevice*, bool);
 };
 
 //---------------------------------------------------------
@@ -322,7 +322,7 @@ class GuitarPro3 : public GuitarPro1
 public:
     GuitarPro3(MasterScore* s, int v)
         : GuitarPro1(s, v) {}
-    virtual bool read(mu::io::IODevice*);
+    virtual bool read(mu::io::IODevice*, bool);
 };
 
 //---------------------------------------------------------
@@ -342,7 +342,7 @@ class GuitarPro4 : public GuitarPro
 public:
     GuitarPro4(MasterScore* s, int v)
         : GuitarPro(s, v) {}
-    virtual bool read(mu::io::IODevice*);
+    virtual bool read(mu::io::IODevice*, bool);
 };
 
 //---------------------------------------------------------
@@ -369,7 +369,7 @@ class GuitarPro5 : public GuitarPro
 public:
     GuitarPro5(MasterScore* s, int v)
         : GuitarPro(s, v) {}
-    virtual bool read(mu::io::IODevice*);
+    virtual bool read(mu::io::IODevice*, bool createLinkedTabForce);
 };
 
 //---------------------------------------------------------
@@ -378,8 +378,6 @@ public:
 
 class GuitarPro6 : public GuitarPro
 {
-    Fraction _lastTick;
-    Volta* _lastVolta{ nullptr };
     // an integer stored in the header indicating that the file is not compressed (BCFS).
     const int GPX_HEADER_UNCOMPRESSED = 1397113666;
     // an integer stored in the header indicating that the file is not compressed (BCFZ).
@@ -396,13 +394,11 @@ class GuitarPro6 : public GuitarPro
         QDomNode notes;
         QDomNode rhythms;
     };
-    Slur** legatos;
-    // a mapping from identifiers to fret diagrams
-    QMap<int, FretDiagram*> fretDiagrams;
-    void parseFile(const char* filename, QByteArray* data);
+
+    void parseFile(const char* filename, QByteArray* data, const IGPDomBuilder::GPProperties& properties = IGPDomBuilder::GPProperties());
     int readBit(QByteArray* buffer);
     QByteArray getBytes(QByteArray* buffer, int offset, int length);
-    void readGPX(QByteArray* buffer);
+    void readGPX(QByteArray* buffer, const IGPDomBuilder::GPProperties& gpProperties = IGPDomBuilder::GPProperties());
     int readInteger(QByteArray* buffer, int offset);
     QByteArray readString(QByteArray* buffer, int offset, int length);
     int readBits(QByteArray* buffer, int bitsToRead);
@@ -419,8 +415,7 @@ class GuitarPro6 : public GuitarPro
 
 protected:
     const static std::map<QString, QString> instrumentMapping;
-    int* previousDynamic;
-    void readGpif(QByteArray* data);
+    void readGpif(QByteArray* data, const IGPDomBuilder::GPProperties& properties = IGPDomBuilder::GPProperties());
 
     virtual std::unique_ptr<IGPDomBuilder> createGPDomBuilder() const override;
 
@@ -429,7 +424,7 @@ public:
         : GuitarPro(s, 6) {}
     GuitarPro6(MasterScore* s, int v)
         : GuitarPro(s, v) {}
-    bool read(mu::io::IODevice*) override;
+    bool read(mu::io::IODevice*, bool createLinkedTabForce) override;
 };
 
 class GuitarPro7 : public GuitarPro6
@@ -439,7 +434,8 @@ class GuitarPro7 : public GuitarPro6
 public:
     GuitarPro7(MasterScore* s)
         : GuitarPro6(s, 7) {}
-    bool read(mu::io::IODevice*) override;
+    bool read(mu::io::IODevice*, bool createLinkedTabForce) override;
+    IGPDomBuilder::GPProperties readProperties(QByteArray* data);
 };
 } // namespace Ms
 #endif


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/11924*

*keep gp import preferences (standard, tab, st+tab) when it's possible (otherwise open linked: standard+tab)*

Example:
GP:
<img width="482" alt="Screenshot 2022-06-22 at 18 03 26" src="https://user-images.githubusercontent.com/24373905/175063723-4158e219-2a14-4faf-a669-d68343d6d1fb.png">

GPX/GP5:
<img width="459" alt="Screenshot 2022-06-22 at 18 04 10" src="https://user-images.githubusercontent.com/24373905/175063899-b298687a-d385-4ee9-9eac-9cca05953c5b.png">


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
