### PR TITLE
Fix #12864: fix crashes when there is no staff

### DIFF
--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -3833,6 +3833,10 @@ void Score::setScoreOrder(ScoreOrder order)
 
 void Score::updateBracesAndBarlines(Part* part, size_t newIndex)
 {
+    if (part->nstaves() == 0) {
+        return;
+    }
+
     bool noBracesFound = true;
     for (size_t indexInPart = 0; indexInPart < part->nstaves(); ++indexInPart) {
         size_t indexInScore = part->staves()[indexInPart]->idx();
@@ -3868,8 +3872,8 @@ void Score::updateBracesAndBarlines(Part* part, size_t newIndex)
                 undoAddBracket(part->staves()[0], 0, tp->bracket[0], part->nstaves());
             }
         }
-    } else {
-        updateBracketSpan(newIndex, newIndex - 1);
+    } else if (newIndex == 1) {
+        updateBracketSpan(1, 0);
     }
 }
 

--- a/src/instrumentsscene/view/instrumentspaneltreemodel.cpp
+++ b/src/instrumentsscene/view/instrumentspaneltreemodel.cpp
@@ -661,7 +661,6 @@ void InstrumentsPanelTreeModel::updateRemovingAvailability()
         if (item && static_cast<ItemType>(item->type()) == ItemType::STAFF) {
             const AbstractInstrumentsPanelTreeItem* parentItem = item->parentItem();
             if (parentItem) {
-
                 // The selected staff is the only one
                 if (parentItem->childCount() == 2) {
                     isRemovingAvailable = false;
@@ -676,7 +675,6 @@ void InstrumentsPanelTreeModel::updateRemovingAvailability()
                             && childItem != item
                             && static_cast<ItemType>(childItem->type()) == ItemType::STAFF
                             && !childItem->isSelected()) {
-
                             hasUnselectedStaff = true;
                             break;
                         }

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -841,8 +841,11 @@ void NotationParts::removeStaves(const IDList& stavesIds)
             }
         }
         score()->cmdRemoveStaff(staff->idx());
-        for (BracketData bd : newBrackets) {
-            score()->undoAddBracket(score()->staff(staffIdx), static_cast<int>(bd.column), BracketType::BRACE, bd.span);
+
+        if (staffIdx < score()->nstaves()) {
+            for (BracketData bd : newBrackets) {
+                score()->undoAddBracket(score()->staff(staffIdx), static_cast<int>(bd.column), BracketType::BRACE, bd.span);
+            }
         }
     }
 


### PR DESCRIPTION
Resolves: #12864 

Hello,

There were various places where the code tried to access a staff even if there were none. I added additional checks to prevent this.
Now it works as intended:

https://user-images.githubusercontent.com/36641081/184849252-f43563b0-7f50-48d6-8e82-2e1b2a9dc342.mp4

Have a good day,
Martin