### PR TITLE
Fix page size on 302 import

### DIFF
--- a/src/engraving/data/styles/legacy-style-defaults-v302.mss
+++ b/src/engraving/data/styles/legacy-style-defaults-v302.mss
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="4.00">
   <Style>
-    <pageWidth>8.5</pageWidth>
-    <pageHeight>11</pageHeight>
+    <pageWidth>8.26772</pageWidth>
+    <pageHeight>11.6929</pageHeight>
     <pagePrintableWidth>7.08661</pagePrintableWidth>
     <pageEvenLeftMargin>0.590551</pageEvenLeftMargin>
     <pageOddLeftMargin>0.590551</pageOddLeftMargin>


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14570

The legacy 302 style file has the wrong default page size (Letter instead of A4), causing scores using the A4 default to change to Letter on import.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
