### PR TITLE
Repeat test follow-up and skipped scores

### DIFF
--- a/src/engraving/libmscore/repeatlist.cpp
+++ b/src/engraving/libmscore/repeatlist.cpp
@@ -834,10 +834,10 @@ void RepeatList::unwind()
                     activeVolta = nullptr;
                     // Start next rs on the following measure
                     Measure const* const possibleNextMeasure = (*repeatListElementIt)->measure->nextMeasure();
-                    rs = new RepeatSegment(playbackCount);
                     if (possibleNextMeasure == nullptr) {
-                        // end of score, but will still encounter section break, notify it
+                        rs = nullptr;                   // end of score, but will still encounter section break, notify it
                     } else {
+                        rs = new RepeatSegment(playbackCount);
                         rs->addMeasure(possibleNextMeasure);
                     }
                 }

--- a/src/engraving/libmscore/repeatlist.cpp
+++ b/src/engraving/libmscore/repeatlist.cpp
@@ -263,7 +263,11 @@ int RepeatList::utime2utick(double secs) const
         }
     }
 
-    ASSERT_X(String(u"time %1 not found in RepeatList").arg(secs));
+    if (!empty()) {
+        ASSERT_X(String(u"time %1 not found in RepeatList").arg(secs));
+    }
+    // else: requesting from an empty map can be expected as a valid scenario
+
     return 0;
 }
 
@@ -1028,14 +1032,16 @@ void RepeatList::unwind()
         }
 
         // Reached the end of this section
-        // Inform the last RepeatSegment that the Section Break pause property should be honored now
-        rs = this->back();
-        repeatListElementIt = sectionIt->cend() - 1;
-        assert((*repeatListElementIt)->repeatListElementType == RepeatListElementType::SECTION_BREAK);
+        if (!this->empty()) {
+            // Inform the last RepeatSegment that the Section Break pause property should be honored now
+            rs = this->back();
+            repeatListElementIt = sectionIt->cend() - 1;
+            assert((*repeatListElementIt)->repeatListElementType == RepeatListElementType::SECTION_BREAK);
 
-        LayoutBreak const* const layoutBreak = toMeasureBase((*repeatListElementIt)->element)->sectionBreakElement();
-        if (layoutBreak != nullptr) {
-            rs->pause = layoutBreak->pause();
+            LayoutBreak const* const layoutBreak = toMeasureBase((*repeatListElementIt)->element)->sectionBreakElement();
+            if (layoutBreak != nullptr) {
+                rs->pause = layoutBreak->pause();
+            }
         }
     }
 

--- a/src/engraving/tests/repeat_data/repeat68.mscx
+++ b/src/engraving/tests/repeat_data/repeat68.mscx
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.00">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <showMeasureNumberOne>1</showMeasureNumberOne>
+      <measureNumberInterval>1</measureNumberInterval>
+      <measureNumberSystem>0</measureNumberSystem>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="mscVersion">4.00</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Repeat Test</metaTag>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument id="piano">
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>13</height>
+        <bottomGap>1</bottomGap>
+        <boxAutoSize>0</boxAutoSize>
+        <Text>
+          <style>title</style>
+          <text>repeat68</text>
+          </Text>
+        <Text>
+          <style>subtitle</style>
+          <text>Volta skipping entire score</text>
+          </Text>
+        </VBox>
+      <TBox>
+        <height>1</height>
+        <topGap>0</topGap>
+        <leftMargin>1</leftMargin>
+        <rightMargin>1</rightMargin>
+        <topMargin>1</topMargin>
+        <bottomMargin>1</bottomMargin>
+        <Text>
+          <style>frame</style>
+          <text>no playback
+</text>
+          </Text>
+        </TBox>
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Tempo>
+            <tempo>6.66667</tempo>
+            <followText>1</followText>
+            <family>FreeSerif</family>
+            <bold>0</bold>
+            <text><b></b><font face="ScoreText"></font><b><font face="FreeSerif"></font> = 400</b></text>
+            </Tempo>
+          <Spanner type="Volta">
+            <Volta>
+              <beginText>2. (skip)</beginText>
+              <endings>2</endings>
+              </Volta>
+            <next>
+              <location>
+                <fractions>1/1</fractions>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>64</pitch>
+              <tpc>18</tpc>
+              </Note>
+            </Chord>
+          <Spanner type="Volta">
+            <prev>
+              <location>
+                <fractions>-1/1</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/tests/repeat_tests.cpp
+++ b/src/engraving/tests/repeat_tests.cpp
@@ -356,7 +356,7 @@ TEST_F(Engraving_RepeatTests, repeat56) {
     repeat("repeat56.mscx", u"1;2;3;4; 2; 5;6;7; 5;6;7;8");
 }
 
-TEST_F(Engraving_RepeatTests, DISABLED_repeat57) {
+TEST_F(Engraving_RepeatTests, repeat57) {
     // no repeat, skip volta until section end, relates to #274690
     repeat("repeat57.mscx", u"1;2;3");
 }
@@ -406,7 +406,7 @@ TEST_F(Engraving_RepeatTests, repeat66) {
     repeat("repeat66.mscx", u"1;2;3;4; 2;3;4; 1;2; 5; 1;2;3;4; 2;3;4; 2; 5");
 }
 
-TEST_F(Engraving_RepeatTests, DISABLED_repeat67) {
+TEST_F(Engraving_RepeatTests, repeat67) {
     // Jump at skipped open volta end with end repeat at end of score: #327681
     repeat("repeat67.mscx", u"1;2; 1");
 }

--- a/src/engraving/tests/repeat_tests.cpp
+++ b/src/engraving/tests/repeat_tests.cpp
@@ -410,3 +410,8 @@ TEST_F(Engraving_RepeatTests, repeat67) {
     // Jump at skipped open volta end with end repeat at end of score: #327681
     repeat("repeat67.mscx", u"1;2; 1");
 }
+
+TEST_F(Engraving_RepeatTests, repeat68) {
+    // Entire score skipped by volta: gh#14685
+    repeat("repeat68.mscx", u"");
+}


### PR DESCRIPTION
Resolves: #14685 (with additional test case 68) and re-enables repeat tests 57 and 67 as a follow-up to https://github.com/musescore/MuseScore/pull/16213

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
