### PR TITLE
Align the rows in "Create from template" to the rows in "Choose instruments" in the New Score wizard

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/NewScore/CreateFromTemplatePage.qml
+++ b/src/project/qml/MuseScore/Project/internal/NewScore/CreateFromTemplatePage.qml
@@ -57,8 +57,9 @@ Item {
         spacing: 12
 
         TitleListView {
+            Layout.minimumWidth: 200
+            Layout.preferredWidth: parent.width / 5
             Layout.fillHeight: true
-            Layout.preferredWidth: parent.width / 4
 
             navigationPanel.section: root.navigationSection
             navigationPanel.name: "Category"
@@ -84,8 +85,9 @@ Item {
         TitleListView {
             id: templatesView
 
-            Layout.fillHeight: true
+            Layout.minimumWidth: 276
             Layout.preferredWidth: parent.width / 4
+            Layout.fillHeight: true
 
             navigationPanel.section: root.navigationSection
             navigationPanel.name: "Template"


### PR DESCRIPTION

Previously, when creating a new score the rows in these two tabs weren't aligned. Having them being the same is a bit more aesthetically pleasing.

Before:
![Choose_instruments_before](https://user-images.githubusercontent.com/69506927/209562701-d2eeae86-ed76-4c25-b091-2d90e982c99c.png)
![Choose_from_template_before](https://user-images.githubusercontent.com/69506927/209562745-d473f2b5-6ddc-4220-bfbe-7e3be0b46e26.png)


After:
![Choose_instruments_after](https://user-images.githubusercontent.com/69506927/209562775-1ac205ad-650e-4293-b73b-21cc34cfd0fb.png)
![Choose_from_template_after](https://user-images.githubusercontent.com/69506927/209562785-113f77df-05c8-49ec-9a51-55de9acf8945.png)



- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
