### PR TITLE
Extending minimum tie length implementation to apply at start of system

### DIFF
--- a/src/engraving/layout/layoutchords.cpp
+++ b/src/engraving/layout/layoutchords.cpp
@@ -1271,6 +1271,7 @@ void LayoutChords::updateLineAttachPoints(Measure* measure)
             }
         }
     }
+    bool isFirstChordRestInMeasure = true;
     for (Segment& s : measure->segments()) {
         if (!s.isChordRestType()) {
             continue;
@@ -1280,11 +1281,12 @@ void LayoutChords::updateLineAttachPoints(Measure* measure)
                 continue;
             }
             Chord* c = toChord(e);
-            doUpdateLineAttachPoints(c);
+            doUpdateLineAttachPoints(c, isFirstChordRestInMeasure);
             for (Chord* gn : c->graceNotes()) {
-                doUpdateLineAttachPoints(gn);
+                doUpdateLineAttachPoints(gn, false);
             }
         }
+        isFirstChordRestInMeasure = false;
     }
     for (Segment& s : measure->segments()) {
         s.createShapes();
@@ -1294,7 +1296,7 @@ void LayoutChords::updateLineAttachPoints(Measure* measure)
 /* We perform a pre-layout of ties and glissandi to obtain the attach points and attach them to
  * the notes of the chord. Will be needed for spacing calculation, particularly to
  * enforce minTieLength. The true layout of ties and glissandi is done much later. */
-void LayoutChords::doUpdateLineAttachPoints(Chord* chord)
+void LayoutChords::doUpdateLineAttachPoints(Chord* chord, bool isFirstInMeasure)
 {
     if (chord->endsGlissando()) {
         for (Note* note : chord->notes()) {
@@ -1308,6 +1310,14 @@ void LayoutChords::doUpdateLineAttachPoints(Chord* chord)
                         }
                     }
                 }
+            }
+        }
+    }
+    if (isFirstInMeasure) {
+        for (Note* note : chord->notes()) {
+            Tie* tieBack = note->tieBack();
+            if (tieBack && tieBack->startNote()->findMeasure() != note->findMeasure()) {
+                tieBack->layoutBack(note->findMeasure()->system());
             }
         }
     }

--- a/src/engraving/layout/layoutchords.h
+++ b/src/engraving/layout/layoutchords.h
@@ -46,7 +46,7 @@ public:
     static void repositionGraceNotesAfter(Segment* segment);
     static void appendGraceNotes(Chord* chord);
     static void updateLineAttachPoints(Measure* measure);
-    static void doUpdateLineAttachPoints(Chord* chord);
+    static void doUpdateLineAttachPoints(Chord* chord, bool isFirstInMeasure);
 };
 }
 

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -2629,6 +2629,28 @@ double Segment::minHorizontalDistance(Segment* ns, bool systemHeaderGap) const
         }
     }
 
+    // Allocate space to ensure minimum length of "dangling" ties at start of system
+    if (systemHeaderGap && ns && ns->isChordRestType()) {
+        for (EngravingItem* e : ns->elist()) {
+            if (!e || !e->isChord()) {
+                continue;
+            }
+            double headerTieMargin = score()->styleMM(Sid::HeaderToLineStartDistance);
+            for (Note* note : toChord(e)->notes()) {
+                if (!note->tieBack() || note->lineAttachPoints().empty()) {
+                    continue;
+                }
+                double tieStartPointX = minRight() + headerTieMargin;
+                double notePosX = w + note->pos().x() + toChord(e)->pos().x() + note->headWidth() / 2;
+                double tieEndPointX = notePosX + note->lineAttachPoints().at(0).pos().x();
+                double tieLength = tieEndPointX - tieStartPointX;
+                if (tieLength < score()->styleMM(Sid::MinTieLength)) {
+                    w += score()->styleMM(Sid::MinTieLength) - tieLength;
+                }
+            }
+        }
+    }
+
     if (ns) {
         w += ns->extraLeadingSpace().val() * spatium();
     }

--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -1746,7 +1746,7 @@ Spacer* System::downSpacer(staff_idx_t staffIdx) const
 
 double System::firstNoteRestSegmentX(bool leading)
 {
-    double margin = score()->spatium();
+    double margin = score()->styleMM(Sid::HeaderToLineStartDistance);
     for (const MeasureBase* mb : measures()) {
         if (mb->isMeasure()) {
             const Measure* measure = static_cast<const Measure*>(mb);

--- a/src/engraving/libmscore/tie.cpp
+++ b/src/engraving/libmscore/tie.cpp
@@ -844,10 +844,8 @@ void TieSegment::addLineAttachPoints()
     // Add tie attach point to start and end note
     Note* startNote = tie()->startNote();
     Note* endNote = tie()->endNote();
-    if (endNote && endNote->findMeasure() == startNote->findMeasure()) {
-        startNote->addLineAttachPoint(ups(Grip::START).pos(), tie());
-        endNote->addLineAttachPoint(ups(Grip::END).pos(), tie());
-    }
+    startNote->addLineAttachPoint(ups(Grip::START).pos(), tie());
+    endNote->addLineAttachPoint(ups(Grip::END).pos(), tie());
 }
 
 //---------------------------------------------------------
@@ -1215,12 +1213,13 @@ TieSegment* Tie::layoutBack(System* system)
     TieSegment* segment = segmentAt(1);
     segment->setSystem(system);
 
-    double x = system->firstNoteRestSegmentX(true);
+    double x = system ? system->firstNoteRestSegmentX(true) : 0;
 
     segment->adjustY(PointF(x, sPos.p2.y()), sPos.p2);
     segment->setSpannerSegmentType(SpannerSegmentType::END);
     segment->adjustX();
     segment->finalizeSegment();
+    segment->addLineAttachPoints();
     return segment;
 }
 

--- a/src/engraving/libmscore/tie.cpp
+++ b/src/engraving/libmscore/tie.cpp
@@ -844,8 +844,12 @@ void TieSegment::addLineAttachPoints()
     // Add tie attach point to start and end note
     Note* startNote = tie()->startNote();
     Note* endNote = tie()->endNote();
-    startNote->addLineAttachPoint(ups(Grip::START).pos(), tie());
-    endNote->addLineAttachPoint(ups(Grip::END).pos(), tie());
+    if (startNote) {
+        startNote->addLineAttachPoint(ups(Grip::START).pos(), tie());
+    }
+    if (endNote) {
+        endNote->addLineAttachPoint(ups(Grip::END).pos(), tie());
+    }
 }
 
 //---------------------------------------------------------

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -469,6 +469,8 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::SlurDottedWidth,         "slurDottedWidth",         Spatium(.10) },
     { Sid::MinTieLength,            "minTieLength",            Spatium(1.0) },
     { Sid::SlurMinDistance,         "slurMinDistance",         Spatium(0.5) },
+    { Sid::HeaderToLineStartDistance,   "headerSlurTieDistance",   Spatium(1.0) },
+
     { Sid::SectionPause,            "sectionPause",            PropertyValue(double(3.0)) },
     { Sid::MusicalSymbolFont,       "musicalSymbolFont",       PropertyValue(String(u"Leland")) },
     { Sid::MusicalTextFont,         "musicalTextFont",         PropertyValue(String(u"Leland Text")) },

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -478,6 +478,7 @@ enum class Sid {
     SlurDottedWidth,
     MinTieLength,
     SlurMinDistance,
+    HeaderToLineStartDistance, // determines start point of "dangling" lines (ties, gliss, lyrics...) at start of system
 
     SectionPause,
     MusicalSymbolFont,


### PR DESCRIPTION
At the moment, minimum tie length is only enforced between adjacent chords. That was by design in my first implementation. @oktophonie pointed out that it can be necessary to enforce it also at the start of a system. That case requires special handling, which is now implemented.
Additionally, the space between the end of the header and the start of the tie (which used to be determined by an anonimous variable set to 1 sp) has been moved into a dedicated style setting (though not exposed in UI).

Before:
<img width="285" alt="Immagine 2022-07-15 181819" src="https://user-images.githubusercontent.com/93707756/179503741-7da03c71-cc87-4647-8246-4a603e6800d4.png">

After
<img width="280" alt="Immagine 2022-07-15 182043" src="https://user-images.githubusercontent.com/93707756/179503766-ab73b31d-711c-4c2d-b14e-11bf5b204daf.png">

