### PR TITLE
Don't invoke undefined behaviour when converting empty mu::String to QString

### DIFF
--- a/src/framework/global/tests/string_tests.cpp
+++ b/src/framework/global/tests/string_tests.cpp
@@ -107,7 +107,23 @@ TEST_F(Global_Types_StringTests, String_Convert)
         //! DO
         String str = String::fromQString(qstr_origin);
         //! CHECK
+        EXPECT_EQ(str, String(u"123abcПыф"));
         EXPECT_EQ(str.size(), qstr_origin.size()); // both utf16, so size is equal
+
+        //! DO back
+        QString qstr = str.toQString();
+        //! CHECK
+        EXPECT_EQ(qstr, qstr_origin);
+    }
+
+    {
+        //! GIVEN Empty QString
+        QString qstr_origin;
+        //! DO
+        String str = String::fromQString(qstr_origin);
+        //! CHECK
+        EXPECT_EQ(str, String());
+        EXPECT_EQ(str.size(), qstr_origin.size());
 
         //! DO back
         QString qstr = str.toQString();

--- a/src/framework/global/types/string.cpp
+++ b/src/framework/global/types/string.cpp
@@ -477,9 +477,8 @@ String String::fromQString(const QString& str)
 
 QString String::toQString() const
 {
-    const char16_t* u = &constStr().front();
     static_assert(sizeof(QChar) == sizeof(char16_t));
-    return QString(reinterpret_cast<const QChar*>(u), static_cast<int>(size()));
+    return QString(reinterpret_cast<const QChar*>(constStr().data()), static_cast<int>(size()));
 }
 
 #endif


### PR DESCRIPTION
Resolves: #12751