### PR TITLE
Fix #16446: Remove chordrests in deleted measures from beams

### DIFF
--- a/src/engraving/libmscore/undo.cpp
+++ b/src/engraving/libmscore/undo.cpp
@@ -2083,6 +2083,28 @@ void InsertRemoveMeasures::removeMeasures()
     Fraction tick1 = fm->tick();
     Fraction tick2 = lm->endTick();
 
+    // remove beams from chordrests in affected area, they will be rebuilt later but we need
+    // to avoid situations where notes from deleted measures remain in beams
+    // when undoing, we need to check the previous measure as well as there could be notes in there
+    // that need to have their beams recalculated (esp. when adding time signature)
+    MeasureBase* prev = fm->prev();
+    Segment* first = toMeasure(prev && prev->isMeasure() ? prev : fm)->first();
+    for (Segment* s = first; s && s != toMeasure(lm)->last(); s = s->next1()) {
+        if (!s) {
+            break;
+        }
+        if (!s->isChordRestType()) {
+            continue;
+        }
+
+        for (track_idx_t track = 0; track < score->ntracks(); ++track) {
+            EngravingItem* e = s->element(track);
+            if (e && e->isChordRest()) {
+                toChordRest(e)->removeDeleteBeam(false);
+            }
+        }
+    }
+
     std::list<System*> systemList;
     for (MeasureBase* mb = lm;; mb = mb->prev()) {
         System* system = mb->system();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/16446

The issue originates from the fact that dragging a time signature onto a measure rewrites the measures by cloning all its elements. The beams then think there are way more chordrests in the beam than there actually are due to the cloned notes being added to the list that contains the notes in the removed measures as well.

The way I've solved this is to remove beams entirely from notes in deleted measures. The beams are rebuilt on first layout anyway, and this way we know they're being rebuilt using only relevant non-deleted chordrests.