### PR TITLE
Implement custom `QAbstractOAuthReplyHandler` subclass to redirect to fancy MuseScore.com "Success!" page

### DIFF
--- a/src/cloud/CMakeLists.txt
+++ b/src/cloud/CMakeLists.txt
@@ -38,6 +38,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/cloudservice.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/cloudconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/cloudconfiguration.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/oauthhttpserverreplyhandler.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/oauthhttpserverreplyhandler.cpp
     )
 
 include(${PROJECT_SOURCE_DIR}/build/module.cmake)

--- a/src/cloud/icloudconfiguration.h
+++ b/src/cloud/icloudconfiguration.h
@@ -40,6 +40,7 @@ public:
     virtual QUrl cloudUrl() const = 0;
     virtual QUrl authorizationUrl() const = 0;
     virtual QUrl signUpUrl() const = 0;
+    virtual QUrl signInSuccessUrl() const = 0;
     virtual QUrl scoreManagerUrl() const = 0;
     virtual QUrl accessTokenUrl() const = 0;
 

--- a/src/cloud/internal/cloudconfiguration.cpp
+++ b/src/cloud/internal/cloudconfiguration.cpp
@@ -106,6 +106,12 @@ QUrl CloudConfiguration::signUpUrl() const
     return QUrl("https://musescore.com/oauth/authorize-new");
 }
 
+QUrl CloudConfiguration::signInSuccessUrl() const
+{
+    // TODO
+    return QUrl("https://musescore.com");
+}
+
 QUrl CloudConfiguration::scoreManagerUrl() const
 {
     return QUrl("https://musescore.com/my-scores");

--- a/src/cloud/internal/cloudconfiguration.h
+++ b/src/cloud/internal/cloudconfiguration.h
@@ -41,6 +41,7 @@ public:
     QUrl cloudUrl() const override;
     QUrl authorizationUrl() const override;
     QUrl signUpUrl() const override;
+    QUrl signInSuccessUrl() const override;
     QUrl scoreManagerUrl() const override;
     QUrl accessTokenUrl() const override;
 

--- a/src/cloud/internal/cloudservice.cpp
+++ b/src/cloud/internal/cloudservice.cpp
@@ -24,7 +24,6 @@
 #include "config.h"
 
 #include <QOAuth2AuthorizationCodeFlow>
-#include <QOAuthHttpServerReplyHandler>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QUrlQuery>
@@ -37,6 +36,7 @@
 #include "global/async/async.h"
 
 #include "clouderrors.h"
+#include "oauthhttpserverreplyhandler.h"
 
 #include "log.h"
 
@@ -100,7 +100,7 @@ void CloudService::init()
     TRACEFUNC;
 
     m_oauth2 = new QOAuth2AuthorizationCodeFlow(this);
-    m_replyHandler = new QOAuthHttpServerReplyHandler(this);
+    m_replyHandler = new OAuthHttpServerReplyHandler(this);
 
     m_oauth2->setAuthorizationUrl(configuration()->authorizationUrl());
     m_oauth2->setAccessTokenUrl(configuration()->accessTokenUrl());

--- a/src/cloud/internal/cloudservice.h
+++ b/src/cloud/internal/cloudservice.h
@@ -25,7 +25,6 @@
 #include <QObject>
 
 class QOAuth2AuthorizationCodeFlow;
-class QOAuthHttpServerReplyHandler;
 
 #include "iauthorizationservice.h"
 #include "iuploadingservice.h"
@@ -40,6 +39,8 @@ class QOAuthHttpServerReplyHandler;
 #include "iinteractive.h"
 
 namespace mu::cloud {
+class OAuthHttpServerReplyHandler;
+
 class CloudService : public QObject, public IAuthorizationService, public IUploadingService, public async::Asyncable
 {
     Q_OBJECT
@@ -100,7 +101,7 @@ private:
     void executeRequest(const RequestCallback& requestCallback);
 
     QOAuth2AuthorizationCodeFlow* m_oauth2 = nullptr;
-    QOAuthHttpServerReplyHandler* m_replyHandler = nullptr;
+    OAuthHttpServerReplyHandler* m_replyHandler = nullptr;
 
     ValCh<bool> m_userAuthorized;
     ValCh<AccountInfo> m_accountInfo;

--- a/src/cloud/internal/oauthhttpserverreplyhandler.cpp
+++ b/src/cloud/internal/oauthhttpserverreplyhandler.cpp
@@ -1,0 +1,382 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2022 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "oauthhttpserverreplyhandler.h"
+
+#include <cctype>
+#include <cstring>
+#include <functional>
+
+#include <QCoreApplication>
+#include <QNetworkReply>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QUrl>
+#include <QUrlQuery>
+
+#include "modularity/ioc.h"
+#include "icloudconfiguration.h"
+
+#include "translation.h"
+
+#include "log.h"
+
+using namespace mu::cloud;
+
+class OAuthHttpServerReplyHandler::Impl
+{
+    INJECT(cloud, ICloudConfiguration, configuration)
+
+public:
+    explicit Impl(OAuthHttpServerReplyHandler* p);
+    ~Impl();
+
+    QTcpServer m_httpServer;
+    QHostAddress m_listenAddress = QHostAddress::LocalHost;
+    QString m_path;
+
+private:
+    void onClientConnected();
+    void readData(QTcpSocket* socket);
+    void answerClient(QTcpSocket* socket, const QUrl& url);
+
+    struct HttpRequest {
+        quint16 port = 0;
+
+        bool readMethod(QTcpSocket* socket);
+        bool readUrl(QTcpSocket* socket);
+        bool readStatus(QTcpSocket* socket);
+        bool readHeader(QTcpSocket* socket);
+
+        enum class State {
+            ReadingMethod,
+            ReadingUrl,
+            ReadingStatus,
+            ReadingHeader,
+            ReadingBody,
+            AllDone
+        } state = State::ReadingMethod;
+
+        QByteArray m_fragment;
+
+        enum class Method {
+            Unknown,
+            Head,
+            Get,
+            Put,
+            Post,
+            Delete,
+        } method = Method::Unknown;
+
+        QUrl url;
+        QPair<quint8, quint8> version;
+        QMap<QByteArray, QByteArray> headers;
+    };
+
+    QMap<QTcpSocket*, HttpRequest> m_clients;
+
+    OAuthHttpServerReplyHandler* m_public;
+};
+
+OAuthHttpServerReplyHandler::Impl::Impl(OAuthHttpServerReplyHandler* p)
+    : m_public(p)
+{
+    QObject::connect(&m_httpServer, &QTcpServer::newConnection, [this]() { onClientConnected(); });
+}
+
+OAuthHttpServerReplyHandler::Impl::~Impl()
+{
+    if (m_httpServer.isListening()) {
+        m_httpServer.close();
+    }
+}
+
+void OAuthHttpServerReplyHandler::Impl::onClientConnected()
+{
+    QTcpSocket* socket = m_httpServer.nextPendingConnection();
+
+    QObject::connect(socket, &QTcpSocket::disconnected, socket, &QTcpSocket::deleteLater);
+    QObject::connect(socket, &QTcpSocket::readyRead, [this, socket]() { readData(socket); });
+}
+
+void OAuthHttpServerReplyHandler::Impl::readData(QTcpSocket* socket)
+{
+    if (!m_clients.contains(socket)) {
+        m_clients[socket].port = m_httpServer.serverPort();
+    }
+
+    HttpRequest* request = &m_clients[socket];
+    bool error = false;
+
+    if (Q_LIKELY(request->state == HttpRequest::State::ReadingMethod)) {
+        if (Q_UNLIKELY(error = !request->readMethod(socket))) {
+            LOGW() << "Invalid Method";
+        }
+    }
+
+    if (Q_LIKELY(!error && request->state == HttpRequest::State::ReadingUrl)) {
+        if (Q_UNLIKELY(error = !request->readUrl(socket))) {
+            LOGW() << "Invalid URL";
+        }
+    }
+
+    if (Q_LIKELY(!error && request->state == HttpRequest::State::ReadingStatus)) {
+        if (Q_UNLIKELY(error = !request->readStatus(socket))) {
+            LOGW() << "Invalid Status";
+        }
+    }
+
+    if (Q_LIKELY(!error && request->state == HttpRequest::State::ReadingHeader)) {
+        if (Q_UNLIKELY(error = !request->readHeader(socket))) {
+            LOGW() << "Invalid Header";
+        }
+    }
+
+    if (error) {
+        socket->disconnectFromHost();
+        m_clients.remove(socket);
+    } else if (!request->url.isEmpty()) {
+        Q_ASSERT(request->state != HttpRequest::State::ReadingUrl);
+        answerClient(socket, request->url);
+        m_clients.remove(socket);
+    }
+}
+
+void OAuthHttpServerReplyHandler::Impl::answerClient(QTcpSocket* socket, const QUrl& url)
+{
+    if (!url.path().startsWith(QLatin1String("/") + m_path)) {
+        LOGW() << "Invalid request: " << url;
+        socket->disconnectFromHost();
+        return;
+    }
+
+    QVariantMap receivedData;
+    const QUrlQuery query(url.query());
+    const auto items = query.queryItems();
+    for (auto it = items.begin(), end = items.end(); it != end; ++it) {
+        receivedData.insert(it->first, it->second);
+    }
+
+    Q_EMIT m_public->callbackReceived(receivedData);
+
+    // Fallback text, shown while redirecting
+    const QString text = qtrc("cloud", "Sign in successful! You're good to go back to the MuseScore desktop app.");
+
+    const QByteArray html = QByteArrayLiteral("<html><head><title>")
+                            + qApp->applicationName().toUtf8()
+                            + QByteArrayLiteral("</title></head><body>")
+                            + text.toUtf8()
+                            + ("</body></html>");
+
+    const QUrl redirectUrl = configuration()->signInSuccessUrl();
+
+    const QByteArray htmlSize = QByteArray::number(html.size());
+    const QByteArray replyMessage = QByteArrayLiteral("HTTP/1.0 301 Moved Permanently \r\n"
+                                                      "Location: ") + redirectUrl.toString().toUtf8()
+                                    + QByteArrayLiteral("\r\nContent-Type: text/html; "
+                                                        "charset=\"utf-8\"\r\n"
+                                                        "Content-Length: ") + htmlSize
+                                    + QByteArrayLiteral("\r\n\r\n")
+                                    + html;
+
+    socket->write(replyMessage);
+}
+
+bool OAuthHttpServerReplyHandler::Impl::HttpRequest::readMethod(QTcpSocket* socket)
+{
+    bool finished = false;
+    while (socket->bytesAvailable() && !finished) {
+        char c;
+        socket->getChar(&c);
+        if (std::isupper(c) && m_fragment.size() < 6) {
+            m_fragment += c;
+        } else {
+            finished = true;
+        }
+    }
+    if (finished) {
+        if (m_fragment == "HEAD") {
+            method = Method::Head;
+        } else if (m_fragment == "GET") {
+            method = Method::Get;
+        } else if (m_fragment == "PUT") {
+            method = Method::Put;
+        } else if (m_fragment == "POST") {
+            method = Method::Post;
+        } else if (m_fragment == "DELETE") {
+            method = Method::Delete;
+        } else {
+            LOGW() << "Invalid operation: " << m_fragment;
+        }
+
+        state = State::ReadingUrl;
+        m_fragment.clear();
+
+        return method != Method::Unknown;
+    }
+    return true;
+}
+
+bool OAuthHttpServerReplyHandler::Impl::HttpRequest::readUrl(QTcpSocket* socket)
+{
+    bool finished = false;
+    while (socket->bytesAvailable() && !finished) {
+        char c;
+        socket->getChar(&c);
+        if (std::isspace(c)) {
+            finished = true;
+        } else {
+            m_fragment += c;
+        }
+    }
+    if (finished) {
+        if (!m_fragment.startsWith("/")) {
+            LOGW() << "Invalid URL path: " << m_fragment;
+            return false;
+        }
+        url.setUrl(QStringLiteral("http://127.0.0.1:") + QString::number(port)
+                   + QString::fromUtf8(m_fragment));
+        state = State::ReadingStatus;
+        if (!url.isValid()) {
+            LOGW() << "Invalid URL " << m_fragment;
+            return false;
+        }
+        m_fragment.clear();
+        return true;
+    }
+    return true;
+}
+
+bool OAuthHttpServerReplyHandler::Impl::HttpRequest::readStatus(QTcpSocket* socket)
+{
+    bool finished = false;
+    while (socket->bytesAvailable() && !finished) {
+        char c;
+        socket->getChar(&c);
+        m_fragment += c;
+        if (m_fragment.endsWith("\r\n")) {
+            finished = true;
+            m_fragment.resize(m_fragment.size() - 2);
+        }
+    }
+    if (finished) {
+        if (!std::isdigit(m_fragment.at(m_fragment.size() - 3))
+            || !std::isdigit(m_fragment.at(m_fragment.size() - 1))) {
+            LOGW() << "Invalid version";
+            return false;
+        }
+        version = qMakePair(m_fragment.at(m_fragment.size() - 3) - '0',
+                            m_fragment.at(m_fragment.size() - 1) - '0');
+        state = State::ReadingHeader;
+        m_fragment.clear();
+    }
+    return true;
+}
+
+bool OAuthHttpServerReplyHandler::Impl::HttpRequest::readHeader(QTcpSocket* socket)
+{
+    while (socket->bytesAvailable()) {
+        char c;
+        socket->getChar(&c);
+        m_fragment += c;
+        if (m_fragment.endsWith("\r\n")) {
+            if (m_fragment == "\r\n") {
+                state = State::ReadingBody;
+                m_fragment.clear();
+                return true;
+            } else {
+                m_fragment.chop(2);
+                const int index = m_fragment.indexOf(':');
+                if (index == -1) {
+                    return false;
+                }
+
+                const QByteArray key = m_fragment.mid(0, index).trimmed();
+                const QByteArray value = m_fragment.mid(index + 1).trimmed();
+                headers.insert(key, value);
+                m_fragment.clear();
+            }
+        }
+    }
+    return false;
+}
+
+OAuthHttpServerReplyHandler::OAuthHttpServerReplyHandler(QObject* parent)
+    : OAuthHttpServerReplyHandler(QHostAddress::Any, 0, parent)
+{}
+
+OAuthHttpServerReplyHandler::OAuthHttpServerReplyHandler(quint16 port, QObject* parent)
+    : OAuthHttpServerReplyHandler(QHostAddress::Any, port, parent)
+{}
+
+OAuthHttpServerReplyHandler::OAuthHttpServerReplyHandler(const QHostAddress& address,
+                                                         quint16 port, QObject* parent)
+    : QOAuthOobReplyHandler(parent), m_impl(std::make_unique<Impl>(this))
+{
+    listen(address, port);
+}
+
+OAuthHttpServerReplyHandler::~OAuthHttpServerReplyHandler()
+{}
+
+QString OAuthHttpServerReplyHandler::callback() const
+{
+    Q_ASSERT(m_impl->m_httpServer.isListening());
+    const QUrl url(QString::fromLatin1("http://127.0.0.1:%1/%2")
+                   .arg(m_impl->m_httpServer.serverPort()).arg(m_impl->m_path));
+    return url.toString(QUrl::EncodeDelimiters);
+}
+
+QString OAuthHttpServerReplyHandler::callbackPath() const
+{
+    return m_impl->m_path;
+}
+
+void OAuthHttpServerReplyHandler::setCallbackPath(const QString& path)
+{
+    QString copy = path;
+    while (copy.startsWith(QLatin1Char('/'))) {
+        copy = copy.mid(1);
+    }
+
+    m_impl->m_path = copy;
+}
+
+quint16 OAuthHttpServerReplyHandler::port() const
+{
+    return m_impl->m_httpServer.serverPort();
+}
+
+bool OAuthHttpServerReplyHandler::listen(const QHostAddress& address, quint16 port)
+{
+    return m_impl->m_httpServer.listen(address, port);
+}
+
+void OAuthHttpServerReplyHandler::close()
+{
+    return m_impl->m_httpServer.close();
+}
+
+bool OAuthHttpServerReplyHandler::isListening() const
+{
+    return m_impl->m_httpServer.isListening();
+}

--- a/src/cloud/internal/oauthhttpserverreplyhandler.h
+++ b/src/cloud/internal/oauthhttpserverreplyhandler.h
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2022 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_CLOUD_OAUTHHTTPSERVERREPLYHANDLER_H
+#define MU_CLOUD_OAUTHHTTPSERVERREPLYHANDLER_H
+
+#include <QOAuthOobReplyHandler>
+
+#include <QHostAddress>
+
+class QUrlQuery;
+
+namespace mu::cloud {
+class OAuthHttpServerReplyHandler : public QOAuthOobReplyHandler
+{
+    Q_OBJECT
+
+public:
+    explicit OAuthHttpServerReplyHandler(QObject* parent = nullptr);
+    explicit OAuthHttpServerReplyHandler(quint16 port, QObject* parent = nullptr);
+    explicit OAuthHttpServerReplyHandler(const QHostAddress& address, quint16 port, QObject* parent = nullptr);
+    ~OAuthHttpServerReplyHandler();
+
+    QString callback() const override;
+
+    QString callbackPath() const;
+    void setCallbackPath(const QString& path);
+
+    quint16 port() const;
+
+    bool listen(const QHostAddress& address = QHostAddress::Any, quint16 port = 0);
+    void close();
+    bool isListening() const;
+
+private:
+    class Impl;
+
+    std::unique_ptr<Impl> m_impl;
+};
+}
+
+#endif // MU_CLOUD_OAUTHHTTPSERVERREPLYHANDLER_H


### PR DESCRIPTION
Inspired by [`QOAuthHttpServerReplyHandler`](https://codebrowser.dev/qt5/qtnetworkauth/src/oauth/qoauthhttpserverreplyhandler.cpp.html). (We could decide to make the implementation even simpler since we don't use everything of it.)

Resolves: #13460

TODO: currently, this will redirect to the MuseScore.com homepage, for demo purposes. The MuseScore.com team needs to implement the real page, and give us the URL, so that we can redirect to that page instead.