### PR TITLE
Ignore slur offsets pre-4.0

### DIFF
--- a/src/engraving/libmscore/slurtie.cpp
+++ b/src/engraving/libmscore/slurtie.cpp
@@ -375,7 +375,9 @@ void SlurTieSegment::read(XmlReader& e)
     double _spatium = score()->spatium();
     while (e.readNextStartElement()) {
         const AsciiStringView tag(e.name());
-        if (tag == "o1") {
+        if (score()->mscVersion() < 400 && (tag == "o1" || tag == "o2" || tag == "o3" || tag == "o4")) {
+            e.skipCurrentElement(); // Ignore slur user offsets from pre-4.0
+        } else if (tag == "o1") {
             ups(Grip::START).off = e.readPoint() * _spatium;
         } else if (tag == "o2") {
             ups(Grip::BEZIER1).off = e.readPoint() * _spatium;


### PR DESCRIPTION
Resolves: #16433

Slur offsets are reset upon migration in Score::doLayoutRange, but the rest happens after the first layout. So at first layout the slur will appear with the offset. Here, I'm skipping the offset when reading the slur itself.