### PR TITLE
Fix #16697: Relayout articulations on stem extension for cross-staff

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -1277,6 +1277,12 @@ void Beam::extendStem(Chord* chord, double addition)
     if (chord->stemSlash()) {
         chord->stemSlash()->layout();
     }
+
+    if (cross()) {
+        // stem-side articulations on cross-staff beams must be re-laid-out
+        chord->layoutArticulations();
+        chord->layoutArticulations2();
+    }
 }
 
 bool Beam::isBeamInsideStaff(int yPos, int staffLines, bool allowFloater) const


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/16697

For cross-staff beams, it is necessary to relayout the articulations, or else there will be a discrepancy between where they are and where they are expected to be, which is a problem that compounds every time you reset shape and position. This fixes that issue by ensuring that articulations are placed correctly when the stems are extended to meet the beam.