### PR TITLE
Fix name when saving project to cloud after re-opening

### DIFF
--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -408,9 +408,8 @@ bool NotationProject::isCloudProject() const
 const CloudProjectInfo& NotationProject::cloudInfo() const
 {
     if (!m_cloudInfo.isValid()) {
-        auto tags = m_masterNotation->masterScore()->metaTags();
-        m_cloudInfo.name = tags[WORK_TITLE_TAG].toQString();
-        m_cloudInfo.sourceUrl = tags[SOURCE_TAG].toQString();
+        m_cloudInfo.name = io::filename(m_path, false).toQString();
+        m_cloudInfo.sourceUrl = m_masterNotation->masterScore()->metaTags()[SOURCE_TAG].toQString();
     }
 
     return m_cloudInfo;

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -575,11 +575,13 @@ bool ProjectActionsController::saveProjectToCloud(CloudProjectInfo info, SaveMod
         // Get up-to-date visibility information
         RetVal<cloud::ScoreInfo> scoreInfo = cloudProjectsService()->downloadScoreInfo(info.sourceUrl);
         if (scoreInfo.ret) {
+            info.name = scoreInfo.val.title;
             info.visibility = scoreInfo.val.visibility;
             isPublic = info.visibility == cloud::Visibility::Public;
         } else {
             LOGE() << "Failed to download up-to-date score info for " << info.sourceUrl
-                   << "; falling back to last known visibility setting, namely " << static_cast<int>(info.visibility);
+                   << "; falling back to last known name and visibility setting, namely "
+                   << info.name << " and " << static_cast<int>(info.visibility);
         }
 
         if (isPublic) {


### PR DESCRIPTION
Resolves: #13968

When reopening a project, the cloud name for that project is unknown. When re-saving the project, we used the work title as a fallback, but this should be the filename.

Also, when the score is renamed on MuseScore.com, we respect this during saving, so that we don't override it back to the old name.