### PR TITLE
[MU4] fix #14600: Crash when pasting a two-note tremolo that is too long to fit the bar

### DIFF
--- a/src/engraving/playback/metaparsers/internal/tremolometaparser.cpp
+++ b/src/engraving/playback/metaparsers/internal/tremolometaparser.cpp
@@ -35,8 +35,15 @@ void TremoloMetaParser::doParse(const EngravingItem* item, const RenderingContex
 
     const Tremolo* tremolo = toTremolo(item);
 
-    if (tremolo->twoNotes() && tremolo->chord2()->tick().ticks() == ctx.nominalPositionStartTick) {
-        return;
+    if (tremolo->twoNotes()) {
+        const Chord* chord2 = tremolo->chord2();
+        IF_ASSERT_FAILED(chord2) {
+            return;
+        }
+
+        if (chord2->tick().ticks() == ctx.nominalPositionStartTick) {
+            return;
+        }
     }
 
     mpe::ArticulationType type = mpe::ArticulationType::Undefined;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14600

From now, it will crash only in the debug mode. The current behavior will be improved later, see: https://github.com/musescore/MuseScore/issues/14656