### PR TITLE
Refactor implementation of IMainWindow interface

### DIFF
--- a/src/appshell/qml/AppWindow.qml
+++ b/src/appshell/qml/AppWindow.qml
@@ -54,13 +54,13 @@ ApplicationWindow {
         id: titleProvider
     }
 
-    MainWindowProvider {
-        id: windowProvider
+    MainWindowBridge {
+        id: bridge
 
         window: root
 
         //! NOTE These properties of QWindow (of which ApplicationWindow is derived)
-        //!      are not available in QML, so we access them via MainWindowProvider
+        //!      are not available in QML, so we access them via MainWindowBridge
         filePath: titleProvider.filePath
         fileModified: titleProvider.fileModified
     }
@@ -80,6 +80,6 @@ ApplicationWindow {
     }
 
     function showMinimizedWithSavePreviousState() {
-        windowProvider.showMinimizedWithSavePreviousState()
+        bridge.showMinimizedWithSavePreviousState()
     }
 }

--- a/src/framework/accessibility/tests/accessibilitycontroller_tests.cpp
+++ b/src/framework/accessibility/tests/accessibilitycontroller_tests.cpp
@@ -26,7 +26,7 @@
 
 #include "accessibility/internal/accessibilitycontroller.h"
 
-#include "ui/tests/mocks/mainwindowprovidermock.h"
+#include "ui/tests/mocks/mainwindowmock.h"
 #include "global/tests/mocks/applicationmock.h"
 #include "mocks/accessibilityconfigurationmock.h"
 
@@ -46,7 +46,7 @@ public:
     {
         m_controller = std::make_shared<AccessibilityController>();
 
-        m_mainWindow = std::make_shared<ui::MainWindowProviderMock>();
+        m_mainWindow = std::make_shared<ui::MainWindowMock>();
         m_controller->setmainWindow(m_mainWindow);
 
         m_application = std::make_shared<framework::ApplicationMock>();
@@ -149,7 +149,7 @@ public:
 #endif
 
     std::shared_ptr<AccessibilityController> m_controller;
-    std::shared_ptr<ui::MainWindowProviderMock> m_mainWindow;
+    std::shared_ptr<ui::MainWindowMock> m_mainWindow;
     std::shared_ptr<AccessibilityConfigurationMock> m_configuration;
     std::shared_ptr<framework::ApplicationMock> m_application;
 };

--- a/src/framework/ui/CMakeLists.txt
+++ b/src/framework/ui/CMakeLists.txt
@@ -28,13 +28,13 @@ if (OS_IS_MAC)
     set(PLATFORM_THEME_SRC
         ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosplatformtheme.mm
         ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosplatformtheme.h
-        ${CMAKE_CURRENT_LIST_DIR}/view/platform/macos/macosmainwindowprovider.mm
-        ${CMAKE_CURRENT_LIST_DIR}/view/platform/macos/macosmainwindowprovider.h
+        ${CMAKE_CURRENT_LIST_DIR}/view/platform/macos/macosmainwindowbridge.mm
+        ${CMAKE_CURRENT_LIST_DIR}/view/platform/macos/macosmainwindowbridge.h
     )
     # Don't mix C++ and Objective-C++ in Unity Build
     set_source_files_properties(
         ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosplatformtheme.mm
-        ${CMAKE_CURRENT_LIST_DIR}/view/platform/macos/macosmainwindowprovider.mm
+        ${CMAKE_CURRENT_LIST_DIR}/view/platform/macos/macosmainwindowbridge.mm
         PROPERTIES
         SKIP_UNITY_BUILD_INCLUSION ON
         SKIP_PRECOMPILE_HEADERS ON
@@ -76,6 +76,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/interactiveuriregister.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/uiengine.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/uiengine.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/mainwindow.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/mainwindow.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/uiconfiguration.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/uiconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/themeconverter.cpp
@@ -119,8 +121,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/navigationevent.h
     ${CMAKE_CURRENT_LIST_DIR}/view/qmlaccessible.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/qmlaccessible.h
-    ${CMAKE_CURRENT_LIST_DIR}/view/mainwindowprovider.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/view/mainwindowprovider.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/mainwindowbridge.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/mainwindowbridge.h
     ${CMAKE_CURRENT_LIST_DIR}/view/focuslistener.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/focuslistener.h
     ${CMAKE_CURRENT_LIST_DIR}/view/widgetnavigationfix.cpp

--- a/src/framework/ui/internal/mainwindow.cpp
+++ b/src/framework/ui/internal/mainwindow.cpp
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "mainwindow.h"
+
+#include <QWindow>
+
+#include "view/mainwindowbridge.h"
+
+#include "log.h"
+
+using namespace mu::ui;
+using namespace mu::modularity;
+
+void MainWindow::init(MainWindowBridge* bridge)
+{
+    IF_ASSERT_FAILED(!m_bridge) {
+        LOGW() << "MainWindowBridge is already set. Refusing to set it again.";
+        return;
+    }
+
+    m_bridge = bridge;
+}
+
+void MainWindow::deinit()
+{
+    m_bridge = nullptr;
+}
+
+QWindow* MainWindow::qWindow() const
+{
+    return m_bridge ? m_bridge->qWindow() : nullptr;
+}
+
+void MainWindow::requestShowOnBack()
+{
+    if (!m_bridge) {
+        return;
+    }
+
+    m_bridge->showOnBack();
+}
+
+void MainWindow::requestShowOnFront()
+{
+    if (!m_bridge) {
+        return;
+    }
+
+    m_bridge->showOnFront();
+}
+
+bool MainWindow::isFullScreen() const
+{
+    return m_bridge ? m_bridge->isFullScreen() : false;
+}
+
+void MainWindow::toggleFullScreen()
+{
+    if (!m_bridge) {
+        return;
+    }
+
+    m_bridge->showOnFront();
+}
+
+QScreen* MainWindow::screen() const
+{
+    return m_bridge ? m_bridge->screen() : nullptr;
+}

--- a/src/framework/ui/internal/mainwindow.h
+++ b/src/framework/ui/internal/mainwindow.h
@@ -19,33 +19,36 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_APPSHELL_MACOS_MAINWINDOWPROVIDER_H
-#define MU_APPSHELL_MACOS_MAINWINDOWPROVIDER_H
 
-#include "async/asyncable.h"
-#include "modularity/ioc.h"
-#include "ui/iuiconfiguration.h"
+#ifndef MU_DOCK_MAINWINDOW_H
+#define MU_DOCK_MAINWINDOW_H
 
-#include "ui/view/mainwindowprovider.h"
+#include <QObject>
+#include <QWindow>
+
+#include "framework/ui/imainwindow.h"
 
 namespace mu::ui {
-class MacOSMainWindowProvider : public MainWindowProvider, public async::Asyncable
+class MainWindow : public IMainWindow
 {
-    Q_OBJECT
-
-    INJECT(appshell, IUiConfiguration, uiConfiguration)
-
 public:
-    explicit MacOSMainWindowProvider(QObject* parent = nullptr);
+    MainWindow() = default;
 
-    bool fileModified() const override;
+    void init(MainWindowBridge* bridge) override;
+    void deinit() override;
 
-public slots:
-    void setFileModified(bool modified) override;
+    QWindow* qWindow() const override;
+
+    void requestShowOnBack() override;
+    void requestShowOnFront() override;
+
+    bool isFullScreen() const override;
+    void toggleFullScreen() override;
+    QScreen* screen() const override;
 
 private:
-    void init() override;
+    MainWindowBridge* m_bridge = nullptr;
 };
 }
 
-#endif // MU_APPSHELL_MACOS_MAINWINDOWPROVIDER_H
+#endif // MU_DOCK_MAINWINDOW_H

--- a/src/framework/ui/tests/CMakeLists.txt
+++ b/src/framework/ui/tests/CMakeLists.txt
@@ -24,7 +24,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/environment.cpp
     ${CMAKE_CURRENT_LIST_DIR}/navigationcontroller_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mocks/navigationmocks.h
-    ${CMAKE_CURRENT_LIST_DIR}/mocks/mainwindowprovidermock.h
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/mainwindowmock.h
     )
 
 set(MODULE_TEST_LINK

--- a/src/framework/ui/tests/mocks/mainwindowmock.h
+++ b/src/framework/ui/tests/mocks/mainwindowmock.h
@@ -19,36 +19,29 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_UI_IMAINWINDOW_H
-#define MU_UI_IMAINWINDOW_H
+#ifndef MU_UI_MAINWINDOWMOCK_H
+#define MU_UI_MAINWINDOWMOCK_H
 
-#include "modularity/imoduleexport.h"
+#include <gmock/gmock.h>
 
-class QWindow;
-class QScreen;
+#include "framework/ui/imainwindow.h"
 
 namespace mu::ui {
-class MainWindowBridge;
-
-class IMainWindow : MODULE_EXPORT_INTERFACE
+class MainWindowMock : public IMainWindow
 {
-    INTERFACE_ID(IMainWindow)
-
 public:
-    virtual ~IMainWindow() = default;
+    MOCK_METHOD(void, init, (MainWindowBridge * bridge), (override));
+    MOCK_METHOD(void, deinit, (), (override));
 
-    virtual void init(MainWindowBridge* bridge) = 0;
-    virtual void deinit() = 0;
+    MOCK_METHOD(QWindow*, qWindow, (), (const, override));
 
-    virtual QWindow* qWindow() const = 0;
+    MOCK_METHOD(void, requestShowOnBack, (), (override));
+    MOCK_METHOD(void, requestShowOnFront, (), (override));
 
-    virtual void requestShowOnBack() = 0;
-    virtual void requestShowOnFront() = 0;
-
-    virtual bool isFullScreen() const = 0;
-    virtual void toggleFullScreen() = 0;
-    virtual QScreen* screen() const = 0;
+    MOCK_METHOD(bool, isFullScreen, (), (const, override));
+    MOCK_METHOD(void, toggleFullScreen, (), (override));
+    MOCK_METHOD(QScreen*, screen, (), (const, override));
 };
 }
 
-#endif // MU_UI_IMAINWINDOW_H
+#endif // MU_UI_MAINWINDOWMOCK_H

--- a/src/framework/ui/tests/navigationcontroller_tests.cpp
+++ b/src/framework/ui/tests/navigationcontroller_tests.cpp
@@ -32,7 +32,7 @@
 
 #include "mocks/navigationmocks.h"
 #include "global/tests/mocks/applicationmock.h"
-#include "ui/tests/mocks/mainwindowprovidermock.h"
+#include "ui/tests/mocks/mainwindowmock.h"
 
 #include "ui/view/navigationcontrol.h"
 #include "ui/view/navigationpanel.h"
@@ -60,7 +60,7 @@ public:
         m_dispatcher = std::make_shared<actions::ActionsDispatcher>();
         m_controller->setdispatcher(m_dispatcher);
 
-        m_mainWindow = std::make_shared<ui::MainWindowProviderMock>();
+        m_mainWindow = std::make_shared<ui::MainWindowMock>();
         ON_CALL(*m_mainWindow, qWindow()).WillByDefault(Return(&m_window));
         m_controller->setmainWindow(m_mainWindow);
 
@@ -230,7 +230,7 @@ public:
 
     std::shared_ptr<NavigationController> m_controller;
     std::shared_ptr<actions::IActionsDispatcher> m_dispatcher;
-    std::shared_ptr<MainWindowProviderMock> m_mainWindow;
+    std::shared_ptr<MainWindowMock> m_mainWindow;
     std::shared_ptr<framework::ApplicationMock> m_applicationMock;
 
     QQuickWindow m_window;

--- a/src/framework/ui/uimodule.cpp
+++ b/src/framework/ui/uimodule.cpp
@@ -27,6 +27,7 @@
 #include "modularity/ioc.h"
 
 #include "internal/uiengine.h"
+#include "internal/mainwindow.h"
 #include "internal/uiconfiguration.h"
 #include "internal/interactiveuriregister.h"
 #include "internal/uiactionsregister.h"
@@ -35,16 +36,16 @@
 
 #ifdef Q_OS_MAC
 #include "internal/platform/macos/macosplatformtheme.h"
-#include "view/platform/macos/macosmainwindowprovider.h"
+#include "view/platform/macos/macosmainwindowbridge.h"
 #elif defined(Q_OS_WIN)
 #include "internal/platform/windows/windowsplatformtheme.h"
-#include "view/mainwindowprovider.h"
+#include "view/mainwindowbridge.h"
 #elif defined(Q_OS_LINUX)
 #include "internal/platform/linux/linuxplatformtheme.h"
-#include "view/mainwindowprovider.h"
+#include "view/mainwindowbridge.h"
 #else
 #include "internal/platform/stub/stubplatformtheme.h"
-#include "view/mainwindowprovider.h"
+#include "view/mainwindowbridge.h"
 #endif
 
 #include "view/qmltooltip.h"
@@ -95,6 +96,7 @@ void UiModule::registerExports()
 {
     ioc()->registerExport<IUiConfiguration>(moduleName(), s_configuration);
     ioc()->registerExportNoDelete<IUiEngine>(moduleName(), UiEngine::instance());
+    ioc()->registerExport<IMainWindow>(moduleName(), new MainWindow());
     ioc()->registerExport<IInteractiveProvider>(moduleName(), UiEngine::instance()->interactiveProvider());
     ioc()->registerExport<IInteractiveUriRegister>(moduleName(), new InteractiveUriRegister());
     ioc()->registerExport<IPlatformTheme>(moduleName(), s_platformTheme);
@@ -143,9 +145,9 @@ void UiModule::registerUiTypes()
     qmlRegisterType<FocusListener>("MuseScore.Ui", 1, 0, "FocusListener");
 
 #ifdef Q_OS_MAC
-    qmlRegisterType<MacOSMainWindowProvider>("MuseScore.Ui", 1, 0, "MainWindowProvider");
+    qmlRegisterType<MacOSMainWindowBridge>("MuseScore.Ui", 1, 0, "MainWindowBridge");
 #else
-    qmlRegisterType<MainWindowProvider>("MuseScore.Ui", 1, 0, "MainWindowProvider");
+    qmlRegisterType<MainWindowBridge>("MuseScore.Ui", 1, 0, "MainWindowBridge");
 #endif
 
     qmlRegisterType<ErrorDetailsModel>("MuseScore.Ui", 1, 0, "ErrorDetailsModel");

--- a/src/framework/ui/view/mainwindowbridge.h
+++ b/src/framework/ui/view/mainwindowbridge.h
@@ -20,19 +20,18 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MU_DOCK_MAINWINDOWPROVIDER_H
-#define MU_DOCK_MAINWINDOWPROVIDER_H
+#ifndef MU_DOCK_MAINWINDOWBRIDGE_H
+#define MU_DOCK_MAINWINDOWBRIDGE_H
 
 #include <QObject>
 #include <QWindow>
 
 #include "modularity/ioc.h"
-#include "../iinteractiveprovider.h"
 
 #include "framework/ui/imainwindow.h"
 
 namespace mu::ui {
-class MainWindowProvider : public QObject, public IMainWindow
+class MainWindowBridge : public QObject
 {
     Q_OBJECT
 
@@ -40,22 +39,23 @@ class MainWindowProvider : public QObject, public IMainWindow
     Q_PROPERTY(QString filePath READ filePath WRITE setFilePath NOTIFY filePathChanged)
     Q_PROPERTY(bool fileModified READ fileModified WRITE setFileModified NOTIFY fileModifiedChanged)
 
-    INJECT(ui, IInteractiveProvider, interactiveProvider)
+    INJECT(ui, IMainWindow, mainWindow)
 
 public:
-    explicit MainWindowProvider(QObject* parent = nullptr);
+    explicit MainWindowBridge(QObject* parent = nullptr);
+    ~MainWindowBridge();
 
-    QWindow* qWindow() const override;
+    QWindow* qWindow() const;
 
     QString filePath() const;
     virtual bool fileModified() const;
 
-    void requestShowOnBack() override;
-    void requestShowOnFront() override;
+    void showOnBack();
+    void showOnFront();
 
-    bool isFullScreen() const override;
-    void toggleFullScreen() override;
-    QScreen* screen() const override;
+    bool isFullScreen() const;
+    void toggleFullScreen();
+    QScreen* screen() const;
 
     Q_INVOKABLE void showMinimizedWithSavePreviousState();
 
@@ -78,4 +78,4 @@ private slots: // Should only be used from QML
 };
 }
 
-#endif // MU_DOCK_MAINWINDOWPROVIDER_H
+#endif // MU_DOCK_MAINWINDOWBRIDGE_H

--- a/src/framework/ui/view/platform/macos/macosmainwindowbridge.h
+++ b/src/framework/ui/view/platform/macos/macosmainwindowbridge.h
@@ -19,27 +19,33 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_UI_MAINWINDOWPROVIDERMOCK_H
-#define MU_UI_MAINWINDOWPROVIDERMOCK_H
+#ifndef MU_APPSHELL_MACOS_MAINWINDOWBRIDGE_H
+#define MU_APPSHELL_MACOS_MAINWINDOWBRIDGE_H
 
-#include <gmock/gmock.h>
+#include "async/asyncable.h"
+#include "modularity/ioc.h"
+#include "ui/iuiconfiguration.h"
 
-#include "framework/ui/imainwindow.h"
+#include "ui/view/mainwindowbridge.h"
 
 namespace mu::ui {
-class MainWindowProviderMock : public IMainWindow
+class MacOSMainWindowBridge : public MainWindowBridge, public async::Asyncable
 {
+    Q_OBJECT
+
+    INJECT(appshell, IUiConfiguration, uiConfiguration)
+
 public:
+    explicit MacOSMainWindowBridge(QObject* parent = nullptr);
 
-    MOCK_METHOD(QWindow*, qWindow, (), (const, override));
+    bool fileModified() const override;
 
-    MOCK_METHOD(void, requestShowOnBack, (), (override));
-    MOCK_METHOD(void, requestShowOnFront, (), (override));
+public slots:
+    void setFileModified(bool modified) override;
 
-    MOCK_METHOD(bool, isFullScreen, (), (const, override));
-    MOCK_METHOD(void, toggleFullScreen, (), (override));
-    MOCK_METHOD(QScreen*, screen, (), (const, override));
+private:
+    void init() override;
 };
 }
 
-#endif // MU_UI_MAINWINDOWPROVIDERMOCK_H
+#endif // MU_APPSHELL_MACOS_MAINWINDOWBRIDGE_H

--- a/src/framework/ui/view/platform/macos/macosmainwindowbridge.mm
+++ b/src/framework/ui/view/platform/macos/macosmainwindowbridge.mm
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include "macosmainwindowprovider.h"
+#include "macosmainwindowbridge.h"
 
 #include <Cocoa/Cocoa.h>
 #include <QWindow>
@@ -37,14 +37,14 @@ static NSWindow* nsWindowForQWindow(QWindow* qWindow)
     return nsWindow;
 }
 
-MacOSMainWindowProvider::MacOSMainWindowProvider(QObject* parent)
-    : MainWindowProvider(parent)
+MacOSMainWindowBridge::MacOSMainWindowBridge(QObject* parent)
+    : MainWindowBridge(parent)
 {
 }
 
-void MacOSMainWindowProvider::init()
+void MacOSMainWindowBridge::init()
 {
-    MainWindowProvider::init();
+    MainWindowBridge::init();
 
     uiConfiguration()->applyPlatformStyle(m_window);
 
@@ -53,7 +53,7 @@ void MacOSMainWindowProvider::init()
     });
 }
 
-bool MacOSMainWindowProvider::fileModified() const
+bool MacOSMainWindowBridge::fileModified() const
 {
     //! NOTE QWindow misses an API for this, so we'll do it ourselves.
     NSWindow* nsWindow = nsWindowForQWindow(m_window);
@@ -64,7 +64,7 @@ bool MacOSMainWindowProvider::fileModified() const
     return [nsWindow isDocumentEdited];
 }
 
-void MacOSMainWindowProvider::setFileModified(bool modified)
+void MacOSMainWindowBridge::setFileModified(bool modified)
 {
     NSWindow* nsWindow = nsWindowForQWindow(m_window);
     if (!nsWindow) {


### PR DESCRIPTION
Before:
the MainWindowProvider class is created in QML, and then registered as the implementation of IMainWindow. This means that while the app is still launching, `mainWindow()` will return nullptr, making it impossible to start listening for notifications from it at the desired moment. (so we would create another initialisation step somewhere at some point where we are sure that the main window has been created blah blah...)

After:
the MainWindowProvider class is split into two parts:
- MainWindow: the implementation of the IMainWindow interface. It is always there, so that you can start using it even before the actual QML window is created.
- MainWindowHelper: created in QML, and acts as a bridge between C++ and QML. It connects the QML window to the `MainWindow` class, and performs tasks for the QML window that cannot be done in QML, such as platform specific things.

This is a prerequisite for #16870.