### PR TITLE
Allow user style settings for page format to override template (DRAFT)

### DIFF
--- a/src/engraving/style/defaultstyle.cpp
+++ b/src/engraving/style/defaultstyle.cpp
@@ -57,12 +57,12 @@ void DefaultStyle::init(const path_t& defaultStyleFilePath, const path_t& partSt
     if (useLetter) {
         m_defaultStyle = new MStyle();
         m_defaultStyle->set(Sid::pageWidth, 8.5);
-        m_defaultStyle->set(Sid::pageHeight, 11);
-        m_defaultStyle.precomputeValues();
+        m_defaultStyle->set(Sid::pageHeight, 11.0);
+        m_defaultStyle->precomputeValues();
         m_defaultStyleForParts = new MStyle();
         m_defaultStyleForParts->set(Sid::pageWidth, 8.5);
-        m_defaultStyleForParts->set(Sid::pageHeight, 11);
-        m_defaultStyleForParts.precomputeValues();
+        m_defaultStyleForParts->set(Sid::pageHeight, 11.0);
+        m_defaultStyleForParts->precomputeValues();
     }
 
     if (!defaultStyleFilePath.empty()) {

--- a/src/engraving/style/defaultstyle.cpp
+++ b/src/engraving/style/defaultstyle.cpp
@@ -51,9 +51,10 @@ void DefaultStyle::init(const path_t& defaultStyleFilePath, const path_t& partSt
 {
     m_baseStyle.precomputeValues();
 
-    std::string pagesize = getenv("PAGESIZE");
+    char* ps = getenv("PAGESIZE");
+    std::string defaultPageSize = ps ? ps : "A4";
     std::string letter = "Letter";
-    bool useLetter = (pagesize == letter);
+    bool useLetter = (defaultPageSize == letter);
     if (useLetter) {
         m_defaultStyle = new MStyle();
         m_defaultStyle->set(Sid::pageWidth, 8.5);

--- a/src/engraving/style/defaultstyle.cpp
+++ b/src/engraving/style/defaultstyle.cpp
@@ -51,12 +51,14 @@ void DefaultStyle::init(const path_t& defaultStyleFilePath, const path_t& partSt
 {
     m_baseStyle.precomputeValues();
 
-    auto useLetter = (getenv("PAGESIZE") == "Letter");
+    std::string pagesize = getenv("PAGESIZE");
+    std::string letter = "Letter";
+    auto useLetter = (pagesize == letter);
     if (useLetter) {
         m_defaultStyle = new MStyle();
         m_defaultStyle->set(Sid::pageWidth, 8.5);
         m_defaultStyle->set(Sid::pageHeight, 11);
-        m_defaultStyleForParts = newMStyle();
+        m_defaultStyleForParts = new MStyle();
         m_defaultStyleForParts->set(Sid::pageWidth, 8.5);
         m_defaultStyleForParts->set(Sid::pageHeight, 11);
     }

--- a/src/engraving/style/defaultstyle.cpp
+++ b/src/engraving/style/defaultstyle.cpp
@@ -48,12 +48,13 @@ DefaultStyle* DefaultStyle::instance()
     return &s;
 }
 
-static bool defaultPageSizeIsLetter() {
+static bool defaultPageSizeIsLetter()
+{
     // first try PAPERSIZE environment variable
     char* papersize = getenv("PAPERSIZE");
     if (papersize) {
         std::string letter = "letter";
-        return (ps == letter);
+        return papersize == letter;
     }
     // try locale
     QLocale::Country country = QLocale::system().country();

--- a/src/engraving/style/defaultstyle.cpp
+++ b/src/engraving/style/defaultstyle.cpp
@@ -53,14 +53,16 @@ void DefaultStyle::init(const path_t& defaultStyleFilePath, const path_t& partSt
 
     std::string pagesize = getenv("PAGESIZE");
     std::string letter = "Letter";
-    auto useLetter = (pagesize == letter);
+    bool useLetter = (pagesize == letter);
     if (useLetter) {
         m_defaultStyle = new MStyle();
         m_defaultStyle->set(Sid::pageWidth, 8.5);
         m_defaultStyle->set(Sid::pageHeight, 11);
+        m_defaultStyle.precomputeValues();
         m_defaultStyleForParts = new MStyle();
         m_defaultStyleForParts->set(Sid::pageWidth, 8.5);
         m_defaultStyleForParts->set(Sid::pageHeight, 11);
+        m_defaultStyleForParts.precomputeValues();
     }
 
     if (!defaultStyleFilePath.empty()) {

--- a/src/engraving/style/defaultstyle.cpp
+++ b/src/engraving/style/defaultstyle.cpp
@@ -21,6 +21,8 @@
  */
 #include "defaultstyle.h"
 
+#include <cstdlib>
+
 #include "io/file.h"
 
 #include "log.h"
@@ -49,8 +51,20 @@ void DefaultStyle::init(const path_t& defaultStyleFilePath, const path_t& partSt
 {
     m_baseStyle.precomputeValues();
 
-    if (!defaultStyleFilePath.empty()) {
+    auto useLetter = (getenv("PAGESIZE") == "Letter");
+    if (useLetter) {
         m_defaultStyle = new MStyle();
+        m_defaultStyle->set(Sid::pageWidth, 8.5);
+        m_defaultStyle->set(Sid::pageHeight, 11);
+        m_defaultStyleForParts = newMStyle();
+        m_defaultStyleForParts->set(Sid::pageWidth, 8.5);
+        m_defaultStyleForParts->set(Sid::pageHeight, 11);
+    }
+
+    if (!defaultStyleFilePath.empty()) {
+        if (!m_defaultStyle) {
+            m_defaultStyle = new MStyle();
+        }
         bool ok = doLoadStyle(m_defaultStyle, defaultStyleFilePath);
         if (!ok) {
             delete m_defaultStyle;
@@ -61,8 +75,10 @@ void DefaultStyle::init(const path_t& defaultStyleFilePath, const path_t& partSt
     }
 
     if (!partStyleFilePath.empty()) {
-        m_defaultStyleForParts = new MStyle();
-        bool ok = doLoadStyle(m_defaultStyleForParts, defaultStyleFilePath);
+        if (!m_defaultStyleForParts) {
+            m_defaultStyleForParts = new MStyle();
+        }
+        bool ok = doLoadStyle(m_defaultStyleForParts, partStyleFilePath);
         if (!ok) {
             delete m_defaultStyleForParts;
             m_defaultStyleForParts = nullptr;

--- a/src/engraving/style/defaultstyle.cpp
+++ b/src/engraving/style/defaultstyle.cpp
@@ -51,9 +51,9 @@ void DefaultStyle::init(const path_t& defaultStyleFilePath, const path_t& partSt
 {
     m_baseStyle.precomputeValues();
 
-    char* ps = getenv("PAGESIZE");
-    std::string defaultPageSize = ps ? ps : "A4";
-    std::string letter = "Letter";
+    char* ps = getenv("PAPERSIZE");
+    std::string defaultPageSize = ps ? ps : "a4";
+    std::string letter = "letter";
     bool useLetter = (defaultPageSize == letter);
     if (useLetter) {
         m_defaultStyle = new MStyle();

--- a/src/engraving/style/defaultstyle.cpp
+++ b/src/engraving/style/defaultstyle.cpp
@@ -22,6 +22,7 @@
 #include "defaultstyle.h"
 
 #include <cstdlib>
+#include <QLocale>
 
 #include "io/file.h"
 
@@ -47,15 +48,29 @@ DefaultStyle* DefaultStyle::instance()
     return &s;
 }
 
+static bool defaultPageSizeIsLetter() {
+    // first try PAPERSIZE environment variable
+    char* papersize = getenv("PAPERSIZE");
+    if (papersize) {
+        std::string letter = "letter";
+        return (ps == letter);
+    }
+    // try locale
+    QLocale::Country country = QLocale::system().country();
+    switch (country) {
+    case QLocale::UnitedStates:
+    case QLocale::Canada:
+        return true;
+    default:
+        return false;
+    }
+}
+
 void DefaultStyle::init(const path_t& defaultStyleFilePath, const path_t& partStyleFilePath)
 {
     m_baseStyle.precomputeValues();
 
-    char* ps = getenv("PAPERSIZE");
-    std::string defaultPageSize = ps ? ps : "a4";
-    std::string letter = "letter";
-    bool useLetter = (defaultPageSize == letter);
-    if (useLetter) {
+    if (defaultPageSizeIsLetter()) {
         m_defaultStyle = new MStyle();
         m_defaultStyle->set(Sid::pageWidth, 8.5);
         m_defaultStyle->set(Sid::pageHeight, 11.0);

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -305,7 +305,7 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
         }
 
         // for templates using built-in base page style, set score page style to default (may be user-defined)
-        if (score->style().styleD(Sid::pageHeight) == DefaultStyle::baseStyle().value(Sid::pageHeight)) {
+        if (score->style().value(Sid::pageHeight) == DefaultStyle::baseStyle().value(Sid::pageHeight)) {
             LOGE() << "base page height found: " << DefaultStyle::baseStyle().styleD(Sid::pageHeight);
             for (auto st : pageStyles()) {
                 score->setStyleValue(st, DefaultStyle::defaultStyle().value(st));

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -310,6 +310,8 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
             for (auto st : pageStyles()) {
                 score->setStyleValue(st, DefaultStyle::defaultStyle().value(st));
             }
+        } else {
+            LOGE() << "custom page style: height " << score->style().styleD(Sid::pageHeight) << ", expected " << DefaultStyle::baseStyle().styleD(Sid::pageHeight);
         }
     }
 

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -25,7 +25,6 @@
 #include <QFileInfo>
 
 #include "log.h"
-#include "realfn.h"
 #include "translation.h"
 
 #include "engraving/style/defaultstyle.h"
@@ -307,13 +306,12 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
         }
 
         // for templates using built-in base page style, set score page style to default (may be user-defined)
-        if (std::abs(score->style().styleD(Sid::pageHeight) - DefaultStyle::baseStyle().styleD(Sid::pageHeight)) < 0.1) {
-            LOGE() << "base page height found: " << DefaultStyle::baseStyle().styleD(Sid::pageHeight);
+        bool isBaseHeight = (std::abs(score->style().styleD(Sid::pageHeight) - DefaultStyle::baseStyle().styleD(Sid::pageHeight)) < 0.1);
+        bool isBaseWidth = (std::abs(score->style().styleD(Sid::pageWidth) - DefaultStyle::baseStyle().styleD(Sid::pageWidth)) < 0.1);
+        if (isBaseHeight && isBaseWidth) {
             for (auto st : pageStyles()) {
                 score->setStyleValue(st, DefaultStyle::defaultStyle().value(st));
             }
-        } else {
-            LOGE() << "custom page style: height " << score->style().styleD(Sid::pageHeight) << ", expected " << DefaultStyle::baseStyle().styleD(Sid::pageHeight);
         }
     }
 

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -306,7 +306,7 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
         }
 
         // for templates using built-in base page style, set score page style to default (may be user-defined)
-        if (RealIsEqual(score->style().styleD(Sid::pageHeight), DefaultStyle::baseStyle().styleD(Sid::pageHeight)) {
+        if (RealIsEqual(score->style().styleD(Sid::pageHeight), DefaultStyle::baseStyle().styleD(Sid::pageHeight))) {
             LOGE() << "base page height found: " << DefaultStyle::baseStyle().styleD(Sid::pageHeight);
             for (auto st : pageStyles()) {
                 score->setStyleValue(st, DefaultStyle::defaultStyle().value(st));

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -300,6 +300,13 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
             nvb->setRightMargin(tvb->rightMargin());
             nvb->setAutoSizeEnabled(tvb->isAutoSizeEnabled());
         }
+    
+        // for templates using built-in base page style, set score page style to default (may be user-defined)
+        if (score->style()->value(Sid::pageHeight) == DefaultStyle::baseStyle().value(Sid::pageHeight)) {
+            for (auto st : pageStyles()) {
+                score->resetStyleValue(st);
+            }
+        }
     }
 
     score->setSaved(true);

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -305,13 +305,12 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
         }
 
         // for templates using built-in base page style, set score page style to default (may be user-defined)
-        //if (score->style().value(Sid::pageHeight) == DefaultStyle::baseStyle().value(Sid::pageHeight)) {
-            LOGE() << "base page height found: " << DefaultStyle::baseStyle().value(Sid::pageHeight);
+        if (score->style().styleD(Sid::pageHeight) == DefaultStyle::baseStyle().value(Sid::pageHeight)) {
+            LOGE() << "base page height found: " << DefaultStyle::baseStyle().styleD(Sid::pageHeight);
             for (auto st : pageStyles()) {
-                LOGE() << "resetting style value to " << DefaultStyle::defaultStyle().value(st);
                 score->setStyleValue(st, DefaultStyle::defaultStyle().value(st));
             }
-        //}
+        }
     }
 
     score->setSaved(true);

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -308,7 +308,7 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
         //if (score->style().value(Sid::pageHeight) == DefaultStyle::baseStyle().value(Sid::pageHeight)) {
             LOGE() << "base page height found: " << DefaultStyle::baseStyle().value(Sid::pageHeight);
             for (auto st : pageStyles()) {
-                LOGE() << "resetting style value " << st << " to " << DefaultStyle::defaultStyle().value(st);
+                LOGE() << "resetting style value to " << DefaultStyle::defaultStyle().value(st);
                 score->setStyleValue(st, DefaultStyle::defaultStyle().value(st));
             }
         //}

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -306,9 +306,9 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
         }
 
         // for templates using built-in base page style, set score page style to default (may be user-defined)
-        bool isBaseHeight = (std::abs(score->style().styleD(Sid::pageHeight) - DefaultStyle::baseStyle().styleD(Sid::pageHeight)) < 0.1);
         bool isBaseWidth = (std::abs(score->style().styleD(Sid::pageWidth) - DefaultStyle::baseStyle().styleD(Sid::pageWidth)) < 0.1);
-        if (isBaseHeight && isBaseWidth) {
+        bool isBaseHeight = (std::abs(score->style().styleD(Sid::pageHeight) - DefaultStyle::baseStyle().styleD(Sid::pageHeight)) < 0.1);
+        if (isBaseWidth && isBaseHeight) {
             for (auto st : pageStyles()) {
                 score->setStyleValue(st, DefaultStyle::defaultStyle().value(st));
             }

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -24,6 +24,7 @@
 #include <QFileInfo>
 
 #include "log.h"
+#include "realfn.h"
 #include "translation.h"
 
 #include "engraving/style/defaultstyle.h"
@@ -305,7 +306,7 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
         }
 
         // for templates using built-in base page style, set score page style to default (may be user-defined)
-        if (score->style().value(Sid::pageHeight) == DefaultStyle::baseStyle().value(Sid::pageHeight)) {
+        if (RealIsEqual(score->style().styleD(Sid::pageHeight), DefaultStyle::baseStyle().styleD(Sid::pageHeight)) {
             LOGE() << "base page height found: " << DefaultStyle::baseStyle().styleD(Sid::pageHeight);
             for (auto st : pageStyles()) {
                 score->setStyleValue(st, DefaultStyle::defaultStyle().value(st));

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -21,6 +21,7 @@
  */
 #include "masternotation.h"
 
+#include <cmath>
 #include <QFileInfo>
 
 #include "log.h"
@@ -306,7 +307,7 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
         }
 
         // for templates using built-in base page style, set score page style to default (may be user-defined)
-        if (RealIsEqual(score->style().styleD(Sid::pageHeight), DefaultStyle::baseStyle().styleD(Sid::pageHeight))) {
+        if (std::abs(score->style().styleD(Sid::pageHeight) - DefaultStyle::baseStyle().styleD(Sid::pageHeight)) < 0.1) {
             LOGE() << "base page height found: " << DefaultStyle::baseStyle().styleD(Sid::pageHeight);
             for (auto st : pageStyles()) {
                 score->setStyleValue(st, DefaultStyle::defaultStyle().value(st));

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -26,6 +26,9 @@
 #include "log.h"
 #include "translation.h"
 
+#include "engraving/style/defaultstyle.h"
+#include "engraving/style/pagestyle.h"
+
 #include "libmscore/factory.h"
 #include "libmscore/masterscore.h"
 #include "libmscore/part.h"
@@ -300,9 +303,9 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
             nvb->setRightMargin(tvb->rightMargin());
             nvb->setAutoSizeEnabled(tvb->isAutoSizeEnabled());
         }
-    
+
         // for templates using built-in base page style, set score page style to default (may be user-defined)
-        if (score->style()->value(Sid::pageHeight) == DefaultStyle::baseStyle().value(Sid::pageHeight)) {
+        if (score->style().value(Sid::pageHeight) == DefaultStyle::baseStyle().value(Sid::pageHeight)) {
             for (auto st : pageStyles()) {
                 score->resetStyleValue(st);
             }

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -309,7 +309,7 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
             LOGE() << "base page height found: " << DefaultStyle::baseStyle().value(Sid::pageHeight);
             for (auto st : pageStyles()) {
                 LOGE() << "resetting style value " << st << " to " << DefaultStyle::defaultStyle().value(st);
-                score->setStyleValue(DefaultStyle::defaultStyle().value(st));
+                score->setStyleValue(st, DefaultStyle::defaultStyle().value(st));
             }
         //}
     }

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -305,11 +305,13 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
         }
 
         // for templates using built-in base page style, set score page style to default (may be user-defined)
-        if (score->style().value(Sid::pageHeight) == DefaultStyle::baseStyle().value(Sid::pageHeight)) {
+        //if (score->style().value(Sid::pageHeight) == DefaultStyle::baseStyle().value(Sid::pageHeight)) {
+            LOGE() << "base page height found: " << DefaultStyle::baseStyle().value(Sid::pageHeight);
             for (auto st : pageStyles()) {
-                score->resetStyleValue(st);
+                LOGE() << "resetting style value " << st << " to " << DefaultStyle::defaultStyle().value(st);
+                score->setStyleValue(DefaultStyle::defaultStyle().value(st));
             }
-        }
+        //}
     }
 
     score->setSaved(true);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/12829

If template uses base page format (as most do), let user default override

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
