### PR TITLE
[MU4] fix #14896: Percussion Note Input: Previous Drum Sound Gets Carried to New Instrument

### DIFF
--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -33,6 +33,7 @@
 
 #include "async/channel.h"
 #include "io/iodevice.h"
+#include "types/ret.h"
 
 #include "modularity/ioc.h"
 #include "draw/iimageprovider.h"
@@ -469,7 +470,7 @@ private:
 
     void cmdToggleVisible();
 
-    void putNote(const Position&, bool replace);
+    Ret putNote(const Position&, bool replace);
 
     void resetTempo();
     void resetTempoRange(const Fraction& tick1, const Fraction& tick2);
@@ -736,14 +737,14 @@ public:
     void cmdDeleteSelection();
     void cmdFullMeasureRest();
 
-    void putNote(const mu::PointF&, bool replace, bool insert);
-    void insertChord(const Position&);
+    Ret putNote(const mu::PointF&, bool replace, bool insert);
+    Ret insertChord(const Position&);
     void localInsertChord(const Position&);
     void globalInsertChord(const Position&);
 
     void cloneVoice(track_idx_t strack, track_idx_t dtrack, Segment* sf, const Fraction& lTick, bool link = true, bool spanner = true);
 
-    void repitchNote(const Position& pos, bool replace);
+    Ret repitchNote(const Position& pos, bool replace);
     void regroupNotesAndRests(const Fraction& startTick, const Fraction& endTick, track_idx_t track);
     bool checkTimeDelete(Segment*, Segment*);
     void timeDelete(Measure*, Segment*, const Fraction&);

--- a/src/notation/inotationnoteinput.h
+++ b/src/notation/inotationnoteinput.h
@@ -41,7 +41,7 @@ public:
     virtual void toggleNoteInputMethod(NoteInputMethod method) = 0;
     virtual void addNote(NoteName noteName, NoteAddingMode addingMode) = 0;
     virtual void padNote(const Pad& pad)  = 0;
-    virtual void putNote(const PointF& pos, bool replace, bool insert) = 0;
+    virtual Ret putNote(const PointF& pos, bool replace, bool insert) = 0;
     virtual void removeNote(const PointF& pos) = 0;
     virtual async::Notification noteInputStarted() const = 0;
     virtual async::Notification noteInputEnded() const = 0;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -733,9 +733,10 @@ void NotationActionController::putNote(const actions::ActionData& args)
     bool replace = args.arg<bool>(1);
     bool insert = args.arg<bool>(2);
 
-    noteInput->putNote(pos, replace, insert);
-
-    playSelectedElement();
+    Ret ret = noteInput->putNote(pos, replace, insert);
+    if (ret) {
+        playSelectedElement();
+    }
 }
 
 void NotationActionController::removeNote(const actions::ActionData& args)

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -351,16 +351,18 @@ void NotationNoteInput::padNote(const Pad& pad)
     notifyAboutStateChanged();
 }
 
-void NotationNoteInput::putNote(const PointF& pos, bool replace, bool insert)
+mu::Ret NotationNoteInput::putNote(const PointF& pos, bool replace, bool insert)
 {
     TRACEFUNC;
 
     startEdit();
-    score()->putNote(pos, replace, insert);
+    Ret ret = score()->putNote(pos, replace, insert);
     apply();
 
     notifyNoteAddedChanged();
     notifyAboutStateChanged();
+
+    return ret;
 }
 
 void NotationNoteInput::removeNote(const PointF& pos)

--- a/src/notation/internal/notationnoteinput.h
+++ b/src/notation/internal/notationnoteinput.h
@@ -55,7 +55,7 @@ public:
     void toggleNoteInputMethod(NoteInputMethod method) override;
     void addNote(NoteName noteName, NoteAddingMode addingMode) override;
     void padNote(const Pad& pad) override;
-    void putNote(const PointF& pos, bool replace, bool insert) override;
+    Ret putNote(const PointF& pos, bool replace, bool insert) override;
     void removeNote(const PointF& pos) override;
     async::Notification noteInputStarted() const override;
     async::Notification noteInputEnded() const override;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14896