### PR TITLE
Fix #14699: Align fields for old / new shortcut

### DIFF
--- a/src/framework/shortcuts/qml/MuseScore/Shortcuts/EditShortcutDialog.qml
+++ b/src/framework/shortcuts/qml/MuseScore/Shortcuts/EditShortcutDialog.qml
@@ -87,11 +87,15 @@ StyledDialogView {
                     text: model.conflictWarning
                 }
 
-                RowLayout {
+                GridLayout {
                     width: parent.width
                     height: childrenRect.height
 
-                    spacing: 12
+                    columnSpacing: 12
+                    rowSpacing: 12
+
+                    columns: 2
+                    rows: 2
 
                     StyledTextLabel {
                         Layout.alignment: Qt.AlignVCenter
@@ -105,13 +109,6 @@ StyledDialogView {
                         enabled: false
                         currentText: model.originSequence
                     }
-                }
-
-                RowLayout {
-                    width: parent.width
-                    height: childrenRect.height
-
-                    spacing: 12
 
                     StyledTextLabel {
                         Layout.alignment: Qt.AlignVCenter


### PR DESCRIPTION
From Preferences > Shortcuts > Define shortcut.

Resolves: #14699

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
