### PR TITLE
Stop increasing/decreasing a spinbox when you keep long-pressing after the increase/decrease button has become disabled

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/ValueAdjustControl.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/ValueAdjustControl.qml
@@ -53,6 +53,14 @@ Column {
             iconCode: IconCode.SMALL_ARROW_UP
         }
 
+        onEnabledChanged: {
+            // If the button becomes disabled, the mouse area does not emit the
+            // `released` signal anymore, so we'll stop the repeat timer here.
+            if (!enabled) {
+                continuousIncreaseTimer.running = false
+            }
+        }
+
         MouseArea {
             id: increaseMouseArea
             anchors.fill: parent
@@ -109,6 +117,14 @@ Column {
         StyledIconLabel {
             anchors.centerIn: parent
             iconCode: IconCode.SMALL_ARROW_DOWN
+        }
+
+        onEnabledChanged: {
+            // If the button becomes disabled, the mouse area does not emit the
+            // `released` signal anymore, so we'll stop the repeat timer here.
+            if (!enabled) {
+                continuousDecreaseTimer.running = false
+            }
         }
 
         MouseArea {


### PR DESCRIPTION
Resolves: a bug that probably nobody knows about yet

If you long-press the increase/decrease button in a spinbox control, a "timer" will start, which will fire every 100 milliseconds and increase/decrease the spinbox value. If you then release the mouse, the timer is stopped.
However, if you reach the maximum/minimum value of the spinbox, the button becomes disabled, and due to Qt behavior, it does not receive the "mouse released" signal anymore when it has become disabled, so the timer will never stop anymore (unless you somehow manage to get the button enabled again and click it again in order to send a new "mouse released" signal). Video:

https://user-images.githubusercontent.com/48658420/177038186-f8dddd86-1808-417f-9ede-e4e7ac851e2e.mov

This solution is to stop the timer not only when the button receives a "mouse released" signal, but also when the button becomes disabled. 
