### PR TITLE
Update MuseSampler API wrapper for v0.4 support

### DIFF
--- a/src/framework/musesampler/imusesamplerconfiguration.h
+++ b/src/framework/musesampler/imusesamplerconfiguration.h
@@ -37,8 +37,6 @@ public:
 
     virtual mu::io::path_t backupLibraryPath() const = 0;
     virtual mu::io::path_t userLibraryPath() const = 0;
-
-    virtual std::string minimumSupportedVersion() const = 0;
 };
 }
 

--- a/src/framework/musesampler/internal/apitypes.h
+++ b/src/framework/musesampler/internal/apitypes.h
@@ -64,11 +64,25 @@ typedef struct ms_DynamicsEvent
     double _value; // 0.0 - 1.0
 } ms_DynamicsEvent;
 
+// Added in v0.4
+typedef struct ms_DynamicsEvent_2
+{
+    long long _location_us;
+    double _value; // 0.0 - 1.0
+} ms_DynamicsEvent_2;
+
 typedef struct ms_PedalEvent
 {
     long _location_us;
     double _value; // 0.0 - 1.0
 } ms_PedalEvent;
+
+// Added in v0.4
+typedef struct ms_PedalEvent_2
+{
+    long long _location_us;
+    double _value; // 0.0 - 1.0
+} ms_PedalEvent_2;
 
 enum ms_NoteArticulation : uint64_t
 {
@@ -130,12 +144,45 @@ typedef struct ms_NoteEvent
     ms_NoteArticulation _articulation;
 } ms_NoteEvent;
 
+// Added in v0.3
+typedef struct ms_NoteEvent_2
+{
+    int _voice; // 0-3
+    long _location_us;
+    long _duration_us;
+    int _pitch; // MIDI pitch
+    double _tempo;
+    int _offset_cents;
+    ms_NoteArticulation _articulation;
+} ms_NoteEvent_2;
+
+// Added in v0.4
+typedef struct ms_NoteEvent_3
+{
+    int _voice; // 0-3
+    long long _location_us;
+    long long _duration_us;
+    int _pitch; // MIDI pitch
+    double _tempo;
+    int _offset_cents;
+    ms_NoteArticulation _articulation;
+} ms_NoteEvent_3;
+
 typedef struct ms_AuditionStartNoteEvent
 {
     int _pitch; // MIDI pitch
     ms_NoteArticulation _articulation;
     double _dynamics;
 } ms_AuditionStartNoteEvent;
+
+// Added in v0.3
+typedef struct ms_AuditionStartNoteEvent_2
+{
+    int _pitch; // MIDI pitch
+    int _offset_cents;
+    ms_NoteArticulation _articulation;
+    double _dynamics;
+} ms_AuditionStartNoteEvent_2;
 
 typedef struct ms_AuditionStopNoteEvent
 {
@@ -147,6 +194,14 @@ typedef struct ms_LivePlayStartNoteEvent
     int _pitch; // MIDI pitch
     double _dynamics;
 } ms_LivePlayStartNoteEvent;
+
+// Added in v0.3
+typedef struct ms_LivePlayStartNoteEvent_2
+{
+    int _pitch; // MIDI pitch
+    int _offset_cents;
+    double _dynamics;
+} ms_LivePlayStartNoteEvent_2;
 
 typedef struct ms_LivePlayStopNoteEvent
 {
@@ -182,19 +237,31 @@ typedef ms_Result (* ms_MuseSampler_finalize_track)(ms_MuseSampler ms, ms_Track 
 typedef ms_Result (* ms_MuseSampler_clear_track)(ms_MuseSampler ms, ms_Track track);
 
 typedef ms_Result (* ms_MuseSampler_add_track_note_event)(ms_MuseSampler ms, ms_Track track, ms_NoteEvent evt);
+// Added in 0.3
+typedef ms_Result (* ms_MuseSampler_add_track_note_event_2)(ms_MuseSampler ms, ms_Track track, ms_NoteEvent_2 evt);
+// Added in 0.4
+typedef ms_Result (* ms_MuseSampler_add_track_note_event_3)(ms_MuseSampler ms, ms_Track track, ms_NoteEvent_3 evt);
 typedef ms_Result (* ms_MuseSampler_add_track_dynamics_event)(ms_MuseSampler ms, ms_Track track, ms_DynamicsEvent evt);
+// Added in 0.4
+typedef ms_Result (* ms_MuseSampler_add_track_dynamics_event_2)(ms_MuseSampler ms, ms_Track track, ms_DynamicsEvent_2 evt);
 typedef ms_Result (* ms_MuseSampler_add_track_pedal_event)(ms_MuseSampler ms, ms_Track track, ms_PedalEvent evt);
+// Added in 0.4
+typedef ms_Result (* ms_MuseSampler_add_track_pedal_event_2)(ms_MuseSampler ms, ms_Track track, ms_PedalEvent_2 evt);
 
 typedef int (* ms_MuseSampler_is_ranged_articulation)(ms_NoteArticulation);
 typedef ms_Result (* ms_MuseSampler_add_track_event_range_start)(ms_MuseSampler, ms_Track, int voice, ms_NoteArticulation);
 typedef ms_Result (* ms_MuseSampler_add_track_event_range_end)(ms_MuseSampler, ms_Track, int voice, ms_NoteArticulation);
 
 typedef ms_Result (* ms_MuseSampler_start_audition_note)(ms_MuseSampler ms, ms_Track track, ms_AuditionStartNoteEvent evt);
+// Added in 0.3
+typedef ms_Result (* ms_MuseSampler_start_audition_note_2)(ms_MuseSampler ms, ms_Track track, ms_AuditionStartNoteEvent_2 evt);
 typedef ms_Result (* ms_MuseSampler_stop_audition_note)(ms_MuseSampler ms, ms_Track track, ms_AuditionStopNoteEvent evt);
 
 typedef ms_Result (* ms_MuseSampler_start_liveplay_mode)(ms_MuseSampler ms);
 typedef ms_Result (* ms_MuseSampler_stop_liveplay_mode)(ms_MuseSampler ms);
 typedef ms_Result (* ms_MuseSampler_start_liveplay_note)(ms_MuseSampler ms, ms_Track track, ms_LivePlayStartNoteEvent evt);
+// Added in 0.3
+typedef ms_Result (* ms_MuseSampler_start_liveplay_note_2)(ms_MuseSampler ms, ms_Track track, ms_LivePlayStartNoteEvent_2 evt);
 typedef ms_Result (* ms_MuseSampler_stop_liveplay_note)(ms_MuseSampler ms, ms_Track track, ms_LivePlayStopNoteEvent evt);
 
 typedef ms_Result (* ms_MuseSampler_start_offline_mode)(ms_MuseSampler ms, double sample_rate);

--- a/src/framework/musesampler/internal/libhandler.h
+++ b/src/framework/musesampler/internal/libhandler.h
@@ -34,6 +34,8 @@
 #include "apitypes.h"
 #endif
 
+#include "types/version.h"
+
 namespace mu::musesampler {
 #ifdef USE_MUSESAMPLER_SRC
 struct MuseSamplerLibHandler
@@ -79,17 +81,28 @@ struct MuseSamplerLibHandler
     ms_Result finalizeTrack(ms_MuseSampler ms, ms_Track track) { return ms_MuseSampler_finalize_track(ms, track); }
     ms_Result clearTrack(ms_MuseSampler ms, ms_Track track) { return ms_MuseSampler_clear_track(ms, track); }
 
-    ms_Result addDynamicsEvent(ms_MuseSampler ms, ms_Track track, ms_DynamicsEvent evt)
+    bool addDynamicsEvent(ms_MuseSampler ms, ms_Track track, long long timestamp, float value)
     {
-        return ms_MuseSampler_add_track_dynamics_event(ms, track, evt);
+        ms_DynamicsEvent_2 evt;
+        evt._location_us = timestamp;
+        evt._value = value;
+        return ms_MuseSampler_add_track_dynamics_event_2(ms, track, evt) == ms_Result_OK;
     }
 
-    ms_Result addPedalEvent(ms_MuseSampler ms, ms_Track track, ms_PedalEvent evt)
+    bool addPedalEvent(ms_MuseSampler ms, ms_Track track, long long timestamp, float value)
     {
-        return ms_MuseSampler_add_track_pedal_event(ms, track, evt);
+        ms_PedalEvent_2 evt;
+        evt._location_us = timestamp;
+        evt._value = value;
+        return ms_MuseSampler_add_track_pedal_event_2(ms, track, evt) == ms_Result_OK;
     }
 
-    ms_Result addNoteEvent(ms_MuseSampler ms, ms_Track track, ms_Event evt) { return ms_MuseSampler_add_track_note_event(ms, track, evt); }
+    bool addNoteEvent(ms_MuseSampler ms, ms_Track track, int voice, long long location_us, long long duration_us, int pitch, double tempo,
+                      int offset_cents, ms_NoteArticulation articulation)
+    {
+        ms_NoteEvent_3 evt{ voice, location_us, duration_us, pitch, tempo, offset_cents, articulation };
+        return ms_MuseSampler_add_track_note_event_3(ms, track, evt) == ms_Result_OK
+    }
 
     bool isRangedArticulation(ms_NoteArticulation art) { return ms_MuseSampler_is_ranged_articulation(art) == 1; }
     ms_Result addTrackEventRangeStart(ms_MuseSampler ms, ms_Track track, int voice, ms_NoteArticulation art)
@@ -104,9 +117,9 @@ struct MuseSamplerLibHandler
 
     ms_Result startAuditionMode(ms_MuseSampler ms) { return ms_MuseSampler_start_audition_mode(ms); }
     ms_Result stopAuditionMode(ms_MuseSampler ms) { return ms_MuseSampler_stop_audition_mode(ms); }
-    ms_Result startAuditionNote(ms_MuseSampler ms, ms_Track track, ms_AuditionStartNoteEvent evt)
+    ms_Result startAuditionNote(ms_MuseSampler ms, ms_Track track, ms_AuditionStartNoteEvent_2 evt)
     {
-        return ms_MuseSampler_start_audition_note(ms, track, evt);
+        return ms_MuseSampler_start_audition_note_2(ms, track, evt) == ms_Result_OK;
     }
 
     ms_Result stopAuditionNote(ms_MuseSampler ms, ms_Track track, ms_AuditionStopNoteEvent evt)
@@ -116,9 +129,9 @@ struct MuseSamplerLibHandler
 
     ms_Result startLivePlayMode(ms_MuseSampler ms) { return ms_MuseSampler_start_liveplay_mode(ms); }
     ms_Result stopLivePlayMode(ms_MuseSampler ms) { return ms_MuseSampler_stop_liveplay_mode(ms); }
-    ms_Result startLivePlayNote(ms_MuseSampler ms, ms_Track track, ms_LivePlayStartNoteEvent evt)
+    ms_Result startLivePlayNote(ms_MuseSampler ms, ms_Track track, ms_LivePlayStartNoteEvent_2 evt)
     {
-        return ms_MuseSampler_start_liveplay_note(ms, track, evt);
+        return ms_MuseSampler_start_liveplay_note_2(ms, track, evt) == ms_Result_OK;
     }
 
     ms_Result stopLivePlayNote(ms_MuseSampler ms, ms_Track track, ms_LivePlayStopNoteEvent evt)
@@ -185,19 +198,20 @@ struct MuseSamplerLibHandler
     ms_MuseSampler_finalize_track finalizeTrack = nullptr;
     ms_MuseSampler_clear_track clearTrack = nullptr;
 
-    ms_MuseSampler_add_track_dynamics_event addDynamicsEvent = nullptr;
-    ms_MuseSampler_add_track_pedal_event addPedalEvent = nullptr;
-    ms_MuseSampler_add_track_note_event addNoteEvent = nullptr;
+    std::function<bool(ms_MuseSampler ms, ms_Track track, long long timestamp, float value)> addDynamicsEvent = nullptr;
+    std::function<bool(ms_MuseSampler ms, ms_Track track, long long timestamp, float value)> addPedalEvent = nullptr;
+    std::function<bool(ms_MuseSampler ms, ms_Track track, int voice, long long location_us, long long duration_us, int pitch, double tempo,
+                       int offset_cents, ms_NoteArticulation articulation)> addNoteEvent = nullptr;
     ms_MuseSampler_is_ranged_articulation isRangedArticulation = nullptr;
     ms_MuseSampler_add_track_event_range_start addTrackEventRangeStart = nullptr;
     ms_MuseSampler_add_track_event_range_end addTrackEventRangeEnd = nullptr;
 
-    ms_MuseSampler_start_audition_note startAuditionNote = nullptr;
+    std::function<bool(ms_MuseSampler ms, ms_Track track, ms_AuditionStartNoteEvent_2)> startAuditionNote = nullptr;
     ms_MuseSampler_stop_audition_note stopAuditionNote = nullptr;
 
     ms_MuseSampler_start_liveplay_mode startLivePlayMode = nullptr;
     ms_MuseSampler_stop_liveplay_mode stopLivePlayMode = nullptr;
-    ms_MuseSampler_start_liveplay_note startLivePlayNote = nullptr;
+    std::function<bool(ms_MuseSampler ms, ms_Track track, ms_LivePlayStartNoteEvent_2)> startLivePlayNote = nullptr;
     ms_MuseSampler_stop_liveplay_note stopLivePlayNote = nullptr;
 
     ms_MuseSampler_start_offline_mode startOfflineMode = nullptr;
@@ -209,8 +223,26 @@ struct MuseSamplerLibHandler
     ms_MuseSampler_process process = nullptr;
     ms_MuseSampler_all_notes_off allNotesOff = nullptr;
 
+private:
+    ms_MuseSampler_add_track_dynamics_event addDynamicsEventInternal = nullptr;
+    ms_MuseSampler_add_track_dynamics_event_2 addDynamicsEventInternal2 = nullptr;
+    ms_MuseSampler_add_track_pedal_event addPedalEventInternal = nullptr;
+    ms_MuseSampler_add_track_pedal_event_2 addPedalEventInternal2 = nullptr;
+    ms_MuseSampler_add_track_note_event addNoteEventInternal = nullptr;
+    ms_MuseSampler_add_track_note_event_2 addNoteEventInternal2 = nullptr;
+    ms_MuseSampler_add_track_note_event_3 addNoteEventInternal3 = nullptr;
+    ms_MuseSampler_start_audition_note startAuditionNoteInternal = nullptr;
+    ms_MuseSampler_start_audition_note_2 startAuditionNoteInternal2 = nullptr;
+    ms_MuseSampler_start_liveplay_note startLivePlayNoteInternal = nullptr;
+    ms_MuseSampler_start_liveplay_note_2 startLivePlayNoteInternal2 = nullptr;
+public:
+
     MuseSamplerLibHandler(const io::path_t& path)
     {
+        // The specific versions supported, based on known functions/etc:
+        const framework::Version minimumSupported{ 0, 2, 2 };
+        constexpr int maximumMajorVersion = 0;
+
         m_lib = loadLib(path);
 
         if (!m_lib) {
@@ -223,6 +255,30 @@ struct MuseSamplerLibHandler
         getVersionMinor = (ms_get_version_minor)getLibFunc(m_lib, "ms_get_version_minor");
         getVersionRevision = (ms_get_version_revision)getLibFunc(m_lib, "ms_get_version_revision");
         getVersionString = (ms_get_version_string)getLibFunc(m_lib, "ms_get_version_string");
+
+        // Invalid...
+        if (!getVersionMajor || !getVersionMinor || !getVersionRevision) {
+            return;
+        }
+
+        framework::Version current(getVersionMajor(),
+                                   getVersionMinor(),
+                                   getVersionRevision());
+        if (current < minimumSupported) {
+            LOGE() << "MuseSampler " << current.toString() << " is not supported (too old -- update MuseSampler); ignoring";
+            return;
+        }
+        // Major versions have incompatible changes; we can only support
+        // interfaces we know about.
+        // TODO: check when we fixed the issue with version numbers not reporting?  Was this ever an issue?
+        if (current.major() > maximumMajorVersion) {
+            LOGE() << "MuseSampler " << current.toString() << " is not supported (too new -- update MuseScore); ignoring";
+            return;
+        }
+
+        // Check versions here; define optional functions below
+        bool at_least_v_0_3 = (getVersionMajor() == 0 && getVersionMinor() >= 3) || getVersionMajor() > 0;
+        bool at_least_v_0_4 = (getVersionMajor() == 0 && getVersionMinor() >= 4) || getVersionMajor() > 0;
 
         containsInstrument = (ms_contains_instrument)getLibFunc(m_lib, "ms_contains_instrument");
         getMatchingInstrumentId = (ms_get_matching_instrument_id)getLibFunc(m_lib, "ms_get_matching_instrument_id");
@@ -248,21 +304,122 @@ struct MuseSamplerLibHandler
         finalizeTrack = (ms_MuseSampler_finalize_track)getLibFunc(m_lib, "ms_MuseSampler_finalize_track");
         clearTrack = (ms_MuseSampler_clear_track)getLibFunc(m_lib, "ms_MuseSampler_clear_track");
 
-        addDynamicsEvent = (ms_MuseSampler_add_track_dynamics_event)getLibFunc(m_lib, "ms_MuseSampler_add_track_dynamics_event");
-        addPedalEvent = (ms_MuseSampler_add_track_pedal_event)getLibFunc(m_lib, "ms_MuseSampler_add_track_pedal_event");
-        addNoteEvent = (ms_MuseSampler_add_track_note_event)getLibFunc(m_lib, "ms_MuseSampler_add_track_note_event");
+        if (at_least_v_0_4) {
+            if (addDynamicsEventInternal2
+                    = (ms_MuseSampler_add_track_dynamics_event_2)getLibFunc(m_lib, "ms_MuseSampler_add_track_dynamics_event_2");
+                addDynamicsEventInternal2 != nullptr) {
+                addDynamicsEvent = [this](ms_MuseSampler ms, ms_Track track, long long timestamp, float value) {
+                    ms_DynamicsEvent_2 evt{ timestamp, value };
+                    return addDynamicsEventInternal2(ms, track, evt) == ms_Result_OK;
+                };
+            }
+        } else {
+            if (addDynamicsEventInternal
+                    = (ms_MuseSampler_add_track_dynamics_event)getLibFunc(m_lib, "ms_MuseSampler_add_track_dynamics_event");
+                addDynamicsEventInternal != nullptr) {
+                addDynamicsEvent = [this](ms_MuseSampler ms, ms_Track track, long long timestamp, float value) {
+                    ms_DynamicsEvent evt{ static_cast<long>(timestamp), value };
+                    return addDynamicsEventInternal(ms, track, evt) == ms_Result_OK;
+                };
+            }
+        }
+
+        if (at_least_v_0_4) {
+            if (addPedalEventInternal2
+                    = (ms_MuseSampler_add_track_pedal_event_2)getLibFunc(m_lib, "ms_MuseSampler_add_track_pedal_event_2");
+                addPedalEventInternal2 != nullptr) {
+                addPedalEvent = [this](ms_MuseSampler ms, ms_Track track, long long timestamp, float value) {
+                    ms_PedalEvent_2 evt{ timestamp, value };
+                    return addPedalEventInternal2(ms, track, evt) == ms_Result_OK;
+                };
+            }
+        } else {
+            if (addPedalEventInternal = (ms_MuseSampler_add_track_pedal_event)getLibFunc(m_lib, "ms_MuseSampler_add_track_pedal_event");
+                addPedalEventInternal != nullptr) {
+                addPedalEvent = [this](ms_MuseSampler ms, ms_Track track, long long timestamp, float value) {
+                    // TODO: down cast of long long? trim?
+                    ms_PedalEvent evt{ static_cast<long>(timestamp), value };
+                    return addPedalEventInternal(ms, track, evt) == ms_Result_OK;
+                };
+            }
+        }
+
+        if (at_least_v_0_4) {
+            if (addNoteEventInternal3 = (ms_MuseSampler_add_track_note_event_3)getLibFunc(m_lib, "ms_MuseSampler_add_track_note_event_3");
+                addNoteEventInternal3 != nullptr) {
+                addNoteEvent
+                    = [this](ms_MuseSampler ms, ms_Track track, int voice, long long location_us, long long duration_us, int pitch,
+                             double tempo, int offset_cents, ms_NoteArticulation articulation) {
+                    ms_NoteEvent_3 evt{ voice, location_us, duration_us, pitch, tempo, offset_cents, articulation };
+                    return addNoteEventInternal3(ms, track, evt) == ms_Result_OK;
+                };
+            }
+        } else if (at_least_v_0_3) {
+            if (addNoteEventInternal2 = (ms_MuseSampler_add_track_note_event_2)getLibFunc(m_lib, "ms_MuseSampler_add_track_note_event_2");
+                addNoteEventInternal2 != nullptr) {
+                addNoteEvent
+                    = [this](ms_MuseSampler ms, ms_Track track, int voice, long long location_us, long long duration_us, int pitch,
+                             double tempo, int offset_cents, ms_NoteArticulation articulation) {
+                    ms_NoteEvent_2 evt{ voice, static_cast<long>(location_us), static_cast<long>(duration_us), pitch, tempo, offset_cents,
+                                        articulation };
+                    return addNoteEventInternal2(ms, track, evt) == ms_Result_OK;
+                };
+            }
+        } else {
+            if (addNoteEventInternal = (ms_MuseSampler_add_track_note_event)getLibFunc(m_lib, "ms_MuseSampler_add_track_note_event");
+                addNoteEventInternal != nullptr) {
+                addNoteEvent
+                    = [this](ms_MuseSampler ms, ms_Track track, int voice, long long location_us, long long duration_us, int pitch,
+                             double tempo, int /*offset_cents*/, ms_NoteArticulation articulation) {
+                    ms_NoteEvent evt{ voice, static_cast<long>(location_us), static_cast<long>(duration_us), pitch, tempo, articulation };
+                    return addNoteEventInternal(ms, track, evt) == ms_Result_OK;
+                };
+            }
+        }
 
         isRangedArticulation = (ms_MuseSampler_is_ranged_articulation)getLibFunc(m_lib, "ms_MuseSampler_is_ranged_articulation");
         addTrackEventRangeStart
             = (ms_MuseSampler_add_track_event_range_start)getLibFunc(m_lib, "ms_MuseSampler_add_track_event_range_start");
         addTrackEventRangeEnd = (ms_MuseSampler_add_track_event_range_end)getLibFunc(m_lib, "ms_MuseSampler_add_track_event_range_end");
 
-        startAuditionNote = (ms_MuseSampler_start_audition_note)getLibFunc(m_lib, "ms_MuseSampler_start_audition_note");
+        if (at_least_v_0_3) {
+            if (startAuditionNoteInternal2
+                    = (ms_MuseSampler_start_audition_note_2)getLibFunc(m_lib, "ms_MuseSampler_start_audition_note_2");
+                startAuditionNoteInternal2 != nullptr) {
+                startAuditionNote = [this](ms_MuseSampler ms, ms_Track track, ms_AuditionStartNoteEvent_2 evt) {
+                    return startAuditionNoteInternal2(ms, track, evt) == ms_Result_OK;
+                };
+            }
+        } else {
+            if (startAuditionNoteInternal = (ms_MuseSampler_start_audition_note)getLibFunc(m_lib, "ms_MuseSampler_start_audition_note");
+                startAuditionNoteInternal != nullptr) {
+                startAuditionNote = [this](ms_MuseSampler ms, ms_Track track, ms_AuditionStartNoteEvent_2 evt2) {
+                    ms_AuditionStartNoteEvent evt{ evt2._pitch, evt2._articulation, evt2._dynamics };
+                    return startAuditionNoteInternal(ms, track, evt) == ms_Result_OK;
+                };
+            }
+        }
         stopAuditionNote = (ms_MuseSampler_stop_audition_note)getLibFunc(m_lib, "ms_MuseSampler_stop_audition_note");
 
         startLivePlayMode = (ms_MuseSampler_start_liveplay_mode)getLibFunc(m_lib, "ms_MuseSampler_start_liveplay_mode");
         stopLivePlayMode = (ms_MuseSampler_stop_liveplay_mode)getLibFunc(m_lib, "ms_MuseSampler_stop_liveplay_mode");
-        startLivePlayNote = (ms_MuseSampler_start_liveplay_note)getLibFunc(m_lib, "ms_MuseSampler_start_liveplay_note");
+        if (at_least_v_0_3) {
+            if (startLivePlayNoteInternal2
+                    = (ms_MuseSampler_start_liveplay_note_2)getLibFunc(m_lib, "ms_MuseSampler_start_liveplay_note_2");
+                startLivePlayNoteInternal2 != nullptr) {
+                startLivePlayNote = [this](ms_MuseSampler ms, ms_Track track, ms_LivePlayStartNoteEvent_2 evt) {
+                    return startLivePlayNoteInternal2(ms, track, evt) == ms_Result_OK;
+                };
+            }
+        } else {
+            if (startLivePlayNoteInternal = (ms_MuseSampler_start_liveplay_note)getLibFunc(m_lib, "ms_MuseSampler_start_liveplay_note");
+                startLivePlayNoteInternal != nullptr) {
+                startLivePlayNote = [this](ms_MuseSampler ms, ms_Track track, ms_LivePlayStartNoteEvent_2 evt2) {
+                    ms_LivePlayStartNoteEvent evt{ evt2._pitch, evt2._dynamics };
+                    return startLivePlayNoteInternal(ms, track, evt) == ms_Result_OK;
+                };
+            }
+        }
         stopLivePlayNote = (ms_MuseSampler_stop_liveplay_note)getLibFunc(m_lib, "ms_MuseSampler_stop_liveplay_note");
 
         startOfflineMode = (ms_MuseSampler_start_offline_mode)getLibFunc(m_lib, "ms_MuseSampler_start_offline_mode");
@@ -364,13 +521,20 @@ private:
                << "\n ms_MuseSampler_clear_score - " << reinterpret_cast<uint64_t>(clearScore)
                << "\n ms_MuseSampler_add_track - " << reinterpret_cast<uint64_t>(addTrack)
                << "\n ms_MuseSampler_finalize_track - " << reinterpret_cast<uint64_t>(finalizeTrack)
-               << "\n ms_MuseSampler_add_track_dynamics_event - " << reinterpret_cast<uint64_t>(addDynamicsEvent)
-               << "\n ms_MuseSampler_add_track_note_event - " << reinterpret_cast<uint64_t>(addNoteEvent)
-               << "\n ms_MuseSampler_start_audition_note - " << reinterpret_cast<uint64_t>(startAuditionNote)
+               << "\n ms_MuseSampler_add_track_dynamics_event - " << reinterpret_cast<uint64_t>(addDynamicsEventInternal)
+               << "\n ms_MuseSampler_add_track_dynamics_event_2 - " << reinterpret_cast<uint64_t>(addDynamicsEventInternal2)
+               << "\n ms_MuseSampler_add_track_pedal_event - " << reinterpret_cast<uint64_t>(addPedalEventInternal)
+               << "\n ms_MuseSampler_add_track_pedal_event_2 - " << reinterpret_cast<uint64_t>(addPedalEventInternal2)
+               << "\n ms_MuseSampler_add_track_note_event - " << reinterpret_cast<uint64_t>(addNoteEventInternal)
+               << "\n ms_MuseSampler_add_track_note_event_2 - " << reinterpret_cast<uint64_t>(addNoteEventInternal2)
+               << "\n ms_MuseSampler_add_track_note_event_3 - " << reinterpret_cast<uint64_t>(addNoteEventInternal3)
+               << "\n ms_MuseSampler_start_audition_note - " << reinterpret_cast<uint64_t>(startAuditionNoteInternal)
+               << "\n ms_MuseSampler_start_audition_note_2 - " << reinterpret_cast<uint64_t>(startAuditionNoteInternal2)
                << "\n ms_MuseSampler_stop_audition_note - " << reinterpret_cast<uint64_t>(stopAuditionNote)
                << "\n ms_MuseSampler_start_liveplay_mode - " << reinterpret_cast<uint64_t>(startLivePlayMode)
                << "\n ms_MuseSampler_stop_liveplay_mode - " << reinterpret_cast<uint64_t>(stopLivePlayMode)
-               << "\n ms_MuseSampler_start_liveplay_note - " << reinterpret_cast<uint64_t>(startLivePlayNote)
+               << "\n ms_MuseSampler_start_liveplay_note - " << reinterpret_cast<uint64_t>(startLivePlayNoteInternal)
+               << "\n ms_MuseSampler_start_liveplay_note_2 - " << reinterpret_cast<uint64_t>(startLivePlayNoteInternal2)
                << "\n ms_MuseSampler_stop_liveplay_note - " << reinterpret_cast<uint64_t>(stopLivePlayNote)
                << "\n ms_MuseSampler_start_offline_mode - " << reinterpret_cast<uint64_t>(startOfflineMode)
                << "\n ms_MuseSampler_stop_offline_mode - " << reinterpret_cast<uint64_t>(stopOfflineMode)

--- a/src/framework/musesampler/internal/musesamplerconfiguration.cpp
+++ b/src/framework/musesampler/internal/musesamplerconfiguration.cpp
@@ -50,8 +50,6 @@ io::path_t MuseSamplerConfiguration::defaultPath() const
 
 #endif
 
-static const std::string MINIMUM_SUPPORTED_VERSION = "0.2.2";
-
 // If installed on the system instead of user dir...do this as a backup
 io::path_t MuseSamplerConfiguration::backupLibraryPath() const
 {
@@ -67,9 +65,4 @@ io::path_t MuseSamplerConfiguration::userLibraryPath() const
     }
 
     return defaultPath();
-}
-
-std::string MuseSamplerConfiguration::minimumSupportedVersion() const
-{
-    return MINIMUM_SUPPORTED_VERSION;
 }

--- a/src/framework/musesampler/internal/musesamplerconfiguration.h
+++ b/src/framework/musesampler/internal/musesamplerconfiguration.h
@@ -38,8 +38,6 @@ public:
     // Preferred local user install path; try this first.
     io::path_t userLibraryPath() const override;
 
-    std::string minimumSupportedVersion() const override;
-
 private:
     io::path_t defaultPath() const;
 };

--- a/src/framework/musesampler/internal/musesamplerresolver.cpp
+++ b/src/framework/musesampler/internal/musesamplerresolver.cpp
@@ -159,15 +159,6 @@ bool MuseSamplerResolver::checkLibrary() const
         return false;
     }
 
-    Version current(m_libHandler->getVersionMajor(),
-                    m_libHandler->getVersionMinor(),
-                    m_libHandler->getVersionRevision());
-    Version minimumSupported(String::fromStdString(configuration()->minimumSupportedVersion()));
-    if (current < minimumSupported) {
-        LOGE() << "MuseSampler " << version() << " is not supported; ignoring";
-        return false;
-    }
-
     return true;
 }
 

--- a/src/framework/musesampler/internal/musesamplersequencer.h
+++ b/src/framework/musesampler/internal/musesamplersequencer.h
@@ -28,7 +28,7 @@
 #include "internal/apitypes.h"
 #include "internal/libhandler.h"
 
-typedef typename std::variant<mu::mpe::NoteEvent, ms_AuditionStartNoteEvent, ms_AuditionStopNoteEvent> MuseSamplerEvent;
+typedef typename std::variant<mu::mpe::NoteEvent, ms_AuditionStartNoteEvent_2, ms_AuditionStopNoteEvent> MuseSamplerEvent;
 
 template<>
 struct std::less<MuseSamplerEvent>
@@ -40,8 +40,13 @@ struct std::less<MuseSamplerEvent>
             return first.index() < second.index();
         }
 
-        if (std::holds_alternative<ms_AuditionStartNoteEvent>(first)) {
-            return std::get<ms_AuditionStartNoteEvent>(first)._pitch < std::get<ms_AuditionStartNoteEvent>(second)._pitch;
+        if (std::holds_alternative<ms_AuditionStartNoteEvent_2>(first)) {
+            auto& e1 = std::get<ms_AuditionStartNoteEvent_2>(first);
+            auto& e2 = std::get<ms_AuditionStartNoteEvent_2>(second);
+            if (e1._pitch == e2._pitch) {
+                return e1._offset_cents < e2._offset_cents;
+            }
+            return e1._pitch < e2._pitch;
         }
 
         if (std::holds_alternative<ms_AuditionStopNoteEvent>(first)) {
@@ -53,7 +58,7 @@ struct std::less<MuseSamplerEvent>
 };
 
 namespace mu::musesampler {
-class MuseSamplerSequencer : public audio::AbstractEventSequencer<mu::mpe::NoteEvent, ms_AuditionStartNoteEvent, ms_AuditionStopNoteEvent>
+class MuseSamplerSequencer : public audio::AbstractEventSequencer<mu::mpe::NoteEvent, ms_AuditionStartNoteEvent_2, ms_AuditionStopNoteEvent>
 {
 public:
     void init(MuseSamplerLibHandlerPtr samplerLib, ms_MuseSampler sampler, ms_Track track);
@@ -69,7 +74,7 @@ private:
     void loadDynamicEvents(const mpe::DynamicLevelMap& changes);
 
     void addNoteEvent(const mpe::NoteEvent& noteEvent);
-    int pitchIndex(const mpe::pitch_level_t pitchLevel) const;
+    void pitchAndTuning(const mpe::pitch_level_t nominalPitch, int& pitch, int& centsOffset) const;
     double dynamicLevelRatio(const mpe::dynamic_level_t level) const;
 
     ms_NoteArticulation convertArticulationType(mpe::ArticulationType articulation) const;

--- a/src/framework/musesampler/internal/musesamplerwrapper.cpp
+++ b/src/framework/musesampler/internal/musesamplerwrapper.cpp
@@ -288,8 +288,8 @@ void MuseSamplerWrapper::handleAuditionEvents(const MuseSamplerSequencer::EventT
         return;
     }
 
-    if (std::holds_alternative<ms_AuditionStartNoteEvent>(event)) {
-        m_samplerLib->startAuditionNote(m_sampler, m_track, std::get<ms_AuditionStartNoteEvent>(event));
+    if (std::holds_alternative<ms_AuditionStartNoteEvent_2>(event)) {
+        m_samplerLib->startAuditionNote(m_sampler, m_track, std::get<ms_AuditionStartNoteEvent_2>(event));
         return;
     }
 


### PR DESCRIPTION
Resolves: #15768 (once MuseSampler v0.4 is released)
Resolves Partially: #15078 (addresses most of tuning issues; v0.4 of MuseSampler should resolve remainder)

- New functions in v0.4 fix issue for long scores
- Also uses specific events from v0.3 that support "per-note-tuning", and appropriately calls these functions (note -- still a musesampler bug in playback in v0.3; works when dragging a note but not completely in ordinary playback)
- Moves version checking logic into the libhandler, and adds per-version behavior here for new API functions

