### PR TITLE
fix rest commands for tab staves & rhythm mode

### DIFF
--- a/src/engraving/libmscore/noteentry.cpp
+++ b/src/engraving/libmscore/noteentry.cpp
@@ -92,7 +92,6 @@ NoteVal Score::noteValForPosition(Position pos, AccidentalType at, bool& error)
     }
     case StaffGroup::TAB: {
         if (_is.rest()) {
-            error = true;
             return nval;
         }
         stringData = instr->stringData();

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -472,6 +472,7 @@ void NotationActionController::init()
     registerTabPadNoteAction("pad-note-256-TAB", Pad::NOTE256);
     registerTabPadNoteAction("pad-note-512-TAB", Pad::NOTE512);
     registerTabPadNoteAction("pad-note-1024-TAB", Pad::NOTE1024);
+    registerAction("rest-TAB", &Interaction::putRestToSelection);
 
     for (int i = 0; i < MAX_FRET; ++i) {
         registerAction("fret-" + std::to_string(i), [i, this]() { addFret(i); }, &Controller::isTablatureStaff);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3842,7 +3842,11 @@ void NotationInteraction::putRestToSelection()
     if (!is.duration().isValid() || is.duration().isZero() || is.duration().isMeasure()) {
         is.setDuration(DurationType::V_QUARTER);
     }
-    putRest(is.duration());
+    if (is.usingNoteEntryMethod(NoteEntryMethod::RHYTHM)) {
+        m_noteInput->padNote(Pad::REST);
+    } else {
+        putRest(is.duration());
+    }
 }
 
 void NotationInteraction::putRest(Duration duration)

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1091,6 +1091,12 @@ const UiActionList NotationUiActions::m_actions = {
              TranslatableString("action", "Eighth rest"),
              TranslatableString("action", "Enter rest: eighth")
              ),
+    UiAction("rest-TAB",
+             mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_NOTE_INPUT_STAFF_TAB,
+             X_TAB.arg(TranslatableString("action", "Rest")),
+             X_TAB.arg(TranslatableString("action", "Enter rest"))
+             ),
     UiAction("fret-0",
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_NOTATION_NOTE_INPUT_STAFF_TAB,
@@ -2178,6 +2184,7 @@ const UiActionList NotationUiActions::m_actions = {
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "Rest"),
+             TranslatableString("action", "Toggle rest"),
              IconCode::Code::REST
              ),
     UiAction("next-segment-element",


### PR DESCRIPTION
Resolves: #11736
Resolves: #14654

The rest shortcuts are not functioning correctly on tab staves or in rhythm input mode.  The code is present but not hooked up properly.  This addresses those issues.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
