### PR TITLE
Slur collision correction (ignore all text-base items)

### DIFF
--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -388,7 +388,7 @@ Shape SlurSegment::getSegmentShape(Segment* seg, ChordRest* startCR, ChordRest* 
         const EngravingItem* item = shapeEl.toItem;
         const EngravingItem* parent = item->parentItem();
         // Its own startCR or items belonging to it, lyrics, fingering, ledger lines, articulation on endCR
-        if (item == startCR || parent == startCR || item->isLyrics() || item->isFingering() || item->isLedgerLine()
+        if (item == startCR || parent == startCR || item->isTextBase() || item->isLedgerLine()
             || (item->isArticulation() && parent == endCR)) {
             return true;
         }


### PR DESCRIPTION
Resolves: #15455

I probably should have realized this earlier. Slurs should ignore (in terms of collision-avoidance) all text-based items and there is already a convenient "isTextBase" flag to do that.