### PR TITLE
Fix #15298: Maintain stem direction for created tuplets

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -3469,6 +3469,7 @@ void Score::cmdCreateTuplet(ChordRest* ocr, Tuplet* tuplet)
     ChordRest* cr;
     if (ocr->isChord()) {
         cr = Factory::createChord(this->dummy()->segment());
+        toChord(cr)->setStemDirection(toChord(ocr)->stemDirection());
         for (Note* oldNote : toChord(ocr)->notes()) {
             Note* note = Factory::createNote(toChord(cr));
             note->setPitch(oldNote->pitch());


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/15298

Along with PR #15383, which solves beams respecting stem directions, this resolves #15298 by ensuring that stem direction is maintained when a chord is converted into a tuplet. This ia particularly important for drum scores, where each chord has an explicit stem direction (which would be erased when converting chords to tuplets).