### PR TITLE
not deforming slurs over bends

### DIFF
--- a/src/engraving/libmscore/slur.cpp
+++ b/src/engraving/libmscore/slur.cpp
@@ -389,7 +389,7 @@ Shape SlurSegment::getSegmentShape(Segment* seg, ChordRest* startCR, ChordRest* 
         const EngravingItem* parent = item->parentItem();
         // Its own startCR or items belonging to it, lyrics, fingering, ledger lines, articulation on endCR
         if (item == startCR || parent == startCR || item->isTextBase() || item->isLedgerLine()
-            || (item->isArticulation() && parent == endCR)) {
+            || (item->isArticulation() && parent == endCR) || item->isBend() || item->isStretchedBend()) {
             return true;
         }
         // Items that are on the start segment but in a different voice


### PR DESCRIPTION
Current behaviour:
![Screenshot 2023-01-16 at 23 02 44](https://user-images.githubusercontent.com/24373905/212765238-274c155e-4e8f-4745-a786-87339dba6cdd.png)


Expected:
![Screenshot 2023-01-16 at 23 03 00](https://user-images.githubusercontent.com/24373905/212765271-c76dd1a5-e23d-419f-bd28-ff856c7b3ced.png)

