### PR TITLE
Tempo text: correct wrong offset position

### DIFF
--- a/src/engraving/libmscore/tempotext.cpp
+++ b/src/engraving/libmscore/tempotext.cpp
@@ -452,7 +452,7 @@ void TempoText::layout()
     if (autoplace() && s->rtick().isZero()) {
         Segment* p = segment()->prev(SegmentType::TimeSig);
         if (p) {
-            movePosX(-s->x() - p->x());
+            movePosX(-(s->x() - p->x()));
             EngravingItem* e = p->element(staffIdx() * VOICES);
             if (e) {
                 movePosX(e->x());


### PR DESCRIPTION
Resolves: #12252 
Seems like it was just missing parenthesis.

Before:
<img width="569" alt="image" src="https://user-images.githubusercontent.com/93707756/178672781-4cfcb7a6-3387-4ec2-baaf-b5865674c47a.png">

After:
<img width="651" alt="image" src="https://user-images.githubusercontent.com/93707756/178672613-48ebd40e-54ac-47a0-b815-846d636a4d98.png">
