### PR TITLE
fixing spanners cloning

### DIFF
--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -620,6 +620,12 @@ static void cloneSpanner(Spanner* s, Score* score, track_idx_t dstTrack, track_i
             LOGD("clone Slur: no end element");
         }
     }
+
+    if (!ns->startElement() && !ns->endElement()) {
+        delete ns;
+        return;
+    }
+
     score->undo(new AddElement(ns));
 }
 


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

*fixed regression in https://github.com/musescore/MuseScore/pull/12270 from cloning staves*
*was initially fixed by https://github.com/musescore/MuseScore/pull/12187*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
