### PR TITLE
Disabled accidentals on tablature, fixing bug where it would always result in C9 or variation upon it

### DIFF
--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -1995,8 +1995,8 @@ void Score::changeAccidental(Note* note, AccidentalType accidental)
         return;
     }
     ClefType clef = estaff->clef(tick);
-    if (clef == ClefType::TAB 
-        || clef == ClefType::TAB4 
+    if (clef == ClefType::TAB
+        || clef == ClefType::TAB4
         || clef == ClefType::TAB_SERIF
         || clef == ClefType::TAB4_SERIF) {
         return;

--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -1995,6 +1995,12 @@ void Score::changeAccidental(Note* note, AccidentalType accidental)
         return;
     }
     ClefType clef = estaff->clef(tick);
+    if (clef == ClefType::TAB 
+        || clef == ClefType::TAB4 
+        || clef == ClefType::TAB_SERIF
+        || clef == ClefType::TAB4_SERIF) {
+        return;
+    }
     int step      = ClefInfo::pitchOffset(clef) - note->line();
     while (step < 0) {
         step += 7;


### PR DESCRIPTION
Added a guard clause so that changes of accidentals do not affect tablature, as the concept of accidentals makes little sense in the context of tablature.

Resolves: #15284 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
This fixes the above issue where, previously, accidentals on tablature would cause the note to become a C9 (or variant upon it depending on the selected accidental). Alternatively, I could have made it so accidentals on tablature worked like with other clefs, but since they make little sense in regards to tablature, I, as well as @Nyde42, decided that it would make more sense to disable them.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits (N/a)
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
