### PR TITLE
midi-renderer: fixed rendering of slides out before grace note

### DIFF
--- a/src/engraving/libmscore/rendermidi.cpp
+++ b/src/engraving/libmscore/rendermidi.cpp
@@ -1337,24 +1337,24 @@ static void adjustPreviousChordLength(Chord* currentChord, Chord* prevChord)
         int reducedTicks = graceNotesBeforeBar[0]->ticks().ticks();
         int prevTicks = prevChord->ticks().ticks();
         if (reducedTicks < prevTicks) {
-            int newLength = static_cast<int>((float)(prevTicks - reducedTicks) / (float)prevTicks * 1000.0f);
+            double lengthMultiply = std::min(1.f, (float)(prevTicks - reducedTicks) / (float)prevTicks);
 
             for (size_t i = 0; i < prevChord->notes().size(); i++) {
                 Note* prevChordNote = prevChord->notes()[i];
-
                 NoteEventList evList;
+                const auto& prevEvents = prevChordNote->playEvents();
 
-                for (auto it = prevChordNote->playEvents().begin(); it != prevChordNote->playEvents().end(); it++) {
-                    if (it->ontime() >= newLength) {
-                        continue;
-                    }
+                int curPos = prevEvents.front().ontime();
 
+                for (size_t i = 0; i < prevEvents.size(); i++) {
                     NoteEvent event;
-                    event.setOntime(it->ontime());
-                    event.setPitch(it->pitch());
-                    event.setLen(std::min(newLength, it->offtime()) - it->ontime());
-
+                    const NoteEvent& prevEvent = prevEvents[i];
+                    event.setOntime(curPos);
+                    event.setPitch(prevEvent.pitch());
+                    int newEventLength = prevEvent.len() * lengthMultiply;
+                    event.setLen(newEventLength);
                     evList.push_back(event);
+                    curPos += newEventLength;
                 }
 
                 prevChordNote->setPlayEvents(evList);


### PR DESCRIPTION
slides were not included in recalculation of previous chord sound after grace note "before beat" was applied to current chord