### PR TITLE
Fix #13464: Changed default time stretch property for fermatas

### DIFF
--- a/src/engraving/libmscore/fermata.cpp
+++ b/src/engraving/libmscore/fermata.cpp
@@ -60,7 +60,6 @@ Fermata::Fermata(EngravingItem* parent)
 {
     setPlacement(PlacementV::ABOVE);
     _symId         = SymId::noSym;
-    _timeStretch   = 1.0;
     setPlay(true);
     initElementStyle(&fermataStyle);
 }
@@ -337,7 +336,21 @@ PropertyValue Fermata::propertyDefault(Pid propertyId) const
     case Pid::PLACEMENT:
         return track() & 1 ? PlacementV::BELOW : PlacementV::ABOVE;
     case Pid::TIME_STRETCH:
-        return 1.0;           // articulationList[int(articulationType())].timeStretch;
+        switch (fermataType()) {
+        case FermataType::VeryShort:
+            return 1.25;
+        case FermataType::Short:
+        case FermataType::ShortHenze:
+            return 1.5;
+        case FermataType::Normal:
+        case FermataType::Undefined:
+            return 2.0;
+        case FermataType::Long:
+        case FermataType::LongHenze:
+            return 3.0;
+        case FermataType::VeryLong:
+            return 4.0;
+        }
     case Pid::PLAY:
         return true;
     default:
@@ -382,6 +395,12 @@ Sid Fermata::getPropertyStyle(Pid pid) const
 double Fermata::mag() const
 {
     return staff() ? staff()->staffMag(tick()) * score()->styleD(Sid::articulationMag) : 1.0;
+}
+
+void Fermata::setSymId(SymId id)
+{
+    _symId  = id;
+    _timeStretch = _timeStretch == -1 ? propertyDefault(Pid::TIME_STRETCH).value<double>() : -1;
 }
 
 FermataType Fermata::fermataType() const

--- a/src/engraving/libmscore/fermata.h
+++ b/src/engraving/libmscore/fermata.h
@@ -44,7 +44,7 @@ class Fermata final : public EngravingItem
     OBJECT_ALLOCATOR(engraving, Fermata)
 
     SymId _symId;
-    double _timeStretch;
+    double _timeStretch = -1.0;
     bool _play;
 
     friend class Factory;
@@ -63,7 +63,7 @@ public:
     double mag() const override;
 
     SymId symId() const { return _symId; }
-    void setSymId(SymId id) { _symId  = id; }
+    void setSymId(SymId id);
     FermataType fermataType() const;
     int subtype() const override;
     TranslatableString typeUserName() const override;

--- a/src/importexport/guitarpro/tests/data/fermata.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fermata.gp-ref.mscx
@@ -102,7 +102,6 @@
             </Chord>
           <Fermata>
             <subtype>fermataAbove</subtype>
-            <timeStretch>2</timeStretch>
             </Fermata>
           <Chord>
             <durationType>quarter</durationType>
@@ -136,7 +135,6 @@
         <voice>
           <Fermata>
             <subtype>fermataAbove</subtype>
-            <timeStretch>2</timeStretch>
             </Fermata>
           <Chord>
             <durationType>quarter</durationType>
@@ -150,14 +148,12 @@
             </Chord>
           <Fermata>
             <subtype>fermataAbove</subtype>
-            <timeStretch>2</timeStretch>
             </Fermata>
           <Rest>
             <durationType>quarter</durationType>
             </Rest>
           <Fermata>
             <subtype>fermataAbove</subtype>
-            <timeStretch>2</timeStretch>
             </Fermata>
           <Chord>
             <durationType>quarter</durationType>
@@ -181,7 +177,6 @@
         <voice>
           <Fermata>
             <subtype>fermataAbove</subtype>
-            <timeStretch>2</timeStretch>
             </Fermata>
           <Chord>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/fermata.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fermata.gpx-ref.mscx
@@ -100,7 +100,6 @@
             </Chord>
           <Fermata>
             <subtype>fermataAbove</subtype>
-            <timeStretch>2</timeStretch>
             </Fermata>
           <Chord>
             <durationType>quarter</durationType>
@@ -132,7 +131,6 @@
         <voice>
           <Fermata>
             <subtype>fermataAbove</subtype>
-            <timeStretch>2</timeStretch>
             </Fermata>
           <Chord>
             <durationType>quarter</durationType>
@@ -145,14 +143,12 @@
             </Chord>
           <Fermata>
             <subtype>fermataAbove</subtype>
-            <timeStretch>2</timeStretch>
             </Fermata>
           <Rest>
             <durationType>quarter</durationType>
             </Rest>
           <Fermata>
             <subtype>fermataAbove</subtype>
-            <timeStretch>2</timeStretch>
             </Fermata>
           <Chord>
             <durationType>quarter</durationType>
@@ -175,7 +171,6 @@
         <voice>
           <Fermata>
             <subtype>fermataAbove</subtype>
-            <timeStretch>2</timeStretch>
             </Fermata>
           <Chord>
             <durationType>quarter</durationType>


### PR DESCRIPTION
Resolves: #13464 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
