### PR TITLE
Implement #14209-2: Allow setting line hook heights to negative values

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/LineTypeSection.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/LineTypeSection.qml
@@ -102,7 +102,7 @@ Column {
 
             step: 0.5
             maxValue: 10.0
-            minValue: 0.1
+            minValue: -10.0
             decimals: 2
 
             navigationName: "HookHeight"


### PR DESCRIPTION
Resolves: #14209-2 #15871 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Text lines under staves may be expected to have hooks pointing up, 
as the behavior of built-in lines, e.g., the pedal line. 
User should be allowed to set hook height to negative values in the Properties tab.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
