### PR TITLE
Accessibility: Improve speech output for notes and common elements

### DIFF
--- a/src/engraving/libmscore/chordrest.cpp
+++ b/src/engraving/libmscore/chordrest.cpp
@@ -683,7 +683,8 @@ String ChordRest::durationUserName() const
             tupletType = mtrc("engraving", "Nonuplet");
             break;
         default:
-            tupletType = mtrc("engraving", "Custom tuplet");
+            //: %1 is tuplet ratio numerator (i.e. the number of notes in the tuplet)
+            tupletType = mtrc("engraving", "%1 note tuplet").arg(tuplet()->ratio().numerator());
         }
     }
     String dotString;

--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -3332,7 +3332,15 @@ String Note::screenReaderInfo() const
         pitchName = mtrc("engraving", "%1; String: %2; Fret: %3")
                     .arg(tpcUserName(true), String::number(string() + 1), String::number(fret()));
     } else {
-        pitchName = tpcUserName(true);
+        pitchName = _headGroup == NoteHeadGroup::HEAD_NORMAL
+                    ? tpcUserName(true)
+                    //: head as in note head. %1 is head type (circle, cross, etc.). %2 is pitch (e.g. Db4).
+                    : mtrc("engraving", "%1 head %2").arg(subtypeName()).arg(tpcUserName(true));
+        if (chord()->staffMove() < 0) {
+            duration += u"; " + mtrc("engraving", "Cross-staff above");
+        } else if (chord()->staffMove() > 0) {
+            duration += u"; " + mtrc("engraving", "Cross-staff below");
+        }
     }
     return String(u"%1 %2 %3%4").arg(noteTypeUserName(), pitchName, duration, (chord()->isGrace() ? u"" : String(u"; %1").arg(voice)));
 }

--- a/src/engraving/libmscore/rest.cpp
+++ b/src/engraving/libmscore/rest.cpp
@@ -863,8 +863,14 @@ String Rest::screenReaderInfo() const
 {
     Measure* m = measure();
     bool voices = m ? m->hasVoices(staffIdx()) : false;
-    String voice = voices ? mtrc("engraving", "Voice: %1").arg(track() % VOICES + 1) : u"";
-    return String(u"%1 %2 %3").arg(EngravingItem::accessibleInfo(), durationUserName(), voice);
+    String voice = voices ? (u"; " + mtrc("engraving", "Voice: %1").arg(track() % VOICES + 1)) : u"";
+    String crossStaff;
+    if (staffMove() < 0) {
+        crossStaff = u"; " + mtrc("engraving", "Cross-staff above");
+    } else if (staffMove() > 0) {
+        crossStaff = u"; " + mtrc("engraving", "Cross-staff below");
+    }
+    return String(u"%1 %2%3%4").arg(EngravingItem::accessibleInfo(), durationUserName(), crossStaff, voice);
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Screen readers will now announce:

- Accidentals in note names (e.g. "A♯", "B♭", etc.).

- [Fix [MU#312625](https://musescore.org/en/node/312625)] Notehead group type (e.g. "cross", "triangle", etc.).

- [Fix [MU#312628](https://musescore.org/en/node/312628)] When notes or rests use cross-staff notation.

- [Fix [MU#312627](https://musescore.org/en/node/312627)] When elements are invisible.

- [Fix [MU#307442](https://musescore.org/en/node/307442)] Tuplet length for custom tuplets (more than 9 notes).

Replaces PR #8877.