### PR TITLE
Fix crash when applying TextBase-derived element to empty segment

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1712,6 +1712,10 @@ void NotationInteraction::applyDropPaletteElement(mu::engraving::Score* score, m
                                                   Qt::KeyboardModifiers modifiers,
                                                   PointF pt, bool pasteMode)
 {
+    if (!target) {
+        return;
+    }
+
     mu::engraving::EditData newData(&m_scoreCallbacks);
     mu::engraving::EditData* dropData = &newData;
 


### PR DESCRIPTION
Resolves: #12622

Simpler steps to reproduce the issue:
1. Enter notes like this and make a range selection like this:
    <img width="205" alt="Schermafbeelding 2022-08-02 om 01 19 05" src="https://user-images.githubusercontent.com/48658420/182261072-1e253f88-35c2-4574-a14f-300d14326495.png">
    Note that the second staff is empty, i.e. on this staff, the selected "segment" does not contain any element, which causes the crash.
    _Do not_ select the first note of the measure, because the full measure rest is technically part of the first segment, so if you select the first segment, it will contain an element on every staff, so no crash will occur. 
    The notes on the outer staves are necessary purely in order to be able to make such a range selection
2. Click any text-derived element in the Palettes, for example a dynamic -> crash

This PR simply adds a check to see if there was actually an element.