### PR TITLE
fixed #10399: Closing the last score shouldn't close MU

### DIFF
--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -170,6 +170,10 @@ void ApplicationActionController::quit(bool isAllInstances, const io::path_t& in
             interactive()->openUrl(QUrl::fromLocalFile(installerPath.toQString()));
         }
 
+        if (multiInstancesProvider()->instances().size() > 1) {
+            multiInstancesProvider()->notifyAboutInstanceWasQuited();
+        }
+
         QCoreApplication::quit();
     }
 }

--- a/src/multiinstances/imultiinstancesprovider.h
+++ b/src/multiinstances/imultiinstancesprovider.h
@@ -66,6 +66,8 @@ public:
     virtual std::vector<InstanceMeta> instances() const = 0;
     virtual async::Notification instancesChanged() const = 0;
 
+    virtual void notifyAboutInstanceWasQuited() = 0;
+
     // Quit for all
     virtual void quitForAll() = 0;
     virtual void quitAllAndRestartLast() = 0;

--- a/src/multiinstances/internal/ipc/ipcsocket.cpp
+++ b/src/multiinstances/internal/ipc/ipcsocket.cpp
@@ -133,6 +133,11 @@ void IpcSocket::onDataReceived(const QByteArray& data)
         return;
     }
 
+    if (receivedMsg.method == "METHOD_QUITED") {
+        m_instances.removeAll(receivedMsg.srcID);
+        m_instancesChanged.notify();
+    }
+
     m_msgReceived.send(receivedMsg);
 }
 

--- a/src/multiinstances/internal/multiinstancesprovider.cpp
+++ b/src/multiinstances/internal/multiinstancesprovider.cpp
@@ -50,6 +50,7 @@ static const QString METHOD_SETTINGS_SET_VALUE("SETTINGS_SET_VALUE");
 static const QString METHOD_QUIT("METHOD_QUIT");
 static const QString METHOD_QUIT_WITH_RESTART_LAST_INSTANCE("METHOD_QUIT_WITH_RESTART_LAST_INSTANCE");
 static const QString METHOD_QUIT_WITH_RUNING_INSTALLATION("METHOD_QUIT_WITH_RUNING_INSTALLATION");
+static const QString METHOD_QUITED("METHOD_QUITED");
 static const QString METHOD_RESOURCE_CHANGED("RESOURCE_CHANGED");
 
 MultiInstancesProvider::~MultiInstancesProvider()
@@ -135,6 +136,8 @@ void MultiInstancesProvider::onMsg(const Msg& msg)
     } else if (msg.method == METHOD_QUIT_WITH_RUNING_INSTALLATION) {
         CHECK_ARGS_COUNT(1);
         dispatcher()->dispatch("quit", actions::ActionData::make_arg2<bool, std::string>(false, msg.args.at(0).toStdString()));
+    } else if (msg.method == METHOD_QUITED) {
+        m_ipcChannel->response(METHOD_QUITED, { }, msg.srcID);
     } else if (msg.method == METHOD_RESOURCE_CHANGED) {
         resourceChanged().send(msg.args.at(0).toStdString());
     }
@@ -383,6 +386,15 @@ std::vector<InstanceMeta> MultiInstancesProvider::instances() const
 mu::async::Notification MultiInstancesProvider::instancesChanged() const
 {
     return m_instancesChanged;
+}
+
+void MultiInstancesProvider::notifyAboutInstanceWasQuited()
+{
+    if (!isInited()) {
+        return;
+    }
+
+    m_ipcChannel->broadcast(METHOD_QUITED);
 }
 
 void MultiInstancesProvider::quitForAll()

--- a/src/multiinstances/internal/multiinstancesprovider.h
+++ b/src/multiinstances/internal/multiinstancesprovider.h
@@ -78,6 +78,8 @@ public:
     std::vector<InstanceMeta> instances() const override;
     async::Notification instancesChanged() const override;
 
+    void notifyAboutInstanceWasQuited();
+
     // Quit for all
     void quitForAll() override;
     void quitAllAndRestartLast() override;


### PR DESCRIPTION
Resolves: #10399

When the program instance is closed -> the sockets are destroyed -> the server updates the list of open instances.

What happened:
The user closes the score and the window closes. The program starts cleaning up the created objects, one of which is MidiDevicesListener. The listener contains a thread in which the list of available devices is updated, to optimize resource consumption, the thread goes to sleep for 500ms after each check. In the listener's destructor, the thread is terminated, but in order to terminate the thread, the program needs to wait until it wakes up. There are two such listeners: midiIn + midiOut = 1s. The user can close the main instance during this time.

The same with AudioThread

Notify another instances about quitting before quitting application