### PR TITLE
[MU4] Fix MSCV/MinGW Compiler warnings

### DIFF
--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -1468,7 +1468,7 @@ bool GuitarPro5::readNote(int string, Note* note)
             return false;
         }
     }
-    dead_end[{ note->staffIdx(), string }] = false;
+    dead_end[{ static_cast<int>(note->staffIdx()), string }] = false;
     return slur;
 }
 

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -2905,10 +2905,10 @@ static void createLinkedTabs(MasterScore* score)
     for (size_t partNum = 0; partNum < score->parts().size(); partNum++) {
         Part* part = score->parts()[partNum];
         Fraction fr = Fraction(0, 1);
-        int lines = part->instrument()->stringData()->strings();
-        int stavesNum = part->nstaves();
+        size_t lines = part->instrument()->stringData()->strings();
+        size_t stavesNum = part->nstaves();
 
-        part->setStaves(stavesNum * 2);
+        part->setStaves(static_cast<int>(stavesNum * 2));
 
         for (int i = 0; i < stavesNum; i++) {
             staff_idx_t staffIdx = static_cast<int>(stavesNum + i);
@@ -2945,7 +2945,7 @@ static void createLinkedTabs(MasterScore* score)
             }
 
             dstStaff->setStaffType(fr, *StaffType::preset(tabType));
-            dstStaff->setLines(fr, lines);
+            dstStaff->setLines(fr, static_cast<int>(lines));
             Excerpt::cloneStaff(srcStaff, dstStaff);
         }
     }

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -2910,8 +2910,8 @@ static void createLinkedTabs(MasterScore* score)
 
         part->setStaves(static_cast<int>(stavesNum * 2));
 
-        for (int i = 0; i < stavesNum; i++) {
-            staff_idx_t staffIdx = static_cast<int>(stavesNum + i);
+        for (size_t i = 0; i < stavesNum; i++) {
+            staff_idx_t staffIdx = stavesNum + i;
 
             for (auto it = score->spanner().cbegin(); it != score->spanner().cend(); ++it) {
                 Spanner* s = it->second;

--- a/src/palette/internal/palettecell.h
+++ b/src/palette/internal/palettecell.h
@@ -93,19 +93,18 @@ public:
     mu::engraving::ElementPtr element;
     mu::engraving::ElementPtr untranslatedElement;
     QString id;
+
     QString name; // used for tool tip
     qreal mag { 1.0 };
+    double xoffset { 0.0 }; // in spatium units of "gscore"
+    double yoffset { 0.0 };
     QString tag;
 
     bool drawStaff { false };
-    double xoffset { 0.0 }; // in spatium units of "gscore"
-    double yoffset { 0.0 };
     bool readOnly { false };
-
     bool visible { true };
     bool custom { false };
     bool active { false };
-
     bool focused { false };
 
 private:


### PR DESCRIPTION
* Fix MSCV compiler warnings:
    * reg. conversion from 'size_t' to 'int', possible loss of data (C4267)

* Fix MinGW compiler warnings:
    * reg. comparison of integer expressions of different signedness (-Wsign-compare)
    * reg. variable will be initialized after ... vs. when initialized here (-Wreorder)