### PR TITLE
Make engraving debugging options more advanced

### DIFF
--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -358,10 +358,12 @@ MenuItem* AppMenuModel::makeDiagnosticMenu()
     MenuItemList engravingItems {
         makeMenuItem("diagnostic-show-engraving-elements"),
         makeSeparator(),
-        makeMenuItem("show-skylines"),
+        makeMenuItem("show-element-bounding-rects"),
+        makeMenuItem("color-element-shapes"),
         makeMenuItem("show-segment-shapes"),
-        makeMenuItem("show-bounding-rect"),
-        makeMenuItem("show-system-bounding-rect"),
+        makeMenuItem("color-segment-shapes"),
+        makeMenuItem("show-skylines"),
+        makeMenuItem("show-system-bounding-rects"),
         makeMenuItem("show-corrupted-measures")
     };
 

--- a/src/engraving/iengravingconfiguration.h
+++ b/src/engraving/iengravingconfiguration.h
@@ -75,10 +75,12 @@ public:
     virtual draw::Color highlightSelectionColor(voice_idx_t voiceIndex = 0) const = 0;
 
     struct DebuggingOptions {
-        bool showSkylines = false;
+        bool showElementBoundingRects = false;
+        bool colorElementShapes = false;
         bool showSegmentShapes = false;
-        bool showBoundingRect = false;
-        bool showSystemBoundingRect = false;
+        bool colorSegmentShapes = false;
+        bool showSkylines = false;
+        bool showSystemBoundingRects = false;
         bool showCorruptedMeasures = true;
     };
 

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -58,10 +58,12 @@ static const QMap<ActionCode, Fraction> DURATIONS_FOR_TEXT_NAVIGATION {
 
 using EngravingDebuggingOptions = NotationActionController::EngravingDebuggingOptions;
 const std::unordered_map<ActionCode, bool EngravingDebuggingOptions::*> NotationActionController::engravingDebuggingActions {
-    { "show-skylines", &EngravingDebuggingOptions::showSkylines },
+    { "show-element-bounding-rects", &EngravingDebuggingOptions::showElementBoundingRects },
+    { "color-element-shapes", &EngravingDebuggingOptions::colorElementShapes },
     { "show-segment-shapes", &EngravingDebuggingOptions::showSegmentShapes },
-    { "show-bounding-rect", &EngravingDebuggingOptions::showBoundingRect },
-    { "show-system-bounding-rect", &EngravingDebuggingOptions::showSystemBoundingRect },
+    { "color-segment-shapes", &EngravingDebuggingOptions::colorSegmentShapes },
+    { "show-skylines", &EngravingDebuggingOptions::showSkylines },
+    { "show-system-bounding-rects", &EngravingDebuggingOptions::showSystemBoundingRects },
     { "show-corrupted-measures", &EngravingDebuggingOptions::showCorruptedMeasures }
 };
 

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -2332,34 +2332,46 @@ const UiActionList NotationUiActions::m_scoreConfigActions = {
 };
 
 const UiActionList NotationUiActions::m_engravingDebuggingActions = {
-    UiAction("show-skylines",
+    UiAction("show-element-bounding-rects",
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_NOTATION_OPENED,
-             TranslatableString("action", "Show &skylines"),
+             TranslatableString::untranslatable("Show element bounding rectangles"),
+             Checkable::Yes
+             ),
+    UiAction("color-element-shapes",
+             mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             TranslatableString::untranslatable("Color element shapes"),
              Checkable::Yes
              ),
     UiAction("show-segment-shapes",
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_NOTATION_OPENED,
-             TranslatableString("action", "Show s&egment shapes"),
+             TranslatableString::untranslatable("Show segment shapes"),
              Checkable::Yes
              ),
-    UiAction("show-bounding-rect",
+    UiAction("color-segment-shapes",
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_NOTATION_OPENED,
-             TranslatableString("action", "Show &bounding rectangles"),
+             TranslatableString::untranslatable("Color segment shapes"),
              Checkable::Yes
              ),
-    UiAction("show-system-bounding-rect",
+    UiAction("show-skylines",
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_NOTATION_OPENED,
-             TranslatableString("action", "Show s&ystem bounding rectangles"),
+             TranslatableString::untranslatable("Show skylines"),
+             Checkable::Yes
+             ),
+    UiAction("show-system-bounding-rects",
+             mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             TranslatableString::untranslatable("Show system bounding rectangles"),
              Checkable::Yes
              ),
     UiAction("show-corrupted-measures",
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_NOTATION_OPENED,
-             TranslatableString("action", "Show &corrupted measures"),
+             TranslatableString::untranslatable("Show corrupted measures"),
              Checkable::Yes
              )
 };


### PR DESCRIPTION
Add options to color the shapes, with a translucent color, and each element gets a different color. The colors are generated in a seemingly random way, but not entirely random because then the color would change on every redraw (also on scroll, zoom), which would make it pretty useless.

Useful for:
- debugging any engraving issue that has to do with shapes of segments and elements
- spotting shape/bbox calculation mistakes that are difficult to find otherwise
- finding out when an element gets replaced during the layout process: the new element will have a different memory address, and thus will get a different color
- fun
<img width="1948" alt="Scherm­afbeelding 2022-09-18 om 00 43 53" src="https://user-images.githubusercontent.com/48658420/190878690-abdac71a-6d46-4540-847b-737799f74e93.png">
For example, in this image you can see that the bbox of the end repeat barline is too wide. These new debugging options were helpful while fixing that, see #13407.