### PR TITLE
Fix crash when dragging spanner that spans over mmrest

### DIFF
--- a/src/engraving/libmscore/line.cpp
+++ b/src/engraving/libmscore/line.cpp
@@ -665,7 +665,7 @@ void LineSegment::rebaseAnchors(EditData& ed, Grip grip)
         // the line will just push away other systems according to autoplacement
         // rules if necessary.
         PointF cpos = canvasPos();
-        cpos.setY(l->startSegment()->system()->staffCanvasYpage(l->staffIdx()));           // prevent cross-system move
+        cpos.setY(system()->staffCanvasYpage(l->staffIdx()));           // prevent cross-system move
 
         Segment* seg1 = findSegmentForGrip(Grip::START, cpos);
         Segment* seg2 = findSegmentForGrip(Grip::END, cpos + pos2());

--- a/src/engraving/libmscore/line.cpp
+++ b/src/engraving/libmscore/line.cpp
@@ -452,12 +452,11 @@ Segment* LineSegment::findSegmentForGrip(Grip grip, PointF pos) const
     SLine* l = line();
     const bool left = (grip == Grip::START);
 
-    Segment* const oldSeg = left ? l->startSegment() : score()->tick2leftSegmentMM(l->tick2() - Fraction::eps());
     const staff_idx_t oldStaffIndex = left ? staffIdx() : track2staff(l->effectiveTrack2());
 
     const double spacingFactor = left ? 0.5 : 1.0;   // defines the point where canvas is divided between segments, systems etc.
 
-    System* sys = oldSeg->system();
+    System* sys = system();
     const std::vector<System*> foundSystems = score()->searchSystem(pos, sys, spacingFactor);
 
     if (!foundSystems.empty() && !mu::contains(foundSystems, sys) && foundSystems[0]->staves().size()) {


### PR DESCRIPTION
It is recommended to review the commits separately.

**First commit:**
Resolves: #13674

This fix will need some explanation...

First, I found using the debugger that the cause of the crash is that in https://github.com/musescore/MuseScore/blob/eb5174099da996369df43eddee7f51c0961fa1e2/src/engraving/libmscore/line.cpp#L668 `l->startSegment()` is nullptr.

Looking at the definition of the startSegment method:
https://github.com/musescore/MuseScore/blob/eb5174099da996369df43eddee7f51c0961fa1e2/src/engraving/libmscore/spanner.cpp#L1002-L1006
and the definition of `Score::tick2rightSegment`, I intuitively guessed that the problem was that we were excluding mmrests, and that _therefore_ the `startSegment` was nullptr.

When that turned out to fix the crash, I found that the crash could be reproduced using the following simple steps:
1. create score; one instrument is enough
2. place ritenuto that spans multiple bars
3. enable mmrests, so that there is now an mmrest under the ritenuto
4. drag the ritenuto

It can also be reproduced with other spanners/lines, as long as they span over a mmrest.

P.S. It seems that the crash is also fixed without the change in `Spanner::endSegment`, but I think it is good to keep it consistent with `Spanner::startSegment`, and it might solve other crashes too that we don't know yet. 

P.S. 2. There seem to be more crashes related to the interaction of spanners with mmrests... I'll have a look to see if I can fix those too.


**Second commit:**
Resolves: #13677

Similar problem; after using Shift + arrow keys, the startSegment of the hairpin would point to the segment in the non-mmrest measure, but that measure was not part of any system at that point, because instead the mmrest measure would be in the system. (The mysterious part about it, is that actually the segment is not stored in the hairpin, only the tick. So you'd say that which segment gets taken shouldn't matter. Still, it does, apparently.)


**Third commit:**
some cleanup


**Fourth commit:**
a simplification/optimisation that would have 'hidden' the two crashes, but I think the crash fixes still make sense.