### PR TITLE
Fix #12934 Delete images inside a frame

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -687,6 +687,12 @@ bool NotationInteraction::elementIsLess(const EngravingItem* e1, const Engraving
     if (e1->isBox() && e2->isText()) {
         return true;
     }
+    if (e1->isImage() && e2->isBox()) {
+        return false;
+    }
+    if (e1->isBox() && e2->isImage()) {
+        return true;
+    }
     if (e1->z() == e2->z()) {
         // same stacking order, prefer non-hidden elements
         if (e1->type() == e2->type()) {


### PR DESCRIPTION
Resolves: #12934

Before this PR, we could not select images inside a frame because of their z-order. The z-order of a frame is higher than an image, so musescore prefers selecting the higher z-order (frame) first.

This PR solves this issue by adding a special case to let musescore select an image (lower z-order) over a frame (higher z-order)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
