### PR TITLE
[MU4] Layout grace note tremolos

### DIFF
--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -3277,6 +3277,16 @@ void Measure::layoutMeasureElements()
                         tr->layout();
                     }
                 }
+                for (Chord* g : c->graceNotes()) {
+                    if (g->tremolo()) {
+                        Tremolo* tr = g->tremolo();
+                        Chord* c1 = tr->chord1();
+                        Chord* c2 = tr->chord2();
+                        if (!tr->twoNotes() || (c1 && !c1->staffMove() && c2 && !c2->staffMove())) {
+                            tr->layout();
+                        }
+                    }
+                }
             } else if (e->isBarLine()) {
                 e->setPosY(0.0);
                 // for end barlines, x position was set in createEndBarLines


### PR DESCRIPTION
The issue:
![image](https://user-images.githubusercontent.com/89263931/187571368-c0c24f2b-2e57-4071-9fae-788fbb73a38a.png)
Grace note tremolos were not being laid out.

![image](https://user-images.githubusercontent.com/89263931/187571714-383344fd-f9b9-4346-9262-9d479585b23a.png)
Grace notes now behave like cue notes!