### PR TITLE
[MU4] fix #14588: Crash when open a score with plugin on Master channel which not installed in the current system 

### DIFF
--- a/src/framework/vst/internal/fx/vstfxresolver.cpp
+++ b/src/framework/vst/internal/fx/vstfxresolver.cpp
@@ -177,7 +177,9 @@ void VstFxResolver::updateMasterFxMap(const AudioFxChain& newFxChain)
     fxChainToCreate(currentFxChain, newFxChain, fxToCreate);
 
     for (const auto& pair : fxToCreate) {
-        m_masterFxMap.emplace(pair.first, createMasterFx(pair.second));
+        if (VstFxPtr fx = createMasterFx(pair.second)) {
+            m_masterFxMap.emplace(pair.first, fx);
+        }
     }
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14588