### PR TITLE
Fix #13154: Limit tuplet ratio denominator to 2 or higher

### DIFF
--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -810,7 +810,9 @@ void NotationActionController::putTuplet(int tupletCount)
 
     TupletOptions options;
     options.ratio.setNumerator(tupletCount);
+    options.ratio.setDenominator(2);
     options.autoBaseLen = true;
+
     putTuplet(options);
 }
 

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -469,8 +469,16 @@ void NotationNoteInput::addTuplet(const TupletOptions& options)
     score()->expandVoice();
     mu::engraving::ChordRest* chordRest = inputState.cr();
     if (chordRest) {
+        Fraction ratio = options.ratio;
+        // prevent weird dotted tuplets when adding tuplets to dotted durations
+        if (options.autoBaseLen) {
+            ratio.setDenominator(inputState.duration().dots() ? 3 : 2);
+            while (ratio.numerator() >= ratio.denominator() * 2) {
+                ratio.setDenominator(ratio.denominator() * 2);      // operator*= reduces, we don't want that here
+            }
+        }
         score()->changeCRlen(chordRest, inputState.duration());
-        score()->addTuplet(chordRest, options.ratio, options.numberType, options.bracketType);
+        score()->addTuplet(chordRest, ratio, options.numberType, options.bracketType);
     }
     apply();
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/13154

Due to a change in how tuplet base lengths were decided, in https://github.com/musescore/MuseScore/pull/12931, the tuplet ratio was has become much more literal. Originally, the code that adds a tuplet in note input mode just kept the denominator of the ratio as 1, safe in the knowledge that it will necessarily be increased to higher numbers later on in the auto base length calculation. So to fix this issue, I just had to set the default ratio denominator as :2, as anything :1 probably shouldn't be generated by anything other than the custom tuplet dialog.