### PR TITLE
[MU4] Fix #11617: Regression: tempo override control missing (formerly in Play Panel)

### DIFF
--- a/src/engraving/libmscore/tempo.h
+++ b/src/engraving/libmscore/tempo.h
@@ -26,6 +26,7 @@
 #include <map>
 
 #include "global/allocator.h"
+#include "global/async/notification.h"
 #include "types/flags.h"
 #include "types/types.h"
 
@@ -71,9 +72,10 @@ class TempoMap : public std::map<int, TEvent>
 {
     OBJECT_ALLOCATOR(engraving, TempoMap)
 
-    int _tempoSN;             // serial no to track tempo changes
-    BeatsPerSecond _tempo;    // tempo if not using tempo list (beats per second)
-    BeatsPerSecond _relTempo;          // rel. tempo
+    int _tempoSN = 0; // serial no to track tempo changes
+    BeatsPerSecond _tempo; // tempo if not using tempo list (beats per second)
+    BeatsPerSecond _tempoMultiplier;
+    async::Notification _tempoMultiplierChanged;
 
     void normalize();
     void del(int tick);
@@ -98,8 +100,9 @@ public:
     void setPause(int t, double);
     void delTempo(int tick);
 
-    void setRelTempo(BeatsPerSecond val);
-    BeatsPerSecond relTempo() const { return _relTempo; }
+    BeatsPerSecond tempoMultiplier() const;
+    async::Notification tempoMultiplierChanged() const;
+    void setTempoMultiplier(BeatsPerSecond val);
 };
 } // namespace mu::engraving
 #endif

--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -86,6 +86,10 @@ void PlaybackModel::load(Score* score)
         notifyAboutChanges(oldTracks, trackChanges);
     });
 
+    m_score->tempomap()->tempoMultiplierChanged().onNotify(this, [this]() {
+        reload();
+    });
+
     update(0, m_score->lastMeasure()->endTick().ticks(), 0, m_score->ntracks());
 
     for (const auto& pair : m_playbackDataMap) {

--- a/src/engraving/rw/compat/read114.cpp
+++ b/src/engraving/rw/compat/read114.cpp
@@ -2779,7 +2779,7 @@ Err Read114::read114(MasterScore* masterScore, XmlReader& e, ReadContext& ctx)
         } else if (tag == "tempolist") {
             // store the tempo list to create invisible tempo text later
             double tempo = e.doubleAttribute("fix", 2.0);
-            tm.setRelTempo(tempo);
+            tm.setTempoMultiplier(tempo);
             while (e.readNextStartElement()) {
                 if (e.name() == "tempo") {
                     int tick   = e.attribute("tick").toInt();

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/NumberInputField.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/NumberInputField.qml
@@ -59,7 +59,7 @@ FocusScope {
     }
 
     QtObject {
-        id: privateProperties
+        id: prv
 
         function pad(value) {
             var str = value.toString()
@@ -81,7 +81,9 @@ FocusScope {
     }
 
     onValueChanged: {
-        textField.text = privateProperties.pad(value)
+        if (textField.textAsInt() >= root.minValue) {
+            textField.text = prv.pad(root.value)
+        }
     }
 
     NavigationControl {
@@ -107,14 +109,18 @@ FocusScope {
         padding: 0
 
         readOnly: root.maxValue === 0
-        text: privateProperties.pad(root.value)
+        text: prv.pad(root.value)
+
+        function textAsInt() {
+             return textField.text.length > 0 ? parseInt(textField.text) : 0
+        }
 
         onTextEdited: {
-            var currentValue = text.length > 0 ? parseInt(text) : 0
+            var currentValue = textField.textAsInt()
             var str = currentValue.toString()
             var newValue = 0
 
-            if (str.length > privateProperties.displayedNumberLength || currentValue > root.maxValue) {
+            if (str.length > root.displayedNumberLength || currentValue > root.maxValue) {
                 var lastDigit = str.charAt(str.length - 1)
                 newValue = parseInt(lastDigit)
             } else {
@@ -122,9 +128,19 @@ FocusScope {
             }
 
             newValue = Math.min(newValue, root.maxValue)
-            text = privateProperties.pad(newValue)
+
+            //! NOTE: displayed text can have a value less than minValue
+            // to allow the user to easily enter a new value
+            textField.text = prv.pad(newValue)
+            newValue = Math.max(newValue, root.minValue)
 
             root.valueEdited(newValue)
+        }
+
+        onActiveFocusChanged: {
+            if (!activeFocus) {
+                textField.text = prv.pad(root.value)
+            }
         }
 
         background: Rectangle {

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledSlider.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledSlider.qml
@@ -27,6 +27,8 @@ import MuseScore.Ui 1.0
 Slider {
     id: root
 
+    property bool fillBackground: true
+
     implicitWidth: vertical ? prv.handleSize : prv.defaultLength
     implicitHeight: vertical ? prv.defaultLength : prv.handleSize
 
@@ -37,6 +39,7 @@ Slider {
         id: prv
 
         readonly property int lineSize: 4
+        readonly property int radius: 4
         readonly property int handleSize: 14
         readonly property int defaultLength: 220
     }
@@ -51,12 +54,13 @@ Slider {
 
             anchors.verticalCenter: parent.verticalCenter
 
-            width: handleBackground.x + handleBackground.width / 2
-            height: prv.lineSize
+            width: root.fillBackground ? handleBackground.x + handleBackground.width / 2 : 0
+            height: root.fillBackground ? prv.lineSize : 0
+            visible: root.fillBackground
 
             opacity: 1
             color: ui.theme.accentColor
-            radius: height
+            radius: prv.radius
         }
 
         Rectangle {
@@ -71,7 +75,7 @@ Slider {
 
             opacity: 0.5
             color: ui.theme.fontPrimaryColor
-            radius: filledBackground.radius
+            radius: prv.radius
         }
     }
 
@@ -146,8 +150,8 @@ Slider {
 
                 y: blankBackground.height
 
-                width: prv.lineSize
-                height: root.height - blankBackground.height
+                width: root.fillBackground ? prv.lineSize : 0
+                height: root.fillBackground ? root.height - blankBackground.height : 0
             }
 
             PropertyChanges {

--- a/src/importexport/midi/internal/midiexport/exportmidi.cpp
+++ b/src/importexport/midi/internal/midiexport/exportmidi.cpp
@@ -187,14 +187,14 @@ void ExportMidi::writeHeader()
     //--------------------------------------------
 
     TempoMap* tempomap = m_pauseMap.tempomapWithPauses;
-    BeatsPerSecond relTempo = tempomap->relTempo();
+    BeatsPerSecond tempoMultiplier = tempomap->tempoMultiplier();
     for (auto it = tempomap->cbegin(); it != tempomap->cend(); ++it) {
         MidiEvent ev;
         ev.setType(ME_META);
         //
         // compute midi tempo: microseconds / quarter note
         //
-        int tempo = lrint((1.0 / it->second.tempo.val * relTempo.val) * 1000000.0);
+        int tempo = lrint((1.0 / it->second.tempo.val * tempoMultiplier.val) * 1000000.0);
 
         ev.setMetaType(META_TEMPO);
         ev.setLen(3);
@@ -389,7 +389,7 @@ void ExportMidi::PauseMap::calculate(const Score* s)
     this->insert(std::pair<const int, int>(0, 0));    // can't start with a pause
 
     tempomapWithPauses = new TempoMap();
-    tempomapWithPauses->setRelTempo(tempomap->relTempo());
+    tempomapWithPauses->setTempoMultiplier(tempomap->tempoMultiplier());
 
     for (const RepeatSegment* rs : s->repeatList()) {
         int startTick  = rs->tick;

--- a/src/notation/inotationplayback.h
+++ b/src/notation/inotationplayback.h
@@ -74,6 +74,9 @@ public:
     virtual const Tempo& tempo(midi::tick_t tick) const = 0;
     virtual MeasureBeat beat(midi::tick_t tick) const = 0;
     virtual midi::tick_t beatToTick(int measureIndex, int beatIndex) const = 0;
+
+    virtual double tempoMultiplier() const = 0;
+    virtual void setTempoMultiplier(double multiplier) = 0;
 };
 
 using INotationPlaybackPtr = std::shared_ptr<INotationPlayback>;

--- a/src/notation/internal/notationplayback.cpp
+++ b/src/notation/internal/notationplayback.cpp
@@ -344,3 +344,15 @@ tick_t NotationPlayback::beatToTick(int measureIndex, int beatIndex) const
 {
     return score() ? score()->sigmap()->bar2tick(measureIndex, beatIndex) : 0;
 }
+
+double NotationPlayback::tempoMultiplier() const
+{
+    return score() ? score()->tempomap()->tempoMultiplier().val : 1.0;
+}
+
+void NotationPlayback::setTempoMultiplier(double multiplier)
+{
+    if (score()) {
+        score()->tempomap()->setTempoMultiplier(multiplier);
+    }
+}

--- a/src/notation/internal/notationplayback.h
+++ b/src/notation/internal/notationplayback.h
@@ -76,6 +76,9 @@ public:
     MeasureBeat beat(midi::tick_t tick) const override;
     midi::tick_t beatToTick(int measureIndex, int beatIndex) const override;
 
+    double tempoMultiplier() const override;
+    void setTempoMultiplier(double multiplier) override;
+
 private:
     engraving::Score* score() const;
 

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -1081,6 +1081,19 @@ msecs_t PlaybackController::beatToMilliseconds(int measureIndex, int beatIndex) 
     return tickToMsecs(tick);
 }
 
+double PlaybackController::tempoMultiplier() const
+{
+    INotationPlaybackPtr playback = notationPlayback();
+    return playback ? playback->tempoMultiplier() : 1.0;
+}
+
+void PlaybackController::setTempoMultiplier(double multiplier)
+{
+    if (INotationPlaybackPtr playback = notationPlayback()) {
+        playback->setTempoMultiplier(multiplier);
+    }
+}
+
 mu::framework::Progress PlaybackController::loadingProgress() const
 {
     return m_loadingProgress;

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -327,7 +327,7 @@ void PlaybackController::onNotationChanged()
     });
 
     notationPlayback()->loopBoundariesChanged().onNotify(this, [this]() {
-        setLoop(notationPlayback()->loopBoundaries());
+        updateLoop();
     });
 
     m_notation->interaction()->selectionChanged().onNotify(this, [this]() {
@@ -345,7 +345,7 @@ void PlaybackController::onSelectionChanged()
 
     if (!isRangeSelection) {
         if (selectionTypeChanged) {
-            setLoop(notationPlayback()->loopBoundaries());
+            updateLoop();
             updateMuteStates();
         }
 
@@ -577,11 +577,13 @@ void PlaybackController::addLoopBoundaryToTick(LoopBoundaryType type, int tick)
     }
 }
 
-void PlaybackController::setLoop(const LoopBoundaries& boundaries)
+void PlaybackController::updateLoop()
 {
-    IF_ASSERT_FAILED(playback()) {
+    IF_ASSERT_FAILED(notationPlayback() && playback()) {
         return;
     }
+
+    const LoopBoundaries& boundaries = notationPlayback()->loopBoundaries();
 
     if (!boundaries.visible) {
         hideLoop();
@@ -1106,6 +1108,7 @@ void PlaybackController::setTempoMultiplier(double multiplier)
 
     playback->setTempoMultiplier(multiplier);
     seek(tick);
+    updateLoop();
 
     if (playing) {
         resume();

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -950,8 +950,11 @@ void PlaybackController::setupSequencePlayer()
             return;
         }
 
-        tick_t tick = notationPlayback()->secToTick(msecs / 1000.);
+        if (!isPlaying()) {
+            return;
+        }
 
+        tick_t tick = notationPlayback()->secToTick(msecs / 1000.);
         setCurrentTick(tick);
         m_tickPlayed.send(std::move(tick));
     });
@@ -1089,8 +1092,23 @@ double PlaybackController::tempoMultiplier() const
 
 void PlaybackController::setTempoMultiplier(double multiplier)
 {
-    if (INotationPlaybackPtr playback = notationPlayback()) {
-        playback->setTempoMultiplier(multiplier);
+    INotationPlaybackPtr playback = notationPlayback();
+    if (!playback) {
+        return;
+    }
+
+    tick_t tick = m_currentTick;
+    bool playing = isPlaying();
+
+    if (playing) {
+        pause();
+    }
+
+    playback->setTempoMultiplier(multiplier);
+    seek(tick);
+
+    if (playing) {
+        resume();
     }
 }
 

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -93,6 +93,9 @@ public:
     notation::MeasureBeat currentBeat() const override;
     audio::msecs_t beatToMilliseconds(int measureIndex, int beatIndex) const override;
 
+    double tempoMultiplier() const override;
+    void setTempoMultiplier(double multiplier) override;
+
     framework::Progress loadingProgress() const override;
 
 private:

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -142,8 +142,7 @@ private:
 
     void addLoopBoundary(notation::LoopBoundaryType type);
     void addLoopBoundaryToTick(notation::LoopBoundaryType type, int tick);
-
-    void setLoop(const notation::LoopBoundaries& boundaries);
+    void updateLoop();
 
     void showLoop();
     void hideLoop();

--- a/src/playback/iplaybackcontroller.h
+++ b/src/playback/iplaybackcontroller.h
@@ -77,6 +77,9 @@ public:
     virtual notation::MeasureBeat currentBeat() const = 0;
     virtual audio::msecs_t beatToMilliseconds(int measureIndex, int beatIndex) const = 0;
 
+    virtual double tempoMultiplier() const = 0;
+    virtual void setTempoMultiplier(double multiplier) = 0;
+
     virtual framework::Progress loadingProgress() const = 0;
 };
 }

--- a/src/playback/playback.qrc
+++ b/src/playback/playback.qrc
@@ -3,6 +3,7 @@
         <file>qml/MuseScore/Playback/qmldir</file>
         <file>qml/MuseScore/Playback/PlaybackToolBar.qml</file>
         <file>qml/MuseScore/Playback/internal/MeasureAndBeatFields.qml</file>
+        <file>qml/MuseScore/Playback/internal/TempoSlider.qml</file>
         <file>qml/MuseScore/Playback/MixerPanel.qml</file>
         <file>qml/MuseScore/Playback/internal/MixerPanelSection.qml</file>
         <file>qml/MuseScore/Playback/internal/MixerBalanceSection.qml</file>

--- a/src/playback/qml/MuseScore/Playback/PlaybackToolBar.qml
+++ b/src/playback/qml/MuseScore/Playback/PlaybackToolBar.qml
@@ -81,5 +81,15 @@ Item {
                 playbackModel.playPosition = value
             }
         }
+
+        TempoSlider {
+            width: playbackActions.width - 12
+            visible: root.floating
+            value: playbackModel.tempoMultiplier
+
+            onMoved: function(newValue) {
+                playbackModel.tempoMultiplier = newValue
+            }
+        }
     }
 }

--- a/src/playback/qml/MuseScore/Playback/internal/TempoSlider.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/TempoSlider.qml
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+
+import MuseScore.UiComponents 1.0
+import MuseScore.Ui 1.0
+
+RowLayout {
+    id: root
+
+    property real value: 0
+    property real from: 0.1
+    property real to: 3
+    property real stepSize: 0.05
+
+    signal moved(real newValue)
+
+    height: 30
+    spacing: 0
+
+    StyledTextLabel {
+        Layout.fillHeight: true
+        Layout.alignment: Qt.AlignVCenter
+
+        text: qsTrc("playback", "Tempo")
+        font: ui.theme.largeBodyFont
+    }
+
+    Item {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+    }
+
+    NumberInputField {
+        value: root.value * 100
+        minValue: root.from * 100
+        maxValue: root.to * 100
+
+        addLeadingZeros: false
+        font: ui.theme.largeBodyFont
+
+        onValueEdited: function(newValue) {
+            root.moved(newValue / 100)
+        }
+    }
+
+    StyledTextLabel {
+        text: "%"
+        font: ui.theme.largeBodyFont
+    }
+
+    StyledSlider {
+        id: slider
+
+        Layout.preferredWidth: root.width / 2
+        Layout.leftMargin: 12
+
+        value: root.value
+        from: root.from
+        to: root.to
+        stepSize: root.stepSize
+
+        fillBackground: false
+
+        onMoved: {
+            root.moved(slider.value)
+        }
+    }
+}

--- a/src/playback/view/playbacktoolbarmodel.cpp
+++ b/src/playback/view/playbacktoolbarmodel.cpp
@@ -288,6 +288,16 @@ void PlaybackToolBarModel::setBeatNumber(int beatNumber)
     rewindToBeat(measureBeat);
 }
 
+void PlaybackToolBarModel::setTempoMultiplier(qreal multiplier)
+{
+    if (multiplier == tempoMultiplier()) {
+        return;
+    }
+
+    playbackController()->setTempoMultiplier(multiplier);
+    emit tempoChanged();
+}
+
 int PlaybackToolBarModel::maxBeatNumber() const
 {
     return measureBeat().maxBeatIndex + 1;
@@ -303,4 +313,9 @@ QVariant PlaybackToolBarModel::tempo() const
     obj["value"] = tempo.valueBpm;
 
     return obj;
+}
+
+qreal PlaybackToolBarModel::tempoMultiplier() const
+{
+    return playbackController()->tempoMultiplier();
 }

--- a/src/playback/view/playbacktoolbarmodel.h
+++ b/src/playback/view/playbacktoolbarmodel.h
@@ -47,6 +47,7 @@ class PlaybackToolBarModel : public uicomponents::AbstractMenuModel
     Q_PROPERTY(int maxBeatNumber READ maxBeatNumber NOTIFY playPositionChanged)
 
     Q_PROPERTY(QVariant tempo READ tempo NOTIFY tempoChanged)
+    Q_PROPERTY(qreal tempoMultiplier READ tempoMultiplier WRITE setTempoMultiplier NOTIFY tempoChanged)
 
 public:
     explicit PlaybackToolBarModel(QObject* parent = nullptr);
@@ -64,6 +65,7 @@ public:
     int maxBeatNumber() const;
 
     QVariant tempo() const;
+    qreal tempoMultiplier() const;
 
     Q_INVOKABLE void load() override;
 
@@ -73,6 +75,7 @@ public slots:
     void setPlayTime(const QDateTime& time);
     void setMeasureNumber(int measureNumber);
     void setBeatNumber(int beatNumber);
+    void setTempoMultiplier(qreal multiplier);
 
 signals:
     void isToolbarFloatingChanged(bool floating);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11617