### PR TITLE
Fix crash when setting Chords with ledger lines invisible using Inspector

### DIFF
--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -1367,7 +1367,7 @@ double Chord::centerX() const
 //   processSiblings
 //---------------------------------------------------------
 
-void Chord::processSiblings(std::function<void(EngravingItem*)> func) const
+void Chord::processSiblings(std::function<void(EngravingItem*)> func, bool includeTemporarySiblings) const
 {
     if (_hook) {
         func(_hook);
@@ -1384,8 +1384,10 @@ void Chord::processSiblings(std::function<void(EngravingItem*)> func) const
     if (_tremolo) {
         func(_tremolo);
     }
-    for (LedgerLine* ll = _ledgerLines; ll; ll = ll->next()) {
-        func(ll);
+    if (includeTemporarySiblings) {
+        for (LedgerLine* ll = _ledgerLines; ll; ll = ll->next()) {
+            func(ll);
+        }
     }
     for (Articulation* a : _articulations) {
         func(a);
@@ -1405,7 +1407,7 @@ void Chord::processSiblings(std::function<void(EngravingItem*)> func) const
 void Chord::setTrack(track_idx_t val)
 {
     ChordRest::setTrack(val);
-    processSiblings([val](EngravingItem* e) { e->setTrack(val); });
+    processSiblings([val](EngravingItem* e) { e->setTrack(val); }, true);
 }
 
 //---------------------------------------------------------
@@ -1415,7 +1417,7 @@ void Chord::setTrack(track_idx_t val)
 void Chord::setScore(Score* s)
 {
     ChordRest::setScore(s);
-    processSiblings([s](EngravingItem* e) { e->setScore(s); });
+    processSiblings([s](EngravingItem* e) { e->setScore(s); }, true);
 }
 
 // all values are in quarter spaces
@@ -2640,7 +2642,7 @@ void Chord::layoutTablature()
         _notes.at(i)->layout2();
     }
     RectF bb;
-    processSiblings([&bb](EngravingItem* e) { bb.unite(e->bbox().translated(e->pos())); });
+    processSiblings([&bb](EngravingItem* e) { bb.unite(e->bbox().translated(e->pos())); }, true);
     if (_tabDur) {
         bb.unite(_tabDur->bbox().translated(_tabDur->pos()));
     }
@@ -3718,7 +3720,7 @@ void Chord::undoChangeProperty(Pid id, const PropertyValue& newValue, PropertyFl
     if (id == Pid::VISIBLE) {
         processSiblings([=](EngravingItem* element) {
             element->undoChangeProperty(id, newValue, ps);
-        });
+        }, false);
     }
 
     EngravingItem::undoChangeProperty(id, newValue, ps);

--- a/src/engraving/libmscore/chord.h
+++ b/src/engraving/libmscore/chord.h
@@ -151,7 +151,9 @@ class Chord final : public ChordRest
     double downPos() const override;
     double centerX() const;
     void addLedgerLines();
-    void processSiblings(std::function<void(EngravingItem*)> func) const;
+
+    // `includeTemporarySiblings`: whether items that are deleted & recreated during every layout should also be processed
+    void processSiblings(std::function<void(EngravingItem*)> func, bool includeTemporarySiblings) const;
 
     void layoutPitched();
     void layoutTablature();


### PR DESCRIPTION
What happened:
- The Inspector toggles the visibility of the selected `Chord`
- When the visibility of a `Chord` is changed, it also sets the visibility of its subitems (since https://github.com/musescore/MuseScore/commit/d26cbf8b7d4f779b901fb5055582b2452156af04#diff-13f3103b0fd80f2da9ba0db1ff1f3d864eb6f0e0b16d1903000eae4d6721cec8R3645-R3649), including Ledger Lines; this is recorded in the Undo Stack
- After the changes are done, the score is laid out again; as part of this, the ledger lines are deleted to be replaced with new ones
- Finally, information from the Undo Stack is requested to determine to what extent the playback needs to be re-rendered. While generating this info, the UndoStack comes across the deleted ledger lines that it still referenced, which causes a crash
- Pressing the 'V' shortcut toggles the visibility of the _notes_, rather than their parent Chords, so is not affected.

The solution is that we should not process temporary items like Ledger Lines for anything that outlives them, like undoable commands.

Resolves: #15932