### PR TITLE
midi-render: fixed rendering of tied slides and glissando

### DIFF
--- a/src/engraving/libmscore/noteevent.cpp
+++ b/src/engraving/libmscore/noteevent.cpp
@@ -36,11 +36,11 @@ void NoteEvent::read(XmlReader& e)
     while (e.readNextStartElement()) {
         const AsciiStringView tag(e.name());
         if (tag == "pitch") {
-            _pitch = e.readInt();
+            m_pitch = e.readInt();
         } else if (tag == "ontime") {
-            _ontime = e.readInt();
+            m_ontime = e.readInt();
         } else if (tag == "len") {
-            _len = e.readInt();
+            m_len = e.readInt();
         } else {
             e.unknown();
         }
@@ -54,9 +54,9 @@ void NoteEvent::read(XmlReader& e)
 void NoteEvent::write(XmlWriter& xml) const
 {
     xml.startElement("Event");
-    xml.tag("pitch", _pitch, 0);
-    xml.tag("ontime", _ontime, 0);
-    xml.tag("len", _len, NOTE_LENGTH);
+    xml.tag("pitch", m_pitch, 0);
+    xml.tag("ontime", m_ontime, 0);
+    xml.tag("len", m_len, NOTE_LENGTH);
     xml.endElement();
 }
 
@@ -75,6 +75,6 @@ NoteEventList::NoteEventList()
 
 bool NoteEvent::operator==(const NoteEvent& e) const
 {
-    return (e._pitch == _pitch) && (e._ontime == _ontime) && (e._len == _len);
+    return (e.m_pitch == m_pitch) && (e.m_ontime == m_ontime) && (e.m_len == m_len);
 }
 }

--- a/src/engraving/libmscore/noteevent.h
+++ b/src/engraving/libmscore/noteevent.h
@@ -38,34 +38,38 @@ class XmlReader;
 
 class NoteEvent
 {
-    int _pitch;     // relative pitch to note pitch
-    int _ontime;    // one unit is 1/1000 of nominal note len
-    int _len;       // one unit is 1/1000 of nominal note len
-
-    double _velocityMultiplier = 1.0;
-
 public:
     constexpr static int NOTE_LENGTH = 1000;
     constexpr static double GLISSANDO_VELOCITY_MULTIPLIER = 0.7;
+    constexpr static double DEFAULT_VELOCITY_MULTIPLIER = 1.0;
 
-    NoteEvent()
-        : _pitch(0), _ontime(0), _len(NOTE_LENGTH), _velocityMultiplier(1.0) {}
-    NoteEvent(int a, int b, int c, double d = 1.0)
-        : _pitch(a), _ontime(b), _len(c), _velocityMultiplier(d) {}
+    NoteEvent() {}
+    NoteEvent(int a, int b, int c, double d = 1.0, double play = true)
+        : m_pitch(a), m_ontime(b), m_len(c), m_velocityMultiplier(d), m_play(play) {}
 
     void read(XmlReader&);
     void write(XmlWriter&) const;
 
-    int  pitch() const { return _pitch; }
-    int ontime() const { return _ontime; }
-    int offtime() const { return _ontime + _len; }
-    int len() const { return _len; }
-    double velocityMultiplier() const { return _velocityMultiplier; }
-    void setPitch(int v) { _pitch = v; }
-    void setOntime(int v) { _ontime = v; }
-    void setLen(int v) { _len = v; }
-    void setVelocityMultiplier(double velocityMultiplier) { _velocityMultiplier = velocityMultiplier; }
+    int  pitch() const { return m_pitch; }
+    int ontime() const { return m_ontime; }
+    int offtime() const { return m_ontime + m_len; }
+    int len() const { return m_len; }
+    double velocityMultiplier() const { return m_velocityMultiplier; }
+    bool play() const { return m_play; }
+    void setPitch(int v) { m_pitch = v; }
+    void setOntime(int v) { m_ontime = v; }
+    void setLen(int v) { m_len = v; }
+    void setVelocityMultiplier(double velocityMultiplier) { m_velocityMultiplier = velocityMultiplier; }
+    void setPlay(bool play) { m_play = play; }
+
     bool operator==(const NoteEvent&) const;
+
+private:
+    int m_pitch = 0;     // relative pitch to note pitch
+    int m_ontime = 0;    // one unit is 1/1000 of nominal note len
+    int m_len = NOTE_LENGTH;       // one unit is 1/1000 of nominal note len
+    double m_velocityMultiplier = DEFAULT_VELOCITY_MULTIPLIER; // can be used to lower sound (0-1)
+    bool m_play = true; // when 'false', note event is used only for length calculation
 };
 
 //---------------------------------------------------------


### PR DESCRIPTION
Midi events for tied notes were doubled due to recursive calls: https://github.com/musescore/MuseScore/pull/978

Recursion is removed in this PR, ornaments were checked on these files:
[ornaments.zip](https://github.com/musescore/MuseScore/files/10677014/ornaments.zip)

Also "play" field was added to NoteEvent not to play tied note again, but still to use events for calculating the length of previous note