### PR TITLE
midi-render: fixed render of glissando with 1 semitone

### DIFF
--- a/src/engraving/libmscore/rendermidi.cpp
+++ b/src/engraving/libmscore/rendermidi.cpp
@@ -816,7 +816,10 @@ static bool renderNoteArticulation(NoteEventList* events, Note* note, bool chrom
                 makeEvent(body[j], onTimes[j], onTimes[j + 1] - onTimes[j],
                           glissandoVelocityMultiplier);
             }
-            makeEvent(body[b - 1], onTimes[b - 1], (millespernote * b - onTimes[b - 1]) + sustain, glissandoVelocityMultiplier);
+
+            if (b > 1) {
+                makeEvent(body[b - 1], onTimes[b - 1], (millespernote * b - onTimes[b - 1]) + sustain, glissandoVelocityMultiplier);
+            }
         } else {
             // render the body, but not the final repetition
             for (int r = 0; r < numrepeat - 1; r++) {


### PR DESCRIPTION
first midi event (main note) was duplicated with smaller volume

compare files
[glissando-render.zip](https://github.com/musescore/MuseScore/files/10814257/glissando-render.zip)
