### PR TITLE
Fix crash when rendering chord symbol for utick past end of repeat list

### DIFF
--- a/src/engraving/libmscore/harmony.cpp
+++ b/src/engraving/libmscore/harmony.cpp
@@ -1140,6 +1140,10 @@ Fraction Harmony::ticksTillNext(int utick, bool stopAtMeasureEnd) const
     Segment* cur = seg->next();
     auto rsIt = score()->repeatList().findRepeatSegmentFromUTick(utick);
 
+    if (rsIt == score()->repeatList().end()) {
+        stopAtMeasureEnd = true;
+    }
+
     Measure const* currentMeasure = seg->measure();
     Measure const* endMeasure = (stopAtMeasureEnd) ? currentMeasure : (*rsIt)->lastMeasure();
     Harmony const* nextHarmony = nullptr;


### PR DESCRIPTION
Resolves: #16442

Not quite convinced yet that this should be the solution though...