### PR TITLE
fixed crashed during importing guitar pro files

### DIFF
--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -527,6 +527,10 @@ static void cloneSpanner(Spanner* s, Score* score, track_idx_t dstTrack, track_i
         if (!ns->endElement()) {
             LOGD("clone Slur: no end element");
         }
+        if (!ns->startElement() && !ns->endElement()) {
+            delete ns;
+            return;
+        }
     }
     score->undo(new AddElement(ns));
 }

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1731,7 +1731,7 @@ void GPConverter::addBend(const GPNote* gpnote, Note* note)
 
     bend->points().push_back(PitchValue(0, gpBend->originValue));
 
-    const auto& lastPoint = bend->points().back();
+    PitchValue lastPoint = bend->points().back();
 
     if (bendHasMiddleValue) {
         if (PitchValue value(gpBend->middleOffset1, gpBend->middleValue);
@@ -1770,7 +1770,6 @@ void GPConverter::addLineElement(ChordRest* cr, std::vector<TextLineBase*>& elem
                                  bool forceSplitByRests)
 {
     track_idx_t track = cr->track();
-    LOGE() << "@# add line element for track : " << cr->track();
 
     auto& lastTypeForTrack = m_lastImportTypes[track][muType];
 


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

crash happen during creating tabulature staff for guitar elements. Slur don't have start element so it is setted during layout. Layout sets rest for start element. It leads to crash

tab 
[crash.gp.zip](https://github.com/musescore/MuseScore/files/8998695/crash.gp.zip)


<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://musescore.org/en/cla)
- [ ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ ] I made sure the code compiles on my machine
- [ ] I made sure there are no unnecessary changes in the code
- [ ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
