### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/engraving/rw/400/connectorinforeader.cpp
+++ b/src/engraving/rw/400/connectorinforeader.cpp
@@ -176,6 +176,9 @@ void ConnectorInfoReader::addToScore(bool pasteMode)
     }
     while (r) {
         bool found = ReadAddConnectorVisitor::visit(ReadAddConnectorTypes {}, r->_connectorReceiver, r, pasteMode);
+#ifdef NDEBUG // avoid compiler warning
+        (void)(found);
+#endif
         assert(found);
         r = r->next();
     }


### PR DESCRIPTION
reg. local variable is initialized but not referenced (C4189), seen when not in a Debug build