### PR TITLE
Fix for Issue #16219: [MU4 Issue] Customise note input toolbar popup points to empty space

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/internal/NoteInputBarCustomisePopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/NoteInputBarCustomisePopup.qml
@@ -31,7 +31,7 @@ StyledPopupView {
     id: root
 
     contentWidth: 280
-    contentHeight: 600
+    contentHeight: (parent.parent.height < 80) ? 600 : 500
 
     NoteInputBarCustomiseModel {
         id: customiseModel


### PR DESCRIPTION
Resolves: #16219

Customise note input toolbar popup now points to the settings cog when the toolbar is set vertical.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
