### PR TITLE
Add unlisted to cloud saving options

### DIFF
--- a/src/project/internal/saveprojectscenario.h
+++ b/src/project/internal/saveprojectscenario.h
@@ -80,8 +80,9 @@ class QMLCloudVisibility
 
 public:
     enum CloudVisibility {
-        Private = int(cloud::Visibility::Private),
-        Public = int(cloud::Visibility::Public)
+        Public = int(cloud::Visibility::Public),
+        Unlisted = int(cloud::Visibility::Unlisted),
+        Private = int(cloud::Visibility::Private)
     };
     Q_ENUM(CloudVisibility);
 };

--- a/src/project/qml/MuseScore/Project/SaveToCloudDialog.qml
+++ b/src/project/qml/MuseScore/Project/SaveToCloudDialog.qml
@@ -128,7 +128,7 @@ StyledDialogView {
 
                     StyledTextLabel {
                         Layout.fillWidth: true
-                        //: visibility of a score on MuseScore.com: private or public
+                        //: visibility of a score on MuseScore.com: private, public or unlisted
                         text: qsTrc("project/save", "Visibility")
                         horizontalAlignment: Text.AlignLeft
                     }
@@ -137,8 +137,9 @@ StyledDialogView {
                         Layout.fillWidth: true
 
                         model: [
-                            { value: CloudVisibility.Private, text: qsTrc("project/save", "Private") },
-                            { value: CloudVisibility.Public, text: qsTrc("project/save", "Public") }
+                            { value: CloudVisibility.Public, text: qsTrc("project/save", "Public") },
+                            { value: CloudVisibility.Unlisted, text: qsTrc("project/save", "Unlisted") },
+                            { value: CloudVisibility.Private, text: qsTrc("project/save", "Private") }
                         ]
 
                         currentIndex: indexOfValue(root.visibility)


### PR DESCRIPTION
Resolves: #14434

Adds the option to save project as unlisted in the cloud.

I left the "force audio saving" logic untouched, which I think means that it is the same as for private projects. If this needs to be different, let me know

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
