### PR TITLE
fixed #14599: Crash when doing "Repeat selection" with 256th notes or shorter. 4.0.2

### DIFF
--- a/src/engraving/libmscore/paste.cpp
+++ b/src/engraving/libmscore/paste.cpp
@@ -129,8 +129,8 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fractio
                 break;
             }
         }
-        Fraction tickStart = Fraction::fromTicks(e.intAttribute("tick", 0));
-        tickLen       =  Fraction::fromTicks(e.intAttribute("len", 0));
+        Fraction tickStart = Fraction::fromString(e.attribute("tick"));
+        tickLen       =  Fraction::fromString(e.attribute("len"));
         Fraction oTickLen =  tickLen;
         tickLen       *= scale;
         int staffStart    = e.intAttribute("staff", 0);
@@ -1083,8 +1083,8 @@ static bool canPasteStaff(XmlReader& reader, const Fraction& scale)
     if (scale != Fraction(1, 1)) {
         while (reader.readNext() && reader.tokenType() != XmlReader::TokenType::EndDocument) {
             AsciiStringView tag(reader.name());
-            int len = reader.intAttribute("len", 0);
-            if (len && !TDuration(Fraction::fromTicks(len) * scale).isValid()) {
+            Fraction len = Fraction::fromString(reader.attribute("len"));
+            if (!len.isZero() && !TDuration(len * scale).isValid()) {
                 return false;
             }
             if (tag == "durationType") {

--- a/src/engraving/libmscore/select.cpp
+++ b/src/engraving/libmscore/select.cpp
@@ -840,8 +840,8 @@ ByteArray Selection::staffMimeData() const
     int staves = static_cast<int>(staffEnd() - staffStart());
 
     xml.startElement("StaffList", { { "version", (MScore::testMode ? "2.00" : MSC_VERSION) },
-                         { "tick", tickStart().ticks() },
-                         { "len", ticks.ticks() },
+                         { "tick", tickStart().toString() },
+                         { "len", ticks.toString() },
                          { "staff", staffStart() },
                          { "staves", staves } });
 

--- a/src/engraving/utests/selectionfilter_data/selectionfilter1-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter1-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter1-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter1-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter10-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter10-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter10-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter10-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter11-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter11-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter11-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter11-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter12-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter12-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter12-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter12-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter13-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter13-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter13-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter13-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter14-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter14-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter14-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter14-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter15-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter15-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="3840" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="8/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter15-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter15-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="3840" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="8/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter16-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter16-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter16-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter16-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter17-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter17-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter17-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter17-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="1">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter18-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter18-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter18-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter18-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter19-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter19-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter19-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter19-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter2-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter2-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter2-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter2-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter20-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter20-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter20-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter20-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter22-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter22-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter22-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter22-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter23-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter23-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter23-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter23-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter3-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter3-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter3-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter3-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter4-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter4-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter4-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter4-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter5-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter5-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter5-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter5-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter6-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter6-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter6-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter6-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter7-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter7-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter7-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter7-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter8-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter8-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter8-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter8-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter9-base-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter9-base-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>

--- a/src/engraving/utests/selectionfilter_data/selectionfilter9-ref.xml
+++ b/src/engraving/utests/selectionfilter_data/selectionfilter9-ref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StaffList version="2.00" tick="0" len="1920" staff="0" staves="1">
+<StaffList version="2.00" tick="0/1" len="4/4" staff="0" staves="1">
   <Staff id="0">
     <voiceOffset>
       <voice id="0">0</voice>


### PR DESCRIPTION
see https://github.com/musescore/MuseScore/pull/16254