### PR TITLE
#12673 Issue: On wide screens, the text in Learn > Classes is too wide to be comfortably readable

### DIFF
--- a/src/learn/qml/MuseScore/Learn/LearnPage.qml
+++ b/src/learn/qml/MuseScore/Learn/LearnPage.qml
@@ -104,20 +104,6 @@ FocusScope {
             font: ui.theme.titleBoldFont
             horizontalAlignment: Text.AlignLeft
         }
-
-        SearchField {
-            id: searchField
-
-            Layout.preferredWidth: 220
-
-            navigation.name: "LearnSearch"
-            navigation.panel: navSearchPanel
-            navigation.order: 1
-
-            onSearchTextChanged: {
-                pageModel.setSearchText(searchText)
-            }
-        }
     }
 
     StyledTabBar {

--- a/src/learn/qml/MuseScore/Learn/LearnPage.qml
+++ b/src/learn/qml/MuseScore/Learn/LearnPage.qml
@@ -104,8 +104,23 @@ FocusScope {
             font: ui.theme.titleBoldFont
             horizontalAlignment: Text.AlignLeft
         }
+
+        SearchField {
+            id: searchField
+
+            Layout.preferredWidth: 220
+
+            navigation.name: "LearnSearch"
+            navigation.panel: navSearchPanel
+            navigation.order: 1
+
+            onSearchTextChanged: {
+                pageModel.setSearchText(searchText)
+            }
+        }
     }
 
+    
     StyledTabBar {
         id: tabBar
 
@@ -153,6 +168,7 @@ FocusScope {
             navigation.name: "Get started"
             navigation.panel: navTabPanel
             navigation.column: 1
+            onClicked: searchField.visible = true
         }
 
         //! NOTE: see https://github.com/musescore/MuseScore/issues/14886
@@ -172,6 +188,7 @@ FocusScope {
             navigation.name: "Classes"
             navigation.panel: navTabPanel
             navigation.column: 3
+            onClicked: searchField.visible = false
         }
     }
 

--- a/src/learn/qml/MuseScore/Learn/internal/ClassesPage.qml
+++ b/src/learn/qml/MuseScore/Learn/internal/ClassesPage.qml
@@ -27,8 +27,9 @@ import QtGraphicalEffects 1.0
 import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
 
-FocusScope {
+StyledGridView {
     id: root
+    flickableDirection: Flickable.VerticalFlick
 
     property string authorName: ""
     property string authorRole: ""
@@ -63,141 +64,159 @@ FocusScope {
         }
     }
 
-    Rectangle {
-        anchors.top: parent.top
-        anchors.left: parent.left
-        anchors.leftMargin: root.sideMargin
+    ScrollBar.vertical: StyledScrollBar {
+        parent: root.parent
+
+        anchors.top: root.top
+        anchors.bottom: root.bottom
         anchors.right: parent.right
-        anchors.rightMargin: root.sideMargin
 
-        height: authorInfo.height
+        visible: root.contentHeight > root.height
+        z: 1
+    }
 
-        radius: 12
-
-        color: ui.theme.backgroundPrimaryColor
-
-        Column {
-            id: authorInfo
-
-            anchors.left: parent.left
-            anchors.leftMargin: 36
-            anchors.right: parent.horizontalCenter
+    header: Item {
+        height: authorInfoContainer.height
+        anchors.left: parent.left
+        anchors.right: parent.right
+        Rectangle {
+            id: authorInfoContainer
             anchors.top: parent.top
-            anchors.topMargin: 36
+            anchors.left: parent.left
+            anchors.leftMargin: root.sideMargin
+            anchors.rightMargin: root.sideMargin
 
-            height: childrenRect.height + 72
+            height: authorInfo.height
+            width: (parent.width > 1100) ? 1000 : parent.width - 96
 
-            spacing: 30
+            radius: 12
 
-            AccessibleItem {
-                id: accessibleInfo
-                accessibleParent: root.navigation.accessible
-                visualItem: authorInfo
-                role: MUAccessible.Button
-                name: {
-                    var template = "%1 %2. %3. %4. %5"
+            color: ui.theme.backgroundPrimaryColor
 
-                    return template.arg(root.authorRole)
-                    .arg(root.authorName)
-                    .arg(root.authorPosition)
-                    .arg(root.authorDescription)
-                    .arg(openMoreInfoButton.text)
-                }
-            }
+            Column {
+                id: authorInfo
 
-            Row {
-                width: parent.width
-                height: childrenRect.height
+                anchors.left: parent.left
+                anchors.leftMargin: 36
+                anchors.rightMargin: 36
+                anchors.right: parent.right
+                anchors.top: parent.top
+                anchors.topMargin: 36
+
+                height: childrenRect.height + 72
 
                 spacing: 30
 
-                Image {
-                    id: avatar
+                AccessibleItem {
+                    id: accessibleInfo
+                    accessibleParent: root.navigation.accessible
+                    visualItem: authorInfo
+                    role: MUAccessible.Button
+                    name: {
+                        var template = "%1 %2. %3. %4. %5"
 
-                    height: implicitHeight
-
-                    source: root.authorAvatarUrl
-                    sourceSize: Qt.size(120, 120)
-
-                    fillMode: Image.PreserveAspectCrop
-
-                    layer.enabled: true
-                    layer.effect: OpacityMask {
-                        maskSource: Rectangle {
-                            width: avatar.width
-                            height: avatar.height
-                            radius: width / 2
-                            visible: false
-                        }
+                        return template.arg(root.authorRole)
+                        .arg(root.authorName)
+                        .arg(root.authorPosition)
+                        .arg(root.authorDescription)
+                        .arg(openMoreInfoButton.text)
                     }
                 }
 
-                Column {
+                Row {
+                    width: parent.width
                     height: childrenRect.height
-                    anchors.verticalCenter: avatar.verticalCenter
 
-                    spacing: 8
+                    spacing: 30
 
-                    StyledTextLabel {
+                    Image {
+                        id: avatar
+
                         height: implicitHeight
 
-                        text: root.authorRole
-                        horizontalAlignment: Text.AlignLeft
-                        font {
-                            family: ui.theme.bodyFont.family
-                            pixelSize: ui.theme.bodyFont.pixelSize
-                            capitalization: Font.AllUppercase
+                        source: root.authorAvatarUrl
+                        sourceSize: Qt.size(120, 120)
+
+                        fillMode: Image.PreserveAspectCrop
+
+                        layer.enabled: true
+                        layer.effect: OpacityMask {
+                            maskSource: Rectangle {
+                                width: avatar.width
+                                height: avatar.height
+                                radius: width / 2
+                                visible: false
+                            }
                         }
                     }
 
-                    StyledTextLabel {
-                        height: implicitHeight
+                    Column {
+                        height: childrenRect.height
+                        anchors.verticalCenter: avatar.verticalCenter
 
-                        text: root.authorName
-                        horizontalAlignment: Text.AlignLeft
-                        font: ui.theme.headerBoldFont
-                    }
+                        spacing: 8
 
-                    StyledTextLabel {
-                        height: implicitHeight
+                        StyledTextLabel {
+                            height: implicitHeight
 
-                        text: root.authorPosition
-                        horizontalAlignment: Text.AlignLeft
-                        font: ui.theme.largeBodyFont
-                    }
-                }
-            }
+                            text: root.authorRole
+                            horizontalAlignment: Text.AlignLeft
+                            font {
+                                family: ui.theme.bodyFont.family
+                                pixelSize: ui.theme.bodyFont.pixelSize
+                                capitalization: Font.AllUppercase
+                            }
+                        }
 
-            StyledTextLabel {
-                height: implicitHeight
-                width: parent.width
+                        StyledTextLabel {
+                            height: implicitHeight
 
-                text: root.authorDescription
-                horizontalAlignment: Text.AlignLeft
-                font: ui.theme.largeBodyFont
-                wrapMode: Text.Wrap
-            }
+                            text: root.authorName
+                            horizontalAlignment: Text.AlignLeft
+                            font: ui.theme.headerBoldFont
+                        }
 
-            FlatButton {
-                id: openMoreInfoButton
-                orientation: Qt.Horizontal
-                icon: IconCode.OPEN_LINK
-                text: qsTrc("learn", "Open %1").arg(root.authorOrganizationName)
-                accentButton: true
+                        StyledTextLabel {
+                            height: implicitHeight
 
-                navigation.panel: root.navigation
-                navigation.name: "OpenMoreInfoButton"
-                navigation.column: 1
-                navigation.accessible.ignored: true
-                navigation.onActiveChanged: {
-                    if (!navigation.active) {
-                        accessible.ignored = false
-                        accessibleInfo.ignored = true
+                            text: root.authorPosition
+                            horizontalAlignment: Text.AlignLeft
+                            font: ui.theme.largeBodyFont
+                        }
                     }
                 }
 
-                onClicked: {
-                    root.requestOpenOrganizationUrl()
+                StyledTextLabel {
+                    height: implicitHeight
+                    width: parent.width
+
+                    text: root.authorDescription
+                    horizontalAlignment: Text.AlignLeft
+                    font: ui.theme.largeBodyFont
+                    wrapMode: Text.Wrap
+                }
+
+                FlatButton {
+                    id: openMoreInfoButton
+                    orientation: Qt.Horizontal
+                    icon: IconCode.OPEN_LINK
+                    text: qsTrc("learn", "Open %1").arg(root.authorOrganizationName)
+                    accentButton: true
+
+                    navigation.panel: root.navigation
+                    navigation.name: "OpenMoreInfoButton"
+                    navigation.column: 1
+                    navigation.accessible.ignored: true
+                    navigation.onActiveChanged: {
+                        if (!navigation.active) {
+                            accessible.ignored = false
+                            accessibleInfo.ignored = true
+                        }
+                    }
+
+                    onClicked: {
+                        root.requestOpenOrganizationUrl()
+                    }
                 }
             }
         }

--- a/src/learn/view/learnpagemodel.cpp
+++ b/src/learn/view/learnpagemodel.cpp
@@ -96,7 +96,7 @@ QVariantMap LearnPageModel::classesAuthor() const
                                           "or are a power user eager to explore advanced engraving and playback techniques, "
                                           "my flagship online course Mastering MuseScore "
                                           "covers everything you need to know to get the most out of MuseScore. "
-                                          "In addition, Mastering MuseScore features a supportive community of musicians, "
+                                          "\n\nIn addition, Mastering MuseScore features a supportive community of musicians, "
                                           "with discussion spaces, live streams, "
                                           "and other related courses and services to help you create your best music. "
                                           "Take advantage of this opportunity to learn MuseScore from one of its most recognized experts!");


### PR DESCRIPTION
Resolves: #12673

After struggling to compile MuseScore days I can finally compile it with no fatal errors and make changes and see them in the app itself (this is so cool!).

Tasks Done:
1. The card is now have a maximum size of 1000 pixels.
2. The card is now vertically scrollable (so many trials and errors. I may have made some unnecessary changes to make this work).
3. Divided the second paragraph into 2.
4. Removed the search box from

**I was not able to remove search box only from the classes tab in Learn, In this commit it's also removed from Get Started tab as well**

**I was not able to add extend the paragraph spacing to 6. ** 

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
