### PR TITLE
[MU4] Fix #12972: Loop region length is not recalculated after tempo change

### DIFF
--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -84,6 +84,7 @@ void PlaybackController::init()
 
     m_totalPlayTimeChanged.onNotify(this, [this]() {
         updateCurrentTempo();
+        updateLoop();
     });
 
     m_playbackPositionChanged.onNotify(this, [this]() {
@@ -1166,7 +1167,6 @@ void PlaybackController::setTempoMultiplier(double multiplier)
 
     playback->setTempoMultiplier(multiplier);
     seek(tick);
-    updateLoop();
 
     if (playing) {
         resume();


### PR DESCRIPTION
Resolves (partially): https://github.com/musescore/MuseScore/issues/12972