### PR TITLE
Fix playback with FluidSynth at higher sample rates

### DIFF
--- a/thirdparty/fluidsynth/fluidsynth-2.3.3/src/synth/fluid_synth.c
+++ b/thirdparty/fluidsynth/fluidsynth-2.3.3/src/synth/fluid_synth.c
@@ -228,7 +228,7 @@ void fluid_synth_settings(fluid_settings_t *settings)
     fluid_settings_register_int(settings, "synth.audio-groups", 1, 1, 128, 0);
     fluid_settings_register_int(settings, "synth.effects-channels", 2, 2, 2, 0);
     fluid_settings_register_int(settings, "synth.effects-groups", 1, 1, 128, 0);
-    fluid_settings_register_num(settings, "synth.sample-rate", 44100.0f, 8000.0f, 96000.0f, 0);
+    fluid_settings_register_num(settings, "synth.sample-rate", 44100.0f, 8000.0f, 384000.0f, 0);
     fluid_settings_register_int(settings, "synth.device-id", 0, 0, 127, 0);
 #ifdef ENABLE_MIXER_THREADS
     fluid_settings_register_int(settings, "synth.cpu-cores", 1, 1, 256, 0);


### PR DESCRIPTION
Resolves: #15615
Resolves the high-pitch part of: #16014

I `git blame`d the FluidSynth source code to see if there is a reason that FluidSynth only supports sample rates up to 96kHz, but the only thing I found was that it has just always been like that, for the past 20 years. So I expect it should be possible to move this limit up a bit. 

Also adds support for exporting audio at higher sample rates. Since we (intend to) support those for live playback, I see no problem in supporting them for export too.