### PR TITLE
Fix #340288: Concert Band template is missing

### DIFF
--- a/share/templates/07-Band_and_Percussion/01-Concert_Band/01-Concert_Band.mscx
+++ b/share/templates/07-Band_and_Percussion/01-Concert_Band/01-Concert_Band.mscx
@@ -90,7 +90,7 @@
       <section id="clarinets">
         <family>clarinets</family>
         </section>
-      <section id="saxophones"">
+      <section id="saxophones">
         <family>saxophones</family>
         </section>
       <unsorted group="woodwinds"/>


### PR DESCRIPTION
because it is "corrupt", `Error=XML_ERROR_PARSING_ELEMENT ErrorID=6 (0x6) Line number=93`, simply a `"` too much.

It is not really missing, just not shown in the list of templates to choose from.

Resolves https://musescore.org/en/node/340288#comment-1175489 ff.