### PR TITLE
[MU4] Fix compiler warnings

### DIFF
--- a/src/engraving/libmscore/articulation.cpp
+++ b/src/engraving/libmscore/articulation.cpp
@@ -640,6 +640,7 @@ Sid Articulation::getPropertyStyle(Pid id) const
         }
     }
         assert(false);           // should never be reached
+    // fallthrough
     default:
         return Sid::NOSTYLE;
     }

--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -1376,7 +1376,8 @@ void Beam::setValidBeamPositions(int& dictator, int& pointer, int beamCountD, in
                     continue;
                 }
                 // we can use dictator beam position because all of the notes have the same beam position
-                if (currOffset = findValidBeamOffset(dictator, cr->beams(), staffLines, isStartDictator, isAscending, isFlat)) {
+                currOffset = findValidBeamOffset(dictator, cr->beams(), staffLines, isStartDictator, isAscending, isFlat);
+                if (currOffset) {
                     break;
                 }
             }

--- a/src/engraving/libmscore/chordline.cpp
+++ b/src/engraving/libmscore/chordline.cpp
@@ -472,6 +472,7 @@ bool ChordLine::setProperty(Pid propertyId, const PropertyValue& val)
         break;
     case Pid::CHORD_LINE_STRAIGHT:
         setStraight(val.toBool());
+        break;
     case Pid::CHORD_LINE_WAVY:
         setWavy(val.toBool());
         break;

--- a/src/engraving/libmscore/fermata.cpp
+++ b/src/engraving/libmscore/fermata.cpp
@@ -351,6 +351,7 @@ PropertyValue Fermata::propertyDefault(Pid propertyId) const
         case FermataType::VeryLong:
             return 4.0;
         }
+        break;
     case Pid::PLAY:
         return true;
     default:

--- a/src/engraving/libmscore/midimapping.cpp
+++ b/src/engraving/libmscore/midimapping.cpp
@@ -159,7 +159,7 @@ void MasterScore::rebuildExcerptsMidiMapping()
                 continue;
             }
             assert(p->instruments().size() == masterPart->instruments().size());
-            for (const auto [tick, iMaster] : masterPart->instruments()) {
+            for (const auto&[tick, iMaster] : masterPart->instruments()) {
                 Instrument* iLocal = p->instrument(Fraction::fromTicks(tick));
                 const size_t nchannels = iMaster->channel().size();
                 if (iLocal->channel().size() != nchannels) {

--- a/src/engraving/libmscore/noteentry.cpp
+++ b/src/engraving/libmscore/noteentry.cpp
@@ -360,8 +360,6 @@ Ret Score::putNote(const PointF& pos, bool replace, bool insert)
             return score->putNote(p, replace);
         }
     }
-
-    return make_ok();
 }
 
 Ret Score::putNote(const Position& p, bool replace)

--- a/src/engraving/libmscore/rest.cpp
+++ b/src/engraving/libmscore/rest.cpp
@@ -903,7 +903,7 @@ void Rest::add(EngravingItem* e)
         break;
     case ElementType::DEAD_SLAPPED:
         _deadSlapped = toDeadSlapped(e);
-    /// fallthrough
+    // fallthrough
     case ElementType::SYMBOL:
     case ElementType::IMAGE:
         el().push_back(e);
@@ -928,7 +928,7 @@ void Rest::remove(EngravingItem* e)
         break;
     case ElementType::DEAD_SLAPPED:
         _deadSlapped = nullptr;
-    /// fallthrough
+    // fallthrough
     case ElementType::SYMBOL:
     case ElementType::IMAGE:
         if (!el().remove(e)) {

--- a/src/engraving/libmscore/select.cpp
+++ b/src/engraving/libmscore/select.cpp
@@ -769,13 +769,13 @@ void Selection::setState(SelState s)
 String Selection::mimeType() const
 {
     switch (_state) {
-    default:
-    case SelState::NONE:
-        return String();
     case SelState::LIST:
         return isSingle() ? String::fromAscii(mimeSymbolFormat) : String::fromAscii(mimeSymbolListFormat);
     case SelState::RANGE:
         return String::fromAscii(mimeStaffListFormat);
+    case SelState::NONE:
+    default:
+        break;
     }
 
     return String();

--- a/src/engraving/libmscore/shape.cpp
+++ b/src/engraving/libmscore/shape.cpp
@@ -172,8 +172,8 @@ double Shape::minVerticalDistance(const Shape& a) const
 //----------------------------------------------------------------
 bool Shape::clearsVertically(const Shape& a) const
 {
-    for (const RectF r1 : a) {
-        for (const RectF r2 : *this) {
+    for (const RectF& r1 : a) {
+        for (const RectF& r2 : *this) {
             if (mu::engraving::intersects(r1.left(), r1.right(), r2.left(), r2.right(), 0.0)) {
                 if (std::min(r1.top(), r1.bottom()) <= std::max(r2.top(), r2.bottom())) {
                     return false;

--- a/src/engraving/libmscore/stretchedbend.cpp
+++ b/src/engraving/libmscore/stretchedbend.cpp
@@ -89,11 +89,11 @@ void StretchedBend::fillDrawPoints()
     }
 
     m_drawPoints.clear();
-    auto isExtraPointHelper = [this](int i, std::function<bool(int, int)> compare) {
+    auto isExtraPointHelper = [this](size_t i, std::function<bool(int, int)> compare) {
         return compare(m_points[i - 1].pitch, m_points[i].pitch) && compare(m_points[i].pitch, m_points[i + 1].pitch);
     };
 
-    auto isExtraPoint = [isExtraPointHelper](int i) {
+    auto isExtraPoint = [isExtraPointHelper](size_t i) {
         return isExtraPointHelper(i, std::less<int>())
                || isExtraPointHelper(i, std::greater<int>())
                || isExtraPointHelper(i, std::equal_to<int>());

--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -755,7 +755,7 @@ Bracket* System::createBracket(const LayoutContext& ctx, BracketItem* bi, size_t
     //
     if (span > 1
         || (bi->bracketSpan() == span)
-        || (span == 1 && score()->styleB(Sid::alwaysShowBracketsWhenEmptyStavesAreHidden)) && bi->bracketType() != BracketType::SQUARE
+        || (span == 1 && score()->styleB(Sid::alwaysShowBracketsWhenEmptyStavesAreHidden) && bi->bracketType() != BracketType::SQUARE)
         || (span == 1 && score()->styleB(Sid::alwaysShowSquareBracketsWhenEmptyStavesAreHidden)
             && bi->bracketType() == BracketType::SQUARE)) {
         //

--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -817,14 +817,7 @@ size_t System::getBracketsColumnsCount()
 void System::setBracketsXPosition(const double xPosition)
 {
     for (Bracket* b1 : _brackets) {
-        // Obtain correct distance
-        double bracketDistance = 0.0;
         BracketType bracketType = b1->bracketType();
-        if (bracketType == BracketType::NORMAL || bracketType == BracketType::LINE) {
-            bracketDistance = score()->styleMM(Sid::bracketDistance);
-        } else if (bracketType == BracketType::BRACE) {
-            bracketDistance = score()->styleMM(Sid::akkoladeBarDistance);
-        }
         // For brackets that are drawn, we must correct for half line width
         double lineWidthCorrection = 0.0;
         if (bracketType == BracketType::NORMAL || bracketType == BracketType::LINE) {

--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -384,8 +384,8 @@ void PlaybackModel::processSegment(const int tickPositionOffset, const Segment* 
             int referringMeasureTick = referringMeasure->tick().ticks();
             int repeatPositionTickOffset = currentMeasureTick - referringMeasureTick;
 
-            for (Segment* segment = referringMeasure->first(); segment; segment = segment->next()) {
-                processSegment(tickPositionOffset + repeatPositionTickOffset, segment, { staffIdx }, trackChanges);
+            for (Segment* seg = referringMeasure->first(); seg; seg = seg->next()) {
+                processSegment(tickPositionOffset + repeatPositionTickOffset, seg, { staffIdx }, trackChanges);
             }
         }
 

--- a/src/framework/audio/internal/audiobuffer.h
+++ b/src/framework/audio/internal/audiobuffer.h
@@ -37,6 +37,11 @@ constexpr size_t cache_line_size = std::hardware_destructive_interference_size;
 constexpr size_t cache_line_size = 64;
 #endif
 
+#if (defined (_MSCVER) || defined (_MSC_VER))
+// structure was padded due to alignment specifier
+#pragma warning(disable: 4324)
+#endif
+
 namespace mu::audio {
 class AudioBuffer
 {

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsequencer.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsequencer.cpp
@@ -27,9 +27,9 @@ using namespace mu::audio;
 using namespace mu::midi;
 using namespace mu::mpe;
 
-static constexpr mpe::pitch_level_t MIN_SUPPORTED_LEVEL = mpe::pitchLevel(PitchClass::C, 0);
+static constexpr mpe::pitch_level_t MIN_SUPPORTED_PITCH_LEVEL = mpe::pitchLevel(PitchClass::C, 0);
 static constexpr note_idx_t MIN_SUPPORTED_NOTE = 12; // MIDI equivalent for C0
-static constexpr mpe::pitch_level_t MAX_SUPPORTED_LEVEL = mpe::pitchLevel(PitchClass::C, 8);
+static constexpr mpe::pitch_level_t MAX_SUPPORTED_PITCH_LEVEL = mpe::pitchLevel(PitchClass::C, 8);
 static constexpr note_idx_t MAX_SUPPORTED_NOTE = 108; // MIDI equivalent for C8
 
 void FluidSequencer::init(const PlaybackSetupData& setupData)
@@ -228,15 +228,15 @@ channel_t FluidSequencer::channel(const mpe::NoteEvent& noteEvent) const
 
 note_idx_t FluidSequencer::noteIndex(const mpe::pitch_level_t pitchLevel) const
 {
-    if (pitchLevel <= MIN_SUPPORTED_LEVEL) {
+    if (pitchLevel <= MIN_SUPPORTED_PITCH_LEVEL) {
         return MIN_SUPPORTED_NOTE;
     }
 
-    if (pitchLevel >= MAX_SUPPORTED_LEVEL) {
+    if (pitchLevel >= MAX_SUPPORTED_PITCH_LEVEL) {
         return MAX_SUPPORTED_NOTE;
     }
 
-    float stepCount = MIN_SUPPORTED_NOTE + ((pitchLevel - MIN_SUPPORTED_LEVEL) / static_cast<float>(mpe::PITCH_LEVEL_STEP));
+    float stepCount = MIN_SUPPORTED_NOTE + ((pitchLevel - MIN_SUPPORTED_PITCH_LEVEL) / static_cast<float>(mpe::PITCH_LEVEL_STEP));
 
     return stepCount;
 }
@@ -261,21 +261,21 @@ velocity_t FluidSequencer::noteVelocity(const mpe::NoteEvent& noteEvent) const
 
 int FluidSequencer::expressionLevel(const mpe::dynamic_level_t dynamicLevel) const
 {
-    static constexpr mpe::dynamic_level_t MIN_SUPPORTED_LEVEL = mpe::dynamicLevelFromType(DynamicType::ppp);
-    static constexpr mpe::dynamic_level_t MAX_SUPPORTED_LEVEL = mpe::dynamicLevelFromType(DynamicType::fff);
+    static constexpr mpe::dynamic_level_t MIN_SUPPORTED_DYNAMICS_LEVEL = mpe::dynamicLevelFromType(DynamicType::ppp);
+    static constexpr mpe::dynamic_level_t MAX_SUPPORTED_DYNAMICS_LEVEL = mpe::dynamicLevelFromType(DynamicType::fff);
     static constexpr int MIN_SUPPORTED_VOLUME = 16; // MIDI equivalent for PPP
     static constexpr int MAX_SUPPORTED_VOLUME = 127; // MIDI equivalent for FFF
     static constexpr int VOLUME_STEP = 16;
 
-    if (dynamicLevel <= MIN_SUPPORTED_LEVEL) {
+    if (dynamicLevel <= MIN_SUPPORTED_DYNAMICS_LEVEL) {
         return MIN_SUPPORTED_VOLUME;
     }
 
-    if (dynamicLevel >= MAX_SUPPORTED_LEVEL) {
+    if (dynamicLevel >= MAX_SUPPORTED_DYNAMICS_LEVEL) {
         return MAX_SUPPORTED_VOLUME;
     }
 
-    float stepCount = ((dynamicLevel - MIN_SUPPORTED_LEVEL) / static_cast<float>(mpe::DYNAMIC_LEVEL_STEP));
+    float stepCount = ((dynamicLevel - MIN_SUPPORTED_DYNAMICS_LEVEL) / static_cast<float>(mpe::DYNAMIC_LEVEL_STEP));
 
     if (dynamicLevel == mpe::dynamicLevelFromType(DynamicType::Natural)) {
         stepCount -= 0.5;
@@ -287,7 +287,7 @@ int FluidSequencer::expressionLevel(const mpe::dynamic_level_t dynamicLevel) con
 
     dynamic_level_t result = RealRound(MIN_SUPPORTED_VOLUME + (stepCount * VOLUME_STEP), 0);
 
-    return std::min(result, MAX_SUPPORTED_LEVEL);
+    return std::min(result, MAX_SUPPORTED_DYNAMICS_LEVEL);
 }
 
 int FluidSequencer::pitchBendLevel(const mpe::pitch_level_t pitchLevel) const

--- a/src/framework/global/dlib.h
+++ b/src/framework/global/dlib.h
@@ -53,6 +53,7 @@ inline void* getLibFunc(void* libHandle, const char* funcName)
 inline void closeLib(void* libHandle)
 {
 #ifdef Q_OS_WIN
+    UNUSED(libHandle);
     return;
 #else
     dlclose(libHandle);

--- a/src/framework/global/types/string.cpp
+++ b/src/framework/global/types/string.cpp
@@ -881,7 +881,7 @@ void String::doArgs(std::u16string& out, const std::vector<std::u16string_view>&
                 } else {
                     // When there are 5 args, %6 becomes %1
                     out.push_back(u'%');
-                    out.push_back(u'1' + argIdxToInsertAfter - args.size());
+                    out.push_back(u'1' + static_cast<char16_t>(argIdxToInsertAfter - args.size()));
                 }
             }
         }

--- a/src/framework/mpe/internal/articulationprofilesrepository.cpp
+++ b/src/framework/mpe/internal/articulationprofilesrepository.cpp
@@ -249,7 +249,7 @@ PitchPattern ArticulationProfilesRepository::pitchPatternFromJson(const QJsonObj
 
     QJsonArray offsets = obj.value(PITCH_OFFSETS_KEY).toArray();
 
-    for (const QJsonValue& pitchOffset : offsets) {
+    for (const QJsonValue pitchOffset : offsets) {
         QJsonObject offsetObj = pitchOffset.toObject();
 
         result.pitchOffsetMap.emplace(offsetObj.value(OFFSET_POS_KEY).toInt(),
@@ -284,7 +284,7 @@ ExpressionPattern ArticulationProfilesRepository::expressionPatternFromJson(cons
 
     QJsonArray offsets = obj.value(DYNAMIC_OFFSETS_KEY).toArray();
 
-    for (const QJsonValue& offset : offsets) {
+    for (const QJsonValue offset : offsets) {
         QJsonObject offsetObj = offset.toObject();
         result.dynamicOffsetMap.emplace(offsetObj.value(OFFSET_POS_KEY).toInt(),
                                         offsetObj.value(OFFSET_VAL_KEY).toInt());

--- a/src/framework/musesampler/internal/musesamplersequencer.cpp
+++ b/src/framework/musesampler/internal/musesamplersequencer.cpp
@@ -190,10 +190,10 @@ void MuseSamplerSequencer::addNoteEvent(const mpe::NoteEvent& noteEvent)
         auto ms_art = convertArticulationType(art.first);
 
         if (art.first == mpe::ArticulationType::Pedal) {
-            ms_PedalEvent pedalOnEvent { art.second.meta.timestamp, 1.0 };
+            ms_PedalEvent pedalOnEvent { static_cast<long>(art.second.meta.timestamp), 1.0 };
             m_samplerLib->addPedalEvent(m_sampler, m_track, std::move(pedalOnEvent));
 
-            ms_PedalEvent pedalOffEvent { art.second.meta.timestamp + art.second.meta.overallDuration, 0.0 };
+            ms_PedalEvent pedalOffEvent { static_cast<long>(art.second.meta.timestamp + art.second.meta.overallDuration), 0.0 };
             m_samplerLib->addPedalEvent(m_sampler, m_track, std::move(pedalOffEvent));
         }
 

--- a/src/framework/musesampler/internal/musesamplersequencer.cpp
+++ b/src/framework/musesampler/internal/musesamplersequencer.cpp
@@ -236,32 +236,32 @@ void MuseSamplerSequencer::addNoteEvent(const mpe::NoteEvent& noteEvent)
 
 int MuseSamplerSequencer::pitchIndex(const mpe::pitch_level_t pitchLevel) const
 {
-    static constexpr mpe::pitch_level_t MIN_SUPPORTED_LEVEL = mpe::pitchLevel(mpe::PitchClass::C, 0);
+    static constexpr mpe::pitch_level_t MIN_SUPPORTED_PITCH_LEVEL = mpe::pitchLevel(mpe::PitchClass::C, 0);
     static constexpr int MIN_SUPPORTED_NOTE = 12; // equivalent for C0
-    static constexpr mpe::pitch_level_t MAX_SUPPORTED_LEVEL = mpe::pitchLevel(mpe::PitchClass::C, 8);
+    static constexpr mpe::pitch_level_t MAX_SUPPORTED_PITCH_LEVEL = mpe::pitchLevel(mpe::PitchClass::C, 8);
     static constexpr int MAX_SUPPORTED_NOTE = 108; // equivalent for C8
 
-    if (pitchLevel <= MIN_SUPPORTED_LEVEL) {
+    if (pitchLevel <= MIN_SUPPORTED_PITCH_LEVEL) {
         return MIN_SUPPORTED_NOTE;
     }
 
-    if (pitchLevel >= MAX_SUPPORTED_LEVEL) {
+    if (pitchLevel >= MAX_SUPPORTED_PITCH_LEVEL) {
         return MAX_SUPPORTED_NOTE;
     }
 
-    float stepCount = MIN_SUPPORTED_NOTE + ((pitchLevel - MIN_SUPPORTED_LEVEL) / static_cast<float>(mpe::PITCH_LEVEL_STEP));
+    float stepCount = MIN_SUPPORTED_NOTE + ((pitchLevel - MIN_SUPPORTED_PITCH_LEVEL) / static_cast<float>(mpe::PITCH_LEVEL_STEP));
 
     return RealRound(stepCount, 0);
 }
 
 double MuseSamplerSequencer::dynamicLevelRatio(const mpe::dynamic_level_t level) const
 {
-    static constexpr mpe::dynamic_level_t MIN_SUPPORTED_LEVEL = mpe::dynamicLevelFromType(mpe::DynamicType::ppppppppp);
-    static constexpr mpe::dynamic_level_t MAX_SUPPORTED_LEVEL = mpe::dynamicLevelFromType(mpe::DynamicType::fffffffff);
+    static constexpr mpe::dynamic_level_t MIN_SUPPORTED_DYNAMIC_LEVEL = mpe::dynamicLevelFromType(mpe::DynamicType::ppppppppp);
+    static constexpr mpe::dynamic_level_t MAX_SUPPORTED_DYNAMIC_LEVEL = mpe::dynamicLevelFromType(mpe::DynamicType::fffffffff);
 
     // Piecewise linear simple scaling to expected MuseSampler values:
     static const std::list<std::pair<mpe::dynamic_level_t, double> > conversionMap = {
-        { MIN_SUPPORTED_LEVEL, 0.0 },
+        { MIN_SUPPORTED_DYNAMIC_LEVEL, 0.0 },
         { mpe::dynamicLevelFromType(mpe::DynamicType::ppppp), 1.0 / 127.0 },
         { mpe::dynamicLevelFromType(mpe::DynamicType::pppp), 2.0 / 127.0 },
         { mpe::dynamicLevelFromType(mpe::DynamicType::ppp), 4.0 / 127.0 },
@@ -272,7 +272,7 @@ double MuseSamplerSequencer::dynamicLevelRatio(const mpe::dynamic_level_t level)
         { mpe::dynamicLevelFromType(mpe::DynamicType::f), 96.0 / 127.0 },
         { mpe::dynamicLevelFromType(mpe::DynamicType::ff), 120.0 / 127.0 },
         { mpe::dynamicLevelFromType(mpe::DynamicType::fff), 127.0 / 127.0 },
-        { MAX_SUPPORTED_LEVEL, 127.0 / 127.0 }
+        { MAX_SUPPORTED_DYNAMIC_LEVEL, 127.0 / 127.0 }
     };
 
     auto prev_level = conversionMap.begin();

--- a/src/framework/vst/internal/fx/vstfxresolver.cpp
+++ b/src/framework/vst/internal/fx/vstfxresolver.cpp
@@ -177,7 +177,8 @@ void VstFxResolver::updateMasterFxMap(const AudioFxChain& newFxChain)
     fxChainToCreate(currentFxChain, newFxChain, fxToCreate);
 
     for (const auto& pair : fxToCreate) {
-        if (VstFxPtr fx = createMasterFx(pair.second)) {
+        VstFxPtr fx = createMasterFx(pair.second);
+        if (fx) {
             m_masterFxMap.emplace(pair.first, fx);
         }
     }

--- a/src/framework/vst/internal/synth/vstsequencer.cpp
+++ b/src/framework/vst/internal/synth/vstsequencer.cpp
@@ -28,9 +28,9 @@ using namespace mu::vst;
 static constexpr ControllIdx SUSTAIN_IDX = static_cast<ControllIdx>(Steinberg::Vst::kCtrlSustainOnOff);
 static const mpe::ArticulationTypeSet PEDAL_CC_SUPPORTED_TYPES { mpe::ArticulationType::Pedal };
 
-static constexpr mpe::pitch_level_t MIN_SUPPORTED_LEVEL = mpe::pitchLevel(mpe::PitchClass::C, 0);
+static constexpr mpe::pitch_level_t MIN_SUPPORTED_PITCH_LEVEL = mpe::pitchLevel(mpe::PitchClass::C, 0);
 static constexpr int MIN_SUPPORTED_NOTE = 12; // VST equivalent for C0
-static constexpr mpe::pitch_level_t MAX_SUPPORTED_LEVEL = mpe::pitchLevel(mpe::PitchClass::C, 8);
+static constexpr mpe::pitch_level_t MAX_SUPPORTED_PITCH_LEVEL = mpe::pitchLevel(mpe::PitchClass::C, 8);
 static constexpr int MAX_SUPPORTED_NOTE = 108; // VST equivalent for C8
 
 void VstSequencer::init(ParamsMapping&& mapping)
@@ -166,15 +166,15 @@ PluginParamInfo VstSequencer::buildParamInfo(const PluginParamId id, const Plugi
 
 int32_t VstSequencer::noteIndex(const mpe::pitch_level_t pitchLevel) const
 {
-    if (pitchLevel <= MIN_SUPPORTED_LEVEL) {
+    if (pitchLevel <= MIN_SUPPORTED_PITCH_LEVEL) {
         return MIN_SUPPORTED_NOTE;
     }
 
-    if (pitchLevel >= MAX_SUPPORTED_LEVEL) {
+    if (pitchLevel >= MAX_SUPPORTED_PITCH_LEVEL) {
         return MAX_SUPPORTED_NOTE;
     }
 
-    float stepCount = MIN_SUPPORTED_NOTE + ((pitchLevel - MIN_SUPPORTED_LEVEL) / static_cast<float>(mpe::PITCH_LEVEL_STEP));
+    float stepCount = MIN_SUPPORTED_NOTE + ((pitchLevel - MIN_SUPPORTED_PITCH_LEVEL) / static_cast<float>(mpe::PITCH_LEVEL_STEP));
 
     return stepCount;
 }
@@ -195,17 +195,17 @@ float VstSequencer::noteVelocityFraction(const mpe::NoteEvent& noteEvent) const
 
 float VstSequencer::expressionLevel(const mpe::dynamic_level_t dynamicLevel) const
 {
-    static constexpr mpe::dynamic_level_t MIN_SUPPORTED_LEVEL = mpe::dynamicLevelFromType(mpe::DynamicType::ppp);
-    static constexpr mpe::dynamic_level_t MAX_SUPPORTED_LEVEL = mpe::dynamicLevelFromType(mpe::DynamicType::fff);
-    static constexpr mpe::dynamic_level_t AVAILABLE_RANGE = MAX_SUPPORTED_LEVEL - MIN_SUPPORTED_LEVEL;
+    static constexpr mpe::dynamic_level_t MIN_SUPPORTED_DYNAMIC_LEVEL = mpe::dynamicLevelFromType(mpe::DynamicType::ppp);
+    static constexpr mpe::dynamic_level_t MAX_SUPPORTED_DYNAMIC_LEVEL = mpe::dynamicLevelFromType(mpe::DynamicType::fff);
+    static constexpr mpe::dynamic_level_t AVAILABLE_RANGE = MAX_SUPPORTED_DYNAMIC_LEVEL - MIN_SUPPORTED_DYNAMIC_LEVEL;
 
-    if (dynamicLevel <= MIN_SUPPORTED_LEVEL) {
+    if (dynamicLevel <= MIN_SUPPORTED_DYNAMIC_LEVEL) {
         return (0.5f * mpe::ONE_PERCENT) / AVAILABLE_RANGE;
     }
 
-    if (dynamicLevel >= MAX_SUPPORTED_LEVEL) {
+    if (dynamicLevel >= MAX_SUPPORTED_DYNAMIC_LEVEL) {
         return 1.f;
     }
 
-    return RealRound((dynamicLevel - MIN_SUPPORTED_LEVEL) / static_cast<float>(AVAILABLE_RANGE), 2);
+    return RealRound((dynamicLevel - MIN_SUPPORTED_DYNAMIC_LEVEL) / static_cast<float>(AVAILABLE_RANGE), 2);
 }

--- a/src/framework/vst/internal/vstplugin.cpp
+++ b/src/framework/vst/internal/vstplugin.cpp
@@ -173,7 +173,7 @@ void VstPlugin::stateBufferFromString(VstMemoryStream& buffer, char* strData, co
     static Steinberg::int32 numBytesRead = 0;
 
     buffer.write(strData, strSize, &numBytesRead);
-    buffer.seek(0, Steinberg::IBStream::kIBSeekSet, nullptr);
+    buffer.seek(0, static_cast<size_t>(Steinberg::IBStream::kIBSeekSet), nullptr);
 }
 
 PluginViewPtr VstPlugin::view() const

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -3062,7 +3062,7 @@ static void createLinkedTabs(MasterScore* score)
                 StaffTypes::TAB_8SIMPLE
             };
 
-            int index = (lines >= 4 && lines <= 8) ? lines - 4 : 2;
+            size_t index = (lines >= 4 && lines <= 8) ? lines - 4 : 2;
 
             dstStaff->setStaffType(fr, *StaffType::preset(types.at(index)));
             dstStaff->setLines(fr, static_cast<int>(lines));

--- a/src/inspector/models/general/playback/playbackproxymodel.h
+++ b/src/inspector/models/general/playback/playbackproxymodel.h
@@ -24,6 +24,11 @@
 
 #include "models/abstractinspectorproxymodel.h"
 
+#if (defined(_MSCVER) || defined(_MSC_VER))
+// unreferenced function with internal linkage has been removed
+#pragma warning(disable: 4505)
+#endif
+
 namespace mu::inspector {
 class PlaybackProxyModel : public AbstractInspectorProxyModel
 {

--- a/src/inspector/models/pointfpropertyitem.h
+++ b/src/inspector/models/pointfpropertyitem.h
@@ -24,6 +24,11 @@
 
 #include "propertyitem.h"
 
+#if (defined(_MSCVER) || defined(_MSC_VER))
+// unreferenced function with internal linkage has been removed
+#pragma warning(disable: 4505)
+#endif
+
 namespace mu::inspector {
 class PointFPropertyItem : public PropertyItem
 {

--- a/src/learn/internal/learnservice.cpp
+++ b/src/learn/internal/learnservice.cpp
@@ -175,7 +175,7 @@ QStringList LearnService::parsePlaylistItemsIds(const QJsonDocument& playlistDoc
     QJsonObject obj = playlistDoc.object();
     QJsonArray items = obj.value("items").toArray();
 
-    for (const QJsonValue& itemVal : items) {
+    for (const QJsonValue itemVal : items) {
         QJsonObject itemObj = itemVal.toObject();
         QJsonObject snippetObj = itemObj.value("snippet").toObject();
         QJsonObject resourceIdObj = snippetObj.value("resourceId").toObject();
@@ -194,7 +194,7 @@ Playlist LearnService::parsePlaylist(const QJsonDocument& playlistDoc) const
     QJsonObject obj = playlistDoc.object();
     QJsonArray items = obj.value("items").toArray();
 
-    for (const QJsonValue& itemVal : items) {
+    for (const QJsonValue itemVal : items) {
         QJsonObject itemObj = itemVal.toObject();
         QJsonObject snippetObj = itemObj.value("snippet").toObject();
 

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -566,8 +566,8 @@ void MasterNotation::sortExcerpts(ExcerptNotationList& excerpts)
         const ID& initialPart1 = get_impl(f)->excerpt()->initialPartId();
         const ID& initialPart2 = get_impl(s)->excerpt()->initialPartId();
 
-        int index1 = mu::indexOf(partIdList, initialPart1);
-        int index2 = mu::indexOf(partIdList, initialPart2);
+        size_t index1 = mu::indexOf(partIdList, initialPart1);
+        size_t index2 = mu::indexOf(partIdList, initialPart2);
 
         return index1 < index2;
     });

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -935,8 +935,6 @@ void NotationParts::appendStaves(Part* part, const InstrumentTemplate& templ, co
     }
 
     for (staff_idx_t staffIndex = 0; staffIndex < templ.staffCount; ++staffIndex) {
-        staff_idx_t lastStaffIndex = !score()->staves().empty() ? score()->staves().back()->idx() : 0;
-
         Staff* staff = engraving::Factory::createStaff(part);
         const mu::engraving::StaffType* staffType = templ.staffTypePreset;
         if (!staffType) {

--- a/src/notation/view/noteinputbarcustomisemodel.h
+++ b/src/notation/view/noteinputbarcustomisemodel.h
@@ -31,6 +31,11 @@
 
 class QItemSelectionModel;
 
+#if (defined(_MSCVER) || defined(_MSC_VER))
+// unreferenced function with internal linkage has been removed
+#pragma warning(disable: 4505)
+#endif
+
 namespace mu::notation {
 class NoteInputBarCustomiseItem;
 class NoteInputBarCustomiseModel : public uicomponents::SelectableItemListModel, public async::Asyncable

--- a/src/playback/view/internal/outputresourceitem.h
+++ b/src/playback/view/internal/outputresourceitem.h
@@ -35,6 +35,11 @@
 
 #include "abstractaudioresourceitem.h"
 
+#if (defined(_MSCVER) || defined(_MSC_VER))
+// unreferenced function with internal linkage has been removed
+#pragma warning(disable: 4505)
+#endif
+
 namespace mu::playback {
 class OutputResourceItem : public AbstractAudioResourceItem, public async::Asyncable
 {

--- a/src/playback/view/soundprofilesmodel.cpp
+++ b/src/playback/view/soundprofilesmodel.cpp
@@ -55,7 +55,7 @@ SoundProfilesModel::SoundProfilesModel(QObject* parent)
 
 int SoundProfilesModel::rowCount(const QModelIndex& /*parent*/) const
 {
-    return m_profiles.size();
+    return static_cast<int>(m_profiles.size());
 }
 
 QVariant SoundProfilesModel::data(const QModelIndex& index, int role) const

--- a/src/plugins/api/apitypes.h
+++ b/src/plugins/api/apitypes.h
@@ -486,18 +486,18 @@ enum class NoteHeadGroup {
 };
 Q_ENUM_NS(NoteHeadGroup);
 
-enum class NoteType : char {
+enum class NoteType {
     ///.\{
-    NORMAL        = char(mu::engraving::NoteType::NORMAL),
-    ACCIACCATURA  = char(mu::engraving::NoteType::ACCIACCATURA),
-    APPOGGIATURA  = char(mu::engraving::NoteType::APPOGGIATURA),
-    GRACE4        = char(mu::engraving::NoteType::GRACE4),
-    GRACE16       = char(mu::engraving::NoteType::GRACE16),
-    GRACE32       = char(mu::engraving::NoteType::GRACE32),
-    GRACE8_AFTER  = char(mu::engraving::NoteType::GRACE8_AFTER),
-    GRACE16_AFTER = char(mu::engraving::NoteType::GRACE16_AFTER),
-    GRACE32_AFTER = char(mu::engraving::NoteType::GRACE32_AFTER),
-    INVALID       = char(mu::engraving::NoteType::INVALID)
+    NORMAL        = (int)(mu::engraving::NoteType::NORMAL),
+    ACCIACCATURA  = (int)(mu::engraving::NoteType::ACCIACCATURA),
+    APPOGGIATURA  = (int)(mu::engraving::NoteType::APPOGGIATURA),
+    GRACE4        = (int)(mu::engraving::NoteType::GRACE4),
+    GRACE16       = (int)(mu::engraving::NoteType::GRACE16),
+    GRACE32       = (int)(mu::engraving::NoteType::GRACE32),
+    GRACE8_AFTER  = (int)(mu::engraving::NoteType::GRACE8_AFTER),
+    GRACE16_AFTER = (int)(mu::engraving::NoteType::GRACE16_AFTER),
+    GRACE32_AFTER = (int)(mu::engraving::NoteType::GRACE32_AFTER),
+    INVALID       = (int)(mu::engraving::NoteType::INVALID)
                     ///\}
 };
 Q_ENUM_NS(NoteType);

--- a/src/plugins/tests/environment.cpp
+++ b/src/plugins/tests/environment.cpp
@@ -44,6 +44,10 @@ static mu::testing::SuiteEnvironment plugins_env(
 
     ON_CALL(*uiEngine, qmlEngine()).WillByDefault(testing::Return(qmlEngine));
 
+#if (defined (_MSCVER) || defined (_MSC_VER))
+// "the usage of 'method' requires the compiler to capture 'this' but the current default capture mode does not allow it"
+#pragma warning(disable: 4573)
+#endif
     QObject::connect(qmlEngine, &QQmlEngine::warnings, [](const QList<QQmlError>& warnings) {
         for (const QQmlError& e : warnings) {
             LOGE() << "error: " << e.toString() << "\n";

--- a/src/project/internal/projectaudiosettings.cpp
+++ b/src/project/internal/projectaudiosettings.cpp
@@ -193,7 +193,7 @@ mu::Ret ProjectAudioSettings::read(const engraving::MscReader& reader)
 
     QJsonArray tracksArray = rootObj.value("tracks").toArray();
 
-    for (const QJsonValue& value : tracksArray) {
+    for (const QJsonValue value : tracksArray) {
         QJsonObject trackObject = value.toObject();
 
         ID partId = trackObject.value("partId").toString();

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -185,7 +185,7 @@ io::paths_t ProjectConfiguration::parseRecentProjectsPaths(const Val& value) con
         return result;
     }
 
-    for (const QJsonValue& val : jsonDoc.array()) {
+    for (const QJsonValue val : jsonDoc.array()) {
         result.push_back(val.toString());
     }
 

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -314,7 +314,7 @@ io::path_t ProjectConfiguration::cloudProjectSavingFilePath(const io::path_t& pr
 {
     io::path_t savingPathWithoutSuffix = cloudProjectsPath() + '/' + projectName;
 
-    auto makeSavingPath = [savingPathWithoutSuffix](int num = 0) {
+    auto makeSavingPath = [savingPathWithoutSuffix](size_t num = 0) {
         std::string numPart = num > 0 ? ' ' + std::to_string(num) : "";
         return savingPathWithoutSuffix + numPart + DEFAULT_FILE_SUFFIX;
     };

--- a/src/update/internal/updateservice.cpp
+++ b/src/update/internal/updateservice.cpp
@@ -158,7 +158,7 @@ mu::RetVal<ReleaseInfo> UpdateService::parseRelease(const QByteArray& json) cons
     std::string fileSuffix = platformFileSuffix();
 
     QJsonArray assets = release.value("assets").toArray();
-    for (const QJsonValue& asset : assets) {
+    for (const QJsonValue asset : assets) {
         QJsonObject assetObj = asset.toObject();
 
         QString name = assetObj.value("name").toString();

--- a/thirdparty/KDDockWidgets/src/DockWidgetQuick.h
+++ b/thirdparty/KDDockWidgets/src/DockWidgetQuick.h
@@ -26,6 +26,11 @@ class QCloseEvent;
 class QQmlEngine;
 QT_END_NAMESPACE
 
+#if (defined(_MSCVER) || defined(_MSC_VER))
+// unreferenced function with internal linkage has been removed
+#pragma warning(disable: 4505)
+#endif
+
 namespace KDDockWidgets {
 
 class Frame;


### PR DESCRIPTION
* MSVC: reg. conversion from 'size_t' to 'int', possible loss of data (C4267).
* MinGW: reg. comparison of integer expressions of different signedness [-Wsign-compare].
* MSVC: reg. cast truncates constant value (C4310).
* MSVC: reg. "the usage of 'method' requires the compiler to capture 'this' but the current default capture mode does not allow it (C4573)", by disabling it.
* MSVC: reg. "unreferenced function with internal linkage has been removed", by disabling them resp. removing the code.
* MSCV/MinGW: reg. unreferenced formal parameter (C4100) resp. unused parameter [-Wunused-parameter].
* MinGW: reg. this statement may fall through [-Wimplicit-fallthrough=] (at least one of which is a bug!).
* MSVC: reg. unreachable code (C4702).
* MinGW: reg. suggest parentheses around '&&' within '||' [-Wparentheses].
* MinGW: reg. variable set but not used [-Wunused-but-set-variable].
* MinGW: reg. suggest parentheses around assignment used as truth value [-Wparentheses].
* MSVC: reg. declaration hides global declaration (C4459).
* MSVC: reg. declaration hides function parameter (C4457).
* MSVC: reg. conversion requires a narrowing conversion (C4838)
* MSVC: reg. "structure was padded due to alignment specifier (C4324)", by disabling it
* GitHub CI: reg. Node.js 12 actions being deprecated vs. 16
* GitHub CI: reg. `set-output` command being deprecated
* XCode: reg. loop variable is always a copy because the range of type 'QJsonArray' does not return a reference [-Wrange-loop-analysis]
* MSVC: reg.  local variable is initialized but not referenced (C4189)