### PR TITLE
FIX 15499: remove default Qt icons

### DIFF
--- a/src/framework/ui/view/uitheme.cpp
+++ b/src/framework/ui/view/uitheme.cpp
@@ -798,6 +798,30 @@ QSize UiTheme::sizeFromContents(QStyle::ContentsType type, const QStyleOption* o
     return proxyStyleSize;
 }
 
+QIcon UiTheme::standardIcon(QStyle::StandardPixmap standardIcon, const QStyleOption *option, const QWidget *widget) const {
+	switch (standardIcon) {
+		case SP_DialogOkButton:
+		case SP_DialogCancelButton:
+		case SP_DialogHelpButton:
+		case SP_DialogOpenButton:
+		case SP_DialogSaveButton:
+		case SP_DialogCloseButton:
+		case SP_DialogApplyButton:
+		case SP_DialogResetButton:
+		case SP_DialogDiscardButton:
+		case SP_DialogYesButton:
+		case SP_DialogNoButton:
+		case SP_DialogYesToAllButton:
+		case SP_DialogNoToAllButton:
+		case SP_DialogSaveAllButton:
+		case SP_DialogAbortButton:
+		case SP_DialogRetryButton:
+		case SP_DialogIgnoreButton:
+			return {};
+		default:
+			return QProxyStyle::standardIcon(standardIcon, option, widget);
+	}
+}
 int UiTheme::styleHint(QStyle::StyleHint hint, const QStyleOption* option, const QWidget* widget, QStyleHintReturn* returnData) const
 {
     switch (hint) {

--- a/src/framework/ui/view/uitheme.cpp
+++ b/src/framework/ui/view/uitheme.cpp
@@ -798,30 +798,32 @@ QSize UiTheme::sizeFromContents(QStyle::ContentsType type, const QStyleOption* o
     return proxyStyleSize;
 }
 
-QIcon UiTheme::standardIcon(QStyle::StandardPixmap standardIcon, const QStyleOption *option, const QWidget *widget) const {
-	switch (standardIcon) {
-		case SP_DialogOkButton:
-		case SP_DialogCancelButton:
-		case SP_DialogHelpButton:
-		case SP_DialogOpenButton:
-		case SP_DialogSaveButton:
-		case SP_DialogCloseButton:
-		case SP_DialogApplyButton:
-		case SP_DialogResetButton:
-		case SP_DialogDiscardButton:
-		case SP_DialogYesButton:
-		case SP_DialogNoButton:
-		case SP_DialogYesToAllButton:
-		case SP_DialogNoToAllButton:
-		case SP_DialogSaveAllButton:
-		case SP_DialogAbortButton:
-		case SP_DialogRetryButton:
-		case SP_DialogIgnoreButton:
-			return {};
-		default:
-			return QProxyStyle::standardIcon(standardIcon, option, widget);
-	}
+QIcon UiTheme::standardIcon(QStyle::StandardPixmap standardIcon, const QStyleOption* option, const QWidget* widget) const
+{
+    switch (standardIcon) {
+    case SP_DialogOkButton:
+    case SP_DialogCancelButton:
+    case SP_DialogHelpButton:
+    case SP_DialogOpenButton:
+    case SP_DialogSaveButton:
+    case SP_DialogCloseButton:
+    case SP_DialogApplyButton:
+    case SP_DialogResetButton:
+    case SP_DialogDiscardButton:
+    case SP_DialogYesButton:
+    case SP_DialogNoButton:
+    case SP_DialogYesToAllButton:
+    case SP_DialogNoToAllButton:
+    case SP_DialogSaveAllButton:
+    case SP_DialogAbortButton:
+    case SP_DialogRetryButton:
+    case SP_DialogIgnoreButton:
+        return {};
+    default:
+        return QProxyStyle::standardIcon(standardIcon, option, widget);
+    }
 }
+
 int UiTheme::styleHint(QStyle::StyleHint hint, const QStyleOption* option, const QWidget* widget, QStyleHintReturn* returnData) const
 {
     switch (hint) {

--- a/src/framework/ui/view/uitheme.h
+++ b/src/framework/ui/view/uitheme.h
@@ -147,6 +147,7 @@ public:
     int pixelMetric(PixelMetric metric, const QStyleOption* option, const QWidget* widget) const override;
     QSize sizeFromContents(ContentsType type, const QStyleOption* option, const QSize& contentsSize,
                            const QWidget* widget = nullptr) const override;
+	QIcon standardIcon(QStyle::StandardPixmap standardIcon, const QStyleOption *option = nullptr, const QWidget *widget = nullptr) const override;
     int styleHint(StyleHint hint, const QStyleOption* option = nullptr, const QWidget* widget = nullptr,
                   QStyleHintReturn* returnData = nullptr) const override;
 

--- a/src/framework/ui/view/uitheme.h
+++ b/src/framework/ui/view/uitheme.h
@@ -147,7 +147,8 @@ public:
     int pixelMetric(PixelMetric metric, const QStyleOption* option, const QWidget* widget) const override;
     QSize sizeFromContents(ContentsType type, const QStyleOption* option, const QSize& contentsSize,
                            const QWidget* widget = nullptr) const override;
-	QIcon standardIcon(QStyle::StandardPixmap standardIcon, const QStyleOption *option = nullptr, const QWidget *widget = nullptr) const override;
+    QIcon standardIcon(QStyle::StandardPixmap standardIcon, const QStyleOption* option = nullptr,
+                       const QWidget* widget = nullptr) const override;
     int styleHint(StyleHint hint, const QStyleOption* option = nullptr, const QWidget* widget = nullptr,
                   QStyleHintReturn* returnData = nullptr) const override;
 


### PR DESCRIPTION
Resolves: #15499 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [X] I created a unit test or vtest to verify the changes I made (if applicable)
