### PR TITLE
Fix beamgroups not set correctly on score created from template

### DIFF
--- a/src/engraving/libmscore/staff.cpp
+++ b/src/engraving/libmscore/staff.cpp
@@ -675,7 +675,9 @@ void Staff::addTimeSig(TimeSig* timesig)
 void Staff::removeTimeSig(TimeSig* timesig)
 {
     if (timesig->segment()->segmentType() == SegmentType::TimeSig) {
-        timesigs.erase(timesig->segment()->tick().ticks());
+        if (timesigs[timesig->segment()->tick().ticks()] == timesig) {
+            timesigs.erase(timesig->segment()->tick().ticks());
+        }
     }
 //      dumpTimeSigs("after removeTimeSig");
 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11657

When `Staff::removeTimeSig` is called with a `TimeSig` object, it removes the signature at that object's position without even checking to see if it's the right one to remove. This PR adds that check!