### PR TITLE
Remove drum 39 'Hand Clap' from Percussion instrument

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -8419,13 +8419,6 @@
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
-                  <Drum pitch="39"> <!--Hand Clap-->
-                        <head>normal</head>
-                        <line>1</line>
-                        <voice>0</voice>
-                        <name>Hand Clap</name>
-                        <stem>1</stem>
-                  </Drum>
                   <Drum pitch="54"> <!--Tambourine-->
                         <head>diamond</head>
                         <line>2</line>


### PR DESCRIPTION
It is notated exactly the same as drum 85 'Castanets', and they use the same sound too so it is impossible to tell them apart, at least with our Sound Font. (In MS Basic, drum notes 39 and 85 in the Orchestra Kit sound identical to each other.)

The Percussion instrument in MU3 doesn't have a 'Hand Clap' drum. It has a 'Castanets' drum that is incorrectly assigned to pitch 39. PR https://github.com/musescore/MuseScore/pull/7893 attempted to fix this in MU4 by ensuring we have both drums, but in reality we just want the Castanets on pitch 85.