### PR TITLE
[MXML Import] Interpret common tempo markings as musescore-native tempo objects

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
@@ -197,6 +197,7 @@ using OttavasStack = std::array<MusicXmlExtendedSpannerDesc, MAX_NUMBER_LEVEL>;
 using HairpinsStack = std::array<MusicXmlExtendedSpannerDesc, MAX_NUMBER_LEVEL>;
 using SpannerStack = std::array<MusicXmlExtendedSpannerDesc, MAX_NUMBER_LEVEL>;
 using SpannerSet = std::set<Spanner*>;
+using TempoTextMap = std::map<int, std::set<QString> >;
 
 class TempoLineManager
 {
@@ -390,6 +391,8 @@ private:
     size_t _nstaves;                              ///< Number of staves in current part
     std::vector<int> _measureRepeatNumMeasures;
     std::vector<int> _measureRepeatCount;
+
+    TempoTextMap _tempoTextMap;
 };
 
 struct TempoInformation
@@ -456,7 +459,7 @@ public:
     MusicXMLParserDirection(QXmlStreamReader& e, Score* score, const MusicXMLParserPass1& pass1, MusicXMLParserPass2& pass2,
                             MxmlLogger* logger);
     void direction(const QString& partId, Measure* measure, const Fraction& tick, const int divisions, MusicXmlSpannerMap& spanners,
-                   TempoLineManager& tempoLine);
+                   TempoLineManager& tempoLine, TempoTextMap& tempoTextMap);
 
 private:
     QXmlStreamReader& _e;

--- a/src/importexport/musicxml/tests/data/testTempo1.xml
+++ b/src/importexport/musicxml/tests/data/testTempo1.xml
@@ -50,7 +50,7 @@
         </attributes>
       <direction placement="above">
         <direction-type>
-          <words font-weight="bold" font-size="12">Largo </words>
+          <words font-weight="bold" font-size="12">Largo</words>
           </direction-type>
         <direction-type>
           <metronome parentheses="no">

--- a/src/importexport/musicxml/tests/data/testTempo1.xml
+++ b/src/importexport/musicxml/tests/data/testTempo1.xml
@@ -237,8 +237,9 @@
     <measure number="5">
       <direction placement="above">
         <direction-type>
-          <words>Vivace</words>
+          <words font-weight="bold" font-size="12">Vivace</words>
           </direction-type>
+        <sound tempo="126"/>
         </direction>
       <direction placement="above">
         <direction-type>


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/16797
Resolves: https://github.com/musescore/MuseScore/issues/17052
Resolves: https://github.com/musescore/MuseScore/issues/17069
Resolves: https://github.com/musescore/MuseScore/issues/17081
Resolves: https://github.com/musescore/MuseScore/issues/17099

- Recognized tempo text is added as a Tempo Text object rather than Staff Text
- Recognized gradual tempo change text is added as GradualTempoChange
- Gradual tempo changes' length is guessed based on context clues (i.e. proceeding tempo markings)
- The tempo lines' factor can stretch, if appropriate (so Largo -> accel. -> Presto will produce a smooth gradient between the two tempos)
- Relative tempos also work, with piu mosso for example adding 10% of the current tempo.
- Interpret dotted line with gradual tempo change text as an explicit indication of the length of the line, such as this combo generated by the Dolet plugin for Sibelius: [sib rit with line.zip](https://github.com/musescore/MuseScore/files/11254068/sib.rit.with.line.zip)

This PR also fixes an issue that was sorta created in #7171, an example of which can be found in the comments in the PR after it was merged. Now, instead of only adding tempo if no tempo has been added to that tick, it now only refuses to add if there is a tempo on that tick _and_ the text is identical.
