### PR TITLE
Inspector: Avoid using "notehead type" to mean different things

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/notation/notes/HeadSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/notes/HeadSettings.qml
@@ -141,7 +141,7 @@ FocusableItem {
 
                 NoteheadTypeSelector {
                     id: noteHeadTypeSection
-                    titleText: qsTrc("inspector", "Notehead type (visual only)")
+                    titleText: qsTrc("inspector", "Override visual duration")
                     propertyItem: root.model ? root.model.headType : null
 
                     navigationName: "NoteHeadTypeSection"

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/notes/internal/NoteheadTypeSelector.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/notes/internal/NoteheadTypeSelector.qml
@@ -30,7 +30,7 @@ import "../../../common"
 
 FlatRadioButtonGroupPropertyView {
     id: root
-    titleText: qsTrc("inspector", "Notehead type")
+    titleText: qsTrc("inspector", "Notehead duration")
 
     radioButtonGroup.height: 40
     model: [


### PR DESCRIPTION
We already use "notehead type" to mean the shape of the notehead so we shouldn't use it to mean the duration as well. This affects the Note Inspector and the Ambitus Inspector.

## Ambitus

<img alt="image" src="https://user-images.githubusercontent.com/11011881/198749283-4e8e4ff8-7fc7-414e-a19f-968d48480ece.png">

In the Properties panel, **"Notehead type"** becomes **"Notehead duration"** where appropriate.

Before | After
---|---
<img width="301" alt="image" src="https://user-images.githubusercontent.com/11011881/198748688-9ad67804-4092-47b8-a207-8d4c24dfc0a4.png"> | <img width="301" alt="image" src="https://user-images.githubusercontent.com/11011881/198748805-f2f0563c-1f73-4266-91ad-f29cdd38c89b.png">


## Notes

<img alt="image" src="https://user-images.githubusercontent.com/11011881/198749382-0b3d6126-e9c0-49c5-acb5-f48fdecf9697.png">

In the Properties panel, **"Notehead type (visual only)"** becomes **"Override visual duration"** to indicate that this option changes the visual appearance of the notehead without affecting playback or horizontal spacing.

Before | After
---|---
<img width="302" src="https://user-images.githubusercontent.com/11011881/198739055-c74fe238-3380-47f2-90f5-fe3fbc80e37a.png"> | <img width="302" src="https://user-images.githubusercontent.com/11011881/198739091-32bac0e9-3751-4c2c-a4ef-3af854daaa47.png">

