### PR TITLE
Fix #12256: Correct fermata position for displaced chords

### DIFF
--- a/src/engraving/libmscore/fermata.cpp
+++ b/src/engraving/libmscore/fermata.cpp
@@ -233,7 +233,7 @@ void Fermata::layout()
     EngravingItem* e = s->element(track());
     if (e) {
         if (e->isChord()) {
-            movePosX(score()->noteHeadWidth() * staff()->staffMag(Fraction(0, 1)) * .5);
+            movePosX(score()->noteHeadWidth() * staff()->staffMag(Fraction(0, 1)) * .5 + toChord(e)->pos().x());
         } else {
             movePosX(e->x() + e->width() * staff()->staffMag(Fraction(0, 1)) * .5);
         }


### PR DESCRIPTION
Resolves: #12256 

Fermatas are wrongly placed for displaced chords. Now corrected.

Before:
<img width="536" alt="Immagine 2022-07-08 095659" src="https://user-images.githubusercontent.com/93707756/177946448-18ff0242-f2f0-4239-9778-871cc7573d16.png">
After:
<img width="479" alt="Immagine 2022-07-08 095754" src="https://user-images.githubusercontent.com/93707756/177946472-c23ca16e-8c54-4211-9092-5c03e07aa63d.png">

