### PR TITLE
Fix playback of tremolos on 8th notes or shorter

### DIFF
--- a/src/engraving/playback/renderers/tremolorenderer.cpp
+++ b/src/engraving/playback/renderers/tremolorenderer.cpp
@@ -54,7 +54,7 @@ void TremoloRenderer::doRender(const EngravingItem* item, const mpe::Articulatio
 
     const ArticulationAppliedData& articulationData = context.commonArticulations.at(preferredType);
 
-    duration_t stepDuration = durationFromTicks(context.beatsPerSecond.val, stepDurationTicksByType(preferredType));
+    duration_t stepDuration = durationFromTicks(context.beatsPerSecond.val, stepDurationTicks(chord, tremolo));
 
     if (stepDuration <= 0) {
         LOGE() << "Unable to render unsupported tremolo type";
@@ -89,20 +89,13 @@ void TremoloRenderer::doRender(const EngravingItem* item, const mpe::Articulatio
     }
 }
 
-int TremoloRenderer::stepDurationTicksByType(const mpe::ArticulationType& type)
+int TremoloRenderer::stepDurationTicks(const Chord* chord, const Tremolo* tremolo)
 {
-    static constexpr int QUAVER_NOTE_DURATION_TICKS = Constants::division / 2;
-    static constexpr int SEMI_QUAVER_NOTE_DURATION_TICKS = QUAVER_NOTE_DURATION_TICKS / 2;
-    static constexpr int DEMI_SEMI_QUAVER_NOTE_DURATION_TICKS = SEMI_QUAVER_NOTE_DURATION_TICKS / 2;
-    static constexpr int HEMI_SEMI_DEMI_QUAVER_NOTE_DURATION_TICKS = DEMI_SEMI_QUAVER_NOTE_DURATION_TICKS / 2;
-
-    switch (type) {
-    case ArticulationType::Tremolo8th: return QUAVER_NOTE_DURATION_TICKS;
-    case ArticulationType::Tremolo16th: return SEMI_QUAVER_NOTE_DURATION_TICKS;
-    case ArticulationType::Tremolo32nd: return DEMI_SEMI_QUAVER_NOTE_DURATION_TICKS;
-    case ArticulationType::Tremolo64th: return HEMI_SEMI_DEMI_QUAVER_NOTE_DURATION_TICKS;
-    default: return 0;
+    int ticks = Constants::division / (1 << (chord->beams() + tremolo->lines()));
+    if (ticks <= 0) {
+        return 1;
     }
+    return ticks;
 }
 
 void TremoloRenderer::buildAndAppendEvents(const Chord* chord, const ArticulationType type,

--- a/src/engraving/playback/renderers/tremolorenderer.h
+++ b/src/engraving/playback/renderers/tremolorenderer.h
@@ -26,6 +26,8 @@
 #include "renderbase.h"
 
 namespace mu::engraving {
+class Tremolo;
+
 class TremoloRenderer : public RenderBase<TremoloRenderer>
 {
 public:
@@ -35,7 +37,7 @@ public:
                          mpe::PlaybackEventList& result);
 
 private:
-    static int stepDurationTicksByType(const mpe::ArticulationType& type);
+    static int stepDurationTicks(const Chord* chord, const Tremolo* tremolo);
     static void buildAndAppendEvents(const Chord* chord, const mpe::ArticulationType type, const mpe::duration_t stepDuration,
                                      const mpe::timestamp_t timestampOffset, const RenderingContext& context,
                                      mpe::PlaybackEventList& result);


### PR DESCRIPTION
Resolves: #13369 (the part about tremolos on eighth notes and shorter; the part about triplets not yet but that turns out to be a more general problem; will log a separate issue later)

To do: add a test case
I have a test case in mind, namely a score with 2 staves, where the upper staff contains notes with tremolos, and the lower staff contains the same information but written with short notes instead of tremolos. Both staves should generate equal playback data. I think the best way to render and compare the two staves would be using PlaybackModel (so the test case would be added in playbackmodel_tests.cpp), but I was not sure.