### PR TITLE
Place dynamics correctly on migrated 114 scores

### DIFF
--- a/src/engraving/rw/compat/read114.cpp
+++ b/src/engraving/rw/compat/read114.cpp
@@ -1963,7 +1963,10 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx
             segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
             Dynamic* dyn = Factory::createDynamic(segment);
             dyn->setTrack(ctx.track());
-            dyn->read(e);
+            dyn->read(e); // for 114 scores, dynamics are frontloaded in the measure with <tick> attributes.
+                          // so we need to reset its parent to the correct one after that element is read.
+            segment = m->getSegment(SegmentType::ChordRest, e.context()->tick());
+            dyn->setParent(segment);
             if (dyn->dynamicType() == DynamicType::OTHER && dyn->xmlText().isEmpty()) {
                 // if we add this dynamic, it will be an unselectable invisible object that
                 // messes with collision detection.


### PR DESCRIPTION
In 1.14 scores, dynamics are all declared at the beginning of the measure, with `tick` fields indicating where they should go. This is now respected on import instead of all of the dynamics objects being added to the first tick of the measure.