### PR TITLE
Fix #16703: swap zoom in/out controls in status bar

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/ZoomControl.qml
+++ b/src/notation/qml/MuseScore/NotationScene/ZoomControl.qml
@@ -45,27 +45,7 @@ RowLayout {
     spacing: 0
 
     FlatButton {
-        id: zoomInButton
-        icon: IconCode.ZOOM_IN
-        iconFont: ui.theme.toolbarIconsFont
-
-        width: height
-        height: 28
-        transparent: true
-
-        navigation.panel: root.navigationPanel
-        navigation.order: root.navigationOrderMin
-        accessible.name: qsTrc("notation", "Zoom in")
-
-        onClicked: {
-            root.zoomInRequested()
-        }
-    }
-
-    FlatButton {
         id: zoomOutButton
-        Layout.leftMargin: 4
-
         icon: IconCode.ZOOM_OUT
         iconFont: ui.theme.toolbarIconsFont
 
@@ -74,11 +54,31 @@ RowLayout {
         transparent: true
 
         navigation.panel: root.navigationPanel
-        navigation.order: zoomInButton.navigation.order + 1
+        navigation.order: root.navigationOrderMin
         accessible.name: qsTrc("notation", "Zoom out")
 
         onClicked: {
             root.zoomOutRequested()
+        }
+    }
+
+    FlatButton {
+        id: zoomInButton
+        Layout.leftMargin: 4
+
+        icon: IconCode.ZOOM_IN
+        iconFont: ui.theme.toolbarIconsFont
+
+        width: height
+        height: 28
+        transparent: true
+
+        navigation.panel: root.navigationPanel
+        navigation.order: zoomOutButton.navigation.order + 1
+        accessible.name: qsTrc("notation", "Zoom in")
+
+        onClicked: {
+            root.zoomInRequested()
         }
     }
 


### PR DESCRIPTION
Resolves: #16703 

Status bar now shows zoom out control before zoom in control, as standard in other programs.

![image](https://user-images.githubusercontent.com/26545465/223774177-2e85a78d-1062-4762-a65a-7a7696ff063f.png)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
