### PR TITLE
Gradual tempo change should have Segment anchor

### DIFF
--- a/src/engraving/libmscore/gradualtempochange.cpp
+++ b/src/engraving/libmscore/gradualtempochange.cpp
@@ -87,7 +87,7 @@ GradualTempoChange::GradualTempoChange(EngravingItem* parent)
     : TextLineBase(ElementType::GRADUAL_TEMPO_CHANGE, parent, ElementFlag::SYSTEM)
 {
     initElementStyle(&tempoStyle);
-    setAnchor(Anchor::MEASURE);
+    setAnchor(Anchor::SEGMENT);
 
     resetProperty(Pid::LINE_VISIBLE);
     resetProperty(Pid::BEGIN_TEXT_PLACE);


### PR DESCRIPTION
Currently, `GradualTempoChange `uses a `Measure `anchor. This causes an engraving problem (it aligns with barlines instead of aligning to the notes), but also a UI problem (it is not possible to let the line start/end at chosen notes). It should use instead a `Segment `anchor. This lets the item behave in the same way as all the other staff/text lines, as one would expect. @oktophonie @bkunda @Tantacrul 
**Note**: you'll need to manually reset the metronome palette for the change to take effect.
**Note2**: the fact that the line finishes before the last selected note is an issue common to all our text lines and is also in 3.6. I will log it as a separate issue.
**Question**: @vpereverzev I hope this doesn't have implications on playback, I have zero knowledge there.


https://user-images.githubusercontent.com/93707756/180964963-b8da15ca-1274-49d4-83a7-72913c88c056.mp4



https://user-images.githubusercontent.com/93707756/180964899-66d42ee1-8fb0-41ac-a343-1bc244e1576c.mp4


