### PR TITLE
Fix #12558: Lines ending note

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -1987,17 +1987,6 @@ void Score::cmdAddOttava(OttavaType type)
 
 std::vector<Hairpin*> Score::addHairpins(HairpinType type)
 {
-    // special case for two selected chordrests on same staff
-    bool twoNotesSameStaff = false;
-
-    if (selection().isList() && selection().elements().size() == 2) {
-        ChordRest* cr1 = selection().firstChordRest();
-        ChordRest* cr2 = selection().lastChordRest();
-        if (cr1 && cr2 && cr1 != cr2 && cr1->staffIdx() == cr2->staffIdx()) {
-            twoNotesSameStaff = true;
-        }
-    }
-
     std::vector<Hairpin*> hairpins;
 
     // add hairpin on each staff if possible
@@ -2005,16 +1994,15 @@ std::vector<Hairpin*> Score::addHairpins(HairpinType type)
         for (staff_idx_t staffIdx = selection().staffStart(); staffIdx < selection().staffEnd(); ++staffIdx) {
             ChordRest* cr1 = selection().firstChordRest(staffIdx * VOICES);
             ChordRest* cr2 = selection().lastChordRest(staffIdx * VOICES);
-            hairpins.push_back(addHairpin(type, cr1, cr2, /* toCr2End */ true));
+            hairpins.push_back(addHairpin(type, cr1, cr2));
         }
-    } else if (selection().isRange() || selection().isSingle() || twoNotesSameStaff) {
+    } else {
         // for single staff range selection, or single selection,
         // find start & end elements elements
         ChordRest* cr1 = nullptr;
         ChordRest* cr2 = nullptr;
         getSelectedChordRest2(&cr1, &cr2);
-
-        hairpins.push_back(addHairpin(type, cr1, cr2, /* toCr2End */ !twoNotesSameStaff));
+        hairpins.push_back(addHairpin(type, cr1, cr2));
     }
 
     return hairpins;
@@ -3405,7 +3393,7 @@ Hairpin* Score::addHairpin(HairpinType t, const Fraction& tickStart, const Fract
 //   Score::addHairpin
 //---------------------------------------------------------
 
-Hairpin* Score::addHairpin(HairpinType type, ChordRest* cr1, ChordRest* cr2, bool toCr2End)
+Hairpin* Score::addHairpin(HairpinType type, ChordRest* cr1, ChordRest* cr2)
 {
     if (!cr1) {
         return nullptr;
@@ -3414,7 +3402,7 @@ Hairpin* Score::addHairpin(HairpinType type, ChordRest* cr1, ChordRest* cr2, boo
         cr2 = cr1;
     }
     assert(cr1->staffIdx() == cr2->staffIdx());
-    const Fraction end = toCr2End ? cr2->tick() + cr2->actualTicks() : cr2->tick();
+    const Fraction end = cr2->tick() + cr2->actualTicks();
     return addHairpin(type, cr1->tick(), end, cr1->track());
 }
 

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -1148,7 +1148,7 @@ public:
     void removeUnmanagedSpanner(Spanner*);
 
     Hairpin* addHairpin(HairpinType, const Fraction& tickStart, const Fraction& tickEnd, track_idx_t track);
-    Hairpin* addHairpin(HairpinType, ChordRest* cr1, ChordRest* cr2 = nullptr, bool toCr2End = true);
+    Hairpin* addHairpin(HairpinType, ChordRest* cr1, ChordRest* cr2 = nullptr);
 
     ChordRest* findCR(Fraction tick, track_idx_t track) const;
     ChordRest* findCRinStaff(const Fraction& tick, staff_idx_t staffIdx) const;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1543,6 +1543,10 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
             mu::engraving::Segment* endSegment = cr2->segment();
             if (element->type() == mu::engraving::ElementType::PEDAL && cr2 != cr1) {
                 endSegment = endSegment->nextCR(cr2->track());
+            } else if (endSegment->next() && endSegment->next()->enabled()) {
+                // Must behave the same as range selection, where endSegment
+                // is assumed to be one past the last selected
+                endSegment = endSegment->next();
             }
             // TODO - handle cross-voice selections
             staff_idx_t idx = cr1->staffIdx();


### PR DESCRIPTION
Resolves: #12558 

Entering a line from a list selection (Ctrl+Click on two notes) or from a range selection (Shift+Click on two notes) should produce the same result. But currently Ctrl+Click causes the line to end on the note _preceding_ the last selected, which is unintuitive.
Before:

https://user-images.githubusercontent.com/93707756/187879297-e0ad4bd0-3759-4bee-b2f2-1020d42be51c.mp4

After:

https://user-images.githubusercontent.com/93707756/187879333-0d51132b-577d-4fef-bfdb-a6b9edf72ea3.mp4

