### PR TITLE
Fix #10403: Moving same-beat notes between strings

### DIFF
--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -1646,6 +1646,14 @@ void Score::upDown(bool up, UpDownMode mode)
 {
     std::list<Note*> el = selection().uniqueNotes();
 
+    el.sort([up](Note* a, Note* b) {
+        if (up) {
+            return a->string() < b->string();
+        } else {
+            return a->string() > b->string();
+        }
+    });
+
     for (Note* oNote : el) {
         Fraction tick     = oNote->chord()->tick();
         Staff* staff = oNote->staff();


### PR DESCRIPTION
Sort the notes by string, so that moved notes don't block each other.

Resolves: #10403 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

Moving same-beat notes between strings currently depends on selection order.
We first try to move the notes that are selected first, resulting in conflicts when moving chords.

By sorting the notes by string, we ensure that the notes of a chord won't block each other if a move is possible.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
