### PR TITLE
Disable nightly builds for 4.0.2

### DIFF
--- a/.github/workflows/ci_linux_arm_mu4.yml
+++ b/.github/workflows/ci_linux_arm_mu4.yml
@@ -16,6 +16,9 @@ on:
         required: false
         default: ''  
 
+env:
+  CURRENT_RELEASE_BRANCH: 4.0.2
+
 jobs:
   build_armhf:
     runs-on: ubuntu-22.04
@@ -27,11 +30,11 @@ jobs:
     - name: Clone repository (default)
       uses: actions/checkout@v3
       if: ${{ github.event_name != 'schedule' || github.event.schedule == '0 3 */1 */1 *' }}
-    - name: Clone repository (4.0.2)
+    - name: Clone repository (${{ env.CURRENT_RELEASE_BRANCH }})
       uses: actions/checkout@v3
       if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' }}
       with:
-        ref: 4.0.2
+        ref: ${{ env.CURRENT_RELEASE_BRANCH }}
     - name: setup QEMU
       uses: docker/setup-qemu-action@v2
     - name: "Configure workflow"
@@ -86,7 +89,7 @@ jobs:
         fi
 
         ADD_INFO="_${GITHUB_REF#refs/heads/}"
-        if [ "${{ github.event_name }}" == "schedule" ] && [ "${{ github.event.schedule }}" == "0 5 */1 */1 *" ]; then ADD_INFO="_4.0.2"; fi
+        if [ "${{ github.event_name }}" == "schedule" ] && [ "${{ github.event.schedule }}" == "0 5 */1 */1 *" ]; then ADD_INFO="_${CURRENT_RELEASE_BRANCH}"; fi
         if [ "${{ github.event_name }}" == "pull_request" ]; then ADD_INFO="_${{ github.event.pull_request.number }}_${pull_request_title}"; fi
         UPLOAD_ARTIFACT_NAME="$(tr '":<>|*?/\\' '_' <<<"MU4_${BUILD_NUMBER}_Lin_armv7l${ADD_INFO}")"
 
@@ -147,11 +150,11 @@ jobs:
     - name: Clone repository (default)
       uses: actions/checkout@v3
       if: ${{ github.event_name != 'schedule' || github.event.schedule == '0 3 */1 */1 *' }}
-    - name: Clone repository (4.0.2)
+    - name: Clone repository (${{ env.CURRENT_RELEASE_BRANCH }})
       uses: actions/checkout@v3
       if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' }}
       with:
-        ref: 4.0.2
+        ref: ${{ env.CURRENT_RELEASE_BRANCH }}
     - name: setup QEMU
       uses: docker/setup-qemu-action@v2
     - name: "Configure workflow"
@@ -206,7 +209,7 @@ jobs:
         fi
 
         ADD_INFO="_${GITHUB_REF#refs/heads/}"
-        if [ "${{ github.event_name }}" == "schedule" ] && [ "${{ github.event.schedule }}" == "0 5 */1 */1 *" ]; then ADD_INFO="_4.0.2"; fi
+        if [ "${{ github.event_name }}" == "schedule" ] && [ "${{ github.event.schedule }}" == "0 5 */1 */1 *" ]; then ADD_INFO="_${CURRENT_RELEASE_BRANCH}"; fi
         if [ "${{ github.event_name }}" == "pull_request" ]; then ADD_INFO="_${{ github.event.pull_request.number }}_${pull_request_title}"; fi
         UPLOAD_ARTIFACT_NAME="$(tr '":<>|*?/\\' '_' <<<"MU4_${BUILD_NUMBER}_Lin_aarch64${ADD_INFO}")"
 

--- a/.github/workflows/ci_linux_mu4.yml
+++ b/.github/workflows/ci_linux_mu4.yml
@@ -7,7 +7,7 @@ on:
     
   schedule:
     - cron: '0 3 */1 */1 *' # At 03:00 on every day-of-month for master
-    - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for 4.0.2
+    - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for current release branch
   workflow_dispatch:
     inputs:
       build_mode:
@@ -23,6 +23,9 @@ on:
         required: false
         default: ''  
 
+env:
+  CURRENT_RELEASE_BRANCH: 4.0.2
+
 jobs:
   build_mu4:
     runs-on: ubuntu-20.04
@@ -34,11 +37,11 @@ jobs:
     - name: Clone repository (default)
       uses: actions/checkout@v3
       if: ${{ github.event_name != 'schedule' || github.event.schedule == '0 3 */1 */1 *' }}
-    - name: Clone repository (4.0.2)
+    - name: Clone repository (${{ env.CURRENT_RELEASE_BRANCH }})
       uses: actions/checkout@v3
       if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' }}
       with:
-        ref: 4.0.2
+        ref: ${{ env.CURRENT_RELEASE_BRANCH }}
     - name: Ccache cache files
       uses: actions/cache@v3
       with:
@@ -109,7 +112,7 @@ jobs:
         fi
 
         ADD_INFO="_${GITHUB_REF#refs/heads/}"
-        if [ "${{ github.event_name }}" == "schedule" ] && [ "${{ github.event.schedule }}" == "0 5 */1 */1 *" ]; then ADD_INFO="_4.0.2"; fi
+        if [ "${{ github.event_name }}" == "schedule" ] && [ "${{ github.event.schedule }}" == "0 5 */1 */1 *" ]; then ADD_INFO="_${{ env.CURRENT_RELEASE_BRANCH }}"; fi
         if [ "${{ github.event_name }}" == "pull_request" ]; then ADD_INFO="_${{ github.event.pull_request.number }}_${pull_request_title}"; fi
         UPLOAD_ARTIFACT_NAME="$(tr '":<>|*?/\\' '_' <<<"MU4_${BUILD_NUMBER}_Lin${ADD_INFO}")"
 

--- a/.github/workflows/ci_linux_mu4.yml
+++ b/.github/workflows/ci_linux_mu4.yml
@@ -7,7 +7,7 @@ on:
     
   schedule:
     - cron: '0 3 */1 */1 *' # At 03:00 on every day-of-month for master
-    - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for current release branch
+    # - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for current release branch
   workflow_dispatch:
     inputs:
       build_mode:

--- a/.github/workflows/ci_macos_mu4.yml
+++ b/.github/workflows/ci_macos_mu4.yml
@@ -7,7 +7,7 @@ on:
     
   schedule:
     - cron: '0 3 */1 */1 *' # At 03:00 on every day-of-month for master
-    - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for 4.0.2
+    - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for current release branch
   workflow_dispatch:
     inputs:
       build_mode:
@@ -24,7 +24,8 @@ on:
         default: ''    
 
 env:
-    DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+  CURRENT_RELEASE_BRANCH: 4.0.2
+  DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
 
 jobs:
   build_mu4:    
@@ -37,11 +38,11 @@ jobs:
     - name: Clone repository (default)
       uses: actions/checkout@v3
       if: ${{ github.event_name != 'schedule' || github.event.schedule == '0 3 */1 */1 *' }}
-    - name: Clone repository (4.0.2)
+    - name: Clone repository (${{ env.CURRENT_RELEASE_BRANCH }})
       uses: actions/checkout@v3
       if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' }}
       with:
-        ref: 4.0.2
+        ref: ${{ env.CURRENT_RELEASE_BRANCH }}
     - name: Ccache cache files
       uses: actions/cache@v3
       with:
@@ -126,7 +127,7 @@ jobs:
         fi
 
         ADD_INFO="_${GITHUB_REF#refs/heads/}"
-        if [ "${{ github.event_name }}" == "schedule" ] && [ "${{ github.event.schedule }}" == "0 5 */1 */1 *" ]; then ADD_INFO="_4.0.2"; fi
+        if [ "${{ github.event_name }}" == "schedule" ] && [ "${{ github.event.schedule }}" == "0 5 */1 */1 *" ]; then ADD_INFO="_${CURRENT_RELEASE_BRANCH}"; fi
         if [ "${{ github.event_name }}" == "pull_request" ]; then ADD_INFO="_${{ github.event.pull_request.number }}_${pull_request_title}"; fi
         UPLOAD_ARTIFACT_NAME="$(tr '":<>|*?/\\' '_' <<<"MU4_${BUILD_NUMBER}_Mac${ADD_INFO}")"
 

--- a/.github/workflows/ci_macos_mu4.yml
+++ b/.github/workflows/ci_macos_mu4.yml
@@ -7,7 +7,7 @@ on:
     
   schedule:
     - cron: '0 3 */1 */1 *' # At 03:00 on every day-of-month for master
-    - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for current release branch
+    # - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for current release branch
   workflow_dispatch:
     inputs:
       build_mode:

--- a/.github/workflows/ci_windows_mu4.yml
+++ b/.github/workflows/ci_windows_mu4.yml
@@ -7,7 +7,7 @@ on:
     
   schedule:
     - cron: '0 3 */1 */1 *' # At 03:00 on every day-of-month for master
-    - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for 4.0.2
+    - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for current release branch
   workflow_dispatch:
     inputs:
       build_mode:
@@ -23,6 +23,9 @@ on:
         required: false
         default: ''   
 
+env:
+  CURRENT_RELEASE_BRANCH: 4.0.2
+
 jobs:
   build_mu4_x64:
     runs-on: windows-2022
@@ -36,12 +39,12 @@ jobs:
       if: ${{ github.event_name != 'schedule' || github.event.schedule == '0 3 */1 */1 *' }}
       with:
         fetch-depth: 3
-    - name: Clone repository (4.0.2)
+    - name: Clone repository (${{ env.CURRENT_RELEASE_BRANCH }})
       uses: actions/checkout@v3
       if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' }}
       with:
         fetch-depth: 3
-        ref: 4.0.2
+        ref: ${{ env.CURRENT_RELEASE_BRANCH }}
     - name: Fetch submodules
       run: |
         git submodule update --init --recursive
@@ -107,7 +110,7 @@ jobs:
         fi
 
         ADD_INFO="_${GITHUB_REF#refs/heads/}"
-        if [ "${{ github.event_name }}" == "schedule" ] && [ "${{ github.event.schedule }}" == "0 5 */1 */1 *" ]; then ADD_INFO="_4.0.2"; fi
+        if [ "${{ github.event_name }}" == "schedule" ] && [ "${{ github.event.schedule }}" == "0 5 */1 */1 *" ]; then ADD_INFO="_${CURRENT_RELEASE_BRANCH}"; fi
         if [ "${{ github.event_name }}" == "pull_request" ]; then ADD_INFO="_${{ github.event.pull_request.number }}_${pull_request_title}"; fi
         UPLOAD_ARTIFACT_NAME="$(tr '":<>|*?/\\' '_' <<<"MU4_${BUILD_NUMBER}_Win${ADD_INFO}")"
 

--- a/.github/workflows/ci_windows_mu4.yml
+++ b/.github/workflows/ci_windows_mu4.yml
@@ -7,7 +7,7 @@ on:
     
   schedule:
     - cron: '0 3 */1 */1 *' # At 03:00 on every day-of-month for master
-    - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for current release branch
+    # - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for current release branch
   workflow_dispatch:
     inputs:
       build_mode:


### PR DESCRIPTION
And use a variable for specifying the current release branch rather than typing 4.0.2 everywhere, to make it easy to switch to a 4.1.x branch in the future