### PR TITLE
[MU4] Fix #12170: Period tablature: "cue marks" for bass courses are not being shown in note-input mode #12170

### DIFF
--- a/src/engraving/libmscore/stafftype.cpp
+++ b/src/engraving/libmscore/stafftype.cpp
@@ -824,6 +824,64 @@ String StaffType::tabBassStringPrefix(int strg, bool* hasFret) const
 }
 
 //---------------------------------------------------------
+//   drawInputStringMarks
+//
+//    in TAB's, draws the marks within the input 'blue cursor' required to identify the current target input string.
+//
+//    Implements the specific of historic TAB styles for instruments with more strings than TAB lines.
+//    For strings normally represented by TAB lines, no mark is required.
+//    For strings not represented by TAB lines (e.g. bass strings in lutes and similar),
+//    either a sequence of slashes OR some ledger line-like lines OR the ordinal of the string
+//    are used, according to the TAB style (French or Italian) and the string position.
+//
+//    Note: assumes the string parameter is within legal bounds, i.e.:
+//    0 <= string <= [instrument strings] - 1
+//
+//    p       the Painter to draw into
+//    string  the instrument physical string for which to draw the mark (0 = top string)
+//    voice   the current input voice (affects mark colour)
+//    rect    the rect of the 'blue rectangle' showing the input position
+//---------------------------------------------------------
+
+void StaffType::drawInputStringMarks(mu::draw::Painter* p, int string, int voice, const RectF& rect) const
+{
+    if (_group != StaffGroup::TAB) {
+        return;
+    }
+
+    static constexpr double LEDGER_LINE_THICKNESS = 0.15; // in sp
+    static constexpr double LEDGER_LINE_LEFTX = 0.25; // in % of cursor rectangle width
+    static constexpr double LEDGER_LINE_RIGHTX = 0.75; // in % of cursor rectangle width
+
+    double spatium = SPATIUM20;
+    double lineDist = _lineDistance.val() * spatium;
+    bool hasFret = false;
+    String text = tabBassStringPrefix(string, &hasFret);
+    double lw = LEDGER_LINE_THICKNESS * spatium; // use a fixed width
+    mu::draw::Pen pen(engravingConfiguration()->selectionColor(voice), lw);
+    p->setPen(pen);
+    // draw conventional 'ledger lines', if required
+    int numOfLedgerLines  = numOfTabLedgerLines(string);
+    double x1 = rect.x() + rect.width() * LEDGER_LINE_LEFTX;
+    double x2 = rect.x() + rect.width() * LEDGER_LINE_RIGHTX;
+    // cursor rect is 1 line dist. high, and it is:
+    // centred on the line for "frets on strings"    => lower top ledger line 1/2 line dist.
+    // sitting on the line for "frets above strings" => lower top ledger line 1 full line dist
+    double y = rect.top() + lineDist * (_onLines ? 0.5 : 1.0);
+    for (int i = 0; i < numOfLedgerLines; i++) {
+        p->drawLine(LineF(x1, y, x2, y));
+        y += lineDist / numOfLedgerLines;     // insert other lines between top line and tab body
+    }
+    // draw the text, if any
+    if (!text.isEmpty()) {
+        mu::draw::Font f = fretFont();
+        f.setPointSizeF(f.pointSizeF() * MScore::pixelRatio);
+        p->setFont(f);
+        p->drawText(PointF(rect.left(), rect.top() + lineDist), text);
+    }
+}
+
+//---------------------------------------------------------
 //   numOfLedgerLines
 //
 //    in TAB's, returns the number of ledgerlines needed by bass lines in some TAB styles.

--- a/src/engraving/libmscore/stafftype.h
+++ b/src/engraving/libmscore/stafftype.h
@@ -353,6 +353,7 @@ public:
     int     visualStringToPhys(int line) const;                   // return the string in physical order from visual string
     double   physStringToYOffset(int strg) const;                  // return the string Y offset (in sp, chord-relative)
     String tabBassStringPrefix(int strg, bool* hasFret) const;   // return a string with the prefix, if any, identifying a bass string
+    void    drawInputStringMarks(mu::draw::Painter* p, int string, int voice, const RectF& rect) const;
     int     numOfTabLedgerLines(int string) const;
 
     // properties getters (some getters require updated metrics)

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -74,9 +74,11 @@ NoteInputState NotationNoteInput::state() const
     noteInputState.withSlur = inputState.slur() != nullptr;
     noteInputState.currentVoiceIndex = inputState.voice();
     noteInputState.currentTrack = inputState.track();
+    noteInputState.currentString = inputState.string();
     noteInputState.drumset = inputState.drumset();
     noteInputState.isRest = inputState.rest();
     noteInputState.staffGroup = inputState.staffGroup();
+    noteInputState.staff = score()->staff(mu::engraving::track2staff(inputState.track()));
     noteInputState.segment = inputState.segment();
 
     return noteInputState;

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -268,8 +268,10 @@ struct NoteInputState
     bool withSlur = false;
     engraving::voice_idx_t currentVoiceIndex = 0;
     engraving::track_idx_t currentTrack = 0;
+    int currentString = 0;
     const Drumset* drumset = nullptr;
     StaffGroup staffGroup = StaffGroup::STANDARD;
+    const Staff* staff = nullptr;
     Segment* segment = nullptr;
 };
 

--- a/src/notation/view/noteinputcursor.cpp
+++ b/src/notation/view/noteinputcursor.cpp
@@ -26,18 +26,31 @@ using namespace mu::engraving;
 
 void NoteInputCursor::paint(mu::draw::Painter* painter)
 {
-    if (!isNoteInputMode()) {
+    INotationNoteInputPtr noteInput = currentNoteInput();
+    if (!noteInput || !noteInput->isNoteInputMode()) {
         return;
     }
 
-    RectF cursorRect = rect();
-    QColor cursorRectColor = cursorColor();
+    NoteInputState state = noteInput->state();
+    RectF cursorRect = noteInput->cursorRect();
+
+    Color fillColor = configuration()->selectionColor(state.currentVoiceIndex);
+    Color cursorRectColor = fillColor;
+    cursorRectColor.setAlpha(configuration()->cursorOpacity());
     painter->fillRect(cursorRect, cursorRectColor);
 
     constexpr int leftLineWidth = 3;
     RectF leftLine(cursorRect.topLeft().x(), cursorRect.topLeft().y(), leftLineWidth, cursorRect.height());
-    QColor lineColor = fillColor();
+    Color lineColor = fillColor;
     painter->fillRect(leftLine, lineColor);
+
+    if (state.staffGroup == StaffGroup::TAB) {
+        const StaffType* staffType = state.staff ? state.staff->staffType() : nullptr;
+
+        if (staffType) {
+            staffType->drawInputStringMarks(painter, state.currentString, state.currentVoiceIndex, cursorRect);
+        }
+    }
 }
 
 INotationNoteInputPtr NoteInputCursor::currentNoteInput() const
@@ -53,42 +66,4 @@ INotationNoteInputPtr NoteInputCursor::currentNoteInput() const
     }
 
     return interaction->noteInput();
-}
-
-bool NoteInputCursor::isNoteInputMode() const
-{
-    auto noteInput = currentNoteInput();
-    if (!noteInput) {
-        return false;
-    }
-
-    return noteInput->isNoteInputMode();
-}
-
-mu::RectF NoteInputCursor::rect() const
-{
-    auto noteInput = currentNoteInput();
-    if (!noteInput) {
-        return {};
-    }
-
-    return noteInput->cursorRect();
-}
-
-QColor NoteInputCursor::cursorColor() const
-{
-    QColor color = fillColor();
-    color.setAlpha(configuration()->cursorOpacity());
-    return color;
-}
-
-QColor NoteInputCursor::fillColor() const
-{
-    auto noteInput = currentNoteInput();
-    if (!noteInput) {
-        return QColor();
-    }
-
-    voice_idx_t voiceIndex = noteInput->state().currentVoiceIndex;
-    return configuration()->selectionColor(voiceIndex);
 }

--- a/src/notation/view/noteinputcursor.h
+++ b/src/notation/view/noteinputcursor.h
@@ -37,17 +37,10 @@ class NoteInputCursor
     INJECT(notation, INotationConfiguration, configuration)
 
 public:
-    NoteInputCursor() = default;
-
     void paint(draw::Painter* painter);
 
 private:
     INotationNoteInputPtr currentNoteInput() const;
-
-    bool isNoteInputMode() const;
-    RectF rect() const;
-    QColor cursorColor() const;
-    QColor fillColor() const;
 };
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/12170