### PR TITLE
[MU4] Fix some bogus translatable strings

### DIFF
--- a/src/appshell/qml/MainToolBar.qml
+++ b/src/appshell/qml/MainToolBar.qml
@@ -61,7 +61,7 @@ Item {
         id: navPanel
         name: "MainToolBar"
         enabled: root.enabled && root.visible
-        accessible.name: qsTrc("appshell", "Main tool bar") + " " + navPanel.directionInfo
+        accessible.name: qsTrc("appshell", "Main toolbar") + " " + navPanel.directionInfo
     }
 
     RadioButtonGroup {

--- a/src/appshell/view/preferences/preferencesmodel.cpp
+++ b/src/appshell/view/preferences/preferencesmodel.cpp
@@ -166,7 +166,7 @@ void PreferencesModel::load(const QString& currentPageId)
         makeItem("note-input", QT_TRANSLATE_NOOP("appshell/preferences", "Note input"), IconCode::Code::EDIT,
                  "Preferences/NoteInputPreferencesPage.qml"),
 
-        makeItem("midi-device-mapping", QT_TRANSLATE_NOOP("appshell/preferences", "MIDI device mapping"), IconCode::Code::MIDI_INPUT,
+        makeItem("midi-device-mapping", QT_TRANSLATE_NOOP("appshell/preferences", "MIDI mappings"), IconCode::Code::MIDI_INPUT,
                  "Preferences/MidiDeviceMappingPreferencesPage.qml"),
 
         makeItem("score", QT_TRANSLATE_NOOP("appshell/preferences", "Score"), IconCode::Code::SCORE,

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -1162,13 +1162,41 @@ struct AccidentalUnicodeItem {
 };
 
 static const std::vector<AccidentalUnicodeItem> ACCIDENTALS_NAMES = {
-    { AccidentalVal::SHARP3, QT_TRANSLATE_NOOP("engraving", "triple ♯"), QT_TRANSLATE_NOOP("engraving", "triple sharp") },
-    { AccidentalVal::SHARP2, QT_TRANSLATE_NOOP("engraving", "double ♯"), QT_TRANSLATE_NOOP("engraving", "double sharp") },
-    { AccidentalVal::SHARP, QT_TRANSLATE_NOOP("engraving", "♯"), QT_TRANSLATE_NOOP("engraving", "sharp") },
-    { AccidentalVal::NATURAL, QT_TRANSLATE_NOOP("engraving", "natural") },
-    { AccidentalVal::FLAT, QT_TRANSLATE_NOOP("engraving", "♭"), QT_TRANSLATE_NOOP("engraving", "flat") },
-    { AccidentalVal::FLAT2, QT_TRANSLATE_NOOP("engraving", "double ♭"), QT_TRANSLATE_NOOP("engraving", "double flat") },
-    { AccidentalVal::FLAT3, QT_TRANSLATE_NOOP("engraving", "triple ♭"), QT_TRANSLATE_NOOP("engraving", "triple flat") }
+    { AccidentalVal::SHARP3,
+      //: Visible text in the UI. Please preserve the accidental symbol in the translation
+      QT_TRANSLATE_NOOP("engraving", "triple ♯"),
+      //: Accessible text for screen readers. Please avoid using accidental symbols in the translation
+      QT_TRANSLATE_NOOP("engraving", "triple sharp") },
+    { AccidentalVal::SHARP2,
+      //: Visible text in the UI. Please preserve the accidental symbol in the translation
+      QT_TRANSLATE_NOOP("engraving", "double ♯"),
+      //: Visible text in the UI. Please preserve the accidental symbol in the translation
+      QT_TRANSLATE_NOOP("engraving", "double sharp") },
+    { AccidentalVal::SHARP,
+      //: Visible text in the UI. Please preserve the accidental symbol in the translation
+      QT_TRANSLATE_NOOP("engraving", "♯"),
+      //: Visible text in the UI. Please preserve the accidental symbol in the translation
+      QT_TRANSLATE_NOOP("engraving", "sharp") },
+    { AccidentalVal::NATURAL,
+      //: Visible text in the UI. Please preserve the accidental symbol in the translation
+      QT_TRANSLATE_NOOP("engraving", "♮"),
+      //: Visible text in the UI. Please preserve the accidental symbol in the translation
+      QT_TRANSLATE_NOOP("engraving", "natural") },
+    { AccidentalVal::FLAT,
+      //: Visible text in the UI. Please preserve the accidental symbol in the translation
+      QT_TRANSLATE_NOOP("engraving", "♭"),
+      //: Visible text in the UI. Please preserve the accidental symbol in the translation
+      QT_TRANSLATE_NOOP("engraving", "flat") },
+    { AccidentalVal::FLAT2,
+      //: Visible text in the UI. Please preserve the accidental symbol in the translation
+      QT_TRANSLATE_NOOP("engraving", "double ♭"),
+      //: Visible text in the UI. Please preserve the accidental symbol in the translation
+      QT_TRANSLATE_NOOP("engraving", "double flat") },
+    { AccidentalVal::FLAT3,
+      //: Visible text in the UI. Please preserve the accidental symbol in the translation
+      QT_TRANSLATE_NOOP("engraving", "triple ♭"),
+      //: Visible text in the UI. Please preserve the accidental symbol in the translation
+      QT_TRANSLATE_NOOP("engraving", "triple flat") }
 };
 
 const char* TConv::userName(AccidentalVal accidental, bool full)

--- a/src/framework/shortcuts/qml/MuseScore/Shortcuts/internal/MidiMappingBottomPanel.qml
+++ b/src/framework/shortcuts/qml/MuseScore/Shortcuts/internal/MidiMappingBottomPanel.qml
@@ -40,7 +40,7 @@ Row {
         name: "MidiMappingBottomPanel"
         enabled: root.enabled && root.visible
         direction: NavigationPanel.Horizontal
-        accessible.name: qsTrc("shortcuts", "Midi mapping bottom panel")
+        accessible.name: qsTrc("shortcuts", "MIDI mapping bottom panel")
 
         onActiveChanged: function(active) {
             if (active) {

--- a/src/framework/shortcuts/qml/MuseScore/Shortcuts/internal/MidiMappingTopPanel.qml
+++ b/src/framework/shortcuts/qml/MuseScore/Shortcuts/internal/MidiMappingTopPanel.qml
@@ -36,7 +36,7 @@ RowLayout {
         name: "MidiMappingTopPanel"
         enabled: root.enabled && root.visible
         direction: NavigationPanel.Horizontal
-        accessible.name: qsTrc("shortcuts", "Midi mapping top panel")
+        accessible.name: qsTrc("shortcuts", "MIDI mapping top panel")
 
         onActiveChanged: function(active) {
             if (active) {

--- a/src/importexport/capella/internal/capella.cpp
+++ b/src/importexport/capella/internal/capella.cpp
@@ -1211,7 +1211,7 @@ void convertCapella(Score* score, Capella* cap, bool capxMode)
     Part* part = 0;
     for (int staffIdx = 0; staffIdx < staves; ++staffIdx) {
         CapStaffLayout* cl = cap->staffLayout(staffIdx);
-        // LOGD("Midi staff %d program %d", staffIdx, cl->sound);
+        // LOGD("MIDI staff %d program %d", staffIdx, cl->sound);
 
         // create a new part if necessary
         if (needPart(midiPatch, cl->sound, staffIdx, cap->brackets)) {

--- a/src/importexport/midi/internal/midiimport/importmidi_chord.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_chord.cpp
@@ -143,7 +143,7 @@ void removeOverlappingNotes(QList<MidiNote>& notes)
                     noteIt1->offTime = noteIt2->offTime;
                 }
                 noteIt2 = tempNotes.erase(noteIt2);
-                LOGD() << "Midi import: removeOverlappingNotes: note was removed";
+                LOGD() << "MIDI import: removeOverlappingNotes: note was removed";
                 continue;
             }
             ++noteIt2;
@@ -207,7 +207,7 @@ void removeOverlappingNotes(std::multimap<int, MTrack>& tracks)
                 }
                 if (note1.offTime - onTime1 < MChord::minAllowedDuration()) {
                     note1It = chord1.notes.erase(note1It);
-                    LOGD("Midi import: removeOverlappingNotes: note was removed");
+                    LOGD("MIDI import: removeOverlappingNotes: note was removed");
                     continue;
                 }
                 ++note1It;

--- a/src/importexport/midi/internal/midiimport/importmidi_model.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_model.cpp
@@ -437,7 +437,7 @@ void TracksModel::reset(const MidiOperations::Opers& opers,
         {
             const QStringList list = value.toStringList();
 
-            Q_ASSERT_X(list.size() > 5, "Midi import operations",
+            Q_ASSERT_X(list.size() > 5, "MIDI import operations",
                        "Invalid size of the tuplets value list");
 
             bool searchTuplets = false;
@@ -569,18 +569,18 @@ void TracksModel::reset(const MidiOperations::Opers& opers,
             {
                 const QStringList list = value.toStringList();
 
-                Q_ASSERT_X(list.size() == 2, "Midi import operations",
+                Q_ASSERT_X(list.size() == 2, "MIDI import operations",
                            "Invalid size of the time signature value list");
 
                 bool ok = false;
                 _opers.timeSigNumerator.setValue((MidiOperations::TimeSigNumerator)list[0].toInt(&ok));
 
-                Q_ASSERT_X(ok, "Midi import operations", "Invalid numerator value");
+                Q_ASSERT_X(ok, "MIDI import operations", "Invalid numerator value");
 
                 ok = false;
                 _opers.timeSigDenominator.setValue((MidiOperations::TimeSigDenominator)list[1].toInt(&ok));
 
-                Q_ASSERT_X(ok, "Midi import operations", "Invalid denominator value");
+                Q_ASSERT_X(ok, "MIDI import operations", "Invalid denominator value");
             }
 
             QStringList valueList(int /*trackIndex*/) const override

--- a/src/importexport/midi/internal/midishared/midifile.cpp
+++ b/src/importexport/midi/internal/midishared/midifile.cpp
@@ -574,7 +574,7 @@ bool MidiFile::readEvent(MidiEvent* event)
     for (;;) {
         read(&me, 1);
         if (me >= 0xf1 && me <= 0xfe && me != 0xf7) {
-            LOGD("Midi: Unknown Message 0x%02x", me & 0xff);
+            LOGD("MIDI: Unknown Message 0x%02x", me & 0xff);
         } else {
             break;
         }

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/chordsymbols/ChordSymbolSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/chordsymbols/ChordSymbolSettings.qml
@@ -86,7 +86,7 @@ Column {
 
         model: [
             { text: qsTrc("inspector", "Until the next chord symbol"), value: ChordSymbolTypes.DURATION_UNTIL_NEXT_CHORD_SYMBOL },
-            { text: qsTrc("inspector", "Until the end of the bar"), value: ChordSymbolTypes.DURATION_STOP_AT_MEASURE_END },
+            { text: qsTrc("inspector", "Until the end of the measure"), value: ChordSymbolTypes.DURATION_STOP_AT_MEASURE_END },
             { text: qsTrc("inspector", "Until the end of the attached duration"), value: ChordSymbolTypes.DURATION_SEGMENT_DURATION }
         ]
     }

--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
@@ -110,7 +110,7 @@ Column {
 
         model: [
             { text: qsTrc("inspector", "None"), value: TextTypes.FRAME_TYPE_NONE, titleRole: qsTrc("inspector", "None") },
-            { iconCode: IconCode.FRAME_SQUARE, value: TextTypes.FRAME_TYPE_SQUARE, titleRole: qsTrc("inspector", "Square") },
+            { iconCode: IconCode.FRAME_SQUARE, value: TextTypes.FRAME_TYPE_SQUARE, titleRole: qsTrc("inspector", "Rectangle") },
             { iconCode: IconCode.FRAME_CIRCLE, value: TextTypes.FRAME_TYPE_CIRCLE, titleRole: qsTrc("inspector", "Circle") }
         ]
     }

--- a/src/notation/view/widgets/editstringdata.cpp
+++ b/src/notation/view/widgets/editstringdata.cpp
@@ -47,7 +47,7 @@ EditStringData::EditStringData(QWidget* parent, std::vector<mu::engraving::instr
     setupUi(this);
     setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
     _strings = strings;
-    stringList->setHorizontalHeaderLabels({ qtrc("notation/editstringdata", "Open"),
+    stringList->setHorizontalHeaderLabels({ qtrc("notation/editstringdata", "Always open"),
                                             qtrc("notation/editstringdata", "Pitch") });
     int numOfStrings = static_cast<int>(_strings->size());
     stringList->setRowCount(numOfStrings);
@@ -64,7 +64,7 @@ EditStringData::EditStringData(QWidget* parent, std::vector<mu::engraving::instr
             newCheck->setFlags(Qt::ItemFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled));
             newCheck->setCheckState(strg.open ? Qt::Checked : Qt::Unchecked);
 
-            newCheck->setData(OPEN_ACCESSIBLE_TITLE_ROLE, qtrc("notation/editstringdata", "Open"));
+            newCheck->setData(OPEN_ACCESSIBLE_TITLE_ROLE, qtrc("notation/editstringdata", "Always open"));
             newCheck->setData(Qt::AccessibleTextRole, openColumnAccessibleText(newCheck));
 
             stringList->setItem(i, 0, newCheck);

--- a/src/notation/view/widgets/editstringdata.ui
+++ b/src/notation/view/widgets/editstringdata.ui
@@ -35,7 +35,7 @@
          </attribute>
          <column>
           <property name="text">
-           <string>Open</string>
+           <string>Always open</string>
           </property>
          </column>
          <column>

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -6645,7 +6645,7 @@ By default, they will be placed such as that their right end are at the same lev
            <item row="3" column="0" colspan="3">
             <widget class="QCheckBox" name="arpeggioHiddenInStdIfTab">
              <property name="text">
-              <string>Do not show arpeggio in standard notation when displayed in tablature</string>
+              <string>Do not show arpeggios in standard notation when displayed in tablature</string>
              </property>
             </widget>
            </item>

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -4512,7 +4512,7 @@ By default, they will be placed such as that their right end are at the same lev
                <item row="1" column="0">
                 <widget class="QLabel" name="label_11">
                  <property name="text">
-                  <string>Spacing curve:</string>
+                  <string>Spacing ratio:</string>
                  </property>
                  <property name="buddy">
                   <cstring>measureSpacing</cstring>

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -11843,7 +11843,7 @@ By default, they will be placed such as that their right end are at the same lev
                <item>
                 <widget class="QLabel" name="label">
                  <property name="text">
-                  <string> Select the elements you would like displayed in common and simple tablature staves</string>
+                  <string>Select the elements you would like displayed in common and simple tablature staves</string>
                  </property>
                  <property name="margin">
                   <number>0</number>

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -5385,7 +5385,7 @@ By default, they will be placed such as that their right end are at the same lev
            <item row="1" column="3" colspan="2">
             <widget class="QCheckBox" name="mmRestNumberMaskHBar">
              <property name="text">
-              <string>Mask H-bar around number</string>
+              <string>Break H-bar if it collides with number</string>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
* a frame around text is a "rectangle" rather than a "square", most of the time (and a square is a rectangle, but not always vice versa)
* strings (of plucked instruments) are "Always open" rather than just "Open", when not over the fretboard, that term is at least clearer
* "arpeggio" should be plural here
* "Midi" to "MIDI", being an acronym
* "Spacing curve" to "Spacing ratio"
* "tool bar" to "toolbar"
* Remove leading space
* "MIDI device mapping" to "MIDI mappings"
* "bar" to "measure"
* Clarify some translation needs, for sharp, flat, natural, reg. accessibility
* "Mask H-bar around number" to "Break H-bar if it collides with number"

See also #12664, for changes to intruments.xml / instrumentsxml.h