### PR TITLE
changed layout ordering of staff text, system text, instrumentchanged

### DIFF
--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -1101,12 +1101,36 @@ void LayoutSystem::layoutSystemElements(const LayoutOptions& options, LayoutCont
     }
 
     //-------------------------------------------------------------
-    // StaffText, InstrumentChange
+    // StaffText
     //-------------------------------------------------------------
 
     for (const Segment* s : sl) {
         for (EngravingItem* e : s->annotations()) {
-            if (e->isPlayTechAnnotation() || e->isStaffText() || e->isSystemText() || e->isTripletFeel() || e->isInstrumentChange()) {
+            if (e->isStaffText()) {
+                e->layout();
+            }
+        }
+    }
+
+    //-------------------------------------------------------------
+    // InstrumentChange
+    //-------------------------------------------------------------
+
+    for (const Segment* s : sl) {
+        for (EngravingItem* e : s->annotations()) {
+            if (e->isInstrumentChange()) {
+                e->layout();
+            }
+        }
+    }
+
+    //-------------------------------------------------------------
+    // SystemText
+    //-------------------------------------------------------------
+
+    for (const Segment* s : sl) {
+        for (EngravingItem* e : s->annotations()) {
+            if (e->isPlayTechAnnotation() || e->isSystemText() || e->isTripletFeel()) {
                 e->layout();
             }
         }


### PR DESCRIPTION
Stave text is closer to stave than system text because of their names. Stave is a part of System so it looks like stave text shoud be closer to stave than system text. 