### PR TITLE
Issue triage: switch to our own `assign-by-label` action

### DIFF
--- a/.github/workflows/ci_issues_triage.yml
+++ b/.github/workflows/ci_issues_triage.yml
@@ -1,7 +1,7 @@
 name: "Issue triage"
 on:
   issues:
-    types: [opened, labeled]
+    types: [opened, labeled, unlabeled]
 
 permissions:
   issues: write
@@ -19,41 +19,44 @@ jobs:
         not-before: 2023-02-27T00:00:00Z
         enable-versioned-regex: 0
 
-  move_and_assing:
+  add_to_projects:
     if: github.event.action == 'labeled'
     runs-on: ubuntu-latest
     steps:
-    - name: 'Engraving: move to project'
+    - name: 'Engraving'
       uses: actions/add-to-project@main
       with:
         project-url: https://github.com/orgs/musescore/projects/23
         github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
         labeled: engraving
 
-    - name: 'Cloud saving/loading: move to project'
+    - name: 'Cloud saving/loading'
       uses: actions/add-to-project@main
       with:
         project-url: https://github.com/orgs/musescore/projects/22
         github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
         labeled: cloud
 
-    - name: 'Muse Sounds: move to project'
+    - name: 'Muse Sounds'
       uses: actions/add-to-project@main
       with:
         project-url: https://github.com/orgs/musescore/projects/21
         github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
         labeled: 'Muse Sounds'
 
-    - name: 'VSTs: move to project'
+    - name: 'VST'
       uses: actions/add-to-project@main
       with:
         project-url: https://github.com/orgs/musescore/projects/20
         github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
         labeled: VST
 
-    - uses: actions/checkout@v3
+  assign:
+    if: github.event.action == 'labeled' || github.event.action == 'unlabeled'
+    runs-on: ubuntu-latest
+    steps:
     - name: 'Set assignees on issue'
-      uses: kyanagimoto/assignee4label@main
+      uses: cbjeukendrup/assign-by-label@main
       with:
         github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
         configuration-path: '.github/issue_assign_by_label_config.yml'

--- a/.github/workflows/ci_issues_triage.yml
+++ b/.github/workflows/ci_issues_triage.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: 'Set assignees on issue'
-      uses: cbjeukendrup/assign-by-label@main
+      uses: musescore/github_actions/assign-by-label@main
       with:
         github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
         configuration-path: '.github/issue_assign_by_label_config.yml'


### PR DESCRIPTION
Resolves: #16717 

I wrote my own "assign by label" action, that works slightly smarter than the one we were using previously: whenever a label was added, that one removed all assignees, and then tried to re-add them as appropriate for the current labels but the re-adding did not work well when multiple labels are specified. 
My action looks _which_ label was added or removed, and only assigns or unassigns the people who are specified for that label. It does not unassign other people that were assigned manually for example.

You can see it at https://github.com/cbjeukendrup/assign-by-label, and I have tested it at https://github.com/cbjeukendrup/MuseScore/issues/4. (edit: moved to https://github.com/musescore/github_actions/tree/main/assign-by-label)