### PR TITLE
Add setting to choose whether invisible parts should be muted or not

### DIFF
--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -152,6 +152,7 @@ private:
     void toggleMidiInput();
     void toggleCountIn();
     void toggleLoopPlayback();
+    void toggleMuteInvisibleParts();
 
     void openPlaybackSetupDialog();
 

--- a/src/playback/internal/playbackuiactions.cpp
+++ b/src/playback/internal/playbackuiactions.cpp
@@ -135,6 +135,16 @@ const UiActionList PlaybackUiActions::m_loopBoundaryActions = {
              ),
 };
 
+const UiActionList PlaybackUiActions::m_otherActions = {
+    UiAction("toggle-mute-invisible-parts",
+             mu::context::UiCtxAny,
+             mu::context::CTX_NOTATION_FOCUSED,
+             TranslatableString("action", "Mute invisible parts"),
+             TranslatableString("action", "Toggle 'Mute invisible parts'"),
+             Checkable::Yes
+             ),
+};
+
 PlaybackUiActions::PlaybackUiActions(std::shared_ptr<PlaybackController> controller)
     : m_controller(controller)
 {
@@ -164,6 +174,7 @@ const UiActionList& PlaybackUiActions::actionsList() const
         alist.insert(alist.end(), m_mainActions.cbegin(), m_mainActions.cend());
         alist.insert(alist.end(), m_settingsActions.cbegin(), m_settingsActions.cend());
         alist.insert(alist.end(), m_loopBoundaryActions.cbegin(), m_loopBoundaryActions.cend());
+        alist.insert(alist.end(), m_otherActions.cbegin(), m_otherActions.cend());
     }
     return alist;
 }

--- a/src/playback/internal/playbackuiactions.h
+++ b/src/playback/internal/playbackuiactions.h
@@ -56,6 +56,7 @@ private:
     static const ui::UiActionList m_mainActions;
     static const ui::UiActionList m_settingsActions;
     static const ui::UiActionList m_loopBoundaryActions;
+    static const ui::UiActionList m_otherActions;
 
     std::shared_ptr<PlaybackController> m_controller;
     async::Channel<actions::ActionCodeList> m_actionEnabledChanged;

--- a/src/playback/view/mixerpanelcontextmenumodel.cpp
+++ b/src/playback/view/mixerpanelcontextmenumodel.cpp
@@ -107,6 +107,7 @@ void MixerPanelContextMenuModel::load()
 
     MenuItemList items {
         makeMenuItem("playback-setup"),
+        makeMenuItem("toggle-mute-invisible-parts"),
         makeMenu(TranslatableString("playback", "View"), viewMenuItems, VIEW_MENU_ID)
     };
 

--- a/src/playback/view/mixerpanelcontextmenumodel.cpp
+++ b/src/playback/view/mixerpanelcontextmenumodel.cpp
@@ -98,6 +98,8 @@ bool MixerPanelContextMenuModel::titleSectionVisible() const
 
 void MixerPanelContextMenuModel::load()
 {
+    AbstractMenuModel::load();
+
     dispatcher()->reg(this, TOGGLE_MIXER_SECTION_ACTION, this, &MixerPanelContextMenuModel::toggleMixerSection);
 
     MenuItemList viewMenuItems;

--- a/src/project/internal/projectaudiosettings.cpp
+++ b/src/project/internal/projectaudiosettings.cpp
@@ -142,6 +142,26 @@ void ProjectAudioSettings::setSoloMuteState(const InstrumentTrackId& partId, con
     setNeedSave(true);
 }
 
+bool ProjectAudioSettings::muteInvisibleParts() const
+{
+    return m_muteInvisibleParts;
+}
+
+void ProjectAudioSettings::setMuteInvisibleParts(bool mute)
+{
+    if (mute == m_muteInvisibleParts) {
+        return;
+    }
+
+    m_muteInvisibleParts = mute;
+    m_muteInvisiblePartsChanged.notify();
+}
+
+mu::async::Notification ProjectAudioSettings::muteInvisiblePartsChanged() const
+{
+    return m_muteInvisiblePartsChanged;
+}
+
 void ProjectAudioSettings::removeTrackParams(const InstrumentTrackId& partId)
 {
     auto inSearch = m_trackInputParamsMap.find(partId);
@@ -210,6 +230,8 @@ mu::Ret ProjectAudioSettings::read(const engraving::MscReader& reader)
         m_soloMuteStatesMap.emplace(id, std::move(soloMuteState));
     }
 
+    m_muteInvisibleParts = rootObj.value("muteInvisibleParts").toBool(/*defaultValue=*/ m_muteInvisibleParts);
+
     m_activeSoundProfileName = rootObj.value("activeSoundProfile").toString();
     if (m_activeSoundProfileName.empty()) {
         m_activeSoundProfileName = playbackConfig()->defaultProfileForNewProjects();
@@ -229,6 +251,7 @@ mu::Ret ProjectAudioSettings::write(engraving::MscWriter& writer)
     }
 
     rootObj["tracks"] = tracksArray;
+    rootObj["muteInvisibleParts"] = m_muteInvisibleParts;
     rootObj["activeSoundProfile"] = m_activeSoundProfileName.toQString();
 
     QByteArray json = QJsonDocument(rootObj).toJson();

--- a/src/project/internal/projectaudiosettings.h
+++ b/src/project/internal/projectaudiosettings.h
@@ -37,6 +37,7 @@ namespace mu::project {
 class ProjectAudioSettings : public IProjectAudioSettings
 {
     INJECT_STATIC(project, playback::IPlaybackConfiguration, playbackConfig)
+
 public:
     audio::AudioOutputParams masterAudioOutputParams() const override;
     void setMasterAudioOutputParams(const audio::AudioOutputParams& params) override;
@@ -50,6 +51,10 @@ public:
     SoloMuteState soloMuteState(const engraving::InstrumentTrackId& trackId) const override;
     void setSoloMuteState(const engraving::InstrumentTrackId& trackId, const SoloMuteState& soloMuteState) override;
     async::Channel<engraving::InstrumentTrackId, SoloMuteState> soloMuteStateChanged() const override;
+
+    bool muteInvisibleParts() const override;
+    void setMuteInvisibleParts(bool mute) override;
+    async::Notification muteInvisiblePartsChanged() const override;
 
     void removeTrackParams(const engraving::InstrumentTrackId& partId) override;
 
@@ -100,9 +105,12 @@ private:
 
     std::unordered_map<engraving::InstrumentTrackId, audio::AudioInputParams> m_trackInputParamsMap;
     std::unordered_map<engraving::InstrumentTrackId, audio::AudioOutputParams> m_trackOutputParamsMap;
-    std::unordered_map<engraving::InstrumentTrackId, SoloMuteState> m_soloMuteStatesMap;
 
+    std::unordered_map<engraving::InstrumentTrackId, SoloMuteState> m_soloMuteStatesMap;
     async::Channel<engraving::InstrumentTrackId, SoloMuteState> m_soloMuteStateChanged;
+
+    bool m_muteInvisibleParts = true;
+    async::Notification m_muteInvisiblePartsChanged;
 
     bool m_needSave = false;
     async::Notification m_needSaveNotification;

--- a/src/project/iprojectaudiosettings.h
+++ b/src/project/iprojectaudiosettings.h
@@ -59,6 +59,10 @@ public:
     virtual void setSoloMuteState(const engraving::InstrumentTrackId& trackId, const SoloMuteState& soloMuteState) = 0;
     virtual async::Channel<engraving::InstrumentTrackId, SoloMuteState> soloMuteStateChanged() const = 0;
 
+    virtual bool muteInvisibleParts() const = 0;
+    virtual void setMuteInvisibleParts(bool mute) = 0;
+    virtual async::Notification muteInvisiblePartsChanged() const = 0;
+
     virtual void removeTrackParams(const engraving::InstrumentTrackId& trackId) = 0;
 
     virtual mu::ValNt<bool> needSave() const = 0;


### PR DESCRIPTION
Resolves: #15945

This is a (possibly temporary) solution for #15945, that allows users to choose whether invisible parts should be muted:
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/48658420/213935694-b90ca6d6-6f9f-4d28-ae68-98fdb19ba1a9.png">
The value of this setting is saved with the score.

If you enable this setting (default), then things will behave like they do now.
If you disable it, then MuseScore won't mute any invisible parts at all, not even in part scores, so that users can do whatever they want. 

This is obviously not a full solution, but at least it provides users who need to override MuseScore's behaviour with a way to do so.

The second commit should resolve #13787.