### PR TITLE
Fix volta hiding utest ref file

### DIFF
--- a/src/importexport/musicxml/tests/data/testVoltaHiding_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testVoltaHiding_ref.mscx
@@ -13,6 +13,7 @@
       <stringNumberFontSize>10</stringNumberFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
+      <tempoChangeFontSize>10</tempoChangeFontSize>
       <metronomeFontSize>10</metronomeFontSize>
       <measureNumberFontSize>10</measureNumberFontSize>
       <mmRestRangeFontSize>10</mmRestRangeFontSize>
@@ -1254,7 +1255,6 @@
             </Rest>
           <BarLine>
             <subtype>end</subtype>
-            <span>1</span>
             </BarLine>
           </voice>
         </Measure>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -931,7 +931,7 @@ TEST_F(Musicxml_Tests, volta1) {
 TEST_F(Musicxml_Tests, volta2) {
     mxmlIoTest("testVolta2");
 }
-TEST_F(Musicxml_Tests, DISABLED_voltaHiding1) {
+TEST_F(Musicxml_Tests, voltaHiding1) {
     mxmlImportTestRef("testVoltaHiding");
 }
 TEST_F(Musicxml_Tests, voltaHiding2) {


### PR DESCRIPTION
Fixes issue with volta hiding utest from https://github.com/musescore/MuseScore/pull/16714 which was disabled in https://github.com/musescore/MuseScore/pull/16934 due to test failure. The test is now fixed and re-enabled.