### PR TITLE
Inspector: Fix the "Stemless" property

### DIFF
--- a/src/inspector/CMakeLists.txt
+++ b/src/inspector/CMakeLists.txt
@@ -180,6 +180,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/models/notation/notes/beams/beamsettingsmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/models/notation/notes/beams/internal/beammodesmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/models/notation/notes/beams/internal/beammodesmodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/models/notation/notes/chords/chordsettingsmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/models/notation/notes/chords/chordsettingsmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/models/notation/notes/hooks/hooksettingsmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/models/notation/notes/hooks/hooksettingsmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/models/notation/notes/noteheads/noteheadsettingsmodel.cpp

--- a/src/inspector/models/abstractinspectormodel.h
+++ b/src/inspector/models/abstractinspectormodel.h
@@ -69,6 +69,7 @@ public:
     enum class InspectorModelType {
         TYPE_UNDEFINED = -1,
         TYPE_NOTE,
+        TYPE_CHORD,
         TYPE_BEAM,
         TYPE_NOTEHEAD,
         TYPE_STEM,

--- a/src/inspector/models/inspectormodelcreator.cpp
+++ b/src/inspector/models/inspectormodelcreator.cpp
@@ -23,6 +23,7 @@
 
 #include "notation/notes/notesettingsproxymodel.h"
 #include "notation/notes/noteheads/noteheadsettingsmodel.h"
+#include "notation/notes/chords/chordsettingsmodel.h"
 #include "notation/notes/beams/beamsettingsmodel.h"
 #include "notation/notes/hooks/hooksettingsmodel.h"
 #include "notation/notes/stems/stemsettingsmodel.h"
@@ -79,6 +80,8 @@ AbstractInspectorModel* InspectorModelCreator::newInspectorModel(InspectorModelT
         return new NoteSettingsProxyModel(parent, repository);
     case InspectorModelType::TYPE_NOTEHEAD:
         return new NoteheadSettingsModel(parent, repository);
+    case InspectorModelType::TYPE_CHORD:
+        return new ChordSettingsModel(parent, repository);
     case InspectorModelType::TYPE_STEM:
         return new StemSettingsModel(parent, repository);
     case InspectorModelType::TYPE_HOOK:

--- a/src/inspector/models/notation/notes/chords/chordsettingsmodel.cpp
+++ b/src/inspector/models/notation/notes/chords/chordsettingsmodel.cpp
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "chordsettingsmodel.h"
+
+#include "translation.h"
+
+using namespace mu::inspector;
+using namespace mu::engraving;
+
+ChordSettingsModel::ChordSettingsModel(QObject* parent, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, repository)
+{
+    setModelType(InspectorModelType::TYPE_CHORD);
+    setTitle(qtrc("inspector", "Chord"));
+
+    createProperties();
+}
+
+void ChordSettingsModel::createProperties()
+{
+    m_isStemless = buildPropertyItem(Pid::NO_STEM);
+}
+
+void ChordSettingsModel::requestElements()
+{
+    m_elementList = m_repository->findElementsByType(ElementType::CHORD);
+}
+
+void ChordSettingsModel::loadProperties()
+{
+    loadPropertyItem(m_isStemless);
+}
+
+void ChordSettingsModel::resetProperties()
+{
+    m_isStemless->resetToDefault();
+}
+
+PropertyItem* ChordSettingsModel::isStemless() const
+{
+    return m_isStemless;
+}

--- a/src/inspector/models/notation/notes/chords/chordsettingsmodel.h
+++ b/src/inspector/models/notation/notes/chords/chordsettingsmodel.h
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_INSPECTOR_CHORDSETTINGSMODEL_H
+#define MU_INSPECTOR_CHORDSETTINGSMODEL_H
+
+#include "models/abstractinspectormodel.h"
+
+namespace mu::inspector {
+class ChordSettingsModel : public AbstractInspectorModel
+{
+    Q_OBJECT
+
+    Q_PROPERTY(PropertyItem * isStemless READ isStemless CONSTANT)
+
+public:
+    explicit ChordSettingsModel(QObject* parent, IElementRepositoryService* repository);
+
+    PropertyItem* isStemless() const;
+
+private:
+    void createProperties() override;
+    void requestElements() override;
+    void loadProperties() override;
+    void resetProperties() override;
+
+    PropertyItem* m_isStemless = nullptr;
+};
+}
+
+#endif // MU_INSPECTOR_CHORDSETTINGSMODEL_H

--- a/src/inspector/models/notation/notes/notesettingsproxymodel.cpp
+++ b/src/inspector/models/notation/notes/notesettingsproxymodel.cpp
@@ -32,6 +32,7 @@ using namespace mu::inspector;
 
 static const QMap<mu::engraving::ElementType, InspectorModelType> NOTE_PART_TYPES {
     { mu::engraving::ElementType::NOTEHEAD, InspectorModelType::TYPE_NOTEHEAD },
+    { mu::engraving::ElementType::CHORD, InspectorModelType::TYPE_CHORD },
     { mu::engraving::ElementType::STEM, InspectorModelType::TYPE_STEM },
     { mu::engraving::ElementType::BEAM, InspectorModelType::TYPE_BEAM },
     { mu::engraving::ElementType::HOOK, InspectorModelType::TYPE_HOOK },

--- a/src/inspector/models/notation/notes/stems/stemsettingsmodel.cpp
+++ b/src/inspector/models/notation/notes/stems/stemsettingsmodel.cpp
@@ -40,10 +40,6 @@ StemSettingsModel::StemSettingsModel(QObject* parent, IElementRepositoryService*
 
 void StemSettingsModel::createProperties()
 {
-    m_isStemHidden = buildPropertyItem(Pid::VISIBLE, [this](const Pid pid, const QVariant& isStemHidden) {
-        onPropertyValueChanged(pid, !isStemHidden.toBool());
-    });
-
     m_thickness = buildPropertyItem(Pid::LINE_WIDTH);
     m_length = buildPropertyItem(Pid::USER_LEN);
 
@@ -75,16 +71,10 @@ void StemSettingsModel::loadProperties()
 
 void StemSettingsModel::resetProperties()
 {
-    m_isStemHidden->resetToDefault();
     m_thickness->resetToDefault();
     m_length->resetToDefault();
     m_stemDirection->resetToDefault();
     m_offset->resetToDefault();
-}
-
-PropertyItem* StemSettingsModel::isStemHidden() const
-{
-    return m_isStemHidden;
 }
 
 PropertyItem* StemSettingsModel::thickness() const
@@ -152,12 +142,6 @@ void StemSettingsModel::onNotationChanged(const PropertyIdSet& changedPropertyId
 
 void StemSettingsModel::loadProperties(const PropertyIdSet& propertyIdSet)
 {
-    if (mu::contains(propertyIdSet, Pid::VISIBLE)) {
-        loadPropertyItem(m_isStemHidden, [](const QVariant& isVisible) -> QVariant {
-            return !isVisible.toBool();
-        });
-    }
-
     if (mu::contains(propertyIdSet, Pid::LINE_WIDTH)) {
         loadPropertyItem(m_thickness, formatDoubleFunc);
     }

--- a/src/inspector/models/notation/notes/stems/stemsettingsmodel.h
+++ b/src/inspector/models/notation/notes/stems/stemsettingsmodel.h
@@ -19,8 +19,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_INSPECTOR_NOTATIONINSPECTORMODEL_H
-#define MU_INSPECTOR_NOTATIONINSPECTORMODEL_H
+#ifndef MU_INSPECTOR_STEMSETTINGSMODEL_H
+#define MU_INSPECTOR_STEMSETTINGSMODEL_H
 
 #include "models/abstractinspectormodel.h"
 
@@ -29,7 +29,6 @@ class StemSettingsModel : public AbstractInspectorModel
 {
     Q_OBJECT
 
-    Q_PROPERTY(PropertyItem * isStemHidden READ isStemHidden CONSTANT)
     Q_PROPERTY(PropertyItem * thickness READ thickness CONSTANT)
     Q_PROPERTY(PropertyItem * length READ length CONSTANT)
     Q_PROPERTY(PropertyItem * offset READ offset CONSTANT)
@@ -40,7 +39,6 @@ class StemSettingsModel : public AbstractInspectorModel
 public:
     explicit StemSettingsModel(QObject* parent, IElementRepositoryService* repository);
 
-    PropertyItem* isStemHidden() const;
     PropertyItem* thickness() const;
     PropertyItem* length() const;
 
@@ -65,7 +63,6 @@ private:
 
     void loadProperties(const mu::engraving::PropertyIdSet& propertyIdSet);
 
-    PropertyItem* m_isStemHidden = nullptr;
     PropertyItem* m_thickness = nullptr;
     PropertyItem* m_length = nullptr;
     PointFPropertyItem* m_offset = nullptr;
@@ -73,4 +70,4 @@ private:
 };
 }
 
-#endif // MU_INSPECTOR_NOTATIONINSPECTORMODEL_H
+#endif // MU_INSPECTOR_STEMSETTINGSMODEL_H

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/notes/NoteSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/notes/NoteSettings.qml
@@ -46,6 +46,7 @@ Column {
     }
 
     readonly property QtObject headModel: model ? model.modelByType(Inspector.TYPE_NOTEHEAD) : null
+    readonly property QtObject chordModel: model ? model.modelByType(Inspector.TYPE_CHORD) : null
     readonly property QtObject stemModel: model ? model.modelByType(Inspector.TYPE_STEM) : null
     readonly property QtObject hookModel: model ? model.modelByType(Inspector.TYPE_HOOK) : null
     readonly property QtObject beamModel: model ? model.modelByType(Inspector.TYPE_BEAM) : null
@@ -110,9 +111,9 @@ Column {
         StemSettings {
             height: implicitHeight
 
+            chordModel: root.chordModel
             stemModel: root.stemModel
             hookModel: root.hookModel
-            beamModel: root.beamModel
 
             navigationPanel: root.navigationPanel
             navigationRowStart: root.navigationRowStart + 2000

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/notes/StemSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/notes/StemSettings.qml
@@ -33,9 +33,9 @@ FocusableItem {
 
     //@note Current design assumes that stems and hooks should be represented at the same tab,
     //      but semantically it's different things, so they should have different models
+    property QtObject chordModel: null
     property QtObject stemModel: null
     property QtObject hookModel: null
-    property QtObject beamModel: null
 
     property NavigationPanel navigationPanel: null
     property int navigationRowStart: 1
@@ -51,21 +51,13 @@ FocusableItem {
 
         spacing: 12
 
-        CheckBox {
-            width: parent.width
-            isIndeterminate: root.stemModel && root.beamModel ? root.stemModel.isStemHidden.isUndefined || root.beamModel.isBeamHidden.isUndefined : false
-            checked: root.stemModel && !isIndeterminate && root.beamModel ? root.stemModel.isStemHidden.value && root.beamModel.isBeamHidden.value : false
-            text: qsTrc("inspector", "Hide stem (also hides beam)")
+        CheckBoxPropertyView {
+            text: qsTrc("inspector", "Stemless")
+            propertyItem: root.chordModel ? root.chordModel.isStemless : null
 
-            navigation.name: "HideStem"
+            navigation.name: "Stemless"
             navigation.panel: root.navigationPanel
             navigation.row: root.navigationRowStart + 1
-
-            onClicked: {
-                var isHidden = !checked
-                root.stemModel.isStemHidden.value = isHidden
-                root.beamModel.isBeamHidden.value = isHidden
-            }
         }
 
         DirectionSection {


### PR DESCRIPTION
It is a property of the chord rather than the stem, so we need a ChordSettingsModel.

(By the way, I think we'll need to move the (stem) direction property to this new model too, since direction is also relevant for chords without stem, and in fact it is also a chord property rather than a stem property. But that's a separate issue.)

Resolves: #10672