### PR TITLE
Updating backend build env to Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build_mu4:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.11.0

--- a/build/ci/backend/docker/Dockerfile
+++ b/build/ci/backend/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/ubuntu:18.04
+FROM library/ubuntu:20.04
 COPY setup.sh /setup.sh
 COPY install_mu.sh /install_mu.sh
 RUN bash -ex setup.sh

--- a/build/ci/backend/docker/setup.sh
+++ b/build/ci/backend/docker/setup.sh
@@ -52,7 +52,6 @@ apt_packages_runtime=(
   libegl1-mesa-dev
   libodbc1
   libpq-dev
-  libssl1.0.0
   libxcomposite-dev
   libxcursor-dev
   libxi-dev

--- a/build/ci/backend/setup.sh
+++ b/build/ci/backend/setup.sh
@@ -20,4 +20,4 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
-bash $HERE/../linux/setup.sh --gcc_version 7
+bash $HERE/../linux/setup.sh 

--- a/build/ci/linux/setup.sh
+++ b/build/ci/linux/setup.sh
@@ -21,17 +21,9 @@
 
 # For maximum AppImage compatibility, build on the oldest Linux distribution
 # that still receives security updates from its manufacturer.
+
 echo "Setup Linux build environment"
 trap 'echo Setup failed; exit 1' ERR
-
-GCC_VERSION="10"
-while [[ "$#" -gt 0 ]]; do
-    case $1 in
-        -g|--gcc_version) GCC_VERSION="$2"; shift ;;
-    esac
-    shift
-done
-
 
 df -h .
 
@@ -143,16 +135,17 @@ echo export QML2_IMPORT_PATH="${qt_dir}/qml" >> ${ENV_FILE}
 ##########################################################################
 
 # COMPILER
-sudo apt-get install -y --no-install-recommends "g++-${GCC_VERSION}"
+gcc_version="10"
+sudo apt-get install -y --no-install-recommends "g++-${gcc_version}"
 sudo update-alternatives \
-  --install /usr/bin/gcc gcc "/usr/bin/gcc-${GCC_VERSION}" 40 \
-  --slave /usr/bin/g++ g++ "/usr/bin/g++-${GCC_VERSION}"
+  --install /usr/bin/gcc gcc "/usr/bin/gcc-${gcc_version}" 40 \
+  --slave /usr/bin/g++ g++ "/usr/bin/g++-${gcc_version}"
 
-echo export CC="/usr/bin/gcc-${GCC_VERSION}" >> ${ENV_FILE}
-echo export CXX="/usr/bin/g++-${GCC_VERSION}" >> ${ENV_FILE}
+echo export CC="/usr/bin/gcc-${gcc_version}" >> ${ENV_FILE}
+echo export CXX="/usr/bin/g++-${gcc_version}" >> ${ENV_FILE}
 
-gcc-${GCC_VERSION} --version
-g++-${GCC_VERSION} --version
+gcc-${gcc_version} --version
+g++-${gcc_version} --version
 
 # CMAKE
 # Get newer CMake (only used cached version if it is the same)


### PR DESCRIPTION
as 18.04 is deprecated and will get discontinued shortly, _fully unsupported by 2023/04/01_

See https://github.com/musescore/MuseScore/actions/runs/4433107633