### PR TITLE
fixed #12619: The focused element might be empty if it is range selection

### DIFF
--- a/src/engraving/accessibility/accessibleroot.cpp
+++ b/src/engraving/accessibility/accessibleroot.cpp
@@ -68,7 +68,10 @@ AccessibleItemWeakPtr AccessibleRoot::focusedElement() const
 void AccessibleRoot::notifyAboutFocuedElemntNameChanged()
 {
     m_staffInfo = "";
-    m_focusedElement.lock()->accessiblePropertyChanged().send(accessibility::IAccessible::Property::Name, Val());
+
+    if (auto focusedElement = m_focusedElement.lock()) {
+        focusedElement->accessiblePropertyChanged().send(accessibility::IAccessible::Property::Name, Val());
+    }
 }
 
 mu::RectF AccessibleRoot::toScreenRect(const RectF& rect, bool* ok) const


### PR DESCRIPTION
Resolves: #12619