### PR TITLE
Format > Style: fix initial enabled-ness of user text style name reset button

### DIFF
--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -2178,7 +2178,7 @@ void EditStyle::textStyleChanged(int row)
 
     styleName->setText(score->getTextStyleUserName(tid).qTranslated());
     styleName->setEnabled(int(tid) >= int(TextStyleType::USER1));
-    resetTextStyleName->setEnabled(false);
+    resetTextStyleName->setEnabled(styleName->text() != TConv::translatedUserName(tid));
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: #12810
(the biggest part of that issue is already fixed, but this was the only remaining flaw with text style names that I could find)