### PR TITLE
Some cleanup regarding strings and unicode surrogates, fixing exceptions in debug mode on macOS

### DIFF
--- a/src/engraving/internal/engravingfont.cpp
+++ b/src/engraving/internal/engravingfont.cpp
@@ -541,14 +541,9 @@ SymId EngravingFont::fromCode(char32_t code) const
     return static_cast<SymId>(it == m_symbols.end() ? 0 : it - m_symbols.begin());
 }
 
-static String codeToString(char32_t code)
-{
-    return String::fromUcs4(&code, 1);
-}
-
 String EngravingFont::toString(SymId id) const
 {
-    return codeToString(symCode(id));
+    return String::fromUcs4(symCode(id));
 }
 
 bool EngravingFont::isValid(SymId id) const

--- a/src/engraving/libmscore/chordlist.cpp
+++ b/src/engraving/libmscore/chordlist.cpp
@@ -1683,22 +1683,20 @@ void ChordList::read(XmlReader& e)
             while (e.readNextStartElement()) {
                 if (e.name() == "sym") {
                     ChordSymbol cs;
-                    String code;
-                    String symClass;
                     cs.fontIdx = fontIdx;
                     cs.name    = e.attribute("name");
                     cs.value   = e.attribute("value");
-                    code       = e.attribute("code");
-                    symClass   = e.attribute("class");
-                    if (code != "") {
+                    String code = e.attribute("code");
+                    String symClass = e.attribute("class");
+                    if (!code.empty()) {
                         bool ok = true;
                         char32_t val = code.toUInt(&ok, 0);
                         if (!ok) {
                             cs.code = 0;
                             cs.value = code;
-                        } else if (val & 0xffff0000) {
+                        } else if (Char::requiresSurrogates(val)) {
                             cs.code = 0;
-                            cs.value = String::fromUcs4(&val, 1);
+                            cs.value = String::fromUcs4(val);
                         } else {
                             cs.code = val;
                             cs.value = String(cs.code);
@@ -1706,7 +1704,7 @@ void ChordList::read(XmlReader& e)
                     } else {
                         cs.code = 0;
                     }
-                    if (cs.value == "") {
+                    if (cs.value.empty()) {
                         cs.value = cs.name;
                     }
                     cs.name = symClass + cs.name;

--- a/src/engraving/libmscore/chordlist.cpp
+++ b/src/engraving/libmscore/chordlist.cpp
@@ -1692,15 +1692,13 @@ void ChordList::read(XmlReader& e)
                     symClass   = e.attribute("class");
                     if (code != "") {
                         bool ok = true;
-                        int val = code.toInt(&ok, 0);
+                        char32_t val = code.toUInt(&ok, 0);
                         if (!ok) {
                             cs.code = 0;
                             cs.value = code;
                         } else if (val & 0xffff0000) {
                             cs.code = 0;
-                            Char high = Char::highSurrogate(val);
-                            Char low = Char::lowSurrogate(val);
-                            cs.value = String(u"%1%2").arg(high, low);
+                            cs.value = String::fromUcs4(&val, 1);
                         } else {
                             cs.code = val;
                             cs.value = String(cs.code);

--- a/src/engraving/libmscore/symbol.cpp
+++ b/src/engraving/libmscore/symbol.cpp
@@ -240,13 +240,7 @@ FSymbol::FSymbol(const FSymbol& s)
 
 String FSymbol::toString() const
 {
-    if (_code & 0xffff0000) {
-        String s;
-        s = Char(Char::highSurrogate(_code));
-        s += Char(Char::lowSurrogate(_code));
-        return s;
-    }
-    return Char(_code);
+    return String::fromUcs4(_code);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/symbol.h
+++ b/src/engraving/libmscore/symbol.h
@@ -89,7 +89,7 @@ class FSymbol final : public BSymbol
     OBJECT_ALLOCATOR(engraving, FSymbol)
 
     mu::draw::Font _font;
-    int _code; // character code point (Unicode)
+    char32_t _code; // character code point (Unicode)
 
 public:
     FSymbol(EngravingItem* parent);
@@ -108,9 +108,9 @@ public:
     double baseLine() const override { return 0.0; }
     Segment* segment() const { return (Segment*)explicitParent(); }
     mu::draw::Font font() const { return _font; }
-    int code() const { return _code; }
+    char32_t code() const { return _code; }
     void setFont(const mu::draw::Font& f);
-    void setCode(int val) { _code = val; }
+    void setCode(char32_t val) { _code = val; }
 };
 } // namespace mu::engraving
 #endif

--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -1230,8 +1230,7 @@ String TextBlock::remove(int column, TextCursor* cursor)
     int col = 0;
     String s;
     for (auto it = _fragments.begin(); it != _fragments.end(); ++it) {
-        int idx  = 0;
-        int rcol = 0;
+        size_t idx = 0;
 
         for (size_t i = 0; i < it->text.size(); ++i) {
             if (col == column) {
@@ -1254,7 +1253,6 @@ String TextBlock::remove(int column, TextCursor* cursor)
                 continue;
             }
             ++col;
-            ++rcol;
         }
     }
     insertEmptyFragmentIfNeeded(cursor);   // without this, cursorRect can't calculate the y position of the cursor correctly
@@ -1298,7 +1296,6 @@ String TextBlock::remove(int start, int n, TextCursor* cursor)
     int col = 0;
     String s;
     for (auto i = _fragments.begin(); i != _fragments.end();) {
-        int rcol = 0;
         bool inc = true;
         for (size_t idx = 0; idx < i->text.size();) {
             Char c = i->text.at(idx);
@@ -1326,7 +1323,6 @@ String TextBlock::remove(int start, int n, TextCursor* cursor)
                 continue;
             }
             ++col;
-            ++rcol;
         }
         if (inc) {
             ++i;
@@ -1639,12 +1635,7 @@ void TextBase::insert(TextCursor* cursor, char32_t code)
         code = ' ';
     }
 
-    String s;
-    if (Char::requiresSurrogates(code)) {
-        s = String(Char(Char::highSurrogate(code))).append(Char(Char::lowSurrogate(code)));
-    } else {
-        s = String::fromUcs4(&code, 1);
-    }
+    String s = String::fromUcs4(code);
 
     if (cursor->row() < rows()) {
         _layout[cursor->row()].insert(cursor, s);

--- a/src/engraving/libmscore/textedit.cpp
+++ b/src/engraving/libmscore/textedit.cpp
@@ -810,8 +810,7 @@ EngravingItem* TextBase::drop(EditData& ed)
 
     case ElementType::FSYMBOL:
     {
-        char32_t code = static_cast<char32_t>(toFSymbol(e)->code());
-        String s = String::fromUcs4(&code, 1);
+        String s = toFSymbol(e)->toString();
         delete e;
 
         deleteSelectedText(ed);
@@ -863,9 +862,9 @@ void TextBase::paste(EditData& ed, const String& txt)
                         assert(i + 1 < txt.size());
                         i++;
                         Char lowSurrogate = txt.at(i);
-                        insertText(ed, String(Char::surrogateToUcs4(highSurrogate, lowSurrogate)));
+                        insertText(ed, String::fromUcs4(Char::surrogateToUcs4(highSurrogate, lowSurrogate)));
                     } else {
-                        insertText(ed, String(Char(c.unicode())));
+                        insertText(ed, String(c));
                     }
                 }
             }
@@ -932,7 +931,7 @@ void TextBase::endHexState(EditData& ed)
             TextBlock& t = _layout[cursor->row()];
             String ss   = t.remove(static_cast<int>(c1), hexState + 1, cursor);
             bool ok;
-            int code     = ss.mid(1).toInt(&ok, 16);
+            char16_t code = ss.mid(1).toInt(&ok, 16);
             cursor->setColumn(c1);
             cursor->clearSelection();
             if (ok) {

--- a/src/framework/global/types/string.cpp
+++ b/src/framework/global/types/string.cpp
@@ -285,6 +285,39 @@ const std::u16string& String::constStr() const
     return *m_data.get();
 }
 
+struct String::Mutator {
+    std::u16string& s;
+    String* self = nullptr;
+
+    Mutator(std::u16string& s, String* self)
+        : s(s), self(self) {}
+    ~Mutator()
+    {
+#ifdef STRING_DEBUG_HACK
+        self->updateDebugView();
+#endif
+    }
+
+    operator std::u16string& () {
+        return s;
+    }
+
+    void reserve(size_t n) { s.reserve(n); }
+    void resize(size_t n) { s.resize(n); }
+    void clear() { s.clear(); }
+    void insert(size_t p, const std::u16string& v) { s.insert(p, v); }
+    void erase(size_t p, size_t n) { s.erase(p, n); }
+
+    std::u16string& operator=(const std::u16string& v) { return s.operator=(v); }
+    std::u16string& operator=(const char16_t* v) { return s.operator=(v); }
+    std::u16string& operator=(const char16_t v) { return s.operator=(v); }
+
+    std::u16string& operator+=(const std::u16string& v) { return s.operator+=(v); }
+    std::u16string& operator+=(const char16_t* v) { return s.operator+=(v); }
+    std::u16string& operator+=(const char16_t v) { return s.operator+=(v); }
+    char16_t& operator[](size_t i) { return s.operator[](i); }
+};
+
 String::Mutator String::mutStr(bool do_detach)
 {
     if (do_detach) {

--- a/src/framework/global/types/string.cpp
+++ b/src/framework/global/types/string.cpp
@@ -486,6 +486,11 @@ String String::fromUcs4(const char32_t* str, size_t size)
     return s;
 }
 
+String String::fromUcs4(char32_t chr)
+{
+    return fromUcs4(&chr, 1);
+}
+
 std::u32string String::toStdU32String() const
 {
     std::string s;

--- a/src/framework/global/types/string.h
+++ b/src/framework/global/types/string.h
@@ -55,12 +55,12 @@ enum SplitBehavior {
 struct AsciiChar
 {
 public:
-    AsciiChar() = default;
-    explicit AsciiChar(char c)
+    constexpr AsciiChar() = default;
+    constexpr explicit AsciiChar(char c)
         : m_ch(c) {}
 
-    inline char ascii() const noexcept { return m_ch; }
-    inline char16_t unicode() const noexcept { return char16_t(m_ch); }
+    constexpr char ascii() const noexcept { return m_ch; }
+    constexpr char16_t unicode() const noexcept { return char16_t(m_ch); }
     inline char toLower() const { return toLower(m_ch); }
     inline char toUpper() const { return toUpper(m_ch); }
 
@@ -96,43 +96,43 @@ public:
         LastValidCodePoint = 0x10ffff
     };
 
-    Char() = default;
-    Char(char16_t c)
+    constexpr Char() = default;
+    constexpr Char(char16_t c)
         : m_ch(c) {}
     Char(AsciiChar c)
         : m_ch(c.unicode()) {}
 
 #ifndef NO_QT_SUPPORT
-    Char(QChar c)
+    constexpr Char(QChar c)
         : m_ch(c.unicode()) {}
-    operator QChar() const {
+    constexpr operator QChar() const {
         return QChar(m_ch);
     }
 #endif
 
-    inline bool operator ==(Char c) const { return m_ch == c.m_ch; }
-    inline bool operator !=(Char c) const { return !operator ==(c); }
-    inline bool operator ==(char16_t c) const { return m_ch == c; }
-    inline bool operator !=(char16_t c) const { return !operator ==(c); }
-    inline bool operator ==(AsciiChar c) const { return m_ch == c.unicode(); }
-    inline bool operator !=(AsciiChar c) const { return !operator ==(c); }
+    constexpr bool operator ==(Char c) const { return m_ch == c.m_ch; }
+    constexpr bool operator !=(Char c) const { return !operator ==(c); }
+    constexpr bool operator ==(char16_t c) const { return m_ch == c; }
+    constexpr bool operator !=(char16_t c) const { return !operator ==(c); }
+    constexpr bool operator ==(AsciiChar c) const { return m_ch == c.unicode(); }
+    constexpr bool operator !=(AsciiChar c) const { return !operator ==(c); }
 
-    inline bool operator >(Char c) const { return m_ch > c.m_ch; }
-    inline bool operator >(char16_t c) const { return m_ch > c; }
-    inline bool operator <(Char c) const { return m_ch < c.m_ch; }
-    inline bool operator <(char16_t c) const { return m_ch < c; }
+    constexpr bool operator >(Char c) const { return m_ch > c.m_ch; }
+    constexpr bool operator >(char16_t c) const { return m_ch > c; }
+    constexpr bool operator <(Char c) const { return m_ch < c.m_ch; }
+    constexpr bool operator <(char16_t c) const { return m_ch < c; }
 
-    inline bool operator >=(Char c) const { return m_ch >= c.m_ch; }
-    inline bool operator >=(char16_t c) const { return m_ch >= c; }
-    inline bool operator <=(Char c) const { return m_ch <= c.m_ch; }
-    inline bool operator <=(char16_t c) const { return m_ch <= c; }
+    constexpr bool operator >=(Char c) const { return m_ch >= c.m_ch; }
+    constexpr bool operator >=(char16_t c) const { return m_ch >= c; }
+    constexpr bool operator <=(Char c) const { return m_ch <= c.m_ch; }
+    constexpr bool operator <=(char16_t c) const { return m_ch <= c; }
 
-    inline char16_t unicode() const { return m_ch; }
+    constexpr char16_t unicode() const { return m_ch; }
 
     inline bool isNull() const { return m_ch == 0; }
 
-    inline bool isAscii() const { return isAscii(m_ch); }
-    static inline bool isAscii(char16_t c) { return c <= 0x7f; }
+    constexpr bool isAscii() const { return isAscii(m_ch); }
+    static constexpr bool isAscii(char16_t c) { return c <= 0x7f; }
     inline char toAscii(bool* ok = nullptr) const { return toAscii(m_ch, ok); }
     static char toAscii(char16_t c, bool* ok = nullptr);
     static inline Char fromAscii(char c) { return static_cast<char16_t>(c); }
@@ -158,14 +158,14 @@ public:
     inline bool isLowSurrogate() const { return isLowSurrogate(m_ch); }
     inline bool isSurrogate() const { return isSurrogate(m_ch); }
 
-    static inline char32_t surrogateToUcs4(char16_t high, char16_t low) { return (char32_t(high) << 10) + low - 0x35fdc00; }
-    static inline char32_t surrogateToUcs4(Char high, Char low) { return surrogateToUcs4(high.m_ch, low.m_ch); }
-    static inline bool isHighSurrogate(char32_t ucs4) { return (ucs4 & 0xfffffc00) == 0xd800; }
-    static inline bool isLowSurrogate(char32_t ucs4) { return (ucs4 & 0xfffffc00) == 0xdc00; }
-    static inline bool isSurrogate(char32_t ucs4) { return ucs4 - 0xd800u < 2048u; }
-    static inline char16_t highSurrogate(char32_t ucs4) { return char16_t((ucs4 >> 10) + 0xd7c0); }
-    static inline char16_t lowSurrogate(char32_t ucs4) { return char16_t(ucs4 % 0x400 + 0xdc00); }
-    static inline bool requiresSurrogates(char32_t ucs4) { return ucs4 >= 0x10000; }
+    static constexpr char32_t surrogateToUcs4(char16_t high, char16_t low) { return (char32_t(high) << 10) + low - 0x35fdc00; }
+    static constexpr char32_t surrogateToUcs4(Char high, Char low) { return surrogateToUcs4(high.m_ch, low.m_ch); }
+    static constexpr bool isHighSurrogate(char32_t ucs4) { return (ucs4 & 0xfffffc00) == 0xd800; }
+    static constexpr bool isLowSurrogate(char32_t ucs4) { return (ucs4 & 0xfffffc00) == 0xdc00; }
+    static constexpr bool isSurrogate(char32_t ucs4) { return ucs4 - 0xd800u < 2048u; }
+    static constexpr char16_t highSurrogate(char32_t ucs4) { return char16_t((ucs4 >> 10) + 0xd7c0); }
+    static constexpr char16_t lowSurrogate(char32_t ucs4) { return char16_t(ucs4 % 0x400 + 0xdc00); }
+    static constexpr bool requiresSurrogates(char32_t ucs4) { return ucs4 >= 0x10000; }
 
 private:
     char16_t m_ch = 0;

--- a/src/framework/global/types/string.h
+++ b/src/framework/global/types/string.h
@@ -339,39 +339,7 @@ public:
     inline size_t hash() const { return std::hash<std::u16string> {}(constStr()); }
 
 private:
-
-    struct Mutator {
-        std::u16string& s;
-        String* self = nullptr;
-        Mutator(std::u16string& s, String* self)
-            : s(s), self(self) {}
-        ~Mutator()
-        {
-#ifdef STRING_DEBUG_HACK
-            self->updateDebugView();
-#endif
-        }
-
-        operator std::u16string& () {
-            return s;
-        }
-
-        void reserve(size_t n) { s.reserve(n); }
-        void resize(size_t n) { s.resize(n); }
-        void clear() { s.clear(); }
-        void insert(size_t p, const std::u16string& v) { s.insert(p, v); }
-        void erase(size_t p, size_t n) { s.erase(p, n); }
-
-        std::u16string& operator=(const std::u16string& v) { return s.operator=(v); }
-        std::u16string& operator=(const char16_t* v) { return s.operator=(v); }
-        std::u16string& operator=(const char16_t v) { return s.operator=(v); }
-
-        std::u16string& operator+=(const std::u16string& v) { return s.operator+=(v); }
-        std::u16string& operator+=(const char16_t* v) { return s.operator+=(v); }
-        std::u16string& operator+=(const char16_t v) { return s.operator+=(v); }
-        char16_t& operator[](size_t i) { return s.operator[](i); }
-    };
-
+    struct Mutator;
     const std::u16string& constStr() const;
     Mutator mutStr(bool do_detach = true);
     void detach();

--- a/src/framework/global/types/string.h
+++ b/src/framework/global/types/string.h
@@ -253,7 +253,9 @@ public:
     static String fromStdString(const std::string& str);
     std::string toStdString() const;
     std::u16string toStdU16String() const;
+
     static String fromUcs4(const char32_t* str, size_t size = mu::nidx);
+    static String fromUcs4(char32_t chr);
     std::u32string toStdU32String() const;
 
     size_t size() const;

--- a/src/palette/view/widgets/specialcharactersdialog.cpp
+++ b/src/palette/view/widgets/specialcharactersdialog.cpp
@@ -90,8 +90,8 @@ static constexpr SymId commonScoreSymbols[] = {
 };
 
 struct UnicodeRange {
-    int first;
-    int last;
+    char32_t first;
+    char32_t last;
     const char* name;
 };
 static constexpr UnicodeRange unicodeRanges[] = {
@@ -517,7 +517,7 @@ int SpecialCharactersDialog::static_metaTypeId()
 //   populateCommon
 //---------------------------------------------------------
 
-static constexpr int unicodeAccidentals[] = { //better size and alignment, so put these first
+static constexpr char32_t unicodeAccidentals[] = { //better size and alignment, so put these first
     0x1d12b, // double flat
     0x266d, // flat
     0x266e, // natural
@@ -525,7 +525,7 @@ static constexpr int unicodeAccidentals[] = { //better size and alignment, so pu
     0x1d12a // double sharp
 };
 
-static constexpr int commonTextSymbols[] = {
+static constexpr char32_t commonTextSymbols[] = {
     0x00a9,      // &copy;
 
     // upper case ligatures
@@ -668,20 +668,20 @@ void SpecialCharactersDialog::populateCommon()
 {
     m_pCommon->clear();
 
-    for (auto id : unicodeAccidentals) {
+    for (char32_t id : unicodeAccidentals) {
         std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(gpaletteScore->dummy());
         fs->setCode(id);
         fs->setFont(m_font);
         m_pCommon->appendElement(fs, QString(id));
     }
 
-    for (auto id : commonScoreSymbols) {
+    for (SymId id : commonScoreSymbols) {
         std::shared_ptr<Symbol> s = std::make_shared<Symbol>(gpaletteScore->dummy());
         s->setSym(id, gpaletteScore->engravingFont());
         m_pCommon->appendElement(s, SymNames::translatedUserNameForSymId(id));
     }
 
-    for (auto id : commonTextSymbols) {
+    for (char32_t id : commonTextSymbols) {
         std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(gpaletteScore->dummy());
         fs->setCode(id);
         fs->setFont(m_font);
@@ -718,7 +718,7 @@ void SpecialCharactersDialog::populateUnicode()
     int row = m_lwu->currentItem()->data(Qt::UserRole).toInt();
     const UnicodeRange& range = unicodeRanges[row];
     m_pUnicode->clear();
-    for (int code = range.first; code <= range.last; ++code) {
+    for (char32_t code = range.first; code <= range.last; ++code) {
         std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(gpaletteScore->dummy());
         fs->setCode(code);
         fs->setFont(m_font);


### PR DESCRIPTION
May also fix some hidden bugs like truncating `char32_t` to `char16_t` when constructing a `Char` from it