### PR TITLE
Fix for issue #12772: [MU4 Issue] PNG Export dialog - Resolution - unable to enter more than 3 digits

### DIFF
--- a/src/framework/uicomponents/view/validators/intinputvalidator.cpp
+++ b/src/framework/uicomponents/view/validators/intinputvalidator.cpp
@@ -48,8 +48,10 @@ QValidator::State IntInputValidator::validate(QString& inputStr, int& cursorPos)
 {
     QValidator::State state = Invalid;
 
-    if (inputStr.contains(QRegularExpression("^\\-?\\d{1,3}$"))) {
-        if (inputStr.contains(QRegularExpression("^\\-?0{2,3}"))
+    //maxDigits is the number of digits in the maximum absolute value between m_top and m_bottom.
+    int maxDigits = std::ceil(std::log10(std::max(std::abs(m_top), std::abs(m_bottom))));
+    if (inputStr.contains(QRegularExpression(QString("^\\-?\\d{1,%1}$").arg(maxDigits)))) {
+        if ((maxDigits >= 2 && inputStr.contains(QRegularExpression(QString("^\\-?0{2,%1}").arg(maxDigits))))
             || (inputStr.startsWith("-") && inputStr.toDouble() == 0.0)) {
             state = Intermediate;
         } else {

--- a/src/framework/uicomponents/view/validators/intinputvalidator.cpp
+++ b/src/framework/uicomponents/view/validators/intinputvalidator.cpp
@@ -48,10 +48,12 @@ QValidator::State IntInputValidator::validate(QString& inputStr, int& cursorPos)
 {
     QValidator::State state = Invalid;
 
-    //maxDigits is the number of digits in the maximum absolute value between m_top and m_bottom.
-    int maxDigits = std::ceil(std::log10(std::max(std::abs(m_top), std::abs(m_bottom))));
-    if (inputStr.contains(QRegularExpression(QString("^\\-?\\d{1,%1}$").arg(maxDigits)))) {
-        if ((maxDigits >= 2 && inputStr.contains(QRegularExpression(QString("^\\-?0{2,%1}").arg(maxDigits))))
+    const int maxAbsoluteValue = std::max(std::abs(m_top), std::abs(m_bottom));
+    const int maxNumberOfDigits = maxAbsoluteValue > 0
+                                  ? std::floor(std::log10(maxAbsoluteValue)) + 1
+                                  : 1;
+    if (inputStr.contains(QRegularExpression(QString("^\\-?\\d{1,%1}$").arg(maxNumberOfDigits)))) {
+        if ((maxNumberOfDigits >= 2 && inputStr.contains(QRegularExpression(QString("^\\-?0{2,%1}").arg(maxNumberOfDigits))))
             || (inputStr.startsWith("-") && inputStr.toDouble() == 0.0)) {
             state = Intermediate;
         } else {


### PR DESCRIPTION
Changed the regular expression to validate integers of maximum length 4.

Resolves: #12772 

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
