### PR TITLE
Fix instrument change text

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1439,7 +1439,7 @@ void GPConverter::addInstrumentChanges()
                 instrName = soundAutomation.second.value;
             } else {
                 midiProgramm = it->second.programm;
-                instrName = it->second.name;
+                instrName = it->second.label;
             }
 
             if (bar == 0 && pos == 0 && midiProgramm == track.second->programm()) {


### PR DESCRIPTION
Fixes the issue with instrument change
<img width="802" alt="image" src="https://user-images.githubusercontent.com/16940972/232755436-b9c6ca08-bcc2-4745-8b07-efab5b0a3d0e.png">
Removes (1) from the text.
