### PR TITLE
Address #11218: Change toggle behavior of vertical panels

### DIFF
--- a/src/appshell/view/dockwindow/dockpageview.cpp
+++ b/src/appshell/view/dockwindow/dockpageview.cpp
@@ -27,6 +27,7 @@
 #include "dockcentralview.h"
 #include "dockpanelview.h"
 #include "dockstatusbarview.h"
+#include "appshelltypes.h"
 
 #include "ui/view/navigationcontrol.h"
 
@@ -178,7 +179,7 @@ bool DockPageView::isDockOpen(const QString& dockName) const
 
 void DockPageView::toggleDock(const QString& dockName)
 {
-    setDockOpen(dockName, !isDockOpen(dockName));
+        setDockOpen(dockName, !isDockOpen(dockName));
 }
 
 void DockPageView::setDockOpen(const QString& dockName, bool open)
@@ -188,7 +189,13 @@ void DockPageView::setDockOpen(const QString& dockName, bool open)
         return;
     }
 
-    if (!open) {
+    bool relevantPanel =
+        (dockName == mu::appshell::INSTRUMENTS_PANEL_NAME
+        || dockName == mu::appshell::PALETTES_PANEL_NAME
+        || dockName == mu::appshell::INSPECTOR_PANEL_NAME
+        || dockName == mu::appshell::SELECTION_FILTERS_PANEL_NAME);
+
+    if (!open && !relevantPanel) {
         dock->close();
         return;
     }
@@ -202,6 +209,9 @@ void DockPageView::setDockOpen(const QString& dockName, bool open)
     DockPanelView* destinationPanel = findPanelForTab(panel);
     if (destinationPanel) {
         destinationPanel->addPanelAsTab(panel);
+        if (!open && relevantPanel) {
+            destinationPanel->toggleTabSelection(panel);
+        }
     } else {
         panel->open();
     }

--- a/src/appshell/view/dockwindow/dockpanelview.cpp
+++ b/src/appshell/view/dockwindow/dockpanelview.cpp
@@ -271,6 +271,23 @@ void DockPanelView::addPanelAsTab(DockPanelView* tab)
     tab->setVisible(true);
 }
 
+void DockPanelView::toggleTabSelection(DockPanelView* tab)
+{
+    IF_ASSERT_FAILED(tab && dockWidget()) {
+        return;
+    }
+    
+    if (!isTabAllowed(tab)) {
+        return;
+    }
+
+    if (!tab->dockWidget()->isCurrentTab()) {
+        tab->dockWidget()->setAsCurrentTab();
+    } else {
+        tab->close();
+    }
+}
+
 void DockPanelView::setCurrentTabIndex(int index)
 {
     IF_ASSERT_FAILED(dockWidget()) {

--- a/src/appshell/view/dockwindow/dockpanelview.h
+++ b/src/appshell/view/dockwindow/dockpanelview.h
@@ -54,6 +54,7 @@ public:
 
     bool isTabAllowed(const DockPanelView* tab) const;
     void addPanelAsTab(DockPanelView* tab);
+    void toggleTabSelection(DockPanelView* tab);
     void setCurrentTabIndex(int index);
 
 public slots:


### PR DESCRIPTION
Resolves: [Issue #11218](https://github.com/musescore/MuseScore/issues/11218)

Changed DockPageView::setDockOpen() to select vertical panels rather than close them when open but not selected. Added function toggleTabSelection() to DockPanelView class to accomplish this. Changes behavior for both shortcuts and drop-down menus as they make the same function calls.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
