### PR TITLE
Optimization: avoiding unnecessary layout calls

### DIFF
--- a/src/engraving/layout/layoutchords.cpp
+++ b/src/engraving/layout/layoutchords.cpp
@@ -602,6 +602,9 @@ double LayoutChords::layoutChords2(std::vector<Note*>& notes, bool up)
             }
         }
         note->setMirror(mirror);
+        if (chord->stem()) {
+            chord->stem()->layout(); // needed because mirroring can cause stem position to change
+        }
 
         // accumulate return value
         if (!mirror) {

--- a/src/engraving/libmscore/arpeggio.cpp
+++ b/src/engraving/libmscore/arpeggio.cpp
@@ -188,6 +188,30 @@ double Arpeggio::calcTop() const
 }
 
 //---------------------------------------------------------
+//   computeHeight
+//---------------------------------------------------------
+
+void Arpeggio::computeHeight(bool includeCrossStaffHeight)
+{
+    Chord* topChord = chord();
+    if (!topChord) {
+        return;
+    }
+    double y = topChord->upNote()->pagePos().y() - topChord->upNote()->headHeight() * .5;
+
+    Note* bottomNote = topChord->downNote();
+    if (includeCrossStaffHeight) {
+        track_idx_t bottomTrack = track() + (_span - 1) * VOICES;
+        EngravingItem* element = topChord->segment()->element(bottomTrack);
+        Chord* bottomChord = (element && element->isChord()) ? toChord(element) : topChord;
+        bottomNote = bottomChord->downNote();
+    }
+
+    double h = bottomNote->pagePos().y() + bottomNote->headHeight() * .5 - y;
+    setHeight(h);
+}
+
+//---------------------------------------------------------
 //   calcBottom
 //---------------------------------------------------------
 

--- a/src/engraving/libmscore/arpeggio.h
+++ b/src/engraving/libmscore/arpeggio.h
@@ -92,6 +92,7 @@ public:
     int span() const { return _span; }
     void setSpan(int val) { _span = val; }
     void setHeight(double) override;
+    void computeHeight(bool includeCrossStaffHeight = false);
 
     double userLen1() const { return _userLen1; }
     double userLen2() const { return _userLen2; }

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -2182,8 +2182,8 @@ void Chord::layoutPitched()
     addLedgerLines();
 
     if (_arpeggio) {
-        _arpeggio->layout();        // only for width() !
-        _arpeggio->setHeight(0.0);
+        _arpeggio->computeHeight();
+        _arpeggio->layout();
 
         double arpeggioNoteDistance = score()->styleMM(Sid::ArpeggioNoteDistance) * mag_;
 
@@ -2695,19 +2695,10 @@ void Chord::crossMeasureSetup(bool on)
 
 void Chord::layoutArpeggio2()
 {
-    if (!_arpeggio) {
+    if (!_arpeggio || _arpeggio->span() < 2) {
         return;
     }
-    double y           = upNote()->pagePos().y() - upNote()->headHeight() * .5;
-    int span          = _arpeggio->span();
-    track_idx_t btrack = track() + (span - 1) * VOICES;
-
-    EngravingItem* element = segment()->element(btrack);
-    ChordRest* bchord = element ? toChordRest(element) : nullptr;
-    Note* dnote       = (bchord && bchord->type() == ElementType::CHORD) ? toChord(bchord)->downNote() : downNote();
-
-    double h = dnote->pagePos().y() + dnote->headHeight() * .5 - y;
-    _arpeggio->setHeight(h);
+    _arpeggio->computeHeight(/*includeCrossStaffHeight = */ true);
     _arpeggio->layout();
 }
 

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -3695,14 +3695,6 @@ Shape Chord::shape() const
 //            shape.add(_tremolo->shape().translated(_tremolo->pos()));
     for (Note* note : _notes) {
         shape.add(note->shape().translated(note->pos()));
-        for (EngravingItem* e : note->el()) {
-            if (!e->addToSkyline()) {
-                continue;
-            }
-            if (e->isFingering() && toFingering(e)->layoutType() == ElementType::CHORD && e->bbox().isValid()) {
-                shape.add(e->bbox().translated(e->pos() + note->pos()), e);
-            }
-        }
     }
     for (EngravingItem* e : el()) {
         if (e->addToSkyline()) {

--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -337,7 +337,7 @@ void Score::undoRedo(bool undo, EditData* ed)
 ///   and (always) updating the redraw area.
 //---------------------------------------------------------
 
-void Score::endCmd(bool rollback)
+void Score::endCmd(bool rollback, bool layoutAllParts)
 {
     if (undoStack()->locked()) {
         return;
@@ -357,7 +357,7 @@ void Score::endCmd(bool rollback)
         undoStack()->current()->unwind();
     }
 
-    update(false);
+    update(false, layoutAllParts);
 
     ScoreChangesRange range = changesRange();
 
@@ -408,7 +408,7 @@ void CmdState::dump()
 //    layout & update
 //---------------------------------------------------------
 
-void Score::update(bool resetCmdState)
+void Score::update(bool resetCmdState, bool layoutAllParts)
 {
     TRACEFUNC;
 
@@ -419,6 +419,9 @@ void Score::update(bool resetCmdState)
         ms->deletePostponed();
         if (cs.layoutRange()) {
             for (Score* s : ms->scoreList()) {
+                if (!s->isOpen() && ms->scoreList().size() > 1 && !layoutAllParts) {
+                    continue;
+                }
                 s->doLayoutRange(cs.startTick(), cs.endTick());
             }
             updateAll = true;

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -3277,6 +3277,7 @@ void Measure::layoutMeasureElements()
                     e->setPosX(measureWidth - .5 * e->width());
                 } else {
                     // full measure rest or one-measure repeat, center within this measure
+                    e->layout();
                     e->setPosX((x2 - x1 - e->width()) * .5 + x1 - s.x() - e->bbox().x());
                 }
                 s.createShape(staffIdx);            // DEBUG

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -4220,7 +4220,7 @@ void Measure::computeWidth(Segment* s, double x, bool isSystemHeader, Fraction m
             }
 
             int n = 1;
-            for (Segment* ps = s; ps && !ps->isMMRestSegment(); ps=ps->prevActive()) {
+            for (Segment* ps = s; ps; ps=ps->prevActive()) {
                 double ww;
 
                 assert(ps);         // ps should never be nullptr but better be safe.
@@ -4307,7 +4307,7 @@ void Measure::computeWidth(Fraction minTicks, Fraction maxTicks, double stretchC
     //
     Shape ls(first ? RectF(0.0, -1000000.0, 0.0, 2000000.0) : RectF(0.0, 0.0, 0.0, spatium() * 4));
 
-    x = s->isMMRestSegment() ? 0 : s->minLeft(ls);
+    x = s->minLeft(ls);
 
     if (s->isStartRepeatBarLineType()) {
         System* sys = system();
@@ -4629,8 +4629,11 @@ Fraction Measure::maxTicks() const
 {
     Segment* s = first();
     Fraction maxticks = Fraction(0, 1);
+    if (isMMRest()) {
+        return timesig();
+    }
     while (s) {
-        if (s->enabled() && s->isChordRestType() && !s->isMMRestSegment()) {
+        if (s->enabled() && s->isChordRestType()) {
             maxticks = std::max(maxticks, s->ticks());
         }
         s = s->next();

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -903,6 +903,9 @@ bool Score::isOpen() const
 void Score::setIsOpen(bool open)
 {
     _isOpen = open;
+    if (open) {
+        doLayout();
+    }
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -5452,35 +5452,6 @@ void Score::connectTies(bool silent)
 }
 
 //---------------------------------------------------------
-//   relayoutForStyles
-///   some styles can't properly apply if score hasn't been laid out yet,
-///   so temporarily disable them and then reenable after layout
-///   (called during score load)
-//---------------------------------------------------------
-
-void Score::relayoutForStyles()
-{
-    std::vector<Sid> stylesToTemporarilyDisable;
-
-    for (Sid sid : { Sid::createMultiMeasureRests, Sid::mrNumberSeries }) {
-        // only necessary if boolean style is true
-        if (styleB(sid)) {
-            stylesToTemporarilyDisable.push_back(sid);
-        }
-    }
-
-    if (!stylesToTemporarilyDisable.empty()) {
-        for (Sid sid : stylesToTemporarilyDisable) {
-            style().set(sid, false); // temporarily disable
-        }
-        doLayout();
-        for (Sid sid : stylesToTemporarilyDisable) {
-            style().set(sid, true); // and immediately reenable
-        }
-    }
-}
-
-//---------------------------------------------------------
 //   doLayout
 //    do a complete (re-) layout
 //---------------------------------------------------------

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -1014,7 +1014,6 @@ public:
     Segment* lastSegmentMM() const;
 
     void connectTies(bool silent = false);
-    void relayoutForStyles();
 
     double point(const Spatium sp) const { return sp.val() * spatium(); }
 

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -477,7 +477,7 @@ private:
                                     const SelectionFilter& filter);
     ChordRest* deleteRange(Segment* segStart, Segment* segEnd, track_idx_t trackStart, track_idx_t trackEnd, const SelectionFilter& filter);
 
-    void update(bool resetCmdState);
+    void update(bool resetCmdState, bool layoutAllParts = false);
 
     ID newStaffId() const;
     ID newPartId() const;
@@ -744,7 +744,7 @@ public:
     void timeDelete(Measure*, Segment*, const Fraction&);
 
     void startCmd();                    // start undoable command
-    void endCmd(bool rollback = false); // end undoable command
+    void endCmd(bool rollback = false, bool layoutAllParts = false); // end undoable command
     void update() { update(true); }
     void undoRedo(bool undo, EditData*);
 

--- a/src/engraving/libmscore/segment.h
+++ b/src/engraving/libmscore/segment.h
@@ -316,7 +316,6 @@ public:
     bool isEndBarLineType() const { return _segmentType == SegmentType::EndBarLine; }
     bool isKeySigAnnounceType() const { return _segmentType == SegmentType::KeySigAnnounce; }
     bool isTimeSigAnnounceType() const { return _segmentType == SegmentType::TimeSigAnnounce; }
-    bool isMMRestSegment() const;
 
     Fraction shortestChordRest() const;
     void computeCrossBeamType(Segment* nextSeg);

--- a/src/engraving/rw/compat/read302.cpp
+++ b/src/engraving/rw/compat/read302.cpp
@@ -219,7 +219,6 @@ bool Read302::readScore302(Score* score, XmlReader& e, ReadContext& ctx)
     }
 
     score->connectTies();
-    score->relayoutForStyles(); // force relayout if certain style settings are enabled
 
     score->_fileDivision = Constants::division;
 

--- a/src/engraving/rw/read400.cpp
+++ b/src/engraving/rw/read400.cpp
@@ -223,7 +223,6 @@ bool Read400::readScore400(Score* score, XmlReader& e, ReadContext& ctx)
     }
 
     score->connectTies();
-    score->relayoutForStyles(); // force relayout if certain style settings are enabled
 
     score->_fileDivision = Constants::division;
 

--- a/src/engraving/utests/chordsymbol_tests.cpp
+++ b/src/engraving/utests/chordsymbol_tests.cpp
@@ -212,7 +212,7 @@ TEST_F(Engraving_ChordSymbolTests, testTransposePart)
     score->startCmd();
     score->cmdSelectAll();
     score->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 4, false, true, true);
-    score->endCmd();
+    score->endCmd(false, /*layoutAllParts = */ true);
     test_post(score, u"transpose-part");
 }
 

--- a/src/engraving/utests/exchangevoices_tests.cpp
+++ b/src/engraving/utests/exchangevoices_tests.cpp
@@ -104,7 +104,7 @@ TEST_F(Engraving_ExchangevoicesTests, undoChangeVoice)
     // change voice
     score->startCmd();
     score->changeSelectedNotesVoice(1);
-    score->endCmd();
+    score->endCmd(false, /*layoutAllParts = */ true);
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
 
     // undo

--- a/src/engraving/utests/remove_tests.cpp
+++ b/src/engraving/utests/remove_tests.cpp
@@ -96,7 +96,7 @@ TEST_F(Engraving_RemoveTests, removeStaff)
     // Remove the second staff and see what happens
     score->startCmd();
     score->cmdRemoveStaff(1);
-    score->endCmd();
+    score->endCmd(false, /*layoutAllParts = */ true);
 
     EXPECT_FALSE(staffHasElements(score, 1));
     for (Excerpt* ex : score->excerpts()) {

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -133,7 +133,6 @@ void ExcerptNotation::setName(const QString& name)
 
     excerptTitle->setPlainText(name);
     score()->setMetaTag(u"partName", name);
-    score()->doLayout();
 
     notifyAboutNotationChanged();
 }

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -431,6 +431,12 @@ mu::ValNt<bool> MasterNotation::needSave() const
 
 void MasterNotation::initExcerpts(const ExcerptNotationList& excerpts)
 {
+    // Scores that are closed may have never been laid out, so we lay them out now
+    for (auto score : masterScore()->scoreList()) {
+        if (!score->isOpen()) {
+            score->doLayout();
+        }
+    }
     for (IExcerptNotationPtr excerptNotation : excerpts) {
         ExcerptNotation* impl = get_impl(excerptNotation);
 

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -431,12 +431,6 @@ mu::ValNt<bool> MasterNotation::needSave() const
 
 void MasterNotation::initExcerpts(const ExcerptNotationList& excerpts)
 {
-    // Scores that are closed may have never been laid out, so we lay them out now
-    for (auto score : masterScore()->scoreList()) {
-        if (!score->isOpen()) {
-            score->doLayout();
-        }
-    }
     for (IExcerptNotationPtr excerptNotation : excerpts) {
         ExcerptNotation* impl = get_impl(excerptNotation);
 

--- a/src/project/internal/exportprojectscenario.cpp
+++ b/src/project/internal/exportprojectscenario.cpp
@@ -56,6 +56,14 @@ bool ExportProjectScenario::exportScores(const INotationPtrList& notations, cons
         return false;
     }
 
+    // Scores that are closed may have never been laid out, so we lay them out now
+    for (INotationPtr notation : notations) {
+        mu::engraving::Score* score = notation->elements()->msScore();
+        if (!score->isOpen()) {
+            score->doLayout();
+        }
+    }
+
     return exportScores(notations, chosenPath, unitType, openDestinationFolderOnExport);
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/13660

This PR collects together three of my (not yet merged) PRs, namely #13686, #13657 and #13659. Those will be now closed.

The point of this PR is to avoid unnecessary calls to `Score::doLayoutRange()`, which is the main engraving layout function and is extremely expensive. Basically:
- I've eliminated unnecessary layout of closed scores (those are only laid out when they are opened or when they are exported).
- I've eliminated unnecessary relayout for mmRests and measure repeats (this was just a brute-force workaround for a bug, but now I've fixed the bug at the origin so I can eliminate these calls).

The other bug fixes (separated by commit) are necessary because these are our typical "relayout bugs", meaning that the layout is initially wrong and correct itself after a relayout. Now that I have eliminated the relayouts, these bugs have surfaced and have been fixed (which is a good thing). _The vtest differences are due exclusively to the bug fixes_. I've run the tests locally and made sure that the optimization commits leave the vtests absolutely unchanged.

How much of an advantage this PR can give depends on how many parts exist and how many are opened. On an orchestral score, it can make a pretty big difference:

Before (28 layout calls):
<img width="711" alt="before" src="https://user-images.githubusercontent.com/93707756/195397481-3f9593ba-f450-4eab-ba46-7af49c3a83d6.png">

After (1 single layout call):
<img width="677" alt="after" src="https://user-images.githubusercontent.com/93707756/195397492-a7bf6d3d-91c8-47a8-8cbf-5fa7ad76197a.png">

This needs careful reviewing, especially about the non-layout of closed scores, and making sure that everything still works, especially on export. Everything I've tried seems to work as it should.
