### PR TITLE
Format > Style > Header/Footer: Restore info about meta tags in tooltips

### DIFF
--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -36,6 +36,7 @@
 #include "offsetSelect.h"
 
 #include "engraving/libmscore/figuredbass.h"
+#include "engraving/libmscore/masterscore.h"
 #include "engraving/libmscore/realizedharmony.h"
 #include "engraving/libmscore/text.h"
 #include "engraving/style/textstyle.h"
@@ -1184,7 +1185,19 @@ void EditStyle::setHeaderFooterToolTip()
           + qtrc("notation/editstyle", "(in File > Score properties…):")
           + QString("</p><table>");
 
-    // show all tags for current score/part, see also Score::init()
+    // show all tags for current score/part
+    Score* score = globalContext()->currentNotation()->elements()->msScore();
+    if (!score->isMaster()) {
+        for (const auto& tag : score->masterScore()->metaTags()) {
+            toolTipHeaderFooter += QString("<tr><td>%1</td><td>-</td><td>%2</td></tr>")
+                                   .arg(tag.first.toQString()).arg(tag.second.toQString());
+        }
+    }
+    for (const auto& tag : score->masterScore()->metaTags()) {
+        toolTipHeaderFooter += QString("<tr><td>%1</td><td>-</td><td>%2</td></tr>")
+                               .arg(tag.first.toQString()).arg(tag.second.toQString());
+    }
+
     QList<QMap<QString, QString> > tags; // FIXME
     for (const QMap<QString, QString>& tag: tags) {
         QMapIterator<QString, QString> i(tag);


### PR DESCRIPTION
Resolves: #16065

Fixes an old "FIXME"