### PR TITLE
Fix #13986: Adjust spanners when measures are deleted

### DIFF
--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -739,6 +739,7 @@ public:
 
     void deleteItem(EngravingItem*);
     void deleteMeasures(MeasureBase* firstMeasure, MeasureBase* lastMeasure, bool preserveTies = false);
+    void reconnectSlurs(MeasureBase* mbStart, MeasureBase* mbLast);
     void cmdDeleteSelection();
     void cmdFullMeasureRest();
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/13986

First, if the highlighted measure here is deleted, the endpoints of the slur do not change:
![image](https://user-images.githubusercontent.com/89263931/198136800-4162c009-3d70-4e52-9791-a0a9698b7f05.png)

If these highlighted measures are deleted, the slur's start point will be moved up to the first beat of the third measure:
![image](https://user-images.githubusercontent.com/89263931/198136920-abac74cf-4c4f-4d0c-8bfc-d16bd3d94a35.png)

(The same will happen when the second two measures are deleted--its endpoint will adjust back to the 4th beat of the first measure)

Finally, when this measure is deleted, all of these slurs will be removed as well:
![image](https://user-images.githubusercontent.com/89263931/198137117-fc3f7937-2c65-41fd-bbdf-40d1ccdf5ea8.png)

The middle slur will be deleted because both of its endpoints are inside of the removed range. The outer slurs could potentially be adjusted backwards like the ones above, except that would put the endpoint of the slur on the same note as the startpoint. So instead of dealing with zero-length slurs, they are removed.