### PR TITLE
16735 - Random crash on program exit

### DIFF
--- a/src/update/internal/updateservice.cpp
+++ b/src/update/internal/updateservice.cpp
@@ -59,9 +59,9 @@ mu::RetVal<ReleaseInfo> UpdateService::checkForUpdate()
     clear();
 
     QBuffer buff;
-    m_networkManager = networkManagerCreator()->makeNetworkManager();
-    Ret getUpdateInfo = m_networkManager->get(QString::fromStdString(configuration()->checkForUpdateUrl()), &buff,
-                                              configuration()->checkForUpdateHeaders());
+    INetworkManagerPtr manager = networkManagerCreator()->makeNetworkManager();
+    Ret getUpdateInfo = manager->get(QString::fromStdString(configuration()->checkForUpdateUrl()), &buff,
+                                     configuration()->checkForUpdateHeaders());
 
     if (!getUpdateInfo) {
         result.ret = make_ret(Err::NetworkError);


### PR DESCRIPTION
Resolves: #16735, #15714

checkForUpdate() is called every time the program is run. It was creating a NetworkManager smart pointer in a global (static) variable. When the program exits, the destructor for the smart pointer was called by the C++ runtime which (sometimes) causes QT Networking code to blow up. This breaks the normal flow of the shutdown in random ways. In #15714, it was reported that sometimes some stray processes linger on Linux, or the shutdown just freezes. On Windows, I never saw this -- it randomly blows up in NetworkManager's destructor when QT blows up.

This fix causes checkForUpdate() to free the pointer when the program is in a known state, unlike shutdown where the state of things appears to be somewhat random. 


- [ x] I signed the [CLA](https://musescore.org/en/cla)
- [x ] The title of the PR describes the problem it addresses
- [x ] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x ] If changes are extensive, there is a sequence of easily reviewable commits
- [x ] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x ] There are no unnecessary changes
- [x ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
