### PR TITLE
[MU4] Fix #12235: Reordering instruments in Instruments panel only works in one direction (Parts)

### DIFF
--- a/src/instrumentsscene/view/roottreeitem.cpp
+++ b/src/instrumentsscene/view/roottreeitem.cpp
@@ -40,7 +40,11 @@ void RootTreeItem::moveChildren(int sourceRow, int count, AbstractInstrumentsPan
     IDList partIds;
 
     for (int i = sourceRow; i < sourceRow + count; ++i) {
-        partIds.push_back(childAtRow(i)->id());
+        ID partId = childAtRow(i)->id();
+
+        if (notation()->parts()->partExists(partId)) {
+            partIds.push_back(partId);
+        }
     }
 
     int destinationRow_ = destinationRow;

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -851,6 +851,8 @@ void NotationParts::removeStaves(const IDList& stavesIds)
 
 void NotationParts::moveParts(const IDList& sourcePartsIds, const ID& destinationPartId, InsertMode mode)
 {
+    TRACEFUNC;
+
     std::vector<Part*> sourceParts = parts(sourcePartsIds);
     if (sourceParts.empty()) {
         return;
@@ -865,16 +867,17 @@ void NotationParts::moveParts(const IDList& sourcePartsIds, const ID& destinatio
         return;
     }
 
-    TRACEFUNC;
+    for (const ID& sourcePartId: sourcePartsIds) {
+        allScorePartIds.removeOne(sourcePartId);
+    }
 
-    for (const Part* sourcePart: sourceParts) {
-        int srcIndex = allScorePartIds.indexOf(sourcePart->id());
-        int dstIndex = allScorePartIds.indexOf(destinationPartId);
-        dstIndex += (mode == InsertMode::Before) && (srcIndex < dstIndex) ? -1 : 0;
+    int dstIndex = allScorePartIds.indexOf(destinationPartId);
+    if (mode == InsertMode::After) {
+        dstIndex++;
+    }
 
-        if (dstIndex >= 0 && dstIndex < allScorePartIds.size()) {
-            allScorePartIds.move(srcIndex, dstIndex);
-        }
+    for (size_t i = 0; i < sourcePartsIds.size(); ++i, ++dstIndex) {
+        allScorePartIds.insert(dstIndex, sourcePartsIds[i]);
     }
 
     PartInstrumentList parts;
@@ -889,7 +892,6 @@ void NotationParts::moveParts(const IDList& sourcePartsIds, const ID& destinatio
     startEdit();
 
     sortParts(parts, score()->staves());
-
     setBracketsAndBarlines();
 
     apply();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/12235