### PR TITLE
Fret diagram Inspector: bring back missing Orientation property

### DIFF
--- a/src/inspector/models/notation/fretdiagrams/fretdiagramsettingsmodel.cpp
+++ b/src/inspector/models/notation/fretdiagrams/fretdiagramsettingsmodel.cpp
@@ -21,8 +21,10 @@
  */
 #include "fretdiagramsettingsmodel.h"
 
-#include "translation.h"
 #include "dataformatter.h"
+#include "translation.h"
+
+#include "engraving/libmscore/fret.h"
 
 using namespace mu::inspector;
 
@@ -64,6 +66,7 @@ void FretDiagramSettingsModel::createProperties()
     });
 
     m_placement = buildPropertyItem(mu::engraving::Pid::PLACEMENT);
+    m_orientation = buildPropertyItem(mu::engraving::Pid::ORIENTATION);
 }
 
 void FretDiagramSettingsModel::requestElements()
@@ -88,6 +91,7 @@ void FretDiagramSettingsModel::loadProperties()
 
     loadPropertyItem(m_isNutVisible);
     loadPropertyItem(m_placement);
+    loadPropertyItem(m_orientation);
 }
 
 void FretDiagramSettingsModel::resetProperties()
@@ -115,6 +119,11 @@ PropertyItem* FretDiagramSettingsModel::fretsCount() const
     return m_fretsCount;
 }
 
+PropertyItem* FretDiagramSettingsModel::fretNumber() const
+{
+    return m_fretNumber;
+}
+
 PropertyItem* FretDiagramSettingsModel::isNutVisible() const
 {
     return m_isNutVisible;
@@ -125,9 +134,9 @@ PropertyItem* FretDiagramSettingsModel::placement() const
     return m_placement;
 }
 
-PropertyItem* FretDiagramSettingsModel::fretNumber() const
+PropertyItem* FretDiagramSettingsModel::orientation() const
 {
-    return m_fretNumber;
+    return m_orientation;
 }
 
 QVariant FretDiagramSettingsModel::fretDiagram() const

--- a/src/inspector/models/notation/fretdiagrams/fretdiagramsettingsmodel.h
+++ b/src/inspector/models/notation/fretdiagrams/fretdiagramsettingsmodel.h
@@ -23,8 +23,12 @@
 #define MU_INSPECTOR_FRETDIAGRAMSETTINGSMODEL_H
 
 #include "models/abstractinspectormodel.h"
+
 #include "types/fretdiagramtypes.h"
-#include "fret.h"
+
+namespace mu::engraving {
+class FretDiagram;
+}
 
 namespace mu::inspector {
 class FretDiagramSettingsModel : public AbstractInspectorModel
@@ -34,9 +38,10 @@ class FretDiagramSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(PropertyItem * scale READ scale CONSTANT)
     Q_PROPERTY(PropertyItem * stringsCount READ stringsCount CONSTANT)
     Q_PROPERTY(PropertyItem * fretsCount READ fretsCount CONSTANT)
+    Q_PROPERTY(PropertyItem * fretNumber READ fretNumber CONSTANT)
     Q_PROPERTY(PropertyItem * isNutVisible READ isNutVisible CONSTANT)
     Q_PROPERTY(PropertyItem * placement READ placement CONSTANT)
-    Q_PROPERTY(PropertyItem * fretNumber READ fretNumber CONSTANT)
+    Q_PROPERTY(PropertyItem * orientation READ orientation CONSTANT)
 
     Q_PROPERTY(bool isBarreModeOn READ isBarreModeOn WRITE setIsBarreModeOn NOTIFY isBarreModeOnChanged)
     Q_PROPERTY(bool isMultipleDotsModeOn READ isMultipleDotsModeOn WRITE setIsMultipleDotsModeOn NOTIFY isMultipleDotsModeOnChanged)
@@ -57,9 +62,10 @@ public:
     PropertyItem* scale() const;
     PropertyItem* stringsCount() const;
     PropertyItem* fretsCount() const;
+    PropertyItem* fretNumber() const;
     PropertyItem* isNutVisible() const;
     PropertyItem* placement() const;
-    PropertyItem* fretNumber() const;
+    PropertyItem* orientation() const;
 
     QVariant fretDiagram() const;
 
@@ -84,13 +90,13 @@ signals:
     void areSettingsAvailableChanged(bool areSettingsAvailable);
 
 private:
-
     PropertyItem* m_scale = nullptr;
     PropertyItem* m_stringsCount = nullptr;
     PropertyItem* m_fretsCount = nullptr;
+    PropertyItem* m_fretNumber = nullptr;
     PropertyItem* m_isNutVisible = nullptr;
     PropertyItem* m_placement = nullptr;
-    PropertyItem* m_fretNumber = nullptr;
+    PropertyItem* m_orientation = nullptr;
 
     mu::engraving::FretDiagram* m_fretDiagram = nullptr;
 

--- a/src/inspector/types/commontypes.h
+++ b/src/inspector/types/commontypes.h
@@ -27,7 +27,7 @@
 #include "ui/view/iconcodes.h"
 #include "dataformatter.h"
 
-#include "libmscore/types.h"
+#include "engraving/types/types.h"
 
 namespace mu::inspector {
 struct ElementKey

--- a/src/inspector/types/fretdiagramtypes.h
+++ b/src/inspector/types/fretdiagramtypes.h
@@ -46,8 +46,14 @@ public:
         MARKER_CROSS
     };
 
+    enum class Orientation {
+        ORIENTATION_VERTICAL,
+        ORIENTATION_HORIZONTAL
+    };
+
     Q_ENUM(FretDot)
     Q_ENUM(FretMarker)
+    Q_ENUM(Orientation)
 };
 
 #endif // MU_INSPECTOR_FRETDIAGRAMTYPES_H

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/fermatas/FermataSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/fermatas/FermataSettings.qml
@@ -46,7 +46,6 @@ Column {
 
     PlacementSection {
         id: placementOnStaffSection
-        titleText: qsTrc("inspector", "Placement on staff")
         propertyItem: root.model ? root.model.placementType : null
 
         navigationPanel: root.navigationPanel

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/fretdiagrams/FretDiagramSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/fretdiagrams/FretDiagramSettings.qml
@@ -65,6 +65,19 @@ Item {
 
             spacing: 12
 
+            FretCanvas {
+                id: fretCanvas
+
+                diagram: root.model ? root.model.fretDiagram : null
+                isBarreModeOn: root.model ? root.model.isBarreModeOn : false
+                isMultipleDotsModeOn: root.model ? root.model.isMultipleDotsModeOn : false
+                currentFretDotType: root.model ? root.model.currentFretDotType : false
+                visible: root.model ? root.model.areSettingsAvailable : false
+                color: ui.theme.fontPrimaryColor
+
+                width: parent.width
+            }
+
             FlatButton {
                 width: parent.width
 
@@ -79,19 +92,6 @@ Item {
                 onClicked: {
                     fretCanvas.clear()
                 }
-            }
-
-            FretCanvas {
-                id: fretCanvas
-
-                diagram: root.model ? root.model.fretDiagram : null
-                isBarreModeOn: root.model ? root.model.isBarreModeOn : false
-                isMultipleDotsModeOn: root.model ? root.model.isMultipleDotsModeOn : false
-                currentFretDotType: root.model ? root.model.currentFretDotType : false
-                visible: root.model ? root.model.areSettingsAvailable : false
-                color: ui.theme.fontPrimaryColor
-
-                width: parent.width
             }
         }
     }

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/fretdiagrams/internal/FretAdvancedSettingsTab.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/fretdiagrams/internal/FretAdvancedSettingsTab.qml
@@ -163,7 +163,6 @@ FocusableItem {
 
         PlacementSection {
             id: placementSection
-            titleText: qsTrc("inspector", "Placement on staff")
             propertyItem: root.model ? root.model.placement : null
 
             navigationPanel: root.navigationPanel

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/fretdiagrams/internal/FretAdvancedSettingsTab.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/fretdiagrams/internal/FretAdvancedSettingsTab.qml
@@ -133,16 +133,8 @@ FocusableItem {
             }
         }
 
-        PlacementSection {
-            id: placementSection
-            titleText: qsTrc("inspector", "Placement on staff")
-            propertyItem: root.model ? root.model.placement : null
-
-            navigationPanel: root.navigationPanel
-            navigationRowStart: fretNumber.navigationRowEnd + 1
-        }
-
         CheckBoxPropertyView {
+            id: multipleDotsCheckbox
             anchors.left: parent.left
             anchors.right: parent.horizontalCenter
             anchors.rightMargin: 2
@@ -152,7 +144,30 @@ FocusableItem {
 
             navigation.name: "MultipleDotsCheckBox"
             navigation.panel: root.navigationPanel
-            navigation.row: placementSection.navigationRowEnd + 2
+            navigation.row: fretNumber.navigationRowEnd + 1
+        }
+
+        FlatRadioButtonGroupPropertyView {
+            id: orientationSection
+            titleText: qsTrc("inspector", "Orientation")
+            propertyItem: root.model ? root.model.orientation : null
+
+            model: [
+                { text: qsTrc("inspector", "Vertical"), value: FretDiagramTypes.ORIENTATION_VERTICAL },
+                { text: qsTrc("inspector", "Horizontal"), value: FretDiagramTypes.ORIENTATION_HORIZONTAL }
+            ]
+
+            navigationPanel: root.navigationPanel
+            navigationRowStart: multipleDotsCheckbox.navigation.row + 1
+        }
+
+        PlacementSection {
+            id: placementSection
+            titleText: qsTrc("inspector", "Placement on staff")
+            propertyItem: root.model ? root.model.placement : null
+
+            navigationPanel: root.navigationPanel
+            navigationRowStart: orientationSection.navigationRowEnd + 1
         }
     }
 }


### PR DESCRIPTION
Resolves: #13655

<img width="300" alt="Scherm­afbeelding 2023-02-12 om 15 12 03" src="https://user-images.githubusercontent.com/48658420/218316110-d9a3a145-5fed-4b93-9fae-8013bdafd1b3.png">

@bkunda Could you please check if you agree with this design? I also moved some other controls around a little bit:
- moved the "show nut" checkbox closer to the spin boxes, because all these things are about the "contents" of the diagram
- moved the "clear" button below the diagram preview, because it looked strange to have it immediately below the "orientation" property (it almost looked like it belonged to that property).