### PR TITLE
gp-import: fixed gp-file bug with ties

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -2186,22 +2186,22 @@ void GPConverter::addTie(const GPNote* gpnote, Note* note)
         return;
     }
 
-    using tieMap = std::unordered_multimap<track_idx_t, Tie*>;
+    using tieMap = std::unordered_map<track_idx_t, std::vector<Tie*> >;
 
     auto startTie = [](Note* note, Score* sc, tieMap& ties, track_idx_t curTrack) {
         Tie* tie = Factory::createTie(sc->dummy());
         note->add(tie);
-        ties.insert(std::make_pair(curTrack, tie));
+        ties[curTrack].push_back(tie);
     };
 
     auto endTie = [](Note* note, tieMap& ties, track_idx_t curTrack) {
-        auto range = ties.equal_range(curTrack);
-        for (auto it = range.first; it != range.second; it++) {
-            Tie* tie = it->second;
+        auto& tiesOnTrack = ties[curTrack];
+        for (auto it = tiesOnTrack.rbegin(); it != tiesOnTrack.rend(); it++) {
+            Tie* tie = *it;
             if (tie->startNote()->pitch() == note->pitch() && tie->startNote()->string() == note->string()) {
                 tie->setEndNote(note);
                 note->setTieBack(tie);
-                ties.erase(it);
+                mu::remove(tiesOnTrack, tie);
                 break;
             }
         }
@@ -2894,15 +2894,18 @@ void GPConverter::addTextToNote(String string, Note* note)
 
 void GPConverter::clearDefectedSpanner()
 {
-    for (const auto& element : _ties) {
-        Tie* tie = element.second;
-        if (tie->startNote()) {
-            tie->startNote()->setTieFor(nullptr);
+    for (const auto& [track, elems] : _ties) {
+        for (Tie* tie : elems) {
+            if (tie->startNote()) {
+                tie->startNote()->setTieFor(nullptr);
+            }
+
+            if (tie->endNote()) {
+                tie->endNote()->setTieBack(nullptr);
+            }
+
+            delete tie;
         }
-        if (tie->endNote()) {
-            tie->endNote()->setTieBack(nullptr);
-        }
-        delete tie;
     }
 }
 

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.h
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.h
@@ -205,7 +205,7 @@ private:
     std::unordered_map<track_idx_t, GPBar::Clef> _clefs;
     std::unordered_map<track_idx_t, GPBeat::DynamicType> _dynamics;
     std::unordered_map<track_idx_t, bool> m_hasCapo;
-    std::unordered_multimap<track_idx_t, Tie*> _ties; // map(track, tie)
+    std::unordered_map<track_idx_t, std::vector<Tie*> > _ties; // map(track, tie)
     std::unordered_map<track_idx_t, Slur*> _slurs; // map(track, slur)
 
     mutable GPBeat* m_currentGPBeat = nullptr; // used for passing info from notes


### PR DESCRIPTION
<img width="250" alt="Screenshot 2022-11-23 at 06 56 28" src="https://user-images.githubusercontent.com/24373905/203471783-918cb6d2-f598-472f-a288-cfc8238c4ca4.png">

guitar pro sometimes stores "start tie" flag where there is no tie, so order of checking the ties is important
[ties.zip](https://github.com/musescore/MuseScore/files/10073840/ties.zip)

