### PR TITLE
Fix visibility of instrument name when single part

### DIFF
--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -5375,6 +5375,17 @@ Part* Score::partById(const ID& partId) const
     return nullptr;
 }
 
+int Score::visiblePartCount() const
+{
+    int count = 0;
+    for (const Part* part : _parts) {
+        if (part->show()) {
+            ++count;
+        }
+    }
+    return count;
+}
+
 ShadowNote& Score::shadowNote() const
 {
     return *m_shadowNote;

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -778,6 +778,7 @@ public:
     void changeSelectedNotesVoice(voice_idx_t);
 
     const std::vector<Part*>& parts() const { return _parts; }
+    int visiblePartCount() const;
     std::set<ID> partIdsFromRange(const track_idx_t trackFrom, const track_idx_t trackTo) const;
 
     void appendPart(const InstrumentTemplate*);

--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -1073,7 +1073,7 @@ void System::setInstrumentNames(const LayoutContext& ctx, bool longName, Fractio
         return;
     }
     if (!score()->showInstrumentNames()
-        || (style()->styleB(Sid::hideInstrumentNameIfOneInstrument) && score()->parts().size() == 1)) {
+        || (style()->styleB(Sid::hideInstrumentNameIfOneInstrument) && score()->visiblePartCount() <= 1)) {
         for (SysStaff* staff : _staves) {
             for (InstrumentName* t : staff->instrumentNames) {
                 ctx.score()->removeElement(t);


### PR DESCRIPTION
Resolves: #11211

Given the way that parts interact with the instrument panel, the decision of showing the name shouldn't be taken based on how many parts are in the score, but rather how many of them are visible.