### PR TITLE
[MU4] Fix #12925: Dock panel does not respect maximum size anymore after moving it from leftmost column to other location

### DIFF
--- a/src/appshell/view/dockwindow/internal/dockbase.cpp
+++ b/src/appshell/view/dockwindow/internal/dockbase.cpp
@@ -620,10 +620,14 @@ void DockBase::listenFloatingChanges()
         //! and emit floatingChanged() after that
         QTimer::singleShot(0, this, [this]() {
             updateFloatingStatus();
+
+            if (m_floating) {
+                applySizeConstraints();
+            }
         });
 
-        *frameConn
-            = connect(frame, &KDDockWidgets::Frame::isInMainWindowChanged, this, &DockBase::updateFloatingStatus, Qt::UniqueConnection);
+        *frameConn = connect(frame, &KDDockWidgets::Frame::isInMainWindowChanged,
+                             this, &DockBase::onIsInMainWindowChanged, Qt::UniqueConnection);
     });
 
     connect(m_dockWidget->toggleAction(), &QAction::toggled, this, [this]() {
@@ -638,6 +642,12 @@ void DockBase::updateFloatingStatus()
     bool floating = m_dockWidget && m_dockWidget->floatingWindow();
 
     doSetFloating(floating);
+}
+
+void DockBase::onIsInMainWindowChanged()
+{
+    applySizeConstraints();
+    updateFloatingStatus();
 }
 
 void DockBase::doSetFloating(bool floating)

--- a/src/appshell/view/dockwindow/internal/dockbase.cpp
+++ b/src/appshell/view/dockwindow/internal/dockbase.cpp
@@ -377,6 +377,8 @@ void DockBase::open()
 
     m_dockWidget->show();
     setVisible(true);
+
+    applySizeConstraints();
 }
 
 void DockBase::close()

--- a/src/appshell/view/dockwindow/internal/dockbase.h
+++ b/src/appshell/view/dockwindow/internal/dockbase.h
@@ -157,6 +157,7 @@ protected slots:
 
 private slots:
     void updateFloatingStatus();
+    void onIsInMainWindowChanged();
 
 private:
     void listenFloatingChanges();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/12925
Resolves: https://github.com/musescore/MuseScore/issues/12806
Resolves: https://github.com/musescore/MuseScore/issues/12789
Resolves: https://github.com/musescore/MuseScore/issues/12976

Reworked [my solution](https://github.com/musescore/MuseScore/pull/12431/commits/d89f2cb6146b0d51605aecca7515c7a097d3b825) for the bug https://github.com/musescore/MuseScore/issues/12421, because it doesn't cover some cases

