### PR TITLE
fixed #13033: Plugins are absent in shortcuts

### DIFF
--- a/src/plugins/internal/pluginsuiactions.cpp
+++ b/src/plugins/internal/pluginsuiactions.cpp
@@ -56,6 +56,7 @@ const mu::ui::UiActionList& PluginsUiActions::actionsList() const
         action.uiCtx = mu::context::UiCtxNotationOpened;
         action.scCtx = mu::context::CTX_NOTATION_OPENED;
         action.title = TranslatableString("plugins", "Run plugin %1").arg(plugin.codeKey);
+        action.description = action.title;
 
         result.push_back(action);
     }


### PR DESCRIPTION
Resolves: #13033

All ui actions that should be in the shortcuts list should have a description and a title at all times.