### PR TITLE
Added option to run autobot tests on startup

### DIFF
--- a/src/appshell/internal/startupscenario.cpp
+++ b/src/appshell/internal/startupscenario.cpp
@@ -99,6 +99,12 @@ void StartupScenario::run()
     });
 
     interactive()->open(startupUri);
+
+    bool result = false;
+    std::istringstream(std::getenv("MU_RUN_AUTOBOT_TESTS_ON_START")) >> result;
+    if (result) {
+        dispatcher()->dispatch("autobot-show-scripts", actions::ActionData::make_arg1<bool>(result));
+    }
 }
 
 bool StartupScenario::startupCompleted() const

--- a/src/autobot/internal/autobotactionscontroller.cpp
+++ b/src/autobot/internal/autobotactionscontroller.cpp
@@ -31,7 +31,13 @@ static const mu::UriQuery SHOW_SCRIPTS_URI("musescore://autobot/scripts?sync=fal
 void AutobotActionsController::init()
 {
     dispatcher()->reg(this, "autobot-show-batchtests", [this]() { openUri(SHOW_BATCHTESTS_URI); });
-    dispatcher()->reg(this, "autobot-show-scripts", [this]() { openUri(SHOW_SCRIPTS_URI); });
+    dispatcher()->reg(this, "autobot-show-scripts", [this](const ActionData& args) {
+        bool runTests = false;
+        if (args.count() > 0) {
+            runTests = args.arg<bool>(0);
+        }
+        openAutobotTests(runTests);
+    });
 }
 
 void AutobotActionsController::openUri(const mu::UriQuery& uri, bool isSingle)
@@ -41,4 +47,11 @@ void AutobotActionsController::openUri(const mu::UriQuery& uri, bool isSingle)
     }
 
     interactive()->open(uri);
+}
+
+void AutobotActionsController::openAutobotTests(bool runTests)
+{
+    UriQuery uri = SHOW_SCRIPTS_URI;
+    uri.addParam("runTests", Val(runTests));
+    openUri(uri);
 }

--- a/src/autobot/internal/autobotactionscontroller.h
+++ b/src/autobot/internal/autobotactionscontroller.h
@@ -40,6 +40,7 @@ public:
 
 private:
     void openUri(const mu::UriQuery& uri, bool isSingle = true);
+    void openAutobotTests(bool runTests);
 };
 }
 

--- a/src/autobot/qml/MuseScore/Autobot/ScriptsDialog.qml
+++ b/src/autobot/qml/MuseScore/Autobot/ScriptsDialog.qml
@@ -37,8 +37,11 @@ StyledDialogView {
 
     x: 850
 
+    property var runTests
+
     ScriptsPanel {
         id: panel
         anchors.fill: parent
+        runTests: root.runTests
     }
 }

--- a/src/autobot/qml/MuseScore/Autobot/ScriptsPanel.qml
+++ b/src/autobot/qml/MuseScore/Autobot/ScriptsPanel.qml
@@ -24,10 +24,13 @@ import MuseScore.UiComponents 1.0
 import MuseScore.Autobot 1.0
 
 Rectangle {
+    id: root
 
     color: ui.theme.backgroundPrimaryColor
 
     objectName: "DiagnosticAutobotScriptPanel"
+
+    property var runTests
 
     AutobotScriptsModel {
         id: scriptsModel
@@ -37,6 +40,9 @@ Rectangle {
 
     Component.onCompleted: {
         scriptsModel.load()
+        if (root.runTests) {
+            runAllTestsButton.toggleTests()
+        }
     }
 
     Item {
@@ -46,11 +52,14 @@ Rectangle {
         height: 48
 
         FlatButton {
+            id: runAllTestsButton
             anchors.left: parent.left
             anchors.leftMargin: 8
             anchors.verticalCenter: parent.verticalCenter
             text: scriptsModel.isRunAllTCMode ? "Stop Run All TC" : "Run All TC"
-            onClicked: {
+            onClicked: toggleTests()
+
+            function toggleTests() {
                 if (scriptsModel.isRunAllTCMode) {
                     scriptsModel.stopRunAllTC()
                 } else {


### PR DESCRIPTION
*(short description of the changes and the motivation to make the changes)*

When you add the environment variable "MU_RUN_AUTOBOT_TESTS_ON_START" and set it to 1, MuseScore on startup will run all autobot tests

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
