### PR TITLE
Added error after adding interval with no note selected

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3989,6 +3989,8 @@ void NotationInteraction::addIntervalToSelectedNotes(int interval)
     }
 
     if (notes.empty()) {
+        MScore::setError(MsError::NO_NOTE_SELECTED);
+        checkAndShowMScoreError();
         return;
     }
 


### PR DESCRIPTION
Shows an error if the "add interval" function is called when no note or chord is selected.
Resolves: #13296 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
