### PR TITLE
Play note in rhythm mode

### DIFF
--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -714,6 +714,9 @@ void NotationActionController::padNote(const Pad& pad)
     startNoteInputIfNeed();
 
     noteInput->padNote(pad);
+    if (currentNotationElements()->msScore()->inputState().usingNoteEntryMethod(NoteEntryMethod::RHYTHM)) {
+        playSelectedElement();
+    }
 }
 
 void NotationActionController::putNote(const actions::ActionData& args)


### PR DESCRIPTION
Resolves: #16184

Entering notes in rhythm mode should play the notes entered, but a call to playSelectedElement(0 was missing.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
