### PR TITLE
fix #10316: import gp slides as chordlines

### DIFF
--- a/src/engraving/libmscore/chordline.cpp
+++ b/src/engraving/libmscore/chordline.cpp
@@ -109,7 +109,16 @@ void ChordLine::layout()
 
     double _spatium = spatium();
     if (explicitParent()) {
-        Note* note = _note ? _note : chord()->upNote();
+        Note* note = nullptr;
+
+        if (_note) {
+            note = chord()->findNote(_note->pitch());
+        }
+
+        if (!note) {
+            note = chord()->upNote();
+        }
+
         double x = note->pos().x();
         double y = note->pos().y();
         double horOffset = 0.33 * spatium(); // one third of a space away from the note

--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -5477,17 +5477,6 @@ void Score::undoAddElement(EngravingItem* element, bool ctrlModifier)
                 ne->setTrack(ntrack);
                 ChordRest* ncr = toChordRest(seg->element(ntrack));
                 ne->setParent(ncr);
-                if (element->isChordLine() && toChordLine(element)->note() && cr->isChord()) {
-                    // ChordLine must be attached to the new note in the linked staff:
-                    Note* note = toChordLine(element)->note();
-                    Chord* chord = toChord(cr);
-                    auto iter = std::find(chord->notes().begin(), chord->notes().end(), note); // find note index in start chord
-                    if (iter != chord->notes().end()) {
-                        int index = iter - chord->notes().begin();
-                        Note* newNote = toChord(ncr)->notes().at(index); // find corresponding note in end chord
-                        toChordLine(ne)->setNote(newNote); // ... attach chordLine to the new note
-                    }
-                }
                 undo(new AddElement(ne));
             }
             //

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1122,7 +1122,8 @@ void GPConverter::addContinuousSlideHammerOn()
                 return note;
             }
         }
-        return nullptr;
+
+        return nextChord->upNote();
     };
 
     std::unordered_map<Note*, Slur*> legatoSlides;
@@ -1696,6 +1697,7 @@ void GPConverter::addSingleSlide(const GPNote* gpnote, Note* note)
             cl->setChordLineType(type.first);
             cl->setStraight(true);
             note->chord()->add(cl);
+            cl->setNote(note);
 
             Note::Slide sl{ type.second, nullptr };
             note->attachSlide(sl);

--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -1122,7 +1122,9 @@ bool GuitarPro5::readNoteEffects(Note* note)
             };
 
             sld->setChordLineType(slideType);
+            sld->setStraight(true);
             note->chord()->add(sld);
+            sld->setNote(note);
             Note::Slide sl{ convertSlideType(slideType), nullptr };
             note->attachSlide(sl);
         }


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/10316*

*fixes in importing the improved chordline element*

*update: importing glissando even if the notes aren't on the same string. Before this used to skip in the gp import*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
