### PR TITLE
[MU4] Fix ledger lines extending unnecessarily

### DIFF
--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -872,7 +872,8 @@ void Chord::addLedgerLines()
         int from, delta;
         std::vector<LedgerLineData> vecLines;
         hw = 0.0;
-        minX  = maxX = 0;
+        minX = std::numeric_limits<double>::max();
+        maxX = std::numeric_limits<double>::min();
         minLine = 0;
         maxLine = lineBelow;
         if (j == 0) {                           // ...once from lowest up...


### PR DESCRIPTION
The issue:
![image](https://user-images.githubusercontent.com/89263931/181275438-d30d206c-aa14-47e4-8403-4202c4b5625a.png)

Ledger lines were being lengthened unnecessarily in some cases with flipped stems.

The fix:
![image](https://user-images.githubusercontent.com/89263931/181281455-af64dd77-53e4-4b7b-ad2f-35c7bae821d1.png)
