### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/libmscore/instrtemplate.cpp
+++ b/src/engraving/libmscore/instrtemplate.cpp
@@ -531,8 +531,8 @@ void InstrumentTemplate::read(XmlReader& e)
             midiActions.push_back(a);
         } else if (tag == "Channel" || tag == "channel") {
             InstrChannel a;
-            InstrumentTrackId id;
-            a.read(e, nullptr, id);
+            InstrumentTrackId tId;
+            a.read(e, nullptr, tId);
             channel.push_back(a);
         } else if (tag == "Articulation") {
             MidiArticulation a;

--- a/src/plugins/api/instrument.h
+++ b/src/plugins/api/instrument.h
@@ -151,7 +151,7 @@ public:
         return false;
     }
 
-    void setMute(bool val)
+    void setMute(bool)
     {
         DEPRECATED;
         //!@NOTE since MuseScore 4.0 mixer doen/t work via Channel


### PR DESCRIPTION
* reg. declaration hides class member (C4458)
* reg. unreferenced formal parameter (C4100)

I still can't get my head round the remaining warning reg. conversion from 'float' to '_Rx', possible loss of data  (C4244)
