### PR TITLE
[MU4] Small adjustments to beam placement / slope

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -611,13 +611,13 @@ int Beam::getMaxSlope() const
         maxSlope = _maxSlopes[1];
     } else if (beamWidth < 5.0) {
         maxSlope = _maxSlopes[2];
-    } else if (beamWidth < 8.0) {
+    } else if (beamWidth < 7.5) {
         maxSlope = _maxSlopes[3];
-    } else if (beamWidth < 13.0) {
+    } else if (beamWidth < 10.0) {
         maxSlope = _maxSlopes[4];
-    } else if (beamWidth < 21.0) {
+    } else if (beamWidth < 15.0) {
         maxSlope = _maxSlopes[5];
-    } else if (beamWidth < 34.0) {
+    } else if (beamWidth < 20.0) {
         maxSlope = _maxSlopes[6];
     } else {
         maxSlope = _maxSlopes[7];
@@ -1194,8 +1194,9 @@ void Beam::extendStem(Chord* chord, double addition)
 
 bool Beam::isBeamInsideStaff(int yPos, int staffLines, bool isDictator) const
 {
-    int aboveStaff = isDictator ? -3 : -2;
-    int belowStaff = (staffLines - 1) * 4 + (isDictator ? 3 : 2);
+    UNUSED(isDictator); // we can use isDictator to determine custom distances outside the staff for pointer/dictator
+    int aboveStaff = -3;
+    int belowStaff = (staffLines - 1) * 4 + 3;
     return yPos > aboveStaff && yPos < belowStaff;
 }
 

--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -103,9 +103,9 @@ class Beam final : public EngravingItem
                                       const double endX, bool isFlat, bool isStartDictator) const;
     void offsetBeamWithAnchorShortening(std::vector<ChordRest*> chordRests, int& dictator, int& pointer, int beamCount, int staffLines,
                                         bool isStartDictator, int stemLengthDictator, int stemLengthPointer) const;
-    bool isBeamInsideStaff(int yPos, int staffLines, bool isDictator) const;
+    bool isBeamInsideStaff(int yPos, int staffLines, bool isInner) const;
     int getOuterBeamPosOffset(int innerBeam, int beamCount, int staffLines) const;
-    bool isValidBeamPosition(int yPos, bool isStart, bool isAscending, bool isFlat, int staffLines, int beamCount) const;
+    bool isValidBeamPosition(int yPos, bool isStart, bool isAscending, bool isFlat, int staffLines) const;
     bool is64thBeamPositionException(int& yPos, int staffLines) const;
     int findValidBeamOffset(int outer, int beamCount, int staffLines, bool isStart, bool isAscending, bool isFlat) const;
     void setValidBeamPositions(int& dictator, int& pointer, int beamCount, int staffLines, bool isStartDictator, bool isFlat,

--- a/src/engraving/utests/beam_data/Beam-A.mscx
+++ b/src/engraving/utests/beam_data/Beam-A.mscx
@@ -157,8 +157,8 @@
         <voice>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>-4</l1>
-            <l2>-6</l2>
+            <l1>-6</l1>
+            <l2>-8</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -731,7 +731,7 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>36</l1>
+            <l1>38</l1>
             <l2>42</l2>
             </Beam>
           <Chord>
@@ -951,7 +951,7 @@
             </Chord>
           <Beam>
             <l1>42</l1>
-            <l2>36</l2>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -969,7 +969,7 @@
             </Chord>
           <Beam>
             <l1>42</l1>
-            <l2>36</l2>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -996,7 +996,7 @@
           <Beam>
             <StemDirection>down</StemDirection>
             <l1>42</l1>
-            <l2>36</l2>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -1015,7 +1015,7 @@
           <Beam>
             <StemDirection>down</StemDirection>
             <l1>42</l1>
-            <l2>36</l2>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -1035,7 +1035,7 @@
           <Beam>
             <StemDirection>down</StemDirection>
             <l1>42</l1>
-            <l2>36</l2>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/beam_data/Beam-B.mscx
+++ b/src/engraving/utests/beam_data/Beam-B.mscx
@@ -518,8 +518,8 @@
         <voice>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>-6</l1>
-            <l2>-4</l2>
+            <l1>-8</l1>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -537,8 +537,8 @@
             </Chord>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>-6</l1>
-            <l2>-4</l2>
+            <l1>-8</l1>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -666,8 +666,8 @@
         <voice>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>38</l1>
-            <l2>36</l2>
+            <l1>40</l1>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -684,8 +684,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>38</l1>
-            <l2>36</l2>
+            <l1>40</l1>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>

--- a/src/engraving/utests/beam_data/Beam-C.mscx
+++ b/src/engraving/utests/beam_data/Beam-C.mscx
@@ -274,7 +274,7 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-4</l1>
+            <l1>-6</l1>
             <l2>-10</l2>
             </Beam>
           <Chord>
@@ -417,8 +417,8 @@
       <Measure>
         <voice>
           <Beam>
-            <l1>36</l1>
-            <l2>38</l2>
+            <l1>38</l1>
+            <l2>40</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -455,7 +455,7 @@
             </Chord>
           <Beam>
             <l1>-10</l1>
-            <l2>-4</l2>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -473,7 +473,7 @@
             </Chord>
           <Beam>
             <l1>-10</l1>
-            <l2>-4</l2>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -499,7 +499,7 @@
         <voice>
           <Beam>
             <l1>-10</l1>
-            <l2>-4</l2>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -517,7 +517,7 @@
             </Chord>
           <Beam>
             <l1>-10</l1>
-            <l2>-4</l2>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -536,7 +536,7 @@
             </Chord>
           <Beam>
             <l1>-10</l1>
-            <l2>-4</l2>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -703,8 +703,8 @@
       <Measure>
         <voice>
           <Beam>
-            <l1>36</l1>
-            <l2>38</l2>
+            <l1>38</l1>
+            <l2>40</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -741,7 +741,7 @@
             </Chord>
           <Beam>
             <l1>-10</l1>
-            <l2>-4</l2>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -759,7 +759,7 @@
             </Chord>
           <Beam>
             <l1>-10</l1>
-            <l2>-4</l2>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -782,7 +782,7 @@
         <voice>
           <Beam>
             <l1>-10</l1>
-            <l2>-4</l2>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/beam_data/Beam-D.mscx
+++ b/src/engraving/utests/beam_data/Beam-D.mscx
@@ -261,7 +261,7 @@
             </Chord>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>-4</l1>
+            <l1>-6</l1>
             <l2>-10</l2>
             </Beam>
           <Chord>
@@ -751,8 +751,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>36</l1>
-            <l2>38</l2>
+            <l1>38</l1>
+            <l2>40</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -771,7 +771,7 @@
             </Chord>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>36</l1>
+            <l1>38</l1>
             <l2>42</l2>
             </Beam>
           <Chord>

--- a/src/engraving/utests/beam_data/Beam-E.mscx
+++ b/src/engraving/utests/beam_data/Beam-E.mscx
@@ -241,7 +241,7 @@
         <voice>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>-4</l1>
+            <l1>-6</l1>
             <l2>-10</l2>
             </Beam>
           <Chord>
@@ -791,8 +791,8 @@
             </Chord>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>36</l1>
-            <l2>38</l2>
+            <l1>38</l1>
+            <l2>40</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/beam_data/Beam-F.mscx
+++ b/src/engraving/utests/beam_data/Beam-F.mscx
@@ -214,7 +214,7 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-4</l1>
+            <l1>-6</l1>
             <l2>-10</l2>
             </Beam>
           <Chord>
@@ -811,8 +811,8 @@
             </Chord>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>36</l1>
-            <l2>38</l2>
+            <l1>38</l1>
+            <l2>40</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>

--- a/src/engraving/utests/beam_data/Beam-G.mscx
+++ b/src/engraving/utests/beam_data/Beam-G.mscx
@@ -176,8 +176,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-4</l1>
-            <l2>-6</l2>
+            <l1>-6</l1>
+            <l2>-8</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -195,7 +195,7 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-4</l1>
+            <l1>-6</l1>
             <l2>-10</l2>
             </Beam>
           <Chord>
@@ -807,8 +807,8 @@
         <voice>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>36</l1>
-            <l2>38</l2>
+            <l1>38</l1>
+            <l2>40</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/beam_data/beamPositions.mscx
+++ b/src/engraving/utests/beam_data/beamPositions.mscx
@@ -1344,8 +1344,8 @@
       <Measure>
         <voice>
           <Beam>
-            <l1>18</l1>
-            <l2>18</l2>
+            <l1>16</l1>
+            <l2>16</l2>
             </Beam>
           <Chord>
             <durationType>64th</durationType>
@@ -1729,8 +1729,8 @@
             <durationType>32nd</durationType>
             </Rest>
           <Beam>
-            <l1>14</l1>
-            <l2>14</l2>
+            <l1>16</l1>
+            <l2>16</l2>
             </Beam>
           <Chord>
             <durationType>64th</durationType>

--- a/src/engraving/utests/chordsymbol_data/realize-triplet-ref.mscx
+++ b/src/engraving/utests/chordsymbol_data/realize-triplet-ref.mscx
@@ -749,7 +749,7 @@
             </Tuplet>
           <Beam>
             <l1>-8</l1>
-            <l2>-4</l2>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <durationType>16th</durationType>

--- a/src/engraving/utests/copypaste_data/copypaste11-ref.mscx
+++ b/src/engraving/utests/copypaste_data/copypaste11-ref.mscx
@@ -117,8 +117,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-6</l1>
-            <l2>-4</l2>
+            <l1>-8</l1>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -215,8 +215,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-6</l1>
-            <l2>-4</l2>
+            <l1>-8</l1>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/implode_explode_data/implode1-ref.mscx
+++ b/src/engraving/utests/implode_explode_data/implode1-ref.mscx
@@ -1113,8 +1113,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-6</l1>
-            <l2>-4</l2>
+            <l1>-8</l1>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/implode_explode_data/implode1.mscx
+++ b/src/engraving/utests/implode_explode_data/implode1.mscx
@@ -698,8 +698,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-6</l1>
-            <l2>-4</l2>
+            <l1>-8</l1>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/implode_explode_data/undoExplode01-ref.mscx
+++ b/src/engraving/utests/implode_explode_data/undoExplode01-ref.mscx
@@ -732,8 +732,8 @@
               </Number>
             </Tuplet>
           <Beam>
-            <l1>36</l1>
-            <l2>38</l2>
+            <l1>38</l1>
+            <l2>40</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -912,8 +912,8 @@
               </Number>
             </Tuplet>
           <Beam>
-            <l1>-6</l1>
-            <l2>-4</l2>
+            <l1>-8</l1>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/rhythmicGrouping_data/groupArticulationsTies-ref.mscx
+++ b/src/engraving/utests/rhythmicGrouping_data/groupArticulationsTies-ref.mscx
@@ -90,8 +90,8 @@
               </Number>
             </Tuplet>
           <Beam>
-            <l1>36</l1>
-            <l2>38</l2>
+            <l1>38</l1>
+            <l2>40</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/unrollrepeats_data/clef-key-ts-ref.mscx
+++ b/src/engraving/utests/unrollrepeats_data/clef-key-ts-ref.mscx
@@ -270,7 +270,7 @@
             </Chord>
           <Beam>
             <l1>44</l1>
-            <l2>36</l2>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <durationType>16th</durationType>
@@ -473,7 +473,7 @@
             </Chord>
           <Beam>
             <l1>44</l1>
-            <l2>36</l2>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <durationType>16th</durationType>
@@ -811,7 +811,7 @@
             </Chord>
           <Beam>
             <l1>44</l1>
-            <l2>36</l2>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <durationType>16th</durationType>
@@ -1110,8 +1110,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-6</l1>
-            <l2>-4</l2>
+            <l1>-8</l1>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <linkedMain/>
@@ -1653,8 +1653,8 @@
                 </Note>
               </Chord>
             <Beam>
-              <l1>-6</l1>
-              <l2>-4</l2>
+              <l1>-8</l1>
+              <l2>-6</l2>
               </Beam>
             <Chord>
               <linked>

--- a/src/importexport/capella/tests/data/test4.cap-ref.mscx
+++ b/src/importexport/capella/tests/data/test4.cap-ref.mscx
@@ -140,8 +140,8 @@
           </LayoutBreak>
         <voice>
           <Beam>
-            <l1>-4</l1>
-            <l2>-6</l2>
+            <l1>-6</l1>
+            <l2>-8</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/importexport/capella/tests/data/test4.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/test4.capx-ref.mscx
@@ -140,8 +140,8 @@
           </LayoutBreak>
         <voice>
           <Beam>
-            <l1>-4</l1>
-            <l2>-6</l2>
+            <l1>-6</l1>
+            <l2>-8</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/importexport/capella/tests/data/test7.cap-ref.mscx
+++ b/src/importexport/capella/tests/data/test7.cap-ref.mscx
@@ -92,7 +92,7 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-4</l1>
+            <l1>-6</l1>
             <l2>-10</l2>
             </Beam>
           <Chord>

--- a/src/importexport/guitarpro/tests/data/dotted-tuplets.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dotted-tuplets.gp5-ref.mscx
@@ -84,8 +84,8 @@
               </Number>
             </Tuplet>
           <Beam>
-            <l1>38</l1>
-            <l2>36</l2>
+            <l1>40</l1>
+            <l2>38</l2>
             </Beam>
           <Chord>
             <dots>1</dots>

--- a/src/importexport/guitarpro/tests/data/tuplets2.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tuplets2.gpx-ref.mscx
@@ -232,8 +232,8 @@ solo concert</text>
               </Number>
             </Tuplet>
           <Beam>
-            <l1>-6</l1>
-            <l2>-4</l2>
+            <l1>-8</l1>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/89263931/183445132-80664c4e-4bba-44f0-8167-ab16a7dca216.png)
This beam's start position is in a 'floater' position, but was still considered outside the staff, so it was fine for pointers. Now, that is an invalid beam position for both pointers and dictators:
![image](https://user-images.githubusercontent.com/89263931/183446073-e6ed1a96-69aa-47e9-8858-e3dcd25fe6cf.png)

Additionally, the horizontal length of the beam required for certain slope constraints have been changed to be more forgiving and slightly slantier.