### PR TITLE
Reword "margin" to "padding" in frames

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/notation/frames/internal/HorizontalMarginsSection.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/frames/internal/HorizontalMarginsSection.qml
@@ -46,7 +46,7 @@ Item {
         anchors.right: parent.horizontalCenter
         anchors.rightMargin: 4
 
-        titleText: qsTrc("inspector", "Left margin")
+        titleText: qsTrc("inspector", "Left padding")
         propertyItem: root.frameLeftMargin
 
         icon: IconCode.LEFT_MARGIN
@@ -62,7 +62,7 @@ Item {
         anchors.leftMargin: 4
         anchors.right: parent.right
 
-        titleText: qsTrc("inspector", "Right margin")
+        titleText: qsTrc("inspector", "Right padding")
         propertyItem: root.frameRightMargin
 
         icon: IconCode.RIGHT_MARGIN


### PR DESCRIPTION
Resolves: #16625 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Reword margin to padding in frames.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
