### PR TITLE
midi-renderer: improved slides rendering

### DIFF
--- a/src/engraving/libmscore/noteevent.h
+++ b/src/engraving/libmscore/noteevent.h
@@ -40,7 +40,6 @@ public:
     constexpr static double GLISSANDO_VELOCITY_MULTIPLIER = 0.7;
     constexpr static double GHOST_VELOCITY_MULTIPLIER = 0.6;
     constexpr static double DEFAULT_VELOCITY_MULTIPLIER = 1.0;
-    constexpr static int SLIDE_DURATION = 20;
     constexpr static int SLIDE_AMOUNT = 3;
 
     NoteEvent() {}
@@ -57,6 +56,7 @@ public:
     void setPitch(int v) { m_pitch = v; }
     void setOntime(int v) { m_ontime = v; }
     void setLen(int v) { m_len = v; }
+    void setOffset(int v) { m_offset = v; }
 
     bool operator==(const NoteEvent&) const;
 

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -503,7 +503,7 @@ protected:
     int _fileDivision;   ///< division of current loading *.msc file
     SynthesizerState _synthesizerState;
 
-    void createPlayEvents(Chord*);
+    void createPlayEvents(Chord* chord, Chord* prevChord = nullptr);
     void createGraceNotesPlayEvents(const Fraction& tick, Chord* chord, int& ontime, int& trailtime);
     void cmdPitchUp();
     void cmdPitchDown();


### PR DESCRIPTION
Slide midi-rendering changed according to approach:

* If the slide placed after the note :
the main note should play half of its duration and the second half should play slide notes
* If the slide placed before the note :
the slide should play second half of the previous note