### PR TITLE
Fix: retry the command -> retry

### DIFF
--- a/src/notation/notationerrors.h
+++ b/src/notation/notationerrors.h
@@ -60,7 +60,7 @@ inline Ret make_ret(Err err)
                + "\n" + trc("notation", "Please select a measure and retry");
         break;
     case Err::SelectCompleteTupletOrTremolo:
-        text = trc("notation", "Please select the complete tuplet/tremolo and retry the command");
+        text = trc("notation", "Please select the complete tuplet or tremolo and retry");
         break;
     case Err::EmptySelection:
         text = trc("notation", "The selection is empty");


### PR DESCRIPTION
The "...and retry the command" occurs only once in strings to translate - only in this case. These cases above are with "or" instead of "/"; and this case name is: Err::SelectCompleteTupletOrTremolo.

Greetings,
Gootector

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [x] I created the test (mtest, vtest, script test) to verify the changes I made
