### PR TITLE
Fix a bunch of GitHub Actions deprecations

### DIFF
--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
     - name: Clone repository

--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -68,7 +68,7 @@ jobs:
 
     - name: Upload artifacts on GitHub
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ env.GITHUB_ARTIFACT_NAME }}
         path: ./build.artifacts/

--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         access_token: ${{ github.token }}
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: "Configure workflow"
       run: |

--- a/.github/workflows/ci_codestyle.yml
+++ b/.github/workflows/ci_codestyle.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Clone repository
-      uses: actions/checkout@v2    
+      uses: actions/checkout@v3    
     - name: Test coding style
       run: |
         bash ./build/ci/linux/checkcodestyle.sh

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -109,7 +109,7 @@ jobs:
         sudo bash ./build/ci/tools/osuosl/publish.sh -s ${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }} --os linux -v $VER
     - name: Upload artifacts on GitHub
       if: env.DO_BUILD == 'true'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: MuseScore_${{ github.run_id }}
         path: ./build.artifacts/

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -27,10 +27,10 @@ jobs:
         access_token: ${{ github.token }}
     - name: Clone repository (default)
       if: ${{ github.event_name != 'schedule' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Clone repository (3.x for build nightly )
       if: ${{ github.event_name == 'schedule' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: 3.x
     - name: Prepare ccache timestamp
@@ -122,7 +122,7 @@ jobs:
         CXXFLAGS: "-fsanitize=address -fno-omit-frame-pointer"
     steps:
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup environment
       run: |
         sudo bash ./build/ci/linux/setup.sh

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.5.0
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
     - name: Clone repository (default)

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -39,7 +39,7 @@ jobs:
         NOW=$(date -u +"%F-%T")
         echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
     - name: Ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.ccache
         key: ${{github.workflow}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -37,7 +37,7 @@ jobs:
       id: ccache_cache_timestamp
       run: |
         NOW=$(date -u +"%F-%T")
-        echo "::set-output name=timestamp::${NOW}"
+        echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
     - name: Ccache cache files
       uses: actions/cache@v2
       with:

--- a/.github/workflows/ci_linux_mu4.yml
+++ b/.github/workflows/ci_linux_mu4.yml
@@ -32,10 +32,10 @@ jobs:
       with:
         access_token: ${{ github.token }}
     - name: Clone repository (default)
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       if: ${{ github.event_name != 'schedule' || github.event.schedule == '0 3 */1 */1 *' }}
     # - name: Clone repository (<rc branch name>)
-    #   uses: actions/checkout@v2
+    #   uses: actions/checkout@v3
     #   if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' }}
     #   with:
     #     ref: <rc branch name>

--- a/.github/workflows/ci_linux_mu4.yml
+++ b/.github/workflows/ci_linux_mu4.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
     - name: Clone repository (default)

--- a/.github/workflows/ci_linux_mu4.yml
+++ b/.github/workflows/ci_linux_mu4.yml
@@ -40,7 +40,7 @@ jobs:
     #   with:
     #     ref: <rc branch name>
     - name: Ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.ccache
         key: ${{github.workflow}}-ccache-$(date -u +"%F-%T")

--- a/.github/workflows/ci_linux_mu4.yml
+++ b/.github/workflows/ci_linux_mu4.yml
@@ -186,7 +186,7 @@ jobs:
         sudo bash ./build/ci/tools/osuosl/publish.sh -s ${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }} --os linux -v 4
     - name: Upload artifacts on GitHub
       if: env.DO_BUILD == 'true'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ env.UPLOAD_ARTIFACT_NAME }}
         path: ./build.artifacts/      

--- a/.github/workflows/ci_lupdate.yml
+++ b/.github/workflows/ci_lupdate.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: "Configure workflow"
       run: |
         bash ./build/ci/tools/make_build_number.sh

--- a/.github/workflows/ci_lupdate.yml
+++ b/.github/workflows/ci_lupdate.yml
@@ -44,7 +44,7 @@ jobs:
         sudo bash ./build/ci/translation/tx_install.sh -t ${{ secrets.TRANSIFEX_API_TOKEN }} -s linux
         sudo bash ./build/ci/translation/tx_push.sh
     - name: Upload artifacts on GitHub
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: MuseScore_tsfiles_${{ env.BUILD_NUMBER }}
         path: ./share/locale

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -119,7 +119,7 @@ jobs:
         bash ./build/ci/tools/sparkle_appcast_gen.sh -p macos
     - name: Upload artifacts on GitHub
       if: env.DO_BUILD == 'true'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: MuseScore_${{ github.run_id }}
         path: ./build.artifacts/

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: macos-10.15
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.5.0
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
     - name: Clone repository (default)

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -31,10 +31,10 @@ jobs:
         access_token: ${{ github.token }}
     - name: Clone repository (default)
       if: ${{ github.event_name != 'schedule' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Clone repository (3.x for build nightly )
       if: ${{ github.event_name == 'schedule' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: 3.x
     - name: "Configure workflow"

--- a/.github/workflows/ci_macos_mu4.yml
+++ b/.github/workflows/ci_macos_mu4.yml
@@ -217,7 +217,7 @@ jobs:
         bash ./build/ci/tools/sparkle_appcast_gen.sh -p macos   
     - name: Upload artifacts on GitHub
       if: env.DO_BUILD == 'true'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ env.UPLOAD_ARTIFACT_NAME }}
         path: ./build.artifacts/

--- a/.github/workflows/ci_macos_mu4.yml
+++ b/.github/workflows/ci_macos_mu4.yml
@@ -35,10 +35,10 @@ jobs:
       with:
         access_token: ${{ github.token }}
     - name: Clone repository (default)
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       if: ${{ github.event_name != 'schedule' || github.event.schedule == '0 3 */1 */1 *' }}
     # - name: Clone repository (<rc branch name>)
-    #   uses: actions/checkout@v2
+    #   uses: actions/checkout@v3
     #   if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' }}
     #   with:
     #     ref: <rc branch name>

--- a/.github/workflows/ci_macos_mu4.yml
+++ b/.github/workflows/ci_macos_mu4.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: macos-11
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
     - name: Clone repository (default)

--- a/.github/workflows/ci_macos_mu4.yml
+++ b/.github/workflows/ci_macos_mu4.yml
@@ -43,7 +43,7 @@ jobs:
     #   with:
     #     ref: <rc branch name>
     - name: Ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.ccache
         key: ${{github.workflow}}-ccache-$(date -u +"%F-%T")

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Update info about the latest release in musescore-updates
         run: |

--- a/.github/workflows/ci_release_clear.yml
+++ b/.github/workflows/ci_release_clear.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Clear info about the latest release in musescore-updates
         run: |

--- a/.github/workflows/ci_tx2s3.yml
+++ b/.github/workflows/ci_tx2s3.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Clone repository
       if: env.DO_RUN == 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup environment
       if: env.DO_RUN == 'true'

--- a/.github/workflows/ci_tx2s3.yml
+++ b/.github/workflows/ci_tx2s3.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Upload artifacts on GitHub
       if: env.DO_RUN == 'true'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: MuseScore_locale_${{ env.BUILD_NUMBER }}
         path: ./share/locale

--- a/.github/workflows/ci_utests.yml
+++ b/.github/workflows/ci_utests.yml
@@ -14,7 +14,7 @@ jobs:
         CXXFLAGS: "-fsanitize=address -fno-omit-frame-pointer"
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
     - name: Clone repository

--- a/.github/workflows/ci_utests.yml
+++ b/.github/workflows/ci_utests.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         access_token: ${{ github.token }}
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: "Configure workflow"
       run: |
         sudo bash ./build/ci/tools/make_build_number.sh

--- a/.github/workflows/ci_utests.yml
+++ b/.github/workflows/ci_utests.yml
@@ -27,7 +27,7 @@ jobs:
         echo "BUILD_NUMBER=$BUILD_NUMBER" >> $GITHUB_ENV
         echo "BUILD_NUMBER: $BUILD_NUMBER"
     - name: Ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.ccache
         key: ${{github.workflow}}-ccache-$(date -u +"%F-%T")

--- a/.github/workflows/ci_vtests.yml
+++ b/.github/workflows/ci_vtests.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         access_token: ${{ github.token }}
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: "Configure workflow"
       run: |
         sudo bash ./build/ci/tools/make_build_number.sh
@@ -65,7 +65,7 @@ jobs:
     if: needs.setup.outputs.do_run == 'true' # Can't use env: see https://github.com/actions/runner/issues/480
     steps:
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Ccache cache files
       uses: actions/cache@v2
       with:
@@ -100,7 +100,7 @@ jobs:
     if: needs.setup.outputs.do_run == 'true'
     steps:
     - name: Clone repository and checkout reference commit
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ needs.setup.outputs.reference_sha }}
     - name: Ccache cache files
@@ -122,7 +122,7 @@ jobs:
         bash ninja_build.sh -t clean
         MUSESCORE_INSTALL_DIR="$HOME/musescore_install" bash ninja_build.sh -t installdebug
     - name: Checkout current commit
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Generate reference PNGs
       run: |
         xvfb-run ./vtest/vtest-generate-pngs.sh -o ./reference_pngs -m $HOME/musescore_install/bin/mscore
@@ -139,7 +139,7 @@ jobs:
     if: needs.setup.outputs.do_run == 'true'
     steps:
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Download current PNGs
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/ci_vtests.yml
+++ b/.github/workflows/ci_vtests.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Clone repository
       uses: actions/checkout@v3
     - name: Ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.ccache
         key: ${{github.workflow}}-ccache-$(date -u +"%F-%T")
@@ -104,7 +104,7 @@ jobs:
       with:
         ref: ${{ needs.setup.outputs.reference_sha }}
     - name: Ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.ccache
         key: ${{github.workflow}}-ccache-$(date -u +"%F-%T")

--- a/.github/workflows/ci_vtests.yml
+++ b/.github/workflows/ci_vtests.yml
@@ -88,7 +88,7 @@ jobs:
       run: |
         xvfb-run ./vtest/vtest-generate-pngs.sh -o ./current_pngs -m $HOME/musescore_install/bin/mscore
     - name: Upload PNGs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Current PNGs
         path: ./current_pngs
@@ -127,7 +127,7 @@ jobs:
       run: |
         xvfb-run ./vtest/vtest-generate-pngs.sh -o ./reference_pngs -m $HOME/musescore_install/bin/mscore
     - name: Upload PNGs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Reference PNGs
         path: ./reference_pngs
@@ -156,7 +156,7 @@ jobs:
         ./vtest/vtest-compare-pngs.sh
     - name: Upload comparison
       if: env.VTEST_DIFF_FOUND == 'true'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ needs.setup.outputs.artifact_name }}
         path: ./comparison

--- a/.github/workflows/ci_vtests.yml
+++ b/.github/workflows/ci_vtests.yml
@@ -176,7 +176,7 @@ jobs:
         exit 1
     - name: Comment push commit
       if: github.event_name == 'push' && contains( env.VTEST_DIFF_FOUND, 'true')
-      uses: peter-evans/commit-comment@v1.1.0
+      uses: peter-evans/commit-comment@v2
       with:
         body: |
           This is an automatic message. This commit appears to change some of the visual tests.

--- a/.github/workflows/ci_vtests.yml
+++ b/.github/workflows/ci_vtests.yml
@@ -50,12 +50,12 @@ jobs:
       env:
         pr_info: ${{ env.PR_INFO }}
       run: |
-        echo "::set-output name=do_run::${{ env.DO_RUN }}"
+        echo "do_run=${{ env.DO_RUN }}" >> $GITHUB_OUTPUT
         echo "DO_RUN=${{ env.DO_RUN }}"
-        echo "::set-output name=reference_sha::${{ env.REFERENCE_SHA }}"
+        echo "reference_sha=${{ env.REFERENCE_SHA }}" >> $GITHUB_OUTPUT
         echo "REFERENCE_SHA=${{ env.REFERENCE_SHA }}"
         UPLOAD_ARTIFACT_NAME="$(tr '":<>|*?/\\' '_' <<<"VTests Comparison ${{ env.BUILD_NUMBER }}${pr_info}")"
-        echo "::set-output name=artifact_name::$UPLOAD_ARTIFACT_NAME"
+        echo "artifact_name=$UPLOAD_ARTIFACT_NAME" >> $GITHUB_OUTPUT
         echo "UPLOAD_ARTIFACT_NAME=$UPLOAD_ARTIFACT_NAME"
 
   generate_current_pngs:

--- a/.github/workflows/ci_vtests.yml
+++ b/.github/workflows/ci_vtests.yml
@@ -15,7 +15,7 @@ jobs:
       artifact_name: ${{ steps.output_data.outputs.artifact_name }}
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
     - name: Clone repository

--- a/.github/workflows/ci_vtests.yml
+++ b/.github/workflows/ci_vtests.yml
@@ -141,12 +141,12 @@ jobs:
     - name: Clone repository
       uses: actions/checkout@v3
     - name: Download current PNGs
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: Current PNGs
         path: ./current_pngs
     - name: Download reference PNGs
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: Reference PNGs
         path: ./reference_pngs

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: windows-2019
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.5.0
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
     - name: Clone repository (default)

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -28,12 +28,12 @@ jobs:
         access_token: ${{ github.token }}
     - name: Clone repository (default)
       if: ${{ github.event_name != 'schedule' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'true'
     - name: Clone repository (3.x for build nightly )
       if: ${{ github.event_name == 'schedule' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'true'
         ref: 3.x

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -116,7 +116,7 @@ jobs:
         bash ./build/ci/tools/sparkle_appcast_gen.sh -p windows
     - name: Upload artifacts on GitHub
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: MuseScore_x64_${{ github.run_id }}
         path: build.artifacts\ 

--- a/.github/workflows/ci_windows_mu4.yml
+++ b/.github/workflows/ci_windows_mu4.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: windows-2019
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
     - name: Clone repository (default)
@@ -213,7 +213,7 @@ jobs:
     runs-on: windows-2019
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
     - name: Clone repository

--- a/.github/workflows/ci_windows_mu4.yml
+++ b/.github/workflows/ci_windows_mu4.yml
@@ -203,7 +203,7 @@ jobs:
         bash ./build/ci/tools/sparkle_appcast_gen.sh -p windows 
     - name: Upload artifacts on GitHub
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ env.UPLOAD_ARTIFACT_NAME }}
         path: build.artifacts\ 
@@ -288,7 +288,7 @@ jobs:
       shell: cmd
     - name: Upload artifacts on GitHub
       if: env.DO_BUILD == 'true'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ env.UPLOAD_ARTIFACT_NAME }}
         path: build.artifacts\

--- a/.github/workflows/ci_windows_mu4.yml
+++ b/.github/workflows/ci_windows_mu4.yml
@@ -31,12 +31,12 @@ jobs:
       with:
         access_token: ${{ github.token }}
     - name: Clone repository (default)
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       if: ${{ github.event_name != 'schedule' || github.event.schedule == '0 3 */1 */1 *' }}
       with:
         fetch-depth: 3
     # - name: Clone repository (<rc branch name>)
-    #   uses: actions/checkout@v2
+    #   uses: actions/checkout@v3
     #   if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' }}
     #   with:
     #     fetch-depth: 3
@@ -217,7 +217,7 @@ jobs:
       with:
         access_token: ${{ github.token }}
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 3
     - name: Fetch submodules

--- a/.github/workflows/ci_withoutqt.yml
+++ b/.github/workflows/ci_withoutqt.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         access_token: ${{ github.token }}
     - name: Clone repository
-      uses: actions/checkout@v2    
+      uses: actions/checkout@v3    
     - name: Setup environment
       run: |
         sudo bash ./build/ci/withoutqt/setup.sh

--- a/.github/workflows/ci_withoutqt.yml
+++ b/.github/workflows/ci_withoutqt.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
     - name: Clone repository


### PR DESCRIPTION
See:
- https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
    - https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter