### PR TITLE
Various articulation improvements

### DIFF
--- a/src/engraving/libmscore/articulation.h
+++ b/src/engraving/libmscore/articulation.h
@@ -61,6 +61,14 @@ enum class ArticulationAnchor : char {
     BOTTOM_CHORD,     // attribute is placed at bottom of chord
 };
 
+enum class ArticulationStemSideAlign : char
+{
+    // horizontal align for stem-side articulation layout
+    STEM,                // attribute is placed directly over the stem
+    NOTEHEAD,            // attribute is centered on the notehead
+    AVERAGE,             // attribute is placed at the average of stem pos and notehead center
+};
+
 // flags:
 enum class ArticulationShowIn : char {
     PITCHED_STAFF = 1, TABLATURE = 2
@@ -198,6 +206,7 @@ public:
 
     bool isOrnament() const;
     static bool isOrnament(int subtype);
+    bool isBasicArticulation() const;
 
     void doAutoplace();
 

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -225,6 +225,8 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::articulationAnchorDefault, "articulationAnchorDefault", int(ArticulationAnchor::CHORD) },
     { Sid::articulationAnchorLuteFingering, "articulationAnchorLuteFingering", int(ArticulationAnchor::BOTTOM_CHORD) },
     { Sid::articulationAnchorOther, "articulationAnchorOther", int(ArticulationAnchor::TOP_STAFF) },
+    { Sid::articulationStemHAlign,  "articulationStemHAlign",  int(ArticulationStemSideAlign::AVERAGE) },
+    { Sid::articulationKeepTogether, "articulationKeepTogether", true },
     { Sid::lastSystemFillLimit,     "lastSystemFillLimit",     PropertyValue(0.3) },
 
     { Sid::hairpinPlacement,        "hairpinPlacement",        PlacementV::BELOW },

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -241,6 +241,8 @@ enum class Sid {
     articulationAnchorDefault,
     articulationAnchorLuteFingering,
     articulationAnchorOther,
+    articulationStemHAlign,
+    articulationKeepTogether,
     lastSystemFillLimit,
 
     hairpinPlacement,


### PR DESCRIPTION
**Articulation engraving improvements**
- Fixed distance between tenuto and staccato when outside of the staff (before, it was 1sp at all times rather than the articulation distance style setting):
![unnamed](https://user-images.githubusercontent.com/89263931/234660691-583dee09-e036-4a89-8e1c-4c360e67977e.png)
- Added some fake kearning to move the accent and staccato closer to each other, since the bbox of the accent doesn't really indicate where the staccato is in danger of colliding with the accent:
![image](https://user-images.githubusercontent.com/89263931/234661435-b15182d4-5f77-4c02-9177-007e407b14cc.png)
- In-the-staff articulations won't go below (for downstem) or above (for upstem) the staff:
![image](https://user-images.githubusercontent.com/89263931/234660918-fad32dde-0eea-4a55-8520-e6beb398ba69.png)
- Added a new style setting for stem-side articulation align. 
![image](https://user-images.githubusercontent.com/89263931/234662383-2e7def0f-e288-4d62-a4e1-97cd5d285625.png)
The articulation can align over the stem, over the center of the note, or the average of those two placements.
- Added a style setting to align the in-the-staff articulations with the out of the staff ones, if present and on the same side: 
![image](https://user-images.githubusercontent.com/89263931/234663136-ebdb6ed9-1e97-4b8b-bba6-b6d651962043.png)

**Behavior improvements**
- Articulations are now able to be added when a different articulation is selected--MuseScore will add the articulation to the same chord the selected articulation is attached to. This is useful for palette elements, which explicitly select the added item after adding it. Now it is possible to add multiple articulations from the palette without having to reselect the note every time.
- Adding articulations via the top bar no longer resets styling on all other accidentals on the chord. The exception to this is combined articulations, such as `articTenutoStaccato`, which are separated out into their constituent parts (i.e. tenuto and staccato) and added without custom styling.
- If there is a pre-existing articulation on the chord you are adding an accidental to (with either the palette or the top bar), and that pre-existing artic has a manually-set anchor (top chord, top staff, etc), the new articulation will be added using either top chord or bottom chord, to match the direction of the already-added artics. This allows accidentals to be kept together by default. If there are no manually-set anchors, or if there are two manually-anchored articulations on the chord in different directions, the articulation will have default styling applied.

**Still to come** (In a different PR as it is rather crunchy)
- Articulation anchors having 5 options to choose from is excessive. We will pare that down to three: above, below, and auto, and whether or not that articulation will go inside the staff will be based on the type of articulation it is, which is to say how it already works.