### PR TITLE
Fix #14280: Disable solo when muted

### DIFF
--- a/src/playback/qml/MuseScore/Playback/internal/MixerMuteAndSoloSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerMuteAndSoloSection.qml
@@ -77,6 +77,8 @@ MixerPanelSection {
                 icon: IconCode.SOLO
                 checked: channelItem.solo
 
+                enabled: !channelItem.muted
+
                 navigation.name: "SoloButton"
                 navigation.panel: channelItem.panel
                 navigation.row: root.navigationRowStart + 1

--- a/src/playback/view/internal/mixerchannelitem.cpp
+++ b/src/playback/view/internal/mixerchannelitem.cpp
@@ -247,6 +247,10 @@ void MixerChannelItem::loadOutputParams(AudioOutputParams&& newParams)
         emit mutedChanged();
     }
 
+    if (newParams.muted) {
+        setSolo(false);
+    }
+
     loadOutputResourceItems(newParams.fxChain);
     loadAuxSendItems(newParams.auxSends);
 }


### PR DESCRIPTION
Resolves: #14280<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

- Disable solo when the instrument is set muted as well as when the instrument become invisible
- Disable solo toggle button while the instrument is muted

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
