### PR TITLE
Fix: #15848: Rounding errors in sub-beam placement for cross-staff beams

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -804,10 +804,9 @@ void Beam::createBeamSegment(ChordRest* startCr, ChordRest* endCr, int level)
     // avoid adjusting for beams on opposite side of level 0
     if (level != 0) {
         for (const BeamSegment* beam : _beamSegments) {
-            if (beam->level == 0 || beam->line.x2() < startX || beam->line.x1() > endX) {
+            if (beam->level == 0 || beam->endTick < startCr->tick() || beam->startTick > endCr->tick()) {
                 continue;
             }
-
             ++(beam->above ? beamsAbove : beamsBelow);
         }
 
@@ -835,6 +834,8 @@ void Beam::createBeamSegment(ChordRest* startCr, ChordRest* endCr, int level)
     b->above = !overallUp;
     b->level = level;
     b->line = LineF(startX, startY, endX, endY);
+    b->startTick = startCr->tick();
+    b->endTick = endCr->tick();
     _beamSegments.push_back(b);
 
     if (level > 0) {

--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -43,6 +43,8 @@ struct BeamSegment {
     mu::LineF line;
     int level;
     bool above; // above level 0 or below? (meaningless for level 0)
+    Fraction startTick;
+    Fraction endTick;
 };
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/15848

Turns out it was an incredibly weird rounding error that only surfaced when vertical staff justification was on. Especially weird considering that it is a rounding error involving horizontal position rather than vertical.

This PR changes the sub-beam construction / layout logic to check for collisions using start and end ticks rather than x-position and width. 