### PR TITLE
General improvements to slur shape and collision avoidance

### DIFF
--- a/src/engraving/layout/layoutpage.cpp
+++ b/src/engraving/layout/layoutpage.cpp
@@ -336,17 +336,15 @@ void LayoutPage::collectPage(const LayoutOptions& options, LayoutContext& ctx)
             continue;
         }
         auto spanners = ctx.score()->spannerMap().findOverlapping(stick, etick);
-        std::vector<Spanner*> spanner;
         for (auto interval : spanners) {
             Spanner* sp = interval.value;
-            if (sp->tick().ticks() < etick && sp->tick2().ticks() >= stick) {
-                if (sp->isSlur()) {
-                    ChordRest* scr = sp->startCR();
-                    ChordRest* ecr = sp->endCR();
-                    if (scr && ecr && scr->vStaffIdx() != ecr->vStaffIdx()) {
-                        toSlur(sp)->layout();
-                    }
-                }
+            if (!sp->isSlur()) {
+                continue;
+            }
+            ChordRest* scr = sp->startCR();
+            ChordRest* ecr = sp->endCR();
+            if (scr && ecr && scr->vStaffIdx() != ecr->vStaffIdx()) {
+                toSlur(sp)->layout();
             }
         }
     }

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -673,6 +673,8 @@ void LayoutSystem::layoutSystemElements(const LayoutOptions& options, LayoutCont
                 b->layout();
             }
         }
+        // Must recreate the shapes because stem lengths may have been changed!
+        s->createShapes();
     }
 
     //-------------------------------------------------------------

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -4004,20 +4004,22 @@ void Chord::layoutArticulations2()
 
 bool Chord::isSlurStartEnd() const
 {
-    auto spanners = score()->spannerMap().findOverlapping(tick().ticks(), tick().ticks());
+    int ticks = tick().ticks();
+    auto spanners = score()->spannerMap().findOverlapping(ticks, ticks);
     if (spanners.empty()) {
         return false;
     }
     for (auto sp : spanners) {
         Spanner* spanner = sp.value;
-        if (spanner->isSlur()) {
-            Slur* slur = toSlur(spanner);
-            if (slur->startElement() && slur->startElement()->isChord() && toChord(slur->startElement()) == this) {
-                return true;
-            }
-            if (slur->endElement() && slur->endElement()->isChord() && toChord(slur->endElement()) == this) {
-                return true;
-            }
+        if (!spanner->isSlur() || spanner->staffIdx() != staffIdx()) {
+            continue;
+        }
+        Slur* slur = toSlur(spanner);
+        if (slur->startElement() && slur->startElement()->isChord() && toChord(slur->startElement()) == this) {
+            return true;
+        }
+        if (slur->endElement() && slur->endElement()->isChord() && toChord(slur->endElement()) == this) {
+            return true;
         }
     }
     return false;

--- a/src/engraving/libmscore/chord.h
+++ b/src/engraving/libmscore/chord.h
@@ -325,6 +325,8 @@ public:
     Shape shape() const override;
     void undoChangeProperty(Pid id, const PropertyValue& newValue);
     void undoChangeProperty(Pid id, const PropertyValue& newValue, PropertyFlags ps) override;
+
+    bool isSlurStartEnd() const;
 };
 } // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/shape.cpp
+++ b/src/engraving/libmscore/shape.cpp
@@ -175,12 +175,8 @@ double Shape::minVerticalDistance(const Shape& a) const
 bool Shape::clearsVertically(const Shape& a) const
 {
     for (const RectF r1 : a) {
-        double left1 = r1.left();
-        double right1 = r1.right();
         for (const RectF r2 : *this) {
-            double left2 = r2.left();
-            double right2 = r2.right();
-            if (mu::engraving::intersects(left1, right1, left2, right2, 0.0)) {
+            if (mu::engraving::intersects(r1.left(), r1.right(), r2.left(), r2.right(), 0.0)) {
                 if (std::min(r1.top(), r1.bottom()) <= std::max(r2.top(), r2.bottom())) {
                     return false;
                 }

--- a/src/engraving/libmscore/shape.cpp
+++ b/src/engraving/libmscore/shape.cpp
@@ -166,6 +166,30 @@ double Shape::minVerticalDistance(const Shape& a) const
     return dist;
 }
 
+//----------------------------------------------------------------
+// clearsVertically()
+// a is located below this shape
+// returns true if, within the horizontal width of both shapes,
+// all parts of this shape are above all parts of a
+//----------------------------------------------------------------
+bool Shape::clearsVertically(const Shape& a) const
+{
+    for (const RectF r1 : a) {
+        double left1 = r1.left();
+        double right1 = r1.right();
+        for (const RectF r2 : *this) {
+            double left2 = r2.left();
+            double right2 = r2.right();
+            if (mu::engraving::intersects(left1, right1, left2, right2, 0.0)) {
+                if (std::min(r1.top(), r1.bottom()) <= std::max(r2.top(), r2.bottom())) {
+                    return false;
+                }
+            }
+        }
+    }
+    return true;
+}
+
 //---------------------------------------------------------
 //   left
 //    compute left border

--- a/src/engraving/libmscore/shape.h
+++ b/src/engraving/libmscore/shape.h
@@ -101,6 +101,7 @@ public:
     bool contains(const mu::PointF&) const;
     bool intersects(const mu::RectF& rr) const;
     bool intersects(const Shape&) const;
+    bool clearsVertically(const Shape& a) const;
 
     void paint(mu::draw::Painter& painter) const;
 #ifndef NDEBUG

--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -416,7 +416,7 @@ void SlurSegment::computeBezier(mu::PointF p6offset)
     // Set up coordinate transforms
     // CAUTION: transform operations are applies in reverse order to how
     // they are added to the transformation.
-    qreal slurAngle = atan((pp2.y() - pp1.y()) / (pp2.x() - pp1.x()));
+    double slurAngle = atan((pp2.y() - pp1.y()) / (pp2.x() - pp1.x()));
     Transform rotate;
     rotate.rotateRadians(-slurAngle);
     Transform toSlurCoordinates;
@@ -433,9 +433,9 @@ void SlurSegment::computeBezier(mu::PointF p6offset)
      * ***********************************************/
 
     // Compute default shoulder height and width
-    qreal _spatium  = spatium();
-    qreal shoulderW; // expressed as fraction of slur-length
-    qreal shoulderH;
+    double _spatium  = spatium();
+    double shoulderW; // expressed as fraction of slur-length
+    double shoulderH;
     double d = p2.x() / _spatium;
 
     if (d < 2) {
@@ -454,9 +454,9 @@ void SlurSegment::computeBezier(mu::PointF p6offset)
         shoulderH = -shoulderH;
     }
 
-    qreal c    = p2.x();
-    qreal c1   = (c - c * shoulderW) * .5 + p6offset.x();
-    qreal c2   = c1 + c * shoulderW + p6offset.x();
+    double c    = p2.x();
+    double c1   = (c - c * shoulderW) * .5 + p6offset.x();
+    double c2   = c1 + c * shoulderW + p6offset.x();
 
     PointF p3(c1, -shoulderH);
     PointF p4(c2, -shoulderH);
@@ -700,7 +700,7 @@ void SlurSegment::computeBezier(mu::PointF p6offset)
     ups(Grip::SHOULDER).p = toSystemCoordinates.map(p6);
 
     // Set slur thickness
-    qreal w = score()->styleMM(Sid::SlurMidWidth) - score()->styleMM(Sid::SlurEndWidth);
+    double w = score()->styleMM(Sid::SlurMidWidth) - score()->styleMM(Sid::SlurEndWidth);
     if (staff()) {
         w *= staff()->staffMag(slur()->tick());
     }
@@ -729,7 +729,7 @@ void SlurSegment::computeBezier(mu::PointF p6offset)
     _shape.clear();
     PointF start = pp1;
     int nbShapes  = 32;
-    qreal minH    = qAbs(3 * w);
+    double minH    = abs(3 * w);
     const CubicBezier b(ups(Grip::START).pos(), ups(Grip::BEZIER1).pos(), ups(Grip::BEZIER2).pos(), ups(Grip::END).pos());
     for (int i = 1; i <= nbShapes; i++) {
         const PointF point = b.pointAtPercent(i / float(nbShapes));

--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -387,7 +387,7 @@ void SlurSegment::avoidCollisions(PointF& pp1, PointF& p2, PointF& p3, PointF& p
         // Divide slur in several rectangles to localize collisions
         const unsigned npoints = 20;
         std::vector<RectF> slurRects;
-        slurRects.reserve(2 * npoints);
+        slurRects.reserve(npoints);
         // Define separate collision areas (left-mid-center)
         SlurCollision collision;
 
@@ -401,17 +401,13 @@ void SlurSegment::avoidCollisions(PointF& pp1, PointF& p2, PointF& p3, PointF& p
             toSystemCoordinates.rotateRadians(slurAngle);
             // Create rectangles
             slurRects.clear();
-            CubicBezier bezier(PointF(0, 0), p3, p4, p2);
             CubicBezier clearanceBezier(PointF(0, 0), p3 + PointF(0.0, vertClearance), p4 + PointF(0.0, vertClearance), p2);
             for (unsigned i = 0; i < npoints - 1; i++) {
-                PointF slurPoint1 = bezier.pointAtPercent(double(i) / double(npoints));
-                PointF slurPoint2 = bezier.pointAtPercent(double(i + 1) / double(npoints));
-                PointF clearancePoint = clearanceBezier.pointAtPercent(double(i) / double(npoints));
-                slurPoint1 = toSystemCoordinates.map(slurPoint1);
-                slurPoint2 = toSystemCoordinates.map(slurPoint2);
-                clearancePoint = toSystemCoordinates.map(clearancePoint);
-                slurRects.push_back(RectF(clearancePoint, slurPoint1));
-                slurRects.push_back(RectF(clearancePoint, slurPoint2));
+                PointF clearancePoint1 = clearanceBezier.pointAtPercent(double(i) / double(npoints));
+                PointF clearancePoint2 = clearanceBezier.pointAtPercent(double(i + 1) / double(npoints));
+                clearancePoint1 = toSystemCoordinates.map(clearancePoint1);
+                clearancePoint2 = toSystemCoordinates.map(clearancePoint2);
+                slurRects.push_back(RectF(clearancePoint1, clearancePoint2));
             }
             // Check collisions
             for (Segment* seg = startSeg;;) {

--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -55,6 +55,13 @@ struct SlurCollision
     bool left = false;
     bool mid = false;
     bool right = false;
+
+    void reset()
+    {
+        left = false;
+        mid = false;
+        right = false;
+    }
 };
 
 namespace mu::engraving {
@@ -394,7 +401,7 @@ void SlurSegment::avoidCollisions(PointF& pp1, PointF& p2, PointF& p3, PointF& p
         // CHECK FOR COLLISIONS
         unsigned iter = 0;
         do {
-            collision.left = collision.mid = collision.right = false;
+            collision.reset();
             // Update tranform because pp1 may change
             toSystemCoordinates.reset();
             toSystemCoordinates.translate(pp1.x(), pp1.y());

--- a/src/engraving/libmscore/slur.h
+++ b/src/engraving/libmscore/slur.h
@@ -62,6 +62,7 @@ public:
     Slur* slur() const { return toSlur(spanner()); }
     void adjustEndpoints();
     void computeBezier(mu::PointF so = mu::PointF()) override;
+    void avoidCollisions(PointF& pp1, PointF& p2, PointF& p3, PointF& p4, mu::draw::Transform& toSystemCoordinates, double& slurAngle);
 };
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/slur.h
+++ b/src/engraving/libmscore/slur.h
@@ -39,6 +39,8 @@ class SlurSegment final : public SlurTieSegment
 protected:
     double _extraHeight = 0.0;
     void changeAnchor(EditData&, EngravingItem*) override;
+    PointF _endPointOff1 = PointF(0.0, 0.0);
+    PointF _endPointOff2 = PointF(0.0, 0.0);
 
 public:
     SlurSegment(System* parent);
@@ -51,8 +53,11 @@ public:
     void layoutSegment(const mu::PointF& p1, const mu::PointF& p2);
 
     bool isEdited() const;
+    bool isEndPointsEdited() const;
     bool isEditAllowed(EditData&) const override;
     bool edit(EditData&) override;
+
+    void editDrag(EditData& ed) override;
 
     Slur* slur() const { return toSlur(spanner()); }
     void adjustEndpoints();


### PR DESCRIPTION
Adapting the shape and position of slurs to avoid collisions with the underlying items, and at the same time obtain a good looking arc, is quite a tricky matter. A vast improvement over version 3.6 was already done by @asattely. 

This PR extends the idea and includes a more general algorithm for the optimization of the slur shape and end points positions. Specifically:
- The Bezier pointes are adjusted at the same time as the end points and have a lot more flexibility in doing so.
- Also the width (and not only the height) of the arc is optimized.
- The arc is allowed to become slightly asymmetrical if the contour of the music is asymmetrical.
- Unnecessary asymmetries in end point height (making the slurs look tilted) are avoided.
- "Non-ugliness" rules are introduced to avoid bad looking arcs.
- Position of cross-staff slurs is corrected (though a lot more work will be needed there in future).

Here is a very artificial example constructed to show the difference in the absolute worst cases.
Before:
![Screenshot from 2022-07-05 19-06-36](https://user-images.githubusercontent.com/93707756/177386477-f2f88e22-dc40-4303-9ce0-b6f7905349bf.png)
After:
![Screenshot from 2022-07-05 19-15-08](https://user-images.githubusercontent.com/93707756/177386490-357cad90-7c93-4a63-8be6-3321be93235b.png)

@oktophonie @Tantacrul 
