### PR TITLE
Fix #14355 Only adjust dots for note if note has dots

### DIFF
--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -2339,7 +2339,7 @@ void Note::layout2()
     // so that the results are available there
 
     int dots = chord()->dots();
-    if (dots) {
+    if (dots && !_dots.empty()) {
         double d  = score()->point(score()->styleS(Sid::dotNoteDistance)) * mag();
         double dd = score()->point(score()->styleS(Sid::dotDotDistance)) * mag();
         double x  = chord()->dotPosX() - pos().x() - chord()->pos().x();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14355

The dot adjustment stuff (per-note) was happening if the chord had dots. In the test file, a dotted chord contains notes with no dots. Regardless, we shouldn't be laying out the dots of a note without checking to see if the note actually has dots, so I've added a check for that.

If you liked this PR, you'll love https://github.com/musescore/MuseScore/pull/12547