### PR TITLE
[MU4] fluid_synth_pitch_bend_intervals

### DIFF
--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsequencer.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsequencer.cpp
@@ -180,7 +180,7 @@ void FluidSequencer::appendPitchBend(EventSequenceMap& destination, const mpe::N
             }
 
             percentage_t positionDistance = nextToCurrent->first - it->first;
-            int stepsCount = positionDistance / (mpe::ONE_PERCENT * 2);
+            int stepsCount = positionDistance / (mpe::ONE_PERCENT * 5);
             float posStep = positionDistance / static_cast<float>(stepsCount);
             float pitchStep = (nextToCurrent->second - it->second) / static_cast<float>(stepsCount);
 


### PR DESCRIPTION
Resolves: #13027

Turned out that FluidSynth can't carry this amount of messages on lower sampler rates, which produces huge delays after pitch bend messages being sent