### PR TITLE
adding annotations to segment after iterating on them

### DIFF
--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -1215,7 +1215,10 @@ void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff, bool cloneSpanners)
                     DeleteAll(ncr->lyrics());
                     ncr->lyrics().clear();
 
-                    for (EngravingItem* e : seg->annotations()) {
+                    // creating copy for iteration, cause seg->annotations() may change during loop
+                    const std::vector<EngravingItem*> iterableAnnotations = seg->annotations();
+
+                    for (EngravingItem* e : iterableAnnotations) {
                         if (!e) {
                             LOGD("cloneStaff: corrupted annotation found.");
                             continue;


### PR DESCRIPTION
fermatas were added to the vector which was begin iterated through, this led to crash in some cases