### PR TITLE
Fix #14267: graceAfters ignore other chords on this segment

### DIFF
--- a/src/engraving/libmscore/tie.cpp
+++ b/src/engraving/libmscore/tie.cpp
@@ -739,9 +739,14 @@ void TieSegment::adjustX()
             std::vector<Chord*> chords;
             track_idx_t strack = ec->staffIdx() * VOICES;
             track_idx_t etrack = ec->staffIdx() * VOICES + VOICES;
-            for (track_idx_t track = strack; track < etrack; ++track) {
-                if (Chord* ch = ec->measure()->findChord(ec->tick(), track)) {
-                    chords.push_back(ch);
+            chords.push_back(ec);
+            if (!ec->isGraceAfter()) {
+                for (track_idx_t track = strack; track < etrack; ++track) {
+                    if (Chord* ch = ec->measure()->findChord(ec->tick(), track)) {
+                        if (ch != ec) {
+                            chords.push_back(ch);
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14267

Ties ending on grace notes _after_ a note now no longer adjust for other chords on that tick, as that would include the note to which the grace is attached, as well as any other chords that might be miles away from the endpoint. In the future, there may be a better way to do this but I figure it's not worth the development time to rewrite how tie collisions work and instead chalk this one up to an extreme edge case that the user can fix very easily by flipping direction, adjusting endpoints, etc.