### PR TITLE
Add information about MS version to sign-up and authorize links on musescore

### DIFF
--- a/src/cloud/iauthorizationservice.h
+++ b/src/cloud/iauthorizationservice.h
@@ -35,6 +35,7 @@ class IAuthorizationService : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IAuthorizationService() = default;
 
+    virtual void signUp() = 0;
     virtual void signIn() = 0;
     virtual void signOut() = 0;
 

--- a/src/cloud/icloudconfiguration.h
+++ b/src/cloud/icloudconfiguration.h
@@ -39,6 +39,7 @@ public:
     virtual QByteArray uploadingLicense() const = 0;
 
     virtual QUrl authorizationUrl() const = 0;
+    virtual QUrl signUpUrl() const = 0;
     virtual QUrl accessTokenUrl() const = 0;
     virtual QUrl refreshApiUrl() const = 0;
     virtual QUrl userInfoApiUrl() const = 0;

--- a/src/cloud/internal/cloudconfiguration.cpp
+++ b/src/cloud/internal/cloudconfiguration.cpp
@@ -101,6 +101,11 @@ QUrl CloudConfiguration::authorizationUrl() const
     return QUrl("https://musescore.com/oauth/authorize");
 }
 
+QUrl CloudConfiguration::signUpUrl() const
+{
+    return QUrl("https://musescore.com/user/register");
+}
+
 QUrl CloudConfiguration::accessTokenUrl() const
 {
     return apiRootUrl() + "/oauth/token";

--- a/src/cloud/internal/cloudconfiguration.h
+++ b/src/cloud/internal/cloudconfiguration.h
@@ -40,6 +40,7 @@ public:
     QByteArray uploadingLicense() const override;
 
     QUrl authorizationUrl() const override;
+    QUrl signUpUrl() const override;
     QUrl accessTokenUrl() const override;
     QUrl refreshApiUrl() const override;
     QUrl userInfoApiUrl() const override;

--- a/src/cloud/internal/cloudservice.h
+++ b/src/cloud/internal/cloudservice.h
@@ -55,6 +55,7 @@ public:
 
     void init();
 
+    void signUp() override;
     void signIn() override;
     void signOut() override;
 

--- a/src/cloud/view/accountmodel.cpp
+++ b/src/cloud/view/accountmodel.cpp
@@ -79,7 +79,7 @@ void AccountModel::setAccountInfo(const AccountInfo& info)
 
 void AccountModel::createAccount()
 {
-    NOT_IMPLEMENTED;
+    authorizationService()->signUp();
 }
 
 void AccountModel::signIn()


### PR DESCRIPTION
Add information about MS version to sign-up and authorize links on musescore.

Sign-up link is opened by clicking on 'Create new account' button. Oauth flow is not started at this point. I'm going to check possibility later and add as separate PR.

For authorization I set ModifyParametersFunction to QOAuth2AuthorizationCodeFlow to add one more query parameter to the URL. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
