### PR TITLE
Fix compiler warnings about uninitialized fields

### DIFF
--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -36,6 +36,14 @@ struct Item
     T type;
     AsciiStringView xml;
     TranslatableString userName;
+
+    // NOTE Ideally we would write `TranslatableString userName = {};` and omit these constructors
+    // But that causes internal compiler errors with certain versions of GCC/MinGW
+    // See discussion at https://github.com/musescore/MuseScore/pull/12612
+
+    Item() = default;
+    Item(T type, AsciiStringView xml, const TranslatableString& userName = {})
+        : type(type), xml(xml), userName(userName) {}
 };
 
 template<typename T, typename C>


### PR DESCRIPTION
The workaround for an internal error in certain versions of GCC/MinGW from PR #12612 turned out to cause a lot of (correct) compiler warnings about uninitialized members. So we use another workaround. Added a comment in the code to describe the situation.