### PR TITLE
[MU4] Fix #11255: Properties. Bar Width reset button is disabled after changes and deselecting current element

### DIFF
--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -1015,7 +1015,7 @@ PropertyValue Segment::propertyDefault(Pid propertyId) const
     case Pid::LEADING_SPACE:
         return Spatium(0.0);
     default:
-        return EngravingItem::getProperty(propertyId);
+        return EngravingItem::propertyDefault(propertyId);
     }
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11255