### PR TITLE
Possible fix for Issue #14338: [MU4 Issue] Missclicking while selecting several things, although still holding control shouldn't remove all the selections.

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -790,9 +790,11 @@ void NotationViewInputController::mouseReleaseEvent(QMouseEvent* event)
     INotationNoteInputPtr noteInput = interaction->noteInput();
     const EngravingItem* hitElement = hitElementContext().element;
 
-    if (!hitElement && !m_isCanvasDragged && !interaction->isGripEditStarted()
-        && !interaction->isDragStarted() && !noteInput->isNoteInputMode()) {
-        interaction->clearSelection();
+    if (event->modifiers() != Qt::ControlModifier && event->modifiers() != Qt::ShiftModifier) {
+        if (!hitElement && !m_isCanvasDragged && !interaction->isGripEditStarted()
+            && !interaction->isDragStarted() && !noteInput->isNoteInputMode()) {
+            interaction->clearSelection();
+        }
     }
 
     if (event->button() == Qt::LeftButton && event->modifiers() == Qt::NoModifier) {


### PR DESCRIPTION
Resolves: #14338 

Nested the condition which clears selection inside a condition which checks for control modifier.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
