### PR TITLE
[MU4] Fix #14752: Changing volume faders causes VST effects to be removed

### DIFF
--- a/src/playback/view/internal/mixerchannelitem.cpp
+++ b/src/playback/view/internal/mixerchannelitem.cpp
@@ -155,6 +155,8 @@ void MixerChannelItem::loadOutputParams(AudioOutputParams&& newParams)
         emit mutedChanged();
     }
 
+    m_outParams.fxChain = newParams.fxChain;
+
     QMap<AudioFxChainOrder, OutputResourceItem*> newItems = m_outputResourceItems;
 
     for (AudioFxChainOrder chainOrder : m_outputResourceItems.keys()) {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14752