### PR TITLE
Fix crash on deleting "system object" staff

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -5153,6 +5153,8 @@ void Score::undoRemoveStaff(Staff* staff)
 
     staff->undoUnlink();
 
+    mu::remove_if(systemObjectStaves, [staff](Staff* s){ return s == staff; });
+
     undo(new RemoveStaff(staff));
 }
 


### PR DESCRIPTION
Resolves: #15796 

When deleting a staff, we weren't deleting it from the list of "system object staves", so further down the line we end up trying to reference a staff that doesn't exist anymore.

@vpereverzev @Tantacrul this one definitely needs to go into the patch release