### PR TITLE
#13652 [MU4 Issue] Regression: opacity control missing in color picker

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,7 +45,10 @@
         "memory": "cpp",
         "qgroupbox": "cpp",
         "qbytearray": "cpp",
-        "qcombobox": "cpp"
+        "qcombobox": "cpp",
+        "xhash": "cpp",
+        "xstring": "cpp",
+        "xtree": "cpp"
     },
     "cmake.buildDirectory": "${workspaceRoot}/build.debug",
     "cmake.configureOnOpen": true

--- a/src/framework/global/internal/interactive.cpp
+++ b/src/framework/global/internal/interactive.cpp
@@ -225,13 +225,12 @@ io::paths_t Interactive::selectMultipleDirectories(const QString& title, const i
 
 QColor Interactive::selectColor(const QColor& color, const QString& title)
 {
-    QColor temp = color;
-    if (temp.alpha() == 0)
-    {
-        temp.setAlpha(255);
+    QColor colorEditable = color;
+    if (colorEditable.alpha() == 0){
+        colorEditable.setAlpha(255);
     }
-    QColor selectedColor = QColorDialog::getColor(temp, nullptr, title, QColorDialog::ShowAlphaChannel);
-    return selectedColor.isValid() ? selectedColor : temp;
+    QColor selectedColor = QColorDialog::getColor(colorEditable, nullptr, title, QColorDialog::ShowAlphaChannel);
+    return selectedColor.isValid() ? selectedColor : color;
 }
 
 RetVal<Val> Interactive::open(const std::string& uri) const

--- a/src/framework/global/internal/interactive.cpp
+++ b/src/framework/global/internal/interactive.cpp
@@ -225,8 +225,13 @@ io::paths_t Interactive::selectMultipleDirectories(const QString& title, const i
 
 QColor Interactive::selectColor(const QColor& color, const QString& title)
 {
-    QColor selectedColor = QColorDialog::getColor(color, nullptr, title);
-    return selectedColor.isValid() ? selectedColor : color;
+    QColor temp = color;
+    if (temp.alpha() == 0)
+    {
+        temp.setAlpha(255);
+    }
+    QColor selectedColor = QColorDialog::getColor(temp, nullptr, title, QColorDialog::ShowAlphaChannel);
+    return selectedColor.isValid() ? selectedColor : temp;
 }
 
 RetVal<Val> Interactive::open(const std::string& uri) const

--- a/src/framework/global/internal/interactive.cpp
+++ b/src/framework/global/internal/interactive.cpp
@@ -226,7 +226,7 @@ io::paths_t Interactive::selectMultipleDirectories(const QString& title, const i
 QColor Interactive::selectColor(const QColor& color, const QString& title)
 {
     QColor colorEditable = color;
-    if (colorEditable.alpha() == 0){
+    if (colorEditable.alpha() == 0) {
         colorEditable.setAlpha(255);
     }
     QColor selectedColor = QColorDialog::getColor(colorEditable, nullptr, title, QColorDialog::ShowAlphaChannel);


### PR DESCRIPTION
Resolves: #13652

Color picker now have alpha value. If the alpha value is 0 and the color picker is launched the value is changed to 255 automatically.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ ] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
