### PR TITLE
Fix crash when inserting horizontal frame before a system full of grouped measures

### DIFF
--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -217,7 +217,7 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
 
                 ctx.nextMeasure = ctx.curMeasure;
                 ctx.curMeasure  = ctx.prevMeasure;
-                ctx.prevMeasure = ctx.curMeasure->prevMeasure();
+                ctx.prevMeasure = ctx.curMeasure->prev();
 
                 curSysWidth -= system->lastMeasure()->width();
                 system->removeLastMeasure();
@@ -333,6 +333,8 @@ System* LayoutSystem::collectSystem(const LayoutOptions& options, LayoutContext&
             break;
         }
     }
+
+    assert(ctx.prevMeasure);
 
     if (ctx.endTick < ctx.prevMeasure->tick()) {
         // we've processed the entire range


### PR DESCRIPTION
Resolves: #14523

`ctx.prevMeasure` doesn't need to be a `Measure` but can be any `MeasureBase`.