### PR TITLE
reverted #8174: lasso list selection

### DIFF
--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -4061,7 +4061,7 @@ void Score::lassoSelect(const RectF& bbox)
 //   lassoSelectEnd
 //---------------------------------------------------------
 
-void Score::lassoSelectEnd(bool convertToRange)
+void Score::lassoSelectEnd()
 {
     int noteRestCount     = 0;
     Segment* startSegment = 0;
@@ -4076,11 +4076,6 @@ void Score::lassoSelectEnd(bool convertToRange)
         return;
     }
     _selection.setState(SelState::LIST);
-
-    if (!convertToRange) {
-        setUpdateAll();
-        return;
-    }
 
     for (const EngravingItem* e : _selection.elements()) {
         if (e->type() != ElementType::NOTE && e->type() != ElementType::REST) {

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -973,7 +973,7 @@ public:
     void setBracketsAndBarlines();
 
     void lassoSelect(const mu::RectF&);
-    void lassoSelectEnd(bool);
+    void lassoSelectEnd();
 
     Page* searchPage(const mu::PointF&) const;
     std::vector<System*> searchSystem(const mu::PointF& p, const System* preferredSystem = nullptr, double spacingFactor = 0.5,

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1049,7 +1049,7 @@ void NotationInteraction::endLasso()
 
     score()->addRefresh(m_lasso->canvasBoundingRect());
     m_lasso->setbbox(RectF());
-    score()->lassoSelectEnd(m_dragData.mode != DragMode::LassoList);
+    score()->lassoSelectEnd();
     score()->update();
 }
 
@@ -1059,7 +1059,6 @@ void NotationInteraction::drag(const PointF& fromPos, const PointF& toPos, DragM
         m_dragData.beginMove = fromPos;
         m_dragData.ed.pos = fromPos;
     }
-    m_dragData.mode = mode;
 
     PointF normalizedBegin = m_dragData.beginMove - m_dragData.elementOffset;
     PointF delta = toPos - normalizedBegin;
@@ -1069,7 +1068,6 @@ void NotationInteraction::drag(const PointF& fromPos, const PointF& toPos, DragM
     if (constrainDirection) {
         switch (mode) {
         case DragMode::BothXY:
-        case DragMode::LassoList:
             break;
         case DragMode::OnlyX:
             delta.setY(m_dragData.ed.delta.y());

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -388,7 +388,6 @@ private:
         mu::engraving::EditData ed;
         std::vector<EngravingItem*> elements;
         std::vector<std::unique_ptr<mu::engraving::ElementGroup> > dragGroups;
-        DragMode mode { DragMode::BothXY };
         void reset();
     };
 

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -159,8 +159,7 @@ enum class DragMode
 {
     BothXY = 0,
     OnlyX,
-    OnlyY,
-    LassoList
+    OnlyY
 };
 
 enum class MoveDirection

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -708,11 +708,11 @@ void NotationViewInputController::mouseMoveEvent(QMouseEvent* event)
             viewInteraction()->drag(m_beginPoint, logicPos, mode);
 
             return;
-        } else if (hitElement == nullptr && (keyState & (Qt::ShiftModifier | Qt::ControlModifier))) {
+        } else if (hitElement == nullptr && (keyState & Qt::ShiftModifier)) {
             if (!viewInteraction()->isDragStarted()) {
                 viewInteraction()->startDrag(std::vector<EngravingItem*>(), PointF(), [](const EngravingItem*) { return false; });
             }
-            viewInteraction()->drag(m_beginPoint, logicPos, keyState & Qt::ControlModifier ? DragMode::LassoList : DragMode::BothXY);
+            viewInteraction()->drag(m_beginPoint, logicPos, DragMode::BothXY);
 
             return;
         }


### PR DESCRIPTION
Resolves: #15002

In fact, the feature works, but the user can use this feature in non-standard cases, for example, as in the issue. 

The result that the user wants to achieve can be solved using Shift+drag - the range will be selected. Operations on range work fine, unlike element-by-element selection.

We will return to this feature after fixing the problems with element-by-element selection. 