### PR TITLE
Fix: #11060: Add missing shortcuts to Preferences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ VERSION
 # Files created during build process
 /thirdparty/lame/config.h
 /thirdparty/flac/flac-1.3.4/config.h
+
+# Backup Files created by Merging Softwares (Example: Meld)
+*.orig

--- a/src/appshell/internal/applicationuiactions.cpp
+++ b/src/appshell/internal/applicationuiactions.cpp
@@ -38,50 +38,61 @@ const ActionCode TOGGLE_NAVIGATOR_ACTION_CODE("toggle-navigator");
 const UiActionList ApplicationUiActions::m_actions = {
     UiAction("quit",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Quit"),
              QT_TRANSLATE_NOOP("action", "Quit")
              ),
     UiAction("restart",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Restart")
              ),
     UiAction("fullscreen",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Full screen"),
-             QT_TRANSLATE_NOOP("action", "Enter full screen"),
+             QT_TRANSLATE_NOOP("action", "Full screen"),
              Checkable::Yes
              ),
     UiAction("about",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&About…")
              ),
     UiAction("about-qt",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "About &Qt…")
              ),
     UiAction("about-musicxml",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "About &MusicXML…")
              ),
     UiAction("online-handbook",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Online &handbook")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Online &handbook"),
+             QT_TRANSLATE_NOOP("action", "Go to online handbook")
              ),
     UiAction("ask-help",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "As&k for help")
              ),
     UiAction("report-bug",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "&Report a bug"),
-             QT_TRANSLATE_NOOP("action", "Report a bug")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "&Report a bug")
              ),
     UiAction("leave-feedback",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "F&eedback"),
-             QT_TRANSLATE_NOOP("action", "Leave feedback")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "F&eedback")
              ),
     UiAction("revert-factory",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Revert to &factory settings"),
              QT_TRANSLATE_NOOP("action", "Revert to factory settings")
              ),
@@ -89,6 +100,7 @@ const UiActionList ApplicationUiActions::m_actions = {
     // Docking
     UiAction("dock-restore-default-layout",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Restore the &default layout"),
              QT_TRANSLATE_NOOP("action", "Restore the default layout")
              ),
@@ -96,95 +108,107 @@ const UiActionList ApplicationUiActions::m_actions = {
     // Toolbars
     UiAction("toggle-transport",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "&Playback controls"),
-             QT_TRANSLATE_NOOP("action", "Toggle 'Playback controls' toolbar"),
+             QT_TRANSLATE_NOOP("action", "Show/hide playback controls"),
              Checkable::Yes
              ),
     UiAction("toggle-noteinput",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Note input"),
-             QT_TRANSLATE_NOOP("action", "Toggle 'Note input' toolbar"),
+             QT_TRANSLATE_NOOP("action", "Show/hide note input toolbar"),
              Checkable::Yes
              ),
 
     // Vertical panels
     UiAction("toggle-palettes",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Palettes"),
-             QT_TRANSLATE_NOOP("action", "Toggle 'Palettes'"),
+             QT_TRANSLATE_NOOP("action", "Show/hide palettes"),
              Checkable::Yes
              ),
     UiAction("toggle-instruments",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Instr&uments"),
-             QT_TRANSLATE_NOOP("action", "Toggle 'Instruments'"),
+             QT_TRANSLATE_NOOP("action", "Open instruments dialog…"),
              Checkable::Yes
              ),
     UiAction("inspector",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Propert&ies"),
-             QT_TRANSLATE_NOOP("action", "Toggle 'Properties'"),
+             QT_TRANSLATE_NOOP("action", "Show/hide properties"),
              Checkable::Yes
              ),
     UiAction("toggle-selection-filter",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Se&lection filter"),
-             QT_TRANSLATE_NOOP("action", "Toggle 'Selection filter'"),
+             QT_TRANSLATE_NOOP("action", "Show/hide selection filter"),
              Checkable::Yes
              ),
 
     // Navigator
     UiAction("toggle-navigator",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Navigator"),
-             QT_TRANSLATE_NOOP("action", "Toggle 'Navigator'"),
+             QT_TRANSLATE_NOOP("action", "Show/hide navigator"),
              Checkable::Yes
              ),
 
     // Horizontal panels
     UiAction("toggle-timeline",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Tim&eline"),
-             QT_TRANSLATE_NOOP("action", "Toggle timeline"),
+             QT_TRANSLATE_NOOP("action", "Show/hide timeline"),
              Checkable::Yes
              ),
     UiAction("toggle-mixer",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Mixer"),
-             QT_TRANSLATE_NOOP("action", "Toggle mixer"),
+             QT_TRANSLATE_NOOP("action", "Show/hide mixer"),
              IconCode::Code::MIXER,
              Checkable::Yes
              ),
     UiAction("toggle-piano-keyboard",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Piano &keyboard"),
-             QT_TRANSLATE_NOOP("action", "Toggle piano keyboard"),
+             QT_TRANSLATE_NOOP("action", "Show/hide piano keyboard"),
              Checkable::Yes
              ),
     UiAction("toggle-scorecmp-tool",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Score comparison tool"),
-             QT_TRANSLATE_NOOP("action", "Toggle score comparison tool"),
              Checkable::Yes
              ),
 
     // Status bar
     UiAction("toggle-statusbar",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "&Status bar"),
-             QT_TRANSLATE_NOOP("action", "Toggle 'Status bar'"),
+             QT_TRANSLATE_NOOP("action", "Show/hide status bar"),
              Checkable::Yes
              ),
 
     UiAction("preference-dialog",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Preferences"),
-             QT_TRANSLATE_NOOP("action", "Open preferences dialog")
+             QT_TRANSLATE_NOOP("action", "Preferences…")
              ),
     UiAction("check-update",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Check for &update"),
-             QT_TRANSLATE_NOOP("action", "Check for update")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Check for &update")
              )
 };
 

--- a/src/autobot/internal/autobotactions.cpp
+++ b/src/autobot/internal/autobotactions.cpp
@@ -30,10 +30,12 @@ using namespace mu::autobot;
 const UiActionList AutobotActions::m_actions = {
     UiAction("autobot-show-batchtests",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Show batch tests…")
              ),
     UiAction("autobot-show-scripts",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Show &scripts…")
              ),
 };

--- a/src/diagnostics/internal/diagnosticsactions.cpp
+++ b/src/diagnostics/internal/diagnosticsactions.cpp
@@ -30,26 +30,32 @@ using namespace mu::diagnostics;
 const UiActionList DiagnosticsActions::m_actions = {
     UiAction("diagnostic-show-paths",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Show p&aths…")
              ),
     UiAction("diagnostic-show-profiler",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Show pr&ofiler…")
              ),
     UiAction("diagnostic-show-navigation-tree",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Show &navigation tree…")
              ),
     UiAction("diagnostic-show-accessible-tree",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Show &accessible tree…")
              ),
     UiAction("diagnostic-accessible-tree-dump",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Accessible &dump")
              ),
     UiAction("diagnostic-show-engraving-elements",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Engraving &elements")
              )
 };

--- a/src/framework/shortcuts/data/shortcuts-Mac.xml
+++ b/src/framework/shortcuts/data/shortcuts-Mac.xml
@@ -23,84 +23,68 @@
         <key>nav-next-section</key>
         <seq>F6</seq>
         <seq>`</seq>
-        <ctx>any</ctx>
     </SC>
     <SC>
         <key>nav-prev-section</key>
         <seq>Shift+F6</seq>
         <seq>Shift+`</seq>
-        <ctx>any</ctx>
     </SC>
     <SC>
         <key>nav-next-panel</key>
         <seq>Tab</seq>
-        <ctx>any</ctx>
     </SC>
     <SC>
         <key>nav-prev-panel</key>
         <seq>Shift+Tab</seq>
-        <ctx>any</ctx>
     </SC>
     <SC>
         <key>nav-next-tab</key>
         <seq>Ctrl+Tab</seq>
-        <ctx>any</ctx>
     </SC>
     <SC>
         <key>nav-prev-tab</key>
         <seq>Ctrl+Shift+Tab</seq>
-        <ctx>any</ctx>
     </SC>
     <SC>
         <key>nav-right</key>
         <seq>Right</seq>
-        <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
         <key>nav-left</key>
         <seq>Left</seq>
-        <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
         <key>nav-up</key>
         <seq>Up</seq>
-        <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
         <key>nav-down</key>
         <seq>Down</seq>
-        <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-first-control</key>
       <seq>Home</seq>
-      <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-last-control</key>
       <seq>End</seq>
-      <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-nextrow-control</key>
       <seq>PgDown</seq>
-      <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-prevrow-control</key>
       <seq>PgUp</seq>
-      <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-trigger-control</key>
       <seq>Return</seq>
       <seq>Space</seq>
-      <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-escape</key>
       <seq>Esc</seq>
-      <ctx>not-notation-focused</ctx>
     </SC>
 <!-- end Keyboard navigation -->
 
@@ -147,32 +131,26 @@
   <SC>
     <key>notation-cut</key>
     <seq>Ctrl+X</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-copy</key>
     <seq>Ctrl+C</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-paste</key>
     <seq>Ctrl+V</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-paste-half</key>
     <seq>Ctrl+Shift+Q</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-paste-double</key>
     <seq>Ctrl+Shift+W</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-swap</key>
     <seq>Ctrl+Shift+X</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>instruments</key>
@@ -313,7 +291,6 @@
   <SC>
     <key>rest</key>
     <seq>0</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>realtime-advance</key>
@@ -350,7 +327,6 @@
   <SC>
     <key>pitch-up</key>
     <seq>Up</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pitch-up-diatonic</key>
@@ -359,32 +335,26 @@
   <SC>
     <key>pitch-up-octave</key>
     <seq>Ctrl+Up</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>up-chord</key>
     <seq>Alt+Up</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>top-chord</key>
     <seq>Ctrl+Alt+Up</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>top-staff</key>
     <seq></seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>first-element</key>
     <seq>Ctrl+Home</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>last-element</key>
     <seq>Ctrl+End</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>next-segment-element</key>
@@ -397,12 +367,10 @@
   <SC>
     <key>next-element</key>
     <seq>Alt+Right</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>prev-element</key>
     <seq>Alt+Left</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>palette-search</key>
@@ -415,12 +383,10 @@
   <SC>
     <key>move-up</key>
     <seq>Ctrl+Shift+Up</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>pitch-down</key>
     <seq>Down</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pitch-down-diatonic</key>
@@ -429,42 +395,34 @@
   <SC>
     <key>pitch-down-octave</key>
     <seq>Ctrl+Down</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>down-chord</key>
     <seq>Alt+Down</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>bottom-chord</key>
     <seq>Ctrl+Alt+Down</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>move-down</key>
     <seq>Ctrl+Shift+Down</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-move-left</key>
     <seq>Left</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-move-left-quickly</key>
     <seq>Ctrl+Left</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-move-right</key>
     <seq>Right</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-move-right-quickly</key>
     <seq>Ctrl+Right</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>select-prev-chord</key>
@@ -561,13 +519,11 @@
   <SC>
     <key>notation-escape</key>
     <seq>Esc</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-delete</key>
     <seq>Del</seq>
     <seq>Backspace</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>time-delete</key>
@@ -630,52 +586,42 @@
   <SC>
     <key>note-longa</key>
     <seq>9</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>note-breve</key>
     <seq>8</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-1</key>
     <seq>7</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-2</key>
     <seq>6</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-4</key>
     <seq>5</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-8</key>
     <seq>4</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-16</key>
     <seq>3</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-32</key>
     <seq>2</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-64</key>
     <seq>1</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-dot</key>
     <seq>.</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>tie</key>
@@ -756,7 +702,6 @@
   <SC>
     <key>play</key>
     <seq>Space</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>play-prev-chord</key>
@@ -785,7 +730,6 @@
   <SC>
     <key>notation-select-all</key>
     <seq>Ctrl+A</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>clef-violin</key>
@@ -798,7 +742,6 @@
   <SC>
     <key>system-break</key>
     <seq>Return</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>page-break</key>
@@ -939,12 +882,10 @@
   <SC>
     <key>next-text-element</key>
     <seq>Space</seq>
-    <ctx>notation-text-editing</ctx>
     </SC>
   <SC>
     <key>prev-text-element</key>
     <seq>Shift+Space</seq>
-    <ctx>notation-text-editing</ctx>
     </SC>
   <SC>
     <key>toggle-visible</key>
@@ -1012,92 +953,75 @@
   <SC>
     <key>string-above</key>
     <seq>Up</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>string-below</key>
     <seq>Down</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-0</key>
     <seq>0</seq>
     <seq>A</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-1</key>
     <seq>1</seq>
     <seq>B</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-2</key>
     <seq>2</seq>
     <seq>C</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-3</key>
     <seq>3</seq>
     <seq>D</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-4</key>
     <seq>4</seq>
     <seq>E</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-5</key>
     <seq>5</seq>
     <seq>F</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-6</key>
     <seq>6</seq>
     <seq>G</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-7</key>
     <seq>7</seq>
     <seq>H</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-8</key>
     <seq>8</seq>
     <seq>J</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-9</key>
     <seq>9</seq>
     <seq>K</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-10</key>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-11</key>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-12</key>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-13</key>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-14</key>
-    <ctx>notation-staff-tab</ctx>
     </SC>
 <!-- HARMONY / FIGURED BASS specific shortcuts -->
   <SC>
@@ -1208,6 +1132,5 @@
     <key>notation-context-menu</key>
     <seq>Shift+F10</seq>
     <seq>Ctrl+Shift+F10</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   </Shortcuts>

--- a/src/framework/shortcuts/data/shortcuts.xml
+++ b/src/framework/shortcuts/data/shortcuts.xml
@@ -23,84 +23,68 @@
         <key>nav-next-section</key>
         <seq>F6</seq>
         <seq>`</seq>
-        <ctx>any</ctx>
     </SC>
     <SC>
         <key>nav-prev-section</key>
         <seq>Shift+F6</seq>
         <seq>Shift+`</seq>
-        <ctx>any</ctx>
     </SC>
     <SC>
         <key>nav-next-panel</key>
         <seq>Tab</seq>
-        <ctx>any</ctx>
     </SC>
     <SC>
         <key>nav-prev-panel</key>
         <seq>Shift+Tab</seq>
-        <ctx>any</ctx>
     </SC>
     <SC>
         <key>nav-next-tab</key>
         <seq>Ctrl+Tab</seq>
-        <ctx>any</ctx>
     </SC>
     <SC>
         <key>nav-prev-tab</key>
         <seq>Ctrl+Shift+Tab</seq>
-        <ctx>any</ctx>
     </SC>
     <SC>
         <key>nav-right</key>
         <seq>Right</seq>
-        <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
         <key>nav-left</key>
         <seq>Left</seq>
-        <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
         <key>nav-up</key>
         <seq>Up</seq>
-        <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
         <key>nav-down</key>
         <seq>Down</seq>
-        <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-first-control</key>
       <seq>Home</seq>
-      <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-last-control</key>
       <seq>End</seq>
-      <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-nextrow-control</key>
       <seq>PgDown</seq>
-      <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-prevrow-control</key>
       <seq>PgUp</seq>
-      <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-trigger-control</key>
       <seq>Return</seq>
       <seq>Space</seq>
-      <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-escape</key>
       <seq>Esc</seq>
-      <ctx>not-notation-focused</ctx>
     </SC>
 <!-- end Keyboard navigation -->
 
@@ -147,32 +131,26 @@
   <SC>
     <key>notation-cut</key>
     <seq>Ctrl+X</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-copy</key>
     <seq>Ctrl+C</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-paste</key>
     <seq>Ctrl+V</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-paste-half</key>
     <seq>Ctrl+Shift+Q</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-paste-double</key>
     <seq>Ctrl+Shift+W</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-swap</key>
     <seq>Ctrl+Shift+X</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>instruments</key>
@@ -313,7 +291,6 @@
   <SC>
     <key>rest</key>
     <seq>0</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>realtime-advance</key>
@@ -350,7 +327,6 @@
   <SC>
     <key>pitch-up</key>
     <seq>Up</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pitch-up-diatonic</key>
@@ -359,32 +335,26 @@
   <SC>
     <key>pitch-up-octave</key>
     <seq>Ctrl+Up</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>up-chord</key>
     <seq>Alt+Up</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>top-chord</key>
     <seq>Ctrl+Alt+Up</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>top-staff</key>
     <seq></seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>first-element</key>
     <seq>Ctrl+Home</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>last-element</key>
     <seq>Ctrl+End</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>next-segment-element</key>
@@ -397,12 +367,10 @@
   <SC>
     <key>next-element</key>
     <seq>Alt+Right</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>prev-element</key>
     <seq>Alt+Left</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>palette-search</key>
@@ -415,12 +383,10 @@
   <SC>
     <key>move-up</key>
     <seq>Ctrl+Shift+Up</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>pitch-down</key>
     <seq>Down</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pitch-down-diatonic</key>
@@ -429,42 +395,34 @@
   <SC>
     <key>pitch-down-octave</key>
     <seq>Ctrl+Down</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>down-chord</key>
     <seq>Alt+Down</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>bottom-chord</key>
     <seq>Ctrl+Alt+Down</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>move-down</key>
     <seq>Ctrl+Shift+Down</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-move-left</key>
     <seq>Left</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-move-left-quickly</key>
     <seq>Ctrl+Left</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-move-right</key>
     <seq>Right</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-move-right-quickly</key>
     <seq>Ctrl+Right</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>select-prev-chord</key>
@@ -561,13 +519,11 @@
   <SC>
     <key>notation-escape</key>
     <seq>Esc</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-delete</key>
     <seq>Del</seq>
     <seq>Backspace</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>time-delete</key>
@@ -630,52 +586,42 @@
   <SC>
     <key>note-longa</key>
     <seq>9</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>note-breve</key>
     <seq>8</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-1</key>
     <seq>7</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-2</key>
     <seq>6</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-4</key>
     <seq>5</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-8</key>
     <seq>4</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-16</key>
     <seq>3</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-32</key>
     <seq>2</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-64</key>
     <seq>1</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-dot</key>
     <seq>.</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>tie</key>
@@ -752,7 +698,6 @@
   <SC>
     <key>play</key>
     <seq>Space</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>play-prev-chord</key>
@@ -781,7 +726,6 @@
   <SC>
     <key>notation-select-all</key>
     <seq>Ctrl+A</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>clef-violin</key>
@@ -794,7 +738,6 @@
   <SC>
     <key>system-break</key>
     <seq>Return</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>page-break</key>
@@ -934,42 +877,34 @@
   <SC>
     <key>next-text-element</key>
     <seq>Space</seq>
-    <ctx>notation-text-editing</ctx>
     </SC>
   <SC>
     <key>next-text-element</key>
     <seq>Right</seq>
-    <ctx>notation-text-editing</ctx>
     </SC>
   <SC>
     <key>prev-text-element</key>
     <seq>Shift+Space</seq>
-    <ctx>notation-text-editing</ctx>
     </SC>
   <SC>
     <key>prev-text-element</key>
     <seq>Left</seq>
-    <ctx>notation-text-editing</ctx>
   </SC>
   <SC>
     <key>next-syllable</key>
     <seq>-</seq>
-    <ctx>notation-text-editing</ctx>
   </SC>
   <SC>
     <key>add-melisma</key>
     <seq>_</seq>
-    <ctx>notation-text-editing</ctx>
   </SC>
   <SC>
     <key>next-lyric-verse</key>
     <seq>Down</seq>
-    <ctx>notation-text-editing</ctx>
   </SC>
   <SC>
     <key>prev-lyric-verse</key>
     <seq>Up</seq>
-    <ctx>notation-text-editing</ctx>
   </SC>
   <SC>
     <key>add-lyric-verse</key>
@@ -1041,92 +976,75 @@
   <SC>
     <key>string-above</key>
     <seq>Up</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>string-below</key>
     <seq>Down</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-0</key>
     <seq>0</seq>
     <seq>A</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-1</key>
     <seq>1</seq>
     <seq>B</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-2</key>
     <seq>2</seq>
     <seq>C</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-3</key>
     <seq>3</seq>
     <seq>D</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-4</key>
     <seq>4</seq>
     <seq>E</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-5</key>
     <seq>5</seq>
     <seq>F</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-6</key>
     <seq>6</seq>
     <seq>G</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-7</key>
     <seq>7</seq>
     <seq>H</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-8</key>
     <seq>8</seq>
     <seq>J</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-9</key>
     <seq>9</seq>
     <seq>K</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-10</key>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-11</key>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-12</key>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-13</key>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-14</key>
-    <ctx>notation-staff-tab</ctx>
     </SC>
 <!-- HARMONY / FIGURED BASS specific shortcuts -->
   <SC>
@@ -1237,6 +1155,5 @@
     <key>notation-context-menu</key>
     <seq>Shift+F10</seq>
     <seq>Ctrl+Shift+F10</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   </Shortcuts>

--- a/src/framework/shortcuts/data/shortcuts_AZERTY.xml
+++ b/src/framework/shortcuts/data/shortcuts_AZERTY.xml
@@ -23,84 +23,68 @@
         <key>nav-next-section</key>
         <seq>F6</seq>
         <seq>`</seq>
-        <ctx>any</ctx>
     </SC>
     <SC>
         <key>nav-prev-section</key>
         <seq>Shift+F6</seq>
         <seq>Shift+`</seq>
-        <ctx>any</ctx>
     </SC>
     <SC>
         <key>nav-next-panel</key>
         <seq>Tab</seq>
-        <ctx>any</ctx>
     </SC>
     <SC>
         <key>nav-prev-panel</key>
         <seq>Shift+Tab</seq>
-        <ctx>any</ctx>
     </SC>
     <SC>
         <key>nav-next-tab</key>
         <seq>Ctrl+Tab</seq>
-        <ctx>any</ctx>
     </SC>
     <SC>
         <key>nav-prev-tab</key>
         <seq>Ctrl+Shift+Tab</seq>
-        <ctx>any</ctx>
     </SC>
     <SC>
         <key>nav-right</key>
         <seq>Right</seq>
-        <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
         <key>nav-left</key>
         <seq>Left</seq>
-        <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
         <key>nav-up</key>
         <seq>Up</seq>
-        <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
         <key>nav-down</key>
         <seq>Down</seq>
-        <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-first-control</key>
       <seq>Home</seq>
-      <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-last-control</key>
       <seq>End</seq>
-      <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-nextrow-control</key>
       <seq>PgDown</seq>
-      <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-prevrow-control</key>
       <seq>PgUp</seq>
-      <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-trigger-control</key>
       <seq>Return</seq>
       <seq>Space</seq>
-      <ctx>not-notation-focused</ctx>
     </SC>
     <SC>
       <key>nav-escape</key>
       <seq>Esc</seq>
-      <ctx>not-notation-focused</ctx>
     </SC>
 <!-- end Keyboard navigation -->
   <SC>
@@ -146,32 +130,26 @@
   <SC>
     <key>notation-cut</key>
     <seq>Ctrl+X</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-copy</key>
     <seq>Ctrl+C</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>paste</key>
     <seq>Ctrl+V</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-paste-half</key>
     <seq>Ctrl+Shift+Q</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-paste-double</key>
     <seq>Ctrl+Shift+W</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-swap</key>
     <seq>Ctrl+Shift+X</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>instruments</key>
@@ -322,7 +300,6 @@
     <key>rest</key>
     <seq>0</seq>
     <seq>À</seq> <!-- AZERTY for 0 -->
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>realtime-advance</key>
@@ -359,7 +336,6 @@
   <SC>
     <key>pitch-up</key>
     <seq>Up</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pitch-up-diatonic</key>
@@ -368,32 +344,26 @@
   <SC>
     <key>pitch-up-octave</key>
     <seq>Ctrl+Up</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>up-chord</key>
     <seq>Alt+Up</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>top-chord</key>
     <seq>Ctrl+Alt+Up</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>top-staff</key>
     <seq></seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>first-element</key>
     <seq>Ctrl+Home</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>last-element</key>
     <seq>Ctrl+End</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>next-segment-element</key>
@@ -406,12 +376,10 @@
   <SC>
     <key>next-element</key>
     <seq>Alt+Right</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>prev-element</key>
     <seq>Alt+Left</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>palette-search</key>
@@ -424,12 +392,10 @@
   <SC>
     <key>move-up</key>
     <seq>Ctrl+Shift+Up</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>pitch-down</key>
     <seq>Down</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pitch-down-diatonic</key>
@@ -438,42 +404,34 @@
   <SC>
     <key>pitch-down-octave</key>
     <seq>Ctrl+Down</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>down-chord</key>
     <seq>Alt+Down</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>bottom-chord</key>
     <seq>Ctrl+Alt+Down</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>move-down</key>
     <seq>Ctrl+Shift+Down</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-move-left</key>
     <seq>Left</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-move-left-quickly</key>
     <seq>Ctrl+Left</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-move-right</key>
     <seq>Right</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-move-right-quickly</key>
     <seq>Ctrl+Right</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>select-prev-chord</key>
@@ -570,13 +528,11 @@
   <SC>
     <key>notation-escape</key>
     <seq>Esc</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>notation-delete</key>
     <seq>Del</seq>
     <seq>Backspace</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>time-delete</key>
@@ -648,60 +604,50 @@
     <key>note-longa</key>
     <seq>9</seq>
     <seq>Ç</seq> <!-- AZERTY for 9 -->
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>note-breve</key>
     <seq>8</seq>
     <seq>_</seq> <!-- AZERTY for 8 -->
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-1</key>
     <seq>7</seq>
     <seq>È</seq> <!-- AZERTY for 7 -->
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-2</key>
     <seq>6</seq>
     <seq>-</seq> <!-- AZERTY for 6 -->
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-4</key>
     <seq>5</seq>
     <seq>(</seq> <!-- AZERTY for 5 -->
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-8</key>
     <seq>4</seq>
     <seq>'</seq> <!-- AZERTY for 4 -->
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-16</key>
     <seq>3</seq>
     <seq>&quot;</seq> <!-- AZERTY for 3 -->
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-32</key>
     <seq>2</seq>
     <seq>É</seq> <!-- AZERTY for 2 -->
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-note-64</key>
     <seq>1</seq>
     <seq>&amp;</seq> <!-- AZERTY for 1 -->
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>pad-dot</key>
     <seq>.</seq>
-    <ctx>notation-staff-not-tab</ctx>
     </SC>
   <SC>
     <key>tie</key>
@@ -778,7 +724,6 @@
   <SC>
     <key>play</key>
     <seq>Space</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>play-prev-chord</key>
@@ -807,7 +752,6 @@
   <SC>
     <key>notation-select-all</key>
     <seq>Ctrl+A</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>clef-violin</key>
@@ -820,7 +764,6 @@
   <SC>
     <key>system-break</key>
     <seq>Return</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   <SC>
     <key>page-break</key>
@@ -960,12 +903,10 @@
   <SC>
     <key>next-text-element</key>
     <seq>Space</seq>
-    <ctx>notation-text-editing</ctx>
     </SC>
   <SC>
     <key>prev-text-element</key>
     <seq>Shift+Space</seq>
-    <ctx>notation-text-editing</ctx>
     </SC>
   <SC>
     <key>toggle-visible</key>
@@ -1033,92 +974,75 @@
   <SC>
     <key>string-above</key>
     <seq>Up</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>string-below</key>
     <seq>Down</seq>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-0</key>
     <seq>A</seq>
     <seq>À</seq> <!-- AZERTY for 0 -->
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-1</key>
     <seq>B</seq>
     <seq>&amp;</seq> <!-- AZERTY for 1 -->
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-2</key>
     <seq>C</seq>
     <seq>É</seq> <!-- AZERTY for 2 -->
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-3</key>
     <seq>D</seq>
     <seq>&quot;</seq> <!-- AZERTY for 3 -->
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-4</key>
     <seq>E</seq>
     <seq>'</seq> <!-- AZERTY for 4 -->
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-5</key>
     <seq>F</seq>
     <seq>(</seq> <!-- AZERTY for 5 -->
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-6</key>
     <seq>G</seq>
     <seq>-</seq> <!-- AZERTY for 6 -->
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-7</key>
     <seq>H</seq>
     <seq>È</seq> <!-- AZERTY for 7 -->
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-8</key>
     <seq>J</seq>
     <seq>_</seq> <!-- AZERTY for 8 -->
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-9</key>
     <seq>K</seq>
     <seq>Ç</seq> <!-- AZERTY for 9 -->
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-10</key>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-11</key>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-12</key>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-13</key>
-    <ctx>notation-staff-tab</ctx>
     </SC>
   <SC>
     <key>fret-14</key>
-    <ctx>notation-staff-tab</ctx>
     </SC>
 <!-- HARMONY / FIGURED BASS specific shortcuts -->
   <SC>
@@ -1238,6 +1162,5 @@
     <key>notation-context-menu</key>
     <seq>Shift+F10</seq>
     <seq>Ctrl+Shift+F10</seq>
-    <ctx>notation-focused</ctx>
     </SC>
   </Shortcuts>

--- a/src/framework/shortcuts/internal/shortcutsregister.cpp
+++ b/src/framework/shortcuts/internal/shortcutsregister.cpp
@@ -277,16 +277,12 @@ Shortcut ShortcutsRegister::readShortcut(framework::XmlReader& reader) const
             shortcut.standardKey = QKeySequence::StandardKey(reader.readInt());
         } else if (tag == SEQUENCE_TAG) {
             shortcut.sequences.push_back(reader.readString());
-        } else if (tag == CONTEXT_TAG) {
-            shortcut.context = reader.readString();
         } else {
             reader.skipCurrentElement();
         }
     }
 
-    if (shortcut.context.empty()) {
-        shortcut.context = "any";
-    }
+    shortcut.context = uiactionsRegister()->action(shortcut.action).scCtx;
 
     return shortcut;
 }

--- a/src/framework/shortcuts/internal/shortcutsregister.h
+++ b/src/framework/shortcuts/internal/shortcutsregister.h
@@ -25,6 +25,7 @@
 #include "../ishortcutsregister.h"
 #include "modularity/ioc.h"
 #include "ishortcutsconfiguration.h"
+#include "ui/iuiactionsregister.h"
 #include "async/asyncable.h"
 #include "io/ifilesystem.h"
 #include "multiinstances/imultiinstancesprovider.h"
@@ -40,6 +41,7 @@ class ShortcutsRegister : public IShortcutsRegister, public async::Asyncable
     INJECT(shortcuts, IShortcutsConfiguration, configuration)
     INJECT(shortcuts, io::IFileSystem, fileSystem)
     INJECT(shortcuts, mi::IMultiInstancesProvider, multiInstancesProvider)
+    INJECT(shortcuts, ui::IUiActionsRegister, uiactionsRegister)
 
 public:
     ShortcutsRegister() = default;

--- a/src/framework/shortcuts/view/shortcutsmodel.h
+++ b/src/framework/shortcuts/view/shortcutsmodel.h
@@ -83,6 +83,8 @@ signals:
 private:
     const ui::UiAction& action(const std::string& actionCode) const;
     const QString& actionTitle(const std::string& actionCode) const;
+    const QString& actionDescription(const std::string& actionCode) const;
+    const QString& actionText(const std::string& actionCode) const;
 
     QModelIndex currentShortcutIndex() const;
     void notifyAboutShortcutChanged(const QModelIndex& index);

--- a/src/framework/ui/internal/navigationuiactions.cpp
+++ b/src/framework/ui/internal/navigationuiactions.cpp
@@ -28,55 +28,72 @@ using namespace mu::actions;
 
 const UiActionList NavigationUiActions::m_actions = {
     UiAction("nav-dev-show-controls",
-             mu::context::UiCtxAny
+             mu::context::UiCtxAny,
+             mu::context::CTX_ANY
              ),
     UiAction("nav-next-section",
-             mu::context::UiCtxAny
+             mu::context::UiCtxAny,
+             mu::context::CTX_ANY
              ),
     UiAction("nav-prev-section",
-             mu::context::UiCtxAny
+             mu::context::UiCtxAny,
+             mu::context::CTX_ANY
              ),
     UiAction("nav-next-panel",
-             mu::context::UiCtxAny
+             mu::context::UiCtxAny,
+             mu::context::CTX_ANY
              ),
     UiAction("nav-prev-panel",
-             mu::context::UiCtxAny
+             mu::context::UiCtxAny,
+             mu::context::CTX_ANY
              ),
     UiAction("nav-next-tab",
-             mu::context::UiCtxAny
+             mu::context::UiCtxAny,
+             mu::context::CTX_ANY
              ),
     UiAction("nav-prev-tab",
-             mu::context::UiCtxAny
+             mu::context::UiCtxAny,
+             mu::context::CTX_ANY
              ),
     UiAction("nav-right",
-             mu::context::UiCtxAny
+             mu::context::UiCtxAny,
+             mu::context::CTX_NOT_NOTATION_FOCUSED
              ),
     UiAction("nav-left",
-             mu::context::UiCtxAny
+             mu::context::UiCtxAny,
+             mu::context::CTX_NOT_NOTATION_FOCUSED
              ),
     UiAction("nav-up",
-             mu::context::UiCtxAny
+             mu::context::UiCtxAny,
+             mu::context::CTX_NOT_NOTATION_FOCUSED
              ),
     UiAction("nav-down",
-             mu::context::UiCtxAny
+             mu::context::UiCtxAny,
+             mu::context::CTX_NOT_NOTATION_FOCUSED
              ),
     UiAction("nav-escape",
-             mu::context::UiCtxAny
+             mu::context::UiCtxAny,
+             mu::context::CTX_NOT_NOTATION_FOCUSED
              ),
     UiAction("nav-trigger-control",
-             mu::context::UiCtxAny
+             mu::context::UiCtxAny,
+             mu::context::CTX_NOT_NOTATION_FOCUSED
              ),
     UiAction("nav-first-control",
-             mu::context::UiCtxAny
+             mu::context::UiCtxAny,
+             mu::context::CTX_NOT_NOTATION_FOCUSED
              ),
     UiAction("nav-last-control",
-             mu::context::UiCtxAny
+             mu::context::UiCtxAny,
+             mu::context::CTX_NOT_NOTATION_FOCUSED
              ),
     UiAction("nav-nextrow-control",
-             mu::context::UiCtxAny
+             mu::context::UiCtxAny,
+             mu::context::CTX_NOT_NOTATION_FOCUSED
              ),
     UiAction("nav-prevrow-control",
-             mu::context::UiCtxAny
+             mu::context::UiCtxAny,
+             mu::context::CTX_NOT_NOTATION_FOCUSED
              )
 };
 

--- a/src/framework/ui/internal/uiactionsregister.cpp
+++ b/src/framework/ui/internal/uiactionsregister.cpp
@@ -99,6 +99,17 @@ const UiAction& UiActionsRegister::action(const ActionCode& code) const
     return info(code).action;
 }
 
+const std::vector<UiAction> UiActionsRegister::getActions() const
+{
+    std::vector<UiAction> allActions;
+
+    for (auto it = m_actions.begin(); it != m_actions.end(); it++) {
+        allActions.push_back(it->second.action);
+    }
+
+    return allActions;
+}
+
 UiActionState UiActionsRegister::actionState(const ActionCode& code) const
 {
     const Info& inf = info(code);
@@ -142,7 +153,7 @@ void UiActionsRegister::doUpdateEnabled(Info& inf,
     bool oldEnabled = inf.state.enabled;
     inf.state.enabled = false;
 
-    if (ctxResolver->match(currentCtx, inf.action.context)) {
+    if (ctxResolver->match(currentCtx, inf.action.uiCtx)) {
         inf.state.enabled = inf.module->actionEnabled(inf.action);
     }
 

--- a/src/framework/ui/internal/uiactionsregister.h
+++ b/src/framework/ui/internal/uiactionsregister.h
@@ -43,6 +43,7 @@ public:
 
     void reg(const IUiActionsModulePtr& actions) override;
     const UiAction& action(const actions::ActionCode& code) const override;
+    const std::vector<UiAction> getActions() const override;
     UiActionState actionState(const actions::ActionCode& code) const override;
     async::Channel<actions::ActionCodeList> actionStateChanged() const override;
 

--- a/src/framework/ui/iuiactionsregister.h
+++ b/src/framework/ui/iuiactionsregister.h
@@ -39,6 +39,7 @@ public:
     virtual void reg(const IUiActionsModulePtr& actions) = 0;
 
     virtual const UiAction& action(const actions::ActionCode& code) const = 0;
+    virtual const std::vector<UiAction> getActions() const = 0;
     virtual UiActionState actionState(const actions::ActionCode& code) const = 0;
     virtual async::Channel<actions::ActionCodeList> actionStateChanged() const = 0;
 };

--- a/src/framework/ui/uitypes.h
+++ b/src/framework/ui/uitypes.h
@@ -33,6 +33,7 @@
 #include "actions/actiontypes.h"
 #include "view/iconcodes.h"
 #include "shortcuts/shortcutstypes.h"
+#include "context/shortcutcontext.h"
 
 namespace mu::ui {
 using ThemeCode = std::string;
@@ -188,7 +189,8 @@ enum class Checkable {
 struct UiAction
 {
     actions::ActionCode code;
-    UiContext context = UiCtxAny;
+    UiContext uiCtx = UiCtxAny;
+    std::string scCtx = "NULL";
     QString title;
     QString description;
     IconCode::Code iconCode = IconCode::Code::NONE;
@@ -196,17 +198,24 @@ struct UiAction
     std::vector<std::string> shortcuts;
 
     UiAction() = default;
-    UiAction(const actions::ActionCode& code, UiContext ctx, Checkable ch = Checkable::No)
-        : code(code), context(ctx), checkable(ch) {}
-    UiAction(const actions::ActionCode& code, UiContext ctx, const QString& title, Checkable ch = Checkable::No)
-        : code(code), context(ctx), title(title), description(title), checkable(ch) {}
-    UiAction(const actions::ActionCode& code, UiContext ctx, const QString& title, const QString& desc, Checkable ch = Checkable::No)
-        : code(code), context(ctx), title(title), description(desc), checkable(ch) {}
-    UiAction(const actions::ActionCode& code, UiContext ctx, const QString& title, const QString& desc, IconCode::Code icon,
+    UiAction(const actions::ActionCode& code, UiContext ctx, std::string scCtx, Checkable ch = Checkable::No)
+        : code(code), uiCtx(ctx), scCtx(scCtx), checkable(ch) {}
+
+    UiAction(const actions::ActionCode& code, UiContext ctx, std::string scCtx, const QString& title,  Checkable ch = Checkable::No)
+        : code(code), uiCtx(ctx), scCtx(scCtx), title(title), checkable(ch) {}
+
+    UiAction(const actions::ActionCode& code, UiContext ctx, std::string scCtx, const QString& title, const QString& desc,
              Checkable ch = Checkable::No)
-        : code(code), context(ctx), title(title), description(desc), iconCode(icon), checkable(ch) {}
-    UiAction(const actions::ActionCode& code, UiContext ctx, const QString& title, IconCode::Code icon, Checkable ch = Checkable::No)
-        : code(code), context(ctx), title(title), description(title), iconCode(icon), checkable(ch) {}
+        : code(code), uiCtx(ctx), scCtx(scCtx), title(title), description(desc),  checkable(ch) {}
+
+    UiAction(const actions::ActionCode& code, UiContext ctx, std::string scCtx, const QString& title, const QString& desc,
+             IconCode::Code icon,
+             Checkable ch = Checkable::No)
+        : code(code), uiCtx(ctx), scCtx(scCtx), title(title), description(desc), iconCode(icon), checkable(ch) {}
+
+    UiAction(const actions::ActionCode& code, UiContext ctx, std::string scCtx, const QString& title, IconCode::Code icon,
+             Checkable ch = Checkable::No)
+        : code(code), uiCtx(ctx), scCtx(scCtx), title(title), iconCode(icon), checkable(ch) {}
 
     bool isValid() const
     {
@@ -233,7 +242,8 @@ struct UiAction
     bool operator==(const UiAction& other) const
     {
         return code == other.code
-               && context == other.context
+               && uiCtx == other.uiCtx
+               && scCtx == other.scCtx
                && title == other.title
                && description == other.description
                && iconCode == other.iconCode

--- a/src/instrumentsscene/internal/instrumentsuiactions.cpp
+++ b/src/instrumentsscene/internal/instrumentsuiactions.cpp
@@ -31,10 +31,14 @@ using namespace mu::ui;
 const UiActionList InstrumentsUiActions::m_actions = {
     UiAction("instruments",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Add or remove instruments…"),
              QT_TRANSLATE_NOOP("action", "Add or remove instruments…")
              ),
     UiAction("change-instrument",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Select instrument…"),
              QT_TRANSLATE_NOOP("action", "Select instrument…")
              )
 };

--- a/src/multiinstances/internal/multiinstancesuiactions.cpp
+++ b/src/multiinstances/internal/multiinstancesuiactions.cpp
@@ -30,6 +30,7 @@ using namespace mu::mi;
 const UiActionList MultiInstancesUiActions::m_actions = {
     UiAction("multiinstances-dev-show-info",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Multiinstances")
              )
 };

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -62,7 +62,6 @@ static const QString Enter_note_X(QT_TRANSLATE_NOOP("action", "Enter note %1"));
 static const QString Add_X_to_chord(QT_TRANSLATE_NOOP("action", "Add %1 to chord"));
 static const QString Add_note_X_to_chord(QT_TRANSLATE_NOOP("action", "Add note %1 to chord"));
 static const QString Insert_X(QT_TRANSLATE_NOOP("action", "Insert %1"));
-static const QString Insert_note_X(QT_TRANSLATE_NOOP("action", "Insert note %1"));
 
 //! NOTE Each notation actions should has context is UiCtxNotationOpened.
 //! If you want what action to dispatch by shortcut only when notation is focused (ex notation-move-right by press Right key),
@@ -72,1733 +71,2200 @@ static const QString Insert_note_X(QT_TRANSLATE_NOOP("action", "Insert note %1")
 const UiActionList NotationUiActions::m_actions = {
     UiAction("notation-escape",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Esc")
+             mu::context::CTX_NOTATION_FOCUSED,
+             QT_TRANSLATE_NOOP("action", "Esc"),
+             QT_TRANSLATE_NOOP("action", "Escape (Esc)")
              ),
     UiAction("put-note", // args: PointF pos, bool replace, bool insert
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Put note")
              ),
     UiAction("remove-note", // args: PointF pos
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Remove note")
              ),
     UiAction("next-element",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Next element"),
-             QT_TRANSLATE_NOOP("action", "Accessibility: Next element")
+             QT_TRANSLATE_NOOP("action", "Select next element in score")
              ),
     UiAction("prev-element",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Previous element"),
-             QT_TRANSLATE_NOOP("action", "Accessibility: Previous element")
+             QT_TRANSLATE_NOOP("action", "Select previous element")
              ),
     UiAction("notation-move-right",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Next chord / Shift text right"),
-             QT_TRANSLATE_NOOP("action", "Go to next chord or shift text right")
+             QT_TRANSLATE_NOOP("action", "Select next chord / move text right")
              ),
     UiAction("notation-move-left",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Previous chord / Shift text left"),
-             QT_TRANSLATE_NOOP("action", "Go to previous chord or shift text left")
+             QT_TRANSLATE_NOOP("action", "Select previous chord / move text left")
              ),
     UiAction("notation-move-right-quickly",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Next measure / Shift text right quickly"),
-             QT_TRANSLATE_NOOP("action", "Go to next measure or shift text right quickly")
+             QT_TRANSLATE_NOOP("action", "Go to next measure / move text right quickly")
              ),
     UiAction("notation-move-left-quickly",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Previous measure / Shift text left quickly"),
-             QT_TRANSLATE_NOOP("action", "Go to previous measure or shift text left quickly")
+             QT_TRANSLATE_NOOP("action", "Select first element in previous measure / move text left quickly")
              ),
     UiAction("up-chord",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Up note in chord"),
-             QT_TRANSLATE_NOOP("action", "Go to higher pitched note in chord")
+             QT_TRANSLATE_NOOP("action", "Select note/rest above")
              ),
     UiAction("down-chord",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Down note in chord"),
-             QT_TRANSLATE_NOOP("action", "Go to lower pitched note in chord")
+             QT_TRANSLATE_NOOP("action", "Select note/rest below")
              ),
     UiAction("top-chord",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Top note in chord"),
-             QT_TRANSLATE_NOOP("action", "Go to top note in chord")
+             QT_TRANSLATE_NOOP("action", "Select top note in chord")
              ),
     UiAction("bottom-chord",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Bottom note in chord"),
-             QT_TRANSLATE_NOOP("action", "Go to bottom note in chord")
+             QT_TRANSLATE_NOOP("action", "Select bottom note in chord")
              ),
     UiAction("first-element",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "First element"),
              QT_TRANSLATE_NOOP("action", "Go to first element in score")
              ),
     UiAction("last-element",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Last element"),
              QT_TRANSLATE_NOOP("action", "Go to last element in score")
              ),
     UiAction("move-up",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Move to staff above"),
-             QT_TRANSLATE_NOOP("action", "Move chord/rest to staff above")
+             QT_TRANSLATE_NOOP("action", "Move selected note/rest to staff above")
              ),
     UiAction("move-down",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Move to staff below"),
-             QT_TRANSLATE_NOOP("action", "Move chord/rest to staff below")
+             QT_TRANSLATE_NOOP("action", "Move selected note/rest to staff below")
              ),
     UiAction("next-track",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Next staff or voice")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Next staff or voice"),
+             QT_TRANSLATE_NOOP("action", "Go to next staff or voice")
              ),
     UiAction("prev-track",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Previous staff or voice")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Previous staff or voice"),
+             QT_TRANSLATE_NOOP("action", "Go to previous staff or voice")
              ),
     UiAction("next-frame",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Next frame")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Next frame"),
+             QT_TRANSLATE_NOOP("action", "Go to next frame")
              ),
     UiAction("prev-frame",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Previous frame")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Previous frame"),
+             QT_TRANSLATE_NOOP("action", "Go to previous frame")
              ),
     UiAction("next-system",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Next system")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Next system"),
+             QT_TRANSLATE_NOOP("action", "Go to next system")
              ),
     UiAction("prev-system",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Previous system")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Previous system"),
+             QT_TRANSLATE_NOOP("action", "Go to previous system")
              ),
     UiAction("toggle-insert-mode",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Toggle 'insert mode'")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Toggle 'insert mode'"),
+             QT_TRANSLATE_NOOP("action", "Note input: toggle ‘insert’ mode")
              ),
     UiAction("select-next-chord",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Add next chord to selection")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Add next chord to selection"),
+             QT_TRANSLATE_NOOP("action", "Add to selection: next note/rest")
              ),
     UiAction("select-prev-chord",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Add previous chord to selection")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Add previous chord to selection"),
+             QT_TRANSLATE_NOOP("action", "Add to selection: previous note/rest")
              ),
     UiAction("move-left",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Move chord/rest left"),
              QT_TRANSLATE_NOOP("action", "Move chord/rest left")
              ),
     UiAction("move-right",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Move chord/rest right"),
              QT_TRANSLATE_NOOP("action", "Move chord/rest right")
              ),
     UiAction("pitch-up",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_NOT_TAB,
              QT_TRANSLATE_NOOP("action", "Up"),
-             QT_TRANSLATE_NOOP("action", "Pitch up or move text or articulation up")
+             QT_TRANSLATE_NOOP("action", "Move pitch/selection up")
              ),
     UiAction("pitch-down",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_NOT_TAB,
              QT_TRANSLATE_NOOP("action", "Down"),
-             QT_TRANSLATE_NOOP("action", "Pitch down or move text or articulation down")
+             QT_TRANSLATE_NOOP("action", "Move pitch/selection down")
              ),
     UiAction("pitch-down-octave",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Down octave"),
-             QT_TRANSLATE_NOOP("action", "Pitch down by an octave or move text or articulation down")
+             QT_TRANSLATE_NOOP("action", "Move pitch down an octave")
              ),
     UiAction("pitch-up-octave",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Up octave"),
-             QT_TRANSLATE_NOOP("action", "Pitch up by an octave or move text or articulation up")
+             QT_TRANSLATE_NOOP("action", "Move pitch up an octave")
              ),
     UiAction("double-duration",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Double duration")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Double duration"),
+             QT_TRANSLATE_NOOP("action", "Double selected duration")
              ),
     UiAction("half-duration",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Halve duration")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Halve duration"),
+             QT_TRANSLATE_NOOP("action", "Halve selected duration")
              ),
     UiAction("inc-duration-dotted",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Double selected duration (dotted)")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Double selected duration (dotted)"),
+             QT_TRANSLATE_NOOP("action", "Double selected duration (includes dotted values)")
              ),
     UiAction("dec-duration-dotted",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Halve selected duration (dotted)")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Halve selected duration (dotted)"),
+             QT_TRANSLATE_NOOP("action", "Halve selected duration (includes dotted values)")
              ),
     UiAction("notation-cut",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Cu&t"),
+             QT_TRANSLATE_NOOP("action", "Cut"),
              IconCode::Code::CUT
              ),
     UiAction("notation-copy",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "&Copy"),
+             QT_TRANSLATE_NOOP("action", "Copy"),
              IconCode::Code::COPY
              ),
     UiAction("notation-paste",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Past&e"),
+             QT_TRANSLATE_NOOP("action", "Paste"),
              IconCode::Code::PASTE
              ),
     UiAction("notation-paste-half",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Paste &half duration")
+             mu::context::CTX_NOTATION_FOCUSED,
+             QT_TRANSLATE_NOOP("action", "Paste &half duration"),
+             QT_TRANSLATE_NOOP("action", "Paste half duration")
              ),
     UiAction("notation-paste-double",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Paste &double duration")
+             mu::context::CTX_NOTATION_FOCUSED,
+             QT_TRANSLATE_NOOP("action", "Paste &double duration"),
+             QT_TRANSLATE_NOOP("action", "Paste double duration")
              ),
     UiAction("notation-paste-special",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Paste special"),
              QT_TRANSLATE_NOOP("action", "Paste special")
              ),
     UiAction("notation-swap",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "&Swap with clipboard")
+             mu::context::CTX_NOTATION_FOCUSED,
+             QT_TRANSLATE_NOOP("action", "&Swap with clipboard"),
+             QT_TRANSLATE_NOOP("action", "Copy/paste: swap with clipboard")
              ),
     UiAction("toggle-visible",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Toggle visibility of elements"),
              QT_TRANSLATE_NOOP("action", "Toggle visibility of elements")
              ),
     UiAction("notation-select-all",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Select &all")
+             mu::context::CTX_NOTATION_FOCUSED,
+             QT_TRANSLATE_NOOP("action", "Select &all"),
+             QT_TRANSLATE_NOOP("action", "Select all")
              ),
     UiAction("notation-select-section",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Select sectio&n")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Select sectio&n"),
+             QT_TRANSLATE_NOOP("action", "Select section")
              ),
     UiAction("select-similar",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Similar"),
-             QT_TRANSLATE_NOOP("action", "Select all similar elements")
+             QT_TRANSLATE_NOOP("action", "Select similar elements")
              ),
     UiAction("select-similar-staff",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Similar on this staff"),
-             QT_TRANSLATE_NOOP("action", "Select all similar elements on the same staff")
+             QT_TRANSLATE_NOOP("action", "Select similar elements on the same staff")
              ),
     UiAction("select-similar-range",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Similar in this range"),
-             QT_TRANSLATE_NOOP("action", "Select all similar elements in the range selection")
+             QT_TRANSLATE_NOOP("action", "Select similar elements in the selected range")
              ),
     UiAction("select-dialog",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "More…"),
-             QT_TRANSLATE_NOOP("action", "Select all similar elements with more options")
+             QT_TRANSLATE_NOOP("action", "Select similar elements with more options…")
              ),
     UiAction("notation-delete",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "De&lete"),
-             QT_TRANSLATE_NOOP("action", "Delete the selected element(s)"),
+             QT_TRANSLATE_NOOP("action", "Delete"),
              IconCode::Code::DELETE_TANK
              ),
     UiAction("edit-style",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "&Style…"),
-             QT_TRANSLATE_NOOP("action", "Edit style")
+             QT_TRANSLATE_NOOP("action", "Format style…")
              ),
     UiAction("page-settings",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "&Page settings…"),
-             QT_TRANSLATE_NOOP("action", "Page settings")
+             QT_TRANSLATE_NOOP("action", "Page settings…")
              ),
     UiAction("load-style",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "&Load style…"),
-             QT_TRANSLATE_NOOP("action", "Load style")
+             QT_TRANSLATE_NOOP("action", "Load style…")
              ),
     UiAction("save-style",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "S&ave style…"),
-             QT_TRANSLATE_NOOP("action", "Save style")
+             QT_TRANSLATE_NOOP("action", "Save style…")
              ),
     UiAction("transpose",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "&Transpose…"),
-             QT_TRANSLATE_NOOP("action", "Transpose")
+             QT_TRANSLATE_NOOP("action", "Transpose…")
              ),
     UiAction("explode",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "&Explode"),
-             QT_TRANSLATE_NOOP("action", "Explode contents of top selected staff into staves below")
+             QT_TRANSLATE_NOOP("action", "Explode")
              ),
     UiAction("implode",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "&Implode"),
-             QT_TRANSLATE_NOOP("action", "Implode contents of selected staves into top selected staff")
+             QT_TRANSLATE_NOOP("action", "Implode")
              ),
     UiAction("realize-chord-symbols",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Realize &chord symbols"),
-             QT_TRANSLATE_NOOP("action", "Convert chord symbols into notes")
+             QT_TRANSLATE_NOOP("action", "Realize chord symbols")
              ),
     UiAction("time-delete",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Remove selected ran&ge"),
+             QT_TRANSLATE_NOOP("action", "Delete selected measures"),
              IconCode::Code::DELETE_TANK
              ),
     UiAction("slash-fill",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Fill with slashes"),
              QT_TRANSLATE_NOOP("action", "Fill with slashes")
              ),
     UiAction("slash-rhythm",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Toggle rhythmic sl&ash notation")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Toggle rhythmic sl&ash notation"),
+             QT_TRANSLATE_NOOP("action", "Toggle ‘rhythmic slash notation’")
              ),
     UiAction("pitch-spell",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Respell &pitches")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Respell &pitches"),
+             QT_TRANSLATE_NOOP("action", "Respell pitches")
              ),
     UiAction("reset-groupings",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Regroup &rhythms"),
-             QT_TRANSLATE_NOOP("action", "Combine rests and tied notes from selection and resplit at rhythmical boundaries")
+             QT_TRANSLATE_NOOP("action", "Regroup rhythms")
              ),
     UiAction("resequence-rehearsal-marks",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Resequence re&hearsal marks")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Resequence re&hearsal marks"),
+             QT_TRANSLATE_NOOP("action", "Resequence rehearsal marks")
              ),
     UiAction("unroll-repeats",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Unroll repeats"),
              QT_TRANSLATE_NOOP("action", "Unroll repeats")
              ),
     UiAction("copy-lyrics-to-clipboard",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Copy &lyrics to clipboard")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Copy &lyrics to clipboard"),
+             QT_TRANSLATE_NOOP("action", "Copy lyrics")
              ),
     UiAction("del-empty-measures",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Remove empty trailing meas&ures")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Remove empty trailing meas&ures"),
+             QT_TRANSLATE_NOOP("action", "Remove empty trailing measures")
              ),
     UiAction("parts",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Parts"),
-             QT_TRANSLATE_NOOP("action", "Manage parts"),
+             QT_TRANSLATE_NOOP("action", "Parts…"),
              IconCode::Code::PAGE
              ),
     UiAction("view-mode-page",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Page view"),
+             QT_TRANSLATE_NOOP("action", "Display page view"),
              IconCode::Code::PAGE_VIEW
              ),
     UiAction("view-mode-continuous",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Continuous view (horizontal)"),
+             QT_TRANSLATE_NOOP("action", "Display continuous view (horizontal)"),
              IconCode::Code::CONTINUOUS_VIEW
              ),
     UiAction("view-mode-single",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Continuous view (vertical)"),
+             QT_TRANSLATE_NOOP("action", "Display continuous view (vertical)"),
              IconCode::Code::CONTINUOUS_VIEW_VERTICAL
              ),
     UiAction("find",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "&Find / Go To")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "&Find / Go To"),
+             QT_TRANSLATE_NOOP("action", "Find / Go to")
              ),
     UiAction("staff-properties",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Staff/part properties…"),
-             QT_TRANSLATE_NOOP("action", "Staff/part properties")
+             QT_TRANSLATE_NOOP("action", "Staff/part properties…")
              ),
     UiAction("staff-text-properties",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Staff text properties…"),
-             QT_TRANSLATE_NOOP("action", "Staff text properties")
+             QT_TRANSLATE_NOOP("action", "Staff text properties…")
              ),
     UiAction("system-text-properties",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "System text properties…"),
-             QT_TRANSLATE_NOOP("action", "System text properties")
+             QT_TRANSLATE_NOOP("action", "System text properties…")
              ),
     UiAction("measure-properties",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Measure properties…"),
-             QT_TRANSLATE_NOOP("action", "Measure properties")
+             QT_TRANSLATE_NOOP("action", "Measure properties…")
              ),
     UiAction("add-remove-breaks",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Add/remove s&ystem breaks…"),
-             QT_TRANSLATE_NOOP("action", "Add/remove system breaks")
+             QT_TRANSLATE_NOOP("action", "Add/remove system breaks…")
              ),
     UiAction("undo",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Undo"),
-             QT_TRANSLATE_NOOP("action", "Undo last change"),
+             QT_TRANSLATE_NOOP("action", "Undo"),
              IconCode::Code::UNDO
              ),
     UiAction("redo",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Redo"),
-             QT_TRANSLATE_NOOP("action", "Redo last undo"),
+             QT_TRANSLATE_NOOP("action", "Redo"),
              IconCode::Code::REDO
              ),
     UiAction("voice-x12",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Exchange voice &1-2"),
              QT_TRANSLATE_NOOP("action", "Exchange voice 1-2")
              ),
     UiAction("voice-x13",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Exchange voice 1-3"),
              QT_TRANSLATE_NOOP("action", "Exchange voice 1-3")
              ),
     UiAction("voice-x14",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Exchange voice 1-&4"),
              QT_TRANSLATE_NOOP("action", "Exchange voice 1-4")
              ),
     UiAction("voice-x23",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Exchange voice &2-3"),
              QT_TRANSLATE_NOOP("action", "Exchange voice 2-3")
              ),
     UiAction("voice-x24",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Exchange voice 2-4"),
              QT_TRANSLATE_NOOP("action", "Exchange voice 2-4")
              ),
     UiAction("voice-x34",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Exchange voice &3-4"),
              QT_TRANSLATE_NOOP("action", "Exchange voice 3-4")
              ),
     UiAction("system-break",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Toggle system break"),
-             QT_TRANSLATE_NOOP("action", "Toggle 'system break'")
+             QT_TRANSLATE_NOOP("action", "Toggle system break")
              ),
     UiAction("page-break",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Toggle page break"),
-             QT_TRANSLATE_NOOP("action", "Toggle 'page break'")
+             QT_TRANSLATE_NOOP("action", "Toggle page break")
              ),
     UiAction("section-break",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Toggle section break"),
-             QT_TRANSLATE_NOOP("action", "Toggle 'section break'")
+             QT_TRANSLATE_NOOP("action", "Add/remove section break")
              ),
     UiAction("split-measure",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "&Split measure before selected note/rest")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "&Split measure before selected note/rest"),
+             QT_TRANSLATE_NOOP("action", "Split measure before selected note/rest")
              ),
     UiAction("join-measures",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "&Join selected measures")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "&Join selected measures"),
+             QT_TRANSLATE_NOOP("action", "Join selected measures")
              ),
     UiAction("insert-measure",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Insert one measure before selection"),
              QT_TRANSLATE_NOOP("action", "Insert one measure before selection"),
              IconCode::Code::INSERT_ONE_MEASURE
              ),
     UiAction("insert-measures",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Insert measures before selection…"),
              QT_TRANSLATE_NOOP("action", "Insert measures before selection…")
              ),
     UiAction("insert-measures-after-selection",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Insert measures after selection…"),
              QT_TRANSLATE_NOOP("action", "Insert measures after selection…")
              ),
     UiAction("insert-measures-at-start-of-score",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Insert measures at start of score…"),
              QT_TRANSLATE_NOOP("action", "Insert measures at start of score…")
              ),
     UiAction("append-measure",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Insert one measure at end of score"),
              QT_TRANSLATE_NOOP("action", "Insert one measure at end of score")
              ),
     UiAction("append-measures",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Insert measures at end of score…"),
              QT_TRANSLATE_NOOP("action", "Insert measures at end of score…")
              ),
     UiAction("insert-hbox",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Insert &horizontal frame"),
+             QT_TRANSLATE_NOOP("action", "Insert horizontal frame"),
              IconCode::Code::HORIZONTAL_FRAME
              ),
     UiAction("insert-vbox",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Insert &vertical frame"),
+             QT_TRANSLATE_NOOP("action", "Insert vertical frame"),
              IconCode::Code::VERTICAL_FRAME
              ),
     UiAction("insert-textframe",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Insert &text frame"),
+             QT_TRANSLATE_NOOP("action", "Insert text frame"),
              IconCode::Code::TEXT_FRAME
              ),
     UiAction("append-hbox",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Append h&orizontal frame")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Append h&orizontal frame"),
+             QT_TRANSLATE_NOOP("action", "Append horizontal frame")
              ),
     UiAction("append-vbox",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Append v&ertical frame")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Append v&ertical frame"),
+             QT_TRANSLATE_NOOP("action", "Append vertical frame")
              ),
     UiAction("append-textframe",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Append te&xt frame")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Append te&xt frame"),
+             QT_TRANSLATE_NOOP("action", "Append text frame")
              ),
     UiAction("acciaccatura",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Acciaccatura"),
+             QT_TRANSLATE_NOOP("action", "Add grace note: acciaccatura"),
              IconCode::Code::ACCIACCATURA
              ),
     UiAction("appoggiatura",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Appoggiatura"),
+             QT_TRANSLATE_NOOP("action", "Add grace note: appoggiatura"),
              IconCode::Code::APPOGGIATURA
              ),
     UiAction("grace4",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Grace: quarter"),
+             QT_TRANSLATE_NOOP("action", "Add grace note: quarter"),
              IconCode::Code::GRACE4
              ),
     UiAction("grace16",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Grace: 16th"),
+             QT_TRANSLATE_NOOP("action", "Add grace note: 16th"),
              IconCode::Code::GRACE16
              ),
     UiAction("grace32",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Grace: 32nd"),
+             QT_TRANSLATE_NOOP("action", "Add grace note: 32nd"),
              IconCode::Code::GRACE32
              ),
     UiAction("grace8after",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Grace: 8th after"),
+             QT_TRANSLATE_NOOP("action", "Add grace note: eighth after"),
              IconCode::Code::GRACE8_AFTER
              ),
     UiAction("grace16after",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Grace: 16th after"),
+             QT_TRANSLATE_NOOP("action", "Add grace note: 16th after"),
              IconCode::Code::GRACE16_AFTER
              ),
     UiAction("grace32after",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Grace: 32nd after"),
+             QT_TRANSLATE_NOOP("action", "Add grace note: 32nd after"),
              IconCode::Code::GRACE32_AFTER
              ),
     UiAction("beam-auto",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Auto beam"),
              QT_TRANSLATE_NOOP("action", "Auto beam"),
              IconCode::Code::AUTO_TEXT
              ),
     UiAction("beam-none",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "No beam"),
+             QT_TRANSLATE_NOOP("action", "Remove beams"),
              IconCode::Code::NOTE_HEAD_EIGHTH
              ),
     UiAction("beam-break-left",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Break beam left"),
              QT_TRANSLATE_NOOP("action", "Break beam left"),
              IconCode::Code::BEAM_BREAK_LEFT
              ),
     UiAction("beam-break-inner-8th",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Break inner beams (8th)"),
+             QT_TRANSLATE_NOOP("action", "Break inner beams (eighth)"),
              IconCode::Code::BEAM_BREAK_INNER_8TH
              ),
     UiAction("beam-break-inner-16th",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Break inner beams (16th)"),
              QT_TRANSLATE_NOOP("action", "Break inner beams (16th)"),
              IconCode::Code::BEAM_BREAK_INNER_16TH
              ),
     UiAction("beam-join",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Join beams"),
              QT_TRANSLATE_NOOP("action", "Join beams"),
              IconCode::Code::BEAM_JOIN
              ),
     UiAction("beam-feathered-decelerate",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Feathered beam, decelerate"),
+             QT_TRANSLATE_NOOP("action", "Add feathered beam: decelerate"),
              IconCode::Code::BEAM_FEATHERED_DECELERATE
              ),
     UiAction("beam-feathered-accelerate",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Feathered beam, accelerate"),
+             QT_TRANSLATE_NOOP("action", "Add feathered beam: accelerate"),
              IconCode::Code::BEAM_FEATHERED_ACCELERATE
              ),
     UiAction("add-brackets",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Add brackets to accidental"),
              QT_TRANSLATE_NOOP("action", "Add brackets to accidental"),
              IconCode::Code::BRACKET
              ),
     UiAction("add-braces",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Add braces to element"),
              QT_TRANSLATE_NOOP("action", "Add braces to element"),
              IconCode::Code::BRACE
              ),
     UiAction("add-parentheses",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Add parentheses to element"),
              QT_TRANSLATE_NOOP("action", "Add parentheses to element"),
              IconCode::Code::BRACKET_PARENTHESES
              ),
     UiAction("interval1",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Unison above"),
-             QT_TRANSLATE_NOOP("action", "Enter unison above")
+             QT_TRANSLATE_NOOP("action", "Enter interval: unison")
              ),
     UiAction("interval2",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Se&cond above"),
-             QT_TRANSLATE_NOOP("action", "Enter second above")
+             QT_TRANSLATE_NOOP("action", "Enter interval: second above")
              ),
     UiAction("interval3",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Thir&d above"),
-             QT_TRANSLATE_NOOP("action", "Enter third above")
+             QT_TRANSLATE_NOOP("action", "Enter interval: third above")
              ),
     UiAction("interval4",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Fou&rth above"),
-             QT_TRANSLATE_NOOP("action", "Enter fourth above")
+             QT_TRANSLATE_NOOP("action", "Enter interval: fourth above")
              ),
     UiAction("interval5",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Fift&h above"),
-             QT_TRANSLATE_NOOP("action", "Enter fifth above")
+             QT_TRANSLATE_NOOP("action", "Enter interval: fifth above")
              ),
     UiAction("interval6",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Si&xth above"),
-             QT_TRANSLATE_NOOP("action", "Enter sixth above")
+             QT_TRANSLATE_NOOP("action", "Enter interval: sixth above")
              ),
     UiAction("interval7",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Seve&nth above"),
-             QT_TRANSLATE_NOOP("action", "Enter seventh above")
+             QT_TRANSLATE_NOOP("action", "Enter interval: seventh above")
              ),
     UiAction("interval8",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Octave &above"),
-             QT_TRANSLATE_NOOP("action", "Enter octave above")
+             QT_TRANSLATE_NOOP("action", "Enter interval: octave above")
              ),
     UiAction("interval9",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Ninth abov&e"),
-             QT_TRANSLATE_NOOP("action", "Enter ninth above")
+             QT_TRANSLATE_NOOP("action", "Enter interval: ninth above")
              ),
     UiAction("interval-2",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "&Second below"),
-             QT_TRANSLATE_NOOP("action", "Enter second below")
+             QT_TRANSLATE_NOOP("action", "Enter interval: second below")
              ),
     UiAction("interval-3",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "&Third below"),
-             QT_TRANSLATE_NOOP("action", "Enter third below")
+             QT_TRANSLATE_NOOP("action", "Enter interval: third below")
              ),
     UiAction("interval-4",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "F&ourth below"),
-             QT_TRANSLATE_NOOP("action", "Enter fourth below")
+             QT_TRANSLATE_NOOP("action", "Enter interval: fourth below")
              ),
     UiAction("interval-5",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "&Fifth below"),
-             QT_TRANSLATE_NOOP("action", "Enter fifth below")
+             QT_TRANSLATE_NOOP("action", "Enter interval: fifth below")
              ),
     UiAction("interval-6",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "S&ixth below"),
-             QT_TRANSLATE_NOOP("action", "Enter sixth below")
+             QT_TRANSLATE_NOOP("action", "Enter interval: sixth below")
              ),
     UiAction("interval-7",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Se&venth below"),
-             QT_TRANSLATE_NOOP("action", "Enter seventh below")
+             QT_TRANSLATE_NOOP("action", "Enter interval: seventh below")
              ),
     UiAction("interval-8",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Octave &below"),
-             QT_TRANSLATE_NOOP("action", "Enter octave below")
+             QT_TRANSLATE_NOOP("action", "Enter interval: octave below")
              ),
     UiAction("interval-9",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Ninth belo&w"),
-             QT_TRANSLATE_NOOP("action", "Enter ninth below")
+             QT_TRANSLATE_NOOP("action", "Enter interval: ninth below")
              ),
     UiAction("note-c",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              noteC,
              Enter_note_X.arg(noteC)
              ),
     UiAction("note-d",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              noteD,
              Enter_note_X.arg(noteD)
              ),
     UiAction("note-e",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              noteE,
              Enter_note_X.arg(noteE)
              ),
     UiAction("note-f",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              noteF,
              Enter_note_X.arg(noteF)
              ),
     UiAction("note-g",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              noteG,
              Enter_note_X.arg(noteG)
              ),
     UiAction("note-a",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              noteA,
              Enter_note_X.arg(noteA)
              ),
     UiAction("note-b",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              noteB,
              Enter_note_X.arg(noteB)
              ),
     UiAction("chord-c",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              Add_X_to_chord.arg(noteC),
              Add_note_X_to_chord.arg(noteC)
              ),
     UiAction("chord-d",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              Add_X_to_chord.arg(noteD),
              Add_note_X_to_chord.arg(noteD)
              ),
     UiAction("chord-e",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              Add_X_to_chord.arg(noteE),
              Add_note_X_to_chord.arg(noteE)
              ),
     UiAction("chord-f",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              Add_X_to_chord.arg(noteF),
              Add_note_X_to_chord.arg(noteF)
              ),
     UiAction("chord-g",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              Add_X_to_chord.arg(noteG),
              Add_note_X_to_chord.arg(noteG)
              ),
     UiAction("chord-a",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              Add_X_to_chord.arg(noteA),
              Add_note_X_to_chord.arg(noteA)
              ),
     UiAction("chord-b",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              Add_X_to_chord.arg(noteB),
              Add_note_X_to_chord.arg(noteB)
              ),
     UiAction("insert-c",
              mu::context::UiCtxNotationOpened,
-             Insert_X.arg(noteC),
-             Insert_note_X.arg(noteC)
+             mu::context::CTX_ANY,
+             Insert_X.arg(noteC)
              ),
     UiAction("insert-d",
              mu::context::UiCtxNotationOpened,
-             Insert_X.arg(noteD),
-             Insert_note_X.arg(noteD)
+             mu::context::CTX_ANY,
+             Insert_X.arg(noteD)
              ),
     UiAction("insert-e",
              mu::context::UiCtxNotationOpened,
-             Insert_X.arg(noteE),
-             Insert_note_X.arg(noteE)
+             mu::context::CTX_ANY,
+             Insert_X.arg(noteE)
              ),
     UiAction("insert-f",
              mu::context::UiCtxNotationOpened,
-             Insert_X.arg(noteF),
-             Insert_note_X.arg(noteF)
+             mu::context::CTX_ANY,
+             Insert_X.arg(noteF)
              ),
     UiAction("insert-g",
              mu::context::UiCtxNotationOpened,
-             Insert_X.arg(noteG),
-             Insert_note_X.arg(noteG)
+             mu::context::CTX_ANY,
+             Insert_X.arg(noteG)
              ),
     UiAction("insert-a",
              mu::context::UiCtxNotationOpened,
-             Insert_X.arg(noteA),
-             Insert_note_X.arg(noteA)
+             mu::context::CTX_ANY,
+             Insert_X.arg(noteA)
              ),
     UiAction("insert-b",
              mu::context::UiCtxNotationOpened,
-             Insert_X.arg(noteB),
-             Insert_note_X.arg(noteB)
+             mu::context::CTX_ANY,
+             Insert_X.arg(noteB)
              ),
     UiAction("rest",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_NOT_TAB,
              QT_TRANSLATE_NOOP("action", "Rest"),
              QT_TRANSLATE_NOOP("action", "Enter rest")
              ),
     UiAction("rest-1",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Whole rest"),
-             QT_TRANSLATE_NOOP("action", "Note input: Whole rest")
+             QT_TRANSLATE_NOOP("action", "Enter rest: whole")
              ),
     UiAction("rest-2",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Half rest"),
-             QT_TRANSLATE_NOOP("action", "Note input: Half rest")
+             QT_TRANSLATE_NOOP("action", "Enter rest: half")
              ),
     UiAction("rest-4",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Quarter rest"),
-             QT_TRANSLATE_NOOP("action", "Note input: Quarter rest")
+             QT_TRANSLATE_NOOP("action", "Enter rest: quarter")
              ),
     UiAction("rest-8",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Eighth rest"),
-             QT_TRANSLATE_NOOP("action", "Note input: Eighth rest")
+             QT_TRANSLATE_NOOP("action", "Enter rest: eighth")
              ),
     UiAction("fret-0",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_TAB,
              QT_TRANSLATE_NOOP("action", "Fret 0 (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Add fret 0 on current string (TAB only)")
+             QT_TRANSLATE_NOOP("action", "Enter TAB: fret 0")
              ),
     UiAction("fret-1",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_TAB,
              QT_TRANSLATE_NOOP("action", "Fret 1 (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Add fret 1 on current string (TAB only)")
+             QT_TRANSLATE_NOOP("action", "Enter TAB: fret 1")
              ),
     UiAction("fret-2",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_TAB,
              QT_TRANSLATE_NOOP("action", "Fret 2 (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Add fret 2 on current string (TAB only)")
+             QT_TRANSLATE_NOOP("action", "Enter TAB: fret 2")
              ),
     UiAction("fret-3",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_TAB,
              QT_TRANSLATE_NOOP("action", "Fret 3 (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Add fret 3 on current string (TAB only)")
+             QT_TRANSLATE_NOOP("action", "Enter TAB: fret 3")
              ),
     UiAction("fret-4",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_TAB,
              QT_TRANSLATE_NOOP("action", "Fret 4 (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Add fret 4 on current string (TAB only)")
+             QT_TRANSLATE_NOOP("action", "Enter TAB: fret 4")
              ),
     UiAction("fret-5",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_TAB,
              QT_TRANSLATE_NOOP("action", "Fret 5 (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Add fret 5 on current string (TAB only)")
+             QT_TRANSLATE_NOOP("action", "Enter TAB: fret 5")
              ),
     UiAction("fret-6",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_TAB,
              QT_TRANSLATE_NOOP("action", "Fret 6 (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Add fret 6 on current string (TAB only)")
+             QT_TRANSLATE_NOOP("action", "Enter TAB: fret 6")
              ),
     UiAction("fret-7",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_TAB,
              QT_TRANSLATE_NOOP("action", "Fret 7 (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Add fret 7 on current string (TAB only)")
+             QT_TRANSLATE_NOOP("action", "Enter TAB: fret 7")
              ),
     UiAction("fret-8",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_TAB,
              QT_TRANSLATE_NOOP("action", "Fret 8 (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Add fret 8 on current string (TAB only)")
+             QT_TRANSLATE_NOOP("action", "Enter TAB: fret 8")
              ),
     UiAction("fret-9",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_TAB,
              QT_TRANSLATE_NOOP("action", "Fret 9 (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Add fret 9 on current string (TAB only)")
+             QT_TRANSLATE_NOOP("action", "Enter TAB: fret 9")
              ),
     UiAction("fret-10",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_TAB,
              QT_TRANSLATE_NOOP("action", "Fret 10 (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Add fret 10 on current string (TAB only)")
+             QT_TRANSLATE_NOOP("action", "Enter TAB: fret 10")
              ),
     UiAction("fret-11",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_TAB,
              QT_TRANSLATE_NOOP("action", "Fret 11 (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Add fret 11 on current string (TAB only)")
+             QT_TRANSLATE_NOOP("action", "Enter TAB: fret 11")
              ),
     UiAction("fret-12",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_TAB,
              QT_TRANSLATE_NOOP("action", "Fret 12 (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Add fret 12 on current string (TAB only)")
+             QT_TRANSLATE_NOOP("action", "Enter TAB: fret 12")
              ),
     UiAction("fret-13",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_TAB,
              QT_TRANSLATE_NOOP("action", "Fret 13 (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Add fret 13 on current string (TAB only)")
+             QT_TRANSLATE_NOOP("action", "Enter TAB: fret 13")
              ),
     UiAction("fret-14",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_TAB,
              QT_TRANSLATE_NOOP("action", "Fret 14 (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Add fret 14 on current string (TAB only)")
+             QT_TRANSLATE_NOOP("action", "Enter TAB: fret 14")
              ),
     UiAction("add-8va",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Ottava 8va &alta"),
-             QT_TRANSLATE_NOOP("action", "Add ottava 8va alta")
+             QT_TRANSLATE_NOOP("action", "Add line: ottava 8va alta")
              ),
     UiAction("add-8vb",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Ottava 8va &bassa"),
-             QT_TRANSLATE_NOOP("action", "Add ottava 8va bassa")
+             QT_TRANSLATE_NOOP("action", "Add line: ottava 8va bassa")
              ),
     UiAction("add-hairpin",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Crescendo"),
-             QT_TRANSLATE_NOOP("action", "Add crescendo")
+             QT_TRANSLATE_NOOP("action", "Add hairpin: crescendo")
              ),
     UiAction("add-hairpin-reverse",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Decrescendo"),
-             QT_TRANSLATE_NOOP("action", "Add decrescendo")
+             QT_TRANSLATE_NOOP("action", "Add hairpin: decrescendo")
              ),
     UiAction("add-noteline",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "&Note anchored line")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "&Note anchored line"),
+             QT_TRANSLATE_NOOP("action", "Add line: note anchored")
              ),
     UiAction("chord-tie",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Add tied note to chord")
              ),
     UiAction("title-text",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Title"),
-             QT_TRANSLATE_NOOP("action", "Add title text")
+             QT_TRANSLATE_NOOP("action", "Add text: title")
              ),
     UiAction("subtitle-text",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "&Subtitle"),
-             QT_TRANSLATE_NOOP("action", "Add subtitle text")
+             QT_TRANSLATE_NOOP("action", "Add text: subtitle")
              ),
     UiAction("composer-text",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "&Composer"),
-             QT_TRANSLATE_NOOP("action", "Add composer text")
+             QT_TRANSLATE_NOOP("action", "Add text: composer")
              ),
     UiAction("poet-text",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Lyricist"),
-             QT_TRANSLATE_NOOP("action", "Add lyricist text")
+             QT_TRANSLATE_NOOP("action", "Add text: lyricist")
              ),
     UiAction("part-text",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "&Part name"),
-             QT_TRANSLATE_NOOP("action", "Add part name")
+             QT_TRANSLATE_NOOP("action", "Add text: part name")
              ),
     UiAction("system-text",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Syst&em text"),
-             QT_TRANSLATE_NOOP("action", "Add system text")
+             QT_TRANSLATE_NOOP("action", "Add text: system text")
              ),
     UiAction("staff-text",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "St&aff text"),
-             QT_TRANSLATE_NOOP("action", "Add staff text")
+             QT_TRANSLATE_NOOP("action", "Add text: staff text")
              ),
     UiAction("expression-text",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "E&xpression text"),
-             QT_TRANSLATE_NOOP("action", "Add expression text")
+             QT_TRANSLATE_NOOP("action", "Add text: expression text")
              ),
     UiAction("rehearsalmark-text",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Rehearsal mark"),
-             QT_TRANSLATE_NOOP("action", "Add rehearsal mark")
+             QT_TRANSLATE_NOOP("action", "Add text: rehearsal mark")
              ),
     UiAction("instrument-change-text",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "&Instrument change"),
-             QT_TRANSLATE_NOOP("action", "Add instrument change")
+             QT_TRANSLATE_NOOP("action", "Add text: instrument change")
              ),
     UiAction("fingering-text",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "&Fingering"),
-             QT_TRANSLATE_NOOP("action", "Add fingering")
+             QT_TRANSLATE_NOOP("action", "Add text: fingering")
              ),
     UiAction("sticking-text",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Stic&king"),
-             QT_TRANSLATE_NOOP("action", "Add sticking")
+             QT_TRANSLATE_NOOP("action", "Add text: sticking")
              ),
     UiAction("chord-text",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Chor&d symbol"),
-             QT_TRANSLATE_NOOP("action", "Add chord symbol")
+             QT_TRANSLATE_NOOP("action", "Add text: chord symbol")
              ),
     UiAction("roman-numeral-text",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "R&oman numeral analysis"),
-             QT_TRANSLATE_NOOP("action", "Add Roman numeral analysis")
+             QT_TRANSLATE_NOOP("action", "Add text: Roman numeral analysis")
              ),
     UiAction("nashville-number-text",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Nashville number"),
-             QT_TRANSLATE_NOOP("action", "Add Nashville number")
+             QT_TRANSLATE_NOOP("action", "Add text: Nashville number")
              ),
     UiAction("lyrics",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "L&yrics"),
-             QT_TRANSLATE_NOOP("action", "Add lyrics")
+             QT_TRANSLATE_NOOP("action", "Add text: lyrics")
              ),
     UiAction("figured-bass",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Figured &bass"),
-             QT_TRANSLATE_NOOP("action", "Add figured bass")
+             QT_TRANSLATE_NOOP("action", "Add text: figured bass")
              ),
     UiAction("tempo",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Tempo &marking"),
-             QT_TRANSLATE_NOOP("action", "Add tempo marking")
+             QT_TRANSLATE_NOOP("action", "Add text: tempo marking")
              ),
     UiAction("duplet",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Duplet"),
-             QT_TRANSLATE_NOOP("action", "Add duplet")
+             QT_TRANSLATE_NOOP("action", "Enter tuplet: duplet")
              ),
     UiAction("triplet",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Triplet"),
-             QT_TRANSLATE_NOOP("action", "Add triplet")
+             QT_TRANSLATE_NOOP("action", "Enter tuplet: triplet")
              ),
     UiAction("quadruplet",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Quadruplet"),
-             QT_TRANSLATE_NOOP("action", "Add quadruplet")
+             QT_TRANSLATE_NOOP("action", "Enter tuplet: quadruplet")
              ),
     UiAction("quintuplet",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Q&uintuplet"),
-             QT_TRANSLATE_NOOP("action", "Add quintuplet")
+             QT_TRANSLATE_NOOP("action", "Enter tuplet: quintuplet")
              ),
     UiAction("sextuplet",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Se&xtuplet"),
-             QT_TRANSLATE_NOOP("action", "Add sextuplet")
+             QT_TRANSLATE_NOOP("action", "Enter tuplet: sextuplet")
              ),
     UiAction("septuplet",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Se&ptuplet"),
-             QT_TRANSLATE_NOOP("action", "Add septuplet")
+             QT_TRANSLATE_NOOP("action", "Enter tuplet: septuplet")
              ),
     UiAction("octuplet",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Octuplet"),
-             QT_TRANSLATE_NOOP("action", "Add octuplet")
+             QT_TRANSLATE_NOOP("action", "Enter tuplet: octuplet")
              ),
     UiAction("nonuplet",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Nontuplet"),
-             QT_TRANSLATE_NOOP("action", "Add nontuplet")
+             QT_TRANSLATE_NOOP("action", "Enter tuplet: nonuplet")
              ),
     UiAction("tuplet-dialog",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Othe&r…"),
-             QT_TRANSLATE_NOOP("action", "Other tuplets")
+             QT_TRANSLATE_NOOP("action", "Create custom tuplet…")
              ),
     UiAction("stretch-",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Decrease layout stretch"),
-             QT_TRANSLATE_NOOP("action", "Decrease layout stretch factor of selected measures")
+             QT_TRANSLATE_NOOP("action", "Decrease layout stretch")
              ),
     UiAction("stretch+",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Increase layout stretch"),
-             QT_TRANSLATE_NOOP("action", "Increase layout stretch factor of selected measures")
+             QT_TRANSLATE_NOOP("action", "Increase layout stretch")
              ),
     UiAction("reset-stretch",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "&Reset layout stretch"),
-             QT_TRANSLATE_NOOP("action", "Reset layout stretch factor of selected measures or entire score")
+             QT_TRANSLATE_NOOP("action", "Reset layout stretch")
              ),
     UiAction("reset-text-style-overrides",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Reset &text style overrides"),
              QT_TRANSLATE_NOOP("action", "Reset all text style overrides to default")
              ),
     UiAction("reset-beammode",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Reset &beams"),
-             QT_TRANSLATE_NOOP("action", "Reset beams of selected measures")
+             QT_TRANSLATE_NOOP("action", "Reset beams to default grouping")
              ),
     UiAction("reset",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Reset shapes and &positions"),
-             QT_TRANSLATE_NOOP("action", "Reset shapes and positions of selected elements to their defaults")
+             QT_TRANSLATE_NOOP("action", "Reset shapes and positions")
              ),
     UiAction("zoomin",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Zoom in"),
              QT_TRANSLATE_NOOP("action", "Zoom in"),
              IconCode::Code::ZOOM_IN
              ),
     UiAction("zoomout",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Zoom out"),
              QT_TRANSLATE_NOOP("action", "Zoom out"),
              IconCode::Code::ZOOM_OUT
              ),
     UiAction("zoom100",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Zoom to 100%"),
              QT_TRANSLATE_NOOP("action", "Zoom to 100%")
              ),
     UiAction("get-location",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Accessibility: Get location")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Accessibility: Get location"),
+             QT_TRANSLATE_NOOP("action", "Accessibility: get location")
              ),
     UiAction("edit-element",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Edit element"),
              QT_TRANSLATE_NOOP("action", "Edit element")
              ),
     UiAction("select-prev-measure",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Select to beginning of measure"),
              QT_TRANSLATE_NOOP("action", "Select to beginning of measure")
              ),
     UiAction("select-next-measure",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Select to end of measure"),
              QT_TRANSLATE_NOOP("action", "Select to end of measure")
              ),
     UiAction("select-begin-line",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Select to beginning of line"),
              QT_TRANSLATE_NOOP("action", "Select to beginning of line")
              ),
     UiAction("select-end-line",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Select to end of line"),
              QT_TRANSLATE_NOOP("action", "Select to end of line")
              ),
     UiAction("select-begin-score",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Select to beginning of score"),
              QT_TRANSLATE_NOOP("action", "Select to beginning of score")
              ),
     UiAction("select-end-score",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Select to end of score"),
              QT_TRANSLATE_NOOP("action", "Select to end of score")
              ),
     UiAction("select-staff-above",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Add staff above to selection")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Add staff above to selection"),
+             QT_TRANSLATE_NOOP("action", "Add to selection: staff above")
              ),
     UiAction("select-staff-below",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Add staff below to selection")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Add staff below to selection"),
+             QT_TRANSLATE_NOOP("action", "Add to selection: staff below")
              ),
     UiAction("scr-prev",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Screen: Previous")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Screen: Previous"),
+             QT_TRANSLATE_NOOP("action", "Go to screen: previous")
              ),
     UiAction("scr-next",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Screen: Next")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Screen: Next"),
+             QT_TRANSLATE_NOOP("action", "Go to screen: next")
              ),
     UiAction("page-prev",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Page: Previous")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Page: Previous"),
+             QT_TRANSLATE_NOOP("action", "Go to page: previous")
              ),
     UiAction("page-next",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Page: Next")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Page: Next"),
+             QT_TRANSLATE_NOOP("action", "Go to page: next")
              ),
     UiAction("page-top",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Page: Top of first")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Page: Top of first"),
+             QT_TRANSLATE_NOOP("action", "Go to page: top of first")
              ),
     UiAction("page-end",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Page: Bottom of last")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Page: Bottom of last"),
+             QT_TRANSLATE_NOOP("action", "Go to page: bottom of last")
              ),
     UiAction("help",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Context sensitive help")
              ),
     UiAction("repeat-sel",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Repeat selection"),
              QT_TRANSLATE_NOOP("action", "Repeat selection")
              ),
     UiAction("lock",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Toggle score lock"),
              QT_TRANSLATE_NOOP("action", "Toggle score lock")
              ),
     UiAction("enh-both",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Change enharmonic spelling (both modes)"),
-             QT_TRANSLATE_NOOP("action", "Change enharmonic spelling (both modes)"),
+             QT_TRANSLATE_NOOP("action", "Change enharmonic spelling (concert and written pitch)"),
              IconCode::Code::NONE
              ),
     UiAction("enh-current",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Change enharmonic spelling (current mode)"),
-             QT_TRANSLATE_NOOP("action", "Change enharmonic spelling (current mode)"),
+             QT_TRANSLATE_NOOP("action", "Change enharmonic spelling (current mode only)"),
              IconCode::Code::NONE
              ),
     UiAction("flip",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Flip direction"),
              QT_TRANSLATE_NOOP("action", "Flip direction"),
              IconCode::Code::NOTE_FLIP
              ),
     UiAction(TOGGLE_CONCERT_PITCH_CODE,
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Concert pitch"),
-             QT_TRANSLATE_NOOP("action", "Toggle 'Concert pitch'"),
+             QT_TRANSLATE_NOOP("action", "Toggle concert pitch"),
              IconCode::Code::TUNING_FORK,
              Checkable::Yes
              ),
     UiAction("next-text-element",
              mu::context::UiCtxNotationFocused,
+             mu::context::CTX_NOTATION_TEXT_EDITING,
              QT_TRANSLATE_NOOP("action", "Next text element"),
-             QT_TRANSLATE_NOOP("action", "Move to text element on next note")
+             QT_TRANSLATE_NOOP("action", "Go to next syllable")
              ),
     UiAction("prev-text-element",
              mu::context::UiCtxNotationFocused,
+             mu::context::CTX_NOTATION_TEXT_EDITING,
              QT_TRANSLATE_NOOP("action", "Previous text element"),
-             QT_TRANSLATE_NOOP("action", "Move to text element on previous note")
+             QT_TRANSLATE_NOOP("action", "Go to previous syllable")
              ),
     UiAction("next-beat-TEXT",
              mu::context::UiCtxNotationFocused,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Next beat (Chord symbol)"),
-             QT_TRANSLATE_NOOP("action", "Next beat (Chord symbol)")
+             QT_TRANSLATE_NOOP("action", "Advance cursor: next beat (chord symbols)")
              ),
     UiAction("prev-beat-TEXT",
              mu::context::UiCtxNotationFocused,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Previous beat (Chord symbol)"),
-             QT_TRANSLATE_NOOP("action", "Previous beat (Chord symbol)")
+             QT_TRANSLATE_NOOP("action", "Move cursor to previous beat (chord symbols)")
              ),
     UiAction("advance-longa",
              mu::context::UiCtxNotationFocused,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Longa advance (F.B./Chord symbol)"),
-             QT_TRANSLATE_NOOP("action", "Advance of a longa (Figured bass/Chord symbol only)")
+             QT_TRANSLATE_NOOP("action", "Advance cursor: longa (figured bass/chord symbols)")
              ),
     UiAction("advance-breve",
              mu::context::UiCtxNotationFocused,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Breve advance (F.B./Chord symbol)"),
-             QT_TRANSLATE_NOOP("action", "Advance of a double whole note (Figured bass/Chord symbol only)")
+             QT_TRANSLATE_NOOP("action", "Advance cursor: breve (figured bass/chord symbols)")
              ),
     UiAction("advance-1",
              mu::context::UiCtxNotationFocused,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Whole note advance (F.B./Chord symbol)"),
-             QT_TRANSLATE_NOOP("action", "Advance of a whole note (Figured bass/Chord symbol only)")
+             QT_TRANSLATE_NOOP("action", "Advance cursor: whole note (figured bass/chord symbols)")
              ),
     UiAction("advance-2",
              mu::context::UiCtxNotationFocused,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Half note advance (F.B./Chord symbol)"),
-             QT_TRANSLATE_NOOP("action", "Advance of a half note (Figured bass/Chord symbol only)")
+             QT_TRANSLATE_NOOP("action", "Advance cursor: half note (figured bass/chord symbols)")
              ),
     UiAction("advance-4",
              mu::context::UiCtxNotationFocused,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Quarter note advance (F.B./Chord symbol)"),
-             QT_TRANSLATE_NOOP("action", "Advance of a quarter note (Figured bass/Chord symbol only)")
+             QT_TRANSLATE_NOOP("action", "Advance cursor: quarter note (figured bass/chord symbols)")
              ),
     UiAction("advance-8",
              mu::context::UiCtxNotationFocused,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Eighth note advance (F.B./Chord symbol)"),
-             QT_TRANSLATE_NOOP("action", "Advance of an eighth note (Figured bass/Chord symbol only)")
+             QT_TRANSLATE_NOOP("action", "Advance cursor: eighth note (figured bass/chord symbols)")
              ),
     UiAction("advance-16",
              mu::context::UiCtxNotationFocused,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "16th note advance (F.B./Chord symbol)"),
-             QT_TRANSLATE_NOOP("action", "Advance of a 16th note (Figured bass/Chord symbol only)")
+             QT_TRANSLATE_NOOP("action", "Advance cursor: 16th note (figured bass/chord symbols)")
              ),
     UiAction("advance-32",
              mu::context::UiCtxNotationFocused,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "32nd note advance (F.B./Chord symbol)"),
-             QT_TRANSLATE_NOOP("action", "Advance of a 32nd note (Figured bass/Chord symbol only)")
+             QT_TRANSLATE_NOOP("action", "Advance cursor: 32nd note (figured bass/chord symbols)")
              ),
     UiAction("advance-64",
              mu::context::UiCtxNotationFocused,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "64th note advance (F.B./Chord symbol)"),
-             QT_TRANSLATE_NOOP("action", "Advance of a 64th note (Figured bass/Chord symbol only)")
+             QT_TRANSLATE_NOOP("action", "Advance cursor: 64th note (figured bass/chord symbols)")
              ),
     UiAction("next-lyric-verse",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_TEXT_EDITING,
              QT_TRANSLATE_NOOP("action", "Next lyric verse"),
-             QT_TRANSLATE_NOOP("action", "Move to lyric in the next verse")
+             QT_TRANSLATE_NOOP("action", "Move text/go to next lyric verse")
              ),
     UiAction("prev-lyric-verse",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_TEXT_EDITING,
              QT_TRANSLATE_NOOP("action", "Previous lyric verse"),
-             QT_TRANSLATE_NOOP("action", "Move to lyric in the previous verse")
+             QT_TRANSLATE_NOOP("action", "Move text/go to previous lyric verse")
              ),
     UiAction("next-syllable",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_TEXT_EDITING,
              QT_TRANSLATE_NOOP("action", "Next syllable"),
-             QT_TRANSLATE_NOOP("action", "Add hyphen and move to lyric on next note")
+             QT_TRANSLATE_NOOP("action", "Hyphenate lyrics")
              ),
     UiAction("add-melisma",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_TEXT_EDITING,
              QT_TRANSLATE_NOOP("action", "Add melisma"),
-             QT_TRANSLATE_NOOP("action", "Add melisma line and move to lyric on next note")
+             QT_TRANSLATE_NOOP("action", "Enter melisma")
              ),
     UiAction("add-lyric-verse",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Add lyric verse"),
-             QT_TRANSLATE_NOOP("action", "Adds a new verse and starts editing")
+             QT_TRANSLATE_NOOP("action", "Add lyric verse")
              ),
     UiAction("text-b",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Bold face"),
+             QT_TRANSLATE_NOOP("action", "Format text: bold"),
              Checkable::Yes
              ),
     UiAction("text-i",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Italic"),
+             QT_TRANSLATE_NOOP("action", "Format text: italic"),
              Checkable::Yes
              ),
     UiAction("text-u",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Underline"),
+             QT_TRANSLATE_NOOP("action", "Format text: underline"),
              Checkable::Yes
              ),
     UiAction("text-s",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Strike"),
+             QT_TRANSLATE_NOOP("action", "Format text: strikethrough"),
              Checkable::Yes
              ),
     UiAction("pitch-up-diatonic",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Diatonic pitch up")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Diatonic pitch up"),
+             QT_TRANSLATE_NOOP("action", "Move pitch up diatonically")
              ),
     UiAction("pitch-down-diatonic",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Diatonic pitch down")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Diatonic pitch down"),
+             QT_TRANSLATE_NOOP("action", "Move pitch down diatonically")
              ),
     UiAction("top-staff",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
+             QT_TRANSLATE_NOOP("action", "Go to top staff"),
              QT_TRANSLATE_NOOP("action", "Go to top staff")
              ),
     UiAction("empty-trailing-measure",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Go to first empty trailing measure"),
              QT_TRANSLATE_NOOP("action", "Go to first empty trailing measure")
              ),
     UiAction("mirror-note",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Mirror notehead"),
              QT_TRANSLATE_NOOP("action", "Mirror notehead")
              ),
     UiAction("add-trill",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Toggle trill")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Toggle trill"),
+             QT_TRANSLATE_NOOP("action", "Add/remove ornament: trill")
              ),
     UiAction("add-up-bow",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Toggle up bow")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Toggle up bow"),
+             QT_TRANSLATE_NOOP("action", "Add/remove bowing: up bow")
              ),
     UiAction("add-down-bow",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Toggle down bow")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Toggle down bow"),
+             QT_TRANSLATE_NOOP("action", "Add/remove bowing: down bow")
              ),
     UiAction("reset-style",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Reset style"),
              QT_TRANSLATE_NOOP("action", "Reset all style values to default")
              ),
     UiAction("clef-violin",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Add treble clef")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Add treble clef"),
+             QT_TRANSLATE_NOOP("action", "Add clef: treble")
              ),
     UiAction("clef-bass",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Add bass clef")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Add bass clef"),
+             QT_TRANSLATE_NOOP("action", "Add clef: bass")
              ),
     UiAction("sharp2-post",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Double ♯ (non-toggle)")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Double ♯ (non-toggle)"),
+             QT_TRANSLATE_NOOP("action", "Apply accidental retrospectively: double sharp")
              ),
     UiAction("sharp-post",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "♯ (non-toggle)")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "♯ (non-toggle)"),
+             QT_TRANSLATE_NOOP("action", "Apply accidental retrospectively: sharp")
              ),
     UiAction("nat-post",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "♮ (non-toggle)")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "♮ (non-toggle)"),
+             QT_TRANSLATE_NOOP("action", "Apply accidental retrospectively: natural")
              ),
     UiAction("flat-post",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "♭ (non-toggle)")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "♭ (non-toggle)"),
+             QT_TRANSLATE_NOOP("action", "Apply accidental retrospectively: flat")
              ),
     UiAction("flat2-post",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Double ♭ (non-toggle)")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Double ♭ (non-toggle)"),
+             QT_TRANSLATE_NOOP("action", "Apply accidental retrospectively: double flat")
              ),
     UiAction("transpose-up",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Transpose up")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Transpose up"),
+             QT_TRANSLATE_NOOP("action", "Transpose up half a step")
              ),
     UiAction("transpose-down",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Transpose down")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Transpose down"),
+             QT_TRANSLATE_NOOP("action", "Transpose down half a step")
              ),
     UiAction("pitch-up-diatonic-alterations",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Diatonic pitch up (keep degree alterations)")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Diatonic pitch up (keep degree alterations)"),
+             QT_TRANSLATE_NOOP("action", "Move pitch up diatonically (keep degree alterations)")
              ),
     UiAction("pitch-down-diatonic-alterations",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Diatonic pitch down (keep degree alterations)")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Diatonic pitch down (keep degree alterations)"),
+             QT_TRANSLATE_NOOP("action", "Move pitch down diatonically (keep degree alterations)")
              ),
     UiAction("full-measure-rest",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Full measure rest")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Full measure rest"),
+             QT_TRANSLATE_NOOP("action", "Insert full measure rest")
              ),
     UiAction("toggle-mmrest",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Toggle 'Create multimeasure rest'")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Toggle 'Create multimeasure rest'"),
+             QT_TRANSLATE_NOOP("action", "Toggle multimeasure rest")
              ),
     UiAction("toggle-hide-empty",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Toggle 'Hide empty staves'")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Toggle 'Hide empty staves'"),
+             QT_TRANSLATE_NOOP("action", "Show/hide empty staves")
              ),
     UiAction("set-visible",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Set visible")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Set visible"),
+             QT_TRANSLATE_NOOP("action", "Make selected element(s) visible")
              ),
     UiAction("unset-visible",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Set invisible")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Set invisible"),
+             QT_TRANSLATE_NOOP("action", "Make selected element(s) invisible")
              ),
     UiAction("toggle-autoplace",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Toggle 'automatic placement' for selected elements")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Toggle 'automatic placement' for selected elements"),
+             QT_TRANSLATE_NOOP("action", "Toggle automatic placement for selected elements")
              ),
     UiAction("autoplace-enabled",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Toggle 'automatic placement' (whole score)")
+             mu::context::CTX_NOTATION_OPENED,
+             QT_TRANSLATE_NOOP("action", "Toggle 'automatic placement' (whole score)"),
+             QT_TRANSLATE_NOOP("action", "Toggle ‘automatic placement’ (whole score)")
              ),
     UiAction("string-above",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "String Above (TAB)")
+             mu::context::CTX_NOTATION_STAFF_TAB,
+             QT_TRANSLATE_NOOP("action", "String Above (TAB)"),
+             QT_TRANSLATE_NOOP("action", "Go to string above (TAB)")
              ),
     UiAction("string-below",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "String Below (TAB)")
+             mu::context::CTX_NOTATION_STAFF_TAB,
+             QT_TRANSLATE_NOOP("action", "String Below (TAB)"),
+             QT_TRANSLATE_NOOP("action", "Go to string below (TAB)")
              ),
     UiAction("pad-note-1-TAB",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Whole note (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Note duration: whole note (TAB)"),
+             QT_TRANSLATE_NOOP("action", "Set duration: whole note (TAB)"),
              IconCode::Code::NOTE_WHOLE
              ),
     UiAction("pad-note-2-TAB",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Half note (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Note duration: half note (TAB)"),
+             QT_TRANSLATE_NOOP("action", "Set duration: half note (TAB)"),
              IconCode::Code::NOTE_HALF
              ),
     UiAction("pad-note-4-TAB",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Quarter note (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Note duration: quarter note (TAB)"),
+             QT_TRANSLATE_NOOP("action", "Set duration: quarter note (TAB)"),
              IconCode::Code::NOTE_QUARTER
              ),
     UiAction("pad-note-8-TAB",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "8th note (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Note duration: 8th note (TAB)"),
+             QT_TRANSLATE_NOOP("action", "Set duration: eighth note (TAB)"),
              IconCode::Code::NOTE_8TH
              ),
     UiAction("pad-note-16-TAB",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "16th note (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Note duration: 16th note (TAB)"),
+             QT_TRANSLATE_NOOP("action", "Set duration: 16th note (TAB)"),
              IconCode::Code::NOTE_16TH
              ),
     UiAction("pad-note-32-TAB",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "32nd note (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Note duration: 32nd note (TAB)"),
+             QT_TRANSLATE_NOOP("action", "Set duration: 32nd note (TAB)"),
              IconCode::Code::NOTE_32ND
              ),
     UiAction("pad-note-64-TAB",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "64th note (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Note duration: 64th note (TAB)"),
+             QT_TRANSLATE_NOOP("action", "Set duration: 64th note (TAB)"),
              IconCode::Code::NOTE_64TH
              ),
     UiAction("pad-note-128-TAB",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "128th note (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Note duration: 128th note (TAB)"),
+             QT_TRANSLATE_NOOP("action", "Set duration: 128th note (TAB)"),
              IconCode::Code::NOTE_128TH
              ),
     UiAction("pad-note-256-TAB",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "256th note (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Note duration: 256th note (TAB)"),
+             QT_TRANSLATE_NOOP("action", "Set duration: 256th note (TAB)"),
              IconCode::Code::NOTE_256TH
              ),
     UiAction("pad-note-512-TAB",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "512th note (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Note duration: 512th note (TAB)"),
+             QT_TRANSLATE_NOOP("action", "Set duration: 512th note (TAB)"),
              IconCode::Code::NOTE_512TH
              ),
     UiAction("pad-note-1024-TAB",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "1024th note (TAB)"),
-             QT_TRANSLATE_NOOP("action", "Note duration: 1024th note (TAB)"),
+             QT_TRANSLATE_NOOP("action", "Set duration: 1024th note (TAB)"),
              IconCode::Code::NOTE_1024TH
              ),
     UiAction("notation-context-menu",
-             mu::context::UiCtxNotationFocused
+             mu::context::UiCtxNotationFocused,
+             mu::context::CTX_NOTATION_FOCUSED
              )
 };
 
 const UiActionList NotationUiActions::m_noteInputActions = {
     UiAction(NOTE_INPUT_ACTION_CODE,
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Note input"),
-             QT_TRANSLATE_NOOP("action", "Enter notes with a mouse or keyboard"),
+             QT_TRANSLATE_NOOP("action", "Note input: toggle note input mode"),
              IconCode::Code::EDIT,
              Checkable::Yes
              ),
     UiAction("note-input-steptime",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Default (step time)"),
-             QT_TRANSLATE_NOOP("action", "Enter notes with a mouse or keyboard"),
+             QT_TRANSLATE_NOOP("action", "Note input: toggle ‘default (step-time)’ mode"),
              IconCode::Code::EDIT
              ),
     UiAction("note-input-rhythm",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Rhythm only (not pitch)"),
-             QT_TRANSLATE_NOOP("action", "Enter durations with a single click or keypress"),
+             QT_TRANSLATE_NOOP("action", "Note input: toggle ‘rhythm only (not pitch)’ mode"),
              IconCode::Code::RHYTHM_ONLY
              ),
     UiAction("note-input-repitch",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Re-pitch existing notes"),
-             QT_TRANSLATE_NOOP("action", "Replace pitches without changing rhythms"),
+             QT_TRANSLATE_NOOP("action", "Note input: toggle ‘re-pitch existing notes’ mode"),
              IconCode::Code::RE_PITH
              ),
     UiAction("note-input-realtime-auto",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Real-time (metronome)"),
-             QT_TRANSLATE_NOOP("action", "Enter notes at a fixed tempo indicated by a metronome beat"),
+             QT_TRANSLATE_NOOP("action", "Note input: toggle ‘real-time (metronome)’ mode"),
              IconCode::Code::METRONOME
              ),
     UiAction("note-input-realtime-manual",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Real-time (foot pedal)"),
-             QT_TRANSLATE_NOOP("action", "Enter notes while tapping a key or pedal to set the tempo"),
+             QT_TRANSLATE_NOOP("action", "Note input: toggle ‘real-time (foot pedal)’ mode"),
              IconCode::Code::FOOT_PEDAL
              ),
     UiAction("note-input-timewise",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Insert"),
-             QT_TRANSLATE_NOOP("action", "Insert notes by increasing measure duration"),
+             QT_TRANSLATE_NOOP("action", "Note input: toggle ‘insert’ mode (increases measure duration)"),
              IconCode::Code::NOTE_PLUS
              ),
     UiAction("note-longa",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_NOT_TAB,
              QT_TRANSLATE_NOOP("action", "Longa"),
-             QT_TRANSLATE_NOOP("action", "Note duration: longa"),
+             QT_TRANSLATE_NOOP("action", "Set duration: longa"),
              IconCode::Code::LONGO
              ),
     UiAction("note-breve",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_NOT_TAB,
              QT_TRANSLATE_NOOP("action", "Double whole note"),
-             QT_TRANSLATE_NOOP("action", "Note duration: double whole note"),
+             QT_TRANSLATE_NOOP("action", "Set duration: double whole note"),
              IconCode::Code::NOTE_WHOLE_DOUBLE
              ),
     UiAction("pad-note-1",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_NOT_TAB,
              QT_TRANSLATE_NOOP("action", "Whole note"),
-             QT_TRANSLATE_NOOP("action", "Note duration: whole note"),
+             QT_TRANSLATE_NOOP("action", "Set duration: whole note"),
              IconCode::Code::NOTE_WHOLE
              ),
     UiAction("pad-note-2",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_NOT_TAB,
              QT_TRANSLATE_NOOP("action", "Half note"),
-             QT_TRANSLATE_NOOP("action", "Note duration: half note"),
+             QT_TRANSLATE_NOOP("action", "Set duration: half note"),
              IconCode::Code::NOTE_HALF
              ),
     UiAction("pad-note-4",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_NOT_TAB,
              QT_TRANSLATE_NOOP("action", "Quarter note"),
-             QT_TRANSLATE_NOOP("action", "Note duration: quarter note"),
+             QT_TRANSLATE_NOOP("action", "Set duration: quarter note"),
              IconCode::Code::NOTE_QUARTER
              ),
     UiAction("pad-note-8",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_NOT_TAB,
              QT_TRANSLATE_NOOP("action", "8th note"),
-             QT_TRANSLATE_NOOP("action", "Note duration: 8th note"),
+             QT_TRANSLATE_NOOP("action", "Set duration: eighth note"),
              IconCode::Code::NOTE_8TH
              ),
     UiAction("pad-note-16",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_NOT_TAB,
              QT_TRANSLATE_NOOP("action", "16th note"),
-             QT_TRANSLATE_NOOP("action", "Note duration: 16th note"),
+             QT_TRANSLATE_NOOP("action", "Set duration: 16th note"),
              IconCode::Code::NOTE_16TH
              ),
     UiAction("pad-note-32",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_NOT_TAB,
              QT_TRANSLATE_NOOP("action", "32nd note"),
-             QT_TRANSLATE_NOOP("action", "Note duration: 32nd note"),
+             QT_TRANSLATE_NOOP("action", "Set duration: 32nd note"),
              IconCode::Code::NOTE_32ND
              ),
     UiAction("pad-note-64",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_NOT_TAB,
              QT_TRANSLATE_NOOP("action", "64th note"),
-             QT_TRANSLATE_NOOP("action", "Note duration: 64th note"),
+             QT_TRANSLATE_NOOP("action", "Set duration: 64th note"),
              IconCode::Code::NOTE_64TH
              ),
     UiAction("pad-note-128",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_NOT_TAB,
              QT_TRANSLATE_NOOP("action", "128th note"),
-             QT_TRANSLATE_NOOP("action", "Note duration: 128th note"),
+             QT_TRANSLATE_NOOP("action", "Set duration: 128th note"),
              IconCode::Code::NOTE_128TH
              ),
     UiAction("pad-note-256",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_NOT_TAB,
              QT_TRANSLATE_NOOP("action", "256th note"),
-             QT_TRANSLATE_NOOP("action", "Note duration: 256th note"),
+             QT_TRANSLATE_NOOP("action", "Set duration: 256th note"),
              IconCode::Code::NOTE_256TH
              ),
     UiAction("pad-note-512",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_NOT_TAB,
              QT_TRANSLATE_NOOP("action", "512th note"),
-             QT_TRANSLATE_NOOP("action", "Note duration: 512th note"),
+             QT_TRANSLATE_NOOP("action", "Set duration: 512th note"),
              IconCode::Code::NOTE_512TH
              ),
     UiAction("pad-note-1024",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_NOT_TAB,
              QT_TRANSLATE_NOOP("action", "1024th note"),
-             QT_TRANSLATE_NOOP("action", "Note duration: 1024th note"),
+             QT_TRANSLATE_NOOP("action", "Set duration: 1024th note"),
              IconCode::Code::NOTE_1024TH
              ),
     UiAction("pad-dot",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_STAFF_NOT_TAB,
              QT_TRANSLATE_NOOP("action", "Augmentation dot"),
-             QT_TRANSLATE_NOOP("action", "Note duration: augmentation dot"),
+             QT_TRANSLATE_NOOP("action", "Toggle duration dot"),
              IconCode::Code::NOTE_DOTTED
              ),
     UiAction("pad-dot2",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Double augmentation dot"),
-             QT_TRANSLATE_NOOP("action", "Note duration: double augmentation dot"),
+             QT_TRANSLATE_NOOP("action", "Toggle duration dot: double"),
              IconCode::Code::NOTE_DOTTED_2
              ),
     UiAction("pad-dot3",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Triple augmentation dot"),
-             QT_TRANSLATE_NOOP("action", "Note duration: triple augmentation dot"),
+             QT_TRANSLATE_NOOP("action", "Toggle duration dot: triple"),
              IconCode::Code::NOTE_DOTTED_3
              ),
     UiAction("pad-dot4",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Quadruple augmentation dot"),
-             QT_TRANSLATE_NOOP("action", "Note duration: quadruple augmentation dot"),
+             QT_TRANSLATE_NOOP("action", "Toggle duration dot: quadruple"),
              IconCode::Code::NOTE_DOTTED_4
              ),
     UiAction("pad-rest",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Rest"),
-             QT_TRANSLATE_NOOP("action", "Note input: rest"),
              IconCode::Code::REST
              ),
     UiAction("next-segment-element",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Accessibility: Next segment element")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Accessibility: Next segment element"),
+             QT_TRANSLATE_NOOP("action", "Select next in-staff element")
              ),
     UiAction("prev-segment-element",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Accessibility: Previous segment element")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Accessibility: Previous segment element"),
+             QT_TRANSLATE_NOOP("action", "Select previous in-staff element")
              ),
     UiAction("flat",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Flat"),
-             QT_TRANSLATE_NOOP("action", "Toggle accidental: Flat"),
+             QT_TRANSLATE_NOOP("action", "Toggle accidental: flat"),
              IconCode::Code::FLAT
              ),
     UiAction("flat2",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Double flat"),
-             QT_TRANSLATE_NOOP("action", "Toggle accidental: Double flat"),
+             QT_TRANSLATE_NOOP("action", "Toggle accidental: double flat"),
              IconCode::Code::FLAT_DOUBLE
              ),
     UiAction("nat",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Natural"),
-             QT_TRANSLATE_NOOP("action", "Toggle accidental: Natural"),
+             QT_TRANSLATE_NOOP("action", "Toggle accidental: natural"),
              IconCode::Code::NATURAL
              ),
     UiAction("sharp",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Sharp"),
-             QT_TRANSLATE_NOOP("action", "Toggle accidental: Sharp"),
+             QT_TRANSLATE_NOOP("action", "Toggle accidental: sharp"),
              IconCode::Code::SHARP
              ),
     UiAction("sharp2",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Double sharp"),
-             QT_TRANSLATE_NOOP("action", "Toggle accidental: Double sharp"),
+             QT_TRANSLATE_NOOP("action", "Toggle accidental: double sharp"),
              IconCode::Code::SHARP_DOUBLE
              ),
     UiAction("tie",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Tie"),
-             QT_TRANSLATE_NOOP("action", "Note duration: Tie"),
+             QT_TRANSLATE_NOOP("action", "Add tied note"),
              IconCode::Code::NOTE_TIE
              ),
     UiAction("add-slur",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Slur"),
-             QT_TRANSLATE_NOOP("action", "Add slur"),
+             QT_TRANSLATE_NOOP("action", "Add articulation: slur"),
              IconCode::Code::NOTE_SLUR
              ),
     UiAction("add-marcato",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Marcato"),
-             QT_TRANSLATE_NOOP("action", "Toggle marcato"),
+             QT_TRANSLATE_NOOP("action", "Add articulation: marcato"),
              IconCode::Code::MARCATO
              ),
     UiAction("add-sforzato",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Accent"),
-             QT_TRANSLATE_NOOP("action", "Toggle accent"),
+             QT_TRANSLATE_NOOP("action", "Add articulation: accent"),
              IconCode::Code::ACCENT
              ),
     UiAction("add-tenuto",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Tenuto"),
-             QT_TRANSLATE_NOOP("action", "Toggle tenuto"),
+             QT_TRANSLATE_NOOP("action", "Add articulation: tenuto"),
              IconCode::Code::TENUTO
              ),
     UiAction("add-staccato",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Staccato"),
-             QT_TRANSLATE_NOOP("action", "Toggle staccato"),
+             QT_TRANSLATE_NOOP("action", "Add articulation: staccato"),
              IconCode::Code::STACCATO
              ),
     UiAction("cross-staff-beaming",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Cross-staff beaming"),
-             QT_TRANSLATE_NOOP("action", "Move notes to staff above or below"),
              IconCode::Code::CROSS_STAFF_BEAMING
              ),
     UiAction("tuplet",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Tuplet"),
-             QT_TRANSLATE_NOOP("action", "Add tuplet"),
              IconCode::Code::NOTE_TUPLET
              ),
     UiAction("voice-1",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Voice 1"),
-             QT_TRANSLATE_NOOP("action", "Voice 1"),
+             QT_TRANSLATE_NOOP("action", "Use voice 1"),
              IconCode::Code::VOICE_1
              ),
     UiAction("voice-2",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Voice 2"),
-             QT_TRANSLATE_NOOP("action", "Voice 2"),
+             QT_TRANSLATE_NOOP("action", "Use voice 2"),
              IconCode::Code::VOICE_2
              ),
     UiAction("voice-3",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Voice 3"),
-             QT_TRANSLATE_NOOP("action", "Voice 3"),
+             QT_TRANSLATE_NOOP("action", "Use voice 3"),
              IconCode::Code::VOICE_3
              ),
     UiAction("voice-4",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Voice 4"),
-             QT_TRANSLATE_NOOP("action", "Voice 4"),
+             QT_TRANSLATE_NOOP("action", "Use voice 4"),
              IconCode::Code::VOICE_4
              )
 };
@@ -1806,30 +2272,35 @@ const UiActionList NotationUiActions::m_noteInputActions = {
 const UiActionList NotationUiActions::m_scoreConfigActions = {
     UiAction(SHOW_INVISIBLE_CODE,
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Show &invisible"),
-             QT_TRANSLATE_NOOP("action", "Show invisible"),
+             QT_TRANSLATE_NOOP("action", "Show/hide invisible elements"),
              Checkable::Yes
              ),
     UiAction(SHOW_UNPRINTABLE_CODE,
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Show f&ormatting"),
-             QT_TRANSLATE_NOOP("action", "Show formatting"),
+             QT_TRANSLATE_NOOP("action", "Show/hide formatting"),
              Checkable::Yes
              ),
     UiAction(SHOW_FRAMES_CODE,
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Show &frames"),
-             QT_TRANSLATE_NOOP("action", "Show frames"),
+             QT_TRANSLATE_NOOP("action", "Show/hide frames"),
              Checkable::Yes
              ),
     UiAction(SHOW_PAGEBORDERS_CODE,
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Show page &margins"),
-             QT_TRANSLATE_NOOP("action", "Show page margins"),
+             QT_TRANSLATE_NOOP("action", "Show/hide page margins"),
              Checkable::Yes
              ),
     UiAction(SHOW_IRREGULAR_CODE,
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Mark i&rregular measures"),
              QT_TRANSLATE_NOOP("action", "Mark irregular measures"),
              Checkable::Yes
@@ -1839,26 +2310,31 @@ const UiActionList NotationUiActions::m_scoreConfigActions = {
 const UiActionList NotationUiActions::m_engravingDebuggingActions = {
     UiAction("show-skylines",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Show &skylines"),
              Checkable::Yes
              ),
     UiAction("show-segment-shapes",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Show s&egment shapes"),
              Checkable::Yes
              ),
     UiAction("show-bounding-rect",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Show &bounding rectangles"),
              Checkable::Yes
              ),
     UiAction("show-system-bounding-rect",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Show s&ystem bounding rectangles"),
              Checkable::Yes
              ),
     UiAction("show-corrupted-measures",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Show &corrupted measures"),
              Checkable::Yes
              )

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -176,10 +176,6 @@ const UiActionList NotationUiActions::m_actions = {
              mu::context::UiCtxNotationOpened,
              QT_TRANSLATE_NOOP("action", "Previous system")
              ),
-    UiAction("show-irregular",
-             mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Mark irregular measures")
-             ),
     UiAction("toggle-insert-mode",
              mu::context::UiCtxNotationOpened,
              QT_TRANSLATE_NOOP("action", "Toggle 'insert mode'")
@@ -1245,12 +1241,6 @@ const UiActionList NotationUiActions::m_actions = {
              IconCode::Code::TUNING_FORK,
              Checkable::Yes
              ),
-    UiAction("print",
-             mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Print"),
-             QT_TRANSLATE_NOOP("action", "Print score/part"),
-             IconCode::Code::PRINT
-             ),
     UiAction("next-text-element",
              mu::context::UiCtxNotationFocused,
              QT_TRANSLATE_NOOP("action", "Next text element"),
@@ -1441,14 +1431,6 @@ const UiActionList NotationUiActions::m_actions = {
     UiAction("pitch-down-diatonic-alterations",
              mu::context::UiCtxNotationOpened,
              QT_TRANSLATE_NOOP("action", "Diatonic pitch down (keep degree alterations)")
-             ),
-    UiAction("transpose-down",
-             mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Transpose down")
-             ),
-    UiAction("transpose-up",
-             mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Transpose up")
              ),
     UiAction("full-measure-rest",
              mu::context::UiCtxNotationOpened,

--- a/src/notation/view/noteinputbarmodel.cpp
+++ b/src/notation/view/noteinputbarmodel.cpp
@@ -548,7 +548,7 @@ MenuItem* NoteInputBarModel::makeActionItem(const UiAction& action, const QStrin
 
 MenuItem* NoteInputBarModel::makeAddItem(const QString& section)
 {
-    UiAction addAction(ADD_ACTION_CODE, UiCtxAny, ADD_ACTION_TITLE, ADD_ACTION_ICON_CODE);
+    UiAction addAction(ADD_ACTION_CODE, UiCtxAny, mu::context::CTX_ANY, ADD_ACTION_TITLE, ADD_ACTION_ICON_CODE);
     return makeActionItem(addAction, section, makeAddItems());
 }
 

--- a/src/palette/internal/paletteuiactions.cpp
+++ b/src/palette/internal/paletteuiactions.cpp
@@ -32,26 +32,34 @@ static const mu::actions::ActionCode MASTERPALETTE_CODE("masterpalette");
 const UiActionList PaletteUiActions::m_actions = {
     UiAction(MASTERPALETTE_CODE,
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Master palette"),
+             QT_TRANSLATE_NOOP("action", "Open master palette…"),
              Checkable::Yes
              ),
     UiAction("palette-search",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Palette search")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Palette search"),
+             QT_TRANSLATE_NOOP("action", "Search palettes")
              ),
     UiAction("time-signature-properties",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Time signature properties…"),
-             QT_TRANSLATE_NOOP("action", "Time signature properties")
+             QT_TRANSLATE_NOOP("action", "Time signature properties…")
              ),
     UiAction("edit-drumset",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Edit drumset…"),
-             QT_TRANSLATE_NOOP("action", "Edit drumset")
+             QT_TRANSLATE_NOOP("action", "Edit drumset…")
              ),
     UiAction("show-keys",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Insert special characters")
+             mu::context::CTX_NOTATION_TEXT_EDITING,
+             QT_TRANSLATE_NOOP("action", "Insert special characters"),
+             QT_TRANSLATE_NOOP("action", "Insert special characters…")
              )
 };
 

--- a/src/playback/internal/playbackuiactions.cpp
+++ b/src/playback/internal/playbackuiactions.cpp
@@ -30,33 +30,38 @@ using namespace mu::actions;
 const UiActionList PlaybackUiActions::m_mainActions = {
     UiAction("play",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Play"),
-             QT_TRANSLATE_NOOP("action", "Start or stop playback"),
+             QT_TRANSLATE_NOOP("action", "Play"),
              IconCode::Code::PLAY
              ),
     UiAction("stop",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Stop"),
              QT_TRANSLATE_NOOP("action", "Stop playback"),
              IconCode::Code::STOP
              ),
     UiAction("rewind",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Rewind"),
-             QT_TRANSLATE_NOOP("action", "Rewind to start position"),
+             QT_TRANSLATE_NOOP("action", "Rewind"),
              IconCode::Code::REWIND
              ),
     UiAction("loop",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Loop playback"),
-             QT_TRANSLATE_NOOP("action", "Toggle 'Loop playback'"),
+             QT_TRANSLATE_NOOP("action", "Toggle ‘Loop playback’"),
              IconCode::Code::LOOP,
              Checkable::Yes
              ),
     UiAction("metronome",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Metronome"),
-             QT_TRANSLATE_NOOP("action", "Play metronome during playback"),
+             QT_TRANSLATE_NOOP("action", "Toggle metronome playback"),
              IconCode::Code::METRONOME,
              Checkable::Yes
              )
@@ -65,13 +70,15 @@ const UiActionList PlaybackUiActions::m_mainActions = {
 const UiActionList PlaybackUiActions::m_settingsActions = {
     UiAction("midi-on",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "MIDI input"),
-             QT_TRANSLATE_NOOP("action", "Enable 'MIDI input'"),
+             QT_TRANSLATE_NOOP("action", "Toggle ‘Enable MIDI input’"),
              IconCode::Code::MIDI_INPUT,
              Checkable::Yes
              ),
     UiAction("repeat",
              mu::context::UiCtxAny,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Play repeats"),
              QT_TRANSLATE_NOOP("action", "Play repeats"),
              IconCode::Code::PLAY_REPEATS,
@@ -79,6 +86,7 @@ const UiActionList PlaybackUiActions::m_settingsActions = {
              ),
     UiAction("pan",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Pan score"),
              QT_TRANSLATE_NOOP("action", "Pan score automatically"),
              IconCode::Code::PAN_SCORE,
@@ -86,8 +94,9 @@ const UiActionList PlaybackUiActions::m_settingsActions = {
              ),
     UiAction("countin",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Count-in"),
-             QT_TRANSLATE_NOOP("action", "Enable count-in when playing"),
+             QT_TRANSLATE_NOOP("action", "Enable count-in"),
              IconCode::Code::COUNT_IN,
              Checkable::Yes
              ),
@@ -96,12 +105,14 @@ const UiActionList PlaybackUiActions::m_settingsActions = {
 const UiActionList PlaybackUiActions::m_loopBoundaryActions = {
     UiAction("loop-in",
              mu::context::UiCtxAny,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Loop in"),
              QT_TRANSLATE_NOOP("action", "Set loop marker left"),
              IconCode::Code::LOOP_IN
              ),
     UiAction("loop-out",
              mu::context::UiCtxAny,
+             mu::context::CTX_NOTATION_FOCUSED,
              QT_TRANSLATE_NOOP("action", "Loop out"),
              QT_TRANSLATE_NOOP("action", "Set loop marker right"),
              IconCode::Code::LOOP_OUT

--- a/src/plugins/internal/pluginsuiactions.cpp
+++ b/src/plugins/internal/pluginsuiactions.cpp
@@ -40,7 +40,9 @@ PluginsUiActions::PluginsUiActions(std::shared_ptr<PluginsService> service)
 static UiAction MANAGE_ACTION = UiAction(
     "manage-plugins",
     mu::context::UiCtxAny,
-    QT_TRANSLATE_NOOP("action", "&Manage plugins…")
+    mu::context::CTX_ANY,
+    QT_TRANSLATE_NOOP("action", "&Manage plugins…"),
+    QT_TRANSLATE_NOOP("action", "Manage plugins…")
     );
 
 const mu::ui::UiActionList& PluginsUiActions::actionsList() const
@@ -50,7 +52,8 @@ const mu::ui::UiActionList& PluginsUiActions::actionsList() const
     for (const PluginInfo& plugin : values(m_service->plugins().val)) {
         UiAction action;
         action.code = codeFromQString(plugin.codeKey);
-        action.context = mu::context::UiCtxNotationOpened;
+        action.uiCtx = mu::context::UiCtxNotationOpened;
+        action.scCtx = mu::context::CTX_NOTATION_OPENED;
         action.title = qtrc("plugins", "Run plugin %1").arg(plugin.codeKey);
 
         result.push_back(action);

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -27,77 +27,92 @@ using namespace mu::ui;
 const UiActionList ProjectUiActions::m_actions = {
     UiAction("file-open",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Open…"),
-             QT_TRANSLATE_NOOP("action", "Load score from file"),
+             QT_TRANSLATE_NOOP("action", "Open…"),
              IconCode::Code::OPEN_FILE
              ),
     UiAction("file-new",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&New…"),
-             QT_TRANSLATE_NOOP("action", "Create new score"),
+             QT_TRANSLATE_NOOP("action", "New…"),
              IconCode::Code::NEW_FILE
              ),
     UiAction("file-close",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Close"),
-             QT_TRANSLATE_NOOP("action", "Close current score")
+             QT_TRANSLATE_NOOP("action", "Close")
              ),
     UiAction("file-save",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Save"),
-             QT_TRANSLATE_NOOP("action", "Save score to file"),
+             QT_TRANSLATE_NOOP("action", "Save"),
              IconCode::Code::SAVE
              ),
     UiAction("file-save-as",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Save &as…"),
-             QT_TRANSLATE_NOOP("action", "Save score under a new file name")
+             QT_TRANSLATE_NOOP("action", "Save as…")
              ),
     UiAction("file-save-a-copy",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Save a cop&y…"),
-             QT_TRANSLATE_NOOP("action", "Save a copy of the score in addition to the current file")
+             QT_TRANSLATE_NOOP("action", "Save a copy…")
              ),
     UiAction("file-save-selection",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Save se&lection…"),
-             QT_TRANSLATE_NOOP("action", "Save current selection as new score")
+             QT_TRANSLATE_NOOP("action", "Save selection…")
              ),
     UiAction("file-save-to-cloud",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Save to clo&ud…"),
+             QT_TRANSLATE_NOOP("action", "Save to cloud…"),
              IconCode::Code::CLOUD_FILE
              ),
     UiAction("file-publish",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Pu&blish to MuseScore.com…"),
+             QT_TRANSLATE_NOOP("action", "Publish to MuseScore.com…"),
              IconCode::Code::CLOUD_FILE
              ),
     UiAction("file-export",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Export…"),
-             QT_TRANSLATE_NOOP("action", "Save a copy of the score in various formats"),
+             QT_TRANSLATE_NOOP("action", "Export…"),
              IconCode::Code::SHARE_FILE
              ),
     UiAction("file-import-pdf",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Import P&DF…"),
-             QT_TRANSLATE_NOOP("action", "Import a PDF file with an experimental service on musescore.com"),
              IconCode::Code::IMPORT
              ),
     UiAction("project-properties",
              mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
              QT_TRANSLATE_NOOP("action", "Project propert&ies…"),
-             QT_TRANSLATE_NOOP("action", "Edit project properties")
+             QT_TRANSLATE_NOOP("action", "Project properties…")
              ),
     UiAction("print",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Print…"),
-             QT_TRANSLATE_NOOP("action", "Print score/part"),
+             QT_TRANSLATE_NOOP("action", "Print…"),
              IconCode::Code::PRINT
              ),
     UiAction("clear-recent",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "&Clear recent files")
              )
 };

--- a/src/workspace/internal/workspaceuiactions.cpp
+++ b/src/workspace/internal/workspaceuiactions.cpp
@@ -29,11 +29,14 @@ using namespace mu::ui;
 const UiActionList WorkspaceUiActions::m_actions = {
     UiAction("select-workspace",
              mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
              QT_TRANSLATE_NOOP("action", "Select workspace")
              ),
     UiAction("configure-workspaces",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Configure workspace")
+             mu::context::CTX_ANY,
+             QT_TRANSLATE_NOOP("action", "Configure workspace"),
+             QT_TRANSLATE_NOOP("action", "Configure workspace…")
              )
 };
 


### PR DESCRIPTION
Resolves: #11060 
This PR intends to add the missing shortcuts in shortcuts list.
It also adds the shortcut contexts to the cpp files alongside newly added descriptions (which are now displayed in the Preferences page instead of the titles)

Note: There is an existing issue that you can't clear shortcuts that already have default shortcuts. I have not tried to resolve that issue in this PR because it has consequences to adding new default shortcuts. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
