### PR TITLE
Fix #13886: Improved cross-staff validity checks

### DIFF
--- a/src/engraving/layout/layoutmeasure.cpp
+++ b/src/engraving/layout/layoutmeasure.cpp
@@ -690,6 +690,11 @@ void LayoutMeasure::getNextMeasure(const LayoutOptions& options, LayoutContext& 
                     if (!cr) {
                         continue;
                     }
+                    // Check if requested cross-staff is possible
+                    if (cr->staffMove() || cr->storedStaffMove()) {
+                        cr->checkStaffMoveValidity();
+                    }
+
                     double m = staff->staffMag(&segment);
                     if (cr->isSmall()) {
                         m *= score->styleD(Sid::smallNoteMag);

--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -1479,11 +1479,6 @@ void LayoutSystem::updateCrossBeams(System* system, const LayoutContext& ctx)
                 }
             }
         }
-        for (Segment& seg : toMeasure(mb)->segments()) {
-            if (seg.next()) {
-                seg.computeCrossBeamType(seg.next());
-            }
-        }
     }
 }
 

--- a/src/engraving/libmscore/chordrest.h
+++ b/src/engraving/libmscore/chordrest.h
@@ -56,7 +56,8 @@ class ChordRest : public DurationElement
 
     ElementList _el;
     TDuration _durationType;
-    int _staffMove;           // -1, 0, +1, used for crossbeaming
+    int _staffMove; // -1, 0, +1, used for crossbeaming
+    int _storedStaffMove = 0; // used to remember and re-apply staff move if needed
 
     void processSiblings(std::function<void(EngravingItem*)> func);
 
@@ -123,8 +124,10 @@ public:
     void undoSetSmall(bool val);
 
     int staffMove() const { return _staffMove; }
+    int storedStaffMove() const { return _storedStaffMove; }
     void setStaffMove(int val) { _staffMove = val; }
     staff_idx_t vStaffIdx() const override { return staffIdx() + _staffMove; }
+    void checkStaffMoveValidity();
 
     const TDuration durationType() const
     {

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -4231,6 +4231,7 @@ void Measure::computeWidth(Segment* s, double x, bool isSystemHeader, Fraction m
             }
 
             // Adjust spacing for cross-beam situations
+            s->computeCrossBeamType(ns);
             CrossBeamType crossBeamType = s->crossBeamType();
             double displacement = score()->noteHeadWidth() - score()->styleMM(Sid::stemWidth);
             if (crossBeamType.upDown) {

--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -3020,18 +3020,6 @@ void Note::updateRelLine(int relLine, bool undoable)
     const Staff* staff  = score()->staff(idx);
     const StaffType* st = staff->staffTypeForElement(this);
 
-    if (chord()->staffMove()) {
-        // check that destination staff makes sense (might have been deleted)
-        staff_idx_t minStaff = part()->startTrack() / VOICES;
-        staff_idx_t maxStaff = part()->endTrack() / VOICES;
-        const Staff* stf = this->staff();
-        if (idx < minStaff || idx >= maxStaff || st->group() != stf->staffTypeForElement(this)->group()) {
-            LOGD("staffMove out of scope %zu + %d min %zu max %zu",
-                 staffIdx(), chord()->staffMove(), minStaff, maxStaff);
-            chord()->undoChangeProperty(Pid::STAFF_MOVE, 0);
-        }
-    }
-
     ClefType clef = staff->clef(chord()->tick());
     int line      = relStep(relLine, clef);
 


### PR DESCRIPTION
Resolves: #13886

The main problem is that `Note::updateRelLine()` is the wrong place to be checking the validy of cross-staff moves (rests can also be cross-staff). The validity of `_staffMove` should be checked by ChordRest because it is a ChordRest property, and it should be checked much earlier. 

The first commit fixes that, and does the only correct thing to do: if the destination staff is invalid, reset the _staffMove to zero (i.e., bring it back to the origin staff).

The second commit is more of a "nice to have": if the destination staff is invalid, we store the _staffMove before resetting it, and re-apply it in case the destination staff become valid again (for example, it is unhidden). @oktophonie @cbjeukendrup let me know what you think. The PR can be also merged without the second commit, in which case when a _staffMove becomes invalid it will simply be reset and forgotten.


https://user-images.githubusercontent.com/93707756/197523266-d37a0c83-a404-4061-9a7f-96164315d871.mp4

