### PR TITLE
OS Information now displays correctly, Added OS kernel version to revision string

### DIFF
--- a/src/appshell/view/aboutmodel.cpp
+++ b/src/appshell/view/aboutmodel.cpp
@@ -86,9 +86,15 @@ QVariantMap AboutModel::musicXMLLicenseDeedUrl() const
 
 void AboutModel::copyRevisionToClipboard() const
 {
+    QString prettyProductName = QSysInfo::prettyProductName();
+    if (prettyProductName == "Windows 10 Version 2009") {
+        prettyProductName += " ";
+        prettyProductName += qtrc("appshell/about", "or newer");
+    }
     QApplication::clipboard()->setText(
-        QString("OS: %1, Arch.: %2, MuseScore version (%3-bit): %4-%5, revision: github-musescore-musescore-%6")
-        .arg(QSysInfo::prettyProductName())
+        QString("OS: %1, Kernel Version: %2, Arch.: %3, MuseScore version (%4-bit): %5-%6, revision: github-musescore-musescore-%7")
+        .arg(prettyProductName)
+        .arg(QSysInfo::kernelVersion())
         .arg(QSysInfo::currentCpuArchitecture())
         .arg(QSysInfo::WordSize)
         .arg(MUSESCORE_VERSION)


### PR DESCRIPTION
Resolves: #16618

Revision string now reports 'Windows 10 Version 2009 or newer' as the OS when 'Windows 10 Version 2009' is reported by QSysInfo, as all versions newer than that are misreported as that version by QSysInfo
Also added Kernel Version to Revision String as that disambiguates the OS version

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
