### PR TITLE
fix #15707 use saved parts of older score as generic parts, even if name doesn't match

### DIFF
--- a/src/engraving/rw/compat/compatutils.cpp
+++ b/src/engraving/rw/compat/compatutils.cpp
@@ -191,7 +191,7 @@ void CompatUtils::assignInitialPartToExcerpts(const std::vector<Excerpt*>& excer
         excerpt->setInitialPartId(initialPartId);
         assignedPartIdSet.insert(initialPartId);
     };
-
+    // Excerpt name is same as Part name (Violin - Violin)
     for (Excerpt* excerpt : excerpts) {
         for (const Part* part : excerpt->excerptScore()->parts()) {
             if (excerpt->name() == part->partName()) {
@@ -200,7 +200,7 @@ void CompatUtils::assignInitialPartToExcerpts(const std::vector<Excerpt*>& excer
             }
         }
     }
-
+    // Excerpt name contains Part name (Violin1 - Violin)
     for (Excerpt* excerpt : excerpts) {
         if (excerpt->initialPartId().isValid()) {
             continue;
@@ -211,10 +211,42 @@ void CompatUtils::assignInitialPartToExcerpts(const std::vector<Excerpt*>& excer
                 continue;
             }
 
-            if (excerpt->name().contains(part->partName()) || excerpt->excerptScore()->parts().size() == 1) {
+            if (excerpt->name().contains(part->partName())) {
                 assignInitialPartId(excerpt, part->id());
                 break;
             }
+        }
+    }
+    // Excerpt contains only single instrument
+    for (Excerpt* excerpt : excerpts) {
+        if (excerpt->initialPartId().isValid()) {
+            continue;
+        }
+
+        for (Part* part : excerpt->excerptScore()->parts()) {
+            if (mu::contains(assignedPartIdSet, part->id())) {
+                continue;
+            }
+
+            if (excerpt->excerptScore()->parts().size() == 1) {
+                assignInitialPartId(excerpt, part->id());
+                break;
+            }
+        }
+    }
+    // Excerpt contains instrument
+    for (Excerpt* excerpt : excerpts) {
+        if (excerpt->initialPartId().isValid()) {
+            continue;
+        }
+
+        for (Part* part : excerpt->excerptScore()->parts()) {
+            if (mu::contains(assignedPartIdSet, part->id())) {
+                continue;
+            }
+
+            assignInitialPartId(excerpt, part->id());
+            break;
         }
     }
 }

--- a/src/engraving/rw/compat/compatutils.cpp
+++ b/src/engraving/rw/compat/compatutils.cpp
@@ -211,7 +211,7 @@ void CompatUtils::assignInitialPartToExcerpts(const std::vector<Excerpt*>& excer
                 continue;
             }
 
-            if (excerpt->name().contains(part->partName())) {
+            if (excerpt->name().contains(part->partName()) || excerpt->excerptScore()->parts().size() == 1) {
                 assignInitialPartId(excerpt, part->id());
                 break;
             }

--- a/src/engraving/tests/compat206_data/lidemptytext-ref.mscx
+++ b/src/engraving/tests/compat206_data/lidemptytext-ref.mscx
@@ -228,6 +228,7 @@
         </Measure>
       </Staff>
     <Score>
+      <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
         <pedalPosBelow x="0" y="0"/>


### PR DESCRIPTION
Resolves: #15707  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
When opening older scores, program during creating parts compares saved parts and if name match, uses them as generic parts (to aviod unwanted duplicities). But If name didnt match, program generated duplicite parts. 

It is changed now, if name doesn't match, check, wheater Part ("Excerpt") contains only one Instrument "Part". Is yes, use saved Part as generic.

I think, different name is OK, as it is allowed to change names of generic parts anyway.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
