### PR TITLE
Fix #15327: Apply 1/8sp inset regardless of manual adjustment

### DIFF
--- a/src/engraving/layout/slurtielayout.cpp
+++ b/src/engraving/layout/slurtielayout.cpp
@@ -1104,6 +1104,7 @@ TieSegment* SlurTieLayout::tieLayoutBack(Tie* item, System* system)
 
 void SlurTieLayout::tiePos(Tie* item, SlurPos* sp)
 {
+    const double smallInset = item->isInside() ? 0.0 : 0.125; // 1/8 spatium, slight visual adjust so that ties don't hit the center
     const StaffType* staffType = item->staffType();
     bool useTablature = staffType->isTabStaff();
     double _spatium = item->spatium();
@@ -1184,7 +1185,9 @@ void SlurTieLayout::tiePos(Tie* item, SlurPos* sp)
             x1 = item->startNote()->outsideTieAttachX(item->_up);
         }
     }
-
+    if (!(item->up() && sc->up())) {
+        x1 += smallInset * _spatium;
+    }
     sp->p1 += PointF(x1, y1);
 
     //------p2
@@ -1205,6 +1208,9 @@ void SlurTieLayout::tiePos(Tie* item, SlurPos* sp)
         } else {
             x2 = item->endNote()->outsideTieAttachX(item->_up);
         }
+    }
+    if (!(!item->up() && !ec->up())) {
+        x2 -= smallInset * _spatium;
     }
     sp->p2 += PointF(x2, y2);
     // adjust for cross-staff

--- a/src/engraving/libmscore/tie.cpp
+++ b/src/engraving/libmscore/tie.cpp
@@ -723,8 +723,6 @@ void TieSegment::adjustX()
                 }
             } else if (sn->tieBack()) {
                 xo += spatium() / 6; // 1/3 spatium in either direction, so .33/2
-            } else {
-                xo += spatium() / 8; // tiny offset to the right
             }
         }
         xo *= sc->mag();
@@ -801,8 +799,6 @@ void TieSegment::adjustX()
                 xo -= offsetMargin;
             } else if (en && en->tieFor()) {
                 xo -= spatium() / 6;
-            } else {
-                xo -= spatium() / 8;
             }
         }
         xo *= ec->mag();


### PR DESCRIPTION
Partly resolves: https://github.com/musescore/MuseScore/issues/15327

This ends up being an issue that affects both normal and tab ties. The cause was that we add a 1/8 spatium inset to tie endpoints to make them look slightly better, but it was only being applied when the tie isn't manually adjusted or nudged. Now that inset happens regardless.