### PR TITLE
Cleanup "Expand repeats" option; fix it for MIDI export

### DIFF
--- a/src/engraving/libmscore/masterscore.h
+++ b/src/engraving/libmscore/masterscore.h
@@ -84,9 +84,9 @@ class MasterScore : public Score
     UndoStack* _undoStack = nullptr;
     TimeSigMap* _sigmap;
     TempoMap* _tempomap;
-    RepeatList* _repeatList;
-    RepeatList* _repeatList2;
-    bool _expandRepeats = MScore::playRepeats;
+    RepeatList* _expandedRepeatList;
+    RepeatList* _nonExpandedRepeatList;
+    bool _expandRepeats = true;
     bool _playlistDirty = true;
     std::vector<Excerpt*> _excerpts;
     std::vector<PartChannelSettingsLink> _playbackSettingsLinks;
@@ -158,12 +158,15 @@ public:
     void setPlaylistDirty() override;
     void setPlaylistClean() { _playlistDirty = false; }
 
+    /// Always call this before calling `repeatList()`
+    /// No need to set it back after use, because everyone always calls it before using `repeatList()`
     void setExpandRepeats(bool expandRepeats);
     bool expandRepeats() const { return _expandRepeats; }
+
     void updateRepeatListTempo();
     void updateRepeatList();
     const RepeatList& repeatList() const override;
-    const RepeatList& repeatList2() const override;
+    const RepeatList& repeatList(bool expandRepeats) const override;
 
     std::vector<Excerpt*>& excerpts() { return _excerpts; }
     const std::vector<Excerpt*>& excerpts() const { return _excerpts; }

--- a/src/engraving/libmscore/mscore.cpp
+++ b/src/engraving/libmscore/mscore.cpp
@@ -57,8 +57,6 @@ double MScore::horizontalPageGapOdd = 50.0;
 bool MScore::warnPitchRange;
 int MScore::pedalEventsMinTicks;
 
-bool MScore::playRepeats;
-int MScore::playbackSpeedIncrement;
 double MScore::nudgeStep;
 double MScore::nudgeStep10;
 double MScore::nudgeStep50;
@@ -92,8 +90,6 @@ void MScore::init()
     defaultPlayDuration = 300;        // ms
     warnPitchRange      = true;
     pedalEventsMinTicks = 1;
-    playRepeats         = true;
-    playbackSpeedIncrement = 5;
 
     //
     //  initialize styles

--- a/src/engraving/libmscore/mscore.h
+++ b/src/engraving/libmscore/mscore.h
@@ -246,8 +246,6 @@ public:
     static bool warnPitchRange;
     static int pedalEventsMinTicks;
 
-    static bool playRepeats;
-    static int playbackSpeedIncrement;
     static double nudgeStep;
     static double nudgeStep10;
     static double nudgeStep50;

--- a/src/engraving/libmscore/rendermidi.cpp
+++ b/src/engraving/libmscore/rendermidi.cpp
@@ -1489,9 +1489,7 @@ void Score::createPlayEvents(Measure const* start, Measure const* const end)
 
 void Score::renderMidi(EventMap* events, const MidiRenderer::Context& ctx, bool expandRepeats)
 {
-    bool expandRepeatsBackup = masterScore()->expandRepeats();
     masterScore()->setExpandRepeats(expandRepeats);
     MidiRenderer(this).renderScore(events, ctx);
-    masterScore()->setExpandRepeats(expandRepeatsBackup);
 }
 }

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -5104,8 +5104,7 @@ int Score::keysig()
 
 int Score::duration()
 {
-    masterScore()->setExpandRepeats(true);
-    const RepeatList& rl = repeatList();
+    const RepeatList& rl = masterScore()->repeatList(true);
     if (rl.empty()) {
         return 0;
     }
@@ -5119,7 +5118,7 @@ int Score::duration()
 
 int Score::durationWithoutRepeats()
 {
-    const RepeatList& rl = repeatList2();
+    const RepeatList& rl = masterScore()->repeatList(false);
     if (rl.empty()) {
         return 0;
     }
@@ -5960,7 +5959,7 @@ void Score::autoUpdateSpatium()
 
 UndoStack* Score::undoStack() const { return _masterScore->undoStack(); }
 const RepeatList& Score::repeatList()  const { return _masterScore->repeatList(); }
-const RepeatList& Score::repeatList2()  const { return _masterScore->repeatList2(); }
+const RepeatList& Score::repeatList(bool expandRepeats)  const { return _masterScore->repeatList(expandRepeats); }
 TempoMap* Score::tempomap() const { return _masterScore->tempomap(); }
 TimeSigMap* Score::sigmap() const { return _masterScore->sigmap(); }
 //QQueue<MidiInputEvent>* Score::midiInputQueue() { return _masterScore->midiInputQueue(); }

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -999,8 +999,13 @@ public:
     void adjustKeySigs(track_idx_t sidx, track_idx_t eidx, KeyList km);
     KeyList keyList() const;
 
+    /// To be used together with setExpandRepeats.
+    /// For bigger operations, where suboperations might also use it,
+    /// where those need to have the same value for expandRepeats.
     virtual const RepeatList& repeatList() const;
-    virtual const RepeatList& repeatList2() const;
+    /// For small, one-step operations, where you need to get the relevant repeatList just once
+    virtual const RepeatList& repeatList(bool expandRepeats) const;
+
     double utick2utime(int tick) const;
     int utime2utick(double utime) const;
 

--- a/src/engraving/libmscore/spanner.cpp
+++ b/src/engraving/libmscore/spanner.cpp
@@ -1244,28 +1244,6 @@ void Spanner::setTicks(const Fraction& f)
     }
 }
 
-int Spanner::startUniqueTicks() const
-{
-    Score* score = this->score();
-
-    if (!score) {
-        return 0;
-    }
-
-    return score->repeatList().tick2utick(tick().ticks());
-}
-
-int Spanner::endUniqueTicks() const
-{
-    Score* score = this->score();
-
-    if (!score) {
-        return 0;
-    }
-
-    return score->repeatList().tick2utick(tick2().ticks());
-}
-
 //---------------------------------------------------------
 //   triggerLayout
 //---------------------------------------------------------

--- a/src/engraving/libmscore/spanner.h
+++ b/src/engraving/libmscore/spanner.h
@@ -202,9 +202,6 @@ public:
     void setTick2(const Fraction&);
     void setTicks(const Fraction&);
 
-    int startUniqueTicks() const;
-    int endUniqueTicks() const;
-
     track_idx_t track2() const { return _track2; }
     void setTrack2(track_idx_t v) { _track2 = v; }
     track_idx_t effectiveTrack2() const { return _track2 == mu::nidx ? track() : _track2; }

--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -24,13 +24,13 @@
 
 #include "libmscore/fret.h"
 #include "libmscore/instrument.h"
+#include "libmscore/masterscore.h"
 #include "libmscore/measure.h"
+#include "libmscore/measurerepeat.h"
 #include "libmscore/part.h"
 #include "libmscore/repeatlist.h"
-#include "libmscore/score.h"
 #include "libmscore/segment.h"
 #include "libmscore/tempo.h"
-#include "libmscore/measurerepeat.h"
 
 #include "log.h"
 
@@ -605,7 +605,7 @@ void PlaybackModel::clearExpiredEvents(const int tickFrom, const int tickTo, con
         return;
     }
 
-    for (const RepeatSegment* repeatSegment : m_score->repeatList()) {
+    for (const RepeatSegment* repeatSegment : repeatList()) {
         int tickPositionOffset = repeatSegment->utick - repeatSegment->tick;
         int repeatStartTick = repeatSegment->tick;
         int repeatEndTick = repeatStartTick + repeatSegment->len();
@@ -722,6 +722,8 @@ PlaybackModel::TickBoundaries PlaybackModel::tickBoundaries(const ScoreChangesRa
 
 const RepeatList& PlaybackModel::repeatList() const
 {
+    m_score->masterScore()->setExpandRepeats(m_expandRepeats);
+
     return m_score->repeatList();
 }
 

--- a/src/importexport/midi/imidiconfiguration.h
+++ b/src/importexport/midi/imidiconfiguration.h
@@ -35,13 +35,18 @@ class IMidiImportExportConfiguration : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IMidiImportExportConfiguration() = default;
 
+    // import
     virtual int midiShortestNote() const = 0; //ticks
     virtual void setMidiShortestNote(int ticks) = 0;
 
-    virtual bool isMidiExportRpns() const = 0;
-    virtual void setIsMidiExportRpns(bool exportRpns) const = 0;
-
     virtual void setMidiImportOperationsFile(const std::optional<io::path_t>& filePath) const = 0;
+
+    // export
+    virtual bool isExpandRepeats() const = 0;
+    virtual void setExpandRepeats(bool expand) = 0;
+
+    virtual bool isMidiExportRpns() const = 0;
+    virtual void setIsMidiExportRpns(bool exportRpns) = 0;
 };
 }
 

--- a/src/importexport/midi/internal/midiconfiguration.cpp
+++ b/src/importexport/midi/internal/midiconfiguration.cpp
@@ -23,19 +23,21 @@
 
 #include "settings.h"
 
-#include "libmscore/mscore.h"
+#include "engraving/types/constants.h"
 
-#include "internal/midiimport/importmidi_operations.h"
+#include "midiimport/importmidi_operations.h"
 
 using namespace mu::framework;
 using namespace mu::iex::midi;
 
 static const Settings::Key SHORTEST_NOTE_KEY("iex_midi", "io/midi/shortestNote");
 static const Settings::Key EXPORTRPNS_KEY("iex_midi", "io/midi/exportRPNs");
+static const Settings::Key EXPAND_REPEATS_KEY("iex_midi", "io/midi/expandRepeats");
 
 void MidiConfiguration::init()
 {
     settings()->setDefaultValue(SHORTEST_NOTE_KEY, Val(mu::engraving::Constants::division / 4));
+    settings()->setDefaultValue(EXPAND_REPEATS_KEY, Val(true));
     settings()->setDefaultValue(EXPORTRPNS_KEY, Val(true));
 }
 
@@ -49,19 +51,29 @@ void MidiConfiguration::setMidiShortestNote(int ticks)
     settings()->setSharedValue(SHORTEST_NOTE_KEY, Val(ticks));
 }
 
-bool MidiConfiguration::isMidiExportRpns() const
-{
-    return settings()->value(EXPORTRPNS_KEY).toBool();
-}
-
-void MidiConfiguration::setIsMidiExportRpns(bool exportRpns) const
-{
-    settings()->setSharedValue(EXPORTRPNS_KEY, Val(exportRpns));
-}
-
 void MidiConfiguration::setMidiImportOperationsFile(const std::optional<io::path_t>& filePath) const
 {
     if (filePath) {
         midiImportOperations.setOperationsFile(filePath.value().toQString());
     }
+}
+
+bool MidiConfiguration::isExpandRepeats() const
+{
+    return settings()->value(EXPAND_REPEATS_KEY).toBool();
+}
+
+void MidiConfiguration::setExpandRepeats(bool expand)
+{
+    settings()->setSharedValue(EXPAND_REPEATS_KEY, Val(expand));
+}
+
+bool MidiConfiguration::isMidiExportRpns() const
+{
+    return settings()->value(EXPORTRPNS_KEY).toBool();
+}
+
+void MidiConfiguration::setIsMidiExportRpns(bool exportRpns)
+{
+    settings()->setSharedValue(EXPORTRPNS_KEY, Val(exportRpns));
 }

--- a/src/importexport/midi/internal/midiconfiguration.h
+++ b/src/importexport/midi/internal/midiconfiguration.h
@@ -31,13 +31,18 @@ class MidiConfiguration : public IMidiImportExportConfiguration
 public:
     void init();
 
+    // import
     int midiShortestNote() const override; // ticks
     void setMidiShortestNote(int ticks) override;
 
-    bool isMidiExportRpns() const override;
-    void setIsMidiExportRpns(bool exportRpns) const override;
-
     void setMidiImportOperationsFile(const std::optional<io::path_t>& filePath) const override;
+
+    // export
+    bool isExpandRepeats() const override;
+    void setExpandRepeats(bool expand) override;
+
+    bool isMidiExportRpns() const override;
+    void setIsMidiExportRpns(bool exportRpns) override;
 };
 }
 

--- a/src/importexport/midi/internal/notationmidiwriter.cpp
+++ b/src/importexport/midi/internal/notationmidiwriter.cpp
@@ -56,7 +56,7 @@ mu::Ret NotationMidiWriter::write(INotationPtr notation, QIODevice& destinationD
 
     ExportMidi exportMidi(score);
 
-    bool isPlayRepeatsEnabled = notationConfiguration()->isPlayRepeatsEnabled();
+    bool isPlayRepeatsEnabled = midiImportExportConfiguration()->isExpandRepeats();
     bool isMidiExportRpns = midiImportExportConfiguration()->isMidiExportRpns();
     SynthesizerState synthesizerState = score->synthesizerState();
 

--- a/src/notation/internal/notation.cpp
+++ b/src/notation/internal/notation.cpp
@@ -123,8 +123,6 @@ void Notation::init()
 {
     bool isVertical = configuration()->canvasOrientation().val == framework::Orientation::Vertical;
     mu::engraving::MScore::setVerticalOrientation(isVertical);
-
-    mu::engraving::MScore::playRepeats = configuration()->isPlayRepeatsEnabled();
 }
 
 void Notation::setScore(mu::engraving::Score* score)

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -545,7 +545,6 @@ bool NotationConfiguration::isPlayRepeatsEnabled() const
 void NotationConfiguration::setIsPlayRepeatsEnabled(bool enabled)
 {
     settings()->setSharedValue(IS_PLAY_REPEATS_ENABLED, Val(enabled));
-    mu::engraving::MScore::playRepeats = enabled;
     m_isPlayRepeatsChanged.notify();
 }
 

--- a/src/notation/internal/notationplayback.cpp
+++ b/src/notation/internal/notationplayback.cpp
@@ -25,21 +25,18 @@
 
 #include "log.h"
 
-#include "libmscore/masterscore.h"
-#include "libmscore/tempo.h"
-#include "libmscore/part.h"
-#include "libmscore/instrument.h"
-#include "libmscore/repeatlist.h"
-#include "libmscore/measure.h"
-#include "libmscore/segment.h"
-#include "libmscore/system.h"
-#include "libmscore/page.h"
-#include "libmscore/staff.h"
 #include "libmscore/chordrest.h"
-#include "libmscore/chord.h"
-#include "libmscore/harmony.h"
-#include "libmscore/tempotext.h"
+#include "libmscore/instrument.h"
+#include "libmscore/masterscore.h"
+#include "libmscore/measure.h"
+#include "libmscore/page.h"
+#include "libmscore/part.h"
+#include "libmscore/repeatlist.h"
+#include "libmscore/segment.h"
+#include "libmscore/staff.h"
+#include "libmscore/system.h"
 #include "libmscore/tempo.h"
+#include "libmscore/tempotext.h"
 
 #include "notationerrors.h"
 
@@ -171,7 +168,7 @@ void NotationPlayback::updateTotalPlayTime()
         return;
     }
 
-    int lastTick = score->repeatList().ticks();
+    int lastTick = score->repeatList(m_playbackModel.isPlayRepeatsEnabled()).ticks();
     qreal secs = score->utick2utime(lastTick);
     secs += PLAYBACK_TAIL_SECS;
 
@@ -217,7 +214,7 @@ tick_t NotationPlayback::secToTick(float sec) const
 
     tick_t utick = secToPlayedTick(sec);
 
-    return score()->repeatList().utick2tick(utick);
+    return score()->repeatList(m_playbackModel.isPlayRepeatsEnabled()).utick2tick(utick);
 }
 
 RetVal<midi::tick_t> NotationPlayback::playPositionTickByRawTick(midi::tick_t tick) const
@@ -226,7 +223,7 @@ RetVal<midi::tick_t> NotationPlayback::playPositionTickByRawTick(midi::tick_t ti
         return make_ret(Err::Undefined);
     }
 
-    midi::tick_t playbackTick = score()->repeatList().tick2utick(tick);
+    midi::tick_t playbackTick = score()->repeatList(m_playbackModel.isPlayRepeatsEnabled()).tick2utick(tick);
 
     return RetVal<midi::tick_t>::make_ok(std::move(playbackTick));
 }

--- a/src/plugins/api/cursor.cpp
+++ b/src/plugins/api/cursor.cpp
@@ -30,7 +30,6 @@
 #include "libmscore/note.h"
 #include "libmscore/stafftext.h"
 #include "libmscore/measure.h"
-#include "libmscore/repeatlist.h"
 #include "libmscore/page.h"
 #include "libmscore/system.h"
 #include "libmscore/segment.h"

--- a/src/plugins/api/score.h
+++ b/src/plugins/api/score.h
@@ -204,9 +204,6 @@ public:
 
     Q_INVOKABLE QString extractLyrics() { return score()->extractLyrics(); }
 
-//      //@ ??
-//      Q_INVOKABLE void updateRepeatList(bool expandRepeats) { score()->updateRepeatList(); } // TODO: needed?
-
     /// \cond MS_INTERNAL
     int nmeasures() const { return static_cast<int>(score()->nmeasures()); }
     int npages() const { return static_cast<int>(score()->npages()); }

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -680,6 +680,18 @@ ProjectActionsController::AudioFile ProjectActionsController::exportMp3(const IN
         return AudioFile();
     }
 
+    // In the uploaded audio file, the repeats need to be expanded
+    bool wasExpandRepeats = notationConfiguration()->isPlayRepeatsEnabled();
+    if (!wasExpandRepeats) {
+        notationConfiguration()->setIsPlayRepeatsEnabled(true);
+    }
+
+    DEFER {
+        if (!wasExpandRepeats) {
+            notationConfiguration()->setIsPlayRepeatsEnabled(false);
+        }
+    };
+
     if (!exportProjectScenario()->exportScores({ notation }, mp3Path)) {
         LOGE() << "Could not export an mp3";
         delete tempFile;

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -40,6 +40,7 @@
 #include "isaveprojectscenario.h"
 #include "io/ifilesystem.h"
 #include "internal/iexportprojectscenario.h"
+#include "notation/inotationconfiguration.h"
 
 #include "async/asyncable.h"
 
@@ -65,6 +66,7 @@ class ProjectActionsController : public IProjectFilesController, public QObject,
     INJECT(project, mi::IMultiInstancesProvider, multiInstancesProvider)
     INJECT(project, cloud::IAuthorizationService, authorizationService)
     INJECT(project, cloud::ICloudProjectsService, cloudProjectsService)
+    INJECT(project, notation::INotationConfiguration, notationConfiguration)
     INJECT(project, playback::IPlaybackController, playbackController)
     INJECT(project, print::IPrintProvider, printProvider)
     INJECT(project, io::IFileSystem, fileSystem)

--- a/src/project/view/exportdialogmodel.cpp
+++ b/src/project/view/exportdialogmodel.cpp
@@ -439,8 +439,7 @@ void ExportDialogModel::setBitRate(int rate)
 
 bool ExportDialogModel::midiExpandRepeats() const
 {
-    NOT_IMPLEMENTED;
-    return true;
+    return midiImportExportConfiguration()->isExpandRepeats();
 }
 
 void ExportDialogModel::setMidiExpandRepeats(bool expandRepeats)
@@ -449,7 +448,7 @@ void ExportDialogModel::setMidiExpandRepeats(bool expandRepeats)
         return;
     }
 
-    NOT_IMPLEMENTED;
+    midiImportExportConfiguration()->setExpandRepeats(expandRepeats);
     emit midiExpandRepeatsChanged(expandRepeats);
 }
 


### PR DESCRIPTION
Resolves: #16021 
Improves: #16029 

This eliminates one source of truth, namely MScore::playRepeats, and creates a clear structure for the other three: notation configuration determines playback model, and playback model (and other things) determine master score. 
Also optimise the use of the two RepeatLists in MasterScore; one is for expanding, the other not. Previously, one was for general use and switched between expanded and not expanded every time; the other only for a few specific methods.