### PR TITLE
Fix crash when Ctrl+A in 206 score with Glissandos without end element

### DIFF
--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -5708,6 +5708,18 @@ void Score::connectTies(bool silent)
                     }
                 }
             }
+            for (Chord* gc : c->graceNotes()) {
+                for (Note* n : gc->notes()) {
+                    // spanner with no end element apparently happens when reading some 206 files
+                    // (and possibly in other situations too)
+                    for (Spanner* spanner : n->spannerFor()) {
+                        if (spanner->endElement() == nullptr) {
+                            n->removeSpannerFor(spanner);
+                            delete spanner;
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves: #15108

The crash was because apparently we expect Glissandos to always have an end element. In the 206 score where this happened, there were apparently Glissandos that did not have an end element. Those are removed; that is, they _were_ already removed for spanners starting on a normal note, but now I'll also remove them when starting on a _grace_ note.

As a next step, we could try to reconnect those Glissandos by trying to guess their end element. But I haven't done that yet in this PR.

(Maybe relevant info: if you'd open the crashing score in MS2.3.2, then those Glissandos that would be deleted by MS4 would not be visible in MS2.3.2 either.)