### PR TITLE
Fix for issue #16125 | [MU4 Issue] [Workspaces] UI glitch in workspaces window when adding too much workspaces

### DIFF
--- a/src/workspace/qml/MuseScore/Workspace/WorkspacesDialog.qml
+++ b/src/workspace/qml/MuseScore/Workspace/WorkspacesDialog.qml
@@ -86,7 +86,7 @@ StyledDialogView {
         WorkspacesView {
             id: view
             Layout.fillWidth: true
-            Layout.fillHeight: true
+            Layout.preferredHeight: root.height - 190
             Layout.leftMargin: -parent.anchors.leftMargin
             Layout.rightMargin: -parent.anchors.rightMargin
             leftPadding: parent.anchors.leftMargin

--- a/src/workspace/qml/MuseScore/Workspace/internal/WorkspacesView.qml
+++ b/src/workspace/qml/MuseScore/Workspace/internal/WorkspacesView.qml
@@ -77,7 +77,7 @@ RadioButtonGroup {
 
         function onSelectedWorkspaceChanged(selectedWorkspace) {
             if (Boolean(selectedWorkspace)) {
-                root.positionViewAtIndex(selectedWorkspace.index + 1, ListView.Contain)
+                root.positionViewAtIndex(selectedWorkspace.index, ListView.Contain)
             }
         }
     }

--- a/src/workspace/qml/MuseScore/Workspace/internal/WorkspacesView.qml
+++ b/src/workspace/qml/MuseScore/Workspace/internal/WorkspacesView.qml
@@ -46,6 +46,7 @@ RadioButtonGroup {
     }
 
     spacing: 0
+    clip: true
     orientation: Qt.Vertical
 
     interactive: height < contentHeight
@@ -76,7 +77,7 @@ RadioButtonGroup {
 
         function onSelectedWorkspaceChanged(selectedWorkspace) {
             if (Boolean(selectedWorkspace)) {
-                root.positionViewAtIndex(selectedWorkspace.index, ListView.Contain)
+                root.positionViewAtIndex(selectedWorkspace.index + 1, ListView.Contain)
             }
         }
     }


### PR DESCRIPTION
Resolves: #16125 

added `clip: true` property to `src\workspace\qml\MuseScore\Workspace\internal\WorkspacesView.qml` which overrides the `clip: false` property used in `StyledListView` in `src\framework\uicomponents\qml\MuseScore\UiComponents\RadioButtonGroup.qml`

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
