### PR TITLE
Fix that channels in `_midiMapping` got out of sync with channels in `Parts`

### DIFF
--- a/src/engraving/rw/400/tread.cpp
+++ b/src/engraving/rw/400/tread.cpp
@@ -21,8 +21,6 @@
  */
 #include "tread.h"
 
-#include "global/defer.h"
-
 #include "../../types/typesconv.h"
 #include "../../types/symnames.h"
 #include "../../infrastructure/rtti.h"
@@ -914,9 +912,6 @@ bool TRead::readProperties(Instrument* item, XmlReader& e, Part* part, bool* cus
 void TRead::read(InstrChannel* item, XmlReader& e, Part* part, const InstrumentTrackId& instrId)
 {
     item->setNotifyAboutChangedEnabled(false);
-    DEFER {
-        item->setNotifyAboutChangedEnabled(true);
-    };
 
     // synti = 0;
     item->setName(e.attribute("name"));
@@ -1003,6 +998,8 @@ void TRead::read(InstrChannel* item, XmlReader& e, Part* part, const InstrumentT
     if (e.context()) {
         e.context()->addPartAudioSettingCompat(partAudioSetting);
     }
+
+    item->setNotifyAboutChangedEnabled(true);
 
     if ((midiPort != -1 || midiChannel != -1) && part && part->score()->isMaster()) {
         part->masterScore()->addMidiMapping(item, part, midiPort, midiChannel);


### PR DESCRIPTION
The MasterScore stores `InstrChannel`s in its `_midiMapping` field, and the `Instrument`s stored by the `Part`s also store `InstrChannel`s. The data of these `InstrChannel`s is synchronised from the `_midiMapping`'s `InstrChannel`s to the `Part`s' `InstrChannel`s.

In the old reading code for `InstrChannel`, the member fields would be set directly. But in the new code, we have to call the `set…` methods. But these methods normally emit the notification to sync with the other `InstrChannel`. To emulate the behaviour of the old code, we temporarily disable this notification. But we re-enable it too late, namely at the end of the method. This means that when `MasterScore::addMidiMapping` is called, which copies the `InstrChannel`, the notification is still disabled, so in the copy it will be disabled too, and will never be enabled again. And the synchronisation is supposed to go from the copy to the "original", so because the copy will never emit any notification, the synchronisation won't happen. This causes things to get out of sync, which causes a crash much later, as described in #17387. This crash happened in `int MasterScore::updateMidiMapping()`, due to reading out of bounds.

Resolves: #17387