### PR TITLE
Fix #16653: Ensure tuplet bracket type is set according to score style on tuplet creation

### DIFF
--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -845,6 +845,13 @@ void NotationActionController::putTuplet(int tupletCount)
     options.ratio.setNumerator(tupletCount);
     options.ratio.setDenominator(2);
     options.autoBaseLen = true;
+    // get the bracket type from score style settings
+    if (INotationStylePtr style = currentNotationStyle()) {
+        int bracketType = style->styleValue(StyleId::tupletBracketType).toInt();
+        options.bracketType = static_cast<TupletBracketType>(bracketType);
+        int numberType = style->styleValue(StyleId::tupletNumberType).toInt();
+        options.numberType = static_cast<TupletNumberType>(numberType);
+    }
 
     putTuplet(options);
 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/16653