### PR TITLE
Fix #16506: add inverted engraving colors for inverted score

### DIFF
--- a/src/engraving/libmscore/engravingitem.cpp
+++ b/src/engraving/libmscore/engravingitem.cpp
@@ -629,7 +629,7 @@ mu::draw::Color EngravingItem::curColor(bool isVisible, Color normalColor) const
     }
 
     if (m_colorsInversionEnabled && engravingConfiguration()->scoreInversionEnabled()) {
-        return engravingConfiguration()->scoreInversionColor();
+        return normalColor.invert();
     }
 
     return normalColor;

--- a/src/framework/draw/types/color.cpp
+++ b/src/framework/draw/types/color.cpp
@@ -189,6 +189,14 @@ void Color::setRgba(Rgba rgba)
     m_isValid = true;
 }
 
+Color Color::invert()
+{
+    int m = std::min(red() < green() ? red() : green(), blue());
+    int M = std::max(red() > green() ? red() : green(), blue());
+    int x = 255 - m - M;
+    return Color(red() + x, green() + x, blue() + x, alpha());
+}
+
 static constexpr int fromHex(char c)
 {
     return ((c >= '0') && (c <= '9')) ? int(c - '0')

--- a/src/framework/draw/types/color.h
+++ b/src/framework/draw/types/color.h
@@ -61,6 +61,7 @@ public:
     void setGreen(int value);
     void setBlue(int value);
     void setAlpha(int value);
+    Color invert();
 
     bool operator==(const Color& other) const;
     bool operator!=(const Color& other) const;


### PR DESCRIPTION
Resolves: #16506

Add colors to engravings when "Invert score" is checked. Inverted colors are calculated according to algorithm given by @PepijndeMaat

Here are some examples of the result.

"Invert score" unchecked:
![image](https://user-images.githubusercontent.com/26545465/223892814-e7c73706-9f31-419a-ab6a-b720e2872b25.png)

"Invert score" checked:
![image](https://user-images.githubusercontent.com/26545465/223892833-240610fa-37e0-4de3-829a-e2ac68b798ea.png)


- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
