### PR TITLE
Fix #9697: align opened scores in the middle instead of the top left

### DIFF
--- a/src/notation/view/abstractnotationpaintview.h
+++ b/src/notation/view/abstractnotationpaintview.h
@@ -181,6 +181,7 @@ private:
     void clear();
     void initBackground();
     void initNavigatorOrientation();
+    void initPosition();
 
     bool canReceiveAction(const actions::ActionCode& actionCode) const override;
     void onCurrentNotationChanged();


### PR DESCRIPTION
Resolves: #9697

Hello,

I first tried to fix this issue by simply centering the view horizontally with a small margin from the top vertically, but I didn't find the result very helpful for long scores with more than one page or continuous views. I thus thought it made sense to make the choice of the default position depend on the view mode and the number of pages.

Here is what it looks like so far:

## Page mode, 1 page

Center horizontally, and align top with a small margin.

![](https://recordit.co/SBdvYWv1qy.gif)

## Page mode, 2 pages or more

It aligns the score on the top left with a small margin.

I initially thought to center the first page, but I think the space is better used by showing more of the score.

![](https://recordit.co/12e5WJcDst.gif)

## Horizontal continuous mode

Center vertically, and align left with a small margin.

![](https://recordit.co/U5RdvNaVXD.gif)

## Vertical continuous mode

Same as 1 page. This is the fallback alignment.

![](https://recordit.co/yC6NEnKc1n.gif)

## Switching tabs

I also noticed that the score was being moved to the top left each time one of the "Score"/"Publish"/... tabs was changed.

![](https://recordit.co/YNsUQRdoen.gif)

With a simple fix, it can stay as it was in the previous tab (in the code, it feeled like an unwanted side effect). Though, we might want to reset the default position instead of keeping the previous one?

![](https://recordit.co/tcFCytnH28.gif)

I included the fix, but idk if I should create a separate issue?

Let me know what you think :-)
