### PR TITLE
[MU4] Fix #14394: VST plugin on master section sounds when bypassed

### DIFF
--- a/src/framework/audio/internal/worker/mixer.cpp
+++ b/src/framework/audio/internal/worker/mixer.cpp
@@ -207,6 +207,26 @@ void Mixer::setMasterOutputParams(const AudioOutputParams& params)
         });
     }
 
+    auto findFxProcessor = [this](const std::pair<AudioFxChainOrder, AudioFxParams>& params) -> IFxProcessorPtr {
+        for (IFxProcessorPtr& fx : m_masterFxProcessors) {
+            if (fx->params().chainOrder != params.first) {
+                continue;
+            }
+
+            if (fx->params().resourceMeta == params.second.resourceMeta) {
+                return fx;
+            }
+        }
+
+        return nullptr;
+    };
+
+    for (auto it = params.fxChain.begin(); it != params.fxChain.end(); ++it) {
+        if (IFxProcessorPtr fx = findFxProcessor(*it)) {
+            fx->setActive(it->second.active);
+        }
+    }
+
     m_masterOutputParamsChanged.send(params);
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14394