### PR TITLE
fixed #11883: Bracket item may be invalid

### DIFF
--- a/src/engraving/libmscore/bracket.cpp
+++ b/src/engraving/libmscore/bracket.cpp
@@ -557,7 +557,7 @@ void Bracket::undoChangeProperty(Pid id, const PropertyValue& v, PropertyFlags p
 
 void Bracket::setSelected(bool f)
 {
-    _bi->setSelected(f);
+//    _bi->setSelected(f);
     EngravingItem::setSelected(f);
 }
 


### PR DESCRIPTION
Resolves: #11883

Reverted this change https://github.com/musescore/MuseScore/pull/10506/commits/f5b52a01578a9161728854d11d7ff1dfaba3b1eb#diff-1f645f84d28c99c1375eb5c9be16aeec5f619cef0ba0fe42834b955b4dd47b89L524