### PR TITLE
Fix #17287: Division by 0 causes crash

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -1853,6 +1853,7 @@ Shape BeamSegment::shape() const
     // If not, break the beam shape into multiple rectangles
     double beamHeightDiff = endPoint.y() - startPoint.y();
     int subBoxesCount = floor(beamHorizontalLength / parentElement->spatium());
+    subBoxesCount = std::max(subBoxesCount, 1); // at least one rectangle, of course (avoid division by zero)
     double horizontalStep = beamHorizontalLength / subBoxesCount;
     double verticalStep = beamHeightDiff / subBoxesCount;
     std::vector<PointF> pointsOnBeamLine;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/17287

The new shape calculation for slanted beams splits them up into 1sp-length blocks, but would go crazy when the beamlet in a grace note would have a length of <1sp, making the number of blocks 0, and then later on that divides the space to create a gradient.

Now the number of blocks for any beam segment is 1.