### PR TITLE
LanguagesService: redirect "en" language code to "en_US"

### DIFF
--- a/src/languages/internal/languagesservice.cpp
+++ b/src/languages/internal/languagesservice.cpp
@@ -215,6 +215,18 @@ QString LanguagesService::effectiveLanguageCode(const QString& languageCode) con
                 return code;
             }
 
+            static const std::map<QString, QString> SHORT_TO_LONG_FALLBACK_CODES {
+                { "en", "en_US" },
+                { "hi", "hi_IN" },
+                { "mn", "mn_MN" },
+                { "zh", "zh_CN" }
+            };
+
+            auto it = SHORT_TO_LONG_FALLBACK_CODES.find(code);
+            if (it != SHORT_TO_LONG_FALLBACK_CODES.cend()) {
+                return it->second;
+            }
+
             int rightmost = code.lastIndexOf('_');
             if (rightmost <= 0) {
                 break;


### PR DESCRIPTION
If the system language code happens to be something like "en_CY", that will decay to "en". But we don't have that, only "en_US". That causes some problems. To fix that, we map "en" to "en_US".

Might resolve: #13926 
May resolve: https://github.com/musescore/MuseScore/pull/12917#issuecomment-1323621684