### PR TITLE
[MU4] Fix #339006: Change `.[sm]posXML` files (back) to `.[sm]pos` files

### DIFF
--- a/src/converter/internal/compat/backendapi.cpp
+++ b/src/converter/internal/compat/backendapi.cpp
@@ -54,7 +54,8 @@ static const std::string SVG_WRITER_NAME = "svg";
 static const std::string SEGMENTS_POSITIONS_WRITER_NAME = "spos";
 static const std::string MEASURES_POSITIONS_WRITER_NAME = "mpos";
 static const std::string PDF_WRITER_NAME = "pdf";
-static const std::string MIDI_WRITER_NAME = "midi";
+static const std::string MIDI_WRITER_NAME = "mid";
+static const std::string MIDI_JSON_NAME = "midi";
 static const std::string MUSICXML_WRITER_NAME = "mxl";
 static const std::string MUSICXML_JSON_NAME = "mxml";
 static const std::string META_DATA_NAME = "metadata";
@@ -413,7 +414,7 @@ Ret BackendApi::exportScoreMidi(const INotationPtr notation, BackendJsonWriter& 
         return writerRetVal.ret;
     }
 
-    jsonWriter.addKey(MIDI_WRITER_NAME.c_str());
+    jsonWriter.addKey(MIDI_JSON_NAME.c_str());
     jsonWriter.addValue(writerRetVal.val, addSeparator);
 
     return make_ret(Ret::Code::Ok);

--- a/src/converter/internal/compat/backendapi.cpp
+++ b/src/converter/internal/compat/backendapi.cpp
@@ -51,8 +51,8 @@ using namespace mu::io;
 
 static const std::string PNG_WRITER_NAME = "png";
 static const std::string SVG_WRITER_NAME = "svg";
-static const std::string SEGMENTS_POSITIONS_WRITER_NAME = "sposXML";
-static const std::string MEASURES_POSITIONS_WRITER_NAME = "mposXML";
+static const std::string SEGMENTS_POSITIONS_WRITER_NAME = "spos";
+static const std::string MEASURES_POSITIONS_WRITER_NAME = "mpos";
 static const std::string PDF_WRITER_NAME = "pdf";
 static const std::string MIDI_WRITER_NAME = "midi";
 static const std::string MUSICXML_WRITER_NAME = "mxl";

--- a/src/notation/notationmodule.cpp
+++ b/src/notation/notationmodule.cpp
@@ -116,8 +116,8 @@ void NotationModule::resolveImports()
 
     auto writers = modularity::ioc()->resolve<project::INotationWritersRegister>(moduleName());
     if (writers) {
-        writers->reg({ "sposXML" }, std::make_shared<PositionsWriter>(PositionsWriter::ElementType::SEGMENT));
-        writers->reg({ "mposXML" }, std::make_shared<PositionsWriter>(PositionsWriter::ElementType::MEASURE));
+        writers->reg({ "spos" }, std::make_shared<PositionsWriter>(PositionsWriter::ElementType::SEGMENT));
+        writers->reg({ "mpos" }, std::make_shared<PositionsWriter>(PositionsWriter::ElementType::MEASURE));
         writers->reg({ "mscz" }, std::make_shared<MscNotationWriter>(engraving::MscIoMode::Zip));
         writers->reg({ "mscx" }, std::make_shared<MscNotationWriter>(engraving::MscIoMode::Dir));
     }


### PR DESCRIPTION
like it was in MuseScore 3

Resolves https://musescore.org/en/node/339006