### PR TITLE
Avoid multiple copies of system objects on staff with linked clones

### DIFF
--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -1453,7 +1453,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                     for (EngravingItem* e : oseg->annotations()) {
                         if (e->generated()
                             || (e->track() != srcTrack && !(e->systemFlag() && e->track() == 0)) // system items must be cloned even if they are on different tracks
-                            || (e->track() != srcTrack && e->systemFlag() && e->findLinkedInScore(score))) { // ...but only once!
+                            || (e->systemFlag() && e->findLinkedInScore(score))) { // ...but only once!
                             continue;
                         }
 


### PR DESCRIPTION
Resolves: #16428