### PR TITLE
Fix grace notes stem shape glitch

### DIFF
--- a/src/engraving/layout/layoutbeams.cpp
+++ b/src/engraving/layout/layoutbeams.cpp
@@ -582,3 +582,35 @@ void LayoutBeams::respace(const std::vector<ChordRest*>& elements)
         cr->movePosX(dx);
     }
 }
+
+/************************************************************
+ * layoutNonCrossBeams()
+ * layout all non-cross-staff beams starting on this segment
+ * **********************************************************/
+
+void LayoutBeams::layoutNonCrossBeams(Segment* s)
+{
+    for (EngravingItem* e : s->elist()) {
+        if (!e || !e->isChordRest() || !e->score()->staff(e->staffIdx())->show()) {
+            // the beam and its system may still be referenced when selecting all,
+            // even if the staff is invisible. The old system is invalid and does cause problems in #284012
+            if (e && e->isChordRest() && !e->score()->staff(e->staffIdx())->show() && toChordRest(e)->beam()) {
+                toChordRest(e)->beam()->resetExplicitParent();
+            }
+            continue;
+        }
+        ChordRest* cr = toChordRest(e);
+        // layout beam
+        if (LayoutBeams::isTopBeam(cr)) {
+            cr->beam()->layout();
+        }
+        if (!cr->isChord()) {
+            continue;
+        }
+        for (Chord* grace : toChord(cr)->graceNotes()) {
+            if (LayoutBeams::isTopBeam(grace)) {
+                grace->beam()->layout();
+            }
+        }
+    }
+}

--- a/src/engraving/layout/layoutbeams.h
+++ b/src/engraving/layout/layoutbeams.h
@@ -29,6 +29,7 @@ class Chord;
 class ChordRest;
 class Measure;
 class Score;
+class Segment;
 
 class LayoutContext;
 class LayoutBeams
@@ -41,6 +42,7 @@ public:
     static void restoreBeams(Measure* m);
     static void breakCrossMeasureBeams(const LayoutContext& ctx, Measure* measure);
     static void respace(const std::vector<ChordRest*>& elements);
+    static void layoutNonCrossBeams(Segment* s);
 
 private:
     static void beamGraceNotes(Score* score, Chord* mainNote, bool after);

--- a/src/engraving/layout/layoutmeasure.cpp
+++ b/src/engraving/layout/layoutmeasure.cpp
@@ -758,24 +758,7 @@ void LayoutMeasure::getNextMeasure(const LayoutOptions& options, LayoutContext& 
         if (!s.isChordRestType()) {
             continue;
         }
-        for (EngravingItem* e : s.elist()) {
-            if (!e || !e->isChordRest() || !score->staff(e->staffIdx())->show()) {
-                continue;
-            }
-            ChordRest* cr = toChordRest(e);
-            if (LayoutBeams::isTopBeam(cr)) {
-                Beam* b = cr->beam();
-                b->layout();
-            }
-            if (cr->isChord() && !toChord(cr)->graceNotes().empty()) {
-                for (Chord* grace : toChord(cr)->graceNotes()) {
-                    if (LayoutBeams::isTopBeam(grace)) {
-                        Beam* b = grace->beam();
-                        b->layout();
-                    }
-                }
-            }
-        }
+        LayoutBeams::layoutNonCrossBeams(&s);
     }
 
     for (staff_idx_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -711,32 +711,10 @@ void LayoutSystem::layoutSystemElements(const LayoutOptions& options, LayoutCont
     //-------------------------------------------------------------
 
     for (Segment* s : sl) {
-        for (EngravingItem* e : s->elist()) {
-            if (!e || !e->isChordRest() || !score->staff(e->staffIdx())->show()) {
-                // the beam and its system may still be referenced when selecting all,
-                // even if the staff is invisible. The old system is invalid and does cause problems in #284012
-                if (e && e->isChordRest() && !score->staff(e->staffIdx())->show() && toChordRest(e)->beam()) {
-                    toChordRest(e)->beam()->resetExplicitParent();
-                }
-                continue;
-            }
-            ChordRest* cr = toChordRest(e);
-
-            // layout beam
-            if (LayoutBeams::isTopBeam(cr)) {
-                Beam* b = cr->beam();
-                b->layout();
-            }
-            if (!cr->isChord()) {
-                continue;
-            }
-            for (Chord* grace : toChord(cr)->graceNotes()) {
-                Beam* beam = grace->beam();
-                if (beam && !beam->elements().empty() && beam->elements().front() == grace) {
-                    beam->layout();
-                }
-            }
+        if (!s->isChordRestType()) {
+            continue;
         }
+        LayoutBeams::layoutNonCrossBeams(s);
         // Must recreate the shapes because stem lengths may have been changed!
         s->createShapes();
     }

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -727,6 +727,15 @@ void LayoutSystem::layoutSystemElements(const LayoutOptions& options, LayoutCont
                 Beam* b = cr->beam();
                 b->layout();
             }
+            if (!cr->isChord()) {
+                continue;
+            }
+            for (Chord* grace : toChord(cr)->graceNotes()) {
+                Beam* beam = grace->beam();
+                if (beam && !beam->elements().empty() && beam->elements().front() == grace) {
+                    beam->layout();
+                }
+            }
         }
         // Must recreate the shapes because stem lengths may have been changed!
         s->createShapes();

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -4152,7 +4152,7 @@ GraceNotesGroup::GraceNotesGroup(Chord* c)
 
 void GraceNotesGroup::layout()
 {
-    _shape.clear();
+    Shape _shape;
     for (size_t i = this->size() - 1; i != mu::nidx; --i) {
         Chord* grace = this->at(i);
         Shape graceShape = grace->shape();
@@ -4198,5 +4198,14 @@ void GraceNotesGroup::setPos(double x, double y)
         Chord* chord = this->at(i);
         chord->movePos(PointF(x, y));
     }
+}
+
+Shape GraceNotesGroup::shape() const
+{
+    Shape shape;
+    for (Chord* grace : *this) {
+        shape.add(grace->shape().translated(grace->pos() - this->pos()));
+    }
+    return shape;
 }
 }

--- a/src/engraving/libmscore/chord.h
+++ b/src/engraving/libmscore/chord.h
@@ -63,7 +63,7 @@ public:
     GraceNotesGroup(Chord* c);
 
     Chord* parent() const { return _parent; }
-    Shape shape() const override { return _shape; }
+    Shape shape() const override;
     void layout() override;
     void setPos(double x, double y) override;
     Segment* appendedSegment() const { return _appendedSegment; }
@@ -71,7 +71,6 @@ public:
 
 private:
     Chord* _parent = nullptr;
-    Shape _shape;
     Segment* _appendedSegment = nullptr; // the graceNoteGroup is appended to this segment
 };
 


### PR DESCRIPTION
Resolves a glitch with grace notes which can cause slurs to change shape when a relayout is triggered.

https://user-images.githubusercontent.com/93707756/188924009-c424792c-18e9-4d1b-9e14-6b31af16e08e.mp4

