### PR TITLE
Fix #15473: No platform menu bar support on Linux

### DIFF
--- a/build/cmake/FindQt5.cmake
+++ b/build/cmake/FindQt5.cmake
@@ -41,6 +41,13 @@ if (WIN32)
       )
 endif(WIN32)
 
+if (OS_IS_LIN)
+    set(_components
+      ${_components}
+      DBus
+      )
+endif()
+
 find_package(Qt5Core ${QT_MIN_VERSION} REQUIRED)
 
 foreach(_component ${_components})

--- a/src/appshell/appshell.qrc
+++ b/src/appshell/appshell.qrc
@@ -105,6 +105,7 @@
         <file>qml/platform/win/AppSystemButtons.qml</file>
         <file>qml/platform/AppMenuBar.qml</file>
         <file>qml/platform/AppButtonBackground.qml</file>
+        <file>qml/platform/PlatformMenuBar.qml</file>
         <file>resources/LoadingScreen.svg</file>
     </qresource>
 </RCC>

--- a/src/appshell/appshellmodule.cpp
+++ b/src/appshell/appshellmodule.cpp
@@ -162,8 +162,11 @@ void AppShellModule::registerUiTypes()
     qmlRegisterType<IOPreferencesModel>("MuseScore.Preferences", 1, 0, "IOPreferencesModel");
     qmlRegisterType<CommonAudioApiConfigurationModel>("MuseScore.Preferences", 1, 0, "CommonAudioApiConfigurationModel");
 
-#ifdef Q_OS_MACOS
+#if defined(Q_OS_MACOS)
     qmlRegisterType<AppMenuModel>("MuseScore.AppShell", 1, 0, "AppMenuModel");
+#elif defined(Q_OS_LINUX)
+    qmlRegisterType<AppMenuModel>("MuseScore.AppShell", 1, 0, "PlatformAppMenuModel");
+    qmlRegisterType<NavigableAppMenuModel>("MuseScore.AppShell", 1, 0, "AppMenuModel");
 #else
     qmlRegisterType<NavigableAppMenuModel>("MuseScore.AppShell", 1, 0, "AppMenuModel");
 #endif

--- a/src/appshell/appshellmodule.cpp
+++ b/src/appshell/appshellmodule.cpp
@@ -163,7 +163,7 @@ void AppShellModule::registerUiTypes()
     qmlRegisterType<CommonAudioApiConfigurationModel>("MuseScore.Preferences", 1, 0, "CommonAudioApiConfigurationModel");
 
 #if defined(Q_OS_MACOS)
-    qmlRegisterType<AppMenuModel>("MuseScore.AppShell", 1, 0, "AppMenuModel");
+    qmlRegisterType<AppMenuModel>("MuseScore.AppShell", 1, 0, "PlatformAppMenuModel");
 #elif defined(Q_OS_LINUX)
     qmlRegisterType<AppMenuModel>("MuseScore.AppShell", 1, 0, "PlatformAppMenuModel");
     qmlRegisterType<NavigableAppMenuModel>("MuseScore.AppShell", 1, 0, "AppMenuModel");

--- a/src/appshell/qml/platform/PlatformMenuBar.qml
+++ b/src/appshell/qml/platform/PlatformMenuBar.qml
@@ -1,0 +1,138 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+import Qt.labs.platform 1.1 as PLATFORM
+
+import MuseScore.AppShell 1.0
+
+Item {
+    // Loading subitems on Linux causes crashes when adding menus, but it works without it
+    property bool loadSubitems: true
+    readonly property bool available: menuModel.isGlobalMenuAvailable()
+
+    PLATFORM.MenuBar {
+        id: menuBar
+    }
+
+    PlatformAppMenuModel {
+        id: menuModel
+    }
+
+    function load() {
+        menuModel.load()
+
+        var items = menuModel.items
+        for (var i in items) {
+            var item = items[i]
+            var menu = makeMenu(item)
+
+            if (loadSubitems) {
+                for (var j in item.subitems) {
+                    var menuItem = makeMenuItem(menu, item.subitems[j])
+                    menu.addItem(menuItem)
+                }
+            }
+
+            item.subitemsChanged.connect(function(subitems, menuId) {
+                for (var l in menuBar.menus) {
+                    var menu = menuBar.menus[l]
+                    if (menu.id === menuId) {
+                        menuBar.menus[l].subitems = subitems
+                    }
+                }
+            })
+
+            menuBar.addMenu(menu)
+        }
+
+        menuModel.itemsChanged.connect(function() {
+            for (var i in menuModel.items) {
+                menuBar.menus[i].subitems = menuModel.items[i].subitems
+            }
+        })
+    }
+
+    function makeMenu(menuInfo) {
+        var menu = menuComponent.createObject(menuBar)
+
+        menu.id = menuInfo.id
+        menu.title = menuInfo.title
+        menu.enabled = menuInfo.enabled
+        menu.subitems = menuInfo.subitems
+
+        return menu
+    }
+
+    function makeMenuItem(parentMenu, itemInfo) {
+        var menuItem = menuItemComponent.createObject(parentMenu)
+
+        menuItem.id = itemInfo.id
+        menuItem.text = itemInfo.title + "\t" + itemInfo.portableShortcuts
+        menuItem.enabled = itemInfo.enabled
+        menuItem.checked = itemInfo.checked
+        menuItem.checkable = itemInfo.checkable
+        menuItem.separator = !Boolean(itemInfo.title)
+        menuItem.role = itemInfo.role
+
+        return menuItem
+    }
+
+    Component {
+        id: menuComponent
+
+        PLATFORM.Menu {
+            property string id: ""
+            property var subitems: []
+
+            onAboutToShow: {
+                clear()
+
+                for (var i in subitems) {
+                    var item = subitems[i]
+                    var isMenu = Boolean(item.subitems) && item.subitems.length > 0
+
+                    if (isMenu) {
+                        var subMenu = makeMenu(item)
+
+                        addMenu(subMenu)
+                    } else {
+                        var menuItem = makeMenuItem(this, item)
+
+                        addItem(menuItem)
+                    }
+                }
+            }
+        }
+    }
+
+    Component {
+        id: menuItemComponent
+
+        PLATFORM.MenuItem {
+            property string id: ""
+
+            onTriggered: {
+                Qt.callLater(menuModel.handleMenuItem, id)
+            }
+        }
+    }
+}

--- a/src/appshell/qml/platform/linux/Main.qml
+++ b/src/appshell/qml/platform/linux/Main.qml
@@ -30,17 +30,28 @@ import "../../"
 AppWindow {
     id: root
 
-    AppMenuBar {
+    Loader {
         id: appMenuBar
 
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
+    }
 
-        appWindow: root
+    Loader {
+        id: platformMenuBar
     }
 
     Component.onCompleted: {
+        platformMenuBar.setSource("../PlatformMenuBar.qml", { "loadSubitems": false });
+        if (platformMenuBar.item.available) {
+            platformMenuBar.item.load();
+            appMenuBar.active = 0;
+        } else {
+            appMenuBar.setSource("../AppMenuBar.qml", { "appWindow": root });
+            platformMenuBar.active = 0;
+        }
+
         window.init()
     }
 

--- a/src/appshell/qml/platform/mac/Main.qml
+++ b/src/appshell/qml/platform/mac/Main.qml
@@ -20,120 +20,22 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import QtQuick 2.15
-import Qt.labs.platform 1.1 as PLATFORM
 
 import MuseScore.AppShell 1.0
 
+import "../"
 import "../../"
 
 AppWindow {
     id: root
 
-    PLATFORM.MenuBar {
+    PlatformMenuBar {
         id: menuBar
     }
 
-    AppMenuModel {
-        id: menuModel
-    }
-
     Component.onCompleted: {
-        menuModel.load()
-
-        var items = menuModel.items
-        for (var i in items) {
-            var item = items[i]
-            var menu = makeMenu(item)
-
-            for (var j in item.subitems) {
-                var menuItem = makeMenuItem(menu, item.subitems[j])
-                menu.addItem(menuItem)
-            }
-
-            item.subitemsChanged.connect(function(subitems, menuId) {
-                for (var l in menuBar.menus) {
-                    var menu = menuBar.menus[l]
-                    if (menu.id === menuId) {
-                        menuBar.menus[l].subitems = subitems
-                    }
-                }
-            })
-
-            menuBar.addMenu(menu)
-        }
-
-        menuModel.itemsChanged.connect(function() {
-            for (var i in menuModel.items) {
-                menuBar.menus[i].subitems = menuModel.items[i].subitems
-            }
-        })
-
+        menuBar.load();
         window.init()
-    }
-
-    function makeMenu(menuInfo) {
-        var menu = menuComponent.createObject(menuBar)
-
-        menu.id = menuInfo.id
-        menu.title = menuInfo.title
-        menu.enabled = menuInfo.enabled
-        menu.subitems = menuInfo.subitems
-
-        return menu
-    }
-
-    function makeMenuItem(parentMenu, itemInfo) {
-        var menuItem = menuItemComponent.createObject(parentMenu)
-
-        menuItem.id = itemInfo.id
-        menuItem.text = itemInfo.title + "\t" + itemInfo.portableShortcuts
-        menuItem.enabled = itemInfo.enabled
-        menuItem.checked = itemInfo.checked
-        menuItem.checkable = itemInfo.checkable
-        menuItem.separator = !Boolean(itemInfo.title)
-        menuItem.role = itemInfo.role
-
-        return menuItem
-    }
-
-    Component {
-        id: menuComponent
-
-        PLATFORM.Menu {
-            property string id: ""
-            property var subitems: []
-
-            onAboutToShow: {
-                clear()
-
-                for (var i in subitems) {
-                    var item = subitems[i]
-                    var isMenu = Boolean(item.subitems) && item.subitems.length > 0
-
-                    if (isMenu) {
-                        var subMenu = makeMenu(item)
-
-                        addMenu(subMenu)
-                    } else {
-                        var menuItem = makeMenuItem(this, item)
-
-                        addItem(menuItem)
-                    }
-                }
-            }
-        }
-    }
-
-    Component {
-        id: menuItemComponent
-
-        PLATFORM.MenuItem {
-            property string id: ""
-
-            onTriggered: {
-                Qt.callLater(menuModel.handleMenuItem, id)
-            }
-        }
     }
 
     WindowContent {

--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -72,6 +72,11 @@ void AppMenuModel::load()
     appMenuModelHook()->onAppMenuInited();
 }
 
+bool AppMenuModel::isGlobalMenuAvailable()
+{
+    return uiConfiguration()->isGlobalMenuAvailable();
+}
+
 void AppMenuModel::setupConnections()
 {
     recentProjectsProvider()->recentProjectListChanged().onNotify(this, [this]() {

--- a/src/appshell/view/appmenumodel.h
+++ b/src/appshell/view/appmenumodel.h
@@ -31,6 +31,7 @@
 #include "ui/imainwindow.h"
 #include "ui/iuiactionsregister.h"
 #include "ui/inavigationcontroller.h"
+#include "ui/iuiconfiguration.h"
 #include "actions/iactionsdispatcher.h"
 #include "workspace/iworkspacemanager.h"
 #include "iappshellconfiguration.h"
@@ -47,6 +48,7 @@ class AppMenuModel : public uicomponents::AbstractMenuModel
     INJECT(appshell, ui::IMainWindow, mainWindow)
     INJECT(appshell, ui::IUiActionsRegister, uiActionsRegister)
     INJECT(appshell, ui::INavigationController, navigationController)
+    INJECT(notation, ui::IUiConfiguration, uiConfiguration)
     INJECT(appshell, actions::IActionsDispatcher, actionsDispatcher)
     INJECT(appshell, workspace::IWorkspaceManager, workspacesManager)
     INJECT(appshell, IAppShellConfiguration, configuration)
@@ -59,6 +61,7 @@ public:
     explicit AppMenuModel(QObject* parent = nullptr);
 
     Q_INVOKABLE void load() override;
+    Q_INVOKABLE bool isGlobalMenuAvailable();
 
 private:
     void setupConnections();

--- a/src/framework/ui/CMakeLists.txt
+++ b/src/framework/ui/CMakeLists.txt
@@ -44,6 +44,11 @@ elseif(OS_IS_WIN)
         ${CMAKE_CURRENT_LIST_DIR}/internal/platform/windows/windowsplatformtheme.cpp
         ${CMAKE_CURRENT_LIST_DIR}/internal/platform/windows/windowsplatformtheme.h
     )
+elseif(OS_IS_LIN)
+    set(PLATFORM_THEME_SRC
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/linux/linuxplatformtheme.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/linux/linuxplatformtheme.h
+    )
 else()
     set(PLATFORM_THEME_SRC
         ${CMAKE_CURRENT_LIST_DIR}/internal/platform/stub/stubplatformtheme.cpp

--- a/src/framework/ui/internal/iplatformtheme.h
+++ b/src/framework/ui/internal/iplatformtheme.h
@@ -45,6 +45,8 @@ public:
     virtual bool isSystemThemeDark() const = 0;
     virtual async::Notification platformThemeChanged() const = 0;
 
+    virtual bool isGlobalMenuAvailable() const = 0;
+
     virtual void applyPlatformStyleOnAppForTheme(const ThemeCode& themeCode) = 0;
     virtual void applyPlatformStyleOnWindowForTheme(QWindow* window, const ThemeCode& themeCode) = 0;
 };

--- a/src/framework/ui/internal/platform/linux/linuxplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/linux/linuxplatformtheme.cpp
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2023 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <QtDBus/QDBusConnection>
+#include <QtDBus/QDBusConnectionInterface>
+
+#include "linuxplatformtheme.h"
+
+using namespace mu::ui;
+using namespace mu::async;
+
+LinuxPlatformTheme::LinuxPlatformTheme()
+{
+}
+
+void LinuxPlatformTheme::startListening()
+{
+}
+
+void LinuxPlatformTheme::stopListening()
+{
+}
+
+bool LinuxPlatformTheme::isFollowSystemThemeAvailable() const
+{
+    return false;
+}
+
+bool LinuxPlatformTheme::isSystemThemeDark() const
+{
+    return false;
+}
+
+bool LinuxPlatformTheme::isGlobalMenuAvailable() const
+{
+    const QDBusConnection connection = QDBusConnection::sessionBus();
+    static const QString registrarService = QStringLiteral("com.canonical.AppMenu.Registrar");
+    if (const auto iface = connection.interface()) {
+        return iface->isServiceRegistered(registrarService);
+    }
+    return false;
+}
+
+Notification LinuxPlatformTheme::platformThemeChanged() const
+{
+    return m_platformThemeChanged;
+}
+
+void LinuxPlatformTheme::applyPlatformStyleOnAppForTheme(const ThemeCode&)
+{
+}
+
+void LinuxPlatformTheme::applyPlatformStyleOnWindowForTheme(QWindow*, const ThemeCode&)
+{
+}

--- a/src/framework/ui/internal/platform/linux/linuxplatformtheme.h
+++ b/src/framework/ui/internal/platform/linux/linuxplatformtheme.h
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2023 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_UI_LINUXPLATFORMTHEME_H
+#define MU_UI_LINUXPLATFORMTHEME_H
+
+#include "internal/iplatformtheme.h"
+
+namespace mu::ui {
+class LinuxPlatformTheme : public IPlatformTheme
+{
+public:
+    LinuxPlatformTheme();
+
+    void startListening() override;
+    void stopListening() override;
+
+    bool isFollowSystemThemeAvailable() const override;
+
+    bool isSystemThemeDark() const override;
+    async::Notification platformThemeChanged() const override;
+
+    bool isGlobalMenuAvailable() const override;
+
+    void applyPlatformStyleOnAppForTheme(const ThemeCode& themeCode) override;
+    void applyPlatformStyleOnWindowForTheme(QWindow* window, const ThemeCode& themeCode) override;
+
+private:
+    async::Notification m_platformThemeChanged;
+};
+}
+
+#endif // MU_UI_LINUXPLATFORMTHEME_H

--- a/src/framework/ui/internal/platform/macos/macosplatformtheme.h
+++ b/src/framework/ui/internal/platform/macos/macosplatformtheme.h
@@ -37,6 +37,8 @@ public:
     bool isSystemThemeDark() const override;
     async::Notification platformThemeChanged() const override;
 
+    bool isGlobalMenuAvailable() const override;
+
     void applyPlatformStyleOnAppForTheme(const ThemeCode& themeCode) override;
     void applyPlatformStyleOnWindowForTheme(QWindow* window, const ThemeCode& themeCode) override;
 

--- a/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
+++ b/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
@@ -66,6 +66,11 @@ bool MacOSPlatformTheme::isSystemThemeDark() const
     return [systemMode isEqualToString:@"Dark"];
 }
 
+bool MacOSPlatformTheme::isGlobalMenuAvailable() const
+{
+    return true;
+}
+
 Notification MacOSPlatformTheme::platformThemeChanged() const
 {
     return m_platformThemeChanged;

--- a/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
@@ -43,6 +43,11 @@ bool StubPlatformTheme::isSystemThemeDark() const
     return false;
 }
 
+bool StubPlatformTheme::isGlobalMenuAvailable() const
+{
+    return false;
+}
+
 Notification StubPlatformTheme::platformThemeChanged() const
 {
     return m_platformThemeChanged;

--- a/src/framework/ui/internal/platform/stub/stubplatformtheme.h
+++ b/src/framework/ui/internal/platform/stub/stubplatformtheme.h
@@ -37,6 +37,8 @@ public:
     bool isSystemThemeDark() const override;
     async::Notification platformThemeChanged() const override;
 
+    bool isGlobalMenuAvailable() const override;
+
     void applyPlatformStyleOnAppForTheme(const ThemeCode& themeCode) override;
     void applyPlatformStyleOnWindowForTheme(QWindow* window, const ThemeCode& themeCode) override;
 

--- a/src/framework/ui/internal/platform/windows/windowsplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/windows/windowsplatformtheme.cpp
@@ -99,6 +99,11 @@ bool WindowsPlatformTheme::isSystemThemeDark() const
     return isSystemThemeCurrentlyDark();
 }
 
+bool WindowsPlatformTheme::isGlobalMenuAvailable() const
+{
+    return false;
+}
+
 Notification WindowsPlatformTheme::platformThemeChanged() const
 {
     return m_isSystemThemeDark.notification;

--- a/src/framework/ui/internal/platform/windows/windowsplatformtheme.h
+++ b/src/framework/ui/internal/platform/windows/windowsplatformtheme.h
@@ -41,6 +41,8 @@ public:
     bool isSystemThemeDark() const override;
     async::Notification platformThemeChanged() const override;
 
+    bool isGlobalMenuAvailable() const override;
+
     void applyPlatformStyleOnAppForTheme(const ThemeCode& themeCode) override;
     void applyPlatformStyleOnWindowForTheme(QWindow* window, const ThemeCode& themeCode) override;
 

--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -701,6 +701,11 @@ Notification UiConfiguration::windowGeometryChanged() const
     return m_windowGeometryChanged;
 }
 
+bool UiConfiguration::isGlobalMenuAvailable() const
+{
+    return platformTheme()->isGlobalMenuAvailable();
+}
+
 void UiConfiguration::applyPlatformStyle(QWindow* window)
 {
     platformTheme()->applyPlatformStyleOnWindowForTheme(window, currentThemeCodeKey());

--- a/src/framework/ui/internal/uiconfiguration.h
+++ b/src/framework/ui/internal/uiconfiguration.h
@@ -97,6 +97,8 @@ public:
     void setWindowGeometry(const QByteArray& geometry) override;
     async::Notification windowGeometryChanged() const override;
 
+    bool isGlobalMenuAvailable() const override;
+
     void applyPlatformStyle(QWindow* window) override;
 
     bool isVisible(const QString& key, bool def = true) const override;

--- a/src/framework/ui/iuiconfiguration.h
+++ b/src/framework/ui/iuiconfiguration.h
@@ -96,6 +96,8 @@ public:
     virtual void setWindowGeometry(const QByteArray& state) = 0;
     virtual async::Notification windowGeometryChanged() const = 0;
 
+    virtual bool isGlobalMenuAvailable() const = 0;
+
     virtual void applyPlatformStyle(QWindow* window) = 0;
 
     virtual bool isVisible(const QString& key, bool def = true) const = 0;

--- a/src/framework/ui/uimodule.cpp
+++ b/src/framework/ui/uimodule.cpp
@@ -39,6 +39,9 @@
 #elif defined(Q_OS_WIN)
 #include "internal/platform/windows/windowsplatformtheme.h"
 #include "view/mainwindowprovider.h"
+#elif defined(Q_OS_LINUX)
+#include "internal/platform/linux/linuxplatformtheme.h"
+#include "view/mainwindowprovider.h"
 #else
 #include "internal/platform/stub/stubplatformtheme.h"
 #include "view/mainwindowprovider.h"
@@ -70,6 +73,8 @@ static std::shared_ptr<NavigationUiActions> s_keyNavigationUiActions = std::make
 static std::shared_ptr<MacOSPlatformTheme> s_platformTheme = std::make_shared<MacOSPlatformTheme>();
 #elif defined(Q_OS_WIN)
 static std::shared_ptr<WindowsPlatformTheme> s_platformTheme = std::make_shared<WindowsPlatformTheme>();
+#elif defined(Q_OS_LINUX)
+static std::shared_ptr<LinuxPlatformTheme> s_platformTheme = std::make_shared<LinuxPlatformTheme>();
 #else
 static std::shared_ptr<StubPlatformTheme> s_platformTheme = std::make_shared<StubPlatformTheme>();
 #endif


### PR DESCRIPTION
Resolves: #15473 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Native menu bar support is only implemented for macOS. This pull request contains changes that will enable it on Linux-based systems as well (for example the global menu bar in KDE Plasma).
Uses D-Bus (com.canonical.AppMenu.Registrar) to check whether global menu is available.

I've tested this in KDE Plasma and it properly detects whether global menu is enabled.

![Global menu bar](https://user-images.githubusercontent.com/68537469/211918525-7f25a225-1bfb-4b4a-a079-64aa2399d9f3.png)


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
