### PR TITLE
Fix #15861: Printing scores prints square the number of requested copies

### DIFF
--- a/src/print/internal/printprovider.cpp
+++ b/src/print/internal/printprovider.cpp
@@ -66,7 +66,8 @@ Ret PrintProvider::printNotation(INotationPtr notation)
     INotationPainting::Options opt;
     opt.fromPage = printerDev.fromPage() - 1;
     opt.toPage = printerDev.toPage() - 1;
-    opt.copyCount = printerDev.copyCount();
+    // See https://doc.qt.io/qt-5/qprinter.html#supportsMultipleCopies
+    opt.copyCount = printerDev.supportsMultipleCopies() ? 1 : printerDev.copyCount();
     opt.deviceDpi = printerDev.logicalDpiX();
     opt.onNewPage = [&printerDev]() { printerDev.newPage(); };
 


### PR DESCRIPTION
On most systems, the QPrinter already prints $n$ copies of what we feed it with, so we ourselves don't need to feed it with $n$ copies too.

Resolves: #15861

Note: I have not tested this by really printing; only sending it to the printer queue and checking the info there. That's probably sufficient, but if anyone wants to test with real paper I'd recommend to create a score and delete all instruments and text frames, so that the score is only an empty page; that way, you can just reuse the paper after testing.