### PR TITLE
Select time signature after changed

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -1245,6 +1245,7 @@ void Score::cmdAddTimeSig(Measure* fm, staff_idx_t staffIdx, TimeSig* ts, bool l
         //  ignore if there is already a timesig
         //  with same values
         //
+        select(ots, SelectType::SINGLE, staffIdx); // keep selected
         delete ts;
         return;
     }
@@ -1300,6 +1301,8 @@ void Score::cmdAddTimeSig(Measure* fm, staff_idx_t staffIdx, TimeSig* ts, bool l
                 nsig->undoChangeProperty(Pid::GROUP_NODES, ts->groups().nodes());
                 nsig->setSelected(false);
                 nsig->setDropTarget(false);
+
+                select(nsig, SelectType::SINGLE, staffIdx);
             }
         }
     } else {
@@ -1382,6 +1385,8 @@ void Score::cmdAddTimeSig(Measure* fm, staff_idx_t staffIdx, TimeSig* ts, bool l
                 if (score->isMaster()) {
                     masterTimeSigs[nsig->track()] = nsig;
                 }
+
+                select(nsig, SelectType::SINGLE, staffIdx);
             }
         }
     }


### PR DESCRIPTION
Time signatures are now selected after changed to allow for multiple successive modifications to time signature

Resolves: #9584 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
This change allows users to change a time signature multiple times in succession, like with key signatures or clefs.
<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
