### PR TITLE
fixed #14698: Preferences > Shortcuts > Define shortcut: Enter and Esc close dialog instead of being interpreted as input 

### DIFF
--- a/src/framework/shortcuts/qml/MuseScore/Shortcuts/EditMidiMappingDialog.qml
+++ b/src/framework/shortcuts/qml/MuseScore/Shortcuts/EditMidiMappingDialog.qml
@@ -21,23 +21,22 @@
  */
 import QtQuick 2.15
 import QtQuick.Layouts 1.12
-import QtQuick.Dialogs 1.3
 
 import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
 import MuseScore.Shortcuts 1.0
 
-Dialog {
+StyledDialogView {
     id: root
-
-    signal mapToEventRequested(var event)
 
     title: qsTrc("shortcuts", "MIDI remote control")
 
-    height: 220
-    width: 538
+    contentWidth: 538
+    contentHeight: 164
 
-    standardButtons: Dialog.NoButton
+    margins: 20
+
+    signal mapToEventRequested(var event)
 
     function startEdit(action) {
         model.load(action.mappedType, action.mappedValue)
@@ -47,18 +46,18 @@ Dialog {
         open()
     }
 
-    EditMidiMappingModel {
-        id: model
-    }
 
     Rectangle {
         anchors.fill: parent
 
         color: ui.theme.backgroundPrimaryColor
 
+        EditMidiMappingModel {
+            id: model
+        }
+
         Column {
             anchors.fill: parent
-            anchors.margins: 8
 
             spacing: 24
 

--- a/src/framework/shortcuts/qml/MuseScore/Shortcuts/EditShortcutDialog.qml
+++ b/src/framework/shortcuts/qml/MuseScore/Shortcuts/EditShortcutDialog.qml
@@ -169,7 +169,7 @@ StyledDialogView {
         }
 
         Keys.onShortcutOverride: function(event) {
-            event.accepted = true
+            event.accepted = event.key !== Qt.Key_Escape && event.key !== Qt.Key_Tab
         }
 
         Keys.onPressed: function(event) {

--- a/src/framework/shortcuts/qml/MuseScore/Shortcuts/EditShortcutDialog.qml
+++ b/src/framework/shortcuts/qml/MuseScore/Shortcuts/EditShortcutDialog.qml
@@ -21,14 +21,20 @@
  */
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Dialogs 1.3
 
 import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
 import MuseScore.Shortcuts 1.0
 
-Dialog {
+StyledDialogView {
     id: root
+
+    title: qsTrc("shortcuts", "Enter shortcut sequence")
+
+    contentWidth: 538
+    contentHeight: 200
+
+    margins: 20
 
     signal applySequenceRequested(string newSequence, int conflictShortcutIndex)
 
@@ -36,21 +42,6 @@ Dialog {
         model.load(shortcut, allShortcuts)
         open()
         content.forceActiveFocus()
-    }
-
-    height: 240
-    width: 538
-
-    title: qsTrc("shortcuts", "Enter shortcut sequence")
-
-    standardButtons: Dialog.NoButton
-
-    EditShortcutModel {
-        id: model
-
-        onApplyNewSequenceRequested: function(newSequence, conflictShortcutIndex) {
-            root.applySequenceRequested(newSequence, conflictShortcutIndex)
-        }
     }
 
     Rectangle {
@@ -62,9 +53,16 @@ Dialog {
 
         focus: true
 
+        EditShortcutModel {
+            id: model
+
+            onApplyNewSequenceRequested: function(newSequence, conflictShortcutIndex) {
+                root.applySequenceRequested(newSequence, conflictShortcutIndex)
+            }
+        }
+
         Column {
             anchors.fill: parent
-            anchors.margins: 8
 
             spacing: 20
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/TextInputField.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/TextInputField.qml
@@ -177,6 +177,10 @@ FocusScope {
             }
 
             Keys.onShortcutOverride: function(event) {
+                if (readOnly) {
+                    return
+                }
+
                 if (event.key === Qt.Key_Enter || event.key === Qt.Key_Return
                         || event.key === Qt.Key_Escape) {
                     event.accepted = true

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -80,9 +80,7 @@ static const TranslatableString X_TAB = TranslatableString("action", "%1 (TAB)")
 const UiActionList NotationUiActions::m_actions = {
     UiAction("notation-escape",
              mu::context::UiCtxNotationOpened,
-             mu::context::CTX_NOTATION_FOCUSED,
-             TranslatableString("action", "Esc"),
-             TranslatableString("action", "Escape (Esc)")
+             mu::context::CTX_NOTATION_FOCUSED
              ),
     UiAction("put-note", // args: PointF pos, bool replace, bool insert
              mu::context::UiCtxNotationOpened,


### PR DESCRIPTION
Resolves: #14698
