### PR TITLE
Fix compilation error with GCC 13

### DIFF
--- a/thirdparty/google_crashpad_client/third_party/mini_chromium/mini_chromium/base/logging.h
+++ b/thirdparty/google_crashpad_client/third_party/mini_chromium/mini_chromium/base/logging.h
@@ -8,6 +8,7 @@
 #include <assert.h>
 #include <errno.h>
 
+#include <cstdint>
 #include <limits>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
<!-- Add a short description of and motivation for the changes here -->

GCC 13 streamlined some C++ headers, with the result that cstdint is not implicitly included in some places where it was before.  This leads to a MuseScore build failure, because `uint32_t` is undefined in the code patched by this PR.  Patching third party code inside third party code might be a bit weird, but does fix the issue.  (Although GCC 13 has not been released publicly, the Fedora Linux distribution is using it to build packages for the upcoming Fedora 38 release.)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
