### PR TITLE
Fix -Wlogical-op-parentheses warning

### DIFF
--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -382,7 +382,7 @@ Shape SlurSegment::getSegmentShape(Segment* seg, ChordRest* startCR, ChordRest* 
         segShape.add(secondStaffShape);
     }
     // Remove items that the slur shouldn't try to avoid
-    mu::remove_if(segShape, [&](ShapeElement& shapeEl){
+    mu::remove_if(segShape, [&](ShapeElement& shapeEl) {
         if (!shapeEl.toItem || !shapeEl.toItem->parentItem()) {
             return true;
         }
@@ -1303,7 +1303,7 @@ void Slur::slurPos(SlurPos* sp)
 
             // adjustments for stem and/or beam
             Tremolo* trem = ec ? ec->tremolo() : nullptr;
-            if (stem2 || trem && trem->twoNotes()) {       //ec can't be null
+            if (stem2 || (trem && trem->twoNotes())) {       //ec can't be null
                 Beam* beam2 = ec->beam();
                 if ((stemPos && (scr->up() == ec->up()))
                     || (beam2


### PR DESCRIPTION
Fixes a compiler warning introduced in https://github.com/musescore/MuseScore/commit/b2ad2e02fead91a4c07a1cbd5628b0b5ae18b034

My bad!