### PR TITLE
Tie jump fix

### DIFF
--- a/src/engraving/libmscore/tie.cpp
+++ b/src/engraving/libmscore/tie.cpp
@@ -384,7 +384,7 @@ void TieSegment::adjustY(const PointF& p1, const PointF& p2)
     shoulderHeightMax = 1.3;
     double tieAdjustSp = 0;
 
-    const double staffLineOffset = 0.125 + (styleP(Sid::staffLineWidth) / 2 / ld); // sp
+    const double staffLineOffset = 0.110 + (styleP(Sid::staffLineWidth) / 2 / ld); // sp
     const double noteHeadOffset = 0.185; // sp
     bool isUp = t->up();
 


### PR DESCRIPTION
Fixing an inconsistency in tie position due to the different size of noteheads.

Before:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/93707756/196406768-e470b860-b9e9-40fc-be2c-1e0d198d8f6f.png">

After:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/93707756/196406439-a1af0c5d-5a27-4541-999f-14499035019c.png">
