### PR TITLE
Fix crash on transpose of specific 3.6 score

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -4697,7 +4697,7 @@ void Score::updateInstrumentChangeTranspositions(KeySigEvent& key, Staff* staff,
                     e.setKey(nkey);
                 }
                 KeySig* keySig = nullptr;
-                EngravingItem* keySigElem = s->element(track);
+                EngravingItem* keySigElem = s ? s->element(track) : nullptr;
                 if (keySigElem && keySigElem->isKeySig()) {
                     keySig = toKeySig(keySigElem);
                 }


### PR DESCRIPTION
Resolves: #15727

The problem arises because, in this specific file (see related issue), the Clarinet 1 part has gone out of sync with the score, and there is an orphaned KeySig event which, for some reason, exists in the Clarinet 1 part, but not in the score.
<img width="345" alt="image" src="https://user-images.githubusercontent.com/93707756/224743670-24bce154-e512-44d8-bc89-a05d399e69ab.png">

How or why exactly that happened, I really can't tell. I've tried everything I could think of to recreate the same issue in Musescore 4, but I couldn't (and by looking at the code, it really seems not possible to do so with the score-part model we have in Musescore 4). So I'm inclined to think that this is entirely a 3.6 problem (the file was originally created in 3.6 and the crash indeed also happens in 3.6, so it isn't about anything new that we have introduced).

In terms of avoiding the crash, it is simply a matter of null-checking the segment before using it (which I think is worth doing anyway for safety, given that's it's obtained from a function that may return null).