### PR TITLE
Revert "[MU4] Fix #12140: Tempo marking ignored when they follow a rit, accel or other gradual tempo change"

### DIFF
--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -575,7 +575,7 @@ void Score::setUpTempoMap()
         BeatsPerSecond newBps = currentBps * tempoChange->tempoChangeFactor();
 
         std::map<int, double> tempoCurve = TConv::easingValueCurve(tempoChange->ticks().ticks(),
-                                                                   4 /*stepsCount*/,
+                                                                   4,
                                                                    newBps.val - currentBps.val,
                                                                    tempoChange->easingMethod());
 

--- a/src/engraving/playback/playbackcontext.cpp
+++ b/src/engraving/playback/playbackcontext.cpp
@@ -202,7 +202,7 @@ void PlaybackContext::handleSpanners(const ID partId, const Score* score, const 
                                                                        hairpin->isCrescendo());
 
         std::map<int, int> dynamicsCurve = TConv::easingValueCurve(spannerDurationTicks,
-                                                                   24 /*stepsCount*/,
+                                                                   24,
                                                                    static_cast<int>(overallDynamicRange),
                                                                    hairpin->veloChangeMethod());
 

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -1121,7 +1121,7 @@ static std::map<int /*tickPosition*/, T> buildEasedValueCurve(const int ticksDur
 
     float durationStep = static_cast<float>(ticksDuration) / static_cast<float>(stepsCount);
 
-    for (int i = 0; i < stepsCount; ++i) {
+    for (int i = 0; i <= stepsCount; ++i) {
         result.emplace(i * durationStep, easingFactor(i / static_cast<float>(stepsCount), method) * amplitude);
     }
 


### PR DESCRIPTION
Reverts musescore/MuseScore#13492