### PR TITLE
Avoid huge cursor when editing dynamics text

### DIFF
--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -256,6 +256,10 @@ RectF TextCursor::cursorRect() const
     const TextFragment* fragment = tline.fragment(static_cast<int>(column()));
 
     mu::draw::Font _font  = fragment ? fragment->font(_text) : _text->font();
+    if (_font.family() == _text->score()->styleSt(Sid::MusicalSymbolFont)) {
+        _font.setFamily(_text->score()->styleSt(Sid::MusicalTextFont));
+        _font.setPointSizeF(fragment->format.fontSize());
+    }
     double ascent = mu::draw::FontMetrics::ascent(_font);
     double h = ascent;
     double x = tline.xpos(column(), _text);


### PR DESCRIPTION
Resolves: #11173 

In some cases (such as dynamics), symbols from the music font are used within blocks of text. The cursor then wants to adapt itself to the maximum height of the font in use, but in the case of the music font this means it becomes huge (see issue).
This PR ensures that the size of the cursor is always related to the text font.

@oktophonie @Tantacrul 
