### PR TITLE
export-midi: fixed crash

### DIFF
--- a/src/engraving/compat/midi/midirender.cpp
+++ b/src/engraving/compat/midi/midirender.cpp
@@ -599,6 +599,7 @@ void MidiRenderer::doCollectMeasureEvents(EventMap* events, Measure const* m, co
 
             for (const Note* note : chord->notes()) {
                 int channel = getChannel(instr, note);
+                events->registerChannel(channel);
                 collectNote(events, channel, note, veloMultiplier, tickOffset, st1, pitchWheelRenderer);
             }
 
@@ -606,6 +607,7 @@ void MidiRenderer::doCollectMeasureEvents(EventMap* events, Measure const* m, co
                 for (Chord* c : chord->graceNotesAfter()) {
                     for (const Note* note : c->notes()) {
                         int channel = getChannel(instr, note);
+                        events->registerChannel(channel);
                         collectNote(events, channel, note, veloMultiplier, tickOffset, st1, pitchWheelRenderer);
                     }
                 }

--- a/src/importexport/midi/internal/midiexport/exportmidi.cpp
+++ b/src/importexport/midi/internal/midiexport/exportmidi.cpp
@@ -220,7 +220,6 @@ void ExportMidi::writeHeader()
 
 bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPNs, const SynthesizerState& synthState)
 {
-    UNUSED(midiExpandRepeats);
     m_midiFile.setDivision(Constants::division);
     m_midiFile.setFormat(1);
     std::vector<MidiTrack>& tracks = m_midiFile.tracks();
@@ -234,7 +233,7 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
     ctx.eachStringHasChannel = false;
     ctx.metronome = false;
     ctx.synthState = synthState;
-    m_score->renderMidi(&events, ctx, true);
+    m_score->renderMidi(&events, ctx, midiExpandRepeats);
 
     m_pauseMap.calculate(m_score);
     writeHeader();


### PR DESCRIPTION
exportmidi.cpp was fixed due to the regression in https://github.com/musescore/MuseScore/pull/16265