### PR TITLE
[MU4] Fix #12279: Crash after opening parts and adding additional staff

### DIFF
--- a/src/instrumentsscene/view/staffcontroltreeitem.cpp
+++ b/src/instrumentsscene/view/staffcontroltreeitem.cpp
@@ -25,6 +25,7 @@
 
 using namespace mu::instrumentsscene;
 using namespace mu::notation;
+using namespace mu::engraving;
 
 StaffControlTreeItem::StaffControlTreeItem(IMasterNotationPtr masterNotation, INotationPtr notation, QObject* parent)
     : AbstractInstrumentsPanelTreeItem(InstrumentsTreeItemType::ItemType::CONTROL_ADD_STAFF, masterNotation, notation, parent)
@@ -44,17 +45,10 @@ void StaffControlTreeItem::appendNewItem()
         return;
     }
 
-    size_t insertStaffIndex = part->nstaves();
-    const AbstractInstrumentsPanelTreeItem* par = parentItem();
-    for (int row = 0; row < par->childCount() - 1; ++row) {
-        if (par->childAtRow(row)->isSelected()) {
-            insertStaffIndex = row + 1;
-        }
-    }
+    staff_idx_t lastStaffIndex = part->nstaves();
 
-    Staff* staff = engraving::Factory::createStaff(const_cast<Part*>(part));
+    Staff* staff = Factory::createStaff(const_cast<Part*>(part));
+    staff->setDefaultClefType(part->instrument()->clefType(lastStaffIndex));
 
-    staff->setDefaultClefType(part->staff(insertStaffIndex - 1)->defaultClefType());
-
-    masterNotation()->parts()->insertStaff(staff, m_partId, insertStaffIndex);
+    masterNotation()->parts()->appendStaff(staff, m_partId);
 }

--- a/src/notation/inotationparts.h
+++ b/src/notation/inotationparts.h
@@ -69,7 +69,7 @@ public:
     virtual void moveParts(const IDList& sourcePartsIds, const ID& destinationPartId, InsertMode mode = InsertMode::Before) = 0;
     virtual void moveStaves(const IDList& sourceStavesIds, const ID& destinationStaffId, InsertMode mode = InsertMode::Before) = 0;
 
-    virtual void insertStaff(Staff* staff, const ID& destinationPartId, size_t index = 0) = 0;
+    virtual void appendStaff(Staff* staff, const ID& destinationPartId) = 0;
     virtual void appendLinkedStaff(Staff* staff, const ID& sourceStaffId, const ID& destinationPartId) = 0;
 
     virtual void insertPart(Part* part, size_t index) = 0;

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -82,7 +82,7 @@ void MasterNotationParts::removeStaves(const IDList& stavesIds)
     endGlobalEdit();
 }
 
-void MasterNotationParts::insertStaff(Staff* staff, const ID& destinationPartId, size_t index)
+void MasterNotationParts::appendStaff(Staff* staff, const ID& destinationPartId)
 {
     TRACEFUNC;
 
@@ -91,19 +91,11 @@ void MasterNotationParts::insertStaff(Staff* staff, const ID& destinationPartId,
     //! NOTE: will be generated later after adding to the score
     staff->setId(mu::engraving::INVALID_ID);
 
-    NotationParts::insertStaff(staff, destinationPartId, index);
-
-    size_t firstStaffInPartIndex = 0;
-    for (const Part* part : partList()) {
-        if (part->id() == destinationPartId) {
-            break;
-        }
-        firstStaffInPartIndex += part->nstaves();
-    }
+    NotationParts::appendStaff(staff, destinationPartId);
 
     for (INotationPartsPtr parts : excerptsParts()) {
         Staff* excerptStaff = mu::engraving::toStaff(staff->linkedClone());
-        parts->insertStaff(excerptStaff, destinationPartId, index - firstStaffInPartIndex);
+        parts->appendStaff(excerptStaff, destinationPartId);
     }
 
     endGlobalEdit();

--- a/src/notation/internal/masternotationparts.h
+++ b/src/notation/internal/masternotationparts.h
@@ -37,7 +37,7 @@ public:
     void removeParts(const IDList& partsIds) override;
     void removeStaves(const IDList& stavesIds) override;
 
-    void insertStaff(Staff* staff, const ID& destinationPartId, size_t index=0) override;
+    void appendStaff(Staff* staff, const ID& destinationPartId) override;
     void appendLinkedStaff(Staff* staff, const ID& sourceStaffId, const ID& destinationPartId) override;
 
     void replaceInstrument(const InstrumentKey& instrumentKey, const Instrument& newInstrument) override;

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -499,7 +499,7 @@ void NotationParts::setStaffConfig(const ID& staffId, const StaffConfig& config)
     notifyAboutStaffChanged(staff);
 }
 
-void NotationParts::insertStaff(Staff* staff, const ID& destinationPartId, size_t index)
+void NotationParts::appendStaff(Staff* staff, const ID& destinationPartId)
 {
     TRACEFUNC;
 
@@ -510,7 +510,7 @@ void NotationParts::insertStaff(Staff* staff, const ID& destinationPartId, size_
 
     startEdit();
 
-    doInsertStaff(staff, destinationPart, index);
+    doAppendStaff(staff, destinationPart);
     updateTracks();
 
     apply();
@@ -530,7 +530,7 @@ void NotationParts::appendLinkedStaff(Staff* staff, const ID& sourceStaffId, con
 
     startEdit();
 
-    doInsertStaff(staff, destinationPart, destinationPart->nstaves());
+    doAppendStaff(staff, destinationPart);
 
     ///! NOTE: need to unlink before linking
     staff->setLinks(nullptr);
@@ -731,8 +731,9 @@ void NotationParts::doRemoveParts(const std::vector<Part*>& parts)
     }
 }
 
-void NotationParts::doInsertStaff(Staff* staff, Part* destinationPart, size_t staffLocalIndex)
+void NotationParts::doAppendStaff(Staff* staff, Part* destinationPart)
 {
+    staff_idx_t staffLocalIndex = destinationPart->nstaves();
     mu::engraving::KeyList keyList = score()->keyList();
 
     staff->setScore(score());
@@ -740,7 +741,7 @@ void NotationParts::doInsertStaff(Staff* staff, Part* destinationPart, size_t st
 
     insertStaff(staff, staffLocalIndex);
 
-    track_idx_t staffGlobalIndex = staff->idx();
+    staff_idx_t staffGlobalIndex = staff->idx();
     score()->adjustKeySigs(staffGlobalIndex, staffGlobalIndex + 1, keyList);
 
     score()->updateBracesAndBarlines(destinationPart, staffLocalIndex);

--- a/src/notation/internal/notationparts.h
+++ b/src/notation/internal/notationparts.h
@@ -64,7 +64,7 @@ public:
     void moveParts(const IDList& sourcePartsIds, const ID& destinationPartId, InsertMode mode = InsertMode::Before) override;
     void moveStaves(const IDList& sourceStavesIds, const ID& destinationStaffId, InsertMode mode = InsertMode::Before) override;
 
-    void insertStaff(Staff* staff, const ID& destinationPartId, size_t index=0) override;
+    void appendStaff(Staff* staff, const ID& destinationPartId) override;
     void appendLinkedStaff(Staff* staff, const ID& sourceStaffId, const ID& destinationPartId) override;
 
     void insertPart(Part* part, size_t index) override;
@@ -90,7 +90,7 @@ private:
     void doSetScoreOrder(const ScoreOrder& order);
     void doMoveStaves(const std::vector<Staff*>& staves, engraving::staff_idx_t destinationStaffIndex, Part* destinationPart = nullptr);
     void doRemoveParts(const std::vector<Part*>& parts);
-    void doInsertStaff(Staff* staff, Part* destinationPart, size_t staffLocalIndex = 0);
+    void doAppendStaff(Staff* staff, Part* destinationPart);
     void doSetStaffConfig(Staff* staff, const StaffConfig& config);
     void doInsertPart(Part* part, size_t index);
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/12279

Removed the ability to insert staves into arbitrary places in the list, because it causes a lot of crashes and other problems

For more context see: https://github.com/musescore/MuseScore/pull/10526