### PR TITLE
Fix re-translatability for theme names

### DIFF
--- a/src/framework/ui/internal/themeconverter.cpp
+++ b/src/framework/ui/internal/themeconverter.cpp
@@ -22,8 +22,11 @@
 
 #include "themeconverter.h"
 
+#include "translation.h"
+
 #include "log.h"
 
+using namespace mu;
 using namespace mu::ui;
 
 static const QString CODEKEY_KEY("codeKey");
@@ -57,6 +60,25 @@ static const std::vector<std::pair<ThemeStyleKey, QString > > s_keys = {
 
     { ITEM_OPACITY_DISABLED, "itemOpacityDisabled" },
 };
+
+static QString titleForTheme(const ThemeInfo& theme)
+{
+    if (theme.codeKey == LIGHT_THEME_CODE) {
+        //: The name of the light ui theme
+        return qtrc("ui", "Light");
+    } else if (theme.codeKey == DARK_THEME_CODE) {
+        //: The name of the dark ui theme
+        return qtrc("ui", "Dark");
+    } else if (theme.codeKey == HIGH_CONTRAST_WHITE_THEME_CODE) {
+        //: The name of the high contrast light ui theme
+        return qtrc("ui", "White");
+    } else if (theme.codeKey == HIGH_CONTRAST_BLACK_THEME_CODE) {
+        //: The name of the high contrast dark ui theme
+        return qtrc("ui", "Black");
+    }
+
+    return QString::fromStdString(theme.title);
+}
 
 static const QString& themeStyleKeyToString(ThemeStyleKey key)
 {
@@ -92,7 +114,7 @@ QVariantMap ThemeConverter::toMap(const ThemeInfo& theme)
     QVariantMap obj;
 
     obj[CODEKEY_KEY] = QString::fromStdString(theme.codeKey);
-    obj[TITLE_KEY] = QString::fromStdString(theme.title);
+    obj[TITLE_KEY] = titleForTheme(theme);
 
     for (ThemeStyleKey key : theme.values.keys()) {
         obj[themeStyleKeyToString(key)] = theme.values[key];

--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -329,20 +329,12 @@ ThemeInfo UiConfiguration::makeStandardTheme(const ThemeCode& codeKey) const
     theme.codeKey = codeKey;
 
     if (codeKey == LIGHT_THEME_CODE) {
-        //: The name of the light ui theme
-        theme.title = trc("ui", "Light");
         theme.values = LIGHT_THEME_VALUES;
     } else if (codeKey == DARK_THEME_CODE) {
-        //: The name of the dark ui theme
-        theme.title = trc("ui", "Dark");
         theme.values = DARK_THEME_VALUES;
     } else if (codeKey == HIGH_CONTRAST_WHITE_THEME_CODE) {
-        //: The name of the high contrast light ui theme
-        theme.title = trc("ui", "White");
         theme.values = HIGH_CONTRAST_WHITE_THEME_VALUES;
     } else if (codeKey == HIGH_CONTRAST_BLACK_THEME_CODE) {
-        //: The name of the high contrast dark ui theme
-        theme.title = trc("ui", "Black");
         theme.values = HIGH_CONTRAST_BLACK_THEME_VALUES;
     }
 


### PR DESCRIPTION
Theme names are initialized once and then stored forever as part of the theme values. This means that after changing the ui language, the theme names won't be re-translated even after restarting MuseScore. Instead, determine the theme name based on the theme code, in a way that is ready to handle user-defined themes in the future.

Resolves: #13742 (the theme names problem; other problems mentioned in comments there covered by other PRs and issues)