### PR TITLE
Incremental improvements to horizontal spacing

### DIFF
--- a/src/engraving/layout/layout.cpp
+++ b/src/engraving/layout/layout.cpp
@@ -356,9 +356,12 @@ void Layout::collectLinearSystem(const LayoutOptions& options, LayoutContext& ct
     ctx.tick = Fraction(0, 1);
     LayoutMeasure::getNextMeasure(options, ctx);
 
-    static constexpr Fraction minTicks = Fraction(1, 16); // In continuous view, we cannot look fot the shortest note
+    static constexpr Fraction minTicks = Fraction(1, 16);
+    static constexpr Fraction maxTicks = Fraction(4, 4);
+    // CAUTION: In continuous view, we cannot look fot the shortest (or longest) note
     // of the system (as we do in page view), because the whole music is a single big system. Therefore,
-    // we simply assume a shortest note of 1/16. This ensures perfect spacing consistency.
+    // we simply assume a shortest note of 1/16 and longest of 4/4. This ensures perfect spacing consistency,
+    // even if the actual values may be be different.
 
     while (ctx.curMeasure) {
         double ww = 0.0;
@@ -399,7 +402,7 @@ void Layout::collectLinearSystem(const LayoutOptions& options, LayoutContext& ct
                     m->stretchMeasureInPracticeMode(ww);
                 } else {
                     m->createEndBarLines(false);
-                    m->computeWidth(minTicks, 1);
+                    m->computeWidth(minTicks, maxTicks, 1);
                     ww = m->width();
                     m->layoutMeasureElements();
                 }

--- a/src/engraving/layout/layoutsystem.h
+++ b/src/engraving/layout/layoutsystem.h
@@ -47,6 +47,7 @@ private:
     static void processLines(System* system, std::vector<Spanner*> lines, bool align);
     static void layoutTies(Chord* ch, System* system, const Fraction& stick);
     static void doLayoutTies(System* system, std::vector<Segment*> sl, const Fraction& stick, const Fraction& etick);
+    static void justifySystem(System* system, double curSysWidth, double targetSystemWidth);
 };
 }
 

--- a/src/engraving/libmscore/measure.h
+++ b/src/engraving/libmscore/measure.h
@@ -369,7 +369,7 @@ public:
     Fraction quantumOfSegmentCell() const;
 
     void stretchMeasureInPracticeMode(double stretch);
-    double squeezableSpace() const { return _squeezableSpace; }
+    double squeezableSpace() const { return _isWidthLocked ? 0.0 : _squeezableSpace; }
 
 private:
     double _squeezableSpace = 0;
@@ -385,6 +385,7 @@ private:
     void fillGap(const Fraction& pos, const Fraction& len, track_idx_t track, const Fraction& stretch, bool useGapRests = true);
     void computeWidth(Segment* s, double x, bool isSystemHeader, Fraction minTicks, double stretchCoeff);
     void setWidthToTargetValue(Segment* s, double x, bool isSystemHeader, Fraction minTicks, double stretchCoeff, double targetWidth);
+    double computeMinMeasureWidth() const;
 
     MStaff* mstaff(staff_idx_t staffIndex) const;
 

--- a/src/engraving/libmscore/measure.h
+++ b/src/engraving/libmscore/measure.h
@@ -346,8 +346,8 @@ public:
     void triggerLayout() const override;
     double basicStretch() const;
     double basicWidth() const;
-    float durationStretch(Fraction curTicks, const Fraction minTicks) const;
-    void computeWidth(Fraction minTicks, double stretchCoeff);
+    float durationStretch(Fraction curTicks, const Fraction minTicks, const Fraction maxTicks) const;
+    void computeWidth(Fraction minTicks, Fraction maxTicks, double stretchCoeff);
     void checkHeader();
     void checkTrailer();
     void layoutStaffLines();
@@ -383,7 +383,7 @@ private:
     void push_front(Segment* e);
 
     void fillGap(const Fraction& pos, const Fraction& len, track_idx_t track, const Fraction& stretch, bool useGapRests = true);
-    void computeWidth(Segment* s, double x, bool isSystemHeader, Fraction minTicks, double stretchCoeff);
+    void computeWidth(Segment* s, double x, bool isSystemHeader, Fraction minTicks, Fraction maxTicks, double stretchCoeff);
     void setWidthToTargetValue(Segment* s, double x, bool isSystemHeader, Fraction minTicks, double stretchCoeff, double targetWidth);
     double computeMinMeasureWidth() const;
 

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -2696,6 +2696,24 @@ Fraction Segment::shortestChordRest() const
     return shortest;
 }
 
+bool Segment::hasAccidentals() const
+{
+    if (!isChordRestType()) {
+        return false;
+    }
+    for (EngravingItem* e : elist()) {
+        if (!e || !e->isChord()) {
+            continue;
+        }
+        for (Note* note : toChord(e)->notes()) {
+            if (note->accidental()) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 CrossStaffContent Segment::crossStaffContent() const
 {
     CrossStaffContent crossStaffContent;

--- a/src/engraving/libmscore/segment.h
+++ b/src/engraving/libmscore/segment.h
@@ -300,6 +300,8 @@ public:
     Fraction shortestChordRest() const;
     CrossStaffContent crossStaffContent() const;
 
+    bool hasAccidentals() const;
+
     EngravingItem* preAppendedItem(int track) { return _preAppendedItems[track]; }
     void preAppend(EngravingItem* item, int track) { _preAppendedItems[track] = item; }
     void clearPreAppended(int track) { _preAppendedItems[track] = nullptr; }


### PR DESCRIPTION
UPDATED DESCRIPTION.
This PR contains three separate improvements (made in the three separate commits), all related to horizontal spacing. Some of them seem like a lot of code, but 90% of it is actually just refactoring.
1) When enforcing minimum measure width we should not take into account the space occupied by the header, otherwise the result is irregular. I've added the check to do this, and moved all the minMeasureWidth logic to a dedicated method.
Before:
<img width="350" alt="minMeasWidthAFTER" src="https://user-images.githubusercontent.com/93707756/181595114-b13ef2a6-66b8-4807-844d-ba077a8642f6.png">
After:
<img width="350" alt="minMeasWidthBEFORE" src="https://user-images.githubusercontent.com/93707756/181595139-ad3adb40-64d6-4550-b442-fcbd2ab199a8.png">

2) The longest note of a system (which is needed for the spacing calculation) is calculated at the system level and passed down until Measure::durationStretch(), instead of computing it inside durationStretch(). This potentially saves thousands of pointless loops through the system segments.

3) System justification has been updated to use a bisection algorithm rather than a gradient descent, which makes it stronger against edge cases. Side benefit: I could reduce the safety exit from 100 down to 50 iteration. I also moved the logic to a dedicated method, which I probably should have done earlier.

