### PR TITLE
Fix #14643 - Crash when opening score with nested boxes

### DIFF
--- a/src/engraving/libmscore/box.cpp
+++ b/src/engraving/libmscore/box.cpp
@@ -312,21 +312,29 @@ bool Box::readProperties(XmlReader& e)
         //! but when we add it to Box, the parent will be rewritten.
         add(f);
     } else if (tag == "HBox") {
-        HBox* hb = new HBox(this->system());
-        hb->read(e);
-        //! TODO Looks like a bug.
-        //! The HBox parent must be System
-        //! there is a method: `System* system() const { return (System*)parent(); }`,
-        //! but when we add it to Box, the parent will be rewritten.
-        add(hb);
+        // m_parent is used here (rather than system()) because explicit parent isn't set for this object
+        // until it is fully read. m_parent is nonetheless valid and using it here matches MU3 behavior.
+        // If we do not set the parent of this new box correctly, it will cause a crash on read()
+        // because it needs access to the system it is being added to. (c.r. issue #14643)
+        if (m_parent && m_parent->isSystem()) {
+            HBox* hb = new HBox(toSystem(m_parent));
+            hb->read(e);
+            //! TODO Looks like a bug.
+            //! The HBox parent must be System
+            //! there is a method: `System* system() const { return (System*)parent(); }`,
+            //! but when we add it to Box, the parent will be rewritten.
+            add(hb);
+        }
     } else if (tag == "VBox") {
-        VBox* vb = new VBox(this->system());
-        vb->read(e);
-        //! TODO Looks like a bug.
-        //! The VBox parent must be System
-        //! there is a method: `System* system() const { return (System*)parent(); }`,
-        //! but when we add it to Box, the parent will be rewritten.
-        add(vb);
+        if (m_parent && m_parent->isSystem()) {
+            VBox* vb = new VBox(toSystem(m_parent));
+            vb->read(e);
+            //! TODO Looks like a bug.
+            //! The VBox parent must be System
+            //! there is a method: `System* system() const { return (System*)parent(); }`,
+            //! but when we add it to Box, the parent will be rewritten.
+            add(vb);
+        }
     } else if (MeasureBase::readProperties(e)) {
     } else {
         return false;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14643

The crash resulted from the outer box trying to create an inner box using its own system as a parent (which is what MU3 does). Using the `system()` call in MU4, however, requires that the parent of an object be explicitly parented, which doesn't happen until after the entire box is read. I added a check to make sure that the vbox's parent is in fact a system (or else it ignores any inner vboxes).

This PR restores behavior of MU3, but there is still some weirdness going on that existed in MU3 as well. There was a good amount of commenting that detailed a bug that exists in this part of code, and upon finding the same method in the 3.6.2 branch, it had the same problem.

Regardless, this is a straight crash fix and doesn't attempt to redo how we parent boxes. There is an argument to be made for ignoring nested boxes on import, as well.