### PR TITLE
Fix #12402: Close popups when MuseScore looses focus

### DIFF
--- a/src/framework/uicomponents/view/internal/popupviewclosecontroller.cpp
+++ b/src/framework/uicomponents/view/internal/popupviewclosecontroller.cpp
@@ -53,6 +53,22 @@ void PopupViewCloseController::setActive(bool active)
     doUpdateEventFiletrs();
 }
 
+bool PopupViewCloseController::isDialog() const
+{
+    return m_isDialog;
+}
+
+void PopupViewCloseController::setIsDialog(bool isDialog)
+{
+    if (m_isDialog == isDialog) {
+        return;
+    }
+
+    m_isDialog = isDialog;
+
+    doUpdateEventFiletrs();
+}
+
 QQuickItem* PopupViewCloseController::parentItem() const
 {
     return m_parentItem;
@@ -112,6 +128,12 @@ bool PopupViewCloseController::eventFilter(QObject* watched, QEvent* event)
     } else {
         if (QEvent::FocusOut == event->type() && watched == popupWindow()) {
             doFocusOut();
+        }
+    }
+
+    if (QEvent::ApplicationStateChange == event->type() && !m_isDialog) {
+        if (qApp->applicationState() != Qt::ApplicationActive) {
+            notifyAboutClose();
         }
     }
 

--- a/src/framework/uicomponents/view/internal/popupviewclosecontroller.h
+++ b/src/framework/uicomponents/view/internal/popupviewclosecontroller.h
@@ -47,6 +47,9 @@ public:
     bool active() const;
     void setActive(bool active);
 
+    bool isDialog() const;
+    void setIsDialog(bool isDialog);
+
     QQuickItem* parentItem() const;
     void setParentItem(QQuickItem* parentItem);
 
@@ -75,6 +78,7 @@ private:
     void notifyAboutClose();
 
     bool m_active = false;
+    bool m_isDialog = false;
 
     QQuickItem* m_parentItem = nullptr;
     QWindow* m_popupWindow = nullptr;

--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -199,6 +199,7 @@ void PopupView::open()
     m_closeController->setWindow(window());
     m_closeController->setIsCloseOnPressOutsideParent(m_closePolicy == CloseOnPressOutsideParent);
     m_closeController->setActive(true);
+    m_closeController->setIsDialog(isDialog());
 
     qApp->installEventFilter(this);
 


### PR DESCRIPTION
Resolves: #12402

- [ ] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made

**Additional Notes**
- Is `doUpdateEventFiletrs()` meant to be `doUpdateEventFilters()`? If so I would be happy to change this in either this PR or a new PR.
- I am aware of the method `PopupViewCloseController::onApplicationStateChanged()` but wasn't sure if I should use it. If the preferred solution is to use this method then I'll update the PR.
