### PR TITLE
Reset HitElementContext when deleting element

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3697,6 +3697,7 @@ void NotationInteraction::deleteSelection()
     }
 
     apply();
+    resetHitElementContext();
 }
 
 void NotationInteraction::flipSelection()


### PR DESCRIPTION
In particular, this fixes #13590, where the problem is that the just deleted frame is still stored in the HitElementContext. Therefore, any newly created text object will be added to that deleted frame instead of to a newly created frame in the score.

Resolves: #13590