### PR TITLE
fix #16343 playback model outdated upon score creation

### DIFF
--- a/src/notation/internal/inotationundostack.h
+++ b/src/notation/internal/inotationundostack.h
@@ -54,6 +54,7 @@ public:
     virtual void lock() = 0;
     virtual void unlock() = 0;
     virtual bool isLocked() const = 0;
+    virtual async::Notification stackLockedChanged() const = 0;
 
     virtual async::Notification stackChanged() const = 0;
     virtual async::Channel<ChangesRange> changesChannel() const = 0;

--- a/src/notation/internal/notationplayback.cpp
+++ b/src/notation/internal/notationplayback.cpp
@@ -76,9 +76,11 @@ void NotationPlayback::init(INotationUndoStackPtr undoStack)
 
     m_playbackModel.load(score());
 
-    updateTotalPlayTime();
     m_playbackModel.dataChanged().onNotify(this, [this]() {
         updateTotalPlayTime();
+    });
+    undoStack->stackLockedChanged().onNotify(this, [this]() {
+        m_playbackModel.reload();
     });
 
     configuration()->isPlayRepeatsChanged().onNotify(this, [this]() {

--- a/src/notation/internal/notationundostack.cpp
+++ b/src/notation/internal/notationundostack.cpp
@@ -140,7 +140,10 @@ void NotationUndoStack::lock()
         return;
     }
 
-    undoStack()->setLocked(true);
+    if (!isLocked()) {
+        undoStack()->setLocked(true);
+        notifyAboutLockChanged();
+    }
 }
 
 void NotationUndoStack::unlock()
@@ -149,12 +152,20 @@ void NotationUndoStack::unlock()
         return;
     }
 
-    undoStack()->setLocked(false);
+    if (isLocked()) {
+        undoStack()->setLocked(false);
+        notifyAboutLockChanged();
+    }
 }
 
 bool NotationUndoStack::isLocked() const
 {
     return undoStack()->locked();
+}
+
+mu::async::Notification NotationUndoStack::stackLockedChanged() const
+{
+    return m_stackLockedChanged;
 }
 
 mu::async::Notification NotationUndoStack::stackChanged() const
@@ -190,6 +201,11 @@ void NotationUndoStack::notifyAboutNotationChanged()
 void NotationUndoStack::notifyAboutStateChanged()
 {
     m_stackStateChanged.notify();
+}
+
+void NotationUndoStack::notifyAboutLockChanged()
+{
+    m_stackLockedChanged.notify();
 }
 
 void NotationUndoStack::notifyAboutUndo()

--- a/src/notation/internal/notationundostack.h
+++ b/src/notation/internal/notationundostack.h
@@ -54,6 +54,7 @@ public:
     void lock() override;
     void unlock() override;
     bool isLocked() const override;
+    async::Notification stackLockedChanged() const override;
 
     async::Notification stackChanged() const override;
     async::Channel<ChangesRange> changesChannel() const override;
@@ -61,6 +62,7 @@ public:
 private:
     void notifyAboutNotationChanged();
     void notifyAboutStateChanged();
+    void notifyAboutLockChanged();
     void notifyAboutUndo();
     void notifyAboutRedo();
 
@@ -74,6 +76,7 @@ private:
 
     async::Notification m_notationChanged;
     async::Notification m_stackStateChanged;
+    async::Notification m_stackLockedChanged;
     async::Notification m_undoNotification;
     async::Notification m_redoNotification;
 };


### PR DESCRIPTION
Resolves: #16343<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Creating a new score means the notation has changed for it. Which also means the playback model for it has changed. (compared to the template the score may have started from)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [N/A] I created a unit test or vtest to verify the changes I made (if applicable)
