### PR TITLE
fix GH#15323: Align properties can't save to style

### DIFF
--- a/src/inspector/models/abstractinspectormodel.h
+++ b/src/inspector/models/abstractinspectormodel.h
@@ -165,7 +165,8 @@ protected:
     void setElementType(mu::engraving::ElementType type);
 
     PropertyItem* buildPropertyItem(const mu::engraving::Pid& pid, std::function<void(const mu::engraving::Pid propertyId,
-                                                                                      const QVariant& newValue)> onPropertyChangedCallBack = nullptr);
+                                                                                      const QVariant& newValue)> onPropertyChangedCallBack = nullptr, std::function<void(const mu::engraving::Sid styleId,
+                                                                                                                                                                         const QVariant& newValue)> onStyleChangedCallBack = nullptr);
     PointFPropertyItem* buildPointFPropertyItem(const mu::engraving::Pid& pid, std::function<void(const mu::engraving::Pid propertyId,
                                                                                                   const QVariant& newValue)> onPropertyChangedCallBack = nullptr);
 
@@ -209,7 +210,9 @@ private:
     void setupCurrentNotationChangedConnection();
 
     void initPropertyItem(PropertyItem* propertyItem, std::function<void(const mu::engraving::Pid propertyId,
-                                                                         const QVariant& newValue)> onPropertyChangedCallBack = nullptr);
+                                                                         const QVariant& newValue)> onPropertyChangedCallBack = nullptr,
+                          std::function<void(const mu::engraving::Sid styleId,
+                                             const QVariant& newValue)> onStyleChangedCallBack = nullptr);
 
     mu::engraving::Sid styleIdByPropertyId(const mu::engraving::Pid pid) const;
     mu::engraving::PropertyIdSet propertyIdSetFromStyleIdSet(const mu::engraving::StyleIdSet& styleIdSet) const;

--- a/src/inspector/models/text/textsettingsmodel.cpp
+++ b/src/inspector/models/text/textsettingsmodel.cpp
@@ -56,9 +56,17 @@ void TextSettingsModel::createProperties()
 
     m_horizontalAlignment = buildPropertyItem(mu::engraving::Pid::ALIGN, [this](const mu::engraving::Pid pid, const QVariant& newValue) {
         onPropertyValueChanged(pid, QVariantList({ newValue.toInt(), m_verticalAlignment->value().toInt() }));
+    }, [this](const mu::engraving::Sid sid, const QVariant& newValue) {
+        updateStyleValue(sid, QVariantList({ newValue.toInt(), m_verticalAlignment->value().toInt() }));
+
+        emit requestReloadPropertyItems();
     });
     m_verticalAlignment = buildPropertyItem(mu::engraving::Pid::ALIGN, [this](const mu::engraving::Pid pid, const QVariant& newValue) {
         onPropertyValueChanged(pid, QVariantList({ m_horizontalAlignment->value().toInt(), newValue.toInt() }));
+    }, [this](const mu::engraving::Sid sid, const QVariant& newValue) {
+        updateStyleValue(sid, QVariantList({ m_horizontalAlignment->value().toInt(), newValue.toInt() }));
+
+        emit requestReloadPropertyItems();
     });
 
     m_isSizeSpatiumDependent = buildPropertyItem(mu::engraving::Pid::SIZE_SPATIUM_DEPENDENT);


### PR DESCRIPTION
Resolves: #15323 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

To update the Align style value properly, it should be set as a `QVariantList` of 2 variants, but the default call to `updateStyleValue()` only gives it a single `QVariant`, which means an assertion failure is triggered when attempting to treat this `QVariant` as a `QVariantList` in `PropertyValue::fromQVariant()`, returning a `PropertyValue` of undefined type.

In this commit I added an optional parameter to `buildPropertyItem()` and `initPropertyItem()` that can be used to specify the style update callback, just like the existing property update callback parameter, so that `updateStyleValue()` can be given a customised `newValue` when needed.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
