### PR TITLE
Fix: Beam types -> Beam type

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/notation/notes/BeamSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/notes/BeamSettings.qml
@@ -49,7 +49,7 @@ FocusableItem {
 
         BeamTypeSelector {
             id: beamTypeSection
-            titleText: qsTrc("inspector", "Beam types")
+            titleText: qsTrc("inspector", "Beam type")
             propertyItem: root.beamModesModel ? root.beamModesModel.mode : null
             enabled: root.beamModesModel && !root.beamModesModel.isEmpty
 


### PR DESCRIPTION
The first argument: should be "Beam type" because we select beam type, not types. The second argument: "types" occurs only once in strings to translate - only in this case.

Greetings,
Gootector

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
