### PR TITLE
fixed infinite loop during layout for small page sizes

### DIFF
--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -1549,6 +1549,6 @@ void LayoutSystem::manageNarrowSpacing(System* system, double& curSysWidth, doub
             m->respaceSegments();
             curSysWidth += m->width() - prevWidth;
         }
-        widthReduction *= 1 - smallerStep;
+        widthReduction -= smallerStep;
     }
 }


### PR DESCRIPTION
`widthReduction *= 1 - smallerStep;`  Actually the the series is convergent. Title is not correct. But it's slowly convergented series. Besides `widthReduction *= 1 - smallerStep;` is double calculation. So we can face the situation when  `widthReduction == widthReduction * ( 1 - smallerStep)`. Because double is not rational number. It's  finite field. We need to limit loop. Here https://github.com/musescore/MuseScore/blob/0c3d87c4c8692d864cb968b527d9422ef412fe7f/src/engraving/layout/layoutsystem.cpp#L1524  another series was chosen. Seems that series suits us.