### PR TITLE
Fix crash when opening/closing mixer very quickly during playback

### DIFF
--- a/src/framework/global/thirdparty/kors_async/async/internal/abstractinvoker.cpp
+++ b/src/framework/global/thirdparty/kors_async/async/internal/abstractinvoker.cpp
@@ -39,6 +39,8 @@ AbstractInvoker::~AbstractInvoker()
     for (QInvoker* qi : m_qInvokers) {
         qi->invalidate();
     }
+
+    m_qInvokers.clear();
 }
 
 void AbstractInvoker::invoke(int type)
@@ -147,9 +149,11 @@ void AbstractInvoker::removeCallBack(int type, Asyncable* receiver)
 
     {
         std::lock_guard<std::mutex> lock(m_qInvokersMutex);
-        for (QInvoker* qi : m_qInvokers) {
+        for (auto it = m_qInvokers.begin(); it != m_qInvokers.end(); ++it) {
+            QInvoker* qi = *it;
             if (qi->call.call == c.call) {
                 qi->invalidate();
+                m_qInvokers.erase(it);
                 break;
             }
         }


### PR DESCRIPTION
Resolves: #13903
Resolves: #9467

What happened: 

0. The Mixer is subscribed to the audio signal changes, and does this from the main thread.
1. In the audio thread, in `AudioSignalsNotifier::updateSignalValues(…)`, we call `audioSignalChanges.send(audioChNumber, signalVal);`.
2. Because the mixer is subscribed from the main thread but "we" are on the audio thread, this results in the allocation of a `QInvoker` in `AbstractInvoker::invoke(int type, const NotifyData& data)`. Also, a call to this `QInvoker`'s `invoke()` method, followed by the deletion of this `QInvoker` is queued to `QueuedInvoker`.
3. In the constructor of this `QInvoker`, it adds itself to the `AbstractInvoker`'s list of `m_qInvokers` by calling `AbstractInvoker::addQInvoker(…)`.
---
4. Then, for some reason, `AbstractInvoker::removeCallBack(…)` is called, which "invalidates" the `QInvoker`; that means: the `QInvoker`'s pointer to the `AbstractInvoker` is set to `nullptr`. 
---
5. Then, the `QInvoker`'s `invoke()` method is still called (because that had been queued already, see point 2). This doesn't do much :)
6. And, the `QInvoker` is deleted, because that was also queued. 
7. Normally, the destructor would remove the `QInvoker` from the `AbstractInvoker`'s list of `m_qInvokers` by calling `AbstractInvoker::removeQInvoker(…)`. But in this case, the `QInvoker` was already invalidated, so it has no reference to the `AbstractInvoker` anymore, so it _doesn't_ remove itself from the list of `m_qInvokers`. So that list now contains a pointer to deleted memory! ⚠️⚠️⚠️
---
8. Later, `AbstractInvoker::removeCallBack(…)` is called again, for some callback (which one exactly isn't relevant).
9. This method loops through the list of `m_qInvokers`, and reads a bit of all of them, to look whether they belong to the callback that is being removed (and thus need to be invalidated). 
10. And thus it also reads from the deleted `QInvoker` that was still in the list! 💥