### PR TITLE
Fix crash on select all

### DIFF
--- a/src/inspector/internal/services/elementrepositoryservice.cpp
+++ b/src/inspector/internal/services/elementrepositoryservice.cpp
@@ -207,6 +207,10 @@ QList<mu::engraving::EngravingItem*> ElementRepositoryService::findNotes() const
             const mu::engraving::Beam* beam = mu::engraving::toBeam(elementBase);
 
             for (mu::engraving::ChordRest* chordRest : beam->elements()) {
+                if (!chordRest->isChord()) {
+                    continue;
+                }
+
                 for (mu::engraving::Note* note : engraving::toChord(chordRest)->notes()) {
                     result << note;
                 }


### PR DESCRIPTION
Resolves: #13831 

Was caused by calling `toChord(elem)` on an element that isn't a Chord.
