### PR TITLE
Set parentItem for pages in DockWindow

### DIFF
--- a/src/appshell/view/dockwindow/dockwindow.cpp
+++ b/src/appshell/view/dockwindow/dockwindow.cpp
@@ -619,6 +619,7 @@ void DockWindow::initDocks(DockPageView* page)
     }
 
     if (page) {
+        page->setParentItem(this);
         page->init();
     }
 


### PR DESCRIPTION
Resolves:  #17276

<!-- Add a short description of and motivation for the changes here -->
After https://invent.kde.org/qt/qt/qtdeclarative/-/merge_requests/40 a QQuickItem without a parentItem is always invisible. While this avoids some crashes in plasmashell, it breaks some applications like MuseScore where pages don't have a parent item.

This is also important for Qt6 porting in the future.
<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
