### PR TITLE
Fix #13762: Verses should have right text style type

### DIFF
--- a/src/engraving/libmscore/lyrics.h
+++ b/src/engraving/libmscore/lyrics.h
@@ -96,7 +96,7 @@ public:
     TranslatableString subtypeUserName() const override;
     void setNo(int n) { _no = n; }
     int no() const { return _no; }
-    bool isEven() const { return _no % 1; }
+    bool isEven() const { return _no % 2; }
     void setSyllabic(Syllabic s) { _syllabic = s; }
     Syllabic syllabic() const { return _syllabic; }
     void add(EngravingItem*) override;


### PR DESCRIPTION
Resolves: #13762

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
