### PR TITLE
midi-export: each string has its own channel

### DIFF
--- a/src/engraving/libmscore/rendermidi.cpp
+++ b/src/engraving/libmscore/rendermidi.cpp
@@ -1418,23 +1418,10 @@ void Score::createPlayEvents(Measure const* start, Measure const* const end)
     }
 }
 
-//---------------------------------------------------------
-//   renderMidi
-//    export score to event list
-//---------------------------------------------------------
-
-void Score::renderMidi(EventMap* events, const SynthesizerState& synthState)
-{
-    renderMidi(events, true, MScore::playRepeats, synthState);
-}
-
-void Score::renderMidi(EventMap* events, bool metronome, bool expandRepeats, const SynthesizerState& synthState)
+void Score::renderMidi(EventMap* events, const MidiRenderer::Context& ctx, bool expandRepeats)
 {
     bool expandRepeatsBackup = masterScore()->expandRepeats();
     masterScore()->setExpandRepeats(expandRepeats);
-    MidiRenderer::Context ctx;
-    ctx.synthState = synthState;
-    ctx.metronome = metronome;
     MidiRenderer(this).renderScore(events, ctx);
     masterScore()->setExpandRepeats(expandRepeatsBackup);
 }

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -34,6 +34,7 @@
 #include "async/channel.h"
 #include "io/iodevice.h"
 #include "types/ret.h"
+#include "compat/midi/midirender.h"
 
 #include "modularity/ioc.h"
 #include "draw/iimageprovider.h"
@@ -935,8 +936,7 @@ public:
     bool pasteStaff(XmlReader&, Segment* dst, staff_idx_t staffIdx, Fraction scale = Fraction(1, 1));
     void readAddConnector(ConnectorInfoReader* info, bool pasteMode) override;
     void pasteSymbols(XmlReader& e, ChordRest* dst);
-    void renderMidi(EventMap* events, const SynthesizerState& synthState);
-    void renderMidi(EventMap* events, bool metronome, bool expandRepeats, const SynthesizerState& synthState);
+    void renderMidi(EventMap* events, const MidiRenderer::Context& ctx, bool expandRepeats);
 
     BeatType tick2beatType(const Fraction& tick) const;
 

--- a/src/importexport/midi/internal/midiexport/exportmidi.cpp
+++ b/src/importexport/midi/internal/midiexport/exportmidi.cpp
@@ -229,7 +229,11 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
     }
 
     EventMap events;
-    m_score->renderMidi(&events, false, midiExpandRepeats, synthState);
+    MidiRenderer::Context ctx;
+    ctx.eachStringHasChannel = false;
+    ctx.metronome = false;
+    ctx.synthState = synthState;
+    m_score->renderMidi(&events, ctx, true);
 
     m_pauseMap.calculate(m_score);
     writeHeader();

--- a/src/importexport/midi/tests/midiexport_tests.cpp
+++ b/src/importexport/midi/tests/midiexport_tests.cpp
@@ -563,7 +563,11 @@ void TestMidi::events()
     EventMap events;
     // a temporary, uninitialized synth state so we can render the midi - should fall back correctly
     SynthesizerState ss;
-    score->renderMidi(&events, ss);
+    MidiRenderer::Context ctx;
+    ctx.eachStringHasChannel = false;
+    ctx.metronome = true;
+    ctx.synthState = ss;
+    score->renderMidi(&events, ctx, true);
     qDebug() << "Opened score " << readFile;
     QFile filehandler(writeFile);
     filehandler.open(QIODevice::WriteOnly | QIODevice::Text);


### PR DESCRIPTION
Musescore org. has mobile and versions of musescore editor. This product is inside a private repository. So I cant link to the issue. But long story short playback engine of mobile version is still based on RenderMidi class. We need to support correct playback of bends. Problem is bend applies for whole chord instead of note. To fix it each string render to separate channel. This behavior is defined by eachStringHasChannel flag.

From editor point of view nothing changed. Because eachStringHasChannel = false