### PR TITLE
[MU4] Apply chord magnitude to the vertical adjustment of slurs

### DIFF
--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -1130,7 +1130,7 @@ void Slur::slurPos(SlurPos* sp)
         } else {
             po.ry() = scr->bbox().top() + scr->height();
         }
-        po.ry() += _spatium * .9 * __up;
+        po.ry() += scr->mag() * _spatium * .9 * __up;
 
         // adjustments for stem and/or beam
 
@@ -1236,7 +1236,7 @@ void Slur::slurPos(SlurPos* sp)
             } else {
                 po.ry() = endCR()->bbox().top() + endCR()->height();
             }
-            po.ry() += _spatium * .9 * __up;
+            po.ry() += ecr->mag() * _spatium * .9 * __up;
 
             // adjustments for stem and/or beam
 


### PR DESCRIPTION
The issue;
![image](https://user-images.githubusercontent.com/89263931/190469426-12034791-7a40-4ba4-8260-9422567c6272.png)

Slur attachment spacing was not being multiplied by the chord magnitude. Now it is, so grace and normal notes have slightly different gaps between the anchor points and noteheads:
![image](https://user-images.githubusercontent.com/89263931/190469607-24f11d70-fc79-4056-8819-ee52463a606b.png)
