### PR TITLE
Fix #13624: allow BeamMode::BEGIN32 and BEGIN64 to continue cross-measure beam

### DIFF
--- a/src/engraving/layout/layoutbeams.cpp
+++ b/src/engraving/layout/layoutbeams.cpp
@@ -330,7 +330,7 @@ void LayoutBeams::createBeams(Score* score, LayoutContext& lc, Measure* measure)
                 firstCR = false;
                 // Handle cross-measure beams
                 BeamMode mode = cr->beamMode();
-                if (mode == BeamMode::MID || mode == BeamMode::END) {
+                if (mode == BeamMode::MID || mode == BeamMode::END || mode == BeamMode::BEGIN32 || mode == BeamMode::BEGIN64) {
                     ChordRest* prevCR = score->findCR(measure->tick() - Fraction::fromTicks(1), track);
                     if (prevCR) {
                         const Measure* pm = prevCR->measure();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/13624