### PR TITLE
Don't force-mute hidden staves

### DIFF
--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -1043,13 +1043,14 @@ void PlaybackController::updateMuteStates()
         }
 
         const Part* part = notationParts->part(instrumentTrackId.partId);
-        bool isPart = part;
+        bool isMasterNotation = m_notation == m_masterNotation->notation();
+        bool isPartActive = part && (isMasterNotation || part->show());
 
         auto soloMuteState = audioSettings()->soloMuteState(instrumentTrackId);
 
         bool shouldBeMuted = soloMuteState.mute
                              || (hasSolo && !soloMuteState.solo)
-                             || (!isPart);
+                             || (!isPartActive);
 
         if (isRangePlaybackMode && !shouldBeMuted) {
             shouldBeMuted = !mu::contains(allowedInstrumentTrackIdSet, instrumentTrackId);

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -1043,13 +1043,13 @@ void PlaybackController::updateMuteStates()
         }
 
         const Part* part = notationParts->part(instrumentTrackId.partId);
-        bool isPartVisible = part && part->show();
+        bool isPart = part;
 
         auto soloMuteState = audioSettings()->soloMuteState(instrumentTrackId);
 
         bool shouldBeMuted = soloMuteState.mute
                              || (hasSolo && !soloMuteState.solo)
-                             || (!isPartVisible);
+                             || (!isPart);
 
         if (isRangePlaybackMode && !shouldBeMuted) {
             shouldBeMuted = !mu::contains(allowedInstrumentTrackIdSet, instrumentTrackId);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10951

Scores that use invisible playback staves were playing incorrectly - the invisible staves were automatically, with no ability to unmute.  This applies to existing score, but it also means new scores could not create invisible playback staves at all.  This PR restores the MU3 behavior, where hiding an instrument does not automatically mute it.  The user can still mute and unmuted the instrument normally.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made

(I did not include a test for this, as I'm not sure how these work anymore)