### PR TITLE
Correct kerning rules for ChordLines

### DIFF
--- a/src/engraving/libmscore/chordline.cpp
+++ b/src/engraving/libmscore/chordline.cpp
@@ -62,6 +62,14 @@ ChordLine::ChordLine(const ChordLine& cl)
     _note = cl._note;
 }
 
+KerningType ChordLine::doComputeKerningType(const EngravingItem* nextItem) const
+{
+    if (nextItem->isBarLine()) {
+        return KerningType::ALLOW_COLLISION;
+    }
+    return KerningType::KERNING;
+}
+
 //---------------------------------------------------------
 //   setChordLineType
 //---------------------------------------------------------

--- a/src/engraving/libmscore/chordline.h
+++ b/src/engraving/libmscore/chordline.h
@@ -63,6 +63,8 @@ private:
     ChordLine(const ChordLine&);
 
     bool sameVoiceKerningLimited() const override { return true; }
+    bool alwaysKernable() const override { return true; }
+    KerningType doComputeKerningType(const EngravingItem* nextItem) const override;
 
 public:
 


### PR DESCRIPTION
Resolves: #16247

Just a matter of defining the appropriate kerning/collision rule for the ChordLine objects.