### PR TITLE
Ensure stems are not shortened if 'shorten stems' style setting is set

### DIFF
--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -1500,6 +1500,9 @@ int Chord::minStaffOverlap(bool up, int staffLines, int beamCount, bool hasHook,
 // all values are in quarter spaces
 int Chord::maxReduction(int extensionOutsideStaff) const
 {
+    if (!score()->styleB(Sid::shortenStem)) {
+        return 0;
+    }
     // [extensionOutsideStaff][beamCount]
     static const int maxReductions[4][5] = {
         //1sp 1.5sp 2sp 2.5sp >=3sp -- extensionOutsideStaff


### PR DESCRIPTION
The issue:
![image](https://user-images.githubusercontent.com/89263931/179576330-48cdf27f-6c59-4d35-bfc7-1067aa17fba0.png)
Checking or unchecking the 'shorten stems' box did nothing.

Now, when the checkbox is unchecked, stems no longer shorten due to extension outside of the staff. Note that this doesn't prevent the shortening of stems to create good beams in the staff. This is by design.

There is something to be said about the benefit of removing both the 'progression' and possibly even 'shortest stem' to make things a little simpler. This is a system that didn't really work very well in 3.6 anyway, so the functionality is going to change regardless. However, neither of those boxes have yet to be removed--that will or won't happen in a future PR once we come up with an idea of whether it's worth it to hook those up or remove them.