### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/diagnostics/internal/drawdata/drawdatagenerator.cpp
+++ b/src/diagnostics/internal/drawdata/drawdatagenerator.cpp
@@ -121,16 +121,16 @@ DrawDataPtr DrawDataGenerator::genDrawData(const io::path_t& scorePath, const Ge
     {
         TRACEFUNC_C("Paint");
         Painter painter(pd, "DrawData");
-        Paint::Options opt;
-        opt.fromPage = 0;
-        opt.toPage = 0;
-        opt.deviceDpi = DrawData::CANVAS_DPI;
-        opt.printPageBackground = true;
-        opt.isSetViewport = true;
-        opt.isMultiPage = false;
-        opt.isPrinting = true;
+        Paint::Options option;
+        option.fromPage = 0;
+        option.toPage = 0;
+        option.deviceDpi = DrawData::CANVAS_DPI;
+        option.printPageBackground = true;
+        option.isSetViewport = true;
+        option.isMultiPage = false;
+        option.isPrinting = true;
 
-        Paint::paintScore(&painter, score, opt);
+        Paint::paintScore(&painter, score, option);
     }
 
     delete score;

--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -6066,7 +6066,7 @@ void Score::undoRemoveElement(EngravingItem* element)
     if (element->isMeasureRepeat()) {
         const MeasureRepeat* repeat = toMeasureRepeat(element);
         Measure* measure = repeat->firstMeasureOfGroup();
-        int staffIdx = repeat->staffIdx();
+        size_t staffIdx = repeat->staffIdx();
 
         for (int i = 0; i < repeat->numMeasures(); ++i) {
             undoChangeMeasureRepeatCount(measure, 0, staffIdx);

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -1699,7 +1699,9 @@ void Score::removeElement(EngravingItem* element)
 
         if (!system) {
             // vertical boxes are not shown in continuous view so no system
+#ifndef NDEBUG
             bool noSystemMode = lineMode() && (element->isVBox() || element->isTBox());
+#endif
             assert(noSystemMode || !isOpen());
             return;
         }


### PR DESCRIPTION
* reg. conversion from 'size_t' to 'int', possible loss of data (C4267)
* reg. local variable is initialized but not referenced (C4189)
* reg. local variable is initialized but not referenced	(C4189)