### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -1093,8 +1093,6 @@ void PlaybackController::setupSequenceTracks()
 
 void PlaybackController::setupSequencePlayer()
 {
-    PlaybackCursorType cursorType = configuration()->cursorType();
-
     playback()->player()->playbackPositionMsecs().onReceive(
         this, [this](const TrackSequenceId id, const audio::msecs_t& msecs) {
         if (m_currentSequenceId != id) {


### PR DESCRIPTION
reg. local variable is initialized but not referenced (C4189)