### PR TITLE
Fix crash when pressing 'repeat selection' shortcut for non-ChordRest selection

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -119,12 +119,13 @@ Note* Score::getSelectedNote()
 
 ChordRest* Score::getSelectedChordRest() const
 {
-    ChordRest* cr = toChordRest(selection().element());
-    if (!cr) {
+    EngravingItem* e = selection().element();
+    if (!e || !e->isChordRest()) {
         MScore::setError(MsError::NO_NOTE_REST_SELECTED);
+        return nullptr;
     }
 
-    return cr;
+    return toChordRest(e);
 }
 
 //---------------------------------------------------------

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3392,7 +3392,7 @@ mu::Ret NotationInteraction::repeatSelection()
     if (!selection.isRange()) {
         ChordRest* cr = score()->getSelectedChordRest();
         if (!cr) {
-            return make_ret(Err::EmptySelection);
+            return make_ret(Err::NoteOrRestIsNotSelected);
         }
         score()->select(cr, SelectType::RANGE);
     }


### PR DESCRIPTION
To reproduce:
select non-ChordRest element, for example hairpin
press <kbd>R</kbd> to 'repeat selection'
-> Crash

Fixed the crash and also improved the error message that you should have seen instead of the crash. Now says "no note or rest selected".