### PR TITLE
Fixed off by one error which incorrectly prohibits a tab note moving …

### DIFF
--- a/src/engraving/libmscore/stringdata.cpp
+++ b/src/engraving/libmscore/stringdata.cpp
@@ -445,7 +445,7 @@ int StringData::fret(int pitch, int string, int pitchOffset) const
     }
 
     // fret number is invalid or string cannot be fretted
-    if (fret < 0 || fret >= _frets || (fret > 0 && strg.open)) {
+    if (fret < 0 || fret > _frets || (fret > 0 && strg.open)) {
         return INVALID_FRET_INDEX;
     }
     return fret;


### PR DESCRIPTION
…to a string at the highest fret.

Resolves: #15729 which was also discussed [here](https://musescore.org/en/node/341410).