### PR TITLE
fix #14859: missing part-group stop in MusicXML export

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -6464,11 +6464,15 @@ static void partList(XmlWriter& xml, Score* score, MxmlInstrumentMap& instrMap)
                             // filter out implicit brackets
                             if (!(st->bracketSpan(j) == part->nstaves()
                                   && st->bracketType(j) == BracketType::BRACE)) {
-                                // add others
-                                int number = findPartGroupNumber(partGroupEnd);
-                                if (number < MAX_PART_GROUPS) {
-                                    partGroupStart(xml, number + 1, st->bracketType(j));
-                                    partGroupEnd[number] = static_cast<int>(staffCount + st->bracketSpan(j));
+                                // filter out brackets starting in the last part
+                                // as they cannot span multiple parts
+                                if (idx < parts.size() - 1) {
+                                    // add others
+                                    int number = findPartGroupNumber(partGroupEnd);
+                                    if (number < MAX_PART_GROUPS) {
+                                        partGroupStart(xml, number + 1, st->bracketType(j));
+                                        partGroupEnd[number] = static_cast<int>(staffCount + st->bracketSpan(j));
+                                    }
                                 }
                             }
                         } else {

--- a/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_invisible_ref.xml
+++ b/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_invisible_ref.xml
@@ -16,9 +16,6 @@
       </encoding>
     </identification>
   <part-list>
-    <part-group type="start" number="1">
-      <group-symbol>brace</group-symbol>
-      </part-group>
     <score-part id="P1">
       <part-name>Piano</part-name>
       <part-abbreviation>Pno.</part-abbreviation>

--- a/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_noinvisible_ref.xml
+++ b/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_noinvisible_ref.xml
@@ -16,9 +16,6 @@
       </encoding>
     </identification>
   <part-list>
-    <part-group type="start" number="1">
-      <group-symbol>brace</group-symbol>
-      </part-group>
     <score-part id="P1">
       <part-name>Piano</part-name>
       <part-abbreviation>Pno.</part-abbreviation>

--- a/src/importexport/musicxml/tests/data/testMaxNumberLevel_ref.xml
+++ b/src/importexport/musicxml/tests/data/testMaxNumberLevel_ref.xml
@@ -13,12 +13,6 @@
       </encoding>
     </identification>
   <part-list>
-    <part-group type="start" number="1">
-      <group-symbol>bracket</group-symbol>
-      </part-group>
-    <part-group type="start" number="2">
-      <group-symbol>square</group-symbol>
-      </part-group>
     <score-part id="P1">
       <part-name>Violins</part-name>
       <part-abbreviation>Vlns.</part-abbreviation>
@@ -33,8 +27,6 @@
         <pan>0</pan>
         </midi-instrument>
       </score-part>
-    <part-group type="stop" number="2"/>
-    <part-group type="stop" number="1"/>
     </part-list>
   <part id="P1">
     <measure number="1">


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14859

See instructions in https://musescore.org/en/node/337405, the MusicXML file exported from the blank staff contains a part-group start, but the corresponding part-group stop is missing.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
