### PR TITLE
Fix #12191: Corrects slide and gliss position for chords with seconds

### DIFF
--- a/src/engraving/libmscore/chordline.cpp
+++ b/src/engraving/libmscore/chordline.cpp
@@ -113,11 +113,22 @@ void ChordLine::layout()
             note = chord()->upNote();
         }
 
-        double x = note->pos().x();
+        double x = 0.0;
         double y = note->pos().y();
         double horOffset = 0.33 * spatium(); // one third of a space away from the note
         double vertOffset = 0.25 * spatium(); // one quarter of a space from the center line
-        x += isToTheLeft() ? -note->shape().left() - horOffset : note->shape().right() + horOffset;
+        // Get chord shape
+        Shape chordShape = chord()->shape();
+        // ...but remove chordLines, otherwise we are spacing chordLines against themselves
+        auto iter = chordShape.begin();
+        while (iter != chordShape.end()) {
+            if (iter->toItem && iter->toItem->isChordLine()) {
+                iter = chordShape.erase(iter);
+            } else {
+                ++iter;
+            }
+        }
+        x += isToTheLeft() ? -chordShape.left() - horOffset : chordShape.right() + horOffset;
         y += isBelow() ? vertOffset : -vertOffset;
         setPos(x, y);
     } else {


### PR DESCRIPTION
Resolves: #12191

Before:
<img width="726" alt="Immagine 2022-07-07 122218" src="https://user-images.githubusercontent.com/93707756/177752651-4b891055-d7a8-4d18-b96e-3cee5ba3661c.png">
After:
<img width="867" alt="Immagine 2022-07-07 122055" src="https://user-images.githubusercontent.com/93707756/177752677-27ff61b9-463f-4c00-9411-e8f3e4667561.png">

