### PR TITLE
Fix: #13143 : Clear button removes FretNumber

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/notation/fretdiagrams/FretDiagramSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/fretdiagrams/FretDiagramSettings.qml
@@ -91,6 +91,7 @@ Item {
 
                 onClicked: {
                     fretCanvas.clear()
+                    root.model.fretNumber.resetToDefault()
                 }
             }
         }


### PR DESCRIPTION
Resolves: #13143
clear button removes FretNumber.



- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
