### PR TITLE
fixed #12128: Scrolling through long list of plugins causes the context menu to close

### DIFF
--- a/src/framework/uicomponents/view/internal/popupviewclosecontroller.cpp
+++ b/src/framework/uicomponents/view/internal/popupviewclosecontroller.cpp
@@ -60,6 +60,10 @@ QQuickItem* PopupViewCloseController::parentItem() const
 
 void PopupViewCloseController::setParentItem(QQuickItem* parentItem)
 {
+    if (m_parentItem) {
+        m_parentItem->disconnect(this);
+    }
+
     m_parentItem = parentItem;
 
     connect(m_parentItem, &QQuickItem::visibleChanged, this, [this]() {

--- a/src/inspector/models/inspectorpopupcontroller.cpp
+++ b/src/inspector/models/inspectorpopupcontroller.cpp
@@ -72,6 +72,10 @@ void InspectorPopupController::setVisualControl(QQuickItem* control)
         return;
     }
 
+    if (m_visualControl) {
+        m_visualControl->disconnect(this);
+    }
+
     m_visualControl = control;
 
     if (m_visualControl) {
@@ -95,6 +99,10 @@ void InspectorPopupController::setPopup(PopupView* popup)
 {
     if (m_popup == popup) {
         return;
+    }
+
+    if (m_popup) {
+        m_popup->disconnect(this);
     }
 
     m_popup = popup;


### PR DESCRIPTION
Resolves: #12128