### PR TITLE
Update SPDX license name in the AppData file

### DIFF
--- a/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in
+++ b/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in
@@ -69,7 +69,7 @@
         <control>touch</control>
         <internet>always</internet>
     </supports>
-    <project_license>GPL-3.0</project_license>
+    <project_license>GPL-3.0-only</project_license>
     <developer_name>MuseScore BVBA</developer_name>
     <screenshots>
         <screenshot type="default">


### PR DESCRIPTION
<!-- Add a short description of and motivation for the changes here -->
The "GPL-3.0" name was deprecated in SPDX License List 3.0, released January 2018.  This PR changes to the name used in the 3.x lists (currently 3.20).  See https://spdx.org/licenses/, where the deprecated list is at the bottom of the page.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
