### PR TITLE
Fix #17068 Add new function for visibility of staff without unhiding …

### DIFF
--- a/src/instrumentsscene/view/abstractinstrumentspaneltreeitem.cpp
+++ b/src/instrumentsscene/view/abstractinstrumentspaneltreeitem.cpp
@@ -244,7 +244,7 @@ void AbstractInstrumentsPanelTreeItem::setTitle(QString title)
     emit titleChanged(m_title);
 }
 
-void AbstractInstrumentsPanelTreeItem::setIsVisible(bool isVisible)
+void AbstractInstrumentsPanelTreeItem::setIsVisible(bool isVisible, bool setChildren)
 {
     if (m_isVisible == isVisible) {
         return;
@@ -253,8 +253,10 @@ void AbstractInstrumentsPanelTreeItem::setIsVisible(bool isVisible)
     m_isVisible = isVisible;
     emit isVisibleChanged(isVisible);
 
-    for (auto child : m_children) {
-        child->setIsVisible(isVisible);
+    if (setChildren) {
+        for (auto child : m_children) {
+            child->setIsVisible(isVisible);
+        }
     }
 }
 

--- a/src/instrumentsscene/view/abstractinstrumentspaneltreeitem.h
+++ b/src/instrumentsscene/view/abstractinstrumentspaneltreeitem.h
@@ -86,7 +86,7 @@ public:
 public slots:
     void setType(InstrumentsTreeItemType::ItemType type);
     void setTitle(QString title);
-    void setIsVisible(bool isVisible);
+    void setIsVisible(bool isVisible, bool setChildren = true);
     void setId(const ID& id);
     void setIsExpandable(bool expandable);
     void setIsEditable(bool editable);

--- a/src/instrumentsscene/view/stafftreeitem.cpp
+++ b/src/instrumentsscene/view/stafftreeitem.cpp
@@ -33,6 +33,9 @@ StaffTreeItem::StaffTreeItem(IMasterNotationPtr masterNotation, INotationPtr not
         if (!m_isInited) {
             return;
         }
+        if (isVisible && !this->parentItem()->isVisible()) {
+            this->parentItem()->setIsVisible(true, false);
+        }
 
         this->notation()->parts()->setStaffVisible(id(), isVisible);
     });


### PR DESCRIPTION

Resolves: #17068 

Added new function setIsVisibleFromStaffTreeItem to allow staves to be unhidden without unhiding the associated instrument first. 



- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
