### PR TITLE
[MU4] Fix slur endpoint collision problems

### DIFF
--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -1281,13 +1281,14 @@ void LayoutSystem::processLines(System* system, std::vector<Spanner*> lines, boo
                 }
                 if (seg2->isSlurSegment()) {
                     SlurSegment* slur2 = toSlurSegment(seg2);
-                    if (slur1->slur()->endChord() == slur2->slur()->startChord()) {
+                    if (slur1->slur()->endChord() == slur2->slur()->startChord()
+                        && compare(slur1->ups(Grip::END).p.y(), slur2->ups(Grip::START).p.y())) {
                         slur1->ups(Grip::END).p.rx() -= slurCollisionHorizOffset;
                         slur2->ups(Grip::START).p.rx() += slurCollisionHorizOffset;
                         slur1->computeBezier();
                         slur2->computeBezier();
+                        continue;
                     }
-                    continue;
                 }
                 SlurTieSegment* slurTie2 = toSlurTieSegment(seg2);
 

--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -1382,9 +1382,11 @@ SpannerSegment* Slur::layoutSystem(System* system)
             if (!adjustedVertically && sc->notes()[0]->tieBack() && !sc->notes()[0]->tieBack()->isInside()
                 && sc->notes()[0]->tieBack()->up() == up()) {
                 // there is a tie that ends on this chordrest
-                //tie = sc->notes()[0]->tieBack();
-                //endPoint = tie->segmentAt(0)->ups(Grip::END).pos();
-                p1.rx() += horizontalTieClearance;
+                tie = sc->notes()[0]->tieBack();
+                endPoint = tie->segmentAt(tie->nsegments() - 1)->ups(Grip::END).pos();
+                if (abs(endPoint.y() - p1.y()) < tieClearance) {
+                    p1.rx() += horizontalTieClearance;
+                }
             }
         }
     } else if (sst == SpannerSegmentType::END || sst == SpannerSegmentType::MIDDLE) {


### PR DESCRIPTION
There were a few situations where slurs would either unnecessarily adjust, or not adjust when necessary:
![image](https://user-images.githubusercontent.com/89263931/178846119-c158cfd2-30ae-414e-88ed-6e2ea023d61f.png)
![image](https://user-images.githubusercontent.com/89263931/178846176-f43dd8d5-ef28-4f62-8834-21380e1db8d7.png)

These cases have now been fixed:
![image](https://user-images.githubusercontent.com/89263931/178846564-77f6324f-177d-441e-84f8-92ba100b7bc8.png)
