### PR TITLE
Fix crash when repeating non-full-measure selection when next measure is measure repeat

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -400,9 +400,13 @@ Chord* Score::addChord(const Fraction& tick, TDuration d, Chord* oc, bool genTie
 ChordRest* Score::addClone(ChordRest* cr, const Fraction& tick, const TDuration& d)
 {
     ChordRest* newcr;
-    // change a MeasureRepeat() into an Rest()
+    // change a MeasureRepeat into an Rest
+    // To do: *properly* remove the measure repeat, like in Score::deleteItem
+    // https://github.com/musescore/MuseScore/issues/15844
+    // https://github.com/musescore/MuseScore/issues/15874
     if (cr->isMeasureRepeat()) {
         newcr = Factory::copyRest(*toRest(cr));
+        toRest(newcr)->hack_toRestType();
     } else {
         newcr = toChordRest(cr->clone());
     }


### PR DESCRIPTION
Does not yet res0lve https://github.com/musescore/MuseScore/issues/15844 and https://github.com/musescore/MuseScore/issues/15874, but fixes at least a crash that happens when you press "repeat selection" when the selection is less than a full measure and the next measure is a measure repeat. 

Note that we're in a situation similar to:
https://github.com/musescore/MuseScore/blob/7a0bfc4b56e7cb3e747e0e751877f9460c494fd5/src/engraving/libmscore/range.cpp#L296-L307