### PR TITLE
Fix #12970: Limit time signature numerator to maximum 63

### DIFF
--- a/src/palette/view/widgets/timedialog.ui
+++ b/src/palette/view/widgets/timedialog.ui
@@ -79,7 +79,7 @@
               <number>1</number>
              </property>
              <property name="maximum">
-              <number>999999</number>
+              <number>63</number>
              </property>
              <property name="value">
               <number>4</number>


### PR DESCRIPTION
Resolves: #12970

This change sets an upper limit of 63 to the value of the numerator of new custom time signatures. If this limitation is not enforced, the application will hang when large values  (e.g. 1000) are typed in.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
