### PR TITLE
Partly reimplement SplashScreen

### DIFF
--- a/src/appshell/appshell.cpp
+++ b/src/appshell/appshell.cpp
@@ -133,6 +133,14 @@ int AppShell::run(int argc, char** argv)
     commandLine.apply();
     framework::IApplication::RunMode runMode = muapplication()->runMode();
 
+    // ====================================================
+    // Setup modules: onPreInit
+    // ====================================================
+    globalModule.onPreInit(runMode);
+    for (mu::modularity::IModuleSetup* m : m_modules) {
+        m->onPreInit(runMode);
+    }
+
     SplashScreen splashScreen;
     if (runMode == framework::IApplication::RunMode::Editor) {
         splashScreen.show();

--- a/src/appshell/appshellmodule.cpp
+++ b/src/appshell/appshellmodule.cpp
@@ -176,6 +176,11 @@ void AppShellModule::registerUiTypes()
     qmlRegisterType<WindowDropArea>("MuseScore.Ui", 1, 0, "WindowDropArea");
 }
 
+void AppShellModule::onPreInit(const framework::IApplication::RunMode&)
+{
+    s_applicationActionController->preInit();
+}
+
 void AppShellModule::onInit(const IApplication::RunMode&)
 {
     DockSetup::onInit();

--- a/src/appshell/appshellmodule.h
+++ b/src/appshell/appshellmodule.h
@@ -39,6 +39,7 @@ public:
     void registerResources() override;
     void registerUiTypes() override;
 
+    void onPreInit(const framework::IApplication::RunMode& mode) override;
     void onInit(const framework::IApplication::RunMode& mode) override;
     void onDeinit() override;
 };

--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -37,6 +37,11 @@ using namespace mu::appshell;
 using namespace mu::framework;
 using namespace mu::actions;
 
+void ApplicationActionController::preInit()
+{
+    qApp->installEventFilter(this);
+}
+
 void ApplicationActionController::init()
 {
     dispatcher()->reg(this, "quit", [this](const ActionData& args) {
@@ -61,8 +66,6 @@ void ApplicationActionController::init()
     dispatcher()->reg(this, "preference-dialog", this, &ApplicationActionController::openPreferencesDialog);
 
     dispatcher()->reg(this, "revert-factory", this, &ApplicationActionController::revertToFactorySettings);
-
-    qApp->installEventFilter(this);
 }
 
 void ApplicationActionController::onDragEnterEvent(QDragEnterEvent* event)

--- a/src/appshell/internal/applicationactioncontroller.h
+++ b/src/appshell/internal/applicationactioncontroller.h
@@ -57,6 +57,7 @@ class ApplicationActionController : public QObject, public IApplicationActionCon
     INJECT(appshell, framework::IApplication, application)
 
 public:
+    void preInit();
     void init();
 
     ValCh<bool> isFullScreen() const;

--- a/src/appshell/view/internal/splashscreen.h
+++ b/src/appshell/view/internal/splashscreen.h
@@ -23,7 +23,7 @@
 #ifndef MU_APPSHELL_SPLASHSCREEN_H
 #define MU_APPSHELL_SPLASHSCREEN_H
 
-#include <QSplashScreen>
+#include <QWidget>
 
 #include "modularity/ioc.h"
 #include "ui/iuiconfiguration.h"
@@ -31,7 +31,7 @@
 class QSvgRenderer;
 
 namespace mu::appshell {
-class SplashScreen : public QSplashScreen
+class SplashScreen : public QWidget
 {
     Q_OBJECT
 
@@ -43,8 +43,12 @@ public:
     SplashScreen();
 
 private:
-    void drawContents(QPainter* painter) override;
+    bool event(QEvent* event) override;
+    void repaint();
+    void draw(QPainter* painter);
+    void setSize(const QSize& size);
 
+    QString m_message;
     QSvgRenderer* m_backgroundRenderer = nullptr;
 };
 }

--- a/src/framework/global/globalmodule.cpp
+++ b/src/framework/global/globalmodule.cpp
@@ -68,7 +68,7 @@ void GlobalModule::registerExports()
     ioc()->registerExport<ICryptographicHash>(moduleName(), new CryptographicHash());
 }
 
-void GlobalModule::onInit(const IApplication::RunMode& mode)
+void GlobalModule::onPreInit(const IApplication::RunMode& mode)
 {
     mu::runtime::mainThreadId(); //! NOTE Needs only call
     mu::runtime::setThreadName("main");

--- a/src/framework/global/globalmodule.h
+++ b/src/framework/global/globalmodule.h
@@ -34,7 +34,7 @@ public:
 
     std::string moduleName() const override;
     void registerExports() override;
-    void onInit(const IApplication::RunMode& mode) override;
+    void onPreInit(const IApplication::RunMode& mode) override;
 };
 }
 

--- a/src/framework/global/modularity/imodulesetup.h
+++ b/src/framework/global/modularity/imodulesetup.h
@@ -41,6 +41,7 @@ public:
     virtual void registerResources() {}
     virtual void registerUiTypes() {}
 
+    virtual void onPreInit(const framework::IApplication::RunMode& mode) { (void)mode; }
     virtual void onInit(const framework::IApplication::RunMode& mode) { (void)mode; }
     virtual void onAllInited(const framework::IApplication::RunMode& mode) { (void)mode; }
     virtual void onDelayedInit() {}

--- a/src/framework/testing/environment.cpp
+++ b/src/framework/testing/environment.cpp
@@ -69,13 +69,18 @@ void Environment::setup()
         m->resolveImports();
     }
 
-    globalModule.onInit(runMode);
+    globalModule.onPreInit(runMode);
     //! NOTE Now we can use logger and profiler
+
+    for (mu::modularity::IModuleSetup* m : m_dependencyModules) {
+        m->onPreInit(runMode);
+    }
 
     if (m_preInit) {
         m_preInit();
     }
 
+    globalModule.onInit(runMode);
     for (mu::modularity::IModuleSetup* m : m_dependencyModules) {
         m->onInit(runMode);
     }


### PR DESCRIPTION
Resolves: #12943

Fixes a macOS bug: it was not possible anymore to open a file from Finder with MuseScore unless MuseScore was already running. (MuseScore would launch correctly, but forget to open the file, since the QOpenEvent would already be consumed by hidden calls to `QApplication::processEvents` in the QSplashScreen implementation. ~This is avoided by specifying `QEventLoop::ExcludeUserInputEvents`~ EDIT: that apparently doesn't work reliably either (see below); implemented a different solution.)

_Might_ fix some problems on Linux too (from #12550), but this is really a blind guess, since I still don't have a Linux installation to test things myself.