### PR TITLE
[MU4] Fix #11841: Changed parameters are not reverted after clicking 'Cancel' button on the 'Page settings' dialog

### DIFF
--- a/src/notation/view/widgets/pagesettings.cpp
+++ b/src/notation/view/widgets/pagesettings.cpp
@@ -293,12 +293,14 @@ void PageSettings::buttonBoxClicked(QAbstractButton* button)
 void PageSettings::accept()
 {
     globalContext()->currentNotation()->undoStack()->commitChanges();
+    globalContext()->currentNotation()->style()->styleChanged().notify();
     QDialog::accept();
 }
 
 void PageSettings::reject()
 {
     globalContext()->currentNotation()->undoStack()->rollbackChanges();
+    globalContext()->currentNotation()->style()->styleChanged().notify();
     QDialog::reject();
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11841