### PR TITLE
Adds font preview and isFontDropdown property to font dropdown menu. Fixes issue #16555

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledDropdown.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledDropdown.qml
@@ -44,6 +44,7 @@ Item {
     property string indeterminateText: "--"
 
     property int popupItemsCount: 18
+    property bool isFontDropdown: false
 
     property alias dropIcon: dropIconItem
     property alias label: mainItem.label
@@ -96,6 +97,7 @@ Item {
 
             textRole: root.textRole
             valueRole: root.valueRole
+            isFontDropdown: root.isFontDropdown
 
             currentIndex: root.currentIndex
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/internal/StyledDropdownLoader.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/internal/StyledDropdownLoader.qml
@@ -36,6 +36,7 @@ Loader {
 
     property alias dropdown: loader.item
     property alias isOpened: loader.active
+    property bool isFontDropdown: false
 
     active: false
 
@@ -63,6 +64,7 @@ Loader {
         currentIndex: loader.currentIndex
         itemWidth: loader.itemWidth
         itemHeight: loader.itemHeight
+        isFontDropdown: root.isFontDropdown
 
         textRole: loader.textRole
         valueRole: loader.valueRole

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/internal/StyledDropdownView.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/internal/StyledDropdownView.qml
@@ -54,6 +54,7 @@ DropdownView {
 
     property int contentWidth: root.itemWidth
     property int contentHeight: content.contentBodyHeight
+    property bool isFontDropdown: false
 
     //! NOTE: Due to the fact that the dropdown window opens without activating focus,
     //!       for all items in the dropdown, the accessible window must be the window
@@ -263,6 +264,7 @@ DropdownView {
                     anchors.leftMargin: 12
                     horizontalAlignment: Text.AlignLeft
 
+                    font.family: root.isFontDropdown ? Utils.getItemValue(root.model, model.index, root.valueRole, undefined) : ui.theme.bodyFont.family
                     text: Utils.getItemValue(root.model, model.index, root.textRole, "")
                 }
 

--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextInspectorView.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextInspectorView.qml
@@ -47,6 +47,7 @@ InspectorSectionView {
             navigationRowStart: root.navigationRowStart + 1
 
             titleText: qsTrc("inspector", "Font")
+            dropdown.isFontDropdown: true
             propertyItem: root.model ? root.model.fontFamily : null
 
             dropdown.textRole: "text"


### PR DESCRIPTION
Resolves: #16555 

This commit adds a font preview feature to the font dropdown, where the dropdown displays what each font looks like. Additionally, a new property `isFontDropdown` has been added to the dropdown to check if the dropdown is a font dropdown.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
