### PR TITLE
#15684 MU4 Issue: Horizontal frame - Properties - "Display key, brackets and braces" should also mention "clef" #15684

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/notation/frames/HorizontalFrameSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/frames/HorizontalFrameSettings.qml
@@ -73,7 +73,7 @@ Column {
     SeparatorLine { anchors.margins: -12 }
 
     CheckBoxPropertyView {
-        text: qsTrc("inspector", "Display clef, key and brackets in the next measure")
+        text: qsTrc("inspector", "Display brackets, clefs and key signatures in the next measure")
         propertyItem: root.model ? root.model.shouldDisplayKeysAndBrackets : null
 
         navigation.name: "DisplayKeysAndBracketsCheckBox"

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/frames/HorizontalFrameSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/frames/HorizontalFrameSettings.qml
@@ -73,7 +73,7 @@ Column {
     SeparatorLine { anchors.margins: -12 }
 
     CheckBoxPropertyView {
-        text: qsTrc("inspector", "Display key, brackets and braces")
+        text: qsTrc("inspector", "Display clef, key and brackets in the next measure")
         propertyItem: root.model ? root.model.shouldDisplayKeysAndBrackets : null
 
         navigation.name: "DisplayKeysAndBracketsCheckBox"


### PR DESCRIPTION
Resolves: #15684 [https://github.com/musescore/MuseScore/issues/15684](link)

Changed string value in Inspector\notation\frames\HorizontalFrameSettings.qml

from: 
text: qsTrc("inspector", "Display key, brackets and braces")
to: 
text: qsTrc("inspector", "Display clef, key and brackets in the next measure")

Update: Commit2 -> Changed the string to "Display brackets, clefs and key signatures in the next measure".

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
