### PR TITLE
Fix crash when (re)setting beam direction when beam contains rests

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -1979,9 +1979,9 @@ void Beam::setBeamDirection(DirectionV d)
         _up = d == DirectionV::UP;
     }
 
-    for (ChordRest* rest : elements()) {
-        if (Chord* chord = toChord(rest)) {
-            chord->setStemDirection(d);
+    for (ChordRest* e : elements()) {
+        if (e->isChord()) {
+            toChord(e)->setStemDirection(d);
         }
     }
 }


### PR DESCRIPTION
Resolves: #13615