### PR TITLE
fix #14029: crash on hiding part with reprise when there is no title

### DIFF
--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -4335,7 +4335,7 @@ void Measure::computeWidth(Fraction minTicks, Fraction maxTicks, double stretchC
     if (s->isStartRepeatBarLineType()) {
         System* sys = system();
         MeasureBase* pmb = prev();
-        if (pmb->isMeasure() && pmb->system() == sys && pmb->repeatEnd()) {
+        if (pmb && pmb->isMeasure() && pmb->system() == sys && pmb->repeatEnd()) {
             Segment* seg = toMeasure(pmb)->last();
             // overlap end repeat barline with start repeat barline
             if (seg->isEndBarLineType()) {


### PR DESCRIPTION
Resolves: *https://github.com/musescore/MuseScore/issues/14029*

<img width="168" alt="Screenshot 2022-11-03 at 16 29 04" src="https://user-images.githubusercontent.com/24373905/199748405-2541d06d-f3bb-43d6-8939-c499aee995a3.png">
this type of files without title box were crashed while hiding the part 