### PR TITLE
fix #15292: Opening a score (clicking its file) launches the homepage instead of opening the score view (macOS only)

### DIFF
--- a/src/appshell/appshellmodule.cpp
+++ b/src/appshell/appshellmodule.cpp
@@ -200,6 +200,14 @@ void AppShellModule::onInit(const IApplication::RunMode&)
 #endif
 }
 
+void AppShellModule::onAllInited(const framework::IApplication::RunMode&)
+{
+    //! NOTE: process QEvent::FileOpen as early as possible if it was postponed
+#ifdef Q_OS_MACOS
+    qApp->processEvents();
+#endif
+}
+
 void AppShellModule::onDeinit()
 {
     s_sessionsManager->deinit();

--- a/src/appshell/appshellmodule.h
+++ b/src/appshell/appshellmodule.h
@@ -41,6 +41,7 @@ public:
 
     void onPreInit(const framework::IApplication::RunMode& mode) override;
     void onInit(const framework::IApplication::RunMode& mode) override;
+    void onAllInited(const framework::IApplication::RunMode& mode) override;
     void onDeinit() override;
 };
 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/15292