### PR TITLE
[MU4] Fix #13876: Stops working after installing mpal palette with wrong image path

### DIFF
--- a/src/engraving/engravingmodule.cpp
+++ b/src/engraving/engravingmodule.cpp
@@ -27,6 +27,7 @@
 #include "draw/ifontprovider.h"
 #include "infrastructure/smufl.h"
 #include "infrastructure/symbolfonts.h"
+#include "infrastructure/localfileinfoprovider.h"
 
 #ifndef ENGRAVING_NO_INTERNAL
 #include "internal/engravingconfiguration.h"
@@ -168,6 +169,8 @@ void EngravingModule::onInit(const framework::IApplication::RunMode&)
         AccessibleItem::enabled = false;
 #endif
         gpaletteScore = compat::ScoreAccess::createMasterScore();
+        gpaletteScore->setFileInfoProvider(std::make_shared<LocalFileInfoProvider>(""));
+
 #ifndef ENGRAVING_NO_ACCESSIBILITY
         AccessibleItem::enabled = true;
 #endif


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/13876