### PR TITLE
Add missed information about platform to oauth requests

### DIFF
--- a/src/cloud/internal/cloudservice.cpp
+++ b/src/cloud/internal/cloudservice.cpp
@@ -45,6 +45,7 @@ static const QString REFRESH_TOKEN_KEY("refresh_token");
 static const QString DEVICE_ID_KEY("device_id");
 static const QString EDITOR_SOURCE_KEY("editor_source");
 static const QString EDITOR_SOURCE_VALUE(QString("Musescore Editor %1").arg(VERSION));
+static const QString PLATFORM_KEY("platform");
 
 static const std::string CLOUD_ACCESS_TOKEN_RESOURCE_NAME("CLOUD_ACCESS_TOKEN");
 
@@ -77,10 +78,13 @@ void CloudService::init()
 
     m_oauth2->setAuthorizationUrl(configuration()->authorizationUrl());
     m_oauth2->setAccessTokenUrl(configuration()->accessTokenUrl());
-    m_oauth2->setModifyParametersFunction([](QAbstractOAuth::Stage stage, QVariantMap* parameters) {
-        if (stage == QAbstractOAuth::Stage::RequestingAuthorization) {
-            (*parameters).insert(EDITOR_SOURCE_KEY, EDITOR_SOURCE_VALUE);
-        }
+    m_oauth2->setModifyParametersFunction([](QAbstractOAuth::Stage, QVariantMap* parameters) {
+        parameters->insert(EDITOR_SOURCE_KEY, EDITOR_SOURCE_VALUE);
+        parameters->insert(PLATFORM_KEY, QString("%1 %2 %3")
+                           .arg(QSysInfo::productType())
+                           .arg(QSysInfo::productVersion())
+                           .arg(QSysInfo::currentCpuArchitecture())
+                           );
     });
     m_oauth2->setReplyHandler(m_replyHandler);
 


### PR DESCRIPTION
Changed function to modify parameters for oauth requests(token, refresh, auth) to include information about platform. Include app version to token and refresh request besides authorization

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
