### PR TITLE
[MU4] Fix MinGW and MSVC compiler warnings

### DIFF
--- a/src/framework/audio/internal/platform/win/wincoreaudiodriver.cpp
+++ b/src/framework/audio/internal/platform/win/wincoreaudiodriver.cpp
@@ -339,6 +339,7 @@ void logError(HRESULT hr)
     case AUDCLNT_S_POSITION_STALLED: LOGE() << "AUDCLNT_S_POSITION_STALLED";
         break;
     case E_POINTER: LOGE() << "E_POINTER";
+        break;
     case E_INVALIDARG: LOGE() << "E_INVALIDARG";
         break;
     default:

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -182,7 +182,7 @@ EngravingItem* NotationNoteInput::resolveNoteInputStartPosition() const
             if (lastSelected && lastSelected->voice()) {
                 // if last selected CR was not in voice 1,
                 // find CR in voice 1 instead
-                int track = mu::engraving::trackZeroVoice(lastSelected->track());
+                track_idx_t track = mu::engraving::trackZeroVoice(lastSelected->track());
                 const mu::engraving::Segment* s = lastSelected->segment();
                 if (s) {
                     lastSelected = s->nextChordRest(track, true);


### PR DESCRIPTION
* Fix MinGW compiler warning reg. implicit fallthrough
* Fix MSVC compiler warning reg. conversion from 'size_t' to 'int', possible loss of data