### PR TITLE
Fix reading files where rests in non-first voices have been deleted

### DIFF
--- a/src/engraving/libmscore/check.cpp
+++ b/src/engraving/libmscore/check.cpp
@@ -270,14 +270,23 @@ void Measure::fillGap(const Fraction& pos, const Fraction& len, track_idx_t trac
          len.numerator(), len.denominator(),
          stretch.numerator(), stretch.denominator(),
          track);
-    std::vector<TDuration> durationList;
-    if (useGapRests) { // fill this gap with a single rest
+
+    if (useGapRests) {
+        // fill this gap with a single gap rest, where the duration does not need to correspond to a valid DurationType
         TDuration d;
         d.setVal(len.ticks());
-        durationList.push_back(d);
-    } else { // break the gap into shorter durations if necessary
-        durationList = toRhythmicDurationList(len, true, pos, score()->sigmap()->timesig(tick()).nominal(), this, 0);
+        Rest* rest = Factory::createRest(score()->dummy()->segment());
+        rest->setTicks(len);
+        rest->setDurationType(d);
+        rest->setTrack(track);
+        rest->setGap(useGapRests);
+        score()->undoAddCR(rest, this, (pos / stretch) + tick());
+        return;
     }
+
+    // break the gap into shorter durations if necessary
+    std::vector<TDuration> durationList = toRhythmicDurationList(len, true, pos, score()->sigmap()->timesig(tick()).nominal(), this, 0);
+
     Fraction curTick = pos;
     for (TDuration d : durationList) {
         Rest* rest = Factory::createRest(score()->dummy()->segment());


### PR DESCRIPTION
Resolves: #16841 

This was a regression in https://github.com/musescore/MuseScore/pull/16260, where the duration of the gap rest would be set to `d.fraction()` where `d` is some `TDuration`. This caused the gap rest to get the wrong duration, namely the duration that is closest to the desired duration and corresponds to a valid `TDuration`. However, for gap rests, the duration doesn't necessarily correspond to a valid `TDuration`; that is the reason that we can use just one to fill the whole gap. 

Summary: now we give the gap rest just the desired duration, rather than the closest duration that corresponds to a valid `TDuration`.