### PR TITLE
Don't clone header segments from score to parts

### DIFF
--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -1429,6 +1429,10 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
             TupletMap tupletMap;          // tuplets cannot cross measure boundaries
             track_idx_t dstTrack = map.at(srcTrack);
             for (Segment* oseg = m->first(); oseg; oseg = oseg->next()) {
+                if (oseg->header()) {
+                    // Generated at layout time, should not be cloned
+                    continue;
+                }
                 Segment* ns = nm->getSegment(oseg->segmentType(), oseg->tick());
                 EngravingItem* oef = oseg->element(trackZeroVoice(srcTrack));
                 if (oef && !oef->generated() && (oef->isTimeSig() || oef->isKeySig())) {

--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -1474,10 +1474,9 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                     }
 
                     for (EngravingItem* e : oseg->annotations()) {
-                        if (e->generated()) {
-                            continue;
-                        }
-                        if (e->track() != srcTrack) {
+                        if (e->generated()
+                            || (e->track() != srcTrack && !e->systemFlag()) // system items must be cloned even if they are on different tracks
+                            || (e->systemFlag() && score->nstaves() > 1)) { // ...but only once!
                             continue;
                         }
 


### PR DESCRIPTION
Resolves: #14287 

Header segments (beginBarLine, headerClef, timeSig, keySig) should not be cloned from score to parts because they are layout-dependent (and very likely will end up in different places in the part than they were in the score). More specifically, when cloning these segments we were loosing track of the `header()` flag, which was messing up with `Measure::removeSystemHeader()` and was causing these faulty spacing and mid-system headers problems. These segments are always generated at layout-time anyway, so it is unnecessary to clone them (which also saves a bit of time and reduces the number of total segments going around in parts).

<img width="550" alt="image" src="https://user-images.githubusercontent.com/93707756/201302411-5ded4584-95ce-4e46-b0dc-e1291ecbe622.png">

<img width="550" alt="image" src="https://user-images.githubusercontent.com/93707756/201302478-4186b0de-e0ed-44cf-be0f-6e94ffb2e21c.png">

Additional commit: also don't duplicate system objects when adding a new instruments to the part.

<img width="550" alt="image" src="https://user-images.githubusercontent.com/93707756/201313227-b1f088c4-aef6-42a3-abfe-e2c2b269729f.png">

