### PR TITLE
Force screen readers to say accessible description on all platforms

### DIFF
--- a/src/engraving/accessibility/accessibleitem.cpp
+++ b/src/engraving/accessibility/accessibleitem.cpp
@@ -199,13 +199,7 @@ QString AccessibleItem::accessibleDescription() const
         return QString();
     }
 
-    QString result;
-#ifdef Q_OS_MACOS
-    result = accessibleName() + " ";
-#endif
-
-    result += readable(m_element->accessibleExtraInfo());
-    return result;
+    return readable(m_element->accessibleExtraInfo());
 }
 
 QVariant AccessibleItem::accessibleValue() const


### PR DESCRIPTION
Previously VoiceOver (macOS) and Narrator (Windows) did not say accessible descriptions, which meant certain information was not available to users of those screen readers.