### PR TITLE
Update the video exporter for newer ffmpeg versions

### DIFF
--- a/src/importexport/videoexport/internal/ffmpeg.h
+++ b/src/importexport/videoexport/internal/ffmpeg.h
@@ -32,6 +32,9 @@ extern "C" {
 #include "libavutil/avstring.h"
 #include "libavutil/opt.h"
 #include "libswscale/swscale.h"
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(54, 6, 100)
+#include "libavutil/imgutils.h"
+#endif
 }
 
 #endif // MU_IMPORTEXPORT_FFMPEG_H

--- a/src/importexport/videoexport/internal/videoencoder.cpp
+++ b/src/importexport/videoexport/internal/videoencoder.cpp
@@ -33,18 +33,26 @@ struct mu::iex::videoexport::FFmpeg {
     unsigned int ptsCounter = 0;
 
     // FFmpeg stuff
-    AVOutputFormat* outputFormat = nullptr;
+    const AVOutputFormat* outputFormat = nullptr;
     AVFormatContext* formatCtx = nullptr;
     AVStream* videoStream = nullptr;
     AVCodecContext* codecCtx = nullptr;
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(57, 33, 100)
     AVCodec* codec = nullptr;
+#else
+    const AVCodec* codec = nullptr;
+#endif
     // Frame data
     AVFrame* ppicture = nullptr;
     uint8_t* picture_buf = nullptr;
     // Conversion
     SwsContext* img_convert_ctx = nullptr;
     // Packet
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 133, 100)
     AVPacket pkt;
+#else
+    AVPacket* pkt;
+#endif
 
     bool opened = false;
 };
@@ -53,8 +61,12 @@ VideoEncoder::VideoEncoder()
 {
     m_ffmpeg = new FFmpeg();
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 10, 100)
     avcodec_register_all();
+#endif
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58, 9, 100)
     av_register_all();
+#endif
 }
 
 VideoEncoder::~VideoEncoder()
@@ -77,7 +89,11 @@ bool VideoEncoder::open(const io::path_t& fileName, unsigned width, unsigned hei
         return false;
     }
     m_ffmpeg->formatCtx->oformat = m_ffmpeg->outputFormat;
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58, 7, 100)
     snprintf(m_ffmpeg->formatCtx->filename, sizeof(m_ffmpeg->formatCtx->filename), "%s", fileName.c_str());
+#else
+    m_ffmpeg->formatCtx->url = strdup(fileName.c_str());
+#endif
 
     // Add the video stream
     m_ffmpeg->videoStream = avformat_new_stream(m_ffmpeg->formatCtx, 0);
@@ -89,10 +105,24 @@ bool VideoEncoder::open(const io::path_t& fileName, unsigned width, unsigned hei
     m_ffmpeg->videoStream->time_base.den = fps;
     m_ffmpeg->videoStream->time_base.num = 1;
 
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(57, 33, 100)
     m_ffmpeg->codecCtx = m_ffmpeg->videoStream->codec;
-    m_ffmpeg->codecCtx->profile = FF_PROFILE_H264_HIGH;
     m_ffmpeg->codecCtx->codec_id = AV_CODEC_ID_H264;
     m_ffmpeg->codecCtx->codec_type = AVMEDIA_TYPE_VIDEO;
+#else
+    // find the video encoder
+    m_ffmpeg->codec = avcodec_find_encoder(AV_CODEC_ID_H264);
+    if (!m_ffmpeg->codec) {
+        LOGE() << "not found codec";
+        return false;
+    }
+    m_ffmpeg->codecCtx = avcodec_alloc_context3(m_ffmpeg->codec);
+    if (m_ffmpeg->codecCtx == nullptr) {
+        LOGE() << "failed to allocate AV context";
+        return false;
+    }
+#endif
+    m_ffmpeg->codecCtx->profile = FF_PROFILE_H264_HIGH;
 
     m_ffmpeg->codecCtx->bit_rate = bitrate;
     m_ffmpeg->codecCtx->width = width;
@@ -106,17 +136,33 @@ bool VideoEncoder::open(const io::path_t& fileName, unsigned width, unsigned hei
     m_ffmpeg->codecCtx->time_base.den = fps;
     m_ffmpeg->codecCtx->time_base.num = 1;
     m_ffmpeg->codecCtx->max_b_frames = 3;
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57, 25, 100)
     m_ffmpeg->codecCtx->b_frame_strategy = 1;
+#else
+    av_opt_set_int(m_ffmpeg->codecCtx, "b_strategy", 1, 0);
+#endif
 
     m_ffmpeg->codecCtx->me_cmp = 1;
     m_ffmpeg->codecCtx->me_range = 16;
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(56, 49, 100)
     m_ffmpeg->codecCtx->me_method = ME_HEX;
+#else
+    av_opt_set_int(m_ffmpeg->codecCtx, "hex", 1, 0);
+#endif
 
     m_ffmpeg->codecCtx->qmin = 10;
     m_ffmpeg->codecCtx->qmax = 51;
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57, 25, 100)
     m_ffmpeg->codecCtx->scenechange_threshold = 40;
+#else
+    av_opt_set_int(m_ffmpeg->codecCtx, "sc_threshold", 40, 0);
+#endif
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(56, 56, 100)
     m_ffmpeg->codecCtx->flags |= CODEC_FLAG_LOOP_FILTER;
+#else
+    m_ffmpeg->codecCtx->flags |= AV_CODEC_FLAG_LOOP_FILTER;
+#endif
     m_ffmpeg->codecCtx->me_subpel_quality = 5;
     m_ffmpeg->codecCtx->i_quant_factor = 0.71;
     m_ffmpeg->codecCtx->qcompress = 0.6;
@@ -124,18 +170,30 @@ bool VideoEncoder::open(const io::path_t& fileName, unsigned width, unsigned hei
 
     // some formats want stream headers to be separate
     if (m_ffmpeg->formatCtx->oformat->flags & AVFMT_GLOBALHEADER) {
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(56, 56, 100)
         m_ffmpeg->codecCtx->flags |= CODEC_FLAG_LOOP_FILTER;
+#else
+        m_ffmpeg->codecCtx->flags |= AV_CODEC_FLAG_LOOP_FILTER;
+#endif
     }
 
     //av_dump_format(m_ffmpeg->formatCtx, 0, fileName.c_str(), 1);
 
     // open_video
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(57, 33, 100)
     // find the video encoder
     m_ffmpeg->codec = avcodec_find_encoder(m_ffmpeg->codecCtx->codec_id);
     if (!m_ffmpeg->codec) {
         LOGE() << "not found codec";
         return false;
     }
+#else
+    if (avcodec_parameters_from_context(m_ffmpeg->videoStream->codecpar, m_ffmpeg->codecCtx) < 0) {
+        avcodec_free_context(&m_ffmpeg->codecCtx);
+        LOGE() << "failed to set AV parameters from context";
+        return false;
+    }
+#endif
     // open the codec
     if (avcodec_open2(m_ffmpeg->codecCtx, m_ffmpeg->codec, 0) < 0) {
         LOGE() << "failed open codec";
@@ -153,7 +211,11 @@ bool VideoEncoder::open(const io::path_t& fileName, unsigned width, unsigned hei
     m_ffmpeg->ppicture->height = height;
     m_ffmpeg->ppicture->format = AV_PIX_FMT_YUV420P;
 
+#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(55, 4, 100)
     int size = avpicture_get_size(m_ffmpeg->codecCtx->pix_fmt, m_ffmpeg->codecCtx->width, m_ffmpeg->codecCtx->height);
+#else
+    int size = av_image_get_buffer_size(m_ffmpeg->codecCtx->pix_fmt, m_ffmpeg->codecCtx->width, m_ffmpeg->codecCtx->height, 1);
+#endif
     m_ffmpeg->picture_buf = new uint8_t[size];
     if (!m_ffmpeg->picture_buf) {
         LOGE() << "failed allocate frame buf";
@@ -162,8 +224,13 @@ bool VideoEncoder::open(const io::path_t& fileName, unsigned width, unsigned hei
     }
 
     // Setup the planes
+#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(55, 4, 100)
     avpicture_fill((AVPicture*)m_ffmpeg->ppicture, m_ffmpeg->picture_buf, m_ffmpeg->codecCtx->pix_fmt, m_ffmpeg->codecCtx->width,
                    m_ffmpeg->codecCtx->height);
+#else
+    av_image_fill_arrays(m_ffmpeg->ppicture->data, m_ffmpeg->ppicture->linesize, m_ffmpeg->picture_buf, m_ffmpeg->codecCtx->pix_fmt,
+                         m_ffmpeg->codecCtx->width, m_ffmpeg->codecCtx->height, 1);
+#endif
 
     if (avio_open(&m_ffmpeg->formatCtx->pb, fileName.c_str(), AVIO_FLAG_WRITE) < 0) {
         LOGE() << "failed open file: " << fileName;
@@ -194,6 +261,7 @@ void VideoEncoder::close()
     }
 
     while (true) {
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 133, 100)
         av_init_packet(&m_ffmpeg->pkt);
         int ret = avcodec_receive_packet(m_ffmpeg->codecCtx, &m_ffmpeg->pkt);
         if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
@@ -213,13 +281,38 @@ void VideoEncoder::close()
             return;
         }
         av_packet_unref(&m_ffmpeg->pkt);
+#else
+        m_ffmpeg->pkt = av_packet_alloc();
+        int ret = avcodec_receive_packet(m_ffmpeg->codecCtx, m_ffmpeg->pkt);
+        if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+            break;
+        } else if (ret < 0) {
+            LOGE() << "error during encoding";
+            return;
+        }
+
+        m_ffmpeg->pkt->pts = av_rescale_q(m_ffmpeg->ptsCounter, m_ffmpeg->codecCtx->time_base, m_ffmpeg->videoStream->time_base);
+        m_ffmpeg->pkt->dts = av_rescale_q(m_ffmpeg->ptsCounter, m_ffmpeg->codecCtx->time_base, m_ffmpeg->videoStream->time_base);
+
+        m_ffmpeg->ptsCounter++;
+
+        ret = av_interleaved_write_frame(m_ffmpeg->formatCtx, m_ffmpeg->pkt);
+        if (ret < 0) {
+            return;
+        }
+        av_packet_unref(m_ffmpeg->pkt);
+#endif
     }
 
     av_write_trailer(m_ffmpeg->formatCtx);
 
     // close_video
 
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(57, 33, 100)
     avcodec_close(m_ffmpeg->videoStream->codec);
+#else
+    avcodec_free_context(&m_ffmpeg->codecCtx);
+#endif
 
     if (m_ffmpeg->picture_buf) {
         delete[] m_ffmpeg->picture_buf;
@@ -234,7 +327,9 @@ void VideoEncoder::close()
     /* free the streams */
 
     for (unsigned int i = 0; i < m_ffmpeg->formatCtx->nb_streams; i++) {
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(57, 33, 100)
         av_freep(&m_ffmpeg->formatCtx->streams[i]->codec);
+#endif
         av_freep(&m_ffmpeg->formatCtx->streams[i]);
     }
 
@@ -262,6 +357,7 @@ bool VideoEncoder::encodeImage(const QImage& img)
     }
 
     while (ret >= 0) {
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 133, 100)
         av_init_packet(&m_ffmpeg->pkt);
         ret = avcodec_receive_packet(m_ffmpeg->codecCtx, &m_ffmpeg->pkt);
         if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
@@ -281,6 +377,27 @@ bool VideoEncoder::encodeImage(const QImage& img)
             return false;
         }
         av_packet_unref(&m_ffmpeg->pkt);
+#else
+        m_ffmpeg->pkt = av_packet_alloc();
+        ret = avcodec_receive_packet(m_ffmpeg->codecCtx, m_ffmpeg->pkt);
+        if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+            return 0;
+        } else if (ret < 0) {
+            LOGE() << "error during encoding";
+            return false;
+        }
+
+        m_ffmpeg->pkt->pts = av_rescale_q(m_ffmpeg->ptsCounter, m_ffmpeg->codecCtx->time_base, m_ffmpeg->videoStream->time_base);
+        m_ffmpeg->pkt->dts = av_rescale_q(m_ffmpeg->ptsCounter, m_ffmpeg->codecCtx->time_base, m_ffmpeg->videoStream->time_base);
+
+        m_ffmpeg->ptsCounter++;
+
+        ret = av_interleaved_write_frame(m_ffmpeg->formatCtx, m_ffmpeg->pkt);
+        if (ret < 0) {
+            return false;
+        }
+        av_packet_unref(m_ffmpeg->pkt);
+#endif
     }
 
     return true;


### PR DESCRIPTION
<!-- Add a short description of and motivation for the changes here -->
I noticed that MuseScore 4 has a video export option, but that it doesn't build with the version of ffmpeg I have.  I went through the ffmpeg deprecation documents and made the indicated changes.  A little code rearranging was necessary, but not much.  With this PR, I can build the video export code on my Fedora 37 machine, and use it to successfully export video.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
