### PR TITLE
Let the Aussies and Kiwis ;-) fall back to British English

### DIFF
--- a/src/languages/internal/languagesservice.cpp
+++ b/src/languages/internal/languagesservice.cpp
@@ -219,6 +219,7 @@ QString LanguagesService::effectiveLanguageCode(const QString& languageCode) con
                 { "ca_valencia", "ca@valencia" },
                 { "ca_ES_valencia", "ca@valencia" },
                 { "en_AU", "en_GB" },
+                { "en_NZ", "en_GB" },
                 { "en", "en_US" },
                 { "hi", "hi_IN" },
                 { "mn", "mn_MN" },

--- a/src/languages/internal/languagesservice.cpp
+++ b/src/languages/internal/languagesservice.cpp
@@ -218,6 +218,7 @@ QString LanguagesService::effectiveLanguageCode(const QString& languageCode) con
             static const std::map<QString, QString> SPECIAL_CASES {
                 { "ca_valencia", "ca@valencia" },
                 { "ca_ES_valencia", "ca@valencia" },
+                { "en_AU", "en_GB" },
                 { "en", "en_US" },
                 { "hi", "hi_IN" },
                 { "mn", "mn_MN" },


### PR DESCRIPTION
rather than to American English, just like it was in 3.x and 2.x (for the Aussies at least)

See the old https://musescore.org/en/node/115191, fixed in 2.0.4, via #2669