### PR TITLE
gp-import: fixed ties for harmonic notes

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.h
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.h
@@ -256,6 +256,8 @@ private:
     std::unordered_map<Measure*, std::array<int, VOICES> > m_chordsInMeasureByVoice; /// if measure has any chord for specific voice, rests are hidden
     std::unordered_map<Measure*, size_t> m_chordsInMeasure;
     BeamMode m_previousBeamMode = BeamMode::AUTO;
+
+    std::unordered_map<Note*, Note*> m_harmonicNotes;
 };
 } //end Ms namespace
 #endif // SCOREDOMBUILDER_H


### PR DESCRIPTION
imported ties for harmonic notes used to be located in random places of the score
also added extra ties on the top notes

Before fix:
<img width="284" alt="Screenshot 2022-12-11 at 22 33 54" src="https://user-images.githubusercontent.com/24373905/206927347-5cdfd7ea-11e5-412f-9924-9fd7571a6b86.png">

After fix:
<img width="105" alt="Screenshot 2022-12-11 at 22 34 31" src="https://user-images.githubusercontent.com/24373905/206927368-ff3ad103-ac5d-4820-a360-1c29adad801a.png">
