### PR TITLE
fix #13357 leading zeros on video duration

### DIFF
--- a/src/learn/view/learnpagemodel.cpp
+++ b/src/learn/view/learnpagemodel.cpp
@@ -131,12 +131,21 @@ QVariantList LearnPageModel::playlistToVariantList(const Playlist& playlist) con
 {
     QVariantList result;
 
+    // h:mm:ss for anything over an hour
+    //    m:ss for anything under an hour
+    //    0:ss for anything under a minute
     auto formatDuration = [](int durationSecs) {
         int seconds = durationSecs;
         int minutes = seconds / 60;
+        seconds -= minutes * 60;
         int hours = minutes / 60;
+        minutes -= hours * 60;
 
-        return (hours > 0 ? QString::number(hours) + ":" : "") + QString::number(minutes % 60) + ":" + QString::number(seconds % 60);
+        return ((hours > 0)
+                ? (QString::number(hours) + ":" + QString::number(minutes).rightJustified(2, '0'))
+                : QString::number(minutes)
+                ) + ":"
+               + QString::number(seconds).rightJustified(2, '0');
     };
 
     for (const PlaylistItem& item : playlist) {


### PR DESCRIPTION
Resolves: #13357 

Pre-applied modulo to determine leading zero necessity

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
