### PR TITLE
Fix #16847: Prevent negative spanners

### DIFF
--- a/src/engraving/libmscore/spanner.cpp
+++ b/src/engraving/libmscore/spanner.cpp
@@ -1097,7 +1097,7 @@ void Spanner::setEndElement(EngravingItem* e)
 #endif
     _endElement = e;
     if (e && ticks() == Fraction() && _tick >= Fraction()) {
-        setTicks(e->tick() - _tick);
+        setTicks(std::max(e->tick() - _tick, Fraction()));
     }
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/16847

This one was caused, at a very low level, from spanners having the ability to have negative lengths (i.e. end tick being before start tick). There is an issue where the new end element passed to setEndElement in undo.cpp:2523 has a global tick of 0/1, which of course changes later after the repositioning process. I have tested this on a whole bunch of scores, and the only ones where this ended up being a problem is when slurs involving grace notes were re-moved after an undo of a deletion of bars where that spanner is moved to a different system, which, as it turns out, is the precise issue at hand.

On a broader scale it might be useful to figure out why the ticks are wrong at that point in the layout process (when called from ChangeSpannerElements in undo.cpp:2523). I'll accept any help from anyone who wants to look into this, but as it stands, this PR fixes the issue. I'm open to changing this PR if anyone has any better / more robust ideas.