### PR TITLE
[MU4] Fix #14963: VST effect window on Master channel becomes blank after re-opening sore during one MU session

### DIFF
--- a/src/framework/audio/iaudiooutput.h
+++ b/src/framework/audio/iaudiooutput.h
@@ -43,6 +43,7 @@ public:
 
     virtual async::Promise<AudioOutputParams> masterOutputParams() const = 0;
     virtual void setMasterOutputParams(const AudioOutputParams& params) = 0;
+    virtual void clearMasterOutputParams() = 0;
     virtual async::Channel<AudioOutputParams> masterOutputParamsChanged() const = 0;
 
     virtual async::Promise<AudioResourceMetaList> availableOutputResources() const = 0;

--- a/src/framework/audio/internal/worker/audiooutputhandler.cpp
+++ b/src/framework/audio/internal/worker/audiooutputhandler.cpp
@@ -120,6 +120,19 @@ void AudioOutputHandler::setMasterOutputParams(const AudioOutputParams& params)
     }, AudioThread::ID);
 }
 
+void AudioOutputHandler::clearMasterOutputParams()
+{
+    Async::call(this, [this]() {
+        ONLY_AUDIO_WORKER_THREAD;
+
+        IF_ASSERT_FAILED(mixer()) {
+            return;
+        }
+
+        mixer()->clearMasterOutputParams();
+    }, AudioThread::ID);
+}
+
 Channel<AudioOutputParams> AudioOutputHandler::masterOutputParamsChanged() const
 {
     ONLY_AUDIO_MAIN_OR_WORKER_THREAD;

--- a/src/framework/audio/internal/worker/audiooutputhandler.h
+++ b/src/framework/audio/internal/worker/audiooutputhandler.h
@@ -45,6 +45,7 @@ public:
 
     async::Promise<AudioOutputParams> masterOutputParams() const override;
     void setMasterOutputParams(const AudioOutputParams& params) override;
+    void clearMasterOutputParams() override;
     async::Channel<AudioOutputParams> masterOutputParamsChanged() const override;
 
     async::Promise<AudioResourceMetaList> availableOutputResources() const override;

--- a/src/framework/audio/internal/worker/mixer.cpp
+++ b/src/framework/audio/internal/worker/mixer.cpp
@@ -251,6 +251,11 @@ void Mixer::setMasterOutputParams(const AudioOutputParams& params)
     m_masterOutputParamsChanged.send(params);
 }
 
+void Mixer::clearMasterOutputParams()
+{
+    setMasterOutputParams(AudioOutputParams());
+}
+
 Channel<AudioOutputParams> Mixer::masterOutputParamsChanged() const
 {
     return m_masterOutputParamsChanged;

--- a/src/framework/audio/internal/worker/mixer.h
+++ b/src/framework/audio/internal/worker/mixer.h
@@ -54,6 +54,7 @@ public:
 
     AudioOutputParams masterOutputParams() const;
     void setMasterOutputParams(const AudioOutputParams& params);
+    void clearMasterOutputParams();
     async::Channel<AudioOutputParams> masterOutputParamsChanged() const;
 
     async::Channel<audioch_t, AudioSignalVal> masterAudioSignalChanges() const;

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -664,6 +664,7 @@ void PlaybackController::resetCurrentSequence()
     playback()->audioOutput()->clearAllFx();
     playback()->audioOutput()->outputParamsChanged().resetOnReceive(this);
     playback()->audioOutput()->masterOutputParamsChanged().resetOnReceive(this);
+    playback()->audioOutput()->clearMasterOutputParams();
 
     setCurrentPlaybackTime(0);
     setCurrentPlaybackStatus(PlaybackStatus::Stopped);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14963