### PR TITLE
Fix more possible crashes due to modifying segment annotations during loop

### DIFF
--- a/src/engraving/layout/layoutmeasure.cpp
+++ b/src/engraving/layout/layoutmeasure.cpp
@@ -361,8 +361,8 @@ void LayoutMeasure::createMMRest(const LayoutOptions& options, Score* score, Mea
 
         // remove stray elements (possibly leftover from a previous layout of this mmr)
         // this should not happen since the elements are linked?
-        for (EngravingItem* e : s->annotations()) {
-            // look at elements in mmr
+        const auto annotations = s->annotations(); // make a copy since we alter the list
+        for (EngravingItem* e : annotations) { // look at elements in mmr
             if (!(e->isRehearsalMark() || e->isTempoText() || e->isHarmony() || e->isStaffText() || e->isSystemText() || e->isTripletFeel()
                   || e->isPlayTechAnnotation() || e->isInstrumentChange())) {
                 continue;

--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -2663,7 +2663,8 @@ void Score::deleteItem(EngravingItem* el)
             // propagate to original measure/element
             m = m->mmRestFirst();
             Segment* ns = m->findSegment(SegmentType::ChordRest, s->tick());
-            for (EngravingItem* e : ns->annotations()) {
+            const auto annotations = ns->annotations(); // make a copy since we alter the list
+            for (EngravingItem* e : annotations) {
                 if (e->type() == el->type() && e->track() == el->track()) {
                     el = e;
                     undoRemoveElement(el);
@@ -2956,7 +2957,7 @@ void Score::deleteAnnotationsFromRange(Segment* s1, Segment* s2, track_idx_t tra
             continue;
         }
         for (Segment* s = s1; s && s != s2; s = s->next1()) {
-            const auto annotations = s->annotations();       // make a copy since we alter the list
+            const auto annotations = s->annotations(); // make a copy since we alter the list
             for (EngravingItem* annotation : annotations) {
                 // skip if not included in selection (eg, filter)
                 if (!filter.canSelect(annotation)) {
@@ -4223,7 +4224,8 @@ void Score::timeDelete(Measure* m, Segment* startSegment, const Fraction& f)
             // Move annotations from the empty segment.
             // TODO: do we need to preserve annotations at all?
             // Maybe only some types (Tempo etc.)?
-            for (EngravingItem* a : s->annotations()) {
+            const auto annotations = s->annotations(); // make a copy since we alter the list
+            for (EngravingItem* a : annotations) {
                 EngravingItem* a1 = a->clone();
                 a1->setParent(ns);
                 undoRemoveElement(a);

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -1963,7 +1963,8 @@ void Measure::adjustToLen(Fraction nf, bool appendRestsIfNecessary)
                 for (Segment* segment = m->last(); segment;) {
                     Segment* pseg = segment->prev();
                     if (segment->segmentType() == SegmentType::ChordRest) {
-                        for (EngravingItem* a : segment->annotations()) {
+                        const auto annotations = segment->annotations(); // make a copy since we alter the list
+                        for (EngravingItem* a : annotations) {
                             if (a->track() == trk) {
                                 s->undoRemoveElement(a);
                             }

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -2962,7 +2962,8 @@ void Score::sortSystemObjects(std::vector<staff_idx_t>& dst)
                 }
                 for (Segment* s = m->first(); s; s = s->next()) {
                     if (s->isChordRest() || !s->annotations().empty()) {
-                        for (EngravingItem* e : s->annotations()) {
+                        const auto annotations = s->annotations(); // make a copy since we alter the list
+                        for (EngravingItem* e : annotations) {
                             if (e->isRehearsalMark()
                                 || e->isSystemText()
                                 || e->isTripletFeel()


### PR DESCRIPTION
In #15391, we saw a crash that was caused by modifying the list of annotations of a segment while looping over that list. It turned out that there are a few more cases like this; let's fix them preventively instead waiting until these crashes will indeed occur.