### PR TITLE
Fix #16146, Copy-paste plain text outside MuseScore

### DIFF
--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -3021,11 +3021,12 @@ void TextBase::editCut(EditData& ed)
 void TextBase::editCopy(EditData& ed)
 {
     //
-    // store selection as plain text
+    // store selection as rich and plain text
     //
     TextEditData* ted = static_cast<TextEditData*>(ed.getData(this).get());
     TextCursor* cursor = ted->cursor();
     ted->selectedText = cursor->selectedText(true);
+    ted->selectedPlainText = cursor->selectedText(false);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/textedit.h
+++ b/src/engraving/libmscore/textedit.h
@@ -45,6 +45,8 @@ public:
     bool deleteText = false;
 
     String selectedText;
+    String selectedPlainText;
+    static constexpr const char* mimeRichTextFormat = "application/musescore/richtext";
 
     TextEditData(TextBase* t)
         : _textBase(t) {}


### PR DESCRIPTION
Resolves: #16146 

Before this PR, when a user copies a text and past it outside of musescore, the text includes formatting tags (e.g. `<font>` `<b>`). This does not happen in `MU3`, where you can copy-paste a text outside of `MU3` and get plain text. However, `MU4` is able to keep the original format when we copy-paste a text to another text object since it also copies the formatting tags. `MU3` failed to do so because it does not copy the formatting tag.

This PR keeps what `MU4` can do (keep the formatting) while letting users paste plain texts outside `MU4`. It is done using `QMimeData` to store both plain and rich text in different MIME types. The plain text is stored with type `text/plain`, and the rich text is stored in a custom MIME type `application/musescore/richtext`. When pasting texts to another text object in MU4, MU4 searches for rich text in custom type `application/musescore/richtext` and paste the rich text to keep the format. When pasting text outside of musescore, the plain text with type `text/plain` will be used so users can get rid of the formatting tags.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
