### PR TITLE
Fix scaling & offset of add/sus/no/omit

### DIFF
--- a/share/styles/chords_std.xml
+++ b/share/styles/chords_std.xml
@@ -383,6 +383,26 @@
     <render>striangle</render>
     </token>
 
+  <token class="modifier">
+    <name>add</name>
+    <render>add</render>
+    </token>
+
+  <token class="modifier">
+    <name>sus</name>
+    <render>sus</render>
+    </token>
+
+  <token class="modifier">
+    <name>no</name>
+    <render>no</render>
+    </token>
+
+  <token class="modifier">
+    <name>omit</name>
+    <render>omit</render>
+    </token>
+
   <renderRoot>:n :a m:0.5:0</renderRoot>
   <renderFunction>:a m:0.5:0 :n</renderFunction>
   <renderBase>m:-0.2:1 / m:0.2:1 :n :a m:0:-2</renderBase>


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14352

Allows "add", "sus", "no", and "omit" to be recognized as modifiers in standard chord symbol style, thus honoring the scaling and offset style settings and aligning properly with parentheses.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
