### PR TITLE
Exit note input mode when changing navigation, fixing mouse panning bug on publish screen

### DIFF
--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -488,6 +488,12 @@ void NotationActionController::init()
         m_currentNotationNoteInputChanged.notify();
     });
 
+    navigationController()->navigationChanged().onNotify(this, [this]() {
+        if (!currentNotationNoteInput()) return;
+        if (!currentNotationNoteInput()->isNoteInputMode()) return;
+        currentNotationNoteInput()->endNoteInput();
+    });
+
     // Register engraving debugging options actions
     for (auto [code, member] : engravingDebuggingActions) {
         dispatcher()->reg(this, code, [this, member = member]() {

--- a/src/notation/internal/notationactioncontroller.h
+++ b/src/notation/internal/notationactioncontroller.h
@@ -35,6 +35,7 @@
 #include "playback/iplaybackcontroller.h"
 #include "engraving/iengravingconfiguration.h"
 #include "inotationconfiguration.h"
+#include "ui/inavigationcontroller.h"
 
 #include "inotation.h"
 
@@ -43,6 +44,7 @@ class NotationActionController : public actions::Actionable, public async::Async
 {
     INJECT(notation, actions::IActionsDispatcher, dispatcher)
     INJECT(notation, ui::IUiActionsRegister, actionRegister)
+    INJECT(notation, ui::INavigationController, navigationController)
     INJECT(notation, context::IGlobalContext, globalContext)
     INJECT(notation, context::IUiContextResolver, uiContextResolver)
     INJECT(notation, framework::IInteractive, interactive)


### PR DESCRIPTION
Fixing bug where unable to pan across publish page with mouse when switched to page while in note input mode.

Resolves: #15277 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Disable note input mode when switching from notation tab, fixing bug where the user is unable to pan across the score in the publish tab due to still being in that mode.
<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
