### PR TITLE
fixed #12487: [Accessibility] Orca does not clear a queue of speaking text when moving to the next element (Linux only)

### DIFF
--- a/src/appshell/view/navigableappmenumodel.cpp
+++ b/src/appshell/view/navigableappmenumodel.cpp
@@ -303,7 +303,8 @@ bool NavigableAppMenuModel::processEventForAppMenu(QEvent* event)
             }
         }
 
-        break;
+        event->accept();
+        return true;
     }
     case QEvent::MouseButtonPress: {
         resetNavigation();

--- a/src/framework/accessibility/internal/accessibilityconfiguration.cpp
+++ b/src/framework/accessibility/internal/accessibilityconfiguration.cpp
@@ -30,6 +30,11 @@ using namespace mu::accessibility;
 class AccessibilityActivationObserver : public QAccessible::ActivationObserver
 {
 public:
+    AccessibilityActivationObserver()
+    {
+        m_isAccessibilityActive = QAccessible::isActive();
+    }
+
     bool isAccessibilityActive() const
     {
         return m_isAccessibilityActive;


### PR DESCRIPTION
Resolves: #12487
Resolves: #12488