### PR TITLE
[MU4] Fix MSVC compiler warning

### DIFF
--- a/src/engraving/libmscore/stafftype.cpp
+++ b/src/engraving/libmscore/stafftype.cpp
@@ -843,7 +843,7 @@ String StaffType::tabBassStringPrefix(int strg, bool* hasFret) const
 //    rect    the rect of the 'blue rectangle' showing the input position
 //---------------------------------------------------------
 
-void StaffType::drawInputStringMarks(mu::draw::Painter* p, int string, int voice, const RectF& rect) const
+void StaffType::drawInputStringMarks(mu::draw::Painter* p, int string, voice_idx_t voice, const RectF& rect) const
 {
     if (_group != StaffGroup::TAB) {
         return;

--- a/src/engraving/libmscore/stafftype.h
+++ b/src/engraving/libmscore/stafftype.h
@@ -353,7 +353,7 @@ public:
     int     visualStringToPhys(int line) const;                   // return the string in physical order from visual string
     double   physStringToYOffset(int strg) const;                  // return the string Y offset (in sp, chord-relative)
     String tabBassStringPrefix(int strg, bool* hasFret) const;   // return a string with the prefix, if any, identifying a bass string
-    void    drawInputStringMarks(mu::draw::Painter* p, int string, int voice, const RectF& rect) const;
+    void    drawInputStringMarks(mu::draw::Painter* p, int string, voice_idx_t voice, const RectF& rect) const;
     int     numOfTabLedgerLines(int string) const;
 
     // properties getters (some getters require updated metrics)


### PR DESCRIPTION
reg.  conversion from 'size_t' to 'int', possible loss of data  (C4267)