### PR TITLE
Fix flying gradual tempo changes in Palettes / Master Palette

### DIFF
--- a/src/engraving/libmscore/gradualtempochange.cpp
+++ b/src/engraving/libmscore/gradualtempochange.cpp
@@ -342,7 +342,7 @@ Sid GradualTempoChangeSegment::getPropertyStyle(Pid id) const
 void GradualTempoChangeSegment::layout()
 {
     TextLineBaseSegment::layout();
-    movePosY(-tempoChange()->lineWidth() / 2); // correct y-pos for linewidth
+    setPosY(-tempoChange()->lineWidth() / 2); // correct y-pos for linewidth
     if (isStyled(Pid::OFFSET)) {
         roffset() = tempoChange()->propertyDefault(Pid::OFFSET).value<PointF>();
     }


### PR DESCRIPTION
On every redraw of the palette cell (which included a call to `layout()`) they would be moved upwards a little bit.

Resolves: #15297

@mike-spa Do you think that the positioning of gradual tempo changes needs to be re-tested thoroughly after this change?