### PR TITLE
fix: #12608 Menu items in the playback settings now read titles

### DIFF
--- a/src/playback/internal/playbackuiactions.cpp
+++ b/src/playback/internal/playbackuiactions.cpp
@@ -72,7 +72,7 @@ const UiActionList PlaybackUiActions::m_settingsActions = {
     UiAction("midi-on",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
-             TranslatableString("action", "MIDI input"),
+             TranslatableString("action", "Enable ‘MIDI input’"),
              TranslatableString("action", "Toggle MIDI input"),
              IconCode::Code::MIDI_INPUT,
              Checkable::Yes
@@ -88,7 +88,7 @@ const UiActionList PlaybackUiActions::m_settingsActions = {
     UiAction("pan",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
-             TranslatableString("action", "Pan score"),
+             TranslatableString("action", "Pan score automatically"),
              TranslatableString("action", "Pan score automatically during playback"),
              IconCode::Code::PAN_SCORE,
              Checkable::Yes
@@ -96,7 +96,7 @@ const UiActionList PlaybackUiActions::m_settingsActions = {
     UiAction("countin",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
-             TranslatableString("action", "Count-in"),
+             TranslatableString("action", "Enable count-in when playing"),
              TranslatableString("action", "Enable count-in when playing"),
              IconCode::Code::COUNT_IN,
              Checkable::Yes
@@ -107,14 +107,14 @@ const UiActionList PlaybackUiActions::m_loopBoundaryActions = {
     UiAction("loop-in",
              mu::context::UiCtxAny,
              mu::context::CTX_NOTATION_FOCUSED,
-             TranslatableString("action", "Loop in"),
+             TranslatableString("action", "Set loop marker left"),
              TranslatableString("action", "Set loop marker left"),
              IconCode::Code::LOOP_IN
              ),
     UiAction("loop-out",
              mu::context::UiCtxAny,
              mu::context::CTX_NOTATION_FOCUSED,
-             TranslatableString("action", "Loop out"),
+             TranslatableString("action", "Set loop marker right"),
              TranslatableString("action", "Set loop marker right"),
              IconCode::Code::LOOP_OUT
              ),

--- a/src/playback/internal/playbackuiactions.cpp
+++ b/src/playback/internal/playbackuiactions.cpp
@@ -72,7 +72,7 @@ const UiActionList PlaybackUiActions::m_settingsActions = {
     UiAction("midi-on",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
-             TranslatableString("action", "Enable ‘MIDI input’"),
+             TranslatableString("action", "Enable MIDI input"),
              TranslatableString("action", "Toggle MIDI input"),
              IconCode::Code::MIDI_INPUT,
              Checkable::Yes

--- a/src/playback/view/playbacktoolbarmodel.cpp
+++ b/src/playback/view/playbacktoolbarmodel.cpp
@@ -93,7 +93,7 @@ void PlaybackToolBarModel::updateActions()
     MenuItemList settingsItems;
 
     for (const UiAction& action : PlaybackUiActions::settingsActions()) {
-        settingsItems << makeActionWithDescriptionAsTitle(action.code);
+        settingsItems << makeMenuItem(action.code);
     }
 
     if (!m_isToolbarFloating) {
@@ -105,7 +105,7 @@ void PlaybackToolBarModel::updateActions()
     for (const ToolConfig::Item& item : config.items) {
         if (isAdditionalAction(item.action) && !m_isToolbarFloating) {
             //! NOTE In this case, we want to see the actions' description instead of the title
-            settingsItems << makeActionWithDescriptionAsTitle(item.action);
+            settingsItems << makeMenuItem(item.action);
         } else {
             result << makeMenuItem(item.action);
         }

--- a/src/playback/view/playbacktoolbarmodel.cpp
+++ b/src/playback/view/playbacktoolbarmodel.cpp
@@ -141,17 +141,6 @@ bool PlaybackToolBarModel::isAdditionalAction(const actions::ActionCode& actionC
     return PlaybackUiActions::loopBoundaryActions().contains(actionCode);
 }
 
-MenuItem* PlaybackToolBarModel::makeActionWithDescriptionAsTitle(const actions::ActionCode& actionCode)
-{
-    MenuItem* item = makeMenuItem(actionCode);
-
-    UiAction action = item->action();
-    action.title = action.description;
-    item->setAction(action);
-
-    return item;
-}
-
 bool PlaybackToolBarModel::isPlayAllowed() const
 {
     return playbackController()->isPlayAllowed();

--- a/src/playback/view/playbacktoolbarmodel.h
+++ b/src/playback/view/playbacktoolbarmodel.h
@@ -89,8 +89,6 @@ private:
 
     bool isAdditionalAction(const actions::ActionCode& actionCode) const;
 
-    uicomponents::MenuItem* makeActionWithDescriptionAsTitle(const actions::ActionCode& actionCode);
-
     QTime totalPlayTime() const;
     notation::MeasureBeat measureBeat() const;
 


### PR DESCRIPTION
Partial(only playback settings) Fix for [[MU4 Issue] Some text strings in toolbar are using incorrect data](https://github.com/musescore/MuseScore/issues/12608)

Hotfix for above-mentioned issue. This simply reads the menu-items text from title of the actions instead of the descriptions.
It also changes the titles to match the titles desired in the issue

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
