### PR TITLE
Fix #17004: Instrument name is distinct from long instrument name

### DIFF
--- a/src/notation/view/widgets/editstaff.cpp
+++ b/src/notation/view/widgets/editstaff.cpp
@@ -213,7 +213,12 @@ void EditStaff::updateInstrument()
 
     longName->setPlainText(m_instrument.nameAsPlainText());
     shortName->setPlainText(m_instrument.abbreviatureAsPlainText());
-    instrumentName->setText(m_instrument.nameAsPlainText());
+    const InstrumentTemplate* templ = mu::engraving::searchTemplate(m_instrument.id());
+    if (templ) {
+        instrumentName->setText(formatInstrumentTitle(templ->trackName, templ->trait));
+    } else {
+        instrumentName->setText(qtrc("notation/editstaff", "Unknown"));
+    }
 
     m_minPitchA = m_instrument.minPitchA();
     m_maxPitchA = m_instrument.maxPitchA();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/17004