### PR TITLE
Fix #13485: cresc. and dim. properties popups affect each other

### DIFF
--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -3853,6 +3853,9 @@ void Score::selectSimilar(EngravingItem* e, bool sameStaff)
         } else {
             pattern.subtype = e->subtype();
         }
+    } else if (e->type() == ElementType::HAIRPIN_SEGMENT) {
+        pattern.subtype = e->subtype();
+        pattern.subtypeValid = true;
     }
     pattern.staffStart = sameStaff ? e->staffIdx() : mu::nidx;
     pattern.staffEnd = sameStaff ? e->staffIdx() + 1 : mu::nidx;
@@ -3885,6 +3888,9 @@ void Score::selectSimilarInRange(EngravingItem* e)
         } else {
             pattern.subtype = e->subtype();
         }
+        pattern.subtypeValid = true;
+    } else if (e->type() == ElementType::HAIRPIN_SEGMENT) {
+        pattern.subtype = e->subtype();
         pattern.subtypeValid = true;
     }
     pattern.staffStart = selection().staffStart();

--- a/src/inspector/models/notation/lines/hairpinlinesettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/hairpinlinesettingsmodel.cpp
@@ -45,6 +45,8 @@ HairpinLineSettingsModel::HairpinLineSettingsModel(QObject* parent, IElementRepo
         setIcon(ui::IconCode::Code::CRESCENDO);
     }
 
+    m_hairpinType = lineType == Crescendo ? engraving::HairpinType::CRESC_LINE : engraving::HairpinType::DECRESC_LINE;
+
     createProperties();
 }
 
@@ -59,7 +61,7 @@ void HairpinLineSettingsModel::createProperties()
 
 void HairpinLineSettingsModel::requestElements()
 {
-    m_elementList = m_repository->findElementsByType(mu::engraving::ElementType::HAIRPIN, [](const mu::engraving::EngravingItem* element) -> bool {
+    m_elementList = m_repository->findElementsByType(mu::engraving::ElementType::HAIRPIN, [this](const mu::engraving::EngravingItem* element) -> bool {
         const mu::engraving::Hairpin* hairpin = mu::engraving::toHairpin(
             element);
 
@@ -67,6 +69,6 @@ void HairpinLineSettingsModel::requestElements()
             return false;
         }
 
-        return hairpin->hairpinType() == mu::engraving::HairpinType::CRESC_LINE || hairpin->hairpinType() == mu::engraving::HairpinType::DECRESC_LINE;
+        return hairpin->hairpinType() == m_hairpinType;
     });
 }

--- a/src/inspector/models/notation/lines/hairpinlinesettingsmodel.h
+++ b/src/inspector/models/notation/lines/hairpinlinesettingsmodel.h
@@ -38,6 +38,8 @@ public:
     explicit HairpinLineSettingsModel(QObject* parent, IElementRepositoryService* repository, HairpinLineType lineType);
 
 private:
+    engraving::HairpinType m_hairpinType = engraving::HairpinType::CRESC_LINE;
+
     void createProperties() override;
     void requestElements() override;
 };

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -1579,6 +1579,9 @@ FilterElementsOptions NotationActionController::elementsFilterOptions(const Engr
         } else {
             options.subtype = element->subtype();
         }
+    } else if (element->type() == ElementType::HAIRPIN_SEGMENT) {
+        options.subtype = element->subtype();
+        options.bySubtype = true;
     }
 
     return options;


### PR DESCRIPTION
Resolves: #13485

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
