### PR TITLE
Load correct style for part

### DIFF
--- a/src/engraving/style/defaultstyle.cpp
+++ b/src/engraving/style/defaultstyle.cpp
@@ -62,7 +62,7 @@ void DefaultStyle::init(const path_t& defaultStyleFilePath, const path_t& partSt
 
     if (!partStyleFilePath.empty()) {
         m_defaultStyleForParts = new MStyle();
-        bool ok = doLoadStyle(m_defaultStyleForParts, defaultStyleFilePath);
+        bool ok = doLoadStyle(m_defaultStyleForParts, partStyleFilePath);
         if (!ok) {
             delete m_defaultStyleForParts;
             m_defaultStyleForParts = nullptr;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14498

A typo in the code causes the wrong style file to be loaded if you specify a "style for part" (the general score style file is loaded instead).  This PR fixes that bug so that specifying a style for part works correctly.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
