### PR TITLE
Separate flows for "Save to cloud" and "Publish"

### DIFF
--- a/src/cloud/iuploadingservice.h
+++ b/src/cloud/iuploadingservice.h
@@ -22,11 +22,12 @@
 #ifndef MU_CLOUD_IUPLOADINGSERVICE_H
 #define MU_CLOUD_IUPLOADINGSERVICE_H
 
+#include <QUrl>
+
 #include "modularity/imoduleexport.h"
 #include "progress.h"
 
 class QIODevice;
-class QUrl;
 class QString;
 
 namespace mu::cloud {

--- a/src/project/inotationproject.h
+++ b/src/project/inotationproject.h
@@ -49,6 +49,8 @@ public:
     virtual Ret createNew(const ProjectCreateOptions& projectInfo) = 0;
 
     virtual bool isCloudProject() const = 0;
+    virtual CloudProjectInfo cloudInfo() const = 0;
+    virtual void setCloudInfo(const CloudProjectInfo& info) = 0;
 
     virtual bool isNewlyCreated() const = 0;
     virtual void markAsNewlyCreated() = 0;

--- a/src/project/internal/isaveprojectscenario.h
+++ b/src/project/internal/isaveprojectscenario.h
@@ -38,9 +38,8 @@ public:
                                                  SaveLocationType preselectedType = SaveLocationType::Undefined) const = 0;
 
     virtual RetVal<io::path_t> askLocalPath(INotationProjectPtr project, SaveMode mode) const = 0;
-    virtual RetVal<SaveLocation::CloudInfo> askCloudLocation(INotationProjectPtr project,
-                                                             CloudProjectVisibility defaultVisibility = CloudProjectVisibility::Private)
-    const = 0;
+    virtual RetVal<CloudProjectInfo> askCloudLocation(INotationProjectPtr project) const = 0;
+    virtual RetVal<CloudProjectInfo> askPublishLocation(INotationProjectPtr project) const = 0;
 };
 }
 

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -391,6 +391,16 @@ bool NotationProject::isCloudProject() const
     return configuration()->isCloudProject(m_path);
 }
 
+CloudProjectInfo NotationProject::cloudInfo() const
+{
+    return m_cloudInfo;
+}
+
+void NotationProject::setCloudInfo(const CloudProjectInfo& info)
+{
+    m_cloudInfo = info;
+}
+
 mu::Ret NotationProject::save(const io::path_t& path, SaveMode saveMode)
 {
     TRACEFUNC;

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -33,7 +33,6 @@
 #include "inotationwritersregister.h"
 
 #include "engraving/engravingproject.h"
-#include "engraving/infrastructure/ifileinfoprovider.h"
 
 #include "notation/internal/masternotation.h"
 #include "projectaudiosettings.h"
@@ -68,6 +67,8 @@ public:
     QString displayName() const override;
 
     bool isCloudProject() const override;
+    CloudProjectInfo cloudInfo() const override;
+    void setCloudInfo(const CloudProjectInfo& info) override;
 
     bool isNewlyCreated() const override;
     void markAsNewlyCreated() override;
@@ -108,6 +109,8 @@ private:
 
     io::path_t m_path;
     async::Notification m_pathChanged;
+
+    CloudProjectInfo m_cloudInfo;
 
     async::Notification m_needSaveNotification;
 

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -100,7 +100,8 @@ private:
 
     bool saveProjectAt(const SaveLocation& saveLocation, SaveMode saveMode = SaveMode::Save);
     bool saveProjectLocally(const io::path_t& path = io::path_t(), SaveMode saveMode = SaveMode::Save);
-    void saveProjectToCloud(const SaveLocation::CloudInfo& info, SaveMode saveMode = SaveMode::Save);
+    bool saveProjectToCloud(const CloudProjectInfo& info, SaveMode saveMode = SaveMode::Save);
+    void uploadProject(const CloudProjectInfo& info);
 
     void importPdf();
 
@@ -126,7 +127,7 @@ private:
 
     bool m_isProjectProcessing = false;
 
-    bool m_saveToCloudAllowed = true;
+    bool m_isUploadingProject = false;
     framework::ProgressPtr m_uploadingProgress;
 };
 }

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -48,7 +48,7 @@ static const Settings::Key LAST_SAVED_PROJECTS_PATH(module_name, "application/pa
 static const Settings::Key USER_PROJECTS_PATH(module_name, "application/paths/myScores");
 static const Settings::Key SHOULD_ASK_SAVE_LOCATION_TYPE(module_name, "project/shouldAskSaveLocationType");
 static const Settings::Key LAST_USED_SAVE_LOCATION_TYPE(module_name, "project/lastUsedSaveLocationType");
-static const Settings::Key SHOULD_WARN_BEFORE_PUBLISHING(module_name, "project/shouldWarnBeforePublishing");
+static const Settings::Key SHOULD_WARN_BEFORE_SAVING_PUBLICLY(module_name, "project/shouldWarnBeforeSavingPublicly");
 static const Settings::Key PREFERRED_SCORE_CREATION_MODE_KEY(module_name, "project/preferredScoreCreationMode");
 static const Settings::Key MIGRATION_OPTIONS(module_name, "project/migration");
 static const Settings::Key AUTOSAVE_ENABLED_KEY(module_name, "project/autoSaveEnabled");
@@ -83,7 +83,7 @@ void ProjectConfiguration::init()
     settings()->setDefaultValue(SHOULD_ASK_SAVE_LOCATION_TYPE, Val(true));
     settings()->setDefaultValue(LAST_USED_SAVE_LOCATION_TYPE, Val(SaveLocationType::Undefined));
 
-    settings()->setDefaultValue(SHOULD_WARN_BEFORE_PUBLISHING, Val(true));
+    settings()->setDefaultValue(SHOULD_WARN_BEFORE_SAVING_PUBLICLY, Val(true));
 
     settings()->setDefaultValue(AUTOSAVE_ENABLED_KEY, Val(true));
     settings()->valueChanged(AUTOSAVE_ENABLED_KEY).onReceive(nullptr, [this](const Val& val) {
@@ -349,14 +349,14 @@ void ProjectConfiguration::setLastUsedSaveLocationType(SaveLocationType type)
     settings()->setSharedValue(LAST_USED_SAVE_LOCATION_TYPE, Val(type));
 }
 
-bool ProjectConfiguration::shouldWarnBeforePublishing() const
+bool ProjectConfiguration::shouldWarnBeforeSavingPublicly() const
 {
-    return settings()->value(SHOULD_WARN_BEFORE_PUBLISHING).toBool();
+    return settings()->value(SHOULD_WARN_BEFORE_SAVING_PUBLICLY).toBool();
 }
 
-void ProjectConfiguration::setShouldWarnBeforePublishing(bool shouldWarn)
+void ProjectConfiguration::setShouldWarnBeforeSavingPublicly(bool shouldWarn)
 {
-    settings()->setSharedValue(SHOULD_WARN_BEFORE_PUBLISHING, Val(shouldWarn));
+    settings()->setSharedValue(SHOULD_WARN_BEFORE_SAVING_PUBLICLY, Val(shouldWarn));
 }
 
 QColor ProjectConfiguration::templatePreviewBackgroundColor() const

--- a/src/project/internal/projectconfiguration.h
+++ b/src/project/internal/projectconfiguration.h
@@ -84,8 +84,8 @@ public:
     SaveLocationType lastUsedSaveLocationType() const override;
     void setLastUsedSaveLocationType(SaveLocationType type) override;
 
-    bool shouldWarnBeforePublishing() const override;
-    void setShouldWarnBeforePublishing(bool shouldWarn) override;
+    bool shouldWarnBeforeSavingPublicly() const override;
+    void setShouldWarnBeforeSavingPublicly(bool shouldWarn) override;
 
     QColor templatePreviewBackgroundColor() const override;
     async::Notification templatePreviewBackgroundChanged() const override;

--- a/src/project/internal/saveprojectscenario.h
+++ b/src/project/internal/saveprojectscenario.h
@@ -44,18 +44,19 @@ public:
                                          SaveLocationType preselectedType = SaveLocationType::Undefined) const override;
 
     RetVal<io::path_t> askLocalPath(INotationProjectPtr project, SaveMode mode) const override;
-    RetVal<SaveLocation::CloudInfo> askCloudLocation(INotationProjectPtr project,
-                                                     CloudProjectVisibility defaultVisibility = CloudProjectVisibility::Private) const
-    override;
+    RetVal<CloudProjectInfo> askCloudLocation(INotationProjectPtr project) const override;
+    RetVal<CloudProjectInfo> askPublishLocation(INotationProjectPtr project) const override;
 
 private:
     RetVal<SaveLocationType> saveLocationType() const;
     RetVal<SaveLocationType> askSaveLocationType() const;
 
-    RetVal<SaveLocation::CloudInfo> doAskCloudLocation(INotationProjectPtr project, bool canSaveLocallyInstead = true,
-                                                       CloudProjectVisibility defaultVisibility = CloudProjectVisibility::Private) const;
+    /// \param isPublish:
+    ///     false -> this is part of a "Save to cloud" action
+    ///     true -> this is part of a "Publish" action
+    RetVal<CloudProjectInfo> doAskCloudLocation(INotationProjectPtr project, bool isPublish) const;
 
-    bool warnBeforePublishing() const;
+    bool warnBeforePublishing(INotationProjectPtr project, bool isPublish) const;
 };
 
 class QMLSaveLocationType

--- a/src/project/iprojectconfiguration.h
+++ b/src/project/iprojectconfiguration.h
@@ -78,8 +78,8 @@ public:
     virtual SaveLocationType lastUsedSaveLocationType() const = 0;
     virtual void setLastUsedSaveLocationType(SaveLocationType type) = 0;
 
-    virtual bool shouldWarnBeforePublishing() const = 0;
-    virtual void setShouldWarnBeforePublishing(bool shouldWarn) = 0;
+    virtual bool shouldWarnBeforeSavingPublicly() const = 0;
+    virtual void setShouldWarnBeforeSavingPublicly(bool shouldWarn) = 0;
 
     virtual QColor templatePreviewBackgroundColor() const = 0;
     virtual async::Notification templatePreviewBackgroundChanged() const = 0;

--- a/src/project/projecttypes.h
+++ b/src/project/projecttypes.h
@@ -23,7 +23,9 @@
 #define MU_PROJECT_PROJECTTYPES_H
 
 #include <variant>
+
 #include <QString>
+#include <QUrl>
 
 #include "io/path.h"
 #include "log.h"
@@ -75,33 +77,39 @@ enum class SaveLocationType
 };
 
 enum class CloudProjectVisibility {
+    Undefined,
     Private,
     Public
 };
 
+struct CloudProjectInfo {
+    QUrl sourceUrl;
+    QString name;
+
+    CloudProjectVisibility visibility = CloudProjectVisibility::Undefined;
+
+    bool isValid() const
+    {
+        return !name.isEmpty();
+    }
+};
+
 struct SaveLocation
 {
-    struct LocalInfo {
-        io::path_t path;
-    };
-
-    struct CloudInfo {
-        // TODO(save-to-cloud)
-    };
-
     SaveLocationType type = SaveLocationType::Undefined;
-    std::variant<LocalInfo, CloudInfo> info;
+
+    std::variant<io::path_t, CloudProjectInfo> data;
 
     bool isLocal() const
     {
         return type == SaveLocationType::Local
-               && std::holds_alternative<LocalInfo>(info);
+               && std::holds_alternative<io::path_t>(data);
     }
 
     bool isCloud() const
     {
         return type == SaveLocationType::Cloud
-               && std::holds_alternative<CloudInfo>(info);
+               && std::holds_alternative<CloudProjectInfo>(data);
     }
 
     bool isValid() const
@@ -109,33 +117,33 @@ struct SaveLocation
         return isLocal() || isCloud();
     }
 
-    const LocalInfo& localInfo() const
+    const io::path_t& localPath() const
     {
         IF_ASSERT_FAILED(isLocal()) {
-            static LocalInfo null;
+            static io::path_t null;
             return null;
         }
 
-        return std::get<LocalInfo>(info);
+        return std::get<io::path_t>(data);
     }
 
-    const CloudInfo& cloudInfo() const
+    const CloudProjectInfo& cloudInfo() const
     {
         IF_ASSERT_FAILED(isCloud()) {
-            static CloudInfo null;
+            static CloudProjectInfo null;
             return null;
         }
 
-        return std::get<CloudInfo>(info);
+        return std::get<CloudProjectInfo>(data);
     }
 
     SaveLocation() = default;
 
-    SaveLocation(const LocalInfo& localInfo)
-        : type(SaveLocationType::Local), info(localInfo) {}
+    SaveLocation(const io::path_t& localPath)
+        : type(SaveLocationType::Local), data(localPath) {}
 
-    SaveLocation(const CloudInfo& cloudInfo)
-        : type(SaveLocationType::Cloud), info(cloudInfo) {}
+    SaveLocation(const CloudProjectInfo& cloudInfo)
+        : type(SaveLocationType::Cloud), data(cloudInfo) {}
 };
 
 struct ProjectMeta

--- a/src/project/qml/MuseScore/Project/SaveToCloudDialog.qml
+++ b/src/project/qml/MuseScore/Project/SaveToCloudDialog.qml
@@ -30,7 +30,7 @@ import MuseScore.Cloud 1.0
 StyledDialogView {
     id: root
 
-    property bool canSaveToComputer: true
+    property bool isPublish: false
     property string name
     property int visibility: CloudVisibility.Private
 
@@ -79,7 +79,7 @@ StyledDialogView {
 
             StyledTextLabel {
                 id: titleLabel
-                text: root.visibility === CloudVisibility.Public
+                text: root.isPublish
                       ? qsTrc("project/save", "Publish to MuseScore.com")
                       : qsTrc("project/save", "Save to cloud")
                 font: ui.theme.largeBodyBoldFont
@@ -170,7 +170,7 @@ StyledDialogView {
 
                 FlatButton {
                     text: qsTrc("project/save", "Save to computer")
-                    visible: root.canSaveToComputer
+                    visible: !root.isPublish
 
                     navigation.panel: buttonsNavPanel
                     navigation.column: 2
@@ -193,7 +193,7 @@ StyledDialogView {
 
                 FlatButton {
                     id: saveButton
-                    text: qsTrc("project/save", "Save")
+                    text: root.isPublish ? qsTrc("project/save", "Publish") : qsTrc("project/save", "Save")
                     accentButton: enabled
                     enabled: Boolean(root.name)
 

--- a/src/project/tests/mocks/projectconfigurationmock.h
+++ b/src/project/tests/mocks/projectconfigurationmock.h
@@ -67,8 +67,8 @@ public:
     MOCK_METHOD(SaveLocationType, lastUsedSaveLocationType, (), (const, override));
     MOCK_METHOD(void, setLastUsedSaveLocationType, (SaveLocationType), (override));
 
-    MOCK_METHOD(bool, shouldWarnBeforePublishing, (), (const, override));
-    MOCK_METHOD(void, setShouldWarnBeforePublishing, (bool), (override));
+    MOCK_METHOD(bool, shouldWarnBeforeSavingPublicly, (), (const, override));
+    MOCK_METHOD(void, setShouldWarnBeforeSavingPublicly, (bool), (override));
 
     MOCK_METHOD(QColor, templatePreviewBackgroundColor, (), (const, override));
     MOCK_METHOD(async::Notification, templatePreviewBackgroundChanged, (), (const, override));


### PR DESCRIPTION
There are two flows:
- "Save to cloud": turns the project into a cloud score. This is very similar to the classic "Save as" command: the only difference is that the score will be saved on MuseScore.com rather than locally. Any subsequent File > Save or Cmd+S will also save the score to the cloud, just like with classic "Save as".

    (in fact, my current idea is that a local copy of the score will be stored in a cache folder on your computer, to facilitate some things, but that's an implementation detail.)

- "Publish": MS3 style uploading. Uploads a copy of the score to MuseScore.com once, but leaves the score itself where it is (which may be either locally or in the cloud). The ability to re-upload to an existing score is planned to be retained, just like it worked in MS3.

Although some dialogs and some logic is shared between the two flows, we should not confuse them. This PR (almost fully) implements proper separation between the flows, while still keeping the code DRY ("don't repeat yourself").
This PR also documents some of the remaining tasks as TODOs.

We should be careful with the concept of "source URLs". Each of the "flows" has its own version of it: the "Save to cloud" flow _needs_ a URL because that determines where the score is saved, and the "Publish" flow _can optionally use_ a URL that tells where this score was published last time. Since it is also possible to publish a project that is saved in the cloud, we need to store both URLs separately. In this regard, this PR doesn't change anything yet.