### PR TITLE
fix playback of harmonic notes in guitar pro

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1576,7 +1576,9 @@ void GPConverter::addHarmonic(const GPNote* gpnote, Note* note)
 
         hnote->setTpcFromPitch();
         note->chord()->add(hnote);
-        hnote->setPlay(false);
+        hnote->setPlay(true);
+        note->setPlay(false);
+
         addTie(gpnote, note);
         note->setHarmonicFret(note->fret() + gpnote->harmonic().fret);
     } else {

--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -1178,6 +1178,8 @@ bool GuitarPro5::readNoteEffects(Note* note)
             Note* harmonicNote = Factory::createNote(note->chord());
 
             harmonicNote->setHarmonic(true);
+            harmonicNote->setPlay(true);
+            note->setPlay(false);
             /// @note option to show or not additional harmonic fret in "<>" to be implemented
             ///harmonicNote->setDisplayFret(Note::DisplayFretOption::ArtificialHarmonic);
             ///note->setDisplayFret(Note::DisplayFretOption::Hide);

--- a/src/importexport/guitarpro/tests/data/artificial-harmonic.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/artificial-harmonic.gp-ref.mscx
@@ -83,6 +83,7 @@
             <Note>
               <pitch>50</pitch>
               <tpc>16</tpc>
+              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -90,7 +91,6 @@
               <pitch>62</pitch>
               <tpc>16</tpc>
               <head>diamond</head>
-              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -118,6 +118,7 @@
             <Note>
               <pitch>50</pitch>
               <tpc>16</tpc>
+              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -125,7 +126,6 @@
               <pitch>69</pitch>
               <tpc>17</tpc>
               <head>diamond</head>
-              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -153,6 +153,7 @@
             <Note>
               <pitch>50</pitch>
               <tpc>16</tpc>
+              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -160,7 +161,6 @@
               <pitch>74</pitch>
               <tpc>16</tpc>
               <head>diamond</head>
-              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -189,6 +189,7 @@
             <Note>
               <pitch>64</pitch>
               <tpc>18</tpc>
+              <play>0</play>
               <fret>5</fret>
               <string>1</string>
               </Note>
@@ -199,7 +200,6 @@
               <pitch>92</pitch>
               <tpc>22</tpc>
               <head>diamond</head>
-              <play>0</play>
               <fret>5</fret>
               <string>1</string>
               </Note>
@@ -232,6 +232,7 @@
             <Note>
               <pitch>50</pitch>
               <tpc>16</tpc>
+              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -239,7 +240,6 @@
               <pitch>81</pitch>
               <tpc>17</tpc>
               <head>diamond</head>
-              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -267,6 +267,7 @@
             <Note>
               <pitch>55</pitch>
               <tpc>15</tpc>
+              <play>0</play>
               <fret>10</fret>
               <string>4</string>
               </Note>
@@ -274,7 +275,6 @@
               <pitch>89</pitch>
               <tpc>13</tpc>
               <head>diamond</head>
-              <play>0</play>
               <fret>10</fret>
               <string>4</string>
               </Note>
@@ -284,6 +284,7 @@
             <Note>
               <pitch>50</pitch>
               <tpc>16</tpc>
+              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -291,7 +292,6 @@
               <pitch>86</pitch>
               <tpc>16</tpc>
               <head>diamond</head>
-              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -301,6 +301,7 @@
             <Note>
               <pitch>50</pitch>
               <tpc>16</tpc>
+              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -308,7 +309,6 @@
               <pitch>86</pitch>
               <tpc>16</tpc>
               <head>diamond</head>
-              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>

--- a/src/importexport/guitarpro/tests/data/artificial-harmonic.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/artificial-harmonic.gpx-ref.mscx
@@ -83,6 +83,7 @@
             <Note>
               <pitch>50</pitch>
               <tpc>16</tpc>
+              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -90,7 +91,6 @@
               <pitch>62</pitch>
               <tpc>16</tpc>
               <head>diamond</head>
-              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -118,6 +118,7 @@
             <Note>
               <pitch>50</pitch>
               <tpc>16</tpc>
+              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -125,7 +126,6 @@
               <pitch>69</pitch>
               <tpc>17</tpc>
               <head>diamond</head>
-              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -153,6 +153,7 @@
             <Note>
               <pitch>50</pitch>
               <tpc>16</tpc>
+              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -160,7 +161,6 @@
               <pitch>74</pitch>
               <tpc>16</tpc>
               <head>diamond</head>
-              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -189,6 +189,7 @@
             <Note>
               <pitch>64</pitch>
               <tpc>18</tpc>
+              <play>0</play>
               <fret>5</fret>
               <string>1</string>
               </Note>
@@ -199,7 +200,6 @@
               <pitch>92</pitch>
               <tpc>22</tpc>
               <head>diamond</head>
-              <play>0</play>
               <fret>5</fret>
               <string>1</string>
               </Note>
@@ -232,6 +232,7 @@
             <Note>
               <pitch>50</pitch>
               <tpc>16</tpc>
+              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -239,7 +240,6 @@
               <pitch>81</pitch>
               <tpc>17</tpc>
               <head>diamond</head>
-              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -267,6 +267,7 @@
             <Note>
               <pitch>55</pitch>
               <tpc>15</tpc>
+              <play>0</play>
               <fret>10</fret>
               <string>4</string>
               </Note>
@@ -274,7 +275,6 @@
               <pitch>89</pitch>
               <tpc>13</tpc>
               <head>diamond</head>
-              <play>0</play>
               <fret>10</fret>
               <string>4</string>
               </Note>
@@ -284,6 +284,7 @@
             <Note>
               <pitch>50</pitch>
               <tpc>16</tpc>
+              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -291,7 +292,6 @@
               <pitch>86</pitch>
               <tpc>16</tpc>
               <head>diamond</head>
-              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -301,6 +301,7 @@
             <Note>
               <pitch>50</pitch>
               <tpc>16</tpc>
+              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -308,7 +309,6 @@
               <pitch>86</pitch>
               <tpc>16</tpc>
               <head>diamond</head>
-              <play>0</play>
               <fret>5</fret>
               <string>4</string>
               </Note>


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

*fix playback of harmonic notes in guitar pro*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
