### PR TITLE
Support building for arm64 on Apple Silicon Macs with arm64 Qt version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ set(MUSESCORE_BUILD_CONFIG "dev" CACHE STRING "Build config")
 # - testing - for testing versions (alpha, beta, RC)
 # - release - for stable release builds
 
+option(BUILD_MACOS_APPLE_SILICON "Build for Apple Silicon architecture. Only applicable on Macs with Apple Silicon, and requires suitable Qt version." OFF)
 option(BUILD_64 "Build 64 bit version of editor" ON)
 option(BUILD_PORTABLEAPPS "Windows build for PortableApps.com" OFF)
 option(BUILD_FOR_WINSTORE "Build for the Windows Store." OFF)

--- a/build/cmake/SetupBuildEnvironment.cmake
+++ b/build/cmake/SetupBuildEnvironment.cmake
@@ -132,8 +132,19 @@ endif()
 
 # APPLE specific
 if (OS_IS_MAC)
-      set(CMAKE_OSX_ARCHITECTURES x86_64)
-      set(MACOSX_DEPLOYMENT_TARGET 10.14)
-      set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14)
+    if (BUILD_MACOS_APPLE_SILICON)
+        set(CMAKE_OSX_ARCHITECTURES ) # leave empty, use default
+    else()
+        set(CMAKE_OSX_ARCHITECTURES x86_64)
+    endif()
+
+    if (CMAKE_OSX_ARCHITECTURES)
+        message(STATUS "Building for architecture(s) ${CMAKE_OSX_ARCHITECTURES}")
+    else()
+        message(STATUS "Building for default architecture(s)")
+    endif()
+
+    set(MACOSX_DEPLOYMENT_TARGET 10.14)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14)
 endif(OS_IS_MAC)
 


### PR DESCRIPTION
Resolves: #15601

On Macs with Apple Silicon, this PR makes it as simple as this:
- Want to build in arm64 mode? Install dependencies in arm64 mode (for example, just via HomeBrew, which conveniently provides Qt 5.15.8) and enable the CMake option `BUILD_MACOS_APPLE_SILICON`.
- Want to build in x86_64 mode? Install dependencies in x86_64 mode (for example, using the x86_64 version of HomeBrew, or via the official Qt installer) and make sure that CMake looks for the x86_64 versions, for example by setting `CMAKE_PREFIX_PATH`.

(This won't enable us to create arm64 releases, because GitHub actions does not yet support Apple Silicon. To make arm64 releases, we would need to create a universal binary of Qt, for example by merging the arm64 and x86_64 versions from HomeBrew using the `lipo` tool, and the same for the other dependencies, and then tell the compiler to cross-compile to create universal binaries. This is far from trivial though. However, the good news is that it seems eventually possible to create universal builds with Qt 5, which is way more realistic than switching to Qt 6 at the moment.)