### PR TITLE
Fix a couple of issues with key signatures and transposing instruments

### DIFF
--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -211,15 +211,13 @@ static void createMeasures(mu::engraving::Score* score, const ScoreCreateOptions
                             nKey.setKey(mu::engraving::transposeKey(nKey.key(), diff, part->preferSharpFlat()));
                         }
                         // do not create empty keysig unless custom or atonal
-                        if (nKey.custom() || nKey.isAtonal() || nKey.key() != Key::C) {
-                            staff->setKey(mu::engraving::Fraction(0, 1), nKey);
-                            mu::engraving::Segment* ss
-                                = measure->getSegment(mu::engraving::SegmentType::KeySig, mu::engraving::Fraction(0, 1));
-                            mu::engraving::KeySig* keysig = mu::engraving::Factory::createKeySig(ss);
-                            keysig->setTrack(staffIdx * mu::engraving::VOICES);
-                            keysig->setKeySigEvent(nKey);
-                            ss->add(keysig);
-                        }
+                        staff->setKey(mu::engraving::Fraction(0, 1), nKey);
+                        mu::engraving::Segment* ss
+                            = measure->getSegment(mu::engraving::SegmentType::KeySig, mu::engraving::Fraction(0, 1));
+                        mu::engraving::KeySig* keysig = mu::engraving::Factory::createKeySig(ss);
+                        keysig->setTrack(staffIdx * mu::engraving::VOICES);
+                        keysig->setKeySigEvent(nKey);
+                        ss->add(keysig);
                     }
                 }
 

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -565,7 +565,10 @@ void NotationParts::replaceInstrument(const InstrumentKey& instrumentKey, const 
 
         QString newInstrumentPartName = formatInstrumentTitle(newInstrument.trackName(), newInstrument.trait());
         score()->undo(new mu::engraving::ChangePart(part, new mu::engraving::Instrument(newInstrument), newInstrumentPartName));
-        score()->transpositionChanged(part, Part::MAIN_INSTRUMENT_TICK, oldTranspose);
+        if (score()->isMaster()) {
+            // this also transposes all linked parts
+            score()->transpositionChanged(part, Part::MAIN_INSTRUMENT_TICK, oldTranspose);
+        }
 
         // Update clefs
         for (staff_idx_t staffIdx = 0; staffIdx < part->nstaves(); ++staffIdx) {


### PR DESCRIPTION
Resolves: #14675 
Resolves: #14873

(First issue) The regression happened in [#13999](https://github.com/musescore/MuseScore/pull/13999). That PR (correctly) filters out local key signatures (i.e. key signatures which are not in all staves). But that relies on the fact that global key signatures must be added to _all_ staves, even if a specific staff ends up being in C because of transposition. Instead, when setting the key of the score via the score-creation dialog, instruments with resulting key in C were not given a key signature, so the key sig was interpreted as local and therefore not applied to the new instrument. Now the keySigEvent is _always_ generated at the start of the score, regardless of being in C or not.

(Second issue) When changing instrument, we were transposing the instrument multiple times (once per excerpt in which the instrument is present. 

