### PR TITLE
Fix #16135: Allow <print-object> tags to apply to measures

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -2161,6 +2161,21 @@ void MusicXMLParserPass2::measure(const QString& partId, const Fraction time)
     measure->setRepeatStart(false);
     measure->setRepeatEnd(false);
 
+    /* TODO: for cutaway measures, i believe we can expect the staff to continue to be cutaway until another
+    * print-object="yes" attribute is found. Here is the code that does that, though I don't want to actually commit this until
+    * we have the exporter dealing with this sort of stuff as well.
+    *
+    * When print-object="yes" is encountered, the measure will explicitly be set to visible (see MusicXMLParserPass2::staffDetails)
+
+    MeasureBase* prevBase = measure->prev();
+    if (prevBase) {
+        Part* part = _pass1.getPart(partId);
+        staff_idx_t staffIdx = _score->staffIdx(part);
+        if (!toMeasure(prevBase)->visible(staffIdx)) {
+            measure->setStaffVisible(staffIdx, false);
+        }
+    } */
+
     Fraction mTime;   // current time stamp within measure
     Fraction prevTime;   // time stamp within measure previous chord
     Chord* prevChord = 0;         // previous chord
@@ -2394,7 +2409,7 @@ void MusicXMLParserPass2::attributes(const QString& partId, Measure* measure, co
         } else if (_e.name() == "measure-style") {
             measureStyle(measure);
         } else if (_e.name() == "staff-details") {
-            staffDetails(partId);
+            staffDetails(partId, measure);
         } else if (_e.name() == "time") {
             time(partId, measure, tick);
         } else if (_e.name() == "transpose") {
@@ -2427,7 +2442,7 @@ static void setStaffLines(Score* score, staff_idx_t staffIdx, int stafflines)
  Parse the /score-partwise/part/measure/attributes/staff-details node.
  */
 
-void MusicXMLParserPass2::staffDetails(const QString& partId)
+void MusicXMLParserPass2::staffDetails(const QString& partId, Measure* measure)
 {
     //logDebugTrace("MusicXMLParserPass2::staffDetails");
 
@@ -2452,9 +2467,29 @@ void MusicXMLParserPass2::staffDetails(const QString& partId)
 
     StringData* t = new StringData;
     QString visible = _e.attributes().value("print-object").toString();
+    QString spacing = _e.attributes().value("print-spacing").toString();
     if (visible == "no") {
-        _score->staff(staffIdx)->setVisible(false);
-    } else if (!visible.isEmpty() && visible != "yes") {
+        // EITHER:
+        //  1) this indicates an empty staff that is hidden
+        //  2) this indicates a cutaway measure. if it is a cutaway measure then print-spacing will be yes
+        if (spacing == "yes") {
+            measure->setStaffVisible(staffIdx, false);
+        } else if (measure && !measure->hasVoices(staffIdx) && measure->isOnlyRests(staffIdx * VOICES)) {
+            // measures with print-object="no" are generally exported by exporters such as dolet when empty staves are hidden.
+            // for this reason, if we see print-object="no" (and no print-spacing), we can assume that this indicates we should set
+            // the hide empty staves style.
+            _score->setStyleValue(Sid::hideEmptyStaves, true);
+            _score->setStyleValue(Sid::dontHideStavesInFirstSystem, false);
+        } else {
+            // this doesn't apply to a measure, so we'll assume the entire staff has to be hidden.
+            _score->staff(staffIdx)->setVisible(false);
+        }
+    } else if (visible == "yes") {
+        if (measure) {
+            _score->staff(staffIdx)->setVisible(true);
+            measure->setStaffVisible(staffIdx, true);
+        }
+    } else {
         _logger->logError(QString("print-object should be \"yes\" or \"no\""));
     }
 

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
@@ -305,7 +305,7 @@ private:
     void stem(DirectionV& sd, bool& nost);
     void doEnding(const QString& partId, Measure* measure, const QString& number, const QString& type, const QString& text,
                   const bool print);
-    void staffDetails(const QString& partId);
+    void staffDetails(const QString& partId, Measure* measure = nullptr);
     void staffTuning(StringData* t);
     void skipLogCurrElem();
 

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -589,9 +589,6 @@ TEST_F(Musicxml_Tests, helloReadCompr) {
 TEST_F(Musicxml_Tests, helloReadWriteCompr) {
     mxmlReadWriteTestCompr("testHello");
 }
-TEST_F(Musicxml_Tests, hiddenStaves) {
-    mxmlIoTest("testHiddenStaves");
-}
 TEST_F(Musicxml_Tests, implicitMeasure1) {
     mxmlIoTest("testImplicitMeasure1");
 }
@@ -966,4 +963,11 @@ TEST_F(Musicxml_Tests, words1) {
 }
 TEST_F(Musicxml_Tests, words2) {
     mxmlIoTest("testWords2");
+}
+TEST_F(Musicxml_Tests, hiddenStaves)
+{
+    String fileName = String::fromUtf8("testHiddenStaves.xml");
+    MasterScore* score = readScore(XML_IO_DATA_DIR + fileName);
+
+    EXPECT_EQ(score->styleB(Sid::hideEmptyStaves), true);
 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/16135

Here's the plan:
1) If there is a print-object=no attribute on a measure, and there is no print-spacing=yes, then the most likely thing that the exporter was trying to convey was hidden empty staves. For that reason if a measure contains print-object=no, we simply set the style setting that hides empty staves. This may produce different results from the exporting program, based on how wide the page is and where the layout breaks fall--Dolet for example adds print-object attributes at the beginning of systems that have hidden staves, but doesn't explicitly mention system breaks, so it would be really difficult to try to reverse engineer where all of the system breaks are by investigating print-object attributes. That said this solves the problem in the issue above.

2) If the print-object=no attribute is accompanied by print-spacing=yes, this is a cutaway staff. There is very little information regarding whether each individual cutout measure should have these attributes, or if they apply until the next `print-object="yes"` attribute. Either way, there is a comment block that will apply this logic when uncommented, which I am holding off on until we have the exporter conforming to it as well. As it stands, it will only make measures that have these explicit attributes cutaway.