### PR TITLE
fixed #16728: Corruption dialog becomes too tall when language is set to German

### DIFF
--- a/src/framework/ui/qml/MuseScore/Ui/internal/StandardDialog.qml
+++ b/src/framework/ui/qml/MuseScore/Ui/internal/StandardDialog.qml
@@ -48,6 +48,7 @@ StyledDialogView {
 
         property int buttonId: 999
         property string title: detailsLoader.active ? qsTrc("global", "Hide details") : qsTrc("global", "Show details")
+        property bool accent: false
     }
 
     contentWidth: content.implicitWidth
@@ -78,7 +79,7 @@ StyledDialogView {
         mainPanel.readInfo()
     }
 
-    ColumnLayout {
+    Column {
         id: content
 
         width: mainPanel.width
@@ -107,8 +108,8 @@ StyledDialogView {
         Loader {
             id: detailsLoader
 
-            Layout.fillWidth: true
-            Layout.preferredHeight: visible ? implicitHeight : 0
+            width: parent.width
+            height: visible ? implicitHeight : 0
 
             active: false
             visible: active


### PR DESCRIPTION
Resolves: #16728

This PR fixes the dialog size, but there are many warnings in qml. 

Also, there is one problem in my solution - focusing on the accent button does not occur. If the user clicks on space after opening the dialog, details info will be displayed.