### PR TITLE
Fix #16497: Include placement attributes for non-string harmonics in <technical> elements

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -3124,8 +3124,11 @@ void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technic
                 _xml.startElementRaw(mxmlTechn + attr);
                 _xml.tag("natural");
                 _xml.endElement();
-            } else {   // TODO: check additional modifier (attr) for other symbols
-                _xml.tagRaw(mxmlTechn);
+            } else {
+                if (placement != "") {
+                    attr += QString(" placement=\"%1\"").arg(placement);
+                }
+                _xml.tagRaw(mxmlTechn + attr);
             }
         }
     }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/16497

For some reason the only elements inside `<technical>` tags that saved placement information was string harmonics. The circle articulations in the file included in the issue are brass markings. This fix saves placement information for any technical articulation in the same way as normal articulations, regardless of symbol.