### PR TITLE
Add oauth flow after sign-up on musescore

### DIFF
--- a/src/cloud/internal/cloudconfiguration.cpp
+++ b/src/cloud/internal/cloudconfiguration.cpp
@@ -103,7 +103,7 @@ QUrl CloudConfiguration::authorizationUrl() const
 
 QUrl CloudConfiguration::signUpUrl() const
 {
-    return QUrl("https://musescore.com/user/register");
+    return QUrl("https://musescore.com/oauth/authorize-new");
 }
 
 QUrl CloudConfiguration::accessTokenUrl() const

--- a/src/cloud/internal/cloudservice.cpp
+++ b/src/cloud/internal/cloudservice.cpp
@@ -206,6 +206,7 @@ void CloudService::authorize(const OnUserAuthorizedCallback& onUserAuthorizedCal
     }
 
     m_onUserAuthorizedCallback = onUserAuthorizedCallback;
+    m_oauth2->setAuthorizationUrl(configuration()->authorizationUrl());
     m_oauth2->grant();
 }
 
@@ -271,12 +272,11 @@ void CloudService::signIn()
 
 void CloudService::signUp()
 {
-    QUrl signUpUrl = configuration()->signUpUrl();
-
-    QUrlQuery query;
-    query.addQueryItem(EDITOR_SOURCE_KEY, EDITOR_SOURCE_VALUE);
-    signUpUrl.setQuery(query);
-    openUrl(signUpUrl);
+    if (m_userAuthorized.val) {
+        return;
+    }
+    m_oauth2->setAuthorizationUrl(configuration()->signUpUrl());
+    m_oauth2->grant();
 }
 
 void CloudService::signOut()


### PR DESCRIPTION
Changed sign-up url to support oauth flow and automatically login user in Editor after account creation.
OAuth autorization url is different for sign-in and sign-up. It's set to QOAuth2AuthorizationCodeFlow before starting of the flow.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
