### PR TITLE
Add missing error dialogs that should be the result of MScore errors

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -23,6 +23,8 @@
 #include <map>
 #include <set>
 
+#include "infrastructure/messagebox.h"
+
 #include "accidental.h"
 #include "articulation.h"
 #include "barline.h"
@@ -243,7 +245,9 @@ Tuplet* Score::addTuplet(ChordRest* destinationChordRest, Fraction ratio, Tuplet
 
     Fraction fr = f * Fraction(1, _ratio.denominator());
     if (!TDuration::isValid(fr)) {
-        // todo: there needs to be some kind of user feedback for failure to add tuplet
+        MessageBox::warning(mtrc("engraving", "Cannot create tuplet with ratio %1 for duration %2")
+                            .arg(_ratio.toString(), f.toString()).toStdString(),
+                            std::string(), { MessageBox::Ok });
         return nullptr;
     }
 

--- a/src/engraving/libmscore/mscore.cpp
+++ b/src/engraving/libmscore/mscore.cpp
@@ -125,4 +125,38 @@ void MScore::registerUiTypes()
 
 #endif
 }
+
+std::string MScore::errorToString(MsError err)
+{
+    switch (err) {
+    case MsError::MS_NO_ERROR: return "MS_NO_ERROR";
+    case MsError::NO_NOTE_SELECTED: return "NO_NOTE_SELECTED";
+    case MsError::NO_CHORD_REST_SELECTED: return "NO_CHORD_REST_SELECTED";
+    case MsError::NO_LYRICS_SELECTED: return "NO_LYRICS_SELECTED";
+    case MsError::NO_NOTE_REST_SELECTED: return "NO_NOTE_REST_SELECTED";
+    case MsError::NO_FLIPPABLE_SELECTED: return "NO_FLIPPABLE_SELECTED";
+    case MsError::NO_STAFF_SELECTED: return "NO_STAFF_SELECTED";
+    case MsError::NO_NOTE_FIGUREDBASS_SELECTED: return "NO_NOTE_FIGUREDBASS_SELECTED";
+    case MsError::CANNOT_INSERT_TUPLET: return "CANNOT_INSERT_TUPLET";
+    case MsError::CANNOT_SPLIT_TUPLET: return "CANNOT_SPLIT_TUPLET";
+    case MsError::CANNOT_SPLIT_MEASURE_FIRST_BEAT: return "CANNOT_SPLIT_MEASURE_FIRST_BEAT";
+    case MsError::CANNOT_SPLIT_MEASURE_TUPLET: return "CANNOT_SPLIT_MEASURE_TUPLET";
+    case MsError::INSUFFICIENT_MEASURES: return "INSUFFICIENT_MEASURES";
+    case MsError::CANNOT_SPLIT_MEASURE_REPEAT: return "CANNOT_SPLIT_MEASURE_REPEAT";
+    case MsError::CANNOT_SPLIT_MEASURE_TOO_SHORT: return "CANNOT_SPLIT_MEASURE_TOO_SHORT";
+    case MsError::CANNOT_REMOVE_TIME_TUPLET: return "CANNOT_REMOVE_TIME_TUPLET";
+    case MsError::CANNOT_REMOVE_TIME_MEASURE_REPEAT: return "CANNOT_REMOVE_TIME_MEASURE_REPEAT";
+    case MsError::NO_DEST: return "NO_DEST";
+    case MsError::DEST_TUPLET: return "DEST_TUPLET";
+    case MsError::TUPLET_CROSSES_BAR: return "TUPLET_CROSSES_BAR";
+    case MsError::DEST_LOCAL_TIME_SIGNATURE: return "DEST_LOCAL_TIME_SIGNATURE";
+    case MsError::DEST_TREMOLO: return "DEST_TREMOLO";
+    case MsError::NO_MIME: return "NO_MIME";
+    case MsError::DEST_NO_CR: return "DEST_NO_CR";
+    case MsError::CANNOT_CHANGE_LOCAL_TIMESIG: return "CANNOT_CHANGE_LOCAL_TIMESIG";
+    case MsError::CORRUPTED_MEASURE: return "CORRUPTED_MEASURE";
+    }
+
+    return {};
+}
 }

--- a/src/engraving/libmscore/mscore.h
+++ b/src/engraving/libmscore/mscore.h
@@ -280,6 +280,8 @@ public:
     static double horizontalPageGapOdd;
 
     static void setError(MsError e) { _error = e; }
+
+    static std::string errorToString(MsError err);
 };
 } // namespace mu::engraving
 

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -174,8 +174,8 @@ public:
     virtual bool needToShowAddFiguredBassErrorMessage() const = 0;
     virtual void setNeedToShowAddFiguredBassErrorMessage(bool show) = 0;
 
-    virtual bool needToShowAddBoxesErrorMessage() const = 0;
-    virtual void setNeedToShowAddBoxesErrorMessage(bool show) = 0;
+    virtual bool needToShowMScoreError(const std::string& errorKey) const = 0;
+    virtual void setNeedToShowMScoreError(const std::string& errorKey, bool show) = 0;
 
     virtual ValCh<int> pianoKeyboardNumberOfKeys() const = 0;
     virtual void setPianoKeyboardNumberOfKeys(int number) = 0;

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -83,7 +83,6 @@ static const Settings::Key VERTICAL_GRID_SIZE_KEY(module_name,  "ui/application/
 
 static const Settings::Key NEED_TO_SHOW_ADD_TEXT_ERROR_MESSAGE_KEY(module_name,  "ui/dialogs/needToShowAddTextErrorMessage");
 static const Settings::Key NEED_TO_SHOW_ADD_FIGURED_BASS_ERROR_MESSAGE_KEY(module_name,  "ui/dialogs/needToShowAddFiguredBassErrorMessage");
-static const Settings::Key NEED_TO_SHOW_ADD_BOXES_ERROR_MESSAGE_KEY(module_name,  "ui/dialogs/needToShowAddBoxesErrorMessage");
 
 static const Settings::Key PIANO_KEYBOARD_NUMBER_OF_KEYS(module_name,  "pianoKeyboard/numberOfKeys");
 
@@ -196,7 +195,6 @@ void NotationConfiguration::init()
 
     settings()->setDefaultValue(NEED_TO_SHOW_ADD_TEXT_ERROR_MESSAGE_KEY, Val(true));
     settings()->setDefaultValue(NEED_TO_SHOW_ADD_FIGURED_BASS_ERROR_MESSAGE_KEY, Val(true));
-    settings()->setDefaultValue(NEED_TO_SHOW_ADD_BOXES_ERROR_MESSAGE_KEY, Val(true));
 
     settings()->setDefaultValue(PIANO_KEYBOARD_NUMBER_OF_KEYS, Val(88));
     m_pianoKeyboardNumberOfKeys.val = settings()->value(PIANO_KEYBOARD_NUMBER_OF_KEYS).toInt();
@@ -789,14 +787,19 @@ void NotationConfiguration::setNeedToShowAddFiguredBassErrorMessage(bool show)
     settings()->setSharedValue(NEED_TO_SHOW_ADD_FIGURED_BASS_ERROR_MESSAGE_KEY, Val(show));
 }
 
-bool NotationConfiguration::needToShowAddBoxesErrorMessage() const
+bool NotationConfiguration::needToShowMScoreError(const std::string& errorKey) const
 {
-    return settings()->value(NEED_TO_SHOW_ADD_BOXES_ERROR_MESSAGE_KEY).toBool();
+    Settings::Key key(module_name, "ui/dialogs/needToShowMScoreError/" + errorKey);
+
+    settings()->setDefaultValue(key, Val(true));
+
+    return settings()->value(key).toBool();
 }
 
-void NotationConfiguration::setNeedToShowAddBoxesErrorMessage(bool show)
+void NotationConfiguration::setNeedToShowMScoreError(const std::string& errorKey, bool show)
 {
-    settings()->setSharedValue(NEED_TO_SHOW_ADD_BOXES_ERROR_MESSAGE_KEY, Val(show));
+    Settings::Key key(module_name, "ui/dialogs/needToShowMScoreError/" + errorKey);
+    settings()->setSharedValue(key, Val(show));
 }
 
 ValCh<int> NotationConfiguration::pianoKeyboardNumberOfKeys() const

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -178,8 +178,8 @@ public:
     bool needToShowAddFiguredBassErrorMessage() const override;
     void setNeedToShowAddFiguredBassErrorMessage(bool show) override;
 
-    bool needToShowAddBoxesErrorMessage() const override;
-    void setNeedToShowAddBoxesErrorMessage(bool show) override;
+    bool needToShowMScoreError(const std::string& errorKey) const override;
+    void setNeedToShowMScoreError(const std::string& errorKey, bool show) override;
 
     ValCh<int> pianoKeyboardNumberOfKeys() const override;
     void setPianoKeyboardNumberOfKeys(int number) override;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -218,6 +218,38 @@ void NotationInteraction::rollback()
     m_undoStack->rollbackChanges();
 }
 
+static std::string MScoreErrorToString(MsError err)
+{
+    switch (err) {
+    case MsError::MS_NO_ERROR: return "MS_NO_ERROR";
+    case MsError::NO_LYRICS_SELECTED: return "NO_LYRICS_SELECTED";
+    case MsError::NO_NOTE_REST_SELECTED: return "NO_NOTE_REST_SELECTED";
+    case MsError::NO_FLIPPABLE_SELECTED: return "NO_FLIPPABLE_SELECTED";
+    case MsError::NO_STAFF_SELECTED: return "NO_STAFF_SELECTED";
+    case MsError::NO_NOTE_FIGUREDBASS_SELECTED: return "NO_NOTE_FIGUREDBASS_SELECTED";
+    case MsError::CANNOT_INSERT_TUPLET: return "CANNOT_INSERT_TUPLET";
+    case MsError::CANNOT_SPLIT_TUPLET: return "CANNOT_SPLIT_TUPLET";
+    case MsError::CANNOT_SPLIT_MEASURE_FIRST_BEAT: return "CANNOT_SPLIT_MEASURE_FIRST_BEAT";
+    case MsError::CANNOT_SPLIT_MEASURE_TUPLET: return "CANNOT_SPLIT_MEASURE_TUPLET";
+    case MsError::INSUFFICIENT_MEASURES: return "INSUFFICIENT_MEASURES";
+    case MsError::CANNOT_SPLIT_MEASURE_REPEAT: return "CANNOT_SPLIT_MEASURE_REPEAT";
+    case MsError::CANNOT_SPLIT_MEASURE_TOO_SHORT: return "CANNOT_SPLIT_MEASURE_TOO_SHORT";
+    case MsError::CANNOT_REMOVE_TIME_TUPLET: return "CANNOT_REMOVE_TIME_TUPLET";
+    case MsError::CANNOT_REMOVE_TIME_MEASURE_REPEAT: return "CANNOT_REMOVE_TIME_MEASURE_REPEAT";
+    case MsError::NO_DEST: return "NO_DEST";
+    case MsError::DEST_TUPLET: return "DEST_TUPLET";
+    case MsError::TUPLET_CROSSES_BAR: return "TUPLET_CROSSES_BAR";
+    case MsError::DEST_LOCAL_TIME_SIGNATURE: return "DEST_LOCAL_TIME_SIGNATURE";
+    case MsError::DEST_TREMOLO: return "DEST_TREMOLO";
+    case MsError::NO_MIME: return "NO_MIME";
+    case MsError::DEST_NO_CR: return "DEST_NO_CR";
+    case MsError::CANNOT_CHANGE_LOCAL_TIMESIG: return "CANNOT_CHANGE_LOCAL_TIMESIG";
+    case MsError::CORRUPTED_MEASURE: return "CORRUPTED_MEASURE";
+    }
+
+    return {};
+}
+
 void NotationInteraction::checkAndShowMScoreError() const
 {
     TRACEFUNC;
@@ -228,6 +260,10 @@ void NotationInteraction::checkAndShowMScoreError() const
     }
 
     MScore::setError(MsError::MS_NO_ERROR); // reset
+
+    if (!configuration()->needToShowMScoreError(MScoreErrorToString(err))) {
+        return;
+    }
 
     std::string title;
     std::string message;
@@ -318,7 +354,11 @@ void NotationInteraction::checkAndShowMScoreError() const
         break;
     }
 
-    interactive()->error(title, message);
+    IInteractive::Result result
+        = interactive()->info(title, message, {}, 0, IInteractive::Option::WithIcon | IInteractive::Option::WithDontShowAgainCheckBox);
+    if (!result.showAgain()) {
+        configuration()->setNeedToShowMScoreError(MScoreErrorToString(err), false);
+    }
 }
 
 void NotationInteraction::notifyAboutDragChanged()

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -163,6 +163,8 @@ NotationInteraction::NotationInteraction(Notation* notation, INotationUndoStackP
 
     m_undoStack->stackChanged().onNotify(this, [this]() {
         notifyAboutSelectionChangedIfNeed();
+
+        checkAndShowMScoreError();
     });
 
     m_dragData.ed = mu::engraving::EditData(&m_scoreCallbacks);
@@ -214,6 +216,109 @@ void NotationInteraction::apply()
 void NotationInteraction::rollback()
 {
     m_undoStack->rollbackChanges();
+}
+
+void NotationInteraction::checkAndShowMScoreError() const
+{
+    TRACEFUNC;
+
+    MsError err = MScore::_error;
+    if (err == MsError::MS_NO_ERROR) {
+        return;
+    }
+
+    MScore::setError(MsError::MS_NO_ERROR); // reset
+
+    std::string title;
+    std::string message;
+
+    switch (err) {
+    case MsError::MS_NO_ERROR:
+        return;
+    case MsError::NO_LYRICS_SELECTED:
+        title = trc("notation", "No note or lyrics selected");
+        message = trc("notation", "Please select a note or lyrics and retry");
+        break;
+    case MsError::NO_NOTE_REST_SELECTED:
+        title = trc("notation", "No note or rest selected");
+        message = trc("notation", "Please select a note or rest and retry");
+        break;
+    case MsError::NO_FLIPPABLE_SELECTED:
+        title = trc("notation", "No flippable element selected");
+        message = trc("notation", "Please select an element that can be flipped and retry");
+        break;
+    case MsError::NO_STAFF_SELECTED:
+        title = trc("notation", "No staff selected");
+        message = trc("notation", "Please select one or more staves and retry");
+        break;
+    case MsError::NO_NOTE_FIGUREDBASS_SELECTED:
+        title = trc("notation", "No note or figured bass selected");
+        message = trc("notation", "Please select a note or figured bass and retry");
+        break;
+    case MsError::CANNOT_INSERT_TUPLET:
+        title = trc("notation", "Cannot insert chord/rest in tuplet");
+        break;
+    case MsError::CANNOT_SPLIT_TUPLET:
+        title = trc("notation", "Cannot split tuplet");
+        break;
+    case MsError::CANNOT_SPLIT_MEASURE_FIRST_BEAT:
+        title = trc("notation", "Cannot split measure at the first beat");
+        break;
+    case MsError::CANNOT_SPLIT_MEASURE_TUPLET:
+        title = trc("notation", "Cannot split measure here");
+        message = trc("notation", "Cannot split tuplet");
+        break;
+    case MsError::INSUFFICIENT_MEASURES:
+        title = trc("notation", "Cannot create measure repeat here");
+        message = trc("notation", "Insufficient or unequal measures");
+        break;
+    case MsError::CANNOT_SPLIT_MEASURE_REPEAT:
+        title = trc("notation", "Cannot split measure repeat");
+        message = trc("notation", "Please select a note or rest and retry");
+        break;
+    case MsError::CANNOT_SPLIT_MEASURE_TOO_SHORT:
+        title = trc("notation", "No note or rest selected");
+        message = trc("notation", "Please select a note or rest and retry");
+        break;
+    case MsError::CANNOT_REMOVE_TIME_TUPLET:
+        title = trc("notation", "Cannot remove time from tuplet");
+        message = trc("notation", "Please select the complete tuplet and retry");
+        break;
+    case MsError::CANNOT_REMOVE_TIME_MEASURE_REPEAT:
+        title = trc("notation", "Cannot remove time from measure repeat");
+        message = trc("notation", "Please select the complete measure repeat and retry");
+        break;
+    case MsError::NO_DEST:
+        title = trc("notation", "No destination to paste");
+        break;
+    case MsError::DEST_TUPLET:
+        title = trc("notation", "Cannot paste into tuplet");
+        break;
+    case MsError::TUPLET_CROSSES_BAR:
+        title = trc("notation", "Tuplet cannot cross barlines");
+        break;
+    case MsError::DEST_LOCAL_TIME_SIGNATURE:
+        title = trc("notation", "Cannot paste in local time signature");
+        break;
+    case MsError::DEST_TREMOLO:
+        title = trc("notation", "Cannot paste in tremolo");
+        break;
+    case MsError::NO_MIME:
+        title = trc("notation", "Nothing to paste");
+        break;
+    case MsError::DEST_NO_CR:
+        title = trc("notation", "Destination is not a chord or rest");
+        break;
+    case MsError::CANNOT_CHANGE_LOCAL_TIMESIG:
+        title = trc("notation", "Cannot change local time signature");
+        message = trc("notation", "Measure is not empty");
+        break;
+    case MsError::CORRUPTED_MEASURE:
+        title = trc("notation", "Cannot change time signature in front of a corrupted measure");
+        break;
+    }
+
+    interactive()->error(title, message);
 }
 
 void NotationInteraction::notifyAboutDragChanged()

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -163,8 +163,6 @@ NotationInteraction::NotationInteraction(Notation* notation, INotationUndoStackP
 
     m_undoStack->stackChanged().onNotify(this, [this]() {
         notifyAboutSelectionChangedIfNeed();
-
-        checkAndShowMScoreError();
     });
 
     m_dragData.ed = mu::engraving::EditData(&m_scoreCallbacks);
@@ -1189,6 +1187,8 @@ void NotationInteraction::endDrag()
     apply();
     notifyAboutDragChanged();
 
+    checkAndShowMScoreError();
+
     //    updateGrips();
     //    if (editData.element->normalModeEditBehavior() == EngravingItem::EditBehavior::Edit
     //        && score()->selection().element() == editData.element) {
@@ -1570,6 +1570,8 @@ bool NotationInteraction::drop(const PointF& pos, Qt::KeyboardModifiers modifier
         notifyAboutDropChanged();
     }
 
+    checkAndShowMScoreError();
+
     return accepted;
 }
 
@@ -1908,6 +1910,8 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
     apply();
 
     setDropTarget(nullptr);
+
+    checkAndShowMScoreError();
 
     return true;
 }
@@ -3348,6 +3352,8 @@ void NotationInteraction::splitSelectedMeasure()
     startEdit();
     score()->cmdSplitMeasure(chordRest);
     apply();
+
+    checkAndShowMScoreError();
 }
 
 void NotationInteraction::joinSelectedMeasures()
@@ -3361,6 +3367,8 @@ void NotationInteraction::joinSelectedMeasures()
     startEdit();
     score()->cmdJoinMeasure(measureRange.startMeasure, measureRange.endMeasure);
     apply();
+
+    checkAndShowMScoreError();
 }
 
 mu::Ret NotationInteraction::canAddBoxes() const
@@ -3602,6 +3610,8 @@ void NotationInteraction::pasteSelection(const Fraction& scale)
         score()->cmdPaste(&ma, nullptr, scale);
     }
     apply();
+
+    checkAndShowMScoreError();
 }
 
 void NotationInteraction::swapSelection()

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -216,40 +216,6 @@ void NotationInteraction::rollback()
     m_undoStack->rollbackChanges();
 }
 
-static std::string MScoreErrorToString(MsError err)
-{
-    switch (err) {
-    case MsError::MS_NO_ERROR: return "MS_NO_ERROR";
-    case MsError::NO_NOTE_SELECTED: return "NO_NOTE_SELECTED";
-    case MsError::NO_CHORD_REST_SELECTED: return "NO_CHORD_REST_SELECTED";
-    case MsError::NO_LYRICS_SELECTED: return "NO_LYRICS_SELECTED";
-    case MsError::NO_NOTE_REST_SELECTED: return "NO_NOTE_REST_SELECTED";
-    case MsError::NO_FLIPPABLE_SELECTED: return "NO_FLIPPABLE_SELECTED";
-    case MsError::NO_STAFF_SELECTED: return "NO_STAFF_SELECTED";
-    case MsError::NO_NOTE_FIGUREDBASS_SELECTED: return "NO_NOTE_FIGUREDBASS_SELECTED";
-    case MsError::CANNOT_INSERT_TUPLET: return "CANNOT_INSERT_TUPLET";
-    case MsError::CANNOT_SPLIT_TUPLET: return "CANNOT_SPLIT_TUPLET";
-    case MsError::CANNOT_SPLIT_MEASURE_FIRST_BEAT: return "CANNOT_SPLIT_MEASURE_FIRST_BEAT";
-    case MsError::CANNOT_SPLIT_MEASURE_TUPLET: return "CANNOT_SPLIT_MEASURE_TUPLET";
-    case MsError::INSUFFICIENT_MEASURES: return "INSUFFICIENT_MEASURES";
-    case MsError::CANNOT_SPLIT_MEASURE_REPEAT: return "CANNOT_SPLIT_MEASURE_REPEAT";
-    case MsError::CANNOT_SPLIT_MEASURE_TOO_SHORT: return "CANNOT_SPLIT_MEASURE_TOO_SHORT";
-    case MsError::CANNOT_REMOVE_TIME_TUPLET: return "CANNOT_REMOVE_TIME_TUPLET";
-    case MsError::CANNOT_REMOVE_TIME_MEASURE_REPEAT: return "CANNOT_REMOVE_TIME_MEASURE_REPEAT";
-    case MsError::NO_DEST: return "NO_DEST";
-    case MsError::DEST_TUPLET: return "DEST_TUPLET";
-    case MsError::TUPLET_CROSSES_BAR: return "TUPLET_CROSSES_BAR";
-    case MsError::DEST_LOCAL_TIME_SIGNATURE: return "DEST_LOCAL_TIME_SIGNATURE";
-    case MsError::DEST_TREMOLO: return "DEST_TREMOLO";
-    case MsError::NO_MIME: return "NO_MIME";
-    case MsError::DEST_NO_CR: return "DEST_NO_CR";
-    case MsError::CANNOT_CHANGE_LOCAL_TIMESIG: return "CANNOT_CHANGE_LOCAL_TIMESIG";
-    case MsError::CORRUPTED_MEASURE: return "CORRUPTED_MEASURE";
-    }
-
-    return {};
-}
-
 void NotationInteraction::checkAndShowMScoreError() const
 {
     TRACEFUNC;
@@ -261,7 +227,7 @@ void NotationInteraction::checkAndShowMScoreError() const
 
     MScore::setError(MsError::MS_NO_ERROR); // reset
 
-    if (!configuration()->needToShowMScoreError(MScoreErrorToString(err))) {
+    if (!configuration()->needToShowMScoreError(MScore::errorToString(err))) {
         return;
     }
 
@@ -365,7 +331,7 @@ void NotationInteraction::checkAndShowMScoreError() const
     IInteractive::Result result
         = interactive()->info(title, message, {}, 0, IInteractive::Option::WithIcon | IInteractive::Option::WithDontShowAgainCheckBox);
     if (!result.showAgain()) {
-        configuration()->setNeedToShowMScoreError(MScoreErrorToString(err), false);
+        configuration()->setNeedToShowMScoreError(MScore::errorToString(err), false);
     }
 }
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -220,6 +220,8 @@ static std::string MScoreErrorToString(MsError err)
 {
     switch (err) {
     case MsError::MS_NO_ERROR: return "MS_NO_ERROR";
+    case MsError::NO_NOTE_SELECTED: return "NO_NOTE_SELECTED";
+    case MsError::NO_CHORD_REST_SELECTED: return "NO_CHORD_REST_SELECTED";
     case MsError::NO_LYRICS_SELECTED: return "NO_LYRICS_SELECTED";
     case MsError::NO_NOTE_REST_SELECTED: return "NO_NOTE_REST_SELECTED";
     case MsError::NO_FLIPPABLE_SELECTED: return "NO_FLIPPABLE_SELECTED";
@@ -269,6 +271,14 @@ void NotationInteraction::checkAndShowMScoreError() const
     switch (err) {
     case MsError::MS_NO_ERROR:
         return;
+    case MsError::NO_NOTE_SELECTED:
+        title = trc("notation", "No note selected");
+        message = trc("notation", "Please select a note and retry");
+        break;
+    case MsError::NO_CHORD_REST_SELECTED:
+        title = trc("notation", "No chord/rest selected");
+        message = trc("notation", "Please select a chord or rest and retry");
+        break;
     case MsError::NO_LYRICS_SELECTED:
         title = trc("notation", "No note or lyrics selected");
         message = trc("notation", "Please select a note or lyrics and retry");

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -27,6 +27,7 @@
 
 #include "modularity/ioc.h"
 #include "async/asyncable.h"
+#include "iinteractive.h"
 
 #include "inotationinteraction.h"
 #include "inotationconfiguration.h"
@@ -50,6 +51,7 @@ class NotationInteraction : public INotationInteraction, public async::Asyncable
 {
     INJECT(notation, INotationConfiguration, configuration)
     INJECT(notation, ISelectInstrumentsScenario, selectInstrumentScenario)
+    INJECT(notation, framework::IInteractive, interactive)
 
 public:
     NotationInteraction(Notation* notation, INotationUndoStackPtr undoStack);
@@ -285,6 +287,8 @@ private:
     void startEdit();
     void apply();
     void rollback();
+
+    void checkAndShowMScoreError() const;
 
     bool needStartEditGrip(QKeyEvent* event) const;
     bool handleKeyPress(QKeyEvent* event);


### PR DESCRIPTION
Resolves: #12887

The error handling in MS3 was relatively straightforward: when an error occurred, this was stored in MScore and the at the end of the current command, the command would be rolled back in Score::endCmd. Then, there's some other method that is _also_ called after every command, which checks the error and displays them. It was perhaps not the most sophisticated system, but at least somewhat consistent. 

In MS4, it has become quite a mess. We added some ad-hoc error handling methods, and some "error prevention", sometimes with or without appropriate UI message. The MScore error field was not checked, resulting in a lot of missing UI messages. 

To some extent, I'm bringing back the MScore error checking, and removing some of the ad-hoc logic. It is certainly not beautiful, and in the future we must come up with something more clever, but at least it brings back the missing error dialogs for 4.0.