### PR TITLE
Fix #14459: Don't adjust staves for instrument name if the staff is hidden

### DIFF
--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -274,7 +274,7 @@ double System::instrumentNamesWidth()
 
     for (staff_idx_t staffIdx = 0; staffIdx < score()->nstaves(); ++staffIdx) {
         const SysStaff* staff = this->staff(staffIdx);
-        if (!staff) {
+        if (!staff || !staff->show()) {
             continue;
         }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14459

The problem described in the issue linked above ended up being the staves adjusting for long instrument names at the start of the score even when the staff was hidden. This has been fixed so that the instrument names of hidden staves no longer factor in to the margin.