### PR TITLE
Antialiase plugin thumbnails

### DIFF
--- a/src/plugins/qml/MuseScore/Plugins/internal/PluginItem.qml
+++ b/src/plugins/qml/MuseScore/Plugins/internal/PluginItem.qml
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import QtQuick 2.15
+import QtQuick.Window 2.15
 import QtGraphicalEffects 1.0
 
 import MuseScore.Ui 1.0
@@ -63,6 +64,8 @@ Item {
             anchors.fill: parent
 
             fillMode: Image.PreserveAspectCrop
+
+            sourceSize: Qt.size(width * Screen.devicePixelRatio, height * Screen.devicePixelRatio)
 
             layer.enabled: true
             layer.effect: OpacityMask {


### PR DESCRIPTION
Resolves: N/A

This PR fixes a subtle, but visible, sharpness to the plugin thumbnails.

**Before**

![Screenshot of before](https://user-images.githubusercontent.com/73422868/209598014-6dfd9d52-bf12-4a53-b551-223f47e22bc1.png)

**After**

![Screenshot of after](https://user-images.githubusercontent.com/73422868/209598026-d589b0da-5b67-4636-99dc-0b1782a46c12.png)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
