### PR TITLE
Fix #15588: Ctrl+Up/Down do not change tablature strings in note input mode

### DIFF
--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -941,14 +941,23 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
             interaction->moveLyrics(direction);
         } else if (selectedElement && (selectedElement->isTextBase() || selectedElement->isArticulationFamily())) {
             interaction->nudge(direction, quickly);
-        } else if (interaction->noteInput()->isNoteInputMode()
-                   && interaction->noteInput()->state().staffGroup == mu::engraving::StaffGroup::TAB) {
-            interaction->moveSelection(direction, MoveSelectionType::String);
-            return;
         } else if (interaction->selection()->isNone()) {
             interaction->selectFirstElement(false);
         } else {
+            bool isTab = interaction->noteInput()->isNoteInputMode()
+                         && interaction->noteInput()->state().staffGroup == mu::engraving::StaffGroup::TAB;
+            bool isNote = isTab && selectedElement->isNote();
+            int oldString = isNote ? toNote(selectedElement)->string() : -1;
+
             interaction->movePitch(direction, quickly ? PitchMode::OCTAVE : PitchMode::CHROMATIC);
+
+            if (isNote) {
+                int newString = toNote(selectedElement)->string();
+                if (oldString != newString) {
+                    interaction->moveSelection(direction, MoveSelectionType::String);
+                    return;
+                }
+            }
         }
         break;
     case MoveDirection::Right:


### PR DESCRIPTION
Resolves: #15588 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
