### PR TITLE
Fix #13487: Retain MU3 behavior by hiding dots when notehead (or rest) is hidden

### DIFF
--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -46,6 +46,7 @@
 #include "mscore.h"
 #include "navigate.h"
 #include "note.h"
+#include "notedot.h"
 #include "noteevent.h"
 #include "part.h"
 #include "score.h"
@@ -1392,6 +1393,9 @@ void Chord::processSiblings(std::function<void(EngravingItem*)> func) const
     }
     for (Note* note : _notes) {
         func(note);
+        for (NoteDot* noteDot : note->dots()) {
+            func(noteDot);
+        }
     }
     for (Chord* chord : _graceNotes) {    // process grace notes last, needed for correct shape calculation
         func(chord);

--- a/src/engraving/libmscore/rest.cpp
+++ b/src/engraving/libmscore/rest.cpp
@@ -1091,6 +1091,21 @@ bool Rest::setProperty(Pid propertyId, const PropertyValue& v)
     return true;
 }
 
+void Rest::undoChangeProperty(Pid id, const PropertyValue& newValue)
+{
+    undoChangeProperty(id, newValue, propertyFlags(id));
+}
+
+void Rest::undoChangeProperty(Pid id, const PropertyValue& newValue, PropertyFlags ps)
+{
+    if (id == Pid::VISIBLE) {
+        for (NoteDot* nd : m_dots) {
+            nd->undoChangeProperty(id, newValue, ps);
+        }
+    }
+    EngravingItem::undoChangeProperty(id, newValue, ps);
+}
+
 //---------------------------------------------------------
 //   undoChangeDotsVisible
 //---------------------------------------------------------

--- a/src/engraving/libmscore/rest.h
+++ b/src/engraving/libmscore/rest.h
@@ -98,6 +98,8 @@ public:
     bool setProperty(Pid propertyId, const PropertyValue& v) override;
     PropertyValue getProperty(Pid propertyId) const override;
     void undoChangeDotsVisible(bool v);
+    void undoChangeProperty(Pid id, const PropertyValue& newValue);
+    void undoChangeProperty(Pid id, const PropertyValue& newValue, PropertyFlags ps) override;
 
     EngravingItem* nextElement() override;
     EngravingItem* prevElement() override;

--- a/src/inspector/internal/services/elementrepositoryservice.cpp
+++ b/src/inspector/internal/services/elementrepositoryservice.cpp
@@ -22,6 +22,8 @@
 #include "elementrepositoryservice.h"
 
 #include "chord.h"
+#include "rest.h"
+#include "notedot.h"
 #include "stem.h"
 #include "hook.h"
 #include "beam.h"
@@ -154,6 +156,25 @@ const
         if (elementType == mu::engraving::ElementType::BRACKET) {
             resultList << mu::engraving::toBracket(element)->bracketItem();
             continue;
+        }
+
+        if (elementType == mu::engraving::ElementType::NOTEDOT) {
+            mu::engraving::EngravingItem* parent = element->elementBase();
+            if (parent && parent->isNote()) {
+                mu::engraving::Note* note = mu::engraving::toNote(parent);
+                for (mu::engraving::NoteDot* dot : note->dots()) {
+                    resultList << dot;
+                }
+                continue;
+            } else if (parent && parent->isRest()) {
+                mu::engraving::Rest* rest = mu::engraving::toRest(parent);
+                for (int n = 0; n < rest->dots(); ++n) {
+                    if (mu::engraving::NoteDot* dot = rest->dot(n)) {
+                        resultList << dot;
+                    }
+                }
+                continue;
+            }
         }
 
         if (!resultList.contains(element->elementBase())) {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/13487