### PR TITLE
Allow deleting auto-created parts

### DIFF
--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -66,13 +66,16 @@
 using namespace mu;
 using namespace mu::engraving;
 
-Excerpt::Excerpt(const Excerpt& ex, bool copyPartScore)
-    : m_masterScore(ex.m_masterScore), m_name(ex.m_name), m_parts(ex.m_parts), m_tracksMapping(ex.m_tracksMapping)
+Excerpt::Excerpt(const Excerpt& ex, bool copyContents)
+    : m_masterScore(ex.m_masterScore), m_name(ex.m_name), m_parts(ex.m_parts), m_initialPartId(ex.m_initialPartId)
 {
-    m_excerptScore = (copyPartScore && ex.m_excerptScore) ? ex.m_excerptScore->clone() : nullptr;
+    if (copyContents) {
+        m_tracksMapping = ex.m_tracksMapping;
+        m_excerptScore = ex.m_excerptScore ? ex.m_excerptScore->clone() : nullptr;
 
-    if (m_excerptScore) {
-        m_excerptScore->setExcerpt(this);
+        if (m_excerptScore) {
+            m_excerptScore->setExcerpt(this);
+        }
     }
 }
 

--- a/src/engraving/libmscore/excerpt.h
+++ b/src/engraving/libmscore/excerpt.h
@@ -43,7 +43,7 @@ class Excerpt
 {
 public:
     Excerpt(MasterScore* masterScore = nullptr) { m_masterScore = masterScore; }
-    Excerpt(const Excerpt& ex, bool copyPartScore = true);
+    Excerpt(const Excerpt& ex, bool copyContents = true);
 
     ~Excerpt();
 

--- a/src/notation/iexcerptnotation.h
+++ b/src/notation/iexcerptnotation.h
@@ -34,6 +34,7 @@ class IExcerptNotation
 public:
     virtual ~IExcerptNotation() = default;
 
+    virtual bool isInited() const = 0;
     virtual bool isCustom() const = 0;
     virtual bool isEmpty() const = 0;
 

--- a/src/notation/iexcerptnotation.h
+++ b/src/notation/iexcerptnotation.h
@@ -43,7 +43,7 @@ public:
     virtual async::Notification nameChanged() const = 0;
 
     virtual INotationPtr notation() = 0;
-    virtual IExcerptNotationPtr clone() const = 0;
+    virtual IExcerptNotationPtr clone(bool copyContents = true) const = 0;
 };
 }
 

--- a/src/notation/iexcerptnotation.h
+++ b/src/notation/iexcerptnotation.h
@@ -43,7 +43,7 @@ public:
     virtual async::Notification nameChanged() const = 0;
 
     virtual INotationPtr notation() = 0;
-    virtual IExcerptNotationPtr clone(bool copyContents = true) const = 0;
+    virtual IExcerptNotationPtr clone() const = 0;
 };
 }
 

--- a/src/notation/imasternotation.h
+++ b/src/notation/imasternotation.h
@@ -52,9 +52,8 @@ public:
     virtual void initExcerpts(const ExcerptNotationList& excerpts) = 0;
     virtual void addExcerpts(const ExcerptNotationList& excerpts) = 0;
     virtual void removeExcerpts(const ExcerptNotationList& excerpts) = 0;
+    virtual void resetExcerpt(IExcerptNotationPtr excerpt) = 0;
     virtual void sortExcerpts(ExcerptNotationList& excerpts) = 0;
-
-    virtual IExcerptNotationPtr resetReplaceExcerpt(IExcerptNotationPtr excerpt) = 0;
 
     virtual void setExcerptIsOpen(const INotationPtr excerptNotation, bool opened) = 0;
 

--- a/src/notation/imasternotation.h
+++ b/src/notation/imasternotation.h
@@ -54,6 +54,8 @@ public:
     virtual void removeExcerpts(const ExcerptNotationList& excerpts) = 0;
     virtual void sortExcerpts(ExcerptNotationList& excerpts) = 0;
 
+    virtual IExcerptNotationPtr resetReplaceExcerpt(IExcerptNotationPtr excerpt) = 0;
+
     virtual void setExcerptIsOpen(const INotationPtr excerptNotation, bool opened) = 0;
 
     virtual INotationPartsPtr parts() const = 0;

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -56,6 +56,11 @@ void ExcerptNotation::init()
     m_inited = true;
 }
 
+bool ExcerptNotation::isInited() const
+{
+    return m_inited;
+}
+
 bool ExcerptNotation::isCustom() const
 {
     return !m_excerpt->initialPartId().isValid();

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -143,8 +143,8 @@ INotationPtr ExcerptNotation::notation()
     return shared_from_this();
 }
 
-IExcerptNotationPtr ExcerptNotation::clone() const
+IExcerptNotationPtr ExcerptNotation::clone(bool copyContents) const
 {
-    mu::engraving::Excerpt* copy = new mu::engraving::Excerpt(*m_excerpt);
+    mu::engraving::Excerpt* copy = new mu::engraving::Excerpt(*m_excerpt, copyContents);
     return std::make_shared<ExcerptNotation>(copy);
 }

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -56,6 +56,16 @@ void ExcerptNotation::init()
     m_inited = true;
 }
 
+void ExcerptNotation::reinit(engraving::Excerpt* newExcerpt)
+{
+    m_inited = false;
+    m_excerpt = newExcerpt;
+
+    init();
+
+    notifyAboutNotationChanged();
+}
+
 bool ExcerptNotation::isInited() const
 {
     return m_inited;
@@ -143,8 +153,8 @@ INotationPtr ExcerptNotation::notation()
     return shared_from_this();
 }
 
-IExcerptNotationPtr ExcerptNotation::clone(bool copyContents) const
+IExcerptNotationPtr ExcerptNotation::clone() const
 {
-    mu::engraving::Excerpt* copy = new mu::engraving::Excerpt(*m_excerpt, copyContents);
+    mu::engraving::Excerpt* copy = new mu::engraving::Excerpt(*m_excerpt);
     return std::make_shared<ExcerptNotation>(copy);
 }

--- a/src/notation/internal/excerptnotation.h
+++ b/src/notation/internal/excerptnotation.h
@@ -38,6 +38,7 @@ public:
 
     mu::engraving::Excerpt* excerpt() const;
 
+    bool isInited() const override;
     bool isCustom() const override;
     bool isEmpty() const override;
 

--- a/src/notation/internal/excerptnotation.h
+++ b/src/notation/internal/excerptnotation.h
@@ -35,8 +35,9 @@ public:
     ~ExcerptNotation() override;
 
     void init();
+    void reinit(engraving::Excerpt* newExcerpt);
 
-    mu::engraving::Excerpt* excerpt() const;
+    engraving::Excerpt* excerpt() const;
 
     bool isInited() const override;
     bool isCustom() const override;
@@ -47,7 +48,7 @@ public:
     async::Notification nameChanged() const override;
 
     INotationPtr notation() override;
-    IExcerptNotationPtr clone(bool copyContents = true) const override;
+    IExcerptNotationPtr clone() const override;
 
 private:
     void fillWithDefaultInfo();

--- a/src/notation/internal/excerptnotation.h
+++ b/src/notation/internal/excerptnotation.h
@@ -47,7 +47,7 @@ public:
     async::Notification nameChanged() const override;
 
     INotationPtr notation() override;
-    IExcerptNotationPtr clone() const override;
+    IExcerptNotationPtr clone(bool copyContents = true) const override;
 
 private:
     void fillWithDefaultInfo();

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -557,6 +557,41 @@ void MasterNotation::removeExcerpts(const ExcerptNotationList& excerpts)
     doSetExcerpts(m_excerpts.val);
 }
 
+IExcerptNotationPtr MasterNotation::resetReplaceExcerpt(IExcerptNotationPtr oldExcerptNotation)
+{
+    if (!oldExcerptNotation) {
+        return nullptr;
+    }
+
+    TRACEFUNC;
+
+    auto it = std::find(m_excerpts.val.begin(), m_excerpts.val.end(), oldExcerptNotation);
+    if (it == m_excerpts.val.end()) {
+        return oldExcerptNotation;
+    }
+
+    undoStack()->prepareChanges();
+
+    mu::engraving::Excerpt* oldExcerpt = get_impl(oldExcerptNotation)->excerpt();
+    masterScore()->deleteExcerpt(oldExcerpt);
+
+    IExcerptNotationPtr newExcerptNotation = oldExcerptNotation->clone(false);
+    ExcerptNotation* newExcerptNotationImpl = get_impl(newExcerptNotation);
+
+    masterScore()->initAndAddExcerpt(newExcerptNotationImpl->excerpt(), false);
+    newExcerptNotationImpl->init();
+
+    *it = newExcerptNotation;
+
+    masterScore()->setExcerptsChanged(false);
+
+    undoStack()->commitChanges();
+
+    doSetExcerpts(m_excerpts.val);
+
+    return newExcerptNotation;
+}
+
 void MasterNotation::sortExcerpts(ExcerptNotationList& excerpts)
 {
     TRACEFUNC;

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -557,40 +557,27 @@ void MasterNotation::removeExcerpts(const ExcerptNotationList& excerpts)
     doSetExcerpts(m_excerpts.val);
 }
 
-IExcerptNotationPtr MasterNotation::resetReplaceExcerpt(IExcerptNotationPtr oldExcerptNotation)
+void MasterNotation::resetExcerpt(IExcerptNotationPtr excerptNotation)
 {
-    if (!oldExcerptNotation) {
-        return nullptr;
+    if (!excerptNotation || !excerptNotation->isInited()) {
+        return;
     }
 
     TRACEFUNC;
 
-    auto it = std::find(m_excerpts.val.begin(), m_excerpts.val.end(), oldExcerptNotation);
-    if (it == m_excerpts.val.end()) {
-        return oldExcerptNotation;
-    }
-
     undoStack()->prepareChanges();
 
-    mu::engraving::Excerpt* oldExcerpt = get_impl(oldExcerptNotation)->excerpt();
+    mu::engraving::Excerpt* oldExcerpt = get_impl(excerptNotation)->excerpt();
     masterScore()->deleteExcerpt(oldExcerpt);
 
-    IExcerptNotationPtr newExcerptNotation = oldExcerptNotation->clone(false);
-    ExcerptNotation* newExcerptNotationImpl = get_impl(newExcerptNotation);
+    mu::engraving::Excerpt* newExcerpt = new mu::engraving::Excerpt(*oldExcerpt, false);
+    masterScore()->initAndAddExcerpt(newExcerpt, false);
 
-    masterScore()->initAndAddExcerpt(newExcerptNotationImpl->excerpt(), false);
-    newExcerptNotationImpl->init();
-    setExcerptIsOpen(newExcerptNotation->notation(), oldExcerptNotation->notation()->isOpen());
-
-    *it = newExcerptNotation;
+    get_impl(excerptNotation)->reinit(newExcerpt);
 
     masterScore()->setExcerptsChanged(false);
 
     undoStack()->commitChanges();
-
-    doSetExcerpts(m_excerpts.val);
-
-    return newExcerptNotation;
 }
 
 void MasterNotation::sortExcerpts(ExcerptNotationList& excerpts)

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -580,6 +580,7 @@ IExcerptNotationPtr MasterNotation::resetReplaceExcerpt(IExcerptNotationPtr oldE
 
     masterScore()->initAndAddExcerpt(newExcerptNotationImpl->excerpt(), false);
     newExcerptNotationImpl->init();
+    setExcerptIsOpen(newExcerptNotation->notation(), oldExcerptNotation->notation()->isOpen());
 
     *it = newExcerptNotation;
 

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -63,6 +63,8 @@ public:
     void removeExcerpts(const ExcerptNotationList& excerpts) override;
     void sortExcerpts(ExcerptNotationList& excerpts) override;
 
+    IExcerptNotationPtr resetReplaceExcerpt(IExcerptNotationPtr excerpt) override;
+
     void setExcerptIsOpen(const INotationPtr excerptNotation, bool open) override;
 
     INotationPartsPtr parts() const override;

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -61,9 +61,8 @@ public:
     void initExcerpts(const ExcerptNotationList& excerpts) override;
     void addExcerpts(const ExcerptNotationList& excerpts) override;
     void removeExcerpts(const ExcerptNotationList& excerpts) override;
+    void resetExcerpt(IExcerptNotationPtr excerptNotation) override;
     void sortExcerpts(ExcerptNotationList& excerpts) override;
-
-    IExcerptNotationPtr resetReplaceExcerpt(IExcerptNotationPtr excerpt) override;
 
     void setExcerptIsOpen(const INotationPtr excerptNotation, bool open) override;
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/PartDelegate.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PartDelegate.qml
@@ -34,7 +34,8 @@ ListItemBlank {
 
     property int currentPartIndex: -1
 
-    property bool isInited: false
+    property bool canReset: false
+    property bool canDelete: false
 
     property int sideMargin: 0
 
@@ -42,6 +43,7 @@ ListItemBlank {
     navigation.accessible.name: title
 
     signal copyPartRequested()
+    signal resetPartRequested()
     signal removePartRequested()
     signal partClicked()
 
@@ -160,10 +162,13 @@ ListItemBlank {
 
         MenuButton {
             Component.onCompleted: {
-                var operations = [ { "id": "duplicate", "title": qsTrc("notation", "Duplicate") },
-                                   { "id": "rename", "title": qsTrc("notation", "Rename") }]
+                var operations = [
+                            { "id": "duplicate", "title": qsTrc("notation", "Duplicate") },
+                            { "id": "rename", "title": qsTrc("notation", "Rename") },
+                            { "id": "reset", "title": qsTrc("notation", "Reset"), "enabled": root.canReset }
+                        ]
 
-                if (root.isInited) {
+                if (root.canDelete) {
                     operations.push({ "id": "delete", "title": qsTrc("notation", "Delete") })
                 }
 
@@ -182,6 +187,9 @@ ListItemBlank {
                     break
                 case "rename":
                     root.startEditTitle()
+                    break
+                case "reset":
+                    root.resetPartRequested()
                     break
                 case "delete":
                     root.removePartRequested()

--- a/src/notation/qml/MuseScore/NotationScene/internal/PartDelegate.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PartDelegate.qml
@@ -34,7 +34,7 @@ ListItemBlank {
 
     property int currentPartIndex: -1
 
-    property bool isCustom: false
+    property bool isInited: false
 
     property int sideMargin: 0
 
@@ -163,7 +163,7 @@ ListItemBlank {
                 var operations = [ { "id": "duplicate", "title": qsTrc("notation", "Duplicate") },
                                    { "id": "rename", "title": qsTrc("notation", "Rename") }]
 
-                if (root.isCustom) {
+                if (root.isInited) {
                     operations.push({ "id": "delete", "title": qsTrc("notation", "Delete") })
                 }
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/PartsView.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PartsView.qml
@@ -110,7 +110,7 @@ Item {
             title: model.title
             currentPartIndex: view.currentIndex
             isSelected: model.isSelected
-            isCustom: model.isCustom
+            isInited: model.isInited
 
             navigation.name: model.title + model.index
             navigation.panel: view.navigationPanel

--- a/src/notation/qml/MuseScore/NotationScene/internal/PartsView.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PartsView.qml
@@ -110,7 +110,8 @@ Item {
             title: model.title
             currentPartIndex: view.currentIndex
             isSelected: model.isSelected
-            isInited: model.isInited
+            canReset: model.isInited
+            canDelete: model.isCustom
 
             navigation.name: model.title + model.index
             navigation.panel: view.navigationPanel
@@ -125,6 +126,10 @@ Item {
             onPartClicked: {
                 root.model.selectPart(model.index)
                 view.currentIndex = model.index
+            }
+
+            onResetPartRequested: {
+                root.model.resetPart(model.index)
             }
 
             onRemovePartRequested: {

--- a/src/notation/view/partlistmodel.cpp
+++ b/src/notation/view/partlistmodel.cpp
@@ -179,15 +179,9 @@ void PartListModel::doResetPart(int partIndex)
         return;
     }
 
-    bool isCurrentNotation = context()->currentNotation() == m_excerpts[partIndex]->notation();
-
-    m_excerpts[partIndex] = masterNotation()->resetReplaceExcerpt(m_excerpts[partIndex]);
+    masterNotation()->resetExcerpt(m_excerpts[partIndex]);
 
     emit dataChanged(index(partIndex), index(partIndex));
-
-    if (isCurrentNotation) {
-        context()->setCurrentNotation(m_excerpts[partIndex]->notation());
-    }
 }
 
 void PartListModel::removePart(int partIndex)

--- a/src/notation/view/partlistmodel.cpp
+++ b/src/notation/view/partlistmodel.cpp
@@ -186,7 +186,7 @@ void PartListModel::doResetPart(int partIndex)
     emit dataChanged(index(partIndex), index(partIndex));
 
     if (isCurrentNotation) {
-        context()->setCurrentNotation(context()->currentMasterNotation()->notation());
+        context()->setCurrentNotation(m_excerpts[partIndex]->notation());
     }
 }
 

--- a/src/notation/view/partlistmodel.cpp
+++ b/src/notation/view/partlistmodel.cpp
@@ -98,8 +98,8 @@ QVariant PartListModel::data(const QModelIndex& index, int role) const
         return excerpt->name();
     case RoleIsSelected:
         return m_selectionModel->isSelected(index);
-    case RoleIsCustom:
-        return excerpt->isCustom();
+    case RoleIsInited:
+        return excerpt->isInited();
     }
 
     return QVariant();
@@ -115,7 +115,7 @@ QHash<int, QByteArray> PartListModel::roleNames() const
     static const QHash<int, QByteArray> roles {
         { RoleTitle, "title" },
         { RoleIsSelected, "isSelected" },
-        { RoleIsCustom, "isCustom" }
+        { RoleIsInited, "isInited" }
     };
 
     return roles;

--- a/src/notation/view/partlistmodel.cpp
+++ b/src/notation/view/partlistmodel.cpp
@@ -100,6 +100,8 @@ QVariant PartListModel::data(const QModelIndex& index, int role) const
         return m_selectionModel->isSelected(index);
     case RoleIsInited:
         return excerpt->isInited();
+    case RoleIsCustom:
+        return excerpt->isCustom();
     }
 
     return QVariant();
@@ -115,7 +117,8 @@ QHash<int, QByteArray> PartListModel::roleNames() const
     static const QHash<int, QByteArray> roles {
         { RoleTitle, "title" },
         { RoleIsSelected, "isSelected" },
-        { RoleIsInited, "isInited" }
+        { RoleIsInited, "isInited" },
+        { RoleIsCustom, "isCustom" }
     };
 
     return roles;
@@ -147,6 +150,44 @@ void PartListModel::selectPart(int partIndex)
     m_selectionModel->select(modelIndex);
 
     emit dataChanged(index(0), index(rowCount() - 1), { RoleIsSelected });
+}
+
+void PartListModel::resetPart(int partIndex)
+{
+    if (!isExcerptIndexValid(partIndex)) {
+        return;
+    }
+
+    if (!m_excerpts[partIndex]->isEmpty()) {
+        std::string question = mu::trc("notation", "Are you sure you want to reset this part?");
+
+        IInteractive::Button btn = interactive()->question("", question, {
+            IInteractive::Button::Yes, IInteractive::Button::No
+        }).standardButton();
+
+        if (btn != IInteractive::Button::Yes) {
+            return;
+        }
+    }
+
+    doResetPart(partIndex);
+}
+
+void PartListModel::doResetPart(int partIndex)
+{
+    if (!isExcerptIndexValid(partIndex)) {
+        return;
+    }
+
+    bool isCurrentNotation = context()->currentNotation() == m_excerpts[partIndex]->notation();
+
+    m_excerpts[partIndex] = masterNotation()->resetReplaceExcerpt(m_excerpts[partIndex]);
+
+    emit dataChanged(index(partIndex), index(partIndex));
+
+    if (isCurrentNotation) {
+        context()->setCurrentNotation(context()->currentMasterNotation()->notation());
+    }
 }
 
 void PartListModel::removePart(int partIndex)

--- a/src/notation/view/partlistmodel.h
+++ b/src/notation/view/partlistmodel.h
@@ -56,6 +56,7 @@ public:
     Q_INVOKABLE void openAllParts();
 
     Q_INVOKABLE void selectPart(int partIndex);
+    Q_INVOKABLE void resetPart(int partIndex);
     Q_INVOKABLE void removePart(int partIndex);
     Q_INVOKABLE void copyPart(int partIndex);
 
@@ -73,6 +74,7 @@ private:
 
     bool isExcerptIndexValid(int index) const;
 
+    void doResetPart(int partIndex);
     void doRemovePart(int partIndex);
 
     IMasterNotationPtr masterNotation() const;
@@ -83,7 +85,8 @@ private:
     enum Roles {
         RoleTitle = Qt::UserRole + 1,
         RoleIsSelected,
-        RoleIsInited
+        RoleIsInited,
+        RoleIsCustom
     };
 
     uicomponents::ItemMultiSelectionModel* m_selectionModel = nullptr;

--- a/src/notation/view/partlistmodel.h
+++ b/src/notation/view/partlistmodel.h
@@ -83,7 +83,7 @@ private:
     enum Roles {
         RoleTitle = Qt::UserRole + 1,
         RoleIsSelected,
-        RoleIsCustom
+        RoleIsInited
     };
 
     uicomponents::ItemMultiSelectionModel* m_selectionModel = nullptr;


### PR DESCRIPTION
Resolves: #15546

When you delete an auto-created part, it will re-appear when you re-open the parts dialog, so that you can open it again to re-create it.