### PR TITLE
gp-import: impoting extra tremolos for tied notes

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.h
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.h
@@ -212,6 +212,7 @@ private:
     std::unordered_map<track_idx_t, bool> m_hasCapo;
     std::unordered_map<track_idx_t, std::vector<Tie*> > _ties; // map(track, tie)
     std::unordered_map<Note*, int> m_originalPitches; // info of changed pitches for keeping track of ties
+    std::unordered_map<Chord*, TremoloType> m_tremolosInChords;
     std::unordered_map<track_idx_t, Slur*> _slurs; // map(track, slur)
 
     mutable GPBeat* m_currentGPBeat = nullptr; // used for passing info from notes

--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -73,6 +73,22 @@ using namespace mu::io;
 using namespace mu::engraving;
 
 namespace mu::engraving {
+static TremoloType tremoloType(int division)
+{
+    static std::map<int, TremoloType> types {
+        { 1, TremoloType::R8 },
+        { 2, TremoloType::R16 },
+        { 3, TremoloType::R32 }
+    };
+
+    if (types.find(division) != types.end()) {
+        return types[division];
+    }
+
+    LOGE() << "wrong tremolo type";
+    return TremoloType::INVALID_TREMOLO;
+}
+
 //---------------------------------------------------------
 //   readInfo
 //---------------------------------------------------------
@@ -1074,21 +1090,16 @@ bool GuitarPro5::readNoteEffects(Note* note)
     if (modMask2 & EFFECT_PALM_MUTE) {
         addPalmMute(note);
     }
-    //note->setPalmMute(true);
 
     if (modMask2 & EFFECT_TREMOLO) {      // tremolo picking length
         int tremoloDivision = readUInt8();
         Chord* chord = note->chord();
         Tremolo* t = Factory::createTremolo(chord);
-        if (tremoloDivision == 1) {
-            t->setTremoloType(TremoloType::R8);
+        if (tremoloDivision >= 1 && tremoloDivision <= 3) {
+            TremoloType type = tremoloType(tremoloDivision);
+            t->setTremoloType(type);
             chord->add(t);
-        } else if (tremoloDivision == 2) {
-            t->setTremoloType(TremoloType::R16);
-            chord->add(t);
-        } else if (tremoloDivision == 3) {
-            t->setTremoloType(TremoloType::R32);
-            chord->add(t);
+            m_tremolosInChords[chord] = type;
         } else {
             LOGD("Unknown tremolo value");
         }
@@ -1471,6 +1482,15 @@ bool GuitarPro5::readNote(int string, Note* note)
                             note->setFret(note2->fret());
                             note->setPitch(note2->pitch());
                             true_note = note2;
+                            if (m_tremolosInChords.find(chord2) != m_tremolosInChords.end()) {
+                                Tremolo* t = Factory::createTremolo(score->dummy()->chord());
+                                TremoloType type = m_tremolosInChords.at(chord2);
+                                t->setTremoloType(type);
+                                chord->add(t);
+                                mu::remove(m_tremolosInChords, chord2);
+                                m_tremolosInChords[chord] = type;
+                            }
+
                             found = true;
                             break;
                         }

--- a/src/importexport/guitarpro/internal/importgtp.h
+++ b/src/importexport/guitarpro/internal/importgtp.h
@@ -392,6 +392,8 @@ class GuitarPro5 : public GuitarPro
 {
     std::map<std::pair<int, int>, bool> dead_end;
     int _beat_counter{ 0 };
+    std::unordered_map<Chord*, TremoloType> m_tremolosInChords;
+
     void readInfo();
     void readPageSetup();
     int readBeatEffects(int track, Segment* segment) override;


### PR DESCRIPTION
In guitar pro tremolos are not added to tied notes, but they all sound as tremolo:

![Screenshot 2023-01-26 at 17 15 44](https://user-images.githubusercontent.com/24373905/214873556-d505209d-edb6-4846-8ddc-ff4628ee6b76.png)

So we need to add tremolos to tied notes in MU to keep correct sound:
![Screenshot 2023-01-26 at 17 18 08](https://user-images.githubusercontent.com/24373905/214874139-a9155c5d-3269-4ed3-9991-c9c7d5a32c49.png)
