### PR TITLE
fix #12125: gp import - showing tempo label

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
@@ -285,6 +285,11 @@ std::vector<GPMasterTracks::Automation> GP67DomBuilder::readTempoMap(XmlDomNode*
                 tempo.bar = currentAutomation.firstChildElement("Bar").text().toInt();
                 tempo.position = currentAutomation.firstChildElement("Position").text().toFloat();
                 tempo.linear = (ln.toElement().text() == u"true");
+                XmlDomElement labelElem = currentAutomation.firstChildElement("Text");
+                if (labelElem.hasChildNodes()) {
+                    tempo.text = labelElem.toElement().text();
+                }
+
                 tempoMap.push_back(tempo);
             }
         }

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1263,7 +1263,14 @@ void GPConverter::addTempoMap()
             int realTemp = realTempo(tempIt->second);
             TempoText* tt = Factory::createTempoText(segment);
             tt->setTempo((double)realTemp / 60);
-            tt->setXmlText(String(u"<sym>metNoteQuarterUp</sym> = %1").arg(realTemp));
+            String& labelText = tempIt->second.text;
+            String tempoText = String(u"<sym>metNoteQuarterUp</sym> = %1").arg(realTemp);
+
+            if (!labelText.isEmpty()) {
+                tempoText.prepend(labelText.append(Char(' ')));
+            }
+
+            tt->setXmlText(tempoText);
             tt->setTrack(0);
             segment->add(tt);
             _score->setTempo(tick, tt->tempo());

--- a/src/importexport/guitarpro/internal/gtp/gpmastertracks.h
+++ b/src/importexport/guitarpro/internal/gtp/gpmastertracks.h
@@ -4,6 +4,8 @@
 #include <stddef.h>
 #include <vector>
 
+#include "types/string.h"
+
 namespace mu::engraving {
 class GPMasterTracks
 {
@@ -18,6 +20,7 @@ public:
         bool linear{ false };
         int value{ 0 };
         int tempoUnit{ 0 };
+        String text;
         friend bool operator<(const Automation& l, const Automation& r) { return l.bar < r.bar; }
     };
 

--- a/src/importexport/guitarpro/tests/data/basic-bend.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/basic-bend.gp-ref.mscx
@@ -65,7 +65,7 @@
             </Dynamic>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Chord>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/basic-bend.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/basic-bend.gpx-ref.mscx
@@ -65,7 +65,7 @@
             </Dynamic>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Chord>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/dotted-tuplets.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dotted-tuplets.gp-ref.mscx
@@ -61,7 +61,7 @@
             </TimeSig>
           <Tempo>
             <tempo>1.666667</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 100</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 100</text>
             </Tempo>
           <Rest>
             <durationType>half</durationType>

--- a/src/importexport/guitarpro/tests/data/dotted-tuplets.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dotted-tuplets.gpx-ref.mscx
@@ -63,7 +63,7 @@
             </TimeSig>
           <Tempo>
             <tempo>1.666667</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 100</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 100</text>
             </Tempo>
           <Rest>
             <durationType>half</durationType>

--- a/src/importexport/guitarpro/tests/data/dynamic.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dynamic.gp-ref.mscx
@@ -65,7 +65,7 @@
             </Dynamic>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Chord>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/dynamic.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dynamic.gpx-ref.mscx
@@ -65,7 +65,7 @@
             </Dynamic>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Chord>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/fade-in.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fade-in.gpx-ref.mscx
@@ -61,7 +61,7 @@
             </TimeSig>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Rest>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/grace.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/grace.gp-ref.mscx
@@ -63,7 +63,7 @@
             </Dynamic>
           <Tempo>
             <tempo>3.166667</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 190</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 190</text>
             </Tempo>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/importexport/guitarpro/tests/data/grace.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/grace.gpx-ref.mscx
@@ -67,7 +67,7 @@
             </Dynamic>
           <Tempo>
             <tempo>3.166667</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 190</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 190</text>
             </Tempo>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/importexport/guitarpro/tests/data/heavy-accent.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/heavy-accent.gp-ref.mscx
@@ -61,7 +61,7 @@
             </TimeSig>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Rest>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/heavy-accent.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/heavy-accent.gpx-ref.mscx
@@ -61,7 +61,7 @@
             </TimeSig>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Rest>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/legato-slide.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/legato-slide.gp-ref.mscx
@@ -61,7 +61,7 @@
             </TimeSig>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Rest>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/legato-slide.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/legato-slide.gpx-ref.mscx
@@ -61,7 +61,7 @@
             </TimeSig>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Rest>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/shift-slide.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/shift-slide.gp-ref.mscx
@@ -61,7 +61,7 @@
             </TimeSig>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Rest>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/shift-slide.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/shift-slide.gpx-ref.mscx
@@ -61,7 +61,7 @@
             </TimeSig>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Rest>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/slide-in-above.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-in-above.gp-ref.mscx
@@ -65,7 +65,7 @@
             </Dynamic>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Chord>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/slide-in-above.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-in-above.gpx-ref.mscx
@@ -65,7 +65,7 @@
             </Dynamic>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Chord>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/slide-in-below.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-in-below.gp-ref.mscx
@@ -65,7 +65,7 @@
             </Dynamic>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Chord>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/slide-in-below.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-in-below.gpx-ref.mscx
@@ -65,7 +65,7 @@
             </Dynamic>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Chord>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/slide-out-down.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-out-down.gp-ref.mscx
@@ -65,7 +65,7 @@
             </Dynamic>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Chord>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/slide-out-down.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-out-down.gpx-ref.mscx
@@ -65,7 +65,7 @@
             </Dynamic>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Chord>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/slide-out-up.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-out-up.gp-ref.mscx
@@ -65,7 +65,7 @@
             </Dynamic>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Chord>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/slide-out-up.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-out-up.gpx-ref.mscx
@@ -65,7 +65,7 @@
             </Dynamic>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Chord>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gp-ref.mscx
@@ -61,7 +61,7 @@
             </TimeSig>
           <Tempo>
             <tempo>1.783333</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 107</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 107</text>
             </Tempo>
           <Rest>
             <durationType>16th</durationType>

--- a/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gpx-ref.mscx
@@ -61,7 +61,7 @@
             </TimeSig>
           <Tempo>
             <tempo>1.783333</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 107</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 107</text>
             </Tempo>
           <Rest>
             <durationType>16th</durationType>

--- a/src/importexport/guitarpro/tests/data/volume-swell.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/volume-swell.gp-ref.mscx
@@ -61,7 +61,7 @@
             </TimeSig>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Rest>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/volume-swell.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/volume-swell.gpx-ref.mscx
@@ -61,7 +61,7 @@
             </TimeSig>
           <Tempo>
             <tempo>2</tempo>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            <text>Moderate <sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Rest>
             <durationType>quarter</durationType>


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/12125*

*showing tempo label*