### PR TITLE
Notify about selection changed after editing selection filter

### DIFF
--- a/src/engraving/libmscore/select.cpp
+++ b/src/engraving/libmscore/select.cpp
@@ -655,6 +655,7 @@ void Selection::updateSelectedElements()
         }
     }
     update();
+    _score->setSelectionChanged(true);
 }
 
 void Selection::setRange(Segment* startSegment, Segment* endSegment, staff_idx_t staffStart, staff_idx_t staffEnd)


### PR DESCRIPTION
Resolves: #13234

We mark the selection as changed, so that in `NotationInteraction::setSelectionTypeFiltered`, `notifyAboutSelectionChangedIfNeed()` will indeed emit a notification. 