### PR TITLE
Fix #12437: TAB: Cannot place note on highest fret using Ctrl+Up/Down

### DIFF
--- a/src/engraving/libmscore/stringdata.cpp
+++ b/src/engraving/libmscore/stringdata.cpp
@@ -445,7 +445,7 @@ int StringData::fret(int pitch, int string, int pitchOffset) const
     }
 
     // fret number is invalid or string cannot be fretted
-    if (fret < 0 || fret >= _frets || (fret > 0 && strg.open)) {
+    if (fret < 0 || fret > _frets || (fret > 0 && strg.open)) {
         return INVALID_FRET_INDEX;
     }
     return fret;


### PR DESCRIPTION
Resolves: #12437