### PR TITLE
Update window title when switching between parts

### DIFF
--- a/src/appshell/view/mainwindowtitleprovider.cpp
+++ b/src/appshell/view/mainwindowtitleprovider.cpp
@@ -35,8 +35,6 @@ void MainWindowTitleProvider::load()
     update();
 
     context()->currentProjectChanged().onNotify(this, [this]() {
-        update();
-
         if (auto currentProject = context()->currentProject()) {
             currentProject->pathChanged().onNotify(this, [this]() {
                 update();
@@ -46,6 +44,10 @@ void MainWindowTitleProvider::load()
                 update();
             });
         }
+    });
+
+    context()->currentNotationChanged().onNotify(this, [this]() {
+        update();
     });
 }
 


### PR DESCRIPTION
When editing a part score, the part name is displayed in the window title, but the window title was not updated when switching between parts, so you might still see the wrong part name or no part name at all. With this PR, the title is correctly updated immediately when switching between parts.