### PR TITLE
Fix crash when dragging glissando

### DIFF
--- a/src/engraving/libmscore/glissando.cpp
+++ b/src/engraving/libmscore/glissando.cpp
@@ -72,7 +72,7 @@ static constexpr double GLISS_PALETTE_HEIGHT = 4.0;
 //=========================================================
 
 GlissandoSegment::GlissandoSegment(Glissando* sp, System* parent)
-    : LineSegment(ElementType::GLISSANDO_SEGMENT, sp, parent)
+    : LineSegment(ElementType::GLISSANDO_SEGMENT, sp, parent, ElementFlag::MOVABLE)
 {
 }
 

--- a/src/engraving/libmscore/line.cpp
+++ b/src/engraving/libmscore/line.cpp
@@ -218,6 +218,9 @@ void LineSegment::startDrag(EditData& ed)
 {
     SpannerSegment::startDrag(ed);
     ElementEditDataPtr eed = ed.getData(this);
+    if (!eed) {
+        return;
+    }
     eed->pushProperty(Pid::OFFSET2);
 }
 
@@ -228,6 +231,9 @@ void LineSegment::startDrag(EditData& ed)
 void LineSegment::startEditDrag(EditData& ed)
 {
     ElementEditDataPtr eed = ed.getData(this);
+    if (!eed) {
+        return;
+    }
     eed->pushProperty(Pid::OFFSET);
     eed->pushProperty(Pid::OFFSET2);
     eed->pushProperty(Pid::AUTOPLACE);


### PR DESCRIPTION
Resolves: #14426 

We assume that element data has just been created, so we use it without thinking about it. But that is not always the case; for non-movable LineSegment subclasses, no edit data will be created (see EngravingItem::startDrag, called from LineSegment::startDrag).

Adding a proper check reveals the next problem: Undoing dragging a glissando (segment) doesn't work well. Glissando segments are not marked movable, but in practice they are (is that maybe the bigger problem? Is the `MOVABLE` flag not honoured?? Anyway...). 
This causes problems: undoing a drag operation doesn't work well. To fix this, mark glissando segments as officially movable, so that the necessary data is recorded to make dragging glissando segments properly undoable.

For reference: in MS3, glissando segments were indeed not really movable. You could move them by dragging their middle grip, but if you try to move the glissando segment by dragging it itself, you end up panning the score view instead. 