### PR TITLE
[MU4] Fix #12644: Playback of chord symbols doesn't respect staff/notes dynamic

### DIFF
--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -299,13 +299,22 @@ void PlaybackModel::updateContext(const track_idx_t trackFrom, const track_idx_t
         }
 
         for (const InstrumentTrackId& trackId : part->instrumentTrackIdSet()) {
-            PlaybackContext& ctx = m_playbackCtxMap[trackId];
-            ctx.update(trackId.partId, m_score);
+            updateContext(trackId);
+        }
 
-            PlaybackData& trackData = m_playbackDataMap[trackId];
-            trackData.dynamicLevelMap = ctx.dynamicLevelMap(m_score);
+        if (part->hasChordSymbol()) {
+            updateContext(chordSymbolsTrackId(part->id()));
         }
     }
+}
+
+void PlaybackModel::updateContext(const InstrumentTrackId& trackId)
+{
+    PlaybackContext& ctx = m_playbackCtxMap[trackId];
+    ctx.update(trackId.partId, m_score);
+
+    PlaybackData& trackData = m_playbackDataMap[trackId];
+    trackData.dynamicLevelMap = ctx.dynamicLevelMap(m_score);
 }
 
 void PlaybackModel::updateEvents(const int tickFrom, const int tickTo, const track_idx_t trackFrom, const track_idx_t trackTo,
@@ -504,6 +513,12 @@ void PlaybackModel::clearExpiredContexts(const track_idx_t trackFrom, const trac
         }
 
         for (const InstrumentTrackId& trackId : part->instrumentTrackIdSet()) {
+            PlaybackContext& ctx = m_playbackCtxMap[trackId];
+            ctx.clear();
+        }
+
+        if (part->hasChordSymbol()) {
+            InstrumentTrackId trackId = chordSymbolsTrackId(part->id());
             PlaybackContext& ctx = m_playbackCtxMap[trackId];
             ctx.clear();
         }

--- a/src/engraving/playback/playbackmodel.h
+++ b/src/engraving/playback/playbackmodel.h
@@ -104,6 +104,7 @@ private:
                 ChangedTrackIdSet* trackChanges = nullptr);
     void updateSetupData();
     void updateContext(const track_idx_t trackFrom, const track_idx_t trackTo);
+    void updateContext(const InstrumentTrackId& trackId);
     void updateEvents(const int tickFrom, const int tickTo, const track_idx_t trackFrom, const track_idx_t trackTo,
                       ChangedTrackIdSet* trackChanges = nullptr);
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/12644