### PR TITLE
Fix #17226: Remove ability to input a negative velocity

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/general/playback/internal/NoteExpandableBlank.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/general/playback/internal/NoteExpandableBlank.qml
@@ -68,7 +68,7 @@ ExpandableBlank {
                 step: 1
                 decimals: 0
                 maxValue: 127
-                minValue: -127
+                minValue: 0
             }
 
             SpinBoxPropertyView {


### PR DESCRIPTION
Resolves: #17226

Prior to this, it was possible to input a negative velocity on a note (this issue does not exist for dynamics) causing MusicXML files to be corrupt.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)