### PR TITLE
Allow Time Signature scaling up to 1000%

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/notation/timesignatures/TimeSignatureSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/timesignatures/TimeSignatureSettings.qml
@@ -89,7 +89,7 @@ Column {
                 measureUnitsSymbol: "%"
                 step: 1
                 decimals: 0
-                maxValue: 300
+                maxValue: 1000
                 minValue: 1
 
                 navigation.name: "HorizontalScale"
@@ -116,7 +116,7 @@ Column {
                 measureUnitsSymbol: "%"
                 step: 1
                 decimals: 0
-                maxValue: 300
+                maxValue: 1000
                 minValue: 1
 
                 navigation.name: "VerticalScale"


### PR DESCRIPTION
Resolves: #https://musescore.org/en/node/341456

The previous limit of 300% seems to be arbitrarily chosen, this PR adresses that.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
