### PR TITLE
gp-import: not importing grace note without main chord

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -542,7 +542,6 @@ Fraction GPConverter::convertBeat(const GPBeat* beat, ChordRestContainer& graceC
 
             curSegment->add(cr);
 
-            configureGraceChord(beat, cr);
             graceChords.push_back({ cr, beat });
 
             return ctx.curTick;
@@ -560,6 +559,7 @@ Fraction GPConverter::convertBeat(const GPBeat* beat, ChordRestContainer& graceC
         if (!graceChords.empty()) {
             int grIndex = 0;
             for (auto [pGrChord, pBeat] : graceChords) {
+                configureGraceChord(pBeat, pGrChord);
                 if (pGrChord->type() == ElementType::CHORD) {
                     static_cast<Chord*>(pGrChord)->setGraceIndex(grIndex++);
                 }


### PR DESCRIPTION
fixed problem with importing grace note in the end of measure, 
not adding it cause chord cannot have only grace notes in MU
<img width="118" alt="Screenshot 2022-11-02 at 09 44 30" src="https://user-images.githubusercontent.com/24373905/199429320-53816dae-bdf8-4fe5-940d-6a5bc8a2acc3.png">
