### PR TITLE
[issue triage] Use regression_ms3 label for MS3 regressions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -66,8 +66,8 @@ body:
         - Choose option...
         - No.
         - I don't know
-        - Yes, this used to work in Musescore 3.x and now is broken 
-        - Yes, this used to work in a previous version of Musescore 4.x
+        - Yes, this used to work in MuseScore 3.x and now is broken 
+        - Yes, this used to work in a previous version of MuseScore 4.x
     validations: 
       required: true
   - type: input
@@ -94,4 +94,3 @@ body:
         * For engraving: sample score (MuseScore project), screenshots
         * For UI issues: Screenshots, screen recordings, system information, GPU drivers
         * For regressions: The last MuseScore version (or even better: commit) that worked well. 
-

--- a/.github/issue_add_label_config.yml
+++ b/.github/issue_add_label_config.yml
@@ -18,10 +18,10 @@ cloud:
     - "Other type of issue"
 
 regression:
-    - "Yes, this used to work in a previous version of Musescore 4.x"
+    - "Yes, this used to work in a previous version of MuseScore 4.x"
 
 regression_ms3:
-    - "Yes, this used to work in Musescore 3.x and now is broken"
+    - "Yes, this used to work in MuseScore 3.x and now is broken"
 
 "feature request":
     - "Problem to be solved"

--- a/.github/issue_add_label_config.yml
+++ b/.github/issue_add_label_config.yml
@@ -1,24 +1,27 @@
 corruption:
-    - 'File corruption'
+    - "File corruption"
 crash:
-    - 'Crash or freeze'
+    - "Crash or freeze"
 engraving:
-    - 'Engraving bug'
+    - "Engraving bug"
 VST:
-    - 'VST bug'
+    - "VST bug"
 "Muse Sounds":
-    - 'Muse Sounds bug'
+    - "Muse Sounds bug"
 playback:
-    - 'General playback bug'
+    - "General playback bug"
 UI:
-    - 'UI bug'
+    - "UI bug"
 cloud:
-    - 'Cloud saving/loading issue'
+    - "Cloud saving/loading issue"
 "needs review":
-    - 'Other type of issue'
+    - "Other type of issue"
 
 regression:
-    - '(Yes, this used to work in Musescore 3.x and now is broken|Yes, this used to work in a previous version of Musescore 4.x)'
+    - "Yes, this used to work in a previous version of Musescore 4.x"
+
+regression_ms3:
+    - "Yes, this used to work in Musescore 3.x and now is broken"
 
 "feature request":
-    - 'Problem to be solved'
+    - "Problem to be solved"


### PR DESCRIPTION
I noticed @DmitryArefiev had created a new `regression_ms3` label specifically for MS3 regressions, so let's apply that label automatically.