### PR TITLE
Fix zoom percentages dropdown

### DIFF
--- a/src/appshell/view/notationstatusbarmodel.cpp
+++ b/src/appshell/view/notationstatusbarmodel.cpp
@@ -198,23 +198,19 @@ void NotationStatusBarModel::load()
             }
         }
     });
-
-    emit availableViewModeListChanged();
-    emit availableZoomListChanged();
 }
 
 void NotationStatusBarModel::onCurrentNotationChanged()
 {
     emit currentViewModeChanged();
     emit availableViewModeListChanged();
+    emit currentZoomPercentageChanged();
     emit availableZoomListChanged();
     emit zoomEnabledChanged();
 
     if (!notation()) {
         return;
     }
-
-    emit currentZoomPercentageChanged();
 
     notation()->notationChanged().onNotify(this, [this]() {
         emit currentViewModeChanged();
@@ -223,7 +219,7 @@ void NotationStatusBarModel::onCurrentNotationChanged()
 
     notation()->viewState()->zoomPercentage().ch.onReceive(this, [this](int) {
         emit currentZoomPercentageChanged();
-        emit availableViewModeListChanged();
+        emit availableZoomListChanged();
     });
 
     listenChangesInAccessibility();

--- a/src/appshell/view/notationstatusbarmodel.cpp
+++ b/src/appshell/view/notationstatusbarmodel.cpp
@@ -22,6 +22,8 @@
 
 #include "notationstatusbarmodel.h"
 
+#include "types/translatablestring.h"
+
 #include "log.h"
 
 using namespace mu::appshell;
@@ -109,9 +111,14 @@ QVariant NotationStatusBarModel::currentViewMode()
 {
     ViewMode viewMode = notation() ? notation()->viewMode() : ViewMode::PAGE;
 
-    for (MenuItem* mode : makeAvailableViewModeList()) {
-        if (ALL_MODE_MAP.key(mode->id().toStdString()) == viewMode) {
-            return QVariant::fromValue(mode);
+    for (MenuItem* modeItem : makeAvailableViewModeList()) {
+        if (ALL_MODE_MAP.key(modeItem->id().toStdString()) == viewMode) {
+            if (viewMode == ViewMode::LINE || viewMode == ViewMode::SYSTEM) {
+                // In continuous view, we don't want to see "horizontal" or "vertical" (those should only be visible in the menu)
+                modeItem->setTitle(TranslatableString("notation", "Continuous view"));
+            }
+
+            return QVariant::fromValue(modeItem);
         }
     }
 

--- a/src/framework/global/tests/string_tests.cpp
+++ b/src/framework/global/tests/string_tests.cpp
@@ -431,6 +431,60 @@ TEST_F(Global_Types_StringTests, String_Args)
         //! CHECK
         EXPECT_EQ(newStr, u"{123}, [abc]");
     }
+
+    {
+        //! GIVEN Some String containing a % character not followed by 1-9
+        String str = u"%1%";
+        //! DO
+        String newStr = str.arg(100);
+        //! CHECK
+        EXPECT_EQ(newStr, u"100%");
+    }
+
+    {
+        //! GIVEN Some String containing a % character not followed by 1-9
+        String str = u"%1%a";
+        //! DO
+        String newStr = str.arg(100);
+        //! CHECK
+        EXPECT_EQ(newStr, u"100%a");
+    }
+
+    {
+        //! GIVEN Some String containing a % character not followed by 1-9
+        String str = u"%1%0";
+        //! DO
+        String newStr = str.arg(100);
+        //! CHECK
+        EXPECT_EQ(newStr, u"100%0");
+    }
+
+    {
+        //! GIVEN Some String containing multiple %1s in succession
+        String str = u"%1%1";
+        //! DO
+        String newStr = str.arg(100);
+        //! CHECK
+        EXPECT_EQ(newStr, u"100100");
+    }
+
+    {
+        //! GIVEN Some String containing multiple %1s in succession and a % character not followed by 1-9
+        String str = u"%1%1%";
+        //! DO
+        String newStr = str.arg(100);
+        //! CHECK
+        EXPECT_EQ(newStr, u"100100%");
+    }
+
+    {
+        //! GIVEN Some String containing a % character followed by another % character
+        String str = u"%1%%1% %1%%%1%%";
+        //! DO
+        String newStr = str.arg(100);
+        //! CHECK
+        EXPECT_EQ(newStr, u"100%100% 100%%100%%");
+    }
 }
 
 TEST_F(Global_Types_StringTests, String_Number)

--- a/src/framework/global/types/translatablestring.h
+++ b/src/framework/global/types/translatablestring.h
@@ -129,11 +129,6 @@ private:
     template<typename ... Args>
     struct Arg;
 
-    template<typename ... Args>
-    using fake_deduction_guides_t = std::conditional_t<std::is_constructible_v<String, Args...>,
-                                                       Arg<String>,
-                                                       Arg<Args...> >;
-
     std::vector<std::shared_ptr<const IArg> > args;
 };
 
@@ -254,7 +249,7 @@ template<typename ... Args>
 TranslatableString TranslatableString::arg(const Args& ... args) const
 {
     TranslatableString res = *this;
-    res.args.push_back(std::make_shared<fake_deduction_guides_t<Args...> >(args ...));
+    res.args.push_back(std::make_shared<Arg<Args...> >(args ...));
     return res;
 }
 }


### PR DESCRIPTION
Resolves: #12603 

Turns out my `TranslatableString::fake_deduction_guides_t` was working a bit too aggressively, interpreting even plain numbers as convertible to String. That had somewhat strange effects. Get rid of it completely for now, since we are not really using it anyway.

Furthermore, actually completely separate from that, fixes String.arg for strings that contain a percent sign not followed by 1-9. 