### PR TITLE
[MU4] Avoid applying magnitude twice for tie attach points

### DIFF
--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -1025,7 +1025,7 @@ double Note::outsideTieAttachX(bool up) const
     if (up) {
         double xNE = symSmuflAnchor(noteHead(), SmuflAnchorId::cutOutNE).x();
         double xNW = symSmuflAnchor(noteHead(), SmuflAnchorId::cutOutNW).x();
-        xo = ((xNE + xNW) / 2) * mag();
+        xo = ((xNE + xNW) / 2);
         if (xNE < xNW) {
             // musejazz is busted
             xo = 0;
@@ -1033,7 +1033,7 @@ double Note::outsideTieAttachX(bool up) const
     } else {
         double xSE = symSmuflAnchor(noteHead(), SmuflAnchorId::cutOutSE).x();
         double xSW = symSmuflAnchor(noteHead(), SmuflAnchorId::cutOutSW).x();
-        xo = ((xSE + xSW) / 2) * mag();
+        xo = ((xSE + xSW) / 2);
         if (xSE < xSW) {
             xo = 0;
         }
@@ -1042,7 +1042,7 @@ double Note::outsideTieAttachX(bool up) const
         return x() + xo;
     }
     // no cutout, not a slash head, default to middle of notehead
-    return x() + ((headWidth() / 2) * mag());
+    return x() + (headWidth() / 2);
 }
 
 void Note::updateHeadGroup(const NoteHeadGroup headGroup)

--- a/src/engraving/libmscore/tie.cpp
+++ b/src/engraving/libmscore/tie.cpp
@@ -858,7 +858,7 @@ void Tie::slurPos(SlurPos* sp)
     const StaffType* staffType = this->staffType();
     bool useTablature = staffType->isTabStaff();
     double _spatium = spatium();
-    double hw = startNote()->tabHeadWidth(staffType) * mag(); // if staffType == 0, defaults to headWidth()
+    double hw = startNote()->tabHeadWidth(staffType); // if staffType == 0, defaults to headWidth()
     /* Inside-style and Outside-style ties
      Outside ties connect above the notehead, in the middle. Ideally, we'd use opticalcenter for this, but
      that Smufl anchor is not available for noteheads yet. For this reason, we rely on Note::outsideTieAttachX()


### PR DESCRIPTION
The issue (this is a 'small staff'):
![image](https://user-images.githubusercontent.com/89263931/190482748-19d18752-bb4e-49f8-9984-e50dd1b3db12.png)

Magnitude was being applied twice in some cases, since it was already applied once via `headWidth()`. This has been fixed and now the behavior is the same between normal- and small-sized staves:
![image](https://user-images.githubusercontent.com/89263931/190482579-46164491-fa52-4d1c-bd62-ef7230096568.png)
