### PR TITLE
Fix #16761: clear measures after box properties are set

### DIFF
--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -305,8 +305,6 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
     mu::engraving::VBox* nvb = nullptr;
 
     if (createdFromTemplate) {
-        clearMeasures(score);
-
         mu::engraving::MeasureBase* mb = score->first();
         if (mb && mb->isVBox()) {
             mu::engraving::VBox* tvb = toVBox(mb);
@@ -321,6 +319,8 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
             nvb->setRightMargin(tvb->rightMargin());
             nvb->setAutoSizeEnabled(tvb->isAutoSizeEnabled());
         }
+
+        clearMeasures(score);
 
         // for templates using built-in base page style, set score page style to default (may be user-defined)
         bool isBaseWidth = (std::abs(score->style().styleD(Sid::pageWidth) - DefaultStyle::baseStyle().styleD(Sid::pageWidth)) < 0.1);


### PR DESCRIPTION
Resolves: #16761

The timing for clearing a measure is now changed to after the vertical frame properties are set.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
