### PR TITLE
Fix #15537: Vertical formatting to avoid text overflow on score export dialog

### DIFF
--- a/src/project/qml/MuseScore/Project/ExportDialog.qml
+++ b/src/project/qml/MuseScore/Project/ExportDialog.qml
@@ -35,7 +35,7 @@ StyledDialogView {
     title: qsTrc("project/export", "Export")
 
     contentWidth: 756
-    contentHeight: 336
+    contentHeight: 372
     margins: 24
 
     ExportDialogModel {

--- a/src/project/qml/MuseScore/Project/internal/Export/ExportOptionItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/ExportOptionItem.qml
@@ -27,7 +27,6 @@ import MuseScore.UiComponents 1.0
 ColumnLayout {
     id: root
 
-    property int labelWidth: 72
     property alias text: label.text
 
     width: Math.min(implicitWidth, parent.width)
@@ -35,7 +34,7 @@ ColumnLayout {
 
     StyledTextLabel {
         id: label
-        Layout.preferredWidth: root.labelWidth
+        Layout.fillWidth: true
         horizontalAlignment: Text.AlignLeft
     }
 }

--- a/src/project/qml/MuseScore/Project/internal/Export/ExportOptionItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/ExportOptionItem.qml
@@ -24,14 +24,14 @@ import QtQuick.Layouts 1.15
 
 import MuseScore.UiComponents 1.0
 
-RowLayout {
+ColumnLayout {
     id: root
 
     property int labelWidth: 72
     property alias text: label.text
 
     width: Math.min(implicitWidth, parent.width)
-    spacing: 12
+    spacing: 8
 
     StyledTextLabel {
         id: label


### PR DESCRIPTION
Resolves: #15537

Changes the formatting for {label / dropdown menu} on the score export dialog from horizontal to vertical. Resolves issue of unreadable overflowing label text in some localizations of Musescore. 

Design as specified by @jessjwilliamson 

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
