### PR TITLE
Fix linking on Linux without Crashpad Client

### DIFF
--- a/build/module.cmake
+++ b/build/module.cmake
@@ -135,5 +135,6 @@ if (NOT ${MODULE} MATCHES global)
 endif()
 
 set(MODULE_LINK ${QT_LIBRARIES} ${MODULE_LINK})
+set(MODULE_LINK ${CMAKE_DL_LIBS} ${MODULE_LINK})
 
 target_link_libraries(${MODULE} PRIVATE ${MODULE_LINK} )


### PR DESCRIPTION
We need to link with the dl libraries, since we use dlopen and friends. We weren't doing that yet, but that was no problem since the libraries come in via gcrasphad. Without Crashpad Client, that would cause a build failure though. With this fix, we link with the dl libraries ourselves.

Resolves: #15164