### PR TITLE
Reset grace notes offset when migrating from pre-4.0

### DIFF
--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -1219,6 +1219,10 @@ void Chord::read(XmlReader& e)
             e.unknown();
         }
     }
+    // Reset horizontal offset of grace notes when migrating from before 4.0
+    if (isGrace() && score()->mscVersion() < 400) {
+        rxoffset() = 0;
+    }
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: #12440 

The default grace notes spacing used to be quite bad in older versions: way too narrow in normal staves, way too wide in TAB staves. Users would often correct by applying manual offset to individual notes. However, the default spacing in 4.0 is much improved, which means that applying the old offsets would often result in a completely wrong layout. This PR resets manual offset of grace notes when importing from 4.0. @oktophonie 

Musescore 3.6 default:
<img width="300" alt="MU3Default" src="https://user-images.githubusercontent.com/93707756/179958364-389e0c42-f957-470e-885e-99cb40c8d7dd.png">
Musescore 3.6 with manual corrections:
<img width="300" alt="MU3Offset" src="https://user-images.githubusercontent.com/93707756/179958409-13976a2f-700c-4b6b-9996-51976def7f7f.png">
Musescore 4 with the same offsets retained:
<img width="300" alt="MU4Offset" src="https://user-images.githubusercontent.com/93707756/179958517-b71c2f2a-5033-464c-b9de-498aeb9f00bc.png">
Musescore 4 default:
<img width="300" alt="MU4Default" src="https://user-images.githubusercontent.com/93707756/179958543-27ed1706-b020-44fa-8232-e25ca5b6749d.png">
