### PR TITLE
AppImage: Add '4' suffix to install paths to prevent conflicts with MU3 on Linux

### DIFF
--- a/build/Linux+BSD/mscore.desktop.in
+++ b/build/Linux+BSD/mscore.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]@Variables_substituted_by_CMAKE_on_installation@
 Version=1.0@This_is_version_of_Desktop_Entry_Specification@@It_is_NOT_MuseScore_version@
-Name=@MUSESCORE_NAME@ @MUSESCORE_VERSION@@MSCORE_INSTALL_SUFFIX@
+Name=@DESKTOP_LAUNCHER_NAME@
 GenericName=Music notation
 GenericName[de]=Notensatz
 GenericName[fr]=Notation musicale

--- a/build/ci/backend/convertor.in
+++ b/build/ci/backend/convertor.in
@@ -5,5 +5,4 @@ HERE="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 export XDG_RUNTIME_DIR=/tmp/runtime-root
 export QT_QPA_PLATFORM=offscreen
 
-"$HERE/bin/mscore-portable" "$@"
-
+exec "$HERE/bin/mscore4-portable"* "$@"

--- a/build/ci/linux/dumpsyms.sh
+++ b/build/ci/linux/dumpsyms.sh
@@ -29,7 +29,7 @@ GEN_SCRIPT=tools/crashdump/generate_syms.sh
 ARTIFACTS_DIR=build.artifacts
 BUILD_DIR=build.release
 SYMBOLS_DIR=$ARTIFACTS_DIR/symbols
-MSCORE_BIN=$BUILD_DIR/src/main/mscore-portable*
+MSCORE_BIN=$BUILD_DIR/src/main/mscore4-portable*
 
 
 echo "GEN_SCRIPT: $GEN_SCRIPT"

--- a/build/cmake/SetupAppImagePackaging.cmake
+++ b/build/cmake/SetupAppImagePackaging.cmake
@@ -5,8 +5,21 @@ if (NOT MINGW AND NOT MSVC AND NOT APPLE)
     #     set library search path for runtime linker to load the same
     #     qt libraries as we used at compile time
     #
+    set(DESKTOP_LAUNCHER_NAME "${MUSESCORE_NAME}")
+
+    if (${MSCORE_INSTALL_SUFFIX} MATCHES "-dev")
+        set(DESKTOP_LAUNCHER_NAME "${DESKTOP_LAUNCHER_NAME}Dev")
+    elseif (${MSCORE_INSTALL_SUFFIX} MATCHES "-nightly")
+        set(DESKTOP_LAUNCHER_NAME "${DESKTOP_LAUNCHER_NAME}Nightly")
+    elseif (${MSCORE_INSTALL_SUFFIX} MATCHES "-testing")
+        set(DESKTOP_LAUNCHER_NAME "${DESKTOP_LAUNCHER_NAME}Testing")
+    endif(${MSCORE_INSTALL_SUFFIX} MATCHES "-dev")
+
+    set(DESKTOP_LAUNCHER_NAME "${DESKTOP_LAUNCHER_NAME} ${MUSESCORE_VERSION}")
+
     string(TOUPPER "mscore${MSCORE_INSTALL_SUFFIX}" MAN_MSCORE_UPPER) # Command name shown in uppercase in man pages by convention
     if (${MSCORE_INSTALL_SUFFIX} MATCHES "portable") # Note: "-portable-anything" would match
+      set(DESKTOP_LAUNCHER_NAME "${DESKTOP_LAUNCHER_NAME} Portable")
       # Build portable AppImage as per https://github.com/probonopd/AppImageKit
       add_subdirectory(build/Linux+BSD/portable)
       if (NOT DEFINED ARCH)
@@ -29,8 +42,9 @@ if (NOT MINGW AND NOT MSVC AND NOT APPLE)
                        build/rm-empty-dirs              DESTINATION bin COMPONENT portable)
       install(FILES    build/Linux+BSD/portable/qt.conf DESTINATION bin COMPONENT portable)
     else (${MSCORE_INSTALL_SUFFIX} MATCHES "portable")
-      set(MAN_PORTABLE .\\\") # comment out lines in man page that are only relevant to the portable version
+      set(MAN_PORTABLE ".\\\"") # comment out lines in man page that are only relevant to the portable version
     endif (${MSCORE_INSTALL_SUFFIX} MATCHES "portable")
+
     # Install desktop file (perform variable substitution first)
     configure_file(build/Linux+BSD/mscore.desktop.in mscore${MSCORE_INSTALL_SUFFIX}.desktop)
     install( FILES ${PROJECT_BINARY_DIR}/mscore${MSCORE_INSTALL_SUFFIX}.desktop DESTINATION share/applications)

--- a/ninja_build.sh
+++ b/ninja_build.sh
@@ -138,7 +138,7 @@ case $TARGET in
 
     appimage)
         MUSESCORE_INSTALL_DIR=../MuseScore 
-        MUSESCORE_INSTALL_SUFFIX="-portable${MUSESCORE_INSTALL_SUFFIX}" # e.g. "-portable" or "-portable-nightly"
+        MUSESCORE_INSTALL_SUFFIX="4-portable${MUSESCORE_INSTALL_SUFFIX}" # e.g. "4-portable" or "4-portable-nightly"
         MUSESCORE_LABEL="Portable AppImage" 
         MUSESCORE_NO_RPATH=ON 
 


### PR DESCRIPTION
This results in the AppImage's internal binary being called `mscore4-portable` instead of `mscore-portable`. AppImage resources are installed to paths like:

    bin/mscore4-portable
    share/applications/mscore4-portable.desktop
    share/icons/hicolor/SIZE/apps/mscore4-portable.png
    share/icons/hicolor/SIZE/mimetypes/application-x-musescore4-portable.png
    share/mime/packages/musescore4-portable.xml
    share/man/man1/mscore4-portable.1.gz

This enables MuseScore 4 to be installed alongside MuseScore 3 on Linux.

It was necessary to change the app name in the .desktop file to avoid MuseScore 4.0 being called "MuseScore 4.04-portable". The new name is "MuseScore 4.0 Portable", with "Portable" there to distinguish our AppImage from distribution packages in the OS's application launcher.

---

FYI, our AppImage can be installed using the `install` option on the command line:
```
chmod +x MuseScore*.AppImage
./MuseScore*.AppImage install
```