### PR TITLE
Introduce MnemonicString to guarantee handling of mnemonics ampersands

### DIFF
--- a/src/appshell/qml/platform/AppMenuBar.qml
+++ b/src/appshell/qml/platform/AppMenuBar.qml
@@ -116,6 +116,7 @@ ListView {
         property var item: model ? model.itemRole : null
         property string menuId: Boolean(item) ? item.id : ""
         property string title: Boolean(item) ? item.title : ""
+        property string titleWithMnemonicUnderline: Boolean(item) ? item.titleWithMnemonicUnderline : ""
 
         property bool isMenuOpened: menuLoader.isMenuOpened && menuLoader.parent === this
 
@@ -147,7 +148,7 @@ ListView {
             accessibleParent: panelAccessibleInfo
             visualItem: radioButtonDelegate
             role: MUAccessible.Button
-            name: Utils.removeAmpersands(radioButtonDelegate.title)
+            name: radioButtonDelegate.title
 
             function readInfo() {
                 accessibleInfo.ignored = false
@@ -165,7 +166,7 @@ ListView {
 
             width: textMetrics.width
 
-            text: correctText(radioButtonDelegate.title)
+            text: appMenuModel.isNavigationStarted ? radioButtonDelegate.titleWithMnemonicUnderline : radioButtonDelegate.title
             textFormat: Text.RichText
             font: ui.theme.defaultFont
 
@@ -173,23 +174,7 @@ ListView {
                 id: textMetrics
 
                 font: textLabel.font
-                text: textLabel.removeAmpersands(radioButtonDelegate.title)
-            }
-
-            function correctText(text) {
-                if (!appMenuModel.isNavigationStarted) {
-                    return removeAmpersands(text)
-                }
-
-                return makeMnemonicText(text)
-            }
-
-            function removeAmpersands(text) {
-                return Utils.removeAmpersands(text)
-            }
-
-            function makeMnemonicText(text) {
-                return Utils.makeMnemonicText(text)
+                text: radioButtonDelegate.title
             }
         }
 

--- a/src/appshell/view/navigableappmenumodel.cpp
+++ b/src/appshell/view/navigableappmenumodel.cpp
@@ -491,7 +491,7 @@ QString NavigableAppMenuModel::openedMenuId() const
 QString NavigableAppMenuModel::menuItemId(const MenuItemList& items, const QSet<int>& activatePossibleKeys)
 {
     for (const MenuItem* item : items) {
-        QString title = item->action().title.translated();
+        QString title = item->action().title.qTranslatedWithMnemonicAmpersand();
 
         int activateKeyIndex = title.indexOf('&');
         if (activateKeyIndex == -1) {

--- a/src/framework/shortcuts/view/mididevicemappingmodel.cpp
+++ b/src/framework/shortcuts/view/mididevicemappingmodel.cpp
@@ -95,7 +95,7 @@ QVariantMap MidiDeviceMappingModel::midiMappingToObject(const MidiControlsMappin
 
     QVariantMap obj;
 
-    obj[TITLE_KEY] = !action.description.isEmpty() ? action.description.qTranslated() : action.title.qTranslated();
+    obj[TITLE_KEY] = !action.description.isEmpty() ? action.description.qTranslated() : action.title.qTranslatedWithoutMnemonic();
     obj[ICON_KEY] = static_cast<int>(action.iconCode);
     obj[ENABLED_KEY] = midiMapping.isValid();
     obj[STATUS_KEY] = midiMapping.isValid() ? midiMapping.event.name().toQString() : qtrc("shortcuts", "Inactive");

--- a/src/framework/shortcuts/view/shortcutsmodel.cpp
+++ b/src/framework/shortcuts/view/shortcutsmodel.cpp
@@ -22,9 +22,11 @@
 
 #include "shortcutsmodel.h"
 
+#include "ui/types/mnemonicstring.h"
 #include "ui/view/iconcodes.h"
 #include "translation.h"
 #include "types/translatablestring.h"
+
 #include "log.h"
 
 using namespace mu::shortcuts;
@@ -54,7 +56,7 @@ QVariant ShortcutsModel::data(const QModelIndex& index, int role) const
     case RoleSequence: return sequencesToNativeText(shortcut.sequences);
     case RoleSearchKey: {
         const UiAction& action = this->action(shortcut.action);
-        return QString::fromStdString(action.code) + action.title.qTranslated() + action.description.qTranslated()
+        return QString::fromStdString(action.code) + action.title.qTranslatedWithoutMnemonic() + action.description.qTranslated()
                + sequencesToNativeText(shortcut.sequences);
     }
     }
@@ -72,7 +74,7 @@ QString ShortcutsModel::actionText(const std::string& actionCode) const
     const UiAction& action = this->action(actionCode);
 
     if (action.description.isEmpty()) {
-        return action.title.qTranslated();
+        return action.title.qTranslatedWithoutMnemonic();
     }
 
     return action.description.qTranslated();

--- a/src/framework/ui/CMakeLists.txt
+++ b/src/framework/ui/CMakeLists.txt
@@ -67,6 +67,9 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/inavigation.h
     ${CMAKE_CURRENT_LIST_DIR}/inavigationcontroller.h
 
+    ${CMAKE_CURRENT_LIST_DIR}/types/mnemonicstring.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/types/mnemonicstring.h
+
     ${CMAKE_CURRENT_LIST_DIR}/internal/interactiveuriregister.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/interactiveuriregister.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/uiengine.cpp

--- a/src/framework/ui/tests/CMakeLists.txt
+++ b/src/framework/ui/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(MODULE_TEST ui_tests)
 
 set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/environment.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/mnemonicstring_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/navigationcontroller_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mocks/navigationmocks.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/mainwindowprovidermock.h

--- a/src/framework/ui/tests/mnemonicstring_tests.cpp
+++ b/src/framework/ui/tests/mnemonicstring_tests.cpp
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <gtest/gtest.h>
+
+#include "ui/types/mnemonicstring.h"
+
+#include "log.h"
+
+using namespace mu;
+using namespace mu::ui;
+
+class Ui_MnemonicStringTests : public ::testing::Test
+{
+public:
+};
+
+TEST_F(Ui_MnemonicStringTests, processMnemonic)
+{
+    {
+        //! [GIVEN] A MnemonicString with the ampersand at the beginning
+        MnemonicString mStr(TranslatableString::untranslatable("&Start Mnemonic"));
+
+        //! [CHECK]
+        EXPECT_EQ(mStr.qTranslatedWithMnemonicAmpersand(), "&Start Mnemonic");
+        EXPECT_EQ(mStr.qTranslatedWithMnemonicUnderline(), "<u>S</u>tart Mnemonic");
+        EXPECT_EQ(mStr.qTranslatedWithoutMnemonic(), "Start Mnemonic");
+    }
+
+    {
+        //! [GIVEN] A MnemonicString with the ampersand in the middle
+        MnemonicString mStr(TranslatableString::untranslatable("Mid&dle Mnemonic"));
+
+        //! [CHECK]
+        EXPECT_EQ(mStr.qTranslatedWithMnemonicAmpersand(), "Mid&dle Mnemonic");
+        EXPECT_EQ(mStr.qTranslatedWithMnemonicUnderline(), "Mid<u>d</u>le Mnemonic");
+        EXPECT_EQ(mStr.qTranslatedWithoutMnemonic(), "Middle Mnemonic");
+    }
+
+    {
+        //! [GIVEN] A MnemonicString with an escaped ampersand (&&)
+        MnemonicString mStr(TranslatableString::untranslatable("Ampersand && Mnemonic"));
+
+        //! [CHECK]
+        EXPECT_EQ(mStr.qTranslatedWithMnemonicAmpersand(), "Ampersand && Mnemonic");
+        EXPECT_EQ(mStr.qTranslatedWithMnemonicUnderline(), "Ampersand & Mnemonic");
+        EXPECT_EQ(mStr.qTranslatedWithoutMnemonic(), "Ampersand & Mnemonic");
+    }
+
+    {
+        //! [GIVEN] A MnemonicString with a trailing ampersand (it's invalid, but shouldn't cause problems)
+        MnemonicString mStr(TranslatableString::untranslatable("Trailing Mnemonic&"));
+
+        //! [CHECK]
+        EXPECT_EQ(mStr.qTranslatedWithMnemonicAmpersand(), "Trailing Mnemonic&");
+        EXPECT_EQ(mStr.qTranslatedWithMnemonicUnderline(), "Trailing Mnemonic");
+        EXPECT_EQ(mStr.qTranslatedWithoutMnemonic(), "Trailing Mnemonic");
+    }
+
+    {
+        //! [GIVEN] A MnemonicString with multiple ampersands (it's invalid, but shouldn't cause problems)
+        MnemonicString mStr(TranslatableString::untranslatable("Mu&lti Mnemo&nic"));
+
+        //! [CHECK]
+        EXPECT_EQ(mStr.qTranslatedWithMnemonicAmpersand(), "Mu&lti Mnemo&nic");
+        EXPECT_EQ(mStr.qTranslatedWithMnemonicUnderline(), "Mu<u>l</u>ti Mnemo<u>n</u>ic");
+        EXPECT_EQ(mStr.qTranslatedWithoutMnemonic(), "Multi Mnemonic");
+    }
+
+    {
+        //! [GIVEN] A MnemonicString with a mnemonic ampersands and an escaped ampersand
+        MnemonicString mStr(TranslatableString::untranslatable("Mu&lti && Mnemonic"));
+
+        //! [CHECK]
+        EXPECT_EQ(mStr.qTranslatedWithMnemonicAmpersand(), "Mu&lti && Mnemonic");
+        EXPECT_EQ(mStr.qTranslatedWithMnemonicUnderline(), "Mu<u>l</u>ti & Mnemonic");
+        EXPECT_EQ(mStr.qTranslatedWithoutMnemonic(), "Multi & Mnemonic");
+    }
+}

--- a/src/framework/ui/types/mnemonicstring.cpp
+++ b/src/framework/ui/types/mnemonicstring.cpp
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2022 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "mnemonicstring.h"
+
+using namespace mu::ui;
+
+static QString processMnemonic(const QString& str, bool showUnderlines)
+{
+    if (str.size() <= 1) {
+        return str;
+    }
+
+    QString result;
+    result.reserve(str.size());
+
+    const QChar* c = str.data();
+    int l = str.length();
+    while (l) {
+        if (*c == '&') {
+            ++c;
+            --l;
+            if (!l) {
+                break;
+            }
+
+            if (showUnderlines && *c != '&') {
+                result.append(QStringLiteral("<u>")).append(*c).append(QStringLiteral("</u>"));
+                ++c;
+                --l;
+                continue;
+            }
+        }
+
+        result.append(*c);
+        ++c;
+        --l;
+    }
+
+    return result;
+}
+
+QString MnemonicString::qTranslatedWithMnemonicUnderline() const
+{
+    return processMnemonic(m_raw.qTranslated(), true);
+}
+
+QString MnemonicString::qTranslatedWithoutMnemonic() const
+{
+    return processMnemonic(m_raw.qTranslated(), false);
+}

--- a/src/framework/ui/types/mnemonicstring.h
+++ b/src/framework/ui/types/mnemonicstring.h
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2022 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_UI_MNEMONICSTRING_H
+#define MU_UI_MNEMONICSTRING_H
+
+#include <QString>
+
+#include "types/translatablestring.h"
+
+namespace mu::ui {
+class MnemonicString
+{
+public:
+    MnemonicString() = default;
+    MnemonicString(const TranslatableString& raw)
+        : m_raw(raw) {}
+
+    inline bool isEmpty() const
+    {
+        return m_raw.isEmpty();
+    }
+
+    inline const TranslatableString& raw() const
+    {
+        return m_raw;
+    }
+
+    inline QString qTranslatedWithMnemonicAmpersand() const
+    {
+        return m_raw.qTranslated();
+    }
+
+    QString qTranslatedWithMnemonicUnderline() const;
+
+    QString qTranslatedWithoutMnemonic() const;
+
+    inline bool operator ==(const MnemonicString& other) const
+    {
+        return m_raw == other.m_raw;
+    }
+
+    inline bool operator !=(const MnemonicString& other) const
+    {
+        return m_raw != other.m_raw;
+    }
+
+private:
+    TranslatableString m_raw;
+};
+}
+
+#endif // MU_UI_MNEMONICSTRING_H

--- a/src/framework/ui/uitypes.h
+++ b/src/framework/ui/uitypes.h
@@ -32,6 +32,7 @@
 #include "types/translatablestring.h"
 #include "types/val.h"
 #include "actions/actiontypes.h"
+#include "types/mnemonicstring.h"
 #include "view/iconcodes.h"
 #include "shortcuts/shortcutstypes.h"
 #include "context/shortcutcontext.h"
@@ -192,7 +193,7 @@ struct UiAction
     actions::ActionCode code;
     UiContext uiCtx = UiCtxAny;
     std::string scCtx = "any";
-    TranslatableString title;
+    MnemonicString title;
     TranslatableString description;
     IconCode::Code iconCode = IconCode::Code::NONE;
     Checkable checkable = Checkable::No;
@@ -202,19 +203,19 @@ struct UiAction
     UiAction(const actions::ActionCode& code, UiContext ctx, std::string scCtx, Checkable ch = Checkable::No)
         : code(code), uiCtx(ctx), scCtx(scCtx), checkable(ch) {}
 
-    UiAction(const actions::ActionCode& code, UiContext ctx, std::string scCtx, const TranslatableString& title,
+    UiAction(const actions::ActionCode& code, UiContext ctx, std::string scCtx, const MnemonicString& title,
              Checkable ch = Checkable::No)
         : code(code), uiCtx(ctx), scCtx(scCtx), title(title), checkable(ch) {}
 
-    UiAction(const actions::ActionCode& code, UiContext ctx, std::string scCtx, const TranslatableString& title,
+    UiAction(const actions::ActionCode& code, UiContext ctx, std::string scCtx, const MnemonicString& title,
              const TranslatableString& desc, Checkable ch = Checkable::No)
         : code(code), uiCtx(ctx), scCtx(scCtx), title(title), description(desc),  checkable(ch) {}
 
-    UiAction(const actions::ActionCode& code, UiContext ctx, std::string scCtx, const TranslatableString& title,
+    UiAction(const actions::ActionCode& code, UiContext ctx, std::string scCtx, const MnemonicString& title,
              const TranslatableString& desc, IconCode::Code icon, Checkable ch = Checkable::No)
         : code(code), uiCtx(ctx), scCtx(scCtx), title(title), description(desc), iconCode(icon), checkable(ch) {}
 
-    UiAction(const actions::ActionCode& code, UiContext ctx, std::string scCtx, const TranslatableString& title, IconCode::Code icon,
+    UiAction(const actions::ActionCode& code, UiContext ctx, std::string scCtx, const MnemonicString& title, IconCode::Code icon,
              Checkable ch = Checkable::No)
         : code(code), uiCtx(ctx), scCtx(scCtx), title(title), iconCode(icon), checkable(ch) {}
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/Utils.js
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/Utils.js
@@ -82,20 +82,3 @@ function getItemValue(model, index, roleName, def) {
 
     return item
 }
-
-function makeMnemonicText(text) {
-    var index = text.indexOf("&")
-    if (index !== -1) {
-        if (index === text.length - 1) {
-            text = removeAmpersands(text)
-        } else {
-            text = text.replace(text.substr(index, 2), ("<u>" + text.substr(index + 1, 1) + "</u>"))
-        }
-    }
-
-    return text
-}
-
-function removeAmpersands(text) {
-    return text.replace('&', '')
-}

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/internal/StyledMenuItem.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/internal/StyledMenuItem.qml
@@ -92,7 +92,7 @@ ListItemBlank {
             text += " " + qsTrc("ui", "Menu")
         }
 
-        return Utils.removeAmpersands(text)
+        return text
     }
 
     QtObject {
@@ -101,6 +101,7 @@ ListItemBlank {
         property string id: Boolean(modelData) && Boolean(modelData.id) ? modelData.id : ""
 
         property string title: Boolean(modelData) && Boolean(modelData.title) ? modelData.title : ""
+        property string titleWithMnemonicUnderline: Boolean(modelData) && Boolean(modelData.titleWithMnemonicUnderline) ? modelData.titleWithMnemonicUnderline : ""
 
         property bool hasShortcuts: Boolean(modelData) && Boolean(modelData.shortcuts)
         property string shortcuts: hasShortcuts ? modelData.shortcuts : ""
@@ -194,7 +195,7 @@ ListItemBlank {
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignLeft
 
-            text: Utils.makeMnemonicText(itemPrv.title)
+            text: itemPrv.titleWithMnemonicUnderline
 
             textFormat: Text.RichText
             //! If the rich text format is set, then the component intercepts the hover state

--- a/src/framework/uicomponents/view/menuitem.cpp
+++ b/src/framework/uicomponents/view/menuitem.cpp
@@ -46,14 +46,14 @@ QString MenuItem::id() const
     return m_id;
 }
 
-mu::TranslatableString MenuItem::title() const
-{
-    return m_action.title;
-}
-
 QString MenuItem::translatedTitle() const
 {
-    return m_action.title.qTranslated();
+    return m_action.title.qTranslatedWithoutMnemonic();
+}
+
+QString MenuItem::titleWithMnemonicUnderline() const
+{
+    return m_action.title.qTranslatedWithMnemonicUnderline();
 }
 
 QString MenuItem::section() const

--- a/src/framework/uicomponents/view/menuitem.h
+++ b/src/framework/uicomponents/view/menuitem.h
@@ -56,6 +56,7 @@ class MenuItem : public QObject, public async::Asyncable
     Q_PROPERTY(QString portableShortcuts READ portableShortcuts NOTIFY actionChanged)
 
     Q_PROPERTY(QString title READ translatedTitle NOTIFY actionChanged)
+    Q_PROPERTY(QString titleWithMnemonicUnderline READ titleWithMnemonicUnderline NOTIFY actionChanged)
     Q_PROPERTY(QString description READ description_property NOTIFY actionChanged)
     Q_PROPERTY(QString section READ section NOTIFY sectionChanged)
 
@@ -78,8 +79,8 @@ public:
     MenuItem(const ui::UiAction& action, QObject* parent = nullptr);
 
     QString id() const;
-    TranslatableString title() const;
     QString translatedTitle() const;
+    QString titleWithMnemonicUnderline() const;
     QString section() const;
 
     bool selectable() const;

--- a/src/notation/view/noteinputbarcustomisemodel.cpp
+++ b/src/notation/view/noteinputbarcustomisemodel.cpp
@@ -218,7 +218,7 @@ NoteInputBarCustomiseItem* NoteInputBarCustomiseModel::makeItem(const UiAction& 
 
     NoteInputBarCustomiseItem* item = new NoteInputBarCustomiseItem(NoteInputBarCustomiseItem::ItemType::ACTION, this);
     item->setId(QString::fromStdString(action.code));
-    item->setTitle(action.title.qTranslated());
+    item->setTitle(action.title.qTranslatedWithoutMnemonic());
     item->setIcon(action.iconCode);
     item->setChecked(checked);
 

--- a/src/palette/internal/palette.cpp
+++ b/src/palette/internal/palette.cpp
@@ -153,7 +153,7 @@ PaletteCellPtr Palette::appendElement(ElementPtr element, const TranslatableStri
 PaletteCellPtr Palette::appendActionIcon(ActionIconType type, actions::ActionCode code)
 {
     const ui::UiAction& action = actionsRegister()->action(code);
-    QString name = !action.description.isEmpty() ? action.description.qTranslated() : action.title.qTranslated();
+    QString name = !action.description.isEmpty() ? action.description.qTranslated() : action.title.qTranslatedWithoutMnemonic();
     auto icon = std::make_shared<ActionIcon>(gpaletteScore->dummy());
     icon->setActionType(type);
     icon->setAction(code, static_cast<char16_t>(action.iconCode));

--- a/src/plugins/internal/pluginsuiactions.cpp
+++ b/src/plugins/internal/pluginsuiactions.cpp
@@ -55,8 +55,8 @@ const mu::ui::UiActionList& PluginsUiActions::actionsList() const
         action.code = codeFromQString(plugin.codeKey);
         action.uiCtx = mu::context::UiCtxNotationOpened;
         action.scCtx = mu::context::CTX_NOTATION_OPENED;
-        action.title = TranslatableString("plugins", "Run plugin %1").arg(plugin.codeKey);
-        action.description = action.title;
+        action.description = TranslatableString("plugins", "Run plugin %1").arg(plugin.codeKey);
+        action.title = action.description;
 
         result.push_back(action);
     }


### PR DESCRIPTION
Resolves: #13295 
Resolves: #12922

This idea was initially proposed by @shoogle, based on my TranslatableString idea, to force at compile time that we don't forget to handle those mnemonics. At first I was a little bit worried about the performance, but we don't have much choice; we have to process every string anyway. Another thing was that some of the work actually needed to be done at the QML side. But I moved all hard work to C++, which is said to be faster than doing it in QML. 
In the end, the performance cost is not _very_ bad:
```
Main thread. Top 150 by sum time (total count: 158)
Function                                                    Call time         Call count        Sum time          
MnemonicString::qTranslatedWithoutMnemonics                 0.018 ms          13998             258.135 ms        
MnemonicString::qTranslatedWithMnemonicUnderlines           0.017 ms          5782              98.640 ms         
```
(This is after a not-very-short stress test where I moved my mouse through various menus to quickly open them all, opened the list of shortcuts in Preferences, etc.. It was on an M1 Mac though.)

To avoid huge diffs (and a _lot_ of work that is not easily automatable), I made the constructor of MnemonicString implicit, so that we don't need to replace TranslatableString(...) with MnemonicString(...) everywhere.