### PR TITLE
skipping draw of some elements on tab

### DIFF
--- a/src/engraving/libmscore/articulation.cpp
+++ b/src/engraving/libmscore/articulation.cpp
@@ -342,8 +342,9 @@ Page* Articulation::page() const
 
 void Articulation::layout()
 {
+    _skipDraw = false;
     if (isHiddenOnTabStaff()) {
-        setbbox(RectF());
+        _skipDraw = true;
         return;
     }
 

--- a/src/engraving/libmscore/dynamic.cpp
+++ b/src/engraving/libmscore/dynamic.cpp
@@ -280,8 +280,9 @@ void Dynamic::layout()
 {
     const StaffType* stType = staffType();
 
+    _skipDraw = false;
     if (stType && stType->isHiddenElementOnTab(score(), Sid::dynamicsShowTabCommon, Sid::dynamicsShowTabSimple)) {
-        setbbox(RectF());
+        _skipDraw = true;
         return;
     }
 

--- a/src/engraving/libmscore/fermata.cpp
+++ b/src/engraving/libmscore/fermata.cpp
@@ -215,8 +215,9 @@ void Fermata::layout()
 {
     const StaffType* stType = staffType();
 
+    _skipDraw = false;
     if (stType && stType->isHiddenElementOnTab(score(), Sid::fermataShowTabCommon, Sid::fermataShowTabSimple)) {
-        setbbox(RectF());
+        _skipDraw = true;
         return;
     }
 

--- a/src/engraving/libmscore/hairpin.cpp
+++ b/src/engraving/libmscore/hairpin.cpp
@@ -115,8 +115,9 @@ void HairpinSegment::layout()
 {
     const StaffType* stType = staffType();
 
+    _skipDraw = false;
     if (stType && stType->isHiddenElementOnTab(score(), Sid::hairpinShowTabCommon, Sid::hairpinShowTabSimple)) {
-        setbbox(RectF());
+        _skipDraw = true;
         return;
     }
 

--- a/src/engraving/libmscore/harmonicmark.cpp
+++ b/src/engraving/libmscore/harmonicmark.cpp
@@ -68,10 +68,11 @@ void HarmonicMarkSegment::layout()
 {
     const StaffType* stType = staffType();
 
+    _skipDraw = false;
     if (stType
         && (!stType->isTabStaff()
             || stType->isHiddenElementOnTab(score(), Sid::harmonicMarkShowTabCommon, Sid::harmonicMarkShowTabSimple))) {
-        setbbox(RectF());
+        _skipDraw = true;
         return;
     }
 

--- a/src/engraving/libmscore/letring.cpp
+++ b/src/engraving/libmscore/letring.cpp
@@ -69,8 +69,9 @@ void LetRingSegment::layout()
 {
     const StaffType* stType = staffType();
 
+    _skipDraw = false;
     if (stType && stType->isHiddenElementOnTab(score(), Sid::letRingShowTabCommon, Sid::letRingShowTabSimple)) {
-        setbbox(RectF());
+        _skipDraw = true;
         return;
     }
 

--- a/src/engraving/libmscore/palmmute.cpp
+++ b/src/engraving/libmscore/palmmute.cpp
@@ -70,8 +70,9 @@ void PalmMuteSegment::layout()
 {
     const StaffType* stType = staffType();
 
+    _skipDraw = false;
     if (stType && stType->isHiddenElementOnTab(score(), Sid::palmMuteShowTabCommon, Sid::palmMuteShowTabSimple)) {
-        setbbox(RectF());
+        _skipDraw = true;
         return;
     }
 

--- a/src/engraving/libmscore/rasgueado.cpp
+++ b/src/engraving/libmscore/rasgueado.cpp
@@ -68,8 +68,9 @@ void RasgueadoSegment::layout()
 {
     const StaffType* stType = staffType();
 
+    _skipDraw = false;
     if (stType && stType->isHiddenElementOnTab(score(), Sid::rasgueadoShowTabCommon, Sid::rasgueadoShowTabSimple)) {
-        setbbox(RectF());
+        _skipDraw = true;
         return;
     }
 

--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -764,8 +764,9 @@ void SlurSegment::layoutSegment(const PointF& p1, const PointF& p2)
 {
     const StaffType* stType = staffType();
 
+    _skipDraw = false;
     if (stType && stType->isHiddenElementOnTab(score(), Sid::slurShowTabCommon, Sid::slurShowTabSimple)) {
-        setbbox(RectF());
+        _skipDraw = true;
         return;
     }
 


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

*using skip draw to skip, instead of setting the invalid bounding rect*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
