### PR TITLE
fix [MU4 Issue] Augmentation dot shortcut doesn't work while editing …

### DIFF
--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -2154,7 +2154,7 @@ const UiActionList NotationUiActions::m_actions = {
              ),
     UiAction("pad-dot",
              mu::context::UiCtxNotationOpened,
-             mu::context::CTX_NOTATION_NOT_NOTE_INPUT_STAFF_TAB,
+             mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "Augmentation dot"),
              TranslatableString("action", "Toggle duration dot"),
              IconCode::Code::NOTE_DOTTED


### PR DESCRIPTION
Resolves: #14574 

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
