### PR TITLE
[MU4] Lyrics copy paste fix

### DIFF
--- a/src/engraving/libmscore/lyrics.cpp
+++ b/src/engraving/libmscore/lyrics.cpp
@@ -431,9 +431,12 @@ void Lyrics::layout2(int nAbove)
 
 void Lyrics::paste(EditData& ed, const String& txt)
 {
-    MuseScoreView* scoreview = ed.view();
+    String correctedText = txt;
+    //! NOTE: Remove formating info. For example, for "<info><info>text" will be "text"
+    correctedText = correctedText.remove(std::regex("\\<(.*?)\\>"));
+
     String regex = String(u"[^\\S") + Char(0xa0) + Char(0x202F) + u"]+";
-    StringList sl = txt.split(std::regex(regex.toStdString()), mu::SkipEmptyParts);
+    StringList sl = correctedText.split(std::regex(regex.toStdString()), mu::SkipEmptyParts);
     if (sl.empty()) {
         return;
     }
@@ -481,6 +484,7 @@ void Lyrics::paste(EditData& ed, const String& txt)
 
     score()->endCmd();
 
+    MuseScoreView* scoreview = ed.view();
     if (minus) {
         scoreview->lyricsMinus();
     } else if (underscore) {

--- a/src/engraving/libmscore/lyrics.cpp
+++ b/src/engraving/libmscore/lyrics.cpp
@@ -443,6 +443,8 @@ void Lyrics::paste(EditData& ed, const String& txt)
     bool underscore = false;
     score()->startCmd();
 
+    deleteSelectedText(ed);
+
     if (hyph.size() > 1) {
         score()->undo(new InsertText(cursorFromEditData(ed), hyph[0]), &ed);
         hyph.removeAt(0);


### PR DESCRIPTION
Fixed this bugs:
- If the user selected text in the lyrics and inserted new text, then insertion at the end occurs, not replacement
- When copying a text from another text box and pasting it to lyrics, formatting text is inserted into the lyric.