### PR TITLE
Add ampersand (&) to action titles to enable mnemonic access keys in menus

### DIFF
--- a/src/appshell/internal/applicationuiactions.cpp
+++ b/src/appshell/internal/applicationuiactions.cpp
@@ -46,7 +46,7 @@ const UiActionList ApplicationUiActions::m_actions = {
              ),
     UiAction("fullscreen",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Enter full screen"),
+             QT_TRANSLATE_NOOP("action", "&Full screen"),
              QT_TRANSLATE_NOOP("action", "Enter full screen"),
              Checkable::Yes
              ),
@@ -64,45 +64,45 @@ const UiActionList ApplicationUiActions::m_actions = {
              ),
     UiAction("online-handbook",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "&Online handbook")
+             QT_TRANSLATE_NOOP("action", "Online &handbook")
              ),
     UiAction("ask-help",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Ask for help")
+             QT_TRANSLATE_NOOP("action", "As&k for help")
              ),
     UiAction("report-bug",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Report a bug"),
+             QT_TRANSLATE_NOOP("action", "&Report a bug"),
              QT_TRANSLATE_NOOP("action", "Report a bug")
              ),
     UiAction("leave-feedback",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Feedback"),
+             QT_TRANSLATE_NOOP("action", "F&eedback"),
              QT_TRANSLATE_NOOP("action", "Leave feedback")
              ),
     UiAction("revert-factory",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Revert to factory settings"),
+             QT_TRANSLATE_NOOP("action", "Revert to &factory settings"),
              QT_TRANSLATE_NOOP("action", "Revert to factory settings")
              ),
 
     // Docking
     UiAction("dock-restore-default-layout",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Restore the default layout"),
+             QT_TRANSLATE_NOOP("action", "Restore the &default layout"),
              QT_TRANSLATE_NOOP("action", "Restore the default layout")
              ),
 
     // Toolbars
     UiAction("toggle-transport",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Playback controls"),
+             QT_TRANSLATE_NOOP("action", "&Playback controls"),
              QT_TRANSLATE_NOOP("action", "Toggle 'Playback controls' toolbar"),
              Checkable::Yes
              ),
     UiAction("toggle-noteinput",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Note input"),
+             QT_TRANSLATE_NOOP("action", "&Note input"),
              QT_TRANSLATE_NOOP("action", "Toggle 'Note input' toolbar"),
              Checkable::Yes
              ),
@@ -110,25 +110,25 @@ const UiActionList ApplicationUiActions::m_actions = {
     // Vertical panels
     UiAction("toggle-palettes",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Palettes"),
+             QT_TRANSLATE_NOOP("action", "&Palettes"),
              QT_TRANSLATE_NOOP("action", "Toggle 'Palettes'"),
              Checkable::Yes
              ),
     UiAction("toggle-instruments",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Instruments"),
+             QT_TRANSLATE_NOOP("action", "Instr&uments"),
              QT_TRANSLATE_NOOP("action", "Toggle 'Instruments'"),
              Checkable::Yes
              ),
     UiAction("inspector",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Properties"),
+             QT_TRANSLATE_NOOP("action", "Propert&ies"),
              QT_TRANSLATE_NOOP("action", "Toggle 'Properties'"),
              Checkable::Yes
              ),
     UiAction("toggle-selection-filter",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Selection filter"),
+             QT_TRANSLATE_NOOP("action", "Se&lection filter"),
              QT_TRANSLATE_NOOP("action", "Toggle 'Selection filter'"),
              Checkable::Yes
              ),
@@ -136,7 +136,7 @@ const UiActionList ApplicationUiActions::m_actions = {
     // Navigator
     UiAction("toggle-navigator",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Navigator"),
+             QT_TRANSLATE_NOOP("action", "&Navigator"),
              QT_TRANSLATE_NOOP("action", "Toggle 'Navigator'"),
              Checkable::Yes
              ),
@@ -144,7 +144,7 @@ const UiActionList ApplicationUiActions::m_actions = {
     // Horizontal panels
     UiAction("toggle-timeline",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Timeline"),
+             QT_TRANSLATE_NOOP("action", "Tim&eline"),
              QT_TRANSLATE_NOOP("action", "Toggle timeline"),
              Checkable::Yes
              ),
@@ -157,7 +157,7 @@ const UiActionList ApplicationUiActions::m_actions = {
              ),
     UiAction("toggle-piano-keyboard",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Piano keyboard"),
+             QT_TRANSLATE_NOOP("action", "Piano &keyboard"),
              QT_TRANSLATE_NOOP("action", "Toggle piano keyboard"),
              Checkable::Yes
              ),
@@ -171,7 +171,7 @@ const UiActionList ApplicationUiActions::m_actions = {
     // Status bar
     UiAction("toggle-statusbar",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Status bar"),
+             QT_TRANSLATE_NOOP("action", "&Status bar"),
              QT_TRANSLATE_NOOP("action", "Toggle 'Status bar'"),
              Checkable::Yes
              ),
@@ -183,7 +183,7 @@ const UiActionList ApplicationUiActions::m_actions = {
              ),
     UiAction("check-update",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Check for update"),
+             QT_TRANSLATE_NOOP("action", "Check for &update"),
              QT_TRANSLATE_NOOP("action", "Check for update")
              )
 };

--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -201,7 +201,7 @@ MenuItem* AppMenuModel::makeViewMenu()
         makeMenu(qtrc("appshell", "&Toolbars"), makeToolbarsItems(), "menu-toolbars"),
         makeMenu(qtrc("appshell", "W&orkspaces"), makeWorkspacesItems(), "menu-workspaces"),
         makeSeparator(),
-        makeMenu(qtrc("appshell", "Show"), makeShowItems(), "menu-show"),
+        makeMenu(qtrc("appshell", "&Show"), makeShowItems(), "menu-show"),
         makeSeparator(),
         makeMenuItem("dock-restore-default-layout")
     };
@@ -212,7 +212,7 @@ MenuItem* AppMenuModel::makeViewMenu()
 MenuItem* AppMenuModel::makeAddMenu()
 {
     MenuItemList addItems {
-        makeMenu(qtrc("appshell", "N&otes"), makeNotesItems(), "menu-notes"),
+        makeMenu(qtrc("appshell", "&Notes"), makeNotesItems(), "menu-notes"),
         makeMenu(qtrc("appshell", "&Intervals"), makeIntervalsItems(), "menu-intervals"),
         makeMenu(qtrc("appshell", "T&uplets"), makeTupletsItems(), "menu-tuplets"),
         makeSeparator(),
@@ -238,7 +238,7 @@ MenuItem* AppMenuModel::makeFormatMenu()
         makeMenuItem("page-settings"),
         makeSeparator(),
         makeMenuItem("add-remove-breaks"),
-        makeMenu(qtrc("appshell", "&Stretch"), stretchItems, "menu-stretch"),
+        makeMenu(qtrc("appshell", "Str&etch"), stretchItems, "menu-stretch"),
         makeSeparator(),
         makeMenuItem("reset-text-style-overrides"),
         makeMenuItem("reset-beammode"),
@@ -489,11 +489,11 @@ MenuItemList AppMenuModel::makeTupletsItems()
 MenuItemList AppMenuModel::makeMeasuresItems()
 {
     MenuItemList items {
-        makeMenuItem("insert-measures-after-selection", qtrc("notation", "Insert after selection…")),
-        makeMenuItem("insert-measures", qtrc("notation", "Insert before selection…")),
+        makeMenuItem("insert-measures-after-selection", qtrc("notation", "Insert &after selection…")),
+        makeMenuItem("insert-measures", qtrc("notation", "Insert &before selection…")),
         makeSeparator(),
-        makeMenuItem("insert-measures-at-start-of-score", qtrc("notation", "Insert at start of score…")),
-        makeMenuItem("append-measures", qtrc("notation", "Insert at end of score…"))
+        makeMenuItem("insert-measures-at-start-of-score", qtrc("notation", "Insert at &start of score…")),
+        makeMenuItem("append-measures", qtrc("notation", "Insert at &end of score…"))
     };
 
     return items;

--- a/src/autobot/internal/autobotactions.cpp
+++ b/src/autobot/internal/autobotactions.cpp
@@ -34,7 +34,7 @@ const UiActionList AutobotActions::m_actions = {
              ),
     UiAction("autobot-show-scripts",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Show scripts…")
+             QT_TRANSLATE_NOOP("action", "Show &scripts…")
              ),
 };
 

--- a/src/diagnostics/internal/diagnosticsactions.cpp
+++ b/src/diagnostics/internal/diagnosticsactions.cpp
@@ -30,27 +30,27 @@ using namespace mu::diagnostics;
 const UiActionList DiagnosticsActions::m_actions = {
     UiAction("diagnostic-show-paths",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Show paths…")
+             QT_TRANSLATE_NOOP("action", "Show p&aths…")
              ),
     UiAction("diagnostic-show-profiler",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Show profiler…")
+             QT_TRANSLATE_NOOP("action", "Show pr&ofiler…")
              ),
     UiAction("diagnostic-show-navigation-tree",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Show navigation tree…")
+             QT_TRANSLATE_NOOP("action", "Show &navigation tree…")
              ),
     UiAction("diagnostic-show-accessible-tree",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Show accessible tree…")
+             QT_TRANSLATE_NOOP("action", "Show &accessible tree…")
              ),
     UiAction("diagnostic-accessible-tree-dump",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Accessible dump")
+             QT_TRANSLATE_NOOP("action", "Accessible &dump")
              ),
     UiAction("diagnostic-show-engraving-elements",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Engraving elements")
+             QT_TRANSLATE_NOOP("action", "Engraving &elements")
              )
 };
 

--- a/src/multiinstances/internal/multiinstancesuiactions.cpp
+++ b/src/multiinstances/internal/multiinstancesuiactions.cpp
@@ -30,7 +30,7 @@ using namespace mu::mi;
 const UiActionList MultiInstancesUiActions::m_actions = {
     UiAction("multiinstances-dev-show-info",
              mu::context::UiCtxAny,
-             "Multiinstances"
+             QT_TRANSLATE_NOOP("action", "&Multiinstances")
              )
 };
 

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -238,26 +238,26 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("notation-cut",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Cut"),
+             QT_TRANSLATE_NOOP("action", "Cu&t"),
              IconCode::Code::CUT
              ),
     UiAction("notation-copy",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Copy"),
+             QT_TRANSLATE_NOOP("action", "&Copy"),
              IconCode::Code::COPY
              ),
     UiAction("notation-paste",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Paste"),
+             QT_TRANSLATE_NOOP("action", "Past&e"),
              IconCode::Code::PASTE
              ),
     UiAction("notation-paste-half",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Paste half duration")
+             QT_TRANSLATE_NOOP("action", "Paste &half duration")
              ),
     UiAction("notation-paste-double",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Paste double duration")
+             QT_TRANSLATE_NOOP("action", "Paste &double duration")
              ),
     UiAction("notation-paste-special",
              mu::context::UiCtxNotationOpened,
@@ -265,7 +265,7 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("notation-swap",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Swap with clipboard")
+             QT_TRANSLATE_NOOP("action", "&Swap with clipboard")
              ),
     UiAction("toggle-visible",
              mu::context::UiCtxNotationOpened,
@@ -273,11 +273,11 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("notation-select-all",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Select all")
+             QT_TRANSLATE_NOOP("action", "Select &all")
              ),
     UiAction("notation-select-section",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Select section")
+             QT_TRANSLATE_NOOP("action", "Select sectio&n")
              ),
     UiAction("select-similar",
              mu::context::UiCtxNotationOpened,
@@ -301,28 +301,28 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("notation-delete",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Delete"),
+             QT_TRANSLATE_NOOP("action", "De&lete"),
              QT_TRANSLATE_NOOP("action", "Delete the selected element(s)"),
              IconCode::Code::DELETE_TANK
              ),
     UiAction("edit-style",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Style…"),
+             QT_TRANSLATE_NOOP("action", "&Style…"),
              QT_TRANSLATE_NOOP("action", "Edit style")
              ),
     UiAction("page-settings",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Page settings…"),
+             QT_TRANSLATE_NOOP("action", "&Page settings…"),
              QT_TRANSLATE_NOOP("action", "Page settings")
              ),
     UiAction("load-style",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Load style…"),
+             QT_TRANSLATE_NOOP("action", "&Load style…"),
              QT_TRANSLATE_NOOP("action", "Load style")
              ),
     UiAction("save-style",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Save style…"),
+             QT_TRANSLATE_NOOP("action", "S&ave style…"),
              QT_TRANSLATE_NOOP("action", "Save style")
              ),
     UiAction("transpose",
@@ -332,22 +332,22 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("explode",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Explode"),
+             QT_TRANSLATE_NOOP("action", "&Explode"),
              QT_TRANSLATE_NOOP("action", "Explode contents of top selected staff into staves below")
              ),
     UiAction("implode",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Implode"),
+             QT_TRANSLATE_NOOP("action", "&Implode"),
              QT_TRANSLATE_NOOP("action", "Implode contents of selected staves into top selected staff")
              ),
     UiAction("realize-chord-symbols",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Realize chord symbols"),
+             QT_TRANSLATE_NOOP("action", "Realize &chord symbols"),
              QT_TRANSLATE_NOOP("action", "Convert chord symbols into notes")
              ),
     UiAction("time-delete",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Remove selected range"),
+             QT_TRANSLATE_NOOP("action", "Remove selected ran&ge"),
              IconCode::Code::DELETE_TANK
              ),
     UiAction("slash-fill",
@@ -356,20 +356,20 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("slash-rhythm",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Toggle 'rhythmic slash notation'")
+             QT_TRANSLATE_NOOP("action", "Toggle rhythmic sl&ash notation")
              ),
     UiAction("pitch-spell",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Respell pitches")
+             QT_TRANSLATE_NOOP("action", "Respell &pitches")
              ),
     UiAction("reset-groupings",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Regroup rhythms"),
+             QT_TRANSLATE_NOOP("action", "Regroup &rhythms"),
              QT_TRANSLATE_NOOP("action", "Combine rests and tied notes from selection and resplit at rhythmical boundaries")
              ),
     UiAction("resequence-rehearsal-marks",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Resequence rehearsal marks")
+             QT_TRANSLATE_NOOP("action", "Resequence re&hearsal marks")
              ),
     UiAction("unroll-repeats",
              mu::context::UiCtxNotationOpened,
@@ -377,11 +377,11 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("copy-lyrics-to-clipboard",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Copy lyrics to clipboard")
+             QT_TRANSLATE_NOOP("action", "Copy &lyrics to clipboard")
              ),
     UiAction("del-empty-measures",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Remove empty trailing measures")
+             QT_TRANSLATE_NOOP("action", "Remove empty trailing meas&ures")
              ),
     UiAction("parts",
              mu::context::UiCtxNotationOpened,
@@ -406,7 +406,7 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("find",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Find / Go To")
+             QT_TRANSLATE_NOOP("action", "&Find / Go To")
              ),
     UiAction("staff-properties",
              mu::context::UiCtxNotationOpened,
@@ -430,7 +430,7 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("add-remove-breaks",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Add/remove system breaks…"),
+             QT_TRANSLATE_NOOP("action", "Add/remove s&ystem breaks…"),
              QT_TRANSLATE_NOOP("action", "Add/remove system breaks")
              ),
     UiAction("undo",
@@ -447,7 +447,7 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("voice-x12",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Exchange voice 1-2"),
+             QT_TRANSLATE_NOOP("action", "Exchange voice &1-2"),
              QT_TRANSLATE_NOOP("action", "Exchange voice 1-2")
              ),
     UiAction("voice-x13",
@@ -457,12 +457,12 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("voice-x14",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Exchange voice 1-4"),
+             QT_TRANSLATE_NOOP("action", "Exchange voice 1-&4"),
              QT_TRANSLATE_NOOP("action", "Exchange voice 1-4")
              ),
     UiAction("voice-x23",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Exchange voice 2-3"),
+             QT_TRANSLATE_NOOP("action", "Exchange voice &2-3"),
              QT_TRANSLATE_NOOP("action", "Exchange voice 2-3")
              ),
     UiAction("voice-x24",
@@ -472,7 +472,7 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("voice-x34",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Exchange voice 3-4"),
+             QT_TRANSLATE_NOOP("action", "Exchange voice &3-4"),
              QT_TRANSLATE_NOOP("action", "Exchange voice 3-4")
              ),
     UiAction("system-break",
@@ -492,11 +492,11 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("split-measure",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Split measure before selected note/rest")
+             QT_TRANSLATE_NOOP("action", "&Split measure before selected note/rest")
              ),
     UiAction("join-measures",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Join selected measures")
+             QT_TRANSLATE_NOOP("action", "&Join selected measures")
              ),
     UiAction("insert-measure",
              mu::context::UiCtxNotationOpened,
@@ -525,30 +525,30 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("insert-hbox",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Insert horizontal frame"),
+             QT_TRANSLATE_NOOP("action", "Insert &horizontal frame"),
              IconCode::Code::HORIZONTAL_FRAME
              ),
     UiAction("insert-vbox",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Insert vertical frame"),
+             QT_TRANSLATE_NOOP("action", "Insert &vertical frame"),
              IconCode::Code::VERTICAL_FRAME
              ),
     UiAction("insert-textframe",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Insert text frame"),
+             QT_TRANSLATE_NOOP("action", "Insert &text frame"),
              IconCode::Code::TEXT_FRAME
              ),
     UiAction("append-hbox",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Append horizontal frame")
+             QT_TRANSLATE_NOOP("action", "Append h&orizontal frame")
              ),
     UiAction("append-vbox",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Append vertical frame")
+             QT_TRANSLATE_NOOP("action", "Append v&ertical frame")
              ),
     UiAction("append-textframe",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Append text frame")
+             QT_TRANSLATE_NOOP("action", "Append te&xt frame")
              ),
     UiAction("acciaccatura",
              mu::context::UiCtxNotationOpened,
@@ -647,87 +647,87 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("interval1",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Unison above"),
+             QT_TRANSLATE_NOOP("action", "&Unison above"),
              QT_TRANSLATE_NOOP("action", "Enter unison above")
              ),
     UiAction("interval2",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Second above"),
+             QT_TRANSLATE_NOOP("action", "Se&cond above"),
              QT_TRANSLATE_NOOP("action", "Enter second above")
              ),
     UiAction("interval3",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Third above"),
+             QT_TRANSLATE_NOOP("action", "Thir&d above"),
              QT_TRANSLATE_NOOP("action", "Enter third above")
              ),
     UiAction("interval4",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Fourth above"),
+             QT_TRANSLATE_NOOP("action", "Fou&rth above"),
              QT_TRANSLATE_NOOP("action", "Enter fourth above")
              ),
     UiAction("interval5",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Fifth above"),
+             QT_TRANSLATE_NOOP("action", "Fift&h above"),
              QT_TRANSLATE_NOOP("action", "Enter fifth above")
              ),
     UiAction("interval6",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Sixth above"),
+             QT_TRANSLATE_NOOP("action", "Si&xth above"),
              QT_TRANSLATE_NOOP("action", "Enter sixth above")
              ),
     UiAction("interval7",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Seventh above"),
+             QT_TRANSLATE_NOOP("action", "Seve&nth above"),
              QT_TRANSLATE_NOOP("action", "Enter seventh above")
              ),
     UiAction("interval8",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Octave above"),
+             QT_TRANSLATE_NOOP("action", "Octave &above"),
              QT_TRANSLATE_NOOP("action", "Enter octave above")
              ),
     UiAction("interval9",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Ninth above"),
+             QT_TRANSLATE_NOOP("action", "Ninth abov&e"),
              QT_TRANSLATE_NOOP("action", "Enter ninth above")
              ),
     UiAction("interval-2",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Second below"),
+             QT_TRANSLATE_NOOP("action", "&Second below"),
              QT_TRANSLATE_NOOP("action", "Enter second below")
              ),
     UiAction("interval-3",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Third below"),
+             QT_TRANSLATE_NOOP("action", "&Third below"),
              QT_TRANSLATE_NOOP("action", "Enter third below")
              ),
     UiAction("interval-4",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Fourth below"),
+             QT_TRANSLATE_NOOP("action", "F&ourth below"),
              QT_TRANSLATE_NOOP("action", "Enter fourth below")
              ),
     UiAction("interval-5",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Fifth below"),
+             QT_TRANSLATE_NOOP("action", "&Fifth below"),
              QT_TRANSLATE_NOOP("action", "Enter fifth below")
              ),
     UiAction("interval-6",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Sixth below"),
+             QT_TRANSLATE_NOOP("action", "S&ixth below"),
              QT_TRANSLATE_NOOP("action", "Enter sixth below")
              ),
     UiAction("interval-7",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Seventh below"),
+             QT_TRANSLATE_NOOP("action", "Se&venth below"),
              QT_TRANSLATE_NOOP("action", "Enter seventh below")
              ),
     UiAction("interval-8",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Octave below"),
+             QT_TRANSLATE_NOOP("action", "Octave &below"),
              QT_TRANSLATE_NOOP("action", "Enter octave below")
              ),
     UiAction("interval-9",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Ninth below"),
+             QT_TRANSLATE_NOOP("action", "Ninth belo&w"),
              QT_TRANSLATE_NOOP("action", "Enter ninth below")
              ),
     UiAction("note-c",
@@ -937,27 +937,27 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("add-8va",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Ottava 8va alta"),
+             QT_TRANSLATE_NOOP("action", "Ottava 8va &alta"),
              QT_TRANSLATE_NOOP("action", "Add ottava 8va alta")
              ),
     UiAction("add-8vb",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Ottava 8va bassa"),
+             QT_TRANSLATE_NOOP("action", "Ottava 8va &bassa"),
              QT_TRANSLATE_NOOP("action", "Add ottava 8va bassa")
              ),
     UiAction("add-hairpin",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Crescendo"),
+             QT_TRANSLATE_NOOP("action", "&Crescendo"),
              QT_TRANSLATE_NOOP("action", "Add crescendo")
              ),
     UiAction("add-hairpin-reverse",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Decrescendo"),
+             QT_TRANSLATE_NOOP("action", "&Decrescendo"),
              QT_TRANSLATE_NOOP("action", "Add decrescendo")
              ),
     UiAction("add-noteline",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Note anchored line")
+             QT_TRANSLATE_NOOP("action", "&Note anchored line")
              ),
     UiAction("chord-tie",
              mu::context::UiCtxNotationOpened,
@@ -965,167 +965,167 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("title-text",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Title"),
+             QT_TRANSLATE_NOOP("action", "&Title"),
              QT_TRANSLATE_NOOP("action", "Add title text")
              ),
     UiAction("subtitle-text",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Subtitle"),
+             QT_TRANSLATE_NOOP("action", "&Subtitle"),
              QT_TRANSLATE_NOOP("action", "Add subtitle text")
              ),
     UiAction("composer-text",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Composer"),
+             QT_TRANSLATE_NOOP("action", "&Composer"),
              QT_TRANSLATE_NOOP("action", "Add composer text")
              ),
     UiAction("poet-text",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Lyricist"),
+             QT_TRANSLATE_NOOP("action", "&Lyricist"),
              QT_TRANSLATE_NOOP("action", "Add lyricist text")
              ),
     UiAction("part-text",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Part name"),
+             QT_TRANSLATE_NOOP("action", "&Part name"),
              QT_TRANSLATE_NOOP("action", "Add part name")
              ),
     UiAction("system-text",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "System text"),
+             QT_TRANSLATE_NOOP("action", "Syst&em text"),
              QT_TRANSLATE_NOOP("action", "Add system text")
              ),
     UiAction("staff-text",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Staff text"),
+             QT_TRANSLATE_NOOP("action", "St&aff text"),
              QT_TRANSLATE_NOOP("action", "Add staff text")
              ),
     UiAction("expression-text",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Expression text"),
+             QT_TRANSLATE_NOOP("action", "E&xpression text"),
              QT_TRANSLATE_NOOP("action", "Add expression text")
              ),
     UiAction("rehearsalmark-text",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Rehearsal mark"),
+             QT_TRANSLATE_NOOP("action", "&Rehearsal mark"),
              QT_TRANSLATE_NOOP("action", "Add rehearsal mark")
              ),
     UiAction("instrument-change-text",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Instrument change"),
+             QT_TRANSLATE_NOOP("action", "&Instrument change"),
              QT_TRANSLATE_NOOP("action", "Add instrument change")
              ),
     UiAction("fingering-text",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Fingering"),
+             QT_TRANSLATE_NOOP("action", "&Fingering"),
              QT_TRANSLATE_NOOP("action", "Add fingering")
              ),
     UiAction("sticking-text",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Sticking"),
+             QT_TRANSLATE_NOOP("action", "Stic&king"),
              QT_TRANSLATE_NOOP("action", "Add sticking")
              ),
     UiAction("chord-text",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Chord symbol"),
+             QT_TRANSLATE_NOOP("action", "Chor&d symbol"),
              QT_TRANSLATE_NOOP("action", "Add chord symbol")
              ),
     UiAction("roman-numeral-text",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Roman numeral analysis"),
+             QT_TRANSLATE_NOOP("action", "R&oman numeral analysis"),
              QT_TRANSLATE_NOOP("action", "Add Roman numeral analysis")
              ),
     UiAction("nashville-number-text",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Nashville number"),
+             QT_TRANSLATE_NOOP("action", "&Nashville number"),
              QT_TRANSLATE_NOOP("action", "Add Nashville number")
              ),
     UiAction("lyrics",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Lyrics"),
+             QT_TRANSLATE_NOOP("action", "L&yrics"),
              QT_TRANSLATE_NOOP("action", "Add lyrics")
              ),
     UiAction("figured-bass",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Figured bass"),
+             QT_TRANSLATE_NOOP("action", "Figured &bass"),
              QT_TRANSLATE_NOOP("action", "Add figured bass")
              ),
     UiAction("tempo",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Tempo marking"),
+             QT_TRANSLATE_NOOP("action", "Tempo &marking"),
              QT_TRANSLATE_NOOP("action", "Add tempo marking")
              ),
     UiAction("duplet",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Duplet"),
+             QT_TRANSLATE_NOOP("action", "&Duplet"),
              QT_TRANSLATE_NOOP("action", "Add duplet")
              ),
     UiAction("triplet",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Triplet"),
+             QT_TRANSLATE_NOOP("action", "&Triplet"),
              QT_TRANSLATE_NOOP("action", "Add triplet")
              ),
     UiAction("quadruplet",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Quadruplet"),
+             QT_TRANSLATE_NOOP("action", "&Quadruplet"),
              QT_TRANSLATE_NOOP("action", "Add quadruplet")
              ),
     UiAction("quintuplet",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Quintuplet"),
+             QT_TRANSLATE_NOOP("action", "Q&uintuplet"),
              QT_TRANSLATE_NOOP("action", "Add quintuplet")
              ),
     UiAction("sextuplet",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Sextuplet"),
+             QT_TRANSLATE_NOOP("action", "Se&xtuplet"),
              QT_TRANSLATE_NOOP("action", "Add sextuplet")
              ),
     UiAction("septuplet",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Septuplet"),
+             QT_TRANSLATE_NOOP("action", "Se&ptuplet"),
              QT_TRANSLATE_NOOP("action", "Add septuplet")
              ),
     UiAction("octuplet",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Octuplet"),
+             QT_TRANSLATE_NOOP("action", "&Octuplet"),
              QT_TRANSLATE_NOOP("action", "Add octuplet")
              ),
     UiAction("nonuplet",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Nontuplet"),
+             QT_TRANSLATE_NOOP("action", "&Nontuplet"),
              QT_TRANSLATE_NOOP("action", "Add nontuplet")
              ),
     UiAction("tuplet-dialog",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Other…"),
+             QT_TRANSLATE_NOOP("action", "Othe&r…"),
              QT_TRANSLATE_NOOP("action", "Other tuplets")
              ),
     UiAction("stretch-",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Decrease layout stretch"),
+             QT_TRANSLATE_NOOP("action", "&Decrease layout stretch"),
              QT_TRANSLATE_NOOP("action", "Decrease layout stretch factor of selected measures")
              ),
     UiAction("stretch+",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Increase layout stretch"),
+             QT_TRANSLATE_NOOP("action", "&Increase layout stretch"),
              QT_TRANSLATE_NOOP("action", "Increase layout stretch factor of selected measures")
              ),
     UiAction("reset-stretch",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Reset layout stretch"),
+             QT_TRANSLATE_NOOP("action", "&Reset layout stretch"),
              QT_TRANSLATE_NOOP("action", "Reset layout stretch factor of selected measures or entire score")
              ),
     UiAction("reset-text-style-overrides",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Reset text style overrides"),
+             QT_TRANSLATE_NOOP("action", "Reset &text style overrides"),
              QT_TRANSLATE_NOOP("action", "Reset all text style overrides to default")
              ),
     UiAction("reset-beammode",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Reset beams"),
+             QT_TRANSLATE_NOOP("action", "Reset &beams"),
              QT_TRANSLATE_NOOP("action", "Reset beams of selected measures")
              ),
     UiAction("reset",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Reset shapes and positions"),
+             QT_TRANSLATE_NOOP("action", "Reset shapes and &positions"),
              QT_TRANSLATE_NOOP("action", "Reset shapes and positions of selected elements to their defaults")
              ),
     UiAction("zoomin",
@@ -1824,31 +1824,31 @@ const UiActionList NotationUiActions::m_noteInputActions = {
 const UiActionList NotationUiActions::m_scoreConfigActions = {
     UiAction(SHOW_INVISIBLE_CODE,
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Show invisible"),
+             QT_TRANSLATE_NOOP("action", "Show &invisible"),
              QT_TRANSLATE_NOOP("action", "Show invisible"),
              Checkable::Yes
              ),
     UiAction(SHOW_UNPRINTABLE_CODE,
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Show formatting"),
+             QT_TRANSLATE_NOOP("action", "Show f&ormatting"),
              QT_TRANSLATE_NOOP("action", "Show formatting"),
              Checkable::Yes
              ),
     UiAction(SHOW_FRAMES_CODE,
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Show frames"),
+             QT_TRANSLATE_NOOP("action", "Show &frames"),
              QT_TRANSLATE_NOOP("action", "Show frames"),
              Checkable::Yes
              ),
     UiAction(SHOW_PAGEBORDERS_CODE,
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Show page margins"),
+             QT_TRANSLATE_NOOP("action", "Show page &margins"),
              QT_TRANSLATE_NOOP("action", "Show page margins"),
              Checkable::Yes
              ),
     UiAction(SHOW_IRREGULAR_CODE,
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Mark irregular measures"),
+             QT_TRANSLATE_NOOP("action", "Mark i&rregular measures"),
              QT_TRANSLATE_NOOP("action", "Mark irregular measures"),
              Checkable::Yes
              )
@@ -1857,27 +1857,27 @@ const UiActionList NotationUiActions::m_scoreConfigActions = {
 const UiActionList NotationUiActions::m_engravingDebuggingActions = {
     UiAction("show-skylines",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Show skylines"),
+             QT_TRANSLATE_NOOP("action", "Show &skylines"),
              Checkable::Yes
              ),
     UiAction("show-segment-shapes",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Show segment shapes"),
+             QT_TRANSLATE_NOOP("action", "Show s&egment shapes"),
              Checkable::Yes
              ),
     UiAction("show-bounding-rect",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Show bounding rectangles"),
+             QT_TRANSLATE_NOOP("action", "Show &bounding rectangles"),
              Checkable::Yes
              ),
     UiAction("show-system-bounding-rect",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Show system bounding rectangles"),
+             QT_TRANSLATE_NOOP("action", "Show s&ystem bounding rectangles"),
              Checkable::Yes
              ),
     UiAction("show-corrupted-measures",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Show corrupted measures"),
+             QT_TRANSLATE_NOOP("action", "Show &corrupted measures"),
              Checkable::Yes
              )
 };

--- a/src/palette/internal/paletteuiactions.cpp
+++ b/src/palette/internal/paletteuiactions.cpp
@@ -32,7 +32,7 @@ static const mu::actions::ActionCode MASTERPALETTE_CODE("masterpalette");
 const UiActionList PaletteUiActions::m_actions = {
     UiAction(MASTERPALETTE_CODE,
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Master palette"),
+             QT_TRANSLATE_NOOP("action", "&Master palette"),
              Checkable::Yes
              ),
     UiAction("palette-search",

--- a/src/plugins/internal/pluginsuiactions.cpp
+++ b/src/plugins/internal/pluginsuiactions.cpp
@@ -40,7 +40,7 @@ PluginsUiActions::PluginsUiActions(std::shared_ptr<PluginsService> service)
 static UiAction MANAGE_ACTION = UiAction(
     "manage-plugins",
     mu::context::UiCtxAny,
-    QT_TRANSLATE_NOOP("action", "Manage plugins…")
+    QT_TRANSLATE_NOOP("action", "&Manage plugins…")
     );
 
 const mu::ui::UiActionList& PluginsUiActions::actionsList() const

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -27,50 +27,50 @@ using namespace mu::ui;
 const UiActionList ProjectUiActions::m_actions = {
     UiAction("file-open",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Open…"),
+             QT_TRANSLATE_NOOP("action", "&Open…"),
              QT_TRANSLATE_NOOP("action", "Load score from file"),
              IconCode::Code::OPEN_FILE
              ),
     UiAction("file-new",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "New…"),
+             QT_TRANSLATE_NOOP("action", "&New…"),
              QT_TRANSLATE_NOOP("action", "Create new score"),
              IconCode::Code::NEW_FILE
              ),
     UiAction("file-close",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Close"),
+             QT_TRANSLATE_NOOP("action", "&Close"),
              QT_TRANSLATE_NOOP("action", "Close current score")
              ),
     UiAction("file-save",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Save"),
+             QT_TRANSLATE_NOOP("action", "&Save"),
              QT_TRANSLATE_NOOP("action", "Save score to file"),
              IconCode::Code::SAVE
              ),
     UiAction("file-save-as",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Save as…"),
+             QT_TRANSLATE_NOOP("action", "Save &as…"),
              QT_TRANSLATE_NOOP("action", "Save score under a new file name")
              ),
     UiAction("file-save-a-copy",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Save a copy…"),
+             QT_TRANSLATE_NOOP("action", "Save a cop&y…"),
              QT_TRANSLATE_NOOP("action", "Save a copy of the score in addition to the current file")
              ),
     UiAction("file-save-selection",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Save selection…"),
+             QT_TRANSLATE_NOOP("action", "Save se&lection…"),
              QT_TRANSLATE_NOOP("action", "Save current selection as new score")
              ),
     UiAction("file-save-to-cloud",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Save to cloud…"),
+             QT_TRANSLATE_NOOP("action", "Save to clo&ud…"),
              IconCode::Code::CLOUD_FILE
              ),
     UiAction("file-publish",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Publish to MuseScore.com…"),
+             QT_TRANSLATE_NOOP("action", "Pu&blish to MuseScore.com…"),
              IconCode::Code::CLOUD_FILE
              ),
     UiAction("file-export",
@@ -81,13 +81,13 @@ const UiActionList ProjectUiActions::m_actions = {
              ),
     UiAction("file-import-pdf",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Import PDF…"),
+             QT_TRANSLATE_NOOP("action", "Import P&DF…"),
              QT_TRANSLATE_NOOP("action", "Import a PDF file with an experimental service on musescore.com"),
              IconCode::Code::IMPORT
              ),
     UiAction("project-properties",
              mu::context::UiCtxNotationOpened,
-             QT_TRANSLATE_NOOP("action", "Project properties…"),
+             QT_TRANSLATE_NOOP("action", "Project propert&ies…"),
              QT_TRANSLATE_NOOP("action", "Edit project properties")
              ),
     UiAction("print",
@@ -98,7 +98,7 @@ const UiActionList ProjectUiActions::m_actions = {
              ),
     UiAction("clear-recent",
              mu::context::UiCtxAny,
-             QT_TRANSLATE_NOOP("action", "Clear recent files")
+             QT_TRANSLATE_NOOP("action", "&Clear recent files")
              )
 };
 


### PR DESCRIPTION
Add ampersand to action titles that appear in menus, excluding any titles that are also used outside of the menu as a tooltip or button text elsewhere in the UI (e.g. "Parts", "Mixer", "Undo", "Redo" and "Slur"). Adding it to those titles would have made the '&' visible in the UI.

I followed these guidelines in choosing mnemonics: https://docs.microsoft.com/en-gb/windows/win32/uxguide/cmd-menus#access-keys

**Important:** This should be merged before #12414 because that one can be easily rebased whereas this one cannot.