### PR TITLE
Add user directory default paths for MuseSampler

### DIFF
--- a/src/framework/musesampler/imusesamplerconfiguration.h
+++ b/src/framework/musesampler/imusesamplerconfiguration.h
@@ -35,7 +35,8 @@ class IMuseSamplerConfiguration : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IMuseSamplerConfiguration() = default;
 
-    virtual mu::io::path_t libraryPath() const = 0;
+    virtual mu::io::path_t backupLibraryPath() const = 0;
+    virtual mu::io::path_t userLibraryPath() const = 0;
 
     virtual std::string minimumSupportedVersion() const = 0;
 };

--- a/src/framework/musesampler/internal/musesamplerconfiguration.cpp
+++ b/src/framework/musesampler/internal/musesamplerconfiguration.cpp
@@ -34,18 +34,21 @@ static io::path_t DEFAULT_PATH()
 {
     return QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/MuseSampler/lib/" + DEFAULT_LIB_NAME;
 }
+
 #elif defined(Q_OS_MAC)
 static const io::path_t DEFAULT_LIB_NAME("libMuseSamplerCoreLib.dylib");
 static io::path_t DEFAULT_PATH()
 {
     return QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/MuseSampler/lib/" + DEFAULT_LIB_NAME;
 }
+
 #else
 static const io::path_t DEFAULT_LIB_NAME("MuseSamplerCoreLib.dll");
 static io::path_t DEFAULT_PATH()
 {
     return QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "\\MuseSampler\\lib\\" + DEFAULT_LIB_NAME;
 }
+
 #endif
 
 static const std::string MINIMUM_SUPPORTED_VERSION = "0.2.2";
@@ -53,7 +56,7 @@ static const std::string MINIMUM_SUPPORTED_VERSION = "0.2.2";
 // If installed on the system instead of user dir...do this as a backup
 io::path_t MuseSamplerConfiguration::backupLibraryPath() const
 {
-  return DEFAULT_LIB_NAME;
+    return DEFAULT_LIB_NAME;
 }
 
 // Preferred location

--- a/src/framework/musesampler/internal/musesamplerconfiguration.cpp
+++ b/src/framework/musesampler/internal/musesamplerconfiguration.cpp
@@ -23,27 +23,48 @@
 #include "musesamplerconfiguration.h"
 
 #include <cstdlib>
+#include <QStandardPaths>
 
 using namespace mu;
 using namespace mu::musesampler;
 
 #if defined(Q_OS_LINUX)
-static const io::path_t DEFAULT_PATH("libMuseSamplerCoreLib.so");
+static const io::path_t DEFAULT_LIB_NAME("libMuseSamplerCoreLib.so");
+static io::path_t DEFAULT_PATH()
+{
+    return QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/MuseSampler/lib/" + DEFAULT_LIB_NAME;
+}
 #elif defined(Q_OS_MAC)
-static const io::path_t DEFAULT_PATH("/usr/local/lib/libMuseSamplerCoreLib.dylib");
+static const io::path_t DEFAULT_LIB_NAME("libMuseSamplerCoreLib.dylib");
+static io::path_t DEFAULT_PATH()
+{
+    return QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/MuseSampler/lib/" + DEFAULT_LIB_NAME;
+}
 #else
-static const io::path_t DEFAULT_PATH("MuseSamplerCoreLib.dll");
+static const io::path_t DEFAULT_LIB_NAME("MuseSamplerCoreLib.dll");
+static io::path_t DEFAULT_PATH()
+{
+    return QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "\\MuseSampler\\lib\\" + DEFAULT_LIB_NAME;
+}
 #endif
 
 static const std::string MINIMUM_SUPPORTED_VERSION = "0.2.2";
 
-io::path_t MuseSamplerConfiguration::libraryPath() const
+// If installed on the system instead of user dir...do this as a backup
+io::path_t MuseSamplerConfiguration::backupLibraryPath() const
 {
+  return DEFAULT_LIB_NAME;
+}
+
+// Preferred location
+io::path_t MuseSamplerConfiguration::userLibraryPath() const
+{
+    // Override for testing/dev:
     if (const char* path = std::getenv("MUSESAMPLER_PATH")) {
         return io::path_t(path);
     }
 
-    return DEFAULT_PATH;
+    return DEFAULT_PATH();
 }
 
 std::string MuseSamplerConfiguration::minimumSupportedVersion() const

--- a/src/framework/musesampler/internal/musesamplerconfiguration.h
+++ b/src/framework/musesampler/internal/musesamplerconfiguration.h
@@ -33,7 +33,10 @@ class MuseSamplerConfiguration : public IMuseSamplerConfiguration
 {
     INJECT(musesampler, framework::IGlobalConfiguration, globalConfig)
 public:
-    io::path_t libraryPath() const override;
+    // Backup location for system-wide sampler install
+    io::path_t backupLibraryPath() const override;
+    // Preferred local user install path; try this first.
+    io::path_t userLibraryPath() const override;
 
     std::string minimumSupportedVersion() const override;
 };

--- a/src/framework/musesampler/internal/musesamplerresolver.cpp
+++ b/src/framework/musesampler/internal/musesamplerresolver.cpp
@@ -37,10 +37,15 @@ using namespace mu::framework;
 
 void MuseSamplerResolver::init()
 {
-    io::path_t path = configuration()->libraryPath();
-
+    io::path_t path = configuration()->userLibraryPath();
     m_libHandler = std::make_shared<MuseSamplerLibHandler>(path);
+    if (checkLibrary()) {
+      return;
+    }
 
+    // Use fallback
+    path = configuration()->backupLibraryPath();
+    m_libHandler = std::make_shared<MuseSamplerLibHandler>(path);
     if (!checkLibrary()) {
         m_libHandler.reset();
     }

--- a/src/framework/musesampler/internal/musesamplerresolver.cpp
+++ b/src/framework/musesampler/internal/musesamplerresolver.cpp
@@ -40,7 +40,7 @@ void MuseSamplerResolver::init()
     io::path_t path = configuration()->userLibraryPath();
     m_libHandler = std::make_shared<MuseSamplerLibHandler>(path);
     if (checkLibrary()) {
-      return;
+        return;
     }
 
     // Use fallback


### PR DESCRIPTION
The MuseSampler library should be able to be loaded from per-user, non-admin privilege directories.  (This will be the preferred install location for future versions of Muse Hub, to reduce dependence on administrative privileges).

This PR attempts to load the sampler first from the specified user directory per platform:
macOS: `~/Library/Application Support/MuseSampler/lib`
linux: `~/.local/share/MuseSampler/lib`
windows: `<userhome>\AppData\Local\MuseSampler\lib`

The fallback is to the current system-wide location, per current behavior.  Other questions noted inline.