### PR TITLE
Fix crash that could occur when opening 206 or 114 scores

### DIFF
--- a/src/engraving/rw/compat/read114.cpp
+++ b/src/engraving/rw/compat/read114.cpp
@@ -1878,7 +1878,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx
                 LOGD("remove keysig c at tick 0");
                 if (ks->links()) {
                     if (ks->links()->size() == 1) {
-                        mu::remove(ctx.linkIds(), ks->links()->lid());
+                        mu::remove(e.context()->linkIds(), ks->links()->lid());
                     }
                 }
             } else {

--- a/src/engraving/rw/compat/read206.cpp
+++ b/src/engraving/rw/compat/read206.cpp
@@ -1820,7 +1820,7 @@ bool Read206::readChordProperties206(XmlReader& e, ReadContext& ctx, Chord* ch)
 //    symbols which were not available for use prior to 3.0
 //---------------------------------------------------------
 
-static void convertDoubleArticulations(Chord* chord, ReadContext& ctx)
+static void convertDoubleArticulations(Chord* chord, XmlReader& e)
 {
     std::vector<Articulation*> pairableArticulations;
     for (Articulation* a : chord->articulations()) {
@@ -1867,7 +1867,7 @@ static void convertDoubleArticulations(Chord* chord, ReadContext& ctx)
             chord->remove(a);
             if (a != newArtic) {
                 if (LinkedObjects* link = a->links()) {
-                    mu::remove(ctx.linkIds(), link->lid());
+                    mu::remove(e.context()->linkIds(), link->lid());
                 }
                 delete a;
             }
@@ -1938,7 +1938,7 @@ static void readChord(Chord* chord, XmlReader& e, ReadContext& ctx)
             e.unknown();
         }
     }
-    convertDoubleArticulations(chord, ctx);
+    convertDoubleArticulations(chord, e);
     fixTies(chord);
 }
 
@@ -2647,7 +2647,7 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
                     ctx.staff(staffIdx)->setDefaultClefType(clef->clefType());
                 }
                 if (clef->links() && clef->links()->size() == 1) {
-                    mu::remove(ctx.linkIds(), clef->links()->lid());
+                    mu::remove(e.context()->linkIds(), clef->links()->lid());
                     LOGD("remove link %d", clef->links()->lid());
                 }
                 delete clef;
@@ -2735,7 +2735,7 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
                 LOGD("remove keysig c at tick 0");
                 if (ks->links()) {
                     if (ks->links()->size() == 1) {
-                        mu::remove(ctx.linkIds(), ks->links()->lid());
+                        mu::remove(e.context()->linkIds(), ks->links()->lid());
                     }
                 }
                 delete ks;
@@ -3379,7 +3379,7 @@ Err Read206::read206(mu::engraving::MasterScore* masterScore, XmlReader& e, Read
     }
 
     int id = 1;
-    for (auto& p : ctx.linkIds()) {
+    for (auto& p : e.context()->linkIds()) {
         LinkedObjects* le = p.second;
         le->setLid(masterScore, id++);
     }


### PR DESCRIPTION
Resolves: #12950 

When reading an element in a pre-301 score, it creates a `LinkedObjects` instance and adds that instance to `e.context()->linkIds()`. See https://github.com/musescore/MuseScore/blob/bf553783109f6b6b2d0759b35087fd819aab50eb/src/engraving/libmscore/engravingitem.cpp#L1031-L1059

But sometimes, the created element needs to be deleted, because it turns out we don't need it (e.g. when older scores needed an explicit element but in newer scores we don't need that anymore, or when it turns out that the element is empty.

Since the `LinkedObjects` instance is deleted when the last `EngravingItem` that was linked to it is deleted, we need to remove that `LinkedObjects` instance from the `linkIds()` of the reader context, otherwise it will contain a deleted object which we try to read later on.

At a first glance, it looks like we're already doing that, for example here: https://github.com/musescore/MuseScore/blob/bf553783109f6b6b2d0759b35087fd819aab50eb/src/engraving/rw/compat/read206.cpp#L2649-L2654

Well, the reality is that _this_ is where it goes wrong. We try to remove the `LinkedObjects` from `ctx.linkIds()`, where `ctx` is the `ReadContext` for the _excerpt score_ that is currently being read. But it was added to `e.context()->linkIds()`, where `e.context()` is the context belonging to the reader and thus corresponds with the _master score_, or rather the whole reading process. So we add it to one place, and then try to remove it from a totally different place.

The result is that the deleted `LinkedObjects` instance remains in the `e.context()->linkIds()`, and (occasionally) causes a crash (at least a use-after-free) when we try to use it in https://github.com/musescore/MuseScore/blob/bf553783109f6b6b2d0759b35087fd819aab50eb/src/engraving/rw/compat/read206.cpp#L3381-L3385

Once all of this is discovered, the solution is simple: just use `e.context()->linkIds()` instead of `ctx.linkIds()` when working with `LinkedObjects` and `linkIds()`.