### PR TITLE
Fix articulation glitch

### DIFF
--- a/src/engraving/layout/layoutmeasure.cpp
+++ b/src/engraving/layout/layoutmeasure.cpp
@@ -880,7 +880,6 @@ void LayoutMeasure::computePreSpacingItems(Measure* m)
             isFirstChordInMeasure = false;
 
             chord->layoutArticulations();
-            chord->layoutArticulations2();
             chord->checkStartEndSlurs();
             chord->computeKerningExceptions();
         }


### PR DESCRIPTION
Resolves: #15475 

`layoutArticulation2()` wasn't actually needed there