### PR TITLE
Only layout a score if the score is open!

### DIFF
--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -419,6 +419,9 @@ void Score::update(bool resetCmdState)
         ms->deletePostponed();
         if (cs.layoutRange()) {
             for (Score* s : ms->scoreList()) {
+                if (!s->isOpen() && !ms->scoreList().size() == 1) {
+                    continue;
+                }
                 s->doLayoutRange(cs.startTick(), cs.endTick());
             }
             updateAll = true;

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -903,6 +903,9 @@ bool Score::isOpen() const
 void Score::setIsOpen(bool open)
 {
     _isOpen = open;
+    if (open) {
+        doLayout();
+    }
 }
 
 //---------------------------------------------------------

--- a/src/notation/inotation.h
+++ b/src/notation/inotation.h
@@ -96,6 +96,9 @@ public:
 
     // notify
     virtual async::Notification notationChanged() const = 0;
+
+    // score
+    virtual mu::engraving::Score* score() = 0;
 };
 }
 

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -133,7 +133,9 @@ void ExcerptNotation::setName(const QString& name)
 
     excerptTitle->setPlainText(name);
     score()->setMetaTag(u"partName", name);
-    score()->doLayout();
+    if (score()->isOpen()) {
+        score()->doLayout();
+    }
 
     notifyAboutNotationChanged();
 }

--- a/src/notation/internal/notation.h
+++ b/src/notation/internal/notation.h
@@ -76,6 +76,7 @@ public:
     async::Notification notationChanged() const override;
 
 protected:
+    mu::engraving::Score* score() override { return m_score; }
     mu::engraving::Score* score() const override;
     void setScore(mu::engraving::Score* score);
     async::Notification scoreInited() const override;

--- a/src/project/internal/exportprojectscenario.cpp
+++ b/src/project/internal/exportprojectscenario.cpp
@@ -56,6 +56,13 @@ bool ExportProjectScenario::exportScores(const INotationPtrList& notations, cons
         return false;
     }
 
+    // Parts that are closed may have never been laid out, so we lay them out now
+    for (INotationPtr notation : notations) {
+        if (!notation->isOpen()) {
+            notation->score()->doLayout();
+        }
+    }
+
     return exportScores(notations, chosenPath, unitType, openDestinationFolderOnExport);
 }
 


### PR DESCRIPTION
Well, what the title says. At the moment, when loading a score, we are also computing the layout of every part, even if all parts are closed. On a big piece with many parts, this dramatically increases the loading time of the project. 
Now, unless there is something deeper that I am missing here (which is very likely), I think it makes more sense that we only compute the layout of things that are going to appear on the screen. So, at first, we don't layout closed scores, and we lay them out when they are opened. This, of course, could mean that there is a small lag when the user opens one or more parts, but I think it is much preferable than bunching all of that waiting time at the beginning (and using it to lay out a huge amount of stuff that the user may likely not even need).
