### PR TITLE
Small tweak to staffline distance to slur endpoint minimum

### DIFF
--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -333,7 +333,7 @@ void SlurSegment::editDrag(EditData& ed)
 //---------------------------------------------------------
 void SlurSegment::adjustEndpoints()
 {
-    const double staffLineMargin = 0.15;
+    const double staffLineMargin = 0.175 + (0.5 * score()->styleS(Sid::staffLineWidth).val());
     PointF p1 = ups(Grip::START).p;
     PointF p2 = ups(Grip::END).p;
 


### PR DESCRIPTION
Slur endpoints were not taking the staff line width into account when determining minimum distance. They now do, and also a small optical tweak to bring the slur endpoints slightly further away.
![image](https://user-images.githubusercontent.com/89263931/186226589-53ded38a-fc7a-4b75-89bb-780bac5dea55.png)
