### PR TITLE
[MU4] Remove read/write .mxml

### DIFF
--- a/build/Linux+BSD/musescore.xml.in
+++ b/build/Linux+BSD/musescore.xml.in
@@ -103,8 +103,7 @@
     <mime-type type="application/vnd.recordare.musicxml">
         <!-- See "Container file" at http://www.musicxml.com/for-developers/musicxml-dtd/ -->
         <comment>MusicXML compressed score</comment>
-        <glob pattern="*.mxl"/><!-- preferred extension must go first -->
-        <glob pattern="*.mxml" weight="40"/><!-- reduced weight (default 50) to avoid matching Macromedia XML files -->
+        <glob pattern="*.mxl"/>
         <sub-class-of type="application/zip"/>
         <icon name="application-vnd.recordare.musicxml@MSCORE_INSTALL_SUFFIX@"/>
     </mime-type>

--- a/build/MacOSXBundleInfo.plist.in
+++ b/build/MacOSXBundleInfo.plist.in
@@ -236,7 +236,6 @@
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>mxl</string>
-				<string>mxml</string>
 			</array>
 			<key>CFBundleTypeMIMETypes</key>
 			<array>

--- a/build/packaging/WIX.template.in
+++ b/build/packaging/WIX.template.in
@@ -100,7 +100,6 @@
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".xml" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".musicxml" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".mxl" Value="" Type="string" />
-            <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".mxml" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".cap" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".capx" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".scw" Value="" Type="string" />

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -3080,7 +3080,7 @@ void MusicXMLParserDirection::dashes(const QString& type, const int number,
         b->setLineStyle(LineType::DASHED);
         // TODO brackets and dashes now share the same storage
         // because they both use ElementType::TEXTLINE
-        // use mxml specific type instead
+        // use MusicXML specific type instead
         starts.append(MusicXmlSpannerDesc(b, ElementType::TEXTLINE, number));
     } else if (type == "stop") {
         auto b = spdesc._isStarted ? toTextLine(spdesc._sp) : Factory::createTextLine(_score->dummy());

--- a/src/importexport/musicxml/internal/musicxmlreader.cpp
+++ b/src/importexport/musicxml/internal/musicxmlreader.cpp
@@ -38,7 +38,7 @@ mu::Ret MusicXmlReader::read(MasterScore* score, const io::path_t& path, const O
     std::string suffix = mu::io::suffix(path);
     if (suffix == "xml" || suffix == "musicxml") {
         err = importMusicXml(score, path.toQString());
-    } else if (suffix == "mxl" || suffix == "mxml") {
+    } else if (suffix == "mxl") {
         err = importCompressedMusicXml(score, path.toQString());
     }
     return make_ret(err, path);

--- a/src/importexport/musicxml/musicxmlmodule.cpp
+++ b/src/importexport/musicxml/musicxmlmodule.cpp
@@ -65,7 +65,7 @@ void MusicXmlModule::resolveImports()
 
     auto readers = modularity::ioc()->resolve<INotationReadersRegister>(moduleName());
     if (readers) {
-        readers->reg({ "xml", "musicxml", "mxl", "mxml" }, std::make_shared<MusicXmlReader>());
+        readers->reg({ "xml", "musicxml", "mxl" }, std::make_shared<MusicXmlReader>());
     }
 
     auto writers = modularity::ioc()->resolve<INotationWritersRegister>(moduleName());

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -599,13 +599,13 @@ void ProjectActionsController::printScore()
 
 io::path_t ProjectActionsController::selectScoreOpeningFile()
 {
-    QString allExt = "*.mscz *.mxl *.mxml *.musicxml *.xml *.mid *.midi *.kar *.md *.mgu *.sgu *.cap *.capx "
+    QString allExt = "*.mscz *.mxl *.musicxml *.xml *.mid *.midi *.kar *.md *.mgu *.sgu *.cap *.capx "
                      "*.ove *.scw *.bmw *.bww *.gtp *.gp3 *.gp4 *.gp5 *.gpx *.gp *.ptb *.mscx *.mscs *.mscz~";
 
     QStringList filter;
     filter << qtrc("project", "All supported files") + " (" + allExt + ")"
            << qtrc("project", "MuseScore files") + " (*.mscz)"
-           << qtrc("project", "MusicXML files") + " (*.mxl *.mxml *.musicxml *.xml)"
+           << qtrc("project", "MusicXML files") + " (*.mxl *.musicxml *.xml)"
            << qtrc("project", "MIDI files") + " (*.mid *.midi *.kar)"
            << qtrc("project", "MuseData files") + " (*.md)"
            << qtrc("project", "Capella files") + " (*.cap *.capx)"

--- a/src/project/qml/MuseScore/Project/internal/ScoreItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoreItem.qml
@@ -262,7 +262,6 @@ FocusScope {
                     case "kar":
                         return "qrc:/resources/Placeholder_MIDI.png"
                     case "mxl":
-                    case "mxml":
                     case "musicxml":
                     case "xml":
                         return "qrc:/resources/Placeholder_MXML.png"


### PR DESCRIPTION
This does revert #13122 and replaces (Read: is an alternative to) #13146

It additionally eliminates `mxml` format writing entirely and also condenses MacOSXBundleInfo.plist.in (as fas as MusicXML is concerned)