### PR TITLE
add inverted noteBackgroundColor

### DIFF
--- a/src/engraving/internal/engravingconfiguration.cpp
+++ b/src/engraving/internal/engravingconfiguration.cpp
@@ -201,7 +201,7 @@ Color EngravingConfiguration::thumbnailBackgroundColor() const
 
 Color EngravingConfiguration::noteBackgroundColor() const
 {
-    return Color::WHITE;
+    return notationConfiguration()->foregroundColor();
 }
 
 double EngravingConfiguration::guiScaling() const

--- a/src/engraving/internal/engravingconfiguration.h
+++ b/src/engraving/internal/engravingconfiguration.h
@@ -27,6 +27,7 @@
 #include "modularity/ioc.h"
 #include "global/iglobalconfiguration.h"
 #include "ui/iuiconfiguration.h"
+#include "notation/inotationconfiguration.h"
 #include "accessibility/iaccessibilityconfiguration.h"
 #include "importexport/guitarpro/iguitarproconfiguration.h"
 
@@ -37,6 +38,7 @@ class EngravingConfiguration : public IEngravingConfiguration, public async::Asy
 {
     INJECT(engraving, mu::framework::IGlobalConfiguration, globalConfiguration)
     INJECT(engraving, mu::ui::IUiConfiguration, uiConfiguration)
+    INJECT(engraving, notation::INotationConfiguration, notationConfiguration)
     INJECT(engraving, mu::accessibility::IAccessibilityConfiguration, accessibilityConfiguration)
     INJECT(engraving, iex::guitarpro::IGuitarProConfiguration, guitarProConfiguration);
 

--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -1416,6 +1416,8 @@ void Note::draw(mu::draw::Painter* painter) const
                 for (MuseScoreView* view : score()->getViewer()) {
                     view->drawBackground(painter, bb);
                 }
+            } else if (score()->printing()) {
+                painter->fillRect(bb, Color::WHITE);
             } else {
                 painter->fillRect(bb, engravingConfiguration()->noteBackgroundColor());
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/346509

This PR is separated from #16715 , preliminary discussion about this issue can be found there.

noteBackgroundColor now queries the current foreground color, so note backgrounds will always match the current score color. 

![image](https://user-images.githubusercontent.com/26545465/225167218-7a6a281b-9031-49f4-b69a-ae75a99da890.png)

![image](https://user-images.githubusercontent.com/26545465/225167231-dfb01da9-12c9-49bf-8674-ca09e0d86ecf.png)


- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
