### PR TITLE
Fix macOS CI

### DIFF
--- a/build/ci/macos/setup.sh
+++ b/build/ci/macos/setup.sh
@@ -91,9 +91,9 @@ installBottleManually libsndfile
 
 # fixing install python 3.9 error (it is a dependency for ninja)
 rm '/usr/local/bin/2to3'
-brew install ninja
+brew install ninja pkg-config
 
-
+# Qt
 export QT_SHORT_VERSION=5.15.2
 export QT_PATH=$HOME/Qt
 export QT_MACOS=$QT_PATH/$QT_SHORT_VERSION/clang_64

--- a/build/ci/macos/setup.sh
+++ b/build/ci/macos/setup.sh
@@ -23,7 +23,7 @@ echo "Setup MacOS build environment"
 trap 'echo Setup failed; exit 1' ERR
 SKIP_ERR_FLAG=true
 
-export MACOSX_DEPLOYMENT_TARGET=10.10
+export MACOSX_DEPLOYMENT_TARGET=10.14
 
 # install dependencies
 wget -c --no-check-certificate -nv -O bottles.zip https://musescore.org/sites/musescore.org/files/2020-02/bottles-MuseScore-3.0-yosemite.zip

--- a/build/cmake/FindSndFile.cmake
+++ b/build/cmake/FindSndFile.cmake
@@ -77,7 +77,7 @@ elseif (OS_IS_WASM)
 
 else()
     # Use pkg-config to get hints about paths
-    find_package(PkgConfig QUIET)
+    find_package(PkgConfig)
     if(PKG_CONFIG_FOUND)
         pkg_check_modules(LIBSNDFILE_PKGCONF sndfile>=1.0.25 QUIET)
     endif()


### PR DESCRIPTION
Apparently `pkg-config` is no longer pre-installed, so we install it ourselves via HomeBrew. I wonder why I can't find any announcement about this.