### PR TITLE
Prevent dots on gap rests, ensure dots on full tab staves

### DIFF
--- a/src/engraving/layout/layoutchords.cpp
+++ b/src/engraving/layout/layoutchords.cpp
@@ -74,7 +74,7 @@ void LayoutChords::layoutChords1(Score* score, Segment* segment, staff_idx_t sta
     const track_idx_t partStartTrack = part ? part->startTrack() : startTrack;
     const track_idx_t partEndTrack = part ? part->endTrack() : endTrack;
 
-    if (staff->isTabStaff(tick)) {
+    if (staff && staff->isTabStaff(tick) && (!staff->staffType() || !staff->staffType()->stemThrough())) {
         layoutSegmentElements(segment, startTrack, endTrack, staffIdx);
         return;
     }

--- a/src/engraving/libmscore/notedot.cpp
+++ b/src/engraving/libmscore/notedot.cpp
@@ -58,6 +58,8 @@ void NoteDot::draw(mu::draw::Painter* painter) const
     TRACE_OBJ_DRAW;
     if (note() && note()->dotsHidden()) {     // don't draw dot if note is hidden
         return;
+    } else if (rest() && rest()->isGap()) {  // don't draw dot for gap rests
+        return;
     }
     Note* n = note();
     Fraction tick = n ? n->chord()->tick() : rest()->tick();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/13047