### PR TITLE
Fix scrollbars in Timeline

### DIFF
--- a/src/framework/uicomponents/view/widgetview.cpp
+++ b/src/framework/uicomponents/view/widgetview.cpp
@@ -132,4 +132,6 @@ void WidgetView::updateSizeConstraints()
 void WidgetView::setWidget(std::shared_ptr<IDisplayableWidget> widget)
 {
     m_widget = widget;
+
+    updateSizeConstraints();
 }

--- a/src/notation/view/widgets/timelineview.cpp
+++ b/src/notation/view/widgets/timelineview.cpp
@@ -24,6 +24,7 @@
 
 #include "timeline.h"
 
+#include <QApplication>
 #include <QSplitter>
 
 #include "log.h"
@@ -61,8 +62,7 @@ private:
 
     bool handleEvent(QEvent* e) override
     {
-        QMouseEvent* me = dynamic_cast<QMouseEvent*>(e);
-        if (me) {
+        if (QMouseEvent* me = dynamic_cast<QMouseEvent*>(e)) {
             return handleMouseEvent(me);
         }
 
@@ -72,14 +72,10 @@ private:
     bool handleMouseEvent(QMouseEvent* event)
     {
         QPoint pos = event ? event->pos() : QPoint();
-        TRowLabels* labelsColumn = m_msTimeline->labelsColumn();
 
-        if (m_msTimeline->geometry().contains(pos)) {
-            event->setLocalPos(m_msTimeline->mapFrom(this, pos));
-            return m_msTimeline->handleEvent(event);
-        } else if (labelsColumn->geometry().contains(pos)) {
-            event->setLocalPos(labelsColumn->mapFrom(this, pos));
-            return labelsColumn->handleEvent(event);
+        if (QWidget* child = childAt(pos)) {
+            event->setLocalPos(child->mapFrom(this, pos));
+            return qApp->notify(child, event);
         }
 
         return false;

--- a/src/notation/view/widgets/timelineview.cpp
+++ b/src/notation/view/widgets/timelineview.cpp
@@ -73,15 +73,22 @@ private:
     {
         QPoint pos = event ? event->pos() : QPoint();
 
-        if (QWidget* child = childAt(pos)) {
-            event->setLocalPos(child->mapFrom(this, pos));
-            return qApp->notify(child, event);
+        if (event->type() == QEvent::MouseButtonPress) {
+            m_mouseDownWidget = childAt(pos);
+        } else if (event->type() == QEvent::MouseButtonRelease) {
+            m_mouseDownWidget = nullptr;
+        }
+
+        if (QWidget* receiver = m_mouseDownWidget ? m_mouseDownWidget : childAt(pos)) {
+            event->setLocalPos(receiver->mapFrom(this, pos));
+            return qApp->notify(receiver, event);
         }
 
         return false;
     }
 
     Timeline* m_msTimeline = nullptr;
+    QWidget* m_mouseDownWidget = nullptr;
 };
 }
 


### PR DESCRIPTION
Now, all child widgets, including scrollbars, receive events when they should.

(This is in fact still not a super thorough advanced solution; that would be recreating almost all event handling of QWidgetWindow (a private Qt class) in WidgetView etc.. But that would be such a large undertaking with so little added value, that it's not worth the effort.)

Resolves: #13000