### PR TITLE
Fix #12189: Glissando end note

### DIFF
--- a/src/engraving/libmscore/glissando.cpp
+++ b/src/engraving/libmscore/glissando.cpp
@@ -32,6 +32,7 @@ NICE-TO-HAVE TODO:
 #include "glissando.h"
 
 #include <cmath>
+#include <algorithm>
 
 #include "draw/fontmetrics.h"
 #include "draw/types/pen.h"
@@ -598,7 +599,7 @@ Note* Glissando::guessInitialNote(Chord* chord)
 //    Returns:    the top note in a suitable following chord or nullptr if none found
 //---------------------------------------------------------
 
-Note* Glissando::guessFinalNote(Chord* chord)
+Note* Glissando::guessFinalNote(Chord* chord, Note* startNote)
 {
     switch (chord->noteType()) {
 //            case NoteType::INVALID:
@@ -677,7 +678,12 @@ Note* Glissando::guessFinalNote(Chord* chord)
                 if (graces.size() > 0) {
                     return graces.front()->upNote();
                 }
-                return target->upNote();              // if no grace before, return top note
+                // normal case: try to return the note in the next chord that is in the
+                // same position as the start note relative to the end chord
+                auto startNoteIter = find(chord->notes().begin(), chord->notes().end(), startNote);
+                int startNoteIdx = std::distance(chord->notes().begin(), startNoteIter);
+                int endNoteIdx = std::min(startNoteIdx, int(target->notes().size()) - 1);
+                return target->notes().at(endNoteIdx);
             }
         }
         segm = segm->next1();

--- a/src/engraving/libmscore/glissando.h
+++ b/src/engraving/libmscore/glissando.h
@@ -75,7 +75,7 @@ public:
     Glissando(const Glissando&);
 
     static Note* guessInitialNote(Chord* chord);
-    static Note* guessFinalNote(Chord* chord);
+    static Note* guessFinalNote(Chord* chord, Note* startNote);
 
     String glissandoTypeName() const;
 

--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -2019,7 +2019,7 @@ EngravingItem* Note::drop(EditData& data)
         }
 
         // this is the glissando initial note, look for a suitable final note
-        Note* finalNote = Glissando::guessFinalNote(chord());
+        Note* finalNote = Glissando::guessFinalNote(chord(), this);
         if (finalNote) {
             // init glissando data
             Glissando* gliss = toGlissando(e);


### PR DESCRIPTION
Resolves: #12189

Making a more reasonable "guess" for the end note of a glissando, i.e. searching for the note that in the same position as the start note relative to its chord.

Before:

https://user-images.githubusercontent.com/93707756/177787767-3e4b2e90-1223-415a-9b16-e8165230ae8d.mp4

After:

https://user-images.githubusercontent.com/93707756/177787784-ec8248a6-507e-46a2-8892-bf85365bc7c0.mp4


