### PR TITLE
Fix drawing barlines in Palettes

### DIFF
--- a/src/engraving/libmscore/barline.h
+++ b/src/engraving/libmscore/barline.h
@@ -69,8 +69,8 @@ class BarLine final : public EngravingItem
     int _spanFrom           { 0 };         // line number on start and end staves
     int _spanTo             { 0 };
     BarLineType _barLineType { BarLineType::NORMAL };
-    mutable double y1;
-    mutable double y2;
+    mutable double y1 = 0.0;
+    mutable double y2 = 0.0;
     ElementList _el;          ///< fermata or other articulations
 
     friend class Factory;


### PR DESCRIPTION
This was broken relatively recently.

|Before|After|
|-|-|
|<img width="302" alt="Scherm­afbeelding 2022-10-13 om 22 38 52" src="https://user-images.githubusercontent.com/48658420/195705813-ef7ba801-7daa-4725-a86b-b48d134ac3ee.png">|<img width="302" alt="Scherm­afbeelding 2022-10-13 om 22 36 57" src="https://user-images.githubusercontent.com/48658420/195705459-f39fa5ec-3383-4985-bfce-3158142ce458.png">|