### PR TITLE
[MU4] Fix #13271:  'Play chord symbols' option doesn't save 'sound off' state for next opened scores and next MU sessions

### DIFF
--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -1045,6 +1045,10 @@ void PlaybackController::updateMuteStates()
                              || (hasSolo && !soloMuteState.solo)
                              || (!isPartVisible);
 
+        if (notationPlayback()->isChordSymbolsTrack(instrumentTrackId) && !shouldBeMuted) {
+            shouldBeMuted = !notationConfiguration()->isPlayChordSymbolsEnabled();
+        }
+
         if (isRangePlaybackMode && !shouldBeMuted) {
             shouldBeMuted = !mu::contains(allowedInstrumentTrackIdSet, instrumentTrackId);
         }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/13271