### PR TITLE
[MU4] Fix #11932: 'Pizz/Arco' & 'Mute/Open' directions cancel out dynamic directions when they happen at the same time

### DIFF
--- a/src/engraving/playback/playbackcontext.cpp
+++ b/src/engraving/playback/playbackcontext.cpp
@@ -225,12 +225,12 @@ void PlaybackContext::handleAnnotations(const ID partId, const Segment* segment,
 
         if (annotation->isDynamic()) {
             updateDynamicMap(toDynamic(annotation), segment, segmentPositionTick);
-            return;
+            continue;
         }
 
         if (annotation->isPlayTechAnnotation()) {
             updatePlayTechMap(toPlayTechAnnotation(annotation), segmentPositionTick);
-            return;
+            continue;
         }
     }
 

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsequencer.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsequencer.cpp
@@ -55,7 +55,7 @@ void FluidSequencer::updateDynamicChanges(const mpe::DynamicLevelMap& changes)
 
     for (const auto& pair : changes) {
         midi::Event event(midi::Event::Opcode::ControlChange, Event::MessageType::ChannelVoice10);
-        event.setIndex(11);
+        event.setIndex(midi::EXPRESSION_CONTROLLER);
         event.setData(expressionLevel(pair.second));
 
         m_dynamicEvents[pair.first].emplace(std::move(event));

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.h
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.h
@@ -75,8 +75,10 @@ private:
 
     bool handleEvent(const midi::Event& event);
 
-    void updateCurrentExpressionLevel(const midi::Event& event);
     void toggleExpressionController();
+
+    int setCurrentExpressionLevel(int level);
+    int setControllerValue(const midi::Event& event);
 
     std::shared_ptr<Fluid> m_fluid = nullptr;
 

--- a/src/framework/midi/miditypes.h
+++ b/src/framework/midi/miditypes.h
@@ -46,6 +46,8 @@ using note_idx_t = uint8_t;
 using TempoMap = std::map<tick_t, tempo_t>;
 using Events = std::map<tick_t, std::vector<Event> >;
 
+static constexpr int EXPRESSION_CONTROLLER = 11;
+
 struct Program {
     Program(bank_t b, program_t p)
         : bank(b), program(p) {}


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11932