### PR TITLE
Show element on various select & insert commands

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -907,6 +907,7 @@ void NotationInteraction::selectFirstElement(bool frame)
 {
     if (EngravingItem* element = score()->firstElement(frame)) {
         select({ element }, SelectType::SINGLE, element->staffIdx());
+        showItem(element);
     }
 }
 
@@ -914,6 +915,7 @@ void NotationInteraction::selectLastElement()
 {
     if (EngravingItem* element = score()->lastElement()) {
         select({ element }, SelectType::SINGLE, element->staffIdx());
+        showItem(element);
     }
 }
 
@@ -2463,6 +2465,7 @@ void NotationInteraction::addToSelection(MoveDirection d, MoveSelectionType type
 
     if (el) {
         select({ el }, SelectType::RANGE, el->staffIdx());
+        showItem(el);
         resetHitElementContext();
     }
 }
@@ -3498,7 +3501,9 @@ void NotationInteraction::addBoxes(BoxType boxType, int count, int beforeBoxInde
     apply();
 
     int indexOfFirstAddedMeasure = beforeBoxIndex >= 0 ? beforeBoxIndex : score()->measures()->size() - count;
-    doSelect({ score()->measure(indexOfFirstAddedMeasure) }, SelectType::REPLACE);
+    MeasureBase* firstAddedMeasure = score()->measure(indexOfFirstAddedMeasure);
+    doSelect({ firstAddedMeasure }, SelectType::REPLACE);
+    showItem(firstAddedMeasure);
 
     // For other box types, it makes little sense to select them all
     if (boxType == BoxType::Measure) {
@@ -4115,6 +4120,7 @@ void NotationInteraction::addText(TextStyleType type, EngravingItem* item)
     }
 
     apply();
+    showItem(textBox);
     startEditText(textBox);
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14579
Resolves: https://github.com/musescore/MuseScore/issues/14691

The commands to select firs/last element of score, as well as inserting measures/frames/text, do not automatically show the selected element.  This change adds the necessary showItem() calls.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
