### PR TITLE
Fix for #17013 - Rounding fix for measure width in inspector

### DIFF
--- a/src/inspector/models/general/appearance/appearancesettingsmodel.cpp
+++ b/src/inspector/models/general/appearance/appearancesettingsmodel.cpp
@@ -116,7 +116,7 @@ void AppearanceSettingsModel::loadProperties(const PropertyIdSet& propertyIdSet)
     }
 
     if (mu::contains(propertyIdSet, Pid::USER_STRETCH)) {
-        loadPropertyItem(m_measureWidth);
+        loadPropertyItem(m_measureWidth, formatDoubleFunc);
     }
 
     if (mu::contains(propertyIdSet, Pid::MIN_DISTANCE)) {


### PR DESCRIPTION
Resolves: #17013 

Just a short one line fix for the inspector measure size property not rounding.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)

Thanks for leaving something simple for me to start with ^_^ Appreciate y'all