### PR TITLE
fixed #14193: Default shortcut restored when reopening MS4

### DIFF
--- a/src/framework/shortcuts/shortcutstypes.h
+++ b/src/framework/shortcuts/shortcutstypes.h
@@ -46,7 +46,7 @@ struct Shortcut
 
     bool isValid() const
     {
-        return !action.empty() && (!sequences.empty() || standardKey != QKeySequence::UnknownKey);
+        return !action.empty();
     }
 
     bool operator ==(const Shortcut& sc) const


### PR DESCRIPTION
Resolves: #14193