### PR TITLE
Update pull request template and fix some ambiguities

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,14 @@
-Resolves: *(direct link to the issue)*
+Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->
 
-*(short description of the changes and the motivation to make the changes)*
+<!-- Add a short description of and motivation for the changes here -->
 
-<!-- Use "x" to fill the checkboxes below like [x] -->
+<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->
 
-- [ ] I signed [CLA](https://musescore.org/en/cla)
-- [ ] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
-- [ ] I made sure the code compiles on my machine
-- [ ] I made sure there are no unnecessary changes in the code
-- [ ] I made sure the title of the PR reflects the core meaning of the issue you are solving
-- [ ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
-- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
-- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
+- [ ] I signed the [CLA](https://musescore.org/en/cla)
+- [ ] The title of the PR describes the problem it addresses
+- [ ] Each commit's message describes its purpose and effects, and references the issue it resolves
+- [ ] If changes are extensive, there is a sequence of easily reviewable commits
+- [ ] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
+- [ ] There are no unnecessary changes
+- [ ] The code compiles and runs on my machine, preferably after each commit individually
+- [ ] I created a unit test or vtest to verify the changes I made (if applicable)


### PR DESCRIPTION
Based on commonly seen ""mistakes"" in PR descriptions, but mainly because now GitHub is mainly used rather than musescore.org's issue tracker, and to prevent confusion because GitHub issue numbers are starting to overlap with musescore.org issue numbers. From now on, we simply ask to link to the GitHub issue so that it will be closed automatically, and don't mention musescore.org anymore. 

(My future vision is that users can continue to create issues on musescore.org, and that we implement an automated way to transfer well-written non-duplicate issues to GitHub, so that the musescore.org issue ends up tracking the status of the GitHub issue, being closed automatically when the GitHub issue is closed etc..)