### PR TITLE
Allow creating layout break under more circumstances

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3752,11 +3752,7 @@ void NotationInteraction::increaseDecreaseDuration(int steps, bool stepByDots)
 
 bool NotationInteraction::toggleLayoutBreakAvailable() const
 {
-    if (isGripEditStarted()) {
-        return true;
-    }
-
-    return !isElementEditStarted();
+    return !selection()->isNone() && !isTextEditingStarted();
 }
 
 void NotationInteraction::toggleLayoutBreak(LayoutBreakType breakType)


### PR DESCRIPTION
Resolves: #13050

If a barline is selected, it gets in Edit Mode, but no grip is selected. Under these circumstances, creating a layout break was disallowed, causing #13050. To fix, update the condition.

(I realized that the fact that we have to check for `!isTextEditingStarted()` might mean that something isn't really right with shortcut contexts / which action takes precedence. In fact the only reason to check for `!isTextEditingStarted()`, is that the shortcut for "system-break" happens to be the Enter key, and thus conflicts with newline / lyrics navigation in text edit mode. I think that in that mode, the Enter shortcut should "automatically" take precedence, rather than that we have to "hack" it by disabling the system break action (since for the rest, there's technically nothing that prevents you from creating a system break while text editing). Not sure though how to achieve this "automatic" precedence.)