### PR TITLE
Fix swap with clipboard

### DIFF
--- a/src/engraving/libmscore/paste.cpp
+++ b/src/engraving/libmscore/paste.cpp
@@ -133,11 +133,14 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fractio
             }
         }
         Fraction tickStart = Fraction::fromString(e.attribute("tick"));
-        tickLen       =  Fraction::fromString(e.attribute("len"));
-        Fraction oTickLen =  tickLen;
-        tickLen       *= scale;
-        int staffStart    = e.intAttribute("staff", 0);
-        staves        = e.intAttribute("staves", 0);
+        Fraction oTickLen = Fraction::fromString(e.attribute("len"));
+        tickLen = oTickLen * scale;
+        int staffStart = e.intAttribute("staff", 0);
+        staves = e.intAttribute("staves", 0);
+
+        if (tickLen.isZero() || staves == 0) {
+            break;
+        }
 
         Fraction oEndTick = dstTick + oTickLen;
         auto oSpanner = spannerMap().findContained(dstTick.ticks(), oEndTick.ticks());

--- a/src/engraving/libmscore/select.cpp
+++ b/src/engraving/libmscore/select.cpp
@@ -538,24 +538,31 @@ void Selection::updateSelectedElements()
     if (_state == SelState::RANGE && _plannedTick1 != Fraction(-1, 1) && _plannedTick2 != Fraction(-1, 1)) {
         const staff_idx_t staffStart = _staffStart;
         const staff_idx_t staffEnd = _staffEnd;
+
         deselectAll();
+
         Segment* s1 = _score->tick2segmentMM(_plannedTick1);
-        Segment* s2 = _score->tick2segmentMM(_plannedTick2, /* first */ true);
+        Segment* s2 = _score->tick2segmentMM(_plannedTick2, /* first */ true /* HACK */);
         if (s2 && s2->measure()->isMMRest()) {
-            s2 = s2->prev1MM();       // HACK both this and the previous "true"
+            s2 = s2->prev1MM(); // HACK
         }
-        // are needed to prevent bug #173381.
-        // This should exclude any segments belonging
-        // to MM-rest range from the selection.
+        // These hacks are needed to prevent https://musescore.org/node/173381.
+        // This should exclude any segments belonging to MM-rest range from the selection.
         if (s1 && s2 && s1->tick() + s1->ticks() > s2->tick()) {
-            // can happen with MM rests as tick2measure returns only
-            // the first segment for them.
+            // can happen with MM rests as tick2measure returns only the first segment for them.
+
+            _plannedTick1 = Fraction(-1, 1);
+            _plannedTick2 = Fraction(-1, 1);
             return;
         }
+
         if (s2 && s2 == s2->measure()->first() && !(s2->measure()->prevMeasure() && s2->measure()->prevMeasure()->mmRest1())) {
-            s2 = s2->prev1();         // we want the last segment of the previous measure (unless it's part of a MMrest)
+            // we want the last segment of the previous measure (unless it's part of a MMrest)
+            s2 = s2->prev1();
         }
+
         setRange(s1, s2, staffStart, staffEnd);
+
         _plannedTick1 = Fraction(-1, 1);
         _plannedTick2 = Fraction(-1, 1);
     }

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3622,6 +3622,7 @@ void NotationInteraction::pasteSelection(const Fraction& scale)
         QMimeDataAdapter ma(mimeData);
         score()->cmdPaste(&ma, nullptr, scale);
     }
+
     apply();
 
     checkAndShowMScoreError();
@@ -3646,7 +3647,7 @@ void NotationInteraction::swapSelection()
         int stavesCount = 0;
 
         if (reader.name() == "StaffList") {
-            tickLen = mu::engraving::Fraction::fromTicks(reader.intAttribute("len", 0));
+            tickLen = mu::engraving::Fraction::fromString(reader.attribute("len"));
             stavesCount = reader.intAttribute("staves", 0);
         }
 


### PR DESCRIPTION
Resolves: #17000

The last commit fixes the root cause of why "Swap with clipboard" itself didn't work, but the other two commits fix the other problem that became apparent because of this bug, namely the inability to create range selections after pasting a zero-length range.