### PR TITLE
Fix crash when doing Add Linked Staff / Undo / DeleteInstrument / Undo on staff with articulation

### DIFF
--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -295,7 +295,7 @@ Chord::Chord(const Chord& c, bool link)
     for (Articulation* a : c._articulations) {      // make deep copy
         Articulation* na = new Articulation(*a);
         if (link) {
-            na->linkTo(a);
+            score()->undo(new Link(na, a));
         }
         na->setParent(this);
         na->setTrack(track());


### PR DESCRIPTION
Fix crash when performing the following actions on a staff containing a chord with an articulation:

1. Create a linked staff
2. Undo
3. Delete the instrument
4. Undo

Resolves: #15165 

What happened, as far as I understand:
- Create linked staff → a new articulation is created for the linked staff, and it is linked to the original articulation
- Undo → the linked articulation is removed from the score and continues to live in the undo stack, but it is not properly unlinked from the original articulation 
- Delete the instrument → the because of doing a new action, the redo stack is cleared and the actions that were in it are cleaned up; the linked articulation is deleted, but the original one still contains a link pointing to it
- Undo → while restoring the instrument, the articulation is restored too, and somehow this causes us to do something with the linked articulation that was deleted, so we're working with freed memory. This caused the crash. 

Solution: when creating a linked staff, link the linked articulation in an undoable way (like we already do for the chord), so that the link is properly removed when undoing, and the original articulation has no pointers to freed memory. 