### PR TITLE
[MU4] Fix #10972: Tempo. Eights are played straight when Swing tempo mark is placed on the score

### DIFF
--- a/src/engraving/libmscore/libmscore.cmake
+++ b/src/engraving/libmscore/libmscore.cmake
@@ -349,4 +349,6 @@ set(LIBMSCORE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/playtechannotation.h
     ${CMAKE_CURRENT_LIST_DIR}/gradualtempochange.cpp
     ${CMAKE_CURRENT_LIST_DIR}/gradualtempochange.h
+    ${CMAKE_CURRENT_LIST_DIR}/swing.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/swing.h
 )

--- a/src/engraving/libmscore/navigate.cpp
+++ b/src/engraving/libmscore/navigate.cpp
@@ -119,38 +119,38 @@ static std::set<ElementPair, decltype(& isChild1beforeChild2)> toChildPairsSet(c
 //    return next Chord or Rest
 //---------------------------------------------------------
 
-ChordRest* nextChordRest(ChordRest* cr, bool skipGrace, bool skipMeasureRepeatRests)
+ChordRest* nextChordRest(const ChordRest* cr, bool skipGrace, bool skipMeasureRepeatRests)
 {
     if (!cr) {
-        return 0;
+        return nullptr;
     }
 
     if (cr->isGrace()) {
-        Chord* c  = toChord(cr);
+        const Chord* c  = toChord(cr);
         Chord* pc = toChord(cr->explicitParent());
 
         if (skipGrace) {
             cr = toChordRest(cr->explicitParent());
         } else if (cr->isGraceBefore()) {
-            std::vector<Chord*> cl = pc->graceNotesBefore();
-            auto i = std::find(cl.begin(), cl.end(), c);
-            if (i == cl.end()) {
-                return 0;           // unable to find self?
+            const GraceNotesGroup& group = pc->graceNotesBefore();
+            auto i = std::find(group.begin(), group.end(), c);
+            if (i == group.end()) {
+                return nullptr;           // unable to find self?
             }
             ++i;
-            if (i != cl.end()) {
+            if (i != group.end()) {
                 return *i;
             }
             // if this was last grace note before, return parent
             return pc;
         } else {
-            std::vector<Chord*> cl = pc->graceNotesAfter();
-            auto i = std::find(cl.begin(), cl.end(), c);
-            if (i == cl.end()) {
-                return 0;           // unable to find self?
+            const GraceNotesGroup& group = pc->graceNotesAfter();
+            auto i = std::find(group.begin(), group.end(), c);
+            if (i == group.end()) {
+                return nullptr;           // unable to find self?
             }
             ++i;
-            if (i != cl.end()) {
+            if (i != group.end()) {
                 return *i;
             }
             // if this was last grace note after, fall through to find next main note
@@ -158,11 +158,11 @@ ChordRest* nextChordRest(ChordRest* cr, bool skipGrace, bool skipMeasureRepeatRe
         }
     } else { // cr is not a grace note
         if (cr->isChord() && !skipGrace) {
-            Chord* c = toChord(cr);
+            const Chord* c = toChord(cr);
             if (!c->graceNotes().empty()) {
-                std::vector<Chord*> cl = c->graceNotesAfter();
-                if (!cl.empty()) {
-                    return cl.front();
+                const GraceNotesGroup& group = c->graceNotesAfter();
+                if (!group.empty()) {
+                    return group.front();
                 }
             }
         }
@@ -180,9 +180,9 @@ ChordRest* nextChordRest(ChordRest* cr, bool skipGrace, bool skipMeasureRepeatRe
             if (e->isChord() && !skipGrace) {
                 Chord* c = toChord(e);
                 if (!c->graceNotes().empty()) {
-                    std::vector<Chord*> cl = c->graceNotesBefore();
-                    if (!cl.empty()) {
-                        return cl.front();
+                    const GraceNotesGroup& group = c->graceNotesBefore();
+                    if (!group.empty()) {
+                        return group.front();
                     }
                 }
             }
@@ -190,7 +190,7 @@ ChordRest* nextChordRest(ChordRest* cr, bool skipGrace, bool skipMeasureRepeatRe
         }
     }
 
-    return 0;
+    return nullptr;
 }
 
 //---------------------------------------------------------
@@ -199,36 +199,36 @@ ChordRest* nextChordRest(ChordRest* cr, bool skipGrace, bool skipMeasureRepeatRe
 //    if grace is true, include grace notes
 //---------------------------------------------------------
 
-ChordRest* prevChordRest(ChordRest* cr, bool skipGrace, bool skipMeasureRepeatRests)
+ChordRest* prevChordRest(const ChordRest* cr, bool skipGrace, bool skipMeasureRepeatRests)
 {
     if (!cr) {
-        return 0;
+        return nullptr;
     }
 
     if (cr->isGrace()) {
-        Chord* c  = toChord(cr);
+        const Chord* c  = toChord(cr);
         Chord* pc = toChord(cr->explicitParent());
 
         if (skipGrace) {
             cr = toChordRest(cr->explicitParent());
         } else if (cr->isGraceBefore()) {
-            std::vector<Chord*> cl = pc->graceNotesBefore();
-            auto i = std::find(cl.begin(), cl.end(), c);
-            if (i == cl.end()) {
-                return 0;           // unable to find self?
+            const GraceNotesGroup& group = pc->graceNotesBefore();
+            auto i = std::find(group.begin(), group.end(), c);
+            if (i == group.end()) {
+                return nullptr;           // unable to find self?
             }
-            if (i != cl.begin()) {
+            if (i != group.begin()) {
                 return *--i;
             }
             // if this was first grace note before, fall through to find previous main note
             cr = pc;
         } else {
-            std::vector<Chord*> cl = pc->graceNotesAfter();
-            auto i = std::find(cl.begin(), cl.end(), c);
-            if (i == cl.end()) {
-                return 0;           // unable to find self?
+            const GraceNotesGroup& group = pc->graceNotesAfter();
+            auto i = std::find(group.begin(), group.end(), c);
+            if (i == group.end()) {
+                return nullptr;           // unable to find self?
             }
-            if (i != cl.begin()) {
+            if (i != group.begin()) {
                 return *--i;
             }
             // if this was first grace note after, return parent
@@ -238,10 +238,10 @@ ChordRest* prevChordRest(ChordRest* cr, bool skipGrace, bool skipMeasureRepeatRe
         //
         // cr is not a grace note
         if (cr->isChord() && !skipGrace) {
-            Chord* c = toChord(cr);
-            std::vector<Chord*> cl = c->graceNotesBefore();
-            if (!cl.empty()) {
-                return cl.back();
+            const Chord* c = toChord(cr);
+            const GraceNotesGroup& group = c->graceNotesBefore();
+            if (!group.empty()) {
+                return group.back();
             }
         }
     }
@@ -255,16 +255,16 @@ ChordRest* prevChordRest(ChordRest* cr, bool skipGrace, bool skipMeasureRepeatRe
                 continue; // these rests are not shown, skip them
             }
             if (e->isChord() && !skipGrace) {
-                std::vector<Chord*> cl = toChord(e)->graceNotesAfter();
-                if (!cl.empty()) {
-                    return cl.back();
+                const GraceNotesGroup& group = toChord(e)->graceNotesAfter();
+                if (!group.empty()) {
+                    return group.back();
                 }
             }
             return e;
         }
     }
 
-    return 0;
+    return nullptr;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/navigate.h
+++ b/src/engraving/libmscore/navigate.h
@@ -27,7 +27,7 @@ namespace mu::engraving {
 class ChordRest;
 
 extern int pitch2y(int pitch, int enh, int clefOffset, int key, int& prefix, const char* tversatz);
-extern ChordRest* nextChordRest(ChordRest* cr, bool skipGrace = false, bool skipMeasureRepeatRests = true);
-extern ChordRest* prevChordRest(ChordRest* cr, bool skipGrace = false, bool skipMeasureRepeatRests = true);
+extern ChordRest* nextChordRest(const ChordRest* cr, bool skipGrace = false, bool skipMeasureRepeatRests = true);
+extern ChordRest* prevChordRest(const ChordRest* cr, bool skipGrace = false, bool skipMeasureRepeatRests = true);
 } // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/rendermidi.cpp
+++ b/src/engraving/libmscore/rendermidi.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SPDX-License-Identifier: GPL-3.0-only
  * MuseScore-CLA-applies
  *
@@ -67,6 +67,7 @@
 #include "utils.h"
 #include "synthesizerstate.h"
 #include "easeInOut.h"
+#include "swing.h"
 
 #include "masterscore.h"
 
@@ -1272,58 +1273,6 @@ void MidiRenderer::renderSpanners(const Chunk& chunk, EventMap* events)
     }
 }
 
-void Score::swingAdjustParams(const Chord* chord, int& gateTime, int& ontime, int swingUnit, int swingRatio)
-{
-    Fraction tick = chord->rtick();
-    // adjust for anacrusis
-    Measure* cm     = chord->measure();
-    MeasureBase* pm = cm->prev();
-    ElementType pt  = pm ? pm->type() : ElementType::INVALID;
-    if (!pm || pm->lineBreak() || pm->pageBreak() || pm->sectionBreak()
-        || pt == ElementType::VBOX || pt == ElementType::HBOX
-        || pt == ElementType::FBOX || pt == ElementType::TBOX) {
-        Fraction offset = cm->timesig() - cm->ticks();
-        if (offset > Fraction(0, 1)) {
-            tick += offset;
-        }
-    }
-
-    int swingBeat           = swingUnit * 2;
-    double ticksDuration     = (double)chord->actualTicks().ticks();
-    double swingTickAdjust   = ((double)swingBeat) * (((double)(swingRatio - 50)) / 100.0);
-    double swingActualAdjust = (swingTickAdjust / ticksDuration) * 1000.0;
-    ChordRest* ncr          = nextChordRest(chord);
-
-    //Check the position of the chord to apply changes accordingly
-    if (tick.ticks() % swingBeat == swingUnit) {
-        if (!isSubdivided(chord, swingUnit)) {
-            ontime = ontime + swingActualAdjust;
-        }
-    }
-    int endTick = tick.ticks() + ticksDuration;
-    if ((endTick % swingBeat == swingUnit) && (!isSubdivided(ncr, swingUnit))) {
-        gateTime = gateTime + (swingActualAdjust / 10);
-    }
-}
-
-//---------------------------------------------------------
-//   isSubdivided
-//   Check for subdivided beat
-//---------------------------------------------------------
-
-bool Score::isSubdivided(const ChordRest* chord, int swingUnit)
-{
-    if (!chord) {
-        return false;
-    }
-    ChordRest* prev = prevChordRest(chord);
-    if (chord->actualTicks().ticks() < swingUnit || (prev && prev->actualTicks().ticks() < swingUnit)) {
-        return true;
-    } else {
-        return false;
-    }
-}
-
 const Drumset* getDrumset(const Chord* chord)
 {
     if (chord->staff() && chord->staff()->isDrumStaff(chord->tick())) {
@@ -2328,11 +2277,9 @@ void Score::createPlayEvents(Chord* chord)
     createGraceNotesPlayEvents(tick, chord, ontime, trailtime);   // ontime and trailtime are modified by this call depending on grace notes before and after
 
     SwingParameters st = chord->staff()->swing(tick);
-    int unit           = st.swingUnit;
-    int ratio          = st.swingRatio;
     // Check if swing needs to be applied
-    if (unit && !chord->tuplet()) {
-        swingAdjustParams(chord, gateTime, ontime, unit, ratio);
+    if (st.swingUnit && !chord->tuplet()) {
+        Swing::swingAdjustParams(chord, st, ontime, gateTime);
     }
     //
     //    render normal (and articulated) chords

--- a/src/engraving/libmscore/rendermidi.cpp
+++ b/src/engraving/libmscore/rendermidi.cpp
@@ -1272,11 +1272,7 @@ void MidiRenderer::renderSpanners(const Chunk& chunk, EventMap* events)
     }
 }
 
-//--------------------------------------------------------
-//   swingAdjustParams
-//--------------------------------------------------------
-
-void Score::swingAdjustParams(Chord* chord, int& gateTime, int& ontime, int swingUnit, int swingRatio)
+void Score::swingAdjustParams(const Chord* chord, int& gateTime, int& ontime, int swingUnit, int swingRatio)
 {
     Fraction tick = chord->rtick();
     // adjust for anacrusis
@@ -1315,7 +1311,7 @@ void Score::swingAdjustParams(Chord* chord, int& gateTime, int& ontime, int swin
 //   Check for subdivided beat
 //---------------------------------------------------------
 
-bool Score::isSubdivided(ChordRest* chord, int swingUnit)
+bool Score::isSubdivided(const ChordRest* chord, int swingUnit)
 {
     if (!chord) {
         return false;

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -472,8 +472,7 @@ private:
 
     bool rewriteMeasures(Measure* fm, Measure* lm, const Fraction&, staff_idx_t staffIdx);
     bool rewriteMeasures(Measure* fm, const Fraction& ns, staff_idx_t staffIdx);
-    void swingAdjustParams(Chord*, int&, int&, int, int);
-    bool isSubdivided(ChordRest*, int);
+    bool isSubdivided(const ChordRest *, int);
     std::list<Fraction> splitGapToMeasureBoundaries(ChordRest*, Fraction);
     void pasteChordRest(ChordRest* cr, const Fraction& tick, const Interval&);
 
@@ -952,6 +951,8 @@ public:
     void updateCapo();
     void updateVelo();
     void updateChannel();
+
+    void swingAdjustParams(const Chord*, int&, int&, int, int);
 
     void cmdConcertPitchChanged(bool);
 

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -472,7 +472,6 @@ private:
 
     bool rewriteMeasures(Measure* fm, Measure* lm, const Fraction&, staff_idx_t staffIdx);
     bool rewriteMeasures(Measure* fm, const Fraction& ns, staff_idx_t staffIdx);
-    bool isSubdivided(const ChordRest *, int);
     std::list<Fraction> splitGapToMeasureBoundaries(ChordRest*, Fraction);
     void pasteChordRest(ChordRest* cr, const Fraction& tick, const Interval&);
 
@@ -951,8 +950,6 @@ public:
     void updateCapo();
     void updateVelo();
     void updateChannel();
-
-    void swingAdjustParams(const Chord*, int&, int&, int, int);
 
     void cmdConcertPitchChanged(bool);
 

--- a/src/engraving/libmscore/staff.h
+++ b/src/engraving/libmscore/staff.h
@@ -59,8 +59,10 @@ enum class Key;
 //---------------------------------------------------------
 
 struct SwingParameters {
-    int swingUnit;
-    int swingRatio;
+    int swingUnit = 0;
+    int swingRatio = 0;
+
+    bool isValid() const { return swingRatio >= 50 && swingUnit != 0; }
 };
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/staff.h
+++ b/src/engraving/libmscore/staff.h
@@ -62,7 +62,7 @@ struct SwingParameters {
     int swingUnit = 0;
     int swingRatio = 0;
 
-    bool isValid() const { return swingRatio >= 50 && swingUnit != 0; }
+    bool isOn() const { return swingUnit != 0; }
 };
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/swing.cpp
+++ b/src/engraving/libmscore/swing.cpp
@@ -1,0 +1,113 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "swing.h"
+
+#include "staff.h"
+#include "chord.h"
+#include "navigate.h"
+#include "realfn.h"
+
+using namespace mu::engraving;
+
+bool Swing::ChordDurationAdjustment::isNull() const
+{
+    return RealIsNull(remainingDurationMultiplier) && RealIsNull(durationMultiplier);
+}
+
+//---------------------------------------------------------
+//   isSubdivided
+//   Check for subdivided beat
+//---------------------------------------------------------
+
+static bool isSubdivided(const ChordRest* chord, int swingUnit)
+{
+    if (!chord) {
+        return false;
+    }
+
+    const ChordRest* prev = prevChordRest(chord);
+    if (chord->actualTicks().ticks() < swingUnit || (prev && prev->actualTicks().ticks() < swingUnit)) {
+        return true;
+    }
+
+    return false;
+}
+
+void Swing::swingAdjustParams(const Chord* chord, const SwingParameters& params, int& onTime, int& gateTime)
+{
+    Fraction tick = chord->rtick();
+
+    // adjust for anacrusis
+    const Measure* cm = chord->measure();
+    const MeasureBase* pm = cm->prev();
+    ElementType pt = pm ? pm->type() : ElementType::INVALID;
+    if (!pm || pm->lineBreak() || pm->pageBreak() || pm->sectionBreak()
+        || pt == ElementType::VBOX || pt == ElementType::HBOX
+        || pt == ElementType::FBOX || pt == ElementType::TBOX) {
+        Fraction offset = cm->timesig() - cm->ticks();
+        if (offset > Fraction(0, 1)) {
+            tick += offset;
+        }
+    }
+
+    int swingBeat            = params.swingUnit * 2;
+    double ticksDuration     = (double)chord->actualTicks().ticks();
+    double swingTickAdjust   = ((double)swingBeat) * (((double)(params.swingRatio - 50)) / 100.0);
+    double swingActualAdjust = (swingTickAdjust / ticksDuration) * 1000.0;
+    int startTick            = tick.ticks();
+
+    //Check the position of the chord to apply changes accordingly
+    if (startTick % swingBeat == params.swingUnit) {
+        if (!isSubdivided(chord, params.swingUnit)) {
+            onTime = onTime + swingActualAdjust;
+            gateTime = (200 - (gateTime + (swingActualAdjust / 10)));
+        }
+    }
+
+    int endTick = startTick + ticksDuration;
+    if (endTick % swingBeat == params.swingUnit) {
+        const ChordRest* ncr = nextChordRest(chord);
+
+        if (!isSubdivided(ncr, params.swingUnit)) {
+            gateTime = gateTime + (swingActualAdjust / 10);
+        }
+    }
+}
+
+Swing::ChordDurationAdjustment Swing::applySwing(const Chord* chord, const SwingParameters& params)
+{
+    int onTime = 0;
+    int gateTime = 100;
+
+    swingAdjustParams(chord, params, onTime, gateTime);
+
+    if (gateTime <= 0) {
+        gateTime = 100;
+    }
+
+    ChordDurationAdjustment result;
+    result.remainingDurationMultiplier = static_cast<double>(onTime) / 1000.;
+    result.durationMultiplier = static_cast<double>(gateTime) / 100.;
+
+    return result;
+}

--- a/src/engraving/libmscore/swing.h
+++ b/src/engraving/libmscore/swing.h
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_ENGRAVING_SWING_H
+#define MU_ENGRAVING_SWING_H
+
+namespace mu::engraving {
+class Chord;
+struct SwingParameters;
+
+class Swing
+{
+public:
+    struct ChordDurationAdjustment
+    {
+        double remainingDurationMultiplier = 0.;
+        double durationMultiplier = 0.;
+
+        bool isNull() const;
+    };
+
+    static ChordDurationAdjustment applySwing(const Chord* chord, const SwingParameters& params);
+    static void swingAdjustParams(const Chord* chord, const SwingParameters& params, int& onTime, int& gateTime);
+};
+}
+
+#endif // MU_ENGRAVING_SWING_H

--- a/src/engraving/libmscore/undo.cpp
+++ b/src/engraving/libmscore/undo.cpp
@@ -872,9 +872,16 @@ void AddElement::endUndoRedo(bool isUndo) const
 
 void AddElement::undo(EditData*)
 {
+    Score* score = element->score();
+
     if (!element->isTuplet()) {
-        element->score()->removeElement(element);
+        score->removeElement(element);
     }
+
+    if (element->isStaffTextBase()) {
+        score->updateSwing();
+    }
+
     endUndoRedo(true);
 }
 
@@ -884,9 +891,16 @@ void AddElement::undo(EditData*)
 
 void AddElement::redo(EditData*)
 {
+    Score* score = element->score();
+
     if (!element->isTuplet()) {
-        element->score()->addElement(element);
+        score->addElement(element);
     }
+
+    if (element->isStaffTextBase()) {
+        score->updateSwing();
+    }
+
     endUndoRedo(false);
 }
 
@@ -1005,9 +1019,16 @@ void RemoveElement::cleanup(bool undo)
 
 void RemoveElement::undo(EditData*)
 {
+    Score* score = element->score();
+
     if (!element->isTuplet()) {
-        element->score()->addElement(element);
+        score->addElement(element);
     }
+
+    if (element->isStaffTextBase()) {
+        score->updateSwing();
+    }
+
     if (element->isChordRest()) {
         if (element->isChord()) {
             Chord* chord = toChord(element);
@@ -1017,9 +1038,9 @@ void RemoveElement::undo(EditData*)
         }
         undoAddTuplet(toChordRest(element));
     } else if (element->isClef()) {
-        element->score()->setLayout(element->staff()->nextClefTick(element->tick()), element->staffIdx());
+        score->setLayout(element->staff()->nextClefTick(element->tick()), element->staffIdx());
     } else if (element->isKeySig()) {
-        element->score()->setLayout(element->staff()->nextKeyTick(element->tick()), element->staffIdx());
+        score->setLayout(element->staff()->nextKeyTick(element->tick()), element->staffIdx());
     }
 }
 
@@ -1029,9 +1050,16 @@ void RemoveElement::undo(EditData*)
 
 void RemoveElement::redo(EditData*)
 {
+    Score* score = element->score();
+
     if (!element->isTuplet()) {
-        element->score()->removeElement(element);
+        score->removeElement(element);
     }
+
+    if (element->isStaffTextBase()) {
+        score->updateSwing();
+    }
+
     if (element->isChordRest()) {
         undoRemoveTuplet(toChordRest(element));
         if (element->isChord()) {
@@ -1041,9 +1069,9 @@ void RemoveElement::redo(EditData*)
             }
         }
     } else if (element->isClef()) {
-        element->score()->setLayout(element->staff()->nextClefTick(element->tick()), element->staffIdx());
+        score->setLayout(element->staff()->nextClefTick(element->tick()), element->staffIdx());
     } else if (element->isKeySig()) {
-        element->score()->setLayout(element->staff()->nextKeyTick(element->tick()), element->staffIdx());
+        score->setLayout(element->staff()->nextKeyTick(element->tick()), element->staffIdx());
     }
 }
 
@@ -1389,6 +1417,7 @@ void ChangeElement::flip(EditData*)
             score->select(newElement, SelectType::ADD);
         }
     }
+
     if (oldElement->explicitParent() == 0) {
         score->removeElement(oldElement);
         score->addElement(newElement);
@@ -1407,7 +1436,7 @@ void ChangeElement::flip(EditData*)
         TempoText* t = toTempoText(oldElement);
         score->setTempo(t->segment(), t->tempo());
     }
-//      if (newElement->isSegmentFlag()) {
+
     if (newElement->isSpannerSegment()) {
         SpannerSegment* os = toSpannerSegment(oldElement);
         SpannerSegment* ns = toSpannerSegment(newElement);
@@ -1418,10 +1447,14 @@ void ChangeElement::flip(EditData*)
             ns->system()->add(ns);
         }
     }
+
+    if (newElement->isStaffTextBase()) {
+        score->updateSwing();
+    }
+
     std::swap(oldElement, newElement);
     oldElement->triggerLayout();
     newElement->triggerLayout();
-    // score->setLayoutAll();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/playback/playbackeventsrenderer.cpp
+++ b/src/engraving/playback/playbackeventsrenderer.cpp
@@ -285,10 +285,10 @@ void PlaybackEventsRenderer::renderNoteArticulations(const Chord* chord, const R
     Swing::ChordDurationAdjustment swingDurationAdjustment;
 
     if (!chord->tuplet()) {
-        SwingParameters params = chord->staff()->swing(chord->tick());
+        SwingParameters swing = chord->staff()->swing(chord->tick());
 
-        if (params.isValid()) {
-            swingDurationAdjustment = Swing::applySwing(chord, params);
+        if (swing.isOn()) {
+            swingDurationAdjustment = Swing::applySwing(chord, swing);
         }
     }
 

--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -387,7 +387,7 @@ bool PlaybackModel::hasToReloadTracks(const std::unordered_set<ElementType>& cha
 {
     static const std::unordered_set<ElementType> REQUIRED_TYPES = {
         ElementType::PLAYTECH_ANNOTATION, ElementType::DYNAMIC, ElementType::HAIRPIN,
-        ElementType::HAIRPIN_SEGMENT, ElementType::HARMONY
+        ElementType::HAIRPIN_SEGMENT, ElementType::HARMONY, ElementType::STAFF_TEXT
     };
 
     for (const ElementType type : REQUIRED_TYPES) {

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -95,6 +95,7 @@ void MasterNotation::setMasterScore(mu::engraving::MasterScore* score)
     TRACEFUNC;
 
     setScore(score);
+    score->updateSwing();
     m_notationPlayback->init(m_undoStack);
     initExcerptNotations(masterScore()->excerpts());
 }
@@ -247,6 +248,7 @@ mu::Ret MasterNotation::setupNewScore(mu::engraving::MasterScore* score, const S
     parts()->setParts(scoreOptions.parts, scoreOptions.order);
 
     score->checkChordList();
+    score->updateSwing();
 
     applyOptions(score, scoreOptions);
 

--- a/src/notation/view/widgets/stafftextpropertiesdialog.cpp
+++ b/src/notation/view/widgets/stafftextpropertiesdialog.cpp
@@ -552,12 +552,26 @@ void StaffTextPropertiesDialog::saveValues()
         m_staffText->setCapo(0);
     }
 
+    INotationUndoStackPtr stack = undoStack();
+    IF_ASSERT_FAILED(stack) {
+        return;
+    }
+
     Score* score = m_originStaffText->score();
     StaffTextBase* nt = toStaffTextBase(m_staffText->clone());
     nt->setScore(score);
+
+    stack->prepareChanges();
     score->undoChangeElement(m_originStaffText, nt);
     score->masterScore()->updateChannel();
     score->updateCapo();
     score->updateSwing();
     score->setPlaylistDirty();
+    stack->commitChanges();
+}
+
+INotationUndoStackPtr StaffTextPropertiesDialog::undoStack() const
+{
+    INotationPtr notation = globalContext()->currentNotation();
+    return notation ? notation->undoStack() : nullptr;
 }

--- a/src/notation/view/widgets/stafftextpropertiesdialog.h
+++ b/src/notation/view/widgets/stafftextpropertiesdialog.h
@@ -66,6 +66,8 @@ private:
 
     void saveChannel(int channel);
 
+    INotationUndoStackPtr undoStack() const;
+
     engraving::StaffTextBase* m_originStaffText = nullptr;
     engraving::StaffTextBase* m_staffText = nullptr;
     QToolButton* m_vb[engraving::VOICES][engraving::VOICES];


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10972