### PR TITLE
fix underflow error in cmdExplode

### DIFF
--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -3210,7 +3210,7 @@ void Score::cmdExplode()
                     // keep note "i" from top, which is backwards from nnotes - 1
                     // reuse notes if there are more instruments than notes
                     size_t stavesPerNote = std::max((lastStaff - srcStaff) / nnotes, static_cast<size_t>(1));
-                    size_t keepIndex = std::max(nnotes - 1 - (i / stavesPerNote), static_cast<size_t>(0));
+                    size_t keepIndex = static_cast<size_t>(std::max(static_cast<int>(nnotes) - 1 - static_cast<int>(i / stavesPerNote), 0));
                     Note* keepNote = c->notes()[keepIndex];
                     for (Note* n : notes) {
                         if (n != keepNote) {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14404

Same as PR https://github.com/musescore/MuseScore/pull/14626