### PR TITLE
Fix #15472: Deal with deleted system object staves

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -5340,7 +5340,9 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
             for (Score* s : scoreList()) {
                 staffList.push_back(s->staff(0)); // system objects always appear on the top staff
                 for (Staff* staff : s->systemObjectStaves()) {
-                    staffList.push_back(staff);
+                    if (staff->idx() != mu::nidx) {
+                        staffList.push_back(staff);
+                    }
                 }
             }
         }

--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -5340,9 +5340,11 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
             for (Score* s : scoreList()) {
                 staffList.push_back(s->staff(0)); // system objects always appear on the top staff
                 for (Staff* staff : s->systemObjectStaves()) {
-                    if (staff->idx() != mu::nidx) {
-                        staffList.push_back(staff);
+                    IF_ASSERT_FAILED(staff->idx() != mu::nidx) {
+                        continue;
                     }
+
+                    staffList.push_back(staff);
                 }
             }
         }

--- a/src/engraving/libmscore/scorefile.cpp
+++ b/src/engraving/libmscore/scorefile.cpp
@@ -168,16 +168,27 @@ void Score::write(XmlWriter& xml, bool selectionOnly, compat::WriteScoreHook& ho
     }
 
     if (!m_systemObjectStaves.empty()) {
-        // write which staves currently have system objects above them
-        xml.startElement("SystemObjects");
+        bool saveSysObjStaves = false;
         for (Staff* s : m_systemObjectStaves) {
-            // TODO: when we add more granularity to system object display, construct this string per staff
-            String sysObjForStaff = u"barNumbers=\"false\"";
-            // for now, everything except bar numbers is shown on system object staves
-            // (also, the code to display bar numbers on system staves other than the first currently does not exist!)
-            xml.tag("Instance", { { "staffId", s->idx() + 1 }, { "barNumbers", "false" } });
+            if (s->idx() != mu::nidx) {
+                saveSysObjStaves = true;
+                break;
+            }
         }
-        xml.endElement();
+        if (saveSysObjStaves) {
+            // write which staves currently have system objects above them
+            xml.startElement("SystemObjects");
+            for (Staff* s : m_systemObjectStaves) {
+                if (s->idx() != mu::nidx) {
+                    // TODO: when we add more granularity to system object display, construct this string per staff
+                    String sysObjForStaff = u"barNumbers=\"false\"";
+                    // for now, everything except bar numbers is shown on system object staves
+                    // (also, the code to display bar numbers on system staves other than the first currently does not exist!)
+                    xml.tag("Instance", { { "staffId", s->idx() + 1 }, { "barNumbers", "false" } });
+                }
+            }
+            xml.endElement();
+        }
     }
 
     xml.context()->setCurTrack(0);

--- a/src/engraving/libmscore/scorefile.cpp
+++ b/src/engraving/libmscore/scorefile.cpp
@@ -170,22 +170,24 @@ void Score::write(XmlWriter& xml, bool selectionOnly, compat::WriteScoreHook& ho
     if (!m_systemObjectStaves.empty()) {
         bool saveSysObjStaves = false;
         for (Staff* s : m_systemObjectStaves) {
-            if (s->idx() != mu::nidx) {
-                saveSysObjStaves = true;
-                break;
+            IF_ASSERT_FAILED(s->idx() != mu::nidx) {
+                continue;
             }
+            saveSysObjStaves = true;
+            break;
         }
         if (saveSysObjStaves) {
             // write which staves currently have system objects above them
             xml.startElement("SystemObjects");
             for (Staff* s : m_systemObjectStaves) {
-                if (s->idx() != mu::nidx) {
-                    // TODO: when we add more granularity to system object display, construct this string per staff
-                    String sysObjForStaff = u"barNumbers=\"false\"";
-                    // for now, everything except bar numbers is shown on system object staves
-                    // (also, the code to display bar numbers on system staves other than the first currently does not exist!)
-                    xml.tag("Instance", { { "staffId", s->idx() + 1 }, { "barNumbers", "false" } });
+                IF_ASSERT_FAILED(s->idx() != mu::nidx) {
+                    continue;
                 }
+                // TODO: when we add more granularity to system object display, construct this string per staff
+                String sysObjForStaff = u"barNumbers=\"false\"";
+                // for now, everything except bar numbers is shown on system object staves
+                // (also, the code to display bar numbers on system staves other than the first currently does not exist!)
+                xml.tag("Instance", { { "staffId", s->idx() + 1 }, { "barNumbers", "false" } });
             }
             xml.endElement();
         }

--- a/src/engraving/rw/read400.cpp
+++ b/src/engraving/rw/read400.cpp
@@ -156,7 +156,9 @@ bool Read400::readScore400(Score* score, XmlReader& e, ReadContext& ctx)
                     // TODO: read the other attributes from this element when we begin treating different classes
                     // of system objects differently. ex:
                     // bool showBarNumbers = !(e.hasAttribute("barNumbers") && e.attribute("barNumbers") == "false");
-                    sysStaves.push_back(staffIdx);
+                    if (staffIdx > 0) {
+                        sysStaves.push_back(staffIdx);
+                    }
                     e.skipCurrentElement();
                 } else {
                     e.skipCurrentElement();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/15472

This PR does three things:

1. When a system object staff is deleted, that staff is not saved to the file (and if there are no extra system object staves, the `<SystemObjects>` tag is not included in the file at all.
2. When a file is loaded, invalid system object staves (i.e. idx < 2) are ignored
3. When a system object is added to a score, it is not added to deleted system object staves.