### PR TITLE
fix Da (Double) Coda is a Marker, not a Jump

### DIFF
--- a/src/engraving/libmscore/jump.cpp
+++ b/src/engraving/libmscore/jump.cpp
@@ -61,8 +61,6 @@ const std::vector<JumpTypeTableItem> jumpTypeTable {
     { JumpType::DSS_AL_CODA,    "D.S.S. al Coda",        "varsegno", "coda",  "codab" },
     { JumpType::DSS_AL_DBLCODA, "D.S.S. al Double Coda", "varsegno", "varcoda", "codab" },
     { JumpType::DSS_AL_FINE,    "D.S.S. al Fine",        "varsegno", "fine",  "" },
-    { JumpType::DCODA,          "Da Coda",               "coda", "end",  "" },
-    { JumpType::DDBLCODA,       "Da Double Coda",        "varcoda", "end",  "" }
 };
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/marker.cpp
+++ b/src/engraving/libmscore/marker.cpp
@@ -113,6 +113,18 @@ void Marker::setMarkerType(MarkerType t)
         setLabel(u"coda");
         break;
 
+    case MarkerType::DA_CODA:
+        txt = "Da Coda";
+        initTextStyleType(TextStyleType::REPEAT_RIGHT, true);
+        setLabel(u"coda");
+        break;
+
+    case MarkerType::DA_DBLCODA:
+        txt = "Da Double Coda";
+        initTextStyleType(TextStyleType::REPEAT_RIGHT, true);
+        setLabel(u"coda");
+        break;
+
     case MarkerType::USER:
         break;
 

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -855,8 +855,6 @@ enum class JumpType : char {
     DSS_AL_CODA,
     DSS_AL_DBLCODA,
     DSS_AL_FINE,
-    DCODA,
-    DDBLCODA,
     USER
 };
 
@@ -869,6 +867,8 @@ enum class MarkerType : char {
     FINE,
     TOCODA,
     TOCODASYM,
+    DA_CODA,
+    DA_DBLCODA,
     USER
 };
 

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -2220,8 +2220,6 @@ static const std::vector<Item<JumpType> > JUMP_TYPES = {
     { JumpType::DSS_AL_CODA,    "", TranslatableString("engraving", "Dal Segno Segno al Coda") },
     { JumpType::DSS_AL_DBLCODA, "", TranslatableString("engraving", "Dal Segno Segno al Double Coda") },
     { JumpType::DSS_AL_FINE,    "", TranslatableString("engraving", "Dal Segno Segno al Fine") },
-    { JumpType::DCODA,          "", TranslatableString("engraving", "Da Coda") },
-    { JumpType::DDBLCODA,       "", TranslatableString("engraving", "Da Double Coda") },
 
     { JumpType::USER,           "", TranslatableString("engraving", "Custom") }
 };
@@ -2236,7 +2234,7 @@ String TConv::translatedUserName(JumpType v)
     return findUserNameByType<JumpType>(JUMP_TYPES, v).translated();
 }
 
-static const std::array<Item<MarkerType>, 9> MARKER_TYPES = { {
+static const std::array<Item<MarkerType>, 11> MARKER_TYPES = { {
     { MarkerType::SEGNO,        "segno",    TranslatableString("engraving", "Segno") },
     { MarkerType::VARSEGNO,     "varsegno", TranslatableString("engraving", "Segno variation") },
     { MarkerType::CODA,         "codab",    TranslatableString("engraving", "Coda") },
@@ -2245,6 +2243,8 @@ static const std::array<Item<MarkerType>, 9> MARKER_TYPES = { {
     { MarkerType::FINE,         "fine",     TranslatableString("engraving", "Fine") },
     { MarkerType::TOCODA,       "coda",     TranslatableString("engraving", "To coda") },
     { MarkerType::TOCODASYM,    "",         TranslatableString("engraving", "To coda (symbol)") },
+    { MarkerType::DA_CODA,      "",         TranslatableString("engraving", "Da Coda") },
+    { MarkerType::DA_DBLCODA,   "",         TranslatableString("engraving", "Da Double Coda") },
     { MarkerType::USER,         "",         TranslatableString("engraving", "Custom") }
 } };
 

--- a/src/importexport/braille/internal/exportbraille.cpp
+++ b/src/importexport/braille/internal/exportbraille.cpp
@@ -2473,6 +2473,8 @@ QString ExportBrailleImpl::brailleMarker(Marker* marker)
         return BRAILLE_FINE;
     case MarkerType::TOCODA:
     case MarkerType::TOCODASYM:
+    case MarkerType::DA_CODA:
+    case MarkerType::DA_DBLCODA:
         return BRAILLE_TOCODA;
     case MarkerType::USER:
         return QString(">") + TextToUEBBraille().braille(marker->plainText().toQString().toLower()) + QString("> ");
@@ -2503,8 +2505,6 @@ QString ExportBrailleImpl::brailleJump(Jump* jump)
     case JumpType::DSS_AL_CODA:
     case JumpType::DSS_AL_DBLCODA:
     case JumpType::DSS_AL_FINE:
-    case JumpType::DCODA:
-    case JumpType::DDBLCODA:
         break;
     }
     return QString();

--- a/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
@@ -1382,6 +1382,11 @@ std::vector<GPMasterBar::Direction> GP67DomBuilder::readRepeatsJumps(XmlDomNode*
         repeatJump.type = (innerNode.nodeName() == "Jump" ? GPMasterBar::Direction::Type::Jump : GPMasterBar::Direction::Type::Repeat);
         repeatJump.name = innerNode.toElement().text();
 
+        // GP encodes "To Coda" instructions as Jumps, but MuseScore uses Markers for that
+        if ((repeatJump.name == u"DaCoda") || (repeatJump.name == u"DaDoubleCoda")) {
+            repeatJump.type = GPMasterBar::Direction::Type::Marker;
+        }
+
         repeatsJumps.push_back(repeatJump);
         innerNode = innerNode.nextSibling();
     }

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -83,9 +83,6 @@ static JumpType jumpType(const String& typeString)
         { u"DaSegnoSegnoAlCoda", JumpType::DSS_AL_CODA },
         { u"DaSegnoSegnoAlDoubleCoda", JumpType::DSS_AL_DBLCODA },
         { u"DaSegnoSegnoAlFine", JumpType::DSS_AL_FINE },
-        { u"DaCoda", JumpType::DCODA },
-        { u"DaDoubleCoda", JumpType::DDBLCODA },
-        { u"DaCoda", JumpType::DCODA },
     };
 
     if (types.find(typeString) != types.end()) {

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -100,7 +100,9 @@ static MarkerType markerType(const String& typeString)
         { u"SegnoSegno", MarkerType::VARSEGNO },
         { u"Coda", MarkerType::CODA },
         { u"DoubleCoda", MarkerType::VARCODA },
-        { u"Fine", MarkerType::FINE }
+        { u"Fine", MarkerType::FINE },
+        { u"DaCoda", MarkerType::DA_CODA },
+        { u"DaDoubleCoda", MarkerType::DA_DBLCODA },
     };
 
     if (types.find(typeString) != types.end()) {

--- a/src/importexport/guitarpro/internal/gtp/gpmasterbar.h
+++ b/src/importexport/guitarpro/internal/gtp/gpmasterbar.h
@@ -51,7 +51,7 @@ public:
 
     struct Direction {
         enum class Type {
-            Repeat, Jump
+            Repeat, Jump, Marker
         };
 
         Type type = Type::Repeat;

--- a/src/importexport/guitarpro/tests/data/directions.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/directions.gp-ref.mscx
@@ -432,13 +432,11 @@
           </voice>
         </Measure>
       <Measure>
-        <Jump>
+        <Marker>
           <style>repeat_right</style>
           <text>Da Coda</text>
-          <jumpTo>coda</jumpTo>
-          <playUntil>end</playUntil>
-          <continueAt></continueAt>
-          </Jump>
+          <label>coda</label>
+          </Marker>
         <voice>
           <Rest>
             <durationType>measure</durationType>
@@ -454,13 +452,11 @@
           </voice>
         </Measure>
       <Measure>
-        <Jump>
+        <Marker>
           <style>repeat_right</style>
           <text>Da Double Coda</text>
-          <jumpTo>varcoda</jumpTo>
-          <playUntil>end</playUntil>
-          <continueAt></continueAt>
-          </Jump>
+          <label>coda</label>
+          </Marker>
         <voice>
           <Rest>
             <durationType>measure</durationType>

--- a/src/importexport/guitarpro/tests/data/directions.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/directions.gpx-ref.mscx
@@ -432,13 +432,11 @@
           </voice>
         </Measure>
       <Measure>
-        <Jump>
+        <Marker>
           <style>repeat_right</style>
           <text>Da Coda</text>
-          <jumpTo>coda</jumpTo>
-          <playUntil>end</playUntil>
-          <continueAt></continueAt>
-          </Jump>
+          <label>coda</label>
+          </Marker>
         <voice>
           <Rest>
             <durationType>measure</durationType>
@@ -454,13 +452,11 @@
           </voice>
         </Measure>
       <Measure>
-        <Jump>
+        <Marker>
           <style>repeat_right</style>
           <text>Da Double Coda</text>
-          <jumpTo>varcoda</jumpTo>
-          <playUntil>end</playUntil>
-          <continueAt></continueAt>
-          </Jump>
+          <label>coda</label>
+          </Marker>
         <voice>
           <Rest>
             <durationType>measure</durationType>

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -5313,7 +5313,9 @@ static void directionMarker(XmlWriter& xml, const Marker* const m, const std::ve
         sound = u"fine=\"yes\"";
         break;
     case MarkerType::TOCODA:
-    case MarkerType::TOCODASYM: {
+    case MarkerType::TOCODASYM:
+    case MarkerType::DA_CODA:
+    case MarkerType::DA_DBLCODA: {
         if (m->xmlText() == "") {
             words = "To Coda";
         } else {
@@ -5413,6 +5415,8 @@ void ExportMusicXml::repeatAtMeasureStart(Attributes& attr, const Measure* const
             case MarkerType::FINE:
             case MarkerType::TOCODA:
             case MarkerType::TOCODASYM:
+            case MarkerType::DA_CODA:
+            case MarkerType::DA_DBLCODA:
                 // ignore
                 break;
             case MarkerType::USER:
@@ -5454,6 +5458,8 @@ void ExportMusicXml::repeatAtMeasureStop(const Measure* const m, track_idx_t str
             case MarkerType::FINE:
             case MarkerType::TOCODA:
             case MarkerType::TOCODASYM:
+            case MarkerType::DA_CODA:
+            case MarkerType::DA_DBLCODA:
                 directionMarker(_xml, mk, _jumpElements);
                 break;
             case MarkerType::SEGNO:

--- a/src/notation/view/widgets/timeline.cpp
+++ b/src/notation/view/widgets/timeline.cpp
@@ -1460,7 +1460,10 @@ void Timeline::jumpMarkerMeta(Segment* seg, int* stagger, int pos)
         measure = marker->measure();
         if (marker->markerType() == MarkerType::FINE
             || marker->markerType() == MarkerType::TOCODA
-            || marker->markerType() == MarkerType::TOCODASYM) {
+            || marker->markerType() == MarkerType::TOCODASYM
+            || marker->markerType() == MarkerType::DA_CODA
+            || marker->markerType() == MarkerType::DA_DBLCODA
+            ) {
             elementType = ElementType::MARKER;
             std::get<2>(_repeatInfo) = std::get<3>(_repeatInfo);
             std::get<3>(_repeatInfo) = nullptr;

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -412,6 +412,8 @@ PalettePtr PaletteCreator::newRepeatsPalette(bool defaultPalette)
         MarkerType::FINE,
         MarkerType::TOCODA,
         MarkerType::TOCODASYM,
+        MarkerType::DA_CODA,
+        MarkerType::DA_DBLCODA,
         MarkerType::USER
     };
 


### PR DESCRIPTION
Resolves: #16294<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

Moved the "Da (Double) Coda" elements from Jumps to Markers.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [N/A] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
