### PR TITLE
More tempo line fixes

### DIFF
--- a/src/engraving/layout/layoutmeasure.cpp
+++ b/src/engraving/layout/layoutmeasure.cpp
@@ -501,7 +501,29 @@ static bool breakMultiMeasureRest(const LayoutContext& ctx, Measure* m)
         }
     }
 
+    // Break for annotations found mid-way into the previous measure
+    Measure* prevMeas = m->prevMeasure();
+    if (prevMeas) {
+        for (Segment* s = prevMeas->first(); s; s = s->next()) {
+            for (EngravingItem* e : s->annotations()) {
+                if (!e->visible()) {
+                    continue;
+                }
+                if ((e->isRehearsalMark()
+                     || e->isTempoText()
+                     || ((e->isHarmony() || e->isStaffText() || e->isSystemText() || e->isTripletFeel() || e->isPlayTechAnnotation()
+                          || e->isInstrumentChange())
+                         && (e->systemFlag() || ctx.score()->staff(e->staffIdx())->show())
+                         ))
+                    && e->rtick() > Fraction(0, 1)) {
+                    return true;
+                }
+            }
+        }
+    }
+
     for (Segment* s = m->first(); s; s = s->next()) {
+        // Break for annotations in this measure
         for (EngravingItem* e : s->annotations()) {
             if (!e->visible()) {
                 continue;

--- a/src/engraving/libmscore/chordrest.cpp
+++ b/src/engraving/libmscore/chordrest.cpp
@@ -602,8 +602,13 @@ EngravingItem* ChordRest::drop(EditData& data)
         if (e->isSpanner()) {
             Spanner* spanner = toSpanner(e);
             spanner->setTick(tick());
-            spanner->setTrack(track());
-            spanner->setTrack2(track());
+            if (spanner->systemFlag()) {
+                spanner->setTrack(0);
+                spanner->setTrack2(0);
+            } else {
+                spanner->setTrack(track());
+                spanner->setTrack2(track());
+            }
             score()->undoAddElement(spanner);
             return e;
         }

--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -1420,6 +1420,21 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                     }
                 }
 
+                for (EngravingItem* e : oseg->annotations()) {
+                    if (e->generated()
+                        || (e->track() != srcTrack && !(e->systemFlag() && e->track() == 0)) // system items must be cloned even if they are on different tracks
+                        || (e->track() != srcTrack && e->systemFlag() && e->findLinkedInScore(score))) { // ...but only once!
+                        continue;
+                    }
+
+                    EngravingItem* ne1 = e->linkedClone();
+                    ne1->setTrack(dstTrack);
+                    ne1->setParent(ns);
+                    ne1->setScore(score);
+                    ne1->styleChanged();
+                    addElement(ne1);
+                }
+
                 EngravingItem* oe = oseg->element(srcTrack);
                 if (oe == 0 || oe->generated()) {
                     continue;
@@ -1448,21 +1463,6 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                         }
                         ncr->setTuplet(nt);
                         nt->add(ncr);
-                    }
-
-                    for (EngravingItem* e : oseg->annotations()) {
-                        if (e->generated()
-                            || (e->track() != srcTrack && !(e->systemFlag() && e->track() == 0)) // system items must be cloned even if they are on different tracks
-                            || (e->systemFlag() && e->findLinkedInScore(score))) { // ...but only once!
-                            continue;
-                        }
-
-                        EngravingItem* ne1 = e->linkedClone();
-                        ne1->setTrack(dstTrack);
-                        ne1->setParent(ns);
-                        ne1->setScore(score);
-                        ne1->styleChanged();
-                        addElement(ne1);
                     }
                     if (oe->isChord()) {
                         Chord* och = toChord(ocr);

--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -1421,12 +1421,15 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                 }
 
                 for (EngravingItem* e : oseg->annotations()) {
-                    if (e->generated()
-                        || (e->track() != srcTrack && !(e->systemFlag() && e->track() == 0)) // system items must be cloned even if they are on different tracks
-                        || (e->track() != srcTrack && e->systemFlag() && e->findLinkedInScore(score))) { // ...but only once!
+                    if (e->generated()) {
                         continue;
                     }
-
+                    bool systemObject = e->systemFlag() && e->track() == 0;
+                    bool alreadyCloned = bool(e->findLinkedInScore(score));
+                    bool cloneAnnotation = e->track() == srcTrack || (systemObject && !alreadyCloned);
+                    if (!cloneAnnotation) {
+                        continue;
+                    }
                     EngravingItem* ne1 = e->linkedClone();
                     ne1->setTrack(dstTrack);
                     ne1->setParent(ns);


### PR DESCRIPTION
Resolves: #14296

Fixing the next bunch of issues with tempo lines.
- Fixed wrong staff on copy-pasting
- Fixed mid-measure tempo indication disappearing in parts
- ~Fixed wrong staff of tempo lines upon reordering instruments~
- ~Fixed lost tempo lines upon save-reopen if they start or end mid-measure~

The layout of tempo lines (actually, all system-level text lines) is still imperfect because (let's all repeat together):

_We cAN't AtTAcH THinGs To RhyTHmIC PoSiTiONS_

Most commonly: things will just snap to the start/end of a measure if there is nothing to attach to within that measure. Can't really do anything about that at the moment.