### PR TITLE
Expose all text styles, including user styles, in the Inspector

### DIFF
--- a/src/inspector/models/text/textsettingsmodel.h
+++ b/src/inspector/models/text/textsettingsmodel.h
@@ -53,6 +53,8 @@ class TextSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(PropertyItem * textPlacement READ textPlacement CONSTANT)
     Q_PROPERTY(PropertyItem * textScriptAlignment READ textScriptAlignment CONSTANT)
 
+    Q_PROPERTY(QVariantList textStyles READ textStyles NOTIFY textStylesChanged)
+
     Q_PROPERTY(bool areStaffTextPropertiesAvailable READ areStaffTextPropertiesAvailable NOTIFY areStaffTextPropertiesAvailableChanged)
     Q_PROPERTY(
         bool isSpecialCharactersInsertionAvailable READ isSpecialCharactersInsertionAvailable NOTIFY isSpecialCharactersInsertionAvailableChanged)
@@ -67,6 +69,9 @@ public:
     void requestElements() override;
     void loadProperties() override;
     void resetProperties() override;
+
+    void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
+                           const mu::engraving::StyleIdSet& changedStyleIdSet) override;
 
     PropertyItem* fontFamily() const;
     PropertyItem* fontStyle() const;
@@ -86,6 +91,8 @@ public:
     PropertyItem* textPlacement() const;
     PropertyItem* textScriptAlignment() const;
 
+    QVariantList textStyles();
+
     bool areStaffTextPropertiesAvailable() const;
 
     bool isSpecialCharactersInsertionAvailable() const;
@@ -95,6 +102,8 @@ public slots:
     void setIsSpecialCharactersInsertionAvailable(bool isSpecialCharactersInsertionAvailable);
 
 signals:
+    void textStylesChanged();
+
     void areStaffTextPropertiesAvailableChanged(bool areStaffTextPropertiesAvailable);
     void isSpecialCharactersInsertionAvailableChanged(bool isSpecialCharactersInsertionAvailable);
 
@@ -122,6 +131,8 @@ private:
     PropertyItem* m_textType = nullptr;
     PropertyItem* m_textPlacement = nullptr;
     PropertyItem* m_textScriptAlignment = nullptr;
+
+    QVariantList m_textStyles;
 
     bool m_areStaffTextPropertiesAvailable = false;
     bool m_isSpecialCharactersInsertionAvailable = false;

--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
@@ -233,35 +233,7 @@ Column {
         navigationPanel: root.navigationPanel
         navigationRowStart: cornerRadiusSection.navigationRowEnd + 1
 
-        model: [
-            { text: qsTrc("inspector", "Title"), value: TextTypes.TEXT_TYPE_TITLE },
-            { text: qsTrc("inspector", "Subtitle"), value: TextTypes.TEXT_TYPE_SUBTITLE},
-            { text: qsTrc("inspector", "Composer"), value: TextTypes.TEXT_TYPE_COMPOSER },
-            { text: qsTrc("inspector", "Lyricist"), value: TextTypes.TEXT_TYPE_POET },
-            { text: qsTrc("inspector", "Translator"), value: TextTypes.TEXT_TYPE_TRANSLATOR },
-            { text: qsTrc("inspector", "Frame"), value: TextTypes.TEXT_TYPE_FRAME },
-            { text: qsTrc("inspector", "Header"), value: TextTypes.TEXT_TYPE_HEADER },
-            { text: qsTrc("inspector", "Footer"), value: TextTypes.TEXT_TYPE_FOOTER },
-            { text: qsTrc("inspector", "Measure number"), value: TextTypes.TEXT_TYPE_MEASURE_NUMBER },
-            { text: qsTrc("inspector", "Instrument name (Part)"), value: TextTypes.TEXT_TYPE_INSTRUMENT_EXCERPT },
-            { text: qsTrc("inspector", "Instrument change"), value: TextTypes.TEXT_TYPE_INSTRUMENT_CHANGE },
-            { text: qsTrc("inspector", "Staff"), value: TextTypes.TEXT_TYPE_STAFF },
-            { text: qsTrc("inspector", "System"), value: TextTypes.TEXT_TYPE_SYSTEM },
-            { text: qsTrc("inspector", "Expression"), value: TextTypes.TEXT_TYPE_EXPRESSION },
-            { text: qsTrc("inspector", "Dynamics"), value: TextTypes.TEXT_TYPE_DYNAMICS },
-            { text: qsTrc("inspector", "Hairpin"), value: TextTypes.TEXT_TYPE_HAIRPIN },
-            { text: qsTrc("inspector", "Tempo"), value: TextTypes.TEXT_TYPE_TEMPO },
-            { text: qsTrc("inspector", "Rehearsal mark"), value: TextTypes.TEXT_TYPE_REHEARSAL_MARK },
-            { text: qsTrc("inspector", "Repeat text left"), value: TextTypes.TEXT_TYPE_REPEAT_LEFT },
-            { text: qsTrc("inspector", "Repeat text right"), value: TextTypes.TEXT_TYPE_REPEAT_RIGHT },
-            { text: qsTrc("inspector", "Lyrics odd lines"), value: TextTypes.TEXT_TYPE_LYRICS_ODD },
-            { text: qsTrc("inspector", "Lyrics even lines"), value: TextTypes.TEXT_TYPE_LYRICS_EVEN },
-            { text: qsTrc("inspector", "Chord symbol"), value: TextTypes.TEXT_TYPE_HARMONY_A },
-            { text: qsTrc("inspector", "Chord symbol (Alternate)"), value: TextTypes.TEXT_TYPE_HARMONY_B },
-            { text: qsTrc("inspector", "Roman numeral analysis"), value: TextTypes.TEXT_TYPE_HARMONY_ROMAN },
-            { text: qsTrc("inspector", "Nashville number"), value: TextTypes.TEXT_TYPE_HARMONY_NASHVILLE },
-            { text: qsTrc("inspector", "Sticking"), value: TextTypes.TEXT_TYPE_STICKING }
-        ]
+        model: root.model ? root.model.textStyles : []
     }
 
     PlacementSection {

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -864,10 +864,12 @@ EditStyle::EditStyle(QWidget* parent)
     connect(setSignalMapper, &QSignalMapper::mappedInt, this, &EditStyle::valueChanged);
     connect(resetSignalMapper, &QSignalMapper::mappedInt, this, &EditStyle::resetStyleValue);
 
+    Score* score = globalContext()->currentNotation()->elements()->msScore();
+
     textStyles->clear();
-    for (auto ss : allTextStyles()) {
-        QListWidgetItem* item = new QListWidgetItem(TConv::translatedUserName(ss));
-        item->setData(Qt::UserRole, int(ss));
+    for (TextStyleType textStyleType : allTextStyles()) {
+        QListWidgetItem* item = new QListWidgetItem(score->getTextStyleUserName(textStyleType).qTranslated());
+        item->setData(Qt::UserRole, int(textStyleType));
         textStyles->addItem(item);
     }
 
@@ -1117,10 +1119,11 @@ void EditStyle::retranslate()
 
     setHeaderFooterToolTip();
 
+    Score* score = globalContext()->currentNotation()->elements()->msScore();
+
     int idx = 0;
-    for (auto ss : allTextStyles()) {
-        QString name = TConv::translatedUserName(ss);
-        textStyles->item(idx)->setText(name);
+    for (TextStyleType textStyleType : allTextStyles()) {
+        textStyles->item(idx)->setText(score->getTextStyleUserName(textStyleType).qTranslated());
         ++idx;
     }
 
@@ -2160,7 +2163,9 @@ void EditStyle::textStyleChanged(int row)
         }
     }
 
-    styleName->setText(TConv::translatedUserName(tid));
+    Score* score = globalContext()->currentNotation()->elements()->msScore();
+
+    styleName->setText(score->getTextStyleUserName(tid).qTranslated());
     styleName->setEnabled(int(tid) >= int(TextStyleType::USER1));
     resetTextStyleName->setEnabled(false);
 }

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -2171,7 +2171,7 @@ void EditStyle::textStyleChanged(int row)
 
 void EditStyle::textStyleValueChanged(Pid pid, QVariant value)
 {
-    TextStyleType tid = TextStyleType(textStyles->item(textStyles->currentRow())->data(Qt::UserRole).toInt());
+    TextStyleType tid = TextStyleType(textStyles->currentItem()->data(Qt::UserRole).toInt());
     const TextStyle* ts = textStyle(tid);
 
     for (const StyledProperty& a : *ts) {
@@ -2189,7 +2189,7 @@ void EditStyle::textStyleValueChanged(Pid pid, QVariant value)
 
 void EditStyle::resetTextStyle(Pid pid)
 {
-    TextStyleType tid = TextStyleType(textStyles->item(textStyles->currentRow())->data(Qt::UserRole).toInt());
+    TextStyleType tid = TextStyleType(textStyles->currentItem()->data(Qt::UserRole).toInt());
     const TextStyle* ts = textStyle(tid);
 
     for (const StyledProperty& a : *ts) {


### PR DESCRIPTION
Resolves: #12794

Include user text styles, taking into account their customized name, if any.

@Tantacrul This will make it slightly different from MS3, where only a subset of text styles was displayed. For fingering text elements, only 4 styles were shown, for other text elements 40 styles or so; now we will show all 56. All these styles are exposed in Format > Style > Text Styles anyway, in MS3 too. I think they could be useful, for example, when you use a text element to create a very special tuplet marking that is not supported using a 'real' tuplet, you will want to use the Tuplet text style, so that it will look the same as other tuplets. However, if there are styles that you think should be excluded, we can easily do so. 