### PR TITLE
Fix #15798: Use a collapsible panel for additional text settings

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextInspectorView.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextInspectorView.qml
@@ -322,31 +322,23 @@ InspectorSectionView {
             }
         }
 
-        PopupViewButton {
-            id: textAdvancedSettingsButton
+        ExpandableBlank {
+            id: showItem
+            isExpanded: false
 
-            width: contentColumn.width
-            anchorItem: root.anchorItem
+            title: isExpanded ? qsTrc("inpsector", "Show less") : qsTrc("inspector", "Show more")
+
+            visible: root.model ? !root.model.isEmpty : false
+            width: parent.width
 
             navigation.panel: root.navigationPanel
             navigation.name: "TextAdvancedSettings"
             navigation.row: insertSpecCharactersButton.navigation.row + 1
 
-            text: qsTrc("inspector", "More…")
-            visible: root.model ? !root.model.isEmpty : false
-
-            popupContent: TextSettings {
+            contentItemComponent: TextSettings {
                 model: root.model
-
-                navigationPanel: textAdvancedSettingsButton.popupNavigationPanel
-            }
-
-            onEnsureContentVisibleRequested: function(invisibleContentHeight) {
-                root.ensureContentVisibleRequested(invisibleContentHeight)
-            }
-
-            onPopupOpened: {
-                root.popupOpened(popup, control)
+                navigationPanel: root.navigationPanel
+                navigationRowStart: showItem.navigation.row + 1
             }
         }
     }


### PR DESCRIPTION
Resolves: #15798 - specifically the following

> the only real change is to replace the 'More' button in the ‘Text‘ properties panel to a ‘Show more‘ (collapsible) panel

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
