### PR TITLE
Fix #14944: Prevent adding multiple beam fragments

### DIFF
--- a/src/engraving/layout/layoutbeams.cpp
+++ b/src/engraving/layout/layoutbeams.cpp
@@ -332,15 +332,20 @@ void LayoutBeams::createBeams(Score* score, LayoutContext& lc, Measure* measure)
                 BeamMode mode = cr->beamMode();
                 if (mode == BeamMode::MID || mode == BeamMode::END || mode == BeamMode::BEGIN32 || mode == BeamMode::BEGIN64) {
                     ChordRest* prevCR = score->findCR(measure->tick() - Fraction::fromTicks(1), track);
+                    Beam* prevBeam = prevCR->beam();
                     if (prevCR) {
                         const Measure* pm = prevCR->measure();
                         if (!beamNoContinue(prevCR->beamMode())
                             && !pm->lineBreak() && !pm->pageBreak() && !pm->sectionBreak()
                             && lc.prevMeasure
                             && !(prevCR->isChord() && prevCR->durationType().type() <= DurationType::V_QUARTER)) {
-                            beam = prevCR->beam();
+                            beam = prevBeam;
                             //a1 = beam ? beam->elements().front() : prevCR;
                             a1 = beam ? nullptr : prevCR;               // when beam is found, a1 is no longer required.
+                        } else if (prevBeam && prevBeam == cr->beam() && prevBeam->elements().front() == prevCR) {
+                            // remove the beam from the previous chordrest because we do not currently
+                            // support cross-system beams
+                            prevCR->removeDeleteBeam(false);
                         }
                     }
                 }

--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -459,7 +459,8 @@ void Beam::layout()
 
     size_t n = 0;
     for (ChordRest* cr : _elements) {
-        if (cr->measure()->system() != system) {
+        auto newSystem = cr->measure()->system();
+        if (newSystem && newSystem != system) {
             SpannerSegmentType st;
             if (n == 0) {
                 st = SpannerSegmentType::BEGIN;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14944

The problem was that during layout, the second measure of a cross-measure beam didn't have its system explicitly set, which made the beam think that the second measure was on a different system. Now, that codepath only happens when chordrests are _explicitly_ on different systems.