### PR TITLE
Don't allow deleting the first key signature of a piece

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -3189,6 +3189,17 @@ void Score::cmdDeleteSelection()
                 //else tick < 0
                 track = e->track();
             }
+            // find element to select
+            if (!cr && tick >= Fraction(0, 1) && track != mu::nidx) {
+                cr = findCR(tick, track);
+            }
+
+            // We should not allow deleting the very first keySig of the piece, because it is
+            // logically incorrect and leads to a state of undefined key/transposition. The correct
+            // action is for the user to set an atonal/custom keySig as needed.
+            if (e->isKeySig() && e->tick() == Fraction(0, 1)) {
+                continue;
+            }
 
             // delete element if we have not done so already
             if (deletedElements.find(e) == deletedElements.end()) {
@@ -3211,12 +3222,6 @@ void Score::cmdDeleteSelection()
                 }
                 deleteItem(e);
             }
-
-            // find element to select
-            if (!cr && tick >= Fraction(0, 1) && track != mu::nidx) {
-                cr = findCR(tick, track);
-            }
-
             // add these linked elements to list of already-deleted elements
             for (EngravingObject* se : links) {
                 deletedElements.insert(se);


### PR DESCRIPTION
(Relates to: #15314)

In general, the effect of deleting a key signature in Musescore is to revert to whatever previous key is present in the score, but this can't apply to the start of the piece. Deleting the first key signature of a piece is a logically incorrect action, because it creates a state of incorrect/undefined key/transposition, and there is no way to correct it or do something logical about it. See the video for an example of the problems it creates: do we assume that the key is C? what about the instruments that should be transposing? do we assume that the key is atonal? Neither can be safely assumed in general.

This PR simply rejects the action of deleting the first key. This forces the user to do the correct action, i.e. set the appropriate initial key signature (which can be made atonal or customized in whatever way desidered, so this doesn't introduce any limitation to what the user can actually do with the starting key sig, it just makes sure it is well-defined).


https://user-images.githubusercontent.com/93707756/209121112-9bf4225d-3f92-4a42-b3bd-e0c463a0f37a.mp4

