### PR TITLE
Fix #341456: Increase max time signature scale from 300% to 1000%

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/notation/timesignatures/TimeSignatureSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/timesignatures/TimeSignatureSettings.qml
@@ -89,7 +89,7 @@ Column {
                 measureUnitsSymbol: "%"
                 step: 1
                 decimals: 0
-                maxValue: 300
+                maxValue: 1000
                 minValue: 1
 
                 navigation.name: "HorizontalScale"
@@ -116,7 +116,7 @@ Column {
                 measureUnitsSymbol: "%"
                 step: 1
                 decimals: 0
-                maxValue: 300
+                maxValue: 1000
                 minValue: 1
 
                 navigation.name: "VerticalScale"


### PR DESCRIPTION
Resolves: #341456 on musescore.org issue tracker https://musescore.org/en/node/341456

MuseScore 3 allowed for time signatures to be any size up to 1000%, and it has been requested to grant the same ability in MuseScore 4.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
