### PR TITLE
Fix #12417: MMRests causing empty staves to unhide

### DIFF
--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -2417,6 +2417,9 @@ bool Measure::hasVoice(track_idx_t track) const
 
 bool Measure::isEmpty(staff_idx_t staffIdx) const
 {
+    if (isMMRest()) {
+        return true;
+    }
     track_idx_t strack = 0;
     track_idx_t etrack = 0;
     if (staffIdx == mu::nidx) {


### PR DESCRIPTION
Resolves: #12417 

An MMrest measure is also empty.