### PR TITLE
Articulation migration: ignore style settings and manual offsets from pre-4.0

### DIFF
--- a/src/engraving/libmscore/articulation.cpp
+++ b/src/engraving/libmscore/articulation.cpp
@@ -205,7 +205,7 @@ bool Articulation::readProperties(XmlReader& e)
     } else if (tag == "play") {
         setPlayArticulation(e.readBool());
     } else if (tag == "offset") {
-        if (score()->mscVersion() > 114) {
+        if (score()->mscVersion() >= 400) {
             EngravingItem::readProperties(e);
         } else {
             e.skipCurrentElement();       // ignore manual layout in older scores

--- a/src/engraving/style/style.cpp
+++ b/src/engraving/style/style.cpp
@@ -328,6 +328,13 @@ void MStyle::read(XmlReader& e, compat::ReadChordListHook* readChordListHook)
             set(Sid::dontHideStavesInFirstSystem, e.readBool());
         } else if (tag == "beamDistance") { // beamDistance maps to useWideBeams in 4.0
             set(Sid::useWideBeams, e.readDouble() > 0.75);
+        } else if ((tag == "articulationMinDistance"
+                    || tag == "propertyDistanceHead"
+                    || tag == "propertyDistanceStem"
+                    || tag == "propertyDistance")
+                   && defaultStyleVersion() < 400) {
+            // Ignoring pre-4.0 articulation style settings. Using the new defaults instead
+            e.skipCurrentElement();
         } else if (!readProperties(e)) {
             e.unknown();
         }


### PR DESCRIPTION
Because the default position has been much improved and some of the settings are used differently.
