### PR TITLE
13093: fixed wrong midi mapping for drums outside general midi for Guitarpro 6/7

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -215,6 +215,44 @@ static GPConverter::TextLineImportType ottavaToImportType(GPBeat::OttavaType t)
 GPConverter::GPConverter(Score* score, std::unique_ptr<GPDomModel>&& gpDom)
     : _score(score), _gpDom(std::move(gpDom))
 {
+    _drumExtension = {
+        { 91, 38 }, //Snare(rim shot)
+        { 92, 46 }, //Hi Hat (half)
+        { 93, 51 }, //Ride (edje)
+        { 94, 51 }, //Ride (choke)
+        { 95, 55 }, //Splash (choke)
+        { 96, 52 }, //Chine(choke)
+        { 97, 49 }, //Crash high (choke)
+        { 98, 57 }, //Crash medium (choke)
+        { 99, 56 }, //Cowbell low (hit)
+        { 100, 56 },//Cowbell low (tip)
+        { 101, 56 },//Cowbell medium (tip)
+        { 102, 56 },//Cowbell high (hit)
+        { 103, 56 },//Cowbell high (tip)
+        { 104, 60 },//Hand (mute)
+        { 105, 60 },//Hand (slap)
+        { 106, 61 },//Hand (mute)
+        { 107, 61 },//Hand (slap)
+        { 108, 64 },//Conga low (slap)
+        { 109, 64 },//Conga low (mute)
+        { 110, 63 },//Conga high (slap)
+        { 111, 54 },//Tambourine (return)
+        { 112, 54 },//Tambourine (roll)
+        { 113, 54 },//Tambourine (hand)
+        { 114, 41 },//Grancassa (hit)
+        { 115, 49 },//Piatti (hit)
+        { 116, 49 },//Piatti (hand)
+        { 117, 69 },//Cabasa (return)
+        { 118, 70 },//Left Maraca (return)
+        { 119, 70 },//Right Maraca (hit)
+        { 120, 70 },//Right Maraca (return)
+        { 122, 82 },//Shaker (return)
+        { 123, 83 },//Bell Tree (return)
+        { 124, 62 },//Golpe (thumb)
+        { 125, 62 },//Golpe (finger)
+        { 126, 59 },//Ride (middle)
+        { 127, 59 }//Ride (bell)
+    };
 }
 
 const std::unique_ptr<GPDomModel>& GPConverter::gpDom() const
@@ -256,17 +294,8 @@ void GPConverter::fixPercussion()
             continue;
         }
 
-        for (size_t j = 0; j < pInstrument->channel().size(); ++j) {
-            mu::engraving::InstrChannel* pChannel = pInstrument->channel()[j];
-            IF_ASSERT_FAILED(!!pChannel) {
-                continue;
-            }
-
-            if (!(pChannel->channel() == 9)) {
-                continue;
-            }
-
-            pChannel->setProgram(0);
+        if (pPart->midiChannel() == 9) {
+            pPart->setMidiProgram(0);
         }
     }
 }
@@ -1863,6 +1892,13 @@ void GPConverter::setPitch(Note* note, const GPNote::MidiPitch& midiPitch)
         musescoreString = getStringNumberFor(note, pitch);
 
         fret = note->part()->instrument()->stringData()->fret(pitch, musescoreString, nullptr);
+    }
+
+    if (note->part()->hasDrumStaff()) {
+        auto it = _drumExtension.find(pitch);
+        if (it != _drumExtension.end()) {
+            pitch =  it->second;
+        }
     }
 
     note->setFret(fret);

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.h
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.h
@@ -203,6 +203,8 @@ private:
     std::map<GPBeat::HarmonicMarkType, std::vector<TextLineBase*> > m_harmonicMarks;
     std::map<GPBeat::OttavaType, std::vector<TextLineBase*> > m_ottavas;
 
+    std::map<uint16_t, uint16_t > _drumExtension;
+
     Volta* _lastVolta = nullptr;
 
     struct NextTupletInfo {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/13093

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://musescore.org/en/cla)
- [ ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ ] I made sure the code compiles on my machine
- [ ] I made sure there are no unnecessary changes in the code
- [ ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
