### PR TITLE
[MU4] When line (hairpin, slur etc.) is located within a range selection, after single selection the grips are disappear

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -697,7 +697,7 @@ void NotationInteraction::doSelect(const std::vector<EngravingItem*>& elements, 
 
     if (needEndTextEditing(elements)) {
         endEditText();
-    } else if (isElementEditStarted() && (elements.size() != 1 || elements.front() != score()->selection().element())) {
+    } else if (needEndElementEditing(elements)) {
         endEditElement();
     }
 
@@ -4257,6 +4257,19 @@ bool NotationInteraction::needEndTextEditing(const std::vector<EngravingItem*>& 
     }
 
     return newSelectedElements.front() != m_editData.element;
+}
+
+bool NotationInteraction::needEndElementEditing(const std::vector<EngravingItem*>& newSelectedElements) const
+{
+    if (!isElementEditStarted()) {
+        return false;
+    }
+
+    if (newSelectedElements.size() != 1) {
+        return true;
+    }
+
+    return newSelectedElements.front() != score()->selection().element();
 }
 
 void NotationInteraction::resetGripEdit()

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -358,6 +358,7 @@ private:
     bool notesHaveActiculation(const std::vector<Note*>& notes, SymbolId articulationSymbolId) const;
 
     bool needEndTextEditing(const std::vector<EngravingItem*>& newSelectedElements) const;
+    bool needEndElementEditing(const std::vector<EngravingItem*>& newSelectedElements) const;
 
     void resetGripEdit();
     void resetHitElementContext();

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -564,8 +564,7 @@ void NotationViewInputController::mousePressEvent(QMouseEvent* event)
             selectType = SelectType::ADD;
         }
         viewInteraction()->select({ hitElement }, selectType, hitStaffIndex);
-    } else if (hitElement && event->button() == Qt::LeftButton
-               && event->modifiers() == Qt::KeyboardModifier::ControlModifier) {
+    } else if (hitElement && button == Qt::LeftButton && keyState == Qt::ControlModifier) {
         viewInteraction()->select({ hitElement }, SelectType::ADD, hitStaffIndex);
     }
 
@@ -622,11 +621,9 @@ void NotationViewInputController::handleLeftClick(const ClickContext& ctx)
         playbackController()->playElements({ ctx.hitElement });
     }
 
-    if (!viewInteraction()->isTextSelected()) {
-        return;
+    if (viewInteraction()->isTextSelected()) {
+        updateTextCursorPosition();
     }
-
-    updateTextCursorPosition();
 }
 
 void NotationViewInputController::handleRightClick(const ClickContext& ctx)
@@ -790,7 +787,7 @@ void NotationViewInputController::handleLeftClickRelease(const QPointF& releaseP
     }
 
     if (interaction->textEditingAllowed(ctx.element)) {
-        dispatcher()->dispatch("edit-text", ActionData::make_arg1<PointF>(m_beginPoint));
+        interaction->startEditText(ctx.element, m_beginPoint);
     }
 }
 

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -607,9 +607,13 @@ void NotationViewInputController::handleLeftClick(const ClickContext& ctx)
         viewInteraction()->endEditGrip();
     }
 
-    if (ctx.hitElement && ctx.hitElement->needStartEditingAfterSelecting()) {
-        viewInteraction()->startEditElement(ctx.hitElement);
-        return;
+    INotationSelectionPtr selection = viewInteraction()->selection();
+
+    if (!selection->isRange()) {
+        if (ctx.hitElement && ctx.hitElement->needStartEditingAfterSelecting()) {
+            viewInteraction()->startEditElement(ctx.hitElement);
+            return;
+        }
     }
 
     if (!ctx.hitElement) {
@@ -777,6 +781,11 @@ void NotationViewInputController::handleLeftClickRelease(const QPointF& releaseP
 
     INotationInteractionPtr interaction = viewInteraction();
     interaction->select({ ctx.element }, SelectType::SINGLE, staffIndex);
+
+    if (ctx.element && ctx.element->needStartEditingAfterSelecting()) {
+        viewInteraction()->startEditElement(ctx.element);
+        return;
+    }
 
     if (ctx.element != m_prevHitElement) {
         return;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11902