### PR TITLE
Create a different latest nightly symlink for each branch

### DIFF
--- a/build/ci/linux/package.sh
+++ b/build/ci/linux/package.sh
@@ -86,7 +86,7 @@ if [ "$PACKTYPE" == "appimage" ]; then
     # https://github.com/AppImage/AppImageSpec/blob/master/draft.md#update-information
     case "${BUILD_MODE}" in
     "stable_build")  export UPDATE_INFORMATION="gh-releases-zsync|musescore|MuseScore|latest|MuseScore-*${PACKARCH}.AppImage.zsync";;
-    "nightly_build") export UPDATE_INFORMATION="zsync|https://ftp.osuosl.org/pub/musescore-nightlies/linux/${MAJOR_VERSION}x/nightly/MuseScoreNightly-latest-${PACKARCH}.AppImage.zsync";;
+    "nightly_build") export UPDATE_INFORMATION="zsync|https://ftp.osuosl.org/pub/musescore-nightlies/linux/${MAJOR_VERSION}x/nightly/MuseScoreNightly-latest-${BUILD_BRANCH}-${PACKARCH}.AppImage.zsync";;
     *) unset UPDATE_INFORMATION;; # disable updates for other build modes
     esac
 

--- a/build/ci/tools/osuosl/publish.sh
+++ b/build/ci/tools/osuosl/publish.sh
@@ -80,8 +80,11 @@ chmod 600 $SSH_KEY
 
 FTP_PATH=${OS}/${MAJOR_VERSION}x/${BUILD_DIR}
 
-file_extension="${ARTIFACT_NAME##*.}"
-LATEST_NAME="MuseScoreNightly-latest-${PACKARCH}.${file_extension}"
+if [ "$BUILD_MODE" == "nightly_build" ]; then
+    file_extension="${ARTIFACT_NAME##*.}"
+    BUILD_BRANCH=$(cat $ARTIFACTS_DIR/env/build_branch.env)
+    LATEST_NAME="MuseScoreNightly-latest-${BUILD_BRANCH}-${PACKARCH}.${file_extension}"
+fi
 
 echo "Copy ${ARTIFACTS_DIR}/${ARTIFACT_NAME} to $FTP_PATH"
 scp -oStrictHostKeyChecking=no -C -i $SSH_KEY $ARTIFACTS_DIR/$ARTIFACT_NAME musescore-nightlies@ftp-osl.osuosl.org:~/ftp/$FTP_PATH


### PR DESCRIPTION
Affects [nightly builds](https://musescore.org/en/nightly-builds) uploaded to the OSUOSL server.

Currently we create a single 'latest' symlink on each platform. E.g. on macOS:

    MuseScoreNightly-latest-x86_64.dmg

Now we will create one for each branch:

    MuseScoreNightly-latest-master-x86_64.dmg
    MuseScoreNightly-latest-4.0.2-x86_64.dmg

This helps to avoid confusion, and also avoids the race condition where the 'latest' symlink sometimes points to a master nightly and sometimes to a 4.0.2 nightly depending on the time of day.

On Linux, for similar reasons, a separate zsync automatic updates file will be created for each branch.

The current "branchless" symlink and zync files will remain unmodified on the server until they are eventually deleted by the same code that is used to delete old nightly files on each upload.