### PR TITLE
Fix crash when opening file

### DIFF
--- a/src/framework/global/serialization/internal/zipcontainer.cpp
+++ b/src/framework/global/serialization/internal/zipcontainer.cpp
@@ -540,7 +540,7 @@ ZipContainer::FileInfo ZipContainer::Impl::fillFileInfo(int index) const
         fileInfo.filePath = fileInfo.filePath.substr(1);
     }
     while (!fileInfo.filePath.empty() && fileInfo.filePath.back() == '/') {
-        fileInfo.filePath = fileInfo.filePath.substr(fileInfo.filePath.size() - 1);
+        fileInfo.filePath = fileInfo.filePath.substr(0, fileInfo.filePath.size() - 1);
     }
     return fileInfo;
 }


### PR DESCRIPTION
Resolves: #13810 

Apparently, just a wrong substring extraction (instead of removing the end "/", it was removing the rest and leaving the "/", thereby getting stuck in the loop).