### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/app/commandlineparser.cpp
+++ b/src/app/commandlineparser.cpp
@@ -228,11 +228,11 @@ void CommandLineParser::parse(int argc, char** argv)
     }
 
     if (m_parser.isSet("register-failed-audio-plugin")) {
-        QStringList args = m_parser.positionalArguments();
+        QStringList args1 = m_parser.positionalArguments();
         m_runMode = IApplication::RunMode::AudioPluginRegistration;
         m_audioPluginRegistration.pluginPath = m_parser.value("register-failed-audio-plugin");
         m_audioPluginRegistration.failedPlugin = true;
-        m_audioPluginRegistration.failCode = !args.empty() ? args[0].toInt() : -1;
+        m_audioPluginRegistration.failCode = !args1.empty() ? args1[0].toInt() : -1;
     }
 
     // Converter mode
@@ -308,14 +308,14 @@ void CommandLineParser::parse(int argc, char** argv)
     }
 
     if (m_parser.isSet("source-update")) {
-        QStringList args = m_parser.positionalArguments();
+        QStringList args2 = m_parser.positionalArguments();
 
         m_runMode = IApplication::RunMode::ConsoleApp;
         m_converterTask.type = ConvertType::SourceUpdate;
-        m_converterTask.inputFile = args[0];
+        m_converterTask.inputFile = args2[0];
 
-        if (args.size() >= 2) {
-            m_converterTask.params[CommandLineParser::ParamKey::ScoreSource] = args[1];
+        if (args2.size() >= 2) {
+            m_converterTask.params[CommandLineParser::ParamKey::ScoreSource] = args2[1];
         } else {
             LOGW() << "Option: --source-update no source specified";
         }

--- a/src/engraving/rw/114/read114.cpp
+++ b/src/engraving/rw/114/read114.cpp
@@ -3162,8 +3162,8 @@ Err Read114::read(Score* score, XmlReader& e, ReadInOutData* out)
     masterScore->rebuildMidiMapping();
     masterScore->updateChannel();
 
-    for (Score* score : masterScore->scoreList()) {
-        CompatUtils::replaceStaffTextWithPlayTechniqueAnnotation(score);
+    for (Score* s : masterScore->scoreList()) {
+        CompatUtils::replaceStaffTextWithPlayTechniqueAnnotation(s);
     }
 
     CompatUtils::assignInitialPartToExcerpts(masterScore->excerpts());

--- a/src/engraving/rw/mscloader.h
+++ b/src/engraving/rw/mscloader.h
@@ -33,7 +33,7 @@ class ReadStyleHook;
 
 namespace mu::engraving {
 class MasterScore;
-class ReadInOutData;
+struct ReadInOutData;
 class XmlReader;
 class MscLoader
 {


### PR DESCRIPTION
* reg. type name first seen using 'class' now seen using 'struct' (C4099)
* reg. declaration hides function parameter (C4457)
* reg. declaration hides previous local declaration (C4456)