### PR TITLE
Fix false filter logic against MIDI system messages

### DIFF
--- a/src/framework/midi/midievent.h
+++ b/src/framework/midi/midievent.h
@@ -104,14 +104,8 @@ struct Event {
             uint32_t full;
         } u;
         u.full = data;
-        if (
-            (u.byte[0] & 0x80)
-            || (u.byte[0] & 0x90)
-            || (u.byte[0] & 0xA0)
-            || (u.byte[0] & 0xB0)
-            || (u.byte[0] & 0xC0)
-            || (u.byte[0] & 0xD0)
-            || (u.byte[0] & 0xE0)
+        if ((u.byte[0] >= 0x80)
+            && (u.byte[0] < 0xF0)
             ) {
             e.m_data[0] = (u.byte[0] << 16) | (u.byte[1] << 8) | u.byte[2];
             e.setMessageType(MessageType::ChannelVoice10);


### PR DESCRIPTION
I spottet a potential problem that accepts system messages (0xFz), though they obviously should be filtered out.

The previous logic was already always true when only the sign bit was set, so 0x80 to 0xFF, effectively not filtering at all.

IMO no cryptic bit-logic is needed. Just checking if the status byte is between 0x80 and 0xF0 (excl.) is enough.

A more 'fancy' way would be `(u.byte[0] >> 7) && (u.byte[0] & 0x70 ^ 0x70)` - but that's less understandable.
