### PR TITLE
Fix #12816: Slur/tie anchor fix after measures rewritten during timesig change

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -992,6 +992,18 @@ bool Score::rewriteMeasures(Measure* fm, Measure* lm, const Fraction& ns, staff_
     }
     connectTies(true);
 
+    // reset start and end elements for slurs that overlap the rewritten measures
+    for (auto spanner : _spanner.findOverlapping(fm->tick().ticks(), lm->tick().ticks())) {
+        Slur* slur = (spanner.value->isSlur() ? toSlur(spanner.value) : nullptr);
+        if (slur) {
+            EngravingItem* startEl = slur->startElement();
+            EngravingItem* endEl = slur->endElement();
+            if (!startEl || !endEl) {
+                continue;
+            }
+            undo(new ChangeStartEndSpanner(spanner.value, slur->findStartCR(), slur->findEndCR()));
+        }
+    }
     // Attempt to move tremolos to correct chords
     for (auto tremPair : tremoloChordTicks) {
         Fraction chord1Tick = std::get<0>(tremPair);

--- a/src/engraving/libmscore/range.cpp
+++ b/src/engraving/libmscore/range.cpp
@@ -734,7 +734,7 @@ bool ScoreRange::write(Score* score, const Fraction& tick) const
         s->setTick(s->tick() + tick);
         if (s->isSlur()) {
             Slur* slur = toSlur(s);
-            if (slur->startCR()->isGrace()) {
+            if (slur->startCR() && slur->startCR()->isGrace()) {
                 Chord* sc = slur->startChord();
                 size_t idx = sc->graceIndex();
                 Chord* dc = toChord(score->findCR(s->tick(), s->track()));
@@ -742,7 +742,7 @@ bool ScoreRange::write(Score* score, const Fraction& tick) const
             } else {
                 s->setStartElement(0);
             }
-            if (slur->endCR()->isGrace()) {
+            if (slur->endCR() && slur->endCR()->isGrace()) {
                 Chord* sc = slur->endChord();
                 size_t idx = sc->graceIndex();
                 Chord* dc = toChord(score->findCR(s->tick2(), s->track2()));

--- a/src/engraving/libmscore/undo.cpp
+++ b/src/engraving/libmscore/undo.cpp
@@ -2252,7 +2252,6 @@ void InsertRemoveMeasures::removeMeasures()
                 sp->removeUnmanaged();
             }
         }
-        score->connectTies(true);       // ??
     }
 
     // remove empty systems


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/12816

Slurs and ties were not reconnected to the rewritten notes when time signatures were added, leading to situations like this:
![image](https://user-images.githubusercontent.com/89263931/184701945-db333a83-6716-4e3b-a298-e9d3587f1cb4.png)

This has now been fixed:
![image](https://user-images.githubusercontent.com/89263931/184702550-3521475d-70f2-41ae-8eaa-e2266b1206f0.png)