### PR TITLE
Fix MSVC Compiler warnings

### DIFF
--- a/src/framework/audio/internal/plugins/knownaudiopluginsregister.cpp
+++ b/src/framework/audio/internal/plugins/knownaudiopluginsregister.cpp
@@ -154,8 +154,8 @@ const mu::io::path_t& KnownAudioPluginsRegister::pluginPath(const AudioResourceI
 {
     auto it = m_pluginInfoMap.find(resourceId);
     if (it == m_pluginInfoMap.end()) {
-        static const io::path_t dummy;
-        return dummy;
+        static const io::path_t _dummy;
+        return _dummy;
     }
 
     return it->second.path;

--- a/src/importexport/guitarpro/internal/importgtp-gp4.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp4.cpp
@@ -845,7 +845,7 @@ bool GuitarPro4::read(IODevice* io)
             for (int beat = 0; beat < beats; ++beat) {
                 slide = -1;
                 if (mu::contains(slides, static_cast<int>(track))) {
-                    slide = mu::take(slides, track);
+                    slide = mu::take(slides, static_cast<int>(track));
                 }
 
                 uint8_t beatBits = readUInt8();

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -2482,7 +2482,7 @@ bool GuitarPro3::read(IODevice* io)
 
                 slide = -1;
                 if (mu::contains(slides, static_cast<int>(track))) {
-                    slide = mu::take(slides, track);
+                    slide = mu::take(slides, static_cast<int>(track));
                 }
 
                 int len = readChar();


### PR DESCRIPTION
* reg. local declaration hides global declaration (C4459)
* reg. conversion from 'size_t' to 'const int', possible loss of data (C4267)