### PR TITLE
Fix formatting links in Interactive standard dialogs

### DIFF
--- a/src/engraving/engravingerrors.h
+++ b/src/engraving/engravingerrors.h
@@ -83,7 +83,7 @@ inline Ret make_ret(Err err, const io::path_t& filePath = "")
                .arg(u"https://musescore.org");
         break;
     case Err::FileOld300Format:
-        text = mtrc("engraving", "This file was last saved with a development version of 3.0.");
+        text = mtrc("engraving", "This file was last saved in a development version of 3.0.");
         break;
     case Err::FileCorrupted:
         text = mtrc("engraving", "File \"%1\" is corrupted.").arg(filePath.toString());

--- a/src/framework/global/iinteractive.h
+++ b/src/framework/global/iinteractive.h
@@ -81,17 +81,19 @@ public:
     using ButtonDatas = std::vector<ButtonData>;
 
     enum class TextFormat {
-        PlainText = 0,
+        Auto = 0,
+        PlainText,
         RichText
     };
 
     struct Text {
         std::string text;
-        TextFormat format = TextFormat::PlainText;
+        TextFormat format = TextFormat::Auto;
+
         Text() = default;
         Text(const char* t)
-            : text(t), format(TextFormat::PlainText) {}
-        Text(const std::string& t, const TextFormat& f = TextFormat::PlainText)
+            : text(t), format(TextFormat::Auto) {}
+        Text(const std::string& t, const TextFormat& f = TextFormat::Auto)
             : text(t), format(f) {}
     };
 

--- a/src/framework/ui/view/interactiveprovider.cpp
+++ b/src/framework/ui/view/interactiveprovider.cpp
@@ -291,6 +291,7 @@ void InteractiveProvider::fillStandardDialogData(QmlLaunchData* data, const QStr
 {
     auto format = [](IInteractive::TextFormat f) {
         switch (f) {
+        case IInteractive::TextFormat::Auto:      return Qt::AutoText;
         case IInteractive::TextFormat::PlainText: return Qt::PlainText;
         case IInteractive::TextFormat::RichText:  return Qt::RichText;
         }


### PR DESCRIPTION
Before: 
<img width="639" alt="Scherm­afbeelding 2022-10-30 om 12 14 59" src="https://user-images.githubusercontent.com/48658420/198875781-21982343-048f-4ec6-8105-783ff61f2794.png">

After:
<img width="639" alt="Scherm­afbeelding 2022-10-30 om 12 13 18" src="https://user-images.githubusercontent.com/48658420/198875792-6bc8cc08-e8bd-4384-bb75-efa7cdc3181e.png">

By default, text will be formatted automatically (interpreted as HTML or Markdown etc. as appropriate). This is the default for StyledTextLabel too, so for consistency we do this in Interactive too.