### PR TITLE
fix Ctrl+Left/Right for chord symbols & figured bass

### DIFF
--- a/src/engraving/libmscore/figuredbass.cpp
+++ b/src/engraving/libmscore/figuredbass.cpp
@@ -1080,6 +1080,10 @@ bool FiguredBass::isEditAllowed(EditData& ed) const
         return false;
     }
 
+    if ((ed.key == Key_Left || ed.key == Key_Right) && (ed.modifiers & ControlModifier)) {
+        return false;
+    }
+
     return TextBase::isEditAllowed(ed);
 }
 

--- a/src/engraving/libmscore/harmony.cpp
+++ b/src/engraving/libmscore/harmony.cpp
@@ -693,6 +693,10 @@ bool Harmony::isEditAllowed(EditData& ed) const
         return false;
     }
 
+    if ((ed.key == Key_Left || ed.key == Key_Right) && (ed.modifiers & ControlModifier)) {
+        return false;
+    }
+
     if (ed.key == Key_Return || ed.key == Key_Enter) {
         // This "edit" is actually handled in NotationInteraction::editElement
         return true;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/15719

Handle Ctrl+Left/Right navigation in isEditAllowed() for harmony and figured bass

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
