### PR TITLE
Fixed crash on change workspace (disabled allocator)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ option(BUILD_PCH "Build using precompiled headers." ON)
 option(BUILD_UNITY "Build using unity build." ON)
 option(TRY_BUILD_SHARED_LIBS_IN_DEBUG "Build shared libs if possible in debug" OFF)
 option(BUILD_ASAN "Enable Address Sanitizer" OFF) # if ON, then disabled custom allocator
-option(BUILD_ALLOCATOR "Enable Custom allocator (used for engraving)" ON)
+option(BUILD_ALLOCATOR "Enable Custom allocator (used for engraving)" OFF)
 option(QML_LOAD_FROM_SOURCE "Load qml files from source (not resource)" OFF)
 option(TRACE_DRAW_OBJ_ENABLED "Trace draw objects" OFF)
 

--- a/src/framework/global/allocator.cpp
+++ b/src/framework/global/allocator.cpp
@@ -205,15 +205,6 @@ ObjectAllocator::Info ObjectAllocator::stateInfo() const
     return info;
 }
 
-bool ObjectAllocator::enabled()
-{
-#ifdef CUSTOM_ALLOCATOR_DISABLED
-    return false;
-#else
-    return used;
-#endif
-}
-
 // ============================================
 // AllocatorsRegister
 // ============================================

--- a/src/framework/global/allocator.h
+++ b/src/framework/global/allocator.h
@@ -104,7 +104,15 @@ public:
 
     Info stateInfo() const;
 
-    static bool enabled();
+    static bool enabled()
+    {
+    #ifdef CUSTOM_ALLOCATOR_DISABLED
+        return false;
+    #else
+        return used;
+    #endif
+    }
+
     static int used;
 
 private:

--- a/src/framework/global/tests/allocator_tests.cpp
+++ b/src/framework/global/tests/allocator_tests.cpp
@@ -22,6 +22,11 @@
 #include <gtest/gtest.h>
 
 #include "types/string.h"
+
+#ifdef CUSTOM_ALLOCATOR_DISABLED
+#undef CUSTOM_ALLOCATOR_DISABLED
+#endif
+
 #include "allocator.h"
 
 #include "log.h"


### PR DESCRIPTION
The idea is that memory management through the allocator works only for the current score, so the allocator turns on when the engraving project is created and turns off when it is destroyed. 
Previously created palette elements were created without an allocator. When changing the workspace, previously created palette elements destroying, but at this moment there is an engraving project, respectively, the allocator is enabled and deletion is done through it, but it did not create these elements - this is a problem.       
At the moment I have disabled the allocator, it is necessary to work out its work in more detail.