### PR TITLE
fix #12150 - prevent crash trying to quit while modal dialog shown

### DIFF
--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -22,6 +22,7 @@
 #include "applicationactioncontroller.h"
 
 #include <QCoreApplication>
+#include <QApplication>
 #include <QCloseEvent>
 #include <QFileOpenEvent>
 #include <QWindow>
@@ -228,4 +229,10 @@ void ApplicationActionController::checkForUpdate()
     NOT_IMPLEMENTED;
 
     interactive()->info(trc("appshell", "No update available"), "");
+}
+
+bool ApplicationActionController::canReceiveAction(const mu::actions::ActionCode& code) const
+{
+    auto focus = QGuiApplication::focusWindow();
+    return !focus || focus->modality() == Qt::WindowModality::NonModal;
 }

--- a/src/appshell/internal/applicationactioncontroller.h
+++ b/src/appshell/internal/applicationactioncontroller.h
@@ -62,6 +62,7 @@ public:
     void onDragEnterEvent(QDragEnterEvent* event) override;
     void onDragMoveEvent(QDragMoveEvent* event) override;
     void onDropEvent(QDropEvent* event) override;
+    bool canReceiveAction(const mu::actions::ActionCode&) const override;
 
 private:
     bool eventFilter(QObject* watched, QEvent* event) override;


### PR DESCRIPTION

Resolves: [#12150](https://github.com/musescore/MuseScore/issues/12150)

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
