### PR TITLE
Fix that view options in Properties panel sometimes work inverted

### DIFF
--- a/src/inspector/models/score/scoredisplaysettingsmodel.h
+++ b/src/inspector/models/score/scoredisplaysettingsmodel.h
@@ -70,11 +70,10 @@ private:
     void updateShouldShowPageMargins(bool isVisible);
 
     notation::ScoreConfig scoreConfig() const;
-    async::Channel<notation::ScoreConfigType> scoreConfigChanged() const;
 
     void updateFromConfig(mu::notation::ScoreConfigType configType);
     void updateAll();
-    void setupConnections();
+    void onCurrentNotationChanged() override;
 
     bool m_shouldShowInvisible = false;
     bool m_shouldShowFormatting = false;


### PR DESCRIPTION
Resolves: #13263

Fix updating the data stored in `ScoreSettingsModel`.

Alternative considered: not storing any data in `ScoreSettingsModel`, but retrieving the actual values from the current notation (or default value if no notation is open) every time the getter is called. But that might give worse performance.