### PR TITLE
Init OAuth lazily

### DIFF
--- a/src/cloud/internal/cloudservice.h
+++ b/src/cloud/internal/cloudservice.h
@@ -77,6 +77,8 @@ private slots:
     void onUserAuthorized();
 
 private:
+    void initOAuthIfNecessary();
+
     bool readTokens();
     bool saveTokens();
     bool updateTokens();


### PR DESCRIPTION
- so that we don't use the resources of having a TCP server running all the time
- so that firewall warnings will only appear at the moment that the user tries to log in, not on every launch. This makes it easier for users to understand that these warnings are related to the login process.

    (This is the dialog I mean: 
    <img width="385" alt="Scherm­afbeelding 2022-12-18 om 02 30 25" src="https://user-images.githubusercontent.com/48658420/208272711-15a4a4e1-5573-4596-9bbb-4635ce8f417d.png">
"Do you want to allow mscore.app to accept incoming connections?"

    This dialog appears every time that MuseScore starts its TCP server, if macOS's default firewall is enabled)