### PR TITLE
Enable Muse Sampler module by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ set(VST3_SDK_VERSION "3.7")
 option(BUILD_VST "Build VST MODULE" OFF)
 set(VST3_SDK_PATH "" CACHE PATH "Path to VST3_SDK. SDK version >= ${VST3_SDK_VERSION} required")
 
-option(BUILD_MUSESAMPLER_MODULE "Build MuseSampler MODULE" OFF)
+option(BUILD_MUSESAMPLER_MODULE "Build MuseSampler MODULE" ON)
 set(MUSESAMPLER_SRC_PATH "" CACHE PATH "Path to MuseSampler sources")
 
 option(ENABLE_AUDIO_EXPORT "Enable audio export" ON)


### PR DESCRIPTION
- enables using Muse Sounds in Nightly builds, PR builds and "self-builds", for people who have installed Muse Sounds
- thus verifies that we don't break (the build of) the Muse Sampler module (that happened a while ago but got fixed)