### PR TITLE
Fix #14251: crash when changing page format after MusicXML import

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.h
@@ -39,15 +39,15 @@ class Score;
 //---------------------------------------------------------
 
 struct PageFormat {
-    QSizeF size;
-    qreal printableWidth;          // _width - left margin - right margin
-    qreal evenLeftMargin;          // values in inch
-    qreal oddLeftMargin;
-    qreal evenTopMargin;
-    qreal evenBottomMargin;
-    qreal oddTopMargin;
-    qreal oddBottomMargin;
-    bool twosided;
+    QSizeF size;                         // automatically initialized (to invalid)
+    qreal printableWidth { 5 };          // _width - left margin - right margin
+    qreal evenLeftMargin { 0.2 };        // values in inch
+    qreal oddLeftMargin { 0.2 };
+    qreal evenTopMargin { 0.2 };
+    qreal evenBottomMargin { 0.2 };
+    qreal oddTopMargin { 0.2 };
+    qreal oddBottomMargin { 0.2 };
+    bool twosided { false };
 };
 
 typedef QMap<QString, Part*> PartMap;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14251

Caused by uninitialized data in the MusicXML importer's PageFormat struct. Solution is to initialize with reasonable defaults.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
