### PR TITLE
Converter. Fixed backslashes in path for Windows

### DIFF
--- a/src/app/commandlineparser.cpp
+++ b/src/app/commandlineparser.cpp
@@ -21,6 +21,7 @@
  */
 #include "commandlineparser.h"
 
+#include "global/io/dir.h"
 #include "global/muversion.h"
 
 #include "log.h"
@@ -169,7 +170,14 @@ void CommandLineParser::parse(int argc, char** argv)
         return std::nullopt;
     };
 
-    QStringList scorefiles = m_parser.positionalArguments();
+    auto fromUserInputPath = [](const QString& path) -> QString {
+        return io::Dir::fromNativeSeparators(path).toQString();
+    };
+
+    QStringList scorefiles;
+    for (const QString& arg : m_parser.positionalArguments()) {
+        scorefiles << fromUserInputPath(arg);
+    }
 
     if (m_parser.isSet("long-version")) {
         printLongVersion();
@@ -199,7 +207,7 @@ void CommandLineParser::parse(int argc, char** argv)
     }
 
     if (m_parser.isSet("M")) {
-        m_options.importMidi.operationsFile = m_parser.value("M").toStdString();
+        m_options.importMidi.operationsFile = fromUserInputPath(m_parser.value("M"));
     }
 
     if (m_parser.isSet("b")) {
@@ -225,14 +233,14 @@ void CommandLineParser::parse(int argc, char** argv)
 
     if (m_parser.isSet("register-audio-plugin")) {
         m_runMode = IApplication::RunMode::AudioPluginRegistration;
-        m_audioPluginRegistration.pluginPath = m_parser.value("register-audio-plugin");
+        m_audioPluginRegistration.pluginPath = fromUserInputPath(m_parser.value("register-audio-plugin"));
         m_audioPluginRegistration.failedPlugin = false;
     }
 
     if (m_parser.isSet("register-failed-audio-plugin")) {
         QStringList args1 = m_parser.positionalArguments();
         m_runMode = IApplication::RunMode::AudioPluginRegistration;
-        m_audioPluginRegistration.pluginPath = m_parser.value("register-failed-audio-plugin");
+        m_audioPluginRegistration.pluginPath = fromUserInputPath(m_parser.value("register-failed-audio-plugin"));
         m_audioPluginRegistration.failedPlugin = true;
         m_audioPluginRegistration.failCode = !args1.empty() ? args1[0].toInt() : -1;
     }
@@ -257,7 +265,7 @@ void CommandLineParser::parse(int argc, char** argv)
                 LOGW() << "Option: -o multiple input files specified; processing only the first one";
             }
             m_converterTask.inputFile = scorefiles[0];
-            m_converterTask.outputFile = m_parser.value("o");
+            m_converterTask.outputFile = fromUserInputPath(m_parser.value("o"));
         }
     }
 
@@ -272,7 +280,7 @@ void CommandLineParser::parse(int argc, char** argv)
     if (m_parser.isSet("j")) {
         m_runMode = IApplication::RunMode::ConsoleApp;
         m_converterTask.type = ConvertType::Batch;
-        m_converterTask.inputFile = m_parser.value("j");
+        m_converterTask.inputFile = fromUserInputPath(m_parser.value("j"));
     }
 
     if (m_parser.isSet("score-media")) {
@@ -280,7 +288,8 @@ void CommandLineParser::parse(int argc, char** argv)
         m_converterTask.type = ConvertType::ExportScoreMedia;
         m_converterTask.inputFile = scorefiles[0];
         if (m_parser.isSet("highlight-config")) {
-            m_converterTask.params[CommandLineParser::ParamKey::HighlightConfigPath] = m_parser.value("highlight-config");
+            m_converterTask.params[CommandLineParser::ParamKey::HighlightConfigPath]
+                = fromUserInputPath(m_parser.value("highlight-config"));
         }
     }
 
@@ -314,7 +323,7 @@ void CommandLineParser::parse(int argc, char** argv)
 
         m_runMode = IApplication::RunMode::ConsoleApp;
         m_converterTask.type = ConvertType::SourceUpdate;
-        m_converterTask.inputFile = args2[0];
+        m_converterTask.inputFile = fromUserInputPath(args2[0]);
 
         if (args2.size() >= 2) {
             m_converterTask.params[CommandLineParser::ParamKey::ScoreSource] = args2[1];
@@ -329,7 +338,7 @@ void CommandLineParser::parse(int argc, char** argv)
         m_runMode = IApplication::RunMode::ConsoleApp;
         m_converterTask.type = ConvertType::ExportScoreVideo;
         m_converterTask.inputFile = scorefiles[0];
-        m_converterTask.outputFile = m_parser.value("o");
+        m_converterTask.outputFile = fromUserInputPath(m_parser.value("o"));
 
         if (m_parser.isSet("view-mode")) {
             NOT_IMPLEMENTED;
@@ -370,7 +379,7 @@ void CommandLineParser::parse(int argc, char** argv)
     }
 
     if (m_parser.isSet("S")) {
-        m_converterTask.params[CommandLineParser::ParamKey::StylePath] = m_parser.value("S");
+        m_converterTask.params[CommandLineParser::ParamKey::StylePath] = fromUserInputPath(m_parser.value("S"));
     }
 
     if (m_parser.isSet("gp-linked")) {
@@ -420,11 +429,11 @@ void CommandLineParser::parse(int argc, char** argv)
     // Autobot
     if (m_parser.isSet("test-case")) {
         m_runMode = IApplication::RunMode::ConsoleApp;
-        m_autobot.testCaseNameOrFile = m_parser.value("test-case");
+        m_autobot.testCaseNameOrFile = fromUserInputPath(m_parser.value("test-case"));
     }
 
     if (m_parser.isSet("test-case-context")) {
-        m_autobot.testCaseContextNameOrFile = m_parser.value("test-case-context");
+        m_autobot.testCaseContextNameOrFile = fromUserInputPath(m_parser.value("test-case-context"));
     }
 
     if (m_parser.isSet("test-case-context-value")) {

--- a/src/converter/internal/convertercontroller.cpp
+++ b/src/converter/internal/convertercontroller.cpp
@@ -27,8 +27,10 @@
 #include <QJsonArray>
 #include <QJsonParseError>
 
-#include "convertercodes.h"
+#include "io/dir.h"
 #include "stringutils.h"
+
+#include "convertercodes.h"
 #include "compat/backendapi.h"
 
 #include "log.h"
@@ -151,12 +153,16 @@ mu::RetVal<ConverterController::BatchJob> ConverterController::parseBatchJob(con
 
     QJsonArray arr = doc.array();
 
+    auto correctUserInputPath = [](const QString& path) -> QString {
+        return io::Dir::fromNativeSeparators(path).toQString();
+    };
+
     for (const QJsonValue v : arr) {
         QJsonObject obj = v.toObject();
 
         Job job;
-        job.in = obj["in"].toString();
-        job.out = obj["out"].toString();
+        job.in = correctUserInputPath(obj["in"].toString());
+        job.out = correctUserInputPath(obj["out"].toString());
 
         if (!job.in.empty() && !job.out.empty()) {
             rv.val.push_back(std::move(job));


### PR DESCRIPTION
If you invoke MuseScore with paths containing backslashes, the file writing in mscz format may be incorrect (see screenshot). 
`.\MuseScore 4.exe' C:\Users\elnur\Downloads\River_Flows_In_You.mxl -o C:\Users\elnur\Downloads\River_Flows_In_You.mscz`

This is because the paths contain backslashes and some algorithms interpret this as escaping special characters. (in our case it is QFileInfo::completeBaseName())

Solution: correct the paths when parsing the command line.

![image](https://user-images.githubusercontent.com/10116828/236148359-bae2d0df-b98a-4fa0-b792-bae37c183b4d.png)
