### PR TITLE
Fix #343436: Crash on saving after adding note-anchored lines

### DIFF
--- a/src/engraving/libmscore/engravingitem.cpp
+++ b/src/engraving/libmscore/engravingitem.cpp
@@ -840,7 +840,7 @@ void EngravingItem::writeProperties(XmlWriter& xml) const
             int index = ctx->assignLocalIndex(loc);
             ctx->setLidLocalIndex(_links->lid(), index);
         } else {
-            if (s->links()) {
+            if (s && s->links()) {
                 Staff* linkedStaff = toStaff(s->links()->mainElement());
                 loc.setStaff(static_cast<int>(linkedStaff->idx()));
             }


### PR DESCRIPTION
to any but the top part/instrument

Fixes https://musescore.org/en/node/343436