### PR TITLE
Fix #303623, GH#16902: Fix multiple issues with chord diagrams in MusicXML export

### DIFF
--- a/src/importexport/musicxml/tests/data/testHarmony2.xml
+++ b/src/importexport/musicxml/tests/data/testHarmony2.xml
@@ -75,11 +75,6 @@
         </note>
       </measure>
     <measure number="2">
-      <direction placement="below">
-        <direction-type>
-          <words>maj(sub5)</words>
-          </direction-type>
-        </direction>
       <harmony print-frame="no">
         <root>
           <root-step>C</root-step>
@@ -91,6 +86,11 @@
           <degree-type>subtract</degree-type>
           </degree>
         </harmony>
+      <direction placement="below">
+        <direction-type>
+          <words>maj(sub5)</words>
+          </direction-type>
+        </direction>
       <note>
         <pitch>
           <step>C</step>
@@ -113,11 +113,6 @@
         </note>
       </measure>
     <measure number="3">
-      <direction placement="below">
-        <direction-type>
-          <words>maj(add2)</words>
-          </direction-type>
-        </direction>
       <harmony print-frame="no">
         <root>
           <root-step>C</root-step>
@@ -129,6 +124,11 @@
           <degree-type>add</degree-type>
           </degree>
         </harmony>
+      <direction placement="below">
+        <direction-type>
+          <words>maj(add2)</words>
+          </direction-type>
+        </direction>
       <note>
         <pitch>
           <step>C</step>
@@ -151,11 +151,6 @@
         </note>
       </measure>
     <measure number="4">
-      <direction placement="below">
-        <direction-type>
-          <words>maj7(alt#5)</words>
-          </direction-type>
-        </direction>
       <harmony print-frame="no">
         <root>
           <root-step>C</root-step>
@@ -167,6 +162,11 @@
           <degree-type>alter</degree-type>
           </degree>
         </harmony>
+      <direction placement="below">
+        <direction-type>
+          <words>maj7(alt#5)</words>
+          </direction-type>
+        </direction>
       <note>
         <pitch>
           <step>C</step>

--- a/src/importexport/musicxml/tests/data/testHarmony3.xml
+++ b/src/importexport/musicxml/tests/data/testHarmony3.xml
@@ -3,7 +3,7 @@
 <score-partwise version="4.0">
   <work>
     <work-number>MuseScore testfile</work-number>
-    <work-title>Harmony 2</work-title>
+    <work-title>Harmony 3</work-title>
     </work>
   <identification>
     <creator type="composer">Leon Vinken</creator>

--- a/src/importexport/musicxml/tests/data/testHarmony7_ref.xml
+++ b/src/importexport/musicxml/tests/data/testHarmony7_ref.xml
@@ -54,6 +54,7 @@
           <line>5</line>
           </clef>
         <staff-details number="2">
+          <staff-type>alternate</staff-type>
           <staff-lines>6</staff-lines>
           <staff-tuning line="1">
             <tuning-step>E</tuning-step>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -682,6 +682,9 @@ TEST_F(Musicxml_Tests, harmony5) {
 TEST_F(Musicxml_Tests, harmony6) {
     mxmlMscxExportTestRef("testHarmony6");
 }
+TEST_F(Musicxml_Tests, harmony7) {
+    mxmlMscxExportTestRef("testHarmony7");
+}
 TEST_F(Musicxml_Tests, harmony8) {
     mxmlIoTest("testHarmony8");
 }


### PR DESCRIPTION
Port/rebase of @thibault's #5958

For some reason that PR's test files (testHarmony6.mscx, testHarmony6_ref.xml) were already in master (as testHarmony7.mscx, testHarmony7_ref.xml), but not used in the unit tests.

Resolves: #16902 and https://musescore.org/en/node/303623
Resolves: #22592