### PR TITLE
Read and write MMRest properties

### DIFF
--- a/src/engraving/libmscore/mmrest.cpp
+++ b/src/engraving/libmscore/mmrest.cpp
@@ -221,9 +221,28 @@ RectF MMRest::numberRect() const
 void MMRest::write(XmlWriter& xml) const
 {
     xml.startElement("Rest"); // for compatibility, see also Measure::readVoice()
-    ChordRest::writeProperties(xml);
+    writeProperties(xml);
     el().write(xml);
     xml.endElement();
+}
+
+void MMRest::writeProperties(XmlWriter& xml) const
+{
+    ChordRest::writeProperties(xml);
+    writeProperty(xml, Pid::MMREST_NUMBER_POS);
+    writeProperty(xml, Pid::MMREST_NUMBER_VISIBLE);
+}
+
+bool MMRest::readProperties(XmlReader& xml)
+{
+    const AsciiStringView tag(xml.name());
+    if (tag == "mmRestNumberVisible") {
+        setProperty(Pid::MMREST_NUMBER_VISIBLE, xml.readBool());
+    } else if (ChordRest::readProperties(xml)) {
+    } else {
+        return false;
+    }
+    return true;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/mmrest.h
+++ b/src/engraving/libmscore/mmrest.h
@@ -43,6 +43,8 @@ public:
     double width() const override { return m_width; }
 
     void write(XmlWriter&) const override;
+    void writeProperties(XmlWriter&) const override;
+    bool readProperties(XmlReader&) override;
 
     PropertyValue propertyDefault(Pid) const override;
     bool setProperty(Pid, const PropertyValue&) override;

--- a/src/engraving/libmscore/rest.cpp
+++ b/src/engraving/libmscore/rest.cpp
@@ -1005,7 +1005,7 @@ void Rest::read(XmlReader& e)
             dot->read(e);
             add(dot);
         } else if (readStyledProperty(e, tag)) {
-        } else if (ChordRest::readProperties(e)) {
+        } else if (readProperties(e)) {
         } else {
             e.unknown();
         }


### PR DESCRIPTION
Resolves: #16010

Seems like read and write properties simply wasn't implemented for MMRests. Now it is.
