### PR TITLE
[4.0.2] Fix untranslatable strings in the corruption details dialog

### DIFF
--- a/src/engraving/libmscore/check.cpp
+++ b/src/engraving/libmscore/check.cpp
@@ -185,7 +185,7 @@ Ret Score::sanityCheckLocal()
             }
 
             if (!repeatsIsValid) {
-                errors << mtrc("engraving", u"<b>Corrupted measure</b>: %1, measure %2, staff %3.")
+                errors << mtrc("engraving", "<b>Corrupted measure</b>: %1, measure %2, staff %3.")
                     .arg(excerptInfo()).arg(mNumber).arg(staffIdx + 1);
 #ifndef NDEBUG
                 m->setCorrupted(staffIdx, true);
@@ -194,7 +194,7 @@ Ret Score::sanityCheckLocal()
 
             if (voices[0] != mLen) {
                 //: %1 describes in which score the corruption is (either `Full score` or `"[part name]" part score`)
-                errors << mtrc("engraving", u"<b>Incomplete measure</b>: %1, measure %2, staff %3. Found: %4. Expected: %5.")
+                errors << mtrc("engraving", "<b>Incomplete measure</b>: %1, measure %2, staff %3. Found: %4. Expected: %5.")
                     .arg(excerptInfo()).arg(mNumber).arg(staffIdx + 1).arg(voices[0].toString(), mLen.toString());
 #ifndef NDEBUG
                 m->setCorrupted(staffIdx, true);
@@ -209,7 +209,7 @@ Ret Score::sanityCheckLocal()
             for (voice_idx_t v = 1; v < VOICES; ++v) {
                 if (voices[v] > mLen) {
                     //: %1 describes in which score the corruption is (either `Full score` or `"[part name]" part score`)
-                    errors << mtrc("engraving", u"<b>Voice too long</b>: %1, measure %2, staff %3, voice %4. Found: %5. Expected: %6.")
+                    errors << mtrc("engraving", "<b>Voice too long</b>: %1, measure %2, staff %3, voice %4. Found: %5. Expected: %6.")
                         .arg(excerptInfo()).arg(mNumber).arg(staffIdx + 1).arg(v + 1).arg(voices[v].toString(), mLen.toString());
 #ifndef NDEBUG
                     m->setCorrupted(staffIdx, true);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/16643

See #16651