### PR TITLE
Fix #16921: Lay out cross-staff beams correctly on first relayout after chord move

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -1661,9 +1661,19 @@ bool Beam::layout2Cross(const std::vector<ChordRest*>& chordRests, int frag)
     double maxY = std::numeric_limits<double>::max();
     double minY = std::numeric_limits<double>::min();
     int otherStaff = 0;
+    // recompute _minMove and _maxMove as they may have shifted since last layout
+    _minMove = std::numeric_limits<int>::max();
+    _maxMove = std::numeric_limits<int>::min();
     for (ChordRest* c : chordRests) {
-        if (c && (otherStaff = c->staffMove())) {
-            break;
+        IF_ASSERT_FAILED(c) {
+            continue;
+        }
+        int staffMove = c->staffMove();
+        _minMove = std::min(_minMove, staffMove);
+        _maxMove = std::max(_maxMove, staffMove);
+
+        if (staffMove != 0) {
+            otherStaff = staffMove;
         }
     }
     if (otherStaff == 0 || _minMove == _maxMove) {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/16921

In some situations, moving the last of a beam's chords to the other staff causes it to still think that the chord is cross-staff, because `_minMove` and `_maxMove` are cached from before the chord is laid out. `layout2` and its cross variant are called after these layout changes happen, so recomputing the min and max move for the beam is enough to fix this issue!