### PR TITLE
Fix #13461 - treble instruments have only treble clefs

### DIFF
--- a/share/templates/01-General/01-Treble_Clef/01-Treble_Clef.mscx
+++ b/share/templates/01-General/01-Treble_Clef/01-Treble_Clef.mscx
@@ -82,6 +82,7 @@
         <minPitchA>21</minPitchA>
         <maxPitchA>108</maxPitchA>
         <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>95</gateTime>

--- a/src/engraving/libmscore/instrument.cpp
+++ b/src/engraving/libmscore/instrument.cpp
@@ -1533,7 +1533,7 @@ ClefTypeList Instrument::clefType(size_t staffIdx) const
 {
     if (staffIdx >= _clefType.size()) {
         if (_clefType.empty()) {
-            return ClefTypeList(staffIdx == 1 ? ClefType::G : ClefType::F);
+            return ClefTypeList();
         }
         return _clefType[0];
     }


### PR DESCRIPTION
Resolves: #13461 
Resolves: #13610

There is no reason for checking staff index (as it is not relevant information for detecting instrument)

In second commit, I changed Treble Clef template, to have "second staf bass clef" information, as it is, in fact piano instrument.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
