### PR TITLE
[MU4] Fix #14977: Crash when adding fret diagram to a note

### DIFF
--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -780,5 +780,10 @@ InstrumentTrackId PlaybackModel::idKey(const ID& partId, const std::string& inst
 
 mpe::ArticulationsProfilePtr PlaybackModel::defaultActiculationProfile(const InstrumentTrackId& trackId) const
 {
-    return profilesRepository()->defaultProfile(m_playbackDataMap.at(trackId).setupData.category);
+    auto it = m_playbackDataMap.find(trackId);
+    if (it == m_playbackDataMap.cend()) {
+        return nullptr;
+    }
+
+    return profilesRepository()->defaultProfile(it->second.setupData.category);
 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14977