### PR TITLE
Fix: #15718 : middle click will drag the score in note-input mode.

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -680,7 +680,8 @@ void NotationViewInputController::mouseMoveEvent(QMouseEvent* event)
     }
 
     bool isNoteEnterMode = m_view->isNoteEnterMode();
-    bool isDragObjectsAllowed = !(isNoteEnterMode || playbackController()->isPlaying() || (event->buttons() & Qt::MiddleButton));
+    bool isMiddleButton  = (event->buttons() & Qt::MiddleButton);
+    bool isDragObjectsAllowed = !(isNoteEnterMode || playbackController()->isPlaying() || isMiddleButton);
     if (isDragObjectsAllowed) {
         const EngravingItem* hitElement = hitElementContext().element;
 
@@ -718,7 +719,7 @@ void NotationViewInputController::mouseMoveEvent(QMouseEvent* event)
     }
 
     // move canvas
-    if (!isNoteEnterMode) {
+    if (!isNoteEnterMode || isMiddleButton) {
         m_view->moveCanvas(dragDelta.x(), dragDelta.y());
         m_isCanvasDragged = true;
     }


### PR DESCRIPTION
Resolves: #15718 

I added the feature in which we can drag the score on middle click in note-input mode.



- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
