### PR TITLE
[MU4] Avoid reading multiple instance of the same system object

### DIFF
--- a/src/engraving/libmscore/range.cpp
+++ b/src/engraving/libmscore/range.cpp
@@ -177,7 +177,8 @@ void TrackList::append(EngravingItem* e)
                 ChordRest* src = toChordRest(e);
                 Segment* s1 = src->segment();
                 for (EngravingItem* ee : s1->annotations()) {
-                    if (ee->track() == e->track()) {
+                    bool addSysObject = ee->systemFlag() && !ee->isLinked() && ee->track() == 0 && e->track() == 0;
+                    if (addSysObject || (!ee->systemFlag() && ee->track() == e->track())) {
                         _range->annotations.push_back({ s1->tick(), ee->clone() });
                     }
                 }


### PR DESCRIPTION
The issue:
![image](https://user-images.githubusercontent.com/89263931/195219753-8c3c8b92-bd6f-4fbd-a0c3-bbb3548a0fa6.png)
System markings were being duplicated when ranges of measures were being read and rewritten, like for example when a time signature is added. This was because each linked clone of the system object was also being read, and in turn added, which automatically adds the system marking on all applicable system staves.

Now, range only reads the "main" system object (which is track 0, always), and when writing it will be added to all system object staves as necessary.