### PR TITLE
Fix 12471: Avoid unnecessary lengthening of tab beams

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -837,7 +837,9 @@ void Beam::createBeamSegment(ChordRest* startCr, ChordRest* endCr, int level)
             addition = grow * (level - extraBeamAdjust) * _beamDist;
         }
 
-        extendStem(chord, addition);
+        if (level == 0 || !RealIsEqual(addition, 0.0)) {
+            extendStem(chord, addition);
+        }
 
         if (chord == endCr) {
             break;

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -1738,8 +1738,8 @@ Chord* Chord::next() const
 void Chord::setBeamExtension(double extension)
 {
     if (_stem) {
-        _stem->setBaseLength(_stem->baseLength() + Millimetre(extension));
-        _defaultStemLength += extension;
+        _stem->setBaseLength(std::max(_stem->baseLength() + Millimetre(extension), Millimetre { 0.0 }));
+        _defaultStemLength = std::max(_defaultStemLength + extension, _stem->baseLength().val());
     }
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/12471

I've also added in a constraint to prevent negative stem lengths. If beams are dragged above their starting points on common tab staves, the stems will just disappear. Note that this is not a problem on regular notation staves, because dragging the beam through the noteheads flips the noteheads' direction.