### PR TITLE
[MU4] Fix GH#13106: Header/Footer Macro `$m` prints current date rather than current time on a 'dirty' score

### DIFF
--- a/src/engraving/libmscore/page.cpp
+++ b/src/engraving/libmscore/page.cpp
@@ -453,7 +453,7 @@ String Page::replaceTextMacros(const String& s) const
             break;
             case 'm':
                 if (score()->dirty()) {
-                    d += Date::currentDate().toString(DateFormat::LocaleShortFormat);
+                    d += Time::currentTime().toString(DateFormat::LocaleShortFormat);
                 } else {
                     d += masterScore()->fileInfo()->lastModified().time().toString(DateFormat::LocaleShortFormat);
                 }


### PR DESCRIPTION
Resolves: #13106