### PR TITLE
When migrating, reset defaults before calling layout

### DIFF
--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -5750,7 +5750,6 @@ void Score::doLayoutRange(const Fraction& st, const Fraction& et)
     _noteHeadWidth = m_engravingFont->width(SymId::noteheadBlack, spatium() / SPATIUM20);
 
     m_layoutOptions.updateFromStyle(style());
-    m_layout.doLayoutRange(m_layoutOptions, st, et);
 
     if (_resetAutoplace) {
         _resetAutoplace = false;
@@ -5761,6 +5760,8 @@ void Score::doLayoutRange(const Fraction& st, const Fraction& et)
         _resetDefaults = false;
         resetDefaults();
     }
+
+    m_layout.doLayoutRange(m_layoutOptions, st, et);
 }
 
 void Score::createPaddingTable()


### PR DESCRIPTION
Resolves: #16433

As far as I can see, the problem is that we are calling the first score layout before doing the resetting operations required by older scores migration. Moving the layout call _after_ the reset operations seems to fix the issue. 


