### PR TITLE
Fix #15219 Received MIDI controller is always CC0

### DIFF
--- a/src/framework/midi/midievent.h
+++ b/src/framework/midi/midievent.h
@@ -767,11 +767,13 @@ struct Event {
                 break;
             //D3.3
             case Opcode::ControlChange: {
-                std::set<uint8_t> skip = { 6, 38, 98, 99, 100, 101 };
-                if (skip.find(index()) == skip.end()) {
-                    break;
-                }
                 switch (index()) {
+                default:
+                    event.setIndex(index());
+                    event.setData(scaleUp(data(), 7, 32));
+                    break;
+                // RPN and NPRN controller messages are no ordenary conrollers
+                // and need special handling in MIDI 2.0
                 case 99:
                     event.setOpcode(Opcode::AssignableController);
                     event.setBank(static_cast<uint16_t>(data()));
@@ -792,9 +794,6 @@ struct Event {
                     event.m_data[0] &= 0xFE03FFFF;
                     event.m_data[0] |= (data() & 0x7F) << 18;
                     break;
-                default:
-                    event.setIndex(index());
-                    event.setData(scaleUp(data(), 7, 32));
                 }
                 break;
             }


### PR DESCRIPTION
Control index was not converted from Midi 1.0 to Midi 2.0 when it was not a RPN or NPRN controller.

Resolves: #15219

In case the controller number was not one of the (N)RPN controllers the `case` `break`'d prematurely and the controller data was never set in the Event. I guess the removed lines were some residue from the initial development phase.

I currently don't have a full dev environment to run a debug version. So this PR is actually only theoretical. Can anybody please counter check this? Thanks.