### PR TITLE
[MU4] Fix #12421: Part, Mixer buttons and Playback panel are not centered after opening/creating a score

### DIFF
--- a/src/appshell/view/dockwindow/dockwindow.cpp
+++ b/src/appshell/view/dockwindow/dockwindow.cpp
@@ -129,7 +129,7 @@ void DockWindow::geometryChanged(const QRectF& newGeometry, const QRectF& oldGeo
 
     QQuickItem::geometryChanged(newGeometry, oldGeometry);
 
-    alignToolBars(m_currentPage);
+    alignTopLevelToolBars(m_currentPage);
 }
 
 void DockWindow::onQuit()
@@ -385,7 +385,7 @@ void DockWindow::loadPanels(const DockPageView* page)
     }
 }
 
-void DockWindow::alignToolBars(const DockPageView* page)
+void DockWindow::alignTopLevelToolBars(const DockPageView* page)
 {
     QList<DockToolBarView*> topToolBars = topLevelToolBars(page);
 
@@ -620,11 +620,19 @@ void DockWindow::initDocks(DockPageView* page)
         page->init();
     }
 
-    alignToolBars(page);
+    alignTopLevelToolBars(page);
 
-    for (DockToolBarView* toolbar : page->mainToolBars()) {
+    for (DockToolBarView* toolbar : topLevelToolBars(page)) {
         connect(toolbar, &DockToolBarView::floatingChanged, this, [this, page]() {
-            alignToolBars(page);
+            alignTopLevelToolBars(page);
+        }, Qt::UniqueConnection);
+
+        connect(toolbar, &DockToolBarView::contentSizeChanged, this, [this, page]() {
+            alignTopLevelToolBars(page);
+        }, Qt::UniqueConnection);
+
+        connect(toolbar, &DockToolBarView::visibleChanged, this, [this, page]() {
+            alignTopLevelToolBars(page);
         }, Qt::UniqueConnection);
     }
 }

--- a/src/appshell/view/dockwindow/dockwindow.h
+++ b/src/appshell/view/dockwindow/dockwindow.h
@@ -113,7 +113,7 @@ private:
     void loadToolBars(const DockPageView* page);
     void loadPanels(const DockPageView* page);
     void loadTopLevelToolBars(const DockPageView* page);
-    void alignToolBars(const DockPageView* page);
+    void alignTopLevelToolBars(const DockPageView* page);
 
     void addDock(DockBase* dock, Location location = Location::Left, const DockBase* relativeTo = nullptr);
     void registerDock(DockBase* dock);

--- a/src/appshell/view/dockwindow/internal/dockbase.cpp
+++ b/src/appshell/view/dockwindow/internal/dockbase.cpp
@@ -349,6 +349,8 @@ void DockBase::init()
 
     setVisible(m_dockWidget->isOpen());
     setInited(true);
+
+    applySizeConstraints();
 }
 
 void DockBase::deinit()
@@ -636,7 +638,6 @@ void DockBase::updateFloatingStatus()
     bool floating = m_dockWidget && m_dockWidget->floatingWindow();
 
     doSetFloating(floating);
-    applySizeConstraints();
 }
 
 void DockBase::doSetFloating(bool floating)


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/12421