### PR TITLE
adjust midi bank and program for bandurria and laud

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -13150,8 +13150,9 @@
                   <pPitchRange>56-98</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 24; MS General: Nylon String Guitar-->
-                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
+                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="25"/>
                   </Channel>
                   <genre>popular</genre>
             </Instrument>
@@ -13187,8 +13188,9 @@
                   <pPitchRange>44-91</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
                   <Channel>
-                        <!--MIDI: Bank 0, Prog 24; MS General: Nylon String Guitar-->
-                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
+                        <!--MIDI: Bank 8, Prog 25; MS General: 12-String Guitar-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="25"/>
                   </Channel>
                   <genre>popular</genre>
             </Instrument>


### PR DESCRIPTION
Since both the Spanish Bandurria and Laúd have 12 steel strings distributed in 6 courses their sound is closer to the 12 steel String Guitar than to the 6 nylon string one. Adjusting this improves a little bit their sound when playing them in musescore.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
