### PR TITLE
Un-XML-escape instrument names in Instruments panel

### DIFF
--- a/src/engraving/libmscore/instrument.cpp
+++ b/src/engraving/libmscore/instrument.cpp
@@ -30,15 +30,16 @@
 #include "compat/midi/event.h"
 #include "compat/midi/midipatch.h"
 
-#include "drumset.h"
 #include "articulation.h"
-#include "utils.h"
-#include "stringdata.h"
+#include "drumset.h"
 #include "instrtemplate.h"
+#include "masterscore.h"
 #include "mscore.h"
 #include "part.h"
 #include "score.h"
-#include "masterscore.h"
+#include "stringdata.h"
+#include "textbase.h"
+#include "utils.h"
 
 #include "log.h"
 
@@ -236,10 +237,10 @@ Instrument::~Instrument()
 //   StaffName
 //---------------------------------------------------------
 
-StaffName::StaffName(const String& s, int p)
-    : _name(s), _pos(p)
+StaffName::StaffName(const String& xmlText, int pos)
+    : _name(xmlText), _pos(pos)
 {
-    Text::validateText(_name);   // enforce HTML encoding
+    TextBase::validateText(_name);   // enforce HTML encoding
 }
 
 //---------------------------------------------------------
@@ -1425,6 +1426,16 @@ String Instrument::family() const
     return search.instrTemplate->familyId();
 }
 
+String StaffName::toPlainText() const
+{
+    return TextBase::unEscape(_name);
+}
+
+StaffName StaffName::fromPlainText(const String& plainText, int pos)
+{
+    return { TextBase::plainToXmlText(plainText), pos };
+}
+
 //---------------------------------------------------------
 //   operator==
 //---------------------------------------------------------
@@ -1694,14 +1705,24 @@ void Instrument::setTrackName(const String& s)
     _trackName = s;
 }
 
-String Instrument::name() const
+String Instrument::nameAsXmlText() const
 {
     return !_longNames.empty() ? _longNames.front().name() : String();
 }
 
-String Instrument::abbreviature() const
+String Instrument::nameAsPlainText() const
+{
+    return !_longNames.empty() ? _longNames.front().toPlainText() : String();
+}
+
+String Instrument::abbreviatureAsXmlText() const
 {
     return !_shortNames.empty() ? _shortNames.front().name() : String();
+}
+
+String Instrument::abbreviatureAsPlainText() const
+{
+    return !_shortNames.empty() ? _shortNames.front().toPlainText() : String();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/instrument.h
+++ b/src/engraving/libmscore/instrument.h
@@ -56,8 +56,11 @@ class StaffName
     int _pos = 0;       // even number -> between staves
 
 public:
-    StaffName() {}
-    StaffName(const String& s, int p=0);
+    StaffName() = default;
+    StaffName(const String& xmlText, int pos = 0);
+
+    String toPlainText() const;
+    static StaffName fromPlainText(const String& plainText, int pos = 0);
 
     bool operator==(const StaffName&) const;
     String toString() const;
@@ -416,8 +419,10 @@ public:
 
     String trackName() const;
     void setTrackName(const String& s);
-    String name() const;
-    String abbreviature() const;
+    String nameAsXmlText() const;
+    String nameAsPlainText() const;
+    String abbreviatureAsXmlText() const;
+    String abbreviatureAsPlainText() const;
     static Instrument fromTemplate(const InstrumentTemplate* t);
 
     Trait trait() const;

--- a/src/instrumentsscene/view/instrumentsettingsmodel.cpp
+++ b/src/instrumentsscene/view/instrumentsettingsmodel.cpp
@@ -49,8 +49,8 @@ void InstrumentSettingsModel::load(const QVariant& instrument)
     }
 
     m_partName = part->partName();
-    m_instrumentName = part->instrument()->name();
-    m_instrumentAbbreviature = part->instrument()->abbreviature();
+    m_instrumentName = part->instrument()->nameAsPlainText();
+    m_instrumentAbbreviature = part->instrument()->abbreviatureAsPlainText();
 
     context()->currentNotationChanged().onNotify(this, [this]() {
         emit isMainScoreChanged();
@@ -75,8 +75,8 @@ void InstrumentSettingsModel::replaceInstrument()
     masterNotationParts()->replaceInstrument(m_instrumentKey, newInstrument);
 
     m_instrumentKey.instrumentId = newInstrument.id();
-    m_instrumentName = newInstrument.name();
-    m_instrumentAbbreviature = newInstrument.abbreviature();
+    m_instrumentName = newInstrument.nameAsPlainText();
+    m_instrumentAbbreviature = newInstrument.abbreviatureAsPlainText();
 
     emit dataChanged();
 }

--- a/src/instrumentsscene/view/parttreeitem.cpp
+++ b/src/instrumentsscene/view/parttreeitem.cpp
@@ -48,7 +48,7 @@ void PartTreeItem::init(const notation::Part* masterPart)
     }
 
     setId(part->id());
-    setTitle(part->instrument()->name());
+    setTitle(part->instrument()->nameAsPlainText());
     setIsVisible(visible);
     setIsEditable(partExists);
     setIsExpandable(partExists);

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -387,7 +387,7 @@ void NotationParts::setInstrumentAbbreviature(const InstrumentKey& instrumentKey
         return;
     }
 
-    if (instrument->abbreviature() == abbreviature) {
+    if (instrument->abbreviatureAsPlainText() == abbreviature) {
         return;
     }
 

--- a/src/notation/view/widgets/editstaff.cpp
+++ b/src/notation/view/widgets/editstaff.cpp
@@ -209,21 +209,15 @@ void EditStaff::updateInstrument()
 {
     updateInterval(m_instrument.transpose());
 
-    std::list<mu::engraving::StaffName>& snl = m_instrument.shortNames();
-    QString df = snl.empty() ? u"" : snl.front().name();
-    shortName->setPlainText(df);
-
-    std::list<mu::engraving::StaffName>& lnl = m_instrument.longNames();
-    df = lnl.empty() ? u"" : lnl.front().name();
-
-    longName->setPlainText(df);
+    longName->setPlainText(m_instrument.nameAsPlainText());
+    shortName->setPlainText(m_instrument.abbreviatureAsPlainText());
 
     if (partName->text() == instrumentName->text()) {
         // Updates part name if no custom name has been set before
-        partName->setText(m_instrument.name());
+        partName->setText(m_instrument.nameAsPlainText());
     }
 
-    instrumentName->setText(m_instrument.name());
+    instrumentName->setText(m_instrument.nameAsPlainText());
 
     m_minPitchA = m_instrument.minPitchA();
     m_maxPitchA = m_instrument.maxPitchA();


### PR DESCRIPTION
and in Staff/Part Properties too

But still allow entering XML tags, to allow text formatting and symbols

Resolves: a comment from Elnur