### PR TITLE
Engraving UTests: more intuitive diffs for failing tests

### DIFF
--- a/src/engraving/utests/utils/scorecomp.cpp
+++ b/src/engraving/utests/utils/scorecomp.cpp
@@ -35,7 +35,8 @@ bool ScoreComp::saveCompareScore(Score* score, const String& saveName, const Str
     if (!ScoreRW::saveScore(score, saveName)) {
         return false;
     }
-    return compareFiles(saveName, ScoreRW::rootPath() + u"/" + compareWithLocalPath);
+
+    return compareFiles(ScoreRW::rootPath() + u"/" + compareWithLocalPath, saveName);
 }
 
 bool ScoreComp::saveCompareMimeData(ByteArray mimeData, const String& saveName, const String& compareWithLocalPath)
@@ -43,7 +44,8 @@ bool ScoreComp::saveCompareMimeData(ByteArray mimeData, const String& saveName, 
     if (!ScoreRW::saveMimeData(mimeData, saveName)) {
         return false;
     }
-    return compareFiles(saveName, ScoreRW::rootPath() + u"/" + compareWithLocalPath);
+
+    return compareFiles(ScoreRW::rootPath() + u"/" + compareWithLocalPath, saveName);
 }
 
 bool ScoreComp::compareFiles(const String& fullPath1, const String& fullPath2)


### PR DESCRIPTION
The ref file should be passed as the first argument, and the current output as the second argument, otherwise the '-' and '+' in front of lines are inverted w.r.t. what you would intuitively expect.

Of course you have those '---' and '+++' lines at the beginning, so you can still easily figure out what's going on, but it's nice if you can use your intuition too.

For example, in https://github.com/musescore/MuseScore/actions/runs/3750636998/jobs/6370607316#step:9:1533, there is an _addition_ w.r.t. the ref files, but it was displayed as a deletion.

This only applies to the engraving module (and maybe other modules that use ScoreComp::saveCompareScore), because other modules still use the old MTest class where the arguments were swapped inside the `compareFiles` method (which is not a great solution IMHO, but we'll remove those MTest class anyway).