### PR TITLE
WASAPI: use closest supported mix format if error occurs

### DIFF
--- a/src/framework/audio/internal/platform/win/wasapiaudioclient.cpp
+++ b/src/framework/audio/internal/platform/win/wasapiaudioclient.cpp
@@ -571,19 +571,94 @@ void WasapiAudioClient::setStateAndNotify(const DeviceState newState, hresult re
     std::string errMsg;
 
     switch (resultCode) {
-    case AUDCLNT_E_ENDPOINT_OFFLOAD_NOT_CAPABLE:
-        errMsg = "ERROR: Endpoint Does Not Support HW Offload";
+    case AUDCLNT_E_NOT_INITIALIZED: errMsg = "AUDCLNT_E_NOT_INITIALIZED";
         break;
-
-    case AUDCLNT_E_RESOURCES_INVALIDATED:
-        errMsg = "ERROR: Endpoint Lost Access To Resources";
+    case AUDCLNT_E_ALREADY_INITIALIZED: errMsg = "AUDCLNT_E_ALREADY_INITIALIZED";
+        break;
+    case AUDCLNT_E_WRONG_ENDPOINT_TYPE: errMsg = "AUDCLNT_E_WRONG_ENDPOINT_TYPE";
+        break;
+    case AUDCLNT_E_DEVICE_INVALIDATED: errMsg = "AUDCLNT_E_DEVICE_INVALIDATED";
+        break;
+    case AUDCLNT_E_NOT_STOPPED: errMsg = "AUDCLNT_E_NOT_STOPPED";
+        break;
+    case AUDCLNT_E_BUFFER_TOO_LARGE: errMsg = "AUDCLNT_E_BUFFER_TOO_LARGE";
+        break;
+    case AUDCLNT_E_OUT_OF_ORDER: errMsg = "AUDCLNT_E_OUT_OF_ORDER";
+        break;
+    case AUDCLNT_E_UNSUPPORTED_FORMAT: errMsg = "AUDCLNT_E_UNSUPPORTED_FORMAT";
+        break;
+    case AUDCLNT_E_INVALID_SIZE: errMsg = "AUDCLNT_E_INVALID_SIZE";
+        break;
+    case AUDCLNT_E_DEVICE_IN_USE: errMsg = "AUDCLNT_E_DEVICE_IN_USE";
+        break;
+    case AUDCLNT_E_BUFFER_OPERATION_PENDING: errMsg = "AUDCLNT_E_BUFFER_OPERATION_PENDING";
+        break;
+    case AUDCLNT_E_THREAD_NOT_REGISTERED: errMsg = "AUDCLNT_E_THREAD_NOT_REGISTERED";
+        break;
+    case AUDCLNT_E_EXCLUSIVE_MODE_NOT_ALLOWED: errMsg = "AUDCLNT_E_EXCLUSIVE_MODE_NOT_ALLOWED";
+        break;
+    case AUDCLNT_E_ENDPOINT_CREATE_FAILED: errMsg = "AUDCLNT_E_ENDPOINT_CREATE_FAILED";
+        break;
+    case AUDCLNT_E_SERVICE_NOT_RUNNING: errMsg = "AUDCLNT_E_SERVICE_NOT_RUNNING";
+        break;
+    case AUDCLNT_E_EVENTHANDLE_NOT_EXPECTED: errMsg = "AUDCLNT_E_EVENTHANDLE_NOT_EXPECTED";
+        break;
+    case AUDCLNT_E_EXCLUSIVE_MODE_ONLY: errMsg = "AUDCLNT_E_EXCLUSIVE_MODE_ONLY";
+        break;
+    case AUDCLNT_E_BUFDURATION_PERIOD_NOT_EQUAL: errMsg = "AUDCLNT_E_BUFDURATION_PERIOD_NOT_EQUAL";
+        break;
+    case AUDCLNT_E_EVENTHANDLE_NOT_SET: errMsg = "AUDCLNT_E_EVENTHANDLE_NOT_SET";
+        break;
+    case AUDCLNT_E_INCORRECT_BUFFER_SIZE: errMsg = "AUDCLNT_E_INCORRECT_BUFFER_SIZE";
+        break;
+    case AUDCLNT_E_BUFFER_SIZE_ERROR: errMsg = "AUDCLNT_E_BUFFER_SIZE_ERROR";
+        break;
+    case AUDCLNT_E_CPUUSAGE_EXCEEDED: errMsg = "AUDCLNT_E_CPUUSAGE_EXCEEDED";
+        break;
+    case AUDCLNT_E_BUFFER_ERROR: errMsg = "AUDCLNT_E_BUFFER_ERROR";
+        break;
+    case AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED: errMsg = "AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED";
+        break;
+    case AUDCLNT_E_INVALID_DEVICE_PERIOD: errMsg = "AUDCLNT_E_INVALID_DEVICE_PERIOD";
+        break;
+    case AUDCLNT_E_INVALID_STREAM_FLAG: errMsg = "AUDCLNT_E_INVALID_STREAM_FLAG";
+        break;
+    case AUDCLNT_E_ENDPOINT_OFFLOAD_NOT_CAPABLE: errMsg = "AUDCLNT_E_ENDPOINT_OFFLOAD_NOT_CAPABLE";
+        break;
+    case AUDCLNT_E_OUT_OF_OFFLOAD_RESOURCES: errMsg = "AUDCLNT_E_OUT_OF_OFFLOAD_RESOURCES";
+        break;
+    case AUDCLNT_E_OFFLOAD_MODE_ONLY: errMsg = "AUDCLNT_E_OFFLOAD_MODE_ONLY";
+        break;
+    case AUDCLNT_E_NONOFFLOAD_MODE_ONLY: errMsg = "AUDCLNT_E_NONOFFLOAD_MODE_ONLY";
+        break;
+    case AUDCLNT_E_RESOURCES_INVALIDATED: errMsg = "AUDCLNT_E_RESOURCES_INVALIDATED";
+        break;
+    case AUDCLNT_E_RAW_MODE_UNSUPPORTED: errMsg = "AUDCLNT_E_RAW_MODE_UNSUPPORTED";
+        break;
+    case AUDCLNT_E_ENGINE_PERIODICITY_LOCKED: errMsg = "AUDCLNT_E_ENGINE_PERIODICITY_LOCKED";
+        break;
+    case AUDCLNT_E_ENGINE_FORMAT_LOCKED: errMsg = "AUDCLNT_E_ENGINE_FORMAT_LOCKED";
+        break;
+    case AUDCLNT_E_HEADTRACKING_ENABLED: errMsg = "AUDCLNT_E_HEADTRACKING_ENABLED";
+        break;
+    case AUDCLNT_E_HEADTRACKING_UNSUPPORTED: errMsg = "AUDCLNT_E_HEADTRACKING_UNSUPPORTED";
+        break;
+    case AUDCLNT_E_EFFECT_NOT_AVAILABLE: errMsg = "AUDCLNT_E_EFFECT_NOT_AVAILABLE";
+        break;
+    case AUDCLNT_E_EFFECT_STATE_READ_ONLY: errMsg = "AUDCLNT_E_EFFECT_STATE_READ_ONLY";
+        break;
+    case AUDCLNT_S_BUFFER_EMPTY: errMsg = "AUDCLNT_S_BUFFER_EMPTY";
+        break;
+    case AUDCLNT_S_THREAD_ALREADY_REGISTERED: errMsg = "AUDCLNT_S_THREAD_ALREADY_REGISTERED";
+        break;
+    case AUDCLNT_S_POSITION_STALLED: errMsg = "AUDCLNT_S_POSITION_STALLED";
         break;
 
     case S_OK:
         break;
 
     default:
-        errMsg = "ERROR: " + to_string(hresult_error(resultCode).message());
+        errMsg = "ERROR: " + std::to_string(resultCode) + " " + to_string(hresult_error(resultCode).message());
         break;
     }
 

--- a/src/framework/audio/internal/platform/win/wasapiaudioclient.h
+++ b/src/framework/audio/internal/platform/win/wasapiaudioclient.h
@@ -47,7 +47,7 @@ public:
     Windows::Devices::Enumeration::DeviceInformationCollection availableDevices() const;
     hstring defaultDeviceId() const;
 
-    void asyncInitializeAudioDevice(const hstring& deviceId) noexcept;
+    void asyncInitializeAudioDevice(const hstring& deviceId, bool useClosestSupportedFormat = false) noexcept;
     void startPlayback() noexcept;
     HRESULT stopPlaybackAsync() noexcept;
 
@@ -101,6 +101,8 @@ private:
     HANDLE m_clientStartedEvent;
     HANDLE m_clientFailedToStartEvent;
     HANDLE m_clientStoppedEvent;
+
+    bool m_useClosestSupportedFormat = false;
 };
 }
 

--- a/src/framework/audio/internal/platform/win/wasapiaudiodriver.cpp
+++ b/src/framework/audio/internal/platform/win/wasapiaudiodriver.cpp
@@ -112,7 +112,16 @@ bool WasapiAudioDriver::open(const Spec& spec, Spec* activeSpec)
     if (waitResult != WAIT_OBJECT_0) {
         // Either the event was the second event (namely s_data.clientFailedToStartEvent)
         // Or some wait error occurred
-        return false;
+
+        LOGE() << "WASAPI: error open the device " << to_string(deviceId) << ", trying to use closest supported format";
+
+        static constexpr bool USE_CLOSEST_SUPPORTED_FORMAT = true;
+        s_data.wasapiClient->asyncInitializeAudioDevice(deviceId, USE_CLOSEST_SUPPORTED_FORMAT);
+
+        waitResult = WaitForMultipleObjects(handleCount, handles, false, INFINITE);
+        if (waitResult != WAIT_OBJECT_0) {
+            return false;
+        }
     }
 
     m_activeSpec = m_desiredSpec;

--- a/src/framework/audio/internal/platform/win/wasapitypes.h
+++ b/src/framework/audio/internal/platform/win/wasapitypes.h
@@ -66,7 +66,9 @@ struct unique_cotaskmem_ptr
     unique_cotaskmem_ptr(unique_cotaskmem_ptr const&) = delete;
     unique_cotaskmem_ptr(unique_cotaskmem_ptr&& other)
         : m_p(std::exchange(other.m_p, nullptr)) {}
-    unique_cotaskmem_ptr& operator=(unique_cotaskmem_ptr const& other)
+
+    unique_cotaskmem_ptr& operator=(const unique_cotaskmem_ptr& other) = delete;
+    unique_cotaskmem_ptr& operator=(unique_cotaskmem_ptr&& other)
     {
         CoTaskMemFree(std::exchange(m_p, std::exchange(other.m_p, nullptr)));
         return *this;
@@ -75,6 +77,7 @@ struct unique_cotaskmem_ptr
     T* operator->() { return m_p; }
     T* get() { return m_p; }
     T** put() { return &m_p; }
+
     T* m_p;
 };
 


### PR DESCRIPTION
Builds on: #15633

and thus resolves: one of the crashes on launch
and additionally resolves: playback problems

Should resolve: https://github.com/musescore/MuseScore/issues/15637
Should resolve: https://github.com/musescore/MuseScore/issues/15685
Should resolve: https://github.com/musescore/MuseScore/issues/15235
Should resolve: https://github.com/musescore/MuseScore/issues/15029
(not 100% sure because it's difficult to tell from those issue descriptions whether it is indeed the same crash that this PR solves or a different one, for example caused by a VST)

And these musescore.org issues:
https://musescore.org/en/node/338043
https://musescore.org/en/node/338149
https://musescore.org/en/node/338271
https://musescore.org/en/node/338378
https://musescore.org/nl/node/339691
https://musescore.org/en/node/340458
https://musescore.org/en/node/340562
https://musescore.org/en/node/341307
https://musescore.org/en/node/341487
and probably there are more reports of the same issue

---

So, after the crash was solved by #15633 by adding proper error handling, it was time to fix the error itself. Turns out that we specify a wave format to the WASAPI device without checking if that format is actually supported by that device. In particular, WASAPI seems not very happy if we specify that we want two channels while the device has more. 

<details>
<summary>EDIT: The following has been postponed:</summary>
What I try to do in this PR is that we check if the format is supported, and if not, use the closest supported format. However, that gives one more problem: because the device needs samples for >2 channels and we only provide samples for 2 channels, the playback is much too fast and therefore also high-pitched; similar to https://github.com/musescore/MuseScore/issues/14921, which seems like it wasn't really fixed yet, so maybe that will be fixed by this PR too.

My solution to that problem is a bit of a "proof of concept" right now; indeed it fixes the problem, but it is a bit ugly. This problem will need some more thought. 
Deeper in the audio module, we seem to rely quite a lot on the assumption that everything has only two channels. For example: `mu::audio::dsp::balanceGain`, the hardcoded 2 in `AudioModule::setupAudioDriver`, and my comment at https://github.com/musescore/MuseScore/pull/14684#discussion_r1030872639. But because everything has a method called `audioChannelsCount()`, this assumption is not very explicit. Not sure whether this is ideal.
And apparently there is also no guarantee that the driver always supports exactly two channels, so we need to do a conversion somewhere. Right now, I have added this in the Wasapi driver itself, but it feels not great. Probably we should better do that on a different level.
</details>

---

But now we do only the following: when an error occurs, we try to use the "closest supported" format. The `IsFormatSupported` method is claimed to be untrustworthy, so we apply trial and error. This may mean that the playback will be high-pitched if the WASAPI device only supports more than two channels (while MuseScore only supports just two). This will need to be fixed later.