### PR TITLE
fixed #15469: Parts generated from a midi file in MU4 only show rests, no notes.

### DIFF
--- a/src/engraving/libmscore/part.cpp
+++ b/src/engraving/libmscore/part.cpp
@@ -299,8 +299,7 @@ void Part::setStaves(int n)
     int staffIdx = static_cast<int>(score()->staffIdx(this)) + ns;
     for (int i = ns; i < n; ++i) {
         Staff* staff = Factory::createStaff(this);
-        _staves.push_back(staff);
-        const_cast<std::vector<Staff*>&>(score()->staves()).insert(score()->staves().begin() + staffIdx, staff);
+        score()->insertStaff(staff, i);
 
         for (Measure* m = score()->firstMeasure(); m; m = m->nextMeasure()) {
             m->insertStaff(staff, staffIdx);


### PR DESCRIPTION
Resolves: #15469