### PR TITLE
Add missing includes (mostly Qt)

### DIFF
--- a/src/appshell/iapplicationactioncontroller.h
+++ b/src/appshell/iapplicationactioncontroller.h
@@ -22,6 +22,9 @@
 #ifndef MU_APPSHELL_IAPPLICATIONACTIONCONTROLLER_H
 #define MU_APPSHELL_IAPPLICATIONACTIONCONTROLLER_H
 
+#include <QDragEnterEvent>
+#include <QDropEvent>
+#include <QDragMoveEvent>
 #include <QEvent>
 
 #include "modularity/imoduleexport.h"

--- a/src/autobot/internal/api/interactiveapi.cpp
+++ b/src/autobot/internal/api/interactiveapi.cpp
@@ -19,6 +19,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#include <QUrl>
+
 #include "interactiveapi.h"
 
 using namespace mu::api;

--- a/src/autobot/internal/jsmoduleloader.cpp
+++ b/src/autobot/internal/jsmoduleloader.cpp
@@ -19,6 +19,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#include <QFileInfo>
+
 #include "jsmoduleloader.h"
 
 #include "scriptengine.h"

--- a/src/framework/audio/internal/worker/playback.cpp
+++ b/src/framework/audio/internal/worker/playback.cpp
@@ -19,6 +19,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
+#include <utility>
+
 #include "playback.h"
 
 #include "log.h"

--- a/src/framework/global/thirdparty/deto_async/async/promise.h
+++ b/src/framework/global/thirdparty/deto_async/async/promise.h
@@ -3,6 +3,9 @@
 
 #include <memory>
 #include <string>
+
+#include <QtCore/qcompilerdetection.h>
+
 #include "internal/abstractinvoker.h"
 #include "async.h"
 

--- a/src/framework/ui/view/uitheme.h
+++ b/src/framework/ui/view/uitheme.h
@@ -24,6 +24,7 @@
 #define MU_UI_UITHEME_H
 
 #include <QFont>
+#include <QPainter>
 #include <QProxyStyle>
 
 #include "modularity/ioc.h"

--- a/src/importexport/bb/internal/bb.cpp
+++ b/src/importexport/bb/internal/bb.cpp
@@ -20,6 +20,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <QFile>
+#include <QFileInfo>
+
 #include "bb.h"
 
 #include "engravingerrors.h"

--- a/src/importexport/imagesexport/internal/svggenerator.cpp
+++ b/src/importexport/imagesexport/internal/svggenerator.cpp
@@ -22,6 +22,7 @@
 
 #include <QTextStream>
 #include <QBuffer>
+#include <QFile>
 #include <QTextCodec>
 #include <QPainterPath>
 #include <QMimeType>

--- a/src/importexport/midi/internal/midiimport/importmidi_model.h
+++ b/src/importexport/midi/internal/midiimport/importmidi_model.h
@@ -26,6 +26,8 @@
 
 #include <memory>
 
+#include <QAbstractTableModel>
+
 namespace mu::iex::midi {
 class TracksModel : public QAbstractTableModel
 {

--- a/src/importexport/midi/internal/midiimport/importmidi_operations.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_operations.cpp
@@ -21,6 +21,7 @@
  */
 #include "importmidi_operations.h"
 
+#include <QFile>
 #include <QXmlStreamReader>
 
 #include "log.h"

--- a/src/importexport/musedata/internal/musedatareader.cpp
+++ b/src/importexport/musedata/internal/musedatareader.cpp
@@ -19,6 +19,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
+#include <QFileInfo>
+
 #include "musedatareader.h"
 
 #include "musedata.h"

--- a/src/multiinstances/internal/ipc/ipc.cpp
+++ b/src/multiinstances/internal/ipc/ipc.cpp
@@ -21,6 +21,8 @@
  */
 #include "ipc.h"
 
+#include <QDataStream>
+
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>

--- a/src/notation/view/notationnavigator.h
+++ b/src/notation/view/notationnavigator.h
@@ -23,6 +23,8 @@
 #define MU_NOTATION_NOTATIONNAVIGATOR_H
 
 #include <QObject>
+#include <QMouseEvent>
+#include <QPainter>
 #include <QQuickPaintedItem>
 
 #include "modularity/ioc.h"

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -21,6 +21,7 @@
  */
 #include "notationviewinputcontroller.h"
 
+#include <QApplication>
 #include <QMimeData>
 #include <QQuickItem>
 #include <QTimer>

--- a/src/palette/view/widgets/palettewidget.cpp
+++ b/src/palette/view/widgets/palettewidget.cpp
@@ -27,8 +27,10 @@
 #include <QAccessible>
 #include <QAccessibleEvent>
 #include <QAction>
+#include <QApplication>
 #include <QContextMenuEvent>
 #include <QDrag>
+#include <QFileInfo>
 #include <QMenu>
 #include <QMimeData>
 #include <QResizeEvent>

--- a/src/project/internal/exportprojectscenario.cpp
+++ b/src/project/internal/exportprojectscenario.cpp
@@ -19,6 +19,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#include <QFile>
+
 #include "exportprojectscenario.h"
 
 #include "async/async.h"

--- a/src/project/view/exportdialogmodel.cpp
+++ b/src/project/view/exportdialogmodel.cpp
@@ -21,6 +21,7 @@
  */
 #include "exportdialogmodel.h"
 
+#include <QApplication>
 #include <QItemSelectionModel>
 
 #include "async/async.h"

--- a/src/workspace/view/newworkspacemodel.h
+++ b/src/workspace/view/newworkspacemodel.h
@@ -24,6 +24,7 @@
 #define MU_WORKSPACE_NEWWORKSPACEMODEL_H
 
 #include <QObject>
+#include <QVariant>
 
 namespace mu::workspace {
 class NewWorkspaceModel : public QObject

--- a/thirdparty/beatroot/AgentList.h
+++ b/thirdparty/beatroot/AgentList.h
@@ -18,6 +18,7 @@
 
 #include "Event.h"
 
+#include <cstddef>
 #include <vector>
 
 


### PR DESCRIPTION
Fix compile issues because of missing includes.

  Add missing includes (mostly Qt)

  When compiling MuseScore, I hit various compile failures because
  of missing includes. I suspect it built before because of either
  unity builds or transitive includes which change between versions
  of Qt.

  e.g.:
  ```
  src/workspace/workspace_autogen/OTUN7GXZT4/moc_newworkspacemodel.cpp:163:29: error: variable ‘QVariant _r’ has initializer but incomplete type
  [...]
  /var/tmp/portage/media-sound/musescore-9999/work/musescore-9999/thirdparty/beatroot/AgentList.h:39:7: error: ‘size_t’ does not name a type
     39 |       size_t size() { return list.size(); }
        |       ^~~~~~
  ```

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [ ] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
