### PR TITLE
Fix navigation after enabling plugin

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/NavigationFocusBorder.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/NavigationFocusBorder.qml
@@ -29,8 +29,14 @@ Rectangle {
     property NavigationControl navigationCtrl: null
     property bool drawOutsideParent: true
 
+    //! NOTE: sometimes, the contrast between the item and the navigation focus
+    //! border might be very low, for example when the item is an image.
+    //! Therefore, we sometimes add some padding between the item and the border,
+    //! to keep the border easily distinguishable.
+    property real padding: 0
+
     anchors.fill: parent
-    anchors.margins: drawOutsideParent ? -border.width : 0
+    anchors.margins: drawOutsideParent ? -border.width - padding : 0
 
     visible: navigationCtrl ? navigationCtrl.highlight : false
 
@@ -39,6 +45,6 @@ Rectangle {
     border.color: ui.theme.fontPrimaryColor
     border.width: ui.theme.navCtrlBorderWidth
     radius: Number(parent.radius) > 0
-            ? (drawOutsideParent ? parent.radius + root.border.width : parent.radius)
+            ? parent.radius - anchors.margins
             : 0
 }

--- a/src/plugins/qml/MuseScore/Plugins/PluginsPage.qml
+++ b/src/plugins/qml/MuseScore/Plugins/PluginsPage.qml
@@ -222,7 +222,7 @@ Item {
 
         onClosed: {
             prv.resetSelectedPlugin()
-            Qt.callLater(resetNavigationFocus)
+            resetNavigationFocus()
         }
 
         function resetNavigationFocus() {

--- a/src/plugins/qml/MuseScore/Plugins/PluginsPage.qml
+++ b/src/plugins/qml/MuseScore/Plugins/PluginsPage.qml
@@ -102,9 +102,7 @@ Item {
 
         anchors.top: parent.top
         anchors.left: parent.left
-        anchors.leftMargin: root.sideMargin
         anchors.right: parent.right
-        anchors.rightMargin: root.sideMargin
         anchors.bottom: panel.visible ? panel.top : parent.bottom
 
         contentWidth: width
@@ -113,20 +111,12 @@ Item {
         topMargin: topGradient.height
         bottomMargin: 24
 
-        ScrollBar.vertical: StyledScrollBar {
-            parent: flickable.parent
-
-            anchors.top: parent.top
-            anchors.bottom: panel.visible ? panel.top : parent.bottom
-            anchors.right: parent.right
-
-            visible: flickable.contentHeight > flickable.height
-            z: 1
-        }
-
         Column {
             id: column
+
             anchors.fill: parent
+            anchors.leftMargin: root.sideMargin
+            anchors.rightMargin: root.sideMargin
 
             spacing: 24
 

--- a/src/plugins/qml/MuseScore/Plugins/internal/PluginItem.qml
+++ b/src/plugins/qml/MuseScore/Plugins/internal/PluginItem.qml
@@ -29,10 +29,8 @@ Item {
     id: root
 
     property alias name: nameLabel.text
-    property alias thumbnailUrl: thumbnail.source
+    property alias thumbnailUrl: thumbnailImage.source
     property bool selected: false
-
-    property real radius: 10
 
     signal clicked()
 
@@ -50,29 +48,19 @@ Item {
         onTriggered: root.clicked()
     }
 
-    Rectangle {
-        id: thumbnailRect
+    Item {
+        id: thumbnail
 
         anchors.top: parent.top
         width: parent.width
         height: 144
 
-        color: "transparent"
-        radius: root.radius + border.width
-
-        border.color: ui.theme.fontPrimaryColor
-        border.width: root.selected ? 2 : 0
-
-        NavigationFocusBorder {
-            navigationCtrl: root.navigation
-            drawOutsideParent: false
-        }
+        property real radius: 10
 
         Image {
-            id: thumbnail
+            id: thumbnailImage
 
             anchors.fill: parent
-            anchors.margins: 4 //! NOTE: makes it easier to distinguish the focused item when using keyboard navigation
 
             fillMode: Image.PreserveAspectCrop
 
@@ -81,16 +69,39 @@ Item {
                 maskSource: Rectangle {
                     width: thumbnail.width
                     height: thumbnail.height
-                    radius: root.radius
+                    radius: thumbnail.radius
                 }
             }
+        }
+
+        Rectangle {
+            id: selectionBorder
+
+            readonly property real padding: 2 // add some padding between image and border, to make border better distinguishable
+
+            anchors.fill: parent
+            anchors.margins: -border.width - padding
+
+            visible: root.selected
+
+            color: "transparent"
+
+            border.color: ui.theme.fontPrimaryColor
+            border.width: 2
+            radius: thumbnail.radius - anchors.margins
+        }
+
+        NavigationFocusBorder {
+            navigationCtrl: root.navigation
+
+            padding: 2
         }
     }
 
     StyledTextLabel {
         id: nameLabel
 
-        anchors.top: thumbnailRect.bottom
+        anchors.top: thumbnail.bottom
         anchors.topMargin: 16
         anchors.horizontalCenter: parent.horizontalCenter
     }

--- a/src/plugins/qml/MuseScore/Plugins/internal/PluginsListView.qml
+++ b/src/plugins/qml/MuseScore/Plugins/internal/PluginsListView.qml
@@ -51,6 +51,10 @@ Column {
     signal navigationActivated(var itemRect)
 
     function focusOnFirst() {
+        // Force the view to load the items. Without this, `view.itemAtIndex(0)` might be null even when `count > 0`,
+        // causing navigation to break when calling this function from `resetNavigationFocus()` in `PluginsPage`.
+        view.forceLayout()
+
         view.itemAtIndex(0).requestActive()
     }
 

--- a/src/project/qml/MuseScore/Project/internal/ScoreItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoreItem.qml
@@ -108,10 +108,7 @@ FocusScope {
                 NavigationFocusBorder {
                     navigationCtrl: navCtrl
 
-                    //! NOTE: the contrast between the navigation focus border and the thumbnail
-                    //! is very low, especially in dark mode. Add a small padding between the
-                    //! focus border and the thumbnail, to make the border easily visible.
-                    anchors.margins: -border.width - 2
+                    padding: 2
                 }
 
                 border.color: ui.theme.strokeColor


### PR DESCRIPTION
Resolves: #12886 

Seems like there's a Qt bug / strange behaviour, which was just revealed by #12854. Problem is that the list view items have not yet been loaded at the time that we call `requestActive`, even though the items _should_ exist. Apparently, assigning something to the `currentIndex` property of the grid view somehow forces the items to be loaded. 

Also tweaks the navigation/selection borders of Plugins and Scores thumbnails yet a bit further.