### PR TITLE
Remove "revision" and "division" from NotationConfiguration

### DIFF
--- a/src/appshell/internal/appshellconfiguration.cpp
+++ b/src/appshell/internal/appshellconfiguration.cpp
@@ -270,7 +270,7 @@ std::string AppShellConfiguration::utmParameters(const std::string& utmMedium) c
 
 std::string AppShellConfiguration::sha() const
 {
-    return "sha=" + notationConfiguration()->notationRevision();
+    return "sha=" MUSESCORE_REVISION;
 }
 
 std::string AppShellConfiguration::currentLanguageCode() const

--- a/src/appshell/view/preferences/importpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/importpreferencesmodel.cpp
@@ -23,9 +23,8 @@
 
 #include <QTextCodec>
 
-#include "libmscore/mscore.h"
+#include "engraving/types/constants.h"
 
-#include "log.h"
 #include "translation.h"
 
 using namespace mu::appshell;
@@ -54,16 +53,18 @@ QVariantList ImportPreferencesModel::charsets() const
 
 QVariantList ImportPreferencesModel::shortestNotes() const
 {
+    constexpr int division =  engraving::Constants::division;
+
     QVariantList result = {
-        QVariantMap { { "title", qtrc("appshell", "Quarter") }, { "value", division() } },
-        QVariantMap { { "title", qtrc("appshell", "Eighth") }, { "value", division() / 2 } },
-        QVariantMap { { "title", qtrc("appshell", "16th") }, { "value", division() / 4 } },
-        QVariantMap { { "title", qtrc("appshell", "32nd") }, { "value", division() / 8 } },
-        QVariantMap { { "title", qtrc("appshell", "64th") }, { "value", division() / 16 } },
-        QVariantMap { { "title", qtrc("appshell", "128th") }, { "value", division() / 32 } },
-        QVariantMap { { "title", qtrc("appshell", "256th") }, { "value", division() / 64 } },
-        QVariantMap { { "title", qtrc("appshell", "512th") }, { "value", division() / 128 } },
-        QVariantMap { { "title", qtrc("appshell", "1024th") }, { "value", division() / 256 } }
+        QVariantMap { { "title", qtrc("appshell", "Quarter") }, { "value", division } },
+        QVariantMap { { "title", qtrc("appshell", "Eighth") }, { "value", division / 2 } },
+        QVariantMap { { "title", qtrc("appshell", "16th") }, { "value", division / 4 } },
+        QVariantMap { { "title", qtrc("appshell", "32nd") }, { "value", division / 8 } },
+        QVariantMap { { "title", qtrc("appshell", "64th") }, { "value", division / 16 } },
+        QVariantMap { { "title", qtrc("appshell", "128th") }, { "value", division / 32 } },
+        QVariantMap { { "title", qtrc("appshell", "256th") }, { "value", division / 64 } },
+        QVariantMap { { "title", qtrc("appshell", "512th") }, { "value", division / 128 } },
+        QVariantMap { { "title", qtrc("appshell", "1024th") }, { "value", division / 256 } }
     };
 
     return result;
@@ -202,9 +203,4 @@ void ImportPreferencesModel::setNeedAskAboutApplyingNewStyle(bool value)
 
     musicXmlConfiguration()->setNeedAskAboutApplyingNewStyle(value);
     emit needAskAboutApplyingNewStyleChanged(value);
-}
-
-int ImportPreferencesModel::division() const
-{
-    return notationConfiguration()->notationDivision();
 }

--- a/src/appshell/view/preferences/importpreferencesmodel.h
+++ b/src/appshell/view/preferences/importpreferencesmodel.h
@@ -105,9 +105,6 @@ signals:
     void needUseDefaultFontChanged(bool needUseDefaultFont);
     void currentShortestNoteChanged(int currentShortestNote);
     void needAskAboutApplyingNewStyleChanged(bool needAskAboutApplyingNewStyle);
-
-private:
-    int division() const;
 };
 }
 

--- a/src/engraving/libmscore/scorefile.cpp
+++ b/src/engraving/libmscore/scorefile.cpp
@@ -365,10 +365,6 @@ bool Score::saveStyle(const String& name)
 //    return true on success
 //---------------------------------------------------------
 
-//! FIXME
-//extern String revision;
-static String revision;
-
 bool Score::writeScore(io::IODevice* f, bool msczFormat, bool onlySelection, compat::WriteScoreHook& hook)
 {
     WriteContext ctx;
@@ -386,7 +382,7 @@ bool Score::writeScore(io::IODevice* f, bool msczFormat, bool onlySelection, com
 
     if (!MScore::testMode) {
         xml.tag("programVersion", VERSION);
-        xml.tag("programRevision", revision);
+        xml.tag("programRevision", MUSESCORE_REVISION);
     }
     write(xml, onlySelection, hook);
 
@@ -395,7 +391,7 @@ bool Score::writeScore(io::IODevice* f, bool msczFormat, bool onlySelection, com
     if (!onlySelection) {
         //update version values for i.e. plugin access
         _mscoreVersion = VERSION;
-        _mscoreRevision = revision.toInt(0, 16);
+        _mscoreRevision = AsciiStringView(MUSESCORE_REVISION).toInt(nullptr, 16);
         _mscVersion = MSCVERSION;
     }
     return true;

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -126,9 +126,6 @@ public:
     virtual double guiScaling() const = 0;
     virtual double notationScaling() const = 0;
 
-    virtual std::string notationRevision() const = 0;
-    virtual int notationDivision() const = 0;
-
     virtual ValCh<framework::Orientation> canvasOrientation() const = 0;
     virtual void setCanvasOrientation(framework::Orientation orientation) = 0;
 

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -35,12 +35,6 @@ using namespace mu::framework;
 using namespace mu::async;
 using namespace mu::ui;
 
-// Global variable
-namespace mu::engraving {
-QString revision;
-}
-// -----
-
 static const std::string module_name("notation");
 
 static const Settings::Key LIGHT_SCORE_BACKGROUND_COLOR(module_name, "ui/canvas/background/lightTheme_score_background_color");
@@ -585,16 +579,6 @@ double NotationConfiguration::guiScaling() const
 double NotationConfiguration::notationScaling() const
 {
     return uiConfiguration()->physicalDpi() / mu::engraving::DPI;
-}
-
-std::string NotationConfiguration::notationRevision() const
-{
-    return mu::engraving::revision.toStdString();
-}
-
-int NotationConfiguration::notationDivision() const
-{
-    return mu::engraving::Constants::division;
 }
 
 ValCh<framework::Orientation> NotationConfiguration::canvasOrientation() const

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -132,9 +132,6 @@ public:
     double guiScaling() const override;
     double notationScaling() const override;
 
-    std::string notationRevision() const override;
-    int notationDivision() const override;
-
     ValCh<framework::Orientation> canvasOrientation() const override;
     void setCanvasOrientation(framework::Orientation orientation) override;
 


### PR DESCRIPTION
Both don't really have to do with Notation.