### PR TITLE
Fix crash when importing MIDI file that contains non-positive time signatures

### DIFF
--- a/src/importexport/midi/internal/midiimport/importmidi.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi.cpp
@@ -711,12 +711,17 @@ std::multimap<int, MTrack> createMTrackList(TimeSigMap* sigmap, const MidiFile* 
                                                track.isDivisionInTps);
             // remove time signature events
             if ((e.type() == ME_META) && (e.metaType() == META_TIME_SIGNATURE)) {
+                Fraction ts = metaTimeSignature(e);
+                if (!ts.isValid() || ts <= Fraction(0, 1)) {
+                    LOGW() << "skipping invalid time signature event from MIDI file at tick " << tick.ticks();
+                    continue;
+                }
                 // because file can have incorrect data
                 // like time sig event not at the beginning of bar
                 // we need to round tick value to integral bar count
                 int bars, beats, ticks;
                 sigmap->tickValues(tick.ticks(), &bars, &beats, &ticks);
-                sigmap->add(sigmap->bar2tick(bars, 0), metaTimeSignature(e));
+                sigmap->add(sigmap->bar2tick(bars, 0), ts);
             } else if (e.type() == ME_NOTE) {
                 hasNotes = true;
                 const int pitch = e.pitch();


### PR DESCRIPTION
Resolves: #14791

We'll just skip these time signatures for now. If anyone who has a better understanding of the MIDI file specification than me has a better idea for how to handle this, that's very welcome!