### PR TITLE
Fix GH#16618: Information copied from Help > About contains incorrect OS information

### DIFF
--- a/src/appshell/view/aboutmodel.cpp
+++ b/src/appshell/view/aboutmodel.cpp
@@ -88,7 +88,9 @@ void AboutModel::copyRevisionToClipboard() const
 {
     QApplication::clipboard()->setText(
         QString("OS: %1, Arch.: %2, MuseScore version (%3-bit): %4-%5, revision: github-musescore-musescore-%6")
-        .arg(QSysInfo::prettyProductName())
+        .arg(QSysInfo::prettyProductName()
+             + ((QSysInfo::productType() == "windows" && (QSysInfo::productVersion() == "10" || QSysInfo::productVersion() == "11"))
+                ? " or later" : ""))
         .arg(QSysInfo::currentCpuArchitecture())
         .arg(QSysInfo::WordSize)
         .arg(MUSESCORE_VERSION)


### PR DESCRIPTION
on Windows 10 and later

Resolves: #16618

We will get "Windows 11" printed once we switched to Qt 6.2, but even then the appended " or later" is still correct (or at the very least not wrong).
Current output (with Qt 5.15.2 and on Windows 11 22H2):

OS: Windows 10 Version 2009 or later, Arch.: x86_64, MuseScore version (64-bit): 4.1.0-\<buildnumber\>, revision: github-musescore-musescore-\<commitSHA\>