### PR TITLE
bugfix compiles with gcc

### DIFF
--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -35,7 +35,7 @@ struct Item
 {
     T type;
     AsciiStringView xml;
-    TranslatableString userName = {};
+    TranslatableString userName;
 };
 
 template<typename T, typename C>


### PR DESCRIPTION
compilability with gcc, though, the initialization would need to be added back at runtime.

- [x ] I signed [CLA](https://musescore.org/en/cla)
