### PR TITLE
Arpeggio custom length error fix

### DIFF
--- a/src/engraving/libmscore/arpeggio.cpp
+++ b/src/engraving/libmscore/arpeggio.cpp
@@ -233,7 +233,7 @@ double Arpeggio::calcBottom() const
         return bottom;
     }
     default: {
-        return bottom + spatium() / 2;
+        return bottom - top + spatium() / 2;
     }
     }
 }
@@ -386,8 +386,8 @@ void Arpeggio::draw(mu::draw::Painter* painter) const
 std::vector<PointF> Arpeggio::gripsPositions(const EditData&) const
 {
     const PointF pp(pagePos());
-    PointF p1(0.0, -_userLen1);
-    PointF p2(0.0, _height + _userLen2);
+    PointF p1(_bbox.width() / 2, _bbox.top());
+    PointF p2(_bbox.width() / 2, _bbox.bottom());
     return { p1 + pp, p2 + pp };
 }
 


### PR DESCRIPTION
Resolves: #13885 

MU4 was not resetting the custom length to default, there was just an error in the layout calculation. Now the result matches MU3 but for a small difference which is expected due to the new default position.
While I was at it, I also corrected the position of the edit grips.

Before:
<img width="700" alt="image" src="https://user-images.githubusercontent.com/93707756/197749508-99eed4e5-5c3a-48da-b8f9-8cc4c4f7e555.png">
<img width="500" alt="image" src="https://user-images.githubusercontent.com/93707756/197749688-906fb7fa-fbfd-4450-910f-82b52fd42ea4.png">


After:
<img width="700" alt="image" src="https://user-images.githubusercontent.com/93707756/197748647-4b7a515d-5d42-475d-8548-b1ec4dc104f2.png">
<img width="500" alt="image" src="https://user-images.githubusercontent.com/93707756/197749367-a531a380-1c6c-461d-bd9f-94fce9e1cfa8.png">
