### PR TITLE
Fix failing asserts when trying to work with invalid plugin

### DIFF
--- a/src/plugins/internal/pluginsservice.cpp
+++ b/src/plugins/internal/pluginsservice.cpp
@@ -107,7 +107,11 @@ PluginInfoMap PluginsService::readPlugins() const
 
     for (const io::path_t& pluginPath: pluginsPaths) {
         QUrl url = QUrl::fromLocalFile(pluginPath.toQString());
-        PluginView view(url);
+        PluginView view;
+
+        if (!view.load(url)) {
+            continue;
+        }
 
         PluginInfo info;
         info.codeKey = io::basename(pluginPath).toQString();
@@ -249,7 +253,13 @@ mu::Ret PluginsService::run(const CodeKey& codeKey)
         return make_ret(Err::PluginNotFound);
     }
 
-    PluginView* view = new PluginView(info.url);
+    PluginView* view = new PluginView();
+
+    Ret ret = view->load(info.url);
+    if (!ret) {
+        return ret;
+    }
+
     view->run();
 
     QObject::connect(view, &PluginView::finished, view, &QObject::deleteLater);

--- a/src/plugins/internal/pluginsservice.cpp
+++ b/src/plugins/internal/pluginsservice.cpp
@@ -253,7 +253,7 @@ mu::Ret PluginsService::run(const CodeKey& codeKey)
         return make_ret(Err::PluginNotFound);
     }
 
-    PluginView* view = new PluginView();
+    PluginView* view = new PluginView(this);
 
     Ret ret = view->load(info.url);
     if (!ret) {

--- a/src/plugins/internal/pluginsservice.h
+++ b/src/plugins/internal/pluginsservice.h
@@ -23,6 +23,8 @@
 #ifndef MU_PLUGINS_PLUGINSSERVICE_H
 #define MU_PLUGINS_PLUGINSSERVICE_H
 
+#include <QObject>
+
 #include "io/path.h"
 #include "async/asyncable.h"
 
@@ -35,8 +37,10 @@
 #include "ipluginsservice.h"
 
 namespace mu::plugins {
-class PluginsService : public IPluginsService, public async::Asyncable
+class PluginsService : public QObject, public IPluginsService, public async::Asyncable
 {
+    Q_OBJECT
+
     INJECT(plugins, io::IFileSystem, fileSystem)
     INJECT(plugins, shortcuts::IShortcutsRegister, shortcutsRegister)
     INJECT(plugins, ui::IUiActionsRegister, uiActionsRegister)

--- a/src/plugins/pluginserrors.h
+++ b/src/plugins/pluginserrors.h
@@ -31,7 +31,8 @@ enum class Err {
     NoError         = int(Ret::Code::Ok),
     UnknownError    = int(Ret::Code::PluginsFirst),
 
-    PluginNotFound
+    PluginNotFound,
+    PluginLoadError
 };
 
 inline Ret make_ret(Err e)
@@ -43,6 +44,7 @@ inline Ret make_ret(Err e)
     case Err::NoError: return Ret(retCode);
     case Err::UnknownError: return Ret(retCode);
     case Err::PluginNotFound: return Ret(retCode, trc("plugins", "Plugin not found"));
+    case Err::PluginLoadError: return Ret(retCode, trc("plugins", "Could not load plugin"));
     }
 
     return Ret(static_cast<int>(e));

--- a/src/plugins/pluginsmodule.cpp
+++ b/src/plugins/pluginsmodule.cpp
@@ -32,7 +32,6 @@
 #include "internal/pluginsactioncontroller.h"
 
 #include "view/pluginsmodel.h"
-#include "view/pluginview.h"
 #include "api/qmlpluginapi.h"
 
 #include "ui/iuiactionsregister.h"

--- a/src/plugins/view/pluginview.cpp
+++ b/src/plugins/view/pluginview.cpp
@@ -24,29 +24,42 @@
 
 #include <QQmlComponent>
 
+#include "pluginserrors.h"
+
 #include "api/qmlplugin.h"
 
 #include "log.h"
 
 using namespace mu::plugins;
 
-PluginView::PluginView(const QUrl& url, QObject* parent)
+PluginView::PluginView(QObject* parent)
     : QObject(parent)
 {
-    m_component = new QQmlComponent(engine(), url);
-    m_qmlPlugin = qobject_cast<mu::engraving::QmlPlugin*>(m_component->create());
-
-    connect(m_qmlPlugin, &mu::engraving::QmlPlugin::closeRequested, [this]() {
-        if (m_view && m_view->isVisible()) {
-            m_view->close();
-        }
-    });
 }
 
 PluginView::~PluginView()
 {
     destroyView();
     delete m_component;
+}
+
+mu::Ret PluginView::load(const QUrl& url)
+{
+    m_component = new QQmlComponent(engine(), url);
+    m_qmlPlugin = qobject_cast<mu::engraving::QmlPlugin*>(m_component->create());
+
+    if (!m_qmlPlugin) {
+        LOGE() << "Failed to load QML plugin from " << url;
+        return make_ret(Err::PluginLoadError);
+    }
+
+    connect(m_qmlPlugin, &mu::engraving::QmlPlugin::closeRequested, [this]() {
+        if (m_view && m_view->isVisible()) {
+            m_view->close();
+        }
+    });
+
+    return make_ok();
 }
 
 void PluginView::destroyView()

--- a/src/plugins/view/pluginview.cpp
+++ b/src/plugins/view/pluginview.cpp
@@ -40,7 +40,14 @@ PluginView::PluginView(QObject* parent)
 PluginView::~PluginView()
 {
     destroyView();
-    delete m_component;
+
+    if (m_component) {
+        delete m_component;
+    }
+
+    if (m_qmlPlugin) {
+        delete m_qmlPlugin;
+    }
 }
 
 mu::Ret PluginView::load(const QUrl& url)

--- a/src/plugins/view/pluginview.h
+++ b/src/plugins/view/pluginview.h
@@ -25,20 +25,18 @@
 
 #include <QQuickView>
 
-#include "io/path.h"
+#include "types/ret.h"
 
 #include "modularity/ioc.h"
 #include "framework/ui/iuiengine.h"
 #include "ipluginsconfiguration.h"
 
-#include "plugins/pluginstypes.h"
+class QQmlComponent;
+class QQuickView;
 
 namespace mu::engraving {
 class QmlPlugin;
 }
-
-class QQuickView;
-class QQmlComponent;
 
 namespace mu::plugins {
 class PluginView : public QObject
@@ -49,8 +47,10 @@ class PluginView : public QObject
     INJECT(plugins, IPluginsConfiguration, configuration)
 
 public:
-    PluginView(const QUrl& url, QObject* parent = nullptr);
+    PluginView(QObject* parent = nullptr);
     ~PluginView();
+
+    Ret load(const QUrl& url);
 
     QString name() const;
     QString description() const;


### PR DESCRIPTION
If a plugin contains errors, this is not MuseScore's fault; MuseScore should ideally handle it gracefully, but it should not cause failing asserts.