### PR TITLE
Fix #15533: Allow setting the thickness of a text frame to zero

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
@@ -175,7 +175,7 @@ Column {
             propertyItem: root.model ? root.model.frameThickness : null
 
             step: 0.1
-            minValue: 0.1
+            minValue: 0
             maxValue: 5
         }
 


### PR DESCRIPTION
Resolves: #15533

https://user-images.githubusercontent.com/73422868/209420103-c1c6b87b-5aac-4349-8610-50e98b45596c.mp4

- [ ] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
