### PR TITLE
Save to cloud: tweak behaviour of asking about audio upload settings

### DIFF
--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -118,8 +118,8 @@ private:
         }
     };
 
-    Ret openAudioGenerationSettings();
-    bool needGenerateAudio(bool isPublic) const;
+    Ret askAudioGenerationSettings() const;
+    RetVal<bool> needGenerateAudio(bool isPublic) const;
     AudioFile exportMp3(const notation::INotationPtr notation) const;
 
     void uploadProject(const CloudProjectInfo& info, const AudioFile& audio = AudioFile(), bool openEditUrl = true);

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -56,7 +56,7 @@ static const Settings::Key AUTOSAVE_ENABLED_KEY(module_name, "project/autoSaveEn
 static const Settings::Key AUTOSAVE_INTERVAL_KEY(module_name, "project/autoSaveInterval");
 static const Settings::Key SHOULD_DESTINATION_FOLDER_BE_OPENED_ON_EXPORT(module_name, "project/shouldDestinationFolderBeOpenedOnExport");
 static const Settings::Key OPEN_DETAILED_PROJECT_UPLOADED_DIALOG(module_name, "project/openDetailedProjectUploadedDialog");
-static const Settings::Key OPEN_AUDIO_GENERATION_SETTINGS(module_name, "project/openAudioGenerationSettings");
+static const Settings::Key HAS_ASKED_AUDIO_GENERATION_SETTINGS(module_name, "project/hasAskedAudioGenerationSettings");
 static const Settings::Key GENERATE_AUDIO_TIME_PERIOD_TYPE_KEY(module_name, "project/generateAudioTimePeriodType");
 static const Settings::Key NUMBER_OF_SAVES_TO_GENERATE_AUDIO_KEY(module_name, "project/numberOfSavesToGenerateAudio");
 static const Settings::Key SHOW_CLOUD_IS_NOT_AVAILABLE_WARNING(module_name, "project/showCloudIsNotAvailableWarning");
@@ -103,7 +103,7 @@ void ProjectConfiguration::init()
 
     settings()->setDefaultValue(SHOULD_DESTINATION_FOLDER_BE_OPENED_ON_EXPORT, Val(false));
     settings()->setDefaultValue(OPEN_DETAILED_PROJECT_UPLOADED_DIALOG, Val(true));
-    settings()->setDefaultValue(OPEN_AUDIO_GENERATION_SETTINGS, Val(true));
+    settings()->setDefaultValue(HAS_ASKED_AUDIO_GENERATION_SETTINGS, Val(false));
     settings()->setDefaultValue(GENERATE_AUDIO_TIME_PERIOD_TYPE_KEY, Val(static_cast<int>(GenerateAudioTimePeriodType::Never)));
     settings()->setDefaultValue(NUMBER_OF_SAVES_TO_GENERATE_AUDIO_KEY, Val(10));
     settings()->setDefaultValue(SHOW_CLOUD_IS_NOT_AVAILABLE_WARNING, Val(true));
@@ -581,14 +581,14 @@ void ProjectConfiguration::setOpenDetailedProjectUploadedDialog(bool show)
     settings()->setSharedValue(OPEN_DETAILED_PROJECT_UPLOADED_DIALOG, Val(show));
 }
 
-bool ProjectConfiguration::openAudioGenerationSettings() const
+bool ProjectConfiguration::hasAskedAudioGenerationSettings() const
 {
-    return settings()->value(OPEN_AUDIO_GENERATION_SETTINGS).toBool();
+    return settings()->value(HAS_ASKED_AUDIO_GENERATION_SETTINGS).toBool();
 }
 
-void ProjectConfiguration::setOpenAudioGenerationSettings(bool open)
+void ProjectConfiguration::setHasAskedAudioGenerationSettings(bool has)
 {
-    settings()->setSharedValue(OPEN_AUDIO_GENERATION_SETTINGS, Val(open));
+    settings()->setSharedValue(HAS_ASKED_AUDIO_GENERATION_SETTINGS, Val(has));
 }
 
 GenerateAudioTimePeriodType ProjectConfiguration::generateAudioTimePeriodType() const

--- a/src/project/internal/projectconfiguration.h
+++ b/src/project/internal/projectconfiguration.h
@@ -118,8 +118,8 @@ public:
     bool openDetailedProjectUploadedDialog() const override;
     void setOpenDetailedProjectUploadedDialog(bool show) override;
 
-    bool openAudioGenerationSettings() const override;
-    void setOpenAudioGenerationSettings(bool open) override;
+    bool hasAskedAudioGenerationSettings() const override;
+    void setHasAskedAudioGenerationSettings(bool has) override;
 
     GenerateAudioTimePeriodType generateAudioTimePeriodType() const override;
     void setGenerateAudioTimePeriodType(GenerateAudioTimePeriodType type) override;

--- a/src/project/iprojectconfiguration.h
+++ b/src/project/iprojectconfiguration.h
@@ -118,8 +118,8 @@ public:
     virtual bool openDetailedProjectUploadedDialog() const = 0;
     virtual void setOpenDetailedProjectUploadedDialog(bool show) = 0;
 
-    virtual bool openAudioGenerationSettings() const = 0;
-    virtual void setOpenAudioGenerationSettings(bool open) = 0;
+    virtual bool hasAskedAudioGenerationSettings() const = 0;
+    virtual void setHasAskedAudioGenerationSettings(bool has) = 0;
 
     virtual GenerateAudioTimePeriodType generateAudioTimePeriodType() const = 0;
     virtual void setGenerateAudioTimePeriodType(GenerateAudioTimePeriodType type) = 0;

--- a/src/project/qml/MuseScore/Project/AudioGenerationSettingsDialog.qml
+++ b/src/project/qml/MuseScore/Project/AudioGenerationSettingsDialog.qml
@@ -120,19 +120,6 @@ StyledDialogView {
                 order: 2
             }
 
-            CheckBox {
-                id: dontAskAgain
-
-                text: qsTrc("global", "Don't ask again")
-
-                navigation.panel: buttons.navigationPanel
-                navigation.order: 2
-
-                onClicked: {
-                    checked = !checked
-                }
-            }
-
             Item {
                 Layout.fillWidth: true
             }
@@ -145,7 +132,7 @@ StyledDialogView {
                 navigation.order: 1
 
                 onClicked: {
-                    root.ret = { "errcode": 0, "value": { "askAgain": !dontAskAgain.checked }}
+                    root.ret = { "errcode": 0 }
                     root.hide()
                 }
             }

--- a/src/project/tests/mocks/projectconfigurationmock.h
+++ b/src/project/tests/mocks/projectconfigurationmock.h
@@ -102,8 +102,8 @@ public:
     MOCK_METHOD(bool, openDetailedProjectUploadedDialog, (), (const, override));
     MOCK_METHOD(void, setOpenDetailedProjectUploadedDialog, (bool), (override));
 
-    MOCK_METHOD(bool, openAudioGenerationSettings, (), (const, override));
-    MOCK_METHOD(void, setOpenAudioGenerationSettings, (bool), (override));
+    MOCK_METHOD(bool, hasAskedAudioGenerationSettings, (), (const, override));
+    MOCK_METHOD(void, setHasAskedAudioGenerationSettings, (bool), (override));
 
     MOCK_METHOD(GenerateAudioTimePeriodType, generateAudioTimePeriodType, (), (const, override));
     MOCK_METHOD(void, setGenerateAudioTimePeriodType, (GenerateAudioTimePeriodType), (override));


### PR DESCRIPTION
- Remove the "don't ask again" checkbox
- Ask the question just once (to change decision, user can go to Preferences > Cloud)
- Ask the question just whenever the user is saving privately to the cloud for the first time, no matter whether that score was newly created or previously stored on disk