### PR TITLE
Import hidden instruments as hidden staves

### DIFF
--- a/src/engraving/rw/compat/read114.cpp
+++ b/src/engraving/rw/compat/read114.cpp
@@ -1,0 +1,3167 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "read114.h"
+
+#include <cmath>
+
+#include "compat/pageformat.h"
+
+#include "infrastructure/htmlparser.h"
+
+#include "rw/xml.h"
+
+#include "style/defaultstyle.h"
+#include "style/style.h"
+
+#include "types/typesconv.h"
+
+#include "libmscore/accidental.h"
+#include "libmscore/barline.h"
+#include "libmscore/beam.h"
+#include "libmscore/box.h"
+#include "libmscore/bracketItem.h"
+#include "libmscore/breath.h"
+#include "libmscore/chord.h"
+#include "libmscore/clef.h"
+#include "libmscore/drumset.h"
+#include "libmscore/dynamic.h"
+#include "libmscore/excerpt.h"
+#include "libmscore/factory.h"
+#include "libmscore/fingering.h"
+#include "libmscore/harmony.h"
+#include "libmscore/image.h"
+#include "libmscore/jump.h"
+#include "libmscore/keysig.h"
+#include "libmscore/linkedobjects.h"
+#include "libmscore/lyrics.h"
+#include "libmscore/marker.h"
+#include "libmscore/masterscore.h"
+#include "libmscore/measure.h"
+#include "libmscore/measurenumber.h"
+#include "libmscore/measurerepeat.h"
+#include "libmscore/mmrest.h"
+#include "libmscore/note.h"
+#include "libmscore/ottava.h"
+#include "libmscore/part.h"
+#include "libmscore/pedal.h"
+#include "libmscore/rest.h"
+#include "libmscore/segment.h"
+#include "libmscore/sig.h"
+#include "libmscore/slur.h"
+#include "libmscore/spacer.h"
+#include "libmscore/staff.h"
+#include "libmscore/stafftext.h"
+#include "libmscore/stafftype.h"
+#include "libmscore/stringdata.h"
+#include "libmscore/tempo.h"
+#include "libmscore/tempotext.h"
+#include "libmscore/text.h"
+#include "libmscore/textframe.h"
+#include "libmscore/textline.h"
+#include "libmscore/timesig.h"
+#include "libmscore/tremolo.h"
+#include "libmscore/tuplet.h"
+#include "libmscore/utils.h"
+#include "libmscore/volta.h"
+
+#include "readchordlisthook.h"
+#include "readstyle.h"
+#include "read206.h"
+
+#include "log.h"
+
+using namespace mu;
+using namespace mu::engraving;
+using namespace mu::engraving::rw;
+using namespace mu::engraving::compat;
+
+static int g_guitarStrings[] = { 40, 45, 50, 55, 59, 64 };
+static int g_bassStrings[]   = { 28, 33, 38, 43 };
+static int g_violinStrings[] = { 55, 62, 69, 76 };
+static int g_violaStrings[]  = { 48, 55, 62, 69 };
+static int g_celloStrings[]  = { 36, 43, 50, 57 };
+
+#define MM(x) ((x) / INCH)
+
+//---------------------------------------------------------
+//   PaperSize
+//---------------------------------------------------------
+
+struct PaperSize {
+    const char* name;
+    double w, h;              // size in inch
+    PaperSize(const char* n, double wi, double hi)
+        : name(n), w(wi), h(hi) {}
+};
+
+static const PaperSize paperSizes114[] = {
+    PaperSize("Custom",    MM(1),    MM(1)),
+    PaperSize("A4",        MM(210),  MM(297)),
+    PaperSize("B5",        MM(176),  MM(250)),
+    PaperSize("Letter",    8.5,      11),
+    PaperSize("Legal",     8.5,      14),
+    PaperSize("Executive", 7.5,      10),
+    PaperSize("A0",        MM(841),  MM(1189)),
+    PaperSize("A1",        MM(594),  MM(841)),
+    PaperSize("A2",        MM(420),  MM(594)),
+    PaperSize("A3",        MM(297),  MM(420)),
+    PaperSize("A5",        MM(148),  MM(210)),
+    PaperSize("A6",        MM(105),  MM(148)),
+    PaperSize("A7",        MM(74),   MM(105)),
+    PaperSize("A8",        MM(52),   MM(74)),
+    PaperSize("A9",        MM(37),   MM(52)),
+    PaperSize("A10",       MM(26),   MM(37)),
+    PaperSize("B0",        MM(1000), MM(1414)),
+    PaperSize("B1",        MM(707),  MM(1000)),
+    PaperSize("B2",        MM(500),  MM(707)),
+    PaperSize("B3",        MM(353),  MM(500)),
+    PaperSize("B4",        MM(250),  MM(353)),
+    PaperSize("B6",        MM(125),  MM(176)),
+    PaperSize("B7",        MM(88),   MM(125)),
+    PaperSize("B8",        MM(62),   MM(88)),
+    PaperSize("B9",        MM(44),   MM(62)),
+    PaperSize("B10",       MM(31),   MM(44)),
+    PaperSize("Comm10E",   MM(105),  MM(241)),
+    PaperSize("DLE",       MM(110),  MM(220)),
+    PaperSize("Folio",     MM(210),  MM(330)),
+    PaperSize("Ledger",    MM(432),  MM(279)),
+    PaperSize("Tabloid",   MM(279),  MM(432)),
+    PaperSize(0,           MM(1),    MM(1))     // mark end of list
+};
+
+//---------------------------------------------------------
+//   getPaperSize
+//---------------------------------------------------------
+
+static const PaperSize* getPaperSize114(const String& name)
+{
+    for (int i = 0; paperSizes114[i].name; ++i) {
+        if (name == paperSizes114[i].name) {
+            return &paperSizes114[i];
+        }
+    }
+    LOGD("unknown paper size");
+    return &paperSizes114[0];
+}
+
+//---------------------------------------------------------
+//   convertFromHtml
+//---------------------------------------------------------
+
+static String convertFromHtml(const String& in_html)
+{
+    if (in_html.isEmpty()) {
+        return in_html;
+    }
+
+    std::string html = in_html.toStdString();
+
+    //! NOTE Get body
+    auto body_b = html.find("<body");
+    auto body_e = html.find_last_of("</body>");
+    if (body_b == std::string::npos || body_e == std::string::npos) {
+        return in_html;
+    }
+    std::string body = html.substr(body_b, body_e - body_b);
+
+    std::vector<std::string> blocks;
+
+    //! NOTE Split blocks
+    std::string::size_type p_b = 0;
+    std::string::size_type p_e = 0;
+    while (true) {
+        p_b = body.find("<p", p_e);
+        p_e = body.find("/p>", p_b);
+        if (p_b == std::string::npos || p_e == std::string::npos) {
+            break;
+        }
+
+        std::string block = body.substr(p_b, p_e - p_b);
+        blocks.push_back(block);
+    }
+
+    if (blocks.empty()) {
+        blocks.push_back(body);
+    }
+
+    //! NOTE Format blocks
+    auto extractText = [](const std::string& block) {
+        std::string text;
+        bool isTag = false;
+        for (const char& c : block) {
+            if (c == '<') {
+                isTag = true;
+            } else if (c == '>') {
+                isTag = false;
+            } else if (!isTag) {
+                text += c;
+            }
+        }
+        return text;
+    };
+
+    auto extractFont = [](const std::string& block) {
+        auto fontsize_b = block.find("font-size");
+        if (fontsize_b != std::string::npos) {
+            std::string fontSize;
+            bool started = false;
+            for (auto i = fontsize_b; i < block.size(); ++i) {
+                const char& c = block.at(i);
+                if (strchr(".0123456789", c) != nullptr) {
+                    started = true;
+                    fontSize += c;
+                } else if (started) {
+                    break;
+                }
+            }
+
+            return std::string("<font size=\"") + fontSize + std::string("\"/>");
+        }
+        return std::string();
+    };
+
+    auto formatRichText = [extractText, extractFont](const std::string& block) {
+        std::string text = extractText(block);
+        std::string font = extractFont(block);
+        if (!font.empty()) {
+            text = font + text;
+        }
+        return text;
+    };
+
+    //! NOTE Format rich text from blocks
+    std::string text;
+    for (const std::string& block : blocks) {
+        if (!text.empty()) {
+            text += "\n";
+        }
+
+        text += formatRichText(block);
+    }
+
+    auto replaceSym = [](std::string& str, int cc, const char* sym) {
+        std::string code;
+        code.resize(3);
+        code[2] = static_cast<char>(cc);
+        code[1] = static_cast<char>(cc >> 8);
+        code[0] = static_cast<char>(cc >> 16);
+
+        auto pos = str.find(code);
+        if (pos != std::string::npos) {
+            str.replace(pos, 3, sym);
+        }
+    };
+
+    //! NOTE replace utf8 code /*utf16 code*/ on sym
+    replaceSym(text, 0xee848e /*0xe10e*/, "<sym>accidentalNatural</sym>");        //natural
+    replaceSym(text, 0xee848c /*0xe10c*/, "<sym>accidentalSharp</sym>");          // sharp
+    replaceSym(text, 0xee848d /*0xe10d*/, "<sym>accidentalFlat</sym>");           // flat
+    replaceSym(text, 0xee8484 /*0xe104*/, "<sym>metNoteHalfUp</sym>");            // note2_Sym
+    replaceSym(text, 0xee8485 /*0xe105*/, "<sym>metNoteQuarterUp</sym>");         // note4_Sym
+    replaceSym(text, 0xee8486 /*0xe106*/, "<sym>metNote8thUp</sym>");             // note8_Sym
+    replaceSym(text, 0xee8487 /*0xe107*/, "<sym>metNote16thUp</sym>");            // note16_Sym
+    replaceSym(text, 0xee8488 /*0xe108*/, "<sym>metNote32ndUp</sym>");            // note32_Sym
+    replaceSym(text, 0xee8489 /*0xe109*/, "<sym>metNote64thUp</sym>");            // note64_Sym
+    replaceSym(text, 0xee848a /*0xe10a*/, "<sym>metAugmentationDot</sym>");       // dot
+    replaceSym(text, 0xee848b /*0xe10b*/, "<sym>metAugmentationDot</sym><sym>space</sym><sym>metAugmentationDot</sym>");          // dotdot
+    replaceSym(text, 0xee85a7 /*0xe167*/, "<sym>segno</sym>");                    // segno
+    replaceSym(text, 0xee85a8 /*0xe168*/, "<sym>coda</sym>");                     // coda
+    replaceSym(text, 0xee85a9 /*0xe169*/, "<sym>codaSquare</sym>");               // varcoda
+
+    return String::fromStdString(text);
+}
+
+//---------------------------------------------------------
+//   readTextProperties
+//---------------------------------------------------------
+
+static bool readTextProperties(XmlReader& e, TextBase* t, EngravingItem*)
+{
+    const AsciiStringView tag(e.name());
+    if (tag == "style") {
+        int i = e.readInt();
+        TextStyleType ss = TextStyleType::DEFAULT;
+        switch (i) {
+        case 2:  ss = TextStyleType::TITLE;
+            break;
+        case 3:  ss = TextStyleType::SUBTITLE;
+            break;
+        case 4:  ss = TextStyleType::COMPOSER;
+            break;
+        case 5:  ss = TextStyleType::POET;
+            break;
+
+        case 6:  ss = TextStyleType::LYRICS_ODD;
+            break;
+        case 7:  ss = TextStyleType::LYRICS_EVEN;
+            break;
+
+        case 8:  ss = TextStyleType::FINGERING;
+            break;
+        case 9:  ss = TextStyleType::INSTRUMENT_LONG;
+            break;
+        case 10: ss = TextStyleType::INSTRUMENT_SHORT;
+            break;
+        case 11: ss = TextStyleType::INSTRUMENT_EXCERPT;
+            break;
+
+        case 12: ss = TextStyleType::DYNAMICS;
+            break;
+        case 13: ss = TextStyleType::EXPRESSION;
+            break;
+        case 14: ss = TextStyleType::TEMPO;
+            break;
+        case 15: ss = TextStyleType::METRONOME;
+            break;
+        case 16: ss = TextStyleType::FOOTER;
+            break;                                      // TextStyleType::COPYRIGHT
+        case 17: ss = TextStyleType::MEASURE_NUMBER;
+            break;
+        case 18: ss = TextStyleType::FOOTER;
+            break;                                     // TextStyleType::PAGE_NUMBER_ODD
+        case 19: ss = TextStyleType::FOOTER;
+            break;                                     // TextStyleType::PAGE_NUMBER_EVEN
+        case 20: ss = TextStyleType::TRANSLATOR;
+            break;
+        case 21: ss = TextStyleType::TUPLET;
+            break;
+
+        case 22: ss = TextStyleType::SYSTEM;
+            break;
+        case 23: ss = TextStyleType::STAFF;
+            break;
+        case 24: ss = TextStyleType::HARMONY_A;
+            break;
+        case 25: ss = TextStyleType::REHEARSAL_MARK;
+            break;
+        case 26: ss = TextStyleType::REPEAT_LEFT;
+            break;
+        case 27: ss = TextStyleType::VOLTA;
+            break;
+        case 28: ss = TextStyleType::FRAME;
+            break;
+        case 29: ss = TextStyleType::TEXTLINE;
+            break;
+        case 30: ss = TextStyleType::GLISSANDO;
+            break;
+        case 31: ss = TextStyleType::STRING_NUMBER;
+            break;
+
+        case 32: ss = TextStyleType::OTTAVA;
+            break;
+//??                  case 33: ss = TextStyleName::BENCH;   break;
+        case 34: ss = TextStyleType::HEADER;
+            break;
+        case 35: ss = TextStyleType::FOOTER;
+            break;
+        case 0:
+        default:
+            LOGD("style %d invalid", i);
+            ss = TextStyleType::DEFAULT;
+            break;
+        }
+        t->initTextStyleType(ss);
+    } else if (tag == "subtype") {
+        e.skipCurrentElement();
+    } else if (tag == "html-data") {
+        String ss = e.readXml();
+        String s  = convertFromHtml(ss);
+// LOGD("html-data <%s>", muPrintable(s));
+        t->setXmlText(s);
+    } else if (tag == "foregroundColor") { // same as "color" ?
+        e.skipCurrentElement();
+    } else if (tag == "frame") {
+        t->setFrameType(e.readBool() ? FrameType::SQUARE : FrameType::NO_FRAME);
+        t->setPropertyFlags(Pid::FRAME_TYPE, PropertyFlags::UNSTYLED);
+    } else if (tag == "halign") {
+        Align align = t->align();
+        align.horizontal = TConv::fromXml(e.readAsciiText(), AlignH::LEFT);
+        t->setAlign(align);
+        t->setPropertyFlags(Pid::ALIGN, PropertyFlags::UNSTYLED);
+    } else if (tag == "valign") {
+        Align align = t->align();
+        align.vertical = TConv::fromXml(e.readAsciiText(), AlignV::TOP);
+        t->setAlign(align);
+        t->setPropertyFlags(Pid::ALIGN, PropertyFlags::UNSTYLED);
+    } else if (tag == "rxoffset") {
+        e.readText();
+    } else if (tag == "ryoffset") {
+        e.readText();
+    } else if (tag == "yoffset") {
+        e.readText();
+    } else if (tag == "systemFlag") {
+        e.readText();
+    } else if (!t->readProperties(e)) {
+        return false;
+    }
+    t->setOffset(PointF());       // ignore user offsets
+    t->setAutoplace(true);
+    return true;
+}
+
+//---------------------------------------------------------
+//   readText114
+//---------------------------------------------------------
+
+static void readText114(XmlReader& e, TextBase* t, EngravingItem* be)
+{
+    while (e.readNextStartElement()) {
+        if (!readTextProperties(e, t, be)) {
+            e.unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readAccidental
+//---------------------------------------------------------
+
+static void readAccidental(Accidental* a, XmlReader& e)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "bracket") {
+            int i = e.readInt();
+            if (i == 0 || i == 1) {
+                a->setBracket(AccidentalBracket(i));
+            }
+        } else if (tag == "subtype") {
+            String text(e.readText());
+            bool isInt;
+            int i = text.toInt(&isInt);
+            if (isInt) {
+                a->setBracket(i & 0x8000 ? AccidentalBracket::PARENTHESIS : AccidentalBracket::BRACKET);
+                i &= ~0x8000;
+                AccidentalType at;
+                switch (i) {
+                case 0:
+                    at = AccidentalType::NONE;
+                    break;
+                case 6:
+                    a->setBracket(AccidentalBracket::PARENTHESIS);
+                // fall through
+                case 1:
+                case 11:
+                    at = AccidentalType::SHARP;
+                    break;
+                case 7:
+                    a->setBracket(AccidentalBracket::PARENTHESIS);
+                // fall through
+                case 2:
+                case 12:
+                    at = AccidentalType::FLAT;
+                    break;
+                case 8:
+                    a->setBracket(AccidentalBracket::PARENTHESIS);
+                // fall through
+                case 3:
+                case 13:
+                    at = AccidentalType::SHARP2;
+                    break;
+                case 9:
+                    a->setBracket(AccidentalBracket::PARENTHESIS);
+                // fall through
+                case 4:
+                case 14:
+                    at = AccidentalType::FLAT2;
+                    break;
+                case 10:
+                    a->setBracket(AccidentalBracket::PARENTHESIS);
+                // fall through
+                case 5:
+                case 15:
+                    at = AccidentalType::NATURAL;
+                    break;
+                case 16:
+                    at = AccidentalType::FLAT_SLASH;
+                    break;
+                case 17:
+                    at = AccidentalType::FLAT_SLASH2;
+                    break;
+                case 18:
+                    at = AccidentalType::MIRRORED_FLAT2;
+                    break;
+                case 19:
+                    at = AccidentalType::MIRRORED_FLAT;
+                    break;
+                case 20:
+                    at = AccidentalType::NONE;                //AccidentalType::MIRRORED_FLAT_SLASH;
+                    break;
+                case 21:
+                    at = AccidentalType::NONE;                //AccidentalType::FLAT_FLAT_SLASH;
+                    break;
+                case 22:
+                    at = AccidentalType::SHARP_SLASH;
+                    break;
+                case 23:
+                    at = AccidentalType::SHARP_SLASH2;
+                    break;
+                case 24:
+                    at = AccidentalType::SHARP_SLASH3;
+                    break;
+                case 25:
+                    at = AccidentalType::SHARP_SLASH4;
+                    break;
+                case 26:
+                    at = AccidentalType::SHARP_ARROW_UP;
+                    break;
+                case 27:
+                    at = AccidentalType::SHARP_ARROW_DOWN;
+                    break;
+                case 28:
+                    at = AccidentalType::NONE;                //AccidentalType::SHARP_ARROW_BOTH;
+                    break;
+                case 29:
+                    at = AccidentalType::FLAT_ARROW_UP;
+                    break;
+                case 30:
+                    at = AccidentalType::FLAT_ARROW_DOWN;
+                    break;
+                case 31:
+                    at = AccidentalType::NONE;                //AccidentalType::FLAT_ARROW_BOTH;
+                    break;
+                case 32:
+                    at = AccidentalType::NATURAL_ARROW_UP;
+                    break;
+                case 33:
+                    at = AccidentalType::NATURAL_ARROW_DOWN;
+                    break;
+                case 34:
+                    at = AccidentalType::NONE;                //AccidentalType::NATURAL_ARROW_BOTH;
+                    break;
+                default:
+                    at = AccidentalType::NONE;
+                    break;
+                }
+                a->setAccidentalType(at);
+            } else {
+                const static std::map<String, AccidentalType> accMap = {
+                    { u"none", AccidentalType::NONE }, { u"sharp", AccidentalType::SHARP },
+                    { u"flat", AccidentalType::FLAT }, { u"natural", AccidentalType::NATURAL },
+                    { u"double sharp", AccidentalType::SHARP2 }, { u"double flat", AccidentalType::FLAT2 },
+                    { u"flat-slash", AccidentalType::FLAT_SLASH }, { u"flat-slash2", AccidentalType::FLAT_SLASH2 },
+                    { u"mirrored-flat2", AccidentalType::MIRRORED_FLAT2 }, { u"mirrored-flat", AccidentalType::MIRRORED_FLAT },
+                    { u"sharp-slash", AccidentalType::SHARP_SLASH }, { u"sharp-slash2", AccidentalType::SHARP_SLASH2 },
+                    { u"sharp-slash3", AccidentalType::SHARP_SLASH3 }, { u"sharp-slash4", AccidentalType::SHARP_SLASH4 },
+                    { u"sharp arrow up", AccidentalType::SHARP_ARROW_UP }, { u"sharp arrow down", AccidentalType::SHARP_ARROW_DOWN },
+                    { u"flat arrow up", AccidentalType::FLAT_ARROW_UP }, { u"flat arrow down", AccidentalType::FLAT_ARROW_DOWN },
+                    { u"natural arrow up", AccidentalType::NATURAL_ARROW_UP },
+                    { u"natural arrow down", AccidentalType::NATURAL_ARROW_DOWN },
+                    { u"sori", AccidentalType::SORI }, { u"koron", AccidentalType::KORON }
+                };
+                auto it = accMap.find(text);
+                if (it == accMap.end()) {
+                    LOGD("invalid type %s", muPrintable(text));
+                    a->setAccidentalType(AccidentalType::NONE);
+                } else {
+                    a->setAccidentalType(it->second);
+                }
+            }
+        } else if (tag == "role") {
+            AccidentalRole r = AccidentalRole(e.readInt());
+            if (r == AccidentalRole::AUTO || r == AccidentalRole::USER) {
+                a->setRole(r);
+            }
+        } else if (tag == "small") {
+            a->setSmall(e.readInt());
+        } else if (tag == "offset") {
+            e.skipCurrentElement();       // ignore manual layout in older scores
+        } else if (a->EngravingItem::readProperties(e)) {
+        } else {
+            e.unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readFingering114
+//---------------------------------------------------------
+
+static void readFingering114(XmlReader& e, Fingering* fing)
+{
+    bool isStringNumber = false;
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+
+        if (tag == "html-data") {
+            auto htmlDdata = HtmlParser::parse(e.readXml());
+            htmlDdata.replace(u" ", u"");
+            fing->setPlainText(htmlDdata);
+        } else if (tag == "subtype") {
+            auto subtype = e.readText();
+            if (subtype == "StringNumber") {
+                isStringNumber = true;
+                fing->setProperty(Pid::TEXT_STYLE, TextStyleType::STRING_NUMBER);
+                fing->setPropertyFlags(Pid::TEXT_STYLE, PropertyFlags::UNSTYLED);
+            }
+        } else if (tag == "frame") {
+            auto frame = e.readInt();
+            if (frame) {
+                if (isStringNumber) {       //default value is circle for stringnumber, square is set in tag circle
+                    fing->setFrameType(FrameType::CIRCLE);
+                } else {     //default value is square for stringnumber, circle is set in tag circle
+                    fing->setFrameType(FrameType::SQUARE);
+                }
+            } else {
+                fing->setFrameType(FrameType::NO_FRAME);
+            }
+        } else if (tag == "circle") {
+            auto circle = e.readInt();
+            if (circle) {
+                fing->setFrameType(FrameType::CIRCLE);
+            } else {
+                fing->setFrameType(FrameType::SQUARE);
+            }
+        } else {
+            e.skipCurrentElement();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readNote
+//---------------------------------------------------------
+
+static void readNote(Note* note, XmlReader& e, ReadContext& ctx)
+{
+    ctx.hasAccidental = false;                       // used for userAccidental backward compatibility
+
+    note->setTpc1(Tpc::TPC_INVALID);
+    note->setTpc2(Tpc::TPC_INVALID);
+
+    if (e.hasAttribute("pitch")) {                   // obsolete
+        note->setPitch(e.intAttribute("pitch"));
+    }
+    if (e.hasAttribute("tpc")) {                     // obsolete
+        note->setTpc1(e.intAttribute("tpc"));
+    }
+
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "Accidental") {
+            // on older scores, a note could have both a <userAccidental> tag and an <Accidental> tag
+            // if a userAccidental has some other property set (like for instance offset)
+            Accidental* a;
+            if (ctx.hasAccidental) {                // if the other tag has already been read,
+                a = note->accidental();                // re-use the accidental it constructed
+            } else {
+                a = Factory::createAccidental(note);
+            }
+            // the accidental needs to know the properties of the
+            // track it belongs to (??)
+            a->setTrack(note->track());
+            readAccidental(a, e);
+            if (!ctx.hasAccidental) {              // only the new accidental, if it has been added previously
+                note->add(a);
+            }
+            ctx.hasAccidental = true;         // we now have an accidental
+        } else if (tag == "Text") {
+            Fingering* f = Factory::createFingering(note);
+            readFingering114(e, f);
+            note->add(f);
+        } else if (tag == "onTimeType") {
+            if (e.readText() == "offset") {
+                note->setOnTimeType(2);
+            } else {
+                note->setOnTimeType(1);
+            }
+        } else if (tag == "offTimeType") {
+            if (e.readText() == "offset") {
+                note->setOffTimeType(2);
+            } else {
+                note->setOffTimeType(1);
+            }
+        } else if (tag == "onTimeOffset") {
+            if (note->onTimeType() == 1) {
+                note->setOnTimeOffset(e.readInt() * 1000 / note->chord()->actualTicks().ticks());
+            } else {
+                note->setOnTimeOffset(e.readInt() * 10);
+            }
+        } else if (tag == "offTimeOffset") {
+            if (note->offTimeType() == 1) {
+                note->setOffTimeOffset(1000 + (e.readInt() * 1000 / note->chord()->actualTicks().ticks()));
+            } else {
+                note->setOffTimeOffset(1000 + (e.readInt() * 10));
+            }
+        } else if (tag == "userAccidental") {
+            String val(e.readText());
+            bool ok;
+            int k = val.toInt(&ok);
+            if (ok) {
+                // on older scores, a note could have both a <userAccidental> tag and an <Accidental> tag
+                // if a userAccidental has some other property set (like for instance offset)
+                // only construct a new accidental, if the other tag has not been read yet
+                // (<userAccidental> tag is only used in older scores: no need to check the score mscVersion)
+                if (!ctx.hasAccidental) {
+                    Accidental* a = Factory::createAccidental(note);
+                    note->add(a);
+                }
+                // TODO: for backward compatibility
+                bool bracket = k & 0x8000;
+                k &= 0xfff;
+                AccidentalType at = AccidentalType::NONE;
+                switch (k) {
+                case 0: at = AccidentalType::NONE;
+                    break;
+                case 1: at = AccidentalType::SHARP;
+                    break;
+                case 2: at = AccidentalType::FLAT;
+                    break;
+                case 3: at = AccidentalType::SHARP2;
+                    break;
+                case 4: at = AccidentalType::FLAT2;
+                    break;
+                case 5: at = AccidentalType::NATURAL;
+                    break;
+
+                case 6: at = AccidentalType::FLAT_SLASH;
+                    break;
+                case 7: at = AccidentalType::FLAT_SLASH2;
+                    break;
+                case 8: at = AccidentalType::MIRRORED_FLAT2;
+                    break;
+                case 9: at = AccidentalType::MIRRORED_FLAT;
+                    break;
+                case 10: at = AccidentalType::NONE;
+                    break;                                               // AccidentalType::MIRRORED_FLAT_SLASH
+                case 11: at = AccidentalType::NONE;
+                    break;                                               // AccidentalType::FLAT_FLAT_SLASH
+
+                case 12: at = AccidentalType::SHARP_SLASH;
+                    break;
+                case 13: at = AccidentalType::SHARP_SLASH2;
+                    break;
+                case 14: at = AccidentalType::SHARP_SLASH3;
+                    break;
+                case 15: at = AccidentalType::SHARP_SLASH4;
+                    break;
+
+                case 16: at = AccidentalType::SHARP_ARROW_UP;
+                    break;
+                case 17: at = AccidentalType::SHARP_ARROW_DOWN;
+                    break;
+                case 18: at = AccidentalType::NONE;
+                    break;                                               // AccidentalType::SHARP_ARROW_BOTH
+                case 19: at = AccidentalType::FLAT_ARROW_UP;
+                    break;
+                case 20: at = AccidentalType::FLAT_ARROW_DOWN;
+                    break;
+                case 21: at = AccidentalType::NONE;
+                    break;                                               // AccidentalType::FLAT_ARROW_BOTH
+                case 22: at = AccidentalType::NATURAL_ARROW_UP;
+                    break;
+                case 23: at = AccidentalType::NATURAL_ARROW_DOWN;
+                    break;
+                case 24: at = AccidentalType::NONE;
+                    break;                                               // AccidentalType::NATURAL_ARROW_BOTH
+                case 25: at = AccidentalType::SORI;
+                    break;
+                case 26: at = AccidentalType::KORON;
+                    break;
+                }
+                note->accidental()->setAccidentalType(at);
+
+                note->accidental()->setBracket(AccidentalBracket(bracket));
+
+                note->accidental()->setRole(AccidentalRole::USER);
+                ctx.hasAccidental = true;           // we now have an accidental
+            }
+        } else if (tag == "offset") {
+            e.skipCurrentElement();       // ignore manual layout in older scores
+        } else if (tag == "move") {
+            note->chord()->setStaffMove(e.readInt());
+        } else if (tag == "head") {
+            int i = e.readInt();
+            NoteHeadGroup val = Read206::convertHeadGroup(i);
+            note->setHeadGroup(val);
+        } else if (tag == "headType") {
+            int i = e.readInt();
+            NoteHeadType val;
+            switch (i) {
+            case 1:
+                val = NoteHeadType::HEAD_WHOLE;
+                break;
+            case 2:
+                val = NoteHeadType::HEAD_HALF;
+                break;
+            case 3:
+                val = NoteHeadType::HEAD_QUARTER;
+                break;
+            case 4:
+                val = NoteHeadType::HEAD_BREVIS;
+                break;
+            default:
+                val = NoteHeadType::HEAD_AUTO;
+            }
+            note->setHeadType(val);
+        } else if (Read206::readNoteProperties206(note, e, ctx)) {
+        } else {
+            e.unknown();
+        }
+    }
+    // ensure sane values:
+    note->setPitch(std::clamp(note->pitch(), 0, 127));
+
+    if (note->concertPitch()) {
+        note->setTpc2(Tpc::TPC_INVALID);
+    } else {
+        note->setPitch(note->pitch() + note->transposition());
+        note->setTpc2(note->tpc1());
+        note->setTpc1(Tpc::TPC_INVALID);
+    }
+    if (!tpcIsValid(note->tpc1()) && !tpcIsValid(note->tpc2())) {
+        Key key = (note->staff() && note->chord()) ? note->staff()->key(note->chord()->tick()) : Key::C;
+        int tpc = pitch2tpc(note->pitch(), key, Prefer::NEAREST);
+        if (note->concertPitch()) {
+            note->setTpc1(tpc);
+        } else {
+            note->setTpc2(tpc);
+        }
+    }
+    if (!(tpcIsValid(note->tpc1()) && tpcIsValid(note->tpc2()))) {
+        Fraction tick = note->chord() ? note->chord()->tick() : Fraction(-1, 1);
+        Interval v = note->staff() ? note->part()->instrument(tick)->transpose() : Interval();
+        if (tpcIsValid(note->tpc1())) {
+            v.flip();
+            if (v.isZero()) {
+                note->setTpc2(note->tpc1());
+            } else {
+                note->setTpc2(mu::engraving::transposeTpc(note->tpc1(), v, true));
+            }
+        } else {
+            if (v.isZero()) {
+                note->setTpc1(note->tpc2());
+            } else {
+                note->setTpc1(mu::engraving::transposeTpc(note->tpc2(), v, true));
+            }
+        }
+    }
+
+    // check consistency of pitch, tpc1, tpc2, and transposition
+    // see note in InstrumentChange::read() about a known case of tpc corruption produced in 2.0.x
+    // but since there are other causes of tpc corruption (eg, https://musescore.org/en/node/74746)
+    // including perhaps some we don't know about yet,
+    // we will attempt to fix some problems here regardless of version
+
+    if (!ctx.pasteMode() && !MScore::testMode) {
+        int tpc1Pitch = (tpc2pitch(note->tpc1()) + 12) % 12;
+        int tpc2Pitch = (tpc2pitch(note->tpc2()) + 12) % 12;
+        int concertPitch = note->pitch() % 12;
+        if (tpc1Pitch != concertPitch) {
+            LOGD("bad tpc1 - concertPitch = %d, tpc1 = %d", concertPitch, tpc1Pitch);
+            note->setPitch(note->pitch() + tpc1Pitch - concertPitch);
+        }
+        Interval v = note->staff()->part()->instrument(ctx.tick())->transpose();
+        int transposedPitch = (note->pitch() - v.chromatic) % 12;
+        if (tpc2Pitch != transposedPitch) {
+            LOGD("bad tpc2 - transposedPitch = %d, tpc2 = %d", transposedPitch, tpc2Pitch);
+            // just in case the staff transposition info is not reliable here,
+            v.flip();
+            note->setTpc2(mu::engraving::transposeTpc(note->tpc1(), v, true));
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readClefType
+//---------------------------------------------------------
+
+static ClefType readClefType(int i)
+{
+    ClefType ct = ClefType::G;
+    // convert obsolete old coding
+    switch (i) {
+    default:
+    case  0: ct = ClefType::G;
+        break;
+    case  1: ct = ClefType::G8_VA;
+        break;
+    case  2: ct = ClefType::G15_MA;
+        break;
+    case  3: ct = ClefType::G8_VB;
+        break;
+    case  4: ct = ClefType::F;
+        break;
+    case  5: ct = ClefType::F8_VB;
+        break;
+    case  6: ct = ClefType::F15_MB;
+        break;
+    case  7: ct = ClefType::F_B;
+        break;
+    case  8: ct = ClefType::F_C;
+        break;
+    case  9: ct = ClefType::C1;
+        break;
+    case 10: ct = ClefType::C2;
+        break;
+    case 11: ct = ClefType::C3;
+        break;
+    case 12: ct = ClefType::C4;
+        break;
+    case 13: ct = ClefType::TAB;
+        break;
+    case 14: ct = ClefType::PERC;
+        break;
+    case 15: ct = ClefType::C5;
+        break;
+    case 16: ct = ClefType::G_1;
+        break;
+    case 17: ct = ClefType::F_8VA;
+        break;
+    case 18: ct = ClefType::F_15MA;
+        break;
+    case 19: ct = ClefType::PERC;
+        break;                                              // PERC2 no longer supported
+    case 20: ct = ClefType::TAB_SERIF;
+        break;
+    }
+
+    return ct;
+}
+
+//---------------------------------------------------------
+//   readClef
+//---------------------------------------------------------
+
+static void readClef(Clef* clef, XmlReader& e)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "subtype") {
+            clef->setClefType(readClefType(e.readInt()));
+        } else if (!clef->readProperties(e)) {
+            e.unknown();
+        }
+    }
+    if (clef->clefType() == ClefType::INVALID) {
+        clef->setClefType(ClefType::G);
+    }
+}
+
+//---------------------------------------------------------
+//   readTuplet
+//---------------------------------------------------------
+
+static void readTuplet(Tuplet* tuplet, XmlReader& e, const ReadContext& ctx)
+{
+    int bl = -1;
+    tuplet->setId(e.intAttribute("id", 0));
+
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "subtype") {      // obsolete
+            e.skipCurrentElement();
+        } else if (tag == "hasNumber") {  // obsolete even in 1.3
+            tuplet->setNumberType(e.readInt() ? TupletNumberType::SHOW_NUMBER : TupletNumberType::NO_TEXT);
+        } else if (tag == "hasLine") {    // obsolete even in 1.3
+            tuplet->setHasBracket(e.readInt());
+            tuplet->setBracketType(TupletBracketType::AUTO_BRACKET);
+        } else if (tag == "baseLen") {    // obsolete even in 1.3
+            bl = e.readInt();
+        } else if (tag == "tick") {
+            tuplet->setTick(Fraction::fromTicks(e.readInt()));
+        } else if (!Read206::readTupletProperties206(e, ctx, tuplet)) {
+            e.unknown();
+        }
+    }
+    Fraction r = (tuplet->ratio() == Fraction(1, 1)) ? tuplet->ratio() : tuplet->ratio().reduced();
+    // this may be wrong, but at this stage it is kept for compatibility. It will be corrected afterwards
+    // during "sanitize" step
+    Fraction f(r.denominator(), tuplet->baseLen().fraction().denominator());
+    tuplet->setTicks(f.reduced());
+    if (bl != -1) {           // obsolete, even in 1.3
+        TDuration d;
+        d.setVal(bl);
+        tuplet->setBaseLen(d);
+        d.setVal(bl * tuplet->ratio().denominator());
+        tuplet->setTicks(d.fraction());
+    }
+}
+
+//---------------------------------------------------------
+//   readTremolo
+//---------------------------------------------------------
+
+static void readTremolo(Tremolo* tremolo, XmlReader& e)
+{
+    enum class OldTremoloType : char {
+        OLD_R8 = 0,
+        OLD_R16,
+        OLD_R32,
+        OLD_C8,
+        OLD_C16,
+        OLD_C32
+    };
+    while (e.readNextStartElement()) {
+        if (e.name() == "subtype") {
+            OldTremoloType sti = OldTremoloType(e.readText().toInt());
+            TremoloType st;
+            switch (sti) {
+            default:
+            case OldTremoloType::OLD_R8:  st = TremoloType::R8;
+                break;
+            case OldTremoloType::OLD_R16: st = TremoloType::R16;
+                break;
+            case OldTremoloType::OLD_R32: st = TremoloType::R32;
+                break;
+            case OldTremoloType::OLD_C8:  st = TremoloType::C8;
+                break;
+            case OldTremoloType::OLD_C16: st = TremoloType::C16;
+                break;
+            case OldTremoloType::OLD_C32: st = TremoloType::C32;
+                break;
+            }
+            tremolo->setTremoloType(st);
+        } else if (!tremolo->EngravingItem::readProperties(e)) {
+            e.unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readChord
+//---------------------------------------------------------
+
+static void readChord(Measure* m, Chord* chord, XmlReader& e, ReadContext& ctx)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "Note") {
+            Note* note = Factory::createNote(chord);
+            // the note needs to know the properties of the track it belongs to
+            note->setTrack(chord->track());
+            note->setParent(chord);
+            readNote(note, e, ctx);
+            chord->add(note);
+        } else if (tag == "Attribute" || tag == "Articulation") {
+            EngravingItem* el = Read206::readArticulation(chord, e, ctx);
+            if (el->isFermata()) {
+                if (!chord->segment()) {
+                    chord->setParent(m->getSegment(SegmentType::ChordRest, ctx.tick()));
+                }
+                chord->segment()->add(el);
+            } else {
+                chord->add(el);
+            }
+        } else if (tag == "Tremolo") {
+            Tremolo* tremolo = Factory::createTremolo(chord);
+            tremolo->setDurationType(chord->durationType());
+            chord->setTremolo(tremolo);
+            tremolo->setTrack(chord->track());
+            readTremolo(tremolo, e);
+            tremolo->setParent(chord);
+        } else if (Read206::readChordProperties206(e, ctx, chord)) {
+        } else {
+            e.unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readRest
+//---------------------------------------------------------
+
+static void readRest(Measure* m, Rest* rest, XmlReader& e, ReadContext& ctx)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "Attribute" || tag == "Articulation") {
+            EngravingItem* el = Read206::readArticulation(rest, e, ctx);
+            if (el->isFermata()) {
+                if (!rest->segment()) {
+                    rest->setParent(m->getSegment(SegmentType::ChordRest, ctx.tick()));
+                }
+                rest->segment()->add(el);
+            } else {
+                rest->add(el);
+            }
+        } else if (Read206::readChordRestProperties206(e, ctx, rest)) {
+        } else {
+            e.unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readTempoText
+//---------------------------------------------------------
+
+void readTempoText(TempoText* t, XmlReader& e)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "tempo") {
+            t->setTempo(e.readDouble());
+        } else if (!readTextProperties(e, t, t)) {
+            e.unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readStaffText
+//---------------------------------------------------------
+
+void readStaffText(StaffText* t, XmlReader& e)
+{
+    while (e.readNextStartElement()) {
+        if (!readTextProperties(e, t, t)) {
+            e.unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readLineSegment114
+//---------------------------------------------------------
+
+static void readLineSegment114(XmlReader& e, LineSegment* ls)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "off1") {
+            ls->setOffset(e.readPoint() * ls->spatium());
+        } else {
+            ls->readProperties(e);
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readTextLineProperties114
+//---------------------------------------------------------
+
+static bool readTextLineProperties114(XmlReader& e, const ReadContext& ctx, TextLineBase* tl)
+{
+    const AsciiStringView tag(e.name());
+
+    if (tag == "beginText") {
+        Text* text = Factory::createText(tl, TextStyleType::DEFAULT, false);
+        readText114(e, text, tl);
+        tl->setBeginText(text->xmlText());
+        tl->setPropertyFlags(Pid::BEGIN_TEXT, PropertyFlags::UNSTYLED);
+        delete text;
+    } else if (tag == "continueText") {
+        Text* text = Factory::createText(tl, TextStyleType::DEFAULT, false);
+        readText114(e, text, tl);
+        tl->setContinueText(text->xmlText());
+        tl->setPropertyFlags(Pid::CONTINUE_TEXT, PropertyFlags::UNSTYLED);
+        delete text;
+    } else if (tag == "endText") {
+        Text* text = Factory::createText(tl, TextStyleType::DEFAULT, false);
+        readText114(e, text, tl);
+        tl->setEndText(text->xmlText());
+        tl->setPropertyFlags(Pid::END_TEXT, PropertyFlags::UNSTYLED);
+        delete text;
+    } else if (tag == "beginHook") {
+        tl->setBeginHookType(e.readBool() ? HookType::HOOK_90 : HookType::NONE);
+    } else if (tag == "endHook") {
+        tl->setEndHookType(e.readBool() ? HookType::HOOK_90 : HookType::NONE);
+    } else if (tag == "beginHookType") {
+        tl->setBeginHookType(e.readInt() == 0 ? HookType::HOOK_90 : HookType::HOOK_45);
+    } else if (tag == "endHookType") {
+        tl->setEndHookType(e.readInt() == 0 ? HookType::HOOK_90 : HookType::HOOK_45);
+    } else if (tag == "Segment") {
+        LineSegment* ls = tl->createLineSegment(ctx.dummy()->system());
+        ls->setTrack(tl->track());     // needed in read to get the right staff mag
+        readLineSegment114(e, ls);
+        // in v1.x "visible" is a property of the segment only;
+        // we must ensure that it propagates also to the parent element.
+        // That's why the visibility is set after adding the segment
+        // to the corresponding spanner
+        ls->setVisible(ls->visible());
+        ls->setOffset(PointF());            // ignore offsets
+        ls->setAutoplace(true);
+        tl->add(ls);
+    } else if (tl->readProperties(e)) {
+        return true;
+    }
+    return true;
+}
+
+//---------------------------------------------------------
+//   readVolta114
+//---------------------------------------------------------
+
+static void readVolta114(XmlReader& e, const ReadContext& ctx, Volta* volta)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "endings") {
+            String s = e.readText();
+            StringList sl = s.split(u',', mu::SkipEmptyParts);
+            volta->endings().clear();
+            for (const String& l : sl) {
+                int i = l.simplified().toInt();
+                volta->endings().push_back(i);
+            }
+        } else if (tag == "subtype") {
+            e.readInt();
+        } else if (tag == "lineWidth") {
+            volta->setLineWidth(Millimetre(e.readDouble() * volta->spatium()));
+            volta->setPropertyFlags(Pid::LINE_WIDTH, PropertyFlags::UNSTYLED);
+        } else if (!readTextLineProperties114(e, ctx, volta)) {
+            e.unknown();
+        }
+    }
+    volta->setOffset(PointF());          // ignore offsets
+    volta->setAutoplace(true);
+}
+
+//---------------------------------------------------------
+//   readOttava114
+//---------------------------------------------------------
+
+static void readOttava114(XmlReader& e, const ReadContext& ctx, Ottava* ottava)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "subtype") {
+            String s = e.readText();
+            bool ok;
+            int idx = s.toInt(&ok);
+            if (!ok) {
+                idx = int(OttavaType::OTTAVA_8VA);
+                for (unsigned i = 0; i < sizeof(ottavaDefault) / sizeof(*ottavaDefault); ++i) {
+                    if (s == ottavaDefault[i].name) {
+                        idx = i;
+                        break;
+                    }
+                }
+            }
+            //subtype are now in a different order...
+            if (idx == 1) {
+                idx = 2;
+            } else if (idx == 2) {
+                idx = 1;
+            }
+            ottava->setOttavaType(OttavaType(idx));
+        } else if (tag == "numbersOnly") {
+            ottava->setNumbersOnly(e.readInt());
+        } else if (tag == "lineWidth") {
+            ottava->readProperty(e, Pid::LINE_WIDTH);
+        } else if (tag == "lineStyle") {
+            ottava->readProperty(e, Pid::LINE_STYLE);
+        } else if (tag == "beginSymbol") {                        // obsolete
+        } else if (tag == "continueSymbol") {                     // obsolete
+        } else if (!readTextLineProperties114(e, ctx, ottava)) {
+            e.unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   resolveSymCompatibility
+//---------------------------------------------------------
+
+static String resolveSymCompatibility(SymId i, String programVersion)
+{
+    if (!programVersion.isEmpty() && programVersion < u"1.1") {
+        i = SymId(int(i) + 5);
+    }
+    switch (int(i)) {
+    case 197:
+        return u"keyboardPedalPed";
+    case 191:
+        return u"keyboardPedalUp";
+    case 193:
+        return u"noSym";           //SymId(pedaldotSym);
+    case 192:
+        return u"noSym";           //SymId(pedaldashSym);
+    case 139:
+        return u"ornamentTrill";
+    default:
+        return u"noSym";
+    }
+}
+
+//---------------------------------------------------------
+//   readTextLine114
+//---------------------------------------------------------
+
+static void readTextLine114(XmlReader& e, const ReadContext& ctx, TextLine* textLine)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+
+        if (tag == "lineVisible") {
+            textLine->setLineVisible(e.readBool());
+        } else if (tag == "beginHookHeight") {
+            textLine->setBeginHookHeight(Spatium(e.readDouble()));
+        } else if (tag == "endHookHeight" || tag == "hookHeight") {   // hookHeight is obsolete
+            textLine->setEndHookHeight(Spatium(e.readDouble()));
+            textLine->setPropertyFlags(Pid::END_HOOK_HEIGHT, PropertyFlags::UNSTYLED);
+        } else if (tag == "hookUp") { // obsolete
+            textLine->setEndHookHeight(Spatium(double(-1.0)));
+        } else if (tag == "beginSymbol" || tag == "symbol") {   // "symbol" is obsolete
+            String text(e.readText());
+            textLine->setBeginText(String(u"<sym>%1</sym>").arg(
+                                       text.at(0).isDigit()
+                                       ? resolveSymCompatibility(SymId(text.toInt()), ctx.mscoreVersion())
+                                       : text));
+        } else if (tag == "continueSymbol") {
+            String text(e.readText());
+            textLine->setContinueText(String(u"<sym>%1</sym>").arg(
+                                          text.at(0).isDigit()
+                                          ? resolveSymCompatibility(SymId(text.toInt()), ctx.mscoreVersion())
+                                          : text));
+        } else if (tag == "endSymbol") {
+            String text(e.readText());
+            textLine->setEndText(String(u"<sym>%1</sym>").arg(
+                                     text.at(0).isDigit()
+                                     ? resolveSymCompatibility(SymId(text.toInt()), ctx.mscoreVersion())
+                                     : text));
+        } else if (tag == "beginSymbolOffset") { // obsolete
+            e.readPoint();
+        } else if (tag == "continueSymbolOffset") { // obsolete
+            e.readPoint();
+        } else if (tag == "endSymbolOffset") { // obsolete
+            e.readPoint();
+        } else if (tag == "beginTextPlace") {
+            textLine->setBeginTextPlace(TConv::fromXml(e.readAsciiText(), TextPlace::AUTO));
+        } else if (tag == "continueTextPlace") {
+            textLine->setContinueTextPlace(TConv::fromXml(e.readAsciiText(), TextPlace::AUTO));
+        } else if (tag == "endTextPlace") {
+            textLine->setEndTextPlace(TConv::fromXml(e.readAsciiText(), TextPlace::AUTO));
+        } else if (!readTextLineProperties114(e, ctx, textLine)) {
+            e.unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readPedal114
+//---------------------------------------------------------
+
+static void readPedal114(XmlReader& e, const ReadContext& ctx, Pedal* pedal)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "subtype") {
+            e.skipCurrentElement();
+        } else if (tag == "endHookHeight" || tag == "hookHeight") {   // hookHeight is obsolete
+            pedal->setEndHookHeight(Spatium(e.readDouble()));
+            pedal->setPropertyFlags(Pid::END_HOOK_HEIGHT, PropertyFlags::UNSTYLED);
+        } else if (tag == "lineWidth") {
+            pedal->setLineWidth(Millimetre(e.readDouble()));
+            pedal->setPropertyFlags(Pid::LINE_WIDTH, PropertyFlags::UNSTYLED);
+        } else if (tag == "lineStyle") {
+            pedal->readProperty(e, Pid::LINE_STYLE);
+            pedal->setPropertyFlags(Pid::LINE_STYLE, PropertyFlags::UNSTYLED);
+        } else if (tag == "beginSymbol" || tag == "symbol") {   // "symbol" is obsolete
+            String text(e.readText());
+            pedal->setBeginText(String(u"<sym>%1</sym>").arg(
+                                    text.at(0).isDigit()
+                                    ? resolveSymCompatibility(SymId(text.toInt()), ctx.mscoreVersion())
+                                    : text));
+        } else if (tag == "continueSymbol") {
+            String text(e.readText());
+            pedal->setContinueText(String(u"<sym>%1</sym>").arg(
+                                       text.at(0).isDigit()
+                                       ? resolveSymCompatibility(SymId(text.toInt()), ctx.mscoreVersion())
+                                       : text));
+        } else if (tag == "endSymbol") {
+            String text(e.readText());
+            pedal->setEndText(String(u"<sym>%1</sym>").arg(
+                                  text.at(0).isDigit()
+                                  ? resolveSymCompatibility(SymId(text.toInt()), ctx.mscoreVersion())
+                                  : text));
+        } else if (tag == "beginSymbolOffset") { // obsolete
+            e.readPoint();
+        } else if (tag == "continueSymbolOffset") { // obsolete
+            e.readPoint();
+        } else if (tag == "endSymbolOffset") { // obsolete
+            e.readPoint();
+        } else if (!readTextLineProperties114(e, ctx, pedal)) {
+            e.unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readHarmony114
+//---------------------------------------------------------
+
+static void readHarmony114(XmlReader& e, const ReadContext& ctx, Harmony* h)
+{
+    // convert table to tpc values
+    static const int table[] = {
+        14, 9, 16, 11, 18, 13, 8, 15, 10, 17, 12, 19
+    };
+
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "base") {
+            if (ctx.mscVersion() >= 106) {
+                h->setBaseTpc(e.readInt());
+            } else {
+                h->setBaseTpc(table[e.readInt() - 1]);
+            }
+        } else if (tag == "baseCase") {
+            h->setBaseCase(static_cast<NoteCaseType>(e.readInt()));
+        } else if (tag == "extension") {
+            h->setId(e.readInt());
+        } else if (tag == "name") {
+            h->setTextName(e.readText());
+        } else if (tag == "root") {
+            if (ctx.mscVersion() >= 106) {
+                h->setRootTpc(e.readInt());
+            } else {
+                h->setRootTpc(table[e.readInt() - 1]);
+            }
+        } else if (tag == "rootCase") {
+            h->setRootCase(static_cast<NoteCaseType>(e.readInt()));
+        } else if (tag == "degree") {
+            int degreeValue = 0;
+            int degreeAlter = 0;
+            String degreeType;
+            while (e.readNextStartElement()) {
+                const AsciiStringView t(e.name());
+                if (t == "degree-value") {
+                    degreeValue = e.readInt();
+                } else if (t == "degree-alter") {
+                    degreeAlter = e.readInt();
+                } else if (t == "degree-type") {
+                    degreeType = e.readText();
+                } else {
+                    e.unknown();
+                }
+            }
+            if (degreeValue <= 0 || degreeValue > 13
+                || degreeAlter < -2 || degreeAlter > 2
+                || (degreeType != "add" && degreeType != "alter" && degreeType != "subtract")) {
+                LOGD("incorrect degree: degreeValue=%d degreeAlter=%d degreeType=%s",
+                     degreeValue, degreeAlter, muPrintable(degreeType));
+            } else {
+                if (degreeType == "add") {
+                    h->addDegree(HDegree(degreeValue, degreeAlter, HDegreeType::ADD));
+                } else if (degreeType == "alter") {
+                    h->addDegree(HDegree(degreeValue, degreeAlter, HDegreeType::ALTER));
+                } else if (degreeType == "subtract") {
+                    h->addDegree(HDegree(degreeValue, degreeAlter, HDegreeType::SUBTRACT));
+                }
+            }
+        } else if (tag == "leftParen") {
+            h->setLeftParen(true);
+            e.readNext();
+        } else if (tag == "rightParen") {
+            h->setRightParen(true);
+            e.readNext();
+        } else if (!readTextProperties(e, h, h)) {
+            e.unknown();
+        }
+    }
+
+    // TODO: now that we can render arbitrary chords,
+    // we could try to construct a full representation from a degree list.
+    // These will typically only exist for chords imported from MusicXML prior to MuseScore 2.0
+    // or constructed in the Chord Symbol Properties dialog.
+
+    if (h->rootTpc() != Tpc::TPC_INVALID) {
+        if (h->id() > 0) {
+            // positive id will happen only for scores that were created with explicit chord lists
+            // lookup id in chord list and generate new description if necessary
+            h->getDescription();
+        } else {
+            // default case: look up by name
+            // description will be found for any chord already read in this score
+            // and we will generate a new one if necessary
+            h->getDescription(h->hTextName());
+        }
+    } else if (h->hTextName() == "") {
+        // unrecognized chords prior to 2.0 were stored as text with markup
+        // we need to strip away the markup
+        // this removes any user-applied formatting,
+        // but we no longer support user-applied formatting for chord symbols anyhow
+        // with any luck, the resulting text will be parseable now, so give it a shot
+//            h->createLayout();
+        String s = h->plainText();
+        if (!s.isEmpty()) {
+            h->setHarmony(s);
+            return;
+        }
+        // empty text could also indicate a root-less slash chord ("/E")
+        // we'll fall through and render it normally
+    }
+
+    // render chord from description (or _textName)
+    h->render();
+}
+
+//---------------------------------------------------------
+//   readMeasure
+//---------------------------------------------------------
+
+static void readMeasure(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx)
+{
+    Segment* segment = 0;
+    double _spatium = m->spatium();
+
+    std::vector<Chord*> graceNotes;
+
+    //sort tuplet elements. needed for nested tuplets #22537
+    for (auto& p : ctx.tuplets()) {
+        Tuplet* t = p.second;
+        t->sortElements();
+    }
+    ctx.tuplets().clear();
+    ctx.setTrack(staffIdx * VOICES);
+
+    m->createStaves(staffIdx);
+
+    // tick is obsolete
+    if (e.hasAttribute("tick")) {
+        ctx.setTick(Fraction::fromTicks(ctx.fileDivision(e.intAttribute("tick"))));
+    }
+
+    if (e.hasAttribute("len")) {
+        StringList sl = e.attribute("len").split('/');
+        if (sl.size() == 2) {
+            m->setTicks(Fraction(sl[0].toInt(), sl[1].toInt()));
+        } else {
+            LOGD("illegal measure size <%s>", muPrintable(e.attribute("len")));
+        }
+        ctx.sigmap()->add(m->tick().ticks(), SigEvent(m->ticks(), m->timesig()));
+        ctx.sigmap()->add(m->endTick().ticks(), SigEvent(m->timesig()));
+    }
+
+    Staff* staff = ctx.staff(staffIdx);
+    Fraction timeStretch(staff->timeStretch(m->tick()));
+
+    // keep track of tick of previous element
+    // this allows markings that need to apply to previous element to do so
+    // even though we may have already advanced to next tick position
+    Fraction lastTick = ctx.tick();
+
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+
+        if (tag == "move") {
+            ctx.setTick(e.readFraction() + m->tick());
+        } else if (tag == "tick") {
+            ctx.setTick(Fraction::fromTicks(ctx.fileDivision(e.readInt())));
+            lastTick = ctx.tick();
+        } else if (tag == "BarLine") {
+            BarLine* barLine = Factory::createBarLine(ctx.dummy()->segment());
+            barLine->setTrack(ctx.track());
+            barLine->resetProperty(Pid::BARLINE_SPAN);
+            barLine->resetProperty(Pid::BARLINE_SPAN_FROM);
+            barLine->resetProperty(Pid::BARLINE_SPAN_TO);
+
+            while (e.readNextStartElement()) {
+                const AsciiStringView tg(e.name());
+                if (tg == "subtype") {
+                    BarLineType t = BarLineType::NORMAL;
+                    switch (e.readInt()) {
+                    default:
+                    case 0:
+                        t = BarLineType::NORMAL;
+                        break;
+                    case 1:
+                        t = BarLineType::DOUBLE;
+                        break;
+                    case 2:
+                        t = BarLineType::START_REPEAT;
+                        break;
+                    case 3:
+                        t = BarLineType::END_REPEAT;
+                        break;
+                    case 4:
+                        t = BarLineType::BROKEN;
+                        break;
+                    case 5:
+                        t = BarLineType::END;
+                        break;
+                    case 6:
+                        t = BarLineType::END_START_REPEAT;
+                        break;
+                    }
+                    barLine->setBarLineType(t);
+                } else if (!barLine->EngravingItem::readProperties(e)) {
+                    e.unknown();
+                }
+            }
+
+            //
+            //  StartRepeatBarLine: always at the beginning tick of a measure, always BarLineType::START_REPEAT
+            //  BarLine:            in the middle of a measure, has no semantic
+            //  EndBarLine:         at the end tick of a measure
+            //  BeginBarLine:       first segment of a measure
+
+            SegmentType st;
+            if ((ctx.tick() != m->tick()) && (ctx.tick() != m->endTick())) {
+                st = SegmentType::BarLine;
+            } else if (barLine->barLineType() == BarLineType::START_REPEAT && ctx.tick() == m->tick()) {
+                st = SegmentType::StartRepeatBarLine;
+            } else if (ctx.tick() == m->tick() && segment == 0) {
+                st = SegmentType::BeginBarLine;
+            } else {
+                st = SegmentType::EndBarLine;
+            }
+            segment = m->getSegment(st, ctx.tick());
+            segment->add(barLine);
+        } else if (tag == "Chord") {
+            Chord* chord = Factory::createChord(m->getSegment(SegmentType::ChordRest, ctx.tick()));
+            chord->setTrack(ctx.track());
+            readChord(m, chord, e, ctx);
+            if (!chord->segment()) {
+                chord->setParent(m->getSegment(SegmentType::ChordRest, ctx.tick()));
+            }
+            segment = chord->segment();
+            if (chord->noteType() != NoteType::NORMAL) {
+                graceNotes.push_back(chord);
+            } else {
+                segment->add(chord);
+                assert(segment->segmentType() == SegmentType::ChordRest);
+
+                for (size_t i = 0; i < graceNotes.size(); ++i) {
+                    Chord* gc = graceNotes[i];
+                    gc->setGraceIndex(static_cast<int>(i));
+                    chord->add(gc);
+                }
+                graceNotes.clear();
+                Fraction crticks = chord->actualTicks();
+
+                if (chord->tremolo()) {
+                    Tremolo* tremolo = chord->tremolo();
+                    if (tremolo->twoNotes()) {
+                        track_idx_t track = chord->track();
+                        Segment* ss = 0;
+                        for (Segment* ps = m->first(SegmentType::ChordRest); ps; ps = ps->next(SegmentType::ChordRest)) {
+                            if (ps->tick() >= ctx.tick()) {
+                                break;
+                            }
+                            if (ps->element(track)) {
+                                ss = ps;
+                            }
+                        }
+                        Chord* pch = 0;                   // previous chord
+                        if (ss) {
+                            ChordRest* cr = toChordRest(ss->element(track));
+                            if (cr && cr->type() == ElementType::CHORD) {
+                                pch = toChord(cr);
+                            }
+                        }
+                        if (pch) {
+                            tremolo->setParent(pch);
+                            pch->setTremolo(tremolo);
+                            chord->setTremolo(0);
+                            // force duration to half
+                            Fraction pts(timeStretch * pch->globalTicks());
+                            pch->setTicks(pts * Fraction(1, 2));
+                            chord->setTicks(crticks * Fraction(1, 2));
+                        } else {
+                            LOGD("tremolo: first note not found");
+                        }
+                        crticks = crticks * Fraction(1, 2);
+                    } else {
+                        tremolo->setParent(chord);
+                    }
+                }
+                lastTick = ctx.tick();
+                ctx.incTick(crticks);
+            }
+        } else if (tag == "Rest") {
+            if (m->isMMRest()) {
+                segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+                MMRest* mmr = new MMRest(segment);
+                mmr->setTrack(ctx.track());
+                mmr->read(e);
+                segment->add(mmr);
+                lastTick = ctx.tick();
+                ctx.incTick(mmr->actualTicks());
+            } else {
+                Segment* segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+                Rest* rest = Factory::createRest(segment);
+                rest->setDurationType(DurationType::V_MEASURE);
+                rest->setTicks(m->timesig() / timeStretch);
+                rest->setTrack(ctx.track());
+                readRest(m, rest, e, ctx);
+                if (!rest->segment()) {
+                    rest->setParent(segment);
+                }
+                segment = rest->segment();
+                segment->add(rest);
+
+                if (!rest->ticks().isValid()) {    // hack
+                    rest->setTicks(m->timesig() / timeStretch);
+                }
+
+                lastTick = ctx.tick();
+                ctx.incTick(rest->actualTicks());
+            }
+        } else if (tag == "Breath") {
+            segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+            Breath* breath = Factory::createBreath(segment);
+            breath->setTrack(ctx.track());
+            Fraction tick = ctx.tick();
+            breath->setPlacement(breath->track() & 1 ? PlacementV::BELOW : PlacementV::ABOVE);
+            breath->read(e);
+            // older scores placed the breath segment right after the chord to which it applies
+            // rather than before the next chordrest segment with an element for the staff
+            // result would be layout too far left if there are other segments due to notes in other staves
+            // we need to find tick of chord to which this applies, and add its duration
+            Fraction prevTick;
+            if (ctx.tick() < tick) {
+                prevTick = ctx.tick();            // use our own tick if we explicitly reset to earlier position
+            } else {
+                prevTick = lastTick;            // otherwise use tick of previous tick/chord/rest tag
+            }
+            // find segment
+            Segment* prev = m->findSegment(SegmentType::ChordRest, prevTick);
+            if (prev) {
+                // find chordrest
+                ChordRest* lastCR = toChordRest(prev->element(ctx.track()));
+                if (lastCR) {
+                    tick = prevTick + lastCR->actualTicks();
+                }
+            }
+            segment = m->getSegment(SegmentType::Breath, tick);
+            segment->add(breath);
+        } else if (tag == "endSpanner") {
+            int id = e.attribute("id").toInt();
+            Spanner* spanner = ctx.findSpanner(id);
+            if (spanner) {
+                spanner->setTicks(ctx.tick() - spanner->tick());
+                // if (spanner->track2() == -1)
+                // the absence of a track tag [?] means the
+                // track is the same as the beginning of the slur
+                if (spanner->track2() == mu::nidx) {
+                    spanner->setTrack2(spanner->track() ? spanner->track() : ctx.track());
+                }
+            } else {
+                // remember "endSpanner" values
+                SpannerValues sv;
+                sv.spannerId = id;
+                sv.track2    = ctx.track();
+                sv.tick2     = ctx.tick();
+                ctx.addSpannerValues(sv);
+            }
+            e.readNext();
+        } else if (tag == "Slur") {
+            Slur* sl = Factory::createSlur(m);
+            sl->setTick(ctx.tick());
+            Read206::readSlur206(e, ctx, sl);
+            //
+            // check if we already saw "endSpanner"
+            //
+            int id = ctx.spannerId(sl);
+            const SpannerValues* sv = ctx.spannerValues(id);
+            if (sv) {
+                sl->setTick2(sv->tick2);
+                sl->setTrack2(sv->track2);
+            }
+            ctx.addSpanner(sl);
+        } else if (tag == "HairPin"
+                   || tag == "Pedal"
+                   || tag == "Ottava"
+                   || tag == "Trill"
+                   || tag == "TextLine"
+                   || tag == "Volta") {
+            Spanner* sp = toSpanner(Factory::createItemByName(tag, m));
+            sp->setTrack(ctx.track());
+            sp->setTick(ctx.tick());
+            // ?? sp->setAnchor(Spanner::Anchor::SEGMENT);
+            if (tag == "Volta") {
+                readVolta114(e, ctx, toVolta(sp));
+            } else {
+                Read206::readTextLine206(e, ctx, toTextLineBase(sp));
+            }
+            ctx.addSpanner(sp);
+            //
+            // check if we already saw "endSpanner"
+            //
+            int id = ctx.spannerId(sp);
+            const SpannerValues* sv = ctx.spannerValues(id);
+            if (sv) {
+                sp->setTicks(sv->tick2 - sp->tick());
+                sp->setTrack2(sv->track2);
+            }
+        } else if (tag == "RepeatMeasure") {
+            segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+            MeasureRepeat* rm = Factory::createMeasureRepeat(segment);
+            rm->setTrack(ctx.track());
+            readRest(m, rm, e, ctx);
+            rm->setNumMeasures(1);
+            m->setMeasureRepeatCount(1, staffIdx);
+            segment->add(rm);
+            if (rm->actualTicks().isZero()) {     // might happen with 1.3 scores
+                rm->setTicks(m->ticks());
+            }
+            lastTick = ctx.tick();
+            ctx.incTick(m->ticks());
+        } else if (tag == "Clef") {
+            // there may be more than one clef segment for same tick position
+            // the first clef may be missing and is added later in layout
+
+            bool header;
+            if (ctx.tick() != m->tick()) {
+                header = false;
+            } else if (!segment) {
+                header = true;
+            } else {
+                header = true;
+                for (Segment* s = m->segments().first(); s && s->rtick().isZero(); s = s->next()) {
+                    if (s->isKeySigType() || s->isTimeSigType()) {
+                        // hack: there may be other segment types which should
+                        // generate a clef at current position
+                        header = false;
+                        break;
+                    }
+                }
+            }
+            segment = m->getSegment(header ? SegmentType::HeaderClef : SegmentType::Clef, ctx.tick());
+
+            Clef* clef = Factory::createClef(segment);
+            clef->setTrack(ctx.track());
+            readClef(clef, e);
+            if (ctx.mscVersion() < 113) {
+                clef->setOffset(PointF());
+            }
+            clef->setGenerated(false);
+            // MS3 doesn't support wrong clef for staff type: Default to G
+            bool isDrumStaff = staff->isDrumStaff(ctx.tick());
+            if (clef->clefType() == ClefType::TAB
+                || (clef->clefType() == ClefType::PERC && !isDrumStaff)
+                || (clef->clefType() != ClefType::PERC && isDrumStaff)) {
+                clef->setClefType(ClefType::G);
+                staff->clefList().erase(ctx.tick().ticks());
+                staff->clefList().insert(std::pair<int, ClefType>(ctx.tick().ticks(), ClefType::G));
+            }
+
+            segment->add(clef);
+        } else if (tag == "TimeSig") {
+            // if time sig not at beginning of measure => courtesy time sig
+            Fraction currTick = ctx.tick();
+            bool courtesySig = (currTick > m->tick());
+            if (courtesySig) {
+                // if courtesy sig., just add it without map processing
+                segment = m->getSegment(SegmentType::TimeSigAnnounce, currTick);
+            } else {
+                // if 'real' time sig., do full process
+                segment = m->getSegment(SegmentType::TimeSig, currTick);
+            }
+
+            TimeSig* ts = Factory::createTimeSig(segment);
+            ts->setTrack(ctx.track());
+            ts->read(e);
+
+            segment->add(ts);
+            if (!courtesySig) {
+                timeStretch = ts->stretch().reduced();
+                m->setTimesig(ts->sig() / timeStretch);
+            }
+        } else if (tag == "KeySig") {
+            KeySig* ks = Factory::createKeySig(ctx.dummy()->segment());
+            ks->setTrack(ctx.track());
+            ks->read(e);
+            Fraction curTick = ctx.tick();
+            if (!ks->isCustom() && !ks->isAtonal() && ks->key() == Key::C && curTick.isZero()) {
+                // ignore empty key signature
+                LOGD("remove keysig c at tick 0");
+                if (ks->links()) {
+                    if (ks->links()->size() == 1) {
+                        mu::remove(e.context()->linkIds(), ks->links()->lid());
+                    }
+                }
+            } else {
+                // if key sig not at beginning of measure => courtesy key sig
+                bool courtesySig = (curTick == m->endTick());
+                segment = m->getSegment(courtesySig ? SegmentType::KeySigAnnounce : SegmentType::KeySig, curTick);
+                segment->add(ks);
+                if (!courtesySig) {
+                    staff->setKey(curTick, ks->keySigEvent());
+                }
+            }
+        } else if (tag == "Lyrics") {
+            Lyrics* l = Factory::createLyrics(ctx.dummy()->chord());
+            l->setTrack(ctx.track());
+
+            int iEndTick = 0;                 // used for backward compatibility
+            Text* _verseNumber = 0;
+
+            while (e.readNextStartElement()) {
+                const AsciiStringView t(e.name());
+                if (t == "no") {
+                    l->setNo(e.readInt());
+                } else if (t == "syllabic") {
+                    String val(e.readText());
+                    if (val == "single") {
+                        l->setSyllabic(Lyrics::Syllabic::SINGLE);
+                    } else if (val == "begin") {
+                        l->setSyllabic(Lyrics::Syllabic::BEGIN);
+                    } else if (val == "end") {
+                        l->setSyllabic(Lyrics::Syllabic::END);
+                    } else if (val == "middle") {
+                        l->setSyllabic(Lyrics::Syllabic::MIDDLE);
+                    } else {
+                        LOGD("bad syllabic property");
+                    }
+                } else if (t == "endTick") {                // obsolete
+                    // store <endTick> tag value until a <ticks> tag has been read
+                    // which positions this lyrics element in the score
+                    iEndTick = e.readInt();
+                } else if (t == "ticks") {
+                    l->setTicks(Fraction::fromTicks(e.readInt()));
+                } else if (t == "Number") {                                 // obsolete
+                    _verseNumber = Factory::createText(l);
+                    readText114(e, _verseNumber, l);
+                } else if (!readTextProperties(e, l, l)) {
+                    e.unknown();
+                }
+            }
+            // if any endTick, make it relative to current tick
+            if (iEndTick) {
+                l->setTicks(Fraction::fromTicks(iEndTick - ctx.tick().ticks()));
+                // LOGD("Lyrics::endTick: %d  ticks %d", iEndTick, _ticks);
+            }
+            if (_verseNumber) {
+                // TODO: add text to main text
+            }
+
+            delete _verseNumber;
+
+            segment       = m->getSegment(SegmentType::ChordRest, ctx.tick());
+            ChordRest* cr = toChordRest(segment->element(l->track()));
+            if (!cr) {
+                cr = toChordRest(segment->element(ctx.track()));         // in case lyric itself has bad track info
+            }
+            if (!cr) {
+                LOGD("Internal error: no chord/rest for lyrics");
+            } else {
+                cr->add(l);
+            }
+        } else if (tag == "Text") {
+            segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+            StaffText* t = Factory::createStaffText(segment);
+            t->setTrack(ctx.track());
+            readStaffText(t, e);
+            if (t->empty()) {
+                LOGD("reading empty text: deleted");
+                delete t;
+            } else {
+                segment->add(t);
+            }
+        } else if (tag == "Dynamic") {
+            segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+            Dynamic* dyn = Factory::createDynamic(segment);
+            dyn->setTrack(ctx.track());
+            dyn->read(e); // for 114 scores, dynamics are frontloaded in the measure with <tick> attributes.
+                          // so we need to reset its parent to the correct one after that element is read.
+            segment = m->getSegment(SegmentType::ChordRest, e.context()->tick());
+            dyn->setParent(segment);
+            if (dyn->dynamicType() == DynamicType::OTHER && dyn->xmlText().isEmpty()) {
+                // if we add this dynamic, it will be an unselectable invisible object that
+                // messes with collision detection.
+                delete dyn;
+            } else {
+                dyn->setDynamicType(dyn->xmlText());
+                segment->add(dyn);
+            }
+        } else if (tag == "Tempo") {
+            segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+            TempoText* t = Factory::createTempoText(segment);
+            t->setTrack(ctx.track());
+            readTempoText(t, e);
+            segment->add(t);
+        } else if (tag == "StaffText") {
+            segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+            StaffText* t = Factory::createStaffText(segment);
+            t->setTrack(ctx.track());
+            readStaffText(t, e);
+            segment->add(t);
+        } else if (tag == "Harmony") {
+            segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+            Harmony* h = Factory::createHarmony(segment);
+            h->setTrack(ctx.track());
+            readHarmony114(e, ctx, h);
+            segment->add(h);
+        } else if (tag == "Harmony"
+                   || tag == "FretDiagram"
+                   || tag == "TremoloBar"
+                   || tag == "Symbol"
+                   || tag == "StaffText"
+                   || tag == "RehearsalMark"
+                   || tag == "InstrumentChange"
+                   || tag == "StaffState"
+                   ) {
+            EngravingItem* el = Factory::createItemByName(tag, ctx.dummy());
+            // hack - needed because tick tags are unreliable in 1.3 scores
+            // for symbols attached to anything but a measure
+            if (el->type() == ElementType::SYMBOL) {
+                el->setParent(m);            // this will get reset when adding to segment
+            }
+            el->setTrack(ctx.track());
+            el->read(e);
+            segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+            segment->add(el);
+        } else if (tag == "Jump") {
+            Jump* j = Factory::createJump(m);
+            j->setTrack(ctx.track());
+            while (e.readNextStartElement()) {
+                const AsciiStringView t(e.name());
+                if (t == "jumpTo") {
+                    j->setJumpTo(e.readText());
+                } else if (t == "playUntil") {
+                    j->setPlayUntil(e.readText());
+                } else if (t == "continueAt") {
+                    j->setContinueAt(e.readText());
+                } else if (t == "playRepeats") {
+                    j->setPlayRepeats(e.readBool());
+                } else if (t == "subtype") {
+                    e.readInt();
+                } else if (!j->TextBase::readProperties(e)) {
+                    e.unknown();
+                }
+            }
+            m->add(j);
+        } else if (tag == "Marker") {
+            Marker* a = Factory::createMarker(m);
+            a->setTrack(ctx.track());
+
+            MarkerType mt = MarkerType::SEGNO;
+            while (e.readNextStartElement()) {
+                const AsciiStringView t(e.name());
+                if (t == "subtype") {
+                    AsciiStringView s(e.readAsciiText());
+                    a->setLabel(String::fromAscii(s.ascii()));
+                    mt = TConv::fromXml(s, MarkerType::USER);
+                } else if (!a->TextBase::readProperties(e)) {
+                    e.unknown();
+                }
+            }
+            a->setMarkerType(mt);
+
+            if (a->markerType() == MarkerType::SEGNO || a->markerType() == MarkerType::CODA
+                || a->markerType() == MarkerType::VARCODA || a->markerType() == MarkerType::CODETTA) {
+                // force the marker type for correct display
+                a->setXmlText(u"");
+                a->setMarkerType(a->markerType());
+            }
+            m->add(a);
+        } else if (tag == "Image") {
+            if (MScore::noImages) {
+                e.skipCurrentElement();
+            } else {
+                segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+                EngravingItem* el = Factory::createItemByName(tag, segment);
+                el->setTrack(ctx.track());
+                el->read(e);
+                segment->add(el);
+            }
+        } else if (tag == "stretch") {
+            double val = e.readDouble();
+            if (val < 0.0) {
+                val = 0;
+            }
+            m->setUserStretch(val);
+        } else if (tag == "noOffset") {
+            m->setNoOffset(e.readInt());
+        } else if (tag == "measureNumberMode") {
+            m->setMeasureNumberMode(MeasureNumberMode(e.readInt()));
+        } else if (tag == "irregular") {
+            m->setIrregular(e.readBool());
+        } else if (tag == "breakMultiMeasureRest") {
+            m->setBreakMultiMeasureRest(e.readBool());
+        } else if (tag == "sysInitBarLineType") {
+            segment = m->getSegment(SegmentType::BeginBarLine, m->tick());
+            BarLine* barLine = Factory::createBarLine(segment);
+            barLine->setTrack(ctx.track());
+            barLine->setBarLineType(TConv::fromXml(e.readAsciiText(), BarLineType::NORMAL));
+            segment->add(barLine);
+        } else if (tag == "Tuplet") {
+            Tuplet* tuplet = Factory::createTuplet(m);
+            tuplet->setTrack(ctx.track());
+            tuplet->setTick(ctx.tick());
+            tuplet->setParent(m);
+            readTuplet(tuplet, e, ctx);
+            ctx.addTuplet(tuplet);
+        } else if (tag == "startRepeat") {
+            m->setRepeatStart(true);
+            e.readNext();
+        } else if (tag == "endRepeat") {
+            m->setRepeatCount(e.readInt());
+            m->setRepeatEnd(true);
+        } else if (tag == "vspacer" || tag == "vspacerDown") {
+            if (!m->vspacerDown(staffIdx)) {
+                Spacer* spacer = Factory::createSpacer(m);
+                spacer->setSpacerType(SpacerType::DOWN);
+                spacer->setTrack(staffIdx * VOICES);
+                m->add(spacer);
+            }
+            m->vspacerDown(staffIdx)->setGap(Millimetre(e.readDouble() * _spatium));
+        } else if (tag == "vspacer" || tag == "vspacerUp") {
+            if (!m->vspacerUp(staffIdx)) {
+                Spacer* spacer = Factory::createSpacer(m);
+                spacer->setSpacerType(SpacerType::UP);
+                spacer->setTrack(staffIdx * VOICES);
+                m->add(spacer);
+            }
+            m->vspacerUp(staffIdx)->setGap(Millimetre(e.readDouble() * _spatium));
+        } else if (tag == "visible") {
+            m->setStaffVisible(staffIdx, e.readInt());
+        } else if (tag == "slashStyle") {
+            m->setStaffStemless(staffIdx, e.readInt());
+        } else if (tag == "Beam") {
+            Beam* beam = Factory::createBeam(ctx.dummy()->system());
+            beam->setTrack(ctx.track());
+            beam->read(e);
+            beam->resetExplicitParent();
+            ctx.addBeam(beam);
+        } else if (tag == "Segment") {
+            if (segment) {
+                segment->read(e);
+            }
+            while (e.readNextStartElement()) {
+                const AsciiStringView t(e.name());
+                if (t == "off1") {
+                    double o = e.readDouble();
+                    LOGD("TODO: off1 %f", o);
+                } else {
+                    e.unknown();
+                }
+            }
+        } else if (tag == "MeasureNumber") {
+            MeasureNumber* noText = new MeasureNumber(m);
+            readText114(e, noText, m);
+            noText->setTrack(ctx.track());
+            noText->setParent(m);
+            m->setNoText(noText->staffIdx(), noText);
+        } else if (tag == "multiMeasureRest") {
+            m->setMMRestCount(e.readInt());
+            // set tick to previous measure
+            m->setTick(ctx.lastMeasure()->tick());
+            ctx.setTick(ctx.lastMeasure()->tick());
+        } else if (m->MeasureBase::readProperties(e)) {
+        } else {
+            e.unknown();
+        }
+    }
+    // For nested tuplets created with MuseScore 1.3 tuplet dialog (i.e. "Other..." dialog),
+    // the parent tuplet was not set. Try to infer if the tuplet was actually a nested tuplet
+    for (auto& p : ctx.tuplets()) {
+        Tuplet* tuplet = p.second;
+        Fraction tupletTick = tuplet->tick();
+        Fraction tupletDuration = tuplet->actualTicks() - Fraction::fromTicks(1);
+        std::vector<DurationElement*> tElements = tuplet->elements();
+        for (auto& p : ctx.tuplets()) {
+            Tuplet* tuplet2 = p.second;
+            if ((tuplet2->tuplet()) || (tuplet2->voice() != tuplet->voice())) {     // already a nested tuplet or in a different voice
+                continue;
+            }
+            // int possibleDuration = tuplet2->duration().ticks() * tuplet->ratio().denominator() / tuplet->ratio().numerator() - 1;
+            Fraction possibleDuration = tuplet2->ticks() * Fraction(tuplet->ratio().denominator(), (tuplet->ratio().numerator() - 1));
+
+            if ((tuplet2 != tuplet) && (tuplet2->tick() >= tupletTick) && (tuplet2->tick() < tupletTick + tupletDuration)
+                && (tuplet2->tick() + possibleDuration < tupletTick + tupletDuration)) {
+                bool found = false;
+                for (DurationElement* de : tElements) {
+                    if (de == tuplet2) {
+                        found = true;
+                    }
+                }
+                if (!found) {
+                    LOGD("Adding tuplet %p as nested tuplet to tuplet %p", tuplet2, tuplet);
+                    tuplet2->setTuplet(tuplet);
+                    tuplet->add(tuplet2);
+                }
+            }
+        }
+    }
+    ctx.checkTuplets();
+    m->connectTremolo();
+}
+
+//---------------------------------------------------------
+//   readBoxProperties
+//---------------------------------------------------------
+
+static void readBox(XmlReader& e, Box* b);
+
+static bool readBoxProperties(XmlReader& e, Box* b)
+{
+    const AsciiStringView tag(e.name());
+    if (tag == "height") {
+        b->setBoxHeight(Spatium(e.readDouble()));
+    } else if (tag == "width") {
+        b->setBoxWidth(Spatium(e.readDouble()));
+    } else if (tag == "topGap") {
+        b->readProperty(e, Pid::TOP_GAP);
+    } else if (tag == "bottomGap") {
+        b->readProperty(e, Pid::BOTTOM_GAP);
+    } else if (tag == "leftMargin") {
+        b->setLeftMargin(e.readDouble());
+    } else if (tag == "rightMargin") {
+        b->setRightMargin(e.readDouble());
+    } else if (tag == "topMargin") {
+        b->setTopMargin(e.readDouble());
+    } else if (tag == "bottomMargin") {
+        b->setBottomMargin(e.readDouble());
+    } else if (tag == "offset") {
+        b->setOffset(e.readPoint() * b->spatium());
+    } else if (tag == "pos") {      // ignore
+        e.readPoint();
+    } else if (tag == "Text") {
+        Text* t;
+        if (b->isTBox()) {
+            t = toTBox(b)->text();
+            readText114(e, t, t);
+        } else {
+            t = Factory::createText(b);
+            readText114(e, t, t);
+            if (t->empty()) {
+                LOGD("read empty text");
+            } else {
+                b->add(t);
+            }
+        }
+    } else if (tag == "Symbol") {
+        Symbol* s = new Symbol(b);
+        s->read(e);
+        b->add(s);
+    } else if (tag == "Image") {
+        if (MScore::noImages) {
+            e.skipCurrentElement();
+        } else {
+            Image* image = new Image(b);
+            image->setTrack(e.context()->track());
+            image->read(e);
+            b->add(image);
+        }
+    } else if (tag == "HBox") {
+        HBox* hb = Factory::createHBox(b->system());
+        readBox(e, hb);
+        b->add(hb);
+    } else if (tag == "VBox") {
+        VBox* vb = Factory::createVBox(b->system());
+        readBox(e, vb);
+        b->add(vb);
+    }
+//      else if (MeasureBase::readProperties(e))
+//            ;
+    else {
+        return false;
+    }
+    return true;
+}
+
+//---------------------------------------------------------
+//   readBox
+//---------------------------------------------------------
+
+static void readBox(XmlReader& e, Box* b)
+{
+    b->setLeftMargin(0.0);
+    b->setRightMargin(0.0);
+    b->setTopMargin(0.0);
+    b->setBottomMargin(0.0);
+    b->setBoxHeight(Spatium(0));       // override default set in constructor
+    b->setBoxWidth(Spatium(0));
+    b->setAutoSizeEnabled(false);
+
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "HBox") {
+            HBox* hb = Factory::createHBox(b->system());
+            readBox(e, hb);
+            b->add(hb);
+        } else if (tag == "VBox") {
+            VBox* vb = Factory::createVBox(b->system());
+            readBox(e, vb);
+            b->add(vb);
+        } else if (!readBoxProperties(e, b)) {
+            e.unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readStaffContent
+//---------------------------------------------------------
+
+static void readStaffContent(Score* score, XmlReader& e, ReadContext& ctx)
+{
+    int staff = e.intAttribute("id", 1) - 1;
+    ctx.setTick(Fraction(0, 1));
+    ctx.setTrack(staff * VOICES);
+
+    Measure* measure = score->firstMeasure();
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+
+        if (tag == "Measure") {
+            if (staff == 0) {
+                measure = Factory::createMeasure(score->dummy()->system());
+                measure->setTick(ctx.tick());
+                const SigEvent& ev = score->sigmap()->timesig(measure->tick());
+                measure->setTicks(ev.timesig());
+                measure->setTimesig(ev.nominal());
+
+                readMeasure(measure, staff, e, ctx);
+                measure->checkMeasure(staff);
+
+                if (!measure->isMMRest()) {
+                    score->measures()->add(measure);
+                    ctx.setLastMeasure(measure);
+                    ctx.setTick(measure->tick() + measure->ticks());
+                } else {
+                    // this is a multi measure rest
+                    // always preceded by the first measure it replaces
+                    Measure* m = ctx.lastMeasure();
+
+                    if (m) {
+                        m->setMMRest(measure);
+                        measure->setTick(m->tick());
+                    }
+                }
+            } else {
+                if (measure == 0) {
+                    LOGD("Score::readStaff(): missing measure!");
+                    measure = Factory::createMeasure(score->dummy()->system());
+                    measure->setTick(ctx.tick());
+                    score->measures()->add(measure);
+                }
+                ctx.setTick(measure->tick());
+
+                readMeasure(measure, staff, e, ctx);
+                measure->checkMeasure(staff);
+
+                if (measure->isMMRest()) {
+                    measure = ctx.lastMeasure()->nextMeasure();
+                } else {
+                    ctx.setLastMeasure(measure);
+                    if (measure->mmRest()) {
+                        measure = measure->mmRest();
+                    } else {
+                        measure = measure->nextMeasure();
+                    }
+                }
+            }
+        } else if (tag == "HBox" || tag == "VBox" || tag == "TBox" || tag == "FBox") {
+            Box* mb = toBox(Factory::createItemByName(tag, score->dummy()));
+            readBox(e, mb);
+            mb->setTick(ctx.tick());
+            score->measures()->add(mb);
+        } else if (tag == "tick") {
+            ctx.setTick(Fraction::fromTicks(score->fileDivision(e.readInt())));
+        } else {
+            e.unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readStaff
+//---------------------------------------------------------
+
+static void readStaff(Staff* staff, XmlReader& e, const ReadContext& ctx)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "lines") {
+            int lines = e.readInt();
+            staff->setLines(Fraction(0, 1), lines);
+            if (lines != 5) {
+                staff->setBarLineFrom(lines == 1 ? BARLINE_SPAN_1LINESTAFF_FROM : 0);
+                staff->setBarLineTo(lines == 1 ? BARLINE_SPAN_1LINESTAFF_TO : (lines - 1) * 2);
+            }
+        } else if (tag == "small") {
+            staff->staffType(Fraction(0, 1))->setSmall(e.readInt());
+        } else if (tag == "invisible") {
+            staff->setIsLinesInvisible(Fraction(0, 1), e.readInt());
+        } else if (tag == "slashStyle") {
+            e.skipCurrentElement();
+        } else if (tag == "cleflist") {
+            staff->clefList().clear();
+            while (e.readNextStartElement()) {
+                if (e.name() == "clef") {
+                    int tick    = e.intAttribute("tick", 0);
+                    ClefType ct = readClefType(e.intAttribute("idx", 0));
+                    staff->clefList().insert(std::pair<int, ClefType>(ctx.fileDivision(tick), ct));
+                    e.readNext();
+                } else {
+                    e.unknown();
+                }
+            }
+            if (staff->clefList().empty()) {
+                staff->clefList().insert(std::pair<int, ClefType>(0, ClefType::G));
+            }
+        } else if (tag == "keylist") {
+            staff->keyList()->read(e, ctx);
+        } else if (tag == "bracket") {
+            size_t col = staff->brackets().size();
+            staff->setBracketType(col, BracketType(e.intAttribute("type", -1)));
+            staff->setBracketSpan(col, e.intAttribute("span", 0));
+            e.readNext();
+        } else if (tag == "barLineSpan") {
+            staff->setBarLineSpan(e.readInt());
+        } else {
+            e.unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readDrumset
+//---------------------------------------------------------
+
+static void readDrumset(Drumset* ds, XmlReader& e)
+{
+    int pitch = e.intAttribute("pitch", -1);
+    if (pitch < 0 || pitch > 127) {
+        LOGD("load drumset: invalid pitch %d", pitch);
+        return;
+    }
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "head") {
+            ds->drum(pitch).notehead = Read206::convertHeadGroup(e.readInt());
+        } else if (ds->readProperties(e, pitch)) {
+        } else {
+            e.unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readInstrument
+//---------------------------------------------------------
+
+static void readInstrument(Instrument* i, Part* p, XmlReader& e)
+{
+    int program = -1;
+    int bank    = 0;
+    int chorus  = 30;
+    int reverb  = 30;
+    int volume  = 100;
+    int pan     = 60;
+    bool customDrumset = false;
+    i->clearChannels();         // remove default channel
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "chorus") {
+            chorus = e.readInt();
+        } else if (tag == "reverb") {
+            reverb = e.readInt();
+        } else if (tag == "midiProgram") {
+            program = e.readInt();
+        } else if (tag == "volume") {
+            volume = e.readInt();
+        } else if (tag == "pan") {
+            pan = e.readInt();
+        } else if (tag == "midiChannel") {
+            e.skipCurrentElement();
+        } else if (tag == "Drum") {
+            // if we see one of this tags, a custom drumset will
+            // be created
+            if (!i->drumset()) {
+                i->setDrumset(new Drumset(*smDrumset));
+            }
+            if (!customDrumset) {
+                i->drumset()->clear();
+                customDrumset = true;
+            }
+            readDrumset(i->drumset(), e);
+        } else if (i->readProperties(e, p, &customDrumset)) {
+        } else {
+            e.unknown();
+        }
+    }
+
+    i->updateInstrumentId();
+
+    if (program == -1) {
+        program = i->recognizeMidiProgram();
+    }
+
+    if (i->channel().empty()) {        // for backward compatibility
+        InstrChannel* a = new InstrChannel;
+        a->setName(String::fromUtf8(InstrChannel::DEFAULT_NAME));
+        a->setProgram(program);
+        a->setBank(bank);
+        a->setVolume(volume);
+        a->setPan(pan);
+        a->setReverb(reverb);
+        a->setChorus(chorus);
+        i->appendChannel(a);
+    } else if (i->channel(0)->program() < 0) {
+        i->channel(0)->setProgram(program);
+    }
+    if (i->useDrumset()) {
+        if (i->channel()[0]->bank() == 0) {
+            i->channel()[0]->setBank(128);
+        }
+    }
+
+    // Fix user bank controller read
+    for (InstrChannel* c : i->channel()) {
+        if (c->bank() == 0) {
+            c->setUserBankController(false);
+        }
+    }
+
+    // Read single-note dynamics from template
+    i->setSingleNoteDynamicsFromTemplate();
+}
+
+//---------------------------------------------------------
+//   readPart
+//---------------------------------------------------------
+
+static void readPart(Part* part, XmlReader& e, ReadContext& ctx)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "Staff") {
+            Staff* staff = Factory::createStaff(part);
+            staff->setStaffType(Fraction(0, 1), StaffType());       // will reset later if needed
+            ctx.appendStaff(staff);
+            readStaff(staff, e, ctx);
+        } else if (tag == "Instrument") {
+            Instrument* i = part->instrument();
+            readInstrument(i, part, e);
+            // add string data from MIDI program number, if possible
+            if (i->stringData()->strings() == 0
+                && i->channel().size() > 0
+                && i->drumset() == nullptr) {
+                int program = i->channel(0)->program();
+                if (program >= 24 && program <= 30) {             // guitars
+                    i->setStringData(StringData(19, 6, g_guitarStrings));
+                } else if ((program >= 32 && program <= 39) || program == 43) {           // bass / double-bass
+                    i->setStringData(StringData(24, 4, g_bassStrings));
+                } else if (program == 40) {                       // violin and other treble string instr.
+                    i->setStringData(StringData(24, 4, g_violinStrings));
+                } else if (program == 41) {                       // viola and other alto string instr.
+                    i->setStringData(StringData(24, 4, g_violaStrings));
+                } else if (program == 42) {                       // cello and other bass string instr.
+                    i->setStringData(StringData(24, 4, g_celloStrings));
+                }
+            }
+            Drumset* d = i->drumset();
+            Staff* st = part->staff(0);
+            if (d && st && st->lines(Fraction(0, 1)) != 5) {
+                int n = 0;
+                if (st->lines(Fraction(0, 1)) == 1) {
+                    n = 4;
+                }
+                for (int j = 0; j < DRUM_INSTRUMENTS; ++j) {
+                    d->drum(j).line -= n;
+                }
+            }
+        } else if (tag == "name") {
+            Text* t = Factory::createText(ctx.dummy(), TextStyleType::DEFAULT, false);
+            readText114(e, t, t);
+            part->instrument()->setLongName(t->xmlText());
+            delete t;
+        } else if (tag == "shortName") {
+            Text* t = Factory::createText(ctx.dummy(), TextStyleType::DEFAULT, false);
+            readText114(e, t, t);
+            part->instrument()->setShortName(t->xmlText());
+            delete t;
+        } else if (tag == "trackName") {
+            part->setPartName(e.readText());
+        } else if (tag == "show") {
+            part->setShow(e.readInt());
+        } else {
+            e.unknown();
+        }
+    }
+    if (part->partName().isEmpty()) {
+        part->setPartName(part->instrument()->trackName());
+    }
+
+    if (part->instrument()->useDrumset()) {
+        for (Staff* staff : part->staves()) {
+            int lines = staff->lines(Fraction(0, 1));
+            int bf    = staff->barLineFrom();
+            int bt    = staff->barLineTo();
+            staff->setStaffType(Fraction(0, 1), *StaffType::getDefaultPreset(StaffGroup::PERCUSSION));
+
+            // this allows 2/3-line percussion staves to keep the double spacing they had in 1.3
+
+            if (lines == 2 || lines == 3) {
+                ((StaffType*)(staff->staffType(Fraction(0, 1))))->setLineDistance(Spatium(2.0));
+            }
+
+            staff->setLines(Fraction(0, 1), lines);             // this also sets stepOffset
+            staff->setBarLineFrom(bf);
+            staff->setBarLineTo(bt);
+        }
+    }
+    //set default articulations
+    std::vector<MidiArticulation> articulations;
+    articulations.push_back(MidiArticulation(u"", u"", 100, 100));
+    articulations.push_back(MidiArticulation(u"staccato", u"", 100, 50));
+    articulations.push_back(MidiArticulation(u"tenuto", u"", 100, 100));
+    articulations.push_back(MidiArticulation(u"sforzato", u"", 120, 100));
+    part->instrument()->setArticulation(articulations);
+}
+
+//---------------------------------------------------------
+//   readPageFormat
+//---------------------------------------------------------
+
+static void readPageFormat(PageFormat* pf, XmlReader& e)
+{
+    double _oddRightMargin  = 0.0;
+    double _evenRightMargin = 0.0;
+    bool landscape         = false;
+    AsciiStringView type;
+
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "landscape") {
+            landscape = e.readInt();
+        } else if (tag == "page-margins") {
+            type = e.asciiAttribute("type", "both");
+            double lm = 0.0, rm = 0.0, tm = 0.0, bm = 0.0;
+            while (e.readNextStartElement()) {
+                const AsciiStringView t(e.name());
+                double val = e.readDouble() * 0.5 / PPI;
+                if (t == "left-margin") {
+                    lm = val;
+                } else if (t == "right-margin") {
+                    rm = val;
+                } else if (t == "top-margin") {
+                    tm = val;
+                } else if (t == "bottom-margin") {
+                    bm = val;
+                } else {
+                    e.unknown();
+                }
+            }
+            pf->setTwosided(type == "odd" || type == "even");
+            if (type == "odd" || type == "both") {
+                pf->setOddLeftMargin(lm);
+                _oddRightMargin = rm;
+                pf->setOddTopMargin(tm);
+                pf->setOddBottomMargin(bm);
+            }
+            if (type == "even" || type == "both") {
+                pf->setEvenLeftMargin(lm);
+                _evenRightMargin = rm;
+                pf->setEvenTopMargin(tm);
+                pf->setEvenBottomMargin(bm);
+            }
+        } else if (tag == "page-height") {
+            pf->setSize(SizeF(pf->size().width(), e.readDouble() * 0.5 / PPI));
+        } else if (tag == "page-width") {
+            pf->setSize(SizeF(e.readDouble() * 0.5 / PPI, pf->size().height()));
+        } else if (tag == "pageFormat") {
+            const PaperSize* s = getPaperSize114(e.readText());
+            pf->setSize(SizeF(s->w, s->h));
+        } else if (tag == "page-offset") {
+            e.readInt();
+        } else {
+            e.unknown();
+        }
+    }
+    if (landscape) {
+        pf->setSize(pf->size().transposed());
+    }
+    double w1 = pf->size().width() - pf->oddLeftMargin() - _oddRightMargin;
+    double w2 = pf->size().width() - pf->evenLeftMargin() - _evenRightMargin;
+    pf->setPrintableWidth(std::min(w1, w2));       // silently adjust right margins
+}
+
+//---------------------------------------------------------
+//   readStyle
+//---------------------------------------------------------
+
+static void readStyle(MStyle* style, XmlReader& e, ReadChordListHook& readChordListHook)
+{
+    while (e.readNextStartElement()) {
+        String tag = String::fromAscii(e.name().ascii());
+
+        if (tag == "lyricsDistance") {          // was renamed
+            tag = u"lyricsPosBelow";
+        }
+
+        if (tag == "TextStyle") {
+            e.skipCurrentElement();
+        } else if (tag == "lyricsMinBottomDistance") {
+            // no longer meaningful since it is now measured from skyline rather than staff
+            //style->set(Sid::lyricsMinBottomDistance, PointF(0.0, y));
+            e.skipCurrentElement();
+        } else if (tag == "Spatium") {
+            style->set(Sid::spatium, e.readDouble() * DPMM);
+        } else if (tag == "page-layout") {
+            readPageFormat206(style, e);
+        } else if (tag == "displayInConcertPitch") {
+            style->set(Sid::concertPitch, bool(e.readInt()));
+        } else if (tag == "ChordList") {
+            readChordListHook.read(e);
+        } else if (tag == "pageFillLimit" || tag == "genTimesig" || tag == "FixMeasureNumbers" || tag == "FixMeasureWidth") {   // obsolete
+            e.skipCurrentElement();
+        } else if (tag == "systemDistance") {  // obsolete
+            style->set(Sid::minSystemDistance, e.readDouble());
+        } else if (tag == "stemDir") {
+            int voice = e.intAttribute("voice", 1) - 1;
+            switch (voice) {
+            case 0: tag = u"StemDir1";
+                break;
+            case 1: tag = u"StemDir2";
+                break;
+            case 2: tag = u"StemDir3";
+                break;
+            case 3: tag = u"StemDir4";
+                break;
+            }
+        }
+        // for compatibility:
+        else if (tag == "oddHeader" || tag == "evenHeader" || tag == "oddFooter" || tag == "evenFooter") {
+            tag += u"C";
+        } else {
+            if (!ReadStyleHook::readStyleProperties(style, e)) {
+                e.skipCurrentElement();
+            }
+        }
+    }
+
+    readChordListHook.validate();
+}
+
+//---------------------------------------------------------
+//   read114
+//    import old version <= 1.3 files
+//---------------------------------------------------------
+
+Err Read114::read114(MasterScore* masterScore, XmlReader& e, ReadContext& ctx)
+{
+    TempoMap tm;
+    while (e.readNextStartElement()) {
+        ctx.setTrack(mu::nidx);
+        const AsciiStringView tag(e.name());
+        if (tag == "Staff") {
+            readStaffContent(masterScore, e, ctx);
+        } else if (tag == "KeySig") {                 // not supported
+            KeySig* ks = Factory::createKeySig(masterScore->dummy()->segment());
+            ks->read(e);
+            delete ks;
+        } else if (tag == "siglist") {
+            masterScore->_sigmap->read(e, ctx.fileDivision());
+        } else if (tag == "programVersion") {
+            masterScore->setMscoreVersion(e.readText());
+        } else if (tag == "programRevision") {
+            masterScore->setMscoreRevision(e.readInt());
+        } else if (tag == "Mag"
+                   || tag == "MagIdx"
+                   || tag == "xoff"
+                   || tag == "Symbols"
+                   || tag == "cursorTrack"
+                   || tag == "yoff") {
+            e.skipCurrentElement();             // obsolete
+        } else if (tag == "tempolist") {
+            // store the tempo list to create invisible tempo text later
+            double tempo = e.doubleAttribute("fix", 2.0);
+            tm.setTempoMultiplier(tempo);
+            while (e.readNextStartElement()) {
+                if (e.name() == "tempo") {
+                    int tick   = e.attribute("tick").toInt();
+                    double tmp = e.readText().toDouble();
+                    tick       = ctx.fileDivision(tick);
+                    auto pos   = tm.find(tick);
+                    if (pos != tm.end()) {
+                        tm.erase(pos);
+                    }
+                    tm.setTempo(tick, tmp);
+                } else if (e.name() == "relTempo") {
+                    e.readText();
+                } else {
+                    e.unknown();
+                }
+            }
+        } else if (tag == "playMode") {
+            masterScore->setPlayMode(PlayMode(e.readInt()));
+        } else if (tag == "SyntiSettings") {
+            masterScore->_synthesizerState.read(e);
+        } else if (tag == "Spatium") {
+            masterScore->setSpatium(e.readDouble() * DPMM);
+        } else if (tag == "Division") {
+            masterScore->_fileDivision = e.readInt();
+        } else if (tag == "showInvisible") {
+            masterScore->setShowInvisible(e.readInt());
+        } else if (tag == "showFrames") {
+            masterScore->setShowFrames(e.readInt());
+        } else if (tag == "showMargins") {
+            masterScore->setShowPageborders(e.readInt());
+        } else if (tag == "Style") {
+            double sp = masterScore->spatium();
+            compat::ReadChordListHook clhook(masterScore);
+            readStyle(&masterScore->style(), e, clhook);
+            //style()->load(e);
+            // adjust this now so chords render properly on read
+            // other style adjustments can wait until reading is finished
+            if (masterScore->styleB(Sid::useGermanNoteNames)) {
+                masterScore->style().set(Sid::useStandardNoteNames, false);
+            }
+            if (masterScore->layoutMode() == LayoutMode::FLOAT) {
+                // style should not change spatium in
+                // float mode
+                masterScore->setSpatium(sp);
+            }
+        } else if (tag == "TextStyle") {
+            e.skipCurrentElement();
+        } else if (tag == "page-layout") {
+            compat::PageFormat pf;
+            readPageFormat(&pf, e);
+        } else if (tag == "copyright" || tag == "rights") {
+            Text* text = Factory::createText(masterScore->dummy(), TextStyleType::DEFAULT, false);
+            readText114(e, text, text);
+            masterScore->setMetaTag(u"copyright", text->plainText());
+            delete text;
+        } else if (tag == "movement-number") {
+            masterScore->setMetaTag(u"movementNumber", e.readText());
+        } else if (tag == "movement-title") {
+            masterScore->setMetaTag(u"movementTitle", e.readText());
+        } else if (tag == "work-number") {
+            masterScore->setMetaTag(u"workNumber", e.readText());
+        } else if (tag == "work-title") {
+            masterScore->setMetaTag(u"workTitle", e.readText());
+        } else if (tag == "source") {
+            masterScore->setMetaTag(u"source", e.readText());
+        } else if (tag == "metaTag") {
+            String name = e.attribute("name");
+            masterScore->setMetaTag(name, e.readText());
+        } else if (tag == "Part") {
+            Part* part = new Part(masterScore);
+            readPart(part, e, ctx);
+            masterScore->appendPart(part);
+        } else if (tag == "Slur") {
+            Slur* slur = Factory::createSlur(ctx.dummy());
+            Read206::readSlur206(e, ctx, slur);
+            ctx.addSpanner(slur);
+        } else if ((tag == "HairPin")
+                   || (tag == "Ottava")
+                   || (tag == "TextLine")
+                   || (tag == "Volta")
+                   || (tag == "Trill")
+                   || (tag == "Pedal")) {
+            Spanner* s = toSpanner(Factory::createItemByName(tag, masterScore->dummy()));
+            if (tag == "Volta") {
+                readVolta114(e, ctx, toVolta(s));
+            } else if (tag == "Ottava") {
+                readOttava114(e, ctx, toOttava(s));
+            } else if (tag == "TextLine") {
+                readTextLine114(e, ctx, toTextLine(s));
+            } else if (tag == "Pedal") {
+                readPedal114(e, ctx, toPedal(s));
+            } else if (tag == "Trill") {
+                Read206::readTrill206(e, toTrill(s));
+            } else {
+                assert(tag == "HairPin");
+                Read206::readHairpin206(e, ctx, toHairpin(s));
+            }
+            if (s->track() == mu::nidx) {
+                s->setTrack(ctx.track());
+            } else {
+                ctx.setTrack(s->track());               // update current track
+            }
+            if (s->tick() == Fraction(-1, 1)) {
+                s->setTick(ctx.tick());
+            } else {
+                ctx.setTick(s->tick());              // update current tick
+            }
+            if (s->track2() == mu::nidx) {
+                s->setTrack2(s->track());
+            }
+            if (s->ticks().isZero()) {
+                LOGD("zero spanner %s ticks: %d", s->typeName(), s->ticks().ticks());
+                delete s;
+            } else {
+                masterScore->addSpanner(s);
+            }
+        } else if (tag == "Excerpt") {
+            if (MScore::noExcerpts) {
+                e.skipCurrentElement();
+            } else {
+                Excerpt* ex = new Excerpt(masterScore);
+                ex->read(e);
+                masterScore->_excerpts.push_back(ex);
+            }
+        } else if (tag == "Beam") {
+            Beam* beam = Factory::createBeam(masterScore->dummy()->system());
+            beam->read(e);
+            beam->resetExplicitParent();
+            // _beams.append(beam);
+            delete beam;
+        } else {
+            e.unknown();
+        }
+    }
+
+    if (e.error() != XmlStreamReader::NoError) {
+        LOGD("%lld %lld: %s ", e.lineNumber(), e.columnNumber(), muPrintable(e.errorString()));
+        return Err::FileBadFormat;
+    }
+
+    for (Staff* s : masterScore->staves()) {
+        size_t idx = s->idx();
+        track_idx_t track = idx * VOICES;
+
+        // check barLineSpan
+        if (s->barLineSpan() > static_cast<int>(masterScore->nstaves() - idx)) {
+            LOGD("read114: invalid barline span %d (max %zu)",
+                 s->barLineSpan(), masterScore->nstaves() - idx);
+            s->setBarLineSpan(static_cast<int>(masterScore->nstaves() - idx));
+        }
+        for (auto i : s->clefList()) {
+            Fraction tick   = Fraction::fromTicks(i.first);
+            ClefType clefId = i.second._concertClef;
+            Measure* m      = masterScore->tick2measure(tick);
+            if (!m) {
+                continue;
+            }
+            SegmentType st = SegmentType::Clef;
+            if (tick == m->tick()) {
+                if (m->prevMeasure()) {
+                    m = m->prevMeasure();
+                } else {
+                    st = SegmentType::HeaderClef;
+                }
+            }
+            Segment* seg = m->getSegment(st, tick);
+            if (seg->element(track)) {
+                seg->element(track)->setGenerated(false);
+            } else {
+                Clef* clef = Factory::createClef(seg);
+                clef->setClefType(clefId);
+                clef->setTrack(track);
+                clef->setGenerated(false);
+                seg->add(clef);
+            }
+        }
+
+        // create missing KeySig
+        KeyList* km = s->keyList();
+        for (auto i = km->begin(); i != km->end(); ++i) {
+            Fraction tick = Fraction::fromTicks(i->first);
+            if (tick < Fraction(0, 1)) {
+                LOGD("read114: Key tick %d", tick.ticks());
+                continue;
+            }
+            if (tick.isZero() && i->second.key() == Key::C) {
+                continue;
+            }
+            Measure* m = masterScore->tick2measure(tick);
+            if (!m) {               //empty score
+                break;
+            }
+            Segment* seg = m->getSegment(SegmentType::KeySig, tick);
+            if (seg->element(track)) {
+                toKeySig(seg->element(track))->setGenerated(false);
+            } else {
+                KeySigEvent ke = i->second;
+                KeySig* ks = Factory::createKeySig(seg);
+                ks->setKeySigEvent(ke);
+                ks->setParent(seg);
+                ks->setTrack(track);
+                ks->setGenerated(false);
+                seg->add(ks);
+            }
+        }
+    }
+
+    for (std::pair<int, Spanner*> p : masterScore->spanner()) {
+        Spanner* s = p.second;
+        if (!s->isSlur()) {
+            if (s->isVolta()) {
+                Volta* volta = toVolta(s);
+                volta->setAnchor(Spanner::Anchor::MEASURE);
+            }
+        }
+
+        if (s->isOttava() || s->isPedal() || s->isTrill() || s->isTextLine()) {
+            double yo = 0;
+            if (s->isOttava()) {
+                // fix ottava position
+                yo = masterScore->styleValue(Pid::OFFSET, Sid::ottavaPosAbove).value<PointF>().y();
+                if (s->placeBelow()) {
+                    yo = -yo + s->staff()->height();
+                }
+            } else if (s->isPedal()) {
+                yo = masterScore->styleValue(Pid::OFFSET, Sid::pedalPosBelow).value<PointF>().y();
+            } else if (s->isTrill()) {
+                yo = masterScore->styleValue(Pid::OFFSET, Sid::trillPosAbove).value<PointF>().y();
+            } else if (s->isTextLine()) {
+                yo = -5.0 * masterScore->spatium();
+            }
+            if (!s->spannerSegments().empty()) {
+                for (SpannerSegment* seg : s->spannerSegments()) {
+                    if (!seg->offset().isNull()) {
+                        seg->ryoffset() = seg->offset().y() - yo;
+                    }
+                }
+            } else {
+                s->ryoffset() = -yo;
+            }
+        }
+    }
+
+    masterScore->connectTies();
+
+    //
+    // remove "middle beam" flags from first ChordRest in
+    // measure
+    //
+    for (Measure* m = masterScore->firstMeasure(); m; m = m->nextMeasure()) {
+        size_t tracks = masterScore->nstaves() * VOICES;
+        bool first = true;
+        for (size_t track = 0; track < tracks; ++track) {
+            for (Segment* s = m->first(); s; s = s->next()) {
+                if (s->segmentType() != SegmentType::ChordRest) {
+                    continue;
+                }
+                ChordRest* cr = toChordRest(s->element(static_cast<int>(track)));
+                if (cr) {
+                    if (!first) {
+                        switch (cr->beamMode()) {
+                        case BeamMode::AUTO:
+                        case BeamMode::BEGIN:
+                        case BeamMode::END:
+                        case BeamMode::NONE:
+                            break;
+                        case BeamMode::MID:
+                        case BeamMode::BEGIN32:
+                        case BeamMode::BEGIN64:
+                            cr->setBeamMode(BeamMode::BEGIN);
+                            break;
+                        case BeamMode::INVALID:
+                            if (cr->isChord()) {
+                                cr->setBeamMode(BeamMode::AUTO);
+                            } else {
+                                cr->setBeamMode(BeamMode::NONE);
+                            }
+                            break;
+                        }
+                        first = false;
+                    }
+                }
+            }
+        }
+    }
+    for (MeasureBase* mb = masterScore->first(); mb; mb = mb->next()) {
+        if (mb->isVBox()) {
+            VBox* b  = toVBox(mb);
+            Millimetre y = masterScore->styleMM(Sid::staffUpperBorder);
+            b->setBottomGap(y);
+        }
+    }
+
+    masterScore->_fileDivision = Constants::division;
+
+    //
+    //    sanity check for barLineSpan and update ottavas
+    //
+    for (Staff* staff : masterScore->staves()) {
+        int barLineSpan = staff->barLineSpan();
+        staff_idx_t idx = staff->idx();
+        size_t n = masterScore->nstaves();
+        if (idx + barLineSpan > n) {
+            LOGD("bad span: idx %zu  span %d staves %zu", idx, barLineSpan, n);
+            staff->setBarLineSpan(static_cast<int>(n - idx));
+        }
+        staff->updateOttava();
+    }
+
+    // adjust some styles
+    if (masterScore->styleB(Sid::hideEmptyStaves)) {        // http://musescore.org/en/node/16228
+        masterScore->style().set(Sid::dontHideStavesInFirstSystem, false);
+    }
+    if (masterScore->styleB(Sid::showPageNumberOne)) {      // http://musescore.org/en/node/21207
+        masterScore->style().set(Sid::evenFooterL, String(u"$P"));
+        masterScore->style().set(Sid::oddFooterR, String(u"$P"));
+    }
+    if (masterScore->styleI(Sid::minEmptyMeasures) == 0) {
+        masterScore->style().set(Sid::minEmptyMeasures, 1);
+    }
+    masterScore->style().set(Sid::frameSystemDistance, masterScore->styleS(Sid::frameSystemDistance) + Spatium(6.0));
+    masterScore->resetStyleValue(Sid::measureSpacing);
+
+    // add invisible tempo text if necessary
+    // some 1.3 scores have tempolist but no tempo text
+    masterScore->setUpTempoMap();
+    for (const auto& i : tm) {
+        Fraction tick = Fraction::fromTicks(i.first);
+        BeatsPerSecond tempo   = i.second.tempo;
+        if (masterScore->tempomap()->tempo(tick.ticks()) != tempo) {
+            TempoText* tt = Factory::createTempoText(masterScore->dummy()->segment());
+            tt->setXmlText(String(u"<sym>metNoteQuarterUp</sym> = %1").arg(std::round(tempo.toBPM().val)));
+            tt->setTempo(tempo);
+            tt->setTrack(0);
+            tt->setVisible(false);
+            Measure* m = masterScore->tick2measure(tick);
+            if (m) {
+                Segment* seg = m->getSegment(SegmentType::ChordRest, tick);
+                seg->add(tt);
+                masterScore->setTempo(tick, tempo);
+            } else {
+                delete tt;
+            }
+        }
+    }
+
+    // create excerpts
+
+    std::vector<Excerpt*> readExcerpts;
+    readExcerpts.swap(masterScore->_excerpts);
+    for (Excerpt* excerpt : readExcerpts) {
+        if (excerpt->parts().empty()) {             // ignore empty parts
+            continue;
+        }
+        if (!excerpt->parts().empty()) {
+            masterScore->_excerpts.push_back(excerpt);
+            Score* nscore = masterScore->createScore();
+            ReadStyleHook::setupDefaultStyle(nscore);
+            excerpt->setExcerptScore(nscore);
+            nscore->style().set(Sid::createMultiMeasureRests, true);
+            Excerpt::createExcerpt(excerpt);
+        }
+    }
+
+    // volta offsets in older scores are hardcoded to be relative to a voltaY of -2.0sp
+    // we'll force this and live with it for the score
+    // but we wait until now to do it so parts don't have this issue
+
+    if (masterScore->styleV(Sid::voltaPosAbove) == DefaultStyle::baseStyle().value(Sid::voltaPosAbove)) {
+        masterScore->style().set(Sid::voltaPosAbove, PointF(0.0, -2.0f));
+    }
+
+    masterScore->setUpTempoMap();
+
+    for (Part* p : masterScore->parts()) {
+        p->updateHarmonyChannels(false);
+        if (!p->show()) {
+            // convert hidden instruments into hidden staves, to preserve playback
+            p->setShow(true);
+            for (Staff* s : p->staves()) {
+                s->setVisible(false);
+            }
+        }
+    }
+
+    masterScore->rebuildMidiMapping();
+    masterScore->updateChannel();
+
+    return Err::NoError;
+}

--- a/src/engraving/rw/compat/read206.cpp
+++ b/src/engraving/rw/compat/read206.cpp
@@ -1,0 +1,3444 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "read206.h"
+
+#include <cmath>
+
+#include "compat/pageformat.h"
+
+#include "infrastructure/symbolfonts.h"
+
+#include "rw/xml.h"
+
+#include "style/style.h"
+#include "style/textstyle.h"
+
+#include "types/symnames.h"
+#include "types/typesconv.h"
+
+#include "libmscore/accidental.h"
+#include "libmscore/ambitus.h"
+#include "libmscore/arpeggio.h"
+#include "libmscore/articulation.h"
+#include "libmscore/audio.h"
+#include "libmscore/barline.h"
+#include "libmscore/beam.h"
+#include "libmscore/bend.h"
+#include "libmscore/box.h"
+#include "libmscore/breath.h"
+#include "libmscore/chord.h"
+#include "libmscore/chordline.h"
+#include "libmscore/drumset.h"
+#include "libmscore/dynamic.h"
+#include "libmscore/excerpt.h"
+#include "libmscore/factory.h"
+#include "libmscore/fermata.h"
+#include "libmscore/fingering.h"
+#include "libmscore/glissando.h"
+#include "libmscore/hairpin.h"
+#include "libmscore/hook.h"
+#include "libmscore/image.h"
+#include "libmscore/keysig.h"
+#include "libmscore/linkedobjects.h"
+#include "libmscore/lyrics.h"
+#include "libmscore/marker.h"
+#include "libmscore/masterscore.h"
+#include "libmscore/measure.h"
+#include "libmscore/measurenumber.h"
+#include "libmscore/measurerepeat.h"
+#include "libmscore/mmrest.h"
+#include "libmscore/ottava.h"
+#include "libmscore/page.h"
+#include "libmscore/part.h"
+#include "libmscore/pedal.h"
+#include "libmscore/rehearsalmark.h"
+#include "libmscore/rest.h"
+#include "libmscore/score.h"
+#include "libmscore/sig.h"
+#include "libmscore/slur.h"
+#include "libmscore/spacer.h"
+#include "libmscore/staff.h"
+#include "libmscore/staff.h"
+#include "libmscore/stafftext.h"
+#include "libmscore/stem.h"
+#include "libmscore/stemslash.h"
+#include "libmscore/systemdivider.h"
+#include "libmscore/systemtext.h"
+#include "libmscore/tempotext.h"
+#include "libmscore/textframe.h"
+#include "libmscore/textline.h"
+#include "libmscore/tie.h"
+#include "libmscore/timesig.h"
+#include "libmscore/trill.h"
+#include "libmscore/tuplet.h"
+#include "libmscore/undo.h"
+#include "libmscore/utils.h"
+#include "libmscore/volta.h"
+
+#include "readchordlisthook.h"
+#include "readstyle.h"
+
+#include "log.h"
+
+using namespace mu;
+using namespace mu::engraving;
+using namespace mu::engraving::rw;
+using namespace mu::engraving::compat;
+
+static void readText206(XmlReader& e, const ReadContext& ctx, TextBase* t, EngravingItem* be);
+
+//---------------------------------------------------------
+//   excessTextStyles206
+//    The first map has the name of the style as the string
+//    The second map has the mapping of each Sid that the style identifies
+//    to the default value for that sid.
+//---------------------------------------------------------
+
+static std::map<String, std::map<Sid, PropertyValue> > excessTextStyles206;
+
+void Read206::readTextStyle206(MStyle* style, XmlReader& e, std::map<String, std::map<Sid, PropertyValue> >& excessStyles)
+{
+    String family = u"FreeSerif";
+    double size = 10;
+    bool sizeIsSpatiumDependent = false;
+    FontStyle fontStyle = FontStyle::Normal;
+    Align align = { AlignH::LEFT, AlignV::TOP };
+    PointF offset;
+    OffsetType offsetType = OffsetType::SPATIUM;
+
+    FrameType frameType = FrameType::NO_FRAME;
+    Spatium paddingWidth(0.0);
+    Spatium frameWidth(0.0);
+    mu::draw::Color foregroundColor = mu::draw::Color::black;
+    mu::draw::Color backgroundColor = mu::draw::Color::transparent;
+
+    PlacementV placement = PlacementV::ABOVE;
+    bool placementValid = false;
+
+    String name = e.attribute("name");
+    mu::draw::Color frameColor = mu::draw::Color::black;
+
+    bool systemFlag = false;
+    double lineWidth = -1.0;
+
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+
+        if (tag == "name") {
+            name = e.readText();
+        } else if (tag == "family") {
+            family = e.readText();
+        } else if (tag == "size") {
+            size = e.readDouble();
+        } else if (tag == "bold") {
+            if (e.readInt()) {
+                fontStyle = fontStyle + FontStyle::Bold;
+            }
+        } else if (tag == "italic") {
+            if (e.readInt()) {
+                fontStyle = fontStyle + FontStyle::Italic;
+            }
+        } else if (tag == "underline") {
+            if (e.readInt()) {
+                fontStyle = fontStyle + FontStyle::Underline;
+            }
+#if 0 // should not happen, but won't harm either
+        } else if (tag == "strike") {
+            if (e.readInt()) {
+                fontStyle = fontStyle + FontStyle::Strike;
+            }
+#endif
+        } else if (tag == "align") {      // obsolete
+            e.skipCurrentElement();
+        } else if (tag == "anchor") {     // obsolete
+            e.skipCurrentElement();
+        } else if (tag == "halign") {
+            align.horizontal = TConv::fromXml(e.readAsciiText(), AlignH::LEFT);
+        } else if (tag == "valign") {
+            align.vertical = TConv::fromXml(e.readAsciiText(), AlignV::TOP);
+        } else if (tag == "xoffset") {
+            double xo = e.readDouble();
+            if (offsetType == OffsetType::ABS) {
+                xo /= INCH;
+            }
+            offset.setX(xo);
+        } else if (tag == "yoffset") {
+            double yo = e.readDouble();
+            if (offsetType == OffsetType::ABS) {
+                yo /= INCH;
+            }
+            offset.setY(yo);
+        } else if (tag == "rxoffset" || tag == "ryoffset") {         // obsolete
+            e.readDouble();
+        } else if (tag == "offsetType") {
+            const String& val(e.readText());
+            OffsetType ot = OffsetType::ABS;
+            if (val == "spatium" || val == "1") {
+                ot = OffsetType::SPATIUM;
+            }
+            if (ot != offsetType) {
+                offsetType = ot;
+                if (ot == OffsetType::ABS) {
+                    offset /= INCH;            // convert spatium -> inch
+                } else {
+                    offset *= INCH;            // convert inch -> spatium
+                }
+            }
+        } else if (tag == "sizeIsSpatiumDependent" || tag == "spatiumSizeDependent") {
+            sizeIsSpatiumDependent = e.readInt();
+        } else if (tag == "frameWidth") {   // obsolete
+            frameType = FrameType::SQUARE;
+            /*frameWidthMM =*/ e.readDouble();
+        } else if (tag == "frameWidthS") {
+            frameType = FrameType::SQUARE;
+            frameWidth = Spatium(e.readDouble());
+        } else if (tag == "frame") {
+            frameType = e.readInt() ? FrameType::SQUARE : FrameType::NO_FRAME;
+        } else if (tag == "paddingWidth") {          // obsolete
+            /*paddingWidthMM =*/
+            e.readDouble();
+        } else if (tag == "paddingWidthS") {
+            paddingWidth = Spatium(e.readDouble());
+        } else if (tag == "frameRound") {
+            e.readInt();
+        } else if (tag == "frameColor") {
+            frameColor = e.readColor();
+        } else if (tag == "foregroundColor") {
+            foregroundColor = e.readColor();
+        } else if (tag == "backgroundColor") {
+            backgroundColor = e.readColor();
+        } else if (tag == "circle") {
+            frameType = e.readInt() ? FrameType::CIRCLE : FrameType::NO_FRAME;
+        } else if (tag == "systemFlag") {
+            systemFlag = e.readInt();
+        } else if (tag == "placement") {
+            String value(e.readText());
+            if (value == "above") {
+                placement = PlacementV::ABOVE;
+            } else if (value == "below") {
+                placement = PlacementV::BELOW;
+            }
+            placementValid = true;
+        } else if (tag == "lineWidth") {
+            lineWidth = e.readDouble();
+        } else {
+            e.unknown();
+        }
+    }
+    if (family == "MuseJazz") {
+        family = u"MuseJazz Text";
+    }
+
+    struct StyleTable {
+        const char* name;
+        TextStyleType ss;
+    } styleTable[] = {
+        { "",                        TextStyleType::DEFAULT },
+        { "Title",                   TextStyleType::TITLE },
+        { "Subtitle",                TextStyleType::SUBTITLE },
+        { "Composer",                TextStyleType::COMPOSER },
+        { "Lyricist",                TextStyleType::POET },
+        { "Lyrics Odd Lines",        TextStyleType::LYRICS_ODD },
+        { "Lyrics Even Lines",       TextStyleType::LYRICS_EVEN },
+        { "Fingering",               TextStyleType::FINGERING },
+        { "LH Guitar Fingering",     TextStyleType::LH_GUITAR_FINGERING },
+        { "RH Guitar Fingering",     TextStyleType::RH_GUITAR_FINGERING },
+        { "String Number",           TextStyleType::STRING_NUMBER },
+        { "Instrument Name (Long)",  TextStyleType::INSTRUMENT_LONG },
+        { "Instrument Name (Short)", TextStyleType::INSTRUMENT_SHORT },
+        { "Instrument Name (Part)",  TextStyleType::INSTRUMENT_EXCERPT },
+        { "Dynamics",                TextStyleType::DYNAMICS },
+        { "Technique",               TextStyleType::EXPRESSION },
+        { "Tempo",                   TextStyleType::TEMPO },
+        { "Metronome",               TextStyleType::METRONOME },
+        { "Measure Number",          TextStyleType::MEASURE_NUMBER },
+        { "Translator",              TextStyleType::TRANSLATOR },
+        { "Tuplet",                  TextStyleType::TUPLET },
+        { "System",                  TextStyleType::SYSTEM },
+        { "Staff",                   TextStyleType::STAFF },
+        { "Chord Symbol",            TextStyleType::HARMONY_A },
+        { "Rehearsal Mark",          TextStyleType::REHEARSAL_MARK },
+        { "Repeat Text Left",        TextStyleType::REPEAT_LEFT },
+        { "Repeat Text Right",       TextStyleType::REPEAT_RIGHT },
+        { "Frame",                   TextStyleType::FRAME },
+        { "Text Line",               TextStyleType::TEXTLINE },
+        { "Glissando",               TextStyleType::GLISSANDO },
+        { "Ottava",                  TextStyleType::OTTAVA },
+        { "Pedal",                   TextStyleType::PEDAL },
+        { "Hairpin",                 TextStyleType::HAIRPIN },
+        { "Bend",                    TextStyleType::BEND },
+        { "Header",                  TextStyleType::HEADER },
+        { "Footer",                  TextStyleType::FOOTER },
+        { "Instrument Change",       TextStyleType::INSTRUMENT_CHANGE },
+        { "Repeat Text",             TextStyleType::IGNORED_TYPES, },         // Repeat Text style no longer exists
+        { "Figured Bass",            TextStyleType::IGNORED_TYPES, },         // F.B. data are in style properties
+        { "Volta",                   TextStyleType::VOLTA },
+    };
+    TextStyleType ss = TextStyleType::TEXT_TYPES;
+    for (const auto& i : styleTable) {
+        if (name == i.name) {
+            ss = i.ss;
+            break;
+        }
+    }
+
+    if (ss == TextStyleType::IGNORED_TYPES) {
+        return;
+    }
+
+    bool isExcessStyle = false;
+    if (ss == TextStyleType::TEXT_TYPES) {
+        ss = e.context()->addUserTextStyle(name);
+        if (ss == TextStyleType::TEXT_TYPES) {
+            LOGD("unhandled substyle <%s>", muPrintable(name));
+            isExcessStyle = true;
+        } else {
+            int idx = int(ss) - int(TextStyleType::USER1);
+            if ((int(ss) < int(TextStyleType::USER1)) || (int(ss) > int(TextStyleType::USER12))) {
+                LOGD("User style index %d outside of range.", idx);
+                return;
+            }
+            Sid sid[] = { Sid::user1Name, Sid::user2Name, Sid::user3Name, Sid::user4Name, Sid::user5Name, Sid::user6Name,
+                          Sid::user7Name, Sid::user8Name, Sid::user9Name, Sid::user10Name, Sid::user11Name, Sid::user12Name };
+            style->set(sid[idx], name);
+        }
+    }
+
+    std::map<Sid, PropertyValue> excessPairs;
+    const TextStyle* ts;
+    if (isExcessStyle) {
+        ts = textStyle(TextStyleType::USER1);
+    } else {
+        ts = textStyle(ss);
+    }
+    for (const auto& i : *ts) {
+        PropertyValue value;
+        if (i.sid == Sid::NOSTYLE) {
+            break;
+        }
+        switch (i.pid) {
+        case Pid::TEXT_STYLE:
+            value = int(ss);
+            break;
+        case Pid::BEGIN_FONT_FACE:
+        case Pid::CONTINUE_FONT_FACE:
+        case Pid::END_FONT_FACE:
+        case Pid::FONT_FACE:
+            value = family;
+            break;
+        case Pid::BEGIN_FONT_SIZE:
+        case Pid::CONTINUE_FONT_SIZE:
+        case Pid::END_FONT_SIZE:
+        case Pid::FONT_SIZE:
+            value = size;
+            break;
+        case Pid::BEGIN_FONT_STYLE:
+        case Pid::CONTINUE_FONT_STYLE:
+        case Pid::END_FONT_STYLE:
+        case Pid::FONT_STYLE:
+            value = int(fontStyle);
+            break;
+        case Pid::FRAME_TYPE:
+            value = int(frameType);
+            break;
+        case Pid::FRAME_WIDTH:
+            value = frameWidth;
+            break;
+        case Pid::FRAME_PADDING:
+            value = paddingWidth;
+            break;
+        case Pid::FRAME_FG_COLOR:
+            value = PropertyValue::fromValue(frameColor);
+            break;
+        case Pid::FRAME_BG_COLOR:
+            value = PropertyValue::fromValue(backgroundColor);
+            break;
+        case Pid::SIZE_SPATIUM_DEPENDENT:
+            value = sizeIsSpatiumDependent;
+            break;
+        case Pid::BEGIN_TEXT_ALIGN:
+        case Pid::CONTINUE_TEXT_ALIGN:
+        case Pid::END_TEXT_ALIGN:
+        case Pid::ALIGN:
+            value = PropertyValue::fromValue(align);
+            break;
+        case Pid::SYSTEM_FLAG:
+            value = systemFlag;
+            break;
+        case Pid::BEGIN_HOOK_HEIGHT:
+        case Pid::END_HOOK_HEIGHT:
+            value = PropertyValue();
+            break;
+        case Pid::PLACEMENT:
+            if (placementValid) {
+                value = int(placement);
+            }
+            break;
+        case Pid::LINE_WIDTH:
+            if (lineWidth != -1.0) {
+                value = Millimetre(lineWidth);
+            }
+            break;
+        default:
+//                        LOGD("unhandled property <%s>%d", propertyName(i.pid), int (i.pid));
+            break;
+        }
+        if (value.isValid()) {
+            if (isExcessStyle) {
+                excessPairs[i.sid] = value;
+            } else {
+                style->set(i.sid, value);
+            }
+        }
+//            else
+//                  LOGD("invalid style value <%s> pid<%s>", MStyle::valueName(i.sid), propertyName(i.pid));
+    }
+
+    if (isExcessStyle && excessPairs.size() > 0) {
+        excessStyles[name] = excessPairs;
+    }
+}
+
+void Read206::readAccidental206(Accidental* a, XmlReader& e)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "bracket") {
+            int i = e.readInt();
+            if (i == 0 || i == 1) {
+                a->setBracket(AccidentalBracket(i));
+            }
+        } else if (tag == "subtype") {
+            String text = e.readText();
+            const static std::map<String, AccidentalType> accMap = {
+                { u"none",               AccidentalType::NONE },
+                { u"sharp",              AccidentalType::SHARP },
+                { u"flat",               AccidentalType::FLAT },
+                { u"natural",            AccidentalType::NATURAL },
+                { u"double sharp",       AccidentalType::SHARP2 },
+                { u"double flat",        AccidentalType::FLAT2 },
+                { u"flat-slash",         AccidentalType::FLAT_SLASH },
+                { u"flat-slash2",        AccidentalType::FLAT_SLASH2 },
+                { u"mirrored-flat2",     AccidentalType::MIRRORED_FLAT2 },
+                { u"mirrored-flat",      AccidentalType::MIRRORED_FLAT },
+                { u"sharp-slash",        AccidentalType::SHARP_SLASH },
+                { u"sharp-slash2",       AccidentalType::SHARP_SLASH2 },
+                { u"sharp-slash3",       AccidentalType::SHARP_SLASH3 },
+                { u"sharp-slash4",       AccidentalType::SHARP_SLASH4 },
+                { u"sharp arrow up",     AccidentalType::SHARP_ARROW_UP },
+                { u"sharp arrow down",   AccidentalType::SHARP_ARROW_DOWN },
+                { u"flat arrow up",      AccidentalType::FLAT_ARROW_UP },
+                { u"flat arrow down",    AccidentalType::FLAT_ARROW_DOWN },
+                { u"natural arrow up",   AccidentalType::NATURAL_ARROW_UP },
+                { u"natural arrow down", AccidentalType::NATURAL_ARROW_DOWN },
+                { u"sori",               AccidentalType::SORI },
+                { u"koron",              AccidentalType::KORON }
+            };
+            auto it = accMap.find(text);
+            if (it == accMap.end()) {
+                LOGD("invalid type %s", muPrintable(text));
+                a->setAccidentalType(AccidentalType::NONE);
+            } else {
+                a->setAccidentalType(it->second);
+            }
+        } else if (tag == "role") {
+            AccidentalRole r = AccidentalRole(e.readInt());
+            if (r == AccidentalRole::AUTO || r == AccidentalRole::USER) {
+                a->setRole(r);
+            }
+        } else if (tag == "small") {
+            a->setSmall(e.readInt());
+        } else if (a->EngravingItem::readProperties(e)) {
+        } else {
+            e.unknown();
+        }
+    }
+}
+
+NoteHeadGroup Read206::convertHeadGroup(int i)
+{
+    NoteHeadGroup val;
+    switch (i) {
+    case 1:
+        val = NoteHeadGroup::HEAD_CROSS;
+        break;
+    case 2:
+        val = NoteHeadGroup::HEAD_DIAMOND;
+        break;
+    case 3:
+        val = NoteHeadGroup::HEAD_TRIANGLE_DOWN;
+        break;
+    case 4:
+        val = NoteHeadGroup::HEAD_MI;
+        break;
+    case 5:
+        val = NoteHeadGroup::HEAD_SLASH;
+        break;
+    case 6:
+        val = NoteHeadGroup::HEAD_XCIRCLE;
+        break;
+    case 7:
+        val = NoteHeadGroup::HEAD_DO;
+        break;
+    case 8:
+        val = NoteHeadGroup::HEAD_RE;
+        break;
+    case 9:
+        val = NoteHeadGroup::HEAD_FA;
+        break;
+    case 10:
+        val = NoteHeadGroup::HEAD_LA;
+        break;
+    case 11:
+        val = NoteHeadGroup::HEAD_TI;
+        break;
+    case 12:
+        val = NoteHeadGroup::HEAD_SOL;
+        break;
+    case 13:
+        val = NoteHeadGroup::HEAD_BREVIS_ALT;
+        break;
+    case 0:
+    default:
+        val = NoteHeadGroup::HEAD_NORMAL;
+    }
+    return val;
+}
+
+static NoteHeadType convertHeadType(int i)
+{
+    NoteHeadType val;
+    switch (i) {
+    case 0:
+        val = NoteHeadType::HEAD_WHOLE;
+        break;
+    case 1:
+        val = NoteHeadType::HEAD_HALF;
+        break;
+    case 2:
+        val = NoteHeadType::HEAD_QUARTER;
+        break;
+    case 3:
+        val = NoteHeadType::HEAD_BREVIS;
+        break;
+    default:
+        val = NoteHeadType::HEAD_AUTO;
+    }
+    return val;
+}
+
+//---------------------------------------------------------
+//   ArticulationNames
+//---------------------------------------------------------
+
+static struct ArticulationNames {
+    SymId id;
+    AsciiStringView name;
+} articulationNames[] = {
+    { SymId::fermataAbove,              "fermata",                   },
+    { SymId::fermataShortAbove,         "shortfermata",              },
+    { SymId::fermataLongAbove,          "longfermata",               },
+    { SymId::fermataVeryLongAbove,      "verylongfermata",           },
+    { SymId::articAccentAbove,          "sforzato",                  },
+    { SymId::articStaccatoAbove,        "staccato",                  },
+    { SymId::articStaccatissimoAbove,   "staccatissimo",             },
+    { SymId::articTenutoAbove,          "tenuto",                    },
+    { SymId::articTenutoStaccatoAbove,  "portato",                   },
+    { SymId::articMarcatoAbove,         "marcato",                   },
+    { SymId::guitarFadeIn,              "fadein",                    },
+    { SymId::guitarFadeOut,             "fadeout",                   },
+    { SymId::guitarVolumeSwell,         "volumeswell",               },
+    { SymId::wiggleSawtooth,            "wigglesawtooth",            },
+    { SymId::wiggleSawtoothWide,        "wigglesawtoothwide",        },
+    { SymId::wiggleVibratoLargeFaster,  "wigglevibratolargefaster",  },
+    { SymId::wiggleVibratoLargeSlowest, "wigglevibratolargeslowest", },
+    { SymId::brassMuteOpen,             "ouvert",                    },
+    { SymId::brassMuteClosed,           "plusstop",                  },
+    { SymId::stringsUpBow,              "upbow",                     },
+    { SymId::stringsDownBow,            "downbow",                   },
+    { SymId::ornamentTurnInverted,      "reverseturn",               },
+    { SymId::ornamentTurn,              "turn",                      },
+    { SymId::ornamentTrill,             "trill",                     },
+    { SymId::ornamentShortTrill,        "prall",                     },
+    { SymId::ornamentMordent,           "mordent",                   },
+    { SymId::ornamentTremblement,       "prallprall",                },
+    { SymId::ornamentPrallMordent,      "prallmordent",              },
+    { SymId::ornamentUpPrall,           "upprall",                   },
+    { SymId::ornamentUpMordent,         "upmordent",                 },
+    { SymId::ornamentDownMordent,       "downmordent",               },
+    { SymId::ornamentPrallDown,         "pralldown",                 },
+    { SymId::ornamentPrallUp,           "prallup",                   },
+    { SymId::ornamentLinePrall,         "lineprall",                 },
+    { SymId::ornamentPrecompSlide,      "schleifer",                 },
+    { SymId::pluckedSnapPizzicatoAbove, "snappizzicato",             },
+    { SymId::stringsThumbPosition,      "thumb",                     },
+    { SymId::luteFingeringRHThumb,      "lutefingeringthumb",        },
+    { SymId::luteFingeringRHFirst,      "lutefingering1st",          },
+    { SymId::luteFingeringRHSecond,     "lutefingering2nd",          },
+    { SymId::luteFingeringRHThird,      "lutefingering3rd",          },
+
+    { SymId::ornamentPrecompMordentUpperPrefix, "downprall" },
+    { SymId::ornamentPrecompMordentUpperPrefix, "ornamentDownPrall" },
+};
+
+SymId Read206::articulationNames2SymId206(const AsciiStringView& s)
+{
+    for (auto i : articulationNames) {
+        if (i.name == s) {
+            return i.id;
+        }
+    }
+    return SymId::noSym;
+}
+
+//---------------------------------------------------------
+//   readDrumset
+//---------------------------------------------------------
+
+static void readDrumset206(Drumset* ds, XmlReader& e)
+{
+    int pitch = e.intAttribute("pitch", -1);
+    if (pitch < 0 || pitch > 127) {
+        LOGD("load drumset: invalid pitch %d", pitch);
+        return;
+    }
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "head") {
+            ds->drum(pitch).notehead = Read206::convertHeadGroup(e.readInt());
+        } else if (tag == "variants") {
+            while (e.readNextStartElement()) {
+                const AsciiStringView tagv(e.name());
+                if (tagv == "variant") {
+                    DrumInstrumentVariant div;
+                    div.pitch = e.attribute("pitch").toInt();
+                    while (e.readNextStartElement()) {
+                        const AsciiStringView taga(e.name());
+                        if (taga == "articulation") {
+                            AsciiStringView oldArticulationName = e.readAsciiText();
+                            SymId oldId = Read206::articulationNames2SymId206(oldArticulationName);
+                            div.articulationName = Articulation::symId2ArticulationName(oldId);
+                        } else if (taga == "tremolo") {
+                            div.tremolo = TConv::fromXml(e.readAsciiText(), TremoloType::INVALID_TREMOLO);
+                        }
+                    }
+                    ds->drum(pitch).addVariant(div);
+                }
+            }
+        } else if (ds->readProperties(e, pitch)) {
+        } else {
+            e.unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readInstrument
+//---------------------------------------------------------
+
+static void readInstrument206(Instrument* i, Part* p, XmlReader& e)
+{
+    int bank    = 0;
+    char volume  = 100;
+    char pan     = 60;
+    char chorus  = 30;
+    char reverb  = 30;
+    bool customDrumset = false;
+    i->clearChannels();         // remove default channel
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "Drum") {
+            // if we see one of this tags, a custom drumset will
+            // be created
+            if (!i->drumset()) {
+                i->setDrumset(new Drumset(*smDrumset));
+            }
+            if (!customDrumset) {
+                i->drumset()->clear();
+                customDrumset = true;
+            }
+            readDrumset206(i->drumset(), e);
+        } else if (i->readProperties(e, p, &customDrumset)) {
+        } else {
+            e.unknown();
+        }
+    }
+
+    i->updateInstrumentId();
+
+    // Read single-note dynamics from template
+    i->setSingleNoteDynamicsFromTemplate();
+
+    if (i->channel().empty()) {        // for backward compatibility
+        InstrChannel* a = new InstrChannel;
+        a->setName(String::fromUtf8(InstrChannel::DEFAULT_NAME));
+        a->setProgram(i->recognizeMidiProgram());
+        a->setBank(bank);
+        a->setVolume(volume);
+        a->setPan(pan);
+        a->setReverb(reverb);
+        a->setChorus(chorus);
+        i->appendChannel(a);
+    } else if (i->channel(0)->program() < 0) {
+        i->channel(0)->setProgram(i->recognizeMidiProgram());
+    }
+    if (i->useDrumset()) {
+        if (i->channel()[0]->bank() == 0) {
+            i->channel()[0]->setBank(128);
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readStaff
+//---------------------------------------------------------
+
+static void readStaff(Staff* staff, XmlReader& e)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "type") {        // obsolete
+            int staffTypeIdx = e.readInt();
+            LOGD("obsolete: Staff::read staffTypeIdx %d", staffTypeIdx);
+        } else if (tag == "neverHide") {
+            bool v = e.readInt();
+            if (v) {
+                staff->setHideWhenEmpty(Staff::HideMode::NEVER);
+            }
+        } else if (tag == "barLineSpan") {
+            staff->setBarLineFrom(e.intAttribute("from", 0));
+            staff->setBarLineTo(e.intAttribute("to", 0));
+            int span     = e.readInt();
+            staff->setBarLineSpan(span - 1);
+        } else if (staff->readProperties(e)) {
+        } else {
+            e.unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readPart
+//---------------------------------------------------------
+
+void Read206::readPart206(Part* part, XmlReader& e, ReadContext& ctx)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "Instrument") {
+            Instrument* i = part->_instruments.instrument(/* tick */ -1);
+            readInstrument206(i, part, e);
+            Drumset* ds = i->drumset();
+            Staff* s = part->staff(0);
+            int lld = s ? std::round(s->lineDistance(Fraction(0, 1))) : 1;
+            if (ds && s && lld > 1) {
+                for (int j = 0; j < DRUM_INSTRUMENTS; ++j) {
+                    ds->drum(j).line /= lld;
+                }
+            }
+        } else if (tag == "Staff") {
+            Staff* staff = Factory::createStaff(part);
+            ctx.appendStaff(staff);
+            readStaff(staff, e);
+        } else if (part->readProperties(e)) {
+        } else {
+            e.unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readAmbitus
+//---------------------------------------------------------
+
+static void readAmbitus(Ambitus* ambitus, XmlReader& e)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "head") {
+            ambitus->setNoteHeadGroup(Read206::convertHeadGroup(e.readInt()));
+        } else if (tag == "headType") {
+            ambitus->setNoteHeadType(convertHeadType(e.readInt()));
+        } else if (ambitus->readProperties(e)) {
+        } else {
+            e.unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readNote
+//---------------------------------------------------------
+
+static void readNote206(Note* note, XmlReader& e, ReadContext& ctx)
+{
+    note->setTpc1(Tpc::TPC_INVALID);
+    note->setTpc2(Tpc::TPC_INVALID);
+
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "Accidental") {
+            Accidental* a = Factory::createAccidental(note);
+            a->setTrack(note->track());
+            Read206::readAccidental206(a, e);
+            note->add(a);
+        } else if (tag == "head") {
+            int i = e.readInt();
+            NoteHeadGroup val = Read206::convertHeadGroup(i);
+            note->setHeadGroup(val);
+        } else if (tag == "headType") {
+            int i = e.readInt();
+            NoteHeadType val = convertHeadType(i);
+            note->setHeadType(val);
+        } else if (Read206::readNoteProperties206(note, e, ctx)) {
+        } else {
+            e.unknown();
+        }
+    }
+    // ensure sane values:
+    note->setPitch(std::clamp(note->pitch(), 0, 127));
+
+    if (!tpcIsValid(note->tpc1()) && !tpcIsValid(note->tpc2())) {
+        Key key = (note->staff() && note->chord()) ? note->staff()->key(note->chord()->tick()) : Key::C;
+        int tpc = pitch2tpc(note->pitch(), key, Prefer::NEAREST);
+        if (note->concertPitch()) {
+            note->setTpc1(tpc);
+        } else {
+            note->setTpc2(tpc);
+        }
+    }
+    if (!(tpcIsValid(note->tpc1()) && tpcIsValid(note->tpc2()))) {
+        Fraction tick = note->chord() ? note->chord()->tick() : Fraction(-1, 1);
+        Interval v = note->staff() ? note->part()->instrument(tick)->transpose() : Interval();
+        if (tpcIsValid(note->tpc1())) {
+            v.flip();
+            if (v.isZero()) {
+                note->setTpc2(note->tpc1());
+            } else {
+                note->setTpc2(mu::engraving::transposeTpc(note->tpc1(), v, true));
+            }
+        } else {
+            if (v.isZero()) {
+                note->setTpc1(note->tpc2());
+            } else {
+                note->setTpc1(mu::engraving::transposeTpc(note->tpc2(), v, true));
+            }
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   adjustPlacement
+//---------------------------------------------------------
+
+static void adjustPlacement(EngravingItem* e)
+{
+    if (!e || !e->staff()) {
+        return;
+    }
+
+    // element to use to determine placement
+    // for spanners, choose first segment
+    EngravingItem* ee;
+    Spanner* spanner;
+    if (e->isSpanner()) {
+        spanner = toSpanner(e);
+        if (spanner->spannerSegments().empty()) {
+            return;
+        }
+        ee = spanner->spannerSegments().front();
+        if (!ee) {
+            return;
+        }
+    } else {
+        spanner = nullptr;
+        ee = e;
+    }
+
+    // determine placement based on offset
+    // anything below staff will be set to below
+    double staffHeight = e->staff()->height();
+    double threshold = staffHeight;
+    double offsetAdjust = 0.0;
+    PlacementV defaultPlacement = e->propertyDefault(Pid::PLACEMENT).value<PlacementV>();
+    PlacementV newPlacement;
+    // most offsets will be recorded as relative to top staff line
+    // exceptions are styled offsets on elements with default placement below
+    double normalize;
+    if (defaultPlacement == PlacementV::BELOW && ee->propertyFlags(Pid::OFFSET) == PropertyFlags::STYLED) {
+        normalize = staffHeight;
+    } else {
+        normalize = 0.0;
+    }
+    double ypos = ee->offset().y() + normalize;
+    if (ypos >= threshold) {
+        newPlacement = PlacementV::BELOW;
+        offsetAdjust -= staffHeight;
+    } else {
+        newPlacement = PlacementV::ABOVE;
+    }
+
+    // set placement
+    e->setProperty(Pid::PLACEMENT, int(newPlacement));
+    if (newPlacement != defaultPlacement) {
+        e->setPropertyFlags(Pid::PLACEMENT, PropertyFlags::UNSTYLED);
+    }
+
+    // adjust offset
+    if (spanner) {
+        // adjust segments individually
+        for (auto a : spanner->spannerSegments()) {
+            // spanner segments share the placement setting of the spanner
+            // just adjust offset
+            if (defaultPlacement == PlacementV::BELOW && a->propertyFlags(Pid::OFFSET) == PropertyFlags::STYLED) {
+                normalize = staffHeight;
+            } else {
+                normalize = 0.0;
+            }
+            double yp = a->offset().y() + normalize;
+            a->ryoffset() += normalize + offsetAdjust;
+
+            // if any segments are offset to opposite side of staff from placement,
+            // or if they are within staff,
+            // disable autoplace
+            bool disableAutoplace;
+            if (yp + a->height() <= 0.0) {
+                disableAutoplace = (newPlacement == PlacementV::BELOW);
+            } else if (yp > staffHeight) {
+                disableAutoplace = (newPlacement == PlacementV::ABOVE);
+            } else {
+                disableAutoplace = true;
+            }
+            if (disableAutoplace) {
+                a->setAutoplace(false);
+            }
+            // needed for https://musescore.org/en/node/281312
+            // ideally we would rebase and calculate new offset
+            // but this may not be possible
+            // since original offset is relative to system
+            a->rxoffset() = 0;
+        }
+    } else {
+        e->ryoffset() += normalize + offsetAdjust;
+        // if within staff, disable autoplace
+        if (ypos + e->height() > 0.0 && ypos <= staffHeight) {
+            e->setAutoplace(false);
+        }
+    }
+}
+
+bool Read206::readNoteProperties206(Note* note, XmlReader& e, ReadContext& ctx)
+{
+    const AsciiStringView tag(e.name());
+
+    if (tag == "pitch") {
+        note->setPitch(e.readInt());
+    } else if (tag == "tpc") {
+        const int tpc = e.readInt();
+        note->setTpc1(tpc);
+        note->setTpc2(tpc);
+    } else if (tag == "track") {          // for performance
+        note->setTrack(e.readInt());
+    } else if (tag == "Accidental") {
+        Accidental* a = Factory::createAccidental(note);
+        a->setTrack(note->track());
+        a->read(e);
+        note->add(a);
+    } else if (tag == "Tie") {
+        Tie* tie = Factory::createTie(note);
+        tie->setParent(note);
+        tie->setTrack(note->track());
+        readTie206(e, ctx, tie);
+        tie->setStartNote(note);
+        note->setTieFor(tie);
+    } else if (tag == "tpc2") {
+        note->setTpc2(e.readInt());
+    } else if (tag == "small") {
+        note->setSmall(e.readInt());
+    } else if (tag == "mirror") {
+        note->readProperty(e, Pid::MIRROR_HEAD);
+    } else if (tag == "dotPosition") {
+        note->readProperty(e, Pid::DOT_POSITION);
+    } else if (tag == "fixed") {
+        note->setFixed(e.readBool());
+    } else if (tag == "fixedLine") {
+        note->setFixedLine(e.readInt());
+    } else if (tag == "head") {
+        note->readProperty(e, Pid::HEAD_GROUP);
+    } else if (tag == "velocity") {
+        note->setVeloOffset(e.readInt());
+    } else if (tag == "play") {
+        note->setPlay(e.readInt());
+    } else if (tag == "tuning") {
+        note->setTuning(e.readDouble());
+    } else if (tag == "fret") {
+        note->setFret(e.readInt());
+    } else if (tag == "string") {
+        note->setString(e.readInt());
+    } else if (tag == "ghost") {
+        note->setGhost(e.readInt());
+    } else if (tag == "headType") {
+        note->readProperty(e, Pid::HEAD_TYPE);
+    } else if (tag == "veloType") {
+        note->readProperty(e, Pid::VELO_TYPE);
+    } else if (tag == "line") {
+        note->setLine(e.readInt());
+    } else if (tag == "Fingering") {
+        Fingering* f = Factory::createFingering(note);
+        f->setTrack(note->track());
+        readText206(e, ctx, f, note);
+        note->add(f);
+    } else if (tag == "Symbol") {
+        Symbol* s = new Symbol(note);
+        s->setTrack(note->track());
+        s->read(e);
+        note->add(s);
+    } else if (tag == "Image") {
+        if (MScore::noImages) {
+            e.skipCurrentElement();
+        } else {
+            Image* image = new Image(note);
+            image->setTrack(note->track());
+            image->read(e);
+            note->add(image);
+        }
+    } else if (tag == "Bend") {
+        Bend* b = Factory::createBend(note);
+        b->setTrack(note->track());
+        b->read(e);
+        note->add(b);
+    } else if (tag == "NoteDot") {
+        NoteDot* dot = Factory::createNoteDot(note);
+        dot->read(e);
+        note->add(dot);
+    } else if (tag == "Events") {
+        note->playEvents().clear();        // remove default event
+        while (e.readNextStartElement()) {
+            const AsciiStringView etag(e.name());
+            if (etag == "Event") {
+                NoteEvent ne;
+                ne.read(e);
+                note->playEvents().push_back(ne);
+            } else {
+                e.unknown();
+            }
+        }
+        if (Chord* ch = note->chord()) {
+            ch->setPlayEventType(PlayEventType::User);
+        }
+    } else if (tag == "endSpanner") {
+        int id = e.intAttribute("id");
+        Spanner* sp = ctx.findSpanner(id);
+        if (sp) {
+            sp->setEndElement(note);
+            if (sp->isTie()) {
+                note->setTieBack(toTie(sp));
+            } else {
+                if (sp->isGlissando() && note->explicitParent() && note->explicitParent()->isChord()) {
+                    toChord(note->explicitParent())->setEndsGlissando(true);
+                }
+                note->addSpannerBack(sp);
+            }
+            ctx.removeSpanner(sp);
+        } else {
+            // End of a spanner whose start element will appear later;
+            // may happen for cross-staff spanner from a lower to a higher staff
+            // (for instance a glissando from bass to treble staff of piano).
+            // Create a place-holder spanner with end data
+            // (a TextLine is used only because both Spanner or SLine are abstract,
+            // the actual class does not matter, as long as it is derived from Spanner)
+            int id1 = e.intAttribute("id", -1);
+            Staff* staff = note->staff();
+            if (id1 != -1
+                &&            // DISABLE if pasting into a staff with linked staves
+                              // because the glissando is not properly cloned into the linked staves
+                staff && (!ctx.pasteMode() || !staff->links() || staff->links()->empty())) {
+                Spanner* placeholder = new TextLine(ctx.dummy());
+                placeholder->setAnchor(Spanner::Anchor::NOTE);
+                placeholder->setEndElement(note);
+                placeholder->setTrack2(note->track());
+                placeholder->setTick(Fraction(0, 1));
+                placeholder->setTick2(ctx.tick());
+                ctx.addSpanner(id1, placeholder);
+            }
+        }
+        e.readNext();
+    } else if (tag == "TextLine"
+               || tag == "Glissando") {
+        Spanner* sp = toSpanner(Factory::createItemByName(tag, ctx.dummy()));
+        // check this is not a lower-to-higher cross-staff spanner we already got
+        int id = e.intAttribute("id");
+        Spanner* placeholder = ctx.findSpanner(id);
+        if (placeholder && placeholder->endElement()) {
+            // if it is, fill end data from place-holder
+            sp->setAnchor(Spanner::Anchor::NOTE);                 // make sure we can set a Note as end element
+            sp->setEndElement(placeholder->endElement());
+            sp->setTrack2(placeholder->track2());
+            sp->setTick(ctx.tick());                                // make sure tick2 will be correct
+            sp->setTick2(placeholder->tick2());
+            toNote(placeholder->endElement())->addSpannerBack(sp);
+            // remove no longer needed place-holder before reading the new spanner,
+            // as reading it also adds it to XML reader list of spanners,
+            // which would overwrite the place-holder
+            ctx.removeSpanner(placeholder);
+            delete placeholder;
+        }
+        sp->setTrack(note->track());
+        sp->read(e);
+        Staff* staff = note->staff();
+        // DISABLE pasting of glissandi into staves with other linked staves
+        // because the glissando is not properly cloned into the linked staves
+        if (ctx.pasteMode() && staff && staff->links() && !staff->links()->empty()) {
+            ctx.removeSpanner(sp);          // read() added the element to the XMLReader: remove it
+            delete sp;
+        } else {
+            sp->setAnchor(Spanner::Anchor::NOTE);
+            sp->setStartElement(note);
+            sp->setTick(ctx.tick());
+            note->addSpannerFor(sp);
+            sp->setParent(note);
+            adjustPlacement(sp);
+        }
+    } else if (tag == "offset") {
+        note->EngravingItem::readProperties(e);
+    } else if (note->EngravingItem::readProperties(e)) {
+    } else {
+        return false;
+    }
+    return true;
+}
+
+//---------------------------------------------------------
+//   ReadStyleName206
+//    Retrieve the content of the "style" tag from the
+//    String with the content of the whole text tag
+//---------------------------------------------------------
+
+static String ReadStyleName206(String xmlTag)
+{
+    size_t beginIdx = xmlTag.indexOf(u"<style>");
+    if (beginIdx == mu::nidx) {
+        return String();
+    }
+    beginIdx += String(u"<style>").size();
+
+    size_t endIdx = xmlTag.indexOf(u"</style>");
+    IF_ASSERT_FAILED(endIdx > 0) {
+        return String();
+    }
+
+    String s = xmlTag.mid(beginIdx, (endIdx - beginIdx));
+    return s;
+}
+
+//---------------------------------------------------------
+//   readTextPropertyStyle206
+//    This reads only the 'style' tag, so that it can be read
+//    before setting anything else.
+//---------------------------------------------------------
+
+static bool readTextPropertyStyle206(String xmlTag, const XmlReader& e, TextBase* t, EngravingItem* be)
+{
+    String s = ReadStyleName206(xmlTag);
+
+    if (s.isEmpty()) {
+        return false;
+    }
+
+    if (!be->isTuplet()) {        // Hack
+        if (excessTextStyles206.find(s) != excessTextStyles206.end()) {
+            // Init the text with a style that can't be stored as a user style
+            // due to the limit on the number of user styles possible.
+            // Use User-1, since it has all the possible user style pids
+            t->initTextStyleType(TextStyleType::DEFAULT);
+            std::map<Sid, PropertyValue> styleVals = excessTextStyles206[s];
+            for (const StyledProperty& p : *textStyle(TextStyleType::USER1)) {
+                if (t->getProperty(p.pid) == t->propertyDefault(p.pid) && styleVals.find(p.sid) != styleVals.end()) {
+                    t->setProperty(p.pid, styleVals[p.sid]);
+                }
+            }
+        } else {
+            TextStyleType ss;
+            ss = e.context()->lookupUserTextStyle(s);
+            if (ss == TextStyleType::TEXT_TYPES) {
+                ByteArray ba = s.toAscii();
+                ss = TConv::fromXml(ba.constChar(), TextStyleType::DEFAULT);
+            }
+            if (ss != TextStyleType::TEXT_TYPES) {
+                t->initTextStyleType(ss);
+            }
+        }
+    }
+
+    return true;
+}
+
+//---------------------------------------------------------
+//   readTextProperties206
+//---------------------------------------------------------
+
+static bool readTextProperties206(XmlReader& e, const ReadContext& ctx, TextBase* t)
+{
+    const AsciiStringView tag(e.name());
+    if (tag == "style") {
+        e.skipCurrentElement();     // read in readTextPropertyStyle206
+    } else if (tag == "foregroundColor") { // same as "color" ?
+        e.skipCurrentElement();
+    } else if (tag == "frame") {
+        t->setFrameType(e.readBool() ? FrameType::SQUARE : FrameType::NO_FRAME);
+        t->setPropertyFlags(Pid::FRAME_TYPE, PropertyFlags::UNSTYLED);
+    } else if (tag == "frameRound") {
+        t->readProperty(e, Pid::FRAME_ROUND);
+    } else if (tag == "circle") {
+        if (e.readBool()) {
+            t->setFrameType(FrameType::CIRCLE);
+        } else {
+            if (t->circle()) {
+                t->setFrameType(FrameType::SQUARE);
+            }
+        }
+        t->setPropertyFlags(Pid::FRAME_TYPE, PropertyFlags::UNSTYLED);
+    } else if (tag == "paddingWidthS") {
+        t->readProperty(e, Pid::FRAME_PADDING);
+    } else if (tag == "frameWidthS") {
+        t->readProperty(e, Pid::FRAME_WIDTH);
+    } else if (tag == "frameColor") {
+        t->readProperty(e, Pid::FRAME_FG_COLOR);
+    } else if (tag == "backgroundColor") {
+        t->readProperty(e, Pid::FRAME_BG_COLOR);
+    } else if (tag == "halign") {
+        Align align = t->align();
+        align.horizontal = TConv::fromXml(e.readAsciiText(), AlignH::LEFT);
+        t->setAlign(align);
+        t->setPropertyFlags(Pid::ALIGN, PropertyFlags::UNSTYLED);
+    } else if (tag == "valign") {
+        Align align = t->align();
+        align.vertical = TConv::fromXml(e.readAsciiText(), AlignV::TOP);
+        t->setAlign(align);
+        t->setPropertyFlags(Pid::ALIGN, PropertyFlags::UNSTYLED);
+    } else if (tag == "pos") {
+        t->readProperty(e, Pid::OFFSET);
+        if (t->align() == AlignV::TOP) {
+            t->ryoffset() += .5 * ctx.spatium();           // HACK: bbox is different in 2.x
+        }
+        adjustPlacement(t);
+    } else if (!t->readProperties(e)) {
+        return false;
+    }
+    return true;
+}
+
+//---------------------------------------------------------
+//   TextReaderContext206
+//    For 2.x files, the style tag could be in a different
+//    position with respect to 3.x files. Since seek
+//    position is not reliable for readline in QIODevices (for
+//    example because of non-single-byte characters in at least
+//    one of the fields; some two-byte characters are counted as
+//    two single-byte characters and thus the reading could
+//    start at the wrong position), a copy of the text tag
+//    is created and read in a separate XmlReader, while
+//    the text style is extracted from a String containing
+//    the whole text xml tag.
+//    TextReaderContext206 takes care of this process
+//---------------------------------------------------------
+
+class TextReaderContext206
+{
+    XmlReader& origReader;
+    XmlReader tagReader;
+    String xmlTag;
+
+public:
+    TextReaderContext206(XmlReader& e)
+        : origReader(e)
+    {
+        // Create a new xml document containing only the (text) xml chunk
+        String name = String::fromAscii(origReader.name().ascii());
+        int64_t additionalLines = origReader.lineNumber() - 2;     // Subtracting the 2 new lines that will be added
+        xmlTag = origReader.readXml();
+        xmlTag.prepend(u"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<" + name + u">");
+        xmlTag.append(u"</" + name + u">\n");
+        ByteArray data = xmlTag.toUtf8();
+        tagReader.setData(data);  // Add the xml data to the XmlReader
+        // the additional lines are needed to output the correct line number
+        // of the original file in case of error
+        tagReader.setOffsetLines(additionalLines);
+        copyProperties(origReader, tagReader);
+        tagReader.readNextStartElement();     // read up to the first "name" tag
+    }
+
+    // Disable copying the TextReaderContext206
+    TextReaderContext206(const TextReaderContext206&) = delete;
+    TextReaderContext206& operator=(const TextReaderContext206&) = delete;
+
+    ~TextReaderContext206()
+    {
+        // Ensure to copy back the potentially changed properties
+        // to the original XmlReader before destruction
+        copyProperties(tagReader, origReader);
+    }
+
+    XmlReader& reader() { return tagReader; }
+    const String& tag() { return xmlTag; }
+private:
+    void copyProperties(XmlReader& original, XmlReader& derived);
+};
+
+//---------------------------------------------------------
+//   copyProperties
+//    Copy some of the XmlReader properties of an original
+//    XmlReader object to a "derived" XmlReader object.
+//    This is used for example when using the derived XmlReader
+//    to read the element properties of a 2.x text, or to
+//    update the base XmlReader object (for example, its
+//    link list) after reading the properties of a 2.x text
+//---------------------------------------------------------
+
+void TextReaderContext206::copyProperties(XmlReader& original, XmlReader& derived)
+{
+    derived.setDocName(original.docName());
+    derived.setContext(original.context());
+}
+
+//---------------------------------------------------------
+//   readText206
+//---------------------------------------------------------
+
+static void readText206(XmlReader& e, const ReadContext& ctx, TextBase* t, EngravingItem* be)
+{
+    TextReaderContext206 tctx(e);
+    readTextPropertyStyle206(tctx.tag(), e, t, be);
+    while (tctx.reader().readNextStartElement()) {
+        if (!readTextProperties206(tctx.reader(), ctx, t)) {
+            tctx.reader().unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   read
+//---------------------------------------------------------
+
+static void readTempoText(TempoText* t, XmlReader& e, const ReadContext& ctx)
+{
+    TextReaderContext206 tctx(e);
+    readTextPropertyStyle206(tctx.tag(), e, t, t);
+    while (tctx.reader().readNextStartElement()) {
+        const AsciiStringView tag(tctx.reader().name());
+        if (tag == "tempo") {
+            t->setTempo(tctx.reader().readDouble());
+        } else if (tag == "followText") {
+            t->setFollowText(tctx.reader().readInt());
+        } else if (!readTextProperties206(tctx.reader(), ctx, t)) {
+            tctx.reader().unknown();
+        }
+    }
+    // check sanity
+    if (t->xmlText().isEmpty()) {
+        t->setXmlText(String(u"<sym>metNoteQuarterUp</sym> = %1").arg(int(lrint(t->tempo().toBPM().val))));
+        t->setVisible(false);
+    } else {
+        t->setXmlText(t->xmlText().replace(u"<sym>unicode", u"<sym>met"));
+    }
+}
+
+//---------------------------------------------------------
+//   readMarker
+//---------------------------------------------------------
+
+static void readMarker(Marker* m, XmlReader& e, const ReadContext& ctx)
+{
+    TextReaderContext206 tctx(e);
+    readTextPropertyStyle206(tctx.tag(), e, m, m);
+    MarkerType mt = MarkerType::SEGNO;
+
+    while (tctx.reader().readNextStartElement()) {
+        const AsciiStringView tag(tctx.reader().name());
+        if (tag == "label") {
+            AsciiStringView s(tctx.reader().readAsciiText());
+            m->setLabel(String::fromAscii(s.ascii()));
+            mt = TConv::fromXml(s, MarkerType::USER);
+        } else if (!readTextProperties206(tctx.reader(), ctx, m)) {
+            tctx.reader().unknown();
+        }
+    }
+    m->setMarkerType(mt);
+}
+
+//---------------------------------------------------------
+//   readDynamic
+//---------------------------------------------------------
+
+static void readDynamic(Dynamic* d, XmlReader& e, const ReadContext& ctx)
+{
+    TextReaderContext206 tctx(e);
+    readTextPropertyStyle206(tctx.tag(), e, d, d);
+    while (tctx.reader().readNextStartElement()) {
+        const AsciiStringView tag = tctx.reader().name();
+        if (tag == "subtype") {
+            d->setDynamicType(tctx.reader().readText());
+        } else if (tag == "velocity") {
+            d->setVelocity(tctx.reader().readInt());
+        } else if (tag == "dynType") {
+            d->setDynRange(TConv::fromXml(tctx.reader().readAsciiText(), DynamicRange::STAFF));
+        } else if (!readTextProperties206(tctx.reader(), ctx, d)) {
+            tctx.reader().unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readTuplet
+//---------------------------------------------------------
+
+static void readTuplet206(Tuplet* tuplet, XmlReader& e, const ReadContext& ctx)
+{
+    tuplet->setId(e.intAttribute("id", 0));
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "Number") {
+            Text* _number = Factory::createText(tuplet);
+            _number->setParent(tuplet);
+            _number->setComposition(true);
+            tuplet->setNumber(_number);
+            // _number reads property defaults from parent tuplet as "composition" is set:
+            tuplet->resetNumberProperty();
+            readText206(e, ctx, _number, tuplet);
+            _number->setVisible(tuplet->visible());           //?? override saved property
+            _number->setTrack(tuplet->track());
+            // move property flags from _number
+            for (auto p : { Pid::FONT_FACE, Pid::FONT_SIZE, Pid::FONT_STYLE, Pid::ALIGN, Pid::SIZE_SPATIUM_DEPENDENT }) {
+                tuplet->setPropertyFlags(p, _number->propertyFlags(p));
+            }
+        } else if (!Read206::readTupletProperties206(e, ctx, tuplet)) {
+            e.unknown();
+        }
+    }
+    Fraction r = (tuplet->ratio() == Fraction(1, 1)) ? tuplet->ratio() : tuplet->ratio().reduced();
+    Fraction f(r.denominator(), tuplet->baseLen().fraction().denominator());
+    tuplet->setTicks(f.reduced());
+}
+
+//---------------------------------------------------------
+//   readLyrics
+//---------------------------------------------------------
+
+static void readLyrics(Lyrics* lyrics, XmlReader& e, const ReadContext& ctx)
+{
+    int iEndTick = 0;               // used for backward compatibility
+    Text* _verseNumber = 0;
+
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "endTick") {
+            // store <endTick> tag value until a <ticks> tag has been read
+            // which positions this lyrics element in the score
+            iEndTick = e.readInt();
+        } else if (tag == "Number") {
+            _verseNumber = Factory::createText(lyrics);
+            readText206(e, ctx, _verseNumber, lyrics);
+            _verseNumber->setParent(lyrics);
+        } else if (tag == "style") {
+            e.readText();          // ignore style
+        } else if (!lyrics->readProperties(e)) {
+            e.unknown();
+        }
+    }
+
+    // if any endTick, make it relative to current tick
+    if (iEndTick) {
+        lyrics->setTicks(Fraction::fromTicks(iEndTick) - ctx.tick());
+    }
+    if (_verseNumber) {
+        // TODO: add text to main text
+        delete _verseNumber;
+    }
+    lyrics->setAutoplace(true);
+    if (!lyrics->isStyled(Pid::OFFSET) && !ctx.pasteMode()) {
+        // fix offset for pre-3.1 scores
+        // 2.x and earlier: y offset was relative to staff; x offset was relative to center of notehead
+        lyrics->rxoffset() -= lyrics->symWidth(SymId::noteheadBlack) * 0.5;
+        //lyrics->ryoffset() -= lyrics->placeBelow() && lyrics->staff() ? lyrics->staff()->height() : 0.0;
+        // temporarily set placement to above, since the original offset is relative to top of staff
+        // depend on adjustPlacement() to change the placement if appropriate
+        lyrics->setPlacement(PlacementV::ABOVE);
+        adjustPlacement(lyrics);
+    }
+}
+
+bool Read206::readDurationProperties206(XmlReader& e, const ReadContext& ctx, DurationElement* de)
+{
+    if (e.name() == "Tuplet") {
+        int i = e.readInt();
+        Tuplet* t = ctx.findTuplet(i);
+        if (!t) {
+            LOGD("readDurationProperties206(): Tuplet id %d not found", i);
+        }
+        if (t) {
+            de->setTuplet(t);
+            if (!ctx.undoStackActive()) {         // HACK, also added in Undo::AddElement()
+                t->add(de);
+            }
+        }
+        return true;
+    } else if (de->EngravingItem::readProperties(e)) {
+        return true;
+    }
+    return false;
+}
+
+bool Read206::readTupletProperties206(XmlReader& e, const ReadContext& ctx, Tuplet* de)
+{
+    const AsciiStringView tag(e.name());
+
+    if (de->readStyledProperty(e, tag)) {
+    } else if (tag == "normalNotes") {
+        de->setProperty(Pid::NORMAL_NOTES, e.readInt());
+    } else if (tag == "actualNotes") {
+        de->setProperty(Pid::ACTUAL_NOTES, e.readInt());
+    } else if (tag == "p1") {
+        de->setProperty(Pid::P1, PropertyValue::fromValue(e.readPoint() * ctx.spatium()));
+    } else if (tag == "p2") {
+        de->setProperty(Pid::P2, PropertyValue::fromValue(e.readPoint() * ctx.spatium()));
+    } else if (tag == "baseNote") {
+        de->setBaseLen(TDuration(TConv::fromXml(e.readAsciiText(), DurationType::V_INVALID)));
+    } else if (tag == "Number") {
+        Text* _number = Factory::createText(de);
+        de->setNumber(_number);
+        _number->setComposition(true);
+        _number->setParent(de);
+//            _number->setSubStyleId(SubStyleId::TUPLET);
+//            initSubStyle(SubStyleId::TUPLET);   // hack: initialize number
+        for (auto p : { Pid::FONT_FACE, Pid::FONT_SIZE, Pid::FONT_STYLE, Pid::ALIGN }) {
+            _number->resetProperty(p);
+        }
+        readText206(e, ctx, _number, de);
+        _number->setVisible(de->visible());         //?? override saved property
+        _number->setTrack(de->track());
+        // move property flags from _number
+        for (auto p : { Pid::FONT_FACE, Pid::FONT_SIZE, Pid::FONT_STYLE, Pid::ALIGN }) {
+            de->setPropertyFlags(p, _number->propertyFlags(p));
+        }
+    } else if (!readDurationProperties206(e, ctx, de)) {
+        return false;
+    }
+    return true;
+}
+
+bool Read206::readChordRestProperties206(XmlReader& e, ReadContext& ctx, ChordRest* ch)
+{
+    const AsciiStringView tag(e.name());
+
+    if (tag == "durationType") {
+        ch->setDurationType(TConv::fromXml(e.readAsciiText(), DurationType::V_QUARTER));
+        if (ch->actualDurationType().type() != DurationType::V_MEASURE) {
+            if (ctx.mscVersion() < 112 && (ch->type() == ElementType::REST)
+                &&            // for backward compatibility, convert V_WHOLE rests to V_MEASURE
+                              // if long enough to fill a measure.
+                              // OTOH, freshly created (un-initialized) rests have numerator == 0 (< 4/4)
+                              // (see Fraction() constructor in fraction.h; this happens for instance
+                              // when pasting selection from clipboard): they should not be converted
+                ch->ticks().numerator() != 0
+                &&            // rest durations are initialized to full measure duration when
+                              // created upon reading the <Rest> tag (see Measure::read() )
+                              // so a V_WHOLE rest in a measure of 4/4 or less => V_MEASURE
+                (ch->actualDurationType() == DurationType::V_WHOLE && ch->ticks() <= Fraction(4, 4))) {
+                // old pre 2.0 scores: convert
+                ch->setDurationType(DurationType::V_MEASURE);
+            } else {    // not from old score: set duration fraction from duration type
+                ch->setTicks(ch->actualDurationType().fraction());
+            }
+        } else {
+            if (ctx.mscVersion() <= 114) {
+                SigEvent event = ctx.sigmap()->timesig(ctx.tick());
+                ch->setTicks(event.timesig());
+            }
+        }
+    } else if (tag == "BeamMode") {
+        BeamMode bm = TConv::fromXml(e.readAsciiText(), BeamMode::AUTO);
+        ch->setBeamMode(bm);
+    } else if (tag == "Articulation") {
+        EngravingItem* el = readArticulation(ch, e, ctx);
+        if (el->isFermata()) {
+            ch->segment()->add(el);
+        } else {
+            ch->add(el);
+        }
+    } else if (tag == "leadingSpace" || tag == "trailingSpace") {
+        LOGD("ChordRest: %s obsolete", tag.ascii());
+        e.skipCurrentElement();
+    } else if (tag == "Beam") {
+        int id = e.readInt();
+        Beam* beam = ctx.findBeam(id);
+        if (beam) {
+            beam->add(ch);              // also calls ch->setBeam(beam)
+        } else {
+            LOGD("Beam id %d not found", id);
+        }
+    } else if (tag == "small") {
+        ch->setSmall(e.readInt());
+    } else if (tag == "duration") {
+        ch->setTicks(e.readFraction());
+    } else if (tag == "ticklen") {      // obsolete (version < 1.12)
+        int mticks = ctx.sigmap()->timesig(ctx.tick()).timesig().ticks();
+        int i = e.readInt();
+        if (i == 0) {
+            i = mticks;
+        }
+        if ((ch->type() == ElementType::REST) && (mticks == i)) {
+            ch->setDurationType(DurationType::V_MEASURE);
+            ch->setTicks(Fraction::fromTicks(i));
+        } else {
+            Fraction f = Fraction::fromTicks(i);
+            ch->setTicks(f);
+            ch->setDurationType(TDuration(f));
+        }
+    } else if (tag == "dots") {
+        ch->setDots(e.readInt());
+    } else if (tag == "move") {
+        ch->setStaffMove(e.readInt());
+    } else if (tag == "Slur") {
+        int id = e.intAttribute("id");
+        if (id == 0) {
+            id = e.intAttribute("number");                        // obsolete
+        }
+        Spanner* spanner = ctx.findSpanner(id);
+        String atype(e.attribute("type"));
+
+        if (!spanner) {
+            if (atype == "stop") {
+                SpannerValues sv;
+                sv.spannerId = id;
+                sv.track2    = ch->track();
+                sv.tick2     = ctx.tick();
+                ctx.addSpannerValues(sv);
+            } else if (atype == "start") {
+                LOGD("spanner: start without spanner");
+            }
+        } else {
+            if (atype == "start") {
+                if (spanner->ticks() > Fraction(0, 1) && spanner->tick() == Fraction(-1, 1)) {       // stop has been read first
+                    spanner->setTicks(spanner->ticks() - ctx.tick() - Fraction::fromTicks(1));
+                }
+                spanner->setTick(ctx.tick());
+                spanner->setTrack(ch->track());
+                if (spanner->type() == ElementType::SLUR) {
+                    spanner->setStartElement(ch);
+                }
+                if (ctx.pasteMode()) {
+                    for (EngravingObject* el : spanner->linkList()) {
+                        if (el == spanner) {
+                            continue;
+                        }
+                        Spanner* ls = static_cast<Spanner*>(el);
+                        ls->setTick(spanner->tick());
+                        for (EngravingObject* ee : ch->linkList()) {
+                            ChordRest* cr = toChordRest(ee);
+                            if (cr->staffIdx() == ls->staffIdx()) {
+                                ls->setTrack(cr->track());
+                                if (ls->type() == ElementType::SLUR) {
+                                    ls->setStartElement(cr);
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+            } else if (atype == "stop") {
+                spanner->setTick2(ctx.tick());
+                spanner->setTrack2(ch->track());
+                if (spanner->isSlur()) {
+                    spanner->setEndElement(ch);
+                }
+                ChordRest* start = toChordRest(spanner->startElement());
+                if (start) {
+                    spanner->setTrack(start->track());
+                }
+                if (ctx.pasteMode()) {
+                    for (EngravingObject* el : spanner->linkList()) {
+                        if (el == spanner) {
+                            continue;
+                        }
+                        Spanner* ls = static_cast<Spanner*>(el);
+                        ls->setTick2(spanner->tick2());
+                        for (EngravingObject* ee : ch->linkList()) {
+                            ChordRest* cr = toChordRest(ee);
+                            if (cr->staffIdx() == ls->staffIdx()) {
+                                ls->setTrack2(cr->track());
+                                if (ls->type() == ElementType::SLUR) {
+                                    ls->setEndElement(cr);
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+            } else {
+                LOGD("readChordRestProperties206(): unknown Slur type <%s>", muPrintable(atype));
+            }
+        }
+        e.readNext();
+    } else if (tag == "Lyrics") {
+        Lyrics* l = Factory::createLyrics(ch);
+        l->setTrack(ctx.track());
+        readLyrics(l, e, ctx);
+        ch->add(l);
+    } else if (tag == "pos") {
+        PointF pt = e.readPoint();
+        ch->setOffset(pt * ch->spatium());
+    } else if (ch->isRest() && tag == "Image") {
+        if (MScore::noImages) {
+            e.skipCurrentElement();
+        } else {
+            Image* image = new Image(ch);
+            image->setTrack(ctx.track());
+            image->read(e);
+            ch->add(image);
+        }
+    } else if (!readDurationProperties206(e, ctx, ch)) {
+        return false;
+    }
+    return true;
+}
+
+bool Read206::readChordProperties206(XmlReader& e, ReadContext& ctx, Chord* ch)
+{
+    const AsciiStringView tag(e.name());
+
+    if (tag == "Note") {
+        Note* note = Factory::createNote(ch);
+        // the note needs to know the properties of the track it belongs to
+        note->setTrack(ch->track());
+        readNote206(note, e, ctx);
+        ch->add(note);
+    } else if (readChordRestProperties206(e, ctx, ch)) {
+    } else if (tag == "Stem") {
+        Stem* s = Factory::createStem(ch);
+        s->read(e);
+        ch->add(s);
+    } else if (tag == "Hook") {
+        Hook* hook = new Hook(ch);
+        hook->read(e);
+        ch->add(hook);
+    } else if (tag == "appoggiatura") {
+        ch->setNoteType(NoteType::APPOGGIATURA);
+        e.readNext();
+    } else if (tag == "acciaccatura") {
+        ch->setNoteType(NoteType::ACCIACCATURA);
+        e.readNext();
+    } else if (tag == "grace4") {
+        ch->setNoteType(NoteType::GRACE4);
+        e.readNext();
+    } else if (tag == "grace16") {
+        ch->setNoteType(NoteType::GRACE16);
+        e.readNext();
+    } else if (tag == "grace32") {
+        ch->setNoteType(NoteType::GRACE32);
+        e.readNext();
+    } else if (tag == "grace8after") {
+        ch->setNoteType(NoteType::GRACE8_AFTER);
+        e.readNext();
+    } else if (tag == "grace16after") {
+        ch->setNoteType(NoteType::GRACE16_AFTER);
+        e.readNext();
+    } else if (tag == "grace32after") {
+        ch->setNoteType(NoteType::GRACE32_AFTER);
+        e.readNext();
+    } else if (tag == "StemSlash") {
+        StemSlash* ss = Factory::createStemSlash(ch);
+        ss->read(e);
+        ch->add(ss);
+    } else if (ch->readProperty(tag, e, Pid::STEM_DIRECTION)) {
+    } else if (tag == "noStem") {
+        ch->setNoStem(e.readInt());
+    } else if (tag == "Arpeggio") {
+        Arpeggio* arpeggio = Factory::createArpeggio(ch);
+        arpeggio->setTrack(ch->track());
+        arpeggio->read(e);
+        arpeggio->setParent(ch);
+        ch->add(arpeggio);
+    }
+    // old glissando format, chord-to-chord, attached to its final chord
+    else if (tag == "Glissando") {
+        // the measure we are reading is not inserted in the score yet
+        // as well as, possibly, the glissando intended initial chord;
+        // then we cannot fully link the glissando right now;
+        // temporarily attach the glissando to its final note as a back spanner;
+        // after the whole score is read, Score::connectTies() will look for
+        // the suitable initial note
+        Note* finalNote = ch->upNote();
+        Glissando* gliss = Factory::createGlissando(ctx.dummy());
+        gliss->read(e);
+        gliss->setAnchor(Spanner::Anchor::NOTE);
+        gliss->setStartElement(nullptr);
+        gliss->setEndElement(nullptr);
+        // in TAB, use straight line with no text
+        if (ctx.staff(static_cast<int>(ctx.track()) >> 2)->isTabStaff(ch->tick())) {
+            gliss->setGlissandoType(GlissandoType::STRAIGHT);
+            gliss->setShowText(false);
+        }
+        finalNote->addSpannerBack(gliss);
+    } else if (tag == "Tremolo") {
+        Tremolo* tremolo = Factory::createTremolo(ch);
+        tremolo->setTrack(ch->track());
+        tremolo->read(e);
+        tremolo->setParent(ch);
+        tremolo->setDurationType(ch->durationType());
+        ch->setTremolo(tremolo);
+    } else if (tag == "tickOffset") {     // obsolete
+    } else if (tag == "ChordLine") {
+        ChordLine* cl = Factory::createChordLine(ch);
+        cl->read(e);
+        PointF o = cl->offset();
+        cl->setOffset(0.0, 0.0);
+        ch->add(cl);
+        ctx.fixOffsets().push_back({ cl, o });
+    } else {
+        return false;
+    }
+    return true;
+}
+
+//---------------------------------------------------------
+//   convertDoubleArticulations
+//    Replace double articulations with proper SMuFL
+//    symbols which were not available for use prior to 3.0
+//---------------------------------------------------------
+
+static void convertDoubleArticulations(Chord* chord, XmlReader& e)
+{
+    std::vector<Articulation*> pairableArticulations;
+    for (Articulation* a : chord->articulations()) {
+        if (a->isStaccato() || a->isTenuto()
+            || a->isAccent() || a->isMarcato()) {
+            pairableArticulations.push_back(a);
+        }
+    }
+    if (pairableArticulations.size() != 2) {
+        // Do not replace triple articulation if this happens
+        return;
+    }
+
+    SymId newSymId = SymId::noSym;
+    for (int i = 0; i < 2; ++i) {
+        if (newSymId != SymId::noSym) {
+            break;
+        }
+        Articulation* ai = pairableArticulations[i];
+        Articulation* aj = pairableArticulations[(i == 0) ? 1 : 0];
+        if (ai->isStaccato()) {
+            if (aj->isAccent()) {
+                newSymId = SymId::articAccentStaccatoAbove;
+            } else if (aj->isMarcato()) {
+                newSymId = SymId::articMarcatoStaccatoAbove;
+            } else if (aj->isTenuto()) {
+                newSymId = SymId::articTenutoStaccatoAbove;
+            }
+        } else if (ai->isTenuto()) {
+            if (aj->isAccent()) {
+                newSymId = SymId::articTenutoAccentAbove;
+            } else if (aj->isMarcato()) {
+                newSymId = SymId::articMarcatoTenutoAbove;
+            }
+        }
+    }
+
+    if (newSymId != SymId::noSym) {
+        // We reuse old articulation and change symbol ID
+        // rather than constructing a new articulation
+        // in order to preserve its other properties.
+        Articulation* newArtic = pairableArticulations[0];
+        for (Articulation* a : pairableArticulations) {
+            chord->remove(a);
+            if (a != newArtic) {
+                if (LinkedObjects* link = a->links()) {
+                    mu::remove(e.context()->linkIds(), link->lid());
+                }
+                delete a;
+            }
+        }
+
+        ArticulationAnchor anchor = newArtic->anchor();
+        newArtic->setSymId(newSymId);
+        newArtic->setAnchor(anchor);
+        chord->add(newArtic);
+    }
+}
+
+//---------------------------------------------------------
+//   fixTies
+//---------------------------------------------------------
+
+static void fixTies(Chord* chord)
+{
+    std::vector<Note*> notes;
+    for (Note* note : chord->notes()) {
+        Tie* tie = note->tieBack();
+        if (tie && tie->startNote()->pitch() != note->pitch()) {
+            notes.push_back(tie->startNote());
+        }
+    }
+    for (Note* note : notes) {
+        Note* endNote = chord->findNote(note->pitch());
+        Note* oldNote = note->tieFor()->endNote();
+        if (oldNote) {
+            oldNote->setTieBack(nullptr);
+        }
+        note->tieFor()->setEndNote(endNote);
+    }
+}
+
+//---------------------------------------------------------
+//   readChord
+//---------------------------------------------------------
+
+static void readChord(Chord* chord, XmlReader& e, ReadContext& ctx)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "Note") {
+            Note* note = Factory::createNote(chord);
+            // the note needs to know the properties of the track it belongs to
+            note->setTrack(chord->track());
+            readNote206(note, e, ctx);
+            chord->add(note);
+        } else if (tag == "Stem") {
+            Stem* stem = Factory::createStem(chord);
+            while (e.readNextStartElement()) {
+                const AsciiStringView t(e.name());
+                if (t == "subtype") {              // obsolete
+                    e.skipCurrentElement();
+                } else if (!stem->readProperties(e)) {
+                    e.unknown();
+                }
+            }
+            chord->add(stem);
+        } else if (tag == "Lyrics") {
+            Lyrics* lyrics = Factory::createLyrics(chord);
+            lyrics->setTrack(ctx.track());
+            readLyrics(lyrics, e, ctx);
+            chord->add(lyrics);
+        } else if (Read206::readChordProperties206(e, ctx, chord)) {
+        } else {
+            e.unknown();
+        }
+    }
+    convertDoubleArticulations(chord, e);
+    fixTies(chord);
+}
+
+//---------------------------------------------------------
+//   readRest
+//---------------------------------------------------------
+
+static void readRest(Rest* rest, XmlReader& e, ReadContext& ctx)
+{
+    while (e.readNextStartElement()) {
+        if (!Read206::readChordRestProperties206(e, ctx, rest)) {
+            e.unknown();
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readTextLineProperties
+//---------------------------------------------------------
+
+static bool readTextLineProperties(XmlReader& e, const ReadContext& ctx, TextLineBase* tl)
+{
+    const AsciiStringView tag(e.name());
+
+    if (tag == "beginText") {
+        Text* text = Factory::createText(ctx.dummy(), TextStyleType::DEFAULT, false);
+        readText206(e, ctx, text, tl);
+        tl->setBeginText(text->xmlText());
+        delete text;
+    } else if (tag == "continueText") {
+        Text* text = Factory::createText(ctx.dummy(), TextStyleType::DEFAULT, false);
+        readText206(e, ctx, text, tl);
+        tl->setContinueText(text->xmlText());
+        delete text;
+    } else if (tag == "endText") {
+        Text* text = Factory::createText(ctx.dummy(), TextStyleType::DEFAULT, false);
+        readText206(e, ctx, text, tl);
+        tl->setEndText(text->xmlText());
+        delete text;
+    } else if (tag == "beginHook") {
+        tl->setBeginHookType(e.readBool() ? HookType::HOOK_90 : HookType::NONE);
+    } else if (tag == "endHook") {
+        tl->setEndHookType(e.readBool() ? HookType::HOOK_90 : HookType::NONE);
+    } else if (tag == "beginHookType") {
+        tl->setBeginHookType(e.readInt() == 0 ? HookType::HOOK_90 : HookType::HOOK_45);
+    } else if (tag == "endHookType") {
+        tl->setEndHookType(e.readInt() == 0 ? HookType::HOOK_90 : HookType::HOOK_45);
+    } else if (tl->readProperties(e)) {
+        return true;
+    }
+    return true;
+}
+
+//---------------------------------------------------------
+//   readVolta206
+//---------------------------------------------------------
+
+static void readVolta206(XmlReader& e, const ReadContext& ctx, Volta* volta)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "endings") {
+            String s = e.readText();
+            StringList sl = s.split(u',', mu::SkipEmptyParts);
+            volta->endings().clear();
+            for (const String& l : sl) {
+                int i = l.simplified().toInt();
+                volta->endings().push_back(i);
+            }
+        } else if (tag == "lineWidth") {
+            volta->setLineWidth(Millimetre(e.readDouble() * volta->spatium()));
+        } else if (!readTextLineProperties(e, ctx, volta)) {
+            e.unknown();
+        }
+    }
+    adjustPlacement(volta);
+}
+
+//---------------------------------------------------------
+//   readPedal
+//---------------------------------------------------------
+
+static void readPedal(XmlReader& e, const ReadContext& ctx, Pedal* pedal)
+{
+    while (e.readNextStartElement()) {
+        if (!readTextLineProperties(e, ctx, pedal)) {
+            e.unknown();
+        }
+    }
+    adjustPlacement(pedal);
+}
+
+//---------------------------------------------------------
+//   readOttava
+//---------------------------------------------------------
+
+static void readOttava(XmlReader& e, const ReadContext& ctx, Ottava* ottava)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "subtype") {
+            String s = e.readText();
+            bool ok;
+            int idx = s.toInt(&ok);
+            if (!ok) {
+                idx = 0;            // OttavaType::OTTAVA_8VA;
+                int i = 0;
+                for (auto p :  { u"8va", u"8vb", u"15ma", u"15mb", u"22ma", u"22mb" }) {
+                    if (p == s) {
+                        idx = i;
+                        break;
+                    }
+                    ++i;
+                }
+            }
+            ottava->setOttavaType(OttavaType(idx));
+        } else if (tag == "numbersOnly") {
+            ottava->setNumbersOnly(e.readBool());
+        } else if (!readTextLineProperties(e, ctx, ottava)) {
+            e.unknown();
+        }
+    }
+    ottava->styleChanged();
+    adjustPlacement(ottava);
+}
+
+void Read206::readHairpin206(XmlReader& e, const ReadContext& ctx, Hairpin* h)
+{
+    bool useText = false;
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "subtype") {
+            h->setHairpinType(HairpinType(e.readInt()));
+        } else if (tag == "lineWidth") {
+            h->setLineWidth(Millimetre(e.readDouble() * h->spatium()));
+            // lineWidthStyle = PropertyFlags::UNSTYLED;
+        } else if (tag == "hairpinHeight") {
+            h->setHairpinHeight(Spatium(e.readDouble()));
+            // hairpinHeightStyle = PropertyFlags::UNSTYLED;
+        } else if (tag == "hairpinContHeight") {
+            h->setHairpinContHeight(Spatium(e.readDouble()));
+            // hairpinContHeightStyle = PropertyFlags::UNSTYLED;
+        } else if (tag == "hairpinCircledTip") {
+            h->setHairpinCircledTip(e.readInt());
+        } else if (tag == "veloChange") {
+            h->setVeloChange(e.readInt());
+        } else if (tag == "dynType") {
+            h->setDynRange(DynamicRange(e.readInt()));
+        } else if (tag == "useTextLine") {        // < 206
+            e.readInt();
+            if (h->hairpinType() == HairpinType::CRESC_HAIRPIN) {
+                h->setHairpinType(HairpinType::CRESC_LINE);
+            } else if (h->hairpinType() == HairpinType::DECRESC_HAIRPIN) {
+                h->setHairpinType(HairpinType::DECRESC_LINE);
+            }
+            useText = true;
+        } else if (!readTextLineProperties(e, ctx, h)) {
+            e.unknown();
+        }
+    }
+    if (!useText) {
+        h->setBeginText(u"");
+        h->setContinueText(u"");
+        h->setEndText(u"");
+    }
+    adjustPlacement(h);
+}
+
+void Read206::readTrill206(XmlReader& e, Trill* t)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "subtype") {
+            t->setTrillType(TConv::fromXml(e.readAsciiText(), TrillType::TRILL_LINE));
+        } else if (tag == "Accidental") {
+            Accidental* _accidental = Factory::createAccidental(t);
+            readAccidental206(_accidental, e);
+            _accidental->setParent(t);
+            t->setAccidental(_accidental);
+        } else if (tag == "ornamentStyle") {
+            t->readProperty(e, Pid::ORNAMENT_STYLE);
+        } else if (tag == "play") {
+            t->setPlayArticulation(e.readBool());
+        } else if (!t->SLine::readProperties(e)) {
+            e.unknown();
+        }
+    }
+    adjustPlacement(t);
+}
+
+void Read206::readTextLine206(XmlReader& e, const ReadContext& ctx, TextLineBase* tlb)
+{
+    while (e.readNextStartElement()) {
+        if (!readTextLineProperties(e, ctx, tlb)) {
+            e.unknown();
+        }
+    }
+    adjustPlacement(tlb);
+}
+
+//---------------------------------------------------------
+//   setFermataPlacement
+//    set fermata placement from old ArticulationAnchor
+//    for backwards compatibility
+//---------------------------------------------------------
+
+static void setFermataPlacement(EngravingItem* el, ArticulationAnchor anchor, DirectionV direction)
+{
+    if (direction == DirectionV::UP) {
+        el->setPlacement(PlacementV::ABOVE);
+    } else if (direction == DirectionV::DOWN) {
+        el->setPlacement(PlacementV::BELOW);
+    } else {
+        switch (anchor) {
+        case ArticulationAnchor::TOP_STAFF:
+        case ArticulationAnchor::TOP_CHORD:
+            el->setPlacement(PlacementV::ABOVE);
+            break;
+
+        case ArticulationAnchor::BOTTOM_STAFF:
+        case ArticulationAnchor::BOTTOM_CHORD:
+            el->setPlacement(PlacementV::BELOW);
+            break;
+
+        case ArticulationAnchor::CHORD:
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+EngravingItem* Read206::readArticulation(EngravingItem* parent, XmlReader& e, const ReadContext& ctx)
+{
+    EngravingItem* el = nullptr;
+    SymId sym = SymId::fermataAbove;            // default -- backward compatibility (no type = ufermata in 1.2)
+    ArticulationAnchor anchor  = ArticulationAnchor::TOP_STAFF;
+    DirectionV direction = DirectionV::AUTO;
+    track_idx_t track = parent->track();
+    double timeStretch = 0.0;
+    bool useDefaultPlacement = true;
+
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "subtype") {
+            String s = e.readText();
+            if (s.at(0).isDigit()) {
+                int oldType = s.toInt();
+                sym = articulationNames[oldType].id;
+            } else {
+                ByteArray ba = s.toAscii();
+                sym = articulationNames2SymId206(ba.constChar());
+                if (sym == SymId::noSym) {
+                    struct {
+                        const char* name;
+                        bool up;
+                        SymId id;
+                    } al[] =
+                    {
+                        { "fadein",                    true,  SymId::guitarFadeIn },
+                        { "fadeout",                   true,  SymId::guitarFadeOut },
+                        { "volumeswell",               true,  SymId::guitarVolumeSwell },
+                        { "wigglesawtooth",            true,  SymId::wiggleSawtooth },
+                        { "wigglesawtoothwide",        true,  SymId::wiggleSawtoothWide },
+                        { "wigglevibratolargefaster",  true,  SymId::wiggleVibratoLargeFaster },
+                        { "wigglevibratolargeslowest", true,  SymId::wiggleVibratoLargeSlowest },
+                        { "umarcato",                  true,  SymId::articMarcatoAbove },
+                        { "dmarcato",                  false, SymId::articMarcatoBelow },
+                        { "ufermata",                  true,  SymId::fermataAbove },
+                        { "dfermata",                  false, SymId::fermataBelow },
+                        { "ushortfermata",             true,  SymId::fermataShortAbove },
+                        { "dshortfermata",             false, SymId::fermataShortBelow },
+                        { "ulongfermata",              true,  SymId::fermataLongAbove },
+                        { "dlongfermata",              false, SymId::fermataLongBelow },
+                        { "uverylongfermata",          true,  SymId::fermataVeryLongAbove },
+                        { "dverylongfermata",          false, SymId::fermataVeryLongBelow },
+
+                        // watch out, bug in 1.2 uportato and dportato are reversed
+                        { "dportato",                  true,  SymId::articTenutoStaccatoAbove },
+                        { "uportato",                  false, SymId::articTenutoStaccatoBelow },
+                        { "ustaccatissimo",            true,  SymId::articStaccatissimoAbove },
+                        { "dstaccatissimo",            false, SymId::articStaccatissimoBelow }
+                    };
+                    int i;
+                    int n = sizeof(al) / sizeof(*al);
+                    for (i = 0; i < n; ++i) {
+                        if (s == al[i].name) {
+                            sym       = al[i].id;
+                            bool up   = al[i].up;
+                            direction = up ? DirectionV::UP : DirectionV::DOWN;
+                            if ((direction == DirectionV::DOWN) != (track & 1)) {
+                                useDefaultPlacement = false;
+                            }
+                            break;
+                        }
+                    }
+                    if (i == n) {
+                        sym = SymNames::symIdByName(s);
+                        if (sym == SymId::noSym) {
+                            LOGD("Articulation: unknown type <%s>", muPrintable(s));
+                        }
+                    }
+                }
+            }
+            switch (sym) {
+            case SymId::fermataAbove:
+            case SymId::fermataBelow:
+            case SymId::fermataShortAbove:
+            case SymId::fermataShortBelow:
+            case SymId::fermataLongAbove:
+            case SymId::fermataLongBelow:
+            case SymId::fermataVeryLongAbove:
+            case SymId::fermataVeryLongBelow: {
+                Fermata* fe = Factory::createFermata(ctx.dummy());
+                fe->setSymId(sym);
+                el = fe;
+            } break;
+            default:
+                Articulation* ar = Factory::createArticulation(ctx.dummy()->chord());
+                ar->setSymId(sym);
+                ar->setDirection(direction);
+                el = ar;
+                break;
+            }
+        } else if (tag == "anchor") {
+            useDefaultPlacement = false;
+            if (!el || el->isFermata()) {
+                anchor = ArticulationAnchor(e.readInt());
+            } else {
+                el->readProperties(e);
+            }
+        } else if (tag == "direction") {
+            useDefaultPlacement = false;
+            if (!el || el->isFermata()) {
+                direction = TConv::fromXml(e.readAsciiText(), DirectionV::AUTO);
+            } else {
+                el->readProperties(e);
+            }
+        } else if (tag == "timeStretch") {
+            timeStretch = e.readDouble();
+        } else {
+            if (!el) {
+                LOGD("not handled <%s>", tag.ascii());
+            }
+            if (!el || !el->readProperties(e)) {
+                e.unknown();
+            }
+        }
+    }
+    // Special case for "no type" = ufermata, with missing subtype tag
+    if (!el) {
+        Fermata* f = Factory::createFermata(ctx.dummy());
+        f->setSymId(sym);
+        el = f;
+    }
+    if (el->isFermata()) {
+        if (timeStretch != 0.0) {
+            el->setProperty(Pid::TIME_STRETCH, timeStretch);
+        }
+        if (useDefaultPlacement) {
+            el->setPlacement(track & 1 ? PlacementV::BELOW : PlacementV::ABOVE);
+        } else {
+            setFermataPlacement(el, anchor, direction);
+        }
+    }
+    el->setTrack(track);
+    return el;
+}
+
+//---------------------------------------------------------
+//   readSlurTieProperties
+//---------------------------------------------------------
+
+static bool readSlurTieProperties(XmlReader& e, const ReadContext& ctx, SlurTie* st)
+{
+    const AsciiStringView tag(e.name());
+
+    if (st->readProperty(tag, e, Pid::SLUR_DIRECTION)) {
+    } else if (tag == "lineType") {
+        st->setStyleType(static_cast<SlurStyleType>(e.readInt()));
+    } else if (tag == "SlurSegment") {
+        SlurTieSegment* s = st->newSlurTieSegment(ctx.dummy()->system());
+        s->read(e);
+        st->add(s);
+    } else if (!st->EngravingItem::readProperties(e)) {
+        return false;
+    }
+    return true;
+}
+
+void Read206::readSlur206(XmlReader& e, ReadContext& ctx, Slur* s)
+{
+    s->setTrack(ctx.track());        // set staff
+    ctx.addSpanner(e.intAttribute("id"), s);
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "track2") {
+            s->setTrack2(e.readInt());
+        } else if (tag == "startTrack") {       // obsolete
+            s->setTrack(e.readInt());
+        } else if (tag == "endTrack") {         // obsolete
+            e.readInt();
+        } else if (!readSlurTieProperties(e, ctx, s)) {
+            e.unknown();
+        }
+    }
+    if (s->track2() == mu::nidx) {
+        s->setTrack2(s->track());
+    }
+}
+
+void Read206::readTie206(XmlReader& e, ReadContext& ctx, Tie* t)
+{
+    ctx.addSpanner(e.intAttribute("id"), t);
+    while (e.readNextStartElement()) {
+        if (readSlurTieProperties(e, ctx, t)) {
+        } else {
+            e.unknown();
+        }
+    }
+    if (ctx.mscVersion() <= 114 && t->spannerSegments().size() == 1) {
+        // ignore manual adjustments to single-segment ties in older scores
+        TieSegment* ss = t->frontSegment();
+        PointF zeroP;
+        ss->ups(Grip::START).off     = zeroP;
+        ss->ups(Grip::BEZIER1).off   = zeroP;
+        ss->ups(Grip::BEZIER2).off   = zeroP;
+        ss->ups(Grip::END).off       = zeroP;
+        ss->setOffset(zeroP);
+        ss->setUserOff2(zeroP);
+    }
+}
+
+//---------------------------------------------------------
+//   readMeasure
+//---------------------------------------------------------
+
+static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx)
+{
+    Segment* segment = 0;
+    double _spatium = m->spatium();
+
+    std::vector<Chord*> graceNotes;
+    ctx.tuplets().clear();
+    ctx.setTrack(staffIdx * VOICES);
+
+    m->createStaves(staffIdx);
+
+    // tick is obsolete
+    if (e.hasAttribute("tick")) {
+        ctx.setTick(Fraction::fromTicks(ctx.fileDivision(e.intAttribute("tick"))));
+    }
+
+    bool irregular;
+    if (e.hasAttribute("len")) {
+        StringList sl = e.attribute("len").split(u'/');
+        if (sl.size() == 2) {
+            m->setTicks(Fraction(sl.at(0).toInt(), sl.at(1).toInt()));
+        } else {
+            LOGD("illegal measure size <%s>", muPrintable(e.attribute("len")));
+        }
+        irregular = true;
+        ctx.sigmap()->add(m->tick().ticks(), SigEvent(m->ticks(), m->timesig()));
+        ctx.sigmap()->add(m->endTick().ticks(), SigEvent(m->timesig()));
+    } else {
+        irregular = false;
+    }
+
+    Staff* staff = ctx.staff(staffIdx);
+    Fraction timeStretch(staff->timeStretch(m->tick()));
+
+    // keep track of tick of previous element
+    // this allows markings that need to apply to previous element to do so
+    // even though we may have already advanced to next tick position
+    Fraction lastTick = ctx.tick();
+
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+
+        if (tag == "move") {
+            ctx.setTick(e.readFraction() + m->tick());
+        } else if (tag == "tick") {
+            ctx.setTick(Fraction::fromTicks(ctx.fileDivision(e.readInt())));
+            lastTick = ctx.tick();
+        } else if (tag == "BarLine") {
+            Fermata* fermataAbove = nullptr;
+            Fermata* fermataBelow = nullptr;
+            BarLine* bl = Factory::createBarLine(ctx.dummy()->segment());
+            bl->setTrack(ctx.track());
+            while (e.readNextStartElement()) {
+                const AsciiStringView t(e.name());
+                if (t == "subtype") {
+                    bl->setBarLineType(TConv::fromXml(e.readAsciiText(), BarLineType::NORMAL));
+                } else if (t == "customSubtype") {                          // obsolete
+                    e.readInt();
+                } else if (t == "span") {
+                    int span = e.readInt();
+                    if (span) {
+                        span--;
+                    }
+                    bl->setSpanStaff(span);
+                } else if (t == "spanFromOffset") {
+                    bl->setSpanFrom(e.readInt());
+                } else if (t == "spanToOffset") {
+                    bl->setSpanTo(e.readInt());
+                } else if (t == "Articulation") {
+                    EngravingItem* el = Read206::readArticulation(bl, e, ctx);
+                    if (el->isFermata()) {
+                        if (el->placement() == PlacementV::ABOVE) {
+                            fermataAbove = toFermata(el);
+                        } else {
+                            fermataBelow = toFermata(el);
+                            fermataBelow->setTrack((bl->staffIdx() + bl->spanStaff()) * VOICES);
+                        }
+                    } else {
+                        bl->add(el);
+                    }
+                } else if (!bl->EngravingItem::readProperties(e)) {
+                    e.unknown();
+                }
+            }
+            //
+            //  StartRepeatBarLine: always at the beginning tick of a measure, always BarLineType::START_REPEAT
+            //  BarLine:            in the middle of a measure, has no semantic
+            //  EndBarLine:         at the end tick of a measure
+            //  BeginBarLine:       first segment of a measure
+
+            SegmentType st;
+            if ((ctx.tick() != m->tick()) && (ctx.tick() != m->endTick())) {
+                st = SegmentType::BarLine;
+            } else if (bl->barLineType() == BarLineType::START_REPEAT && ctx.tick() == m->tick()) {
+                st = SegmentType::StartRepeatBarLine;
+            } else if (ctx.tick() == m->tick() && segment == 0) {
+                st = SegmentType::BeginBarLine;
+            } else {
+                st = SegmentType::EndBarLine;
+            }
+            segment = m->getSegment(st, ctx.tick());
+            segment->add(bl);
+            bl->layout();
+            if (fermataAbove) {
+                segment->add(fermataAbove);
+            }
+            if (fermataBelow) {
+                segment->add(fermataBelow);
+            }
+        } else if (tag == "Chord") {
+            segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+            Chord* chord = Factory::createChord(segment);
+            chord->setTrack(ctx.track());
+            chord->setParent(segment);
+            readChord(chord, e, ctx);
+            if (chord->noteType() != NoteType::NORMAL) {
+                graceNotes.push_back(chord);
+            } else {
+                segment->add(chord);
+                for (size_t i = 0; i < graceNotes.size(); ++i) {
+                    Chord* gc = graceNotes[i];
+                    gc->setGraceIndex(i);
+                    chord->add(gc);
+                }
+                graceNotes.clear();
+                Fraction crticks = chord->actualTicks();
+                lastTick         = ctx.tick();
+                ctx.incTick(crticks);
+            }
+        } else if (tag == "Rest") {
+            if (m->isMMRest()) {
+                segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+                MMRest* mmr = new MMRest(segment);
+                mmr->setTrack(ctx.track());
+                mmr->read(e);
+                segment->add(mmr);
+                lastTick = ctx.tick();
+                ctx.incTick(mmr->actualTicks());
+            } else {
+                segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+                Rest* rest = Factory::createRest(segment);
+                rest->setDurationType(DurationType::V_MEASURE);
+                rest->setTicks(m->timesig() / timeStretch);
+                rest->setTrack(ctx.track());
+                rest->setParent(segment);
+                readRest(rest, e, ctx);
+                segment->add(rest);
+
+                if (!rest->ticks().isValid()) {    // hack
+                    rest->setTicks(m->timesig() / timeStretch);
+                }
+
+                lastTick = ctx.tick();
+                ctx.incTick(rest->actualTicks());
+            }
+        } else if (tag == "Breath") {
+            Breath* breath = Factory::createBreath(ctx.dummy()->segment());
+            breath->setTrack(ctx.track());
+            breath->setPlacement(PlacementV::ABOVE);
+            Fraction tick = ctx.tick();
+            breath->read(e);
+            // older scores placed the breath segment right after the chord to which it applies
+            // rather than before the next chordrest segment with an element for the staff
+            // result would be layout too far left if there are other segments due to notes in other staves
+            // we need to find tick of chord to which this applies, and add its duration
+            Fraction prevTick;
+            if (ctx.tick() < tick) {
+                prevTick = ctx.tick();            // use our own tick if we explicitly reset to earlier position
+            } else {
+                prevTick = lastTick;            // otherwise use tick of previous tick/chord/rest tag
+            }
+            // find segment
+            Segment* prev = m->findSegment(SegmentType::ChordRest, prevTick);
+            if (prev) {
+                // find chordrest
+                ChordRest* lastCR = toChordRest(prev->element(ctx.track()));
+                if (lastCR) {
+                    tick = prevTick + lastCR->actualTicks();
+                }
+            }
+            segment = m->getSegment(SegmentType::Breath, tick);
+            segment->add(breath);
+        } else if (tag == "endSpanner") {
+            int id = e.attribute("id").toInt();
+            Spanner* spanner = ctx.findSpanner(id);
+            if (spanner) {
+                spanner->setTicks(ctx.tick() - spanner->tick());
+                // if (spanner->track2() == -1)
+                // the absence of a track tag [?] means the
+                // track is the same as the beginning of the slur
+                if (spanner->track2() == mu::nidx) {
+                    spanner->setTrack2(spanner->track() ? spanner->track() : ctx.track());
+                }
+            } else {
+                // remember "endSpanner" values
+                SpannerValues sv;
+                sv.spannerId = id;
+                sv.track2    = ctx.track();
+                sv.tick2     = ctx.tick();
+                ctx.addSpannerValues(sv);
+            }
+            e.readNext();
+        } else if (tag == "Slur") {
+            Slur* sl = Factory::createSlur(ctx.dummy());
+            sl->setTick(ctx.tick());
+            Read206::readSlur206(e, ctx, sl);
+            //
+            // check if we already saw "endSpanner"
+            //
+            int id = ctx.spannerId(sl);
+            const SpannerValues* sv = ctx.spannerValues(id);
+            if (sv) {
+                sl->setTick2(sv->tick2);
+                sl->setTrack2(sv->track2);
+            }
+            ctx.addSpanner(sl);
+        } else if (tag == "HairPin"
+                   || tag == "Pedal"
+                   || tag == "Ottava"
+                   || tag == "Trill"
+                   || tag == "TextLine"
+                   || tag == "Volta") {
+            Spanner* sp = toSpanner(Factory::createItemByName(tag, ctx.dummy()));
+            sp->setTrack(ctx.track());
+            sp->setTick(ctx.tick());
+            sp->eraseSpannerSegments();
+            ctx.addSpanner(e.intAttribute("id", -1), sp);
+
+            if (tag == "Volta") {
+                readVolta206(e, ctx, toVolta(sp));
+            } else if (tag == "Pedal") {
+                readPedal(e, ctx, toPedal(sp));
+            } else if (tag == "Ottava") {
+                readOttava(e, ctx, toOttava(sp));
+            } else if (tag == "HairPin") {
+                Read206::readHairpin206(e, ctx, toHairpin(sp));
+            } else if (tag == "Trill") {
+                Read206::readTrill206(e, toTrill(sp));
+            } else {
+                Read206::readTextLine206(e, ctx, toTextLineBase(sp));
+            }
+            ctx.addSpanner(sp);
+            //
+            // check if we already saw "endSpanner"
+            //
+            int id = ctx.spannerId(sp);
+            const SpannerValues* sv = ctx.spannerValues(id);
+            if (sv) {
+                sp->setTicks(sv->tick2 - sp->tick());
+                sp->setTrack2(sv->track2);
+            }
+        } else if (tag == "RepeatMeasure") {
+            segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+            MeasureRepeat* rm = Factory::createMeasureRepeat(segment);
+            rm->setTrack(ctx.track());
+            readRest(rm, e, ctx);
+            rm->setNumMeasures(1);
+            m->setMeasureRepeatCount(1, staffIdx);
+            segment->add(rm);
+            lastTick = ctx.tick();
+            ctx.incTick(m->ticks());
+        } else if (tag == "Clef") {
+            Clef* clef = Factory::createClef(ctx.dummy()->segment());
+            clef->setTrack(ctx.track());
+            clef->read(e);
+            clef->setGenerated(false);
+            if (ctx.tick().isZero()) {
+                if (ctx.staff(staffIdx)->clef(Fraction(0, 1)) != clef->clefType()) {
+                    ctx.staff(staffIdx)->setDefaultClefType(clef->clefType());
+                }
+                if (clef->links() && clef->links()->size() == 1) {
+                    mu::remove(e.context()->linkIds(), clef->links()->lid());
+                    LOGD("remove link %d", clef->links()->lid());
+                }
+                delete clef;
+                continue;
+            }
+            // there may be more than one clef segment for same tick position
+            if (!segment) {
+                // this is the first segment of measure
+                segment = m->getSegment(SegmentType::Clef, ctx.tick());
+            } else {
+                bool firstSegment = false;
+                // the first clef may be missing and is added later in layout
+                for (Segment* s = m->segments().first(); s && s->tick() == ctx.tick(); s = s->next()) {
+                    if (s->segmentType() == SegmentType::Clef
+                        // hack: there may be other segment types which should
+                        // generate a clef at current position
+                        || s->segmentType() == SegmentType::StartRepeatBarLine
+                        ) {
+                        firstSegment = true;
+                        break;
+                    }
+                }
+                if (firstSegment) {
+                    Segment* ns = 0;
+                    if (segment->next()) {
+                        ns = segment->next();
+                        while (ns && ns->tick() < ctx.tick()) {
+                            ns = ns->next();
+                        }
+                    }
+                    segment = 0;
+                    for (Segment* s = ns; s && s->tick() == ctx.tick(); s = s->next()) {
+                        if (s->segmentType() == SegmentType::Clef) {
+                            segment = s;
+                            break;
+                        }
+                    }
+                    if (!segment) {
+                        segment = Factory::createSegment(m, SegmentType::Clef, ctx.tick() - m->tick());
+                        m->segments().insert(segment, ns);
+                    }
+                } else {
+                    // this is the first clef: move to left
+                    segment = m->getSegment(SegmentType::Clef, ctx.tick());
+                }
+            }
+            if (ctx.tick() != m->tick()) {
+                clef->setSmall(true);                 // TODO: layout does this ?
+            }
+            segment->add(clef);
+        } else if (tag == "TimeSig") {
+            TimeSig* ts = Factory::createTimeSig(ctx.dummy()->segment());
+            ts->setTrack(ctx.track());
+            ts->read(e);
+            // if time sig not at beginning of measure => courtesy time sig
+            Fraction currTick = ctx.tick();
+            bool courtesySig = (currTick > m->tick());
+            if (courtesySig) {
+                // if courtesy sig., just add it without map processing
+                segment = m->getSegment(SegmentType::TimeSigAnnounce, currTick);
+                segment->add(ts);
+            } else {
+                // if 'real' time sig., do full process
+                segment = m->getSegment(SegmentType::TimeSig, currTick);
+                segment->add(ts);
+
+                timeStretch = ts->stretch().reduced();
+                m->setTimesig(ts->sig() / timeStretch);
+
+                if (irregular) {
+                    ctx.sigmap()->add(m->tick().ticks(), SigEvent(m->ticks(), m->timesig()));
+                    ctx.sigmap()->add(m->endTick().ticks(), SigEvent(m->timesig()));
+                } else {
+                    m->setTicks(m->timesig());
+                    ctx.sigmap()->add(m->tick().ticks(), SigEvent(m->timesig()));
+                }
+            }
+        } else if (tag == "KeySig") {
+            KeySig* ks = Factory::createKeySig(ctx.dummy()->segment());
+            ks->setTrack(ctx.track());
+            ks->read(e);
+            Fraction curTick = ctx.tick();
+            if (!ks->isCustom() && !ks->isAtonal() && ks->key() == Key::C && curTick.isZero()) {
+                // ignore empty key signature
+                LOGD("remove keysig c at tick 0");
+                if (ks->links()) {
+                    if (ks->links()->size() == 1) {
+                        mu::remove(e.context()->linkIds(), ks->links()->lid());
+                    }
+                }
+                delete ks;
+            } else {
+                // if key sig not at beginning of measure => courtesy key sig
+                bool courtesySig = (curTick == m->endTick());
+                segment = m->getSegment(courtesySig ? SegmentType::KeySigAnnounce : SegmentType::KeySig, curTick);
+                segment->add(ks);
+                if (!courtesySig) {
+                    staff->setKey(curTick, ks->keySigEvent());
+                }
+            }
+        } else if (tag == "Text" || tag == "StaffText") {
+            // MuseScore 3 has different types for system text and
+            // staff text while MuseScore 2 didn't.
+            // We need to decide first which one we should create.
+            TextReaderContext206 tctx(e);
+            String styleName = ReadStyleName206(tctx.tag());
+            StaffTextBase* t;
+            if (styleName == "System" || styleName == "Tempo"
+                || styleName == "Marker" || styleName == "Jump"
+                || styleName == "Volta") {    // TODO: is it possible to get it from style?
+                t = Factory::createSystemText(ctx.dummy()->segment());
+            } else {
+                t = Factory::createStaffText(ctx.dummy()->segment());
+            }
+            t->setTrack(ctx.track());
+            readTextPropertyStyle206(tctx.tag(), e, t, t);
+            while (tctx.reader().readNextStartElement()) {
+                if (!readTextProperties206(tctx.reader(), ctx, t)) {
+                    tctx.reader().unknown();
+                }
+            }
+            if (t->empty()) {
+                if (t->links()) {
+                    if (t->links()->size() == 1) {
+                        LOGD("reading empty text: deleted lid = %d", t->links()->lid());
+                        mu::remove(tctx.reader().context()->linkIds(), t->links()->lid());
+                        delete t;
+                    }
+                }
+            } else {
+                segment = m->getSegment(SegmentType::ChordRest, tctx.reader().context()->tick());
+                segment->add(t);
+            }
+        }
+        //----------------------------------------------------
+        // Annotation
+        else if (tag == "Dynamic") {
+            segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+            Dynamic* dyn = Factory::createDynamic(segment);
+            dyn->setTrack(ctx.track());
+            readDynamic(dyn, e, ctx);
+            segment->add(dyn);
+        } else if (tag == "RehearsalMark") {
+            segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+            RehearsalMark* el = Factory::createRehearsalMark(segment);
+            el->setTrack(ctx.track());
+            readText206(e, ctx, el, el);
+            segment->add(el);
+        } else if (tag == "Harmony"
+                   || tag == "FretDiagram"
+                   || tag == "TremoloBar"
+                   || tag == "Symbol"
+                   || tag == "InstrumentChange"
+                   || tag == "StaffState"
+                   || tag == "FiguredBass"
+                   ) {
+            segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+            EngravingItem* el = Factory::createItemByName(tag, segment);
+            // hack - needed because tick tags are unreliable in 1.3 scores
+            // for symbols attached to anything but a measure
+            el->setTrack(ctx.track());
+            el->read(e);
+            if (el->staff() && (el->isHarmony() || el->isFretDiagram() || el->isInstrumentChange())) {
+                adjustPlacement(el);
+            }
+
+            segment->add(el);
+        } else if (tag == "Tempo") {
+            segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+            TempoText* tt = Factory::createTempoText(segment);
+            // hack - needed because tick tags are unreliable in 1.3 scores
+            // for symbols attached to anything but a measure
+            tt->setTrack(ctx.track());
+            readTempoText(tt, e, ctx);
+            segment->add(tt);
+        } else if (tag == "Marker" || tag == "Jump") {
+            EngravingItem* el = Factory::createItemByName(tag, ctx.dummy());
+            el->setTrack(ctx.track());
+            if (tag == "Marker") {
+                Marker* ma = toMarker(el);
+                readMarker(ma, e, ctx);
+                EngravingItem* markerEl = toEngravingItem(ma);
+                m->add(markerEl);
+            } else {
+                el->read(e);
+                m->add(el);
+            }
+        } else if (tag == "Image") {
+            if (MScore::noImages) {
+                e.skipCurrentElement();
+            } else {
+                segment = m->getSegment(SegmentType::ChordRest, ctx.tick());
+                EngravingItem* el = Factory::createItemByName(tag, segment);
+                el->setTrack(ctx.track());
+                el->read(e);
+                segment->add(el);
+            }
+        }
+        //----------------------------------------------------
+        else if (tag == "stretch") {
+            double val = e.readDouble();
+            if (val < 0.0) {
+                val = 0;
+            }
+            m->setUserStretch(val);
+        } else if (tag == "noOffset") {
+            m->setNoOffset(e.readInt());
+        } else if (tag == "measureNumberMode") {
+            m->setMeasureNumberMode(MeasureNumberMode(e.readInt()));
+        } else if (tag == "irregular") {
+            m->setIrregular(e.readBool());
+        } else if (tag == "breakMultiMeasureRest") {
+            m->setBreakMultiMeasureRest(e.readBool());
+        } else if (tag == "sysInitBarLineType") {
+            segment = m->getSegment(SegmentType::BeginBarLine, m->tick());
+            BarLine* barLine = Factory::createBarLine(segment);
+            barLine->setTrack(ctx.track());
+            barLine->setBarLineType(TConv::fromXml(e.readAsciiText(), BarLineType::NORMAL));
+            segment->add(barLine);
+        } else if (tag == "Tuplet") {
+            Tuplet* tuplet = Factory::createTuplet(m);
+            tuplet->setTrack(ctx.track());
+            tuplet->setTick(ctx.tick());
+            tuplet->setParent(m);
+            readTuplet206(tuplet, e, ctx);
+            ctx.addTuplet(tuplet);
+        } else if (tag == "startRepeat") {
+            m->setRepeatStart(true);
+            e.readNext();
+        } else if (tag == "endRepeat") {
+            m->setRepeatCount(e.readInt());
+            m->setRepeatEnd(true);
+        } else if (tag == "vspacer" || tag == "vspacerDown") {
+            if (!m->vspacerDown(staffIdx)) {
+                Spacer* spacer = Factory::createSpacer(m);
+                spacer->setSpacerType(SpacerType::DOWN);
+                spacer->setTrack(staffIdx * VOICES);
+                m->add(spacer);
+            }
+            m->vspacerDown(staffIdx)->setGap(Millimetre(e.readDouble() * _spatium));
+        } else if (tag == "vspacer" || tag == "vspacerUp") {
+            if (!m->vspacerUp(staffIdx)) {
+                Spacer* spacer = Factory::createSpacer(m);
+                spacer->setSpacerType(SpacerType::UP);
+                spacer->setTrack(staffIdx * VOICES);
+                m->add(spacer);
+            }
+            m->vspacerUp(staffIdx)->setGap(Millimetre(e.readDouble() * _spatium));
+        } else if (tag == "visible") {
+            m->setStaffVisible(staffIdx, e.readInt());
+        } else if (tag == "slashStyle") {
+            m->setStaffStemless(staffIdx, e.readInt());
+        } else if (tag == "Beam") {
+            Beam* beam = Factory::createBeam(ctx.dummy()->system());
+            beam->setTrack(ctx.track());
+            beam->read(e);
+            beam->resetExplicitParent();
+            ctx.addBeam(beam);
+        } else if (tag == "Segment") {
+            if (segment) {
+                segment->read(e);
+            } else {
+                e.unknown();
+            }
+        } else if (tag == "MeasureNumber") {
+            MeasureNumber* noText = new MeasureNumber(m);
+            readText206(e, ctx, noText, m);
+            noText->setTrack(ctx.track());
+            noText->setParent(m);
+            m->setNoText(noText->staffIdx(), noText);
+        } else if (tag == "SystemDivider") {
+            SystemDivider* sd = new SystemDivider(ctx.dummy()->system());
+            sd->read(e);
+            m->add(sd);
+        } else if (tag == "Ambitus") {
+            segment = m->getSegment(SegmentType::Ambitus, ctx.tick());
+            Ambitus* range = Factory::createAmbitus(segment);
+            readAmbitus(range, e);
+            range->setParent(segment);                // a parent segment is needed for setTrack() to work
+            range->setTrack(trackZeroVoice(ctx.track()));
+            segment->add(range);
+        } else if (tag == "multiMeasureRest") {
+            m->setMMRestCount(e.readInt());
+            // set tick to previous measure
+            m->setTick(ctx.lastMeasure()->tick());
+            ctx.setTick(ctx.lastMeasure()->tick());
+        } else if (m->MeasureBase::readProperties(e)) {
+        } else {
+            e.unknown();
+        }
+    }
+    ctx.checkTuplets();
+    m->connectTremolo();
+}
+
+//---------------------------------------------------------
+//   readBox
+//---------------------------------------------------------
+
+static void readBox(Box* b, XmlReader& e, const ReadContext& ctx)
+{
+    b->setLeftMargin(0.0);
+    b->setRightMargin(0.0);
+    b->setTopMargin(0.0);
+    b->setBottomMargin(0.0);
+    b->setTopGap(Millimetre(0.0));
+    b->setBottomGap(Millimetre(0.0));
+    b->setAutoSizeEnabled(false);
+    b->setPropertyFlags(Pid::TOP_GAP, PropertyFlags::UNSTYLED);
+    b->setPropertyFlags(Pid::BOTTOM_GAP, PropertyFlags::UNSTYLED);
+
+    b->setBoxHeight(Spatium(0));       // override default set in constructor
+    b->setBoxWidth(Spatium(0));
+    bool keepMargins = false;          // whether original margins have to be kept when reading old file
+
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "HBox") {
+            HBox* hb = Factory::createHBox(b->system());
+            hb->read(e);
+            b->add(hb);
+            keepMargins = true;           // in old file, box nesting used outer box margins
+        } else if (tag == "VBox") {
+            VBox* vb = Factory::createVBox(b->system());
+            vb->read(e);
+            b->add(vb);
+            keepMargins = true;           // in old file, box nesting used outer box margins
+        } else if (tag == "Text") {
+            Text* t;
+            if (b->isTBox()) {
+                t = toTBox(b)->text();
+                readText206(e, ctx, t, t);
+            } else {
+                t = Factory::createText(b);
+                readText206(e, ctx, t, t);
+                if (t->empty()) {
+                    LOGD("read empty text");
+                } else {
+                    b->add(t);
+                }
+            }
+        } else if (!b->readProperties(e)) {
+            e.unknown();
+        }
+    }
+
+    // with .msc versions prior to 1.17, box margins were only used when nesting another box inside this box:
+    // for backward compatibility set them to 0 in all other cases
+
+    if (ctx.mscVersion() <= 114 && (b->isHBox() || b->isVBox()) && !keepMargins) {
+        b->setLeftMargin(0.0);
+        b->setRightMargin(0.0);
+        b->setTopMargin(0.0);
+        b->setBottomMargin(0.0);
+    }
+}
+
+//---------------------------------------------------------
+//   readStaffContent
+//---------------------------------------------------------
+
+static void readStaffContent206(Score* score, XmlReader& e, ReadContext& ctx)
+{
+    int staff = e.intAttribute("id", 1) - 1;
+    ctx.setTick(Fraction(0, 1));
+    ctx.setTrack(staff * VOICES);
+    Box* lastReadBox = nullptr;
+    bool readMeasureLast = false;
+
+    if (staff == 0) {
+        while (e.readNextStartElement()) {
+            const AsciiStringView tag(e.name());
+
+            if (tag == "Measure") {
+                if (lastReadBox) {
+                    lastReadBox->setBottomGap(lastReadBox->bottomGap() + lastReadBox->propertyDefault(Pid::BOTTOM_GAP).value<Millimetre>());
+                    lastReadBox = nullptr;
+                }
+                readMeasureLast = true;
+
+                Measure* measure = nullptr;
+                measure = Factory::createMeasure(score->dummy()->system());
+                measure->setTick(ctx.tick());
+                //
+                // inherit timesig from previous measure
+                //
+                Measure* m = ctx.lastMeasure();         // measure->prevMeasure();
+                Fraction f(m ? m->timesig() : Fraction(4, 4));
+                measure->setTicks(f);
+                measure->setTimesig(f);
+
+                readMeasure206(measure, staff, e, ctx);
+                measure->checkMeasure(staff);
+                if (!measure->isMMRest()) {
+                    score->measures()->add(measure);
+                    ctx.setLastMeasure(measure);
+                    ctx.setTick(measure->endTick());
+                } else {
+                    // this is a multi measure rest
+                    // always preceded by the first measure it replaces
+                    Measure* lm = ctx.lastMeasure();
+
+                    if (lm) {
+                        lm->setMMRest(measure);
+                        measure->setTick(lm->tick());
+                    }
+                }
+            } else if (tag == "HBox" || tag == "VBox" || tag == "TBox" || tag == "FBox") {
+                Box* b = toBox(Factory::createItemByName(tag, score->dummy()));
+                readBox(b, e, ctx);
+                b->setTick(ctx.tick());
+                score->measures()->add(b);
+
+                // If it's the first box, and comes before any measures, reset to
+                // 301 default.
+                if (!readMeasureLast && !lastReadBox) {
+                    b->setTopGap(b->propertyDefault(Pid::TOP_GAP).value<Millimetre>());
+                    b->setPropertyFlags(Pid::TOP_GAP, PropertyFlags::STYLED);
+                } else if (readMeasureLast) {
+                    b->setTopGap(b->topGap() + b->propertyDefault(Pid::TOP_GAP).value<Millimetre>());
+                }
+
+                lastReadBox = b;
+                readMeasureLast = false;
+            } else if (tag == "tick") {
+                ctx.setTick(Fraction::fromTicks(score->fileDivision(e.readInt())));
+            } else {
+                e.unknown();
+            }
+        }
+    } else {
+        Measure* measure = score->firstMeasure();
+        while (e.readNextStartElement()) {
+            const AsciiStringView tag(e.name());
+
+            if (tag == "Measure") {
+                if (measure == 0) {
+                    LOGD("Score::readStaff(): missing measure!");
+                    measure = Factory::createMeasure(score->dummy()->system());
+                    measure->setTick(ctx.tick());
+                    score->measures()->add(measure);
+                }
+                ctx.setTick(measure->tick());
+                readMeasure206(measure, staff, e, ctx);
+                measure->checkMeasure(staff);
+                if (measure->isMMRest()) {
+                    measure = ctx.lastMeasure()->nextMeasure();
+                } else {
+                    ctx.setLastMeasure(measure);
+                    if (measure->mmRest()) {
+                        measure = measure->mmRest();
+                    } else {
+                        measure = measure->nextMeasure();
+                    }
+                }
+            } else if (tag == "tick") {
+                ctx.setTick(Fraction::fromTicks(score->fileDivision(e.readInt())));
+            } else {
+                e.unknown();
+            }
+        }
+    }
+}
+
+//---------------------------------------------------------
+//   readStyle
+//---------------------------------------------------------
+
+static void readStyle206(MStyle* style, XmlReader& e, ReadChordListHook& readChordListHook)
+{
+    excessTextStyles206.clear();
+    while (e.readNextStartElement()) {
+        AsciiStringView tag = e.name();
+        if (tag == "TextStyle") {
+            Read206::readTextStyle206(style, e, excessTextStyles206);
+        } else if (tag == "Spatium") {
+            style->set(Sid::spatium, e.readDouble() * DPMM);
+        } else if (tag == "page-layout") {
+            readPageFormat206(style, e);
+        } else if (tag == "displayInConcertPitch") {
+            style->set(Sid::concertPitch, bool(e.readInt()));
+        } else if (tag == "pedalY") {
+            double y = e.readDouble();
+            style->set(Sid::pedalPosBelow, PointF(0.0, y));
+        } else if (tag == "lyricsDistance") {
+            double y = e.readDouble();
+            style->set(Sid::lyricsPosBelow, PointF(0.0, y));
+        } else if (tag == "lyricsMinBottomDistance") {
+            // no longer meaningful since it is now measured from skyline rather than staff
+            //style->set(Sid::lyricsMinBottomDistance, PointF(0.0, y));
+            e.skipCurrentElement();
+        } else if (tag == "ottavaHook") {
+            double y = std::abs(e.readDouble());
+            style->set(Sid::ottavaHookAbove, y);
+            style->set(Sid::ottavaHookBelow, -y);
+        } else if (tag == "endBarDistance") {
+            double d = e.readDouble();
+            d += style->value(Sid::barWidth).toReal();
+            d += style->value(Sid::endBarWidth).toReal();
+            style->set(Sid::endBarDistance, d);
+        } else if (tag == "ChordList") {
+            readChordListHook.read(e);
+        } else if (tag == "harmonyY") {
+            double val = -e.readDouble();
+            if (val > 0.0) {
+                style->set(Sid::harmonyPlacement, PlacementV::BELOW);
+                style->set(Sid::chordSymbolAPosBelow,  PointF(.0, val));
+            } else {
+                style->set(Sid::harmonyPlacement, PlacementV::ABOVE);
+                style->set(Sid::chordSymbolAPosBelow,  PointF(.0, val));
+            }
+        } else {
+            if (!ReadStyleHook::readStyleProperties(style, e)) {
+                e.skipCurrentElement();
+            }
+        }
+    }
+
+    readChordListHook.validate();
+}
+
+bool Read206::readScore206(Score* score, XmlReader& e, ReadContext& ctx)
+{
+    while (e.readNextStartElement()) {
+        ctx.setTrack(mu::nidx);
+        const AsciiStringView tag(e.name());
+        if (tag == "Staff") {
+            readStaffContent206(score, e, ctx);
+        } else if (tag == "siglist") {
+            score->sigmap()->read(e, score->fileDivision());
+        } else if (tag == "Omr") {
+            e.skipCurrentElement();
+        } else if (tag == "Audio") {
+            score->setAudio(new Audio);
+            score->audio()->read(e);
+        } else if (tag == "showOmr") {
+            e.skipCurrentElement();
+        } else if (tag == "playMode") {
+            score->setPlayMode(PlayMode(e.readInt()));
+        } else if (tag == "LayerTag") {
+            int id = e.intAttribute("id");
+            const String& t = e.attribute("tag");
+            String val(e.readText());
+            if (id >= 0 && id < 32) {
+                score->layerTags()[id] = t;
+                score->layerTagComments()[id] = val;
+            }
+        } else if (tag == "Layer") {
+            Layer layer;
+            layer.name = e.attribute("name");
+            layer.tags = static_cast<unsigned int>(e.intAttribute("mask"));
+            score->layer().push_back(layer);
+            e.readNext();
+        } else if (tag == "currentLayer") {
+            score->setCurrentLayer(e.readInt());
+        } else if (tag == "Synthesizer") {
+            score->synthesizerState().read(e);
+        } else if (tag == "page-offset") {
+            score->setPageNumberOffset(e.readInt());
+        } else if (tag == "Division") {
+            score->setFileDivision(e.readInt());
+        } else if (tag == "showInvisible") {
+            score->setShowInvisible(e.readInt());
+        } else if (tag == "showUnprintable") {
+            score->setShowUnprintable(e.readInt());
+        } else if (tag == "showFrames") {
+            score->setShowFrames(e.readInt());
+        } else if (tag == "showMargins") {
+            score->setShowPageborders(e.readInt());
+        } else if (tag == "Style") {
+            double sp = score->style().value(Sid::spatium).toReal();
+            ReadChordListHook clhook(score);
+            readStyle206(&score->style(), e, clhook);
+            if (score->style().styleSt(Sid::MusicalTextFont) == "MuseJazz") {
+                score->style().set(Sid::MusicalTextFont, "MuseJazz Text");
+            }
+            // if (_layoutMode == LayoutMode::FLOAT || _layoutMode == LayoutMode::SYSTEM) {
+            if (score->layoutMode() == LayoutMode::FLOAT) {
+                // style should not change spatium in
+                // float mode
+                score->style().set(Sid::spatium, sp);
+            }
+            score->setSymbolFont(SymbolFonts::fontByName(score->style().styleSt(Sid::MusicalSymbolFont)));
+        } else if (tag == "copyright" || tag == "rights") {
+            Text* text = Factory::createText(score->dummy(), TextStyleType::DEFAULT, false);
+            readText206(e, ctx, text, text);
+            score->setMetaTag(u"copyright", text->xmlText());
+            delete text;
+        } else if (tag == "movement-number") {
+            score->setMetaTag(u"movementNumber", e.readText());
+        } else if (tag == "movement-title") {
+            score->setMetaTag(u"movementTitle", e.readText());
+        } else if (tag == "work-number") {
+            score->setMetaTag(u"workNumber", e.readText());
+        } else if (tag == "work-title") {
+            score->setMetaTag(u"workTitle", e.readText());
+        } else if (tag == "source") {
+            score->setMetaTag(u"source", e.readText());
+        } else if (tag == "metaTag") {
+            String name = e.attribute("name");
+            score->setMetaTag(name, e.readText());
+        } else if (tag == "Part") {
+            Part* part = new Part(score);
+            Read206::readPart206(part, e, ctx);
+            score->appendPart(part);
+        } else if ((tag == "HairPin")     // TODO: do this elements exist here?
+                   || (tag == "Ottava")
+                   || (tag == "TextLine")
+                   || (tag == "Volta")
+                   || (tag == "Trill")
+                   || (tag == "Slur")
+                   || (tag == "Pedal")) {
+            Spanner* s = toSpanner(Factory::createItemByName(tag, score->dummy()));
+            if (tag == "HairPin") {
+                readHairpin206(e, ctx, toHairpin(s));
+            } else if (tag == "Ottava") {
+                readOttava(e, ctx, toOttava(s));
+            } else if (tag == "TextLine") {
+                Read206::readTextLine206(e, ctx, toTextLine(s));
+            } else if (tag == "Volta") {
+                readVolta206(e, ctx, toVolta(s));
+            } else if (tag == "Trill") {
+                Read206::readTrill206(e, toTrill(s));
+            } else if (tag == "Slur") {
+                readSlur206(e, ctx, toSlur(s));
+            } else {
+                assert(tag == "Pedal");
+                readPedal(e, ctx, toPedal(s));
+            }
+            score->addSpanner(s);
+        } else if (tag == "Excerpt") {
+            if (MScore::noExcerpts) {
+                e.skipCurrentElement();
+            } else {
+                if (score->isMaster()) {
+                    MasterScore* mScore = static_cast<MasterScore*>(score);
+                    Excerpt* ex = new Excerpt(mScore);
+                    ex->read(e);
+                    mScore->excerpts().push_back(ex);
+                } else {
+                    LOGD("read206: readScore(): part cannot have parts");
+                    e.skipCurrentElement();
+                }
+            }
+        } else if (tag == "Score") {            // recursion
+            if (MScore::noExcerpts) {
+                e.skipCurrentElement();
+            } else {
+                e.context()->tracks().clear();
+                e.context()->clearUserTextStyles();
+                MasterScore* m = score->masterScore();
+                Score* s = m->createScore();
+                ReadStyleHook::setupDefaultStyle(s);
+                Excerpt* ex = new Excerpt(m);
+
+                ex->setExcerptScore(s);
+                ctx.setLastMeasure(nullptr);
+                ReadContext exCtx(s);
+                readScore206(s, e, exCtx);
+                ex->setTracksMapping(e.context()->tracks());
+                m->addExcerpt(ex);
+            }
+        } else if (tag == "PageList") {
+            e.skipCurrentElement();
+        } else if (tag == "name") {
+            String n = e.readText();
+            if (!score->isMaster()) {                 //ignore the name if it's not a child score
+                score->excerpt()->setName(n);
+            }
+        } else if (tag == "layoutMode") {
+            String s = e.readText();
+            if (s == "line") {
+                score->setLayoutMode(LayoutMode::LINE);
+            } else if (s == "system") {
+                score->setLayoutMode(LayoutMode::SYSTEM);
+            } else {
+                LOGD("layoutMode: %s", muPrintable(s));
+            }
+        } else {
+            e.unknown();
+        }
+    }
+    if (e.error() != XmlStreamReader::NoError) {
+        LOGE() << String(u"XML read error at line %1, column %2: %3").arg(e.lineNumber()).arg(e.columnNumber())
+            .arg(String::fromAscii(e.name().ascii()));
+        return false;
+    }
+
+    score->connectTies();
+
+    score->setFileDivision(Constants::division);
+
+    score->setUpTempoMap();
+
+    for (Part* p : score->parts()) {
+        p->updateHarmonyChannels(false);
+        if (!p->show()) {
+            // convert hidden instruments into hidden staves, to preserve playback
+            p->setShow(true);
+            for (Staff* s : p->staves()) {
+                s->setVisible(false);
+            }
+        }
+    }
+
+    if (score->isMaster()) {
+        MasterScore* ms = static_cast<MasterScore*>(score);
+        ms->rebuildMidiMapping();
+        ms->updateChannel();
+        //           ms->createPlayEvents();
+    }
+
+    return true;
+}
+
+Err Read206::read206(mu::engraving::MasterScore* masterScore, XmlReader& e, ReadContext& ctx)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "programVersion") {
+            masterScore->setMscoreVersion(e.readText());
+        } else if (tag == "programRevision") {
+            masterScore->setMscoreRevision(e.readInt(nullptr, 16));
+        } else if (tag == "Score") {
+            if (!readScore206(masterScore, e, ctx)) {
+                return Err::FileBadFormat;
+            }
+        } else if (tag == "Revision") {
+            e.skipCurrentElement();
+        }
+    }
+
+    int id = 1;
+    for (auto& p : e.context()->linkIds()) {
+        LinkedObjects* le = p.second;
+        le->setLid(masterScore, id++);
+    }
+
+    for (Staff* s : masterScore->staves()) {
+        s->updateOttava();
+    }
+
+    // fix segment span
+    SegmentType st = SegmentType::BarLineType;
+    for (Segment* s = masterScore->firstSegment(st); s; s = s->next1(st)) {
+        for (size_t staffIdx = 0; staffIdx < masterScore->nstaves(); ++staffIdx) {
+            BarLine* b = toBarLine(s->element(staffIdx * VOICES));
+            if (!b) {
+                continue;
+            }
+            int sp = b->spanStaff();
+            if (sp <= 0) {
+                continue;
+            }
+            for (int span = 1; span <= sp; ++span) {
+                BarLine* nb = toBarLine(s->element((staffIdx + span) * VOICES));
+                if (!nb) {
+                    nb = b->clone();
+                    nb->setTrack((staffIdx + span) * VOICES);
+                    s->add(nb);
+                }
+                nb->setSpanStaff(sp - span);
+            }
+            staffIdx += sp;
+        }
+    }
+    for (size_t staffIdx = 0; staffIdx < masterScore->nstaves(); ++staffIdx) {
+        Staff* s = masterScore->staff(staffIdx);
+        int sp = s->barLineSpan();
+        if (sp <= 0) {
+            continue;
+        }
+        for (int span = 1; span <= sp; ++span) {
+            Staff* ns = masterScore->staff(staffIdx + span);
+            ns->setBarLineSpan(sp - span);
+        }
+        staffIdx += sp;
+    }
+
+    // fix positions
+    //    offset = saved offset - layout position
+    masterScore->doLayout();
+    for (auto i : ctx.fixOffsets()) {
+        i.first->setOffset(i.second - i.first->pos());
+    }
+
+    return Err::NoError;
+}

--- a/src/engraving/rw/compat/read302.cpp
+++ b/src/engraving/rw/compat/read302.cpp
@@ -1,0 +1,318 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "read302.h"
+
+#include "infrastructure/symbolfonts.h"
+#include "rw/xml.h"
+#include "style/style.h"
+
+#include "libmscore/audio.h"
+#include "libmscore/excerpt.h"
+#include "libmscore/factory.h"
+#include "libmscore/masterscore.h"
+#include "libmscore/measurebase.h"
+#include "libmscore/page.h"
+#include "libmscore/part.h"
+#include "libmscore/score.h"
+#include "libmscore/scoreorder.h"
+#include "libmscore/spanner.h"
+#include "libmscore/staff.h"
+#include "libmscore/text.h"
+
+#include "../staffrw.h"
+#include "readstyle.h"
+
+#include "log.h"
+
+using namespace mu;
+using namespace mu::engraving;
+using namespace mu::engraving::rw;
+using namespace mu::engraving::compat;
+
+bool Read302::readScore302(Score* score, XmlReader& e, ReadContext& ctx)
+{
+    while (e.readNextStartElement()) {
+        ctx.setTrack(mu::nidx);
+        const AsciiStringView tag(e.name());
+        if (tag == "Staff") {
+            StaffRW::readStaff(score, e, ctx);
+        } else if (tag == "Omr") {
+            e.skipCurrentElement();
+        } else if (tag == "Audio") {
+            score->_audio = new Audio;
+            score->_audio->read(e);
+        } else if (tag == "showOmr") {
+            e.skipCurrentElement();
+        } else if (tag == "playMode") {
+            score->_playMode = PlayMode(e.readInt());
+        } else if (tag == "LayerTag") {
+            int id = e.intAttribute("id");
+            const String& t = e.attribute("tag");
+            String val(e.readText());
+            if (id >= 0 && id < 32) {
+                score->_layerTags[id] = t;
+                score->_layerTagComments[id] = val;
+            }
+        } else if (tag == "Layer") {
+            Layer layer;
+            layer.name = e.attribute("name");
+            layer.tags = static_cast<unsigned int>(e.intAttribute("mask"));
+            score->_layer.push_back(layer);
+            e.readNext();
+        } else if (tag == "currentLayer") {
+            score->_currentLayer = e.readInt();
+        } else if (tag == "Synthesizer") {
+            score->_synthesizerState.read(e);
+        } else if (tag == "page-offset") {
+            score->_pageNumberOffset = e.readInt();
+        } else if (tag == "Division") {
+            score->_fileDivision = e.readInt();
+        } else if (tag == "showInvisible") {
+            score->_showInvisible = e.readInt();
+        } else if (tag == "showUnprintable") {
+            score->_showUnprintable = e.readInt();
+        } else if (tag == "showFrames") {
+            score->_showFrames = e.readInt();
+        } else if (tag == "showMargins") {
+            score->_showPageborders = e.readInt();
+        } else if (tag == "markIrregularMeasures") {
+            score->_markIrregularMeasures = e.readInt();
+        } else if (tag == "Style") {
+            double sp = score->style().value(Sid::spatium).toReal();
+
+            ReadStyleHook::readStyleTag(score, e);
+
+            // if (_layoutMode == LayoutMode::FLOAT || _layoutMode == LayoutMode::SYSTEM) {
+            if (score->layoutOptions().isMode(LayoutMode::FLOAT)) {
+                // style should not change spatium in
+                // float mode
+                score->style().set(Sid::spatium, sp);
+            }
+            score->m_symbolFont = SymbolFonts::fontByName(score->style().styleSt(Sid::MusicalSymbolFont));
+        } else if (tag == "copyright" || tag == "rights") {
+            score->setMetaTag(u"copyright", Text::readXmlText(e, score));
+        } else if (tag == "movement-number") {
+            score->setMetaTag(u"movementNumber", e.readText());
+        } else if (tag == "movement-title") {
+            score->setMetaTag(u"movementTitle", e.readText());
+        } else if (tag == "work-number") {
+            score->setMetaTag(u"workNumber", e.readText());
+        } else if (tag == "work-title") {
+            score->setMetaTag(u"workTitle", e.readText());
+        } else if (tag == "source") {
+            score->setMetaTag(u"source", e.readText());
+        } else if (tag == "metaTag") {
+            String name = e.attribute("name");
+            score->setMetaTag(name, e.readText());
+        } else if (tag == "Order") {
+            ScoreOrder order;
+            order.read(e);
+            if (order.isValid()) {
+                score->setScoreOrder(order);
+            }
+        } else if (tag == "Part") {
+            Part* part = new Part(score);
+            part->read(e);
+            score->appendPart(part);
+        } else if ((tag == "HairPin")
+                   || (tag == "Ottava")
+                   || (tag == "TextLine")
+                   || (tag == "Volta")
+                   || (tag == "Trill")
+                   || (tag == "Slur")
+                   || (tag == "Pedal")) {
+            Spanner* s = toSpanner(Factory::createItemByName(tag, score->dummy()));
+            s->read(e);
+            score->addSpanner(s);
+        } else if (tag == "Excerpt") {
+            if (MScore::noExcerpts) {
+                e.skipCurrentElement();
+            } else {
+                if (score->isMaster()) {
+                    MasterScore* mScore = static_cast<MasterScore*>(score);
+                    Excerpt* ex = new Excerpt(mScore);
+                    ex->read(e);
+                    mScore->excerpts().push_back(ex);
+                } else {
+                    LOGD("Score::read(): part cannot have parts");
+                    e.skipCurrentElement();
+                }
+            }
+        } else if (e.name() == "Tracklist") {
+            int strack = e.intAttribute("sTrack",   -1);
+            int dtrack = e.intAttribute("dstTrack", -1);
+            if (strack != -1 && dtrack != -1) {
+                ctx.tracks().insert({ strack, dtrack });
+            }
+            e.skipCurrentElement();
+        } else if (tag == "Score") {            // recursion
+            if (MScore::noExcerpts) {
+                e.skipCurrentElement();
+            } else {
+                ctx.tracks().clear();             // ???
+                MasterScore* m = score->masterScore();
+                Score* s = m->createScore();
+
+                ReadStyleHook::setupDefaultStyle(s);
+
+                Excerpt* ex = new Excerpt(m);
+                ex->setExcerptScore(s);
+                ctx.setLastMeasure(nullptr);
+
+                Score* curScore = e.context()->score();
+                e.context()->setScore(s);
+
+                readScore302(s, e, *e.context());
+
+                e.context()->setScore(curScore);
+
+                s->linkMeasures(m);
+                ex->setTracksMapping(ctx.tracks());
+                m->addExcerpt(ex);
+            }
+        } else if (tag == "name") {
+            String n = e.readText();
+            if (!score->isMaster()) {     //ignore the name if it's not a child score
+                score->excerpt()->setName(n);
+            }
+        } else if (tag == "layoutMode") {
+            String s = e.readText();
+            if (s == "line") {
+                score->setLayoutMode(LayoutMode::LINE);
+            } else if (s == "system") {
+                score->setLayoutMode(LayoutMode::SYSTEM);
+            } else {
+                LOGD("layoutMode: %s", muPrintable(s));
+            }
+        } else {
+            e.unknown();
+        }
+    }
+    e.context()->reconnectBrokenConnectors();
+    if (e.error() != XmlStreamReader::NoError) {
+        if (e.error() == XmlStreamReader::CustomError) {
+            LOGE() << e.errorString();
+        } else {
+            LOGE() << String(u"XML read error at line %1, column %2: %3").arg(e.lineNumber(), e.columnNumber())
+                .arg(String::fromAscii(e.name().ascii()));
+        }
+        return false;
+    }
+
+    score->connectTies();
+    score->relayoutForStyles(); // force relayout if certain style settings are enabled
+
+    score->_fileDivision = Constants::division;
+
+    if (score->mscVersion() == 302) {
+        // MuseScore 3.6.x scores had some wrong instrument IDs
+        for (Part* part : score->parts()) {
+            for (const auto& pair : part->instruments()) {
+                fixInstrumentId(pair.second);
+            }
+        }
+    } else {
+        // Older scores had no IDs at all
+        for (Part* part : score->parts()) {
+            for (const auto& pair : part->instruments()) {
+                pair.second->updateInstrumentId();
+            }
+        }
+    }
+
+    score->setUpTempoMap();
+
+    for (Part* p : score->_parts) {
+        p->updateHarmonyChannels(false);
+        if (!p->show()) {
+            // convert hidden instruments into hidden staves, to preserve playback
+            p->setShow(true);
+            for (Staff* s : p->staves()) {
+                s->setVisible(false);
+            }
+        }
+    }
+
+    score->masterScore()->rebuildMidiMapping();
+    score->masterScore()->updateChannel();
+
+    for (Staff* staff : score->staves()) {
+        staff->updateOttava();
+    }
+
+//      createPlayEvents();
+    return true;
+}
+
+Err Read302::read302(MasterScore* masterScore, XmlReader& e, ReadContext& ctx)
+{
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag(e.name());
+        if (tag == "programVersion") {
+            masterScore->setMscoreVersion(e.readText());
+        } else if (tag == "programRevision") {
+            masterScore->setMscoreRevision(e.readInt(nullptr, 16));
+        } else if (tag == "Score") {
+            if (!readScore302(masterScore, e, ctx)) {
+                if (e.error() == XmlStreamReader::CustomError) {
+                    return Err::FileCriticallyCorrupted;
+                }
+                return Err::FileBadFormat;
+            }
+        } else if (tag == "Revision") {
+            e.skipCurrentElement();
+        }
+    }
+
+    return Err::NoError;
+}
+
+void Read302::fixInstrumentId(Instrument* instrument)
+{
+    String id = instrument->id();
+    String trackName = instrument->trackName().toLower();
+
+    // incorrect instrument IDs in 3.6.x
+    if (id == u"Winds") {
+        id = u"winds";
+    } else if (id == u"harmonica-d12high-g") {
+        id = u"harmonica-d10high-g";
+    } else if (id == u"harmonica-d12f") {
+        id = u"harmonica-d10f";
+    } else if (id == u"harmonica-d12d") {
+        id = u"harmonica-d10d";
+    } else if (id == u"harmonica-d12c") {
+        id = u"harmonica-d10c";
+    } else if (id == u"harmonica-d12a") {
+        id = u"harmonica-d10a";
+    } else if (id == u"harmonica-d12-g") {
+        id = u"harmonica-d10g";
+    } else if (id == u"drumset" && trackName == u"percussion") {
+        id = u"percussion";
+    } else if (id == u"cymbal" && trackName == u"cymbals") {
+        id = u"marching-cymbals";
+    } else if (id == u"bass-drum" && trackName == u"bass drums") {
+        id = u"marching-bass-drums";
+    }
+
+    instrument->setId(id);
+}


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10951 (partially)

MU4 treats hidden instruments as muted with no possibility of unmuting, which breaks older (3.x and earlier) scores that use invisible playback staves.  The change in this PR acts on import, setting the instrument itself to show but marking the staves of the instrument as invisible.  This allows existing scores to both look and sound as before.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made

I did not create a test for this as I am not sure how this should be done.