### PR TITLE
Fix #11414: Improved NumberInputField behavior when selected

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/NumberInputField.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/NumberInputField.qml
@@ -51,6 +51,11 @@ FocusScope {
     function ensureActiveFocus() {
         if (!root.activeFocus) {
             root.forceActiveFocus()
+        } else if (!textField.activeFocus)
+        {
+            // In the case when the FocusScope is still in focus
+            // and therefore doesn't trigger the onActiveFocusChanged
+            textField.forceActiveFocus()
         }
     }
 
@@ -143,6 +148,9 @@ FocusScope {
                 var newValue = Math.max(textField.textAsInt(), root.minValue)
                 textField.text = prv.pad(newValue)
                 root.valueEdited(newValue)
+                textField.deselect()
+            } else if (activeFocus) {
+                textField.selectAll()
             }
         }
 
@@ -185,8 +193,10 @@ FocusScope {
         onPressed: {
             navigation.requestActiveByInteraction()
 
+            if (textField.selectedText == textField.text) {
+                textField.deselect()
+            }
             root.ensureActiveFocus()
-            textField.cursorPosition = textField.text.length
         }
     }
 
@@ -219,7 +229,7 @@ FocusScope {
 
             PropertyChanges {
                 target: textFieldBackground
-                color: ui.theme.accentColor
+                color: ui.theme.buttonColor
                 opacity: ui.theme.accentOpacityNormal
             }
         }

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/NumberInputField.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/NumberInputField.qml
@@ -51,8 +51,7 @@ FocusScope {
     function ensureActiveFocus() {
         if (!root.activeFocus) {
             root.forceActiveFocus()
-        } else if (!textField.activeFocus)
-        {
+        } else if (!textField.activeFocus) {
             // In the case when the FocusScope is still in focus
             // and therefore doesn't trigger the onActiveFocusChanged
             textField.forceActiveFocus()


### PR DESCRIPTION
Resolves: #11414

- Changed the `textFieldBackground` to `buttonColor`, as having it set to `accentColor` makes it seem like all of the text is selected.
- Updated behavior so that when the user clicks on the `NumberInputField`, all of the text in the field is selected, allowing the user to enter their value of choice. If the text is already selected and the user clicks again, then the text is deselected (but still focused). Finally, when focus is taken off of the `NumberInputField`, the text is deselected.
- Fixed an issue where if you updated the `NumberInputField` and tried to immediately click on it again, it would not set the `activeFocus` for the `textField` to `true` because `root` was technically still focused and wouldn't trigger the `onActiveFocusChanged` callback.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
