### PR TITLE
Fix broken editing dynamics when selection starts on music symbol

### DIFF
--- a/src/engraving/libmscore/textedit.cpp
+++ b/src/engraving/libmscore/textedit.cpp
@@ -981,8 +981,6 @@ bool TextBase::deleteSelectedText(EditData& ed)
                 break;
             }
             TextCursor undoCursor(*_cursor);
-            // can't rely on the cursor's current format as it doesn't preserve the special font "ScoreText"
-            undoCursor.setFormat(*_layout[_cursor->row()].formatAt(static_cast<int>(_cursor->column())));
             score()->undo(new RemoveText(&undoCursor, String(_cursor->currentCharacter())), &ed);
         }
     }


### PR DESCRIPTION
Resolves: #13344
Resolves: #12978

The problem arises because, when doing that particular editing operation, we set the cursor to "ScoreText" font, which is used in `TextFragment::font()` to return either the music-font (say, Leland) or the music-text-font (say, Leland Text) family. The problem is that neither of those contain alphabet characters, so the UI will show a random fallback font and the charactes typed won't be registered. 
I _think_ that the system is supposed to work with the cursor always set to the text font. If you then enter special symbols, they will be registered as separate TextFragments and will be set to the music-font or music-text-font as needed. In principle, at least as far as I understand, it shouldn't be necessary to set the cursor to the music fonts. @MarcSabatella @wizofaus this seems to solve the issue, but do let me know if you find it causes problems elsewhere that I'm not seeing.
