### PR TITLE
fix #16764 Font point size fields in Properties panel only show/accept whole numbers

### DIFF
--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -108,7 +108,7 @@ static void sort(size_t& r1, size_t& c1, size_t& r2, size_t& c2)
 }
 
 const String TextBase::UNDEFINED_FONT_FAMILY = String(u"Undefined");
-const int TextBase::UNDEFINED_FONT_SIZE = -1;
+const double TextBase::UNDEFINED_FONT_SIZE = -1.0;
 
 //---------------------------------------------------------
 //   operator==

--- a/src/engraving/libmscore/textbase.h
+++ b/src/engraving/libmscore/textbase.h
@@ -481,7 +481,7 @@ public:
     virtual void initElementStyle(const ElementStyle*) override;
 
     static const String UNDEFINED_FONT_FAMILY;
-    static const int UNDEFINED_FONT_SIZE;
+    static const double UNDEFINED_FONT_SIZE;
 
     bool bold() const { return fontStyle() & FontStyle::Bold; }
     bool italic() const { return fontStyle() & FontStyle::Italic; }

--- a/src/inspector/models/text/textsettingsmodel.cpp
+++ b/src/inspector/models/text/textsettingsmodel.cpp
@@ -111,8 +111,8 @@ void TextSettingsModel::loadProperties()
     m_fontStyle->setIsEnabled(true);
 
     loadPropertyItem(m_fontSize, [](const QVariant& elementPropertyValue) -> QVariant {
-        return elementPropertyValue.toInt() == mu::engraving::TextBase::UNDEFINED_FONT_SIZE
-               ? QVariant() : elementPropertyValue.toInt();
+        return elementPropertyValue.toDouble() == mu::engraving::TextBase::UNDEFINED_FONT_SIZE
+               ? QVariant() : elementPropertyValue.toDouble();
     });
 
     m_fontSize->setIsEnabled(true);

--- a/src/inspector/models/text/textsettingsmodel.cpp
+++ b/src/inspector/models/text/textsettingsmodel.cpp
@@ -31,6 +31,7 @@
 
 #include "translation.h"
 #include "log.h"
+#include "realfn.h"
 
 using namespace mu::inspector;
 using namespace mu::engraving;
@@ -111,7 +112,7 @@ void TextSettingsModel::loadProperties()
     m_fontStyle->setIsEnabled(true);
 
     loadPropertyItem(m_fontSize, [](const QVariant& elementPropertyValue) -> QVariant {
-        return elementPropertyValue.toDouble() == mu::engraving::TextBase::UNDEFINED_FONT_SIZE
+        return RealIsEqual(elementPropertyValue.toDouble(), mu::engraving::TextBase::UNDEFINED_FONT_SIZE)
                ? QVariant() : elementPropertyValue.toDouble();
     });
 


### PR DESCRIPTION
Resolves: #16764 Font point size fields in Properties panel only show/accept whole numbers