### PR TITLE
Fix translations for local debug builds

### DIFF
--- a/share/locale/CMakeLists.txt
+++ b/share/locale/CMakeLists.txt
@@ -22,19 +22,19 @@ file(GLOB INSTRUMENTS_TS_FILES  ${CMAKE_CURRENT_LIST_DIR}/instruments_*.ts )
 file(GLOB MUSESCORE_TS_FILES    ${CMAKE_CURRENT_LIST_DIR}/musescore_*.ts )
 file(GLOB QT_TS_FILES           ${CMAKE_CURRENT_LIST_DIR}/qt_*.ts )
 
-# Translations update and generate on CI
-#add_custom_command(
-#    OUTPUT ${CMAKE_CURRENT_LIST_DIR}/musescore_en_US.qm
-#    COMMAND Qt5::lrelease ${INSTRUMENTS_TS_FILES}
-#    COMMAND Qt5::lrelease ${MUSESCORE_TS_FILES}
-#    COMMAND Qt5::lrelease ${QT_TS_FILES}
-#    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-#)
+# Translations update and generate on CI - but local builds don't have access to those...
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_LIST_DIR}/musescore_en_US.qm
+    COMMAND Qt5::lrelease ${INSTRUMENTS_TS_FILES}
+    COMMAND Qt5::lrelease ${MUSESCORE_TS_FILES}
+    COMMAND Qt5::lrelease ${QT_TS_FILES}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+)
 
-#add_custom_target(lrelease ALL
-#    DEPENDS ${CMAKE_CURRENT_LIST_DIR}/musescore_en_US.qm
-#    COMMENT "Generating .qm files" VERBATIM
-#)
+add_custom_target(lrelease ALL
+    DEPENDS ${CMAKE_CURRENT_LIST_DIR}/musescore_en_US.qm
+    COMMENT "Generating .qm files" VERBATIM
+)
 
 install(FILES
       ${CMAKE_CURRENT_LIST_DIR}/languages.json


### PR DESCRIPTION
Partial revert of ca8b96f23c892757d87061af37a22d8c04a3e39b to allow local debug builds to generate translation files. If not, those builds will assert out upon launch due to missing translations..

Resolves: Local debug builds crash on [this assert](https://github.com/musescore/MuseScore/blob/master/src/languages/internal/languagesservice.cpp#L276) during launch due to the missing qm-files.

Note: This is a stop-gap to allow contributors to build, run and test. Likely a better (configurable) option is required to allow CI to have the up to date languages while still allowing local builds as well.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
