### PR TITLE
fixed #13899: MuseScore 4 won't open in Windows 10

### DIFF
--- a/src/framework/vst/internal/vstmodulesrepository.cpp
+++ b/src/framework/vst/internal/vstmodulesrepository.cpp
@@ -215,5 +215,13 @@ io::paths_t VstModulesRepository::pluginPathsFromCustomLocations(const io::paths
  **/
 PluginModule::PathList VstModulesRepository::pluginPathsFromDefaultLocation() const
 {
-    return PluginModule::getModulePaths();
+    PluginModule::PathList result;
+
+    try {
+        result = PluginModule::getModulePaths();
+    } catch (...) {
+        LOGE() << "Unable to get module paths";
+    }
+
+    return result;
 }


### PR DESCRIPTION
Resolves: #13899