### PR TITLE
Further efficiency of horizontal spacing (faster padding table)

### DIFF
--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -5519,9 +5519,9 @@ void Score::doLayoutRange(const Fraction& st, const Fraction& et)
 
 void Score::createPaddingTable()
 {
-    for (int i=0; i < int(ElementType::MAXTYPE); ++i) {
-        for (int j=0; j < int(ElementType::MAXTYPE); ++j) {
-            _paddingTable[ElementType(i)][ElementType(j)] = _minimumPaddingUnit;
+    for (size_t i=0; i < TOT_ELEMENT_TYPES; ++i) {
+        for (size_t j=0; j < TOT_ELEMENT_TYPES; ++j) {
+            _paddingTable[i][j] = _minimumPaddingUnit;
         }
     }
 
@@ -5638,12 +5638,11 @@ void Score::createPaddingTable()
     _paddingTable[ElementType::TIMESIG][ElementType::TIMESIG] = 1.0 * spatium();
 
     // Obtain the Stem -> * and * -> Stem values from the note equivalents
-    for (auto& elem : _paddingTable[ElementType::STEM]) {
-        elem.second = _paddingTable[ElementType::NOTE][elem.first];
-    }
+    _paddingTable[ElementType::STEM] = _paddingTable[ElementType::NOTE];
     for (auto& elem: _paddingTable) {
-        elem.second[ElementType::STEM] = _paddingTable[elem.first][ElementType::NOTE];
+        elem[ElementType::STEM] = elem[ElementType::NOTE];
     }
+
     _paddingTable[ElementType::STEM][ElementType::NOTE] = styleMM(Sid::minNoteDistance);
     _paddingTable[ElementType::STEM][ElementType::STEM] = 0.85 * spatium();
     _paddingTable[ElementType::STEM][ElementType::ACCIDENTAL] = 0.35 * spatium();
@@ -5651,37 +5650,31 @@ void Score::createPaddingTable()
     _paddingTable[ElementType::LEDGER_LINE][ElementType::STEM] = 0.35 * spatium();
 
     // Ambitus
-    for (auto& elem : _paddingTable[ElementType::AMBITUS]) {
-        elem.second = styleMM(Sid::ambitusMargin);
-    }
+    _paddingTable[ElementType::AMBITUS].fill(styleMM(Sid::ambitusMargin));
     for (auto& elem: _paddingTable) {
-        elem.second[ElementType::AMBITUS] = styleMM(Sid::ambitusMargin);
+        elem[ElementType::AMBITUS] = styleMM(Sid::ambitusMargin);
     }
 
     // Breath
-    for (auto& elem : _paddingTable[ElementType::BREATH]) {
-        elem.second = 1.0 * spatium();
-    }
+    _paddingTable[ElementType::BREATH].fill(1.0 * spatium());
     for (auto& elem: _paddingTable) {
-        elem.second[ElementType::BREATH] = 1.0 * spatium();
+        elem[ElementType::BREATH] = 1.0 * spatium();
     }
 
     // Temporary hack, because some padding is already constructed inside the lyrics themselves.
     _paddingTable[ElementType::BAR_LINE][ElementType::LYRICS] = 0.0 * spatium();
 
     // Chordlines
-    for (auto& elem : _paddingTable[ElementType::CHORDLINE]) {
-        elem.second = 0.35 * spatium();
-    }
+    _paddingTable[ElementType::CHORDLINE].fill(0.35 * spatium());
     for (auto& elem: _paddingTable) {
-        elem.second[ElementType::CHORDLINE] = 0.35 * spatium();
+        elem[ElementType::CHORDLINE] = 0.35 * spatium();
     }
     _paddingTable[ElementType::BAR_LINE][ElementType::CHORDLINE] = 0.65 * spatium();
     _paddingTable[ElementType::CHORDLINE][ElementType::BAR_LINE] = 0.65 * spatium();
 
     // For the x -> fingering padding use the same values as x -> accidental
     for (auto& elem : _paddingTable) {
-        elem.second[ElementType::FINGERING] = _paddingTable[elem.first][ElementType::ACCIDENTAL];
+        elem[ElementType::FINGERING] = elem[ElementType::ACCIDENTAL];
     }
 }
 

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -315,6 +315,19 @@ public:
     std::list<EngravingObject*> _deleteList;
 };
 
+//---------------------------------------------------------
+//   PaddingTable
+//---------------------------------------------------------
+
+template<typename T>
+struct PaddingVector : std::array<T, TOT_ELEMENT_TYPES>
+{
+    T& operator [](size_t i) { return std::array<T, TOT_ELEMENT_TYPES>::operator [](i); }
+    T& operator [](ElementType et) { return std::array<T, TOT_ELEMENT_TYPES>::operator [](static_cast<size_t>(et)); }
+    const T& at(ElementType et) const { return std::array<T, TOT_ELEMENT_TYPES>::at(static_cast<size_t>(et)); }
+};
+using PaddingTable = PaddingVector<PaddingVector<double> >;
+
 //---------------------------------------------------------------------------------------
 //   @@ Score
 //   @P composer        string            composer of the score (read only)
@@ -340,7 +353,6 @@ public:
 //
 //    a Score has always an associated MasterScore
 //---------------------------------------------------------------------------------------
-typedef std::map<ElementType, std::map<ElementType, double> > PaddingTable;
 
 class Score : public EngravingObject
 {

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -189,6 +189,8 @@ enum class ElementType {
     ///\}
 };
 
+constexpr size_t TOT_ELEMENT_TYPES = static_cast<size_t>(ElementType::MAXTYPE);
+
 using ElementTypeSet = std::unordered_set<ElementType>;
 
 // ========================================


### PR DESCRIPTION
When computing horizontal spacing, we are looking into this table tens of thousands of times. I had originally implemented it as a nested map, now I've re-implemented it as a 2D array, which is much faster to read into. On the scores I've tried, this ends up saving approx. 8% on the _total_ layout time of a score, not too bad.