### PR TITLE
Init translation system early, before modules that use it

### DIFF
--- a/src/appshell/view/internal/splashscreen.cpp
+++ b/src/appshell/view/internal/splashscreen.cpp
@@ -52,8 +52,6 @@ SplashScreen::SplashScreen()
     setAttribute(Qt::WA_TranslucentBackground);
     setSize(splashScreenSize);
 
-    // TODO: this is just to make it translatable, but translation won't
-    // actually work here because translation system not yet initialized
     m_message = qtrc("appshell", "Loading…");
 
     repaint();
@@ -84,9 +82,8 @@ void SplashScreen::draw(QPainter* painter)
     m_backgroundRenderer->render(painter);
 
     // Draw message
-    // Can't use font from settings, because that's not yet initialized
-    QFont font(QString::fromStdString(uiConfiguration()->defaultFontFamily()));
-    font.setPixelSize(uiConfiguration()->defaultFontSize());
+    QFont font(QString::fromStdString(uiConfiguration()->fontFamily()));
+    font.setPixelSize(uiConfiguration()->fontSize());
 
     painter->setFont(font);
 

--- a/src/appshell/view/internal/splashscreen.h
+++ b/src/appshell/view/internal/splashscreen.h
@@ -35,8 +35,6 @@ class SplashScreen : public QWidget
 {
     Q_OBJECT
 
-    //! The uiConfiguration has not yet been initialized, so we can't use user settings.
-    //! We only use it for querying the default system font
     INJECT(appshell, ui::IUiConfiguration, uiConfiguration)
 
 public:

--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -163,7 +163,7 @@ static const QMap<ThemeStyleKey, QVariant> HIGH_CONTRAST_WHITE_THEME_VALUES {
     { ITEM_OPACITY_DISABLED, 0.3 }
 };
 
-void UiConfiguration::init()
+void UiConfiguration::initSettings()
 {
     settings()->setDefaultValue(UI_CURRENT_THEME_CODE_KEY, Val(LIGHT_THEME_CODE));
     settings()->setDefaultValue(UI_FOLLOW_SYSTEM_THEME_KEY, Val(false));
@@ -212,8 +212,6 @@ void UiConfiguration::init()
     m_uiArrangement.stateChanged(WINDOW_GEOMETRY_KEY).onNotify(this, [this]() {
         m_windowGeometryChanged.notify();
     });
-
-    initThemes();
 }
 
 void UiConfiguration::load()

--- a/src/framework/ui/internal/uiconfiguration.h
+++ b/src/framework/ui/internal/uiconfiguration.h
@@ -40,7 +40,8 @@ class UiConfiguration : public IUiConfiguration, public async::Asyncable
     INJECT(ui, IPlatformTheme, platformTheme)
 
 public:
-    void init();
+    void initSettings();
+    void initThemes();
     void load();
     void deinit();
 
@@ -109,7 +110,6 @@ public:
     int flickableMaxVelocity() const override;
 
 private:
-    void initThemes();
     void notifyAboutCurrentThemeChanged();
     void updateCurrentTheme();
     void updateThemes();

--- a/src/framework/ui/uimodule.cpp
+++ b/src/framework/ui/uimodule.cpp
@@ -147,11 +147,16 @@ void UiModule::registerUiTypes()
     modularity::ioc()->resolve<ui::IUiEngine>(moduleName())->addSourceImportPath(ui_QML_IMPORT);
 }
 
+void UiModule::onPreInit(const framework::IApplication::RunMode&)
+{
+    s_configuration->initSettings();
+}
+
 void UiModule::onInit(const framework::IApplication::RunMode&)
 {
     QFontDatabase::addApplicationFont(":/fonts/mscore/MusescoreIcon.ttf"); // icons
 
-    s_configuration->init();
+    s_configuration->initThemes();
     s_keyNavigationController->init();
 }
 

--- a/src/framework/ui/uimodule.h
+++ b/src/framework/ui/uimodule.h
@@ -35,6 +35,7 @@ public:
     void resolveImports() override;
     void registerResources() override;
     void registerUiTypes() override;
+    void onPreInit(const framework::IApplication::RunMode& mode) override;
     void onInit(const framework::IApplication::RunMode& mode) override;
     void onAllInited(const framework::IApplication::RunMode& mode) override;
     void onDeinit() override;

--- a/src/languages/languagesmodule.cpp
+++ b/src/languages/languagesmodule.cpp
@@ -45,7 +45,7 @@ void LanguagesModule::registerExports()
     ioc()->registerExport<ILanguagesService>(moduleName(), s_languagesService);
 }
 
-void LanguagesModule::onInit(const framework::IApplication::RunMode& mode)
+void LanguagesModule::onPreInit(const framework::IApplication::RunMode& mode)
 {
     //! NOTE: configurator must be initialized before any service that uses it
     s_languagesConfiguration->init();

--- a/src/languages/languagesmodule.h
+++ b/src/languages/languagesmodule.h
@@ -31,7 +31,7 @@ public:
     std::string moduleName() const override;
 
     void registerExports() override;
-    void onInit(const framework::IApplication::RunMode& mode) override;
+    void onPreInit(const framework::IApplication::RunMode& mode) override;
 };
 }
 


### PR DESCRIPTION
Some modules perform tasks during their initialization that rely on the translation system. For example, the loading of instrument names, and the creation of default ui themes. Thus, the translation system needs to be initialized before everything else. To facilitate this, we give modules a new "onPreInit" method, which is meant to do initialization steps that don't depend on anything else and need to be done very early.
We take the opportunity to make the Splash Screen translatable, and also to init UI module settings early, so that we can use user-chosen fonts in the Splash Screen. 

(Although this solution is not totally unstructured, it feels a bit ad-hoc; by design the modules should not depend on each other, but in practice they just do, and we work around that by adding yet another initialization step. If the graph of dependencies between initialization steps becomes more complicated in the future, we might consider a proper system with dependency management, so that initialization steps are always done in the correct order. However, such a system is bound to be complicated and introduce overhead, so I think that's not yet worth the trouble.) 

Edit: the part about `onPreInit` has been merged through another PR, so now we're simply utilising that.

I have doubts though whether it is good at all that instrument names are translated during loading and then stored in translated form. For now, (after this PR), that is totally fine, but if we ever want to support changing language without restarting the app, it's bad, and then we'll need to switch to TranslatableString. 

Similar concern about UI theme names, but even worse: there, the translated names are even stored in the configuration. This means that even if the user does restart the app after changing the language, the names of the themes will still appear as in the old language, until a factory reset. The idea behind this situation is that we want to keep open the technical possibility to support totally custom themes with custom names. However, names of built-in themes should always be properly translated, so I'll change that in the future. (Edit: this is being fixed by #13743)