### PR TITLE
[MU4] Fix 12432: Ensure staves that are not added to an excerpt are unlinked (and deleted)

### DIFF
--- a/src/instrumentsscene/view/staffsettingsmodel.cpp
+++ b/src/instrumentsscene/view/staffsettingsmodel.cpp
@@ -214,7 +214,10 @@ void StaffSettingsModel::createLinkedStaff()
     }
 
     Staff* linkedStaff = sourceStaff->clone();
-    masterNotationParts()->appendLinkedStaff(linkedStaff, sourceStaff->id(), sourceStaff->part()->id());
+    if (!masterNotationParts()->appendLinkedStaff(linkedStaff, sourceStaff->id(), sourceStaff->part()->id())) {
+        linkedStaff->unlink();
+        delete linkedStaff;
+    }
 }
 
 INotationPartsPtr StaffSettingsModel::notationParts() const

--- a/src/notation/inotationparts.h
+++ b/src/notation/inotationparts.h
@@ -69,8 +69,8 @@ public:
     virtual void moveParts(const IDList& sourcePartsIds, const ID& destinationPartId, InsertMode mode = InsertMode::Before) = 0;
     virtual void moveStaves(const IDList& sourceStavesIds, const ID& destinationStaffId, InsertMode mode = InsertMode::Before) = 0;
 
-    virtual void appendStaff(Staff* staff, const ID& destinationPartId) = 0;
-    virtual void appendLinkedStaff(Staff* staff, const ID& sourceStaffId, const ID& destinationPartId) = 0;
+    virtual bool appendStaff(Staff* staff, const ID& destinationPartId) = 0;
+    virtual bool appendLinkedStaff(Staff* staff, const ID& sourceStaffId, const ID& destinationPartId) = 0;
 
     virtual void insertPart(Part* part, size_t index) = 0;
 

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -82,9 +82,13 @@ void MasterNotationParts::removeStaves(const IDList& stavesIds)
     endGlobalEdit();
 }
 
-void MasterNotationParts::appendStaff(Staff* staff, const ID& destinationPartId)
+bool MasterNotationParts::appendStaff(Staff* staff, const ID& destinationPartId)
 {
     TRACEFUNC;
+
+    IF_ASSERT_FAILED(staff) {
+        return false;
+    }
 
     startGlobalEdit();
 
@@ -95,15 +99,23 @@ void MasterNotationParts::appendStaff(Staff* staff, const ID& destinationPartId)
 
     for (INotationPartsPtr parts : excerptsParts()) {
         Staff* excerptStaff = mu::engraving::toStaff(staff->linkedClone());
-        parts->appendStaff(excerptStaff, destinationPartId);
+        if (!parts->appendStaff(excerptStaff, destinationPartId)) {
+            excerptStaff->unlink();
+            delete excerptStaff;
+        }
     }
 
     endGlobalEdit();
+    return true;
 }
 
-void MasterNotationParts::appendLinkedStaff(Staff* staff, const mu::ID& sourceStaffId, const mu::ID& destinationPartId)
+bool MasterNotationParts::appendLinkedStaff(Staff* staff, const mu::ID& sourceStaffId, const mu::ID& destinationPartId)
 {
     TRACEFUNC;
+
+    IF_ASSERT_FAILED(staff) {
+        return false;
+    }
 
     startGlobalEdit();
 
@@ -113,10 +125,15 @@ void MasterNotationParts::appendLinkedStaff(Staff* staff, const mu::ID& sourceSt
     NotationParts::appendLinkedStaff(staff, sourceStaffId, destinationPartId);
 
     for (INotationPartsPtr parts : excerptsParts()) {
-        parts->appendLinkedStaff(staff->clone(), sourceStaffId, destinationPartId);
+        Staff* excerptStaff = staff->clone();
+        if (!parts->appendLinkedStaff(excerptStaff, sourceStaffId, destinationPartId)) {
+            excerptStaff->unlink();
+            delete excerptStaff;
+        }
     }
 
     endGlobalEdit();
+    return true;
 }
 
 void MasterNotationParts::replaceInstrument(const InstrumentKey& instrumentKey, const Instrument& newInstrument)

--- a/src/notation/internal/masternotationparts.h
+++ b/src/notation/internal/masternotationparts.h
@@ -37,8 +37,8 @@ public:
     void removeParts(const IDList& partsIds) override;
     void removeStaves(const IDList& stavesIds) override;
 
-    void appendStaff(Staff* staff, const ID& destinationPartId) override;
-    void appendLinkedStaff(Staff* staff, const ID& sourceStaffId, const ID& destinationPartId) override;
+    bool appendStaff(Staff* staff, const ID& destinationPartId) override;
+    bool appendLinkedStaff(Staff* staff, const ID& sourceStaffId, const ID& destinationPartId) override;
 
     void replaceInstrument(const InstrumentKey& instrumentKey, const Instrument& newInstrument) override;
     void replaceDrumset(const InstrumentKey& instrumentKey, const Drumset& newDrumset) override;

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -475,13 +475,17 @@ void NotationParts::setStaffConfig(const ID& staffId, const StaffConfig& config)
     notifyAboutStaffChanged(staff);
 }
 
-void NotationParts::appendStaff(Staff* staff, const ID& destinationPartId)
+bool NotationParts::appendStaff(Staff* staff, const ID& destinationPartId)
 {
     TRACEFUNC;
 
+    IF_ASSERT_FAILED(staff) {
+        return false;
+    }
+
     Part* destinationPart = partModifiable(destinationPartId);
-    if (!staff || !destinationPart) {
-        return;
+    if (!destinationPart) {
+        return false;
     }
 
     startEdit();
@@ -489,16 +493,22 @@ void NotationParts::appendStaff(Staff* staff, const ID& destinationPartId)
     apply();
 
     notifyAboutStaffAdded(staff, destinationPartId);
+
+    return true;
 }
 
-void NotationParts::appendLinkedStaff(Staff* staff, const ID& sourceStaffId, const mu::ID& destinationPartId)
+bool NotationParts::appendLinkedStaff(Staff* staff, const ID& sourceStaffId, const mu::ID& destinationPartId)
 {
     TRACEFUNC;
 
+    IF_ASSERT_FAILED(staff) {
+        return false;
+    }
+
     Staff* sourceStaff = staffModifiable(sourceStaffId);
     Part* destinationPart = partModifiable(destinationPartId);
-    if (!staff || !sourceStaff || !destinationPart) {
-        return;
+    if (!sourceStaff || !destinationPart) {
+        return false;
     }
 
     startEdit();
@@ -512,6 +522,8 @@ void NotationParts::appendLinkedStaff(Staff* staff, const ID& sourceStaffId, con
     apply();
 
     notifyAboutStaffAdded(staff, destinationPartId);
+
+    return true;
 }
 
 void NotationParts::insertPart(Part* part, size_t index)

--- a/src/notation/internal/notationparts.h
+++ b/src/notation/internal/notationparts.h
@@ -64,8 +64,8 @@ public:
     void moveParts(const IDList& sourcePartsIds, const ID& destinationPartId, InsertMode mode = InsertMode::Before) override;
     void moveStaves(const IDList& sourceStavesIds, const ID& destinationStaffId, InsertMode mode = InsertMode::Before) override;
 
-    void appendStaff(Staff* staff, const ID& destinationPartId) override;
-    void appendLinkedStaff(Staff* staff, const ID& sourceStaffId, const ID& destinationPartId) override;
+    bool appendStaff(Staff* staff, const ID& destinationPartId) override;
+    bool appendLinkedStaff(Staff* staff, const ID& sourceStaffId, const ID& destinationPartId) override;
 
     void insertPart(Part* part, size_t index) override;
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/12432

There was a bug in the interaction between `MasterNotationParts::appendStaff()` and `NotationParts::appendStaff()`. When creating linked clones of staves to add to excerpts, the linked clone is created before it's even determined whether we need to add that clone to the excerpt. If not, the process of creating a linked clone saves itself in all of its would-be siblings lists of siblings. The fix for that was to make sure that we unlink any staff that is not added to the excerpt in question.

I also noticed that there was a bit of a memory leak, where new Staves were being allocated and not being deleted in the situation described above, so I added some `delete`s in there. I know MuseScore is a huge codebase with tons of macros and whatever magic Qt does, so if there's some behind-the-scenes reference counting going on that makes those `delete`s unnecessary, I can remove them. But I didn't find anything to suggest there was!