### PR TITLE
ChordLine bug spacing fix

### DIFF
--- a/src/engraving/libmscore/chordline.cpp
+++ b/src/engraving/libmscore/chordline.cpp
@@ -124,15 +124,18 @@ void ChordLine::layout()
         double vertOffset = 0.25 * spatium(); // one quarter of a space from the center line
         // Get chord shape
         Shape chordShape = chord()->shape();
-        // ...but remove chordLines, otherwise we are spacing chordLines against themselves
-        auto iter = chordShape.begin();
-        while (iter != chordShape.end()) {
-            if (iter->toItem && iter->toItem->isChordLine()) {
-                iter = chordShape.erase(iter);
-            } else {
-                ++iter;
+        // ...but remove from the shape items that the chordline shouldn't try to avoid
+        // (especially the chordline itself)
+        mu::remove_if(chordShape, [](ShapeElement& shapeEl){
+            if (!shapeEl.toItem) {
+                return true;
             }
-        }
+            const EngravingItem* item = shapeEl.toItem;
+            if (item->isChordLine() || item->isHarmony() || item->isLyrics()) {
+                return true;
+            }
+            return false;
+        });
         x += isToTheLeft() ? -chordShape.left() - horOffset : chordShape.right() + horOffset;
         y += isBelow() ? vertOffset : -vertOffset;
         setPos(x, y);


### PR DESCRIPTION
Resolves: #13907 

ChordLine should ignore Lyrics and Harmony from the chord shape.

Before:
<img width="700" alt="image" src="https://user-images.githubusercontent.com/93707756/197753760-995c7ce3-e38e-4f88-9677-c5e1049cebf1.png">


After:
<img width="700" alt="image" src="https://user-images.githubusercontent.com/93707756/197753523-637cffa1-6ff5-4941-ba3a-60ee1d3c1eca.png">
