### PR TITLE
Use page color for fret number background

### DIFF
--- a/src/engraving/internal/engravingconfiguration.cpp
+++ b/src/engraving/internal/engravingconfiguration.cpp
@@ -201,7 +201,7 @@ Color EngravingConfiguration::thumbnailBackgroundColor() const
 
 Color EngravingConfiguration::noteBackgroundColor() const
 {
-    return Color::white;
+    return notationConfiguration()->foregroundColor();
 }
 
 double EngravingConfiguration::guiScaling() const

--- a/src/engraving/internal/engravingconfiguration.h
+++ b/src/engraving/internal/engravingconfiguration.h
@@ -28,6 +28,7 @@
 #include "global/iglobalconfiguration.h"
 #include "ui/iuiconfiguration.h"
 #include "accessibility/iaccessibilityconfiguration.h"
+#include "notation/inotationconfiguration.h"
 #include "importexport/guitarpro/iguitarproconfiguration.h"
 
 #include "../iengravingconfiguration.h"
@@ -38,6 +39,7 @@ class EngravingConfiguration : public IEngravingConfiguration, public async::Asy
     INJECT(engraving, mu::framework::IGlobalConfiguration, globalConfiguration)
     INJECT(engraving, mu::ui::IUiConfiguration, uiConfiguration)
     INJECT(engraving, mu::accessibility::IAccessibilityConfiguration, accessibilityConfiguration)
+    INJECT(engraving, notation::INotationConfiguration, notationConfiguration)
     INJECT(engraving, iex::guitarpro::IGuitarProConfiguration, guitarProConfiguration);
 
 public:


### PR DESCRIPTION
Resolves: #11570 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Renders the page background color behind tablature numbers instead of just rendering a white rectangle
<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
