### PR TITLE
Fix #12506: check other staves for keysigs when deleting measures

### DIFF
--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -180,16 +180,14 @@ static void createMeasures(mu::engraving::Score* score, const ScoreCreateOptions
                             int diff = -part->instrument()->transpose().chromatic;
                             nKey.setKey(mu::engraving::transposeKey(nKey.key(), diff, part->preferSharpFlat()));
                         }
-                        // do not create empty keysig unless custom or atonal
-                        if (nKey.custom() || nKey.isAtonal() || nKey.key() != Key::C) {
-                            staff->setKey(mu::engraving::Fraction(0, 1), nKey);
-                            mu::engraving::Segment* ss
-                                = measure->getSegment(mu::engraving::SegmentType::KeySig, mu::engraving::Fraction(0, 1));
-                            mu::engraving::KeySig* keysig = mu::engraving::Factory::createKeySig(ss);
-                            keysig->setTrack(staffIdx * mu::engraving::VOICES);
-                            keysig->setKeySigEvent(nKey);
-                            ss->add(keysig);
-                        }
+                        // Add key signature even if empty (C)
+                        staff->setKey(mu::engraving::Fraction(0, 1), nKey);
+                        mu::engraving::Segment* ss
+                            = measure->getSegment(mu::engraving::SegmentType::KeySig, mu::engraving::Fraction(0, 1));
+                        mu::engraving::KeySig* keysig = mu::engraving::Factory::createKeySig(ss);
+                        keysig->setTrack(staffIdx * mu::engraving::VOICES);
+                        keysig->setKeySigEvent(nKey);
+                        ss->add(keysig);
                     }
                 }
 


### PR DESCRIPTION
Resolves: #12506

Hello,

This issue was caused by this chain of events:
- When creating a score from a template, no key signature is added for staves in C major because it is empty
- Then, when disabling concert pitch, only transposing instruments are updated, so only two key signatures are added in a wind quintet, in the third and fourth staves
- When deleting the first measures, the function looks at the first staff to see if a key signature is deleted, in order to get the key and add it if necessary in the first measure after the deleted ones. Since there is no key signature in the first staff in C major, it assumes that there is no key change and doesn't add it afterwards.

I managed to fix it with two fixes:
- I updated the code that creates new scores from templates to add key signatures even if the key signature is "empty"
- I updated the code that checks for key signatures in the deleted measures to look in other staves if nothing was found in the first one (for backward compatibility with scores that were created before the other fix)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
