### PR TITLE
[MU4] Fix some menus/shortcut strings

### DIFF
--- a/src/appshell/view/publish/publishtoolbarmodel.cpp
+++ b/src/appshell/view/publish/publishtoolbarmodel.cpp
@@ -35,9 +35,9 @@ void PublishToolBarModel::load()
     AbstractMenuModel::load();
 
     MenuItemList items {
-        makeMenuItem("print"),
-        makeMenuItem("file-publish"),
-        makeMenuItem("file-export")
+        makeMenuItem("print", TranslatableString("action", "Print")),
+        makeMenuItem("file-publish", TranslatableString("action", "Publish to MuseScore.com")),
+        makeMenuItem("file-export", TranslatableString("action", "Export"))
     };
 
     setItems(items);

--- a/src/engraving/libmscore/fret.cpp
+++ b/src/engraving/libmscore/fret.cpp
@@ -1522,7 +1522,10 @@ String FretDiagram::screenReaderInfo() const
             }
         }
 
-        //: Omit the "%n " for the singular translation (and the "(s)" too)
+        //: Please provide a translation for the singular and all plural forms available in your language.
+        //: See https://github.com/musescore/MuseScore/wiki/Help-translate-MuseScore#plural-forms
+        //: You may translate singular case to the equivalent of "one dot" or even just "dot" instead of the "1 dot" form, but only do this
+        //: if you are sure that the translation is only used for a single value of "%n".
         String dotsInfo = mtrc("engraving", "%n dot(s) on fret(s) %1", "", dotsCount).arg(fretInfo);
 
         detailedInfo = String(u"%1 %2 %3 %4").arg(detailedInfo, stringIdent, markerName, dotsInfo);
@@ -1565,6 +1568,10 @@ String FretDiagram::screenReaderInfo() const
 
     String basicInfo = String(u"%1 %2").arg(translatedTypeUserName(), chordName);
 
+    //: Please provide a translation for the singular and all plural forms available in your language.
+    //: See https://github.com/musescore/MuseScore/wiki/Help-translate-MuseScore#plural-forms
+    //: You may translate singular case to the equivalent of "one string" instead of the "1 string" form, but only do this
+    //: if you are sure that the translation is only used for a single value of "%n".
     String generalInfo = mtrc("engraving", "%n string(s) total", "", _strings);
 
     String res = String(u"%1 %2 %3").arg(basicInfo, generalInfo, detailedInfo);

--- a/src/engraving/libmscore/measurerepeat.cpp
+++ b/src/engraving/libmscore/measurerepeat.cpp
@@ -315,6 +315,10 @@ Fraction MeasureRepeat::ticks() const
 
 String MeasureRepeat::accessibleInfo() const
 {
+    //: Please provide a translation for the singular and all plural forms available in your language.
+    //: See https://github.com/musescore/MuseScore/wiki/Help-translate-MuseScore#plural-forms
+    //: You may translate singular case to the equivalent of "One measure" instead of the "1 meassures" form, but only do this
+    //: if you are sure that the translation is only used for a single value of "%n".
     return mtrc("engraving", "%1; Duration: %n measure(s)", nullptr, numMeasures()).arg(EngravingItem::accessibleInfo());
 }
 

--- a/src/framework/global/dataformatter.cpp
+++ b/src/framework/global/dataformatter.cpp
@@ -44,21 +44,23 @@ String DataFormatter::formatTimeSince(const Date& date)
         return mtrc("global", "Today");
     }
 
-    if (days == 1) {
-        return mtrc("global", "Yesterday");
-    }
-
     if (days < 7) {
+        //: Please provide a translation for the singular and all plural forms available in your language.
+        //: See https://github.com/musescore/MuseScore/wiki/Help-translate-MuseScore#plural-forms
+        //: Possible translations for the 0 case and any value > 6 are not used, yet mandatory.
+        //: You may translate singular case to the equivalent of "Yesterday" instead of the "1 day ago" form, but only do this
+        //: if you are sure that the translation is only used for a single value of "%n".
         return mtrc("global", "%n day(s) ago", nullptr, days);
     }
 
     int weeks = days / 7;
 
-    if (weeks == 1) {
-        return mtrc("global", "Last week");
-    }
-
     if (weeks <= 4) {
+        //: Please provide a translation for the singular and all plural forms available in your language.
+        //: See https://github.com/musescore/MuseScore/wiki/Help-translate-MuseScore#plural-forms
+        //: Possible translations for the 0 case and any value > 6 are not used, yet mandatory.
+        //: You may translate singular case to the equivalent of "Last week" instead of the "1 week ago" form, but only do this
+        //: if you are sure that the translation is only used for a single value of "%n".
         return mtrc("global", "%n week(s) ago", nullptr, weeks);
     }
 
@@ -66,15 +68,21 @@ String DataFormatter::formatTimeSince(const Date& date)
 
     int months = (currentDate.year() - date.year()) * monthsInYear + (currentDate.month() - date.month());
 
-    if (months == 1) {
-        return mtrc("global", "Last month");
-    }
-
     if (months < monthsInYear) {
+        //: Please provide a translation for the singular and all plural forms available in your language.
+        //: See https://github.com/musescore/MuseScore/wiki/Help-translate-MuseScore#plural-forms
+        //: Possible translations for the 0 case and any value > 6 are not used, yet mandatory.
+        //: You may translate singular case to the equivalent of "Last month" instead of the "1 month ago" form, but only do this
+        //: if you are sure that the translation is only used for a single value of "%n".
         return mtrc("global", "%n month(s) ago", nullptr, months);
     }
 
     int years = currentDate.year() - date.year();
 
+    //: Please provide a translation for the singular and all plural forms available in your language.
+    //: See https://github.com/musescore/MuseScore/wiki/Help-translate-MuseScore#plural-forms
+    //: Possible translations for the 0 case and any value > 6 are not used, yet mandatory.
+    //: You may translate singular case to the equivalent of "Last year" instead of the "1 year ago" form, but only do this
+    //: if you are sure that the translation is only used for a single value of "%n".
     return mtrc("global", "%n year(s) ago", nullptr, years);
 }

--- a/src/importexport/musicxml/internal/musicxml/importmxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxml.cpp
@@ -90,6 +90,11 @@ Err importMusicXMLfromBuffer(Score* score, const QString& /*name*/, QIODevice* d
     const auto pass2_errors = pass2.errors();
     if (!(pass1_errors.isEmpty() && pass2_errors.isEmpty())) {
         if (!MScore::noGui) {
+            //: Please provide a translation for the singular and all plural forms available in your language.
+            //: See https://github.com/musescore/MuseScore/wiki/Help-translate-MuseScore#plural-forms
+            //: A possible translation for the 0 case is not used, yet mandatory.
+            //: You may translate singular case to the equivalent of "One error" instead of the "1 error" form, but only do this
+            //: if you are sure that the translation is only used for a single value of "%n".
             const QString text = qtrc("iex_musicxml", "%n error(s) found, import may be incomplete.",
                                       nullptr, pass1_errors.count() + pass2_errors.count());
             if (musicXMLImportErrorDialog(text, pass1.errors() + pass2.errors()) != QMessageBox::Yes) {

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1182,7 +1182,7 @@ void EditStyle::setHeaderFooterToolTip()
           + QString("</i></td></tr></table><p>")
           + qtrc("notation/editstyle", "Available metadata tags and their current values")
           + QString("<br />")
-          + qtrc("notation/editstyle", "(in File > Project properties…):")
+          + qtrc("notation/editstyle", "(in File > Properties…):")
           + QString("</p><table>");
 
     // show all tags for current score/part

--- a/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
@@ -407,6 +407,8 @@ StyledListView {
                 paletteTree.paletteController.remove(modelIndex);
             }
 
+            //: Please provide a translation for the singular and all plural forms available in your language.
+            //: See https://github.com/musescore/MuseScore/wiki/Help-translate-MuseScore#plural-forms
             text: filter.length ? qsTrc("palette", "%1, contains %n matching element(s)", "", mainPalette.count).arg(model.accessibleText)
                                 : model.expanded ? qsTrc("palette", "%1 expanded", "tree item not collapsed").arg(model.accessibleText)
                                                  : model.accessibleText

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -31,14 +31,14 @@ const UiActionList ProjectUiActions::m_actions = {
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "&Open…"),
-             TranslatableString("action", "Open…"),
+             TranslatableString("action", "Open"),
              IconCode::Code::OPEN_FILE
              ),
     UiAction("file-new",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "&New…"),
-             TranslatableString("action", "New…"),
+             TranslatableString("action", "New"),
              IconCode::Code::NEW_FILE
              ),
     UiAction("file-close",
@@ -58,66 +58,66 @@ const UiActionList ProjectUiActions::m_actions = {
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "Save &as…"),
-             TranslatableString("action", "Save as…")
+             TranslatableString("action", "Save as")
              ),
     UiAction("file-save-a-copy",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "Save a cop&y…"),
-             TranslatableString("action", "Save a copy…")
+             TranslatableString("action", "Save a copy")
              ),
     UiAction("file-save-selection",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "Save se&lection…"),
-             TranslatableString("action", "Save selection…")
+             TranslatableString("action", "Save selection")
              ),
     UiAction("file-save-to-cloud",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "Save to clo&ud…"),
-             TranslatableString("action", "Save to cloud…"),
+             TranslatableString("action", "Save to cloud"),
              IconCode::Code::CLOUD_FILE
              ),
     UiAction("file-publish",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "Pu&blish to MuseScore.com…"),
-             TranslatableString("action", "Publish to MuseScore.com…"),
+             TranslatableString("action", "Publish to MuseScore.com"),
              IconCode::Code::CLOUD_FILE
              ),
     UiAction("file-export",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "&Export…"),
-             TranslatableString("action", "Export…"),
+             TranslatableString("action", "Export"),
              IconCode::Code::SHARE_FILE
              ),
     UiAction("file-import-pdf",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "Import P&DF…"),
-             TranslatableString("action", "Import PDF…"),
+             TranslatableString("action", "Import PDF"),
              IconCode::Code::IMPORT
              ),
     UiAction("project-properties",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
-             TranslatableString("action", "Project propert&ies…"),
-             TranslatableString("action", "Project properties…")
+             TranslatableString("action", "Propert&ies…"),
+             TranslatableString("action", "Properties")
              ),
     UiAction("print",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "&Print…"),
-             TranslatableString("action", "Print…"),
+             TranslatableString("action", "Print"),
              IconCode::Code::PRINT
              ),
     UiAction("clear-recent",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
-             TranslatableString("action", "&Clear recent files"),
-             TranslatableString("action", "Clear recent files")
+             TranslatableString("action", "&Clear list of recent files"),
+             TranslatableString("action", "Clear list of recent files")
              )
 };
 

--- a/src/project/qml/MuseScore/Project/internal/NewScore/MeasuresSettings.qml
+++ b/src/project/qml/MuseScore/Project/internal/NewScore/MeasuresSettings.qml
@@ -54,6 +54,8 @@ FlatButton {
         }
 
         font: ui.theme.largeBodyFont
+        //: Please provide a translation for the singular and all plural forms available in your language.
+        //: See https://github.com/musescore/MuseScore/wiki/Help-translate-MuseScore#plural-forms
         text: qsTrc("project/newscore", "%n measure(s),", "", model.measureCount) + "\n" + pickupMessage
     }
 


### PR DESCRIPTION
i.e. differentiate them between the menu and the shortcuts. Esp. have the accelerator key only in the menu, not in the shortcut strings and also, for shortcuts have a better description (which in the Menu comes from their context, here: the File menu)

Changes/adds a few string from/to the translations

Fixes #12921
Fixes #13164, see also #11916
Related to #13295 too