### PR TITLE
Fix issues with applying SMuFL engravingDefaults after switching score fonts

### DIFF
--- a/src/engraving/libmscore/barline.cpp
+++ b/src/engraving/libmscore/barline.cpp
@@ -499,18 +499,24 @@ void BarLine::drawDots(Painter* painter, double x) const
     } else {
         const StaffType* st = staffType();
 
-        //workaround to make new Bravura, Petaluma and Leland font work correctly with repeatDots
-        double offset
-            = (score()->scoreFont()->name() == "Leland" || score()->scoreFont()->name() == "Bravura"
-               || score()->scoreFont()->name() == "Petaluma") ? 0 : 0.5 * score()->spatium() * mag();
-        y1l          = st->doty1() * _spatium + offset;
-        y2l          = st->doty2() * _spatium + offset;
+        y1l = st->doty1() * _spatium;
+        y2l = st->doty2() * _spatium;
+
+        //workaround to make Bravura, Petaluma and Leland font work correctly with repeatDots
+        if (!(score()->scoreFont()->name() == "Leland"
+              || score()->scoreFont()->name() == "Bravura"
+              || score()->scoreFont()->name() == "Petaluma")) {
+            double offset = 0.5 * score()->spatium() * mag();
+            y1l += offset;
+            y2l += offset;
+        }
 
         //adjust for staffType offset
         double stYOffset = st->yoffset().val() * _spatium;
-        y1l             += stYOffset;
-        y2l             += stYOffset;
+        y1l += stYOffset;
+        y2l += stYOffset;
     }
+
     drawSymbol(SymId::repeatDot, painter, PointF(x, y1l));
     drawSymbol(SymId::repeatDot, painter, PointF(x, y2l));
 }

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -2046,31 +2046,8 @@ void EditStyle::valueChanged(int i)
             for (auto j : scoreFont->engravingDefaults()) {
                 setStyleValue(j.first, j.second);
             }
-
-            // fix values, the distances are defined different in MuseScore
-            double barWidthD = styleValue(StyleId::barWidth).toDouble() + styleValue(StyleId::endBarWidth).toDouble() * .5;
-
-            double newEndBarDistance = styleValue(StyleId::endBarDistance).toDouble() + barWidthD;
-            setStyleValue(StyleId::endBarDistance, newEndBarDistance);
-
-            double newDoubleBarDistance = styleValue(StyleId::doubleBarDistance).toDouble() + barWidthD;
-            setStyleValue(StyleId::doubleBarDistance, newDoubleBarDistance);
-
-            // guess the repeat dot width = spatium * .3
-            double newRepeatBarlineDotSeparation = styleValue(StyleId::repeatBarlineDotSeparation).toDouble()
-                                                   + (styleValue(StyleId::barWidth).toDouble() + .3) * .5;
-            setStyleValue(StyleId::repeatBarlineDotSeparation, newRepeatBarlineDotSeparation);
-
-            // adjust mmrest, which is not in engravingDefaults
-            // TODO: create generalized method for setting style vals based on font
-            if (scoreFont->name() == "Bravura") {
-                setStyleValue(StyleId::mmRestHBarThickness, 1.0);
-                setStyleValue(StyleId::multiMeasureRestMargin, 3.0);
-            } else {
-                setStyleValue(StyleId::mmRestHBarThickness, defaultStyleValue(StyleId::mmRestHBarThickness));
-                setStyleValue(StyleId::multiMeasureRestMargin, defaultStyleValue(StyleId::multiMeasureRestMargin));
-            }
         }
+
         setValue = true;
     }
 


### PR DESCRIPTION
- update the `SMuFL engravingDefaults` -> `MuseScore style settings` mapping with the latest SMuFL spec (1.4, which we are supporting), while trying to keep compatibility with fonts designed according to older versions of the spec
- fix a case where one SMuFL engravingDefaults key would point to multiple MuseScore style settings
- fix applying SMuFL engraving defaults after switching score fonts in EditStyle
    in particular, this issue: (look at the end barline)

    https://user-images.githubusercontent.com/48658420/178344335-2a87dcca-b011-4c8a-8750-ec9bd5c308a4.mov