### PR TITLE
Fix "Find" command

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5343,6 +5343,7 @@ void NotationInteraction::getLocation()
             score()->setPlayNote(true);
         }
         select({ e }, SelectType::SINGLE);
+        showItem(e);
     }
 }
 
@@ -5390,6 +5391,10 @@ void NotationInteraction::showItem(const mu::engraving::EngravingItem* el, int s
     } else if (el->isSpanner()) {
         EngravingItem* se = static_cast<const mu::engraving::Spanner*>(el)->startElement();
         m = static_cast<Measure*>(se->findMeasure());
+    } else if (el->isPage()) {
+        const mu::engraving::Page* p = static_cast<const mu::engraving::Page*>(el);
+        mu::engraving::System* s = !p->systems().empty() ? p->systems().front() : nullptr;
+        m = s && !s->measures().empty() ? s->measures().front() : nullptr;
     } else {
         // attempt to find measure
         mu::engraving::EngravingObject* e = el->parent();

--- a/src/notation/qml/MuseScore/NotationScene/internal/SearchPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/SearchPopup.qml
@@ -86,6 +86,10 @@ Rectangle {
             onCurrentTextEdited: function(newTextValue) {
                 model.search(newTextValue)
             }
+
+            onTextEditingFinished: function(newTextValue) {
+                privateProperties.hide();
+            }
         }
     }
 }

--- a/src/notation/view/searchpopupmodel.cpp
+++ b/src/notation/view/searchpopupmodel.cpp
@@ -37,6 +37,7 @@ void SearchPopupModel::search(const QString& text)
     mu::engraving::EngravingItem* element = notation()->elements()->search(text.toStdString());
     if (element) {
         notation()->interaction()->select({ element }, SelectType::SINGLE);
+        notation()->interaction()->showItem(element);
     } else {
         notation()->interaction()->clearSelection();
     }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/10096

Fixes the "Find" and "Get Location" commands to actually go to the selected location, and to close the search box on Esc.

The main issue preventing the command from working at all was just a missing "showItem()" call after selecting the appropriate element in the "Find" and "Get location" commands.  The failure to close the search panel on Esc was just a missing "onTextEditingFinished()" handler.  There was also missing code to handle showing a full page, so I added that to the implementation of "showItem()".

One thing this PR does not do is fix the behavior where keystrokes that represent valid editing shortcuts get passed to the score.  So hitting Enter when done with a search remains unwise - it closes the search panel, but still adds a system break to the score.  I am not sure how to fix that without changing the behavior of TextInputField, which seems dangerous, so I left that alone.  Maybe someone else can find a better fix for that.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
