### PR TITLE
[WIP] Retranslating the UI without restarting

### DIFF
--- a/src/appshell/qml/Preferences/GeneralPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/GeneralPreferencesPage.qml
@@ -51,7 +51,6 @@ PreferencesPage {
 
             languages: preferencesModel.languages
             currentLanguageCode: preferencesModel.currentLanguageCode
-            isNeedRestart: preferencesModel.isNeedRestart
 
             navigation.section: root.navigationSection
             navigation.order: root.navigationOrderStart + 1

--- a/src/appshell/qml/Preferences/internal/LanguagesSection.qml
+++ b/src/appshell/qml/Preferences/internal/LanguagesSection.qml
@@ -34,7 +34,6 @@ BaseSection {
 
     property alias languages: dropdown.model
     property string currentLanguageCode: ""
-    property bool isNeedRestart: false
 
     signal languageSelected(string languageCode)
     signal checkForUpdateRequested()
@@ -86,10 +85,5 @@ BaseSection {
                 root.checkForUpdateRequested()
             }
         }
-    }
-
-    StyledTextLabel {
-        text: qsTrc("appshell/preferences", "Restart required")
-        visible: root.isNeedRestart
     }
 }

--- a/src/appshell/qml/Preferences/internal/PreferencesMenu.qml
+++ b/src/appshell/qml/Preferences/internal/PreferencesMenu.qml
@@ -96,7 +96,7 @@ Item {
         }
 
         itemDelegate: PageTabButton {
-            property bool expanded: Boolean(model) ? model.itemRole.expanded : false
+            property bool expanded: Boolean(model) && Boolean(model.itemRole) ? model.itemRole.expanded : false
             property int navigationRow: styleData.index.row
             property int navigationColumn: styleData.depth
 
@@ -108,7 +108,7 @@ Item {
             normalStateFont: ui.theme.bodyFont
             selectedStateFont: ui.theme.bodyBoldFont
 
-            title: Boolean(model) ? model.itemRole.title : ""
+            title: Boolean(model) && Boolean(model.itemRole) ? model.itemRole.title : ""
             checked: Boolean(model) && Boolean(model.itemRole) ? model.itemRole.id === treeView.model.currentPageId : false
             enabled: visible
 

--- a/src/appshell/qml/platform/PlatformMenuBar.qml
+++ b/src/appshell/qml/platform/PlatformMenuBar.qml
@@ -74,10 +74,10 @@ Item {
     function makeMenu(menuInfo) {
         var menu = menuComponent.createObject(menuBar)
 
-        menu.id = menuInfo.id
-        menu.title = menuInfo.title
-        menu.enabled = menuInfo.enabled
-        menu.subitems = menuInfo.subitems
+        menu.id = Qt.binding(() => { return menuInfo.id })
+        menu.title = Qt.binding(() => { return menuInfo.title })
+        menu.enabled = Qt.binding(() => { return menuInfo.enabled })
+        menu.subitems = Qt.binding(() => { return menuInfo.subitems })
 
         return menu
     }
@@ -85,13 +85,13 @@ Item {
     function makeMenuItem(parentMenu, itemInfo) {
         var menuItem = menuItemComponent.createObject(parentMenu)
 
-        menuItem.id = itemInfo.id
-        menuItem.text = itemInfo.title + "\t" + itemInfo.portableShortcuts
-        menuItem.enabled = itemInfo.enabled
-        menuItem.checked = itemInfo.checked
-        menuItem.checkable = itemInfo.checkable
-        menuItem.separator = !Boolean(itemInfo.title)
-        menuItem.role = itemInfo.role
+        menuItem.id = Qt.binding(() => { return itemInfo.id })
+        menuItem.text = Qt.binding(() => { return itemInfo.title + "\t" + itemInfo.portableShortcuts })
+        menuItem.enabled = Qt.binding(() => { return itemInfo.enabled })
+        menuItem.checked = Qt.binding(() => { return itemInfo.checked })
+        menuItem.checkable = Qt.binding(() => { return itemInfo.checkable })
+        menuItem.separator = Qt.binding(() => { return !Boolean(itemInfo.title) })
+        menuItem.role = Qt.binding(() => { return itemInfo.role })
 
         return menuItem
     }

--- a/src/appshell/view/firstlaunchsetup/themespagemodel.cpp
+++ b/src/appshell/view/firstlaunchsetup/themespagemodel.cpp
@@ -33,6 +33,10 @@ ThemesPageModel::ThemesPageModel(QObject* parent)
 
 void ThemesPageModel::load()
 {
+    languagesService()->currentLanguageChanged().onNotify(this, [this] {
+        emit themesChanged();
+    });
+
     uiConfiguration()->isFollowSystemTheme().notification.onNotify(this, [this]() {
         emit isFollowSystemThemeChanged();
     });

--- a/src/appshell/view/firstlaunchsetup/themespagemodel.h
+++ b/src/appshell/view/firstlaunchsetup/themespagemodel.h
@@ -28,11 +28,15 @@
 
 #include "modularity/ioc.h"
 #include "ui/iuiconfiguration.h"
+#include "languages/ilanguagesservice.h"
 
 namespace mu::appshell {
 class ThemesPageModel : public QObject, public async::Asyncable
 {
     Q_OBJECT
+
+    INJECT(appshell, ui::IUiConfiguration, uiConfiguration)
+    INJECT(appshell, languages::ILanguagesService, languagesService)
 
     Q_PROPERTY(bool isFollowSystemThemeAvailable READ isFollowSystemThemeAvailable CONSTANT)
     Q_PROPERTY(bool isFollowSystemTheme READ isFollowSystemTheme WRITE setFollowSystemTheme NOTIFY isFollowSystemThemeChanged)
@@ -44,8 +48,6 @@ class ThemesPageModel : public QObject, public async::Asyncable
 
     Q_PROPERTY(QString currentThemeCode READ currentThemeCode WRITE setCurrentThemeCode NOTIFY themesChanged)
     Q_PROPERTY(int currentAccentColorIndex READ currentAccentColorIndex WRITE setCurrentAccentColorIndex NOTIFY themesChanged)
-
-    INJECT(appshell, ui::IUiConfiguration, uiConfiguration)
 
 public:
     explicit ThemesPageModel(QObject* parent = nullptr);

--- a/src/appshell/view/internal/maintoolbarmodel.h
+++ b/src/appshell/view/internal/maintoolbarmodel.h
@@ -25,11 +25,14 @@
 
 #include <QAbstractListModel>
 
+#include "types/translatablestring.h"
+
 #include "async/asyncable.h"
 
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
 #include "iglobalconfiguration.h"
+#include "languages/ilanguagesservice.h"
 
 namespace mu::appshell {
 class MainToolBarModel : public QAbstractListModel, public async::Asyncable
@@ -38,6 +41,7 @@ class MainToolBarModel : public QAbstractListModel, public async::Asyncable
 
     INJECT(appshell, context::IGlobalContext, context)
     INJECT(appshell, framework::IGlobalConfiguration, globalConfiguration)
+    INJECT(appshell, languages::ILanguagesService, languagesService)
 
 public:
     explicit MainToolBarModel(QObject* parent = nullptr);
@@ -57,7 +61,13 @@ private:
 
     void updateNotationPageItem();
 
-    QList<QVariantMap> m_items;
+    struct Item {
+        TranslatableString title;
+        QString uri;
+        bool isTitleBold = false;
+    };
+
+    QList<Item> m_items;
 };
 }
 

--- a/src/appshell/view/mainwindowtitleprovider.cpp
+++ b/src/appshell/view/mainwindowtitleprovider.cpp
@@ -49,6 +49,10 @@ void MainWindowTitleProvider::load()
     context()->currentNotationChanged().onNotify(this, [this]() {
         update();
     });
+
+    languagesService()->currentLanguageChanged().onNotify(this, [this] {
+        update();
+    });
 }
 
 QString MainWindowTitleProvider::title() const

--- a/src/appshell/view/mainwindowtitleprovider.h
+++ b/src/appshell/view/mainwindowtitleprovider.h
@@ -24,6 +24,7 @@
 
 #include "async/asyncable.h"
 #include "context/iglobalcontext.h"
+#include "languages/ilanguagesservice.h"
 
 namespace mu::appshell {
 class MainWindowTitleProvider : public QObject, public async::Asyncable
@@ -31,6 +32,7 @@ class MainWindowTitleProvider : public QObject, public async::Asyncable
     Q_OBJECT
 
     INJECT(ui, context::IGlobalContext, context)
+    INJECT(ui, languages::ILanguagesService, languagesService)
 
     Q_PROPERTY(QString title READ title NOTIFY titleChanged)
     Q_PROPERTY(QString filePath READ filePath NOTIFY filePathChanged)

--- a/src/appshell/view/preferences/appearancepreferencesmodel.cpp
+++ b/src/appshell/view/preferences/appearancepreferencesmodel.cpp
@@ -40,6 +40,10 @@ AppearancePreferencesModel::AppearancePreferencesModel(QObject* parent)
 
 void AppearancePreferencesModel::init()
 {
+    languagesService()->currentLanguageChanged().onNotify(this, [this] {
+        emit themesChanged();
+    });
+
     uiConfiguration()->isFollowSystemTheme().notification.onNotify(this, [this]() {
         emit isFollowSystemThemeChanged();
     });

--- a/src/appshell/view/preferences/appearancepreferencesmodel.h
+++ b/src/appshell/view/preferences/appearancepreferencesmodel.h
@@ -27,6 +27,7 @@
 #include "modularity/ioc.h"
 #include "ui/iuiconfiguration.h"
 #include "notation/inotationconfiguration.h"
+#include "languages/ilanguagesservice.h"
 #include "async/asyncable.h"
 
 namespace mu::appshell {
@@ -37,6 +38,7 @@ class AppearancePreferencesModel : public QObject, public async::Asyncable
     INJECT(appshell, ui::IUiConfiguration, uiConfiguration)
     INJECT(appshell, notation::INotationConfiguration, notationConfiguration)
     INJECT(appshell, engraving::IEngravingConfiguration, engravingConfiguration)
+    INJECT(appshell, languages::ILanguagesService, languagesService)
 
     Q_PROPERTY(bool isFollowSystemThemeAvailable READ isFollowSystemThemeAvailable CONSTANT)
     Q_PROPERTY(bool isFollowSystemTheme READ isFollowSystemTheme WRITE setFollowSystemTheme NOTIFY isFollowSystemThemeChanged)

--- a/src/appshell/view/preferences/folderspreferencesmodel.cpp
+++ b/src/appshell/view/preferences/folderspreferencesmodel.cpp
@@ -39,7 +39,7 @@ QVariant FoldersPreferencesModel::data(const QModelIndex& index, int role) const
 {
     const FolderInfo& folder = m_folders.at(index.row());
     switch (role) {
-    case TitleRole: return folder.title;
+    case TitleRole: return folder.title.qTranslated();
     case PathRole: return folder.value;
     case DirRole: return folder.dir;
     case IsMultiDirectoriesRole: return folder.valueType == FolderValueType::MultiDirectories;
@@ -85,29 +85,34 @@ void FoldersPreferencesModel::load()
 
     m_folders = {
         {
-            FolderType::Scores, qtrc("appshell/preferences", "Scores"), projectConfiguration()->userProjectsPath().toQString(),
+            FolderType::Scores, TranslatableString("appshell/preferences", "Scores"),
+            projectConfiguration()->userProjectsPath().toQString(),
             projectConfiguration()->userProjectsPath().toQString()
         },
         {
-            FolderType::Styles, qtrc("appshell/preferences", "Styles"), notationConfiguration()->userStylesPath().toQString(),
+            FolderType::Styles, TranslatableString("appshell/preferences", "Styles"),
+            notationConfiguration()->userStylesPath().toQString(),
             notationConfiguration()->userStylesPath().toQString()
         },
         {
-            FolderType::Templates, qtrc("appshell/preferences", "Templates"), projectConfiguration()->userTemplatesPath().toQString(),
+            FolderType::Templates, TranslatableString("appshell/preferences", "Templates"),
+            projectConfiguration()->userTemplatesPath().toQString(),
             projectConfiguration()->userTemplatesPath().toQString()
         },
         {
-            FolderType::Plugins, qtrc("appshell/preferences", "Plugins"), pluginsConfiguration()->userPluginsPath().toQString(),
+            FolderType::Plugins, TranslatableString("appshell/preferences", "Plugins"),
+            pluginsConfiguration()->userPluginsPath().toQString(),
             pluginsConfiguration()->userPluginsPath().toQString()
         },
         {
-            FolderType::SoundFonts, qtrc("appshell/preferences", "SoundFonts"), pathsToString(
-                audioConfiguration()->userSoundFontDirectories()),
+            FolderType::SoundFonts, TranslatableString("appshell/preferences", "SoundFonts"),
+            pathsToString(audioConfiguration()->userSoundFontDirectories()),
             configuration()->userDataPath().toQString(), FolderValueType::MultiDirectories
         },
 #ifdef MUE_BUILD_VST_MODULE
         {
-            FolderType::VST3, qtrc("appshell/preferences", "VST3"), pathsToString(vstConfiguration()->userVstDirectories()),
+            FolderType::VST3, TranslatableString("appshell/preferences", "VST3"),
+            pathsToString(vstConfiguration()->userVstDirectories()),
             configuration()->userDataPath().toQString(), FolderValueType::MultiDirectories
         }
 #endif
@@ -120,6 +125,10 @@ void FoldersPreferencesModel::load()
 
 void FoldersPreferencesModel::setupConnections()
 {
+    languagesService()->currentLanguageChanged().onNotify(this, [this]{
+        emit dataChanged(index(0), index(rowCount() - 1), { TitleRole });
+    });
+
     projectConfiguration()->userProjectsPathChanged().onReceive(this, [this](const io::path_t& path) {
         setFolderPaths(FolderType::Scores, path.toQString());
     });

--- a/src/appshell/view/preferences/folderspreferencesmodel.h
+++ b/src/appshell/view/preferences/folderspreferencesmodel.h
@@ -24,8 +24,11 @@
 
 #include <QAbstractListModel>
 
+#include "types/translatablestring.h"
+
 #include "modularity/ioc.h"
 #include "async/asyncable.h"
+#include "languages/ilanguagesservice.h"
 #include "project/iprojectconfiguration.h"
 #include "notation/inotationconfiguration.h"
 #include "plugins/ipluginsconfiguration.h"
@@ -38,6 +41,7 @@ class FoldersPreferencesModel : public QAbstractListModel, public async::Asyncab
 {
     Q_OBJECT
 
+    INJECT(appshell, languages::ILanguagesService, languagesService)
     INJECT(appshell, project::IProjectConfiguration, projectConfiguration)
     INJECT(appshell, notation::INotationConfiguration, notationConfiguration)
     INJECT(appshell, plugins::IPluginsConfiguration, pluginsConfiguration)
@@ -82,7 +86,7 @@ private:
 
     struct FolderInfo {
         FolderType type = FolderType::Undefined;
-        QString title;
+        TranslatableString title;
         QString value;
         QString dir;
         FolderValueType valueType = FolderValueType::Directory;

--- a/src/appshell/view/preferences/generalpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/generalpreferencesmodel.cpp
@@ -40,11 +40,6 @@ void GeneralPreferencesModel::load()
         emit currentLanguageCodeChanged(languageCode);
     });
 
-    setIsNeedRestart(languagesService()->needRestartToApplyLanguageChange());
-    languagesService()->needRestartToApplyLanguageChangeChanged().onReceive(this, [this](bool need) {
-        setIsNeedRestart(need);
-    });
-
     projectConfiguration()->autoSaveEnabledChanged().onReceive(this, [this](bool enabled) {
         emit autoSaveEnabledChanged(enabled);
     });
@@ -191,18 +186,4 @@ void GeneralPreferencesModel::setOscPort(int oscPort)
 {
     NOT_IMPLEMENTED;
     emit oscPortChanged(oscPort);
-}
-
-bool GeneralPreferencesModel::isNeedRestart() const
-{
-    return m_isNeedRestart;
-}
-
-void GeneralPreferencesModel::setIsNeedRestart(bool newIsNeedRestart)
-{
-    if (m_isNeedRestart == newIsNeedRestart) {
-        return;
-    }
-    m_isNeedRestart = newIsNeedRestart;
-    emit isNeedRestartChanged();
 }

--- a/src/appshell/view/preferences/generalpreferencesmodel.h
+++ b/src/appshell/view/preferences/generalpreferencesmodel.h
@@ -57,8 +57,6 @@ class GeneralPreferencesModel : public QObject, public async::Asyncable
     Q_PROPERTY(bool isOSCRemoteControl READ isOSCRemoteControl WRITE setIsOSCRemoteControl NOTIFY isOSCRemoteControlChanged)
     Q_PROPERTY(int oscPort READ oscPort WRITE setOscPort NOTIFY oscPortChanged)
 
-    Q_PROPERTY(bool isNeedRestart READ isNeedRestart WRITE setIsNeedRestart NOTIFY isNeedRestartChanged)
-
 public:
     explicit GeneralPreferencesModel(QObject* parent = nullptr);
 
@@ -75,7 +73,6 @@ public:
     int autoSaveInterval() const;
     bool isOSCRemoteControl() const;
     int oscPort() const;
-    bool isNeedRestart() const;
 
 public slots:
     void setCurrentLanguageCode(const QString& currentLanguageCode);
@@ -84,7 +81,6 @@ public slots:
     void setAutoSaveInterval(int minutes);
     void setIsOSCRemoteControl(bool isOSCRemoteControl);
     void setOscPort(int oscPort);
-    void setIsNeedRestart(bool newIsNeedRestart);
 
 signals:
     void languagesChanged(QVariantList languages);
@@ -96,12 +92,9 @@ signals:
     void oscPortChanged(int oscPort);
 
     void receivingUpdateForCurrentLanguage(int current, int total, QString status);
-    void isNeedRestartChanged();
 
 private:
     framework::Progress m_languageUpdateProgress;
-
-    bool m_isNeedRestart = false;
 };
 }
 

--- a/src/appshell/view/preferences/preferencepageitem.cpp
+++ b/src/appshell/view/preferences/preferencepageitem.cpp
@@ -21,13 +21,14 @@
  */
 #include "preferencepageitem.h"
 
-#include "translation.h"
-
 using namespace mu::appshell;
 
 PreferencePageItem::PreferencePageItem(QObject* parent)
     : QObject(parent)
 {
+    languagesService()->currentLanguageChanged().onNotify(this, [this] {
+        emit titleChanged();
+    });
 }
 
 PreferencePageItem::~PreferencePageItem()
@@ -44,7 +45,7 @@ QString PreferencePageItem::id() const
 
 QString PreferencePageItem::title() const
 {
-    return qtrc("appshell/preferences", m_title.toUtf8());
+    return m_title.qTranslated();
 }
 
 int PreferencePageItem::icon() const
@@ -126,14 +127,14 @@ void PreferencePageItem::setId(QString id)
     emit idChanged(m_id);
 }
 
-void PreferencePageItem::setTitle(QString title)
+void PreferencePageItem::setTitle(TranslatableString title)
 {
     if (m_title == title) {
         return;
     }
 
     m_title = title;
-    emit titleChanged(m_title);
+    emit titleChanged();
 }
 
 void PreferencePageItem::setIcon(ui::IconCode::Code icon)

--- a/src/appshell/view/preferences/preferencepageitem.h
+++ b/src/appshell/view/preferences/preferencepageitem.h
@@ -25,12 +25,21 @@
 #include <QObject>
 #include <QVariantMap>
 
+#include "types/translatablestring.h"
+
+#include "async/asyncable.h"
+
+#include "modularity/ioc.h"
+#include "languages/ilanguagesservice.h"
+
 #include "ui/view/iconcodes.h"
 
 namespace mu::appshell {
-class PreferencePageItem : public QObject
+class PreferencePageItem : public QObject, public async::Asyncable
 {
     Q_OBJECT
+
+    INJECT(appshell, languages::ILanguagesService, languagesService)
 
     Q_PROPERTY(QString id READ id NOTIFY idChanged)
     Q_PROPERTY(QString title READ title NOTIFY titleChanged)
@@ -62,7 +71,7 @@ public:
     int row() const;
 
 public slots:
-    void setTitle(QString title);
+    void setTitle(TranslatableString title);
     void setId(QString id);
     void setIcon(ui::IconCode::Code icon);
     void setPath(QString path);
@@ -70,7 +79,7 @@ public slots:
 
 signals:
     void idChanged(QString id);
-    void titleChanged(QString title);
+    void titleChanged();
     void iconChanged(int icon);
     void pathChanged(QString path);
     void expandedChanged(bool expanded);
@@ -79,7 +88,7 @@ private:
     QList<PreferencePageItem*> m_children;
     PreferencePageItem* m_parent = nullptr;
 
-    QString m_title;
+    TranslatableString m_title;
     QString m_id;
     ui::IconCode::Code m_icon = ui::IconCode::Code::NONE;
     QString m_path;

--- a/src/appshell/view/preferences/preferencesmodel.cpp
+++ b/src/appshell/view/preferences/preferencesmodel.cpp
@@ -147,48 +147,48 @@ void PreferencesModel::load(const QString& currentPageId)
     m_rootItem = new PreferencePageItem();
 
     QList<PreferencePageItem*> generalItems {
-        makeItem("general-start", QT_TRANSLATE_NOOP("appshell/preferences", "Program start"), IconCode::Code::NONE,
+        makeItem("general-start", TranslatableString("appshell/preferences", "Program start"), IconCode::Code::NONE,
                  "Preferences/ProgrammeStartPreferencesPage.qml"),
 
-        makeItem("general-folders", QT_TRANSLATE_NOOP("appshell/preferences", "Folders"), IconCode::Code::NONE,
+        makeItem("general-folders", TranslatableString("appshell/preferences", "Folders"), IconCode::Code::NONE,
                  "Preferences/FoldersPreferencesPage.qml")
     };
 
     QList<PreferencePageItem*> items {
-        makeItem("general", QT_TRANSLATE_NOOP("appshell/preferences", "General"), IconCode::Code::SETTINGS_COG,
+        makeItem("general", TranslatableString("appshell/preferences", "General"), IconCode::Code::SETTINGS_COG,
                  "Preferences/GeneralPreferencesPage.qml", generalItems),
 
-        makeItem("appearance", QT_TRANSLATE_NOOP("appshell/preferences", "Appearance"), IconCode::Code::VISIBILITY_ON,
+        makeItem("appearance", TranslatableString("appshell/preferences", "Appearance"), IconCode::Code::VISIBILITY_ON,
                  "Preferences/AppearancePreferencesPage.qml"),
 
-        makeItem("canvas", QT_TRANSLATE_NOOP("appshell/preferences", "Canvas"), IconCode::Code::NEW_FILE,
+        makeItem("canvas", TranslatableString("appshell/preferences", "Canvas"), IconCode::Code::NEW_FILE,
                  "Preferences/CanvasPreferencesPage.qml"),
 
-        makeItem("cloud", QT_TRANSLATE_NOOP("appshell/preferences", "Cloud"), IconCode::Code::CLOUD_FILE,
+        makeItem("cloud", TranslatableString("appshell/preferences", "Cloud"), IconCode::Code::CLOUD_FILE,
                  "Preferences/CloudPreferencesPage.qml"),
 
-        makeItem("note-input", QT_TRANSLATE_NOOP("appshell/preferences", "Note input"), IconCode::Code::EDIT,
+        makeItem("note-input", TranslatableString("appshell/preferences", "Note input"), IconCode::Code::EDIT,
                  "Preferences/NoteInputPreferencesPage.qml"),
 
-        makeItem("midi-device-mapping", QT_TRANSLATE_NOOP("appshell/preferences", "MIDI mappings"), IconCode::Code::MIDI_INPUT,
+        makeItem("midi-device-mapping", TranslatableString("appshell/preferences", "MIDI mappings"), IconCode::Code::MIDI_INPUT,
                  "Preferences/MidiDeviceMappingPreferencesPage.qml"),
 
-        makeItem("score", QT_TRANSLATE_NOOP("appshell/preferences", "Score"), IconCode::Code::SCORE,
+        makeItem("score", TranslatableString("appshell/preferences", "Score"), IconCode::Code::SCORE,
                  "Preferences/ScorePreferencesPage.qml"),
 
-        makeItem("io", QT_TRANSLATE_NOOP("appshell/preferences", "I/O"), IconCode::Code::AUDIO,
+        makeItem("io", TranslatableString("appshell/preferences", "I/O"), IconCode::Code::AUDIO,
                  "Preferences/IOPreferencesPage.qml"),
 
-        makeItem("import", QT_TRANSLATE_NOOP("appshell/preferences", "Import"), IconCode::Code::IMPORT,
+        makeItem("import", TranslatableString("appshell/preferences", "Import"), IconCode::Code::IMPORT,
                  "Preferences/ImportPreferencesPage.qml"),
 
-        makeItem("shortcuts", QT_TRANSLATE_NOOP("appshell/preferences", "Shortcuts"), IconCode::Code::SHORTCUTS,
+        makeItem("shortcuts", TranslatableString("appshell/preferences", "Shortcuts"), IconCode::Code::SHORTCUTS,
                  "Preferences/ShortcutsPreferencesPage.qml"),
 
-        makeItem("update", QT_TRANSLATE_NOOP("appshell/preferences", "Update"), IconCode::Code::UPDATE,
+        makeItem("update", TranslatableString("appshell/preferences", "Update"), IconCode::Code::UPDATE,
                  "Preferences/UpdatePreferencesPage.qml"),
 
-        makeItem("advanced", QT_TRANSLATE_NOOP("appshell/preferences", "Advanced"), IconCode::Code::CONFIGURE,
+        makeItem("advanced", TranslatableString("appshell/preferences", "Advanced"), IconCode::Code::CONFIGURE,
                  "Preferences/AdvancedPreferencesPage.qml")
     };
 
@@ -278,7 +278,7 @@ void PreferencesModel::setCurrentPageId(QString currentPageId)
     emit currentPageIdChanged(m_currentPageId);
 }
 
-PreferencePageItem* PreferencesModel::makeItem(const QString& id, const QString& title, mu::ui::IconCode::Code icon,
+PreferencePageItem* PreferencesModel::makeItem(const QString& id, const TranslatableString& title, mu::ui::IconCode::Code icon,
                                                const QString& path,
                                                const QList<PreferencePageItem*>& children) const
 {

--- a/src/appshell/view/preferences/preferencesmodel.h
+++ b/src/appshell/view/preferences/preferencesmodel.h
@@ -24,6 +24,8 @@
 
 #include <QAbstractItemModel>
 
+#include "types/translatablestring.h"
+
 #include "modularity/ioc.h"
 #include "actions/iactionsdispatcher.h"
 #include "ui/iuiactionsregister.h"
@@ -76,7 +78,7 @@ private:
         ItemRole = Qt::UserRole + 1
     };
 
-    PreferencePageItem* makeItem(const QString& id, const QString& title, ui::IconCode::Code icon = mu::ui::IconCode::Code::NONE,
+    PreferencePageItem* makeItem(const QString& id, const TranslatableString& title, ui::IconCode::Code icon = mu::ui::IconCode::Code::NONE,
                                  const QString& path = "", const QList<PreferencePageItem*>& children = {}) const;
 
     PreferencePageItem* modelIndexToItem(const QModelIndex& index) const;

--- a/src/appshell/view/preferences/programmestartpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/programmestartpreferencesmodel.cpp
@@ -23,13 +23,16 @@
 #include "programmestartpreferencesmodel.h"
 
 #include "log.h"
-#include "translation.h"
 
 using namespace mu::appshell;
 
 ProgrammeStartPreferencesModel::ProgrammeStartPreferencesModel(QObject* parent)
     : QObject(parent)
 {
+    languagesService()->currentLanguageChanged().onNotify(this, [this] {
+        emit startupModesChanged();
+        emit panelsChanged();
+    });
 }
 
 QVariantList ProgrammeStartPreferencesModel::startupModes() const
@@ -38,7 +41,7 @@ QVariantList ProgrammeStartPreferencesModel::startupModes() const
 
     for (const StartMode& mode: allStartupModes()) {
         QVariantMap obj;
-        obj["title"] = mode.title;
+        obj["title"] = mode.title.qTranslated();
         obj["checked"] = mode.checked;
         obj["canSelectScorePath"] = mode.canSelectScorePath;
         obj["scorePath"] = mode.scorePath;
@@ -51,11 +54,11 @@ QVariantList ProgrammeStartPreferencesModel::startupModes() const
 
 ProgrammeStartPreferencesModel::StartModeList ProgrammeStartPreferencesModel::allStartupModes() const
 {
-    static const QMap<StartupModeType, QString> modeTitles {
-        { StartupModeType::StartEmpty,  qtrc("appshell/preferences", "Start empty") },
-        { StartupModeType::ContinueLastSession, qtrc("appshell/preferences", "Continue last session") },
-        { StartupModeType::StartWithNewScore, qtrc("appshell/preferences", "Start with new score") },
-        { StartupModeType::StartWithScore, qtrc("appshell/preferences", "Start with score:") }
+    static const QMap<StartupModeType, TranslatableString> modeTitles {
+        { StartupModeType::StartEmpty,  TranslatableString("appshell/preferences", "Start empty") },
+        { StartupModeType::ContinueLastSession, TranslatableString("appshell/preferences", "Continue last session") },
+        { StartupModeType::StartWithNewScore, TranslatableString("appshell/preferences", "Start with new score") },
+        { StartupModeType::StartWithScore, TranslatableString("appshell/preferences", "Start with score:") }
     };
 
     StartModeList modes;
@@ -82,7 +85,7 @@ QVariantList ProgrammeStartPreferencesModel::panels() const
 
     for (const Panel& panel: allPanels()) {
         QVariantMap obj;
-        obj["title"] = panel.title;
+        obj["title"] = panel.title.qTranslated();
         obj["visible"] = panel.visible;
 
         result << obj;
@@ -98,7 +101,7 @@ ProgrammeStartPreferencesModel::PanelList ProgrammeStartPreferencesModel::allPan
          * TODO: https://github.com/musescore/MuseScore/issues/9807
         Panel { SplashScreen, qtrc("appshell/preferences", "Show splash screen"), configuration()->needShowSplashScreen() },
          */
-        Panel { Navigator, qtrc("appshell/preferences", "Show navigator"), configuration()->isNotationNavigatorVisible() },
+        Panel { Navigator, TranslatableString("appshell/preferences", "Show navigator"), configuration()->isNotationNavigatorVisible() },
     };
 
     return panels;

--- a/src/appshell/view/preferences/programmestartpreferencesmodel.h
+++ b/src/appshell/view/preferences/programmestartpreferencesmodel.h
@@ -24,16 +24,21 @@
 
 #include <QObject>
 
+#include "types/translatablestring.h"
+
+#include "async/asyncable.h"
+
 #include "modularity/ioc.h"
 #include "iappshellconfiguration.h"
-#include "project/iprojectconfiguration.h"
+#include "languages/ilanguagesservice.h"
 
 namespace mu::appshell {
-class ProgrammeStartPreferencesModel : public QObject
+class ProgrammeStartPreferencesModel : public QObject, public async::Asyncable
 {
     Q_OBJECT
 
     INJECT(appshell, IAppShellConfiguration, configuration)
+    INJECT(appshell, languages::ILanguagesService, languagesService)
 
     Q_PROPERTY(QVariantList startupModes READ startupModes NOTIFY startupModesChanged)
     Q_PROPERTY(QVariantList panels READ panels NOTIFY panelsChanged)
@@ -64,7 +69,7 @@ private:
     struct Panel
     {
         PanelType type = Unknown;
-        QString title;
+        TranslatableString title;
         bool visible = false;
     };
 
@@ -73,7 +78,7 @@ private:
     struct StartMode
     {
         StartupModeType type = StartupModeType::StartWithNewScore;
-        QString title;
+        TranslatableString title;
         bool checked = false;
         bool canSelectScorePath = false;
         QString scorePath;

--- a/src/appshell/view/preferences/scorepreferencesmodel.cpp
+++ b/src/appshell/view/preferences/scorepreferencesmodel.cpp
@@ -85,6 +85,15 @@ QHash<int, QByteArray> ScorePreferencesModel::roleNames() const
 
 void ScorePreferencesModel::load()
 {
+    loadItems();
+
+    languagesService()->currentLanguageChanged().onNotify(this, [this]() {
+        loadItems();
+    });
+}
+
+void ScorePreferencesModel::loadItems()
+{
     beginResetModel();
 
     m_defaultFiles = {

--- a/src/appshell/view/preferences/scorepreferencesmodel.h
+++ b/src/appshell/view/preferences/scorepreferencesmodel.h
@@ -29,6 +29,7 @@
 
 #include "notation/inotationconfiguration.h"
 #include "audio/iaudioconfiguration.h"
+#include "languages/ilanguagesservice.h"
 
 namespace mu::appshell {
 class ScorePreferencesModel : public QAbstractListModel, public async::Asyncable
@@ -37,6 +38,7 @@ class ScorePreferencesModel : public QAbstractListModel, public async::Asyncable
 
     INJECT(appshell, notation::INotationConfiguration, notationConfiguration)
     INJECT(appshell, audio::IAudioConfiguration, audioConfiguration)
+    INJECT(appshell, languages::ILanguagesService, languagesService)
 
 public:
     explicit ScorePreferencesModel(QObject* parent = nullptr);
@@ -72,6 +74,8 @@ private:
         QStringList pathFilter;
         QString chooseTitle;
     };
+
+    void loadItems();
 
     void savePath(DefaultFileType fileType, const QString& path);
 

--- a/src/framework/shortcuts/qml/MuseScore/Shortcuts/internal/MidiMappingTopPanel.qml
+++ b/src/framework/shortcuts/qml/MuseScore/Shortcuts/internal/MidiMappingTopPanel.qml
@@ -47,6 +47,9 @@ RowLayout {
 
     CheckBox {
         id: remoteControlCheckBox
+
+        Layout.fillWidth: true
+
         text: qsTrc("shortcuts", "MIDI remote control")
         font: ui.theme.bodyBoldFont
 

--- a/src/framework/shortcuts/view/mididevicemappingmodel.cpp
+++ b/src/framework/shortcuts/view/mididevicemappingmodel.cpp
@@ -124,6 +124,19 @@ QHash<int, QByteArray> MidiDeviceMappingModel::roleNames() const
 
 void MidiDeviceMappingModel::load()
 {
+    loadItems();
+
+    midiRemote()->midiMappingsChanged().onNotify(this, [this](){
+        loadItems();
+    });
+
+    languagesService()->currentLanguageChanged().onNotify(this, [this] {
+        loadItems();
+    });
+}
+
+void MidiDeviceMappingModel::loadItems()
+{
     beginResetModel();
     m_midiMappings.clear();
 
@@ -148,10 +161,6 @@ void MidiDeviceMappingModel::load()
             m_midiMappings.push_back(midiMapping);
         }
     }
-
-    midiRemote()->midiMappingsChanged().onNotify(this, [this](){
-        load();
-    });
 
     endResetModel();
 }

--- a/src/framework/shortcuts/view/mididevicemappingmodel.h
+++ b/src/framework/shortcuts/view/mididevicemappingmodel.h
@@ -33,6 +33,7 @@
 #include "midi/imidiconfiguration.h"
 #include "ishortcutsconfiguration.h"
 #include "imidiremote.h"
+#include "languages/ilanguagesservice.h"
 
 #include "ui/iuiactionsregister.h"
 #include "ui/uitypes.h"
@@ -46,6 +47,7 @@ class MidiDeviceMappingModel : public QAbstractListModel, public async::Asyncabl
     INJECT(shortcuts, shortcuts::IMidiRemote, midiRemote)
     INJECT(shortcuts, IShortcutsConfiguration, configuration)
     INJECT(shortcuts, midi::IMidiConfiguration, midiConfiguration)
+    INJECT(shortcuts, languages::ILanguagesService, languagesService)
 
     Q_PROPERTY(bool useRemoteControl READ useRemoteControl WRITE setUseRemoteControl NOTIFY useRemoteControlChanged)
 
@@ -90,6 +92,8 @@ private:
         RoleMappedType,
         RoleMappedValue
     };
+
+    void loadItems();
 
     QVariantMap midiMappingToObject(const MidiControlsMapping& midiMapping) const;
 

--- a/src/framework/shortcuts/view/shortcutsmodel.cpp
+++ b/src/framework/shortcuts/view/shortcutsmodel.cpp
@@ -99,6 +99,19 @@ QHash<int, QByteArray> ShortcutsModel::roleNames() const
 
 void ShortcutsModel::load()
 {
+    loadItems();
+
+    shortcutsRegister()->shortcutsChanged().onNotify(this, [this]() {
+        loadItems();
+    });
+
+    languagesService()->currentLanguageChanged().onNotify(this, [this] {
+        loadItems();
+    });
+}
+
+void ShortcutsModel::loadItems()
+{
     beginResetModel();
     m_shortcuts.clear();
 
@@ -115,10 +128,6 @@ void ShortcutsModel::load()
 
         m_shortcuts << shortcut;
     }
-
-    shortcutsRegister()->shortcutsChanged().onNotify(this, [this]() {
-        load();
-    });
 
     std::sort(m_shortcuts.begin(), m_shortcuts.end(), [this](const Shortcut& s1, const Shortcut& s2) {
         return actionText(s1.action) < actionText(s2.action);

--- a/src/framework/shortcuts/view/shortcutsmodel.h
+++ b/src/framework/shortcuts/view/shortcutsmodel.h
@@ -33,6 +33,7 @@
 #include "async/asyncable.h"
 #include "iinteractive.h"
 #include "iglobalconfiguration.h"
+#include "languages/ilanguagesservice.h"
 
 class QItemSelection;
 
@@ -46,6 +47,7 @@ class ShortcutsModel : public QAbstractListModel, public async::Asyncable
     INJECT(shortcuts, framework::IInteractive, interactive)
     INJECT(shortcuts, IShortcutsConfiguration, configuration)
     INJECT(shortcuts, framework::IGlobalConfiguration, globalConfiguration)
+    INJECT(shortcuts, languages::ILanguagesService, languagesService)
 
     Q_PROPERTY(QItemSelection selection READ selection WRITE setSelection NOTIFY selectionChanged)
     Q_PROPERTY(QVariant currentShortcut READ currentShortcut NOTIFY selectionChanged)
@@ -81,6 +83,8 @@ signals:
     void selectionChanged();
 
 private:
+    void loadItems();
+
     const ui::UiAction& action(const std::string& actionCode) const;
     QString actionText(const std::string& actionCode) const;
 

--- a/src/framework/ui/internal/uiengine.cpp
+++ b/src/framework/ui/internal/uiengine.cpp
@@ -115,12 +115,17 @@ void UiEngine::setup(QQmlEngine* engine)
     QJSValue translator = m_engine->newQObject(m_translation);
     QQmlEngine::setObjectOwnership(m_translation, QQmlEngine::CppOwnership);
     m_translationFunction = translator.property("translate");
-    m_engine->globalObject().setProperty("qsTrc", m_translationFunction);
+
+    QJSValue qsTrc = m_engine->evaluate(
+        "(function(context, text, disambiguation = \"\", n = -1) {"
+        "    return ui.trc(context, text, disambiguation, n);"
+        "})");
+    m_engine->globalObject().setProperty("qsTrc", qsTrc);
 
 #ifdef Q_OS_WIN
     QDir dir(QCoreApplication::applicationDirPath() + QString("/../qml"));
     m_engine->addImportPath(dir.absolutePath());
- #endif
+#endif
 
     m_engine->addImportPath(":/qml");
 

--- a/src/framework/ui/internal/uiengine.cpp
+++ b/src/framework/ui/internal/uiengine.cpp
@@ -122,6 +122,10 @@ void UiEngine::setup(QQmlEngine* engine)
         "})");
     m_engine->globalObject().setProperty("qsTrc", qsTrc);
 
+    languagesService()->currentLanguageChanged().onNotify(this, [this]() {
+        emit translationChanged();
+    });
+
 #ifdef Q_OS_WIN
     QDir dir(QCoreApplication::applicationDirPath() + QString("/../qml"));
     m_engine->addImportPath(dir.absolutePath());
@@ -147,11 +151,6 @@ void UiEngine::addSourceImportPath(const QString& path)
 #else
     Q_UNUSED(path);
 #endif
-}
-
-void UiEngine::retranslateUi()
-{
-    emit translationFunctionChanged();
 }
 
 QmlApi* UiEngine::api() const

--- a/src/framework/ui/internal/uiengine.h
+++ b/src/framework/ui/internal/uiengine.h
@@ -49,6 +49,8 @@ class UiEngine : public QObject, public IUiEngine
 
     Q_PROPERTY(QQuickItem * rootItem READ rootItem WRITE setRootItem NOTIFY rootItemChanged)
 
+    Q_PROPERTY(QJSValue trc READ translationFunction NOTIFY translationFunctionChanged)
+
     // for internal use
     Q_PROPERTY(InteractiveProvider * _interactiveProvider READ interactiveProvider_property CONSTANT)
 
@@ -60,6 +62,7 @@ public:
     QmlApi* api() const;
     UiTheme* theme() const;
     QmlToolTip* tooltip() const;
+    QJSValue translationFunction() const;
     InteractiveProvider* interactiveProvider_property() const;
     std::shared_ptr<InteractiveProvider> interactiveProvider() const;
 
@@ -67,10 +70,11 @@ public:
     Q_INVOKABLE Qt::LayoutDirection currentLanguageLayoutDirection() const;
 
     // IUiEngine
-    void updateTheme() override;
     QQmlEngine* qmlEngine() const override;
     void clearComponentCache() override;
     void addSourceImportPath(const QString& path) override;
+
+    void retranslateUi() override;
     // ---
 
     void moveQQmlEngine(QQmlEngine* e);
@@ -86,6 +90,8 @@ signals:
 
     void rootItemChanged(QQuickItem* rootItem);
 
+    void translationFunctionChanged();
+
 private:
     UiEngine();
 
@@ -100,6 +106,7 @@ private:
     QmlApi* m_api = nullptr;
     QmlToolTip* m_tooltip = nullptr;
     QQuickItem* m_rootItem = nullptr;
+    QJSValue m_translationFunction;
 };
 }
 

--- a/src/framework/ui/internal/uiengine.h
+++ b/src/framework/ui/internal/uiengine.h
@@ -26,6 +26,8 @@
 #include <QObject>
 #include <memory>
 
+#include "async/asyncable.h"
+
 #include "../iuiengine.h"
 #include "../view/uitheme.h"
 #include "../view/qmltooltip.h"
@@ -33,12 +35,13 @@
 #include "../view/interactiveprovider.h"
 #include "../view/qmlapi.h"
 
+#include "modularity/ioc.h"
 #include "languages/ilanguagesservice.h"
 
 class QQmlEngine;
 
 namespace mu::ui {
-class UiEngine : public QObject, public IUiEngine
+class UiEngine : public QObject, public IUiEngine, public async::Asyncable
 {
     Q_OBJECT
 
@@ -49,7 +52,7 @@ class UiEngine : public QObject, public IUiEngine
 
     Q_PROPERTY(QQuickItem * rootItem READ rootItem WRITE setRootItem NOTIFY rootItemChanged)
 
-    Q_PROPERTY(QJSValue trc READ translationFunction NOTIFY translationFunctionChanged)
+    Q_PROPERTY(QJSValue trc READ translationFunction NOTIFY translationChanged)
 
     // for internal use
     Q_PROPERTY(InteractiveProvider * _interactiveProvider READ interactiveProvider_property CONSTANT)
@@ -73,8 +76,6 @@ public:
     QQmlEngine* qmlEngine() const override;
     void clearComponentCache() override;
     void addSourceImportPath(const QString& path) override;
-
-    void retranslateUi() override;
     // ---
 
     void moveQQmlEngine(QQmlEngine* e);
@@ -90,7 +91,7 @@ signals:
 
     void rootItemChanged(QQuickItem* rootItem);
 
-    void translationFunctionChanged();
+    void translationChanged();
 
 private:
     UiEngine();

--- a/src/framework/ui/iuiengine.h
+++ b/src/framework/ui/iuiengine.h
@@ -40,8 +40,6 @@ public:
     virtual void clearComponentCache() = 0;
 
     virtual void addSourceImportPath(const QString& path) = 0;
-
-    virtual void retranslateUi() = 0;
 };
 }
 

--- a/src/framework/ui/iuiengine.h
+++ b/src/framework/ui/iuiengine.h
@@ -36,11 +36,12 @@ class IUiEngine : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IUiEngine() {}
 
-    virtual void updateTheme() = 0;
     virtual QQmlEngine* qmlEngine() const = 0;
     virtual void clearComponentCache() = 0;
 
     virtual void addSourceImportPath(const QString& path) = 0;
+
+    virtual void retranslateUi() = 0;
 };
 }
 

--- a/src/framework/uicomponents/view/menuitem.cpp
+++ b/src/framework/uicomponents/view/menuitem.cpp
@@ -32,10 +32,13 @@ using namespace mu::ui;
 MenuItem::MenuItem(QObject* parent)
     : QObject(parent)
 {
+    languagesService()->currentLanguageChanged().onNotify(this, [this]() {
+        emit actionChanged();
+    });
 }
 
 MenuItem::MenuItem(const UiAction& action, QObject* parent)
-    : QObject(parent)
+    : MenuItem(parent)
 {
     m_id = QString::fromStdString(action.code);
     m_action = action;

--- a/src/framework/uicomponents/view/menuitem.h
+++ b/src/framework/uicomponents/view/menuitem.h
@@ -27,6 +27,9 @@
 
 #include "async/asyncable.h"
 
+#include "modularity/ioc.h"
+#include "languages/ilanguagesservice.h"
+
 #include "ui/uitypes.h"
 
 namespace mu {
@@ -48,6 +51,8 @@ enum class MenuItemRole {
 class MenuItem : public QObject, public async::Asyncable
 {
     Q_OBJECT
+
+    INJECT_STATIC(uicomponents, languages::ILanguagesService, languagesService)
 
     Q_PROPERTY(QString id READ id NOTIFY idChanged)
 

--- a/src/languages/ilanguagesservice.h
+++ b/src/languages/ilanguagesservice.h
@@ -45,9 +45,6 @@ public:
     virtual const Language& placeholderLanguage() const = 0;
 
     virtual framework::Progress update(const QString& languageCode) = 0;
-
-    virtual bool needRestartToApplyLanguageChange() const = 0;
-    virtual async::Channel<bool> needRestartToApplyLanguageChangeChanged() const = 0;
 };
 }
 

--- a/src/languages/internal/languagesservice.cpp
+++ b/src/languages/internal/languagesservice.cpp
@@ -65,10 +65,8 @@ void LanguagesService::init()
     ValCh<QString> languageCode = configuration()->currentLanguageCode();
     setCurrentLanguage(languageCode.val);
 
-    languageCode.ch.onReceive(this, [this](const QString&) {
-        //! NOTE To change the language at the moment, a restart is required
-        m_needRestartToApplyLanguageChange = true;
-        m_needRestartToApplyLanguageChangeChanged.send(m_needRestartToApplyLanguageChange);
+    languageCode.ch.onReceive(this, [this](const QString& languageCode) {
+        setCurrentLanguage(languageCode);
     });
 
     m_inited = true;
@@ -199,7 +197,7 @@ void LanguagesService::setCurrentLanguage(const QString& languageCode)
 
     lang.direction = locale.textDirection();
 
-    // Currently, no need to retranslate the UI on language change, because we require restart
+    uiEngine()->retranslateUi();
 
     m_currentLanguage = lang;
     m_currentLanguageChanged.notify();

--- a/src/languages/internal/languagesservice.cpp
+++ b/src/languages/internal/languagesservice.cpp
@@ -168,13 +168,13 @@ void LanguagesService::setCurrentLanguage(const QString& languageCode)
     doSetCurrentLanguage(effectiveLanguageCode);
 }
 
-void LanguagesService::doSetCurrentLanguage(const QString& effectiveLanguageCode)
+void LanguagesService::doSetCurrentLanguage(const QString& effectiveLanguageCode, bool forceReload)
 {
     Language& lang = effectiveLanguageCode == PLACEHOLDER_LANGUAGE_CODE
                      ? m_placeholderLanguage
                      : m_languagesHash[effectiveLanguageCode];
 
-    if (!lang.isLoaded()) {
+    if (forceReload || !lang.isLoaded()) {
         loadLanguage(lang);
     }
 
@@ -280,6 +280,8 @@ Ret LanguagesService::loadLanguage(Language& lang)
         return appFilePaths.ret;
     }
 
+    lang.files.clear();
+
     for (const io::path_t& appFilePath : appFilePaths.val) {
         io::path_t filename = io::filename(appFilePath);
         io::path_t userFilePath = languagesUserAppDataPath.appendingComponent(filename);
@@ -336,7 +338,7 @@ Progress LanguagesService::update(const QString& languageCode)
 
         if (res.ret && effectiveLanguageCode == m_currentLanguage.code) {
             // If the current language was succesfully updated, retranslate the UI
-            doSetCurrentLanguage(effectiveLanguageCode);
+            doSetCurrentLanguage(effectiveLanguageCode, true);
         }
     });
 

--- a/src/languages/internal/languagesservice.h
+++ b/src/languages/internal/languagesservice.h
@@ -58,7 +58,7 @@ private:
     void loadLanguages();
 
     void setCurrentLanguage(const QString& languageCode);
-    void doSetCurrentLanguage(const QString& effectiveLanguageCode);
+    void doSetCurrentLanguage(const QString& effectiveLanguageCode, bool forceReload = false);
     QString effectiveLanguageCode(const QString& languageCode) const;
     Ret loadLanguage(Language& lang);
 

--- a/src/languages/internal/languagesservice.h
+++ b/src/languages/internal/languagesservice.h
@@ -29,7 +29,6 @@
 #include "ilanguagesconfiguration.h"
 #include "framework/network/inetworkmanagercreator.h"
 #include "io/ifilesystem.h"
-#include "ui/iuiengine.h"
 #include "multiinstances/imultiinstancesprovider.h"
 
 class QTranslator;
@@ -40,7 +39,6 @@ class LanguagesService : public ILanguagesService, public async::Asyncable
     INJECT(languages, ILanguagesConfiguration, configuration)
     INJECT(languages, network::INetworkManagerCreator, networkManagerCreator)
     INJECT(languages, io::IFileSystem, fileSystem)
-    INJECT(languages, ui::IUiEngine, uiEngine)
     INJECT(languages, mi::IMultiInstancesProvider, multiInstancesProvider)
 
 public:
@@ -56,13 +54,11 @@ public:
 
     framework::Progress update(const QString& languageCode) override;
 
-    bool needRestartToApplyLanguageChange() const override;
-    async::Channel<bool> needRestartToApplyLanguageChangeChanged() const override;
-
 private:
     void loadLanguages();
 
     void setCurrentLanguage(const QString& languageCode);
+    void doSetCurrentLanguage(const QString& effectiveLanguageCode);
     QString effectiveLanguageCode(const QString& languageCode) const;
     Ret loadLanguage(Language& lang);
 
@@ -71,7 +67,6 @@ private:
     Ret downloadLanguage(const QString& languageCode, framework::Progress progress) const;
     RetVal<QString> fileHash(const io::path_t& path);
 
-private:
     LanguagesHash m_languagesHash;
     Language m_currentLanguage;
     async::Notification m_currentLanguageChanged;
@@ -81,8 +76,6 @@ private:
     mutable QHash<QString, framework::Progress> m_updateOperationsHash;
 
     bool m_inited = false;
-    bool m_needRestartToApplyLanguageChange = false;
-    async::Channel<bool> m_needRestartToApplyLanguageChangeChanged;
 };
 }
 

--- a/src/languages/internal/languagesservice.h
+++ b/src/languages/internal/languagesservice.h
@@ -29,6 +29,7 @@
 #include "ilanguagesconfiguration.h"
 #include "framework/network/inetworkmanagercreator.h"
 #include "io/ifilesystem.h"
+#include "ui/iuiengine.h"
 #include "multiinstances/imultiinstancesprovider.h"
 
 class QTranslator;
@@ -39,6 +40,7 @@ class LanguagesService : public ILanguagesService, public async::Asyncable
     INJECT(languages, ILanguagesConfiguration, configuration)
     INJECT(languages, network::INetworkManagerCreator, networkManagerCreator)
     INJECT(languages, io::IFileSystem, fileSystem)
+    INJECT(languages, ui::IUiEngine, uiEngine)
     INJECT(languages, mi::IMultiInstancesProvider, multiInstancesProvider)
 
 public:

--- a/src/learn/qml/MuseScore/Learn/LearnPage.qml
+++ b/src/learn/qml/MuseScore/Learn/LearnPage.qml
@@ -241,7 +241,7 @@ FocusScope {
         ClassesPage {
             id: classesComp
 
-            property var author: pageModel.classesAuthor()
+            property var author: pageModel.classesAuthor
 
             authorName: author.name
             authorPosition: author.position

--- a/src/learn/view/learnpagemodel.cpp
+++ b/src/learn/view/learnpagemodel.cpp
@@ -58,6 +58,10 @@ void LearnPageModel::load()
     learnService()->advancedPlaylistChanged().onReceive(this, [this](const Playlist& playlist) {
         setAdvancedPlaylist(playlist);
     });
+
+    languagesService()->currentLanguageChanged().onNotify(this, [this] {
+        emit classesAuthorChanged();
+    });
 }
 
 void LearnPageModel::openVideo(const QString& videoId) const

--- a/src/learn/view/learnpagemodel.h
+++ b/src/learn/view/learnpagemodel.h
@@ -28,6 +28,7 @@
 #include "async/asyncable.h"
 #include "iinteractive.h"
 #include "ilearnservice.h"
+#include "languages/ilanguagesservice.h"
 
 namespace mu::learn {
 class LearnPageModel : public QObject, public async::Asyncable
@@ -36,9 +37,11 @@ class LearnPageModel : public QObject, public async::Asyncable
 
     Q_PROPERTY(QVariantList startedPlaylist READ startedPlaylist NOTIFY startedPlaylistChanged)
     Q_PROPERTY(QVariantList advancedPlaylist READ advancedPlaylist NOTIFY advancedPlaylistChanged)
+    Q_PROPERTY(QVariantMap classesAuthor READ classesAuthor NOTIFY classesAuthorChanged)
 
     INJECT(learn, framework::IInteractive, interactive)
     INJECT(learn, ILearnService, learnService)
+    INJECT(learn, languages::ILanguagesService, languagesService)
 
 public:
     explicit LearnPageModel(QObject* parent = nullptr);
@@ -46,13 +49,13 @@ public:
     QVariantList startedPlaylist() const;
     QVariantList advancedPlaylist() const;
 
+    QVariantMap classesAuthor() const;
+
     Q_INVOKABLE void load();
     Q_INVOKABLE void openVideo(const QString& videoId) const;
     Q_INVOKABLE void openUrl(const QString& url) const;
 
     Q_INVOKABLE void setSearchText(const QString& text);
-
-    Q_INVOKABLE QVariantMap classesAuthor() const;
 
 private slots:
     void setStartedPlaylist(Playlist startedPlaylist);
@@ -61,6 +64,7 @@ private slots:
 signals:
     void startedPlaylistChanged();
     void advancedPlaylistChanged();
+    void classesAuthorChanged();
 
 private:
     QVariantList playlistToVariantList(const Playlist& playlist) const;

--- a/src/notation/view/selectionfiltermodel.cpp
+++ b/src/notation/view/selectionfiltermodel.cpp
@@ -55,6 +55,10 @@ void SelectionFilterModel::load()
             emit dataChanged(index(0), index(rowCount() - 1), { IsSelectedRole, IsIndeterminateRole });
         }
     });
+
+    languagesService()->currentLanguageChanged().onNotify(this, [this]() {
+        emit dataChanged(index(0), index(rowCount() - 1), { TitleRole });
+    });
 }
 
 QVariant SelectionFilterModel::data(const QModelIndex& index, int role) const

--- a/src/notation/view/selectionfiltermodel.h
+++ b/src/notation/view/selectionfiltermodel.h
@@ -28,6 +28,7 @@
 
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
+#include "languages/ilanguagesservice.h"
 
 namespace mu::notation {
 class SelectionFilterModel : public QAbstractListModel, public async::Asyncable
@@ -35,6 +36,7 @@ class SelectionFilterModel : public QAbstractListModel, public async::Asyncable
     Q_OBJECT
 
     INJECT(notation, context::IGlobalContext, globalContext)
+    INJECT(notation, languages::ILanguagesService, languagesService)
 
     Q_PROPERTY(bool enabled READ enabled NOTIFY enabledChanged)
 

--- a/src/plugins/tests/mocks/uienginemock.h
+++ b/src/plugins/tests/mocks/uienginemock.h
@@ -36,8 +36,6 @@ public:
     MOCK_METHOD(void, clearComponentCache, (), (override));
 
     MOCK_METHOD(void, addSourceImportPath, (const QString& path), (override));
-
-    MOCK_METHOD(void, retranslateUi, (), (override));
 };
 }
 

--- a/src/plugins/tests/mocks/uienginemock.h
+++ b/src/plugins/tests/mocks/uienginemock.h
@@ -32,11 +32,12 @@ namespace mu::plugins {
 class UiEngineMock : public QObject, public ui::IUiEngine
 {
 public:
-    MOCK_METHOD(void, updateTheme, (), (override));
     MOCK_METHOD(QQmlEngine*, qmlEngine, (), (const, override));
     MOCK_METHOD(void, clearComponentCache, (), (override));
 
     MOCK_METHOD(void, addSourceImportPath, (const QString& path), (override));
+
+    MOCK_METHOD(void, retranslateUi, (), (override));
 };
 }
 

--- a/src/project/view/recentprojectsmodel.cpp
+++ b/src/project/view/recentprojectsmodel.cpp
@@ -45,12 +45,14 @@ static const QString IS_CLOUD_KEY("isCloud");
 RecentProjectsModel::RecentProjectsModel(QObject* parent)
     : QAbstractListModel(parent)
 {
-    ProjectMetaList recentProjects = recentProjectsProvider()->recentProjectList();
-    updateRecentScores(recentProjects);
+    updateRecentScores();
 
     recentProjectsProvider()->recentProjectListChanged().onNotify(this, [this]() {
-        ProjectMetaList recentProjects = recentProjectsProvider()->recentProjectList();
-        updateRecentScores(recentProjects);
+        updateRecentScores();
+    });
+
+    languagesService()->currentLanguageChanged().onNotify(this, [this]() {
+        updateRecentScores();
     });
 }
 
@@ -114,8 +116,10 @@ void RecentProjectsModel::setRecentScores(const QVariantList& recentScores)
     endResetModel();
 }
 
-void RecentProjectsModel::updateRecentScores(const ProjectMetaList& recentProjectsList)
+void RecentProjectsModel::updateRecentScores()
 {
+    ProjectMetaList recentProjectsList = recentProjectsProvider()->recentProjectList();
+
     QVariantList recentScores;
 
     QVariantMap addItem;

--- a/src/project/view/recentprojectsmodel.h
+++ b/src/project/view/recentprojectsmodel.h
@@ -30,6 +30,7 @@
 #include "iprojectconfiguration.h"
 #include "irecentprojectsprovider.h"
 #include "iinteractive.h"
+#include "languages/ilanguagesservice.h"
 
 namespace mu::project {
 class RecentProjectsModel : public QAbstractListModel, public async::Asyncable
@@ -40,6 +41,7 @@ class RecentProjectsModel : public QAbstractListModel, public async::Asyncable
     INJECT(project, IProjectConfiguration, configuration)
     INJECT(project, IRecentProjectsProvider, recentProjectsProvider)
     INJECT(project, framework::IInteractive, interactive)
+    INJECT(project, languages::ILanguagesService, languagesService)
 
 public:
     RecentProjectsModel(QObject* parent = nullptr);
@@ -59,7 +61,7 @@ private:
         ScoreRole
     };
 
-    void updateRecentScores(const ProjectMetaList& recentProjectsList);
+    void updateRecentScores();
     void setRecentScores(const QVariantList& recentScores);
 
     QVariantList m_recentScores;

--- a/src/stubs/languages/languagesservicestub.cpp
+++ b/src/stubs/languages/languagesservicestub.cpp
@@ -61,13 +61,3 @@ framework::Progress LanguagesServiceStub::update(const QString&)
 {
     return framework::Progress();
 }
-
-bool LanguagesServiceStub::needRestartToApplyLanguageChange() const
-{
-    return false;
-}
-
-async::Channel<bool> LanguagesServiceStub::needRestartToApplyLanguageChangeChanged() const
-{
-    return async::Channel<bool>();
-}

--- a/src/stubs/languages/languagesservicestub.h
+++ b/src/stubs/languages/languagesservicestub.h
@@ -37,9 +37,6 @@ public:
     const Language& placeholderLanguage() const override;
 
     framework::Progress update(const QString& languageCode) override;
-
-    bool needRestartToApplyLanguageChange() const override;
-    async::Channel<bool> needRestartToApplyLanguageChangeChanged() const override;
 };
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/12379

There were two problems: 
- If we call the QQmlEngine's retranslateUi method, literally every property binding in the whole app is re-evaluated, regardless of whether it has anything to do with strings or not. This is quite inefficient (duh) and causes problems too. So, we can't use this.
- Things in/from C++ also need to be retranslated. 

So, we solve this in two steps:
- [x] Re-evaluate QML bindings that make use of `qsTrc`

    The whole logic now looks like this:
    - We have the `QmlTranslation` object (which subclasses `QObject`) with `translate` as a `Q_INVOKABLE` method 
    - That allows us to get the `"translate"` function as a `QJSValue`, namely by querying it as a property of that `QObject`
    - We use this `QJSValue` to offer the translation function as a `Q_PROPERTY` of the `UiEngine`, with a `NOTIFY` signal. When we want the UI to be retranslated, we simply emit that signal, and all property bindings that use the translation function will be re-evaluated.
    - However, because the translation function is now a property of the `UiEngine` object (which is available in QML as `ui`), we now need to call the translation function as `ui.trc(…)`. This means that we have to replace 1036 calls to `qsTrc`, resulting in a huge diff. However, I can easily be convinced that we should just make this change and don't worry about a big diff.
    - So, I created another `QJSValue` which is a JS function, which is simply a wrapper around `ui.trc`. We make this function available under the name `qsTrc`. Apparently, QML looks inside this JS function, and sees that we use `ui.trc`, so bindings using `qsTrc` are now also re-evaluated when the `trc` property of `ui` is changed.

    See the commit message for _why_ it is now done like this, and not slightly differently.

- [ ] In C++, retranslate things and notify QML about that
    ~I'm planning to create a `Translatable` interface that any class can subclass; this interface will contain a single method `retranslate()`. This method will be called automagically when the UI needs to be retranslated.~

    Methods/classes/modules to do:
    - [ ] AppearancePreferencesModel::wallpaperPathFilter()
    - [ ] GeneralPreferencesModel::languages()
    - [ ] ImportPreferencesModel::shortestNotes()
    - [ ] ProgrammeStartPreferencesModel::scorePathFilter()
    - [ ] instrtemplate.cpp
    - [ ] StaffType names
    - [ ] Available audio/midi devices
    - [ ] MidiDeviceMappingModel::midiMappingToObject
    - [ ] NavigationPanel::directionInfo()
    - [ ] Importmidi module
    - [ ] Inspector model titles
    - [ ] GradualTempoChangePlaybackModel::possibleEasingMethods()
    - [ ] GlissandoSettingsModel::possibleLineTypes()
    - [ ] OttavaSettingsModel hook types
    - [ ] PedalSettingsModel hook types
    - [ ] SlurAndTieSettingsModel::possibleLineStyles()
    - [ ] TextLineSettingsModel hook types
    - [ ] VibratoSettingsModel::possibleLineTypes()
    - [ ] VoltaSettingsModel hook types
    - [ ] NoteheadSettingsModel::possibleHeadSystemTypes()
    - [ ] TupletSettingsModel
    - [ ] InstrumentListModel
    - [ ] StaffControlTreeItem
    - [ ] StaffTreeItem::init
    - [x] LearnPageModel::classesAuthor()
    - [ ] NotationAccessibility (see also NotationActionController::toggleNoteInput())
    - [ ] EditStyle (currently not necessary)
    - [ ] SearchCommandsParser::availableCommands()
    - [ ] formatInstrumentTitle
    - [ ] NotationSwitchListModel::contextMenuItems
    - [ ] Timeline
    - [ ] Palette module
        - [ ] SpecialCharactersDialog
        - [ ] MasterPalette::addPalette
        - [ ] Palette::translatedName()
        - [ ] PaletteCell::translatedName() / retranslate()
        - [ ] PaletteElementEditor::actionName()
    - [ ] PlaybackController::addTrack
    - [ ] PlaybackController::setupSequenceTracks()
    - [ ] inputresourceitem.cpp SOUNDFONTS_MENU_ITEM_ID
    - [ ] MixerChannelItem::MixerChannelItem
    - [ ] NO_FX_MENU_ITEM_ID()
    - [ ] MixerPanelModel::buildMasterChannelItem()
    - [ ] PluginsModel::data
    - [ ] TemplatesRepository::readTemplates
    - [ ] AdditionalInfoModel (currently not necessary)

Note: there _will_ be bugs, inevitably. But I think if we can get 90% there, it's worth it, and the remaining bugs will be corrected one by one.