### PR TITLE
Fix crash when current URI changes while DialogView is open

### DIFF
--- a/src/framework/uicomponents/view/popupview.h
+++ b/src/framework/uicomponents/view/popupview.h
@@ -208,6 +208,8 @@ protected:
     void componentComplete() override;
     bool eventFilter(QObject* watched, QEvent* event) override;
 
+    void initCloseController();
+
     void doFocusOut();
     void windowMoveEvent();
 


### PR DESCRIPTION
We should not attempt to close dialogs when the current URI changes or when the user clicks outside; only popups.

Resolves: #17246
Resolves: https://github.com/musescore/MuseScore/issues/17224
Resolves: #17251