### PR TITLE
[MU4] Apply chord mag to beamlet length

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -933,7 +933,7 @@ void Beam::createBeamletSegment(ChordRest* cr, bool isBefore, int level)
     const double startX = chordBeamAnchorX(cr, isBefore ? ChordBeamAnchorType::End : ChordBeamAnchorType::Start);
 
     const double beamletLength = score()->styleMM(Sid::beamMinLen).val()
-                                 * mag()
+                                 * cr->mag()
                                  * cr->staff()->staffMag(cr);
 
     const double endX = startX + (isBefore ? -beamletLength : beamletLength);


### PR DESCRIPTION
The issue:
![image](https://user-images.githubusercontent.com/89263931/187235766-b207f41c-6c75-4cdf-99a4-cc6dcbd2c89f.png)

This change scales beamlets by their associated chord's magnitude.
![image](https://user-images.githubusercontent.com/89263931/187236224-03652da6-aa92-4984-bc1e-51199632e704.png)
