### PR TITLE
Fix #17252 Modified delete tooltip to be "dynamic"

### DIFF
--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/InstrumentsPanel.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/InstrumentsPanel.qml
@@ -91,6 +91,7 @@ Item {
             isMovingDownAvailable: instrumentsTreeModel.isMovingDownAvailable
             isAddingAvailable: instrumentsTreeModel.isAddingAvailable
             isRemovingAvailable: instrumentsTreeModel.isRemovingAvailable
+            isInstrumentSelected: instrumentsTreeModel.isInstrumentSelected
 
             onAddRequested: {
                 instrumentsTreeModel.addInstruments()

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsControlPanel.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsControlPanel.qml
@@ -32,7 +32,7 @@ RowLayout {
     property bool isMovingDownAvailable: false
     property bool isRemovingAvailable: false
     property bool isAddingAvailable: value
-    property bool isInstrumentSelected: value
+    property bool isInstrumentSelected: false
 
     property alias navigation: keynavSub
 
@@ -82,7 +82,7 @@ RowLayout {
         navigation.panel: keynavSub
         navigation.order: 2
 
-        toolTipTitle: qsTrc("instruments", "Move selected instruments up")
+        toolTipTitle: root.isInstrumentSelected ? qsTrc("instruments", "Move selected instruments up") : qsTrc("instruments", "Move selected staves up")
 
         enabled: root.isMovingUpAvailable
 
@@ -100,7 +100,7 @@ RowLayout {
         navigation.panel: keynavSub
         navigation.order: 3
 
-        toolTipTitle: qsTrc("instruments", "Move selected instruments down")
+        toolTipTitle: root.isInstrumentSelected ? qsTrc("instruments", "Move selected instruments down") : qsTrc("instruments", "Move selected staves down")
 
         enabled: root.isMovingDownAvailable
 

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsControlPanel.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsControlPanel.qml
@@ -32,6 +32,7 @@ RowLayout {
     property bool isMovingDownAvailable: false
     property bool isRemovingAvailable: false
     property bool isAddingAvailable: value
+    property bool isInstrumentSelected: value
 
     property alias navigation: keynavSub
 
@@ -117,7 +118,7 @@ RowLayout {
         navigation.panel: keynavSub
         navigation.order: 4
 
-        toolTipTitle: qsTrc("instruments", "Remove selected instruments")
+        toolTipTitle: root.isInstrumentSelected ? qsTrc("instruments", "Remove selected instruments") : qsTrc("instruments", "Remove selected staves")
 
         enabled: root.isRemovingAvailable
 

--- a/src/instrumentsscene/view/instrumentspaneltreemodel.cpp
+++ b/src/instrumentsscene/view/instrumentspaneltreemodel.cpp
@@ -65,7 +65,7 @@ InstrumentsPanelTreeModel::InstrumentsPanelTreeModel(QObject* parent)
 
         updateRearrangementAvailability();
         updateRemovingAvailability();
-        updateDeleteToolTip();
+        updateIsInstrumentSelected();
     });
 
     connect(this, &InstrumentsPanelTreeModel::rowsInserted, this, [this]() {
@@ -708,7 +708,7 @@ void InstrumentsPanelTreeModel::updateRemovingAvailability()
     setIsRemovingAvailable(isRemovingAvailable);
 }
 
-void InstrumentsPanelTreeModel::updateDeleteToolTip()
+void InstrumentsPanelTreeModel::updateIsInstrumentSelected()
 {
     QModelIndexList selectedIndexes = m_selectionModel->selectedIndexes();
     bool isInstrumentSelected = true;

--- a/src/instrumentsscene/view/instrumentspaneltreemodel.cpp
+++ b/src/instrumentsscene/view/instrumentspaneltreemodel.cpp
@@ -65,6 +65,7 @@ InstrumentsPanelTreeModel::InstrumentsPanelTreeModel(QObject* parent)
 
         updateRearrangementAvailability();
         updateRemovingAvailability();
+        updateDeleteToolTip();
     });
 
     connect(this, &InstrumentsPanelTreeModel::rowsInserted, this, [this]() {
@@ -573,6 +574,11 @@ bool InstrumentsPanelTreeModel::isEmpty() const
     return m_rootItem ? m_rootItem->isEmpty() : true;
 }
 
+bool InstrumentsPanelTreeModel::isInstrumentSelected() const
+{
+    return m_isInstrumentSelected;
+}
+
 QString InstrumentsPanelTreeModel::addInstrumentsKeyboardShortcut() const
 {
     const shortcuts::Shortcut& shortcut = shortcutsRegister()->shortcut(ADD_INSTRUMENTS_ACTIONCODE);
@@ -592,6 +598,16 @@ void InstrumentsPanelTreeModel::setIsRemovingAvailable(bool isRemovingAvailable)
 
     m_isRemovingAvailable = isRemovingAvailable;
     emit isRemovingAvailableChanged(m_isRemovingAvailable);
+}
+
+void InstrumentsPanelTreeModel::setIsInstrumentSelected(bool isInstrumentSelected)
+{
+    if (m_isInstrumentSelected == isInstrumentSelected) {
+        return;
+    }
+
+    m_isInstrumentSelected = isInstrumentSelected;
+    emit isInstrumentSelectedChanged(m_isInstrumentSelected);
 }
 
 void InstrumentsPanelTreeModel::updateRearrangementAvailability()
@@ -690,6 +706,23 @@ void InstrumentsPanelTreeModel::updateRemovingAvailability()
     }
 
     setIsRemovingAvailable(isRemovingAvailable);
+}
+
+void InstrumentsPanelTreeModel::updateDeleteToolTip()
+{
+    QModelIndexList selectedIndexes = m_selectionModel->selectedIndexes();
+    bool isInstrumentSelected = true;
+
+    for (const QModelIndex& index : selectedIndexes) {
+        const AbstractInstrumentsPanelTreeItem* item = modelIndexToItem(index);
+
+        if (item && static_cast<ItemType>(item->type()) == ItemType::STAFF) {
+            isInstrumentSelected = false;
+            break;
+        }
+    }
+
+    setIsInstrumentSelected(isInstrumentSelected);
 }
 
 void InstrumentsPanelTreeModel::setItemsSelected(const QModelIndexList& indexes, bool selected)

--- a/src/instrumentsscene/view/instrumentspaneltreemodel.h
+++ b/src/instrumentsscene/view/instrumentspaneltreemodel.h
@@ -56,6 +56,7 @@ class InstrumentsPanelTreeModel : public QAbstractItemModel, public async::Async
     Q_PROPERTY(bool isAddingAvailable READ isAddingAvailable NOTIFY isAddingAvailableChanged)
     Q_PROPERTY(bool isEmpty READ isEmpty NOTIFY isEmptyChanged)
     Q_PROPERTY(QString addInstrumentsKeyboardShortcut READ addInstrumentsKeyboardShortcut NOTIFY addInstrumentsKeyboardShortcutChanged)
+    Q_PROPERTY(bool isInstrumentSelected READ isInstrumentSelected NOTIFY isInstrumentSelectedChanged)
 
 public:
     explicit InstrumentsPanelTreeModel(QObject* parent = nullptr);
@@ -74,6 +75,7 @@ public:
     bool isAddingAvailable() const;
     bool isEmpty() const;
     QString addInstrumentsKeyboardShortcut() const;
+    bool isInstrumentSelected() const;
 
     Q_INVOKABLE void load();
     Q_INVOKABLE void selectRow(const QModelIndex& rowIndex);
@@ -96,12 +98,14 @@ signals:
     void isRemovingAvailableChanged(bool isRemovingAvailable);
     void isEmptyChanged();
     void addInstrumentsKeyboardShortcutChanged();
+    void isInstrumentSelectedChanged(bool isInstrumentSelected);
 
 private slots:
     void updateRearrangementAvailability();
     void updateMovingUpAvailability(bool isSelectionMovable, const QModelIndex& firstSelectedRowIndex = QModelIndex());
     void updateMovingDownAvailability(bool isSelectionMovable, const QModelIndex& lastSelectedRowIndex = QModelIndex());
     void updateRemovingAvailability();
+    void updateDeleteToolTip();
 
 private:
     bool removeRows(int row, int count, const QModelIndex& parent) override;
@@ -128,6 +132,7 @@ private:
     void setIsMovingUpAvailable(bool isMovingUpAvailable);
     void setIsMovingDownAvailable(bool isMovingDownAvailable);
     void setIsRemovingAvailable(bool isRemovingAvailable);
+    void setIsInstrumentSelected(bool selected);
 
     void setItemsSelected(const QModelIndexList& indexes, bool selected);
 
@@ -141,6 +146,7 @@ private:
     bool m_isMovingDownAvailable = false;
     bool m_isRemovingAvailable = false;
     bool m_isLoadingBlocked = false;
+    bool m_isInstrumentSelected = false;
 
     AbstractInstrumentsPanelTreeItem* m_rootItem = nullptr;
     uicomponents::ItemMultiSelectionModel* m_selectionModel = nullptr;

--- a/src/instrumentsscene/view/instrumentspaneltreemodel.h
+++ b/src/instrumentsscene/view/instrumentspaneltreemodel.h
@@ -105,7 +105,7 @@ private slots:
     void updateMovingUpAvailability(bool isSelectionMovable, const QModelIndex& firstSelectedRowIndex = QModelIndex());
     void updateMovingDownAvailability(bool isSelectionMovable, const QModelIndex& lastSelectedRowIndex = QModelIndex());
     void updateRemovingAvailability();
-    void updateDeleteToolTip();
+    void updateIsInstrumentSelected();
 
 private:
     bool removeRows(int row, int count, const QModelIndex& parent) override;
@@ -132,7 +132,7 @@ private:
     void setIsMovingUpAvailable(bool isMovingUpAvailable);
     void setIsMovingDownAvailable(bool isMovingDownAvailable);
     void setIsRemovingAvailable(bool isRemovingAvailable);
-    void setIsInstrumentSelected(bool selected);
+    void setIsInstrumentSelected(bool isInstrumentSelected);
 
     void setItemsSelected(const QModelIndexList& indexes, bool selected);
 


### PR DESCRIPTION
Resolves: #17252 

Made delete tooltip in instruments panel dynamically change depending on whether instruments or staves selected.

This is my first commit to your project. So if there's something wrong with the naming or implementation of the functions. Id be glad to get comments and solve the problem to the end.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
