### PR TITLE
Some text wrap fixes

### DIFF
--- a/src/appshell/qml/FirstLaunchSetup/Page.qml
+++ b/src/appshell/qml/FirstLaunchSetup/Page.qml
@@ -20,7 +20,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import QtQuick 2.15
-import QtQuick.Layouts 1.15
 
 import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
@@ -92,14 +91,21 @@ Item {
 
         StyledTextLabel {
             id: titleLabel
+
             anchors.horizontalCenter: parent.horizontalCenter
+            width: parent.width
+
             font: ui.theme.largeBodyBoldFont
+            wrapMode: Text.Wrap
         }
 
         StyledTextLabel {
             id: explanationLabel
+
             anchors.horizontalCenter: parent.horizontalCenter
-            wrapMode: Text.WordWrap
+            width: parent.width
+
+            wrapMode: Text.Wrap
         }
     }
 

--- a/src/framework/ui/qml/MuseScore/Ui/StandardDialogPanel.qml
+++ b/src/framework/ui/qml/MuseScore/Ui/StandardDialogPanel.qml
@@ -159,7 +159,6 @@ RowLayout {
 
                 font: ui.theme.largeBodyBoldFont
                 horizontalAlignment: Text.AlignLeft
-                maximumLineCount: 2
                 wrapMode: Text.Wrap
 
                 visible: !isEmpty
@@ -170,7 +169,6 @@ RowLayout {
                 width: parent.width
 
                 horizontalAlignment: Text.AlignLeft
-                maximumLineCount: 5
                 wrapMode: Text.Wrap
 
                 visible: !isEmpty

--- a/src/framework/ui/qml/MuseScore/Ui/ToolTipProvider.qml
+++ b/src/framework/ui/qml/MuseScore/Ui/ToolTipProvider.qml
@@ -44,6 +44,11 @@ Item {
             }
         }
 
+        onLoaded: {
+            var toolTip = toolTipLoader.item
+            toolTip.calculateSize()
+        }
+
         function loadToolTip() {
             toolTipLoader.active = true
         }

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledToolTip.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledToolTip.qml
@@ -63,6 +63,7 @@ StyledPopupView {
                 font: ui.theme.bodyBoldFont
                 horizontalAlignment: Text.AlignLeft
                 wrapMode: Text.Wrap
+                maximumLineCount: 3
             }
 
             StyledTextLabel {

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledToolTip.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledToolTip.qml
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
 import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
@@ -37,41 +38,38 @@ StyledPopupView {
     openPolicy: PopupView.NoActivateFocus
 
     function calculateSize() {
-        x = (root.parent.width / 2) - ((content.width + padding * 2 + margins * 2) / 2)
-        y = root.parent.height
+        contentWidth = Math.min(content.implicitWidth, 300 - margins * 2)
+        contentHeight = content.implicitHeight
 
-        contentWidth = Math.min(content.width, 300 - margins * 2)
-        contentHeight = content.height
+        x = root.parent.width / 2 - (contentWidth + padding * 2 + margins * 2) / 2
+        y = root.parent.height
     }
 
-    Column {
+    ColumnLayout {
         id: content
 
-        width: Math.max(row.width, descriptionLabel.width)
-        height: row.height + (descriptionLabel.visible ? descriptionLabel.height + spacing : 0)
-
+        anchors.fill: parent
         spacing: 4
 
-        Row {
+        RowLayout {
             id: row
 
             spacing: 6
 
-            width: titleLabel.width + (shortcutLabel.visible ? shortcutLabel.width + spacing : 0)
-            height: titleLabel.height
-
             StyledTextLabel {
                 id: titleLabel
+                Layout.fillWidth: true
 
                 font: ui.theme.bodyBoldFont
                 horizontalAlignment: Text.AlignLeft
+                wrapMode: Text.Wrap
             }
 
             StyledTextLabel {
                 id: shortcutLabel
 
                 text: "(" + root.shortcut + ")"
-                horizontalAlignment: Text.AlignLeft
+                horizontalAlignment: Text.AlignRight
                 opacity: 0.8
 
                 visible: Boolean(root.shortcut)
@@ -80,8 +78,10 @@ StyledPopupView {
 
         StyledTextLabel {
             id: descriptionLabel
+            Layout.fillWidth: true
 
             horizontalAlignment: Text.AlignLeft
+            wrapMode: Text.Wrap
 
             visible: Boolean(root.description)
         }


### PR DESCRIPTION
Resolves: #12774
Resolves: https://discord.com/channels/818804595450445834/818852942882275379/1007159359941394523

Enabling word wrap is nice, but when the width of the text field is not properly limited, it doesn't help much...

Also: we could consider replacing all uses of `Text.WordWrap` with `Text.Wrap`, because the latter allows wrapping in the middle of a word in "emergency" cases (word longer than available line length). The former would put words that are too long still on one line, and either clip them or let them just go outside the boundaries of the `StyledTextLabel`. I did not make this change here, but would be happy to do so if we decide it is desired.