### PR TITLE
[MU4] Fix bug re: slur direction for voices

### DIFF
--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -1321,15 +1321,21 @@ SpannerSegment* Slur::layoutSystem(System* system)
 
             _up = !(startCR()->up());
 
-            Measure* m1 = startCR()->measure();
-
+            Measure* m = startCR()->measure();
             if (c1 && c2 && !c1->isGrace() && isDirectionMixture(c1, c2)) {
                 // slurs go above if there are mixed direction stems between c1 and c2
                 // but grace notes are exceptions
                 _up = true;
-            } else if (m1->hasVoices(startCR()->staffIdx(), tick(), ticks()) && c1 && !c1->isGrace()) {
-                // in polyphonic passage, slurs go on the stem side
-                _up = startCR()->up();
+            } else {
+                ChordRest* cr2 = endCR() ? endCR() : startCR();
+                while (m && m->tick() < cr2->tick()) {
+                    if (m->hasVoices(startCR()->staffIdx(), tick(),
+                                     ticks() + (cr2 ? cr2->ticks() : startCR()->ticks())) && c1 && !c1->isGrace()) {
+                        // in polyphonic passage, slurs go on the stem side
+                        _up = startCR()->up();
+                    }
+                    m = m->nextMeasure();
+                }
             }
         }
         break;


### PR DESCRIPTION
The issue:
![image](https://user-images.githubusercontent.com/89263931/179006352-2c1f4425-3928-4df1-b0fc-a10dcd890be6.png)

Slurs were checking their whole length for voices, but they weren't checking the final tick. Now, the check happens not only for the duration of the slur, but also for the duration of both CR's:
![image](https://user-images.githubusercontent.com/89263931/179007093-e7a0d1c9-779a-4d5e-9023-c1ce738e9c97.png)
