### PR TITLE
Fix hairpin dashed lines

### DIFF
--- a/src/engraving/libmscore/hairpin.cpp
+++ b/src/engraving/libmscore/hairpin.cpp
@@ -585,9 +585,9 @@ Sid HairpinSegment::getPropertyStyle(Pid pid) const
     case Pid::LINE_STYLE:
         return hairpin()->isLineType() ? Sid::hairpinLineLineStyle : Sid::hairpinLineStyle;
     case Pid::DASH_LINE_LEN:
-        return hairpin()->isLineType() ? Sid::hairpinLineDashLineLen : Sid::NOSTYLE;
+        return hairpin()->isLineType() ? Sid::hairpinLineDashLineLen : Sid::hairpinDashLineLen;
     case Pid::DASH_GAP_LEN:
-        return hairpin()->isLineType() ? Sid::hairpinLineDashGapLen : Sid::NOSTYLE;
+        return hairpin()->isLineType() ? Sid::hairpinLineDashGapLen : Sid::hairpinDashGapLen;
     default:
         break;
     }
@@ -625,9 +625,9 @@ Sid Hairpin::getPropertyStyle(Pid pid) const
     case Pid::LINE_STYLE:
         return isLineType() ? Sid::hairpinLineLineStyle : Sid::hairpinLineStyle;
     case Pid::DASH_LINE_LEN:
-        return isLineType() ? Sid::hairpinLineDashLineLen : Sid::NOSTYLE;
+        return isLineType() ? Sid::hairpinLineDashLineLen : Sid::hairpinDashLineLen;
     case Pid::DASH_GAP_LEN:
-        return isLineType() ? Sid::hairpinLineDashGapLen : Sid::NOSTYLE;
+        return isLineType() ? Sid::hairpinLineDashGapLen : Sid::hairpinDashGapLen;
     default:
         break;
     }

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -254,6 +254,8 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::hairpinCrescContText,    "hairpinCrescContText",    String(u"(cresc.)") },
     { Sid::hairpinDecrescContText,  "hairpinDecrescContText",  String(u"(dim.)") },
     { Sid::hairpinLineStyle,        "hairpinLineStyle",        PropertyValue(LineType::SOLID) },
+    { Sid::hairpinDashLineLen,      "hairpinDashLineLen",      3.0 },
+    { Sid::hairpinDashGapLen,       "hairpinDashGapLen",       3.0 },
     { Sid::hairpinLineLineStyle,    "hairpinLineLineStyle",    PropertyValue(LineType::DASHED) },
     { Sid::hairpinLineDashLineLen,  "hairpinLineDashLineLen",  6.0 },
     { Sid::hairpinLineDashGapLen,   "hairpinLineDashGapLen",   9.0 },

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -271,6 +271,8 @@ enum class Sid {
     hairpinCrescContText,
     hairpinDecrescContText,
     hairpinLineStyle,
+    hairpinDashLineLen,
+    hairpinDashGapLen,
     hairpinLineLineStyle,
     hairpinLineDashLineLen,
     hairpinLineDashGapLen,


### PR DESCRIPTION
Resolves: #13318 

This is similar to the solution proposed in #13320 but we definitely shouldn't be using the same style of cres./dim. lines, because:
a) They serve completely different purposes (and the default dash-gap settings for cresc./dim. lines feel too large for hairpins).
b) Users wouldn't know that by modifying the default dash-gap settings for dashed hairpins they are also modifying those for cresc./dim. lines, which is bad.
c) Having hairpins and cresc./dim. lines represented by the same object was probably a bad idea to start with, and we should fix that in future, in which case style defaults will have to be different anyway.

I've introduced new styles and set them to reasonable defaults (@oktophonie please feel free to suggest differently).