### PR TITLE
Change "Create Time Signature" dialog to allow time signatures to be placed without adding to the palette

### DIFF
--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -210,7 +210,7 @@ public:
 
     virtual void addStretch(qreal value) = 0;
 
-    virtual void addTimeSignature(Measure* measure, engraving::staff_idx_t staffIndex, TimeSignature* timeSignature) = 0;
+    virtual void addTimeSignature(Measure* measure, engraving::staff_idx_t staffIndex, TimeSignature* timeSignature, bool local = true) = 0;
 
     virtual void explodeSelectedStaff() = 0;
     virtual void implodeSelectedStaff() = 0;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4177,10 +4177,10 @@ void NotationInteraction::addStretch(qreal value)
     apply();
 }
 
-void NotationInteraction::addTimeSignature(Measure* measure, staff_idx_t staffIndex, TimeSignature* timeSignature)
+void NotationInteraction::addTimeSignature(Measure* measure, staff_idx_t staffIndex, TimeSignature* timeSignature, bool local = true)
 {
     startEdit();
-    score()->cmdAddTimeSig(measure, staffIndex, timeSignature, true);
+    score()->cmdAddTimeSig(measure, staffIndex, timeSignature, local);
     apply();
 }
 

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -216,7 +216,7 @@ public:
 
     void addStretch(qreal value) override;
 
-    void addTimeSignature(Measure* measure, engraving::staff_idx_t staffIndex, TimeSignature* timeSignature) override;
+    void addTimeSignature(Measure* measure, engraving::staff_idx_t staffIndex, TimeSignature* timeSignature, bool local) override;
 
     void explodeSelectedStaff() override;
     void implodeSelectedStaff() override;

--- a/src/palette/view/widgets/timedialog.cpp
+++ b/src/palette/view/widgets/timedialog.cpp
@@ -150,12 +150,22 @@ void TimeDialog::placeClicked()
 
     auto notation = globalContext()->currentNotation();
 
+    if (notation->interaction()->selection()->isNone()) {
+        //TODO: Add error here
+        return;
+    }
+
     Measure* measure;
 
     if (notation->interaction()->selection()->isRange()) {
         measure = notation->interaction()->selection()->range()->measureRange().startMeasure;
     } else {
         measure = notation->interaction()->selection()->elements().at(0)->findMeasure();
+    }
+
+    if (!measure) {
+        //TODO: Add error here (no measure selected or something)
+        return;
     }
 
     notation->interaction()->addTimeSignature(

--- a/src/palette/view/widgets/timedialog.cpp
+++ b/src/palette/view/widgets/timedialog.cpp
@@ -149,8 +149,17 @@ void TimeDialog::placeClicked()
     }
 
     auto notation = globalContext()->currentNotation();
+
+    Measure* measure;
+
+    if (notation->interaction()->selection()->isRange()) {
+        measure = notation->interaction()->selection()->range()->measureRange().startMeasure;
+    } else {
+        measure = notation->interaction()->selection()->elements().at(0)->findMeasure();
+    }
+
     notation->interaction()->addTimeSignature(
-        notation->interaction()->selection()->range()->measureRange().startMeasure,
+        measure,
         notation->interaction()->selection()->range()->startStaffIndex(),
         ts.get()->clone(),
         false

--- a/src/palette/view/widgets/timedialog.cpp
+++ b/src/palette/view/widgets/timedialog.cpp
@@ -149,11 +149,11 @@ void TimeDialog::placeClicked()
     }
 
     auto notation = globalContext()->currentNotation();
-
     notation->interaction()->addTimeSignature(
         notation->interaction()->selection()->range()->measureRange().startMeasure,
         notation->interaction()->selection()->range()->startStaffIndex(),
-        ts.get()->clone()
+        ts.get()->clone(),
+        false
     );
 }
 

--- a/src/palette/view/widgets/timedialog.cpp
+++ b/src/palette/view/widgets/timedialog.cpp
@@ -154,7 +154,7 @@ void TimeDialog::placeClicked()
         notation->interaction()->selection()->range()->startStaffIndex(),
         ts.get()->clone(),
         false
-    );
+        );
 }
 
 //---------------------------------------------------------

--- a/src/palette/view/widgets/timedialog.h
+++ b/src/palette/view/widgets/timedialog.h
@@ -41,6 +41,7 @@ class TimeDialog : public QWidget, Ui::TimeDialogBase
 
     INJECT(palette, IPaletteConfiguration, configuration)
     INJECT(palette, IPaletteProvider, paletteProvider)
+    INJECT(palette, mu::context::IGlobalContext, globalContext)
 
 public:
     TimeDialog(QWidget* parent = 0);
@@ -52,6 +53,7 @@ public:
 
 private slots:
     void addClicked();
+    void placeClicked();
     void zChanged(int);
     void nChanged(int);
     void paletteChanged(int idx);

--- a/src/palette/view/widgets/timedialog.ui
+++ b/src/palette/view/widgets/timedialog.ui
@@ -279,6 +279,22 @@
           </spacer>
          </item>
          <item>
+          <widget class="QPushButton" name="placeButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Place time signature in score without adding to master pallete</string>
+           </property>
+           <property name="text">
+            <string>Place without adding</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QPushButton" name="addButton">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">

--- a/src/palette/view/widgets/timedialog.ui
+++ b/src/palette/view/widgets/timedialog.ui
@@ -290,7 +290,7 @@
             <string>Place time signature in score without adding to master pallete</string>
            </property>
            <property name="text">
-            <string>Place without adding</string>
+            <string>Place in score</string>
            </property>
           </widget>
          </item>
@@ -306,7 +306,7 @@
             <string>Add time signature to master palette</string>
            </property>
            <property name="text">
-            <string>Add</string>
+            <string>Add to palette</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Resolves: #13481 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
- Added button "Place in score" to Create Time Signature dialog
- Renamed "Add" to "Add to palette"

<img width="882" alt="Create Time Signature screen" src="https://user-images.githubusercontent.com/43623624/208583639-b9f9252c-79af-4cfe-9bf2-ae1bfc1ec0b9.png">
This is the new create time signature screen, with the only changes being the extra button and changed name.

----
<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
