### PR TITLE
[MU4] Fix MSVC/MinGW Compiler warnings

### DIFF
--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -271,6 +271,7 @@ void ApplicationActionController::checkForUpdate()
 
 bool ApplicationActionController::canReceiveAction(const mu::actions::ActionCode& code) const
 {
+    Q_UNUSED(code);
     auto focus = QGuiApplication::focusWindow();
     return !focus || focus->modality() == Qt::WindowModality::NonModal;
 }

--- a/src/engraving/libmscore/stretchedbend.cpp
+++ b/src/engraving/libmscore/stretchedbend.cpp
@@ -397,7 +397,7 @@ void StretchedBend::glueNeighbor()
             auto bend = t->bend();
 
             auto& lastPoints = bend->points();
-            for (int i = 1; i < lastPoints.size(); ++i) {
+            for (size_t i = 1; i < lastPoints.size(); ++i) {
                 m_points.push_back(lastPoints[i]);
             }
 

--- a/src/engraving/libmscore/stretchedbend.cpp
+++ b/src/engraving/libmscore/stretchedbend.cpp
@@ -92,7 +92,6 @@ void StretchedBend::fillSegments()
 
     PointF dest(0, 0);
 
-    int firstPointPitch = m_points.front().pitch;
     int lastPointPitch = m_points.back().pitch;
     m_releasedToInitial = (0 == lastPointPitch);
 
@@ -111,7 +110,6 @@ void StretchedBend::fillSegments()
 
         BendSegmentType type = BendSegmentType::NO_TYPE;
         int tone = bendTone(nextPitch);
-        bool untilNextSegment = false;
 
         /// PRE-BEND (+BEND, +RELEASE)
         if (pt == 0 && pitch != 0) {
@@ -232,8 +230,6 @@ void StretchedBend::layoutDraw(const bool layoutMode, mu::draw::Painter* painter
     if (!layoutMode && !painter) {
         return;
     }
-
-    double prebendStrokeLength = m_spatium * .5;
 
     for (const BendSegment& bendSegment : m_bendSegments) {
         const PointF& src = bendSegment.src;

--- a/src/engraving/libmscore/tremolo.cpp
+++ b/src/engraving/libmscore/tremolo.cpp
@@ -312,6 +312,7 @@ void Tremolo::layoutOneNoteTremolo(double x, double y, double h, double spatium)
 
 void Tremolo::layoutTwoNotesTremolo(double x, double y, double h, double spatium)
 {
+    Q_UNUSED(h);
     const bool defaultStyle = (!customStyleApplicable()) || (_style == TremoloStyle::DEFAULT);
     const bool isTraditionalAlternate = (_style == TremoloStyle::TRADITIONAL_ALTERNATE);
 

--- a/src/importexport/guitarpro/internal/importptb.cpp
+++ b/src/importexport/guitarpro/internal/importptb.cpp
@@ -445,7 +445,7 @@ void PowerTab::readPosition(int staff, int voice, ptSection& sec)
 
     ptBeat* beat{ nullptr };
     bool add = false;
-    if (voice == 0 || staff >= sec.beats.size() || sec.beats[staff].empty()) {
+    if (voice == 0 || staff >= static_cast<int>(sec.beats.size()) || sec.beats[staff].empty()) {
         beat = new ptBeat(staff, voice);
         beat->position = position;
         add = true;


### PR DESCRIPTION
* Fix MSCV/MinGW compiler warnings
    * reg. unused parameters
    * reg. unused variables
* Fix MinGW compiler warnings
    * reg comparison of integer expressions of different signedness: 'int' and 'size_type' {-Wsign-compare)