### PR TITLE
Added disable implicit shared option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ option(BUILD_UNITY "Build using unity build." ON)
 option(TRY_BUILD_SHARED_LIBS_IN_DEBUG "Build shared libs if possible in debug" OFF)
 option(BUILD_ASAN "Enable Address Sanitizer" OFF) # if ON, then disabled custom allocator
 option(BUILD_ALLOCATOR "Enable Custom allocator (used for engraving)" OFF)
+option(DISABLED_IMPLICIT_SHARED "Disabled implicit shared (String)" OFF)
 option(QML_LOAD_FROM_SOURCE "Load qml files from source (not resource)" OFF)
 option(TRACE_DRAW_OBJ_ENABLED "Trace draw objects" OFF)
 

--- a/build/cmake/SetupBuildEnvironment.cmake
+++ b/build/cmake/SetupBuildEnvironment.cmake
@@ -20,6 +20,10 @@ if (NOT BUILD_ALLOCATOR)
     add_definitions(-DCUSTOM_ALLOCATOR_DISABLED)
 endif()
 
+if (DISABLED_IMPLICIT_SHARED)
+    add_definitions(-DDISABLED_IMPLICIT_SHARED)
+endif()
+
 if (CC_IS_GCC)
     message(STATUS "Using Compiler GCC ${CMAKE_CXX_COMPILER_VERSION}")
 

--- a/src/framework/global/types/string.h
+++ b/src/framework/global/types/string.h
@@ -338,11 +338,15 @@ public:
 
 private:
     const std::u16string& constStr() const;
-    std::u16string& mutStr();
+    std::u16string& mutStr(bool do_detach = true);
     void detach();
     void doArgs(std::u16string& out, const std::vector<std::u16string_view>& args) const;
 
+#ifdef DISABLED_IMPLICIT_SHARED
+    std::u16string m_data;
+#else
     std::shared_ptr<std::u16string> m_data;
+#endif
 };
 
 class StringList : public std::vector<String>


### PR DESCRIPTION
On MacOS with clang there are problems with debugging - the value of the string is not visible. It's probably because use the shared pointer. So, I added an option that disables implicit shared (using shared pointer)