### PR TITLE
Multiple fixes to MIDI output

### DIFF
--- a/src/engraving/playback/playbacksetupdataresolver.cpp
+++ b/src/engraving/playback/playbacksetupdataresolver.cpp
@@ -80,9 +80,5 @@ void PlaybackSetupDataResolver::resolveChordSymbolsSetupData(const Instrument* i
 
 void PlaybackSetupDataResolver::resolveMetronomeSetupData(mpe::PlaybackSetupData& result) const
 {
-    static const mpe::PlaybackSetupData METRONOME_SETUP_DATA = {
-        SoundId::Block, SoundCategory::Percussions, { SoundSubCategory::Wooden }, {}
-    };
-
     result = METRONOME_SETUP_DATA;
 }

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsequencer.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsequencer.cpp
@@ -99,20 +99,17 @@ void FluidSequencer::updatePlaybackEvents(EventSequenceMap& destination, const m
             channel_t channelIdx = channel(noteEvent);
             note_idx_t noteIdx = noteIndex(noteEvent.pitchCtx().nominalPitchLevel);
             velocity_t velocity = noteVelocity(noteEvent);
-            tuning_t tuning = noteTuning(noteEvent, noteIdx);
 
-            midi::Event noteOn(Event::Opcode::NoteOn, Event::MessageType::ChannelVoice20);
+            midi::Event noteOn(Event::Opcode::NoteOn, Event::MessageType::ChannelVoice10);
             noteOn.setChannel(channelIdx);
             noteOn.setNote(noteIdx);
             noteOn.setVelocity(velocity);
-            noteOn.setPitchNote(noteIdx, tuning);
 
             destination[timestampFrom].emplace(std::move(noteOn));
 
-            midi::Event noteOff(Event::Opcode::NoteOff, Event::MessageType::ChannelVoice20);
+            midi::Event noteOff(Event::Opcode::NoteOff, Event::MessageType::ChannelVoice10);
             noteOff.setChannel(channelIdx);
             noteOff.setNote(noteIdx);
-            noteOff.setPitchNote(noteIdx, tuning);
 
             destination[timestampTo].emplace(std::move(noteOff));
 

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
@@ -161,6 +161,10 @@ void FluidSynth::createFluidInstance()
 
 bool FluidSynth::handleEvent(const midi::Event& event)
 {
+    if (event.opcode() == Event::Opcode::NoteOn || event.opcode() == Event::Opcode::NoteOff) {
+        LOGD() << "handleEvent: " << event.opcodeString() << " velocity " << event.velocity() << " channel " << event.channel() <<
+            " note " << event.note() << " pitch " << event.pitchTuningCents();
+    }
     int ret = FLUID_OK;
     switch (event.opcode()) {
     case Event::Opcode::NoteOn: {

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.h
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.h
@@ -107,6 +107,8 @@ private:
     int setExpressionLevel(int level);
     int setControllerValue(const midi::Event& event);
 
+    bool isMetronome() const;
+
     std::shared_ptr<Fluid> m_fluid = nullptr;
 
     async::Channel<unsigned int> m_streamsCountChanged;

--- a/src/framework/midi/internal/platform/lin/alsamidioutport.cpp
+++ b/src/framework/midi/internal/platform/lin/alsamidioutport.cpp
@@ -248,6 +248,8 @@ mu::Ret AlsaMidiOutPort::sendEvent(const Event& e)
     snd_seq_ev_set_source(&seqev, 0);
     snd_seq_ev_set_dest(&seqev, SND_SEQ_ADDRESS_SUBSCRIBERS, 0);
 
+    LOGD() << "Sent midi event " << e.to_string();
+
     switch (e.opcode()) {
     case Event::Opcode::NoteOn:
         snd_seq_ev_set_noteon(&seqev, e.channel(), e.note(), e.velocity());

--- a/src/framework/mpe/events.h
+++ b/src/framework/mpe/events.h
@@ -369,6 +369,13 @@ static const PlaybackSetupData GENERIC_SETUP_DATA = {
 
 static const String GENERIC_SETUP_DATA_STRING = GENERIC_SETUP_DATA.toString();
 
+static const PlaybackSetupData METRONOME_SETUP_DATA = {
+    SoundId::Block,
+    SoundCategory::Percussions,
+    { SoundSubCategory::Wooden },
+    {}
+};
+
 struct PlaybackData {
     PlaybackEventsMap originEvents;
     PlaybackSetupData setupData;


### PR DESCRIPTION
<!-- Add a short description of and motivation for the changes here -->
First, this PR is fixing the MIDI output due to a wrong velocity value (incorrect conversion to MIDI 2.0)
Then, it tries to mute the metronome for the MIDI output. (not very elegant for now)

It's still a work in progress and my ultimate goal is to be able to handle per channel mute state for the midi output.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
