### PR TITLE
Improvements/fixes for MIDI output on macOS

### DIFF
--- a/src/appshell/qml/Preferences/IOPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/IOPreferencesPage.qml
@@ -61,6 +61,9 @@ PreferencesPage {
             inputDevices: ioModel.midiInputDevices
             outputDevices: ioModel.midiOutputDevices
 
+            isMIDI20OutputSupported: ioModel.isMIDI20OutputSupported
+            useMIDI20Output: ioModel.useMIDI20Output
+
             navigation.section: root.navigationSection
             navigation.order: root.navigationOrderStart + 2
 
@@ -70,6 +73,10 @@ PreferencesPage {
 
             onCurrentOutputDeviceIndexChangeRequested: function(newIndex) {
                 ioModel.currentMidiOutputDeviceIndex = newIndex
+            }
+
+            onUseMIDI20OutputChangeRequested: function(use) {
+                ioModel.useMIDI20Output = use
             }
         }
 

--- a/src/appshell/qml/Preferences/internal/MidiDevicesSection.qml
+++ b/src/appshell/qml/Preferences/internal/MidiDevicesSection.qml
@@ -32,8 +32,12 @@ BaseSection {
     property alias inputDevices: inputDevicesBox.model
     property alias outputDevices: outputDevicesBox.model
 
+    property alias isMIDI20OutputSupported: useMIDI20OutputCheckbox.visible
+    property alias useMIDI20Output: useMIDI20OutputCheckbox.checked
+
     signal currentInputDeviceIndexChangeRequested(int newIndex)
     signal currentOutputDeviceIndexChangeRequested(int newIndex)
+    signal useMIDI20OutputChangeRequested(bool use)
 
     title: qsTrc("appshell", "MIDI")
 
@@ -64,6 +68,20 @@ BaseSection {
 
         onValueEdited: function(newIndex, newValue) {
             root.currentOutputDeviceIndexChangeRequested(newIndex)
+        }
+    }
+
+    CheckBox {
+        id: useMIDI20OutputCheckbox
+
+        text: qsTrc("appshell", "Produce MIDI 2.0 output if supported by the receiver")
+
+        navigation.name: "MidiUse20Output"
+        navigation.panel: root.navigation
+        navigation.row: 3
+
+        onClicked: {
+            root.useMIDI20OutputChangeRequested(!checked)
         }
     }
 }

--- a/src/appshell/view/preferences/iopreferencesmodel.cpp
+++ b/src/appshell/view/preferences/iopreferencesmodel.cpp
@@ -179,6 +179,26 @@ QStringList IOPreferencesModel::midiOutputDevices() const
     return list;
 }
 
+bool IOPreferencesModel::isMIDI20OutputSupported() const
+{
+    return midiOutPort()->supportsMIDI20Output();
+}
+
+bool IOPreferencesModel::useMIDI20Output() const
+{
+    return midiConfiguration()->useMIDI20Output();
+}
+
+void IOPreferencesModel::setUseMIDI20Output(bool use)
+{
+    if (use == useMIDI20Output()) {
+        return;
+    }
+
+    midiConfiguration()->setUseMIDI20Output(use);
+    emit useMIDI20OutputChanged();
+}
+
 mu::midi::MidiDeviceID IOPreferencesModel::midiInputDeviceId(int index) const
 {
     std::vector<MidiDevice> devices = midiInPort()->devices();

--- a/src/appshell/view/preferences/iopreferencesmodel.h
+++ b/src/appshell/view/preferences/iopreferencesmodel.h
@@ -51,6 +51,9 @@ class IOPreferencesModel : public QObject, public async::Asyncable
     Q_PROPERTY(
         int currentMidiOutputDeviceIndex READ currentMidiOutputDeviceIndex WRITE setCurrentMidiOutputDeviceIndex NOTIFY currentMidiOutputDeviceIndexChanged)
 
+    Q_PROPERTY(bool isMIDI20OutputSupported READ isMIDI20OutputSupported CONSTANT)
+    Q_PROPERTY(bool useMIDI20Output READ useMIDI20Output WRITE setUseMIDI20Output NOTIFY useMIDI20OutputChanged)
+
 public:
     explicit IOPreferencesModel(QObject* parent = nullptr);
 
@@ -67,10 +70,15 @@ public:
     QStringList midiInputDevices() const;
     QStringList midiOutputDevices() const;
 
+    bool isMIDI20OutputSupported() const;
+    bool useMIDI20Output() const;
+
 public slots:
     void setCurrentAudioApiIndex(int index);
     void setCurrentMidiInputDeviceIndex(int index);
     void setCurrentMidiOutputDeviceIndex(int index);
+
+    void setUseMIDI20Output(bool use);
 
 signals:
     void currentAudioApiIndexChanged(int index);
@@ -79,6 +87,8 @@ signals:
 
     void midiInputDevicesChanged();
     void midiOutputDevicesChanged();
+
+    void useMIDI20OutputChanged();
 
 private:
     midi::MidiDeviceID midiInputDeviceId(int index) const;

--- a/src/framework/midi/imidiconfiguration.h
+++ b/src/framework/midi/imidiconfiguration.h
@@ -45,6 +45,9 @@ public:
 
     virtual MidiDeviceID midiOutputDeviceId() const = 0;
     virtual void setMidiOutputDeviceId(const MidiDeviceID& deviceId) = 0;
+
+    virtual bool useMIDI20Output() const = 0;
+    virtual void setUseMIDI20Output(bool use) = 0;
 };
 }
 

--- a/src/framework/midi/imidioutport.h
+++ b/src/framework/midi/imidioutport.h
@@ -44,6 +44,10 @@ public:
     virtual bool isConnected() const = 0;
     virtual MidiDeviceID deviceID() const = 0;
 
+    // Whether the output port supports it, rather than whether the receiver supports it
+    // (If the receiver does not support MIDI 2.0, then it's the output port's resposibility to convert to MIDI 1.0)
+    virtual bool supportsMIDI20Output() const = 0;
+
     virtual Ret sendEvent(const Event& e) = 0;
 };
 }

--- a/src/framework/midi/internal/dummymidioutport.cpp
+++ b/src/framework/midi/internal/dummymidioutport.cpp
@@ -66,6 +66,11 @@ MidiDeviceID DummyMidiOutPort::deviceID() const
     return m_connectedDeviceID;
 }
 
+bool DummyMidiOutPort::supportsMIDI20Output() const
+{
+    return false;
+}
+
 mu::Ret DummyMidiOutPort::sendEvent(const Event& e)
 {
     if (!isConnected()) {

--- a/src/framework/midi/internal/dummymidioutport.h
+++ b/src/framework/midi/internal/dummymidioutport.h
@@ -39,6 +39,8 @@ public:
     bool isConnected() const override;
     MidiDeviceID deviceID() const override;
 
+    bool supportsMIDI20Output() const override;
+
     Ret sendEvent(const Event& e) override;
 
 private:

--- a/src/framework/midi/internal/midiconfiguration.cpp
+++ b/src/framework/midi/internal/midiconfiguration.cpp
@@ -31,12 +31,14 @@ static const std::string module_name("midi");
 static const Settings::Key USE_REMOTE_CONTROL_KEY(module_name, "io/midi/useRemoteControl");
 static const Settings::Key MIDI_INPUT_DEVICE_ID(module_name, "io/portMidi/inputDevice");
 static const Settings::Key MIDI_OUTPUT_DEVICE_ID(module_name, "io/portMidi/outputDevice");
+static const Settings::Key USE_MIDI20_OUTPUT_KEY(module_name, "io/midi/useMIDI20Output");
 
 void MidiConfiguration::init()
 {
     settings()->setDefaultValue(USE_REMOTE_CONTROL_KEY, Val(true));
     settings()->setDefaultValue(MIDI_INPUT_DEVICE_ID, Val(""));
     settings()->setDefaultValue(MIDI_OUTPUT_DEVICE_ID, Val(""));
+    settings()->setDefaultValue(USE_MIDI20_OUTPUT_KEY, Val(true));
 }
 
 bool MidiConfiguration::useRemoteControl() const
@@ -67,4 +69,14 @@ MidiDeviceID MidiConfiguration::midiOutputDeviceId() const
 void MidiConfiguration::setMidiOutputDeviceId(const MidiDeviceID& deviceId)
 {
     settings()->setSharedValue(MIDI_OUTPUT_DEVICE_ID, Val(deviceId));
+}
+
+bool MidiConfiguration::useMIDI20Output() const
+{
+    return settings()->value(USE_MIDI20_OUTPUT_KEY).toBool();
+}
+
+void MidiConfiguration::setUseMIDI20Output(bool use)
+{
+    settings()->setSharedValue(USE_MIDI20_OUTPUT_KEY, Val(use));
 }

--- a/src/framework/midi/internal/midiconfiguration.h
+++ b/src/framework/midi/internal/midiconfiguration.h
@@ -38,6 +38,9 @@ public:
 
     MidiDeviceID midiOutputDeviceId() const override;
     void setMidiOutputDeviceId(const MidiDeviceID& deviceId) override;
+
+    bool useMIDI20Output() const override;
+    void setUseMIDI20Output(bool use) override;
 };
 }
 

--- a/src/framework/midi/internal/platform/lin/alsamidioutport.cpp
+++ b/src/framework/midi/internal/platform/lin/alsamidioutport.cpp
@@ -188,6 +188,11 @@ MidiDeviceID AlsaMidiOutPort::deviceID() const
     return m_deviceID;
 }
 
+bool AlsaMidiOutPort::supportsMIDI20Output() const
+{
+    return false;
+}
+
 mu::Ret AlsaMidiOutPort::sendEvent(const Event& e)
 {
     // LOGI() << e.to_string();

--- a/src/framework/midi/internal/platform/lin/alsamidioutport.h
+++ b/src/framework/midi/internal/platform/lin/alsamidioutport.h
@@ -45,6 +45,8 @@ public:
     bool isConnected() const override;
     MidiDeviceID deviceID() const override;
 
+    bool supportsMIDI20Output() const override;
+
     Ret sendEvent(const Event& e) override;
 
 private:

--- a/src/framework/midi/internal/platform/osx/coremidiinport.cpp
+++ b/src/framework/midi/internal/platform/osx/coremidiinport.cpp
@@ -110,33 +110,51 @@ void CoreMidiInPort::initCore()
 
         switch (notification->messageID) {
         case kMIDIMsgObjectAdded:
-        case kMIDIMsgObjectRemoved:
-            if (notification->messageSize == sizeof(MIDIObjectAddRemoveNotification)) {
-                auto addRemoveNotification = (const MIDIObjectAddRemoveNotification*)notification;
-                MIDIObjectType objectType = addRemoveNotification->childType;
-
-                if (objectType == kMIDIObjectType_Source) {
-                    if (notification->messageID == kMIDIMsgObjectRemoved) {
-                        MIDIObjectRef removedObject = addRemoveNotification->child;
-
-                        if (self->isConnected() && removedObject == self->m_core->sourceId) {
-                            self->disconnect();
-                        }
-                    }
-
-                    self->devicesChanged().notify();
-                }
-            } else {
+        case kMIDIMsgObjectRemoved: {
+            if (notification->messageSize != sizeof(MIDIObjectAddRemoveNotification)) {
                 LOGW() << "Received corrupted MIDIObjectAddRemoveNotification";
+                break;
             }
-            break;
+
+            auto addRemoveNotification = (const MIDIObjectAddRemoveNotification*)notification;
+
+            if (addRemoveNotification->childType != kMIDIObjectType_Source) {
+                break;
+            }
+
+            if (notification->messageID == kMIDIMsgObjectRemoved) {
+                MIDIObjectRef removedObject = addRemoveNotification->child;
+
+                if (self->isConnected() && removedObject == self->m_core->sourceId) {
+                    self->disconnect();
+                }
+            }
+
+            self->devicesChanged().notify();
+        } break;
+
+        case kMIDIMsgPropertyChanged: {
+            if (notification->messageSize != sizeof(MIDIObjectPropertyChangeNotification)) {
+                LOGW() << "Received corrupted MIDIObjectPropertyChangeNotification";
+                break;
+            }
+
+            auto propertyChangeNotification = (const MIDIObjectPropertyChangeNotification*)notification;
+
+            if (propertyChangeNotification->objectType != kMIDIObjectType_Device
+                && propertyChangeNotification->objectType != kMIDIObjectType_Source) {
+                break;
+            }
+
+            if (CFStringCompare(propertyChangeNotification->propertyName, kMIDIPropertyDisplayName, 0) == kCFCompareEqualTo
+                || CFStringCompare(propertyChangeNotification->propertyName, kMIDIPropertyName, 0) == kCFCompareEqualTo) {
+                self->devicesChanged().notify();
+            }
+        } break;
 
         // General message that should be ignored because we handle specific ones
         case kMIDIMsgSetupChanged:
 
-        // Questionable whether we should send a notification for this ones
-        // Possibly we should send a notification when the changed property is the device name
-        case kMIDIMsgPropertyChanged:
         case kMIDIMsgThruConnectionsChanged:
         case kMIDIMsgSerialPortOwnerChanged:
 

--- a/src/framework/midi/internal/platform/osx/coremidiinport.cpp
+++ b/src/framework/midi/internal/platform/osx/coremidiinport.cpp
@@ -68,8 +68,8 @@ MidiDeviceList CoreMidiInPort::devices() const
     MidiDeviceList ret;
 
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, false);
-    int sources = MIDIGetNumberOfSources();
-    for (int sourceIndex = 0; sourceIndex <= sources; sourceIndex++) {
+    ItemCount sources = MIDIGetNumberOfSources();
+    for (ItemCount sourceIndex = 0; sourceIndex <= sources; sourceIndex++) {
         MIDIEndpointRef sourceRef = MIDIGetSource(sourceIndex);
         if (sourceRef != 0) {
             CFStringRef stringRef = 0;
@@ -161,7 +161,7 @@ void CoreMidiInPort::initCore()
                 if (packet->wordCount != 0 && packet->wordCount <= 4) {
                     Event e = Event::fromRawData(packet->words, packet->wordCount);
                     if (e) {
-                        m_eventReceived.send(packet->timeStamp, e);
+                        m_eventReceived.send((tick_t)packet->timeStamp, e);
                     }
                 } else if (packet->wordCount > 4) {
                     LOGW() << "unsupported midi message size " << packet->wordCount << " bytes";
@@ -184,7 +184,7 @@ void CoreMidiInPort::initCore()
 
                     auto e = Event::fromMIDI10Package(message).toMIDI20();
                     if (e) {
-                        m_eventReceived.send(packet->timeStamp, e);
+                        m_eventReceived.send((tick_t)packet->timeStamp, e);
                     }
                 } else if (packet->length > 4) {
                     LOGW() << "unsupported midi message size " << packet->length << " bytes";

--- a/src/framework/midi/internal/platform/osx/coremidioutport.cpp
+++ b/src/framework/midi/internal/platform/osx/coremidioutport.cpp
@@ -242,6 +242,15 @@ std::string CoreMidiOutPort::deviceID() const
     return m_deviceID;
 }
 
+bool CoreMidiOutPort::supportsMIDI20Output() const
+{
+    if (__builtin_available(macOS 11.0, *)) {
+        return true;
+    }
+
+    return false;
+}
+
 static ByteCount packetListSize(const std::vector<Event>& events)
 {
     if (events.empty()) {
@@ -264,8 +273,10 @@ mu::Ret CoreMidiOutPort::sendEvent(const Event& e)
     MIDITimeStamp timeStamp = AudioGetCurrentHostTime();
 
     if (__builtin_available(macOS 11.0, *)) {
+        MIDIProtocolID protocolId = configuration()->useMIDI20Output() ? m_core->destinationProtocolId : kMIDIProtocol_1_0;
+
         MIDIEventList eventList;
-        MIDIEventPacket* packet = MIDIEventListInit(&eventList, m_core->destinationProtocolId);
+        MIDIEventPacket* packet = MIDIEventListInit(&eventList, protocolId);
         // TODO: Replace '4' with something specific for the type of element?
         MIDIEventListAdd(&eventList, sizeof(eventList), packet, timeStamp, 4, e.rawData());
 

--- a/src/framework/midi/internal/platform/osx/coremidioutport.cpp
+++ b/src/framework/midi/internal/platform/osx/coremidioutport.cpp
@@ -75,33 +75,51 @@ void CoreMidiOutPort::initCore()
 
         switch (notification->messageID) {
         case kMIDIMsgObjectAdded:
-        case kMIDIMsgObjectRemoved:
-            if (notification->messageSize == sizeof(MIDIObjectAddRemoveNotification)) {
-                auto addRemoveNotification = (const MIDIObjectAddRemoveNotification*)notification;
-                MIDIObjectType objectType = addRemoveNotification->childType;
-
-                if (objectType == kMIDIObjectType_Destination) {
-                    if (notification->messageID == kMIDIMsgObjectRemoved) {
-                        MIDIObjectRef removedObject = addRemoveNotification->child;
-
-                        if (self->isConnected() && removedObject == self->m_core->destinationId) {
-                            self->disconnect();
-                        }
-                    }
-
-                    self->devicesChanged().notify();
-                }
-            } else {
+        case kMIDIMsgObjectRemoved: {
+            if (notification->messageSize != sizeof(MIDIObjectAddRemoveNotification)) {
                 LOGW() << "Received corrupted MIDIObjectAddRemoveNotification";
+                break;
             }
-            break;
+
+            auto addRemoveNotification = (const MIDIObjectAddRemoveNotification*)notification;
+
+            if (addRemoveNotification->childType != kMIDIObjectType_Destination) {
+                break;
+            }
+
+            if (notification->messageID == kMIDIMsgObjectRemoved) {
+                MIDIObjectRef removedObject = addRemoveNotification->child;
+
+                if (self->isConnected() && removedObject == self->m_core->destinationId) {
+                    self->disconnect();
+                }
+            }
+
+            self->devicesChanged().notify();
+        } break;
+
+        case kMIDIMsgPropertyChanged: {
+            if (notification->messageSize != sizeof(MIDIObjectPropertyChangeNotification)) {
+                LOGW() << "Received corrupted MIDIObjectPropertyChangeNotification";
+                break;
+            }
+
+            auto propertyChangeNotification = (const MIDIObjectPropertyChangeNotification*)notification;
+
+            if (propertyChangeNotification->objectType != kMIDIObjectType_Device
+                && propertyChangeNotification->objectType != kMIDIObjectType_Destination) {
+                break;
+            }
+
+            if (CFStringCompare(propertyChangeNotification->propertyName, kMIDIPropertyDisplayName, 0) == kCFCompareEqualTo
+                || CFStringCompare(propertyChangeNotification->propertyName, kMIDIPropertyName, 0) == kCFCompareEqualTo) {
+                self->devicesChanged().notify();
+            }
+        } break;
 
         // General message that should be ignored because we handle specific ones
         case kMIDIMsgSetupChanged:
 
-        // Questionable whether we should send a notification for this ones
-        // Possibly we should send a notification when the changed property is the device name
-        case kMIDIMsgPropertyChanged:
         case kMIDIMsgThruConnectionsChanged:
         case kMIDIMsgSerialPortOwnerChanged:
 

--- a/src/framework/midi/internal/platform/osx/coremidioutport.cpp
+++ b/src/framework/midi/internal/platform/osx/coremidioutport.cpp
@@ -129,8 +129,8 @@ MidiDeviceList CoreMidiOutPort::devices() const
     MidiDeviceList ret;
 
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, false);
-    int destinations = MIDIGetNumberOfDestinations();
-    for (int destIndex = 0; destIndex <= destinations; destIndex++) {
+    ItemCount destinations = MIDIGetNumberOfDestinations();
+    for (ItemCount destIndex = 0; destIndex <= destinations; destIndex++) {
         MIDIEndpointRef destRef = MIDIGetDestination(destIndex);
         if (destRef != 0) {
             CFStringRef stringRef = nullptr;

--- a/src/framework/midi/internal/platform/osx/coremidioutport.h
+++ b/src/framework/midi/internal/platform/osx/coremidioutport.h
@@ -47,6 +47,7 @@ public:
 
 private:
     void initCore();
+    void getDestinationProtocolId();
 
     struct Core;
     std::unique_ptr<Core> m_core;

--- a/src/framework/midi/internal/platform/osx/coremidioutport.h
+++ b/src/framework/midi/internal/platform/osx/coremidioutport.h
@@ -26,9 +26,14 @@
 
 #include "midi/imidioutport.h"
 
+#include "modularity/ioc.h"
+#include "imidiconfiguration.h"
+
 namespace mu::midi {
 class CoreMidiOutPort : public IMidiOutPort
 {
+    INJECT(midi, IMidiConfiguration, configuration)
+
 public:
     CoreMidiOutPort();
     ~CoreMidiOutPort() override;
@@ -42,6 +47,8 @@ public:
     void disconnect() override;
     bool isConnected() const override;
     MidiDeviceID deviceID() const override;
+
+    bool supportsMIDI20Output() const override;
 
     Ret sendEvent(const Event& e) override;
 

--- a/src/framework/midi/internal/platform/win/winmidioutport.cpp
+++ b/src/framework/midi/internal/platform/win/winmidioutport.cpp
@@ -149,6 +149,11 @@ MidiDeviceID WinMidiOutPort::deviceID() const
     return m_deviceID;
 }
 
+bool WinMidiOutPort::supportsMIDI20Output() const
+{
+    return false;
+}
+
 mu::Ret WinMidiOutPort::sendEvent(const Event& e)
 {
     if (!isConnected()) {

--- a/src/framework/midi/internal/platform/win/winmidioutport.h
+++ b/src/framework/midi/internal/platform/win/winmidioutport.h
@@ -45,6 +45,8 @@ public:
     bool isConnected() const override;
     MidiDeviceID deviceID() const override;
 
+    bool supportsMIDI20Output() const override;
+
     Ret sendEvent(const Event& e) override;
 
 private:

--- a/src/framework/midi/midievent.h
+++ b/src/framework/midi/midievent.h
@@ -647,9 +647,9 @@ struct Event {
     }
 
     //!convert ChannelVoice from MIDI2.0 to MIDI1.0
-    std::list<Event> toMIDI10() const
+    std::vector<Event> toMIDI10() const
     {
-        std::list<Event> events;
+        std::vector<Event> events;
         switch (messageType()) {
         case MessageType::ChannelVoice10: events.push_back(*this);
             break;
@@ -685,7 +685,7 @@ struct Event {
             //D2.3
             case Opcode::AssignableController:
             case Opcode::RegisteredController: {
-                std::list<std::pair<uint8_t, uint8_t> > controlChanges = {
+                std::vector<std::pair<uint8_t, uint8_t> > controlChanges = {
                     { (opcode() == Opcode::RegisteredController ? 101 : 99), bank() },
                     { (opcode() == Opcode::RegisteredController ? 100 : 98), index() },
                     { 6,  (data() & 0x7FFFFFFF) >> 24 },


### PR DESCRIPTION
- fix some integer type mismatch warnings
- calculate the proper size for MIDIPacketLists on macOS 10.15 and earlier
- listen for device name changes (if the name of a device changes, update the UI in Preferences)
- on macOS 11.0 and later:
    - correct the given size for messages (instead of byte count, e.g. `4 * sizeof(UInt32)`, we should pass word count, e.g. `4`)
    - if the connected receiver does not support the MIDI 2.0 protocol, use the MIDI 1.0 protocol
    - add an option to disable the use of MIDI 2.0 protocol even when the receiver reports that it supports it (see commit message for why this is useful)
        <img width="992" alt="Schermafbeelding 2022-07-09 om 18 41 16" src="https://user-images.githubusercontent.com/48658420/178114996-e625ae8b-7cd6-4cc7-99b3-ba7da5922a71.png">
