### PR TITLE
Fix #10205: Beam groups calculation fix

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -978,11 +978,13 @@ void Beam::createBeamSegments(const std::vector<ChordRest*>& chordRests)
         bool breakBeam = false;
         bool previousBreak32 = false;
         bool previousBreak64 = false;
+        int prevRests = 0;
 
         for (uint i = 0; i < chordRests.size(); i++) {
             ChordRest* chordRest = chordRests[i];
             ChordRest* prevChordRest = i < 1 ? nullptr : chordRests[i - 1];
             if (!chordRest->isChord()) {
+                prevRests++;
                 continue;
             }
             Chord* chord = toChord(chordRest);
@@ -1002,7 +1004,7 @@ void Beam::createBeamSegments(const std::vector<ChordRest*>& chordRests)
             } else {
                 if (startChord && endChord) {
                     if (startChord == endChord) {
-                        bool isBeamletBefore = calcIsBeamletBefore(startChord, i - 1, level, previousBreak32, previousBreak64);
+                        bool isBeamletBefore = calcIsBeamletBefore(startChord, i - 1 - prevRests, level, previousBreak32, previousBreak64);
                         createBeamletSegment(startChord, isBeamletBefore, level);
                     } else {
                         createBeamSegment(startChord, endChord, level);
@@ -1013,6 +1015,7 @@ void Beam::createBeamSegments(const std::vector<ChordRest*>& chordRests)
             }
             previousBreak32 = isBroken32;
             previousBreak64 = isBroken64;
+            prevRests = 0;
         }
 
         // if the beam ends on the last chord

--- a/src/engraving/libmscore/groups.cpp
+++ b/src/engraving/libmscore/groups.cpp
@@ -97,21 +97,39 @@ BeamMode Groups::endBeam(const ChordRest* cr, const ChordRest* prev)
     }
     assert(cr->staff());
 
-    TDuration d      = cr->durationType();
-    const Groups& g  = cr->staff()->group(cr->tick());
-    Fraction stretch = cr->staff()->timeStretch(cr->tick());
-    Fraction tick    = cr->rtick() * stretch;
+    // we need to figure out the longest note value beat upon which cr falls in the measure
+    int maxTickLen = std::max(cr->ticks().ticks(), prev ? prev->ticks().ticks() : 0);
+    int smallestTickLen = Fraction(1, 8).ticks(); // start with 8th
+    int tickLenLimit = Fraction(1, 32).ticks(); // only check up to 32nds because that's all thats available
+                                                // in timesig properties
+    while (smallestTickLen > maxTickLen || cr->tick().ticks() % smallestTickLen != 0) {
+        smallestTickLen /= 2; // proceed to 16th, 32nd, etc
+        if (smallestTickLen < tickLenLimit) {
+            smallestTickLen = cr->ticks().ticks();
+            break;
+        }
+    }
+    DurationType bigBeatDuration = TDuration(Fraction::fromTicks(smallestTickLen)).type();
 
-    BeamMode val = g.beamMode(tick.ticks(), d.type());
+    TDuration crDuration = cr->durationType();
+    const Groups& g = cr->staff()->group(cr->tick());
+    Fraction stretch = cr->staff()->timeStretch(cr->tick());
+    Fraction tick = cr->rtick() * stretch;
+
+    // We can choose to break beams based on its place in the measure, or by its duration. These
+    // can be consolidated mostly, with bias towards its duration.
+    BeamMode byType = g.beamMode(tick.ticks(), crDuration.type());
+    BeamMode byPos = g.beamMode(tick.ticks(), bigBeatDuration);
+    BeamMode val = byType == BeamMode::AUTO ? byPos : byType;
 
     // context-dependent checks
     if (val == BeamMode::AUTO && tick.isNotZero()) {
         // if current or previous cr is in tuplet (but not both in same tuplet):
         // consider it as if this were next shorter duration
-        if (prev && (cr->tuplet() != prev->tuplet()) && (d == prev->durationType())) {
-            if (d >= DurationType::V_EIGHTH) {
+        if (prev && (cr->tuplet() != prev->tuplet()) && (crDuration == prev->durationType())) {
+            if (crDuration >= DurationType::V_EIGHTH) {
                 val = g.beamMode(tick.ticks(), DurationType::V_16TH);
-            } else if (d == DurationType::V_16TH) {
+            } else if (crDuration == DurationType::V_16TH) {
                 val = g.beamMode(tick.ticks(), DurationType::V_32ND);
             } else {
                 val = g.beamMode(tick.ticks(), DurationType::V_64TH);


### PR DESCRIPTION
There are some considerations that went into this one. Generally, the idea is that if notes are in the middle of a beam group, their beamlets go right, unless they are the last note of a group, in which case they go left.

![image](https://user-images.githubusercontent.com/89263931/176495719-0c5e13aa-b66f-4afa-a927-b6938d5d88fd.png)
In this case, the beamlet finds itself at the end of a beam group, so the beamlet goes left.

![image](https://user-images.githubusercontent.com/89263931/176495962-4b54e292-810c-4fd2-a0f5-5ea19d2361c3.png)
In this case, the beamlet finds itself in the middle of a beam group, so the beamlet goes right.

![image](https://user-images.githubusercontent.com/89263931/176496010-af5e2408-ccda-47d1-90a9-24b5bb2a70a6.png)
This is the interesting one. The beamlet is at the end of a beam group, so it goes left. But also, according to the 1/16 beam groups, the primary beam is also broken. According to the 1/8 beam group, the primary beam seems to be unbroken the whole way through the bar.

The way this PR addresses the disagreement is to determine where the third note falls. It doesn't happen to fall on any concrete 8th beat, so the next smallest note length is checked. It _does_ happen to fall on a 16th beat, so the beam groups for that one are used, and the beam group dictates that there is a clean break in the primary beam.