### PR TITLE
[MU4] Fix #12856: Crash if text object is selected and you click the Appearance or More button

### DIFF
--- a/src/inspector/models/inspectorpopupcontroller.cpp
+++ b/src/inspector/models/inspectorpopupcontroller.cpp
@@ -90,6 +90,10 @@ void InspectorPopupController::setVisualControl(QQuickItem* control)
                 closePopup();
             }
         });
+
+        connect(m_visualControl, &QQuickItem::destroyed, this, [this]() {
+            setVisualControl(nullptr);
+        });
     }
 
     emit visualControlChanged();
@@ -114,6 +118,10 @@ void InspectorPopupController::setPopup(PopupView* popup)
             if (m_popup && !m_popup->isOpened()) {
                 setPopup(nullptr);
             }
+        });
+
+        connect(m_popup, &PopupView::destroyed, this, [this]() {
+            setPopup(nullptr);
         });
     } else {
         qApp->removeEventFilter(this);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/12820
Resolves: https://github.com/musescore/MuseScore/issues/12856