### PR TITLE
Fix rounded corners for SplashScreen on macOS

### DIFF
--- a/src/appshell/view/internal/splashscreen.cpp
+++ b/src/appshell/view/internal/splashscreen.cpp
@@ -34,19 +34,26 @@ using namespace mu::appshell;
 
 static const QString imagePath(":/resources/LoadingScreen.svg");
 
-static const QSize splashScreenSize(810, 405);
+static constexpr QSize splashScreenSize(810, 405);
 
 static const QColor messageColor("#99FFFFFF");
-static const QRectF messageRect(splashScreenSize.width() / 2, 269, 0, 0);
+static constexpr QRectF messageRect(splashScreenSize.width() / 2, 269, 0, 0);
 
 static const QString website("www.musescore.org");
-static const QRectF websiteRect(splashScreenSize.width() - 48, splashScreenSize.height() - 48, 0, 0);
+static constexpr QRectF websiteRect(splashScreenSize.width() - 48, splashScreenSize.height() - 48, 0, 0);
 
 static const QColor versionNumberColor("#22A0F4");
 static constexpr qreal versionNumberSpacing = 5.0;
 
+#ifdef Q_OS_MAC
+// Necessary to remove undesired background, so that we really get our rounded corners
+static constexpr Qt::WindowFlags splashScreenWindowFlags = (Qt::SplashScreen | Qt::FramelessWindowHint) & ~Qt::Sheet | Qt::Window;
+#else
+static constexpr Qt::WindowFlags splashScreenWindowFlags = Qt::SplashScreen | Qt::FramelessWindowHint;
+#endif
+
 SplashScreen::SplashScreen()
-    : QWidget(nullptr, Qt::SplashScreen | Qt::FramelessWindowHint),
+    : QWidget(nullptr, splashScreenWindowFlags),
     m_backgroundRenderer(new QSvgRenderer(imagePath, this))
 {
     setAttribute(Qt::WA_TranslucentBackground);


### PR DESCRIPTION
Before: if you look closely, you see that there is a sort of background behind the rounded corners. 
<img width="856" alt="Scherm­afbeelding 2022-10-30 om 14 25 44" src="https://user-images.githubusercontent.com/48658420/198880965-186ce47d-c5f5-4377-adee-46fde79fc398.png">

After: 
<img width="856" alt="Scherm­afbeelding 2022-10-30 om 14 22 01" src="https://user-images.githubusercontent.com/48658420/198880951-76f28ad4-32ea-4fc4-ac0b-7229f31c63d7.png">
