### PR TITLE
[MU4] Fix colornotes to allow undo even on a selection

### DIFF
--- a/share/plugins/colornotes/colornotes.qml
+++ b/share/plugins/colornotes/colornotes.qml
@@ -53,13 +53,13 @@ MuseScore {
             var fullScore = !curScore.selection.elements.length
             if (fullScore) {
                   cmd("select-all")
-                  curScore.startCmd()
             }
+            curScore.startCmd()
             for (var i in curScore.selection.elements)
                   if (curScore.selection.elements[i].pitch)
                         func(curScore.selection.elements[i])
+            curScore.endCmd()
             if (fullScore) {
-                  curScore.endCmd()
                   cmd("escape")
             }
       }


### PR DESCRIPTION
Resolves: came up as a side note in #12867

MuseScore 3 seems to not need this, but this change won't harm there either.