### PR TITLE
Fix 12222: Enter and Esc keys now work with insert measures dialog

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/SelectMeasuresCountDialog.qml
+++ b/src/notation/qml/MuseScore/NotationScene/SelectMeasuresCountDialog.qml
@@ -36,6 +36,15 @@ StyledDialogView {
 
     property int measuresCount: 1
 
+    function okClick() {
+        root.ret = { errcode: 0, value: root.measuresCount }
+        root.hide()
+    }
+
+    function cancelClick() {
+        root.reject()
+    }
+
     ColumnLayout {
         id: content
         anchors.fill: parent
@@ -82,6 +91,14 @@ StyledDialogView {
                 onValueEdited: function(newValue) {
                     root.measuresCount = newValue
                 }
+
+                Keys.onPressed: function(event) {
+                    if (event.key === Qt.Key_Enter || event.key === Qt.Key_Return) {
+                        okClick()
+                    } else if (event.key === Qt.Key_Escape) {
+                        cancelClick()
+                    }
+                }
             }
         }
 
@@ -108,7 +125,7 @@ StyledDialogView {
                 navigation.order: 2
 
                 onClicked: {
-                    root.reject()
+                    cancelClick()
                 }
             }
 
@@ -122,8 +139,7 @@ StyledDialogView {
                 navigation.order: 1
 
                 onClicked: {
-                    root.ret = { errcode: 0, value: root.measuresCount }
-                    root.hide()
+                    okClick()
                 }
             }
         }


### PR DESCRIPTION
Resolves: #12222

- Added keypress listener for when enter/return/esc are pressed while input is focused and called the respective functions for each key.
- Added `okClick()` function to reduce code copying, and added `cancelClick()` to pair with it.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
