### PR TITLE
Only add middle line slant if the beam is not supposed to be flat

### DIFF
--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -94,6 +94,7 @@ class Beam final : public EngravingItem
 
     int getMiddleStaffLine(ChordRest* startChord, ChordRest* endChord, int staffLines) const;
     int computeDesiredSlant(int startNote, int endNote, int middleLine, int dictator, int pointer) const;
+    int isSlopeConstrained(int startNote, int endNote) const;
     int getMaxSlope() const;
     int getBeamCount(std::vector<ChordRest*> chordRests) const;
     void offsetBeamToRemoveCollisions(std::vector<ChordRest*> chordRests, int& dictator, int& pointer, const double startX,


### PR DESCRIPTION
There were a few cases where beams that should be completely horizontal would not be:
![image](https://user-images.githubusercontent.com/89263931/178847213-d8cfd794-6bc1-4037-9d25-e5d7f0ae6f2b.png)

For the curious, the reason this beam would not be horizontal is because there is a note closer to the beam than the two endpoints. 

This bug was due to a a situation where a beam was extended to the middle line for both anchors. In this situation, a small slant through the middle line would happen to maintain the slope of the notes themselves. However, it was not keeping in mind the fact that the beam should in this case have remained flat and ignored the slope of the start and end chords.