### PR TITLE
Fix #11235: Added the ability to delete individual files from recent scores

### DIFF
--- a/src/project/internal/recentfilescontroller.cpp
+++ b/src/project/internal/recentfilescontroller.cpp
@@ -111,6 +111,22 @@ void RecentFilesController::moveRecentFile(const io::path_t& before, const Proje
     }
 }
 
+void RecentFilesController::removeRecentFile(const io::path_t& filePath)
+{
+    TRACEFUNC;
+
+    ProjectFilesList newList;
+    newList.reserve(m_recentFilesList.size() - 1);
+
+    for (const ProjectFile& file : m_recentFilesList) {
+        if (file.path != filePath && fileSystem()->exists(file.path)) {
+            newList.push_back(file);
+        }
+    }
+
+    setRecentFilesList(newList, true);
+}
+
 void RecentFilesController::clearRecentFiles()
 {
     setRecentFilesList({}, true);

--- a/src/project/internal/recentfilescontroller.h
+++ b/src/project/internal/recentfilescontroller.h
@@ -52,6 +52,7 @@ public:
 
     void prependRecentFile(const ProjectFile& file) override;
     void moveRecentFile(const io::path_t& before, const ProjectFile& after) override;
+    void removeRecentFile(const io::path_t& path) override;
     void clearRecentFiles() override;
 
     async::Promise<QPixmap> thumbnail(const io::path_t& file) const override;

--- a/src/project/irecentfilescontroller.h
+++ b/src/project/irecentfilescontroller.h
@@ -44,6 +44,7 @@ public:
 
     virtual void prependRecentFile(const ProjectFile& file) = 0;
     virtual void moveRecentFile(const io::path_t& before, const ProjectFile& after) = 0;
+    virtual void removeRecentFile(const io::path_t& filePath) = 0;
     virtual void clearRecentFiles() = 0;
 
     virtual async::Promise<QPixmap> thumbnail(const io::path_t& filePath) const = 0;

--- a/src/project/qml/MuseScore/Project/ScoresPage.qml
+++ b/src/project/qml/MuseScore/Project/ScoresPage.qml
@@ -229,6 +229,10 @@ FocusScope {
             onOpenScoreRequested: function(scorePath, displayName) {
                 Qt.callLater(scoresPageModel.openScore, scorePath, displayName)
             }
+
+            onRemoveScoreRequested: function(scorePath) {
+                Qt.callLater(scoresPageModel.removeScore, scorePath)
+            }
         }
     }
 

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/RecentScoresView.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/RecentScoresView.qml
@@ -42,7 +42,9 @@ ScoresView {
     Component {
         id: gridComp
 
-        ScoresView.Grid {}
+        ScoresView.Grid {
+            isRemovingScoresAllowed: true
+        }
     }
 
     Component {

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoreItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoreItem.qml
@@ -39,6 +39,7 @@ FocusScope {
     property bool isNoResultFound: false
     property bool isCloud: false
     property int cloudScoreId: 0
+    property bool isRemovingScoresAllowed: false
 
     property alias navigation: navCtrl
 
@@ -182,7 +183,7 @@ FocusScope {
                     anchors.right: parent.right
 
                     icon: IconCode.CLOSE_X_ROUNDED
-                    visible: root.path != "" && parent.containsMouse
+                    visible: root.path != "" && root.isRemovingScoresAllowed && parent.containsMouse
                     transparent: true
 
                     onClicked: {

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoreItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoreItem.qml
@@ -43,6 +43,7 @@ FocusScope {
     property alias navigation: navCtrl
 
     signal clicked()
+    signal removeRequested()
 
     NavigationControl {
         id: navCtrl
@@ -59,18 +60,6 @@ FocusScope {
         }
 
         onTriggered: root.clicked()
-    }
-
-    MouseArea {
-        id: mouseArea
-
-        anchors.fill: parent
-
-        hoverEnabled: true
-
-        onClicked: {
-            root.clicked()
-        }
     }
 
     Column {
@@ -174,6 +163,31 @@ FocusScope {
                     glowRadius: 20
                     color: "#08000000"
                     cornerRadius: thumbnail.radius + glowRadius
+                }
+            }
+    
+            MouseArea {
+                id: mouseArea
+
+                anchors.fill: parent
+
+                hoverEnabled: true
+
+                onClicked: {
+                    root.clicked()
+                }
+
+                FlatButton {
+                    anchors.top: parent.top
+                    anchors.right: parent.right
+
+                    icon: IconCode.CLOSE_X_ROUNDED
+                    visible: root.path != "" && parent.containsMouse
+                    transparent: true
+
+                    onClicked: {
+                        root.removeRequested()
+                    }
                 }
             }
 

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoresGridView.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoresGridView.qml
@@ -41,6 +41,7 @@ Item {
 
     signal createNewScoreRequested()
     signal openScoreRequested(var scorePath, var displayName)
+    signal removeScoreRequested(var scorePath)
 
     clip: true
 
@@ -165,6 +166,10 @@ Item {
                     } else if (!isNoResultFound) {
                         root.openScoreRequested(score.path, score.name)
                     }
+                }
+
+                onRemoveRequested: {
+                    root.removeScoreRequested(score.path)
                 }
             }
         }

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoresGridView.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoresGridView.qml
@@ -39,6 +39,8 @@ Item {
 
     property alias navigation: navPanel
 
+    property bool isRemovingScoresAllowed: false
+
     signal createNewScoreRequested()
     signal openScoreRequested(var scorePath, var displayName)
     signal removeScoreRequested(var scorePath)
@@ -159,6 +161,7 @@ Item {
                 isCloud: score.isCloud
                 cloudScoreId: score.scoreId ?? 0
                 timeSinceModified: score.timeSinceModified ?? ""
+                isRemovingScoresAllowed: root.isRemovingScoresAllowed
 
                 onClicked: {
                     if (isCreateNew) {

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoresView.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoresView.qml
@@ -42,6 +42,7 @@ Loader {
 
     signal createNewScoreRequested()
     signal openScoreRequested(var scorePath, var displayName)
+    signal removeScoreRequested(var scorePath)
 
     enum ViewType {
         ViewType_Grid,
@@ -67,6 +68,10 @@ Loader {
 
         onOpenScoreRequested: function(scorePath, displayName) {
             root.openScoreRequested(scorePath, displayName)
+        }
+
+        onRemoveScoreRequested: function(scorePath) {
+            root.removeScoreRequested(scorePath)
         }
     }
 

--- a/src/project/view/scorespagemodel.cpp
+++ b/src/project/view/scorespagemodel.cpp
@@ -49,6 +49,11 @@ void ScoresPageModel::openScore(const QString& scorePath, const QString& display
     dispatcher()->dispatch("file-open", ActionData::make_arg2<io::path_t, QString>(io::path_t(scorePath), displayNameOverride));
 }
 
+void ScoresPageModel::removeScore(const QString& scorePath)
+{
+    recentFilesController()->removeRecentFile(scorePath);
+}
+
 void ScoresPageModel::openScoreManager()
 {
     interactive()->openUrl(museScoreComService()->scoreManagerUrl());

--- a/src/project/view/scorespagemodel.h
+++ b/src/project/view/scorespagemodel.h
@@ -26,6 +26,7 @@
 
 #include "modularity/ioc.h"
 #include "iprojectconfiguration.h"
+#include "irecentfilescontroller.h"
 #include "actions/iactionsdispatcher.h"
 #include "iinteractive.h"
 #include "cloud/musescorecom/imusescorecomservice.h"
@@ -36,6 +37,7 @@ class ScoresPageModel : public QObject
     Q_OBJECT
 
     INJECT(IProjectConfiguration, configuration)
+    INJECT(IRecentFilesController, recentFilesController)
     INJECT(actions::IActionsDispatcher, dispatcher)
     INJECT(framework::IInteractive, interactive)
     INJECT(cloud::IMuseScoreComService, museScoreComService)
@@ -48,6 +50,7 @@ public:
     Q_INVOKABLE void createNewScore();
     Q_INVOKABLE void openOther();
     Q_INVOKABLE void openScore(const QString& scorePath, const QString& displayNameOverride);
+    Q_INVOKABLE void removeScore(const QString& scorePath);
     Q_INVOKABLE void openScoreManager();
 
     int tabIndex() const;


### PR DESCRIPTION
Resolves: #11235

Added a cross button in the upper right corner of the thumbnail of each score that allows users to remove the score from the recent scores.

https://user-images.githubusercontent.com/102702868/220952882-e1f84e36-4064-4120-b081-6d86b0a58c19.mp4

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)