### PR TITLE
Fix for issue #16141: [MU4 Issue] [Inspector] Text line spacing is missing in Properties

### DIFF
--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -108,7 +108,6 @@ static void sort(size_t& r1, size_t& c1, size_t& r2, size_t& c2)
 
 const String TextBase::UNDEFINED_FONT_FAMILY = String(u"Undefined");
 const int TextBase::UNDEFINED_FONT_SIZE = -1;
-const int TextBase::UNDEFINED_TEXT_LINE_SPACING = -1;
 
 //---------------------------------------------------------
 //   operator==
@@ -1546,7 +1545,6 @@ String TextBlock::text(int col1, int len, bool withFormat) const
 TextBase::TextBase(const ElementType& type, EngravingItem* parent, TextStyleType tid, ElementFlags f)
     : EngravingItem(type, parent, f | ElementFlag::MOVABLE)
 {
-    _textLineSpacing        = 1.0;
     _textStyleType          = tid;
     _bgColor                = mu::draw::Color::transparent;
     _frameColor             = mu::draw::Color::BLACK;
@@ -1579,7 +1577,6 @@ TextBase::TextBase(const TextBase& st)
     hexState                     = -1;
 
     _textStyleType               = st._textStyleType;
-    _textLineSpacing             = st._textLineSpacing;
     _bgColor                     = st._bgColor;
     _frameColor                  = st._frameColor;
     _align                       = st._align;

--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -108,6 +108,7 @@ static void sort(size_t& r1, size_t& c1, size_t& r2, size_t& c2)
 
 const String TextBase::UNDEFINED_FONT_FAMILY = String(u"Undefined");
 const int TextBase::UNDEFINED_FONT_SIZE = -1;
+const int TextBase::UNDEFINED_TEXT_LINE_SPACING = -1;
 
 //---------------------------------------------------------
 //   operator==

--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -1545,6 +1545,7 @@ String TextBlock::text(int col1, int len, bool withFormat) const
 TextBase::TextBase(const ElementType& type, EngravingItem* parent, TextStyleType tid, ElementFlags f)
     : EngravingItem(type, parent, f | ElementFlag::MOVABLE)
 {
+    _textLineSpacing        = 1.0;
     _textStyleType          = tid;
     _bgColor                = mu::draw::Color::transparent;
     _frameColor             = mu::draw::Color::BLACK;
@@ -1577,6 +1578,7 @@ TextBase::TextBase(const TextBase& st)
     hexState                     = -1;
 
     _textStyleType               = st._textStyleType;
+    _textLineSpacing             = st._textLineSpacing;
     _bgColor                     = st._bgColor;
     _frameColor                  = st._frameColor;
     _align                       = st._align;

--- a/src/engraving/libmscore/textbase.h
+++ b/src/engraving/libmscore/textbase.h
@@ -482,7 +482,6 @@ public:
 
     static const String UNDEFINED_FONT_FAMILY;
     static const int UNDEFINED_FONT_SIZE;
-    static const int UNDEFINED_TEXT_LINE_SPACING;
 
     bool bold() const { return fontStyle() & FontStyle::Bold; }
     bool italic() const { return fontStyle() & FontStyle::Italic; }

--- a/src/engraving/libmscore/textbase.h
+++ b/src/engraving/libmscore/textbase.h
@@ -83,7 +83,6 @@ class CharFormat
     FontStyle _style          { FontStyle::Normal };
     VerticalAlignment _valign { VerticalAlignment::AlignNormal };
     double _fontSize           { 12.0 };
-    double _textLineSpacing    { 1.0 };
     String _fontFamily;
 
 public:
@@ -107,7 +106,6 @@ public:
     void setValign(VerticalAlignment val) { _valign = val; }
     void setFontSize(double val) { _fontSize = val; }
     void setFontFamily(const String& val) { _fontFamily = val; }
-    void setTextLineSpacing(double val) { _textLineSpacing = val; }
 
     FormatValue formatValue(FormatId) const;
     void setFormatValue(FormatId, const FormatValue& val);

--- a/src/engraving/libmscore/textbase.h
+++ b/src/engraving/libmscore/textbase.h
@@ -484,6 +484,7 @@ public:
 
     static const String UNDEFINED_FONT_FAMILY;
     static const int UNDEFINED_FONT_SIZE;
+    static const int UNDEFINED_TEXT_LINE_SPACING;
 
     bool bold() const { return fontStyle() & FontStyle::Bold; }
     bool italic() const { return fontStyle() & FontStyle::Italic; }

--- a/src/inspector/models/text/textsettingsmodel.cpp
+++ b/src/inspector/models/text/textsettingsmodel.cpp
@@ -117,7 +117,7 @@ void TextSettingsModel::loadProperties()
 
     m_fontSize->setIsEnabled(true);
 
-    loadPropertyItem(m_textLineSpacing);
+    loadPropertyItem(m_textLineSpacing, formatDoubleFunc);
 
     loadPropertyItem(m_horizontalAlignment, [](const QVariant& elementPropertyValue) -> QVariant {
         QVariantList list = elementPropertyValue.toList();

--- a/src/inspector/models/text/textsettingsmodel.cpp
+++ b/src/inspector/models/text/textsettingsmodel.cpp
@@ -53,6 +53,7 @@ void TextSettingsModel::createProperties()
     m_fontFamily = buildPropertyItem(mu::engraving::Pid::FONT_FACE);
     m_fontStyle = buildPropertyItem(mu::engraving::Pid::FONT_STYLE);
     m_fontSize = buildPropertyItem(mu::engraving::Pid::FONT_SIZE);
+    m_textLineSpacing = buildPropertyItem(mu::engraving::Pid::TEXT_LINE_SPACING);
 
     m_horizontalAlignment = buildPropertyItem(mu::engraving::Pid::ALIGN, [this](const mu::engraving::Pid pid, const QVariant& newValue) {
         onPropertyValueChanged(pid, QVariantList({ newValue.toInt(), m_verticalAlignment->value().toInt() }));
@@ -116,6 +117,13 @@ void TextSettingsModel::loadProperties()
 
     m_fontSize->setIsEnabled(true);
 
+    loadPropertyItem(m_textLineSpacing, [](const QVariant& elementPropertyValue) -> QVariant {
+        return elementPropertyValue.toInt() == mu::engraving::TextBase::UNDEFINED_TEXT_LINE_SPACING
+               ? QVariant() : elementPropertyValue.toInt();
+    });
+
+    m_textLineSpacing->setIsEnabled(true);
+
     loadPropertyItem(m_horizontalAlignment, [](const QVariant& elementPropertyValue) -> QVariant {
         QVariantList list = elementPropertyValue.toList();
         return list.size() >= 2 ? list[0] : QVariant();
@@ -152,6 +160,7 @@ void TextSettingsModel::resetProperties()
     m_fontFamily->resetToDefault();
     m_fontStyle->resetToDefault();
     m_fontSize->resetToDefault();
+    m_textLineSpacing->resetToDefault();
     m_isSizeSpatiumDependent->resetToDefault();
 
     m_frameType->resetToDefault();
@@ -213,6 +222,11 @@ PropertyItem* TextSettingsModel::fontStyle() const
 PropertyItem* TextSettingsModel::fontSize() const
 {
     return m_fontSize;
+}
+
+PropertyItem* TextSettingsModel::textLineSpacing() const
+{
+    return m_textLineSpacing;
 }
 
 PropertyItem* TextSettingsModel::horizontalAlignment() const

--- a/src/inspector/models/text/textsettingsmodel.cpp
+++ b/src/inspector/models/text/textsettingsmodel.cpp
@@ -117,12 +117,7 @@ void TextSettingsModel::loadProperties()
 
     m_fontSize->setIsEnabled(true);
 
-    loadPropertyItem(m_textLineSpacing, [](const QVariant& elementPropertyValue) -> QVariant {
-        return elementPropertyValue.toInt() == mu::engraving::TextBase::UNDEFINED_TEXT_LINE_SPACING
-               ? QVariant() : elementPropertyValue.toInt();
-    });
-
-    m_textLineSpacing->setIsEnabled(true);
+    loadPropertyItem(m_textLineSpacing);
 
     loadPropertyItem(m_horizontalAlignment, [](const QVariant& elementPropertyValue) -> QVariant {
         QVariantList list = elementPropertyValue.toList();

--- a/src/inspector/models/text/textsettingsmodel.h
+++ b/src/inspector/models/text/textsettingsmodel.h
@@ -38,6 +38,7 @@ class TextSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(PropertyItem * fontFamily READ fontFamily CONSTANT)
     Q_PROPERTY(PropertyItem * fontStyle READ fontStyle CONSTANT)
     Q_PROPERTY(PropertyItem * fontSize READ fontSize CONSTANT)
+    Q_PROPERTY(PropertyItem * textLineSpacing READ textLineSpacing CONSTANT)
     Q_PROPERTY(PropertyItem * horizontalAlignment READ horizontalAlignment CONSTANT)
     Q_PROPERTY(PropertyItem * verticalAlignment READ verticalAlignment CONSTANT)
 
@@ -76,6 +77,7 @@ public:
     PropertyItem* fontFamily() const;
     PropertyItem* fontStyle() const;
     PropertyItem* fontSize() const;
+    PropertyItem* textLineSpacing() const;
     PropertyItem* horizontalAlignment() const;
     PropertyItem* verticalAlignment() const;
 
@@ -117,6 +119,7 @@ private:
     PropertyItem* m_fontFamily = nullptr;
     PropertyItem* m_fontStyle = nullptr;
     PropertyItem* m_fontSize = nullptr;
+    PropertyItem* m_textLineSpacing = nullptr;
     PropertyItem* m_horizontalAlignment = nullptr;
     PropertyItem* m_verticalAlignment = nullptr;
 

--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
@@ -243,7 +243,7 @@ Column {
         decimals: 2
         step: 0.1
         minValue: 0
-        maxValue: 99
+        maxValue: 10
     }
 
     SeparatorLine { anchors.margins: -12 }

--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
@@ -115,6 +115,33 @@ Column {
         ]
     }
 
+    SeparatorLine { anchors.margins: -12 }
+
+    Item {
+        height: childrenRect.height
+        width: parent.width
+
+        SpinBoxPropertyView {
+            id: textLineSpacingSection
+            anchors.left: parent.left
+            anchors.right: parent.horizontalCenter
+            anchors.rightMargin: 2
+
+            navigationName: "Line Spacing"
+            navigationPanel: root.navigationPanel
+            navigationRowStart: styleSection.navigationRowEnd + 1
+
+            titleText: qsTrc("inspector", "Line Spacing")
+            measureUnitsSymbol: qsTrc("global", "li")
+            propertyItem: root.model ? root.model.textLineSpacing : null
+
+            decimals: 2
+            step: 0.1
+            minValue: 0
+            maxValue: 99
+        }
+    }
+
     Item {
         height: childrenRect.height
         width: parent.width

--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
@@ -233,7 +233,7 @@ Column {
 
         navigationName: "Line Spacing"
         navigationPanel: root.navigationPanel
-        navigationRowStart: styleSection.navigationRowEnd + 1
+        navigationRowStart: cornerRadiusSection.navigationRowEnd + 1
 
         titleText: qsTrc("inspector", "Line Spacing")
         measureUnitsSymbol: qsTrc("global", "li")
@@ -254,7 +254,7 @@ Column {
 
         navigationName: "Text style"
         navigationPanel: root.navigationPanel
-        navigationRowStart: cornerRadiusSection.navigationRowEnd + 1
+        navigationRowStart: textLineSpacingSection.navigationRowEnd + 1
 
         model: root.model ? root.model.textStyles : []
     }

--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
@@ -235,7 +235,8 @@ Column {
         navigationPanel: root.navigationPanel
         navigationRowStart: cornerRadiusSection.navigationRowEnd + 1
 
-        titleText: qsTrc("inspector", "Line Spacing")
+        titleText: qsTrc("inspector", "Line spacing")
+        //: Stands for "Lines". Used for text line spacing controls, for example.
         measureUnitsSymbol: qsTrc("global", "li")
         propertyItem: root.model ? root.model.textLineSpacing : null
 

--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
@@ -115,33 +115,6 @@ Column {
         ]
     }
 
-    SeparatorLine { anchors.margins: -12 }
-
-    Item {
-        height: childrenRect.height
-        width: parent.width
-
-        SpinBoxPropertyView {
-            id: textLineSpacingSection
-            anchors.left: parent.left
-            anchors.right: parent.horizontalCenter
-            anchors.rightMargin: 2
-
-            navigationName: "Line Spacing"
-            navigationPanel: root.navigationPanel
-            navigationRowStart: styleSection.navigationRowEnd + 1
-
-            titleText: qsTrc("inspector", "Line Spacing")
-            measureUnitsSymbol: qsTrc("global", "li")
-            propertyItem: root.model ? root.model.textLineSpacing : null
-
-            decimals: 2
-            step: 0.1
-            minValue: 0
-            maxValue: 99
-        }
-    }
-
     Item {
         height: childrenRect.height
         width: parent.width
@@ -248,6 +221,28 @@ Column {
         decimals: 2
         minValue: 0
         maxValue: 100
+    }
+
+    SeparatorLine { anchors.margins: -12 }
+
+    SpinBoxPropertyView {
+        id: textLineSpacingSection
+        anchors.left: parent.left
+        anchors.right: parent.horizontalCenter
+        anchors.rightMargin: 2
+
+        navigationName: "Line Spacing"
+        navigationPanel: root.navigationPanel
+        navigationRowStart: styleSection.navigationRowEnd + 1
+
+        titleText: qsTrc("inspector", "Line Spacing")
+        measureUnitsSymbol: qsTrc("global", "li")
+        propertyItem: root.model ? root.model.textLineSpacing : null
+
+        decimals: 2
+        step: 0.1
+        minValue: 0
+        maxValue: 99
     }
 
     SeparatorLine { anchors.margins: -12 }


### PR DESCRIPTION
Resolves: #16141

Added 'Line Spacing' option in the Text properties panel.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)

https://user-images.githubusercontent.com/90182257/218280973-d9721839-b83f-4613-8091-f59caf2a63ff.mp4

