### PR TITLE
Fix #16764: Allow decimal text font size entry in the inspector

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/IncrementalPropertyControl.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/IncrementalPropertyControl.qml
@@ -60,7 +60,7 @@ Item {
             return
         }
 
-        newValue = +newValue.toFixed(decimals)
+        newValue = +newValue.toFixed(root.decimals)
         root.valueEdited(newValue)
         root.valueEditingFinished(newValue)
     }
@@ -73,7 +73,7 @@ Item {
             return
         }
 
-        newValue = +newValue.toFixed(decimals)
+        newValue = +newValue.toFixed(root.decimals)
         root.valueEdited(newValue)
         root.valueEditingFinished(newValue)
     }

--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextInspectorView.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextInspectorView.qml
@@ -148,7 +148,7 @@ InspectorSectionView {
                 measureUnitsSymbol: qsTrc("global", "pt")
                 propertyItem: root.model ? root.model.fontSize : null
 
-                decimals: 1
+                decimals: 2
                 step: 1
                 minValue: 1
                 maxValue: 99


### PR DESCRIPTION
Resolves: #16764 

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
