### PR TITLE
Play tied note during note input (DRAFT)

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -1820,7 +1820,6 @@ void Score::cmdAddTie(bool addToChord)
             NoteVal nval(note->noteVal());
             if (!n) {
                 n = addPitch(nval, addFlag);
-                setPlayNote(true);
             } else {
                 select(n);
             }

--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -1820,6 +1820,7 @@ void Score::cmdAddTie(bool addToChord)
             NoteVal nval(note->noteVal());
             if (!n) {
                 n = addPitch(nval, addFlag);
+                setPlayNote(true);
             } else {
                 select(n);
             }

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -1036,6 +1036,15 @@ void NotationActionController::repeatSelection()
     if (!ret && !ret.text().empty()) {
         interactive()->error("", ret.text());
     }
+
+    auto noteInput = interaction->noteInput();
+    if (!noteInput) {
+        return;
+    }
+
+    if (noteInput->isNoteInputMode()) {
+        playSelectedElement(true);
+    }
 }
 
 void NotationActionController::pasteSelection(PastingType type)

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -1036,10 +1036,6 @@ void NotationActionController::repeatSelection()
     if (!ret && !ret.text().empty()) {
         interactive()->error("", ret.text());
     }
-
-    if (noteInput->isNoteInputMode()) {
-        playSelectedElement(true);
-    }
 }
 
 void NotationActionController::pasteSelection(PastingType type)

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -1036,6 +1036,10 @@ void NotationActionController::repeatSelection()
     if (!ret && !ret.text().empty()) {
         interactive()->error("", ret.text());
     }
+
+    if (noteInput->isNoteInputMode()) {
+        playSelectedElement(true);
+    }
 }
 
 void NotationActionController::pasteSelection(PastingType type)
@@ -1090,6 +1094,7 @@ void NotationActionController::addTie()
 
     if (noteInput->isNoteInputMode()) {
         noteInput->addTie();
+        playSelectedElement(true);
     } else {
         interaction->addTieToSelection();
     }
@@ -1110,6 +1115,7 @@ void NotationActionController::chordTie()
 
     if (noteInput->isNoteInputMode()) {
         noteInput->addTie();
+        playSelectedElement(true);
     } else {
         interaction->addTiedNoteToChord();
     }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/13687

Added call to setPlayNote() when adding a tied note, so the added note is played.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
