### PR TITLE
 Fix # 16371 : Ensure score is inside viewport when notation is changed

### DIFF
--- a/src/notation/view/abstractnotationpaintview.cpp
+++ b/src/notation/view/abstractnotationpaintview.cpp
@@ -239,6 +239,7 @@ void AbstractNotationPaintView::onLoadNotation(INotationPtr)
     m_notation->notationChanged().onNotify(this, [this, interaction]() {
         interaction->hideShadowNote();
         m_shadowNoteRect = RectF();
+        ensureViewportInsideScrollableArea();
         scheduleRedraw();
     });
 


### PR DESCRIPTION
Resolves: #16371
I fix the issue in which we were getting empty window we we change to "continuous view(vertical)" after "page  view".


- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [] I created a unit test or vtest to verify the changes I made (if applicable)
