### PR TITLE
Fix #269926 MusicXML export: don't duplicate fermatas near grace notes

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -2948,13 +2948,15 @@ static void writeChordLines(const Chord* const chord, XmlWriter& xml, Notations&
 void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technical& technical,
                                      TrillHash& trillStart, TrillHash& trillStop)
 {
-    QVector<EngravingItem*> fl;
-    for (EngravingItem* e : chord->segment()->annotations()) {
-        if (e->track() == chord->track() && e->isFermata()) {
-            fl.push_back(e);
+    if (!chord->isGrace()) {
+        QVector<EngravingItem*> fl;
+        for (EngravingItem* e : chord->segment()->annotations()) {
+            if (e->track() == chord->track() && e->isFermata()) {
+                fl.push_back(e);
+            }
         }
+        fermatas(fl, _xml, notations);
     }
-    fermatas(fl, _xml, notations);
 
     const std::vector<Articulation*> na = chord->articulations();
     // first the attributes whose elements are children of <articulations>

--- a/src/importexport/musicxml/tests/data/testGraceFermata.xml
+++ b/src/importexport/musicxml/tests/data/testGraceFermata.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>testGraceFermata</work-title>
+    </work>
+  <identification>
+    <creator type="composer">shoogle</creator>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <grace slash="yes"/>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <notations>
+          <fermata type="upright"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <notations>
+          <fermata type="upright"/>
+          </notations>
+        </note>
+      <note>
+        <grace/>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -550,6 +550,9 @@ TEST_F(Musicxml_Tests, graceAfter3) {
 TEST_F(Musicxml_Tests, DISABLED_graceAfter4) {
     mxmlIoTest("testGraceAfter4");
 }
+TEST_F(Musicxml_Tests, graceFermata) {
+    mxmlIoTest("testGraceFermata");
+}
 TEST_F(Musicxml_Tests, hairpinDynamics) {
     mxmlMscxExportTestRef("testHairpinDynamics");
 }


### PR DESCRIPTION
Previously, if a note had both a fermata and a grace note then the grace note would gain a fermata during export.

Resolves: https://musescore.org/en/node/269926

Replaces #7621