### PR TITLE
Ottava symbols should be taken from the music symbols font

### DIFF
--- a/src/engraving/libmscore/ottava.cpp
+++ b/src/engraving/libmscore/ottava.cpp
@@ -72,6 +72,7 @@ static const ElementStyle ottavaStyle {
 OttavaSegment::OttavaSegment(Ottava* sp, System* parent)
     : TextLineBaseSegment(ElementType::OTTAVA_SEGMENT, sp, parent, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
 {
+    _text->setTextStyleType(TextStyleType::OTTAVA);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -791,7 +791,7 @@ mu::draw::Font TextFragment::font(const TextBase* t) const
 
     String family;
     if (format.fontFamily() == "ScoreText") {
-        if (t->isDynamic()) {
+        if (t->isDynamic() || t->textStyleType() == TextStyleType::OTTAVA) {
             family = t->score()->scoreFont()->fontByName(t->score()->styleSt(Sid::MusicalSymbolFont))->family();
             // to keep desired size ratio (based on 20pt symbol size to 10pt text size)
             m *= 2;


### PR DESCRIPTION
The issue came out of this [discussion](https://github.com/musescore/MuseScore/pull/12203).

Currently, we are taking the Ottava symbols from the music text font. Leland text doesn't have those symbols, which causes it to fall back to Bravura. And with the other fonts, such as Finale Maestro, the font size is incorrect (because it takes the 10pt from the text definition, but should be 20pt like the rest of the music symbols). 
This PR ensures that Ottava symbols are taken instead from the music symbol fonts and are set to the correct size.

@oktophonie @Tantacrul 

PS: there is another issue with Ottava lines (actually, with text lines in general), namely that the settings from Style->Text Styles->Text lines (or Ottava) have no effect, i.e. they seem to be entirely disconnected. I did try to briefly look at it, but this PR does not fix that. The problem also seems to be present in 3.6.
