### PR TITLE
gp-import: fixed ties for grace notes

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -554,8 +554,6 @@ Fraction GPConverter::convertBeat(const GPBeat* beat, ChordRestContainer& graceC
             m_chordsInMeasure[lastMeasure]++;
         }
 
-        convertNotes(beat->notes(), cr);
-
         if (!graceChords.empty()) {
             int grIndex = 0;
             for (auto [pGrChord, pBeat] : graceChords) {
@@ -572,6 +570,8 @@ Fraction GPConverter::convertBeat(const GPBeat* beat, ChordRestContainer& graceC
             }
         }
         graceChords.clear();
+
+        convertNotes(beat->notes(), cr);
 
         addTuplet(beat, cr);
         addTimer(beat, cr);


### PR DESCRIPTION
Ties of grace notes used to connect with next note, creating ties over the whole measure (see gp file)

[grace-ties.gp.zip](https://github.com/musescore/MuseScore/files/9968177/grace-ties.gp.zip)
