### PR TITLE
Fix #15540: Ensure Beam::_elements is sorted

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -446,6 +446,12 @@ void Beam::layout1()
 
 void Beam::layout()
 {
+    // all of the beam layout code depends on _elements being in order by tick
+    // this may not be the case if two cr's were recently swapped.
+    std::sort(_elements.begin(), _elements.end(),
+              [](const ChordRest* a, const ChordRest* b) -> bool {
+        return a->tick() < b->tick();
+    });
     System* system = _elements.front()->measure()->system();
     setParent(system);
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/15540

All of the layout code expects a beam's _elements to be a sorted vector. This is actually a bug that existed in MU3 as well!