### PR TITLE
Fix crash when applying staff type change to MMRest measure

### DIFF
--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -65,6 +65,7 @@
 #include "slur.h"
 #include "staff.h"
 #include "stafftype.h"
+#include "stafftypechange.h"
 #include "stem.h"
 #include "stringdata.h"
 #include "system.h"
@@ -4242,6 +4243,21 @@ void Score::cmdToggleLayoutBreak(LayoutBreakType type)
             }
         }
     }
+}
+
+void Score::cmdAddStaffTypeChange(Measure* measure, staff_idx_t staffIdx, StaffTypeChange* stc)
+{
+    if (!measure) {
+        return;
+    }
+
+    if (measure->isMMRest()) {
+        measure = measure->mmRestFirst();
+    }
+
+    stc->setParent(measure);
+    stc->setTrack(staffIdx * VOICES);
+    score()->undoAddElement(stc);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -588,6 +588,7 @@ public:
     void cmdDecDurationDotted() { cmdIncDecDuration(1, true); }
     void cmdIncDecDuration(int nSteps, bool stepDotted = false);
     void cmdToggleLayoutBreak(LayoutBreakType);
+    void cmdAddStaffTypeChange(Measure* measure, staff_idx_t staffIdx, StaffTypeChange* stc);
     void cmdAddMeasureRepeat(Measure*, int numMeasures, staff_idx_t staffIdx);
     bool makeMeasureRepeatGroup(Measure*, int numMeasures, staff_idx_t staffIdx);
     void cmdFlip();


### PR DESCRIPTION
Resolves: #15769 

We should not apply the staff type change to the MMRest measure, but rather to one of the underlying measures. Elements that are applied to the MMRest measure but not to the underlying measures are deleted during layout (that's fine I guess), but we still use them when constructing the ChangesInfo (`mu::engraving::UndoMacro::changesInfo()`; `mu::engraving::compoundObjects(mu::engraving::EngravingObject const*)`).

This fix does introduce a bit of jank: when you add a staff type change to a MMRest measure, you won't see it while MMRests are enabled (only when they are disabled). This can be fixed using this patch: https://github.com/cbjeukendrup/MuseScore/commit/0b5a160c521794edd2b01f21f05198b930cfab30

The reason that I'm not doing that, is that that introduces a crash when you delete the staff type change while MMRests are enabled. This crash is complicated to fix, because of how StaffTypeChanges work.