### PR TITLE
Fix #11621: implemented independent view modes (page, continuous, ...) per notation

### DIFF
--- a/src/notation/imasternotation.h
+++ b/src/notation/imasternotation.h
@@ -49,6 +49,8 @@ public:
     virtual void addExcerpts(const ExcerptNotationList& excerpts) = 0;
     virtual void removeExcerpts(const ExcerptNotationList& excerpts) = 0;
 
+    virtual std::optional<size_t> findExcerptIndex(INotationPtr excerpt) const = 0;
+
     virtual void setExcerptIsOpen(const INotationPtr excerptNotation, bool opened) = 0;
 
     virtual INotationPartsPtr parts() const = 0;

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -480,6 +480,17 @@ void MasterNotation::removeExcerpts(const ExcerptNotationList& excerpts)
     doSetExcerpts(m_excerpts.val);
 }
 
+std::optional<size_t> MasterNotation::findExcerptIndex(INotationPtr excerpt) const
+{
+    for (size_t i = 0; i < m_excerpts.val.size(); ++i) {
+        if (m_excerpts.val[i]->notation() == excerpt) {
+            return i;
+        }
+    }
+
+    return std::nullopt;
+}
+
 void MasterNotation::setExcerptIsOpen(const INotationPtr excerptNotation, bool open)
 {
     excerptNotation->setIsOpen(open);

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -62,6 +62,8 @@ public:
     void addExcerpts(const ExcerptNotationList& excerpts) override;
     void removeExcerpts(const ExcerptNotationList& excerpts) override;
 
+    std::optional<size_t> findExcerptIndex(INotationPtr excerpt) const override;
+
     void setExcerptIsOpen(const INotationPtr excerptNotation, bool open) override;
 
     INotationPartsPtr parts() const override;

--- a/src/notation/view/abstractnotationpaintview.cpp
+++ b/src/notation/view/abstractnotationpaintview.cpp
@@ -222,7 +222,22 @@ void AbstractNotationPaintView::onLoadNotation(INotationPtr)
     if (publishMode()) {
         m_notation->setViewMode(ViewMode::PAGE);
     } else {
-        m_notation->setViewMode(globalContext()->currentProject()->viewSettings()->notationViewMode());
+        auto viewSettings = globalContext()->currentProject()->viewSettings();
+
+        const IMasterNotationPtr masterNotation = globalContext()->currentMasterNotation();
+
+        if (masterNotation->notation() == m_notation) {
+            m_notation->setViewMode(viewSettings->masterNotationViewMode());
+        } else {
+            const std::optional<size_t> excerptIndex = masterNotation->findExcerptIndex(m_notation);
+
+            // If the excerpt was found, use its index for independent view mode
+            if (excerptIndex.has_value()) {
+                m_notation->setViewMode(viewSettings->excerptViewMode(excerptIndex.value()));
+            }
+
+            // If nothing found, leave it as is
+        }
     }
 
     INotationInteractionPtr interaction = notationInteraction();

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -275,14 +275,29 @@ int NotationViewInputController::zoomPercentageFromScaling(qreal scaling) const
 
 void NotationViewInputController::setViewMode(const ViewMode& viewMode)
 {
+    auto notation = globalContext()->currentNotation();
+    if (!notation) {
+        return;
+    }
+    notation->setViewMode(viewMode);
+
     auto project = globalContext()->currentProject();
     if (project) {
-        project->viewSettings()->setNotationViewMode(viewMode);
-    }
+        auto masterNotation = globalContext()->currentMasterNotation();
 
-    auto notation = globalContext()->currentNotation();
-    if (notation) {
-        notation->setViewMode(viewMode);
+        if (notation == masterNotation->notation()) {
+            project->viewSettings()->setMasterNotationViewMode(viewMode);
+        }
+        // Excerpt: find index to save independent view mode
+        else {
+            auto excerptIndex = masterNotation->findExcerptIndex(notation);
+
+            if (excerptIndex.has_value()) {
+                project->viewSettings()->setExcerptViewMode(excerptIndex.value(), viewMode);
+            }
+
+            // Ignore otherwise: change current view but don't save it
+        }
     }
 }
 

--- a/src/notation/view/partlistmodel.cpp
+++ b/src/notation/view/partlistmodel.cpp
@@ -156,6 +156,7 @@ void PartListModel::doRemovePart(int partIndex)
     beginRemoveRows(QModelIndex(), partIndex, partIndex);
 
     masterNotation()->removeExcerpts({ m_excerpts[partIndex] });
+    context()->currentProject()->viewSettings()->removeExcerpt(partIndex);
     m_excerpts.removeAt(partIndex);
 
     endRemoveRows();

--- a/src/project/internal/projectviewsettings.h
+++ b/src/project/internal/projectviewsettings.h
@@ -33,8 +33,12 @@ namespace mu::project {
 class ProjectViewSettings : public IProjectViewSettings
 {
 public:
-    notation::ViewMode notationViewMode() const override;
-    void setNotationViewMode(const notation::ViewMode& mode) override;
+    notation::ViewMode masterNotationViewMode() const override;
+    void setMasterNotationViewMode(const notation::ViewMode& mode) override;
+
+    notation::ViewMode excerptViewMode(size_t excerptIndex) const override;
+    void setExcerptViewMode(size_t excerptIndex, const notation::ViewMode& mode) override;
+    void removeExcerpt(size_t excerptIndex) override;
 
     mu::ValNt<bool> needSave() const override;
 
@@ -50,7 +54,8 @@ private:
 
     void setNeedSave(bool needSave);
 
-    notation::ViewMode m_viewMode = notation::ViewMode::PAGE;
+    notation::ViewMode m_masterViewMode = notation::ViewMode::PAGE;
+    std::vector<notation::ViewMode> m_excerptsViewModes;
 
     bool m_needSave = false;
     async::Notification m_needSaveNotification;

--- a/src/project/iprojectviewsettings.h
+++ b/src/project/iprojectviewsettings.h
@@ -33,8 +33,12 @@ class IProjectViewSettings
 public:
     virtual ~IProjectViewSettings() = default;
 
-    virtual notation::ViewMode notationViewMode() const = 0;
-    virtual void setNotationViewMode(const notation::ViewMode& mode) = 0;
+    virtual notation::ViewMode masterNotationViewMode() const = 0;
+    virtual void setMasterNotationViewMode(const notation::ViewMode& mode) = 0;
+
+    virtual notation::ViewMode excerptViewMode(size_t excerptIndex) const = 0;
+    virtual void setExcerptViewMode(size_t excerptIndex, const notation::ViewMode& mode) = 0;
+    virtual void removeExcerpt(size_t excerptIndex) = 0;
 
     virtual mu::ValNt<bool> needSave() const = 0;
 };


### PR DESCRIPTION
Resolves: #11621

Half of the work was already done since notations already have independent view modes, but each time the mode was modified, all notations were updated.

I modified the view settings in order to store separate view mode for each excerpt, that will be stored in the save file alongside the global one.

New save files should still work with previous versions (as it is only an addition), and old save files should be usable in the new version as well.

**Video:**

https://user-images.githubusercontent.com/36641081/182047468-dc60e11c-4629-4022-832f-1c062a2d4621.mp4


