### PR TITLE
Fix that previously resetted excerpts are not reopened after reopening the file

### DIFF
--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -573,6 +573,8 @@ void MasterNotation::resetExcerpt(IExcerptNotationPtr excerptNotation)
     mu::engraving::Excerpt* newExcerpt = new mu::engraving::Excerpt(*oldExcerpt, false);
     masterScore()->initAndAddExcerpt(newExcerpt, false);
 
+    newExcerpt->excerptScore()->setIsOpen(oldExcerpt->excerptScore()->isOpen());
+
     get_impl(excerptNotation)->reinit(newExcerpt);
 
     masterScore()->setExcerptsChanged(false);


### PR DESCRIPTION
Resolves: part 2 from https://github.com/musescore/MuseScore/pull/15665#issuecomment-1441873817

The reason that I'm calling the method of the `Score` directly, is that the new `Score` is the only thing that gets out of sync with the rest. When calling it via `->notation()->setIsOpen` or `setExcerptIsOpen`, some unnecessary notifications would be emitted.