### PR TITLE
Fix #16658: Position of articulations is incorrect in imported MusicX…

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -1037,17 +1037,20 @@ static void addArticulationToChord(const Notation& notation, ChordRest* cr)
     Articulation* na = Factory::createArticulation(cr);
     na->setSymId(articSym);
 
-    if (!dir.isNull()) { // Only for case where XML attribute is present (isEmpty wouldn't work)
-        na->setUp(dir.isEmpty() || dir == "up");
+    if (dir == "up" || dir == "down") {
+        na->setUp(dir == "up");
+        na->setPropertyFlags(Pid::DIRECTION, PropertyFlags::UNSTYLED);
     }
-    setElementPropertyFlags(na, Pid::DIRECTION, dir);
 
-    if (place == "above" || dir.isEmpty() || dir == "up") {
-        na->setAnchor(ArticulationAnchor::TOP_STAFF);
-    } else if (place == "below" || dir == "down") {
-        na->setAnchor(ArticulationAnchor::BOTTOM_STAFF);
+    // when setting anchor, assume type up/down without explicit placement
+    // implies placement above/below
+    if (place == "above" || (dir == "up" && place == "")) {
+        na->setAnchor(ArticulationAnchor::TOP_CHORD);
+        na->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
+    } else if (place == "below" || (dir == "down" && place == "")) {
+        na->setAnchor(ArticulationAnchor::BOTTOM_CHORD);
+        na->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
     }
-    setElementPropertyFlags(na, Pid::DIRECTION, dir, place);
 
     cr->add(na);
 }


### PR DESCRIPTION
…ML files from Reaper

Resolves: #16658

Articulations without placement or type attributes import as "chord automatic". Articulations with placement or type attributes import as "above chord" or "below chord".

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
