### PR TITLE
[cleanup] Replace Score::FileError with engraving::Err

### DIFF
--- a/src/engraving/compat/mscxcompat.h
+++ b/src/engraving/compat/mscxcompat.h
@@ -26,8 +26,8 @@
 #include "engravingproject.h"
 
 namespace mu::engraving::compat {
-Score::FileError mscxToMscz(const String& mscxFilePath, ByteArray* msczData);
-Score::FileError loadMsczOrMscx(MasterScore* score, const String& path, bool ignoreVersionError = false);
+Err mscxToMscz(const String& mscxFilePath, ByteArray* msczData);
+Err loadMsczOrMscx(MasterScore* score, const String& path, bool ignoreVersionError = false);
 Err loadMsczOrMscx(EngravingProjectPtr project, const String& path, bool ignoreVersionError = false);
 }
 

--- a/src/engraving/engravingerrors.h
+++ b/src/engraving/engravingerrors.h
@@ -23,9 +23,9 @@
 #ifndef MU_ENGRAVING_ENGRAVINGERRORS_H
 #define MU_ENGRAVING_ENGRAVINGERRORS_H
 
-#include "libmscore/masterscore.h"
-
+#include "io/path.h"
 #include "types/ret.h"
+
 #include "translation.h"
 
 namespace mu::engraving {
@@ -44,7 +44,7 @@ enum class Err {
     FileTooNew = 2007,
     FileOld300Format = 2008,
     FileCorrupted = 2009,
-    FileCriticalCorrupted = 2010,
+    FileCriticallyCorrupted = 2010,
 
     UserAbort = 2011,
     IgnoreError = 2012
@@ -88,7 +88,7 @@ inline Ret make_ret(Err err, const io::path_t& filePath = "")
     case Err::FileCorrupted:
         text = mtrc("engraving", "File \"%1\" is corrupted.").arg(filePath.toString());
         break;
-    case Err::FileCriticalCorrupted:
+    case Err::FileCriticallyCorrupted:
         text = mtrc("engraving", "File \"%1\" is critically corrupted and cannot be processed.").arg(filePath.toString());
         break;
     case Err::Undefined:
@@ -100,32 +100,6 @@ inline Ret make_ret(Err err, const io::path_t& filePath = "")
     }
 
     return mu::Ret(static_cast<int>(err), text.toStdString());
-}
-
-inline Err scoreFileErrorToErr(Score::FileError err)
-{
-    switch (err) {
-    case Score::FileError::FILE_NO_ERROR:       return Err::NoError;
-    case Score::FileError::FILE_ERROR:          return Err::FileUnknownError;
-    case Score::FileError::FILE_NOT_FOUND:      return Err::FileNotFound;
-    case Score::FileError::FILE_OPEN_ERROR:     return Err::FileOpenError;
-    case Score::FileError::FILE_BAD_FORMAT:     return Err::FileBadFormat;
-    case Score::FileError::FILE_UNKNOWN_TYPE:   return Err::FileUnknownType;
-    case Score::FileError::FILE_NO_ROOTFILE:    return Err::FileBadFormat;
-    case Score::FileError::FILE_TOO_OLD:        return Err::FileTooOld;
-    case Score::FileError::FILE_TOO_NEW:        return Err::FileTooNew;
-    case Score::FileError::FILE_OLD_300_FORMAT: return Err::FileOld300Format;
-    case Score::FileError::FILE_CORRUPTED:      return Err::FileCorrupted;
-    case Score::FileError::FILE_CRITICALLY_CORRUPTED: return Err::FileCriticalCorrupted;
-    case Score::FileError::FILE_USER_ABORT:      return Err::UserAbort;
-    case Score::FileError::FILE_IGNORE_ERROR:    return Err::IgnoreError;
-    }
-    return Err::FileUnknownError;
-}
-
-inline Ret scoreFileErrorToRet(Score::FileError err, const io::path_t& filePath)
-{
-    return make_ret(scoreFileErrorToErr(err), filePath);
 }
 }
 

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -366,28 +366,12 @@ public:
 //    a Score has always an associated MasterScore
 //---------------------------------------------------------------------------------------
 typedef std::map<ElementType, std::map<ElementType, double> > PaddingTable;
+
 class Score : public EngravingObject
 {
     OBJECT_ALLOCATOR(engraving, Score)
 
     INJECT(engraving, mu::draw::IImageProvider, imageProvider)
-public:
-    enum class FileError : char {
-        FILE_NO_ERROR,
-        FILE_ERROR,
-        FILE_NOT_FOUND,
-        FILE_OPEN_ERROR,
-        FILE_BAD_FORMAT,
-        FILE_UNKNOWN_TYPE,
-        FILE_NO_ROOTFILE,
-        FILE_TOO_OLD,
-        FILE_TOO_NEW,
-        FILE_OLD_300_FORMAT,
-        FILE_CORRUPTED,
-        FILE_CRITICALLY_CORRUPTED,
-        FILE_USER_ABORT,
-        FILE_IGNORE_ERROR
-    };
 
 private:
 

--- a/src/engraving/rw/compat/read114.cpp
+++ b/src/engraving/rw/compat/read114.cpp
@@ -2751,7 +2751,7 @@ static void readStyle(MStyle* style, XmlReader& e, ReadChordListHook& readChordL
 //    import old version <= 1.3 files
 //---------------------------------------------------------
 
-Score::FileError Read114::read114(MasterScore* masterScore, XmlReader& e, ReadContext& ctx)
+Err Read114::read114(MasterScore* masterScore, XmlReader& e, ReadContext& ctx)
 {
     TempoMap tm;
     while (e.readNextStartElement()) {
@@ -2917,7 +2917,7 @@ Score::FileError Read114::read114(MasterScore* masterScore, XmlReader& e, ReadCo
 
     if (e.error() != XmlStreamReader::NoError) {
         LOGD("%lld %lld: %s ", e.lineNumber(), e.columnNumber(), muPrintable(e.errorString()));
-        return Score::FileError::FILE_BAD_FORMAT;
+        return Err::FileBadFormat;
     }
 
     for (Staff* s : masterScore->staves()) {
@@ -3161,5 +3161,5 @@ Score::FileError Read114::read114(MasterScore* masterScore, XmlReader& e, ReadCo
     masterScore->rebuildMidiMapping();
     masterScore->updateChannel();
 
-    return Score::FileError::FILE_NO_ERROR;
+    return Err::NoError;
 }

--- a/src/engraving/rw/compat/read114.h
+++ b/src/engraving/rw/compat/read114.h
@@ -23,9 +23,11 @@
 #ifndef MU_ENGRAVING_READ114_H
 #define MU_ENGRAVING_READ114_H
 
-#include "libmscore/masterscore.h"
+#include "engravingerrors.h"
 
 namespace mu::engraving {
+class MasterScore;
+class ReadContext;
 class XmlReader;
 }
 
@@ -37,7 +39,7 @@ public:
     //   read114
     //    import old version <= 1.3 files
     //---------------------------------------------------------
-    static Score::FileError read114(MasterScore* masterScore, XmlReader& e, ReadContext& ctx);
+    static Err read114(MasterScore* masterScore, XmlReader& e, ReadContext& ctx);
 };
 }
 

--- a/src/engraving/rw/compat/read206.cpp
+++ b/src/engraving/rw/compat/read206.cpp
@@ -3367,7 +3367,7 @@ bool Read206::readScore206(Score* score, XmlReader& e, ReadContext& ctx)
     return true;
 }
 
-Score::FileError Read206::read206(mu::engraving::MasterScore* masterScore, XmlReader& e, ReadContext& ctx)
+Err Read206::read206(mu::engraving::MasterScore* masterScore, XmlReader& e, ReadContext& ctx)
 {
     while (e.readNextStartElement()) {
         const AsciiStringView tag(e.name());
@@ -3377,7 +3377,7 @@ Score::FileError Read206::read206(mu::engraving::MasterScore* masterScore, XmlRe
             masterScore->setMscoreRevision(e.readInt(nullptr, 16));
         } else if (tag == "Score") {
             if (!readScore206(masterScore, e, ctx)) {
-                return Score::FileError::FILE_BAD_FORMAT;
+                return Err::FileBadFormat;
             }
         } else if (tag == "Revision") {
             e.skipCurrentElement();
@@ -3438,5 +3438,5 @@ Score::FileError Read206::read206(mu::engraving::MasterScore* masterScore, XmlRe
         i.first->setOffset(i.second - i.first->pos());
     }
 
-    return Score::FileError::FILE_NO_ERROR;
+    return Err::NoError;
 }

--- a/src/engraving/rw/compat/read206.h
+++ b/src/engraving/rw/compat/read206.h
@@ -23,6 +23,7 @@
 #ifndef MU_ENGRAVING_READ206_H
 #define MU_ENGRAVING_READ206_H
 
+#include "engravingerrors.h"
 #include "style/styledef.h"
 #include "draw/types/geometry.h"
 #include "libmscore/score.h"
@@ -55,7 +56,7 @@ public:
     //   read206
     //    import old version > 1.3  and < 3.x files
     //---------------------------------------------------------
-    static Score::FileError read206(MasterScore* masterScore, XmlReader& e, ReadContext& ctx);
+    static Err read206(MasterScore* masterScore, XmlReader& e, ReadContext& ctx);
 
     static EngravingItem* readArticulation(EngravingItem*, XmlReader&, const ReadContext& ctx);
     static void readAccidental206(Accidental*, XmlReader&);

--- a/src/engraving/rw/compat/read302.cpp
+++ b/src/engraving/rw/compat/read302.cpp
@@ -263,7 +263,7 @@ bool Read302::readScore302(Score* score, XmlReader& e, ReadContext& ctx)
     return true;
 }
 
-Score::FileError Read302::read302(MasterScore* masterScore, XmlReader& e, ReadContext& ctx)
+Err Read302::read302(MasterScore* masterScore, XmlReader& e, ReadContext& ctx)
 {
     while (e.readNextStartElement()) {
         const AsciiStringView tag(e.name());
@@ -274,14 +274,14 @@ Score::FileError Read302::read302(MasterScore* masterScore, XmlReader& e, ReadCo
         } else if (tag == "Score") {
             if (!readScore302(masterScore, e, ctx)) {
                 if (e.error() == XmlStreamReader::CustomError) {
-                    return Score::FileError::FILE_CRITICALLY_CORRUPTED;
+                    return Err::FileCriticallyCorrupted;
                 }
-                return Score::FileError::FILE_BAD_FORMAT;
+                return Err::FileBadFormat;
             }
         } else if (tag == "Revision") {
             e.skipCurrentElement();
         }
     }
 
-    return Score::FileError::FILE_NO_ERROR;
+    return Err::NoError;
 }

--- a/src/engraving/rw/compat/read302.h
+++ b/src/engraving/rw/compat/read302.h
@@ -22,9 +22,13 @@
 #ifndef MU_ENGRAVING_READ302_H
 #define MU_ENGRAVING_READ302_H
 
-#include "libmscore/masterscore.h"
+#include "engravingerrors.h"
 
 namespace mu::engraving {
+class MasterScore;
+class Score;
+
+class ReadContext;
 class XmlReader;
 }
 
@@ -33,7 +37,7 @@ class Read302
 {
 public:
 
-    static Score::FileError read302(MasterScore* masterScore, XmlReader& e, ReadContext& ctx);
+    static Err read302(MasterScore* masterScore, XmlReader& e, ReadContext& ctx);
 
 private:
     static bool readScore302(Score* score, XmlReader& e, ReadContext& ctx);

--- a/src/engraving/rw/scorereader.cpp
+++ b/src/engraving/rw/scorereader.cpp
@@ -177,14 +177,11 @@ Err ScoreReader::read(MasterScore* score, XmlReader& e, ReadContext& ctx, compat
 
             Err err = Err::NoError;
             if (score->mscVersion() <= 114) {
-                Score::FileError error = compat::Read114::read114(score, e, ctx);
-                err = scoreFileErrorToErr(error);
+                err = compat::Read114::read114(score, e, ctx);
             } else if (score->mscVersion() <= 207) {
-                Score::FileError error = compat::Read206::read206(score, e, ctx);
-                err = scoreFileErrorToErr(error);
+                err = compat::Read206::read206(score, e, ctx);
             } else if (score->mscVersion() < 400 || MScore::testMode) {
-                Score::FileError error = compat::Read302::read302(score, e, ctx);
-                err = scoreFileErrorToErr(error);
+                err = compat::Read302::read302(score, e, ctx);
             } else {
                 //! NOTE: make sure we have a chord list
                 //! Load the default chord list otherwise
@@ -217,7 +214,7 @@ Err ScoreReader::doRead(MasterScore* score, XmlReader& e, ReadContext& ctx)
         } else if (tag == "Score") {
             if (!Read400::readScore400(score, e, ctx)) {
                 if (e.error() == XmlStreamReader::CustomError) {
-                    return Err::FileCriticalCorrupted;
+                    return Err::FileCriticallyCorrupted;
                 }
                 return Err::FileBadFormat;
             }

--- a/src/engraving/utests/utils/scorerw.cpp
+++ b/src/engraving/utests/utils/scorerw.cpp
@@ -58,16 +58,16 @@ MasterScore* ScoreRW::readScore(const String& name, bool isAbsolutePath, ImportF
     std::string suffix = io::suffix(path);
 
     ScoreLoad sl;
-    Score::FileError rv;
+    Err rv;
     if (suffix == "mscz" || suffix == "mscx") {
         rv = compat::loadMsczOrMscx(score, path.toString(), false);
     } else if (importFunc) {
         rv = importFunc(score, path);
     } else {
-        rv = Score::FileError::FILE_UNKNOWN_TYPE;
+        rv = Err::FileUnknownType;
     }
 
-    if (rv != Score::FileError::FILE_NO_ERROR) {
+    if (rv != Err::NoError) {
         LOGE() << "can't load score, path: " << path;
         delete score;
         score = nullptr;

--- a/src/engraving/utests/utils/scorerw.h
+++ b/src/engraving/utests/utils/scorerw.h
@@ -27,6 +27,7 @@
 
 #include "types/string.h"
 
+#include "engraving/engravingerrors.h"
 #include "engraving/libmscore/masterscore.h"
 
 namespace mu::engraving {
@@ -38,7 +39,7 @@ public:
     static void setRootPath(const String& path);
     static String rootPath();
 
-    using ImportFunc = std::function<Score::FileError(MasterScore* score, const io::path_t& path)>;
+    using ImportFunc = std::function<Err(MasterScore* score, const io::path_t& path)>;
 
     static MasterScore* readScore(const String& path, bool isAbsolutePath = false, ImportFunc importFunc = nullptr);
     static bool saveScore(Score* score, const String& name);

--- a/src/importexport/bb/internal/bb.cpp
+++ b/src/importexport/bb/internal/bb.cpp
@@ -20,8 +20,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "libmscore/mscore.h"
 #include "bb.h"
+
+#include "engravingerrors.h"
+#include "libmscore/mscore.h"
 
 #include "libmscore/factory.h"
 #include "libmscore/masterscore.h"
@@ -389,15 +391,15 @@ bool BBFile::read(const QString& name)
 //   importBB
 //---------------------------------------------------------
 
-Score::FileError importBB(MasterScore* score, const QString& name)
+Err importBB(MasterScore* score, const QString& name)
 {
     BBFile bb;
     if (!QFileInfo::exists(name)) {
-        return Score::FileError::FILE_NOT_FOUND;
+        return engraving::Err::FileNotFound;
     }
     if (!bb.read(name)) {
         LOGD("Cannot open file <%s>", qPrintable(name));
-        return Score::FileError::FILE_OPEN_ERROR;
+        return engraving::Err::FileOpenError;
     }
     score->style().set(Sid::chordsXmlFile, true);
     score->chordList()->read(u"chords.xml");
@@ -561,7 +563,7 @@ Score::FileError importBB(MasterScore* score, const QString& name)
         sks->add(keysig);
     }
     score->setUpTempoMap();
-    return Score::FileError::FILE_NO_ERROR;
+    return engraving::Err::NoError;
 }
 
 //---------------------------------------------------------

--- a/src/importexport/bb/internal/notationbbreader.cpp
+++ b/src/importexport/bb/internal/notationbbreader.cpp
@@ -28,11 +28,11 @@ using namespace mu::iex::bb;
 using namespace mu::engraving;
 
 namespace mu::iex::bb {
-extern Score::FileError importBB(MasterScore* score, const QString& name);
+extern Err importBB(MasterScore* score, const QString& name);
 }
 
 mu::Ret NotationBBReader::read(MasterScore* score, const io::path_t& path, const Options&)
 {
-    Score::FileError err = importBB(score, path.toQString());
-    return scoreFileErrorToRet(err, path);
+    Err err = importBB(score, path.toQString());
+    return make_ret(err, path);
 }

--- a/src/importexport/bb/tests/testbase.cpp
+++ b/src/importexport/bb/tests/testbase.cpp
@@ -43,7 +43,7 @@ using namespace mu::io;
 using namespace mu::engraving;
 
 namespace mu::iex::bb {
-extern Score::FileError importBB(MasterScore* score, const QString& name);
+extern Err importBB(MasterScore* score, const QString& name);
 }
 
 namespace mu::engraving {
@@ -60,16 +60,16 @@ MasterScore* MTest::readScore(const QString& name)
     std::string suffix = io::suffix(path);
 
     ScoreLoad sl;
-    Score::FileError rv;
+    Err rv;
     if (suffix == "mscz" || suffix == "mscx") {
         rv = compat::loadMsczOrMscx(score, path, false);
     } else if (suffix == "sgu") {
         rv = iex::bb::importBB(score, path);
     } else {
-        rv = Score::FileError::FILE_UNKNOWN_TYPE;
+        rv = Err::FileUnknownType;
     }
 
-    if (rv != Score::FileError::FILE_NO_ERROR) {
+    if (rv != Err::NoError) {
         LOGE() << "cannot load file at " << path;
         delete score;
         score = nullptr;

--- a/src/importexport/bww/internal/bww/importbww.cpp
+++ b/src/importexport/bww/internal/bww/importbww.cpp
@@ -29,6 +29,7 @@
 #include "writer.h"
 #include "parser.h"
 
+#include "engraving/engravingerrors.h"
 #include "engraving/types/fraction.h"
 
 #include "libmscore/factory.h"
@@ -543,16 +544,16 @@ namespace mu::iex::bww {
 //   importBww
 //---------------------------------------------------------
 
-Score::FileError importBww(MasterScore* score, const QString& path)
+Err importBww(MasterScore* score, const QString& path)
 {
     LOGD("Score::importBww(%s)", qPrintable(path));
 
     QFile fp(path);
     if (!fp.exists()) {
-        return Score::FileError::FILE_NOT_FOUND;
+        return engraving::Err::FileNotFound;
     }
     if (!fp.open(QIODevice::ReadOnly)) {
-        return Score::FileError::FILE_OPEN_ERROR;
+        return engraving::Err::FileOpenError;
     }
 
     Part* part = new Part(score);
@@ -570,6 +571,6 @@ Score::FileError importBww(MasterScore* score, const QString& path)
     score->setSaved(false);
     score->connectTies();
     LOGD("Score::importBww() done");
-    return Score::FileError::FILE_NO_ERROR;        // OK
+    return engraving::Err::NoError; // OK
 }
 }

--- a/src/importexport/bww/internal/notationbwwreader.cpp
+++ b/src/importexport/bww/internal/notationbwwreader.cpp
@@ -28,11 +28,11 @@ using namespace mu::iex::bww;
 using namespace mu::engraving;
 
 namespace mu::iex::bww {
-extern Score::FileError importBww(MasterScore*, const QString& name);
+extern Err importBww(MasterScore*, const QString& name);
 }
 
 mu::Ret NotationBwwReader::read(MasterScore* score, const io::path_t& path, const Options&)
 {
-    Score::FileError err = importBww(score, path.toQString());
-    return scoreFileErrorToRet(err, path);
+    Err err = importBww(score, path.toQString());
+    return make_ret(err, path);
 }

--- a/src/importexport/bww/tests/testbase.cpp
+++ b/src/importexport/bww/tests/testbase.cpp
@@ -57,14 +57,14 @@ MasterScore* MTest::readScore(const QString& name)
     std::string suffix = io::suffix(path);
 
     ScoreLoad sl;
-    Score::FileError rv;
+    Err rv;
     if (suffix == "mscz" || suffix == "mscx") {
         rv = compat::loadMsczOrMscx(score, path.toQString(), false);
     } else {
-        rv = Score::FileError::FILE_UNKNOWN_TYPE;
+        rv = Err::FileUnknownType;
     }
 
-    if (rv != Score::FileError::FILE_NO_ERROR) {
+    if (rv != Err::NoError) {
         LOGE() << "cannot load file at " << path;
         delete score;
         score = nullptr;

--- a/src/importexport/capella/internal/capella.cpp
+++ b/src/importexport/capella/internal/capella.cpp
@@ -23,16 +23,19 @@
 //
 //    Capella 2000 import filter
 //
+#include "capella.h"
+
 #include <assert.h>
 #include <cmath>
+
+#include <QFile>
 #include <QtMath>
 
+#include "engraving/engravingerrors.h"
 #include "libmscore/mscore.h"
-#include "capella.h"
 
 #include "translation.h"
 #include "infrastructure/messagebox.h"
-#include "types/typesconv.h"
 
 #include "libmscore/factory.h"
 #include "libmscore/masterscore.h"
@@ -2793,14 +2796,14 @@ void Capella::read(QFile* fp)
 //   importCapella
 //---------------------------------------------------------
 
-Score::FileError importCapella(MasterScore* score, const QString& name)
+Err importCapella(MasterScore* score, const QString& name)
 {
     QFile fp(name);
     if (!fp.exists()) {
-        return Score::FileError::FILE_NOT_FOUND;
+        return Err::FileNotFound;
     }
     if (!fp.open(QIODevice::ReadOnly)) {
-        return Score::FileError::FILE_OPEN_ERROR;
+        return Err::FileOpenError;
     }
 
     Capella cf;
@@ -2815,10 +2818,10 @@ Score::FileError importCapella(MasterScore* score, const QString& name)
         }
         fp.close();
         // avoid another error message box
-        return Score::FileError::FILE_NO_ERROR;
+        return Err::NoError;
     }
     fp.close();
     convertCapella(score, &cf, false);
-    return Score::FileError::FILE_NO_ERROR;
+    return Err::NoError;
 }
 }

--- a/src/importexport/capella/internal/capella.h
+++ b/src/importexport/capella/internal/capella.h
@@ -26,6 +26,8 @@
 #include "engraving/rw/xml.h"
 #include "engraving/types/types.h"
 
+class QFile;
+
 namespace mu::iex::capella {
 enum class TIMESTEP : char {
     D1, D2, D4, D8, D16, D32, D64, D128, D256, D_BREVE

--- a/src/importexport/capella/internal/capellareader.cpp
+++ b/src/importexport/capella/internal/capellareader.cpp
@@ -30,18 +30,18 @@ using namespace mu::iex::capella;
 using namespace mu::engraving;
 
 namespace mu::iex::capella {
-extern Score::FileError importCapella(MasterScore*, const QString& name);
-extern Score::FileError importCapXml(MasterScore*, const QString& name);
+extern Err importCapella(MasterScore*, const QString& name);
+extern Err importCapXml(MasterScore*, const QString& name);
 }
 
 mu::Ret CapellaReader::read(MasterScore* score, const io::path_t& path, const Options&)
 {
-    Score::FileError err = Score::FileError::FILE_UNKNOWN_TYPE;
+    Err err = Err::FileUnknownType;
     std::string suffix = mu::io::suffix(path);
     if (suffix == "cap") {
         err = importCapella(score, path.toQString());
     } else if (suffix == "capx") {
         err = importCapXml(score, path.toQString());
     }
-    return scoreFileErrorToRet(err, path);
+    return make_ret(err, path);
 }

--- a/src/importexport/capella/internal/capxml.cpp
+++ b/src/importexport/capella/internal/capxml.cpp
@@ -20,6 +20,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include "capella.h"
+
 //    CapXML import filter
 //    Supports the CapXML 1.0 file format version 1.0.8 (capella 2008)
 //    The implementation shares as much code as possible with the capella
@@ -28,11 +30,12 @@
 
 #include <assert.h>
 #include <cmath>
+
 #include <QRegularExpression>
 
+#include "engravingerrors.h"
 #include "libmscore/masterscore.h"
 #include "serialization/zipreader.h"
-#include "capella.h"
 
 #include "log.h"
 
@@ -1301,13 +1304,13 @@ void Capella::readCapx(XmlReader& e)
 
 void convertCapella(Score* score, Capella* cap, bool capxMode);
 
-Score::FileError importCapXml(MasterScore* score, const QString& name)
+Err importCapXml(MasterScore* score, const QString& name)
 {
     LOGD("importCapXml(score %p, name %s)", score, qPrintable(name));
     ZipReader uz(name);
     if (!uz.exists()) {
         LOGD("importCapXml: <%s> not found", qPrintable(name));
-        return Score::FileError::FILE_NOT_FOUND;
+        return Err::FileNotFound;
     }
 
     ByteArray dbuf = uz.fileData("score.xml");
@@ -1326,6 +1329,6 @@ Score::FileError importCapXml(MasterScore* score, const QString& name)
     }
 
     convertCapella(score, &cf, true);
-    return Score::FileError::FILE_NO_ERROR;
+    return Err::NoError;
 }
 }

--- a/src/importexport/capella/tests/capella_tests.cpp
+++ b/src/importexport/capella/tests/capella_tests.cpp
@@ -22,17 +22,18 @@
 
 #include <gtest/gtest.h>
 
-#include "libmscore/masterscore.h"
+#include "engraving/engravingerrors.h"
+#include "engraving/libmscore/masterscore.h"
 
-#include "engraving/utests/utils/scorerw.h"
 #include "engraving/utests/utils/scorecomp.h"
+#include "engraving/utests/utils/scorerw.h"
 
 using namespace mu;
 using namespace mu::engraving;
 
 namespace mu::iex::capella {
-extern Score::FileError importCapella(MasterScore*, const QString& name);
-extern Score::FileError importCapXml(MasterScore*, const QString& name);
+extern engraving::Err importCapella(MasterScore*, const QString& name);
+extern engraving::Err importCapXml(MasterScore*, const QString& name);
 }
 
 static const String CAPELLA_DIR("data/");
@@ -51,7 +52,7 @@ public:
 
 void Capella_Tests::capReadTest(const char* file)
 {
-    auto importFunc = [](MasterScore* score, const io::path_t& path) -> Score::FileError {
+    auto importFunc = [](MasterScore* score, const io::path_t& path) -> engraving::Err {
         return mu::iex::capella::importCapella(score, path.toQString());
     };
 
@@ -71,7 +72,7 @@ void Capella_Tests::capReadTest(const char* file)
 
 void Capella_Tests::capxReadTest(const char* file)
 {
-    auto importFunc = [](MasterScore* score, const io::path_t& path) -> Score::FileError {
+    auto importFunc = [](MasterScore* score, const io::path_t& path) -> engraving::Err {
         return mu::iex::capella::importCapXml(score, path.toQString());
     };
 

--- a/src/importexport/guitarpro/internal/guitarproreader.cpp
+++ b/src/importexport/guitarpro/internal/guitarproreader.cpp
@@ -27,7 +27,7 @@
 #include "engraving/engravingerrors.h"
 
 namespace mu::engraving {
-extern Score::FileError importGTP(MasterScore*, mu::io::IODevice* io, bool createLinkedTabForce = false);
+extern Err importGTP(MasterScore*, mu::io::IODevice* io, bool createLinkedTabForce = false);
 }
 
 using namespace mu::iex::guitarpro;
@@ -35,6 +35,6 @@ using namespace mu::iex::guitarpro;
 mu::Ret GuitarProReader::read(mu::engraving::MasterScore* score, const io::path_t& path, const Options&)
 {
     mu::io::File file(path);
-    mu::engraving::Score::FileError err = mu::engraving::importGTP(score, &file);
-    return mu::engraving::scoreFileErrorToRet(err, path);
+    mu::engraving::Err err = mu::engraving::importGTP(score, &file);
+    return mu::engraving::make_ret(err, path);
 }

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -2952,10 +2952,10 @@ static void createLinkedTabs(MasterScore* score)
 //   importScore
 //---------------------------------------------------------
 
-static Score::FileError importScore(MasterScore* score, mu::io::IODevice* io)
+static Err importScore(MasterScore* score, mu::io::IODevice* io)
 {
     if (!io->open(IODevice::ReadOnly)) {
-        return Score::FileError::FILE_OPEN_ERROR;
+        return Err::FileOpenError;
     }
 
     score->loadStyle(u":/engraving/styles/gp-style.mss");
@@ -3000,7 +3000,7 @@ static Score::FileError importScore(MasterScore* score, mu::io::IODevice* io)
             s = s.mid(21);
         } else {
             LOGD("unknown gtp format <%s>", ss);
-            return Score::FileError::FILE_BAD_FORMAT;
+            return Err::FileBadFormat;
         }
         int a = s.left(1).toInt();
         int b = s.mid(2).toInt();
@@ -3017,18 +3017,18 @@ static Score::FileError importScore(MasterScore* score, mu::io::IODevice* io)
             gp = new GuitarPro5(score, version);
         } else {
             LOGD("unknown gtp format %d", version);
-            return Score::FileError::FILE_BAD_FORMAT;
+            return Err::FileBadFormat;
         }
         gp->initGuitarProDrumset();
         readResult = gp->read(io);
         gp->setTempo(0, 0);
     } else {
-        return Score::FileError::FILE_BAD_FORMAT;
+        return Err::FileBadFormat;
     }
     if (readResult == false) {
         LOGD("guitar pro import error====");
         // avoid another error message box
-        return Score::FileError::FILE_NO_ERROR;
+        return Err::NoError;
     }
 
     addMetaInfo(score, gp);
@@ -3057,18 +3057,18 @@ static Score::FileError importScore(MasterScore* score, mu::io::IODevice* io)
 
     delete gp;
 
-    return Score::FileError::FILE_NO_ERROR;
+    return Err::NoError;
 }
 
 //---------------------------------------------------------
 //   importGTP
 //---------------------------------------------------------
 
-Score::FileError importGTP(MasterScore* score, mu::io::IODevice* io, bool createLinkedTabForce)
+Err importGTP(MasterScore* score, mu::io::IODevice* io, bool createLinkedTabForce)
 {
-    Score::FileError error = importScore(score, io);
+    Err error = importScore(score, io);
 
-    if (error != Score::FileError::FILE_NO_ERROR) {
+    if (error != Err::NoError) {
         return error;
     }
 
@@ -3076,6 +3076,6 @@ Score::FileError importGTP(MasterScore* score, mu::io::IODevice* io, bool create
         createLinkedTabs(score);
     }
 
-    return Score::FileError::FILE_NO_ERROR;
+    return Err::NoError;
 }
 }

--- a/src/importexport/guitarpro/internal/importgtp.h
+++ b/src/importexport/guitarpro/internal/importgtp.h
@@ -31,6 +31,7 @@
 #include "gtp/gp67dombuilder.h"
 #include "libmscore/score.h"
 #include "libmscore/vibrato.h"
+#include "engraving/engravingerrors.h"
 
 #include "modularity/ioc.h"
 #include "iguitarproconfiguration.h"
@@ -55,7 +56,7 @@ static constexpr int GP_INVALID_KEYSIG = 127;
 static constexpr int GP_VOLTA_BINARY = 1;
 static constexpr int GP_VOLTA_FLAGS = 2;
 
-Score::FileError importGTP(Score* score, const String& filename, const char* data, unsigned int data_len);
+Err importGTP(Score* score, const String& filename, const char* data, unsigned int data_len);
 
 enum class Repeat : char;
 

--- a/src/importexport/guitarpro/internal/importptb.cpp
+++ b/src/importexport/guitarpro/internal/importptb.cpp
@@ -1231,10 +1231,10 @@ void PowerTab::ptPosition::addComponent(ptComponent* c)
 //   read
 //---------------------------------------------------------
 
-Score::FileError PowerTab::read()
+Err PowerTab::read()
 {
     if (!readVersion()) {
-        return Score::FileError::FILE_BAD_FORMAT;
+        return Err::FileBadFormat;
     }
     ptSong song;
 
@@ -1293,6 +1293,6 @@ Score::FileError PowerTab::read()
         s->setPlainText(String::fromStdString(name));
         m->add(s);
     }
-    return Score::FileError::FILE_NO_ERROR;
+    return Err::NoError;
 }
 }

--- a/src/importexport/guitarpro/internal/importptb.h
+++ b/src/importexport/guitarpro/internal/importptb.h
@@ -38,6 +38,8 @@
 #include <libmscore/ottava.h>
 #include <libmscore/drumset.h>
 
+#include "engraving/engravingerrors.h"
+
 namespace mu::engraving {
 class PalmMute;
 
@@ -392,6 +394,6 @@ class PowerTab
 public:
     PowerTab(mu::io::IODevice* f, MasterScore* s)
         : _file(f), score(s) {}
-    Score::FileError read();
+    Err read();
 };
 }

--- a/src/importexport/guitarpro/tests/guitarpro_tests.cpp
+++ b/src/importexport/guitarpro/tests/guitarpro_tests.cpp
@@ -39,7 +39,7 @@ using namespace mu::engraving;
 static const String GUITARPRO_DIR(u"data/");
 
 namespace mu::engraving {
-extern Score::FileError importGTP(MasterScore*, mu::io::IODevice* io, bool createLinkedTabForce = false);
+extern Err importGTP(MasterScore*, mu::io::IODevice* io, bool createLinkedTabForce = false);
 }
 
 class GuitarPro_Tests : public ::testing::Test
@@ -52,7 +52,7 @@ void GuitarPro_Tests::gpReadTest(const char* file, const char* ext)
 {
     String fileName = String::fromUtf8(file) + u'.' + String::fromUtf8(ext);
 
-    auto importFunc = [](MasterScore* score, const io::path_t& path) -> Score::FileError {
+    auto importFunc = [](MasterScore* score, const io::path_t& path) -> Err {
         mu::io::File file(path);
         return mu::engraving::importGTP(score, &file);
     };

--- a/src/importexport/midi/internal/midiimport/importmidi.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi.cpp
@@ -22,7 +22,9 @@
 
 #include <set>
 
-#include "engraving/style/style.h"
+#include <QFile>
+
+#include "engraving/engravingerrors.h"
 #include "engraving/rw/xml.h"
 
 #include "translation.h"
@@ -1220,10 +1222,10 @@ void loadMidiData(MidiFile& mf)
     mf.setMidiType(mt);
 }
 
-Score::FileError importMidi(MasterScore* score, const QString& name)
+Err importMidi(MasterScore* score, const QString& name)
 {
     if (name.isEmpty()) {
-        return Score::FileError::FILE_NOT_FOUND;
+        return Err::FileNotFound;
     }
 
     auto& opers = midiImportOperations;
@@ -1237,7 +1239,7 @@ Score::FileError importMidi(MasterScore* score, const QString& name)
         QFile fp(name);
         if (!fp.open(QIODevice::ReadOnly)) {
             LOGD("importMidi: file open error <%s>", qPrintable(name));
-            return Score::FileError::FILE_OPEN_ERROR;
+            return Err::FileOpenError;
         }
         MidiFile mf;
         try {
@@ -1251,7 +1253,7 @@ Score::FileError importMidi(MasterScore* score, const QString& name)
             }
             fp.close();
             LOGD("importMidi: bad file format");
-            return Score::FileError::FILE_BAD_FORMAT;
+            return Err::FileBadFormat;
         }
         fp.close();
 
@@ -1262,6 +1264,6 @@ Score::FileError importMidi(MasterScore* score, const QString& name)
     opers.data()->tracks = convertMidi(score, opers.midiFile(name));
     ++opers.data()->processingsOfOpenedFile;
 
-    return Score::FileError::FILE_NO_ERROR;
+    return Err::NoError;
 }
 }

--- a/src/importexport/midi/internal/notationmidireader.cpp
+++ b/src/importexport/midi/internal/notationmidireader.cpp
@@ -28,11 +28,11 @@ using namespace mu::iex::midi;
 using namespace mu::engraving;
 
 namespace mu::iex::midi {
-extern Score::FileError importMidi(MasterScore*, const QString& name);
+extern Err importMidi(MasterScore*, const QString& name);
 }
 
 mu::Ret NotationMidiReader::read(MasterScore* score, const io::path_t& path, const Options&)
 {
-    Score::FileError err = importMidi(score, path.toQString());
-    return scoreFileErrorToRet(err, path);
+    Err err = importMidi(score, path.toQString());
+    return make_ret(err, path);
 }

--- a/src/importexport/midi/tests/testbase.cpp
+++ b/src/importexport/midi/tests/testbase.cpp
@@ -56,14 +56,14 @@ MasterScore* MTest::readScore(const QString& name)
     std::string suffix = io::suffix(path);
 
     ScoreLoad sl;
-    Score::FileError rv;
+    Err rv;
     if (suffix == "mscz" || suffix == "mscx") {
         rv = compat::loadMsczOrMscx(score, path, false);
     } else {
-        rv = Score::FileError::FILE_UNKNOWN_TYPE;
+        rv = Err::FileUnknownType;
     }
 
-    if (rv != Score::FileError::FILE_NO_ERROR) {
+    if (rv != Err::NoError) {
         LOGE() << "cannot load file at " << path;
         delete score;
         score = nullptr;

--- a/src/importexport/musicxml/internal/musicxml/importmxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxml.cpp
@@ -54,7 +54,7 @@ static int musicXMLImportErrorDialog(QString text, QString detailedText)
 //   importMusicXMLfromBuffer
 //---------------------------------------------------------
 
-Score::FileError importMusicXMLfromBuffer(Score* score, const QString& /*name*/, QIODevice* dev)
+Err importMusicXMLfromBuffer(Score* score, const QString& /*name*/, QIODevice* dev)
 {
     //LOGD("importMusicXMLfromBuffer(score %p, name '%s', dev %p)",
     //       score, qPrintable(name), dev);
@@ -67,12 +67,12 @@ Score::FileError importMusicXMLfromBuffer(Score* score, const QString& /*name*/,
     // pass 1
     dev->seek(0);
     MusicXMLParserPass1 pass1(score, &logger);
-    Score::FileError res = pass1.parse(dev);
+    Err res = pass1.parse(dev);
     const auto pass1_errors = pass1.errors();
 
     // pass 2
     MusicXMLParserPass2 pass2(score, pass1, &logger);
-    if (res == Score::FileError::FILE_NO_ERROR) {
+    if (res == Err::NoError) {
         dev->seek(0);
         res = pass2.parse(dev);
     }
@@ -90,7 +90,7 @@ Score::FileError importMusicXMLfromBuffer(Score* score, const QString& /*name*/,
             const QString text = qtrc("iex_musicxml", "%n error(s) found, import may be incomplete.",
                                       nullptr, pass1_errors.count() + pass2_errors.count());
             if (musicXMLImportErrorDialog(text, pass1.errors() + pass2.errors()) != QMessageBox::Yes) {
-                res = Score::FileError::FILE_USER_ABORT;
+                res = Err::UserAbort;
             }
         }
     }

--- a/src/importexport/musicxml/internal/musicxml/importmxml.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxml.h
@@ -23,12 +23,15 @@
 #ifndef __IMPORTMXML_H__
 #define __IMPORTMXML_H__
 
-#include "libmscore/masterscore.h"
-#include "importxmlfirstpass.h"
-#include "musicxml.h" // for the creditwords definition
-#include "musicxmlsupport.h"
+#include "engravingerrors.h"
+
+class QString;
+class QIODevice;
 
 namespace mu::engraving {
-Score::FileError importMusicXMLfromBuffer(Score* score, const QString&, QIODevice* dev);
-} // namespace Ms
+class Score;
+
+Err importMusicXMLfromBuffer(Score* score, const QString&, QIODevice* dev);
+}
+
 #endif

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -945,13 +945,13 @@ static void fixupSigmap(MxmlLogger* logger, Score* score, const QVector<Fraction
  Parse MusicXML in \a device and extract pass 1 data.
  */
 
-Score::FileError MusicXMLParserPass1::parse(QIODevice* device)
+Err MusicXMLParserPass1::parse(QIODevice* device)
 {
     _logger->logDebugTrace("MusicXMLParserPass1::parse device");
     _parts.clear();
     _e.setDevice(device);
     auto res = parse();
-    if (res != Score::FileError::FILE_NO_ERROR) {
+    if (res != Err::NoError) {
         return res;
     }
 
@@ -974,7 +974,7 @@ Score::FileError MusicXMLParserPass1::parse(QIODevice* device)
  Start the parsing process, after verifying the top-level node is score-partwise
  */
 
-Score::FileError MusicXMLParserPass1::parse()
+Err MusicXMLParserPass1::parse()
 {
     _logger->logDebugTrace("MusicXMLParserPass1::parse");
 
@@ -987,16 +987,16 @@ Score::FileError MusicXMLParserPass1::parse()
             _logger->logError(QString("this is not a MusicXML score-partwise file (top-level node '%1')")
                               .arg(_e.name().toString()), &_e);
             _e.skipCurrentElement();
-            return Score::FileError::FILE_BAD_FORMAT;
+            return Err::FileBadFormat;
         }
     }
 
     if (!found) {
         _logger->logError("this is not a MusicXML score-partwise file, node <score-partwise> not found", &_e);
-        return Score::FileError::FILE_BAD_FORMAT;
+        return Err::FileBadFormat;
     }
 
-    return Score::FileError::FILE_NO_ERROR;
+    return Err::NoError;
 }
 
 //---------------------------------------------------------

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.h
@@ -23,12 +23,17 @@
 #ifndef __IMPORTMXMLPASS1_H__
 #define __IMPORTMXMLPASS1_H__
 
-#include "libmscore/masterscore.h"
+#include <QXmlStreamReader>
+
 #include "importxmlfirstpass.h"
 #include "musicxml.h" // for the creditwords and MusicXmlPartGroupList definitions
 #include "musicxmlsupport.h"
 
+#include "engraving/engravingerrors.h"
+
 namespace mu::engraving {
+class Score;
+
 //---------------------------------------------------------
 //   PageFormat
 //---------------------------------------------------------
@@ -117,8 +122,8 @@ class MusicXMLParserPass1
 public:
     MusicXMLParserPass1(Score* score, MxmlLogger* logger);
     void initPartState(const QString& partId);
-    Score::FileError parse(QIODevice* device);
-    Score::FileError parse();
+    Err parse(QIODevice* device);
+    Err parse();
     QString errors() const { return _errors; }
     void scorePartwise();
     void identification();

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -1557,11 +1557,11 @@ void MusicXMLParserPass2::skipLogCurrElem()
  Parse MusicXML in \a device and extract pass 2 data.
  */
 
-Score::FileError MusicXMLParserPass2::parse(QIODevice* device)
+Err MusicXMLParserPass2::parse(QIODevice* device)
 {
     //LOGD("MusicXMLParserPass2::parse()");
     _e.setDevice(device);
-    Score::FileError res = parse();
+    Err res = parse();
     //LOGD("MusicXMLParserPass2::parse() res %d", int(res));
     return res;
 }
@@ -1574,7 +1574,7 @@ Score::FileError MusicXMLParserPass2::parse(QIODevice* device)
  Start the parsing process, after verifying the top-level node is score-partwise
  */
 
-Score::FileError MusicXMLParserPass2::parse()
+Err MusicXMLParserPass2::parse()
 {
     bool found = false;
     while (_e.readNextStartElement()) {
@@ -1584,16 +1584,16 @@ Score::FileError MusicXMLParserPass2::parse()
         } else {
             _logger->logError("this is not a MusicXML score-partwise file", &_e);
             _e.skipCurrentElement();
-            return Score::FileError::FILE_BAD_FORMAT;
+            return Err::FileBadFormat;
         }
     }
 
     if (!found) {
         _logger->logError("this is not a MusicXML score-partwise file", &_e);
-        return Score::FileError::FILE_BAD_FORMAT;
+        return Err::FileBadFormat;
     }
 
-    return Score::FileError::FILE_NO_ERROR;
+    return Err::NoError;
 }
 
 //---------------------------------------------------------

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
@@ -251,7 +251,7 @@ class MusicXMLParserPass2
 {
 public:
     MusicXMLParserPass2(Score* score, MusicXMLParserPass1& pass1, MxmlLogger* logger);
-    Score::FileError parse(QIODevice* device);
+    Err parse(QIODevice* device);
     QString errors() const { return _errors; }
 
     // part specific data interface functions
@@ -263,7 +263,7 @@ private:
     void addError(const QString& error);      ///< Add an error to be shown in the GUI
     void initPartState(const QString& partId);
     SpannerSet findIncompleteSpannersAtPartEnd();
-    Score::FileError parse();
+    Err parse();
     void scorePartwise();
     void partList();
     void scorePart();

--- a/src/importexport/musicxml/internal/musicxmlreader.cpp
+++ b/src/importexport/musicxml/internal/musicxmlreader.cpp
@@ -22,24 +22,24 @@
 #include "musicxmlreader.h"
 
 #include "io/path.h"
-#include "libmscore/masterscore.h"
 #include "engraving/engravingerrors.h"
 
 namespace mu::engraving {
-extern Score::FileError importMusicXml(MasterScore*, const QString&);
-extern Score::FileError importCompressedMusicXml(MasterScore*, const QString&);
+extern Err importMusicXml(MasterScore*, const QString&);
+extern Err importCompressedMusicXml(MasterScore*, const QString&);
 }
 
 using namespace mu::iex::musicxml;
+using namespace mu::engraving;
 
-mu::Ret MusicXmlReader::read(mu::engraving::MasterScore* score, const io::path_t& path, const Options&)
+mu::Ret MusicXmlReader::read(MasterScore* score, const io::path_t& path, const Options&)
 {
-    mu::engraving::Score::FileError err = mu::engraving::Score::FileError::FILE_UNKNOWN_TYPE;
+    Err err = Err::FileUnknownType;
     std::string suffix = mu::io::suffix(path);
     if (suffix == "xml" || suffix == "musicxml") {
-        err = mu::engraving::importMusicXml(score, path.toQString());
+        err = importMusicXml(score, path.toQString());
     } else if (suffix == "mxl") {
-        err = mu::engraving::importCompressedMusicXml(score, path.toQString());
+        err = importCompressedMusicXml(score, path.toQString());
     }
-    return mu::engraving::scoreFileErrorToRet(err, path);
+    return make_ret(err, path);
 }

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -22,13 +22,8 @@
 
 #include <gtest/gtest.h>
 
-#include "libmscore/masterscore.h"
-
-// start includes required for fixupScore()
-#include "libmscore/measure.h"
-#include "libmscore/staff.h"
-#include "libmscore/keysig.h"
-// end includes required for fixupScore()
+#include "engraving/engravingerrors.h"
+#include "engraving/libmscore/masterscore.h"
 
 #include "settings.h"
 #include "importexport/musicxml/imusicxmlconfiguration.h"
@@ -46,8 +41,8 @@ using namespace mu::engraving;
 
 namespace mu::engraving {
 extern bool saveMxl(Score*, const QString&);
-extern Score::FileError importMusicXml(MasterScore*, const QString&);
-extern Score::FileError importCompressedMusicXml(MasterScore*, const QString&);
+extern engraving::Err importMusicXml(MasterScore*, const QString&);
+extern engraving::Err importCompressedMusicXml(MasterScore*, const QString&);
 }
 
 static const String XML_IO_DATA_DIR("data/");
@@ -102,11 +97,11 @@ MasterScore* Musicxml_Tests::readScore(const String& fileName, bool isAbsolutePa
 {
     String suffix = io::FileInfo::suffix(fileName);
 
-    auto importXml = [](MasterScore* score, const io::path_t& path) -> Score::FileError {
+    auto importXml = [](MasterScore* score, const io::path_t& path) -> engraving::Err {
         return mu::engraving::importMusicXml(score, path.toQString());
     };
 
-    auto importMxl = [](MasterScore* score, const io::path_t& path) -> Score::FileError {
+    auto importMxl = [](MasterScore* score, const io::path_t& path) -> engraving::Err {
         return mu::engraving::importCompressedMusicXml(score, path.toQString());
     };
 

--- a/src/importexport/ove/internal/importove.cpp
+++ b/src/importexport/ove/internal/importove.cpp
@@ -22,7 +22,10 @@
 
 #include "ove.h"
 
+#include <QFile>
 #include <QtMath>
+
+#include "engraving/engravingerrors.h"
 
 #include "libmscore/factory.h"
 #include "libmscore/sig.h"
@@ -2503,18 +2506,18 @@ void OveToMScore::convertWedges(Measure* measure, int part, int staff, int track
     }
 }
 
-Score::FileError importOve(MasterScore* score, const QString& name)
+Err importOve(MasterScore* score, const QString& name)
 {
     ovebase::IOVEStreamLoader* oveLoader = ovebase::createOveStreamLoader();
     ovebase::OveSong oveSong;
 
     QFile oveFile(name);
     if (!oveFile.exists()) {
-        return Score::FileError::FILE_NOT_FOUND;
+        return Err::FileNotFound;
     }
     if (!oveFile.open(QFile::ReadOnly)) {
         // messageOutString(QString("can't read file!"));
-        return Score::FileError::FILE_OPEN_ERROR;
+        return Err::FileOpenError;
     }
 
     QByteArray buffer = oveFile.readAll();
@@ -2534,5 +2537,5 @@ Score::FileError importOve(MasterScore* score, const QString& name)
         // score->connectSlurs();
     }
 
-    return result ? Score::FileError::FILE_NO_ERROR : Score::FileError::FILE_ERROR;
+    return result ? Err::NoError : Err::FileUnknownError;
 }

--- a/src/importexport/ove/internal/overeader.cpp
+++ b/src/importexport/ove/internal/overeader.cpp
@@ -21,15 +21,14 @@
  */
 #include "overeader.h"
 
-#include "libmscore/masterscore.h"
 #include "engraving/engravingerrors.h"
 
-extern mu::engraving::Score::FileError importOve(mu::engraving::MasterScore*, const QString& name);
+extern mu::engraving::Err importOve(mu::engraving::MasterScore*, const QString& name);
 
 using namespace mu::iex::ove;
 
 mu::Ret OveReader::read(mu::engraving::MasterScore* score, const io::path_t& path, const Options&)
 {
-    mu::engraving::Score::FileError err = importOve(score, path.toQString());
-    return mu::engraving::scoreFileErrorToRet(err, path);
+    mu::engraving::Err err = importOve(score, path.toQString());
+    return mu::engraving::make_ret(err, path);
 }

--- a/src/notation/view/widgets/editstafftype.cpp
+++ b/src/notation/view/widgets/editstafftype.cpp
@@ -192,7 +192,7 @@ mu::Ret EditStaffType::loadScore(mu::engraving::MasterScore* score, const mu::io
 {
     mu::engraving::ScoreLoad sl;
 
-    if (compat::loadMsczOrMscx(score, path.toQString()) != mu::engraving::Score::FileError::FILE_NO_ERROR) {
+    if (compat::loadMsczOrMscx(score, path.toQString()) != engraving::Err::NoError) {
         return make_ret(Ret::Code::UnknownError);
     }
 


### PR DESCRIPTION
Removes the duplication of two types with the same meaning, and removes the need to `#include` that massive `score.h` header always when using just these error types.