### PR TITLE
Fix asking about saving score when receiving Quit event

### DIFF
--- a/src/appshell/internal/applicationactioncontroller.h
+++ b/src/appshell/internal/applicationactioncontroller.h
@@ -72,7 +72,7 @@ private:
 
     void setupConnections();
 
-    void quit(bool isAllInstances, const io::path_t& installerPath = io::path_t());
+    bool quit(bool isAllInstances, const io::path_t& installerPath = io::path_t());
     void restart();
 
     void toggleFullScreen();


### PR DESCRIPTION
For example on macOS when clicking "Quit" in the Dock icon context menu or when shutting down the system

Resolves: #15852