### PR TITLE
[MU4] Add missing Aeolian key signature mode

### DIFF
--- a/src/inspector/types/keysignaturetypes.h
+++ b/src/inspector/types/keysignaturetypes.h
@@ -39,6 +39,7 @@ public:
         MODE_PHRYGIAN,
         MODE_LYDIAN,
         MODE_MIXOLYDIAN,
+        MODE_AEOLIAN,
         MODE_IONIAN,
         MODE_LOCRIAN
     };

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/keysignatures/KeySignatureSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/keysignatures/KeySignatureSettings.qml
@@ -71,6 +71,7 @@ Column {
             { text: qsTrc("inspector", "Phrygian"), value: KeySignatureTypes.MODE_PHRYGIAN },
             { text: qsTrc("inspector", "Lydian"), value: KeySignatureTypes.MODE_LYDIAN },
             { text: qsTrc("inspector", "Mixolydian"), value: KeySignatureTypes.MODE_MIXOLYDIAN },
+            { text: qsTrc("inspector", "Aeolian"), value: KeySignatureTypes.MODE_AEOLIAN },
             { text: qsTrc("inspector", "Ionian"), value: KeySignatureTypes.MODE_IONIAN },
             { text: qsTrc("inspector", "Locrian"), value: KeySignatureTypes.MODE_LOCRIAN }
         ]


### PR DESCRIPTION
follow up to #3633, there this had been forgotten (by me)

Resolves: came up in https://musescore.org/en/node/334664#comment-1139385
MuseScore 3 has the same issue