### PR TITLE
fix #13286 - ensure no empty error message shown when adding text and nothing selected

### DIFF
--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -71,6 +71,9 @@ PopupView::PopupView(QQuickItem* parent)
 
 PopupView::~PopupView()
 {
+    if (m_window) {
+        m_window->setOnHidden(std::function<void()>());
+    }
     m_contentItem->deleteLater();
     delete m_closeController;
 }

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3880,16 +3880,12 @@ void NotationInteraction::addTextToTopFrame(TextStyleType type)
 
 mu::Ret NotationInteraction::canAddTextToItem(TextStyleType type, const EngravingItem* item) const
 {
-    if (!item) {
-        return false;
-    }
-
     if (isVerticalBoxTextStyle(type)) {
-        return item->isVBox();
+        return item && item->isVBox();
     }
 
     if (type == TextStyleType::FRAME) {
-        return item->isBox();
+        return item && item->isBox() ? make_ok() : make_ret(Err::EmptySelection);
     }
 
     static const std::set<TextStyleType> needSelectNoteOrRestTypes {
@@ -3918,7 +3914,7 @@ mu::Ret NotationInteraction::canAddTextToItem(TextStyleType type, const Engravin
             ElementType::CHORD,
         };
 
-        bool isNoteOrRestSelected = mu::contains(requiredElementTypes, item->type());
+        bool isNoteOrRestSelected = item && mu::contains(requiredElementTypes, item->type());
         return isNoteOrRestSelected ? make_ok() : make_ret(Err::NoteOrRestIsNotSelected);
     }
 


### PR DESCRIPTION


Resolves: [*(direct link to the issue)*](https://github.com/musescore/MuseScore/issues/13286)

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
