### PR TITLE
Prevent crash after performing specific actions with clef

### DIFF
--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -3758,7 +3758,9 @@ void Measure::addSystemHeader(bool isFirstSystem)
                 clef->layout();
             } else if (clef) {
                 clef->parentItem()->remove(clef);
-                delete clef;
+                if (clef->generated()) {
+                    delete clef;
+                }
             }
             //cSegment->createShape(staffIdx);
             cSegment->setEnabled(true);


### PR DESCRIPTION
Resolves: #13032

Problem: we can't delete the clef, because it is still referenced (and necessary) in the undo stack.

I'm not 100% sure whether this creates a memory leak, but I fear it does. Anyway, a memory leak is less bad than a crash, but at some point we'll really have to properly sort out memory management regarding the combination of the layout process with the undo stack.