### PR TITLE
fix Instrument change from palette

### DIFF
--- a/src/engraving/libmscore/chordrest.cpp
+++ b/src/engraving/libmscore/chordrest.cpp
@@ -528,11 +528,8 @@ EngravingItem* ChordRest::drop(EditData& data)
             InstrumentChange* ic = toInstrumentChange(e);
             ic->setParent(segment());
             ic->setTrack(trackZeroVoice(track()));
-            Instrument* instr = ic->instrument();
-            Instrument* prevInstr = part()->instrument(tick());
-            if (instr && instr->isDifferentInstrument(*prevInstr)) {
-                ic->setupInstrument(instr);
-            }
+            Instrument* instr = part()->instrument(tick());
+            ic->setInstrument(instr);
             score()->undoAddElement(ic);
             return e;
         }


### PR DESCRIPTION
Calculate correct key signature and clef

Resolves case 1 of #14722 

1. Instrument change element is added to score, before "Select instrument" dialog is triggered, so program dont know, which instrument user will select. Therefore doesnt make sense to have all that checks in chordrest.cpp.
2. Once instrument change element is added to score, init function in instrumentchange.cpp compares with this added instrument (not instrument in score before change, as one may expected).

So I did it this way: when user adds instrument change from palette, it adds (temporarily) same instrument as is in staff before this segment, than, when user selects new instrument in dialog, it comapres with correct instrument.

(It would be may be better, to change init function to compare previous segment. But I cant test it anymore, as my QT doesnt work for some reason and I am bit out of computer for while).

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
