### PR TITLE
Added imports necessary to fix without qt windows build.

### DIFF
--- a/src/engraving/infrastructure/paint.h
+++ b/src/engraving/infrastructure/paint.h
@@ -22,6 +22,7 @@
 #ifndef MU_ENGRAVING_PAINT_H
 #define MU_ENGRAVING_PAINT_H
 
+#include <functional>
 #include <vector>
 #include "draw/painter.h"
 

--- a/src/framework/global/types/version.cpp
+++ b/src/framework/global/types/version.cpp
@@ -21,6 +21,7 @@
  */
 #include "version.h"
 
+#include <array>
 #include "log.h"
 
 static const mu::Char SUFFIX_DELIMITER = '-';


### PR DESCRIPTION
I didn't create an issue in advance, but I was playing around with building the without_qt build and had to make a few changes for the build to complete. It's entirely possible that I made a mistake during the environment setup, it will require some small modifications to the build, but I'm happy to make a windows version of the without_qt test to catch issues like this in the future.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
