### PR TITLE
Choose instruments: show trait name when there is only one option

### DIFF
--- a/src/instrumentsscene/view/instrumentlistmodel.cpp
+++ b/src/instrumentsscene/view/instrumentlistmodel.cpp
@@ -284,9 +284,19 @@ void InstrumentListModel::loadInstruments()
     QList<CombinedInstrument> instruments;
 
     for (const InstrumentName& instrumentName : templatesByInstrumentName.keys()) {
+        const InstrumentTemplateList& templates = templatesByInstrumentName[instrumentName];
         CombinedInstrument instrument;
-        instrument.name = instrumentName;
-        instrument.templates = templatesByInstrumentName[instrumentName];
+
+        if (templates.length() == 1) {
+            // Only one trait option so let's display it in the instrument name.
+            const InstrumentTemplate* templ = templates.at(0);
+            instrument.name = formatInstrumentTitle(instrumentName, templ->trait);
+        } else {
+            // Multiple traits to choose from so don't add any to instrument name yet.
+            instrument.name = instrumentName;
+        }
+
+        instrument.templates = templates;
         instrument.currentTemplateIndex = 0;
 
         instruments << instrument;


### PR DESCRIPTION
Fix #14150

This solves an ambiguity for instruments like the clarinet that have muliple traits (i.e. multiple transpositions, tunings or course options) in the New Score / Instruments dialog.

<img width="520" alt="image" src="https://user-images.githubusercontent.com/11011881/201235316-8c54f9de-5282-42ed-8256-f5705591d150.png">

When the genres filter is set to 'Common' rather than 'All instruments', only one clarinet transposition is available and the trait dropdown is hidden. However, this meant that the user was unable to tell which trait is being used (i.e. whether it is the clarinet in A, Bb or C, etc.). I solved this by adding the trait name to the instrument name when there is only one option.

### Before
<img width="513" alt="image" src="https://user-images.githubusercontent.com/11011881/201235975-07c96abb-eeb5-4a57-90f8-303c1b8aa5da.png">

### After
<img width="519" alt="image" src="https://user-images.githubusercontent.com/11011881/201235853-37bca5cb-cb0e-4763-94d5-8d2b24a09151.png">

 An alternative solution would be to make the trait dropdown always visible, but it would be frustrating for the user to expand a dropdown just to find that it only has one option.