### PR TITLE
fixed #15415: CANNOT_SPLIT_MEASURE_TOO_SHORT message

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -287,8 +287,8 @@ void NotationInteraction::checkAndShowMScoreError() const
         message = trc("notation", "Please select a note or rest and retry");
         break;
     case MsError::CANNOT_SPLIT_MEASURE_TOO_SHORT:
-        title = trc("notation", "No note or rest selected");
-        message = trc("notation", "Please select a note or rest and retry");
+        title = trc("notation", "Cannot split measure too short");
+        message = trc("notation", "Please select a longer measure and retry");
         break;
     case MsError::CANNOT_REMOVE_TIME_TUPLET:
         title = trc("notation", "Cannot remove time from tuplet");


### PR DESCRIPTION
Resolves: #15415

Changed CANNOT_SPLIT_MEASURE_TOO_SHORT message from "No note selected" to the correct message.

- [ ] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
