### PR TITLE
[MU4] fix #10971: VST plugin added during playback does not seem to be active

### DIFF
--- a/src/framework/vst/internal/fx/vstfxprocessor.cpp
+++ b/src/framework/vst/internal/fx/vstfxprocessor.cpp
@@ -39,9 +39,11 @@ void VstFxProcessor::init()
 
     if (m_pluginPtr->isLoaded()) {
         m_pluginPtr->updatePluginConfig(m_params.configuration);
+        m_inited = true;
     } else {
         m_pluginPtr->loadingCompleted().onNotify(this, [this]() {
             m_pluginPtr->updatePluginConfig(m_params.configuration);
+            m_inited = true;
         });
     }
 
@@ -87,7 +89,7 @@ void VstFxProcessor::setActive(bool active)
 
 void VstFxProcessor::process(float* buffer, unsigned int sampleCount)
 {
-    if (!buffer) {
+    if (!buffer || !m_inited) {
         return;
     }
 

--- a/src/framework/vst/internal/fx/vstfxprocessor.h
+++ b/src/framework/vst/internal/fx/vstfxprocessor.h
@@ -27,6 +27,8 @@ public:
     void process(float* buffer, unsigned int sampleCount) override;
 
 private:
+    bool m_inited = false;
+
     VstPluginPtr m_pluginPtr = nullptr;
     std::unique_ptr<VstAudioClient> m_vstAudioClient = nullptr;
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10971
Resolves: https://github.com/musescore/MuseScore/issues/13425