### PR TITLE
Play repeated note/chord during note input (DRAFT)

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3384,7 +3384,7 @@ mu::Ret NotationInteraction::repeatSelection()
                 mu::engraving::NoteVal nval = note->noteVal();
                 score()->addPitch(nval, note != c->notes()[0]);
             }
-            setPlayChord(true);
+            score()->setPlayChord(true);
             apply();
         }
         return make_ok();

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3384,6 +3384,7 @@ mu::Ret NotationInteraction::repeatSelection()
                 mu::engraving::NoteVal nval = note->noteVal();
                 score()->addPitch(nval, note != c->notes()[0]);
             }
+            setPlayChord(true);
             apply();
         }
         return make_ok();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/12935

Added call to setPlayChord() when repeating a note/chord, so the added chord is played

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
