### PR TITLE
FIx #12353, Add treble clef staff to treble clef instruments

### DIFF
--- a/src/engraving/libmscore/instrument.cpp
+++ b/src/engraving/libmscore/instrument.cpp
@@ -1535,7 +1535,7 @@ ClefTypeList Instrument::clefType(size_t staffIdx) const
 {
     if (staffIdx >= _clefType.size()) {
         if (_clefType.empty()) {
-            return ClefTypeList(staffIdx == 1 ? ClefType::F : ClefType::G);
+            return ClefTypeList(staffIdx == 1 ? ClefType::G : ClefType::F);
         }
         return _clefType[0];
     }


### PR DESCRIPTION
Resolves: #12353 

When using templates and adding staff to treble clef instruments, new staff using a bass clef is added. Change it to add a treble clef staff.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
