### PR TITLE
Implement #17037: Replacement of 'b' and '#' with '♭' and '♯' for staff names imported from mxml

### DIFF
--- a/src/engraving/libmscore/instrument.cpp
+++ b/src/engraving/libmscore/instrument.cpp
@@ -150,18 +150,6 @@ StaffName::StaffName(const String& xmlText, int pos)
     TextBase::validateText(_name); // enforce HTML encoding
 }
 
-void StaffName::xmlReplaceAccidentals()
-{
-    // instrument names in some musicXML use 'b' instead of '♭' for flat, so we need to convert them.
-    // i don't know if there is a valid reason for # to be in a staff name, but we convert it too just in case.
-
-    _name.replace(std::regex(R"(((?:^|\s)([A-Ga-g]|[Uu][Tt]|[Dd][Oo]|[Rr][EeÉé]|[MmSsTt][Ii]|[FfLl][Aa]|[Ss][Oo][Ll]))b(?=\s|$))"),
-                  String::fromStdString(R"($1♭)"));
-
-    _name.replace(std::regex(R"(((?:^|\s)([A-Ga-g]|[Uu][Tt]|[Dd][Oo]|[Rr][EeÉé]|[MmSsTt][Ii]|[FfLl][Aa]|[Ss][Oo][Ll]))#(?=\s|$))"),
-                  String::fromStdString(R"($1♯)"));
-}
-
 String Instrument::recognizeMusicXmlId() const
 {
     static const String defaultMusicXmlId(u"keyboard.piano");
@@ -1215,17 +1203,6 @@ void Instrument::updateInstrumentId()
 
     if (_id.isEmpty()) {
         _id = recognizeId();
-    }
-}
-
-void Instrument::updateNamesForAccidentals()
-{
-    // change staff names from simple text (eg 'Eb') to text using accidental symbols (eg 'E♭')
-    for (StaffName& sn : _longNames) {
-        sn.xmlReplaceAccidentals();
-    }
-    for (StaffName& sn : _shortNames) {
-        sn.xmlReplaceAccidentals();
     }
 }
 

--- a/src/engraving/libmscore/instrument.cpp
+++ b/src/engraving/libmscore/instrument.cpp
@@ -150,6 +150,18 @@ StaffName::StaffName(const String& xmlText, int pos)
     TextBase::validateText(_name); // enforce HTML encoding
 }
 
+void StaffName::xmlReplaceAccidentals()
+{
+    // instrument names in some musicXML use 'b' instead of '♭' for flat, so we need to convert them.
+    // i don't know if there is a valid reason for # to be in a staff name, but we convert it too just in case.
+
+    _name.replace(std::regex(R"(((?:^|\s)([A-Ga-g]|[Uu][Tt]|[Dd][Oo]|[Rr][EeÉé]|[MmSsTt][Ii]|[FfLl][Aa]|[Ss][Oo][Ll]))b(?=\s|$))"),
+                  String::fromStdString(R"($1♭)"));
+
+    _name.replace(std::regex(R"(((?:^|\s)([A-Ga-g]|[Uu][Tt]|[Dd][Oo]|[Rr][EeÉé]|[MmSsTt][Ii]|[FfLl][Aa]|[Ss][Oo][Ll]))#(?=\s|$))"),
+                  String::fromStdString(R"($1♯)"));
+}
+
 String Instrument::recognizeMusicXmlId() const
 {
     static const String defaultMusicXmlId(u"keyboard.piano");
@@ -1203,6 +1215,17 @@ void Instrument::updateInstrumentId()
 
     if (_id.isEmpty()) {
         _id = recognizeId();
+    }
+}
+
+void Instrument::updateNamesForAccidentals()
+{
+    // change staff names from simple text (eg 'Eb') to text using accidental symbols (eg 'E♭')
+    for (StaffName& sn : _longNames) {
+        sn.xmlReplaceAccidentals();
+    }
+    for (StaffName& sn : _shortNames) {
+        sn.xmlReplaceAccidentals();
     }
 }
 

--- a/src/engraving/libmscore/instrument.h
+++ b/src/engraving/libmscore/instrument.h
@@ -66,8 +66,6 @@ public:
     void setPos(int p) { _pos = p; }
     String name() const { return _name; }
     void setName(const String& n) { _name = n; }
-
-    void xmlReplaceAccidentals();
 };
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/instrument.h
+++ b/src/engraving/libmscore/instrument.h
@@ -66,6 +66,8 @@ public:
     void setPos(int p) { _pos = p; }
     String name() const { return _name; }
     void setName(const String& n) { _name = n; }
+
+    void xmlReplaceAccidentals();
 };
 
 //---------------------------------------------------------
@@ -425,6 +427,7 @@ public:
     void setIsPrimary(bool isPrimary);
 
     void updateInstrumentId();
+    void updateNamesForAccidentals();
 
     bool singleNoteDynamics() const { return _singleNoteDynamics; }
     void setSingleNoteDynamics(bool val) { _singleNoteDynamics = val; }

--- a/src/importexport/musicxml/internal/musicxml/importmxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxml.cpp
@@ -83,6 +83,7 @@ Err importMusicXMLfromBuffer(Score* score, const QString& /*name*/, QIODevice* d
     for (const Part* part : score->parts()) {
         for (const auto& pair : part->instruments()) {
             pair.second->updateInstrumentId();
+            pair.second->updateNamesForAccidentals();
         }
     }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/17037

This replaces b and # with their unicode equivalents during musicxml import iff:

- It is a capital or lowercase letter A-G, OR a valid note name in Italian or French followed by one of those two characters
- That note name is its own token (i.e. surrounded by whitespace or at the end or beginning of the name)

As is pointed out in a comment on the original issue, there is an import option available to replace (or not replace) fonts. This PR does not override that setting, and doesn't touch font stuff at all.