### PR TITLE
Fix #12278: bound line2pitch if line below minimum

### DIFF
--- a/src/engraving/libmscore/utils.cpp
+++ b/src/engraving/libmscore/utils.cpp
@@ -455,10 +455,10 @@ int line2pitch(int line, ClefType clef, Key key)
 {
     int l      = ClefInfo::pitchOffset(clef) - line;
     int octave = 0;
-    while (l < 0) {
-        l += 7;
-        octave++;
+    if (l < 0) {
+        l = 0;
     }
+
     octave += l / 7;
     l       = l % 7;
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/12278

Hello,

This issue appears to be caused by the `line2pitch` function. If the line was below the minimum, the function would add octaves until the note is valid. Replacing that behavior by a simply setting notes that are too low to the minimum fixes the issue.

However, I suppose this behavior had a purpose in one of the usage of the `line2pitch` function. But in this case, why wouldn't there be a similar behavior for notes that are too high?

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
