### PR TITLE
[MU4] Inadmissible floaters

### DIFF
--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -105,8 +105,8 @@ class Beam final : public EngravingItem
     bool isValidBeamPosition(int yPos, bool isStart, bool isAscending, bool isFlat, int staffLines, bool isOuter) const;
     bool is64thBeamPositionException(int& yPos, int staffLines) const;
     int findValidBeamOffset(int outer, int beamCount, int staffLines, bool isStart, bool isAscending, bool isFlat) const;
-    void setValidBeamPositions(int& dictator, int& pointer, int beamCount, int staffLines, bool isStartDictator, bool isFlat,
-                               bool isAscending);
+    void setValidBeamPositions(int& dictator, int& pointer, int beamCountD, int beamCountP, int staffLines, bool isStartDictator,
+                               bool isFlat, bool isAscending);
     void addMiddleLineSlant(int& dictator, int& pointer, int beamCount, int middleLine, int interval, int desiredSlant);
     void add8thSpaceSlant(mu::PointF& dictatorAnchor, int dictator, int pointer, int beamCount, int interval, int middleLine, bool Flat);
     void extendStem(Chord* chord, double addition);

--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -100,9 +100,9 @@ class Beam final : public EngravingItem
                                       const double endX, bool isFlat, bool isStartDictator) const;
     void offsetBeamWithAnchorShortening(std::vector<ChordRest*> chordRests, int& dictator, int& pointer, int staffLines,
                                         bool isStartDictator, int stemLengthDictator) const;
-    bool isBeamInsideStaff(int yPos, int staffLines, bool isInner) const;
+    bool isBeamInsideStaff(int yPos, int staffLines, bool allowFloater) const;
     int getOuterBeamPosOffset(int innerBeam, int beamCount, int staffLines) const;
-    bool isValidBeamPosition(int yPos, bool isStart, bool isAscending, bool isFlat, int staffLines) const;
+    bool isValidBeamPosition(int yPos, bool isStart, bool isAscending, bool isFlat, int staffLines, bool isOuter) const;
     bool is64thBeamPositionException(int& yPos, int staffLines) const;
     int findValidBeamOffset(int outer, int beamCount, int staffLines, bool isStart, bool isAscending, bool isFlat) const;
     void setValidBeamPositions(int& dictator, int& pointer, int beamCount, int staffLines, bool isStartDictator, bool isFlat,

--- a/src/engraving/utests/chordsymbol_data/realize-triplet-ref.mscx
+++ b/src/engraving/utests/chordsymbol_data/realize-triplet-ref.mscx
@@ -749,7 +749,7 @@
             </Tuplet>
           <Beam>
             <l1>-8</l1>
-            <l2>-6</l2>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <durationType>16th</durationType>

--- a/src/engraving/utests/copypaste_data/copypaste11-ref.mscx
+++ b/src/engraving/utests/copypaste_data/copypaste11-ref.mscx
@@ -117,8 +117,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-8</l1>
-            <l2>-6</l2>
+            <l1>-6</l1>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -215,8 +215,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-8</l1>
-            <l2>-6</l2>
+            <l1>-6</l1>
+            <l2>-4</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/engraving/utests/tuplet_data/split4-ref.mscx
+++ b/src/engraving/utests/tuplet_data/split4-ref.mscx
@@ -214,8 +214,8 @@
               </Number>
             </Tuplet>
           <Beam>
-            <l1>6</l1>
-            <l2>6</l2>
+            <l1>-4</l1>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <durationType>32nd</durationType>


### PR DESCRIPTION
Branched from https://github.com/musescore/MuseScore/pull/13345

The beam floaters issue has been fixed, so it can be tested and merged separately from the other beam adjustment stuff that still needs to happen. Beams now occupy floater positions when they need to and flat beams also check every chord to make sure that there are no hidden floaters hiding in the middle of a mixed beam.