### PR TITLE
fixed midi generation for measures with repeats

### DIFF
--- a/src/engraving/compat/midi/midirender.cpp
+++ b/src/engraving/compat/midi/midirender.cpp
@@ -792,6 +792,10 @@ void MidiRenderer::renderStaff(EventMap* events, const Staff* staff, PitchWheelR
                 lastMeasure = m;
                 collectMeasureEvents(events, lastMeasure, staff, tickOffset, pitchWheelRenderer);
             }
+
+            if (m == rs->lastMeasure()) {
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
regression in midi export after removing chunk logic in https://github.com/musescore/MuseScore/pull/16238
measures with repeats started to overlap each other in the exported midi file.
Example:
[Repeats.mscz.zip](https://github.com/musescore/MuseScore/files/11183853/Repeats.mscz.zip)

