### PR TITLE
Fix #16798: Allow beams to be joined over rests which are a quarter note or longer

### DIFF
--- a/src/engraving/layout/layoutbeams.cpp
+++ b/src/engraving/layout/layoutbeams.cpp
@@ -402,7 +402,7 @@ void LayoutBeams::createBeams(Score* score, LayoutContext& lc, Measure* measure)
                 bm = BeamMode::NONE;
             }
 
-            if ((cr->durationType().type() <= DurationType::V_QUARTER) || (bm == BeamMode::NONE)) {
+            if (bm == BeamMode::NONE) {
                 bool removeBeam = true;
                 if (beam) {
                     beam->layout1();


### PR DESCRIPTION
Resolves: #16798

**Video**

https://user-images.githubusercontent.com/73422868/225829953-e63f552c-7424-403d-9762-520990474a95.mp4

**Checklist**

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
