### PR TITLE
Fix: typo in ioretcodes.h: coping -> copying

### DIFF
--- a/src/framework/global/io/ioretcodes.h
+++ b/src/framework/global/io/ioretcodes.h
@@ -57,7 +57,7 @@ inline Ret make_ret(Err e)
     case Err::FSReadError: return Ret(retCode, trc("system", "An error occurred when reading from the file"));
     case Err::FSWriteError: return Ret(retCode, trc("system", "An error occurred when writing to the file"));
     case Err::FSMakingError: return Ret(retCode, trc("system", "An error occurred when making a path"));
-    case Err::FSCopyError: return Ret(retCode, trc("system", "An error occurred when coping the file"));
+    case Err::FSCopyError: return Ret(retCode, trc("system", "An error occurred when copying the file"));
     case Err::FSMoveErrors: return Ret(retCode, trc("system", "An error occurred when moving the file"));
     }
 


### PR DESCRIPTION
Fix: typo in ioretcodes.h: coping -> copying

Greetings,
Gootector

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
