### PR TITLE
[TESTING] stretch system to a page in a case system's width exceeds page's width

### DIFF
--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -499,8 +499,7 @@ void LayoutSystem::justifySystem(System* system, double curSysWidth, double targ
     if (RealIsNull(rest)) {
         return;
     }
-    if (rest < 0) {
-        LOGE("*** System justification error ***");
+    if (targetSystemWidth < system->firstMeasure()->first(SegmentType::ChordRest)->x()) {
         return;
     }
 


### PR DESCRIPTION
When page width is not default, it's smaller. Or there are a lot of 32'th notes. System exceeds page:

<img width="996" alt="Screenshot 2023-01-30 at 12 41 46" src="https://user-images.githubusercontent.com/29576873/215457945-b209c884-a29d-4f1a-8468-8062a68c92c8.png">

New:
<img width="1030" alt="Screenshot 2023-01-30 at 12 43 55" src="https://user-images.githubusercontent.com/29576873/215458162-4ce76843-dd54-46b0-beaf-36dfcaba9a45.png">

It's not perfect solution. For example notes climb on top of each other. It looks weird. But in most cases this compromise is fine.
