### PR TITLE
Check minimum drag delta only before starting a drag operation

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -673,10 +673,14 @@ void NotationViewInputController::mouseMoveEvent(QMouseEvent* event)
     Qt::KeyboardModifiers keyState = event->modifiers();
 
     PointF dragDelta = logicPos - m_beginPoint;
-    // start some drag operations after a minimum of movement:
-    bool isDrag = dragDelta.manhattanLength() > 4;
-    if (!isDrag) {
-        return;
+
+    bool isDragStarted = m_isCanvasDragged || viewInteraction()->isDragStarted();
+    if (!isDragStarted) {
+        // only start drag operations after a minimum of movement:
+        bool canStartDrag = dragDelta.manhattanLength() > 4;
+        if (!canStartDrag) {
+            return;
+        }
     }
 
     bool isNoteEnterMode = m_view->isNoteEnterMode();


### PR DESCRIPTION
Once dragging has started, the dragged thing should move smoothly, and not refuse to be dragged when it is close to its original position.

Resolves: #16383