### PR TITLE
minor tweak in key sig editor - first added accidental aligned to "zero" position

### DIFF
--- a/src/palette/view/widgets/keyedit.cpp
+++ b/src/palette/view/widgets/keyedit.cpp
@@ -284,19 +284,21 @@ void KeyCanvas::snap(Accidental* a)
     double _spatium = gpaletteScore->style().spatium();
     double spatium2 = _spatium * .5;
     double y = a->ldata()->pos().y();
+    double x = KEYEDIT_ACC_ZERO_POINT * _spatium;
     int line = round(y / spatium2);
     y = line * spatium2;
     a->mutldata()->setPosY(y);
     // take default xposition unless Control is pressed
     int i = accidentals.indexOf(a);
     if (i > 0) {
-        qreal accidentalGap = DefaultStyle::baseStyle().styleS(Sid::keysigAccidentalDistance).val();
+        qreal accidentalGap = DefaultStyle::baseStyle().styleS(Sid::keysigAccidentalDistance).val() * _spatium;
         Accidental* prev = accidentals[i - 1];
         double prevX = prev->ldata()->pos().x();
         qreal prevWidth = prev->symWidth(prev->symId());
-        if (!QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
-            a->mutldata()->setPosX(prevX + prevWidth + accidentalGap * _spatium);
-        }
+        x = prevX + prevWidth + accidentalGap;
+    }
+    if (!QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
+        a->mutldata()->setPosX(x);
     }
 }
 
@@ -387,14 +389,7 @@ void KeyEditor::addClicked()
 {
     const QList<Accidental*> al = canvas->getAccidentals();
     double spatium = gpaletteScore->style().spatium();
-    double xoff = 10000000.0;
-
-    for (Accidental* a : al) {
-        PointF pos = a->ldata()->pos();
-        if (pos.x() < xoff) {
-            xoff = pos.x();
-        }
-    }
+    double xoff = KEYEDIT_ACC_ZERO_POINT * spatium;
 
     KeySigEvent e;
     e.setCustom(true);

--- a/src/palette/view/widgets/keyedit.h
+++ b/src/palette/view/widgets/keyedit.h
@@ -68,6 +68,8 @@ private:
 
     bool m_dirty = false;
 };
+
+static const int KEYEDIT_ACC_ZERO_POINT = 3;
 }
 
 #endif


### PR DESCRIPTION
In Custom Key Signatures Editor - now, also firstly added accidental is alligned to its default "zero" position, unless `Ctrl` is pressed.

(Before, "zero position" was calculated from most left accidental.)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
