### PR TITLE
Fix for Issue #13652 MU4 Issue] Regression: opacity control missing in color picker

### DIFF
--- a/src/framework/global/internal/interactive.cpp
+++ b/src/framework/global/internal/interactive.cpp
@@ -225,7 +225,11 @@ io::paths_t Interactive::selectMultipleDirectories(const QString& title, const i
 
 QColor Interactive::selectColor(const QColor& color, const QString& title)
 {
-    QColor selectedColor = QColorDialog::getColor(color, nullptr, title);
+    QColor colorEditable = color;
+    if (colorEditable.alpha() == 0) {
+        colorEditable.setAlpha(255);
+    }
+    QColor selectedColor = QColorDialog::getColor(colorEditable, nullptr, title, QColorDialog::ShowAlphaChannel);
     return selectedColor.isValid() ? selectedColor : color;
 }
 


### PR DESCRIPTION
Resolves: #13652 
Color picker now have alpha value. If the alpha value is 0 and the color picker is launched the value is changed to 255 automatically.

Sorry I had to close the last PR fixing this issue because of me deleting my original fork. 
This PR is a replacement for #16103 .

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
