### PR TITLE
Fix crash when deleting instrument where a segment has multiple annotations

### DIFF
--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -1283,7 +1283,9 @@ void Measure::cmdRemoveStaves(staff_idx_t sStaff, staff_idx_t eStaff)
             }
         }
 
-        for (EngravingItem* e : s->annotations()) {
+        // Create copy, because s->annotations() will be modified during the loop
+        std::vector<EngravingItem*> annotations = s->annotations();
+        for (EngravingItem* e : annotations) {
             if (removingAllowed(e)) {
                 e->undoUnlink();
                 score()->undo(new RemoveElement(e));


### PR DESCRIPTION
Resolves: #15127

Reproducible on any new score by adding pizzicato and a dynamic, for example