### PR TITLE
Fix saving files on the command line

### DIFF
--- a/src/notation/internal/mscnotationwriter.cpp
+++ b/src/notation/internal/mscnotationwriter.cpp
@@ -80,11 +80,16 @@ mu::Ret MscNotationWriter::write(INotationPtr notation, QIODevice& destinationDe
         LOGE() << "MscWriter is not opened";
         return Ret(Ret::Code::UnknownError);
     }
+
     notation->elements()->msScore()->masterScore()->project().lock()->writeMscz(msczWriter, false, true);
 
+    msczWriter.close();
+
     if (m_mode != MscIoMode::Dir) {
+        buf.open(io::IODevice::ReadOnly);
         ByteArray ba = buf.readAll();
         destinationDevice.write(reinterpret_cast<const char*>(ba.constData()), ba.size());
+        buf.close();
     }
 
     return Ret(Ret::Code::Ok);


### PR DESCRIPTION
We were making mistakes with opening/closing IODevices

Resolves: #16334

Unfortunately, this doesn't give very obvious clues about #16339, because saving files in the UI and on the command line go through different flows in the code. The only thing we can do is going through all open/close logic, to make sure that it is correct everywhere. I've already done a bit of that and haven't found anything interesting yet.