### PR TITLE
fix drum palette / concert pitch bug (DRAFT)

### DIFF
--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -1524,7 +1524,7 @@ void Note::setupAfterRead(const Fraction& ctxTick, bool pasteMode)
     // but since there are other causes of tpc corruption (eg, https://musescore.org/en/node/74746)
     // including perhaps some we don't know about yet,
     // we will attempt to fix some problems here regardless of version
-
+#if 0
     if (staff() && !staff()->isDrumStaff(ctxTick) && !pasteMode && !MScore::testMode) {
         int tpc1Pitch = (tpc2pitch(_tpc[0]) + 12) % 12;
         int tpc2Pitch = (tpc2pitch(_tpc[1]) + 12) % 12;
@@ -1552,7 +1552,7 @@ void Note::setupAfterRead(const Fraction& ctxTick, bool pasteMode)
             }
         }
     }
-
+#endif
     for (EngravingItem* item : _el) {
         if (!item->isSymbol()) {
             continue;

--- a/src/palette/view/widgets/drumsetpalette.cpp
+++ b/src/palette/view/widgets/drumsetpalette.cpp
@@ -196,7 +196,7 @@ void DrumsetPalette::previewSound(const Chord* chord, bool newChordSelected, con
 
     Chord* preview = chord->clone();
     preview->setParent(inputState.segment);
-    preview->setScore(inputState.staff.score());
+    preview->setScore(inputState.staff->score());
     preview->setStaffIdx(engraving::track2staff(inputState.currentTrack));
 
     playback()->playElements({ preview });

--- a/src/palette/view/widgets/drumsetpalette.cpp
+++ b/src/palette/view/widgets/drumsetpalette.cpp
@@ -196,6 +196,7 @@ void DrumsetPalette::previewSound(const Chord* chord, bool newChordSelected, con
 
     Chord* preview = chord->clone();
     preview->setParent(inputState.segment);
+    preview->setScore(inputState.staff.score());
     preview->setStaffIdx(engraving::track2staff(inputState.currentTrack));
 
     playback()->playElements({ preview });


### PR DESCRIPTION
Resolves: #15866

A similar issue in 3.x was fixed in a way that seems incomplete.  This is a trial PR to see if the underlying issue is actually the same by disabling the relevant code, which was needed only to auto-fix certain corrupt scores.  If this is indeed the culprit, then a more complete fix can be developed.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [ ] I signed the [CLA](https://musescore.org/en/cla)
- [ ] The title of the PR describes the problem it addresses
- [ ] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [ ] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ ] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
