### PR TITLE
In textLineSegment layout, align line to text, not text to line

### DIFF
--- a/src/engraving/libmscore/gradualtempochange.cpp
+++ b/src/engraving/libmscore/gradualtempochange.cpp
@@ -342,7 +342,6 @@ Sid GradualTempoChangeSegment::getPropertyStyle(Pid id) const
 void GradualTempoChangeSegment::layout()
 {
     TextLineBaseSegment::layout();
-    movePosY(-tempoChange()->lineWidth() / 2); // correct y-pos for linewidth
     if (isStyled(Pid::OFFSET)) {
         roffset() = tempoChange()->propertyDefault(Pid::OFFSET).value<PointF>();
     }


### PR DESCRIPTION
Resolves: #15297 

The issue was caused by [this line](https://github.com/musescore/MuseScore/blob/master/src/engraving/libmscore/gradualtempochange.cpp). That was a quick solution I made to fix the undesirable baseline difference shown here:
<img width="1184" alt="image" src="https://user-images.githubusercontent.com/93707756/208654528-09a0d65d-c193-488d-a464-08a4127b4da5.png">

However, that baseline difference is caused by the fact that we are moving the text down by half-line width to match the baseline to the following line. The better solution (which I admit may sound a bit academic) is that we should align the line to the text, not the text to the line. This way the text isn't offset and that original correction I did isn't needed anymore. 

The vtests will show small differences (all due to a half-line-width offset).