### PR TITLE
fix #13318 - ensure default dash/gap length for hairpins is sensible

### DIFF
--- a/src/engraving/libmscore/hairpin.cpp
+++ b/src/engraving/libmscore/hairpin.cpp
@@ -625,9 +625,9 @@ Sid Hairpin::getPropertyStyle(Pid pid) const
     case Pid::LINE_STYLE:
         return isLineType() ? Sid::hairpinLineLineStyle : Sid::hairpinLineStyle;
     case Pid::DASH_LINE_LEN:
-        return isLineType() ? Sid::hairpinLineDashLineLen : Sid::NOSTYLE;
+        return Sid::hairpinLineDashLineLen;
     case Pid::DASH_GAP_LEN:
-        return isLineType() ? Sid::hairpinLineDashGapLen : Sid::NOSTYLE;
+        return Sid::hairpinLineDashGapLen;
     default:
         break;
     }
@@ -643,9 +643,9 @@ Hairpin::Hairpin(Segment* parent)
 {
     initElementStyle(&hairpinStyle);
 
+    resetProperty(Pid::HAIRPIN_TYPE);
     resetProperty(Pid::BEGIN_TEXT_PLACE);
     resetProperty(Pid::CONTINUE_TEXT_PLACE);
-    resetProperty(Pid::HAIRPIN_TYPE);
     resetProperty(Pid::LINE_VISIBLE);
 
     _hairpinCircledTip     = false;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/13318

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
