### PR TITLE
fixed #12694:Note input from MIDI keyboard can be not so accurate as in MU3, some notes are not picked up sometimes

### DIFF
--- a/src/notation/internal/notationmidiinput.cpp
+++ b/src/notation/internal/notationmidiinput.cpp
@@ -37,7 +37,7 @@
 
 using namespace mu::notation;
 
-static constexpr int PROCESS_INTERVAL = 20;
+static constexpr int PROCESS_INTERVAL = 100;
 
 NotationMidiInput::NotationMidiInput(IGetScore* getScore, INotationInteractionPtr notationInteraction, INotationUndoStackPtr undoStack)
     : m_getScore(getScore), m_notationInteraction(notationInteraction), m_undoStack(undoStack)


### PR DESCRIPTION
Resolves: #12694