### PR TITLE
Allow adding glissando to all notes when range selected

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1679,7 +1679,8 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
                         mu::engraving::Chord* chord = toChord(e);
                         for (mu::engraving::Note* n : chord->notes()) {
                             applyDropPaletteElement(score, n, element, modifiers);
-                            if (!(element->isAccidental() || element->isNoteHead())) {             // only these need to apply to every note
+                            if (!(element->isAccidental() || element->isNoteHead()
+                                  || element->isGlissando() || element->isChordLine())) { // only these need to apply to every note
                                 break;
                             }
                         }


### PR DESCRIPTION
Resolves part of #12190 

This just seems to require one line of code, so I thought it was worth doing it. The second point of the issue, i.e. inserting a glissando between two specifically selected notes, I think requires more work (because there isn't an interaction model for it as far as I can understand) so it should be postponed. 

Note: the choice of end notes for each glissando line is fixed by my other PR #12303 which should be merged together (or before) this.

Before:

https://user-images.githubusercontent.com/93707756/177803061-97fb5a17-2dfe-44c9-ab4f-5cddcdad443a.mp4

After:

https://user-images.githubusercontent.com/93707756/177803109-11751eaa-1f69-41f2-936c-769be2dbafbb.mp4



