### PR TITLE
fix #8964: Added checks for when no score is open

### DIFF
--- a/src/inspector/models/score/scoredisplaysettingsmodel.cpp
+++ b/src/inspector/models/score/scoredisplaysettingsmodel.cpp
@@ -123,6 +123,9 @@ void ScoreSettingsModel::setShouldShowInvisible(bool shouldShowInvisible)
     if (m_shouldShowInvisible == shouldShowInvisible) {
         return;
     }
+    else if (context()->currentNotation() == nullptr) {
+        return;
+    }
 
     dispatcher()->dispatch("show-invisible");
     updateShouldShowInvisible(shouldShowInvisible);
@@ -131,6 +134,9 @@ void ScoreSettingsModel::setShouldShowInvisible(bool shouldShowInvisible)
 void ScoreSettingsModel::setShouldShowFormatting(bool shouldShowFormatting)
 {
     if (m_shouldShowFormatting == shouldShowFormatting) {
+        return;
+    }
+    else if (context()->currentNotation() == nullptr) {
         return;
     }
 
@@ -143,6 +149,9 @@ void ScoreSettingsModel::setShouldShowFrames(bool shouldShowFrames)
     if (m_shouldShowFrames == shouldShowFrames) {
         return;
     }
+    else if (context()->currentNotation() == nullptr) {
+        return;
+    }
 
     dispatcher()->dispatch("show-frames");
     updateShouldShowFrames(shouldShowFrames);
@@ -151,6 +160,9 @@ void ScoreSettingsModel::setShouldShowFrames(bool shouldShowFrames)
 void ScoreSettingsModel::setShouldShowPageMargins(bool shouldShowPageMargins)
 {
     if (m_shouldShowPageMargins == shouldShowPageMargins) {
+        return;
+    }
+    else if (context()->currentNotation() == nullptr) {
         return;
     }
 

--- a/src/inspector/models/score/scoredisplaysettingsmodel.h
+++ b/src/inspector/models/score/scoredisplaysettingsmodel.h
@@ -25,10 +25,14 @@
 #include "models/abstractinspectormodel.h"
 #include "async/asyncable.h"
 #include "notation/notationtypes.h"
+#include "modularity/ioc.h"
+#include "iglobalcontext.h" 
 
 namespace mu::inspector {
 class ScoreSettingsModel : public AbstractInspectorModel
 {
+    INJECT(ScoreSettingsModel, context::IGlobalContext, context)
+
     Q_OBJECT
 
     Q_PROPERTY(bool shouldShowInvisible READ shouldShowInvisible WRITE setShouldShowInvisible NOTIFY shouldShowInvisibleChanged)


### PR DESCRIPTION
Resolves: #8964 

Added checks for when no score is open so that the properties cannot be changed or used by the user if the case that no score is open is true. Checks it in scoredisplaysettingsmodel.cpp so that the variables that dictate whether the properties can be used aren't always true even when no score is open.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
