### PR TITLE
Fix #16748: Fix articulation combinations on MXML import / export, and ensure placement of articulations is respected

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -2779,6 +2779,21 @@ static std::vector<QString> symIdToArtic(const SymId sid)
         return { "soft-accent" };
         break;
 
+    case SymId::articSoftAccentStaccatoAbove:
+    case SymId::articSoftAccentStaccatoBelow:
+        return { "soft-accent", "staccato" };
+        break;
+
+    case SymId::articSoftAccentTenutoAbove:
+    case SymId::articSoftAccentTenutoBelow:
+        return { "soft-accent", "tenuto" };
+        break;
+
+    case SymId::articSoftAccentTenutoStaccatoAbove:
+    case SymId::articSoftAccentTenutoStaccatoBelow:
+        return { "soft-accent", "detached-legato" };
+        break;
+
     case SymId::articStressAbove:
     case SymId::articStressBelow:
         return { "stress" };

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -6356,6 +6356,9 @@ void MusicXMLParserNotations::combineArticulations()
     map[{ SymId::articMarcatoAbove, SymId::articStaccatoAbove }] = SymId::articMarcatoStaccatoAbove;
     map[{ SymId::articMarcatoAbove, SymId::articTenutoAbove }] = SymId::articMarcatoTenutoAbove;
     map[{ SymId::articAccentAbove, SymId::articTenutoAbove }] = SymId::articTenutoAccentAbove;
+    map[{ SymId::articSoftAccentAbove, SymId::articStaccatoAbove }] = SymId::articSoftAccentStaccatoAbove;
+    map[{ SymId::articSoftAccentAbove, SymId::articTenutoAbove }] = SymId::articSoftAccentTenutoAbove;
+    map[{ SymId::articSoftAccentAbove, SymId::articTenutoStaccatoAbove }] = SymId::articSoftAccentTenutoStaccatoAbove;
 
     // Iterate through each distinct pair (backwards, to allow for deletions)
     for (std::vector<Notation>::reverse_iterator n1 = _notations.rbegin(), n1Next = n1; n1 != _notations.rend(); n1 = n1Next) {

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -5555,6 +5555,8 @@ void MusicXMLParserNotations::slur()
     // -> remember slur stop
     if (notation.attribute("type") == "stop") {
         _slurStop = true;
+    } else if (notation.attribute("type") == "start") {
+        _slurStart = true;
     }
 
     _e.skipCurrentElement();  // skip but don't log
@@ -6193,12 +6195,50 @@ Notation Notation::notationWithAttributes(const QString& name, const QXmlStreamA
 }
 
 //---------------------------------------------------------
+//   mergeNotations
+//---------------------------------------------------------
+
+/**
+ Helper function to merge two Notations. Used to combine articulations in combineArticulations.
+ */
+
+Notation Notation::mergeNotations(const Notation& n1, const Notation& n2, const SymId& symId)
+{
+    // Sort and combine the names
+    std::vector<QString> names{ n1.name(), n2.name() };
+    std::sort(names.begin(), names.end());
+    QString name = names[0] + " " + names[1];
+
+    // Parents should match (and will both be "articulation")
+    Q_ASSERT(n1.parent() == n2.parent());
+    QString parent = n1.parent();
+
+    Notation mergedNotation{ name, parent, symId };
+    for (const auto& attr : n1.attributes()) {
+        mergedNotation.addAttribute(attr.first, attr.second);
+    }
+    for (const auto attr : n2.attributes()) {
+        mergedNotation.addAttribute(attr.first, attr.second);
+    }
+    return mergedNotation;
+}
+
+//---------------------------------------------------------
 //   addAttribute
 //---------------------------------------------------------
 
 void Notation::addAttribute(const QStringRef name, const QStringRef value)
 {
-    _attributes.insert(std::pair<QString, QString>(name.toString(), value.toString()));
+    _attributes.emplace(name.toString(), value.toString());
+}
+
+//---------------------------------------------------------
+//   addAttribute
+//---------------------------------------------------------
+
+void Notation::addAttribute(const QString& name, const QString& value)
+{
+    _attributes.emplace(name, value);
 }
 
 //---------------------------------------------------------
@@ -6275,6 +6315,72 @@ void MusicXMLParserNotations::skipLogCurrElem()
 }
 
 //---------------------------------------------------------
+//   skipCombine
+//---------------------------------------------------------
+
+/**
+ Helper function to hold conditions under which a potential combine should be skipped.
+ */
+
+bool MusicXMLParserNotations::skipCombine(const Notation& n1, const Notation& n2)
+{
+    // at this point, if only one placement is specified, don't combine.
+    // we may revisit this in the future once we have a better idea of how we want to combine
+    // things by default.
+    bool placementsSpecifiedAndDifferent = n1.attribute("placement") != n2.attribute("placement");
+    bool upMarcatoDownOther = (n1.name() == "strong-accent" && n1.attribute("type") == "up"
+                               && n2.attribute("placement") == "below")
+                              || (n2.name() == "strong-accent" && n2.attribute("type") == "up"
+                                  && n1.attribute("placement") == "below");
+    bool downMarcatoUpOther = (n1.name() == "strong-accent" && n1.attribute("type") == "down"
+                               && n2.attribute("placement") == "above")
+                              || (n2.name() == "strong-accent" && n2.attribute("type") == "down"
+                                  && n1.attribute("placement") == "above");
+    bool slurEndpoint = _slurStart || _slurStop;
+    return placementsSpecifiedAndDifferent || upMarcatoDownOther || downMarcatoUpOther || slurEndpoint;
+}
+
+//---------------------------------------------------------
+//   combineArticulations
+//---------------------------------------------------------
+
+/**
+ Combine any eligible articulations.
+ i.e. accent + staccato = staccato accent
+ */
+
+void MusicXMLParserNotations::combineArticulations()
+{
+    QMap<std::set<SymId>, SymId> map;       // map set of symbols to combined symbol
+    map[{ SymId::articAccentAbove, SymId::articStaccatoAbove }] = SymId::articAccentStaccatoAbove;
+    map[{ SymId::articMarcatoAbove, SymId::articStaccatoAbove }] = SymId::articMarcatoStaccatoAbove;
+    map[{ SymId::articMarcatoAbove, SymId::articTenutoAbove }] = SymId::articMarcatoTenutoAbove;
+    map[{ SymId::articAccentAbove, SymId::articTenutoAbove }] = SymId::articTenutoAccentAbove;
+
+    // Iterate through each distinct pair (backwards, to allow for deletions)
+    for (std::vector<Notation>::reverse_iterator n1 = _notations.rbegin(), n1Next = n1; n1 != _notations.rend(); n1 = n1Next) {
+        n1Next = std::next(n1);
+        if (n1->parent() != "articulations") {
+            continue;
+        }
+        for (std::vector<Notation>::reverse_iterator n2 = n1 + 1, n2Next = n1; n2 != _notations.rend(); n2 = n2Next) {
+            n2Next = std::next(n2);
+            if (n2->parent() != "articulations" || skipCombine(*n1, *n2)) {
+                continue;
+            }
+            // Combine and remove articulations if present in map
+            std::set<SymId> currentPair = { n1->symId(), n2->symId() };
+            if (map.contains(currentPair)) {
+                Notation mergedNotation = Notation::mergeNotations(*n1, *n2, map.value(currentPair));
+                n1Next = decltype(n1){ _notations.erase(std::next(n1).base()) };
+                n2Next = decltype(n2){ _notations.erase(std::next(n2).base()) };
+                _notations.push_back(mergedNotation);
+            }
+        }
+    }
+}
+
+//---------------------------------------------------------
 //   parse
 //---------------------------------------------------------
 
@@ -6320,6 +6426,7 @@ void MusicXMLParserNotations::parse()
           LOGD("%s", qPrintable(notation.print()));
           }
      */
+    combineArticulations();
 
     addError(checkAtEndElement(_e, "notations"));
 }

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
@@ -154,8 +154,10 @@ class Notation
 public:
     Notation(const QString& name, const QString& parent = "",
              const SymId& symId = SymId::noSym) { _name = name; _parent = parent; _symId = symId; }
+    void addAttribute(const QString& name, const QString& value);
     void addAttribute(const QStringRef name, const QStringRef value);
     QString attribute(const QString& name) const;
+    std::map<QString, QString> attributes() const { return _attributes; }
     QString name() const { return _name; }
     QString parent() const { return _parent; }
     void setSymId(const SymId& symId) { _symId = symId; }
@@ -167,6 +169,7 @@ public:
     QString text() const { return _text; }
     static Notation notationWithAttributes(const QString& name, const QXmlStreamAttributes attributes, const QString& parent = "",
                                            const SymId& symId = SymId::noSym);
+    static Notation mergeNotations(const Notation& n1, const Notation& n2, const SymId& symId = SymId::noSym);
 private:
     QString _name;
     QString _parent;
@@ -211,10 +214,12 @@ public:
     QString tremoloType() const { return _tremoloType; }
     int tremoloNr() const { return _tremoloNr; }
     bool mustStopGraceAFter() const { return _slurStop || _wavyLineStop; }
+    bool skipCombine(const Notation& n1, const Notation& n2);
 private:
     void addError(const QString& error);      ///< Add an error to be shown in the GUI
     void addNotation(const Notation& notation, ChordRest* const cr, Note* const note);
     void addTechnical(const Notation& notation, Note* note);
+    void combineArticulations();
     void harmonic();
     void articulations();
     void dynamics();
@@ -242,6 +247,7 @@ private:
     int _wavyLineNo { 0 };
     QString _arpeggioType;
     bool _slurStop { false };
+    bool _slurStart { false };
     bool _wavyLineStop { false };
 };
 

--- a/src/importexport/musicxml/tests/data/testArticulationCombination.xml
+++ b/src/importexport/musicxml/tests/data/testArticulationCombination.xml
@@ -1,0 +1,450 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Title</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Composer</creator>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <articulations>
+            <accent/>
+            <staccato/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <articulations>
+            <staccato placement="above"/>
+            <strong-accent type="up"/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <articulations>
+            <tenuto placement="above"/>
+            <strong-accent type="up"/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <articulations>
+            <tenuto/>
+            <accent/>
+            </articulations>
+          </notations>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <articulations>
+            <soft-accent/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <articulations>
+            <soft-accent/>
+            <staccato/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <articulations>
+            <soft-accent/>
+            <tenuto/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <articulations>
+            <soft-accent/>
+            <detached-legato/>
+            </articulations>
+          </notations>
+        </note>
+      </measure>
+    <measure number="3">
+      <print new-system="yes"/>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <articulations>
+            <accent/>
+            <staccato/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <articulations>
+            <staccato placement="above"/>
+            <strong-accent type="up"/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <articulations>
+            <tenuto placement="above"/>
+            <strong-accent type="up"/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <articulations>
+            <tenuto/>
+            <accent/>
+            </articulations>
+          </notations>
+        </note>
+      </measure>
+    <measure number="4">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <articulations>
+            <soft-accent/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <articulations>
+            <soft-accent/>
+            <staccato/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <articulations>
+            <soft-accent/>
+            <tenuto/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <articulations>
+            <soft-accent/>
+            <detached-legato/>
+            </articulations>
+          </notations>
+        </note>
+      </measure>
+    <measure number="5">
+      <print new-system="yes"/>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <articulations>
+            <staccato/>
+            <accent placement="below"/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <articulations>
+            <staccato placement="below"/>
+            <strong-accent type="up"/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <articulations>
+            <tenuto placement="below"/>
+            <accent placement="below"/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <articulations>
+            <accent placement="below"/>
+            <staccato placement="below"/>
+            </articulations>
+          </notations>
+        </note>
+      </measure>
+    <measure number="6">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <articulations>
+            <staccato placement="above"/>
+            <strong-accent type="up"/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <articulations>
+            <staccato placement="above"/>
+            <soft-accent/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <articulations>
+            <soft-accent placement="below"/>
+            <detached-legato placement="below"/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <articulations>
+            <soft-accent/>
+            <detached-legato placement="below"/>
+            </articulations>
+          </notations>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -376,6 +376,9 @@ TEST_F(Musicxml_Tests, arpGliss2) {
 TEST_F(Musicxml_Tests, arpGliss3) {
     mxmlIoTest("testArpGliss3");
 }
+TEST_F(Musicxml_Tests, articulationCombination) {
+    mxmlIoTest("testArticulationCombination");
+}
 TEST_F(Musicxml_Tests, barlineFermatas) {
     mxmlMscxExportTestRef("testBarlineFermatas");
 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/16748

This PR began as a direct port of https://github.com/musescore/MuseScore/pull/8190, which deals with articulation marks combining (such as tenuto-staccato being a single combined glyph). We also take care not to combine when the placement of the accidentals suggest that they have been manually set at one placement or another.

In testing this PR, I noticed that musescore doesn't export articulation placement at all, so I added that in as well, as per the MusicXML spec.