### PR TITLE
Fix system flag on parts creation

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -5229,8 +5229,10 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
         std::vector<Staff* > staffList;
 
         if (!addToLinkedStaves || (ctrlModifier && isSystemLine)) {
-            element->setSystemFlag(false);
             staffList.push_back(element->staff());
+            if (ctrlModifier && isSystemLine) {
+                element->setSystemFlag(false);
+            }
         } else {
             for (Score* s : scoreList()) {
                 staffList.push_back(s->staff(0)); // system objects always appear on the top staff


### PR DESCRIPTION
Resolves: #15510 

So the bug happens because [here ](https://github.com/musescore/MuseScore/blob/master/src/engraving/libmscore/excerpt.cpp#L1462) we call `Score::undoAddElement()`, inside of which we are switching off the system flag for these objects (on the line I've now deleted). But these _are_ system objects, so they _should_ have the system flag. I worry that this LOC was needed for something else though. @asattely this one probably needs your help.