### PR TITLE
Fix crash when opening a certain 206 score (with nested frames?)

### DIFF
--- a/src/engraving/rw/206/read206.cpp
+++ b/src/engraving/rw/206/read206.cpp
@@ -2978,12 +2978,12 @@ static void readBox(Box* b, XmlReader& e, ReadContext& ctx)
     while (e.readNextStartElement()) {
         const AsciiStringView tag(e.name());
         if (tag == "HBox") {
-            HBox* hb = Factory::createHBox(b->system());
+            HBox* hb = Factory::createHBox(b->score()->dummy()->system());
             rw400::TRead::read(hb, e, ctx);
             b->add(hb);
             keepMargins = true;           // in old file, box nesting used outer box margins
         } else if (tag == "VBox") {
-            VBox* vb = Factory::createVBox(b->system());
+            VBox* vb = Factory::createVBox(b->score()->dummy()->system());
             rw400::TRead::read(vb, e, ctx);
             b->add(vb);
             keepMargins = true;           // in old file, box nesting used outer box margins


### PR DESCRIPTION
`b->system()` is of course not yet initialized while reading. In MS3.6.2, this was no problem because elements could have nullptr as their parent, but in MS4 the Factory methods expect a non-null parent.

Resolves: #17241