### PR TITLE
Allow stems on either side of beam to shorten, reduce middle stems by less

### DIFF
--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -98,14 +98,16 @@ class Beam final : public EngravingItem
     int getBeamCount(std::vector<ChordRest*> chordRests) const;
     void offsetBeamToRemoveCollisions(std::vector<ChordRest*> chordRests, int& dictator, int& pointer, const double startX,
                                       const double endX, bool isFlat, bool isStartDictator) const;
-    bool isBeamInsideStaff(int yPos, int staffLines) const;
+    void offsetBeamWithAnchorShortening(std::vector<ChordRest*> chordRests, int& dictator, int& pointer, int beamCount, int staffLines,
+                                        bool isStartDictator, int stemLengthDictator, int stemLengthPointer) const;
+    bool isBeamInsideStaff(int yPos, int staffLines, bool isDictator) const;
     int getOuterBeamPosOffset(int innerBeam, int beamCount, int staffLines) const;
     bool isValidBeamPosition(int yPos, bool isStart, bool isAscending, bool isFlat, int staffLines, int beamCount) const;
     bool is64thBeamPositionException(int& yPos, int staffLines) const;
     int findValidBeamOffset(int outer, int beamCount, int staffLines, bool isStart, bool isAscending, bool isFlat) const;
     void setValidBeamPositions(int& dictator, int& pointer, int beamCount, int staffLines, bool isStartDictator, bool isFlat,
                                bool isAscending);
-    void addMiddleLineSlant(int& dictator, int& pointer, int beamCount, int middleLine, int interval);
+    void addMiddleLineSlant(int& dictator, int& pointer, int beamCount, int middleLine, int interval, int desiredSlant);
     void add8thSpaceSlant(mu::PointF& dictatorAnchor, int dictator, int pointer, int beamCount, int interval, int middleLine, bool Flat);
     void extendStem(Chord* chord, double addition);
     bool calcIsBeamletBefore(Chord* chord, int i, int level, bool isAfter32Break, bool isAfter64Break) const;
@@ -233,7 +235,7 @@ public:
 private:
     void initBeamEditData(EditData& ed);
 
-    static constexpr std::array _maxSlopes = { 1, 2, 3, 4, 5, 6, 7 };
+    static constexpr std::array _maxSlopes = { 0, 1, 2, 3, 4, 5, 6, 7 };
 };
 } // namespace mu::engraving
 #endif

--- a/src/engraving/utests/beam_data/Beam-A.mscx
+++ b/src/engraving/utests/beam_data/Beam-A.mscx
@@ -120,8 +120,8 @@
             </Chord>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>40</l1>
-            <l2>40</l2>
+            <l1>42</l1>
+            <l2>42</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -157,8 +157,8 @@
         <voice>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>-6</l1>
-            <l2>-8</l2>
+            <l1>-4</l1>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -176,7 +176,7 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>40</l1>
+            <l1>42</l1>
             <l2>38</l2>
             </Beam>
           <Chord>
@@ -347,8 +347,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>10</l1>
-            <l2>8</l2>
+            <l1>18</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -389,8 +389,8 @@
         <voice>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>2</l1>
-            <l2>0</l2>
+            <l1>10</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -613,8 +613,8 @@
         <voice>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>22</l1>
-            <l2>24</l2>
+            <l1>16</l1>
+            <l2>18</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -650,8 +650,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>30</l1>
-            <l2>32</l2>
+            <l1>22</l1>
+            <l2>26</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -731,8 +731,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>38</l1>
-            <l2>40</l2>
+            <l1>36</l1>
+            <l2>42</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -912,8 +912,8 @@
         <voice>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>40</l1>
-            <l2>38</l2>
+            <l1>42</l1>
+            <l2>40</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -931,7 +931,7 @@
             </Chord>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>40</l1>
+            <l1>42</l1>
             <l2>38</l2>
             </Beam>
           <Chord>
@@ -950,8 +950,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>40</l1>
-            <l2>38</l2>
+            <l1>42</l1>
+            <l2>36</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -968,8 +968,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>40</l1>
-            <l2>38</l2>
+            <l1>42</l1>
+            <l2>36</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -995,8 +995,8 @@
         <voice>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>40</l1>
-            <l2>38</l2>
+            <l1>42</l1>
+            <l2>36</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -1014,8 +1014,8 @@
             </Chord>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>40</l1>
-            <l2>38</l2>
+            <l1>42</l1>
+            <l2>36</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -1034,8 +1034,8 @@
             </Chord>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>40</l1>
-            <l2>38</l2>
+            <l1>42</l1>
+            <l2>36</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/beam_data/Beam-B.mscx
+++ b/src/engraving/utests/beam_data/Beam-B.mscx
@@ -192,8 +192,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>10</l1>
-            <l2>8</l2>
+            <l1>18</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -230,8 +230,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>2</l1>
-            <l2>0</l2>
+            <l1>10</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -324,8 +324,8 @@
         <voice>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>-6</l1>
-            <l2>-8</l2>
+            <l1>-8</l1>
+            <l2>-10</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -518,8 +518,8 @@
         <voice>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>-8</l1>
-            <l2>-6</l2>
+            <l1>-6</l1>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -538,7 +538,7 @@
           <Beam>
             <StemDirection>up</StemDirection>
             <l1>-6</l1>
-            <l2>0</l2>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -666,8 +666,8 @@
         <voice>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>40</l1>
-            <l2>38</l2>
+            <l1>38</l1>
+            <l2>36</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -685,7 +685,7 @@
             </Chord>
           <Beam>
             <l1>38</l1>
-            <l2>32</l2>
+            <l2>36</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -810,8 +810,8 @@
         <voice>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>38</l1>
-            <l2>40</l2>
+            <l1>40</l1>
+            <l2>42</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -1020,8 +1020,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>22</l1>
-            <l2>24</l2>
+            <l1>14</l1>
+            <l2>18</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -1057,8 +1057,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>30</l1>
-            <l2>32</l2>
+            <l1>22</l1>
+            <l2>26</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>

--- a/src/engraving/utests/beam_data/Beam-C.mscx
+++ b/src/engraving/utests/beam_data/Beam-C.mscx
@@ -153,8 +153,8 @@
       <Measure>
         <voice>
           <Beam>
-            <l1>10</l1>
-            <l2>8</l2>
+            <l1>16</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -191,8 +191,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>2</l1>
-            <l2>0</l2>
+            <l1>10</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -274,8 +274,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-6</l1>
-            <l2>-8</l2>
+            <l1>-4</l1>
+            <l2>-10</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -417,8 +417,8 @@
       <Measure>
         <voice>
           <Beam>
-            <l1>38</l1>
-            <l2>40</l2>
+            <l1>36</l1>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -436,7 +436,7 @@
             </Chord>
           <Beam>
             <l1>38</l1>
-            <l2>40</l2>
+            <l2>42</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -454,8 +454,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-8</l1>
-            <l2>-6</l2>
+            <l1>-10</l1>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -472,8 +472,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-8</l1>
-            <l2>-6</l2>
+            <l1>-10</l1>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -498,8 +498,8 @@
           </LayoutBreak>
         <voice>
           <Beam>
-            <l1>-8</l1>
-            <l2>-6</l2>
+            <l1>-10</l1>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -516,8 +516,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-8</l1>
-            <l2>-6</l2>
+            <l1>-10</l1>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -535,8 +535,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-8</l1>
-            <l2>-6</l2>
+            <l1>-10</l1>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -597,8 +597,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>22</l1>
-            <l2>24</l2>
+            <l1>14</l1>
+            <l2>18</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -641,8 +641,8 @@
           </LayoutBreak>
         <voice>
           <Beam>
-            <l1>30</l1>
-            <l2>32</l2>
+            <l1>22</l1>
+            <l2>26</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -703,8 +703,8 @@
       <Measure>
         <voice>
           <Beam>
-            <l1>38</l1>
-            <l2>40</l2>
+            <l1>36</l1>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -722,7 +722,7 @@
             </Chord>
           <Beam>
             <l1>38</l1>
-            <l2>40</l2>
+            <l2>42</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -740,8 +740,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-8</l1>
-            <l2>-6</l2>
+            <l1>-10</l1>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -758,8 +758,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-8</l1>
-            <l2>-6</l2>
+            <l1>-10</l1>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -781,8 +781,8 @@
       <Measure>
         <voice>
           <Beam>
-            <l1>-8</l1>
-            <l2>-6</l2>
+            <l1>-10</l1>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/beam_data/Beam-D.mscx
+++ b/src/engraving/utests/beam_data/Beam-D.mscx
@@ -176,8 +176,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>2</l1>
-            <l2>0</l2>
+            <l1>10</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -261,8 +261,8 @@
             </Chord>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>-6</l1>
-            <l2>-8</l2>
+            <l1>-4</l1>
+            <l2>-10</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -308,8 +308,8 @@
         <voice>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>8</l1>
-            <l2>10</l2>
+            <l1>14</l1>
+            <l2>16</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -326,8 +326,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>8</l1>
-            <l2>10</l2>
+            <l1>14</l1>
+            <l2>18</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -345,8 +345,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>8</l1>
-            <l2>10</l2>
+            <l1>14</l1>
+            <l2>18</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -363,8 +363,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>8</l1>
-            <l2>10</l2>
+            <l1>14</l1>
+            <l2>18</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -386,8 +386,8 @@
       <Measure>
         <voice>
           <Beam>
-            <l1>8</l1>
-            <l2>10</l2>
+            <l1>14</l1>
+            <l2>18</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -404,8 +404,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>8</l1>
-            <l2>10</l2>
+            <l1>14</l1>
+            <l2>18</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -443,7 +443,7 @@
           <Beam>
             <StemDirection>up</StemDirection>
             <l1>-12</l1>
-            <l2>-8</l2>
+            <l2>-10</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -462,7 +462,7 @@
           <Beam>
             <StemDirection>up</StemDirection>
             <l1>-12</l1>
-            <l2>-6</l2>
+            <l2>-8</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -645,8 +645,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>22</l1>
-            <l2>24</l2>
+            <l1>14</l1>
+            <l2>18</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -689,8 +689,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>30</l1>
-            <l2>32</l2>
+            <l1>22</l1>
+            <l2>26</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -751,7 +751,7 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>32</l1>
+            <l1>36</l1>
             <l2>38</l2>
             </Beam>
           <Chord>
@@ -771,8 +771,8 @@
             </Chord>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>38</l1>
-            <l2>40</l2>
+            <l1>36</l1>
+            <l2>42</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/beam_data/Beam-E.mscx
+++ b/src/engraving/utests/beam_data/Beam-E.mscx
@@ -157,8 +157,8 @@
         <voice>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>2</l1>
-            <l2>0</l2>
+            <l1>8</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -241,8 +241,8 @@
         <voice>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>-6</l1>
-            <l2>-8</l2>
+            <l1>-4</l1>
+            <l2>-10</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -345,8 +345,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>10</l1>
-            <l2>8</l2>
+            <l1>18</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -610,8 +610,8 @@
         <voice>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>32</l1>
-            <l2>30</l2>
+            <l1>26</l1>
+            <l2>24</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -628,8 +628,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>32</l1>
-            <l2>30</l2>
+            <l1>26</l1>
+            <l2>22</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -647,8 +647,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>32</l1>
-            <l2>30</l2>
+            <l1>26</l1>
+            <l2>22</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -665,8 +665,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>32</l1>
-            <l2>30</l2>
+            <l1>26</l1>
+            <l2>22</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -691,8 +691,8 @@
           </LayoutBreak>
         <voice>
           <Beam>
-            <l1>32</l1>
-            <l2>30</l2>
+            <l1>26</l1>
+            <l2>22</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -709,8 +709,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>32</l1>
-            <l2>30</l2>
+            <l1>26</l1>
+            <l2>22</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -728,8 +728,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>32</l1>
-            <l2>30</l2>
+            <l1>26</l1>
+            <l2>22</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -791,8 +791,8 @@
             </Chord>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>38</l1>
-            <l2>40</l2>
+            <l1>36</l1>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -811,7 +811,7 @@
           <Beam>
             <StemDirection>down</StemDirection>
             <l1>38</l1>
-            <l2>40</l2>
+            <l2>42</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -926,8 +926,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>22</l1>
-            <l2>24</l2>
+            <l1>14</l1>
+            <l2>18</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -963,8 +963,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>30</l1>
-            <l2>32</l2>
+            <l1>22</l1>
+            <l2>26</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>

--- a/src/engraving/utests/beam_data/Beam-F.mscx
+++ b/src/engraving/utests/beam_data/Beam-F.mscx
@@ -214,8 +214,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-6</l1>
-            <l2>-8</l2>
+            <l1>-4</l1>
+            <l2>-10</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -326,8 +326,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>10</l1>
-            <l2>8</l2>
+            <l1>18</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -363,8 +363,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>2</l1>
-            <l2>0</l2>
+            <l1>10</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -463,8 +463,8 @@
         <voice>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>0</l1>
-            <l2>2</l2>
+            <l1>6</l1>
+            <l2>8</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -482,8 +482,8 @@
             </Chord>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>0</l1>
-            <l2>2</l2>
+            <l1>6</l1>
+            <l2>10</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -502,8 +502,8 @@
             </Chord>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>0</l1>
-            <l2>2</l2>
+            <l1>6</l1>
+            <l2>10</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -521,8 +521,8 @@
             </Chord>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>0</l1>
-            <l2>2</l2>
+            <l1>6</l1>
+            <l2>10</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -548,8 +548,8 @@
         <voice>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>0</l1>
-            <l2>2</l2>
+            <l1>6</l1>
+            <l2>10</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -566,8 +566,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>0</l1>
-            <l2>2</l2>
+            <l1>6</l1>
+            <l2>10</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -585,8 +585,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>0</l1>
-            <l2>2</l2>
+            <l1>6</l1>
+            <l2>10</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -754,8 +754,8 @@
       <Measure>
         <voice>
           <Beam>
-            <l1>30</l1>
-            <l2>32</l2>
+            <l1>24</l1>
+            <l2>26</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -811,8 +811,8 @@
             </Chord>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>38</l1>
-            <l2>40</l2>
+            <l1>36</l1>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -836,7 +836,7 @@
           <Beam>
             <StemDirection>down</StemDirection>
             <l1>38</l1>
-            <l2>40</l2>
+            <l2>42</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -946,8 +946,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>22</l1>
-            <l2>24</l2>
+            <l1>14</l1>
+            <l2>18</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/beam_data/Beam-G.mscx
+++ b/src/engraving/utests/beam_data/Beam-G.mscx
@@ -176,7 +176,7 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>0</l1>
+            <l1>-4</l1>
             <l2>-6</l2>
             </Beam>
           <Chord>
@@ -195,8 +195,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-6</l1>
-            <l2>-8</l2>
+            <l1>-4</l1>
+            <l2>-10</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -326,8 +326,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>10</l1>
-            <l2>8</l2>
+            <l1>18</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -363,8 +363,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>2</l1>
-            <l2>0</l2>
+            <l1>10</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -595,8 +595,8 @@
         <voice>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>24</l1>
-            <l2>22</l2>
+            <l1>18</l1>
+            <l2>16</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -613,8 +613,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>24</l1>
-            <l2>22</l2>
+            <l1>18</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -632,8 +632,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>24</l1>
-            <l2>22</l2>
+            <l1>18</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -650,8 +650,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>24</l1>
-            <l2>22</l2>
+            <l1>18</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -676,8 +676,8 @@
           </LayoutBreak>
         <voice>
           <Beam>
-            <l1>24</l1>
-            <l2>22</l2>
+            <l1>18</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -694,8 +694,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>24</l1>
-            <l2>22</l2>
+            <l1>18</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -744,8 +744,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>30</l1>
-            <l2>32</l2>
+            <l1>22</l1>
+            <l2>26</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -807,8 +807,8 @@
         <voice>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>38</l1>
-            <l2>40</l2>
+            <l1>36</l1>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -826,7 +826,7 @@
             </Chord>
           <Beam>
             <l1>38</l1>
-            <l2>40</l2>
+            <l2>42</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -883,7 +883,7 @@
           <Beam>
             <StemDirection>down</StemDirection>
             <l1>44</l1>
-            <l2>40</l2>
+            <l2>42</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -902,7 +902,7 @@
           <Beam>
             <StemDirection>down</StemDirection>
             <l1>44</l1>
-            <l2>38</l2>
+            <l2>40</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>

--- a/src/engraving/utests/beam_data/beamNoSlope.mscx
+++ b/src/engraving/utests/beam_data/beamNoSlope.mscx
@@ -265,8 +265,8 @@
       <Measure>
         <voice>
           <Beam>
-            <l1>10</l1>
-            <l2>10</l2>
+            <l1>14</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <durationType>32nd</durationType>

--- a/src/engraving/utests/beam_data/beamPositions.mscx
+++ b/src/engraving/utests/beam_data/beamPositions.mscx
@@ -909,8 +909,8 @@
           </LayoutBreak>
         <voice>
           <Beam>
-            <l1>10</l1>
-            <l2>10</l2>
+            <l1>18</l1>
+            <l2>18</l2>
             </Beam>
           <Chord>
             <durationType>32nd</durationType>
@@ -930,8 +930,8 @@
             <durationType>16th</durationType>
             </Rest>
           <Beam>
-            <l1>10</l1>
-            <l2>10</l2>
+            <l1>18</l1>
+            <l2>18</l2>
             </Beam>
           <Chord>
             <durationType>32nd</durationType>
@@ -951,8 +951,8 @@
             <durationType>16th</durationType>
             </Rest>
           <Beam>
-            <l1>10</l1>
-            <l2>10</l2>
+            <l1>14</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <durationType>32nd</durationType>
@@ -1253,8 +1253,8 @@
       <Measure>
         <voice>
           <Beam>
-            <l1>22</l1>
-            <l2>22</l2>
+            <l1>18</l1>
+            <l2>18</l2>
             </Beam>
           <Chord>
             <durationType>32nd</durationType>
@@ -1274,8 +1274,8 @@
             <durationType>16th</durationType>
             </Rest>
           <Beam>
-            <l1>22</l1>
-            <l2>22</l2>
+            <l1>14</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <durationType>32nd</durationType>
@@ -1295,8 +1295,8 @@
             <durationType>16th</durationType>
             </Rest>
           <Beam>
-            <l1>22</l1>
-            <l2>22</l2>
+            <l1>14</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <durationType>32nd</durationType>
@@ -1316,8 +1316,8 @@
             <durationType>16th</durationType>
             </Rest>
           <Beam>
-            <l1>22</l1>
-            <l2>22</l2>
+            <l1>14</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <durationType>32nd</durationType>
@@ -1344,33 +1344,33 @@
       <Measure>
         <voice>
           <Beam>
+            <l1>18</l1>
+            <l2>18</l2>
+            </Beam>
+          <Chord>
+            <durationType>64th</durationType>
+            <Note>
+              <pitch>55</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>64th</durationType>
+            <Note>
+              <pitch>55</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Rest>
+            <durationType>32nd</durationType>
+            </Rest>
+          <Beam>
             <l1>6</l1>
             <l2>6</l2>
             </Beam>
           <Chord>
             <durationType>64th</durationType>
             <Note>
-              <pitch>55</pitch>
-              <tpc>15</tpc>
-              </Note>
-            </Chord>
-          <Chord>
-            <durationType>64th</durationType>
-            <Note>
-              <pitch>55</pitch>
-              <tpc>15</tpc>
-              </Note>
-            </Chord>
-          <Rest>
-            <durationType>32nd</durationType>
-            </Rest>
-          <Beam>
-            <l1>4</l1>
-            <l2>4</l2>
-            </Beam>
-          <Chord>
-            <durationType>64th</durationType>
-            <Note>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
@@ -1428,8 +1428,8 @@
             <durationType>32nd</durationType>
             </Rest>
           <Beam>
-            <l1>2</l1>
-            <l2>2</l2>
+            <l1>0</l1>
+            <l2>0</l2>
             </Beam>
           <Chord>
             <durationType>64th</durationType>
@@ -1470,8 +1470,8 @@
             <durationType>32nd</durationType>
             </Rest>
           <Beam>
-            <l1>-6</l1>
-            <l2>-6</l2>
+            <l1>-8</l1>
+            <l2>-8</l2>
             </Beam>
           <Chord>
             <durationType>64th</durationType>
@@ -1512,8 +1512,8 @@
             <durationType>32nd</durationType>
             </Rest>
           <Beam>
-            <l1>-14</l1>
-            <l2>-14</l2>
+            <l1>-16</l1>
+            <l2>-16</l2>
             </Beam>
           <Chord>
             <durationType>64th</durationType>
@@ -1555,8 +1555,8 @@
             </Rest>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>46</l1>
-            <l2>46</l2>
+            <l1>48</l1>
+            <l2>48</l2>
             </Beam>
           <Chord>
             <durationType>64th</durationType>
@@ -1599,8 +1599,8 @@
             <durationType>32nd</durationType>
             </Rest>
           <Beam>
-            <l1>38</l1>
-            <l2>38</l2>
+            <l1>40</l1>
+            <l2>40</l2>
             </Beam>
           <Chord>
             <durationType>64th</durationType>
@@ -1641,8 +1641,8 @@
             <durationType>32nd</durationType>
             </Rest>
           <Beam>
-            <l1>30</l1>
-            <l2>30</l2>
+            <l1>32</l1>
+            <l2>32</l2>
             </Beam>
           <Chord>
             <durationType>64th</durationType>
@@ -1708,8 +1708,8 @@
             <durationType>32nd</durationType>
             </Rest>
           <Beam>
-            <l1>28</l1>
-            <l2>28</l2>
+            <l1>26</l1>
+            <l2>26</l2>
             </Beam>
           <Chord>
             <durationType>64th</durationType>
@@ -1729,8 +1729,8 @@
             <durationType>32nd</durationType>
             </Rest>
           <Beam>
-            <l1>26</l1>
-            <l2>26</l2>
+            <l1>14</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <durationType>64th</durationType>

--- a/src/engraving/utests/beam_data/beamStemDir-01-ref.mscx
+++ b/src/engraving/utests/beam_data/beamStemDir-01-ref.mscx
@@ -62,8 +62,8 @@
             </TimeSig>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>-8</l1>
-            <l2>-8</l2>
+            <l1>-10</l1>
+            <l2>-10</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/beam_data/flatBeams.mscx
+++ b/src/engraving/utests/beam_data/flatBeams.mscx
@@ -364,8 +364,8 @@
       <Measure>
         <voice>
           <Beam>
-            <l1>0</l1>
-            <l2>0</l2>
+            <l1>-2</l1>
+            <l2>-2</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -749,8 +749,8 @@
       <Measure>
         <voice>
           <Beam>
-            <l1>32</l1>
-            <l2>32</l2>
+            <l1>34</l1>
+            <l2>34</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/beam_data/wideBeams.mscx
+++ b/src/engraving/utests/beam_data/wideBeams.mscx
@@ -166,7 +166,7 @@
             <durationType>eighth</durationType>
             </Rest>
           <Beam>
-            <l1>14</l1>
+            <l1>16</l1>
             <l2>18</l2>
             </Beam>
           <Chord>
@@ -209,7 +209,7 @@
             </Rest>
           <Beam>
             <l1>18</l1>
-            <l2>14</l2>
+            <l2>16</l2>
             </Beam>
           <Chord>
             <durationType>16th</durationType>
@@ -254,7 +254,7 @@
             <durationType>16th</durationType>
             </Rest>
           <Beam>
-            <l1>6</l1>
+            <l1>8</l1>
             <l2>10</l2>
             </Beam>
           <Chord>
@@ -297,7 +297,7 @@
             </Rest>
           <Beam>
             <l1>10</l1>
-            <l2>6</l2>
+            <l2>8</l2>
             </Beam>
           <Chord>
             <durationType>32nd</durationType>
@@ -338,7 +338,7 @@
             <durationType>32nd</durationType>
             </Rest>
           <Beam>
-            <l1>-2</l1>
+            <l1>0</l1>
             <l2>2</l2>
             </Beam>
           <Chord>
@@ -381,7 +381,7 @@
             </Rest>
           <Beam>
             <l1>2</l1>
-            <l2>-2</l2>
+            <l2>0</l2>
             </Beam>
           <Chord>
             <durationType>64th</durationType>
@@ -696,7 +696,7 @@
             <durationType>32nd</durationType>
             </Rest>
           <Beam>
-            <l1>34</l1>
+            <l1>32</l1>
             <l2>30</l2>
             </Beam>
           <Chord>
@@ -739,7 +739,7 @@
             </Rest>
           <Beam>
             <l1>30</l1>
-            <l2>34</l2>
+            <l2>32</l2>
             </Beam>
           <Chord>
             <durationType>64th</durationType>
@@ -823,8 +823,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>10</l1>
-            <l2>10</l2>
+            <l1>18</l1>
+            <l2>18</l2>
             </Beam>
           <Chord>
             <durationType>32nd</durationType>
@@ -890,8 +890,8 @@
           </LayoutBreak>
         <voice>
           <Beam>
-            <l1>2</l1>
-            <l2>2</l2>
+            <l1>14</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <durationType>64th</durationType>
@@ -1020,8 +1020,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>22</l1>
-            <l2>22</l2>
+            <l1>14</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <durationType>32nd</durationType>
@@ -1087,8 +1087,8 @@
           </LayoutBreak>
         <voice>
           <Beam>
-            <l1>30</l1>
-            <l2>30</l2>
+            <l1>18</l1>
+            <l2>18</l2>
             </Beam>
           <Chord>
             <durationType>64th</durationType>

--- a/src/engraving/utests/chordsymbol_data/realize-triplet-ref.mscx
+++ b/src/engraving/utests/chordsymbol_data/realize-triplet-ref.mscx
@@ -749,7 +749,7 @@
             </Tuplet>
           <Beam>
             <l1>-8</l1>
-            <l2>-6</l2>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <durationType>16th</durationType>

--- a/src/engraving/utests/copypaste_data/copypaste11-ref.mscx
+++ b/src/engraving/utests/copypaste_data/copypaste11-ref.mscx
@@ -118,7 +118,7 @@
             </Chord>
           <Beam>
             <l1>-6</l1>
-            <l2>-2</l2>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -216,7 +216,7 @@
             </Chord>
           <Beam>
             <l1>-6</l1>
-            <l2>-2</l2>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/copypaste_data/copypaste17-ref.mscx
+++ b/src/engraving/utests/copypaste_data/copypaste17-ref.mscx
@@ -101,7 +101,7 @@
             <durationType>eighth</durationType>
             </Rest>
           <Beam>
-            <l1>-12</l1>
+            <l1>-14</l1>
             <l2>-16</l2>
             </Beam>
           <Chord>
@@ -120,7 +120,7 @@
             </Chord>
           <Beam>
             <l1>-20</l1>
-            <l2>-16</l2>
+            <l2>-18</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/copypaste_data/copypaste20-ref.mscx
+++ b/src/engraving/utests/copypaste_data/copypaste20-ref.mscx
@@ -91,7 +91,7 @@
             <sigD>4</sigD>
             </TimeSig>
           <Beam>
-            <l1>-8</l1>
+            <l1>-10</l1>
             <l2>-12</l2>
             </Beam>
           <Chord>

--- a/src/engraving/utests/copypastesymbollist_data/copypastesymbollist-articulation-ref.mscx
+++ b/src/engraving/utests/copypastesymbollist_data/copypastesymbollist-articulation-ref.mscx
@@ -181,7 +181,7 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>24</l1>
+            <l1>30</l1>
             <l2>32</l2>
             </Beam>
           <Chord>
@@ -287,7 +287,7 @@
       <Measure>
         <voice>
           <Beam>
-            <l1>24</l1>
+            <l1>30</l1>
             <l2>32</l2>
             </Beam>
           <Chord>

--- a/src/engraving/utests/copypastesymbollist_data/copypastesymbollist-chordnames-ref.mscx
+++ b/src/engraving/utests/copypastesymbollist_data/copypastesymbollist-chordnames-ref.mscx
@@ -166,7 +166,7 @@
             <root>15</root>
             </Harmony>
           <Beam>
-            <l1>24</l1>
+            <l1>30</l1>
             <l2>32</l2>
             </Beam>
           <Chord>
@@ -254,7 +254,7 @@
             <root>16</root>
             </Harmony>
           <Beam>
-            <l1>24</l1>
+            <l1>30</l1>
             <l2>32</l2>
             </Beam>
           <Chord>

--- a/src/engraving/utests/copypastesymbollist_data/copypastesymbollist-lyrics-ref.mscx
+++ b/src/engraving/utests/copypastesymbollist_data/copypastesymbollist-lyrics-ref.mscx
@@ -178,7 +178,7 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>24</l1>
+            <l1>30</l1>
             <l2>32</l2>
             </Beam>
           <Chord>
@@ -287,7 +287,7 @@
       <Measure>
         <voice>
           <Beam>
-            <l1>24</l1>
+            <l1>30</l1>
             <l2>32</l2>
             </Beam>
           <Chord>

--- a/src/engraving/utests/copypastesymbollist_data/copypastesymbollist-stafftext-ref.mscx
+++ b/src/engraving/utests/copypastesymbollist_data/copypastesymbollist-stafftext-ref.mscx
@@ -186,7 +186,7 @@
             <text>11</text>
             </StaffText>
           <Beam>
-            <l1>24</l1>
+            <l1>30</l1>
             <l2>32</l2>
             </Beam>
           <Chord>
@@ -292,7 +292,7 @@
             <text>5</text>
             </StaffText>
           <Beam>
-            <l1>24</l1>
+            <l1>30</l1>
             <l2>32</l2>
             </Beam>
           <Chord>

--- a/src/engraving/utests/copypastesymbollist_data/copypastesymbollist-sticking-ref.mscx
+++ b/src/engraving/utests/copypastesymbollist_data/copypastesymbollist-sticking-ref.mscx
@@ -186,7 +186,7 @@
             <text>11</text>
             </Sticking>
           <Beam>
-            <l1>24</l1>
+            <l1>30</l1>
             <l2>32</l2>
             </Beam>
           <Chord>
@@ -292,7 +292,7 @@
             <text>5</text>
             </Sticking>
           <Beam>
-            <l1>24</l1>
+            <l1>30</l1>
             <l2>32</l2>
             </Beam>
           <Chord>

--- a/src/engraving/utests/exchangevoices_data/exchangevoices-slurs-ref.mscx
+++ b/src/engraving/utests/exchangevoices_data/exchangevoices-slurs-ref.mscx
@@ -88,7 +88,7 @@
         <voice>
           <Beam>
             <l1>60</l1>
-            <l2>52</l2>
+            <l2>54</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/implode_explode_data/implode1-ref.mscx
+++ b/src/engraving/utests/implode_explode_data/implode1-ref.mscx
@@ -1113,8 +1113,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-8</l1>
-            <l2>-6</l2>
+            <l1>-6</l1>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -1155,7 +1155,7 @@
             </Chord>
           <Beam>
             <l1>-6</l1>
-            <l2>-8</l2>
+            <l2>-10</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/implode_explode_data/implode1.mscx
+++ b/src/engraving/utests/implode_explode_data/implode1.mscx
@@ -698,8 +698,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-8</l1>
-            <l2>-6</l2>
+            <l1>-6</l1>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -740,7 +740,7 @@
             </Chord>
           <Beam>
             <l1>-6</l1>
-            <l2>-8</l2>
+            <l2>-10</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/implode_explode_data/undoExplode01-ref.mscx
+++ b/src/engraving/utests/implode_explode_data/undoExplode01-ref.mscx
@@ -372,8 +372,8 @@
               </Number>
             </Tuplet>
           <Beam>
-            <l1>22</l1>
-            <l2>24</l2>
+            <l1>14</l1>
+            <l2>18</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -732,7 +732,7 @@
               </Number>
             </Tuplet>
           <Beam>
-            <l1>32</l1>
+            <l1>36</l1>
             <l2>38</l2>
             </Beam>
           <Chord>
@@ -913,7 +913,7 @@
             </Tuplet>
           <Beam>
             <l1>-6</l1>
-            <l2>0</l2>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/implode_explode_data/undoExplode02-ref.mscx
+++ b/src/engraving/utests/implode_explode_data/undoExplode02-ref.mscx
@@ -526,8 +526,8 @@
               </Number>
             </Tuplet>
           <Beam>
-            <l1>22</l1>
-            <l2>24</l2>
+            <l1>14</l1>
+            <l2>18</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/rhythmicGrouping_data/groupArticulationsTies-ref.mscx
+++ b/src/engraving/utests/rhythmicGrouping_data/groupArticulationsTies-ref.mscx
@@ -90,8 +90,8 @@
               </Number>
             </Tuplet>
           <Beam>
-            <l1>38</l1>
-            <l2>40</l2>
+            <l1>36</l1>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/rhythmicGrouping_data/groupSubbeats-ref.mscx
+++ b/src/engraving/utests/rhythmicGrouping_data/groupSubbeats-ref.mscx
@@ -114,8 +114,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>44</l1>
-            <l2>44</l2>
+            <l1>46</l1>
+            <l2>46</l2>
             </Beam>
           <Chord>
             <durationType>16th</durationType>

--- a/src/engraving/utests/spanners_data/glissando-graces01-ref.mscx
+++ b/src/engraving/utests/spanners_data/glissando-graces01-ref.mscx
@@ -101,7 +101,7 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-22</l1>
+            <l1>-20</l1>
             <l2>-18</l2>
             </Beam>
           <Chord>

--- a/src/engraving/utests/tuplet_data/split2-ref.mscx
+++ b/src/engraving/utests/tuplet_data/split2-ref.mscx
@@ -129,8 +129,8 @@
               </Number>
             </Tuplet>
           <Beam>
-            <l1>8</l1>
-            <l2>8</l2>
+            <l1>2</l1>
+            <l2>2</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/tuplet_data/split4-ref.mscx
+++ b/src/engraving/utests/tuplet_data/split4-ref.mscx
@@ -214,8 +214,8 @@
               </Number>
             </Tuplet>
           <Beam>
-            <l1>8</l1>
-            <l2>7</l2>
+            <l1>6</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <durationType>32nd</durationType>

--- a/src/engraving/utests/unrollrepeats_data/clef-key-ts-ref.mscx
+++ b/src/engraving/utests/unrollrepeats_data/clef-key-ts-ref.mscx
@@ -270,7 +270,7 @@
             </Chord>
           <Beam>
             <l1>44</l1>
-            <l2>38</l2>
+            <l2>36</l2>
             </Beam>
           <Chord>
             <durationType>16th</durationType>
@@ -473,7 +473,7 @@
             </Chord>
           <Beam>
             <l1>44</l1>
-            <l2>38</l2>
+            <l2>36</l2>
             </Beam>
           <Chord>
             <durationType>16th</durationType>
@@ -811,7 +811,7 @@
             </Chord>
           <Beam>
             <l1>44</l1>
-            <l2>38</l2>
+            <l2>36</l2>
             </Beam>
           <Chord>
             <durationType>16th</durationType>
@@ -1110,8 +1110,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-8</l1>
-            <l2>-6</l2>
+            <l1>-6</l1>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <linkedMain/>
@@ -1653,8 +1653,8 @@
                 </Note>
               </Chord>
             <Beam>
-              <l1>-8</l1>
-              <l2>-6</l2>
+              <l1>-6</l1>
+              <l2>-4</l2>
               </Beam>
             <Chord>
               <linked>

--- a/src/importexport/capella/tests/data/test4.cap-ref.mscx
+++ b/src/importexport/capella/tests/data/test4.cap-ref.mscx
@@ -140,7 +140,7 @@
           </LayoutBreak>
         <voice>
           <Beam>
-            <l1>0</l1>
+            <l1>-4</l1>
             <l2>-6</l2>
             </Beam>
           <Chord>

--- a/src/importexport/capella/tests/data/test4.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/test4.capx-ref.mscx
@@ -140,7 +140,7 @@
           </LayoutBreak>
         <voice>
           <Beam>
-            <l1>0</l1>
+            <l1>-4</l1>
             <l2>-6</l2>
             </Beam>
           <Chord>

--- a/src/importexport/capella/tests/data/test7.cap-ref.mscx
+++ b/src/importexport/capella/tests/data/test7.cap-ref.mscx
@@ -60,8 +60,8 @@
             <sigD>4</sigD>
             </TimeSig>
           <Beam>
-            <l1>8</l1>
-            <l2>0</l2>
+            <l1>10</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -92,8 +92,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>0</l1>
-            <l2>-8</l2>
+            <l1>-4</l1>
+            <l2>-10</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -134,8 +134,8 @@
             <accidental>4</accidental>
             </KeySig>
           <Beam>
-            <l1>8</l1>
-            <l2>0</l2>
+            <l1>10</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -209,8 +209,8 @@
             <accidental>5</accidental>
             </KeySig>
           <Beam>
-            <l1>8</l1>
-            <l2>0</l2>
+            <l1>10</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -283,8 +283,8 @@
             <accidental>6</accidental>
             </KeySig>
           <Beam>
-            <l1>8</l1>
-            <l2>0</l2>
+            <l1>10</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -358,8 +358,8 @@
             <accidental>7</accidental>
             </KeySig>
           <Beam>
-            <l1>8</l1>
-            <l2>0</l2>
+            <l1>10</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -432,8 +432,8 @@
             <accidental>-2</accidental>
             </KeySig>
           <Beam>
-            <l1>8</l1>
-            <l2>0</l2>
+            <l1>10</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -507,8 +507,8 @@
             <accidental>-3</accidental>
             </KeySig>
           <Beam>
-            <l1>8</l1>
-            <l2>0</l2>
+            <l1>10</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -581,8 +581,8 @@
             <accidental>-4</accidental>
             </KeySig>
           <Beam>
-            <l1>8</l1>
-            <l2>0</l2>
+            <l1>10</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -656,8 +656,8 @@
             <accidental>-5</accidental>
             </KeySig>
           <Beam>
-            <l1>8</l1>
-            <l2>0</l2>
+            <l1>10</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -730,8 +730,8 @@
             <accidental>-6</accidental>
             </KeySig>
           <Beam>
-            <l1>8</l1>
-            <l2>0</l2>
+            <l1>10</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -808,8 +808,8 @@
             <accidental>-7</accidental>
             </KeySig>
           <Beam>
-            <l1>8</l1>
-            <l2>0</l2>
+            <l1>10</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/importexport/musicxml/tests/data/testDurationRoundingError_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDurationRoundingError_ref.mscx
@@ -129,8 +129,8 @@
             </Tuplet>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>-8</l1>
-            <l2>-8</l2>
+            <l1>-10</l1>
+            <l2>-10</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -167,8 +167,8 @@
             </Tuplet>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>-8</l1>
-            <l2>-8</l2>
+            <l1>-10</l1>
+            <l2>-10</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>


### PR DESCRIPTION
When determining correct beam placement, the start and end stems of the beam should be able to shorten. Additionally, the middle stem shortening found in https://github.com/musescore/MuseScore/pull/11788 turned out to be a bit much, so that's been rolled back a tad by allowing middle stems to only reduce by 0.25sp.