### PR TITLE
Fix: #15799: Page size parameter considers orientation

### DIFF
--- a/src/notation/view/widgets/pagesettings.cpp
+++ b/src/notation/view/widgets/pagesettings.cpp
@@ -339,14 +339,16 @@ void PageSettings::applyToAllParts()
 void PageSettings::pageFormatSelected(int size)
 {
     if (size >= 0) {
+        bool landscape = landscapeButton->isChecked();
         int id = pageGroup->currentData().toInt();
         QSizeF sz = QPageSize::size(QPageSize::PageSizeId(id), QPageSize::Inch);
 
-        setStyleValue(Sid::pageWidth, sz.width());
-        setStyleValue(Sid::pageHeight, sz.height());
+        setStyleValue(Sid::pageWidth, landscape ? sz.height() : sz.width());
+        setStyleValue(Sid::pageHeight, landscape ? sz.width() : sz.height());
 
         double f  = mmUnit ? 1.0 / INCH : 1.0;
-        setStyleValue(Sid::pagePrintableWidth, sz.width() - (oddPageLeftMargin->value() + oddPageRightMargin->value()) * f);
+        setStyleValue(Sid::pagePrintableWidth,
+                      (landscape ? sz.height() : sz.width()) - (oddPageLeftMargin->value() + oddPageRightMargin->value()) * f);
         updateValues();
     }
 }


### PR DESCRIPTION
Resolves: #15799 
I added a small check to ensure that when the paper size is changed, it swaps the heights and widths if we are in landscape mode

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
