### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -322,7 +322,6 @@ void Beam::layout1()
             // if there is no explicit stem direction, default to the direction of the first stem.
             bool firstUp = false;
             bool firstChord = true;
-            DirectionV explicitDirection = DirectionV::AUTO;
             for (ChordRest* cr :_elements) {
                 if (cr->isChord()) {
                     DirectionV crDirection = toChord(cr)->stemDirection();

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -957,7 +957,8 @@ bool ProjectActionsController::askIfUserAgreesToSaveCorruptedScore(const SaveLoc
     }
     case SaveLocationType::Local:
         return askIfUserAgreesToSaveCorruptedScoreLocally(errorText, newlyCreated);
-    case SaveLocationType::Undefined:
+    case SaveLocationType::Undefined: // fallthrough
+    default:
         return false;
     }
 }
@@ -1037,7 +1038,8 @@ bool ProjectActionsController::askIfUserAgreesToSaveCorruptedScoreUponOpenning(c
         return false;
     case SaveLocationType::Local:
         return askIfUserAgreesToSaveCorruptedScoreLocally(errorText, false /*canRevert*/);
-    case SaveLocationType::Undefined:
+    case SaveLocationType::Undefined: // fallthrough
+    default:
         return false;
     }
 }

--- a/thirdparty/lame/Dll/BladeMP3EncDLL.c
+++ b/thirdparty/lame/Dll/BladeMP3EncDLL.c
@@ -945,7 +945,7 @@ static void dump_config( lame_global_flags* gfp )
     case JOINT_STEREO: DebugPrintf( "Joint-Stereo\n" ); break;
     case DUAL_CHANNEL: DebugPrintf( "Forced Stereo\n" ); break;
     case MONO:         DebugPrintf( "Mono\n" ); break;
-    case NOT_SET:      /* FALLTROUGH */
+    case NOT_SET:      /* FALLTHROUGH */
     default:           DebugPrintf( "Error (unknown)\n" ); break;
     }
 


### PR DESCRIPTION
* reg. local variable is initialized but not referenced (C4189)
* reg. not all control paths return a value (C4715)
   and fix a typo