### PR TITLE
Update styles when cloning items from score to parts

### DIFF
--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -4118,6 +4118,17 @@ void Chord::setNoteEventLists(std::vector<NoteEventList>& ell)
     }
 }
 
+//---------------------------------------------------------
+//   styleChanged
+//---------------------------------------------------------
+void Chord::styleChanged()
+{
+    auto updateElementsStyle = [] (void*, EngravingItem* e) {
+        e->styleChanged();
+    };
+    scanElements(0, updateElementsStyle);
+}
+
 //---------------------------------
 // GRACE NOTES
 //---------------------------------

--- a/src/engraving/libmscore/chord.h
+++ b/src/engraving/libmscore/chord.h
@@ -336,6 +336,8 @@ public:
     void undoChangeProperty(Pid id, const PropertyValue& newValue, PropertyFlags ps) override;
 
     bool isSlurStartEnd() const;
+
+    void styleChanged() override;
 };
 } // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -670,6 +670,7 @@ void Excerpt::cloneSpanner(Spanner* s, Score* score, track_idx_t dstTrack, track
     }
 
     score->undo(new AddElement(ns));
+    ns->styleChanged();
 }
 
 static void cloneTuplets(ChordRest* ocr, ChordRest* ncr, Tuplet* ot, TupletMap& tupletMap, Measure* m, track_idx_t track)
@@ -1437,6 +1438,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                         ne->setTrack(trackZeroVoice(dstTrack));
                         ne->setParent(ns);
                         ne->setScore(score);
+                        ne->styleChanged();
                         addElement(ne);
                     }
                 }
@@ -1450,6 +1452,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                 ne->setTrack(dstTrack);
                 ne->setParent(ns);
                 ne->setScore(score);
+                ne->styleChanged();
                 addElement(ne);
                 if (oe->isChordRest()) {
                     ChordRest* ocr = toChordRest(oe);
@@ -1463,6 +1466,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                             nt->clear();
                             nt->setTrack(dstTrack);
                             nt->setParent(nm);
+                            nt->styleChanged();
                             tupletMap.add(ot, nt);
                         }
                         ncr->setTuplet(nt);
@@ -1481,6 +1485,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                         ne1->setTrack(dstTrack);
                         ne1->setParent(ns);
                         ne1->setScore(score);
+                        ne1->styleChanged();
                         addElement(ne1);
                     }
                     if (oe->isChord()) {

--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -1462,7 +1462,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                             nt = toTuplet(ot->linkedClone());
                             nt->clear();
                             nt->setTrack(dstTrack);
-                            nt->setParent(m);
+                            nt->setParent(nm);
                             tupletMap.add(ot, nt);
                         }
                         ncr->setTuplet(nt);


### PR DESCRIPTION
Resolves: #14275 

The issue is more general than just stems. In general, there can be different style settings between score and parts, so I think that every cloned elements should do a style update after cloning. The specific issue happened because stems were using the spatium of the score, which was much smaller. While researching this I also stumbled across an error with tuplets layout (the parent was set to the old measure instead of the new measure), which should be now fixed.

Update: 
Here's an example that the problem was also affecting spanners. Now fixed.
![image](https://user-images.githubusercontent.com/93707756/201345449-b90b2b21-2aad-4525-b347-4ee69ade6d72.png)

