### PR TITLE
fixed #12384: Fixed ampersands in translations

### DIFF
--- a/share/locale/musescore_de.ts
+++ b/share/locale/musescore_de.ts
@@ -512,7 +512,7 @@ erkennen</translation>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="47"/>
         <source>Save</source>
-        <translation>&amp;Speichern</translation>
+        <translation>Speichern</translation>
     </message>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="48"/>
@@ -537,7 +537,7 @@ erkennen</translation>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="78"/>
         <source>Export…</source>
-        <translation>&amp;Export…</translation>
+        <translation>Export…</translation>
     </message>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="79"/>
@@ -612,7 +612,7 @@ erkennen</translation>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="95"/>
         <source>Print…</source>
-        <translation>&amp;Drucken…</translation>
+        <translation>Drucken…</translation>
     </message>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="101"/>
@@ -15118,7 +15118,7 @@ fehlgeschlagen: %2</translation>
     <message>
         <location filename="../../src/project/qml/MuseScore/Project/SaveToCloudDialog.qml" line="195"/>
         <source>Save</source>
-        <translation>&amp;Speichern</translation>
+        <translation>Speichern</translation>
     </message>
     <message>
         <location filename="../../src/project/qml/MuseScore/Project/ScoresPage.qml" line="82"/>
@@ -19203,7 +19203,7 @@ assign it to this function.</source>
     <message>
         <location filename="../../src/framework/global/internal/interactive.cpp" line="84"/>
         <source>Save</source>
-        <translation>&amp;Speichern</translation>
+        <translation>Speichern</translation>
     </message>
     <message>
         <location filename="../../src/framework/global/internal/interactive.cpp" line="85"/>

--- a/share/locale/musescore_en_GB.ts
+++ b/share/locale/musescore_en_GB.ts
@@ -512,7 +512,7 @@ anacrusis</translation>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="47"/>
         <source>Save</source>
-        <translation>&amp;Save</translation>
+        <translation>Save</translation>
     </message>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="48"/>
@@ -537,7 +537,7 @@ anacrusis</translation>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="78"/>
         <source>Export…</source>
-        <translation>&amp;Export…</translation>
+        <translation>Export…</translation>
     </message>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="79"/>
@@ -612,7 +612,7 @@ anacrusis</translation>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="95"/>
         <source>Print…</source>
-        <translation>&amp;Print…</translation>
+        <translation>Print…</translation>
     </message>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="101"/>
@@ -15116,7 +15116,7 @@ failed: %2</translation>
     <message>
         <location filename="../../src/project/qml/MuseScore/Project/SaveToCloudDialog.qml" line="195"/>
         <source>Save</source>
-        <translation>&amp;Save</translation>
+        <translation>Save</translation>
     </message>
     <message>
         <location filename="../../src/project/qml/MuseScore/Project/ScoresPage.qml" line="82"/>
@@ -19201,7 +19201,7 @@ assign it to this function.</source>
     <message>
         <location filename="../../src/framework/global/internal/interactive.cpp" line="84"/>
         <source>Save</source>
-        <translation>&amp;Save</translation>
+        <translation>Save</translation>
     </message>
     <message>
         <location filename="../../src/framework/global/internal/interactive.cpp" line="85"/>

--- a/share/locale/musescore_en_US.ts
+++ b/share/locale/musescore_en_US.ts
@@ -597,7 +597,7 @@ pickup measure</source>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="95"/>
         <source>Print…</source>
-        <translation>&amp;Print…</translation>
+        <translation>Print…</translation>
     </message>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="101"/>
@@ -14696,7 +14696,7 @@ failed: %2</source>
     <message>
         <location filename="../../src/project/qml/MuseScore/Project/ExportDialog.qml" line="164"/>
         <source>Export…</source>
-        <translation>&amp;Export…</translation>
+        <translation>Export…</translation>
     </message>
     <message>
         <location filename="../../src/project/qml/MuseScore/Project/internal/AdditionalInfoView.qml" line="71"/>
@@ -15097,7 +15097,7 @@ failed: %2</source>
     <message>
         <location filename="../../src/project/qml/MuseScore/Project/SaveToCloudDialog.qml" line="195"/>
         <source>Save</source>
-        <translation>&amp;Save</translation>
+        <translation>Save</translation>
     </message>
     <message>
         <location filename="../../src/project/qml/MuseScore/Project/ScoresPage.qml" line="82"/>
@@ -19182,7 +19182,7 @@ assign it to this function.</source>
     <message>
         <location filename="../../src/framework/global/internal/interactive.cpp" line="84"/>
         <source>Save</source>
-        <translation>&amp;Save</translation>
+        <translation>Save</translation>
     </message>
     <message>
         <location filename="../../src/framework/global/internal/interactive.cpp" line="85"/>

--- a/share/locale/musescore_ja.ts
+++ b/share/locale/musescore_ja.ts
@@ -610,7 +610,7 @@ pickup measure</source>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="95"/>
         <source>Print…</source>
-        <translation>印刷…(&amp;P)</translation>
+        <translation>印刷…</translation>
     </message>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="101"/>

--- a/share/locale/musescore_pt.ts
+++ b/share/locale/musescore_pt.ts
@@ -14703,7 +14703,7 @@ failed: %2</source>
     <message>
         <location filename="../../src/project/qml/MuseScore/Project/ExportDialog.qml" line="164"/>
         <source>Export…</source>
-        <translation>&amp;Exportar…</translation>
+        <translation>Exportar…</translation>
     </message>
     <message>
         <location filename="../../src/project/qml/MuseScore/Project/internal/AdditionalInfoView.qml" line="71"/>

--- a/share/locale/musescore_ro.ts
+++ b/share/locale/musescore_ro.ts
@@ -511,7 +511,7 @@ anacruzele</translation>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="47"/>
         <source>Save</source>
-        <translation>&amp;Salvează</translation>
+        <translation>Salvează</translation>
     </message>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="48"/>
@@ -611,7 +611,7 @@ anacruzele</translation>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="95"/>
         <source>Print…</source>
-        <translation>Ti&amp;părește…</translation>
+        <translation>Tipărește…</translation>
     </message>
     <message>
         <location filename="../../src/project/internal/projectuiactions.cpp" line="101"/>
@@ -15114,7 +15114,7 @@ a eșuat: %2</translation>
     <message>
         <location filename="../../src/project/qml/MuseScore/Project/SaveToCloudDialog.qml" line="195"/>
         <source>Save</source>
-        <translation>&amp;Salvează</translation>
+        <translation>Salvează</translation>
     </message>
     <message>
         <location filename="../../src/project/qml/MuseScore/Project/ScoresPage.qml" line="82"/>
@@ -19199,7 +19199,7 @@ assign it to this function.</source>
     <message>
         <location filename="../../src/framework/global/internal/interactive.cpp" line="84"/>
         <source>Save</source>
-        <translation>&amp;Salvează</translation>
+        <translation>Salvează</translation>
     </message>
     <message>
         <location filename="../../src/framework/global/internal/interactive.cpp" line="85"/>


### PR DESCRIPTION
Should only add an ampersand if the source has an ampersand

Resolves: #12384