### PR TITLE
Issue templates: add link to Muse Hub issue tracker

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Muse Hub issue
+    url: https://musehub.zendesk.com/
+    about: All issues to do with installing apps and sounds via Muse Hub.


### PR DESCRIPTION
Muse Hub issues should now be directed to the dedicated issue tracker. This PR mentions this on the "New issue" page. Once this is merged, the page will look like this: (tested on my own fork)
<img width="1011" alt="Scherm­afbeelding 2022-12-15 om 21 18 42" src="https://user-images.githubusercontent.com/48658420/207958657-03853a76-2cfa-4e14-bbdc-71595dbaab32.png">