### PR TITLE
fixed order of notes during guitar pro import

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
@@ -655,8 +655,7 @@ std::pair<int, std::shared_ptr<GPBeat> > GP67DomBuilder::createGPBeat(QDomNode* 
         } else if (nodeName == "Golpe") {
             beat->setGolpe(golpeType(innerNode.toElement().text()));
         } else if (nodeName == "Lyrics") {
-            // this code is almost a copy-paste from android_improvement.
-            // it reads lyrics for the beat (only one line).
+            // this code reads lyrics for the beat (only one line).
 
             QDomElement lyrNode = innerNode.firstChildElement("Line");
             QString str = lyrNode.toElement().text();

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -537,6 +537,11 @@ void GPConverter::convertNotes(const std::vector<std::shared_ptr<GPNote> >& note
     for (const auto& note : notes) {
         convertNote(note.get(), cr);
     }
+
+    //! NOTE: later notes order is used in linked staff to create ties, glissando
+    if (cr->isChord()) {
+        static_cast<Chord*>(cr)->sortNotes();
+    }
 }
 
 void GPConverter::convertNote(const GPNote* gpnote, ChordRest* cr)
@@ -973,8 +978,7 @@ void GPConverter::setUpTrack(const std::unique_ptr<GPTrack>& tR)
         part->instrument()->setSingleNoteDynamics(false);
     }
 
-    // this code is almost a direct copy-paste code from android_improvement branch.
-    // it sets score lyrics from the first processed track.
+    // this code sets score lyrics from the first processed track.
 //    if (_score->OffLyrics.isEmpty())
 //        _score->OffLyrics = tR->lyrics();
 


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

*fixed order of notes during guitar pro import*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
