### PR TITLE
Fix #14200 and #14606: nullcheck in findLinkedVoiceElement

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -4856,7 +4856,7 @@ static EngravingItem* findLinkedVoiceElement(EngravingItem* e, Staff* nstaff)
     Measure* measure = segment->measure();
     Measure* m       = score->tick2measure(measure->tick());
     Segment* s       = m->findSegment(segment->segmentType(), segment->tick());
-    return s->element(dtrack);
+    return s ? s->element(dtrack) : nullptr;
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14200
Resolves: https://github.com/musescore/MuseScore/issues/14606

can't call `->element()` on nullptr!