### PR TITLE
Avoid scaling offset twice when spatium is changed

### DIFF
--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -466,7 +466,7 @@ void Excerpt::createExcerpt(Excerpt* excerpt)
 
     // update style values if spatium different for part
     if (masterScore->spatium() != score->spatium()) {
-        //score->spatiumChanged(oscore->spatium(), score->spatium());
+        score->spatiumChanged(masterScore->spatium(), score->spatium());
         score->styleChanged();
     }
 
@@ -1413,6 +1413,15 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
         score->undoAddElement(element, false /*addToLinkedStaves*/);
     };
 
+    auto updateSpatium = [](void* oldElement, EngravingItem* newElement)
+    {
+        double oldSpatium = static_cast<EngravingItem*>(oldElement)->spatium();
+        double newSpatium = newElement->spatium();
+        if (!RealIsEqual(oldSpatium, newSpatium)) {
+            newElement->spatiumChanged(oldSpatium, newSpatium);
+        }
+    };
+
     for (Measure* m = m1; m && (m != m2); m = m->nextMeasure()) {
         Measure* nm = score->tick2measure(m->tick());
         nm->setMeasureRepeatCount(m->measureRepeatCount(srcStaffIdx), dstStaffIdx);
@@ -1434,6 +1443,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                         ne->setParent(ns);
                         ne->setScore(score);
                         ne->styleChanged();
+                        ne->scanElements(oef, updateSpatium);
                         addElement(ne);
                     }
                 }
@@ -1466,6 +1476,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                 ne->setParent(ns);
                 ne->setScore(score);
                 ne->styleChanged();
+                ne->scanElements(oe, updateSpatium);
                 addElement(ne);
                 if (oe->isChordRest()) {
                     ChordRest* ocr = toChordRest(oe);
@@ -1480,6 +1491,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                             nt->setTrack(dstTrack);
                             nt->setParent(nm);
                             nt->styleChanged();
+                            nt->scanElements(ot, updateSpatium);
                             tupletMap.add(ot, nt);
                         }
                         ncr->setTuplet(nt);

--- a/src/engraving/tests/parts_data/part-all-appendmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-appendmeasures.mscx
@@ -1267,7 +1267,7 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <offset x="1.06662" y="-4.71271"/>
+                  <offset x="1.05809" y="-4.67501"/>
                   <text>2</text>
                   </Fingering>
                 <pitch>67</pitch>

--- a/src/engraving/tests/parts_data/part-all-insertmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-insertmeasures.mscx
@@ -1269,7 +1269,7 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <offset x="1.06662" y="-4.71271"/>
+                  <offset x="1.05809" y="-4.67501"/>
                   <text>2</text>
                   </Fingering>
                 <pitch>67</pitch>

--- a/src/engraving/tests/parts_data/part-all-parts.mscx
+++ b/src/engraving/tests/parts_data/part-all-parts.mscx
@@ -1249,7 +1249,7 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <offset x="1.06662" y="-4.71271"/>
+                  <offset x="1.05809" y="-4.67501"/>
                   <text>2</text>
                   </Fingering>
                 <pitch>67</pitch>

--- a/src/engraving/tests/parts_data/part-all-uappendmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-uappendmeasures.mscx
@@ -1249,7 +1249,7 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <offset x="1.06662" y="-4.71271"/>
+                  <offset x="1.05809" y="-4.67501"/>
                   <text>2</text>
                   </Fingering>
                 <pitch>67</pitch>

--- a/src/engraving/tests/parts_data/part-all-uinsertmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-uinsertmeasures.mscx
@@ -1249,7 +1249,7 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <offset x="1.06662" y="-4.71271"/>
+                  <offset x="1.05809" y="-4.67501"/>
                   <text>2</text>
                   </Fingering>
                 <pitch>67</pitch>

--- a/src/engraving/tests/parts_data/part-fingering-parts.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-parts.mscx
@@ -879,7 +879,7 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <offset x="0.663397" y="-1.51211"/>
+                  <offset x="0.658089" y="-1.50001"/>
                   <text>3</text>
                   </Fingering>
                 <pitch>72</pitch>

--- a/src/engraving/tests/parts_data/part-fingering-udel.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-udel.mscx
@@ -880,7 +880,7 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <offset x="0.663397" y="-1.51211"/>
+                  <offset x="0.658089" y="-1.50001"/>
                   <text>3</text>
                   </Fingering>
                 <pitch>72</pitch>

--- a/src/engraving/tests/parts_data/voices-ref.mscx
+++ b/src/engraving/tests/parts_data/voices-ref.mscx
@@ -1335,7 +1335,7 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <offset x="1.06662" y="-4.71271"/>
+                  <offset x="1.05809" y="-4.67501"/>
                   <text>2</text>
                   </Fingering>
                 <pitch>63</pitch>
@@ -1999,7 +1999,7 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <offset x="1.06662" y="-4.71271"/>
+                  <offset x="1.05809" y="-4.67501"/>
                   <text>2</text>
                   </Fingering>
                 <pitch>43</pitch>
@@ -2499,7 +2499,7 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <offset x="1.06662" y="-4.71271"/>
+                  <offset x="1.05809" y="-4.67501"/>
                   <text>2</text>
                   </Fingering>
                 <pitch>43</pitch>

--- a/src/notation/view/widgets/pagesettings.cpp
+++ b/src/notation/view/widgets/pagesettings.cpp
@@ -468,9 +468,7 @@ void PageSettings::spatiumChanged()
 {
     double val = spatiumEntry->value();
     val *= mmUnit ? DPMM : DPI;
-    double oldVal = score()->spatium();
-    setStyleValue(Sid::spatium, val);
-    score()->spatiumChanged(oldVal, val);
+    setStyleValue(Sid::spatium, val); // this will also call Score::spatiumChanged()
 }
 
 void PageSettings::pageOffsetChanged()


### PR DESCRIPTION
Resolves: #16006

It turns out the that issue happened because Score::spatiumChanged() was being inadvertently called twice when changing the staff size in a piece. This should fix it.