### PR TITLE
Fix #14151: Allow valid note durations inside tuplet

### DIFF
--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -838,7 +838,7 @@ Segment* Score::setNoteRest(Segment* segment, track_idx_t track, NoteVal nval, F
     EngravingItem* nr   = nullptr;
     Tie* tie      = nullptr;
     ChordRest* cr = toChordRest(segment->element(track));
-    Tuplet* tuplet = cr && cr->tuplet() && sd <= cr->tuplet()->ticks() ? cr->tuplet() : nullptr;
+    Tuplet* tuplet = cr && cr->tuplet() ? cr->tuplet() : nullptr;
     Measure* measure = nullptr;
     bool targetIsRest = cr && cr->isRest();
     for (;;) {
@@ -911,7 +911,7 @@ Segment* Score::setNoteRest(Segment* segment, track_idx_t track, NoteVal nval, F
                     note->setTieFor(tie);
                 }
             }
-            if (tuplet && sd <= tuplet->ticks()) {
+            if (tuplet) {
                 ncr->setTuplet(tuplet);
             }
             tuplet = 0;
@@ -943,7 +943,8 @@ Segment* Score::setNoteRest(Segment* segment, track_idx_t track, NoteVal nval, F
         segment = nseg;
 
         cr = toChordRest(segment->element(track));
-
+        // if the cr was too big for the tuplet, get the next tuplet so we can spill into that one
+        tuplet = cr && cr->tuplet() ? cr->tuplet() : nullptr;
         if (!cr) {
             if (track % VOICES) {
                 cr = addRest(segment, track, TDuration(DurationType::V_MEASURE), 0);

--- a/src/engraving/utests/copypaste_data/copypasteNote08-ref.mscx
+++ b/src/engraving/utests/copypaste_data/copypasteNote08-ref.mscx
@@ -79,16 +79,53 @@
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
+          <Tuplet>
+            <normalNotes>2</normalNotes>
+            <actualNotes>3</actualNotes>
+            <baseNote>quarter</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
+            </Tuplet>
           <Chord>
-            <durationType>whole</durationType>
+            <dots>1</dots>
+            <durationType>half</durationType>
+            <Note>
+              <Spanner type="Tie">
+                <Tie>
+                  </Tie>
+                <next>
+                  <location>
+                    <fractions>1/2</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              <pitch>74</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          <endTuplet/>
+          <Chord>
+            <durationType>quarter</durationType>
             <Note>
               <autoplace>0</autoplace>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <fractions>-1/2</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <headScheme>name-pitch-german</headScheme>
               <tuning>30</tuning>
               </Note>
             </Chord>
+          <Rest>
+            <durationType>quarter</durationType>
+            </Rest>
           </voice>
         </Measure>
       <Measure>


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14151

Previously, the tuplet would be removed if the requested note duration is as long or longer than the space the tuplet takes up. This becomes annoying when you want to enter a dotted quarter into an eighth triplet (which is a tuplet that only takes up a quarter note's worth of space, but nevertheless could accept a dotted quarter with no problem). Now the tuplets are retained no matter whether the duration fits in the tuplet or not (if not, they tie outside the tuplet (or into another tuplet if available).