### PR TITLE
Fix #11002: Do not adjust minDistance for cross-staff arpeggios, and trigger layout on arpeggio edit

### DIFF
--- a/src/engraving/libmscore/arpeggio.cpp
+++ b/src/engraving/libmscore/arpeggio.cpp
@@ -480,6 +480,8 @@ bool Arpeggio::edit(EditData& ed)
     Chord* c = chord();
     setPosX(-(width() + spatium() * .5));
     c->layoutArpeggio2();
+    Fraction _tick = tick();
+    score()->setLayout(_tick, _tick, staffIdx(), staffIdx() + _span, this);
     return true;
 }
 

--- a/src/engraving/libmscore/shape.h
+++ b/src/engraving/libmscore/shape.h
@@ -66,8 +66,7 @@ public:
     };
 
     Shape() {}
-    Shape(const mu::RectF& r, const EngravingItem* p) { add(r, p); }
-    Shape(const mu::RectF& r) { add(r); }
+    Shape(const mu::RectF& r, const EngravingItem* p = nullptr) { add(r, p); }
 
     void add(const Shape& s) { insert(end(), s.begin(), s.end()); }
     void add(const mu::RectF& r, const EngravingItem* p) { push_back(ShapeElement(r, p)); }

--- a/src/engraving/libmscore/skyline.h
+++ b/src/engraving/libmscore/skyline.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "draw/types/geometry.h"
+#include "shape.h"
 
 namespace mu::draw {
 class Painter;
@@ -33,7 +34,6 @@ class Painter;
 
 namespace mu::engraving {
 class Segment;
-class Shape;
 
 //---------------------------------------------------------
 //   SkylineSegment
@@ -43,9 +43,10 @@ struct SkylineSegment {
     double x;
     double y;
     double w;
+    int staffSpan;
 
-    SkylineSegment(double _x, double _y, double _w)
-        : x(_x), y(_y), w(_w) {}
+    SkylineSegment(double _x, double _y, double _w, int _staffSpan = 0)
+        : x(_x), y(_y), w(_w), staffSpan(_staffSpan) {}
 };
 
 //---------------------------------------------------------
@@ -59,8 +60,8 @@ class SkylineLine
     typedef std::vector<SkylineSegment>::iterator SegIter;
     typedef std::vector<SkylineSegment>::const_iterator SegConstIter;
 
-    SegIter insert(SegIter i, double x, double y, double w);
-    void append(double x, double y, double w);
+    SegIter insert(SegIter i, double x, double y, double w, int span);
+    void append(double x, double y, double w, int span);
     SegIter find(double x);
     SegConstIter find(double x) const;
 
@@ -68,8 +69,10 @@ public:
     SkylineLine(bool n)
         : north(n) {}
     void add(const Shape& s);
-    void add(const mu::RectF& r);
-    void add(double x, double y, double w);
+    void add(const ShapeElement& r);
+    void add(double x, double y, double w, int span = 0);
+    void add(const RectF& r) { add(ShapeElement(r)); }
+
     void clear() { seg.clear(); }
     void paint(mu::draw::Painter& painter) const;
     void dump() const;
@@ -100,7 +103,8 @@ public:
 
     void clear();
     void add(const Shape& s);
-    void add(const mu::RectF& r);
+    void add(const ShapeElement& r);
+    void add(const RectF& r) { add(ShapeElement(r)); }
 
     double minDistance(const Skyline&) const;
 

--- a/src/engraving/utests/all_elements_data/cross_staff_arp.mscx
+++ b/src/engraving/utests/all_elements_data/cross_staff_arp.mscx
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.00">
+  <programVersion>4.0.0</programVersion>
+  <programRevision></programRevision>
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>4.05512</pageWidth>
+      <pageHeight>2.71654</pageHeight>
+      <pagePrintableWidth>3.8189</pagePrintableWidth>
+      <pageEvenLeftMargin>0.23622</pageEvenLeftMargin>
+      <pageOddLeftMargin>0</pageOddLeftMargin>
+      <pageEvenTopMargin>0.590551</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
+      <pageOddTopMargin>0</pageOddTopMargin>
+      <pageOddBottomMargin>0</pageOddBottomMargin>
+      <hairpinLinePosAbove x="0" y="-1.5"/>
+      <hairpinLinePosBelow x="0" y="2.5"/>
+      <measureNumberPosBelow x="0" y="1"/>
+      <headerAlign>center,center</headerAlign>
+      <footerAlign>center,center</footerAlign>
+      <Spatium>1.75</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Composer / arranger</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2022-09-01</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Microsoft Windows</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="subtitle">Subtitle</metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Untitled score</metaTag>
+    <Order id="orchestral">
+      <name>Orchestral</name>
+      <instrument id="piano">
+        <family id="keyboards">Keyboards</family>
+        </instrument>
+      <section id="woodwind" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>flutes</family>
+        <family>oboes</family>
+        <family>clarinets</family>
+        <family>saxophones</family>
+        <family>bassoons</family>
+        <unsorted group="woodwinds"/>
+        </section>
+      <section id="brass" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>horns</family>
+        <family>trumpets</family>
+        <family>cornets</family>
+        <family>flugelhorns</family>
+        <family>trombones</family>
+        <family>tubas</family>
+        </section>
+      <section id="timpani" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>timpani</family>
+        </section>
+      <section id="percussion" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>keyboard-percussion</family>
+        <family>drums</family>
+        <family>unpitched-metal-percussion</family>
+        <family>unpitched-wooden-percussion</family>
+        <family>other-percussion</family>
+        </section>
+      <family>keyboards</family>
+      <family>harps</family>
+      <family>organs</family>
+      <family>synths</family>
+      <soloists/>
+      <section id="voices" brackets="true" barLineSpan="false" thinBrackets="true">
+        <family>voices</family>
+        <family>voice-groups</family>
+        </section>
+      <section id="strings" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>orchestral-strings</family>
+        </section>
+      <unsorted/>
+      </Order>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="1" span="2" col="2"/>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <defaultClef>F</defaultClef>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument id="piano">
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Rest>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <Accidental>
+                <subtype>accidentalFlat</subtype>
+                </Accidental>
+              <pitch>63</pitch>
+              <tpc>11</tpc>
+              </Note>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            <Note>
+              <Accidental>
+                <subtype>accidentalFlat</subtype>
+                </Accidental>
+              <pitch>70</pitch>
+              <tpc>12</tpc>
+              </Note>
+            <Arpeggio>
+              <subtype>0</subtype>
+              <span>2</span>
+              </Arpeggio>
+            </Chord>
+          <Rest>
+            <durationType>quarter</durationType>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="2">
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <pitch>53</pitch>
+              <tpc>13</tpc>
+              </Note>
+            <Note>
+              <pitch>59</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          <Rest>
+            <durationType>quarter</durationType>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/utests/layoutelements_tests.cpp
+++ b/src/engraving/utests/layoutelements_tests.cpp
@@ -29,6 +29,8 @@
 #include "libmscore/staff.h"
 #include "libmscore/system.h"
 #include "libmscore/tuplet.h"
+#include "libmscore/chord.h"
+#include "libmscore/note.h"
 
 #include "utils/scorerw.h"
 
@@ -130,4 +132,23 @@ TEST_F(Engraving_LayoutElementsTests, tstLayoutMoonlight)
 TEST_F(Engraving_LayoutElementsTests, DISABLED_tstLayoutGoldberg)
 {
     tstLayoutAll(u"goldberg.mscx");
+}
+
+TEST_F(Engraving_LayoutElementsTests, tstLayoutCrossStaffArp)
+{
+    MasterScore* score = ScoreRW::readScore(ALL_ELEMENTS_DATA_DIR + "cross_staff_arp.mscx");
+    EXPECT_TRUE(score);
+
+    // the y-position where the bottom staff is
+    double staff1yPre = score->systems().front()->staves().at(1)->y();
+
+    // re-layout the score
+    score->update();
+    score->doLayout();
+
+    // the bottom staff should not have moved
+    double staff1yPost = score->systems().front()->staves().at(1)->y();
+    EXPECT_FLOAT_EQ(staff1yPre, staff1yPost);
+
+    delete score;
 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11002

Previously, arpeggio lines were added to the skybox, which affects the distance between staves, and then on layout were extended to reach the next chord, and the cycle continued. In MU3, arpeggio lines are not added to the skybox, which is why this spacing problem didn't exist there.

I've added functionality that allows a staff's skybox to disregard cross-staff objects when determining staff spacing.

Speaking of things that happened in MU3, if you add an arpeggio to a chord with accidentals, and then extend that arpeggio line down to the next staff, it would fail to layout and adjust itself for the accidentals:
![image](https://user-images.githubusercontent.com/89263931/188519021-9c4d10f4-0807-466c-9652-1ecf6b0300e2.png)

As a bonus to this PR, I've fixed that issue, and now a layout update for the arpeggio is now triggered.