### PR TITLE
Fix #15373: Add initial score creation tempo markings to all system object staves

### DIFF
--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -431,6 +431,12 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
         tt->setFollowText(true);
         tt->setTrack(0);
         seg->add(tt);
+        for (auto staff : score->getSystemObjectStaves()) {
+            TempoText* linkedTt = toTempoText(tt->linkedClone());
+            linkedTt->setScore(score);
+            linkedTt->setTrack(staff->idx() * VOICES);
+            seg->add(linkedTt);
+        }
     }
 
     score->setUpTempoMap();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/15373

The initial system objects were not being added to all system object staves in the same way as they would be if dropped via palette. Now they are.