### PR TITLE
[MusicXML] Apply fix for #10103 to all non-native imported files

### DIFF
--- a/src/importexport/bww/internal/bww/importbww.cpp
+++ b/src/importexport/bww/internal/bww/importbww.cpp
@@ -554,7 +554,7 @@ Err importBww(MasterScore* score, const QString& path)
     if (!fp.open(QIODevice::ReadOnly)) {
         return engraving::Err::FileOpenError;
     }
-
+    score->checkChordList();
     Part* part = new Part(score);
     score->appendPart(part);
     Staff* staff = Factory::createStaff(part);

--- a/src/importexport/capella/internal/capella.cpp
+++ b/src/importexport/capella/internal/capella.cpp
@@ -2826,6 +2826,7 @@ Err importCapella(MasterScore* score, const QString& name)
         return Err::NoError;
     }
     fp.close();
+    score->checkChordList(); // make sure chordList is populated so we can import harmony objects
     convertCapella(score, &cf, false);
     return Err::NoError;
 }

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -2949,7 +2949,6 @@ static Err importScore(MasterScore* score, mu::io::IODevice* io)
     }
 
     score->loadStyle(u":/engraving/styles/gp-style.mss");
-
     score->checkChordList();
     io->seek(0);
     char header[5];

--- a/src/importexport/midi/internal/midiimport/importmidi.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi.cpp
@@ -1282,7 +1282,7 @@ Err importMidi(MasterScore* score, const QString& name)
         loadMidiData(mf);
         opers.setMidiFileData(name, mf);
     }
-
+    score->checkChordList();
     opers.data()->tracks = convertMidi(score, opers.midiFile(name));
     ++opers.data()->processingsOfOpenedFile;
 

--- a/src/importexport/musicxml/internal/musicxml/importmxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxml.cpp
@@ -74,6 +74,7 @@ Err importMusicXMLfromBuffer(Score* score, const QString& /*name*/, QIODevice* d
     const auto pass1_errors = pass1.errors();
 
     // pass 2
+    score->checkChordList(); // chordList is necessary to import harmony objects
     MusicXMLParserPass2 pass2(score, pass1, &logger);
     if (res == Err::NoError) {
         dev->seek(0);

--- a/src/importexport/ove/internal/importove.cpp
+++ b/src/importexport/ove/internal/importove.cpp
@@ -2533,6 +2533,7 @@ Err importOve(MasterScore* score, const QString& name)
     oveLoader->release();
 
     if (result) {
+        score->checkChordList(); // must make sure the chord list isn't empty so harmony objects import nicely
         OveToMScore otm;
         otm.convert(&oveSong, score);
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/13214

There was an issue (https://github.com/musescore/MuseScore/issues/10103) about chord symbols being mangled in version 4.0 of MuseScore. It was fixed by PR https://github.com/musescore/MuseScore/pull/10113 by adding an explicit call to `score->checkChordList()` for 4.0 scores. The issue at hand appears to be the exact issue that the PR fixed, so this PR follows in its footsteps by adding an explicit call to `checkChordList` in all cases of XML import.
