### PR TITLE
Fix (repeat) barline bbox and layout if Sid::spatium ≉ SPATIUM20

### DIFF
--- a/src/engraving/libmscore/barline.cpp
+++ b/src/engraving/libmscore/barline.cpp
@@ -1160,48 +1160,48 @@ void BarLine::endEditDrag(EditData& ed)
 //   layoutWidth
 //---------------------------------------------------------
 
-double BarLine::layoutWidth(Score* score, BarLineType type)
+double BarLine::layoutWidth() const
 {
-    double dotwidth = score->symbolFont()->width(SymId::repeatDot, 1.0);
+    const double dotWidth = symWidth(SymId::repeatDot);
 
     double w { 0.0 };
-    switch (type) {
+    switch (barLineType()) {
     case BarLineType::DOUBLE:
-        w = (score->styleMM(Sid::doubleBarWidth) * 2.0)
-            + score->styleMM(Sid::doubleBarDistance);
+        w = score()->styleMM(Sid::doubleBarWidth) * 2.0
+            + score()->styleMM(Sid::doubleBarDistance);
         break;
     case BarLineType::DOUBLE_HEAVY:
-        w = (score->styleMM(Sid::endBarWidth) * 2.0)
-            + score->styleMM(Sid::endBarDistance);
+        w = score()->styleMM(Sid::endBarWidth) * 2.0
+            + score()->styleMM(Sid::endBarDistance);
         break;
     case BarLineType::END_START_REPEAT:
-        w = score->styleMM(Sid::endBarWidth)
-            + (score->styleMM(Sid::barWidth) * 2.0)
-            + (score->styleMM(Sid::endBarDistance) * 2.0)
-            + (score->styleMM(Sid::repeatBarlineDotSeparation) * 2.0)
-            + (dotwidth * 2);
+        w = score()->styleMM(Sid::endBarWidth)
+            + score()->styleMM(Sid::barWidth) * 2.0
+            + score()->styleMM(Sid::endBarDistance) * 2.0
+            + score()->styleMM(Sid::repeatBarlineDotSeparation) * 2.0
+            + dotWidth * 2;
         break;
     case BarLineType::START_REPEAT:
     case BarLineType::END_REPEAT:
-        w = score->styleMM(Sid::endBarWidth)
-            + score->styleMM(Sid::barWidth)
-            + score->styleMM(Sid::endBarDistance)
-            + score->styleMM(Sid::repeatBarlineDotSeparation)
-            + dotwidth;
+        w = score()->styleMM(Sid::endBarWidth)
+            + score()->styleMM(Sid::barWidth)
+            + score()->styleMM(Sid::endBarDistance)
+            + score()->styleMM(Sid::repeatBarlineDotSeparation)
+            + dotWidth;
         break;
     case BarLineType::END:
     case BarLineType::REVERSE_END:
-        w = score->styleMM(Sid::endBarWidth)
-            + score->styleMM(Sid::barWidth)
-            + score->styleMM(Sid::endBarDistance);
+        w = score()->styleMM(Sid::endBarWidth)
+            + score()->styleMM(Sid::barWidth)
+            + score()->styleMM(Sid::endBarDistance);
         break;
     case BarLineType::BROKEN:
     case BarLineType::NORMAL:
     case BarLineType::DOTTED:
-        w = score->styleMM(Sid::barWidth);
+        w = score()->styleMM(Sid::barWidth);
         break;
     case BarLineType::HEAVY:
-        w = score->styleMM(Sid::endBarWidth);
+        w = score()->styleMM(Sid::endBarWidth);
         break;
     }
     return w;
@@ -1276,7 +1276,7 @@ void BarLine::layout()
     y1 = _spatium * .5 * _spanFrom;
     y2 = _spatium * .5 * (8.0 + _spanTo);
 
-    double w = layoutWidth(score(), barLineType()) * mag();
+    double w = layoutWidth() * mag();
     RectF r(0.0, y1, w, y2 - y1);
 
     if (score()->styleB(Sid::repeatBarTips)) {

--- a/src/engraving/libmscore/barline.h
+++ b/src/engraving/libmscore/barline.h
@@ -151,7 +151,7 @@ public:
     void undoChangeProperty(Pid id, const PropertyValue&, PropertyFlags ps) override;
     using EngravingObject::undoChangeProperty;
 
-    static double layoutWidth(Score*, BarLineType);
+    double layoutWidth() const;
     mu::RectF layoutRect() const;
 
     EngravingItem* nextSegmentElement() override;


### PR DESCRIPTION
Resolves: 
<img width="282" alt="Scherm­afbeelding 2022-09-17 om 16 01 58" src="https://user-images.githubusercontent.com/48658420/190869516-b7550349-c462-4244-8991-d683d7ebb3d2.png">
Root of the problem: spatium of the score was not taken into account, and the default spatium (24.8) happens to be approximately the same as the spatium which is used when loading SMuFL symbols in the SymbolFont class (SPATIUM20, = 25.0). Therefore this problem doesn't become obvious unless the spatium is significantly customized. 