### PR TITLE
Fixes: 'element in score' and 'Advance cursor:'

### DIFF
--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -128,7 +128,7 @@ const UiActionList NotationUiActions::m_actions = {
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_NOTATION_FOCUSED,
              TranslatableString("action", "Previous measure / Shift text left quickly"),
-             TranslatableString("action", "Select first element in previous measure / move text left quickly")
+             TranslatableString("action", "Go to previous measure / move text left quickly")
              ),
     UiAction("up-chord",
              mu::context::UiCtxNotationOpened,

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -104,7 +104,7 @@ const UiActionList NotationUiActions::m_actions = {
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_NOTATION_FOCUSED,
              TranslatableString("action", "Previous element"),
-             TranslatableString("action", "Select previous element")
+             TranslatableString("action", "Select previous element in score")
              ),
     UiAction("notation-move-right",
              mu::context::UiCtxNotationOpened,
@@ -1600,7 +1600,7 @@ const UiActionList NotationUiActions::m_actions = {
              mu::context::UiCtxNotationFocused,
              mu::context::CTX_ANY,
              TranslatableString("action", "Previous beat (Chord symbol)"),
-             TranslatableString("action", "Move cursor to previous beat (chord symbols)")
+             TranslatableString("action", "Advance cursor: previous beat (chord symbols)")
              ),
     UiAction("advance-longa",
              mu::context::UiCtxNotationFocused,


### PR DESCRIPTION
"Select previous element in score" like "Select next element in score", with "in score".
"Go to previous measure / move text left quickly" like "Go to next measure / move text right quickly".
"Advance cursor: previous beat (chord symbols)" like "Advance cursor: next beat (chord symbols)" and others.

Greetings,
Gootector

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
