### PR TITLE
fix #17049: crash while pasting elements

### DIFF
--- a/src/engraving/libmscore/engravingitem.cpp
+++ b/src/engraving/libmscore/engravingitem.cpp
@@ -1291,6 +1291,7 @@ EngravingItem* EngravingItem::readMimeData(Score* score, const ByteArray& data, 
 {
     XmlReader e(data);
     const ElementType type = EngravingItem::readType(e, dragOffset, duration);
+    e.context()->setScore(score);
     e.context()->setPasteMode(true);
 
     if (type == ElementType::INVALID) {

--- a/src/engraving/libmscore/paste.cpp
+++ b/src/engraving/libmscore/paste.cpp
@@ -778,6 +778,7 @@ void Score::pasteChordRest(ChordRest* cr, const Fraction& t, const Interval& src
 
 void Score::pasteSymbols(XmlReader& e, ChordRest* dst)
 {
+    e.context()->setScore(this);
     e.context()->setPasteMode(true);   // ensure the reader is in paste mode
     Segment* currSegm = dst->segment();
     Fraction destTick = Fraction(0, 1);                // the tick and track to place the pasted element at
@@ -1184,6 +1185,7 @@ void Score::cmdPaste(const IMimeData* ms, MuseScoreView* view, Fraction scale)
             }
             if (canPasteStaff(data, scale)) {
                 XmlReader e(data);
+                e.context()->setScore(this);
                 e.context()->setPasteMode(true);
                 if (!pasteStaff(e, cr->segment(), cr->staffIdx(), scale)) {
                     return;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3577,6 +3577,7 @@ mu::Ret NotationInteraction::repeatSelection()
     }
 
     mu::engraving::XmlReader xml(selection.mimeData());
+    xml.context()->setScore(score());
     xml.context()->setPasteMode(true);
     track_idx_t dStaff = selection.staffStart();
     mu::engraving::Segment* endSegment = selection.endSegment();


### PR DESCRIPTION
seems that crash can happen with any element, but it was caught while pasting copied ottava (either as an element to a note or with the whole measure to another empty measure)
Was reproduced on that file, but may be not reproduced on another machine

[octaves-copy-crash.mscz.zip](https://github.com/musescore/MuseScore/files/11093516/octaves-copy-crash.mscz.zip)
