### PR TITLE
re: #12691 Avoid applying mag twice for grace notes

### DIFF
--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -483,11 +483,7 @@ bool Chord::containsEqualTremolo(const Chord* other) const
 
 double Chord::noteHeadWidth() const
 {
-    double nhw = score()->noteHeadWidth();
-    if (_noteType != NoteType::NORMAL) {
-        nhw *= score()->styleD(Sid::graceNoteMag);
-    }
-    return nhw * mag();
+    return score()->noteHeadWidth() * mag();
 }
 
 //! Returns Chord coordinates

--- a/src/engraving/libmscore/chord.h
+++ b/src/engraving/libmscore/chord.h
@@ -137,7 +137,6 @@ class Chord final : public ChordRest
 
     void layoutPitched();
     void layoutTablature();
-    double noteHeadWidth() const;
 
     bool shouldHaveStem() const;
     bool shouldHaveHook() const;
@@ -177,6 +176,7 @@ public:
     double chordMag() const;
     double mag() const override;
     double relativeMag() const { return _relativeMag; }
+    double noteHeadWidth() const;
 
     void write(XmlWriter& xml) const override;
     void read(XmlReader&) override;

--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -1022,7 +1022,7 @@ void Slur::slurPos(SlurPos* sp)
                 // longer be used. for the time being fakeCutout describes a point on the line y=mx+b, out from the top of the stem
                 // where y = yadj, m = fakeCutoutSlope, and x = y/m + fakeCutout
                 fakeCutout = std::min(0.0, std::abs(yadj) - (hook->width() / fakeCutoutSlope));
-                pt.rx() = sc->stemPosX() / sc->magS() - fakeCutout;
+                pt.rx() = sc->stemPosX() - fakeCutout;
             }
         } else {
             Hook* hook = sc->hook();
@@ -1108,7 +1108,7 @@ void Slur::slurPos(SlurPos* sp)
                 } else {
                     po.ry() = sc->stemPos().y() - sc->pagePos().y() + sh;
                 }
-                po.rx() = (sc->stemPosX() / stem1->mag()) + (beamAnchorInset * _spatium * sc->mag()) + (stem1->lineWidthMag() / 2 * __up);
+                po.rx() = sc->stemPosX() + (beamAnchorInset * _spatium * sc->mag()) + (stem1->lineWidthMag() / 2 * __up);
 
                 // account for articulations
                 fixArticulations(po, sc, __up, true);
@@ -1227,7 +1227,7 @@ void Slur::slurPos(SlurPos* sp)
                         po.ry() = ec->stemPos().y() - ec->pagePos().y() + sh;
                     }
 
-                    po.rx() = (ec->stemPosX() / stem2->mag()) - (beamAnchorInset * _spatium * ec->mag())
+                    po.rx() = ec->stemPosX() - (beamAnchorInset * _spatium * ec->mag())
                               + (stem2->lineWidthMag() / 2 * __up);
 
                     // account for articulations

--- a/src/engraving/libmscore/tremolo.cpp
+++ b/src/engraving/libmscore/tremolo.cpp
@@ -419,12 +419,7 @@ void Tremolo::layoutTwoNotesTremolo(double x, double y, double h, double spatium
     // the outer edge of the stems (non-default beam style)
     double x2 = _chord2->stemPosBeam().x();
     if (!stem2 && _chord2->up()) {
-        double nhw = score()->noteHeadWidth();
-        if (_chord2->noteType() != NoteType::NORMAL) {
-            nhw *= score()->styleD(Sid::graceNoteMag);
-        }
-        nhw *= _chord2->mag();
-        x2 -= nhw;
+        x2 -= _chord2->noteHeadWidth();
     } else if (stem2) {
         if (defaultStyle && _chord2->up()) {
             x2 -= stem2->lineWidthMag();
@@ -435,12 +430,7 @@ void Tremolo::layoutTwoNotesTremolo(double x, double y, double h, double spatium
 
     double x1 = _chord1->stemPosBeam().x();
     if (!stem1 && !_chord1->up()) {
-        double nhw = score()->noteHeadWidth();
-        if (_chord1->noteType() != NoteType::NORMAL) {
-            nhw *= score()->styleD(Sid::graceNoteMag);
-        }
-        nhw *= _chord1->mag();
-        x1 += nhw;
+        x1 += _chord1->noteHeadWidth();
     } else if (stem1) {
         if (defaultStyle && !_chord1->up()) {
             x1 += stem1->lineWidthMag();
@@ -565,9 +555,16 @@ void Tremolo::setBeamDirection(DirectionV d)
     if (d != DirectionV::AUTO) {
         _up = d == DirectionV::UP;
     }
-
-    _chord1->setStemDirection(d);
-    _chord2->setStemDirection(d);
+    if (twoNotes()) {
+        if (_chord1) {
+            _chord1->setStemDirection(d);
+        }
+        if (_chord2) {
+            _chord2->setStemDirection(d);
+        }
+    } else {
+        chord()->setStemDirection(d);
+    }
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Continuation from https://github.com/musescore/MuseScore/pull/12691

From what I can tell, mag() used to be 1.0 for grace notes, so the style grace magnitude had to be applied separately. Now, mag() accounts for that so the exception is no longer necessary. There is still some spacing issues in cross-staff grace beams, so I'm pingponging this one back to @mike-spa for all the spacing goodness! For the time being, check the `grace-7` vtest, which illustrates the issue being solved in this PR.