### PR TITLE
Apply fixing instrument IDs when reading legacy scores, instead of during migration

### DIFF
--- a/src/engraving/rw/compat/read114.cpp
+++ b/src/engraving/rw/compat/read114.cpp
@@ -2482,13 +2482,7 @@ static void readInstrument(Instrument* i, Part* p, XmlReader& e)
         }
     }
 
-    if (i->instrumentId().isEmpty()) {
-        i->setInstrumentId(i->recognizeInstrumentId());
-    }
-
-    if (i->id().isEmpty()) {
-        i->setId(i->recognizeId());
-    }
+    i->updateInstrumentId();
 
     if (program == -1) {
         program = i->recognizeMidiProgram();

--- a/src/engraving/rw/compat/read206.cpp
+++ b/src/engraving/rw/compat/read206.cpp
@@ -678,13 +678,7 @@ static void readInstrument206(Instrument* i, Part* p, XmlReader& e)
         }
     }
 
-    if (i->instrumentId().isEmpty()) {
-        i->setInstrumentId(i->recognizeInstrumentId());
-    }
-
-    if (i->id().isEmpty()) {
-        i->setId(i->recognizeId());
-    }
+    i->updateInstrumentId();
 
     // Read single-note dynamics from template
     i->setSingleNoteDynamicsFromTemplate();

--- a/src/engraving/rw/compat/read302.cpp
+++ b/src/engraving/rw/compat/read302.cpp
@@ -239,10 +239,19 @@ bool Read302::readScore302(Score* score, XmlReader& e, ReadContext& ctx)
 
     score->_fileDivision = Constants::division;
 
-    // Make sure every instrument has an instrumentId set.
-    for (Part* part : score->parts()) {
-        for (const auto& pair : part->instruments()) {
-            pair.second->updateInstrumentId();
+    if (score->mscVersion() == 302) {
+        // MuseScore 3.6.x scores had some wrong instrument IDs
+        for (Part* part : score->parts()) {
+            for (const auto& pair : part->instruments()) {
+                fixInstrumentId(pair.second);
+            }
+        }
+    } else {
+        // Older scores had no IDs at all
+        for (Part* part : score->parts()) {
+            for (const auto& pair : part->instruments()) {
+                pair.second->updateInstrumentId();
+            }
         }
     }
 
@@ -284,4 +293,35 @@ Err Read302::read302(MasterScore* masterScore, XmlReader& e, ReadContext& ctx)
     }
 
     return Err::NoError;
+}
+
+void Read302::fixInstrumentId(Instrument* instrument)
+{
+    String id = instrument->id();
+    String trackName = instrument->trackName().toLower();
+
+    // incorrect instrument IDs in 3.6.x
+    if (id == u"Winds") {
+        id = u"winds";
+    } else if (id == u"harmonica-d12high-g") {
+        id = u"harmonica-d10high-g";
+    } else if (id == u"harmonica-d12f") {
+        id = u"harmonica-d10f";
+    } else if (id == u"harmonica-d12d") {
+        id = u"harmonica-d10d";
+    } else if (id == u"harmonica-d12c") {
+        id = u"harmonica-d10c";
+    } else if (id == u"harmonica-d12a") {
+        id = u"harmonica-d10a";
+    } else if (id == u"harmonica-d12-g") {
+        id = u"harmonica-d10g";
+    } else if (id == u"drumset" && trackName == u"percussion") {
+        id = u"percussion";
+    } else if (id == u"cymbal" && trackName == u"cymbals") {
+        id = u"marching-cymbals";
+    } else if (id == u"bass-drum" && trackName == u"bass drums") {
+        id = u"marching-bass-drums";
+    }
+
+    instrument->setId(id);
 }

--- a/src/engraving/rw/compat/read302.h
+++ b/src/engraving/rw/compat/read302.h
@@ -25,6 +25,7 @@
 #include "engravingerrors.h"
 
 namespace mu::engraving {
+class Instrument;
 class MasterScore;
 class Score;
 
@@ -41,6 +42,8 @@ public:
 
 private:
     static bool readScore302(Score* score, XmlReader& e, ReadContext& ctx);
+
+    static void fixInstrumentId(Instrument* instrument);
 };
 }
 

--- a/src/project/internal/projectmigrator.cpp
+++ b/src/project/internal/projectmigrator.cpp
@@ -128,41 +128,6 @@ Ret ProjectMigrator::askAboutMigration(MigrationOptions& out, const QString& app
     return true;
 }
 
-void ProjectMigrator::fixInstrumentIds(mu::engraving::MasterScore* score)
-{
-    for (mu::engraving::Part* part : score->parts()) {
-        for (auto pair : part->instruments()) {
-            QString id = pair.second->id();
-            QString trackName = pair.second->trackName().toLower();
-
-            // incorrect instrument IDs in pre-4.0
-            if (id == "Winds") {
-                id = "winds";
-            } else if (id == "harmonica-d12high-g") {
-                id = "harmonica-d10high-g";
-            } else if (id == "harmonica-d12f") {
-                id = "harmonica-d10f";
-            } else if (id == "harmonica-d12d") {
-                id = "harmonica-d10d";
-            } else if (id == "harmonica-d12c") {
-                id = "harmonica-d10c";
-            } else if (id == "harmonica-d12a") {
-                id = "harmonica-d10a";
-            } else if (id == "harmonica-d12-g") {
-                id = "harmonica-d10g";
-            } else if (id == "drumset" && trackName == "percussion") {
-                id = "percussion";
-            } else if (id == "cymbal" && trackName == "cymbals") {
-                id = "marching-cymbals";
-            } else if (id == "bass-drum" && trackName == "bass drums") {
-                id = "marching-bass-drums";
-            }
-
-            pair.second->setId(id);
-        }
-    }
-}
-
 void ProjectMigrator::resetStyleSettings(mu::engraving::MasterScore* score)
 {
     // there are a few things that need to be updated no matter which version the score is from (#10499)
@@ -209,9 +174,7 @@ Ret ProjectMigrator::migrateProject(engraving::EngravingProjectPtr project, cons
     if (ok && opt.isApplyAutoSpacing) {
         ok = resetAllElementsPositions(score);
     }
-    if (score->mscVersion() <= 302) {
-        fixInstrumentIds(score);
-    }
+
     if (ok && score->mscVersion() != mu::engraving::MSCVERSION) {
         score->undo(new mu::engraving::ChangeMetaText(score, u"mscVersion", String::fromAscii(MSC_VERSION)));
     }

--- a/src/project/internal/projectmigrator.h
+++ b/src/project/internal/projectmigrator.h
@@ -47,7 +47,6 @@ private:
     bool applyLelandStyle(mu::engraving::MasterScore* score);
     bool applyEdwinStyle(mu::engraving::MasterScore* score);
     bool resetAllElementsPositions(mu::engraving::MasterScore* score);
-    void fixInstrumentIds(mu::engraving::MasterScore* score);
     void resetStyleSettings(mu::engraving::MasterScore* score);
 
     bool m_resetStyleSettings{ false };


### PR DESCRIPTION
This is functionally crucial, so it needs to happen always, not only when "migrating" a score through the UI but always when reading a score, and not only for the MasterScore, but also for parts.