### PR TITLE
[MU4] Fix MSVC/MinGW compiler warning

### DIFF
--- a/src/engraving/libmscore/scorefont.cpp
+++ b/src/engraving/libmscore/scorefont.cpp
@@ -168,6 +168,7 @@ bool ScoreFont::initGlyphNamesJson()
             LOGD() << "could not read alternate codepoint for glyph " << name;
         }
     }
+    return true;
 }
 
 // =============================================


### PR DESCRIPTION
reg. not all control paths return a value	(C4715) resp. control reaches end of non-void function (-Wreturn-type)

Introduced with #12142.