### PR TITLE
Update style after cloning element from/to part/score

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -5755,6 +5755,7 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
             } else {
                 LOGW("undoAddElement: unhandled: <%s>", element->typeName());
             }
+            ne->styleChanged();
         }
     }
 }


### PR DESCRIPTION
Resolves: #14500 

My previous PR #14463 solved the issue when _generating_ the parts. This PR fixes the issue when cloning items from parts that have been already created.
