### PR TITLE
Fix crash when pasting or Ctrl+Shift+dragging certain elements (beam, note flag a.k.a. `Hook`)

### DIFF
--- a/src/engraving/libmscore/factory.cpp
+++ b/src/engraving/libmscore/factory.cpp
@@ -256,8 +256,10 @@ EngravingItem* Factory::doCreateItem(ElementType type, EngravingItem* parent)
     case ElementType::DUMMY:
         break;
     }
-    LOGD("cannot create type %d <%s>", int(type), TConv::toXml(type));
-    return 0;
+
+    LOGD() << "Cannot create element of type " << static_cast<int>(type) << " (" << TConv::toXml(type) << ")";
+
+    return nullptr;
 }
 
 EngravingItem* Factory::createItemByName(const AsciiStringView& name, EngravingItem* parent, bool isAccessibleEnabled)
@@ -265,7 +267,7 @@ EngravingItem* Factory::createItemByName(const AsciiStringView& name, EngravingI
     ElementType type = TConv::fromXml(name, ElementType::INVALID, isAccessibleEnabled);
     if (type == ElementType::INVALID) {
         LOGE() << "Invalid type: " << name;
-        return 0;
+        return nullptr;
     }
     return createItem(type, parent, isAccessibleEnabled);
 }

--- a/src/engraving/libmscore/factory.cpp
+++ b/src/engraving/libmscore/factory.cpp
@@ -112,7 +112,10 @@ using namespace mu::engraving;
 EngravingItem* Factory::createItem(ElementType type, EngravingItem* parent, bool isAccessibleEnabled)
 {
     EngravingItem* item = doCreateItem(type, parent);
-    item->setAccessibleEnabled(isAccessibleEnabled);
+
+    if (item) {
+        item->setAccessibleEnabled(isAccessibleEnabled);
+    }
 
     return item;
 }


### PR DESCRIPTION
These elements are not "creatable" by name, so also not "pasteable". But the code to handle such uncreatable elements had some small mistakes which causes a crash.

Resolves: #14159 