### PR TITLE
Fix brackets and barline in parts

### DIFF
--- a/src/engraving/libmscore/engravingobject.cpp
+++ b/src/engraving/libmscore/engravingobject.cpp
@@ -677,6 +677,22 @@ bool EngravingObject::isLinked(EngravingObject* se) const
 }
 
 //---------------------------------------------------------
+//   findLinkedInScore
+///  if exists, returns the linked object in the required
+///  score, else returns null
+//---------------------------------------------------------
+
+EngravingObject* EngravingObject::findLinkedInScore(Score* score) const
+{
+    if (score == this || !_links || _links->empty()) {
+        return nullptr;
+    }
+    auto findElem = std::find_if(_links->begin(), _links->end(),
+                                 [score](EngravingObject* engObj) { return engObj && engObj->score() == score; });
+    return findElem != _links->end() ? *findElem : nullptr;
+}
+
+//---------------------------------------------------------
 //   undoUnlink
 //---------------------------------------------------------
 

--- a/src/engraving/libmscore/engravingobject.h
+++ b/src/engraving/libmscore/engravingobject.h
@@ -295,6 +295,7 @@ public:
     void linkTo(EngravingObject*);
     void unlink();
     bool isLinked(EngravingObject* se = nullptr) const;
+    EngravingObject* findLinkedInScore(Score* score) const;
 
     virtual void undoUnlink();
     LinkedObjects* links() const { return _links; }

--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -457,6 +457,7 @@ void Excerpt::createExcerpt(Excerpt* excerpt)
     score->setPlaylistDirty();
     masterScore->rebuildMidiMapping();
     masterScore->updateChannel();
+    score->remapBracketsAndBarlines();
 
     score->setLayoutAll();
     score->doLayout();

--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -1040,7 +1040,6 @@ void Excerpt::cloneStaves(Score* sourceScore, Score* dstScore, const std::vector
     size_t n = sourceStavesIndexes.size();
     for (staff_idx_t dstStaffIdx = 0; dstStaffIdx < n; ++dstStaffIdx) {
         Staff* srcStaff = sourceScore->staff(sourceStavesIndexes[dstStaffIdx]);
-        Staff* dstStaff = dstScore->staff(dstStaffIdx);
 
         Measure* m = sourceScore->firstMeasure();
         Measure* nm = dstScore->firstMeasure();
@@ -1049,39 +1048,6 @@ void Excerpt::cloneStaves(Score* sourceScore, Score* dstScore, const std::vector
             nm->setMeasureRepeatCount(m->measureRepeatCount(srcStaff->idx()), dstStaffIdx);
             m = m->nextMeasure();
             nm = nm->nextMeasure();
-        }
-
-        if (srcStaff->isPrimaryStaff()) {
-            int span = srcStaff->barLineSpan();
-            staff_idx_t sIdx = srcStaff->idx();
-            if (dstStaffIdx == 0 && span == 0) {
-                // this is first staff of new score,
-                // but it was somewhere within a barline span in the old score
-                // so, find beginning of span
-                for (staff_idx_t i = 0; i <= sIdx; ++i) {
-                    span = sourceScore->staff(i)->barLineSpan();
-                    if (i + span > sIdx) {
-                        sIdx = i;
-                        break;
-                    }
-                }
-            }
-            staff_idx_t eIdx = sIdx + span;
-            for (staff_idx_t staffIdx = sIdx; staffIdx < eIdx; ++staffIdx) {
-                if (!mu::contains(sourceStavesIndexes, staffIdx)) {
-                    --span;
-                }
-            }
-            if (dstStaffIdx + span > n) {
-                span = static_cast<int>(n - dstStaffIdx - 1);
-            }
-            dstStaff->setBarLineSpan(span);
-            int idx = 0;
-            for (BracketItem* bi : srcStaff->brackets()) {
-                dstStaff->setBracketType(idx, bi->bracketType());
-                dstStaff->setBracketSpan(idx, bi->bracketSpan());
-                ++idx;
-            }
         }
     }
 

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -971,6 +971,7 @@ public:
     void setScoreOrder(ScoreOrder order);
     void updateBracesAndBarlines(Part* part, size_t index);
     void setBracketsAndBarlines();
+    void remapBracketsAndBarlines();
 
     void lassoSelect(const mu::RectF&);
     void lassoSelectEnd();

--- a/src/engraving/libmscore/staff.cpp
+++ b/src/engraving/libmscore/staff.cpp
@@ -1279,13 +1279,6 @@ void Staff::init(const Staff* s)
     _id                = s->_id;
     _staffTypeList     = s->_staffTypeList;
     setDefaultClefType(s->defaultClefType());
-    for (BracketItem* i : s->_brackets) {
-        BracketItem* ni = new BracketItem(*i);
-        ni->setScore(score());
-        ni->setStaff(this);
-        _brackets.push_back(ni);
-    }
-    _barLineSpan       = s->_barLineSpan;
     _barLineFrom       = s->_barLineFrom;
     _barLineTo         = s->_barLineTo;
     _hideWhenEmpty     = s->_hideWhenEmpty;

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -778,6 +778,9 @@ void NotationParts::doInsertPart(Part* part, size_t index)
 
         mu::engraving::Excerpt::cloneStaff2(staff, staffCopy, startTick, endTick);
     }
+
+    part->setScore(score());
+    score()->remapBracketsAndBarlines();
 }
 
 void NotationParts::removeStaves(const IDList& stavesIds)


### PR DESCRIPTION
Resolves: #14210

Currently, system brackets and barlines extensions are mapped on a staff-by-staff basis when cloning staves from score to parts. It is impossible for this to work correctly, because many of the staves that are spanned by a given bracket or barline in the score may literally not exist in the parts, and indeed we run into all kinds of trouble:
If the first staff of the bracket isn't in the part, the bracket will not be cloned:
<img height="200" alt="image" src="https://user-images.githubusercontent.com/93707756/202215298-5d7098e4-027b-4a45-9d6d-993fafb1e490.png"> <img height="200" alt="image" src="https://user-images.githubusercontent.com/93707756/202215550-f4da7bb3-9097-4231-b3b6-20e40dc2a98d.png">

If the first staff of the bracket _is_ in the part, the bracket will be cloned but will span as many staves as it does in the score, leading to incorrect layout in the part:
<img height="200" alt="image" src="https://user-images.githubusercontent.com/93707756/202216024-c697d493-5fb8-4517-ae7b-cd04f013aae5.png">


Barlines can become wrongly connected:
<img height="200" alt="image" src="https://user-images.githubusercontent.com/93707756/202217188-b5a132e1-2340-46fc-bffb-a65e9a17de07.png">


The only reliable way to correctly map brackets and barlines from score to parts is to map them on a score-by-score basis (basically, look at brackets and barlines in the score, see how many of the spanned staves are also present in the part, and adapt accordingly). This has to be done when the part is generate or when a new instrument is added to it.

Edit:
The last commit also resolves #15006 , which had wrong barline extensions on piano at score creation.

Edit-edit:
Last commit has been moved to separate PR.