### PR TITLE
Fix shift + rightArrow system line edit

### DIFF
--- a/src/engraving/libmscore/line.cpp
+++ b/src/engraving/libmscore/line.cpp
@@ -981,6 +981,15 @@ PointF SLine::linePos(Grip grip, System** sys) const
             x += cr->segment()->pos().x() + m->pos().x();
         } else {
             Segment* segment = (grip == Grip::START) ? startSegment() : endSegment();
+            if (grip == Grip::END && segment && segment->rtick().ticks() == 0) {
+                // The line should end on the left-most segment at this tick. If endSegment() is the first of
+                // the measure, we need to look back for other segments (eg endBarLine) in the prev measure
+                Segment* prevSegment = segment->prev1();
+                while (prevSegment && prevSegment->tick() == segment->tick()) {
+                    segment = prevSegment;
+                    prevSegment = segment->prev1();
+                }
+            }
             if (segment) {
                 m = segment->measure();
                 if (m->mmRest()) {

--- a/src/engraving/libmscore/spanner.cpp
+++ b/src/engraving/libmscore/spanner.cpp
@@ -1016,24 +1016,7 @@ Segment* Spanner::startSegment() const
 
 Segment* Spanner::endSegment() const
 {
-    Segment* endSeg = score()->tick2leftSegment(tick2());
-    if (!systemFlag()) {
-        return endSeg;
-    }
-    if (endSeg->rtick().ticks() == 0) {
-        // If this is the first segment of the measure, it may not be the left-most segment at this tick.
-        // There could be segments at the end of the previous measure. We nees those for correct layout of system lines.
-        Measure* prevMeas = endSeg->measure()->prevMeasure();
-        if (prevMeas) {
-            for (Segment& s : prevMeas->segments()) {
-                if (s.tick() == tick2()) {
-                    endSeg = &s;
-                    break;
-                }
-            }
-        }
-    }
-    return endSeg;
+    return score()->tick2leftSegment(tick2());
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: #14952 

The regression started in #14397. 
The correct layout of these lines requires that they end at the left-most segment at that tick (which is often the endBarLine of the previous measure). I originally did it by modifying the endSegment() of the line, but this was preventing it to jump to the next measure. Now I do it at layout stage without modifying the endSegment(). 