### PR TITLE
Correct cross-beam spacing in narrow situations

### DIFF
--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -4223,15 +4223,20 @@ void Measure::computeWidth(Segment* s, double x, bool isSystemHeader, Fraction m
             s->computeCrossBeamType(ns);
             CrossBeamType crossBeamType = s->crossBeamType();
             double displacement = score()->noteHeadWidth() - score()->styleMM(Sid::stemWidth);
-            if (crossBeamType.upDown) {
+            if (crossBeamType.upDown && crossBeamType.canBeAdjusted) {
                 s->setWidthOffset(s->widthOffset() + displacement);
                 w += displacement;
-                _squeezableSpace -= score()->noteHeadWidth();
-            }
-            if (crossBeamType.downUp) {
+                _squeezableSpace -= displacement;
+            } else if (crossBeamType.downUp && crossBeamType.canBeAdjusted) {
                 s->setWidthOffset(s->widthOffset() - displacement);
                 w -= displacement;
-                _squeezableSpace -= score()->noteHeadWidth();
+                _squeezableSpace -= displacement;
+            }
+            if (crossBeamType.upDown) {
+                // Even if it can't be adjusted, the up-down case needs enforced
+                // this minimum width to avoid stems overlapping weirdly
+                w = std::max(w, 2 * displacement);
+                _squeezableSpace -= 2 * displacement;
             }
 
             // look back for collisions with previous segments

--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -2742,6 +2742,9 @@ void Segment::computeCrossBeamType(Segment* nextSeg)
     }
     bool upDown = false;
     bool downUp = false;
+    bool canBeAdjusted = true;
+    // Spacing can be adjusted for cross-beam cases only if there aren't
+    // chords in other voices in this or next segment.
     for (EngravingItem* e : elist()) {
         if (!e || !e->isChordRest() || !e->staff()->visible()) {
             continue;
@@ -2751,7 +2754,8 @@ void Segment::computeCrossBeamType(Segment* nextSeg)
             continue;
         }
         if (!thisCR->beam()) {
-            return;
+            canBeAdjusted = false;
+            continue;
         }
         Beam* beam = thisCR->beam();
         for (EngravingItem* ee : nextSeg->elist()) {
@@ -2763,7 +2767,8 @@ void Segment::computeCrossBeamType(Segment* nextSeg)
                 continue;
             }
             if (!nextCR->beam()) {
-                return;
+                canBeAdjusted = false;
+                continue;
             }
             if (nextCR->beam() != beam) {
                 continue;
@@ -2784,6 +2789,7 @@ void Segment::computeCrossBeamType(Segment* nextSeg)
     }
     _crossBeamType.upDown = upDown;
     _crossBeamType.downUp = downUp;
+    _crossBeamType.canBeAdjusted = canBeAdjusted;
 }
 
 /***********************************************

--- a/src/engraving/libmscore/segment.h
+++ b/src/engraving/libmscore/segment.h
@@ -62,10 +62,12 @@ struct CrossBeamType
 {
     bool upDown = false; // This chord is stem-up, next chord is stem-down
     bool downUp = false; // This chord is stem-down, next chord is stem-up
+    bool canBeAdjusted = true;
     void reset()
     {
         upDown = false;
         downUp = false;
+        canBeAdjusted = true;
     }
 };
 


### PR DESCRIPTION
Bit of an edge case, admittedly, but it needs this solution. Can happen when spacing is particularly narrow (to reproduce it quickly, just reduce the stretch of the measure with ctrl+{ )
Before:
<img width="330" alt="image" src="https://user-images.githubusercontent.com/93707756/212045708-59873a7f-b9ab-4753-b582-e662784c2c1a.png">
After:
<img width="344" alt="image" src="https://user-images.githubusercontent.com/93707756/212045895-d59cd772-eb0a-4d8b-8bb8-358585642c8f.png">

