### PR TITLE
Moving slur direction logic to dedicated method

### DIFF
--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -1333,7 +1333,7 @@ Slur::Slur(EngravingItem* parent)
 
 int calcStemArrangement(EngravingItem* start, EngravingItem* end)
 {
-    return (start && toChord(start)->stem() && toChord(start)->stem()->up() ? 2 : 0)
+    return (start && start->isChord() && toChord(start)->stem() && toChord(start)->stem()->up() ? 2 : 0)
            + (end && end->isChord() && toChord(end)->stem() && toChord(end)->stem()->up() ? 4 : 0);
 }
 
@@ -1460,67 +1460,16 @@ SpannerSegment* Slur::layoutSystem(System* system)
             _up = false;
             break;
         case DirectionV::AUTO:
-        {
-            //
-            // assumption:
-            // slurs have only chords or rests as start/end elements
-            //
-            if (startCR() == 0 || endCR() == 0) {
-                _up = true;
-                break;
-            }
-            Chord* c1 = startCR()->isChord() ? toChord(startCR()) : 0;
-            Chord* c2 = endCR()->isChord() ? toChord(endCR()) : 0;
-            if (c2 && startCR()->measure()->system() != endCR()->measure()->system()) {
-                // If the end chord is in a different system its direction may
-                // have never been computed, so we need to compute it here.
-                c2->computeUp();
-            }
-
+            computeUp();
             if (_sourceStemArrangement != -1) {
-                if (_sourceStemArrangement != calcStemArrangement(c1, c2)) {
+                if (_sourceStemArrangement != calcStemArrangement(startCR(), endCR())) {
                     // copy & paste from incompatible stem arrangement, so reset bezier points
                     for (int g = 0; g < (int)Grip::GRIPS; ++g) {
                         slurSegment->ups((Grip)g) = UP();
                     }
                 }
             }
-
-            if (c1 && c1->beam() && c1->beam()->cross()) {
-                // TODO: stem direction is not finalized, so we cannot use it here
-                _up = true;
-                break;
-            }
-
-            _up = !(startCR()->up());
-
-            // Check if multiple voices
-            bool multipleVoices = false;
-            Measure* m1 = startCR()->measure();
-            while (m1 && m1->tick() <= endCR()->tick()) {
-                if ((m1->hasVoices(startCR()->staffIdx(), tick(), ticks() + endCR()->ticks()))
-                    && c1) {
-                    multipleVoices = true;
-                    break;
-                }
-                m1 = m1->nextMeasure();
-            }
-            if (multipleVoices) {
-                // slurs go on the stem side
-                if (startCR()->voice() > 0 || endCR()->voice() > 0) {
-                    _up = false;
-                } else {
-                    _up = true;
-                }
-            } else if (c1 && c2 && !c1->isGrace() && isDirectionMixture(c1, c2)) {
-                // slurs go above if there are mixed direction stems between c1 and c2
-                // but grace notes are exceptions
-                _up = true;
-            } else if (c1 && c2 && c1->isGrace() && c2 != c1->parent() && isDirectionMixture(c1, c2)) {
-                _up = true;
-            }
-        }
-        break;
+            break;
         }
         sst = tick2() < etick ? SpannerSegmentType::SINGLE : SpannerSegmentType::BEGIN;
     } else if (tick() < stick && tick2() >= etick) {
@@ -1740,6 +1689,59 @@ SpannerSegment* Slur::layoutSystem(System* system)
 
     slurSegment->layoutSegment(p1, p2);
     return slurSegment;
+}
+
+void Slur::computeUp()
+{
+    //
+    // assumption:
+    // slurs have only chords or rests as start/end elements
+    //
+    if (startCR() == 0 || endCR() == 0) {
+        _up = true;
+        return;
+    }
+    Chord* c1 = startCR()->isChord() ? toChord(startCR()) : 0;
+    Chord* c2 = endCR()->isChord() ? toChord(endCR()) : 0;
+    if (c2 && startCR()->measure()->system() != endCR()->measure()->system()) {
+        // If the end chord is in a different system its direction may
+        // have never been computed, so we need to compute it here.
+        c2->computeUp();
+    }
+
+    if (c1 && c1->beam() && c1->beam()->cross()) {
+        // TODO: stem direction is not finalized, so we cannot use it here
+        _up = true;
+        return;
+    }
+
+    _up = !(startCR()->up());
+
+    // Check if multiple voices
+    bool multipleVoices = false;
+    Measure* m1 = startCR()->measure();
+    while (m1 && m1->tick() <= endCR()->tick()) {
+        if ((m1->hasVoices(startCR()->staffIdx(), tick(), ticks() + endCR()->ticks()))
+            && c1) {
+            multipleVoices = true;
+            break;
+        }
+        m1 = m1->nextMeasure();
+    }
+    if (multipleVoices) {
+        // slurs go on the stem side
+        if (startCR()->voice() > 0 || endCR()->voice() > 0) {
+            _up = false;
+        } else {
+            _up = true;
+        }
+    } else if (c1 && c2 && !c1->isGrace() && isDirectionMixture(c1, c2)) {
+        // slurs go above if there are mixed direction stems between c1 and c2
+        // but grace notes are exceptions
+        _up = true;
+    } else if (c1 && c2 && c1->isGrace() && c2 != c1->parent() && isDirectionMixture(c1, c2)) {
+        _up = true;
+    }
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/slur.h
+++ b/src/engraving/libmscore/slur.h
@@ -91,6 +91,7 @@ public:
     SpannerSegment* layoutSystem(System*) override;
     void setTrack(track_idx_t val) override;
     void slurPos(SlurPos*) override;
+    void computeUp();
 
     SlurSegment* frontSegment() { return toSlurSegment(Spanner::frontSegment()); }
     const SlurSegment* frontSegment() const { return toSlurSegment(Spanner::frontSegment()); }


### PR DESCRIPTION
No functional changes, just moving the slur direction logic to a dedicated method so it can be reused. This should be merged before #13204 