### PR TITLE
Get rid of KeyMode when creating a new score

### DIFF
--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -138,7 +138,6 @@ static void createMeasures(mu::engraving::Score* score, const ScoreCreateOptions
         ks.setMode(KeyMode::NONE);
     } else {
         ks.setKey(scoreOptions.key);
-        ks.setMode(scoreOptions.keyMode);
     }
 
     for (int i = 0; i < measures; ++i) {

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -570,7 +570,6 @@ struct ScoreCreateOptions
     TimeSigType timesigType = TimeSigType::NORMAL;
 
     Key key = Key::C;
-    KeyMode keyMode = KeyMode::UNKNOWN;
 
     bool withPickupMeasure = false;
     int measures = 0;

--- a/src/project/view/newscoremodel.cpp
+++ b/src/project/view/newscoremodel.cpp
@@ -92,7 +92,6 @@ ProjectCreateOptions NewScoreModel::parseOptions(const QVariantMap& info) const
 
     QVariantMap keySignature = info["keySignature"].toMap();
     scoreOptions.key = static_cast<Key>(keySignature["key"].toInt());
-    scoreOptions.keyMode = static_cast<KeyMode>(keySignature["mode"].toInt());
 
     QVariantMap measuresPickup = info["pickupTimeSignature"].toMap();
     scoreOptions.withPickupMeasure = info["withPickupMeasure"].toBool();


### PR DESCRIPTION
Since a KeyMode is never communicated to QML, the score creation options passed from QML won't contain a KeyMode either. Still, we try to get the KeyMode, to assign it to `scoreOptions.keyMode`, in `NewScoreModel::parseOptions`. Thus, we get the default int value namely 0, and convert that to a KeyMode, which gives KeyMode::NONE, which is the "dangerous" mode for custom/atonal key signatures. Key signatures with this mode behave very differently when it comes to transposing instruments, which is undesired for normal key signatures. 

Thus, we get rid of the ScoreCreationOptions.keyMode entirely for now, since it will never contain a correct value. (And in practice, the keyMode doesn't matter anything at all, the only place where it is used is in MusicXML export.) This is a bit of a quick fix for now, and we might consider bringing it back later.

Resolves: #12387