### PR TITLE
export-midi: more careful calculation of pitch bend

### DIFF
--- a/src/engraving/compat/midi/compatmidi.cmake
+++ b/src/engraving/compat/midi/compatmidi.cmake
@@ -25,6 +25,8 @@ set(COMPAT_MIDI_SRC
     ${CMAKE_CURRENT_LIST_DIR}/midipatch.h
     ${CMAKE_CURRENT_LIST_DIR}/midirender.cpp
     ${CMAKE_CURRENT_LIST_DIR}/midirender.h
+    ${CMAKE_CURRENT_LIST_DIR}/pitchwheelrenderer.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/pitchwheelrenderer.h
     )
 
 if (NOT MSVC AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0)

--- a/src/engraving/compat/midi/midicoreevent.h
+++ b/src/engraving/compat/midi/midicoreevent.h
@@ -28,6 +28,17 @@
 #include "global/allocator.h"
 
 namespace mu::engraving {
+struct PitchWheelSpecs {
+    //! @note amplitude of the pitch wheel in semitones
+    uint16_t mAmplitude{ 12 };
+
+    //! @note absolute limit of the  wheel pitch value (thus,  pitch shift can be set using values from {-mLimit, mLimit} interval
+    uint16_t mLimit    { 8192 };
+
+    //! @note step of pith wheel in ticks
+    uint16_t mStep     { 10 };
+};
+
 //---------------------------------------------------------
 //   Event types
 //---------------------------------------------------------

--- a/src/engraving/compat/midi/midirender.h
+++ b/src/engraving/compat/midi/midirender.h
@@ -25,6 +25,7 @@
 
 #include "libmscore/measure.h"
 #include "libmscore/synthesizerstate.h"
+#include "pitchwheelrenderer.h"
 
 namespace mu::engraving {
 class EventMap;
@@ -113,14 +114,19 @@ private:
     static bool canBreakChunk(const Measure* last);
     void updateState();
 
-    void renderStaffChunk(const Chunk&, EventMap* events, const StaffContext& sctx);
-    void renderSpanners(const Chunk&, EventMap* events);
+    void renderStaffChunk(const Chunk&, EventMap* events, const StaffContext& sctx, PitchWheelRenderer& pitchWheelRenderer);
+
+    void renderSpanners(const Chunk&, EventMap* events, PitchWheelRenderer& pitchWheelRenderer);
+
     void renderMetronome(const Chunk&, EventMap* events);
     void renderMetronome(EventMap* events, Measure const* m, const Fraction& tickOffset);
 
-    void collectMeasureEvents(EventMap* events, Measure const* m, const MidiRenderer::StaffContext& sctx, int tickOffset);
-    void collectMeasureEventsSimple(EventMap* events, Measure const* m, const StaffContext& sctx, int tickOffset);
-    void collectMeasureEventsDefault(EventMap* events, Measure const* m, const StaffContext& sctx, int tickOffset);
+    void collectMeasureEvents(EventMap* events, Measure const* m, const MidiRenderer::StaffContext& sctx, int tickOffset,
+                              PitchWheelRenderer& pitchWheelRenderer);
+    void collectMeasureEventsSimple(EventMap* events, Measure const* m, const StaffContext& sctx, int tickOffset,
+                                    PitchWheelRenderer& pitchWheelRenderer);
+    void collectMeasureEventsDefault(EventMap* events, Measure const* m, const StaffContext& sctx, int tickOffset,
+                                     PitchWheelRenderer& pitchWheelRenderer);
 
 public:
     explicit MidiRenderer(Score* s);
@@ -135,7 +141,7 @@ public:
     };
 
     void renderScore(EventMap* events, const Context& ctx);
-    void renderChunk(const Chunk&, EventMap* events, const Context& ctx);
+    void renderChunk(const Chunk&, EventMap* events, const Context& ctx, PitchWheelRenderer& pitchWheelRenderer);
 
     void setScoreChanged() { needUpdate = true; }
     void setMinChunkSize(int sizeMeasures) { minChunkSize = sizeMeasures; needUpdate = true; }

--- a/src/engraving/compat/midi/pitchwheelrenderer.cpp
+++ b/src/engraving/compat/midi/pitchwheelrenderer.cpp
@@ -1,0 +1,141 @@
+#include "pitchwheelrenderer.h"
+
+#include "log.h"
+
+using namespace mu::engraving;
+
+PitchWheelRenderer::PitchWheelRenderer(PitchWheelSpecs wheelSpec)
+    : _wheelSpec(wheelSpec)
+{}
+
+void PitchWheelRenderer::addPitchWheelFunction(const PitchWheelFunction& function, uint32_t channel)
+{
+    PitchWheelFunctions& functions =  _functions[channel];
+
+    if (function.mStartTick < functions.startTick) {
+        functions.startTick = function.mStartTick;
+    }
+    if (function.mEndTick > functions.endTick) {
+        functions.endTick = function.mEndTick;
+    }
+
+    functions.functions.push_back(function);
+}
+
+EventMap PitchWheelRenderer::renderPitchWheel() const noexcept
+{
+    EventMap pitchWheelEvents;
+
+    for (const auto& function : _functions) {
+        renderChannelPitchWheel(pitchWheelEvents, function.second, function.first);
+    }
+
+    return pitchWheelEvents;
+}
+
+//! MARK: PRIVATE METHODS
+
+void PitchWheelRenderer::renderChannelPitchWheel(EventMap& pitchWheelEvents,
+                                                 const PitchWheelFunctions& functions,
+                                                 uint32_t channel) const noexcept
+{
+    if (functions.endTick < functions.startTick) {
+        return;
+    }
+
+    int32_t tick = functions.startTick;
+    int prevPitchValue = _wheelSpec.mLimit;
+
+    PitchWheelFunctions unProcessedFunctions = functions;
+
+    for (; tick <= functions.endTick;) {
+        int pitchValue = _wheelSpec.mLimit;
+
+        PitchWheelFunctions processingFunctions;
+        for (const auto& func : unProcessedFunctions.functions) {
+            if (tick >= func.mStartTick) {
+                processingFunctions.functions.push_back(func);
+            }
+        }
+
+        if (processingFunctions.functions.empty()) {
+            //find next tick
+            tick = findNextStartTick(unProcessedFunctions.functions);
+            continue;
+        }
+
+        auto iterBegin = unProcessedFunctions.functions.begin();
+        auto iterEnd = unProcessedFunctions.functions.end();
+        auto funcIter = iterBegin;
+        while (funcIter != iterEnd) {
+            if (tick > funcIter->mEndTick) {
+                funcIter = unProcessedFunctions.functions.erase(funcIter);
+            }
+
+            pitchValue = calculatePitchBend(unProcessedFunctions.functions, tick);
+
+            ++funcIter;
+        }
+
+        if (pitchValue != prevPitchValue) {
+            NPlayEvent evb(ME_PITCHBEND, channel, pitchValue % 128, pitchValue / 128);
+            pitchWheelEvents.emplace_hint(pitchWheelEvents.end(), std::make_pair(tick, evb));
+        }
+
+        prevPitchValue = pitchValue;
+        tick += _wheelSpec.mStep;
+    }
+
+    //!@NOTE handling end of each function. endTick usually
+    //! means end of note and starting of next note.
+    //! But endTick can fall on the segment between two points.
+    //! So next note can start with  pitch value of previous note.
+    for (const auto& endFunc : functions.functions) {
+        int pitchValue = _wheelSpec.mLimit;
+        int32_t endFuncTick = endFunc.mEndTick;
+        if (endFuncTick % _wheelSpec.mStep == 0) {
+            //!already proccessed
+            continue;
+        }
+
+        for (const auto& func : functions.functions) {
+            if (endFuncTick < func.mStartTick || endFuncTick > func.mEndTick || &func == &endFunc) {
+                continue;
+            }
+
+            pitchValue += func.func(endFuncTick);
+        }
+
+        if (endFuncTick == functions.endTick) {
+            pitchValue = _wheelSpec.mLimit;
+        }
+
+        NPlayEvent evb(ME_PITCHBEND, channel, pitchValue % 128, pitchValue / 128);
+        pitchWheelEvents.emplace_hint(pitchWheelEvents.end(), std::make_pair(endFuncTick, evb));
+    }
+}
+
+int32_t PitchWheelRenderer::findNextStartTick(const std::list<PitchWheelFunction>& functions) const noexcept
+{
+    int32_t tick = std::numeric_limits<int32_t>::max();
+    for (const auto& func : functions) {
+        tick = std::min(tick, func.mStartTick);
+    }
+
+    return tick;
+}
+
+int32_t PitchWheelRenderer::calculatePitchBend(const std::list<PitchWheelFunction>& functions, int32_t tick) const noexcept
+{
+    int pitchValue = _wheelSpec.mLimit;
+
+    for (const auto& func : functions) {
+        if (tick < func.mStartTick || tick >= func.mEndTick) {
+            continue;
+        }
+
+        pitchValue += func.func(tick);
+    }
+
+    return pitchValue;
+}

--- a/src/engraving/compat/midi/pitchwheelrenderer.h
+++ b/src/engraving/compat/midi/pitchwheelrenderer.h
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_ENGRAVING_PITCTWHEELRENDERER_H
+#define MU_ENGRAVING_PITCTWHEELRENDERER_H
+
+#include <limits>
+#include <list>
+#include <functional>
+
+#include "event.h"
+
+namespace mu::engraving {
+class PitchWheelRenderer
+{
+public:
+    struct PitchWheelFunction {
+        int32_t mStartTick;
+        int32_t mEndTick;
+        std::function<int(uint32_t)> func;
+    };
+
+    PitchWheelRenderer(PitchWheelSpecs wheelSpec);
+
+    void addPitchWheelFunction(const PitchWheelFunction& function, uint32_t channel);
+
+    EventMap renderPitchWheel() const noexcept;
+
+private:
+
+    struct PitchWheelFunctions
+    {
+        int32_t startTick = std::numeric_limits<int32_t>::max();
+        int32_t endTick = 0;
+        std::list<PitchWheelFunction> functions;
+    };
+
+    void renderChannelPitchWheel(EventMap& pitchWheelEvents, const PitchWheelFunctions& functions, uint32_t channel) const noexcept;
+
+    int32_t findNextStartTick(const std::list<PitchWheelFunction>& functions) const noexcept;
+
+    int32_t calculatePitchBend(const std::list<PitchWheelFunction>& functions, int32_t tick) const noexcept;
+
+    std::map<uint32_t /*channel*/, PitchWheelFunctions> _functions;
+
+    PitchWheelSpecs _wheelSpec;
+};
+}  // namespace mu::engraving
+
+#endif //MU_ENGRAVING_PITCTWHEELRENDERER_H

--- a/src/engraving/tests/CMakeLists.txt
+++ b/src/engraving/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ set(MODULE_TEST_SRC
     #${CMAKE_CURRENT_LIST_DIR}/midimapping_tests.cpp doesn't compile and needs actualization
     ${CMAKE_CURRENT_LIST_DIR}/note_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/parts_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/pitchwheelrender_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/playbackeventsrendering_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/playbackmodel_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/readwriteundoreset_tests.cpp

--- a/src/engraving/tests/pitchwheelrender_tests.cpp
+++ b/src/engraving/tests/pitchwheelrender_tests.cpp
@@ -1,0 +1,394 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <set>
+#include <map>
+
+#include <gtest/gtest.h>
+
+#include "engraving/compat/midi/pitchwheelrenderer.h"
+
+using namespace mu;
+using namespace mu::engraving;
+
+class PitchWheelRender_Tests : public ::testing::Test
+{
+};
+
+int pitch(const NPlayEvent& ev)
+{
+    return ev.dataA() + ev.dataB() * 128;
+}
+
+//---------------------------------------------------------
+///   note
+///   read/write test of note
+//---------------------------------------------------------
+
+TEST_F(PitchWheelRender_Tests, simpleLinear)
+{
+    PitchWheelSpecs wheelSpec;
+    PitchWheelRenderer render(wheelSpec);
+
+    PitchWheelRenderer::PitchWheelFunction func;
+    func.mStartTick = 0;
+    func.mEndTick = 100;
+    //! y = ax + b
+    int a = 1;
+    int b = 0;
+
+    auto linearFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
+        float x = (float)(tick - startTick);
+        float y = a * x + b;
+        return y;
+    };
+    func.func = linearFunc;
+    render.addPitchWheelFunction(func, 0);
+
+    EventMap events = render.renderPitchWheel();
+
+    EXPECT_EQ(events.begin()->second.channel(), 0);
+
+    EXPECT_EQ(events.size(), 10);
+
+    EXPECT_EQ(pitch(events.find(10)->second), 8202);
+    EXPECT_EQ(pitch(events.find(90)->second), 8282);
+    EXPECT_EQ(pitch(events.find(100)->second), 8192);
+}
+
+TEST_F(PitchWheelRender_Tests, twoReverseFunctions)
+{
+    PitchWheelSpecs wheelSpec;
+    PitchWheelRenderer render(wheelSpec);
+
+    PitchWheelRenderer::PitchWheelFunction func;
+    func.mStartTick = 0;
+    func.mEndTick = 100;
+    int a = 1;
+    int b = 0;
+    auto linearFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
+        float x = (float)(tick - startTick);
+        float y = a * x + b;
+        return y;
+    };
+    func.func = linearFunc;
+    render.addPitchWheelFunction(func, 0);
+
+    auto reverseLinearFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
+        float x = (float)(tick - startTick);
+        float y = -1 * a * x + b;
+        return y;
+    };
+    func.func = reverseLinearFunc;
+    render.addPitchWheelFunction(func, 0);
+
+    EventMap events = render.renderPitchWheel();
+    EXPECT_EQ(events.size(), 0);
+}
+
+TEST_F(PitchWheelRender_Tests, channelTest)
+{
+    PitchWheelSpecs wheelSpec;
+    PitchWheelRenderer render(wheelSpec);
+
+    PitchWheelRenderer::PitchWheelFunction func;
+    func.mStartTick = 0;
+    func.mEndTick = 30;
+    //! y = ax + b
+    int a = 1;
+    int b = 0;
+
+    auto linearFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
+        float x = (float)(tick - startTick);
+        float y = a * x + b;
+        return y;
+    };
+    func.func = linearFunc;
+    render.addPitchWheelFunction(func, 0);
+    render.addPitchWheelFunction(func, 1);
+
+    EventMap events = render.renderPitchWheel();
+    std::set<int> channels;
+    for (const auto& ev : events) {
+        channels.insert(ev.second.channel());
+    }
+
+    EXPECT_EQ(channels.size(), 2);
+    EXPECT_EQ(channels.count(0), 1);
+    EXPECT_EQ(channels.count(1), 1);
+}
+
+TEST_F(PitchWheelRender_Tests, twoConnectedFunctions)
+{
+    PitchWheelSpecs wheelSpec;
+    PitchWheelRenderer render(wheelSpec);
+
+    {
+        PitchWheelRenderer::PitchWheelFunction func;
+        func.mStartTick = 0;
+        func.mEndTick = 30;
+        //! y = ax + b
+        int a = 1;
+        int b = 0;
+
+        auto firstFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
+            float x = (float)(tick - startTick);
+            float y = a * x + b;
+            return y;
+        };
+        func.func = firstFunc;
+        render.addPitchWheelFunction(func, 0);
+    }
+
+    {
+        PitchWheelRenderer::PitchWheelFunction func;
+        func.mStartTick = 30;
+        func.mEndTick = 60;
+        //! y = ax + b
+        int a = 1;
+        int b = 30;
+
+        auto secondFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
+            float x = (float)(tick - startTick);
+            float y = a * x + b;
+            return y;
+        };
+        func.func = secondFunc;
+        render.addPitchWheelFunction(func, 0);
+    }
+
+    EventMap events = render.renderPitchWheel();
+
+    EXPECT_EQ(events.size(), 6);
+    std::set<int> expectedValues = { 8192, 8202, 8212, 8222, 8232, 8242 };
+    for (const auto& ev : events) {
+        EXPECT_TRUE(expectedValues.count(pitch(ev.second)) > 0);
+    }
+}
+
+TEST_F(PitchWheelRender_Tests, twoDevidedFunctions)
+{
+    PitchWheelSpecs wheelSpec;
+    PitchWheelRenderer render(wheelSpec);
+
+    {
+        PitchWheelRenderer::PitchWheelFunction func;
+        func.mStartTick = 0;
+        func.mEndTick = 30;
+        //! y = ax + b
+        int a = 1;
+        int b = 0;
+
+        auto firstFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
+            float x = (float)(tick - startTick);
+            float y = a * x + b;
+            return y;
+        };
+        func.func = firstFunc;
+        render.addPitchWheelFunction(func, 0);
+    }
+
+    {
+        PitchWheelRenderer::PitchWheelFunction func;
+        func.mStartTick = 40;
+        func.mEndTick = 60;
+        //! y = ax + b
+        int a = 1;
+        int b = 30;
+
+        auto secondFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
+            float x = (float)(tick - startTick);
+            float y = a * x + b;
+            return y;
+        };
+        func.func = secondFunc;
+        render.addPitchWheelFunction(func, 0);
+    }
+
+    EventMap events = render.renderPitchWheel();
+
+    EXPECT_EQ(events.size(), 6);
+    std::multimap<int, int> expectedValues = { { 10, 8202 }, { 20, 8212 }, { 30, 8192 }, { 40, 8222 }, { 50, 8232 }, { 60, 8192 } };
+    for (const auto& ev : events) {
+        auto it = expectedValues.find(ev.first);
+        EXPECT_TRUE(it != expectedValues.end());
+        EXPECT_EQ(it->second, pitch(ev.second));
+    }
+}
+
+TEST_F(PitchWheelRender_Tests, twoOverlappedFunctions)
+{
+    PitchWheelSpecs wheelSpec;
+    PitchWheelRenderer render(wheelSpec);
+
+    {
+        PitchWheelRenderer::PitchWheelFunction func;
+        func.mStartTick = 0;
+        func.mEndTick = 30;
+        //! y = ax + b
+        int a = 1;
+        int b = 0;
+
+        auto firstFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
+            float x = (float)(tick - startTick);
+            float y = a * x + b;
+            return y;
+        };
+        func.func = firstFunc;
+        render.addPitchWheelFunction(func, 0);
+    }
+
+    {
+        PitchWheelRenderer::PitchWheelFunction func;
+        func.mStartTick = 20;
+        func.mEndTick = 40;
+        //! y = ax + b
+        int a = 1;
+        int b = 10;
+
+        auto secondFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
+            float x = (float)(tick - startTick);
+            float y = a * x + b;
+            return y;
+        };
+        func.func = secondFunc;
+        render.addPitchWheelFunction(func, 0);
+    }
+
+    EventMap events = render.renderPitchWheel();
+
+    EXPECT_EQ(events.size(), 4);
+    std::multimap<int, int> pitches;
+    std::multimap<int, int> expectedValues = { { 10, 8202 }, { 20, 8222 }, { 30, 8212 }, { 40, 8192 } };
+    for (const auto& ev : events) {
+        auto it = expectedValues.find(ev.first);
+        EXPECT_TRUE(it != expectedValues.end());
+        EXPECT_EQ(it->second, pitch(ev.second));
+        pitches.insert({ ev.first, pitch(ev.second) });
+    }
+}
+
+TEST_F(PitchWheelRender_Tests, threeDevidedFunctions)
+{
+    PitchWheelSpecs wheelSpec;
+    PitchWheelRenderer render(wheelSpec);
+
+    {
+        PitchWheelRenderer::PitchWheelFunction func;
+        func.mStartTick = 10;
+        func.mEndTick = 20;
+
+        auto firstFunc = [ startTick = func.mStartTick] (uint32_t tick) {
+            return 10;
+        };
+        func.func = firstFunc;
+        render.addPitchWheelFunction(func, 0);
+    }
+
+    {
+        PitchWheelRenderer::PitchWheelFunction func;
+        func.mStartTick = 30;
+        func.mEndTick = 40;
+
+        auto firstFunc = [ startTick = func.mStartTick] (uint32_t tick) {
+            return 20;
+        };
+        func.func = firstFunc;
+        render.addPitchWheelFunction(func, 0);
+    }
+
+    {
+        PitchWheelRenderer::PitchWheelFunction func;
+        func.mStartTick = 60;
+        func.mEndTick = 70;
+
+        auto firstFunc = [ startTick = func.mStartTick] (uint32_t tick) {
+            return 30;
+        };
+        func.func = firstFunc;
+        render.addPitchWheelFunction(func, 0);
+    }
+
+    EventMap events = render.renderPitchWheel();
+
+    std::multimap<int, int> pitches;
+    std::multimap<int, int> expectedValues = { { 10, 8202 }, { 20, 8192 }, { 30, 8212 }, { 40, 8192 }, { 60, 8222 }, { 70, 8192 } };
+    for (const auto& ev : events) {
+        auto it = expectedValues.find(ev.first);
+        EXPECT_TRUE(it != expectedValues.end());
+        EXPECT_EQ(it->second, pitch(ev.second));
+        pitches.insert({ ev.first, pitch(ev.second) });
+    }
+}
+
+TEST_F(PitchWheelRender_Tests, threeOverLappedFunctions)
+{
+    PitchWheelSpecs wheelSpec;
+    PitchWheelRenderer render(wheelSpec);
+
+    {
+        PitchWheelRenderer::PitchWheelFunction func;
+        func.mStartTick = 0;
+        func.mEndTick = 60;
+
+        auto firstFunc = [ startTick = func.mStartTick] (uint32_t tick) {
+            return 10;
+        };
+        func.func = firstFunc;
+        render.addPitchWheelFunction(func, 0);
+    }
+
+    {
+        PitchWheelRenderer::PitchWheelFunction func;
+        func.mStartTick = 20;
+        func.mEndTick = 50;
+
+        auto firstFunc = [ startTick = func.mStartTick] (uint32_t tick) {
+            return 10;
+        };
+        func.func = firstFunc;
+        render.addPitchWheelFunction(func, 0);
+    }
+
+    {
+        PitchWheelRenderer::PitchWheelFunction func;
+        func.mStartTick = 40;
+        func.mEndTick = 70;
+
+        auto firstFunc = [ startTick = func.mStartTick] (uint32_t tick) {
+            return 10;
+        };
+        func.func = firstFunc;
+        render.addPitchWheelFunction(func, 0);
+    }
+
+    EventMap events = render.renderPitchWheel();
+
+    std::multimap<int, int> pitches;
+    std::multimap<int, int> expectedValues = { { 0, 8202 }, { 20, 8212 }, { 40, 8222 }, { 50, 8212 }, { 60, 8202 }, { 70, 8192 } };
+    for (const auto& ev : events) {
+        auto it = expectedValues.find(ev.first);
+        EXPECT_TRUE(it != expectedValues.end());
+        EXPECT_EQ(it->second, pitch(ev.second));
+        pitches.insert({ ev.first, pitch(ev.second) });
+    }
+}


### PR DESCRIPTION
Problem is different elements change ME_PITCHBEND state of the same channel. They do it independently. Solution: don't render these events all at once, but collect all the changes and apply them once.