### PR TITLE
OSXAudioDriver: fix CFStringRef to std::string conversion for device names

### DIFF
--- a/src/framework/audio/CMakeLists.txt
+++ b/src/framework/audio/CMakeLists.txt
@@ -40,13 +40,16 @@ elseif(OS_IS_LIN)
     )
 elseif(OS_IS_MAC)
     set(DRIVER_SRC
-        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/osx/osxaudiodriver.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/osx/osxaudiodriver.mm
         ${CMAKE_CURRENT_LIST_DIR}/internal/platform/osx/osxaudiodriver.h
     )
 
-    # Conflicted with AudioBuffer
-    set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/internal/platform/osx/osxaudiodriver.cpp
-                                PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+    set_source_files_properties(
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/osx/osxaudiodriver.mm
+        PROPERTIES
+        SKIP_UNITY_BUILD_INCLUSION ON
+        SKIP_PRECOMPILE_HEADERS ON
+    )
 elseif(OS_IS_WASM)
     set(DRIVER_SRC
         ${CMAKE_CURRENT_LIST_DIR}/internal/platform/web/webaudiodriver.cpp

--- a/src/framework/audio/internal/platform/osx/osxaudiodriver.mm
+++ b/src/framework/audio/internal/platform/osx/osxaudiodriver.mm
@@ -216,6 +216,7 @@ void OSXAudioDriver::updateDeviceMap()
     OSStatus result;
     std::vector<AudioObjectID> audioObjects = {};
     m_outputDevices.clear();
+    m_inputDevices.clear();
 
     AudioObjectPropertyAddress devicesPropertyAddress = {
         .mSelector = kAudioHardwarePropertyDevices,
@@ -267,7 +268,6 @@ void OSXAudioDriver::updateDeviceMap()
     }
 
     for (auto&& deviceId : audioObjects) {
-        std::string deviceName;
         CFStringRef nameRef;
 
         result = AudioObjectGetPropertyData(deviceId, &namePropertyAddress, 0, NULL, &propertySize, &nameRef);
@@ -275,9 +275,9 @@ void OSXAudioDriver::updateDeviceMap()
             logError("Failed to get device's name, err: ", result);
             continue;
         }
-        propertySize = CFStringGetLength(nameRef);
-        deviceName.resize(propertySize);
-        CFStringGetCString(nameRef, deviceName.data(), sizeof(deviceName), kCFStringEncodingUTF8);
+
+        NSString* nsString = (NSString*)nameRef;
+        std::string deviceName = [nsString UTF8String];
 
         if (getStreamsCount(deviceId, kAudioObjectPropertyScopeOutput, deviceName) > 0) {
             m_outputDevices[deviceId] = deviceName;


### PR DESCRIPTION
Resolves: #15353

This fixes all of them for me, even the ones that were actually NSStrings in a CFStringRef