### PR TITLE
[MU4] Fix #11113: Palette search excludes elements behind "More" button

### DIFF
--- a/src/palette/internal/paletteprovider.cpp
+++ b/src/palette/internal/paletteprovider.cpp
@@ -601,7 +601,7 @@ void PaletteProvider::init()
 
     m_searchFilterModel = new PaletteCellFilterProxyModel(this);
     m_searchFilterModel->setFilterCaseSensitivity(Qt::CaseInsensitive);
-    m_searchFilterModel->setSourceModel(m_userPaletteModel);
+    m_searchFilterModel->setSourceModel(m_masterPaletteModel);
 
     m_visibilityFilterModel = new QSortFilterProxyModel(this);
     m_visibilityFilterModel->setFilterRole(PaletteTreeModel::VisibleRole);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11113

See: https://github.com/musescore/MuseScore/pull/11126