### PR TITLE
[MU4] Keep gradual tempo change objects on their proper staves

### DIFF
--- a/src/engraving/libmscore/gradualtempochange.cpp
+++ b/src/engraving/libmscore/gradualtempochange.cpp
@@ -149,14 +149,6 @@ LineSegment* GradualTempoChange::createLineSegment(System* parent)
     return lineSegment;
 }
 
-SpannerSegment* GradualTempoChange::layoutSystem(System* system)
-{
-    SpannerSegment* segment = TextLineBase::layoutSystem(system);
-    moveToSystemTopIfNeed(segment);
-
-    return segment;
-}
-
 GradualTempoChangeType GradualTempoChange::tempoChangeType() const
 {
     return m_tempoChangeType;

--- a/src/engraving/libmscore/gradualtempochange.h
+++ b/src/engraving/libmscore/gradualtempochange.h
@@ -42,7 +42,6 @@ public:
     void write(XmlWriter& writer) const override;
 
     LineSegment* createLineSegment(System* parent) override;
-    SpannerSegment* layoutSystem(System* system) override;
 
     GradualTempoChangeType tempoChangeType() const;
     ChangeMethod easingMethod() const;

--- a/src/engraving/libmscore/spanner.cpp
+++ b/src/engraving/libmscore/spanner.cpp
@@ -1416,18 +1416,6 @@ SpannerSegment* Spanner::layoutSystem(System*)
     return 0;
 }
 
-void Spanner::moveToSystemTopIfNeed(SpannerSegment* segment)
-{
-    if (segment->spanner()) {
-        for (SpannerSegment* ss : segment->spanner()->spannerSegments()) {
-            ss->setFlag(ElementFlag::SYSTEM, systemFlag());
-            ss->setTrack(systemFlag() ? 0 : track());
-        }
-        segment->spanner()->setFlag(ElementFlag::SYSTEM, systemFlag());
-        segment->spanner()->setTrack(systemFlag() ? 0 : track());
-    }
-}
-
 //---------------------------------------------------------
 //   getNextLayoutSystemSegment
 //---------------------------------------------------------

--- a/src/engraving/libmscore/spanner.h
+++ b/src/engraving/libmscore/spanner.h
@@ -185,8 +185,6 @@ protected:
 
     const std::vector<SpannerSegment*> spannerSegments() const { return segments; }
 
-    void moveToSystemTopIfNeed(SpannerSegment* segment);
-
 public:
 
     ~Spanner();

--- a/src/engraving/libmscore/textline.cpp
+++ b/src/engraving/libmscore/textline.cpp
@@ -357,17 +357,4 @@ void TextLine::undoChangeProperty(Pid id, const engraving::PropertyValue& v, Pro
     }
     TextLineBase::undoChangeProperty(id, v, ps);
 }
-
-//---------------------------------------------------------
-//   layoutSystem
-//    layout spannersegment for system
-//---------------------------------------------------------
-
-SpannerSegment* TextLine::layoutSystem(System* system)
-{
-    SpannerSegment* segment = TextLineBase::layoutSystem(system);
-    moveToSystemTopIfNeed(segment);
-
-    return segment;
-}
 } // namespace mu::engraving

--- a/src/engraving/libmscore/textline.h
+++ b/src/engraving/libmscore/textline.h
@@ -67,7 +67,6 @@ public:
     ~TextLine() {}
 
     void undoChangeProperty(Pid id, const PropertyValue&, PropertyFlags ps) override;
-    SpannerSegment* layoutSystem(System*) override;
 
     TextLine* clone() const override { return new TextLine(*this); }
 


### PR DESCRIPTION
The new "Gradual Tempo Change" system objects were setting all instances of themselves to staff zero on layout. This is unnecessary, as they and their clones are added to the correct staff on add or load.
![image](https://user-images.githubusercontent.com/89263931/191080808-ab36d2b2-4793-4bb2-be04-b035ce3f5c46.png)
