### PR TITLE
Don't mark audio settings / view settings as saved after AutoSave

### DIFF
--- a/src/notation/inotationviewstate.h
+++ b/src/notation/inotationviewstate.h
@@ -61,6 +61,7 @@ public:
 
     virtual bool needSave() const = 0;
     virtual async::Notification needSaveChanged() const = 0;
+    virtual void markAsSaved() = 0;
 
     virtual void makeDefault() = 0;
 };

--- a/src/notation/internal/notationviewstate.cpp
+++ b/src/notation/internal/notationviewstate.cpp
@@ -99,8 +99,6 @@ Ret NotationViewState::write(engraving::MscWriter& writer, const io::path_t& pat
     QByteArray json = QJsonDocument(rootObj).toJson();
     writer.writeViewSettingsJsonFile(ByteArray::fromQByteArrayNoCopy(json), pathPrefix);
 
-    setNeedSave(false);
-
     return make_ret(Ret::Code::Ok);
 }
 
@@ -176,6 +174,11 @@ bool NotationViewState::needSave() const
 async::Notification NotationViewState::needSaveChanged() const
 {
     return m_needSaveNotification;
+}
+
+void NotationViewState::markAsSaved()
+{
+    setNeedSave(false);
 }
 
 void NotationViewState::makeDefault()

--- a/src/notation/internal/notationviewstate.h
+++ b/src/notation/internal/notationviewstate.h
@@ -57,6 +57,7 @@ public:
 
     bool needSave() const override;
     async::Notification needSaveChanged() const override;
+    void markAsSaved() override;
 
     void makeDefault() override;
 

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -127,12 +127,16 @@ void NotationProject::setupProject()
 
     m_masterNotation = notationCreator()->newMasterNotationPtr();
     m_masterNotation->needSave().notification.onNotify(this, [this]() {
-        m_needSaveNotification.notify();
+        if (!m_needSaveNotificationBlocked) {
+            m_needSaveNotification.notify();
+        }
     });
 
     m_projectAudioSettings = std::shared_ptr<ProjectAudioSettings>(new ProjectAudioSettings());
     m_projectAudioSettings->needSave().notification.onNotify(this, [this]() {
-        m_needSaveNotification.notify();
+        if (!m_needSaveNotificationBlocked) {
+            m_needSaveNotification.notify();
+        }
     });
 }
 
@@ -777,6 +781,8 @@ void NotationProject::markAsSaved(const io::path_t& path)
     //! NOTE: order is important
     m_isNewlyCreated = false;
 
+    m_needSaveNotificationBlocked = true;
+
     // Mark engraving project as saved
     m_masterNotation->setSaved(true);
 
@@ -788,6 +794,9 @@ void NotationProject::markAsSaved(const io::path_t& path)
     for (IExcerptNotationPtr excerpt : m_masterNotation->excerpts().val) {
         excerpt->notation()->viewState()->markAsSaved();
     }
+
+    m_needSaveNotificationBlocked = false;
+    m_needSaveNotification.notify();
 
     setPath(path);
 

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -117,6 +117,7 @@ private:
     async::Notification m_pathChanged;
 
     async::Notification m_needSaveNotification;
+    bool m_needSaveNotificationBlocked = false;
 
     bool m_isNewlyCreated = false; /// true if the file has never been saved yet
     bool m_isImported = false;

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -106,6 +106,8 @@ private:
     Ret makeCurrentFileAsBackup();
     Ret writeProject(engraving::MscWriter& msczWriter, bool onlySelection);
 
+    void markAsSaved(const io::path_t& path);
+
     mu::engraving::EngravingProjectPtr m_engravingProject = nullptr;
     notation::IMasterNotationPtr m_masterNotation = nullptr;
     ProjectAudioSettingsPtr m_projectAudioSettings = nullptr;

--- a/src/project/internal/projectaudiosettings.cpp
+++ b/src/project/internal/projectaudiosettings.cpp
@@ -172,6 +172,11 @@ mu::ValNt<bool> ProjectAudioSettings::needSave() const
     return needSave;
 }
 
+void ProjectAudioSettings::markAsSaved()
+{
+    setNeedSave(false);
+}
+
 const SoundProfileName& ProjectAudioSettings::activeSoundProfile() const
 {
     return m_activeSoundProfileName;
@@ -237,8 +242,6 @@ mu::Ret ProjectAudioSettings::write(engraving::MscWriter& writer)
 
     QByteArray json = QJsonDocument(rootObj).toJson();
     writer.writeAudioSettingsJsonFile(ByteArray::fromQByteArrayNoCopy(json));
-
-    setNeedSave(false);
 
     return make_ret(Ret::Code::Ok);
 }

--- a/src/project/internal/projectaudiosettings.h
+++ b/src/project/internal/projectaudiosettings.h
@@ -54,6 +54,7 @@ public:
     void removeTrackParams(const engraving::InstrumentTrackId& partId) override;
 
     mu::ValNt<bool> needSave() const override;
+    void markAsSaved() override;
 
     const playback::SoundProfileName& activeSoundProfile() const override;
     void setActiveSoundProfile(const playback::SoundProfileName& profileName) override;

--- a/src/project/iprojectaudiosettings.h
+++ b/src/project/iprojectaudiosettings.h
@@ -28,6 +28,7 @@
 #include "audio/audiotypes.h"
 #include "engraving/types/types.h"
 #include "playback/playbacktypes.h"
+#include "types/retval.h"
 
 namespace mu::project {
 class IProjectAudioSettings
@@ -62,6 +63,7 @@ public:
     virtual void removeTrackParams(const engraving::InstrumentTrackId& trackId) = 0;
 
     virtual mu::ValNt<bool> needSave() const = 0;
+    virtual void markAsSaved() = 0;
 
     virtual const playback::SoundProfileName& activeSoundProfile() const = 0;
     virtual void setActiveSoundProfile(const playback::SoundProfileName& profileName) = 0;


### PR DESCRIPTION
Only mark them as saved when *everything* has been saved *successfully* to the *real file* of the project.

So, not after AutoSave; not after "Save a copy" (but certainly after "Save as"); not after writing the audio settings to some buffer but then failing to write that buffer to a file; etc.

Resolves: #16549