### PR TITLE
[MU4] Dynamics alignment in merged scores

### DIFF
--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -2355,7 +2355,7 @@ void Score::resetDefaults()
                     if (e->isDynamic()) {
                         Dynamic* d = toDynamic(e);
                         if (d->xmlText().contains(u"<sym>") && !d->xmlText().contains(u"<font")) {
-                            d->setAlign(Align(AlignH::HCENTER, AlignV::BOTTOM));
+                            d->setAlign(Align(AlignH::HCENTER, AlignV::BASELINE));
                         }
                         d->setSize(10.0);
                     }


### PR DESCRIPTION
The issue:
![image](https://user-images.githubusercontent.com/89263931/176340322-0393f30c-a192-4f89-ae53-79295133a5aa.png)

Due to a small mistake in the migration code, dynamics were being reset to `BOTTOM` rather than `BASELINE`. This alignment was not saved in the xml, so saving and reloading the score would fix it. With this PR, the dynamics display correctly on first migration of a score.