### PR TITLE
Improved score loading time (and some general cleanup regarding multi-measure rests)

### DIFF
--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -3273,6 +3273,7 @@ void Measure::layoutMeasureElements()
                     e->setPosX(measureWidth - .5 * e->width());
                 } else {
                     // full measure rest or one-measure repeat, center within this measure
+                    e->layout();
                     e->setPosX((x2 - x1 - e->width()) * .5 + x1 - s.x() - e->bbox().x());
                 }
                 s.createShape(staffIdx);            // DEBUG

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -4216,7 +4216,7 @@ void Measure::computeWidth(Segment* s, double x, bool isSystemHeader, Fraction m
             }
 
             int n = 1;
-            for (Segment* ps = s; ps && !ps->isMMRestSegment(); ps=ps->prevActive()) {
+            for (Segment* ps = s; ps; ps=ps->prevActive()) {
                 double ww;
 
                 assert(ps);         // ps should never be nullptr but better be safe.
@@ -4303,7 +4303,7 @@ void Measure::computeWidth(Fraction minTicks, Fraction maxTicks, double stretchC
     //
     Shape ls(first ? RectF(0.0, -1000000.0, 0.0, 2000000.0) : RectF(0.0, 0.0, 0.0, spatium() * 4));
 
-    x = s->isMMRestSegment() ? 0 : s->minLeft(ls);
+    x = s->minLeft(ls);
 
     if (s->isStartRepeatBarLineType()) {
         System* sys = system();
@@ -4625,8 +4625,11 @@ Fraction Measure::maxTicks() const
 {
     Segment* s = first();
     Fraction maxticks = Fraction(0, 1);
+    if (isMMRest()) {
+        return timesig();
+    }
     while (s) {
-        if (s->enabled() && s->isChordRestType() && !s->isMMRestSegment()) {
+        if (s->enabled() && s->isChordRestType()) {
             maxticks = std::max(maxticks, s->ticks());
         }
         s = s->next();

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -5458,35 +5458,6 @@ void Score::connectTies(bool silent)
 }
 
 //---------------------------------------------------------
-//   relayoutForStyles
-///   some styles can't properly apply if score hasn't been laid out yet,
-///   so temporarily disable them and then reenable after layout
-///   (called during score load)
-//---------------------------------------------------------
-
-void Score::relayoutForStyles()
-{
-    std::vector<Sid> stylesToTemporarilyDisable;
-
-    for (Sid sid : { Sid::createMultiMeasureRests, Sid::mrNumberSeries }) {
-        // only necessary if boolean style is true
-        if (styleB(sid)) {
-            stylesToTemporarilyDisable.push_back(sid);
-        }
-    }
-
-    if (!stylesToTemporarilyDisable.empty()) {
-        for (Sid sid : stylesToTemporarilyDisable) {
-            style().set(sid, false); // temporarily disable
-        }
-        doLayout();
-        for (Sid sid : stylesToTemporarilyDisable) {
-            style().set(sid, true); // and immediately reenable
-        }
-    }
-}
-
-//---------------------------------------------------------
 //   doLayout
 //    do a complete (re-) layout
 //---------------------------------------------------------

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -1014,7 +1014,6 @@ public:
     Segment* lastSegmentMM() const;
 
     void connectTies(bool silent = false);
-    void relayoutForStyles();
 
     double point(const Spatium sp) const { return sp.val() * spatium(); }
 

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -2297,6 +2297,9 @@ void Segment::createShape(staff_idx_t staffIdx)
                 // A full measure rest in a measure with multiple voices must be ignored
                 continue;
             }
+            if (e->isMMRest()) {
+                continue;
+            }
             if (e->addToSkyline()) {
                 s.add(e->shape().translated(e->pos()));
             }
@@ -2601,15 +2604,6 @@ double Segment::elementsBottomOffsetFromSkyline(staff_idx_t staffIndex) const
 }
 
 //---------------------------------------------------------
-// isMMRestSegment()
-//  true if the segment is a MM rest
-//---------------------------------------------------------
-bool Segment::isMMRestSegment() const
-{
-    return measure()->isMMRest() && isChordRestType();
-}
-
-//---------------------------------------------------------
 //   minHorizontalDistance
 //    calculate the minimum layout distance to Segment ns
 //---------------------------------------------------------
@@ -2619,11 +2613,7 @@ double Segment::minHorizontalDistance(Segment* ns, bool systemHeaderGap) const
     double ww = -1000000.0;          // can remain negative
     double d = 0.0;
     for (unsigned staffIdx = 0; staffIdx < _shapes.size(); ++staffIdx) {
-        if (!isMMRestSegment() && !ns->isMMRestSegment()) {
-            // MM rest segments must be treated separately because
-            // the associated shapes have variable width
-            d = ns ? staffShape(staffIdx).minHorizontalDistance(ns->staffShape(staffIdx), score()) : 0.0;
-        }
+        d = ns ? staffShape(staffIdx).minHorizontalDistance(ns->staffShape(staffIdx), score()) : 0.0;
         // first chordrest of a staff should clear the widest header for any staff
         // so make sure segment is as wide as it needs to be
         if (systemHeaderGap) {

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -38,6 +38,7 @@
 #include "keysig.h"
 #include "masterscore.h"
 #include "measure.h"
+#include "mmrest.h"
 #include "mscore.h"
 #include "note.h"
 #include "part.h"
@@ -2817,15 +2818,12 @@ double Segment::computeDurationStretch(Segment* prevSeg, Fraction minTicks, Frac
     {
         double slope = score()->styleD(Sid::measureSpacing);
 
-        static constexpr int maxMMRestWidth = 20; // At most, MM rests will be spaced "as if" they were 20 bars long.
         static constexpr double longNoteThreshold = Fraction(1, 16).toDouble();
 
-        Fraction timeSig = measure()->timesig();
-        if (curTicks > timeSig) { // This is the case of MM rests
-            curTicks = curTicks - timeSig; // A 2-bar MM rests receives the same space as one bar.
-            if (curTicks > timeSig * maxMMRestWidth) {
-                curTicks = timeSig * maxMMRestWidth; // Avoids long MM rests being excessively wide.
-            }
+        if (measure()->isMMRest() && isChordRestType()) { // This is an MM rest segment
+            int count = measure()->mmRestCount();
+            Fraction timeSig = measure()->timesig();
+            curTicks = timeSig + Fraction(count, timeSig.denominator());
         }
 
         // Prevent long notes from being too wide

--- a/src/engraving/libmscore/segment.h
+++ b/src/engraving/libmscore/segment.h
@@ -316,7 +316,6 @@ public:
     bool isEndBarLineType() const { return _segmentType == SegmentType::EndBarLine; }
     bool isKeySigAnnounceType() const { return _segmentType == SegmentType::KeySigAnnounce; }
     bool isTimeSigAnnounceType() const { return _segmentType == SegmentType::TimeSigAnnounce; }
-    bool isMMRestSegment() const;
 
     Fraction shortestChordRest() const;
     void computeCrossBeamType(Segment* nextSeg);

--- a/src/engraving/rw/compat/read302.cpp
+++ b/src/engraving/rw/compat/read302.cpp
@@ -219,7 +219,6 @@ bool Read302::readScore302(Score* score, XmlReader& e, ReadContext& ctx)
     }
 
     score->connectTies();
-    score->relayoutForStyles(); // force relayout if certain style settings are enabled
 
     score->_fileDivision = Constants::division;
 

--- a/src/engraving/rw/read400.cpp
+++ b/src/engraving/rw/read400.cpp
@@ -223,7 +223,6 @@ bool Read400::readScore400(Score* score, XmlReader& e, ReadContext& ctx)
     }
 
     score->connectTies();
-    score->relayoutForStyles(); // force relayout if certain style settings are enabled
 
     score->_fileDivision = Constants::division;
 


### PR DESCRIPTION
When opening a score, we currently have a `Score::relayoutForStyles()` method which forces a complete relayout if the score contains mmRests or a specific type of measure repeats. That is obviously inefficient: it can end up literally doubling the score loading time for no good reason. The reason this method was created is (probably) to fix a couple of our trademark "first layout is wrong but corrects itself after relayout" problems, by brute-forcing a complete score relayout. I have now removed this relayout and (hopefully) fixed the problems at their origin.
- In the case of MMrests, the issue is caused by the fact that their shape is accounted for when computing horizontal spacing, but the shape itself also changes its width to fill the measure, so in the end we were effectively spacing the MMrest against itself. This is something I had already stuggled with when working on horizontal spacing and had to bodge some kind of solution. The more correct solution, which I've implemented now, is to simply _ignore_ the shape of mmRests. Multi-bar rests are by definition empty measures, so there is never going to be any need of spacing other items against an MMrest. This way, I could also remove my previous bodge solution and simplify the whole thing.
- In the case of these measure repeats, it appears to be just a missing layout call.

I've also taken the change to make a small tweak to the width calculations for MMrests, which at the moment can sometimes end up being disproportionately wide.