### PR TITLE
macOS: fix typing Option-key characters in Chord Symbols, Figured Bass, Fingering, Lyrics and Sticking

### DIFF
--- a/src/engraving/libmscore/textbase.h
+++ b/src/engraving/libmscore/textbase.h
@@ -505,12 +505,16 @@ public:
 inline bool isTextNavigationKey(int key, KeyboardModifiers modifiers)
 {
     if (modifiers & TextEditingControlModifier) {
-        static const std::set<int> standardTextOperationsKeys {
-            Key_Space, // Ctrl + Space inserts the space symbol
-            Key_A // select all
+        static const std::set<int> controlNavigationKeys {
+            Key_Left,
+            Key_Right,
+            Key_Up,
+            Key_Down,
+            Key_Home,
+            Key_End
         };
 
-        return standardTextOperationsKeys.find(key) == standardTextOperationsKeys.end();
+        return controlNavigationKeys.find(key) != controlNavigationKeys.end();
     }
 
     static const std::set<int> navigationKeys {


### PR DESCRIPTION
Resolves: #14789

For certain keyboard layouts on macOS, some characters can only be typed by pressing the Option (Alt) key. For example, On British keyboards, you have this:
<img width="80" alt="Scherm­afbeelding 2022-11-28 om 19 21 35" src="https://user-images.githubusercontent.com/48658420/204351894-59174d70-0f2a-4050-a840-ac84c9b8ae1b.png"> (image source: https://support.apple.com/nl-nl/HT201794)
To type the `#` character, you need to press <kbd>Option</kbd> + <kbd>3</kbd>.

This was broken in MuseScore, because we block <kbd>Option</kbd> + <kbd>[almost any key]</kbd> because that would be a "navigation key" (I'm not completely sure what that means). But I think it's pretty obvious that <kbd>Option</kbd> + <kbd>3</kbd> (and similar) are not navigation keys, so we should not block those. Now we only block specific keys as being "navigation keys", whatever that means.

Because I'm so unsure what a "navigation key" is supposed to mean, this will require a thorough review and testing :)