### PR TITLE
Fix some other cases of overlapping notes

### DIFF
--- a/src/engraving/playback/renderers/chordarticulationsrenderer.cpp
+++ b/src/engraving/playback/renderers/chordarticulationsrenderer.cpp
@@ -155,7 +155,7 @@ duration_t ChordArticulationsRenderer::tiedNotesTotalDuration(const Note* firstN
         }
 
         BeatsPerSecond bps = score->tempomap()->tempo(tiedNote->tick().ticks());
-        result += durationFromTicks(bps.val, tiedNote->chord()->durationTypeTicks().ticks());
+        result += durationFromTicks(bps.val, tiedNote->chord()->actualTicks().ticks());
     }
 
     return result;


### PR DESCRIPTION
- for groups of tied notes where one or more notes were under a triplet
- for "cross-measure" notation

Resolves: remaining case of #14220

Test score where these problems were found: [Test overlapping cross-measure.mscz.zip](https://github.com/musescore/MuseScore/files/10104861/Test.overlapping.cross-measure.mscz.zip)
(see bar 6-7 for the first problem; after that for the second problem)

About "cross-measure notation": you can enable it in `Format` > `Style` > `Display note values across measure boundaries (EXPERIMENTAL, early music only!)`