### PR TITLE
Disconnect MIDI ports in deinit, not when global objects are destructed

### DIFF
--- a/src/framework/midi/internal/platform/lin/alsamidiinport.cpp
+++ b/src/framework/midi/internal/platform/lin/alsamidiinport.cpp
@@ -39,13 +39,6 @@ struct mu::midi::AlsaMidiInPort::Alsa {
 
 using namespace mu::midi;
 
-AlsaMidiInPort::~AlsaMidiInPort()
-{
-    if (isConnected()) {
-        disconnect();
-    }
-}
-
 void AlsaMidiInPort::init()
 {
     m_alsa = std::make_shared<Alsa>();
@@ -68,6 +61,13 @@ void AlsaMidiInPort::init()
 
         m_availableDevicesChanged.notify();
     });
+}
+
+void AlsaMidiInPort::deinit()
+{
+    if (isConnected()) {
+        disconnect();
+    }
 }
 
 MidiDeviceList AlsaMidiInPort::availableDevices() const

--- a/src/framework/midi/internal/platform/lin/alsamidiinport.h
+++ b/src/framework/midi/internal/platform/lin/alsamidiinport.h
@@ -35,9 +35,10 @@ class AlsaMidiInPort : public IMidiInPort, public async::Asyncable
 {
 public:
     AlsaMidiInPort() = default;
-    ~AlsaMidiInPort() override;
+    ~AlsaMidiInPort() = default;
 
     void init();
+    void deinit();
 
     MidiDeviceList availableDevices() const override;
     async::Notification availableDevicesChanged() const override;

--- a/src/framework/midi/internal/platform/lin/alsamidioutport.cpp
+++ b/src/framework/midi/internal/platform/lin/alsamidioutport.cpp
@@ -38,13 +38,6 @@ struct mu::midi::AlsaMidiOutPort::Alsa {
 
 using namespace mu::midi;
 
-AlsaMidiOutPort::~AlsaMidiOutPort()
-{
-    if (isConnected()) {
-        disconnect();
-    }
-}
-
 void AlsaMidiOutPort::init()
 {
     m_alsa = std::make_shared<Alsa>();
@@ -67,6 +60,13 @@ void AlsaMidiOutPort::init()
 
         m_availableDevicesChanged.notify();
     });
+}
+
+void AlsaMidiOutPort::deinit()
+{
+    if (isConnected()) {
+        disconnect();
+    }
 }
 
 std::vector<MidiDevice> AlsaMidiOutPort::availableDevices() const

--- a/src/framework/midi/internal/platform/lin/alsamidioutport.h
+++ b/src/framework/midi/internal/platform/lin/alsamidioutport.h
@@ -33,9 +33,10 @@ class AlsaMidiOutPort : public IMidiOutPort, public async::Asyncable
 {
 public:
     AlsaMidiOutPort() = default;
-    ~AlsaMidiOutPort() override;
+    ~AlsaMidiOutPort() = default;
 
     void init();
+    void deinit();
 
     MidiDeviceList availableDevices() const override;
     async::Notification availableDevicesChanged() const override;

--- a/src/framework/midi/internal/platform/osx/coremidiinport.cpp
+++ b/src/framework/midi/internal/platform/osx/coremidiinport.cpp
@@ -49,6 +49,15 @@ CoreMidiInPort::CoreMidiInPort()
 
 CoreMidiInPort::~CoreMidiInPort()
 {
+}
+
+void CoreMidiInPort::init()
+{
+    initCore();
+}
+
+void CoreMidiInPort::deinit()
+{
     if (isConnected()) {
         disconnect();
     }
@@ -60,11 +69,6 @@ CoreMidiInPort::~CoreMidiInPort()
     if (m_core->client) {
         MIDIClientDispose(m_core->client);
     }
-}
-
-void CoreMidiInPort::init()
-{
-    initCore();
 }
 
 MidiDeviceList CoreMidiInPort::availableDevices() const

--- a/src/framework/midi/internal/platform/osx/coremidiinport.h
+++ b/src/framework/midi/internal/platform/osx/coremidiinport.h
@@ -34,6 +34,7 @@ public:
     ~CoreMidiInPort() override;
 
     void init();
+    void deinit();
 
     MidiDeviceList availableDevices() const override;
     async::Notification availableDevicesChanged() const override;

--- a/src/framework/midi/internal/platform/osx/coremidioutport.cpp
+++ b/src/framework/midi/internal/platform/osx/coremidioutport.cpp
@@ -49,6 +49,15 @@ CoreMidiOutPort::CoreMidiOutPort()
 
 CoreMidiOutPort::~CoreMidiOutPort()
 {
+}
+
+void CoreMidiOutPort::init()
+{
+    initCore();
+}
+
+void CoreMidiOutPort::deinit()
+{
     if (isConnected()) {
         disconnect();
     }
@@ -56,14 +65,10 @@ CoreMidiOutPort::~CoreMidiOutPort()
     if (m_core->outputPort) {
         MIDIPortDispose(m_core->outputPort);
     }
+
     if (m_core->client) {
         MIDIClientDispose(m_core->client);
     }
-}
-
-void CoreMidiOutPort::init()
-{
-    initCore();
 }
 
 void CoreMidiOutPort::getDestinationProtocolId()

--- a/src/framework/midi/internal/platform/osx/coremidioutport.h
+++ b/src/framework/midi/internal/platform/osx/coremidioutport.h
@@ -39,6 +39,7 @@ public:
     ~CoreMidiOutPort() override;
 
     void init();
+    void deinit();
 
     MidiDeviceList availableDevices() const override;
     async::Notification availableDevicesChanged() const override;

--- a/src/framework/midi/internal/platform/win/winmidiinport.cpp
+++ b/src/framework/midi/internal/platform/win/winmidiinport.cpp
@@ -57,13 +57,6 @@ static std::string errorString(MMRESULT ret)
 }
 }
 
-WinMidiInPort::~WinMidiInPort()
-{
-    if (isConnected()) {
-        disconnect();
-    }
-}
-
 void WinMidiInPort::init()
 {
     m_win = std::make_shared<Win>();
@@ -86,6 +79,13 @@ void WinMidiInPort::init()
 
         m_availableDevicesChanged.notify();
     });
+}
+
+void WinMidiInPort::deinit()
+{
+    if (isConnected()) {
+        disconnect();
+    }
 }
 
 MidiDeviceList WinMidiInPort::availableDevices() const

--- a/src/framework/midi/internal/platform/win/winmidiinport.h
+++ b/src/framework/midi/internal/platform/win/winmidiinport.h
@@ -34,9 +34,10 @@ class WinMidiInPort : public IMidiInPort, public async::Asyncable
 {
 public:
     WinMidiInPort() = default;
-    ~WinMidiInPort() override;
+    ~WinMidiInPort() = default;
 
     void init();
+    void deinit();
 
     MidiDeviceList availableDevices() const override;
     async::Notification availableDevicesChanged() const override;

--- a/src/framework/midi/internal/platform/win/winmidioutport.cpp
+++ b/src/framework/midi/internal/platform/win/winmidioutport.cpp
@@ -52,13 +52,6 @@ static std::string errorString(MMRESULT ret)
     return "UNKNOWN";
 }
 
-WinMidiOutPort::~WinMidiOutPort()
-{
-    if (isConnected()) {
-        disconnect();
-    }
-}
-
 void WinMidiOutPort::init()
 {
     m_win = std::make_shared<Win>();
@@ -81,6 +74,13 @@ void WinMidiOutPort::init()
 
         m_availableDevicesChanged.notify();
     });
+}
+
+void WinMidiOutPort::deinit()
+{
+    if (isConnected()) {
+        disconnect();
+    }
 }
 
 MidiDeviceList WinMidiOutPort::availableDevices() const

--- a/src/framework/midi/internal/platform/win/winmidioutport.h
+++ b/src/framework/midi/internal/platform/win/winmidioutport.h
@@ -33,9 +33,10 @@ class WinMidiOutPort : public IMidiOutPort, public async::Asyncable
 {
 public:
     WinMidiOutPort() = default;
-    ~WinMidiOutPort() override;
+    ~WinMidiOutPort() = default;
 
     void init();
+    void deinit();
 
     MidiDeviceList availableDevices() const override;
     async::Notification availableDevicesChanged() const override;

--- a/src/framework/midi/midimodule.cpp
+++ b/src/framework/midi/midimodule.cpp
@@ -27,8 +27,6 @@
 
 #include "internal/midiconfiguration.h"
 
-#include "internal/platform/lin/alsamidioutport.h"
-
 #include "ui/iuiengine.h"
 #include "view/devtools/midiportdevmodel.h"
 
@@ -41,26 +39,26 @@ static std::shared_ptr<MidiConfiguration> s_configuration = std::make_shared<Mid
 #ifdef Q_OS_LINUX
 #include "internal/platform/lin/alsamidioutport.h"
 #include "internal/platform/lin/alsamidiinport.h"
-static std::shared_ptr<AlsaMidiOutPort> midiOutPort = std::make_shared<AlsaMidiOutPort>();
-static std::shared_ptr<AlsaMidiInPort> midiInPort = std::make_shared<AlsaMidiInPort>();
+static std::shared_ptr<AlsaMidiOutPort> s_midiOutPort = std::make_shared<AlsaMidiOutPort>();
+static std::shared_ptr<AlsaMidiInPort> s_midiInPort = std::make_shared<AlsaMidiInPort>();
 
 #elif defined(Q_OS_WIN)
 #include "internal/platform/win/winmidioutport.h"
 #include "internal/platform/win/winmidiinport.h"
-static std::shared_ptr<WinMidiOutPort> midiOutPort = std::make_shared<WinMidiOutPort>();
-static std::shared_ptr<WinMidiInPort> midiInPort = std::make_shared<WinMidiInPort>();
+static std::shared_ptr<WinMidiOutPort> s_midiOutPort = std::make_shared<WinMidiOutPort>();
+static std::shared_ptr<WinMidiInPort> s_midiInPort = std::make_shared<WinMidiInPort>();
 
 #elif defined(Q_OS_MACOS)
 #include "internal/platform/osx/coremidioutport.h"
 #include "internal/platform/osx/coremidiinport.h"
-static std::shared_ptr<CoreMidiOutPort> midiOutPort = std::make_shared<CoreMidiOutPort>();
-static std::shared_ptr<CoreMidiInPort> midiInPort = std::make_shared<CoreMidiInPort>();
+static std::shared_ptr<CoreMidiOutPort> s_midiOutPort = std::make_shared<CoreMidiOutPort>();
+static std::shared_ptr<CoreMidiInPort> s_midiInPort = std::make_shared<CoreMidiInPort>();
 
 #else
 #include "internal/dummymidioutport.h"
 #include "internal/dummymidiinport.h"
-static std::shared_ptr<DummyMidiOutPort> midiOutPort = std::make_shared<DummyMidiOutPort>();
-static std::shared_ptr<DummyMidiInPort> midiInPort = std::make_shared<DummyMidiInPort>();
+static std::shared_ptr<DummyMidiOutPort> s_midiOutPort = std::make_shared<DummyMidiOutPort>();
+static std::shared_ptr<DummyMidiInPort> s_midiInPort = std::make_shared<DummyMidiInPort>();
 #endif
 
 std::string MidiModule::moduleName() const
@@ -71,8 +69,8 @@ std::string MidiModule::moduleName() const
 void MidiModule::registerExports()
 {
     modularity::ioc()->registerExport<IMidiConfiguration>(moduleName(), s_configuration);
-    modularity::ioc()->registerExport<IMidiOutPort>(moduleName(), midiOutPort);
-    modularity::ioc()->registerExport<IMidiInPort>(moduleName(), midiInPort);
+    modularity::ioc()->registerExport<IMidiOutPort>(moduleName(), s_midiOutPort);
+    modularity::ioc()->registerExport<IMidiInPort>(moduleName(), s_midiInPort);
 }
 
 void MidiModule::registerUiTypes()
@@ -85,7 +83,13 @@ void MidiModule::onInit(const framework::IApplication::RunMode& mode)
     s_configuration->init();
 
     if (mode == framework::IApplication::RunMode::Editor) {
-        midiOutPort->init();
-        midiInPort->init();
+        s_midiOutPort->init();
+        s_midiInPort->init();
     }
+}
+
+void MidiModule::onDeinit()
+{
+    s_midiOutPort->deinit();
+    s_midiInPort->deinit();
 }

--- a/src/framework/midi/midimodule.h
+++ b/src/framework/midi/midimodule.h
@@ -28,12 +28,12 @@ namespace mu::midi {
 class MidiModule : public modularity::IModuleSetup
 {
 public:
-
     std::string moduleName() const override;
 
     void registerExports() override;
     void registerUiTypes() override;
     void onInit(const framework::IApplication::RunMode& mode) override;
+    void onDeinit() override;
 };
 }
 


### PR DESCRIPTION
Resolves: #13573