### PR TITLE
Fix #13126: Applying a barline to a note on the first beat changes the previous measure's end barline

### DIFF
--- a/src/engraving/libmscore/barline.cpp
+++ b/src/engraving/libmscore/barline.cpp
@@ -137,6 +137,9 @@ static void undoChangeBarLineType(BarLine* bl, BarLineType barType, bool allStav
                     }
 
                     lmeasure->undoChangeProperty(Pid::REPEAT_END, false);
+                    if (lmeasure->nextMeasure()) {
+                        lmeasure->nextMeasure()->undoChangeProperty(Pid::REPEAT_START, false);
+                    }
                     Segment* lsegment = lmeasure->undoGetSegmentR(SegmentType::EndBarLine, lmeasure->ticks());
                     BarLine* lbl = toBarLine(lsegment->element(ltrack));
                     if (!lbl) {
@@ -883,12 +886,6 @@ EngravingItem* BarLine::drop(EditData& data)
     if (e->isBarLine()) {
         BarLine* bl    = toBarLine(e);
         BarLineType st = bl->barLineType();
-
-        // if no change in subtype or no change in span, do nothing
-        if (st == barLineType() && !bl->spanFrom() && !bl->spanTo()) {
-            delete e;
-            return 0;
-        }
 
         // check if the new property can apply to this single bar line
         BarLineType bt = BarLineType::START_REPEAT | BarLineType::END_REPEAT | BarLineType::END_START_REPEAT;

--- a/src/engraving/libmscore/chordrest.cpp
+++ b/src/engraving/libmscore/chordrest.cpp
@@ -400,6 +400,13 @@ EngravingItem* ChordRest::drop(EditData& data)
             bl->setGenerated(false);
 
             if (tick() == m->tick()) {
+                if (bl->barLineType() != BarLineType::START_REPEAT) {
+                    m = m->prevMeasure();
+                    if (!m) {
+                        delete e;
+                        return 0;
+                    }
+                }
                 return m->drop(data);
             }
 


### PR DESCRIPTION
Resolves: #13126

When a barline is applied to a note on the first beat, it now changes the end barline of the previous measure.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
