### PR TITLE
Revert "fix #12107: fixed wrong import of GP gradual tempo"

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1351,15 +1351,7 @@ void GPConverter::addTempoMap()
         for (auto tempIt = range.first; tempIt != range.second; tempIt++) {
             Fraction tick = m->tick() + Fraction::fromTicks(
                 tempIt->second.position * Constants::division * 4 * m->ticks().numerator() / m->ticks().denominator());
-            Segment* existedSegment = m->findSegment(SegmentType::ChordRest, tick);
             Segment* segment = m->getSegment(SegmentType::ChordRest, tick);
-            Segment* closestChordRestSegment = segment->next(SegmentType::ChordRest);
-            if (!closestChordRestSegment) {
-                closestChordRestSegment = segment->prev(SegmentType::ChordRest);
-            }
-
-            Segment* nextSegment = segment->next(SegmentType::ChordRest | SegmentType::BarLineType);
-
             int realTemp = realTempo(tempIt->second);
             TempoText* tt = Factory::createTempoText(segment);
             tt->setTempo((double)realTemp / 60);
@@ -1376,11 +1368,6 @@ void GPConverter::addTempoMap()
             _score->setTempo(tick, tt->tempo());
 
             if (_lastGradualTempoChange) {
-                // extend duration until the end of chord
-                if (nextSegment) {
-                    tick = nextSegment->tick();
-                }
-
                 _lastGradualTempoChange->setTick2(tick);
                 GradualTempoChangeType tempoChangeType = GradualTempoChangeType::Undefined;
                 String tempoChangeText;
@@ -1402,12 +1389,6 @@ void GPConverter::addTempoMap()
 
             if (tempIt->second.linear) {
                 GradualTempoChange* tempoChange = Factory::createGradualTempoChange(segment);
-
-                /// if segment was created for tempo, set the tick to closest chordRestSegment
-                if (!existedSegment && closestChordRestSegment) {
-                    tick = closestChordRestSegment->tick();
-                }
-
                 tempoChange->setTick(tick);
                 tempoChange->setTrack(0);
                 _lastGradualTempoChange = tempoChange;


### PR DESCRIPTION
why the fix is reverted:
- it is not needed anymore (bug https://github.com/musescore/MuseScore/issues/12107  cannot be reproduced on this PR)
the problem was that gradual tempo change worked incorrectly when put on segment which doesn't have chord/rest
- it works wrong on some files. On the file attached the "tempo change" is placed after "tempo", as a result played tempo is wrong 
[acceleration.gp.zip](https://github.com/musescore/MuseScore/files/11301768/acceleration.gp.zip)

- code looks unstable and should be rewritten if problem reoccurs
