### PR TITLE
fix #12035: gp import - showing arpeggio on standard notation

### DIFF
--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -3002,7 +3002,6 @@ static Err importScore(MasterScore* score, mu::io::IODevice* io)
     }
 
     score->loadStyle(u":/engraving/styles/gp-style.mss");
-    score->style().set(Sid::ArpeggioHiddenInStdIfTab, true);
 
     io->seek(0);
     char header[5];

--- a/src/importexport/guitarpro/internal/importptb.cpp
+++ b/src/importexport/guitarpro/internal/importptb.cpp
@@ -1256,8 +1256,6 @@ Err PowerTab::read()
         }
     }
 
-    score->style().set(Sid::ArpeggioHiddenInStdIfTab, true);
-
     MeasureBase* m;
     if (!score->measures()->first()) {
         m = Factory::createVBox(score->dummy()->system());


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/12035*

*gp import - showing arpeggio on standard notation*