### PR TITLE
fixed #13028: More than one midi parameter can be mapped to one MU parameter

### DIFF
--- a/src/framework/shortcuts/internal/midiremote.cpp
+++ b/src/framework/shortcuts/internal/midiremote.cpp
@@ -209,6 +209,11 @@ bool MidiRemote::needIgnoreEvent(const Event& event) const
         return true;
     }
 
+    if (event.opcode() != Event::Opcode::NoteOn && event.opcode() != Event::Opcode::NoteOn
+        && event.opcode() != Event::Opcode::ControlChange) {
+        return true;
+    }
+
     static const QList<Event::Opcode> releaseOps {
         Event::Opcode::NoteOff
     };


### PR DESCRIPTION
Resolves: #13028