### PR TITLE
Fix crash caused by PR #16223

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -494,6 +494,18 @@ void Beam::layout()
     }
 }
 
+//---------------------------------------------------------
+//   layoutIfNeed
+//   check to see if the layout info is valid, and if not, layout
+//---------------------------------------------------------
+
+void Beam::layoutIfNeed()
+{
+    if (!_layoutInfo.isValid()) {
+        layout();
+    }
+}
+
 PointF Beam::chordBeamAnchor(const ChordRest* chord, BeamTremoloLayout::ChordBeamAnchorType anchorType) const
 {
     return _layoutInfo.chordBeamAnchor(chord, anchorType);

--- a/src/engraving/libmscore/beam.h
+++ b/src/engraving/libmscore/beam.h
@@ -164,6 +164,7 @@ public:
 
     void layout1();
     void layout() override;
+    void layoutIfNeed();
 
     PointF chordBeamAnchor(const ChordRest* chord, BeamTremoloLayout::ChordBeamAnchorType anchorType) const;
     double chordBeamAnchorY(const ChordRest* chord) const;

--- a/src/engraving/libmscore/beamtremololayout.h
+++ b/src/engraving/libmscore/beamtremololayout.h
@@ -56,6 +56,7 @@ public:
     PointF chordBeamAnchor(const ChordRest* chord, ChordBeamAnchorType anchorType) const;
     int getMaxSlope() const;
     void extendStem(Chord* chord, double addition);
+    bool isValid() const { return !(m_beamType == BeamType::INVALID); }
 
 private:
     enum class BeamType {

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -1077,6 +1077,11 @@ void Chord::computeUp()
                 // necessary because this beam was never laid out before, so its position isn't known
                 // and the first chord would calculate wrong stem direction
                 _beam->layout();
+            } else {
+                // otherwise we can use stale layout data; the only reason we would need to lay out here is if
+                // it's literally never been laid out before which due to the insane nature of our layout system
+                // is actually a possible thing
+                _beam->layoutIfNeed();
             }
             PointF base = _beam->pagePos();
             Note* baseNote = _up ? downNote() : upNote();


### PR DESCRIPTION
There was a crash that could be encountered when Chord::computeUp is called before its beam is laid out. We fix this by making sure that the beam has valid layout data in it before trying to do anything with it.