### PR TITLE
Fix #15462: Allow text border radius to be between 0-100 in properties panel

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
@@ -217,7 +217,8 @@ Column {
         titleText: qsTrc("inspector", "Corner radius")
         propertyItem: root.model ? root.model.frameCornerRadius : null
 
-        step: 0.1
+        step: 1
+        decimals: 2
         minValue: 0
         maxValue: 100
     }

--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
@@ -219,7 +219,7 @@ Column {
 
         step: 0.1
         minValue: 0
-        maxValue: 5
+        maxValue: 100
     }
 
     SeparatorLine { anchors.margins: -12 }


### PR DESCRIPTION
Resolves: #15462<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Ensures that the properties panel range limits relating to text border radius match those of the style settings. 

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or test to verify the changes I made (if applicable) **(not applicable to this commit)**
