### PR TITLE
Fix #16701: set MIN_DISPLAYED_ZOOM_PERCENTAGE to 5

### DIFF
--- a/src/appshell/view/notationstatusbarmodel.cpp
+++ b/src/appshell/view/notationstatusbarmodel.cpp
@@ -355,7 +355,7 @@ void NotationStatusBarModel::setCurrentZoom(const QString& zoomId)
 
 int NotationStatusBarModel::minZoomPercentage() const
 {
-    return possibleZoomPercentageList().first();
+    return 5;
 }
 
 int NotationStatusBarModel::maxZoomPercentage() const


### PR DESCRIPTION
Resolves: #16701 

Entering values in zoom controls clipped to 25 while zoom out button clipped to 5. This change sets the min zoom clamp to 5 instead of 25.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
