### PR TITLE
Fix Home menu icons-only threshold calculation

### DIFF
--- a/src/appshell/qml/HomePage/HomePage.qml
+++ b/src/appshell/qml/HomePage/HomePage.qml
@@ -80,7 +80,9 @@ DockPage {
 
             readonly property int maxFixedWidth: 260
             readonly property int minFixedWidth: 76
-            readonly property bool iconsOnly: root.window ? root.window.width - root.window.minimumWidth < maxFixedWidth : false
+            readonly property bool iconsOnly: root.window
+                                                ? root.window.width < (root.window.minimumWidth + maxFixedWidth - minFixedWidth)
+                                                : false
             readonly property int currentFixedWidth: iconsOnly ? minFixedWidth : maxFixedWidth
 
             width: currentFixedWidth


### PR DESCRIPTION
The previous algorithm didn't account for the fact that the Home menu still takes up a little bit space even when it's in icons-only mode and the text labels ("My account", "Scores", "Plugins", etc.) are hidden. This biased the threshold calculation, leading to icons-only mode being used at larger window sizes than was strictly necessary.

Fix #13838