### PR TITLE
render midi: fixed mistake in indexes of chord notes

### DIFF
--- a/src/engraving/libmscore/rendermidi.cpp
+++ b/src/engraving/libmscore/rendermidi.cpp
@@ -1072,10 +1072,10 @@ static std::set<size_t> getNotesIndexesToRender(Chord* chord)
         return true;
     };
 
-    size_t idx = 0;
-    for (Note* n : notes) {
+    for (size_t i = 0; i < notes.size(); i++) {
+        Note* n = notes[i];
         if (noteShouldBeRendered(n) && longestPlayTicksForPitch[n->pitch()] == n->playTicks()) {
-            notesIndexesToRender.insert(idx++);
+            notesIndexesToRender.insert(i);
         }
     }
 


### PR DESCRIPTION
fixed mistake in indexes, which was made in PR https://github.com/musescore/MuseScore/pull/16156