### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/tests/pitchwheelrender_tests.cpp
+++ b/src/engraving/tests/pitchwheelrender_tests.cpp
@@ -59,7 +59,7 @@ TEST_F(PitchWheelRender_Tests, simpleLinear)
     auto linearFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
         float x = (float)(tick - startTick);
         float y = a * x + b;
-        return y;
+        return (int)y;
     };
     func.func = linearFunc;
     render.addPitchWheelFunction(func, 0);
@@ -88,7 +88,7 @@ TEST_F(PitchWheelRender_Tests, twoReverseFunctions)
     auto linearFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
         float x = (float)(tick - startTick);
         float y = a * x + b;
-        return y;
+        return (int)y;
     };
     func.func = linearFunc;
     render.addPitchWheelFunction(func, 0);
@@ -96,7 +96,7 @@ TEST_F(PitchWheelRender_Tests, twoReverseFunctions)
     auto reverseLinearFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
         float x = (float)(tick - startTick);
         float y = -1 * a * x + b;
-        return y;
+        return (int)y;
     };
     func.func = reverseLinearFunc;
     render.addPitchWheelFunction(func, 0);
@@ -120,7 +120,7 @@ TEST_F(PitchWheelRender_Tests, channelTest)
     auto linearFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
         float x = (float)(tick - startTick);
         float y = a * x + b;
-        return y;
+        return (int)y;
     };
     func.func = linearFunc;
     render.addPitchWheelFunction(func, 0);
@@ -153,7 +153,7 @@ TEST_F(PitchWheelRender_Tests, twoConnectedFunctions)
         auto firstFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
             float x = (float)(tick - startTick);
             float y = a * x + b;
-            return y;
+            return (int)y;
         };
         func.func = firstFunc;
         render.addPitchWheelFunction(func, 0);
@@ -170,7 +170,7 @@ TEST_F(PitchWheelRender_Tests, twoConnectedFunctions)
         auto secondFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
             float x = (float)(tick - startTick);
             float y = a * x + b;
-            return y;
+            return (int)y;
         };
         func.func = secondFunc;
         render.addPitchWheelFunction(func, 0);
@@ -201,7 +201,7 @@ TEST_F(PitchWheelRender_Tests, twoDevidedFunctions)
         auto firstFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
             float x = (float)(tick - startTick);
             float y = a * x + b;
-            return y;
+            return (int)y;
         };
         func.func = firstFunc;
         render.addPitchWheelFunction(func, 0);
@@ -218,7 +218,7 @@ TEST_F(PitchWheelRender_Tests, twoDevidedFunctions)
         auto secondFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
             float x = (float)(tick - startTick);
             float y = a * x + b;
-            return y;
+            return (int)y;
         };
         func.func = secondFunc;
         render.addPitchWheelFunction(func, 0);
@@ -251,7 +251,7 @@ TEST_F(PitchWheelRender_Tests, twoOverlappedFunctions)
         auto firstFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
             float x = (float)(tick - startTick);
             float y = a * x + b;
-            return y;
+            return (int)y;
         };
         func.func = firstFunc;
         render.addPitchWheelFunction(func, 0);
@@ -268,7 +268,7 @@ TEST_F(PitchWheelRender_Tests, twoOverlappedFunctions)
         auto secondFunc = [ startTick = func.mStartTick, a, b] (uint32_t tick) {
             float x = (float)(tick - startTick);
             float y = a * x + b;
-            return y;
+            return (int)y;
         };
         func.func = secondFunc;
         render.addPitchWheelFunction(func, 0);

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1470,16 +1470,12 @@ void GPConverter::addInstrumentChanges()
 
 void GPConverter::addSoundEffects(const SLine* const elem)
 {
-    track_idx_t track = elem->track();
     EngravingItem* startEl = elem->startElement();
     EngravingItem* endEl = elem->endElement();
 
     if (!startEl->isChordRest() || !endEl->isChordRest()) {
         return;
     }
-
-    ChordRest* startCR = toChordRest(startEl);
-    ChordRest* endCR = toChordRest(endEl);
 
     if (elem->isPalmMute()) {
         Fraction begTick = elem->tick();

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -2402,6 +2402,7 @@ void GPConverter::addOttava(const GPBeat* gpb, ChordRest* cr)
 
 void GPConverter::addLetRing(const GPNote* gpnote, Note* note)
 {
+    UNUSED(note);
     if (gpnote->letRing() && m_currentGPBeat) {
         m_currentGPBeat->setLetRing(true);
     }


### PR DESCRIPTION
* reg. conversion from 'float' to '_Rx', possible loss of data (C4244)
* reg. unreferenced formal parameter (C4100)
* reg. local variable is initialized but not referenced (C4189)