### PR TITLE
gp-import: fixing let ring for midi

### DIFF
--- a/src/engraving/libmscore/note.h
+++ b/src/engraving/libmscore/note.h
@@ -181,6 +181,7 @@ public:
 private:
     bool _ghost = false;        ///< ghost note
     bool _deadNote = false;     ///< dead note
+    bool _letRing = false;      ///< let ring
     bool _hidden = false;                 ///< marks this note as the hidden one if there are
                                           ///< overlapping notes; hidden notes are not played
                                           ///< and heads + accidentals are not shown
@@ -385,6 +386,8 @@ public:
     void setGhost(bool val) { _ghost = val; }
     bool deadNote() const { return _deadNote; }
     void setDeadNote(bool deadNote) { _deadNote = deadNote; }
+    bool letRing() const { return _letRing; }
+    void setLetRing(bool letRing) { _letRing = letRing; }
 
     bool fretConflict() const { return _fretConflict; }
     void setFretConflict(bool val) { _fretConflict = val; }

--- a/src/engraving/libmscore/rendermidi.cpp
+++ b/src/engraving/libmscore/rendermidi.cpp
@@ -1169,7 +1169,7 @@ void MidiRenderer::renderSpanners(const Chunk& chunk, EventMap* events)
         int idx = s->staff()->channel(s->tick(), 0);
         int channel = s->part()->instrument(s->tick())->channel(idx)->channel();
 
-        if (s->isPedal() || s->isLetRing()) {
+        if (s->isPedal()) {
             channelPedalEvents.insert({ channel, std::vector<std::pair<int, std::pair<bool, int> > >() });
             std::vector<std::pair<int, std::pair<bool, int> > > pedalEventList = channelPedalEvents.at(channel);
             std::pair<int, std::pair<bool, int> > lastEvent;
@@ -1977,7 +1977,11 @@ static std::vector<NoteEventList> renderChord(Chord* chord, int gateTime, int on
         }
         if (trailtime == 0) {   // if trailtime is non-zero that means we have graceNotesAfter, so we don't need additional gate time.
             for (NoteEvent& e : ell[i]) {
-                e.setLen(chord->notes()[i]->deadNote() ? deadNoteDurationInTicks : e.len() * gateTime / 100);
+                Note* note = chord->notes()[i];
+                e.setLen(note->deadNote() ? deadNoteDurationInTicks : e.len() * gateTime / 100);
+                if (note->letRing()) {
+                    e.setLen(e.len() * 2);
+                }
             }
         }
     }

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -2353,11 +2353,11 @@ void GPConverter::addOttava(const GPBeat* gpb, ChordRest* cr)
     }
 }
 
-void GPConverter::addLetRing(const GPNote* gpnote, Note* /*note*/)
+void GPConverter::addLetRing(const GPNote* gpnote, Note* note)
 {
     if (gpnote->letRing() && m_currentGPBeat) {
         m_currentGPBeat->setLetRing(true);
-        //note->setLetRing(true); TODO-gp: let ring playback
+        note->setLetRing(true);
     }
 }
 


### PR DESCRIPTION
while using midi, pedal events don't start if playback doesn't go through very first pedalled chord, also it doesn't end if playback doesn't go through last pedal note.
Made let ring duration just longer for midi