### PR TITLE
[MU4] Fix #12454: Hide empty staves toggle in Properties not working for scores created before MS4.0

### DIFF
--- a/src/inspector/models/abstractinspectormodel.cpp
+++ b/src/inspector/models/abstractinspectormodel.cpp
@@ -137,6 +137,11 @@ void AbstractInspectorModel::setupCurrentNotationChangedConnection()
 
             m_updatePropertiesAllowed = true;
         });
+
+        onStyleChanged();
+        notation->style()->styleChanged().onNotify(this, [this]() {
+            onStyleChanged();
+        });
     };
 
     listenNotationChanged();
@@ -147,6 +152,10 @@ void AbstractInspectorModel::setupCurrentNotationChangedConnection()
 }
 
 void AbstractInspectorModel::updatePropertiesOnNotationChanged()
+{
+}
+
+void AbstractInspectorModel::onStyleChanged()
 {
 }
 

--- a/src/inspector/models/abstractinspectormodel.h
+++ b/src/inspector/models/abstractinspectormodel.h
@@ -191,6 +191,7 @@ protected:
     notation::INotationSelectionPtr selection() const;
 
     virtual void updatePropertiesOnNotationChanged();
+    virtual void onStyleChanged();
 
     IElementRepositoryService* m_repository = nullptr;
 

--- a/src/inspector/models/notation/notes/stems/stemsettingsmodel.cpp
+++ b/src/inspector/models/notation/notes/stems/stemsettingsmodel.cpp
@@ -131,18 +131,12 @@ PropertyItem* StemSettingsModel::stemDirection() const
 
 bool StemSettingsModel::useStraightNoteFlags() const
 {
-    return context()->currentNotation()->style()->styleValue(mu::engraving::Sid::useStraightNoteFlags).toBool();
+    return styleValue(mu::engraving::Sid::useStraightNoteFlags).toBool();
 }
 
 void StemSettingsModel::setUseStraightNoteFlags(bool use)
 {
-    if (use == useStraightNoteFlags()) {
-        return;
-    }
-
-    context()->currentNotation()->undoStack()->prepareChanges();
-    context()->currentNotation()->style()->setStyleValue(mu::engraving::Sid::useStraightNoteFlags, use);
-    context()->currentNotation()->undoStack()->commitChanges();
+    updateStyleValue(mu::engraving::Sid::useStraightNoteFlags, use);
 }
 
 void StemSettingsModel::onStemDirectionChanged(mu::engraving::DirectionV newDirection)

--- a/src/inspector/models/score/scoreappearancesettingsmodel.cpp
+++ b/src/inspector/models/score/scoreappearancesettingsmodel.cpp
@@ -31,61 +31,36 @@ ScoreAppearanceSettingsModel::ScoreAppearanceSettingsModel(QObject* parent, IEle
 {
     setSectionType(InspectorSectionType::SECTION_SCORE_APPEARANCE);
     setTitle(qtrc("inspector", "Score appearance"));
-
-    auto onCurrentNotationChanged = [this]() {
-        emit styleChanged();
-
-        if (style()) {
-            style()->styleChanged().onNotify(this, [this]() {
-                emit styleChanged();
-            });
-        }
-    };
-
-    onCurrentNotationChanged();
-    context()->currentNotationChanged().onNotify(this, onCurrentNotationChanged);
 }
 
 bool ScoreAppearanceSettingsModel::hideEmptyStaves() const
 {
-    return style() ? style()->styleValue(StyleId::hideEmptyStaves).toBool() : false;
+    return styleValue(StyleId::hideEmptyStaves).toBool();
 }
 
 void ScoreAppearanceSettingsModel::setHideEmptyStaves(bool hide)
 {
-    if (hide == hideEmptyStaves() || !style()) {
-        return;
-    }
-
-    style()->setStyleValue(StyleId::hideEmptyStaves, hide);
+    updateStyleValue(StyleId::hideEmptyStaves, hide);
 }
 
 bool ScoreAppearanceSettingsModel::dontHideEmptyStavesInFirstSystem() const
 {
-    return style() ? style()->styleValue(StyleId::dontHideStavesInFirstSystem).toBool() : false;
+    return styleValue(StyleId::dontHideStavesInFirstSystem).toBool();
 }
 
 void ScoreAppearanceSettingsModel::setDontHideEmptyStavesInFirstSystem(bool dont)
 {
-    if (dont == dontHideEmptyStavesInFirstSystem() || !style()) {
-        return;
-    }
-
-    style()->setStyleValue(StyleId::dontHideStavesInFirstSystem, dont);
+    updateStyleValue(StyleId::dontHideStavesInFirstSystem, dont);
 }
 
 bool ScoreAppearanceSettingsModel::showBracketsWhenSpanningSingleStaff() const
 {
-    return style() ? style()->styleValue(StyleId::alwaysShowBracketsWhenEmptyStavesAreHidden).toBool() : false;
+    return styleValue(StyleId::alwaysShowBracketsWhenEmptyStavesAreHidden).toBool();
 }
 
 void ScoreAppearanceSettingsModel::setShowBracketsWhenSpanningSingleStaff(bool show)
 {
-    if (show == showBracketsWhenSpanningSingleStaff() || !style()) {
-        return;
-    }
-
-    style()->setStyleValue(StyleId::alwaysShowBracketsWhenEmptyStavesAreHidden, show);
+    updateStyleValue(StyleId::alwaysShowBracketsWhenEmptyStavesAreHidden, show);
 }
 
 bool ScoreAppearanceSettingsModel::isEmpty() const
@@ -101,4 +76,9 @@ void ScoreAppearanceSettingsModel::showPageSettings()
 void ScoreAppearanceSettingsModel::showStyleSettings()
 {
     dispatcher()->dispatch("edit-style");
+}
+
+void ScoreAppearanceSettingsModel::onStyleChanged()
+{
+    emit styleChanged();
 }

--- a/src/inspector/models/score/scoreappearancesettingsmodel.h
+++ b/src/inspector/models/score/scoreappearancesettingsmodel.h
@@ -52,15 +52,18 @@ public:
     Q_INVOKABLE void showPageSettings();
     Q_INVOKABLE void showStyleSettings();
 
-    virtual void createProperties() override { }
-    virtual void requestElements() override { }
-    virtual void loadProperties() override { }
-    virtual void resetProperties() override { }
-
     bool isEmpty() const override;
 
 signals:
     void styleChanged();
+
+private:
+    void createProperties() override { }
+    void requestElements() override { }
+    void loadProperties() override { }
+    void resetProperties() override { }
+
+    void onStyleChanged() override;
 };
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/12454