### PR TITLE
Fix font size of shortcut in Drumset Panel

### DIFF
--- a/src/framework/draw/types/font.cpp
+++ b/src/framework/draw/types/font.cpp
@@ -58,6 +58,18 @@ double Font::pointSizeF() const
 void Font::setPointSizeF(double s)
 {
     m_pointSizeF = s;
+    m_pixelSize = -1;
+}
+
+int Font::pixelSize() const
+{
+    return m_pixelSize;
+}
+
+void Font::setPixelSize(int s)
+{
+    m_pixelSize = s;
+    m_pointSizeF = -1.0;
 }
 
 Font::Weight Font::weight() const
@@ -137,6 +149,8 @@ QFont Font::toQFont() const
 
     if (pointSizeF() > 0) {
         qf.setPointSizeF(pointSizeF());
+    } else if (pixelSize() > 0) {
+        qf.setPixelSize(pixelSize());
     }
     qf.setWeight(static_cast<QFont::Weight>(weight()));
     qf.setBold(bold());
@@ -154,7 +168,11 @@ QFont Font::toQFont() const
 Font Font::fromQFont(const QFont& qf)
 {
     mu::draw::Font f(qf.family());
-    f.setPointSizeF(qf.pointSizeF());
+    if (qf.pointSizeF() > 0) {
+        f.setPointSizeF(qf.pointSizeF());
+    } else if (qf.pixelSize() > 0) {
+        f.setPixelSize(qf.pixelSize());
+    }
     f.setWeight(static_cast<Font::Weight>(qf.weight()));
     f.setBold(qf.bold());
     f.setItalic(qf.italic());

--- a/src/framework/draw/types/font.h
+++ b/src/framework/draw/types/font.h
@@ -69,6 +69,9 @@ public:
     double pointSizeF() const;
     void setPointSizeF(double s);
 
+    int pixelSize() const;
+    void setPixelSize(int s);
+
     Weight weight() const;
     void setWeight(Weight w);
 
@@ -99,6 +102,7 @@ private:
 
     String m_family;
     double m_pointSizeF = -1.0;
+    int m_pixelSize = -1;
     Weight m_weight = Weight::Normal;
     Flags<Style> m_style{ Style::Normal };
     bool m_noFontMerging = false;

--- a/src/palette/view/widgets/palettewidget.cpp
+++ b/src/palette/view/widgets/palettewidget.cpp
@@ -1032,7 +1032,7 @@ void PaletteWidget::paintEvent(QPaintEvent* /*event*/)
         if (!tag.isEmpty()) {
             painter.setPen(QColor(Qt::darkGray));
             Font font(painter.font());
-            font.setPointSizeF(uiConfiguration()->fontSize(ui::FontSizeType::BODY));
+            font.setPixelSize(uiConfiguration()->fontSize(ui::FontSizeType::BODY));
             painter.setFont(font);
             painter.drawText(rShift, Qt::AlignLeft | Qt::AlignTop, tag);
         }


### PR DESCRIPTION
Resolves: #12792

(For me at least, this fix seems to work well; before on Windows: 
<img width="699" alt="Scherm­afbeelding 2022-09-01 om 00 28 05" src="https://user-images.githubusercontent.com/48658420/187796186-9e943eee-26cd-4b92-8048-c7c13719d6d3.png">
after:
<img width="699" alt="Scherm­afbeelding 2022-09-01 om 00 12 20" src="https://user-images.githubusercontent.com/48658420/187794485-b42280d2-a37a-4f5d-9892-c67447422141.png">
