### PR TITLE
Fix conflict checking with multiple shortcuts

### DIFF
--- a/src/framework/shortcuts/view/editshortcutmodel.cpp
+++ b/src/framework/shortcuts/view/editshortcutmodel.cpp
@@ -116,14 +116,18 @@ void EditShortcutModel::inputKey(int key, Qt::KeyboardModifiers modifiers)
 void EditShortcutModel::checkNewSequenceForConflicts()
 {
     m_conflictShortcut.clear();
-    QString input = newSequence();
+    const std::string input = newSequence().toStdString();
 
     for (const QVariant& shortcut : m_potentialConflictShortcuts) {
         QVariantMap map = shortcut.toMap();
 
-        if (map.value("sequence").toString() == input) {
-            m_conflictShortcut = map;
-            return;
+        std::vector<std::string> toCheckSequences = Shortcut::sequencesFromString(map.value("sequence").toString().toStdString());
+
+        for (const std::string& toCheckSequence : toCheckSequences) {
+            if (input == toCheckSequence) {
+                m_conflictShortcut = map;
+                return;
+            }
         }
     }
 }


### PR DESCRIPTION
When comparing two shortcuts, before it did a single string comparison between the conjoined string form of the sequences. This caused an issue because if there are two shortcuts, and one has, for example, `Ctrl+Z` as the shortcut and some other shortcut, say as its for UNDO `Ctrl+Z; Alt + Backspace`, then even if I assign `Ctrl+Z` to some other shortcut it would not conflict because the `Alt+Backspace` would cause the string to not match and hence not cause the conflict.

![image](https://user-images.githubusercontent.com/75690289/179808340-908863f6-22bd-4abf-99a9-7f85cf12d0cb.png)
This allowed me to set the same shortcut to say Redo
![image](https://user-images.githubusercontent.com/75690289/179808870-8382f0e4-6a4c-4c2a-938a-369fea8fd953.png)


Another such example can been seen here (the shortcuts of marcato were set by me in shortcuts.xml)
![image](https://user-images.githubusercontent.com/75690289/179808630-6d9f9fda-11ae-4f2d-a128-e64c1550c6be.png)

This PR just compares each shortcut and flags the conflict on first sequence match
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
