### PR TITLE
Fix crash when adding text where default font is musical font

### DIFF
--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -252,7 +252,9 @@ RectF TextCursor::cursorRect() const
     mu::draw::Font _font  = fragment ? fragment->font(_text) : _text->font();
     if (_font.family() == _text->score()->styleSt(Sid::MusicalSymbolFont)) {
         _font.setFamily(_text->score()->styleSt(Sid::MusicalTextFont), draw::Font::Type::MusicSymbolText);
-        _font.setPointSizeF(fragment->format.fontSize());
+        if (fragment) {
+            _font.setPointSizeF(fragment->format.fontSize());
+        }
     }
     double ascent = mu::draw::FontMetrics::ascent(_font);
     double h = ascent;


### PR DESCRIPTION
If you had selected Leland (or another musical symbol font) as the default font for some text type in Format > Style > Text Styles, then a crash would occur upon adding a text element of that type.

Resolves: #14620

Alternative way to reproduce the crash:
1. Create a new score with Leland as the musical symbols font
2. In Format > Style > Text Styles, go to "Staff"
3. Change the default font family to "Leland" (not "Leland Text")
4. Press OK
5. Create a Staff Text by selecting a rest and pressing Cmd/Ctrl+T