### PR TITLE
WASAPI Driver: don't crash (or rather hang) when starting client fails

### DIFF
--- a/src/framework/audio/internal/platform/win/wasapiaudioclient.h
+++ b/src/framework/audio/internal/platform/win/wasapiaudioclient.h
@@ -29,7 +29,7 @@ namespace winrt {
 struct WasapiAudioClient : implements<WasapiAudioClient, IActivateAudioInterfaceCompletionHandler>
 {
 public:
-    WasapiAudioClient(HANDLE clientStartedEvent, HANDLE clientStoppedEvent);
+    WasapiAudioClient(HANDLE clientStartedEvent, HANDLE clientFailedToStartEvent, HANDLE clientStoppedEvent);
     ~WasapiAudioClient();
 
     void setHardWareOffload(bool value);
@@ -99,6 +99,7 @@ private:
     DeviceState m_deviceState = DeviceState::Uninitialized;
     SampleRequestCallback m_sampleRequestCallback;
     HANDLE m_clientStartedEvent;
+    HANDLE m_clientFailedToStartEvent;
     HANDLE m_clientStoppedEvent;
 };
 }


### PR DESCRIPTION
We were waiting infinitely for the WASAPI_Client_Started event, but when there was an error while starting the client, that event would never be signaled. So MuseScore would be stuck infinitely on launch.

So, in the cases where MS would hang before this PR, playback won't work, but at least MuseScore will launch. 

This is maybe helpful in some of the cases of "crash on launch".