### PR TITLE
gp-import: fixed import of dynamics for gp5

### DIFF
--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -1360,12 +1360,17 @@ bool GuitarPro5::readNote(int string, Note* note)
         }
     }
 
+    constexpr int defaultDynamicVal = 0;
+
     if (noteBits & NOTE_DYNAMIC) {            // velocity
         int d = readChar();
         if (previousDynamic != d) {
             previousDynamic = d;
             addDynamic(note, d);
         }
+    } else if (previousDynamic != defaultDynamicVal) {
+        previousDynamic = defaultDynamicVal;
+        addDynamic(note, defaultDynamicVal);
     }
 
     int fretNumber = 0;

--- a/src/importexport/guitarpro/tests/data/all-percussion.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/all-percussion.gp5-ref.mscx
@@ -540,6 +540,10 @@
           <RehearsalMark>
             <text>tempo 144</text>
             </RehearsalMark>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            </Dynamic>
           <Tempo>
             <tempo>2.4</tempo>
             <text><sym>metNoteQuarterUp</sym> = 144</text>

--- a/src/importexport/guitarpro/tests/data/beams-stems-ledger-lines.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/beams-stems-ledger-lines.gp5-ref.mscx
@@ -88,6 +88,10 @@
           <StaffText>
             <text>Dadd11/F#</text>
             </StaffText>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            </Dynamic>
           <Beam>
             <l1>-16</l1>
             <l2>-16</l2>
@@ -258,6 +262,10 @@
               <string>0</string>
               </Note>
             </Chord>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            </Dynamic>
           <Beam>
             <l1>-16</l1>
             <l2>-16</l2>
@@ -301,6 +309,10 @@
               <string>0</string>
               </Note>
             </Chord>
+          <Dynamic>
+            <subtype>mf</subtype>
+            <velocity>80</velocity>
+            </Dynamic>
           <Chord>
             <durationType>16th</durationType>
             <Note>
@@ -421,6 +433,10 @@
           <StaffText>
             <text>Gadd9/E</text>
             </StaffText>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            </Dynamic>
           <Beam>
             <l1>-16</l1>
             <l2>-16</l2>
@@ -464,6 +480,10 @@
               <string>0</string>
               </Note>
             </Chord>
+          <Dynamic>
+            <subtype>mf</subtype>
+            <velocity>80</velocity>
+            </Dynamic>
           <Chord>
             <durationType>16th</durationType>
             <Note>
@@ -581,6 +601,10 @@
               <string>0</string>
               </Note>
             </Chord>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            </Dynamic>
           <Beam>
             <l1>-16</l1>
             <l2>-16</l2>
@@ -624,6 +648,10 @@
               <string>0</string>
               </Note>
             </Chord>
+          <Dynamic>
+            <subtype>mf</subtype>
+            <velocity>80</velocity>
+            </Dynamic>
           <Chord>
             <durationType>16th</durationType>
             <Note>

--- a/src/importexport/guitarpro/tests/data/bend.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/bend.gp5-ref.mscx
@@ -82,6 +82,10 @@
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            </Dynamic>
           <Tempo>
             <tempo>2</tempo>
             <text><sym>metNoteQuarterUp</sym> = 120</text>

--- a/src/importexport/guitarpro/tests/data/brush.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/brush.gp5-ref.mscx
@@ -82,6 +82,10 @@
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            </Dynamic>
           <Tempo>
             <tempo>2</tempo>
             <text><sym>metNoteQuarterUp</sym> = 120</text>

--- a/src/importexport/guitarpro/tests/data/copyright.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/copyright.gp5-ref.mscx
@@ -82,6 +82,10 @@
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            </Dynamic>
           <Chord>
             <durationType>half</durationType>
             <Note>

--- a/src/importexport/guitarpro/tests/data/fret-diagram.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram.gp5-ref.mscx
@@ -103,6 +103,10 @@
           <RehearsalMark>
             <text>Intro</text>
             </RehearsalMark>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            </Dynamic>
           <Beam>
             <l1>-28</l1>
             <l2>-28</l2>
@@ -282,6 +286,10 @@
               <string>1</string>
               </Note>
             </Chord>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            </Dynamic>
           <Beam>
             <l1>-28</l1>
             <l2>-28</l2>
@@ -325,6 +333,10 @@
               <string>1</string>
               </Note>
             </Chord>
+          <Dynamic>
+            <subtype>mf</subtype>
+            <velocity>80</velocity>
+            </Dynamic>
           <Chord>
             <durationType>16th</durationType>
             <Note>
@@ -445,6 +457,10 @@
           <StaffText>
             <text>Asus4/E</text>
             </StaffText>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            </Dynamic>
           <Beam>
             <l1>-36</l1>
             <l2>-36</l2>
@@ -494,6 +510,10 @@
               <string>1</string>
               </Note>
             </Chord>
+          <Dynamic>
+            <subtype>mf</subtype>
+            <velocity>80</velocity>
+            </Dynamic>
           <Chord>
             <durationType>16th</durationType>
             <Note>
@@ -611,6 +631,10 @@
               <string>1</string>
               </Note>
             </Chord>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            </Dynamic>
           <Beam>
             <l1>-36</l1>
             <l2>-36</l2>
@@ -654,6 +678,10 @@
               <string>1</string>
               </Note>
             </Chord>
+          <Dynamic>
+            <subtype>mf</subtype>
+            <velocity>80</velocity>
+            </Dynamic>
           <Chord>
             <durationType>16th</durationType>
             <Note>

--- a/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gp5-ref.mscx
@@ -83,6 +83,10 @@
           <Rest>
             <durationType>16th</durationType>
             </Rest>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            </Dynamic>
           <Beam>
             <l1>14</l1>
             <l2>16</l2>

--- a/src/importexport/guitarpro/tests/data/tempo.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tempo.gp5-ref.mscx
@@ -82,6 +82,10 @@
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            </Dynamic>
           <Tempo>
             <tempo>4.166667</tempo>
             <text><sym>metNoteQuarterUp</sym> = 250</text>


### PR DESCRIPTION
guitar pro 5 has "f" as default value of dynamic, so forte was not imported when it didn't exist in gp5.

Compare "ff" (worked) and "f" (didn't work)
[dynamics.zip](https://github.com/musescore/MuseScore/files/10791350/dynamics.zip)
