### PR TITLE
Fix #11851: Allow dotted durations to be added via note input mode

### DIFF
--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -176,7 +176,7 @@ public:
     virtual void addHairpinsToSelection(HairpinType type) = 0;
     virtual void addAccidentalToSelection(AccidentalType type) = 0;
     virtual void putRestToSelection() = 0;
-    virtual void putRest(DurationType duration) = 0;
+    virtual void putRest(Duration duration) = 0;
     virtual void addBracketsToSelection(BracketsType type) = 0;
     virtual void changeSelectedNotesArticulation(SymbolId articulationSymbolId) = 0;
     virtual void addGraceNotesToSelectedNotes(GraceNoteType type) = 0;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -157,10 +157,10 @@ void NotationActionController::init()
     registerAction("sharp2", [this]() { toggleAccidental(AccidentalType::SHARP2); });
 
     registerAction("rest", &Interaction::putRestToSelection);
-    registerAction("rest-1", &Interaction::putRest, DurationType::V_WHOLE);
-    registerAction("rest-2", &Interaction::putRest, DurationType::V_HALF);
-    registerAction("rest-4", &Interaction::putRest, DurationType::V_QUARTER);
-    registerAction("rest-8", &Interaction::putRest, DurationType::V_EIGHTH);
+    registerAction("rest-1", &Interaction::putRest, Duration(DurationType::V_WHOLE));
+    registerAction("rest-2", &Interaction::putRest, Duration(DurationType::V_HALF));
+    registerAction("rest-4", &Interaction::putRest, Duration(DurationType::V_QUARTER));
+    registerAction("rest-8", &Interaction::putRest, Duration(DurationType::V_EIGHTH));
 
     registerAction("add-marcato", [this]() { addArticulation(SymbolId::articMarcatoAbove); });
     registerAction("add-sforzato", [this]() { addArticulation(SymbolId::articAccentAbove); });

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3603,17 +3603,17 @@ void NotationInteraction::putRestToSelection()
     if (!is.duration().isValid() || is.duration().isZero() || is.duration().isMeasure()) {
         is.setDuration(DurationType::V_QUARTER);
     }
-    putRest(is.duration().type());
+    putRest(is.duration());
 }
 
-void NotationInteraction::putRest(DurationType duration)
+void NotationInteraction::putRest(Duration duration)
 {
     if (selection()->isNone()) {
         return;
     }
 
     startEdit();
-    score()->cmdEnterRest(Duration(duration));
+    score()->cmdEnterRest(duration);
     apply();
 }
 

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -180,7 +180,7 @@ public:
     void addHairpinsToSelection(HairpinType type) override;
     void addAccidentalToSelection(AccidentalType type) override;
     void putRestToSelection() override;
-    void putRest(DurationType duration) override;
+    void putRest(Duration duration) override;
     void addBracketsToSelection(BracketsType type) override;
     void changeSelectedNotesArticulation(SymbolId articulationSymbolId) override;
     void addGraceNotesToSelectedNotes(GraceNoteType type) override;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11851

For some reason, `putRest` only accepted `DurationType`, which doesn't include dot information. I've changed it so that it accepts a regular `TDuration`, which fixes the issue.