### PR TITLE
Allow scaling & offset of add/sus/no/omit in chord symbols

### DIFF
--- a/share/styles/chords_std.xml
+++ b/share/styles/chords_std.xml
@@ -383,6 +383,26 @@
     <render>striangle</render>
     </token>
 
+  <token class="modifier">
+    <name>add</name>
+    <render>add</render>
+    </token>
+
+  <token class="modifier">
+    <name>sus</name>
+    <render>sus</render>
+    </token>
+
+  <token class="modifier">
+    <name>no</name>
+    <render>no</render>
+    </token>
+
+  <token class="modifier">
+    <name>omit</name>
+    <render>omit</render>
+    </token>
+
   <renderRoot>:n :a m:0.5:0</renderRoot>
   <renderFunction>:a m:0.5:0 :n</renderFunction>
   <renderBase>m:-0.2:1 / m:0.2:1 :n :a m:0:-2</renderBase>

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -780,7 +780,6 @@ void NotationInteraction::selectFirstElement(bool frame)
 {
     if (EngravingItem* element = score()->firstElement(frame)) {
         select({ element }, SelectType::SINGLE, element->staffIdx());
-        showItem(element);
     }
 }
 
@@ -788,7 +787,6 @@ void NotationInteraction::selectLastElement()
 {
     if (EngravingItem* element = score()->lastElement()) {
         select({ element }, SelectType::SINGLE, element->staffIdx());
-        showItem(element);
     }
 }
 
@@ -3337,9 +3335,7 @@ void NotationInteraction::addBoxes(BoxType boxType, int count, int beforeBoxInde
     apply();
 
     int indexOfFirstAddedMeasure = beforeBoxIndex >= 0 ? beforeBoxIndex : score()->measures()->size() - count;
-    MeasureBase* firstAddedMeasure = score()->measure(indexOfFirstAddedMeasure);
-    doSelect({ firstAddedMeasure }, SelectType::REPLACE);
-    showItem(firstAddedMeasure);
+    doSelect({ score()->measure(indexOfFirstAddedMeasure) }, SelectType::REPLACE);
 
     // For other box types, it makes little sense to select them all
     if (boxType == BoxType::Measure) {
@@ -3954,7 +3950,6 @@ void NotationInteraction::addText(TextStyleType type, EngravingItem* item)
     }
 
     apply();
-    showItem(textBox);
     startEditText(textBox);
 }
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -780,6 +780,7 @@ void NotationInteraction::selectFirstElement(bool frame)
 {
     if (EngravingItem* element = score()->firstElement(frame)) {
         select({ element }, SelectType::SINGLE, element->staffIdx());
+        showItem(element);
     }
 }
 
@@ -787,6 +788,7 @@ void NotationInteraction::selectLastElement()
 {
     if (EngravingItem* element = score()->lastElement()) {
         select({ element }, SelectType::SINGLE, element->staffIdx());
+        showItem(element);
     }
 }
 
@@ -3335,7 +3337,9 @@ void NotationInteraction::addBoxes(BoxType boxType, int count, int beforeBoxInde
     apply();
 
     int indexOfFirstAddedMeasure = beforeBoxIndex >= 0 ? beforeBoxIndex : score()->measures()->size() - count;
-    doSelect({ score()->measure(indexOfFirstAddedMeasure) }, SelectType::REPLACE);
+    MeasureBase* firstAddedMeasure = score()->measure(indexOfFirstAddedMeasure);
+    doSelect({ firstAddedMeasure }, SelectType::REPLACE);
+    showItem(firstAddedMeasure);
 
     // For other box types, it makes little sense to select them all
     if (boxType == BoxType::Measure) {
@@ -3950,6 +3954,7 @@ void NotationInteraction::addText(TextStyleType type, EngravingItem* item)
     }
 
     apply();
+    showItem(textBox);
     startEditText(textBox);
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14352

Allows "add", "sus", "no", and "omit" to be recognized as modifiers in standard chord symbol style, thus honoring the scaling and offset style settings and aligning properly with parentheses.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
