### PR TITLE
fixes #17107, add traitName fields to lutes to avoid confusion in Spanish

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -12373,6 +12373,7 @@
                   <trackName>Lute</trackName>
                   <longName>Lute</longName>
                   <shortName>Lt.</shortName>
+                  <traitName type="variant">Classic</traitName>
                   <description>6-course lute (staff notation).</description>
                   <musicXMLid>pluck.lute</musicXMLid>
                   <StringData>
@@ -13170,6 +13171,7 @@
                   <trackName>Laúd</trackName>
                   <longName>Laúd</longName>
                   <shortName>Laúd</shortName>
+                  <traitName type="variant">Spanish</traitName>
                   <description>Spanish lute similar to the bandurria. (Staff notation).</description>
                   <musicXMLid>pluck.laud</musicXMLid>
                   <StringData>


### PR DESCRIPTION
Resolves: #17107

Adds labels to the empty dropdown options when selecting 'Laúd' instrument in Spanish, as it is shown in the gif screenshot:


![lute-es-fixed](https://user-images.githubusercontent.com/161853/229340278-bef9fb9c-0e27-42b1-9eec-a6750166e73f.gif)



- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
