### PR TITLE
[4.0.2] Create a different latest nightly symlink for each branch

### DIFF
--- a/build/ci/linux/package.sh
+++ b/build/ci/linux/package.sh
@@ -82,7 +82,7 @@ if [ "$PACKTYPE" == "appimage" ]; then
     # https://github.com/AppImage/AppImageSpec/blob/master/draft.md#update-information
     case "${BUILD_MODE}" in
     "stable_build")  export UPDATE_INFORMATION="gh-releases-zsync|musescore|MuseScore|latest|MuseScore-*x86_64.AppImage.zsync";;
-    "nightly_build") export UPDATE_INFORMATION="zsync|https://ftp.osuosl.org/pub/musescore-nightlies/linux/${MAJOR_VERSION}x/nightly/MuseScoreNightly-latest-x86_64.AppImage.zsync";;
+    "nightly_build") export UPDATE_INFORMATION="zsync|https://ftp.osuosl.org/pub/musescore-nightlies/linux/${MAJOR_VERSION}x/nightly/MuseScoreNightly-latest-${BUILD_BRANCH}-x86_64.AppImage.zsync";;
     *) unset UPDATE_INFORMATION;; # disable updates for other build modes
     esac
 

--- a/build/ci/tools/osuosl/publish.sh
+++ b/build/ci/tools/osuosl/publish.sh
@@ -76,8 +76,11 @@ chmod 600 $SSH_KEY
 
 FTP_PATH=${OS}/${MAJOR_VERSION}x/${BUILD_DIR}
 
-file_extension="${ARTIFACT_NAME##*.}"
-LATEST_NAME="MuseScoreNightly-latest-x86_64.${file_extension}"
+if [ "$BUILD_MODE" == "nightly_build" ]; then
+    file_extension="${ARTIFACT_NAME##*.}"
+    BUILD_BRANCH=$(cat $ARTIFACTS_DIR/env/build_branch.env)
+    LATEST_NAME="MuseScoreNightly-latest-${BUILD_BRANCH}-x86_64.${file_extension}"
+fi
 
 echo "Copy ${ARTIFACTS_DIR}/${ARTIFACT_NAME} to $FTP_PATH"
 scp -oStrictHostKeyChecking=no -C -i $SSH_KEY $ARTIFACTS_DIR/$ARTIFACT_NAME musescore-nightlies@ftp-osl.osuosl.org:~/ftp/$FTP_PATH


### PR DESCRIPTION
Backport PR #17105 to the 4.0.2 branch.

Necessary because the latest symlinks of [nightly builds](https://ftp.osuosl.org/pub/musescore-nightlies/macos/4x/nightly/?C=M;O=D) from this branch are still named like:

    MuseScoreNightly-latest-x86_64.dmg

Instead of:

    MuseScoreNightly-latest-4.0.2-x86_64.dmg