### PR TITLE
Fix #15090: add annotations within tuplet consistent with non-tuplet segments

### DIFF
--- a/src/engraving/libmscore/range.cpp
+++ b/src/engraving/libmscore/range.cpp
@@ -92,6 +92,14 @@ void TrackList::appendTuplet(Tuplet* srcTuplet, Tuplet* dstTuplet)
             Tuplet* st = toTuplet(de);
             Tuplet* dt = toTuplet(e);
             appendTuplet(st, dt);
+        } else if (de->explicitParent() && de->explicitParent()->isSegment()) {
+            Segment* seg = toSegment(de->explicitParent());
+            for (EngravingItem* ee : seg->annotations()) {
+                bool addSysObject = ee->systemFlag() && !ee->isLinked() && ee->track() == 0 && e->track() == 0;
+                if (addSysObject || (!ee->systemFlag() && ee->track() == e->track())) {
+                    _range->annotations.push_back({ e->tick(), ee->clone() });
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/15090