### PR TITLE
Fix #12544: Fill empty part with masterscore's information

### DIFF
--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -92,10 +92,18 @@ void ExcerptNotation::fillWithDefaultInfo()
         }
     };
 
-    setText(TextStyleType::TITLE, qtrc("notation", "Title"));
-    setText(TextStyleType::COMPOSER, qtrc("notation", "Composer / arranger"));
-    setText(TextStyleType::SUBTITLE, "");
-    setText(TextStyleType::POET, "");
+    auto getText = [&score](TextStyleType textType, const QString& defaultText) {
+        if (Text* t = score->getText(textType)) {
+            return t->plainText().toQString();
+        } else {
+            return defaultText;
+        }
+    };
+
+    setText(TextStyleType::TITLE, getText(TextStyleType::TITLE, ""));
+    setText(TextStyleType::COMPOSER, getText(TextStyleType::COMPOSER, ""));
+    setText(TextStyleType::SUBTITLE, getText(TextStyleType::SUBTITLE, ""));
+    setText(TextStyleType::POET, getText(TextStyleType::POET, ""));
 }
 
 mu::engraving::Excerpt* ExcerptNotation::excerpt() const


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/12544

New empty parts were being created with hardcoded default values. Now those values match the master score's.