### PR TITLE
Fix find

### DIFF
--- a/src/engraving/layout/layoutmeasure.cpp
+++ b/src/engraving/layout/layoutmeasure.cpp
@@ -33,6 +33,7 @@
 #include "libmscore/lyrics.h"
 #include "libmscore/marker.h"
 #include "libmscore/part.h"
+#include "libmscore/textlinebase.h"
 
 #include "layout.h"
 #include "layoutcontext.h"
@@ -461,7 +462,7 @@ static bool breakMultiMeasureRest(const LayoutContext& ctx, Measure* m)
     for (auto i : sl) {
         Spanner* s = i.value;
         // break for first measure of volta or textline and first measure *after* volta
-        if ((s->isVolta() || s->isTextLine()) && (s->tick() == m->tick() || s->tick2() == m->tick())) {
+        if ((s->isVolta() || s->isGradualTempoChange() || s->isTextLine()) && (s->tick() == m->tick() || s->tick2() == m->tick())) {
             return true;
         }
     }

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -985,6 +985,7 @@ void LayoutSystem::layoutSystemElements(const LayoutOptions& options, LayoutCont
     std::vector<Spanner*> ottavas;
     std::vector<Spanner*> pedal;
     std::vector<Spanner*> voltas;
+    std::vector<Spanner*> tempoChangeLines;
 
     for (auto interval : spanners) {
         Spanner* sp = interval.value;
@@ -1001,12 +1002,15 @@ void LayoutSystem::layoutSystemElements(const LayoutOptions& options, LayoutCont
                 voltas.push_back(sp);
             } else if (sp->isHairpin()) {
                 hairpins.push_back(sp);
+            } else if (sp->isGradualTempoChange()) {
+                tempoChangeLines.push_back(sp);
             } else if (!sp->isSlur() && !sp->isVolta()) {      // slurs are already
                 spanner.push_back(sp);
             }
         }
     }
     processLines(system, hairpins, false);
+    processLines(system, tempoChangeLines, false);
     processLines(system, spanner, false);
 
     //-------------------------------------------------------------

--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -505,8 +505,7 @@ void Score::cmdAddSpanner(Spanner* spanner, const PointF& pos, bool systemStaves
     }
     spanner->eraseSpannerSegments();
 
-    ElementType et = spanner->type();
-    bool ctrlModifier = (et == ElementType::VOLTA || et == ElementType::TEXTLINE) && spanner->systemFlag() && !systemStavesOnly;
+    bool ctrlModifier = isSystemTextLine(spanner) && !systemStavesOnly;
     undoAddElement(spanner, ctrlModifier);
     select(spanner, SelectType::SINGLE, 0);
 }

--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -5136,18 +5136,19 @@ void Score::undoAddElement(EngravingItem* element, bool ctrlModifier)
     // linking:
     //
 
+    bool isSystemLine = isSystemTextLine(element);
+
     if ((et == ElementType::REHEARSAL_MARK)
         || (et == ElementType::SYSTEM_TEXT)
         || (et == ElementType::TRIPLET_FEEL)
         || (et == ElementType::JUMP)
         || (et == ElementType::MARKER)
         || (et == ElementType::TEMPO_TEXT)
-        || (et == ElementType::VOLTA)
-        || ((et == ElementType::TEXTLINE) && element->systemFlag())
+        || isSystemLine
         ) {
         std::list<Staff* > staffList;
 
-        if (ctrlModifier && (et == ElementType::VOLTA || et == ElementType::TEXTLINE)) {
+        if (ctrlModifier && isSystemLine) {
             element->setSystemFlag(false);
             staffList.push_back(element->staff());
         } else {
@@ -5182,7 +5183,7 @@ void Score::undoAddElement(EngravingItem* element, bool ctrlModifier)
                 ne->setTrack(staffIdx * VOICES + element->voice());
             }
 
-            if (et == ElementType::VOLTA || (et == ElementType::TEXTLINE)) {
+            if (isSystemLine) {
                 Spanner* nsp = toSpanner(ne);
                 Spanner* sp = toSpanner(element);
                 staff_idx_t staffIdx1 = sp->track() / VOICES;

--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -479,8 +479,8 @@ static bool scoreContainsSpanner(const Score* score, Spanner* spanner)
 
 static void cloneSpanner(Spanner* s, Score* score, track_idx_t dstTrack, track_idx_t dstTrack2)
 {
-    // don’t clone voltas for track != 0
-    if (((s->isVolta() || s->isTextLine()) && s->systemFlag()) && s->track() != 0) {
+    // don’t clone system lines for track != 0
+    if (isSystemTextLine(s) && s->track() != 0) {
         return;
     }
 
@@ -952,7 +952,7 @@ void Excerpt::cloneStaves(Score* sourceScore, Score* dstScore, const std::vector
         track_idx_t dstTrack  = mu::nidx;
         track_idx_t dstTrack2 = mu::nidx;
 
-        if ((s->isVolta() || s->isTextLine()) && s->systemFlag()) {
+        if (isSystemTextLine(s)) {
             //always export voltas to first staff in part
             dstTrack  = 0;
             dstTrack2 = 0;
@@ -1191,7 +1191,7 @@ void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff)
         staff_idx_t staffIdx = s->staffIdx();
         track_idx_t dstTrack = mu::nidx;
         track_idx_t dstTrack2 = mu::nidx;
-        if (!((s->isVolta() || s->isTextLine()) && s->systemFlag())) {
+        if (!isSystemTextLine(s)) {
             //export other spanner if staffidx matches
             if (srcStaffIdx == staffIdx) {
                 dstTrack = dstStaffIdx * VOICES + s->voice();
@@ -1393,9 +1393,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
         track_idx_t dstTrack = mu::nidx;
         track_idx_t dstTrack2 = mu::nidx;
 
-        bool isSystemLine = (s->isVolta() || (s->isTextLine() && s->systemFlag()));
-
-        if (isSystemLine) {
+        if (isSystemTextLine(s)) {
             if (!scoreContainsSpanner(score, s)) {
                 dstTrack = s->track();
                 dstTrack2 = s->track2();

--- a/src/engraving/libmscore/gradualtempochange.cpp
+++ b/src/engraving/libmscore/gradualtempochange.cpp
@@ -147,6 +147,14 @@ LineSegment* GradualTempoChange::createLineSegment(System* parent)
     return lineSegment;
 }
 
+SpannerSegment* GradualTempoChange::layoutSystem(System* system)
+{
+    SpannerSegment* segment = TextLineBase::layoutSystem(system);
+    moveToSystemTopIfNeed(segment);
+
+    return segment;
+}
+
 GradualTempoChangeType GradualTempoChange::tempoChangeType() const
 {
     return m_tempoChangeType;

--- a/src/engraving/libmscore/gradualtempochange.cpp
+++ b/src/engraving/libmscore/gradualtempochange.cpp
@@ -82,11 +82,12 @@ static const std::unordered_map<GradualTempoChangeType, double> DEFAULT_FACTORS_
 };
 
 GradualTempoChange::GradualTempoChange(EngravingItem* parent)
-    : ChordTextLineBase(ElementType::GRADUAL_TEMPO_CHANGE, parent)
+    : TextLineBase(ElementType::GRADUAL_TEMPO_CHANGE, parent, ElementFlag::SYSTEM)
 {
     initElementStyle(&tempoStyle);
-    resetProperty(Pid::LINE_VISIBLE);
+    setAnchor(Anchor::MEASURE);
 
+    resetProperty(Pid::LINE_VISIBLE);
     resetProperty(Pid::BEGIN_TEXT_PLACE);
     resetProperty(Pid::BEGIN_TEXT);
     resetProperty(Pid::CONTINUE_TEXT_PLACE);
@@ -301,7 +302,8 @@ void GradualTempoChange::requestToRebuildTempo()
 }
 
 GradualTempoChangeSegment::GradualTempoChangeSegment(GradualTempoChange* annotation, System* parent)
-    : TextLineBaseSegment(ElementType::GRADUAL_TEMPO_CHANGE_SEGMENT, annotation, parent, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
+    : TextLineBaseSegment(ElementType::GRADUAL_TEMPO_CHANGE_SEGMENT, annotation, parent,
+                          ElementFlag::MOVABLE | ElementFlag::ON_STAFF | ElementFlag::SYSTEM)
 {
 }
 

--- a/src/engraving/libmscore/gradualtempochange.h
+++ b/src/engraving/libmscore/gradualtempochange.h
@@ -41,6 +41,7 @@ public:
     void write(XmlWriter& writer) const override;
 
     LineSegment* createLineSegment(System* parent) override;
+    SpannerSegment* layoutSystem(System* system) override;
 
     GradualTempoChangeType tempoChangeType() const;
     ChangeMethod easingMethod() const;

--- a/src/engraving/libmscore/gradualtempochange.h
+++ b/src/engraving/libmscore/gradualtempochange.h
@@ -25,12 +25,12 @@
 
 #include <optional>
 
-#include "chordtextlinebase.h"
+#include "textlinebase.h"
 #include "types/types.h"
 
 namespace mu::engraving {
 class GradualTempoChangeSegment;
-class GradualTempoChange : public ChordTextLineBase
+class GradualTempoChange : public TextLineBase
 {
 public:
     GradualTempoChange(EngravingItem* parent);

--- a/src/engraving/libmscore/page.cpp
+++ b/src/engraving/libmscore/page.cpp
@@ -63,6 +63,20 @@ Page::Page(RootItem* parent)
 }
 
 //---------------------------------------------------------
+//   firstMeasure
+//---------------------------------------------------------
+Measure* Page::firstMeasure() const
+{
+    for (System* s : _systems) {
+        Measure* firstMeasure = s->firstMeasure();
+        if (firstMeasure) {
+            return firstMeasure;
+        }
+    }
+    return nullptr;
+}
+
+//---------------------------------------------------------
 //   items
 //---------------------------------------------------------
 
@@ -307,7 +321,7 @@ qreal Page::footerExtension() const
 //   scanElements
 //---------------------------------------------------------
 
-void Page::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
+void Page::scanElements(void* data, void (*func)(void*, EngravingItem*), bool all)
 {
     for (System* s :_systems) {
         for (MeasureBase* m : s->measures()) {

--- a/src/engraving/libmscore/page.h
+++ b/src/engraving/libmscore/page.h
@@ -71,6 +71,7 @@ public:
     const std::vector<System*>& systems() const { return _systems; }
     std::vector<System*>& systems() { return _systems; }
     System* system(int idx) { return _systems[idx]; }
+    Measure* firstMeasure() const;
 
     void write(XmlWriter&) const override;
     void read(XmlReader&) override;
@@ -88,7 +89,7 @@ public:
     qreal footerExtension() const;
 
     void draw(mu::draw::Painter*) const override;
-    void scanElements(void* data, void (* func)(void*, EngravingItem*), bool all=true) override;
+    void scanElements(void* data, void (*func)(void*, EngravingItem*), bool all=true) override;
 
     std::vector<EngravingItem*> items(const mu::RectF& r);
     std::vector<EngravingItem*> items(const mu::PointF& p);

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -2864,8 +2864,7 @@ void Score::sortSystemObjects(std::vector<staff_idx_t>& dst)
                                 || e->isSystemText()
                                 || e->isTripletFeel()
                                 || e->isTempoText()
-                                || (e->isVolta() && e->systemFlag())
-                                || (e->isTextLine() && e->systemFlag())) {
+                                || isSystemTextLine(e)) {
                                 if (e->track() == staff2track(systemObjectStaves[i]->idx()) && e->isLinked()) {
                                     if (moveTo[i] == mu::nidx) {
                                         s->removeAnnotation(e);

--- a/src/engraving/libmscore/scorefile.cpp
+++ b/src/engraving/libmscore/scorefile.cpp
@@ -570,7 +570,7 @@ void Score::writeSegments(XmlWriter& xml, track_idx_t strack, track_idx_t etrack
                         || (et == ElementType::MARKER)
                         || (et == ElementType::TEMPO_TEXT)
                         || (et == ElementType::VOLTA)
-                        || (et == ElementType::TEXTLINE)) {
+                        || (et == ElementType::GRADUAL_TEMPO_CHANGE)) {
                         writeSystem = (e1->track() == track); // always show these on appropriate staves
                     }
                 }

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -881,6 +881,7 @@ void Segment::sortStaves(std::vector<staff_idx_t>& dst)
             ElementType::MARKER,
             ElementType::TEMPO_TEXT,
             ElementType::VOLTA,
+            ElementType::GRADUAL_TEMPO_CHANGE,
             ElementType::TEXTLINE
         };
         if (!e->systemFlag() || (e->isLinked() && (allowedTypes.find(et) != allowedTypes.end()))) {

--- a/src/engraving/libmscore/spanner.cpp
+++ b/src/engraving/libmscore/spanner.cpp
@@ -1385,6 +1385,18 @@ SpannerSegment* Spanner::layoutSystem(System*)
     return 0;
 }
 
+void Spanner::moveToSystemTopIfNeed(SpannerSegment* segment)
+{
+    if (segment->spanner()) {
+        for (SpannerSegment* ss : segment->spanner()->spannerSegments()) {
+            ss->setFlag(ElementFlag::SYSTEM, systemFlag());
+            ss->setTrack(systemFlag() ? 0 : track());
+        }
+        segment->spanner()->setFlag(ElementFlag::SYSTEM, systemFlag());
+        segment->spanner()->setTrack(systemFlag() ? 0 : track());
+    }
+}
+
 //---------------------------------------------------------
 //   getNextLayoutSystemSegment
 //---------------------------------------------------------

--- a/src/engraving/libmscore/spanner.h
+++ b/src/engraving/libmscore/spanner.h
@@ -182,6 +182,8 @@ protected:
 
     const std::vector<SpannerSegment*> spannerSegments() const { return segments; }
 
+    void moveToSystemTopIfNeed(SpannerSegment* segment);
+
 public:
 
     ~Spanner();

--- a/src/engraving/libmscore/textline.cpp
+++ b/src/engraving/libmscore/textline.cpp
@@ -367,17 +367,9 @@ void TextLine::undoChangeProperty(Pid id, const engraving::PropertyValue& v, Pro
 
 SpannerSegment* TextLine::layoutSystem(System* system)
 {
-    TextLineSegment* tls = toTextLineSegment(TextLineBase::layoutSystem(system));
+    SpannerSegment* segment = TextLineBase::layoutSystem(system);
+    moveToSystemTopIfNeed(segment);
 
-    if (tls->spanner()) {
-        for (SpannerSegment* ss : tls->spanner()->spannerSegments()) {
-            ss->setFlag(ElementFlag::SYSTEM, systemFlag());
-            ss->setTrack(systemFlag() ? 0 : track());
-        }
-        tls->spanner()->setFlag(ElementFlag::SYSTEM, systemFlag());
-        tls->spanner()->setTrack(systemFlag() ? 0 : track());
-    }
-
-    return tls;
+    return segment;
 }
 } // namespace mu::engraving

--- a/src/engraving/libmscore/textlinebase.h
+++ b/src/engraving/libmscore/textlinebase.h
@@ -121,6 +121,11 @@ public:
     PropertyValue getProperty(Pid id) const override;
     bool setProperty(Pid propertyId, const PropertyValue&) override;
 };
+
+inline bool isSystemTextLine(const EngravingItem* element)
+{
+    return element && element->isTextLineBase() && element->systemFlag();
+}
 } // namespace mu::engraving
 
 #endif

--- a/src/engraving/libmscore/textlinebase.h
+++ b/src/engraving/libmscore/textlinebase.h
@@ -104,9 +104,6 @@ class TextLineBase : public SLine
     M_PROPERTY(FontStyle, endFontStyle,          setEndFontStyle)
     M_PROPERTY(mu::PointF,   endTextOffset,         setEndTextOffset)
 
-protected:
-    friend class TextLineBaseSegment;
-
 public:
     TextLineBase(const ElementType& type, EngravingItem* parent, ElementFlags = ElementFlag::NOTHING);
 
@@ -120,6 +117,9 @@ public:
 
     PropertyValue getProperty(Pid id) const override;
     bool setProperty(Pid propertyId, const PropertyValue&) override;
+
+protected:
+    friend class TextLineBaseSegment;
 };
 
 inline bool isSystemTextLine(const EngravingItem* element)

--- a/src/engraving/libmscore/volta.cpp
+++ b/src/engraving/libmscore/volta.cpp
@@ -330,7 +330,7 @@ PropertyValue Volta::propertyDefault(Pid propertyId) const
 
 SpannerSegment* Volta::layoutSystem(System* system)
 {
-    SpannerSegment* voltaSegment= SLine::layoutSystem(system);
+    SpannerSegment* voltaSegment = TextLineBase::layoutSystem(system);
 
     // we need set tempo in layout because all tempos of score is set in layout
     // so fermata in seconda volta works correct because fermata apply itself tempo during layouting

--- a/src/engraving/rw/measurerw.cpp
+++ b/src/engraving/rw/measurerw.cpp
@@ -46,6 +46,7 @@
 #include "../libmscore/keysig.h"
 #include "../libmscore/stafftext.h"
 #include "../libmscore/ambitus.h"
+#include "../libmscore/textlinebase.h"
 #include "../libmscore/dynamic.h"
 
 #include "../libmscore/score.h"
@@ -626,8 +627,7 @@ void MeasureRW::writeMeasure(const Measure* measure, XmlWriter& xml, staff_idx_t
                 || (et == ElementType::JUMP)
                 || (et == ElementType::MARKER)
                 || (et == ElementType::TEMPO_TEXT)
-                || (et == ElementType::VOLTA)
-                || (et == ElementType::TEXTLINE && e->systemFlag())) {
+                || isSystemTextLine(e)) {
                 writeSystem = (e->staffIdx() == staff); // always show these on appropriate staves
             }
         }

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/TextInputField.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/TextInputField.qml
@@ -58,6 +58,7 @@ FocusScope {
     readonly property alias clearTextButton: clearTextButtonItem
 
     signal currentTextEdited(var newTextValue)
+    signal textAccepted(var textValue)
     signal textCleared()
     signal textEditingFinished()
 
@@ -173,18 +174,25 @@ FocusScope {
                     event.accepted = true
                 } else {
                     event.accepted = false
-
                     root.focus = false
                     root.textEditingFinished()
                 }
             }
 
             Keys.onPressed: function(event) {
+                //enter and return don't go through this event
+                //https://stackoverflow.com/questions/9677371/qml-keys-onenterpressed-issue
                 if (event.key === Qt.Key_Enter || event.key === Qt.Key_Return
                         || event.key === Qt.Key_Escape) {
                     root.focus = false
                     root.textEditingFinished()
                 }
+
+            }
+            onAccepted: {
+                root.focus = false
+                root.textAccepted(text)
+                root.textEditingFinished()
             }
 
             onActiveFocusChanged: {

--- a/src/framework/uicomponents/view/textinputfieldmodel.cpp
+++ b/src/framework/uicomponents/view/textinputfieldmodel.cpp
@@ -36,7 +36,7 @@ TextInputFieldModel::TextInputFieldModel(QObject* parent)
 
 void TextInputFieldModel::init()
 {
-    shortcutsRegister()->shortcutsChanged().onNotify(this, [this](){
+    shortcutsRegister()->shortcutsChanged().onNotify(this, [this]() {
         loadShortcuts();
     });
 
@@ -49,7 +49,7 @@ bool TextInputFieldModel::isShortcutAllowedOverride(int key, Qt::KeyboardModifie
     int newKey = correctedKeyInput.first;
     int newModifiers = correctedKeyInput.second;
 
-    if (needIgnoreKey(newKey)) {
+    if (needIgnoreKey(newKey) || key == Qt::Key_Enter || key == Qt::Key_Return) {
         return true;
     }
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1090,10 +1090,10 @@ bool NotationInteraction::isDropAccepted(const PointF& pos, Qt::KeyboardModifier
 
     switch (m_dropData.ed.dropElement->type()) {
     case ElementType::VOLTA:
+    case ElementType::GRADUAL_TEMPO_CHANGE:
         return dragMeasureAnchorElement(pos);
     case ElementType::PEDAL:
     case ElementType::LET_RING:
-    case ElementType::GRADUAL_TEMPO_CHANGE:
     case ElementType::VIBRATO:
     case ElementType::PALM_MUTE:
     case ElementType::OTTAVA:
@@ -1193,6 +1193,7 @@ bool NotationInteraction::drop(const PointF& pos, Qt::KeyboardModifiers modifier
         systemStavesOnly = m_dropData.ed.dropElement->systemFlag();
     // fall-thru
     case ElementType::VOLTA:
+    case ElementType::GRADUAL_TEMPO_CHANGE:
         // voltas drop to system staves by default, or closest staff if Control is held
         systemStavesOnly = systemStavesOnly || !(m_dropData.ed.modifiers & Qt::ControlModifier);
     // fall-thru
@@ -1200,7 +1201,6 @@ bool NotationInteraction::drop(const PointF& pos, Qt::KeyboardModifiers modifier
     case ElementType::TRILL:
     case ElementType::PEDAL:
     case ElementType::LET_RING:
-    case ElementType::GRADUAL_TEMPO_CHANGE:
     case ElementType::VIBRATO:
     case ElementType::PALM_MUTE:
     case ElementType::HAIRPIN:
@@ -1631,7 +1631,7 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
         } else if (element->isSLine() && element->type() != ElementType::GLISSANDO) {
             mu::engraving::Segment* startSegment = sel.startSegment();
             mu::engraving::Segment* endSegment = sel.endSegment();
-            bool firstStaffOnly = element->isVolta() && !(modifiers & Qt::ControlModifier);
+            bool firstStaffOnly = isSystemTextLine(element) && !(modifiers & Qt::ControlModifier);
             staff_idx_t startStaff = firstStaffOnly ? 0 : sel.staffStart();
             staff_idx_t endStaff   = firstStaffOnly ? 1 : sel.staffEnd();
             for (staff_idx_t i = startStaff; i < endStaff; ++i) {

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1949,7 +1949,7 @@ bool NotationInteraction::dragMeasureAnchorElement(const PointF& pos)
         m_dropData.ed.dropElement->score()->addRefresh(m_dropData.ed.dropElement->canvasBoundingRect());
         m_dropData.ed.dropElement->setTrack(track);
         m_dropData.ed.dropElement->score()->addRefresh(m_dropData.ed.dropElement->canvasBoundingRect());
-        m_notifyAboutDropChanged = true;
+        notifyAboutDragChanged();
         return true;
     }
     m_dropData.ed.dropElement->score()->addRefresh(m_dropData.ed.dropElement->canvasBoundingRect());

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1424,10 +1424,10 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
         }
 
         auto isEntryDrumStaff = [score]() {
-            const mu::engraving::InputState& is = score->inputState();
-            const mu::engraving::Staff* staff = score->staff(is.track() / mu::engraving::VOICES);
-            return staff ? staff->staffType(is.tick())->group() == mu::engraving::StaffGroup::PERCUSSION : false;
-        };
+                                    const mu::engraving::InputState& is = score->inputState();
+                                    const mu::engraving::Staff* staff = score->staff(is.track() / mu::engraving::VOICES);
+                                    return staff ? staff->staffType(is.tick())->group() == mu::engraving::StaffGroup::PERCUSSION : false;
+                                };
 
         if (isEntryDrumStaff() && element->isChord()) {
             mu::engraving::InputState& is = score->inputState();
@@ -2293,18 +2293,18 @@ void NotationInteraction::moveSelection(MoveDirection d, MoveSelectionType type)
     // TODO: rewrite, Score::move( ) logic needs to be here
 
     auto typeToString = [](MoveSelectionType type) {
-        switch (type) {
-        case MoveSelectionType::Undefined: return QString();
-        case MoveSelectionType::EngravingItem:   return QString();
-        case MoveSelectionType::Chord:     return QString("chord");
-        case MoveSelectionType::Measure:   return QString("measure");
-        case MoveSelectionType::Track:     return QString("track");
-        case MoveSelectionType::Frame:     return QString("frame");
-        case MoveSelectionType::System:    return QString("system");
-        case MoveSelectionType::String:   return QString();
-        }
-        return QString();
-    };
+                            switch (type) {
+                            case MoveSelectionType::Undefined: return QString();
+                            case MoveSelectionType::EngravingItem:   return QString();
+                            case MoveSelectionType::Chord:     return QString("chord");
+                            case MoveSelectionType::Measure:   return QString("measure");
+                            case MoveSelectionType::Track:     return QString("track");
+                            case MoveSelectionType::Frame:     return QString("frame");
+                            case MoveSelectionType::System:    return QString("system");
+                            case MoveSelectionType::String:   return QString();
+                            }
+                            return QString();
+                        };
 
     QString cmd;
     if (MoveDirection::Left == d) {
@@ -3189,16 +3189,16 @@ void NotationInteraction::addBoxes(BoxType boxType, int count, int beforeBoxInde
     }
 
     auto boxTypeToElementType = [](BoxType boxType) {
-        switch (boxType) {
-        case BoxType::Horizontal: return mu::engraving::ElementType::HBOX;
-        case BoxType::Vertical: return mu::engraving::ElementType::VBOX;
-        case BoxType::Text: return mu::engraving::ElementType::TBOX;
-        case BoxType::Measure: return mu::engraving::ElementType::MEASURE;
-        case BoxType::Unknown: return mu::engraving::ElementType::INVALID;
-        }
+                                    switch (boxType) {
+                                    case BoxType::Horizontal: return mu::engraving::ElementType::HBOX;
+                                    case BoxType::Vertical: return mu::engraving::ElementType::VBOX;
+                                    case BoxType::Text: return mu::engraving::ElementType::TBOX;
+                                    case BoxType::Measure: return mu::engraving::ElementType::MEASURE;
+                                    case BoxType::Unknown: return mu::engraving::ElementType::INVALID;
+                                    }
 
-        return ElementType::INVALID;
-    };
+                                    return ElementType::INVALID;
+                                };
 
     mu::engraving::ElementType elementType = boxTypeToElementType(boxType);
     if (elementType == mu::engraving::ElementType::INVALID) {
@@ -4003,14 +4003,14 @@ void NotationInteraction::resetBeamMode()
 void NotationInteraction::resetShapesAndPosition()
 {
     auto resetItem = [](EngravingItem* item) {
-        item->reset();
+                         item->reset();
 
-        if (item->isSpanner()) {
-            for (mu::engraving::SpannerSegment* spannerSegment : toSpanner(item)->spannerSegments()) {
-                spannerSegment->reset();
-            }
-        }
-    };
+                         if (item->isSpanner()) {
+                             for (mu::engraving::SpannerSegment* spannerSegment : toSpanner(item)->spannerSegments()) {
+                                 spannerSegment->reset();
+                             }
+                         }
+                     };
 
     startEdit();
 

--- a/src/notation/qml/MuseScore/NotationScene/NotationView.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NotationView.qml
@@ -223,6 +223,8 @@ FocusScope {
         SearchPopup {
             id: searchPopup
 
+            navigationSection: navSec
+            scoreNavCtrl: fakeNavCtrl
             Layout.fillWidth: true
         }
     }

--- a/src/notation/qml/MuseScore/NotationScene/internal/SearchPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/SearchPopup.qml
@@ -28,17 +28,39 @@ import MuseScore.Ui 1.0
 Rectangle {
     id: root
 
+    property NavigationSection navigationSection: null
+    property NavigationControl scoreNavCtrl: null
+
     visible: false
     height: 50
 
     color: ui.theme.backgroundPrimaryColor
+
+    NavigationPanel {
+        id: navPanel
+
+        name: "SearchPopup"
+        section: navigationSection
+        enabled: root.visible
+        direction: NavigationPanel.Both
+        order: 3
+
+        onNavigationEvent: function(event) {
+            console.log("here 3")
+            if (event.type === NavigationEvent.AboutActive) {
+                event.setData("controlIndex", [textInputField.navigation.row, 
+                                               textInputField.navigation.column])
+            }
+        }
+    }
 
     QtObject {
         id: privateProperties
 
         function show() {
             visible = true
-            Qt.callLater(textInputField.forceActiveFocus)
+            Qt.callLater(textInputField.ensureActiveFocus);
+            Qt.callLater(textInputField.navigation.requestActive);
         }
 
         function hide() {
@@ -68,6 +90,10 @@ Rectangle {
 
             icon: IconCode.CLOSE_X_ROUNDED
 
+            navigation.panel: navPanel
+            navigation.column: 1
+            navigation.accessible.name: qsTrc("notation", "Close Search")
+
             onClicked: {
                 privateProperties.hide()
             }
@@ -83,8 +109,13 @@ Rectangle {
 
             width: 500
 
-            onCurrentTextEdited: function(newTextValue) {
-                model.search(newTextValue)
+            navigation.panel: navPanel
+            navigation.column: 2
+
+            onTextAccepted: function(textValue){
+                if(model.search(textValue)) {
+                    scoreNavCtrl.requestActive()
+                }
             }
         }
     }

--- a/src/notation/view/searchpopupmodel.cpp
+++ b/src/notation/view/searchpopupmodel.cpp
@@ -32,14 +32,22 @@ void SearchPopupModel::load()
     });
 }
 
-void SearchPopupModel::search(const QString& text)
+bool SearchPopupModel::search(const QString& text)
 {
     mu::engraving::EngravingItem* element = notation()->elements()->search(text.toStdString());
     if (element) {
+        if (element->isPage()) {
+            const mu::engraving::Page* p = static_cast<const mu::engraving::Page*>(element);
+            element = p->firstMeasure();
+            if (!element && !p->systems().empty() && !p->systems().front()->measures().empty()) {
+                element = p->systems().front()->measures().front();
+            }
+        }
         notation()->interaction()->select({ element }, SelectType::SINGLE);
-    } else {
-        notation()->interaction()->clearSelection();
+        notation()->interaction()->showItem(element);
+        return true;
     }
+    return false;
 }
 
 INotationPtr SearchPopupModel::notation() const

--- a/src/notation/view/searchpopupmodel.h
+++ b/src/notation/view/searchpopupmodel.h
@@ -39,7 +39,7 @@ class SearchPopupModel : public QObject, public actions::Actionable
 
 public:
     Q_INVOKABLE void load();
-    Q_INVOKABLE void search(const QString& text);
+    Q_INVOKABLE bool search(const QString& text);
 
 signals:
     void showPopupRequested();


### PR DESCRIPTION
Resolves https://github.com/musescore/MuseScore/issues/10096

The find dialog was totally broken. This makes it usable with enter and return, and makes it reachable with keyboard navigation.

I changed the dialog to only activate when "enter" was pressed to avoid jumping around unnecessarily. I made it highlight the first measure of a page if we are searching for a page.

I think there should be some explanation of the format required to search for rehearsal marks or pages, but that was outside of the scope of the issue.

I hope this pull request is okay!

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [] I created the test (mtest, vtest, script test) to verify the changes I made
