### PR TITLE
Fix insert measure before MMRest

### DIFF
--- a/src/engraving/libmscore/measurebase.cpp
+++ b/src/engraving/libmscore/measurebase.cpp
@@ -681,8 +681,12 @@ int MeasureBase::index() const
 {
     int idx = 0;
     MeasureBase* m = score()->first();
+    Measure* mmRestFirst = nullptr;
+    if (isMeasure() && toMeasure(this)->isMMRest()) {
+        mmRestFirst = toMeasure(this)->mmRestFirst();
+    }
     while (m) {
-        if (m == this) {
+        if (m == this || m == mmRestFirst) {
             return idx;
         }
         m = m->next();


### PR DESCRIPTION
Resolves: #14556

This resolves the inserting issue (currently the measure is inserted at the end of the score). The crash should be resolved by #14642 
