### PR TITLE
Chord Symbols duration calculation requires the use of utick

### DIFF
--- a/src/engraving/playback/playbackeventsrenderer.cpp
+++ b/src/engraving/playback/playbackeventsrenderer.cpp
@@ -125,7 +125,7 @@ void PlaybackEventsRenderer::renderChordSymbol(const Harmony* chordSymbol,
     timestamp_t eventTimestamp = timestampFromTicks(score, positionTick + ticksPositionOffset);
     PlaybackEventList& events = result[eventTimestamp];
 
-    int durationTicks = realized.getActualDuration(positionTick).ticks();
+    int durationTicks = realized.getActualDuration(positionTick + ticksPositionOffset).ticks();
     BeatsPerSecond bps = score->tempomap()->tempo(positionTick);
     duration_t duration = durationFromTicks(bps.val, durationTicks);
 


### PR DESCRIPTION
Resolves: #16442

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [N/A] I created a unit test or vtest to verify the changes I made (if applicable)
