### PR TITLE
Init popup close controller *properly*

### DIFF
--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -159,6 +159,11 @@ void PopupView::initCloseController()
 
     m_closeController->init();
 
+    m_closeController->setParentItem(parentItem());
+    m_closeController->setWindow(window());
+    m_closeController->setPopupHasFocus(m_openPolicy != OpenPolicy::NoActivateFocus);
+    m_closeController->setIsCloseOnPressOutsideParent(m_closePolicy == CloseOnPressOutsideParent);
+
     m_closeController->closeNotification().onNotify(this, [this]() {
         close(true);
     });
@@ -240,9 +245,6 @@ void PopupView::open()
             initCloseController();
         }
 
-        m_closeController->setParentItem(parentItem());
-        m_closeController->setWindow(window());
-        m_closeController->setIsCloseOnPressOutsideParent(m_closePolicy == CloseOnPressOutsideParent);
         m_closeController->setActive(true);
     }
 


### PR DESCRIPTION
In #17268, we delayed the initialisation of the PopupView's CloseController until *after* PopupView's constructor, so that we can check if it is a popup or a dialog, and only use the CloseController when it is a popup.

This revealed that when initialising the CloseController, we were forgetting to set some of its properties.

Why it *did* work before that PR? That was because we *do* update the properties of the CloseController at the moment that the properties of the PopupView are updated. That happens very early, so acted as a replacement for setting all properties correctly during initialisation. But after the PR, the CloseController is not yet initialised at that moment, so the properties would not be set at all.

Resolves: #15481 
Resolves: #17352 