### PR TITLE
Flexible translation of instrument names

### DIFF
--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -37,15 +37,39 @@ using namespace mu::engraving;
 
 static const mu::engraving::Fraction DEFAULT_TICK = mu::engraving::Fraction(0, 1);
 
-static QString formatInstrumentTitleOnScore(const QString& instrumentName, const Trait& trait, int instrumentNumber)
+static QString formatInstrumentTitleOnScore(const QString& instrumentName, const Trait& trait)
 {
-    QString numberPart = instrumentNumber > 0 ? " " + QString::number(instrumentNumber) : QString();
+    // Comments for translators start with //:
 
-    if (trait.type != TraitType::Transposition || trait.isHiddenOnScore) {
-        return instrumentName + numberPart;
+    if (trait.type == TraitType::Transposition && !trait.isHiddenOnScore) {
+        //: %1=name ("Horn"), %2=transposition ("C alto"). Example: "Horn in C alto"
+        return mu::qtrc("notation", "%1 in %2", "Transposing instrument displayed in the score")
+               .arg(instrumentName, trait.name);
     }
 
-    return mu::qtrc("notation", "%1 in %2%3", "formatInstrumentTitleOnScore").arg(instrumentName).arg(trait.name).arg(numberPart);
+    return instrumentName; // Example: "Flute"
+}
+
+static QString formatInstrumentTitleOnScore(const QString& instrumentName, const Trait& trait, int instrumentNumber)
+{
+    if (instrumentNumber == 0) {
+        // Only one instance of this instrument in the score
+        return formatInstrumentTitleOnScore(instrumentName, trait);
+    }
+
+    QString number = QString::number(instrumentNumber);
+
+    // Comments for translators start with //:
+
+    if (trait.type == TraitType::Transposition && !trait.isHiddenOnScore) {
+        //: %1=name ("Horn"), %2=transposition ("C alto"), %3=number ("2"). Example: "Horn in C alto 2"
+        return mu::qtrc("notation", "%1 in %2 %3", "One of several transposing instruments displayed in the score")
+               .arg(instrumentName, trait.name, number);
+    }
+
+    //: %1=name ("Flute"), %2=number ("2"). Example: "Flute 2"
+    return mu::qtrc("notation", "%1 %2", "One of several instruments displayed in the score")
+           .arg(instrumentName, number);
 }
 
 static QString formatPartTitle(const Part* part)

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -340,29 +340,57 @@ struct InstrumentKey
     Fraction tick = mu::engraving::Fraction(0, 1);
 };
 
-inline QString formatInstrumentTitle(const QString& instrumentName, const InstrumentTrait& trait, int instrumentNumber = 0)
+inline QString formatInstrumentTitle(const QString& instrumentName, const InstrumentTrait& trait)
 {
-    QString result = instrumentName;
-
+    // Comments for translators start with //:
     switch (trait.type) {
     case TraitType::Tuning:
-        result = mu::qtrc("notation", "%1 %2", "formatInstrumentTitle").arg(trait.name).arg(instrumentName);
-        break;
-    case TraitType::Course:
-        result = mu::qtrc("notation", "%1 (%2)", "formatInstrumentTitle").arg(instrumentName).arg(trait.name);
-        break;
+        //: %1=tuning ("D"), %2=name ("Tin Whistle"). Example: "D Tin Whistle"
+        return mu::qtrc("notation", "%1 %2", "Tuned instrument displayed in the UI")
+               .arg(trait.name, instrumentName);
     case TraitType::Transposition:
-        result = mu::qtrc("notation", "%1 in %2", "formatInstrumentTitle").arg(instrumentName).arg(trait.name);
-        break;
+        //: %1=name ("Horn"), %2=transposition ("C alto"). Example: "Horn in C alto"
+        return mu::qtrc("notation", "%1 in %2", "Transposing instrument displayed in the UI")
+               .arg(instrumentName, trait.name);
+    case TraitType::Course:
+        //: %1=name ("Tenor Lute"), %2=course/strings ("7-course"). Example: "Tenor Lute (7-course)"
+        return mu::qtrc("notation", "%1 (%2)", "String instrument displayed in the UI")
+               .arg(instrumentName, trait.name);
     case TraitType::Unknown:
-        break;
+        return instrumentName; // Example: "Flute"
+    }
+    Q_UNREACHABLE();
+}
+
+inline QString formatInstrumentTitle(const QString& instrumentName, const InstrumentTrait& trait, int instrumentNumber)
+{
+    if (instrumentNumber == 0) {
+        // Only one instance of this instrument in the score
+        return formatInstrumentTitle(instrumentName, trait);
     }
 
-    if (!result.isEmpty() && instrumentNumber > 0) {
-        result += " " + QString::number(instrumentNumber);
-    }
+    QString number = QString::number(instrumentNumber);
 
-    return result;
+    // Comments for translators start with //:
+    switch (trait.type) {
+    case TraitType::Tuning:
+        //: %1=tuning ("D"), %2=name ("Tin Whistle"), %3=number ("2"). Example: "D Tin Whistle 2"
+        return mu::qtrc("notation", "%1 %2 %3", "One of several tuned instruments displayed in the UI")
+               .arg(trait.name, instrumentName, number);
+    case TraitType::Transposition:
+        //: %1=name ("Horn"), %2=transposition ("C alto"), %3=number ("2"). Example: "Horn in C alto 2"
+        return mu::qtrc("notation", "%1 in %2 %3", "One of several transposing instruments displayed in the UI")
+               .arg(instrumentName, trait.name, number);
+    case TraitType::Course:
+        //: %1=name ("Tenor Lute"), %2=course/strings ("7-course"), %3=number ("2"). Example: "Tenor Lute (7-course) 2"
+        return mu::qtrc("notation", "%1 (%2) %3", "One of several string instruments displayed in the UI")
+               .arg(instrumentName, trait.name, number);
+    case TraitType::Unknown:
+        //: %1=name ("Flute"), %2=number ("2"). Example: "Flute 2"
+        return mu::qtrc("notation", "%1 %2", "One of several instruments displayed in the UI")
+               .arg(instrumentName, number);
+    }
+    Q_UNREACHABLE();
 }
 
 struct PartInstrument


### PR DESCRIPTION
Give translators more control over how instrument names will appear in other languages. Add translation comments to make their job easier.