### PR TITLE
Fix crash when duplicating open part

### DIFF
--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -201,7 +201,12 @@ void Excerpt::setTracksMapping(const TracksMap& tracksMapping)
 
     m_tracksMapping = tracksMapping;
 
-    for (Staff* staff : excerptScore()->staves()) {
+    const Score* score = excerptScore();
+    if (!score) {
+        return;
+    }
+
+    for (Staff* staff : score->staves()) {
         const Staff* masterStaff = m_masterScore->staffById(staff->id());
         if (!masterStaff) {
             continue;


### PR DESCRIPTION
When an excerpt is copied, it calls `Score::clone()`. That contains some strange-looking logic about creating yet another excerpt and abusing that to properly clone the excerpt score from the master score etc. I'm sure we can do better, but let's save that for later. The problem is that this strange logic calls Excerpt::setTracksMapping on the fake excerpt, which assumes that the fake excerpt already has an `excerptScore()`. Let's just be careful about that assumption :)

Resolves: #16566