### PR TITLE
Adds a file tooltip to a score preview

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/RecentScoresView.qml
+++ b/src/project/qml/MuseScore/Project/internal/RecentScoresView.qml
@@ -129,7 +129,7 @@ StyledGridView {
                 }
                 // TODO: Set right tooltip position
                 if (mouseInArea) {
-                    ui.tooltip.show(scoreItem, score.name, score.path)
+                    ui.tooltip.show(scoreItem, score.name, score.path, scoreItem.timeSinceModified)
                 } else {
                     ui.tooltip.hide(scoreItem)
                 }

--- a/src/project/qml/MuseScore/Project/internal/RecentScoresView.qml
+++ b/src/project/qml/MuseScore/Project/internal/RecentScoresView.qml
@@ -123,18 +123,6 @@ StyledGridView {
                     root.openScoreRequested(score.path)
                 }
             }
-
-            onHovered: (mouseInArea) => {
-                if (isAdd) {
-                    return
-                }
-                // TODO: Set right tooltip position
-                if (mouseInArea) {
-                    ui.tooltip.show(scoreItem, score.name, score.path, scoreItem.timeSinceModified)
-                } else {
-                    ui.tooltip.hide(scoreItem)
-                }
-            }
         }
     }
 }

--- a/src/project/qml/MuseScore/Project/internal/RecentScoresView.qml
+++ b/src/project/qml/MuseScore/Project/internal/RecentScoresView.qml
@@ -90,6 +90,7 @@ StyledGridView {
         width: root.cellWidth
 
         ScoreItem {
+            id: scoreItem
 
             anchors.centerIn: parent
 
@@ -119,6 +120,18 @@ StyledGridView {
                     root.addNewScoreRequested()
                 } else if (!isNoResultFound) {
                     root.openScoreRequested(score.path)
+                }
+            }
+
+            onHovered: (mouseInArea) => {
+                if (isAdd) {
+                    return
+                }
+                // TODO: Set right tooltip position
+                if (mouseInArea) {
+                    ui.tooltip.show(scoreItem, score.name, score.path)
+                } else {
+                    ui.tooltip.hide(scoreItem)
                 }
             }
         }

--- a/src/project/qml/MuseScore/Project/internal/RecentScoresView.qml
+++ b/src/project/qml/MuseScore/Project/internal/RecentScoresView.qml
@@ -109,6 +109,7 @@ StyledGridView {
             name: score.name
             suffix: score.suffix ?? ""
             thumbnail: score.thumbnail ?? null
+            path: score.path
             isAdd: score.isAddNew
             isNoResultFound: score.isNoResultFound
             isCloud: score.isCloud

--- a/src/project/qml/MuseScore/Project/internal/ScoreItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoreItem.qml
@@ -40,6 +40,7 @@ FocusScope {
     property alias navigation: navCtrl
 
     signal clicked()
+    signal hovered(bool mouseInArea)
 
     NavigationControl {
         id: navCtrl
@@ -323,6 +324,10 @@ FocusScope {
 
         onClicked: {
             root.clicked()
+        }
+
+        onHoveredChanged: {
+            root.hovered(containsMouse)
         }
     }
 }

--- a/src/project/qml/MuseScore/Project/internal/ScoreItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoreItem.qml
@@ -33,6 +33,7 @@ FocusScope {
     property string suffix: ""
     property alias timeSinceModified: timeSinceModified.text
     property var thumbnail: null
+    property var path: null
     property bool isAdd: false
     property bool isNoResultFound: false
     property bool isCloud: false
@@ -328,6 +329,7 @@ FocusScope {
 
         onHoveredChanged: {
             root.hovered(containsMouse)
+            console.log(path)
         }
     }
 }

--- a/src/project/qml/MuseScore/Project/internal/ScoreItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoreItem.qml
@@ -41,7 +41,6 @@ FocusScope {
     property alias navigation: navCtrl
 
     signal clicked()
-    signal hovered(bool mouseInArea)
 
     NavigationControl {
         id: navCtrl
@@ -328,8 +327,15 @@ FocusScope {
         }
 
         onHoveredChanged: {
-            root.hovered(containsMouse)
-            console.log(path)
+            if (root.isAdd) {
+                return
+            }
+
+            if (containsMouse) {
+                ui.tooltip.show(root, root.name, root.path, root.timeSinceModified)
+            } else {
+                ui.tooltip.hide(root)
+            }
         }
     }
 }

--- a/src/project/qml/MuseScore/Project/internal/ScoreItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoreItem.qml
@@ -332,9 +332,9 @@ FocusScope {
             }
 
             if (containsMouse) {
-                ui.tooltip.show(root, root.name, root.path, root.timeSinceModified)
+                ui.tooltip.show(scoreRect, root.name, root.path, root.timeSinceModified)
             } else {
-                ui.tooltip.hide(root)
+                ui.tooltip.hide(scoreRect)
             }
         }
     }


### PR DESCRIPTION
Resolves: #15695

This PR adds a file tooltip to a score preview. It shows the name, path name and the time since modified of the score.

![dev-test-score-tooltip](https://user-images.githubusercontent.com/79419198/219487864-caaffcf6-0bd6-4004-b804-b182315b665b.png)

I would like to know @jessjwilliamson and @bkunda opinions about the positioning (or other). Here is a "troublesome" example:

![dev-long-score-name-tooltip](https://user-images.githubusercontent.com/79419198/219488560-bb25dab2-dd3e-40d9-a780-90266045e0ae.png)


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
