### PR TITLE
fix #11589: clef import in guitar pro

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1353,16 +1353,21 @@ void GPConverter::addClef(const GPBar* bar, int curTrack)
         return ClefType::G;
     };
 
-    if (_clefs.count(curTrack)) {
-        if (_clefs.at(curTrack) == bar->clef()) {
-            return;
-        }
+    Measure* lastMeasure = _score->lastMeasure();
+    Fraction tick = lastMeasure->tick();
+    ClefType clef = convertClef(bar->clef());
+
+    if (tick == Fraction{ 0, 1 }) {
+        _clefs[curTrack] = bar->clef();
+        Staff* s = _score->staff(track2staff(curTrack));
+        s->setDefaultClefType(ClefTypeList(clef, clef));
+        return;
     }
 
-    ClefType clef = convertClef(bar->clef());
-    auto lastMeasure = _score->lastMeasure();
+    if (_clefs.find(curTrack) != _clefs.end() && _clefs.at(curTrack) == bar->clef()) {
+        return;
+    }
 
-    auto tick = lastMeasure->tick();
     Segment* s = lastMeasure->getSegment(SegmentType::HeaderClef, tick);
     Clef* cl = mu::engraving::Factory::createClef(_score->dummy()->segment());
     cl->setTrack(curTrack);

--- a/src/importexport/guitarpro/internal/importgtp-gp4.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp4.cpp
@@ -767,12 +767,18 @@ bool GuitarPro4::read(IODevice* io)
         } else {
             clefId = defaultClef(patch);
         }
+
         Measure* measure = score->firstMeasure();
-        Segment* segment = measure->getSegment(SegmentType::HeaderClef, Fraction(0, 1));
-        Clef* clef = Factory::createClef(segment);
-        clef->setClefType(clefId);
-        clef->setTrack(i * VOICES);
-        segment->add(clef);
+        if (measure->tick() != Fraction(0, 1)) {
+            Segment* segment = measure->getSegment(SegmentType::HeaderClef, Fraction(0, 1));
+
+            Clef* clef = Factory::createClef(segment);
+            clef->setClefType(clefId);
+            clef->setTrack(i * VOICES);
+            segment->add(clef);
+        } else {
+            staff->setDefaultClefType(ClefTypeList(clefId, clefId));
+        }
 
         if (capo > 0) {
             Segment* s = measure->getSegment(SegmentType::ChordRest, measure->tick());

--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -569,12 +569,18 @@ bool GuitarPro5::readTracks()
         } else {
             clefId = defaultClef(patch);
         }
+
         Measure* measure = score->firstMeasure();
-        Segment* segment = measure->getSegment(SegmentType::HeaderClef, Fraction(0, 1));
-        Clef* clef = Factory::createClef(segment);
-        clef->setClefType(clefId);
-        clef->setTrack(i * VOICES);
-        segment->add(clef);
+        if (measure->tick() != Fraction(0, 1)) {
+            Segment* segment = measure->getSegment(SegmentType::HeaderClef, Fraction(0, 1));
+
+            Clef* clef = Factory::createClef(segment);
+            clef->setClefType(clefId);
+            clef->setTrack(i * VOICES);
+            segment->add(clef);
+        } else {
+            staff->setDefaultClefType(ClefTypeList(clefId, clefId));
+        }
 
         if (capo > 0) {
             Segment* s = measure->getSegment(SegmentType::ChordRest, measure->tick());

--- a/src/importexport/guitarpro/tests/data/UncompletedMeasure.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/UncompletedMeasure.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/accent.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/accent.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/accent.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/accent.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/all-percussion.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/all-percussion.gp-ref.mscx
@@ -25,6 +25,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Percussions</trackName>
       <Instrument id="piano">
@@ -507,10 +508,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/all-percussion.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/all-percussion.gp5-ref.mscx
@@ -25,6 +25,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Percussions</trackName>
       <Instrument id="automobile-brake-drums">
@@ -508,10 +509,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/all-percussion.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/all-percussion.gpx-ref.mscx
@@ -25,6 +25,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Hand Clap</trackName>
       <Instrument id="hand-clap">
@@ -510,6 +511,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Congas</trackName>
       <Instrument id="congas">
@@ -995,6 +997,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Timbale</trackName>
       <Instrument id="piano">
@@ -1480,6 +1483,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Agogo</trackName>
       <Instrument id="piano">
@@ -1965,6 +1969,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Cabasa</trackName>
       <Instrument id="cabasa">
@@ -2450,6 +2455,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Maracas</trackName>
       <Instrument id="maracas">
@@ -2935,6 +2941,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Whistle</trackName>
       <Instrument id="piano">
@@ -3420,6 +3427,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Bongos</trackName>
       <Instrument id="bongos">
@@ -3905,6 +3913,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Vibraslap</trackName>
       <Instrument id="vibraslap">
@@ -4390,6 +4399,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Tambourine</trackName>
       <Instrument id="tambourine">
@@ -4875,6 +4885,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Cuica</trackName>
       <Instrument id="cuica">
@@ -5360,6 +5371,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Triangle</trackName>
       <Instrument id="triangle">
@@ -5845,6 +5857,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Claves</trackName>
       <Instrument id="claves">
@@ -6330,6 +6343,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Shaker</trackName>
       <Instrument id="piano">
@@ -6815,6 +6829,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Jingle Bell</trackName>
       <Instrument id="piano">
@@ -7300,6 +7315,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Bell Tree</trackName>
       <Instrument id="piano">
@@ -7785,6 +7801,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Woodblock</trackName>
       <Instrument id="piano">
@@ -8270,6 +8287,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Guiro</trackName>
       <Instrument id="piano">
@@ -8755,6 +8773,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Castanets</trackName>
       <Instrument id="castanets">
@@ -9240,6 +9259,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Surdo</trackName>
       <Instrument id="piano">
@@ -9725,6 +9745,7 @@
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Drumkit</trackName>
       <Instrument id="drumset">
@@ -10207,10 +10228,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -10548,10 +10565,6 @@
     <Staff id="2">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -10885,10 +10898,6 @@
     <Staff id="3">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -11221,10 +11230,6 @@
     <Staff id="4">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -11557,10 +11562,6 @@
     <Staff id="5">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -11889,10 +11890,6 @@
     <Staff id="6">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -12221,10 +12218,6 @@
     <Staff id="7">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -12557,10 +12550,6 @@
     <Staff id="8">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -12893,10 +12882,6 @@
     <Staff id="9">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -13225,10 +13210,6 @@
     <Staff id="10">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -13558,10 +13539,6 @@
     <Staff id="11">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -13894,10 +13871,6 @@
     <Staff id="12">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -14232,10 +14205,6 @@
     <Staff id="13">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -14564,10 +14533,6 @@
     <Staff id="14">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -14896,10 +14861,6 @@
     <Staff id="15">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -15228,10 +15189,6 @@
     <Staff id="16">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -15560,10 +15517,6 @@
     <Staff id="17">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -15896,10 +15849,6 @@
     <Staff id="18">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -16234,10 +16183,6 @@
     <Staff id="19">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -16566,10 +16511,6 @@
     <Staff id="20">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -16904,10 +16845,6 @@
     <Staff id="21">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>PERC</concertClefType>
-            <transposingClefType>PERC</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/arpeggio.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/arpeggio.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/arpeggio.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/arpeggio.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/artificial-harmonic.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/artificial-harmonic.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/artificial-harmonic.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/artificial-harmonic.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/barre.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/barre.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/barre.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/barre.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/basic-bend.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/basic-bend.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/basic-bend.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/basic-bend.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/basic-bend.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/basic-bend.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/beams-stems-ledger-lines.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/beams-stems-ledger-lines.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/beams-stems-ledger-lines.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/beams-stems-ledger-lines.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Acoustic (DADGAD)</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/beams-stems-ledger-lines.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/beams-stems-ledger-lines.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/bend.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/bend.gp-ref.mscx
@@ -53,10 +53,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/bend.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/bend.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Guitar I</trackName>
       <Instrument id="electric-guitar">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/bend.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/bend.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Guitar I</trackName>
       <Instrument id="electric-guitar">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/bend.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/bend.gpx-ref.mscx
@@ -53,10 +53,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/brush.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/brush.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/brush.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/brush.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/brush.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/brush.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/brush.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/brush.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/capo-fret.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/capo-fret.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -57,10 +58,6 @@
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/capo-fret.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/capo-fret.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -57,10 +58,6 @@
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/chordnames_keyboard.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/chordnames_keyboard.gp-ref.mscx
@@ -31,6 +31,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Acoustic Piano</trackName>
       <Instrument id="piano">
@@ -49,10 +50,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -166,10 +163,6 @@
     <Staff id="2">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>F</concertClefType>
-            <transposingClefType>F</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/chordnames_keyboard.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/chordnames_keyboard.gpx-ref.mscx
@@ -31,6 +31,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Acoustic Piano</trackName>
       <Instrument id="piano">
@@ -49,10 +50,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -118,10 +115,6 @@
     <Staff id="2">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>F</concertClefType>
-            <transposingClefType>F</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/clefs.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/clefs.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/clefs.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/clefs.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/copyright.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/copyright.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/copyright.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/copyright.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/copyright.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/copyright.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/copyright.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/copyright.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/crescendo-diminuendo.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/crescendo-diminuendo.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/crescendo-diminuendo.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/crescendo-diminuendo.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/dead-note.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dead-note.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/dead-note.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dead-note.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/directions.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/directions.gp-ref.mscx
@@ -57,10 +57,6 @@
           <label>fine</label>
           </Marker>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/directions.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/directions.gpx-ref.mscx
@@ -57,10 +57,6 @@
           <label>fine</label>
           </Marker>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/dotted-gliss.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dotted-gliss.gp-ref.mscx
@@ -72,10 +72,6 @@ Innuendo</text>
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/dotted-gliss.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dotted-gliss.gpx-ref.mscx
@@ -74,10 +74,6 @@ Innuendo</text>
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/dotted-tuplets.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dotted-tuplets.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/dotted-tuplets.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dotted-tuplets.gp5-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/dotted-tuplets.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dotted-tuplets.gpx-ref.mscx
@@ -54,10 +54,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/double-bar.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/double-bar.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/double-bar.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/double-bar.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/dynamic.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dynamic.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/dynamic.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dynamic.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/dynamic.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dynamic.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/fade-in.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fade-in.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/fade-in.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fade-in.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/fade-in.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fade-in.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/fade-in.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fade-in.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/fermata.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fermata.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/fermata.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fermata.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/fingering.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fingering.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/fingering.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fingering.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/fingering.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fingering.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/fingering.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fingering.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/free-time.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/free-time.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/free-time.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/free-time.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/fret-diagram.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram.gp-ref.mscx
@@ -53,10 +53,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/fret-diagram.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Acoustic</trackName>
       <Instrument id="cavaquinho">
@@ -51,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/fret-diagram.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Acoustic</trackName>
       <Instrument id="cavaquinho">
@@ -51,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/fret-diagram.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram.gpx-ref.mscx
@@ -53,10 +53,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/fret-diagram_2instruments.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram_2instruments.gp-ref.mscx
@@ -86,10 +86,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -269,10 +265,6 @@
     <Staff id="2">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/fret-diagram_2instruments.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram_2instruments.gpx-ref.mscx
@@ -86,10 +86,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -189,10 +185,6 @@
     <Staff id="2">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/ghost-note.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ghost-note.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/ghost-note.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ghost-note.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/grace-before-beat.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/grace-before-beat.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/grace-before-beat.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/grace-before-beat.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/grace-on-beat.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/grace-on-beat.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/grace-on-beat.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/grace-on-beat.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/grace.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/grace.gp-ref.mscx
@@ -50,10 +50,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/grace.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/grace.gp5-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/grace.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/grace.gpx-ref.mscx
@@ -54,10 +54,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/heavy-accent.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/heavy-accent.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/heavy-accent.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/heavy-accent.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/heavy-accent.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/heavy-accent.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/keysig.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/keysig.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/keysig.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/keysig.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Electric Guitar</trackName>
       <Instrument id="electric-guitar">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/keysig.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/keysig.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Electric Guitar</trackName>
       <Instrument id="electric-guitar">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/keysig.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/keysig.gpx-ref.mscx
@@ -51,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/legato-slide.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/legato-slide.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/legato-slide.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/legato-slide.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/legato-slide.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/legato-slide.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/legato-slide.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/legato-slide.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/let-ring.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/let-ring.gp-ref.mscx
@@ -51,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/let-ring.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/let-ring.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Electric Guitar</trackName>
       <Instrument id="electric-guitar">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/let-ring.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/let-ring.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Electric Guitar</trackName>
       <Instrument id="electric-guitar">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/let-ring.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/let-ring.gpx-ref.mscx
@@ -51,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/mordents.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/mordents.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/mordents.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/mordents.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/multivoices.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/multivoices.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/multivoices.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/multivoices.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/ottava1.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava1.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/ottava1.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava1.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/ottava2.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava2.gp-ref.mscx
@@ -86,10 +86,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -254,10 +250,6 @@
     <Staff id="2">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/ottava2.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava2.gpx-ref.mscx
@@ -86,10 +86,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -254,10 +250,6 @@
     <Staff id="2">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/ottava3.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava3.gp-ref.mscx
@@ -86,10 +86,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -143,10 +139,6 @@
     <Staff id="2">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/ottava3.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava3.gpx-ref.mscx
@@ -86,10 +86,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -143,10 +139,6 @@
     <Staff id="2">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/ottava4.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava4.gp-ref.mscx
@@ -86,10 +86,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -254,10 +250,6 @@
     <Staff id="2">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/ottava4.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava4.gpx-ref.mscx
@@ -86,10 +86,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -254,10 +250,6 @@
     <Staff id="2">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/ottava5.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava5.gp-ref.mscx
@@ -86,10 +86,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -167,10 +163,6 @@
     <Staff id="2">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/ottava5.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava5.gpx-ref.mscx
@@ -86,10 +86,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>
@@ -167,10 +163,6 @@
     <Staff id="2">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/palm-mute.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/palm-mute.gp-ref.mscx
@@ -51,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/palm-mute.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/palm-mute.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Electric Guitar</trackName>
       <Instrument id="electric-guitar">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/palm-mute.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/palm-mute.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Electric Guitar</trackName>
       <Instrument id="electric-guitar">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/palm-mute.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/palm-mute.gpx-ref.mscx
@@ -51,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/pick-up-down.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/pick-up-down.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/pick-up-down.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/pick-up-down.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/pick-up-down.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/pick-up-down.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/pick-up-down.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/pick-up-down.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/rasg.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/rasg.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/rasg.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/rasg.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/repeated-bars.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/repeated-bars.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/repeated-bars.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/repeated-bars.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/repeats.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/repeats.gp-ref.mscx
@@ -53,10 +53,6 @@
       <Measure>
         <endRepeat>3</endRepeat>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/repeats.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/repeats.gpx-ref.mscx
@@ -53,10 +53,6 @@
       <Measure>
         <endRepeat>3</endRepeat>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/rest-centered.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/rest-centered.gp-ref.mscx
@@ -51,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/rest-centered.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/rest-centered.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Electric Guitar</trackName>
       <Instrument id="electric-guitar">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/rest-centered.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/rest-centered.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Electric Guitar</trackName>
       <Instrument id="electric-guitar">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/rest-centered.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/rest-centered.gpx-ref.mscx
@@ -51,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/sforzato.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/sforzato.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/sforzato.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/sforzato.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/sforzato.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/sforzato.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/shift-slide.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/shift-slide.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/shift-slide.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/shift-slide.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/shift-slide.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/shift-slide.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/shift-slide.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/shift-slide.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slide-in-above.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-in-above.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slide-in-above.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-in-above.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slide-in-above.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-in-above.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slide-in-above.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-in-above.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slide-in-below.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-in-below.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slide-in-below.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-in-below.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slide-in-below.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-in-below.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slide-in-below.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-in-below.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slide-out-down.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-out-down.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slide-out-down.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-out-down.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slide-out-down.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-out-down.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slide-out-down.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-out-down.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slide-out-up.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-out-up.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slide-out-up.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-out-up.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slide-out-up.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-out-up.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slide-out-up.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-out-up.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gp-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Bass</trackName>
       <Instrument id="bass">
@@ -51,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>F</concertClefType>
-            <transposingClefType>F</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>F8vb</defaultClef>
         </Staff>
       <trackName>Bass</trackName>
       <Instrument id="bass">
@@ -48,10 +49,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>F8vb</concertClefType>
-            <transposingClefType>F8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gpx-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>F</defaultClef>
         </Staff>
       <trackName>Bass</trackName>
       <Instrument id="bass">
@@ -51,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>F</concertClefType>
-            <transposingClefType>F</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slur.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slur.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slur.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slur_hammer_slur.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur_hammer_slur.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slur_hammer_slur.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur_hammer_slur.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slur_over_3_measures.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur_over_3_measures.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slur_over_3_measures.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur_over_3_measures.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slur_slur_hammer.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur_slur_hammer.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slur_slur_hammer.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur_slur_hammer.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slur_voices.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur_voices.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/slur_voices.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur_voices.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/tap-slap-pop.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tap-slap-pop.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/tap-slap-pop.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tap-slap-pop.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Steel Guitar</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/tap-slap-pop.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tap-slap-pop.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/tempo.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tempo.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/tempo.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tempo.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/tempo.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tempo.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/tempo.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tempo.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/testIrrTuplet.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/testIrrTuplet.gp-ref.mscx
@@ -53,10 +53,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/testIrrTuplet.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/testIrrTuplet.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Gtr 2</trackName>
       <Instrument id="electric-guitar">
@@ -52,10 +53,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/testIrrTuplet.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/testIrrTuplet.gpx-ref.mscx
@@ -55,10 +55,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/text.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/text.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/text.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/text.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/timer.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/timer.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/timer.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/timer.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/tremolo-bar.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tremolo-bar.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/tremolo-bar.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tremolo-bar.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/tremolos.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tremolos.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/tremolos.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tremolos.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/tremolos.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tremolos.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/trill.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/trill.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/trill.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/trill.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/trill.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/trill.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/tuplet-with-slur.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tuplet-with-slur.gp-ref.mscx
@@ -55,10 +55,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/tuplet-with-slur.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tuplet-with-slur.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Gtr 2</trackName>
       <Instrument id="electric-guitar">
@@ -52,10 +53,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/tuplet-with-slur.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tuplet-with-slur.gpx-ref.mscx
@@ -55,10 +55,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/tuplets.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tuplets.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/tuplets2.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tuplets2.gpx-ref.mscx
@@ -68,10 +68,6 @@ solo concert</text>
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>1</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/turn.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/turn.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/turn.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/turn.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/vibrato.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/vibrato.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/vibrato.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/vibrato.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Steel Guitar</trackName>
       <Instrument id="cavaquinho">
@@ -50,10 +51,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/vibrato.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/vibrato.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/volta.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/volta.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/volta.gp4-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/volta.gp4-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Track 1</trackName>
       <Instrument id="cavaquinho">
@@ -51,10 +52,6 @@
       <Measure>
         <endRepeat>2</endRepeat>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/volta.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/volta.gp5-ref.mscx
@@ -24,6 +24,7 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
+        <defaultClef>G8vb</defaultClef>
         </Staff>
       <trackName>Guitar</trackName>
       <Instrument id="guitar-steel">
@@ -61,10 +62,6 @@
         </VBox>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G8vb</concertClefType>
-            <transposingClefType>G8vb</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/volta.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/volta.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/volume-swell.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/volume-swell.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/volume-swell.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/volume-swell.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/wah.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/wah.gp-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>

--- a/src/importexport/guitarpro/tests/data/wah.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/wah.gpx-ref.mscx
@@ -52,10 +52,6 @@
     <Staff id="1">
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <KeySig>
             <accidental>0</accidental>
             </KeySig>


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/11589*

*fixed adding extra clef on staff while importing from guitar pro*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
