### PR TITLE
Fix crash due to invalid staff indices

### DIFF
--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -1397,6 +1397,9 @@ void LayoutSystem::processLines(System* system, std::vector<Spanner*> lines, boo
     for (SpannerSegment* ss : segments) {
         if (ss->addToSkyline()) {
             staff_idx_t stfIdx = ss->systemFlag() ? ss->staffIdxOrNextVisible() : ss->staffIdx();
+            if (stfIdx == mu::nidx) {
+                continue;
+            }
             system->staff(stfIdx)->skyline().add(ss->shape().translated(ss->pos()));
         }
     }

--- a/src/engraving/libmscore/spanner.cpp
+++ b/src/engraving/libmscore/spanner.cpp
@@ -1668,6 +1668,10 @@ void SpannerSegment::autoplaceSpannerSegment()
         sl.add(sh.translated(pos()));
         double yd = 0.0;
         staff_idx_t stfIdx = systemFlag() ? staffIdxOrNextVisible() : staffIdx();
+        if (stfIdx == mu::nidx) {
+            _skipDraw = true;
+            return;
+        }
         if (above) {
             double d  = system()->topDistance(stfIdx, sl);
             if (d > -md) {


### PR DESCRIPTION
Resolves: #14729 

When the method `staffIdxOrNextVisible()` can't find a suitable staff, it returns an invalid index, which needs to be properly handled. It was already handled for normal items, but not for system lines.