### PR TITLE
Learn. Playlists getting refactoring

### DIFF
--- a/.github/workflows/ci_learn_update_paylists.yml
+++ b/.github/workflows/ci_learn_update_paylists.yml
@@ -1,0 +1,60 @@
+name: Collect playlists for Home->Learn page
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Mode: stable, testing'
+        required: true
+        default: 'testing'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  update-get-started-playlist:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Update info about the get started playlist in s3
+        run: |
+          S3_URL="s3://extensions.musescore.org/4.0/learn/started_playlist.json"
+          if [ ${{ github.event.inputs.mode }} == "testing" ]; then
+            S3_URL="s3://extensions.musescore.org/4.0/learn/started_playlist.test.json"
+          fi
+
+          sudo bash ./build/ci/learn/make_playlists_info_file.sh \
+            --youtube_api_key ${{ secrets.YOUTUBE_API_KEY }} \
+            --youtube_playlist_id 'PLTYuWi2LmaPEhcwZJwFZqoyQ2xXx_maPa'
+
+          sudo bash ./build/ci/learn/push_file_to_s3.sh \
+            --s3_key ${{ secrets.S3_KEY }} \
+            --s3_secret ${{ secrets.S3_SECRET }} \
+            --s3_url ${S3_URL} \
+            --file_name "playlist.json"
+
+  update-advanced-playlist:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Update info about the advanced playlist in s3
+        run: |
+          S3_URL="s3://extensions.musescore.org/4.0/learn/advanced_playlist.json"
+          if [ ${{ github.event.inputs.mode }} == "testing" ]; then
+            S3_URL="s3://extensions.musescore.org/4.0/learn/advanced_playlist.test.json"
+          fi
+
+          sudo bash ./build/ci/learn/make_playlists_info_file.sh \
+            --youtube_api_key ${{ secrets.YOUTUBE_API_KEY }} \
+            --youtube_playlist_id 'PL24C760637A625BB6'
+
+          sudo bash ./build/ci/learn/push_file_to_s3.sh \
+            --s3_key ${{ secrets.S3_KEY }} \
+            --s3_secret ${{ secrets.S3_SECRET }} \
+            --s3_url ${S3_URL} \
+            --file_name "playlist.json"

--- a/.github/workflows/ci_tx2s3.yml
+++ b/.github/workflows/ci_tx2s3.yml
@@ -33,7 +33,7 @@ jobs:
         # lrelease
         sudo bash ./build/ci/translation/qt_install.sh
         sudo bash ./build/ci/translation/tx_install.sh -s linux -t ${{ secrets.TRANSIFEX_API_TOKEN }}
-        sudo bash ./build/ci/translation/s3_install.sh --s3_key ${{ secrets.S3_KEY }} --s3_secret ${{ secrets.S3_SECRET }}
+        sudo bash ./build/ci/tools/s3_install.sh --s3_key ${{ secrets.S3_KEY }} --s3_secret ${{ secrets.S3_SECRET }}
 
         sudo bash ./build/ci/tools/make_build_number.sh
         BUILD_NUMBER=$(cat ./build.artifacts/env/build_number.env)

--- a/build/ci/learn/make_youtube_playlist_info.py
+++ b/build/ci/learn/make_youtube_playlist_info.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+
+import io
+import sys
+import json
+import requests
+
+YOUTUBE_API_URL = "https://youtube.googleapis.com/youtube/v3"
+MAX_NUMBER_OF_RESULT_ITEMS = 100
+
+class PlaylistItem:
+    def __init__(self):
+        self.title = ""
+        self.author = ""
+        self.videoUrl = ""
+        self.thumbnailUrl = ""
+        self.durationSecs = 0
+
+def videoDurationSecs(durationInIsoFormat):
+    # Available ISO8601 duration format: P#Y#M#DT#H#M#S
+    import re
+    regexp = re.compile(r'('
+                        r'P'
+                        r'((?P<years>[0-9]+)Y)?'
+                        r'((?P<months>[0-9]+)M)?'
+                        r'((?P<days>[0-9]+)D)?'
+                        r'T'
+                        r'((?P<hours>[0-9]+)H)?'
+                        r'((?P<minutes>[0-9]+)M)?'
+                        r'((?P<seconds>[0-9]+)S)?'
+                        r')')
+
+    match = regexp.match(durationInIsoFormat)
+
+    if not match:
+        return 0
+
+    hours = int(match.group("hours") or 0)
+    minutes = int(match.group("minutes") or 0)
+    seconds = int(match.group("seconds") or 0)
+
+    return seconds + minutes * 60 + hours * 60 * 60
+
+def parsePlaylistItemsIds(playlistDoc):
+    result = []
+    items = playlistDoc["items"]
+
+    for item in items:
+        snippetObj = item["snippet"]
+        resourceIdObj = snippetObj["resourceId"]
+        videoId = resourceIdObj["videoId"]
+
+        result.append(videoId)
+
+    return result
+
+def parseVideosInfo(videosInfoDoc):
+    result = []
+    items = videosInfoDoc["items"]
+
+    for item in items:
+        snippetObj = item["snippet"]
+
+        playlistItem = PlaylistItem()
+
+        playlistItem.title = snippetObj["title"]
+        playlistItem.author = snippetObj["channelTitle"]
+
+        playlistItem.url = "https://www.youtube.com/watch?v=" + item["id"]
+
+        thumbnailsObj = snippetObj["thumbnails"]
+        thumbnailsMediumObj = thumbnailsObj["medium"]
+        playlistItem.thumbnailUrl = thumbnailsMediumObj["url"]
+
+        contentDetails = item["contentDetails"]
+        durationInIsoFormat = contentDetails["duration"]
+        playlistItem.durationSecs = videoDurationSecs(durationInIsoFormat)
+
+        result.append(playlistItem)
+
+    return result
+
+YOUTUBE_API_KEY = sys.argv[1]
+PLAYLIST_ID = sys.argv[2]
+PLAYLIST_FILE = sys.argv[3]
+
+print("=== Read json file ===")
+
+json_file = open(PLAYLIST_FILE, "r+")
+jsonDict = json.load(json_file)
+json_file.close()
+
+print("=== Get playlist items ===")
+
+headers = {
+    'Accept': 'application/json',
+}
+
+url = YOUTUBE_API_URL + f"/playlistItems?part=snippet&playlistId={PLAYLIST_ID}&key={YOUTUBE_API_KEY}&maxResults={MAX_NUMBER_OF_RESULT_ITEMS}"
+r = requests.get(url, headers=headers)
+
+playlist_items = json.loads(r.text)
+
+print("=== Parse playlist items ===")
+
+playlist_items_ids = parsePlaylistItemsIds(playlist_items)
+
+print("=== Get videos info ===")
+
+params = f"part=snippet,contentDetails&key={YOUTUBE_API_KEY}&maxResults={MAX_NUMBER_OF_RESULT_ITEMS}"
+for item_id in playlist_items_ids:
+    params += f"&id={item_id}"
+
+url = YOUTUBE_API_URL + f"/videos?{params}"
+r = requests.get(url, headers=headers)
+
+playlist_videos_info = json.loads(r.text)
+
+print("=== Parse videos info ===")
+
+playlist = parseVideosInfo(playlist_videos_info)
+
+for item in playlist:
+    new_item = {"title": item.title,
+                "author": item.author,
+                "url": item.url,
+                "thumbnailUrl": item.thumbnailUrl,
+                "durationSecs": item.durationSecs }
+    jsonDict["default"].append(new_item)
+
+json_file = open(PLAYLIST_FILE, "w")
+json_file.write(json.dumps(jsonDict, indent=4))
+json_file.close()

--- a/build/ci/learn/push_file_to_s3.sh
+++ b/build/ci/learn/push_file_to_s3.sh
@@ -19,17 +19,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+ARTIFACTS_DIR=build.artifacts
+
 S3_KEY=""
 S3_SECRET=""
-S3_URL="s3://convertor.musescore.org"
-ARTIFACTS_DIR=build.artifacts
-ARTIFACT_PATH=""
+S3_URL=""
+
+FILE_NAME=""
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --s3_key) S3_KEY="$2"; shift ;;
         --s3_secret) S3_SECRET="$2"; shift ;;
-        --artifact) ARTIFACT_PATH="$2"; shift ;;
+        --s3_url) S3_URL="$2"; shift ;;
+        --file_name) FILE_NAME="$2"; shift ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
@@ -37,13 +40,6 @@ done
 
 sudo bash ./build/ci/tools/s3_install.sh --s3_key ${S3_KEY} --s3_secret ${S3_SECRET}
 
-if [ -z "$ARTIFACT_PATH" ]; then 
-    ARTIFACT_NAME=$(cat $ARTIFACTS_DIR/env/artifact_name.env)
-    ARTIFACT_PATH=$ARTIFACTS_DIR/$ARTIFACT_NAME
-fi
-
-ARTIFACT_NAME=$(basename $ARTIFACT_PATH)
-
 echo "=== Publish to S3 ==="
 
-s3cmd put --acl-public --guess-mime-type "$ARTIFACT_PATH" "$S3_URL/$ARTIFACT_NAME"
+s3cmd put --acl-public --guess-mime-type "$ARTIFACTS_DIR/$FILE_NAME" "$S3_URL"

--- a/build/ci/tools/s3_install.sh
+++ b/build/ci/tools/s3_install.sh
@@ -34,9 +34,16 @@ done
 if [ -z "$S3_KEY" ]; then echo "error: not set S3_KEY"; exit 1; fi
 if [ -z "$S3_SECRET" ]; then echo "error: not set S3_SECRET"; exit 1; fi
 
+command -v s3cmd >/dev/null 2>&1
+if [[ $? -ne 0 ]]; then
+    echo "=== Install tools ==="
 
-echo "Install s3cmd"
-pip3 install s3cmd
+    apt install python3-setuptools
+
+    echo "Install s3cmd"
+    pip3 install s3cmd
+fi
+
 
 cat >~/.s3cfg <<EOL
 [default]

--- a/src/learn/ilearnconfiguration.h
+++ b/src/learn/ilearnconfiguration.h
@@ -37,9 +37,6 @@ public:
 
     virtual QUrl startedPlaylistUrl() const = 0;
     virtual QUrl advancedPlaylistUrl() const = 0;
-
-    virtual QUrl videosInfoUrl(const QStringList& videosIds) const = 0;
-    virtual QUrl videoOpenUrl(const QString& videoId) const = 0;
 };
 }
 

--- a/src/learn/ilearnservice.h
+++ b/src/learn/ilearnservice.h
@@ -41,8 +41,6 @@ public:
 
     virtual Playlist advancedPlaylist() const = 0;
     virtual async::Channel<Playlist> advancedPlaylistChanged() const = 0;
-
-    virtual void openVideo(const QString& videoId) const = 0;
 };
 }
 

--- a/src/learn/internal/learnconfiguration.cpp
+++ b/src/learn/internal/learnconfiguration.cpp
@@ -21,15 +21,19 @@
  */
 #include "learnconfiguration.h"
 
-#include <QString>
+#include "settings.h"
 
 using namespace mu::learn;
 using namespace mu::network;
+using namespace mu::framework;
 
-static const QString API_KEY(MUE_LEARN_YOUTUBE_API_KEY);
-static const QString GET_STARTED_PLAYLIST_ID("PLTYuWi2LmaPEhcwZJwFZqoyQ2xXx_maPa");
-static const QString ADVANCED_PLAYLIST_ID("PL24C760637A625BB6");
-static const int MAX_NUMBER_OF_RESULT_ITEMS(100);
+static const std::string module_name("learn");
+static const Settings::Key GET_PLAYLISTS_TESTING_MODE_KEY(module_name, "learn/getPlaylistsTestingMode");
+
+void LearnConfiguration::init()
+{
+    settings()->setDefaultValue(GET_PLAYLISTS_TESTING_MODE_KEY, Val(false));
+}
 
 RequestHeaders LearnConfiguration::headers() const
 {
@@ -38,56 +42,19 @@ RequestHeaders LearnConfiguration::headers() const
     return headers;
 }
 
-QUrl mu::learn::LearnConfiguration::startedPlaylistUrl() const
+QUrl LearnConfiguration::startedPlaylistUrl() const
 {
-    return QUrl(apiRootUrl() + "/playlistItems?" + playlistItemsParams(GET_STARTED_PLAYLIST_ID));
+    return !isTestingMode() ? QUrl("https://s3.amazonaws.com/extensions.musescore.org/4.0/learn/started_playlist.json")
+           : QUrl("https://s3.amazonaws.com/extensions.musescore.org/4.0/learn/started_playlist.test.json");
 }
 
 QUrl LearnConfiguration::advancedPlaylistUrl() const
 {
-    return QUrl(apiRootUrl() + "/playlistItems?" + playlistItemsParams(ADVANCED_PLAYLIST_ID));
+    return !isTestingMode() ? QUrl("https://s3.amazonaws.com/extensions.musescore.org/4.0/learn/advanced_playlist.json")
+           : QUrl("https://s3.amazonaws.com/extensions.musescore.org/4.0/learn/advanced_playlist.test.json");
 }
 
-QUrl LearnConfiguration::videosInfoUrl(const QStringList& videosIds) const
+bool LearnConfiguration::isTestingMode() const
 {
-    return QUrl(apiRootUrl() + "/videos?" + videosParams(videosIds));
-}
-
-QUrl LearnConfiguration::videoOpenUrl(const QString& videoId) const
-{
-    return QUrl("https://www.youtube.com/watch?v=" + videoId);
-}
-
-QString LearnConfiguration::apiRootUrl() const
-{
-    return "https://youtube.googleapis.com/youtube/v3";
-}
-
-QString LearnConfiguration::playlistItemsParams(const QString& playlistId) const
-{
-    QStringList params {
-        "part=snippet",
-        "playlistId=" + playlistId,
-        "key=" + API_KEY,
-        "maxResults=" + QString::number(MAX_NUMBER_OF_RESULT_ITEMS)
-    };
-
-    return params.join('&');
-}
-
-QString LearnConfiguration::videosParams(const QStringList& videosIds) const
-{
-    QStringList params {
-        "part=snippet,contentDetails",
-        "key=" + API_KEY,
-        "maxResults=" + QString::number(MAX_NUMBER_OF_RESULT_ITEMS)
-    };
-
-    params.reserve(params.size() + videosIds.size());
-
-    for (const QString& videoId : videosIds) {
-        params << "id=" + videoId;
-    }
-
-    return params.join('&');
+    return settings()->value(GET_PLAYLISTS_TESTING_MODE_KEY).toBool();
 }

--- a/src/learn/internal/learnconfiguration.h
+++ b/src/learn/internal/learnconfiguration.h
@@ -28,19 +28,15 @@ namespace mu::learn {
 class LearnConfiguration : public ILearnConfiguration
 {
 public:
+    void init();
+
     network::RequestHeaders headers() const override;
 
     QUrl startedPlaylistUrl() const override;
     QUrl advancedPlaylistUrl() const override;
 
-    QUrl videosInfoUrl(const QStringList& videosIds) const override;
-    QUrl videoOpenUrl(const QString& videoId) const override;
-
 private:
-    QString apiRootUrl() const;
-
-    QString playlistItemsParams(const QString& playlistId) const;
-    QString videosParams(const QStringList& videosIds) const;
+    bool isTestingMode() const;
 };
 }
 

--- a/src/learn/internal/learnservice.cpp
+++ b/src/learn/internal/learnservice.cpp
@@ -26,6 +26,7 @@
 #include <QJsonObject>
 #include <QBuffer>
 #include <QtConcurrent>
+#include <QLocale>
 
 #include "dataformatter.h"
 #include "learnerrors.h"
@@ -34,32 +35,11 @@
 using namespace mu::learn;
 using namespace mu::network;
 
-static int videoDurationSecs(const QString& durationInIsoFormat)
+static const QString DEFAULT_PLAYLIST_TAG("default");
+
+static QString preferedPlaylistTag()
 {
-    // NOTE Available ISO8601 duration format: P#Y#M#DT#H#M#S
-
-    QRegularExpression regexp(QString("("
-                                      "P"
-                                      "((?<years>[0-9]+)Y)?"
-                                      "((?<months>[0-9]+)M)?"
-                                      "((?<days>[0-9]+)D)?"
-                                      "T"
-                                      "((?<hours>[0-9]+)H)?"
-                                      "((?<minutes>[0-9]+)M)?"
-                                      "((?<seconds>[0-9]+)S)?"
-                                      ")"));
-
-    QRegularExpressionMatch match = regexp.match(durationInIsoFormat);
-
-    if (!match.hasMatch()) {
-        return 0;
-    }
-
-    int hours = match.captured("hours").toInt();
-    int minutes = match.captured("minutes").toInt();
-    int seconds = match.captured("seconds").toInt();
-
-    return seconds + minutes * 60 + hours * 60 * 60;
+    return QLocale().name();
 }
 
 void LearnService::refreshPlaylists()
@@ -116,11 +96,6 @@ mu::async::Channel<Playlist> LearnService::advancedPlaylistChanged() const
     return m_advancedPlaylistChannel;
 }
 
-void LearnService::openVideo(const QString& videoId) const
-{
-    openUrl(configuration()->videoOpenUrl(videoId));
-}
-
 void LearnService::th_requestPlaylist(const QUrl& playlistUrl, std::function<void(RetVal<Playlist>)> callBack) const
 {
     TRACEFUNC;
@@ -128,63 +103,20 @@ void LearnService::th_requestPlaylist(const QUrl& playlistUrl, std::function<voi
     network::INetworkManagerPtr networkManager = networkManagerCreator()->makeNetworkManager();
     RequestHeaders headers = configuration()->headers();
 
-    QBuffer playlistItemsData;
-    Ret playlistItemsRet = networkManager->get(playlistUrl, &playlistItemsData, headers);
+    QBuffer playlistInfoData;
+    Ret playlistItemsRet = networkManager->get(playlistUrl, &playlistInfoData, headers);
     if (!playlistItemsRet) {
         callBack(playlistItemsRet);
         return;
     }
 
-    QJsonDocument playlistInfoDoc = QJsonDocument::fromJson(playlistItemsData.data());
-
-    QStringList playlistItemsIds = parsePlaylistItemsIds(playlistInfoDoc);
-    if (playlistItemsIds.isEmpty()) {
-        callBack(make_ret(Err::PlaylistIsEmpty));
-        return;
-    }
-
-    QUrl playlistVideosInfoUrl = configuration()->videosInfoUrl(playlistItemsIds);
-    QBuffer videosInfoData;
-    Ret videosRet = networkManager->get(playlistVideosInfoUrl, &videosInfoData, headers);
-    if (!videosRet) {
-        callBack(videosRet);
-        return;
-    }
-
-    QJsonDocument videosInfoDoc = QJsonDocument::fromJson(videosInfoData.data());
+    QJsonDocument playlistInfoDoc = QJsonDocument::fromJson(playlistInfoData.data());
 
     RetVal<Playlist> result;
     result.ret = make_ret(Ret::Code::Ok);
-    result.val = parsePlaylist(videosInfoDoc);
+    result.val = parsePlaylist(playlistInfoDoc);
 
     callBack(result);
-}
-
-void LearnService::openUrl(const QUrl& url) const
-{
-    Ret ret = interactive()->openUrl(url);
-    if (!ret) {
-        LOGE() << ret.toString();
-    }
-}
-
-QStringList LearnService::parsePlaylistItemsIds(const QJsonDocument& playlistDoc) const
-{
-    QStringList result;
-
-    QJsonObject obj = playlistDoc.object();
-    QJsonArray items = obj.value("items").toArray();
-
-    for (const QJsonValue itemVal : items) {
-        QJsonObject itemObj = itemVal.toObject();
-        QJsonObject snippetObj = itemObj.value("snippet").toObject();
-        QJsonObject resourceIdObj = snippetObj.value("resourceId").toObject();
-        QString videoId = resourceIdObj.value("videoId").toString();
-
-        result << videoId;
-    }
-
-    return result;
 }
 
 Playlist LearnService::parsePlaylist(const QJsonDocument& playlistDoc) const
@@ -192,25 +124,20 @@ Playlist LearnService::parsePlaylist(const QJsonDocument& playlistDoc) const
     Playlist result;
 
     QJsonObject obj = playlistDoc.object();
-    QJsonArray items = obj.value("items").toArray();
+    QJsonArray items = obj.value(preferedPlaylistTag()).toArray();
+    if (items.isEmpty()) {
+        items = obj.value(DEFAULT_PLAYLIST_TAG).toArray();
+    }
 
     for (const QJsonValue itemVal : items) {
         QJsonObject itemObj = itemVal.toObject();
-        QJsonObject snippetObj = itemObj.value("snippet").toObject();
 
         PlaylistItem item;
-        item.videoId = itemObj.value("id").toString();
-
-        item.title = snippetObj.value("title").toString();
-        item.author = snippetObj.value("channelTitle").toString();
-
-        QJsonObject thumbnailsObj = snippetObj.value("thumbnails").toObject();
-        QJsonObject thumbnailsMediumObj = thumbnailsObj.value("medium").toObject();
-        item.thumbnailUrl = thumbnailsMediumObj.value("url").toString();
-
-        QJsonObject contentDetails = itemObj.value("contentDetails").toObject();
-        QString durationInIsoFormat = contentDetails["duration"].toString();
-        item.durationSecs = videoDurationSecs(durationInIsoFormat);
+        item.title = itemObj.value("title").toString();
+        item.author = itemObj.value("author").toString();
+        item.url = itemObj.value("url").toString();
+        item.thumbnailUrl = itemObj.value("thumbnailUrl").toString();
+        item.durationSecs = itemObj.value("durationSecs").toInt();
 
         result << item;
     }

--- a/src/learn/internal/learnservice.h
+++ b/src/learn/internal/learnservice.h
@@ -47,14 +47,9 @@ public:
     Playlist advancedPlaylist() const override;
     async::Channel<Playlist> advancedPlaylistChanged() const override;
 
-    void openVideo(const QString& videoId) const override;
-
 private:
     void th_requestPlaylist(const QUrl& playlistUrl, std::function<void(RetVal<Playlist>)> callBack) const;
 
-    void openUrl(const QUrl& url) const;
-
-    QStringList parsePlaylistItemsIds(const QJsonDocument& playlistDoc) const;
     Playlist parsePlaylist(const QJsonDocument& playlistDoc) const;
 
     Playlist m_startedPlaylist;

--- a/src/learn/learnmodule.cpp
+++ b/src/learn/learnmodule.cpp
@@ -63,6 +63,11 @@ void LearnModule::registerUiTypes()
     qmlRegisterType<LearnPageModel>("MuseScore.Learn", 1, 0, "LearnPageModel");
 }
 
+void LearnModule::onInit(const framework::IApplication::RunMode&)
+{
+    s_learnConfiguration->init();
+}
+
 void LearnModule::onDelayedInit()
 {
     s_learnService->refreshPlaylists();

--- a/src/learn/learnmodule.h
+++ b/src/learn/learnmodule.h
@@ -32,6 +32,7 @@ public:
     void registerExports() override;
     void registerResources() override;
     void registerUiTypes() override;
+    void onInit(const framework::IApplication::RunMode& mode) override;
     void onDelayedInit() override;
 };
 }

--- a/src/learn/learntypes.h
+++ b/src/learn/learntypes.h
@@ -27,15 +27,15 @@
 
 namespace mu::learn {
 struct PlaylistItem {
-    QString videoId;
     QString title;
     QString author;
+    QString url;
     QString thumbnailUrl;
     int durationSecs = 0;
 
     bool operator==(const PlaylistItem& other) const
     {
-        return videoId == other.videoId;
+        return url == other.url;
     }
 };
 

--- a/src/learn/qml/MuseScore/Learn/LearnPage.qml
+++ b/src/learn/qml/MuseScore/Learn/LearnPage.qml
@@ -210,10 +210,6 @@ FocusScope {
 
             backgroundColor: root.color
             sideMargin: prv.sideMargin
-
-            onRequestOpenVideo: function(videoId) {
-                pageModel.openVideo(videoId)
-            }
         }
 
 
@@ -231,10 +227,6 @@ FocusScope {
 
             backgroundColor: root.color
             sideMargin: prv.sideMargin
-
-            onRequestOpenVideo: function(videoId) {
-                pageModel.openVideo(videoId)
-            }
         }
         */
 
@@ -256,10 +248,6 @@ FocusScope {
             navigation.accessible.name: qsTrc("learn", "Classes") + navigation.directionInfo
 
             sideMargin: prv.sideMargin
-
-            onRequestOpenOrganizationUrl: {
-                pageModel.openUrl(author.organizationUrl)
-            }
         }
     }
 }

--- a/src/learn/qml/MuseScore/Learn/internal/ClassesPage.qml
+++ b/src/learn/qml/MuseScore/Learn/internal/ClassesPage.qml
@@ -36,13 +36,10 @@ FocusScope {
     property string authorDescription: ""
     property string authorOrganizationName: ""
     property string authorAvatarUrl: ""
+    property string authorArganizationUrl: ""
 
     property alias navigation: navPanel
     property int sideMargin: 46
-
-    signal requestOpenVideo(string videoId)
-
-    signal requestOpenOrganizationUrl()
 
     NavigationPanel {
         id: navPanel
@@ -197,7 +194,7 @@ FocusScope {
                 }
 
                 onClicked: {
-                    root.requestOpenOrganizationUrl()
+                    api.launcher.openUrl(root.authorArganizationUrl)
                 }
             }
         }

--- a/src/learn/qml/MuseScore/Learn/internal/Playlist.qml
+++ b/src/learn/qml/MuseScore/Learn/internal/Playlist.qml
@@ -36,8 +36,6 @@ FocusScope {
     property alias navigation: navPanel
     property int sideMargin: 46
 
-    signal requestOpenVideo(string videoId)
-
     NavigationPanel {
         id: navPanel
         name: "Playlist"
@@ -125,7 +123,7 @@ FocusScope {
                 thumbnail: modelData.thumbnailUrl
 
                 onClicked: {
-                    root.requestOpenVideo(modelData.videoId)
+                    api.launcher.openUrl(modelData.url)
                 }
             }
         }

--- a/src/learn/view/learnpagemodel.cpp
+++ b/src/learn/view/learnpagemodel.cpp
@@ -60,16 +60,6 @@ void LearnPageModel::load()
     });
 }
 
-void LearnPageModel::openVideo(const QString& videoId) const
-{
-    learnService()->openVideo(videoId);
-}
-
-void LearnPageModel::openUrl(const QString& url) const
-{
-    interactive()->openUrl(QUrl(url));
-}
-
 void LearnPageModel::setSearchText(const QString& text)
 {
     if (m_searchText == text) {
@@ -150,9 +140,9 @@ QVariantList LearnPageModel::playlistToVariantList(const Playlist& playlist) con
 
     for (const PlaylistItem& item : playlist) {
         QVariantMap itemObj;
-        itemObj["videoId"] = item.videoId;
         itemObj["title"] = item.title;
         itemObj["author"] = item.author;
+        itemObj["url"] = item.url;
         itemObj["thumbnailUrl"] = item.thumbnailUrl;
         itemObj["duration"] = formatDuration(item.durationSecs);
 

--- a/src/learn/view/learnpagemodel.h
+++ b/src/learn/view/learnpagemodel.h
@@ -24,9 +24,9 @@
 
 #include <QObject>
 
-#include "modularity/ioc.h"
 #include "async/asyncable.h"
-#include "iinteractive.h"
+
+#include "modularity/ioc.h"
 #include "ilearnservice.h"
 
 namespace mu::learn {
@@ -37,7 +37,6 @@ class LearnPageModel : public QObject, public async::Asyncable
     Q_PROPERTY(QVariantList startedPlaylist READ startedPlaylist NOTIFY startedPlaylistChanged)
     Q_PROPERTY(QVariantList advancedPlaylist READ advancedPlaylist NOTIFY advancedPlaylistChanged)
 
-    INJECT(learn, framework::IInteractive, interactive)
     INJECT(learn, ILearnService, learnService)
 
 public:
@@ -47,11 +46,7 @@ public:
     QVariantList advancedPlaylist() const;
 
     Q_INVOKABLE void load();
-    Q_INVOKABLE void openVideo(const QString& videoId) const;
-    Q_INVOKABLE void openUrl(const QString& url) const;
-
     Q_INVOKABLE void setSearchText(const QString& text);
-
     Q_INVOKABLE QVariantMap classesAuthor() const;
 
 private slots:


### PR DESCRIPTION
Problem:
When releasing MuseScore 4, we encountered an issue where we exceeded the daily quota for YouTube requests.

Solution:
To solve this issue, we will retrieve YouTube playlists once on GitHub Actions and store them on MuseScore's Amazon server without quotas.

Structure: 
```
{
  "default": [ // from YouTube
    {
      "title": "Announcing MuseScore 4 - a gigantic overhaul!",
      "author": "Musescore",
      "url": "https://www.youtube.com/watch?v=Nc08RhOQDR4",
      "thumbnailUrl": "https://i.ytimg.com/vi/Nc08RhOQDR4/mqdefault.jpg",
      "durationSecs": "241"
    },
    ...
  ],
  "zh_CN": [    // from Bilibili
  ...
  ]
}
```
