### PR TITLE
[MU4] Fix #9520: Play shortcut does not work when VST window is open (Windows only)

### DIFF
--- a/src/framework/uicomponents/view/topleveldialog.h
+++ b/src/framework/uicomponents/view/topleveldialog.h
@@ -37,7 +37,7 @@ public:
     explicit TopLevelDialog(QWidget* parent = nullptr);
     TopLevelDialog(const TopLevelDialog& dialog);
 
-private:
+protected:
     bool event(QEvent* e) override;
 };
 }

--- a/src/framework/vst/view/abstractvsteditorview.cpp
+++ b/src/framework/vst/view/abstractvsteditorview.cpp
@@ -24,6 +24,7 @@
 
 #include <QWindow>
 #include <QTimer>
+#include <QKeyEvent>
 
 #include "vsttypes.h"
 #include "internal/vstplugin.h"
@@ -157,11 +158,27 @@ void AbstractVstEditorView::moveViewToMainWindowCenter()
     move(x, y);
 }
 
-void AbstractVstEditorView::showEvent(QShowEvent* event)
+void AbstractVstEditorView::showEvent(QShowEvent* ev)
 {
     moveViewToMainWindowCenter();
 
-    QDialog::showEvent(event);
+    TopLevelDialog::showEvent(ev);
+}
+
+bool AbstractVstEditorView::event(QEvent* ev)
+{
+    if (ev && ev->spontaneous() && ev->type() == QEvent::ShortcutOverride) {
+        if (QKeyEvent* keyEvent = dynamic_cast<QKeyEvent*>(ev)) {
+            int key = keyEvent->key();
+
+            if (key == 0 || key == static_cast<int>(Qt::Key_unknown)) {
+                keyEvent->accept();
+                return true;
+            }
+        }
+    }
+
+    return TopLevelDialog::event(ev);
 }
 
 FIDString AbstractVstEditorView::currentPlatformUiType() const

--- a/src/framework/vst/view/abstractvsteditorview.h
+++ b/src/framework/vst/view/abstractvsteditorview.h
@@ -73,7 +73,8 @@ private:
     void setupWindowGeometry();
     void moveViewToMainWindowCenter();
 
-    void showEvent(QShowEvent* event) override;
+    void showEvent(QShowEvent* ev) override;
+    bool event(QEvent* ev) override;
 
     FIDString currentPlatformUiType() const;
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/9520