### PR TITLE
Bring back Measure width in Inspector > Appearance

### DIFF
--- a/src/inspector/models/general/appearance/appearancesettingsmodel.cpp
+++ b/src/inspector/models/general/appearance/appearancesettingsmodel.cpp
@@ -44,7 +44,7 @@ AppearanceSettingsModel::AppearanceSettingsModel(QObject* parent, IElementReposi
 void AppearanceSettingsModel::createProperties()
 {
     m_leadingSpace = buildPropertyItem(Pid::LEADING_SPACE);
-    m_barWidth = buildPropertyItem(Pid::USER_STRETCH);
+    m_measureWidth = buildPropertyItem(Pid::USER_STRETCH);
     m_minimumDistance = buildPropertyItem(Pid::MIN_DISTANCE);
     m_color = buildPropertyItem(Pid::COLOR);
     m_arrangeOrder = buildPropertyItem(Pid::Z);
@@ -68,7 +68,7 @@ void AppearanceSettingsModel::loadProperties()
     loadPropertyItem(m_leadingSpace, formatDoubleFunc);
     loadPropertyItem(m_minimumDistance, formatDoubleFunc);
 
-    loadPropertyItem(m_barWidth);
+    loadPropertyItem(m_measureWidth);
     loadPropertyItem(m_color);
     loadPropertyItem(m_arrangeOrder);
 
@@ -81,7 +81,7 @@ void AppearanceSettingsModel::resetProperties()
 {
     m_leadingSpace->resetToDefault();
     m_minimumDistance->resetToDefault();
-    m_barWidth->resetToDefault();
+    m_measureWidth->resetToDefault();
     m_color->resetToDefault();
     m_arrangeOrder->resetToDefault();
     m_horizontalOffset->resetToDefault();
@@ -197,9 +197,9 @@ PropertyItem* AppearanceSettingsModel::leadingSpace() const
     return m_leadingSpace;
 }
 
-PropertyItem* AppearanceSettingsModel::barWidth() const
+PropertyItem* AppearanceSettingsModel::measureWidth() const
 {
-    return m_barWidth;
+    return m_measureWidth;
 }
 
 PropertyItem* AppearanceSettingsModel::minimumDistance() const

--- a/src/inspector/models/general/appearance/appearancesettingsmodel.h
+++ b/src/inspector/models/general/appearance/appearancesettingsmodel.h
@@ -34,7 +34,7 @@ class AppearanceSettingsModel : public AbstractInspectorModel
     INJECT(inspector, notation::INotationConfiguration, notationConfiguration)
 
     Q_PROPERTY(PropertyItem * leadingSpace READ leadingSpace CONSTANT)
-    Q_PROPERTY(PropertyItem * barWidth READ barWidth CONSTANT)
+    Q_PROPERTY(PropertyItem * measureWidth READ measureWidth CONSTANT)
     Q_PROPERTY(PropertyItem * minimumDistance READ minimumDistance CONSTANT)
     Q_PROPERTY(PropertyItem * color READ color CONSTANT)
     Q_PROPERTY(PropertyItem * arrangeOrder READ arrangeOrder CONSTANT)
@@ -58,7 +58,7 @@ public:
     void resetProperties() override;
 
     PropertyItem* leadingSpace() const;
-    PropertyItem* barWidth() const;
+    PropertyItem* measureWidth() const;
     PropertyItem* minimumDistance() const;
     PropertyItem* color() const;
     PropertyItem* arrangeOrder() const;
@@ -82,7 +82,7 @@ private:
     std::vector<mu::engraving::EngravingItem*> getAllOverlappingElements();
 
     PropertyItem* m_leadingSpace = nullptr;
-    PropertyItem* m_barWidth = nullptr;
+    PropertyItem* m_measureWidth = nullptr;
     PropertyItem* m_minimumDistance = nullptr;
     PropertyItem* m_color = nullptr;
     PropertyItem* m_arrangeOrder = nullptr;


### PR DESCRIPTION
Had been renamed from `barWidth` at the QML side, but not in cpp. Happened in c0a0cbf63666d100cbb69636e8270ea90f6a81ac.