### PR TITLE
SplashScreen: fix transparent background (corners) on Windows

### DIFF
--- a/src/appshell/view/internal/splashscreen.cpp
+++ b/src/appshell/view/internal/splashscreen.cpp
@@ -46,6 +46,8 @@ SplashScreen::SplashScreen()
     : QSplashScreen(QPixmap(splashScreenSize)),
     m_backgroundRenderer(new QSvgRenderer(imagePath, this))
 {
+    setAttribute(Qt::WA_TranslucentBackground);
+
     // Can't make translatable, because translation system not yet initialized
     showMessage("Loading…");
 }


### PR DESCRIPTION
Resolves: one part of #12550

Apparently the default on Windows differs from macOS.