### PR TITLE
fix #12036: gp import styles applied correctly

### DIFF
--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -2906,6 +2906,9 @@ Score::FileError importGTP(MasterScore* score, mu::io::IODevice* io, bool create
         return Score::FileError::FILE_OPEN_ERROR;
     }
 
+    score->loadStyle(u":/engraving/styles/gp-style.mss");
+    score->style().set(Sid::ArpeggioHiddenInStdIfTab, true);
+
     char header[5];
     io->read((uint8_t*)(header), 4);
     header[4] = 0;
@@ -2983,13 +2986,9 @@ Score::FileError importGTP(MasterScore* score, mu::io::IODevice* io, bool create
         return Score::FileError::FILE_NO_ERROR;
     }
 
-    score->loadStyle(u":/engraving/styles/gp-style.mss");
-
     if (!mu::engraving::MScore::lastError.isEmpty()) {
         LOGE() << mu::engraving::MScore::lastError;
     }
-
-    score->style().set(Sid::ArpeggioHiddenInStdIfTab, true);
 
     addMetaInfo(score, gp);
 


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/12036*

*gp import styles applied correctly (before import), so elements are placed without mistakes*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
