### PR TITLE
Fix bug for grace note slur upon deleting measure

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -2846,7 +2846,6 @@ void Score::deleteMeasures(MeasureBase* mbStart, MeasureBase* mbEnd, bool preser
     Fraction startTick = mbStart->tick();
     Fraction endTick   = mbEnd->tick();
 
-    undoInsertTime(mbStart->tick(), -(mbEnd->endTick() - mbStart->tick()));
     for (Score* score : scoreList()) {
         Measure* startMeasure = score->tick2measure(startTick);
         Measure* endMeasure = score->tick2measure(endTick);
@@ -2903,6 +2902,7 @@ void Score::deleteMeasures(MeasureBase* mbStart, MeasureBase* mbEnd, bool preser
         }
     }
 
+    undoInsertTime(mbStart->tick(), -(mbEnd->endTick() - mbStart->tick()));
     _is.setSegment(0);          // invalidate position
 }
 


### PR DESCRIPTION
Resolves: #14915 

Basically, the slur endpoint was being updated before the end-chord was, so it was still using the "old" (i.e. before-removing-measure) position of such chord, which caused it to wrongly end up in the next measure (and therefore in the next system). As far as I can tell, this happens inside `Score::deleteMeasures()` because we are calling `undoInsertTime()` (which updates the spanners) before `undoRemoveMeasure()` (which updates all the ticks). Moving the call of undoInsertTime() after the for loop seems to solve the problem.
