### PR TITLE
Fix line thickness bug on reset

### DIFF
--- a/src/engraving/libmscore/line.cpp
+++ b/src/engraving/libmscore/line.cpp
@@ -1498,7 +1498,11 @@ bool SLine::setProperty(Pid id, const PropertyValue& v)
         _lineColor = v.value<mu::draw::Color>();
         break;
     case Pid::LINE_WIDTH:
-        _lineWidth = v.value<Millimetre>();
+        if (v.type() == P_TYPE::MILLIMETRE) {
+            _lineWidth = v.value<Millimetre>();
+        } else if (v.type() == P_TYPE::SPATIUM) {
+            _lineWidth = v.value<Spatium>().toMM(spatium());
+        }
         break;
     case Pid::LINE_STYLE:
         _lineStyle = v.value<LineType>();


### PR DESCRIPTION
Resolves: #13500 
Resolves: #13670 

As far as I can understand, the problem is that `_lineWidth` is encoded in `Millimetre`, but the style setting from which it takes its value is expressed in `Spatium`. The issue (either an assert failure in debug mode or zero-width lines in release mode) arises because propertyvalue.h doesn't have a Spatium to Millimeter conversion. And that conversion can't be done by `PropertyValue` because, obviously, you can only convert Spatium to Millimeter if you know the global `spatium()` of the score. Hope this makes sense.
