### PR TITLE
Fix for #8964: Properties Panel empty when no score open

### DIFF
--- a/src/inspector/models/inspectorlistmodel.cpp
+++ b/src/inspector/models/inspectorlistmodel.cpp
@@ -63,6 +63,11 @@ void InspectorListModel::buildModelsForSelectedElements(const ElementKeySet& sel
 
 void InspectorListModel::buildModelsForEmptySelection()
 {
+    if (context()->currentNotation() == nullptr) {
+        removeUnusedModels({}, false /*isRangeSelection*/);
+        return;
+    }
+
     static const QList<InspectorSectionType> persistentSectionList {
         InspectorSectionType::SECTION_SCORE_DISPLAY,
         InspectorSectionType::SECTION_SCORE_APPEARANCE
@@ -78,6 +83,10 @@ void InspectorListModel::setElementList(const QList<mu::engraving::EngravingItem
     TRACEFUNC;
 
     if (!m_modelList.isEmpty()) {
+        if (context()->currentNotation() == nullptr) {
+            buildModelsForEmptySelection();
+        }
+
         if (!m_repository->needUpdateElementList(selectedElementList, selectionState)) {
             return;
         }

--- a/src/inspector/models/score/scoredisplaysettingsmodel.cpp
+++ b/src/inspector/models/score/scoredisplaysettingsmodel.cpp
@@ -48,6 +48,7 @@ void ScoreSettingsModel::onCurrentNotationChanged()
 
 void ScoreSettingsModel::createProperties()
 {
+    updateAll();
 }
 
 void ScoreSettingsModel::requestElements()


### PR DESCRIPTION
Resolves: #8964

In response to https://github.com/musescore/MuseScore/issues/8964#issuecomment-1079802540, the modules in the Properties Panel that have no effect when no score is open will no longer appear when no score is open. They will appear when a score is opened and nothing is selected, and disappear again if (all) score(s) are closed.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)

I built RUN_TESTS, and the only failing tests seemed to be unrelated ones, such as audio tests and braille tests.