### PR TITLE
Instruments: Make Bb trumpet the default instead of C trumpet

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -4693,7 +4693,7 @@
                   <trackName>Trumpet</trackName>
                   <longName>Trumpet</longName>
                   <shortName>Tpt.</shortName>
-                  <traitName type="transposition">*C</traitName>
+                  <traitName type="transposition">C</traitName>
                   <description>Trumpet in C. Nowadays the most common orchestral trumpet.</description>
                   <musicXMLid>brass.trumpet.c</musicXMLid>
                   <clef>G</clef>
@@ -4734,8 +4734,8 @@
                   <trackName>Trumpet</trackName>
                   <longName>Trumpet</longName>
                   <shortName>Tpt.</shortName>
-                  <traitName type="transposition">B♭</traitName>
-                  <description>Trumpet in B♭.</description>
+                  <traitName type="transposition">*B♭</traitName>
+                  <description>Trumpet in B♭. Still the most common trumpet in non-orchestral contexts.</description>
                   <musicXMLid>brass.trumpet.bflat</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>

--- a/share/instruments/instrumentsxml.h
+++ b/share/instruments/instrumentsxml.h
@@ -2588,7 +2588,7 @@ QT_TRANSLATE_NOOP3("engraving/instruments", "Trumpet", "c-trumpet longName"),
 //: shortName for Trumpet; transposition: C; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Tpt.", "c-trumpet shortName"),
 //: traitName for Trumpet; transposition: C; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "*C", "c-trumpet traitName"),
+QT_TRANSLATE_NOOP3("engraving/instruments", "C", "c-trumpet traitName"),
 //: channel for Trumpet; transposition: C; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "open", "c-trumpet channel"),
 //: channel for Trumpet; transposition: C; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
@@ -2608,7 +2608,7 @@ QT_TRANSLATE_NOOP3("engraving/instruments", "open", "trumpet channel"),
 QT_TRANSLATE_NOOP3("engraving/instruments", "mute", "trumpet channel"),
 
 //: description for Trumpet; transposition: B♭; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Trumpet in B♭.", "bb-trumpet description"),
+QT_TRANSLATE_NOOP3("engraving/instruments", "Trumpet in B♭. Still the most common trumpet in non-orchestral contexts.", "bb-trumpet description"),
 //: trackName for Trumpet; transposition: B♭; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Trumpet", "bb-trumpet trackName"),
 //: longName for Trumpet; transposition: B♭; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
@@ -2616,7 +2616,7 @@ QT_TRANSLATE_NOOP3("engraving/instruments", "Trumpet", "bb-trumpet longName"),
 //: shortName for Trumpet; transposition: B♭; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Tpt.", "bb-trumpet shortName"),
 //: traitName for Trumpet; transposition: B♭; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "B♭", "bb-trumpet traitName"),
+QT_TRANSLATE_NOOP3("engraving/instruments", "*B♭", "bb-trumpet traitName"),
 //: channel for Trumpet; transposition: B♭; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "open", "bb-trumpet channel"),
 //: channel for Trumpet; transposition: B♭; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names


### PR DESCRIPTION
Now Bb will be the default option in the Trumpet dropdown in the NSW and Instruments dialog.

Fix #14957

Before | After
---|---
<img width="290" alt="image" src="https://user-images.githubusercontent.com/11011881/206819492-78d84611-3181-4292-a1f8-9fc156206c67.png"> | <img width="292" alt="image" src="https://user-images.githubusercontent.com/11011881/206819546-6d6cda00-4ed2-461d-b8b8-3bf8b9d53bcf.png">

I also updated the description of the Bb trumpet:

Before | After
---|---
<img width="278" alt="image" src="https://user-images.githubusercontent.com/11011881/206819715-c1614696-a2fd-49a7-8f19-257b90c55ba9.png"> | <img width="436" alt="image" src="https://user-images.githubusercontent.com/11011881/206819619-272dc20f-6276-4d1b-b08f-32588f1fa94a.png">

Ignore the missing space after the full stop. This is a known bug in how Qt strings are displayed on old versions of macOS. In reality there is a space character there that is displayed on other platforms.