### PR TITLE
Use latest AppImage build tool

### DIFF
--- a/build/ci/linux/setup.sh
+++ b/build/ci/linux/setup.sh
@@ -136,7 +136,7 @@ echo export QML2_IMPORT_PATH="${qt_dir}/qml" >> ${ENV_FILE}
 
 # COMPILER
 
-gcc_version="11"
+gcc_version="10"
 sudo apt-get install -y --no-install-recommends "g++-${gcc_version}"
 sudo update-alternatives \
   --install /usr/bin/gcc gcc "/usr/bin/gcc-${gcc_version}" 40 \

--- a/build/ci/linux/tools/make_appimage.sh
+++ b/build/ci/linux/tools/make_appimage.sh
@@ -19,7 +19,12 @@ mkdir -p $BUILD_TOOLS
 function download_github_release()
 {
   local -r repo_slug="$1" release_tag="$2" file="$3"
-  wget -q --show-progress "https://github.com/${repo_slug}/releases/download/${release_tag}/${file}"
+  if [[ "${release_tag}" == "latest" ]]; then
+    local -r url="https://github.com/${repo_slug}/releases/latest/download/${file}"
+  else
+    local -r url="https://github.com/${repo_slug}/releases/download/${release_tag}/${file}"
+  fi
+  wget -q --show-progress "${url}"
   chmod +x "${file}"
 }
 
@@ -45,8 +50,7 @@ function download_appimage_release()
 if [[ ! -d $BUILD_TOOLS/appimagetool ]]; then
   mkdir $BUILD_TOOLS/appimagetool
   cd $BUILD_TOOLS/appimagetool
-  # `12` and not `continuous` because see https://github.com/AppImage/AppImageKit/issues/1060
-  download_appimage_release AppImage/AppImageKit appimagetool 12
+  download_appimage_release AppImage/AppImageKit appimagetool continuous
   cd $ORIGIN_DIR
 fi
 export PATH="$BUILD_TOOLS/appimagetool:$PATH"


### PR DESCRIPTION
Fetch the latest stable version of appimagetool. The [bug](https://github.com/AppImage/AppImageKit/issues/1060) for which we decided to stay pinned at version 12 was fixed long ago.