### PR TITLE
Some slur improvements

### DIFF
--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -379,15 +379,18 @@ void SlurSegment::avoidCollisions(PointF& pp1, PointF& p2, PointF& p3, PointF& p
     ChordRest* startCR = slur()->startCR();
     ChordRest* endCR = slur()->endCR();
 
+    if (!startCR || !endCR) {
+        return;
+    }
     Segment* startSeg = nullptr;
     if (isSingleBeginType()) {
-        startSeg = startCR ? startCR->segment() : nullptr; // first of the slur
+        startSeg = startCR->segment(); // first of the slur
     } else {
         startSeg = system()->firstMeasure()->findFirstR(SegmentType::ChordRest, Fraction(0, 0)); // first of the system
     }
     Segment* endSeg = nullptr;
     if (isSingleEndType()) {
-        endSeg = endCR ? endCR->segment() : nullptr; // last of the slur
+        endSeg = endCR->segment(); // last of the slur
     } else {
         endSeg = system()->lastMeasure()->last(); // last of the system
     }

--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -416,10 +416,29 @@ void SlurSegment::avoidCollisions(PointF& pp1, PointF& p2, PointF& p3, PointF& p
 
     // Collision clearance at the center of the slur
     double clearance = 0.75 * spatium(); // TODO: style
-    // balance: determines how much endpoint adjustment VS shape adjustment
-    // we will do (0 = only shape, 1 = only end point)
-    double leftBalance = isSingleBeginType() ? 0.4 : 0.9;
-    double rightBalance = isSingleEndType() ? 0.4 : 0.9;
+    // balance: determines how much endpoint adjustment VS shape adjustment we will do.
+    // 0 = end point is fixed, only the shape can be adjusted,
+    // 1 = shape is fixed, only end the point can be adjusted.
+    // left and right side of the slur may have different balance depending on context:
+    double leftBalance, rightBalance;
+    if (isSingleBeginType()) {
+        if (startCR->isChord() && toChord(startCR)->stem() && startCR->up() == slur()->up()) {
+            leftBalance = 0.1;
+        } else {
+            leftBalance = 0.4;
+        }
+    } else {
+        leftBalance = 0.9;
+    }
+    if (isSingleEndType()) {
+        if (endCR->isChord() && toChord(endCR)->stem() && endCR->up() == slur()->up()) {
+            rightBalance = 0.1;
+        } else {
+            rightBalance = 0.4;
+        }
+    } else {
+        rightBalance = 0.9;
+    }
 
     static constexpr unsigned maxIter = 30;     // Max iterations allowed
     const double vertClearance = slur()->up() ? clearance : -clearance;

--- a/src/engraving/libmscore/stem.cpp
+++ b/src/engraving/libmscore/stem.cpp
@@ -121,8 +121,11 @@ void Stem::layout()
     double lineX = isTabStaff ? 0.0 : _up * lineWidthCorrection;
     m_line.setLine(lineX, y1, lineX, y2);
 
+    // HACK: if there is a beam, extend the bounding box of the stem (NOT the stem itself) by half beam width.
+    // This way the bbox of the stem covers also the beam position. Hugely helps with all the collision checks.
+    double beamCorrection = chord()->beam() ? _up * score()->styleMM(Sid::beamWidth) * mag() / 2 : 0.0;
     // compute line and bounding rectangle
-    RectF rect(m_line.p1(), m_line.p2());
+    RectF rect(m_line.p1(), m_line.p2() + PointF(0.0, beamCorrection));
     setbbox(rect.normalized().adjusted(-lineWidthCorrection, 0, lineWidthCorrection, 0));
 }
 

--- a/src/engraving/libmscore/tuplet.cpp
+++ b/src/engraving/libmscore/tuplet.cpp
@@ -352,7 +352,7 @@ void Tuplet::layout()
         // special case: one of the bracket endpoints is
         // a rest
         //
-        if (cr1->isChord() && cr2->isChord()) {
+        if (!cr1->isChord() && cr2->isChord()) {
             if (p2.y() < p1.y()) {
                 p1.setY(p2.y());
             } else {

--- a/src/engraving/libmscore/tuplet.cpp
+++ b/src/engraving/libmscore/tuplet.cpp
@@ -315,14 +315,6 @@ void Tuplet::layout()
 
     double xx1 = p1.x();   // use to center the number on the beam
 
-    // follow beam angle if one beam extends over entire tuplet
-    bool followBeam = false;
-    double beamAdjust = 0.0;
-    if (cr1->beam() && cr1->beam() == cr2->beam()) {
-        followBeam = true;
-        beamAdjust = point(score()->styleS(Sid::beamWidth)) * 0.5 * mag();
-    }
-
     if (_isUp) {
         if (cr1->isChord()) {
             const Chord* chord1 = toChord(cr1);
@@ -332,13 +324,7 @@ void Tuplet::layout()
             }
             if (chord1->up()) {
                 if (stem) {
-                    if (followBeam) {
-                        p1.ry() = stem->abbox().y() - beamAdjust;
-                    } else if (chord1->beam()) {
-                        p1.ry() = chord1->beam()->abbox().y();
-                    } else {
-                        p1.ry() = stem->abbox().y();
-                    }
+                    p1.ry() = stem->abbox().y();
                     l2l = vStemDistance;
                 } else {
                     p1.ry() = chord1->upNote()->abbox().top();           // whole note
@@ -355,13 +341,7 @@ void Tuplet::layout()
             const Chord* chord2 = toChord(cr2);
             Stem* stem = chord2->stem();
             if (stem && chord2->up()) {
-                if (followBeam) {
-                    p2.ry() = stem->abbox().top() - beamAdjust;
-                } else if (chord2->beam() && !chord2->staffMove() && !chord2->beam()->cross()) {
-                    p2.ry() = chord2->beam()->abbox().top();
-                } else {
-                    p2.ry() = stem->abbox().top();
-                }
+                p2.ry() = stem->abbox().top();
                 l2r = vStemDistance;
                 p2.rx() = chord2->pagePos().x() + chord2->maxHeadWidth() + stemRight;
             } else {
@@ -442,13 +422,7 @@ void Tuplet::layout()
             }
             if (!chord1->up()) {
                 if (stem) {
-                    if (followBeam) {
-                        p1.ry() = stem->abbox().bottom() + beamAdjust;
-                    } else if (chord1->beam()) {
-                        p1.ry() = chord1->beam()->abbox().bottom();
-                    } else {
-                        p1.ry() = stem->abbox().bottom();
-                    }
+                    p1.ry() = stem->abbox().bottom();
                     l2l = vStemDistance;
                     p1.rx() = cr1->pagePos().x() - stemLeft;
                 } else {
@@ -463,16 +437,7 @@ void Tuplet::layout()
             const Chord* chord2 = toChord(cr2);
             Stem* stem = chord2->stem();
             if (stem && !chord2->up()) {
-                // if (chord2->beam())
-                //      p2.setX(stem->abbox().x());
-                if (followBeam) {                                                //??
-                    p2.ry() = stem->abbox().bottom() + beamAdjust;               //??
-                }
-                if (chord2->beam() && !chord2->staffMove() && !chord2->beam()->cross()) {
-                    p2.ry() = chord2->beam()->abbox().bottom();
-                } else {
-                    p2.ry() = stem->abbox().bottom();
-                }
+                p2.ry() = stem->abbox().bottom();
                 l2r = vStemDistance;
             } else {
                 p2.ry() = chord2->downNote()->abbox().bottom();


### PR DESCRIPTION
The slur collision-avoidance system works by adjusting both the shape and the end-point positions of the slur. "How much we move the shape" VS "how much we move the end points" is determined by a `balance` parameter. 
This PR:
- Separates the balance for the left-side and the right-side of the slur (first commit). Most of the diffs are just exchanging `balance` with `leftBalance` of `rightBalance` accordingly.
- The choice of left- and right-balance is a bit more sophisticated (first & second commit), depending on whether the slur has a floating end or is on stem side.
- A small hack which increases the bounding box of stems to cover also the width of the beam (third commit). Greatly improves the slur VS beams clearance.

Before
<img width="400" alt="image" src="https://user-images.githubusercontent.com/93707756/186206955-78d729ad-63be-4ff2-ad77-4fc2590465fa.png">
After
<img width="400" alt="image" src="https://user-images.githubusercontent.com/93707756/186206815-dd103474-feab-43fe-b49c-2fb5f0753787.png">

