### PR TITLE
Fix #13600: Add roles for description so this can be accessed without…

### DIFF
--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsOnScoreView.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsOnScoreView.qml
@@ -154,6 +154,7 @@ Item {
             navigation.row: 1 + model.index
             navigation.column: 0
             navigation.accessible.name: itemTitleLabel.text
+            navigation.accessible.description: model.description
 
             StyledTextLabel {
                 id: itemTitleLabel

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsView.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsView.qml
@@ -109,6 +109,7 @@ Item {
             navigation.panel: navPanel
             navigation.row: 2 + model.index
             navigation.accessible.name: itemTitleLabel.text
+            navigation.accessible.description: model.description
 
             onNavigationTriggered: {
                 root.addSelectedInstrumentsToScoreRequested()

--- a/src/instrumentsscene/view/instrumentlistmodel.cpp
+++ b/src/instrumentsscene/view/instrumentlistmodel.cpp
@@ -62,6 +62,8 @@ QVariant InstrumentListModel::data(const QModelIndex& index, int role) const
     switch (role) {
     case RoleName:
         return instrument.name;
+    case RoleDescription:
+        return instrument.templates[instrument.currentTemplateIndex]->description.toQString();
     case RoleTraits: {
         QStringList traits;
         for (const InstrumentTemplate* templ : instrument.templates) {
@@ -89,6 +91,7 @@ bool InstrumentListModel::setData(const QModelIndex& index, const QVariant& valu
 
     switch (role) {
     case RoleName:
+    case RoleDescription:
     case RoleTraits:
     case RoleIsSelected:
         break;
@@ -112,6 +115,7 @@ QHash<int, QByteArray> InstrumentListModel::roleNames() const
 {
     static const QHash<int, QByteArray> roles {
         { RoleName, "name" },
+        { RoleDescription, "description" },
         { RoleIsSelected, "isSelected" },
         { RoleTraits, "traits" },
         { RoleCurrentTraitIndex, "currentTraitIndex" }

--- a/src/instrumentsscene/view/instrumentlistmodel.h
+++ b/src/instrumentsscene/view/instrumentlistmodel.h
@@ -90,6 +90,7 @@ signals:
 private:
     enum Roles {
         RoleName = Qt::UserRole + 1,
+        RoleDescription,
         RoleIsSelected,
         RoleTraits,
         RoleCurrentTraitIndex

--- a/src/instrumentsscene/view/instrumentsonscorelistmodel.cpp
+++ b/src/instrumentsscene/view/instrumentsonscorelistmodel.cpp
@@ -65,6 +65,8 @@ QVariant InstrumentsOnScoreListModel::data(const QModelIndex& index, int role) c
     switch (role) {
     case RoleName:
         return instrument->name;
+    case RoleDescription:
+        return instrument->instrumentTemplate.description.toQString();
     case RoleIsSoloist:
         return instrument->isSoloist;
     default:
@@ -93,6 +95,7 @@ bool InstrumentsOnScoreListModel::setData(const QModelIndex& index, const QVaria
         verifyScoreOrder();
         return true;
     case RoleName:
+    case RoleDescription:
         break;
     default:
         return SelectableItemListModel::setData(index, role);
@@ -105,6 +108,7 @@ QHash<int, QByteArray> InstrumentsOnScoreListModel::roleNames() const
 {
     QHash<int, QByteArray> roles = SelectableItemListModel::roleNames();
     roles[RoleName] = "name";
+    roles[RoleDescription] = "description";
     roles[RoleIsSoloist] = "isSoloist";
 
     return roles;

--- a/src/instrumentsscene/view/instrumentsonscorelistmodel.h
+++ b/src/instrumentsscene/view/instrumentsonscorelistmodel.h
@@ -67,6 +67,7 @@ private:
 
     enum Roles {
         RoleName = SelectableItemListModel::UserRole + 1,
+        RoleDescription,
         RoleIsSoloist
     };
 


### PR DESCRIPTION
… selecting the instrument in qml

Resolves: #13600

Added Roles to access instrument description from qml in InstrumentListModel and InstrumentOnScoreModel.  Screenreader now reads out the description after the name upon navigation.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
