### PR TITLE
gp-import: fixed import of ties when octave sigh is present

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.h
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.h
@@ -211,6 +211,7 @@ private:
     std::unordered_map<track_idx_t, GPBeat::DynamicType> _dynamics;
     std::unordered_map<track_idx_t, bool> m_hasCapo;
     std::unordered_map<track_idx_t, std::vector<Tie*> > _ties; // map(track, tie)
+    std::unordered_map<Note*, int> m_originalPitches; // info of changed pitches for keeping track of ties
     std::unordered_map<track_idx_t, Slur*> _slurs; // map(track, slur)
 
     mutable GPBeat* m_currentGPBeat = nullptr; // used for passing info from notes


### PR DESCRIPTION
Current behaviour:
![Screenshot 2023-01-15 at 20 14 38](https://user-images.githubusercontent.com/24373905/212559262-d5222128-dc42-4d51-a0cf-07718ebecee8.png)


Expected:
![Screenshot 2023-01-15 at 20 15 32](https://user-images.githubusercontent.com/24373905/212559305-55337e0b-af7c-4e57-a543-8247aa139f27.png)

[octave-regression.gp.zip](https://github.com/musescore/xtz/files/10420885/octave-regression.gp.zip)
