### PR TITLE
Cross-staff and manually-adjusted two-note trem stem fixes

### DIFF
--- a/src/engraving/layout/layoutmeasure.cpp
+++ b/src/engraving/layout/layoutmeasure.cpp
@@ -788,23 +788,6 @@ void LayoutMeasure::getNextMeasure(const LayoutOptions& options, LayoutContext& 
                         chord->computeUp();
                         chord->layoutStem();               // create stems needed to calculate spacing
                                                            // stem direction can change later during beam processing
-
-                        // if there is a two-note tremolo attached, and it is too steep,
-                        // extend stem of one of the chords (if not cross-staff)
-                        // or extend both stems (if cross-staff)
-                        // this should be done after the stem lengths of two notes are both calculated
-                        if (chord->tremolo() && chord == chord->tremolo()->chord2()) {
-                            Stem* stem1 = chord->tremolo()->chord1()->stem();
-                            Stem* stem2 = chord->tremolo()->chord2()->stem();
-                            if (stem1 && stem2) {
-                                std::pair<double, double> extendedLen = LayoutTremolo::extendedStemLenWithTwoNoteTremolo(
-                                    chord->tremolo(),
-                                    stem1->p2().y(),
-                                    stem2->p2().y());
-                                stem1->setBaseLength(Millimetre(extendedLen.first));
-                                stem2->setBaseLength(Millimetre(extendedLen.second));
-                            }
-                        }
                     }
                     cr->setMag(m);
                     cr->setBeamlet(nullptr); // Will be defined during beam layout

--- a/src/engraving/libmscore/skyline.cpp
+++ b/src/engraving/libmscore/skyline.cpp
@@ -26,6 +26,7 @@
 #include "beam.h"
 #include "chord.h"
 #include "stem.h"
+#include "tremolo.h"
 
 #include "draw/painter.h"
 
@@ -61,14 +62,23 @@ void Skyline::add(const ShapeElement& r)
         Chord* chord = toStem(item)->chord();
         if (chord) {
             Beam* beam = chord->beam();
-            if (beam && beam->cross()) {
+            Tremolo* tremolo = chord->tremolo();
+            bool isCross = (beam && beam->cross())
+                           || (tremolo && tremolo->twoNotes() && tremolo->chord1()->staffMove() != tremolo->chord2()->staffMove());
+            if (isCross) {
+                std::vector<ChordRest*> elements;
+                if (beam) {
+                    elements = beam->elements();
+                } else if (tremolo) {
+                    elements = { tremolo->chord1(), tremolo->chord2() };
+                }
                 int thisStaffMove = chord->staffMove();
                 if (thisStaffMove < 0) {
                     crossNorth = true;
                 } else if (thisStaffMove > 0) {
                     crossSouth = true;
                 }
-                for (ChordRest* element : beam->elements()) {
+                for (ChordRest* element : elements) {
                     int staffMove = element->staffMove();
                     if (staffMove < thisStaffMove) {
                         crossNorth = true;

--- a/src/engraving/libmscore/tremolo.cpp
+++ b/src/engraving/libmscore/tremolo.cpp
@@ -170,7 +170,7 @@ void Tremolo::createBeamSegments()
         for (ChordRest* cr : { _chord1, _chord2 }) {
             Chord* chord = toChord(cr);
             double addition = 0.0;
-            if (cross && cr->staffMove() != 0 && lines() > 1) {
+            if (cr->up() != _up && lines() > 1) {
                 // need to adjust further for beams on the opposite side
                 addition += (lines() - 1.) * beamSpacing / 4. * spatium() * mag();
             }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/89263931/236975134-d9e4585e-2698-49d0-b37c-eb5e0f90be7c.png)
Stems weren't extending far enough in situations where the stems go in opposite directions (i.e. cross-staff and manual adjust). That has been fixed.

There was also an issue with cross-staff stems being added to the skyline, which caused the staves to move apart when the trem was adjusted:
![image](https://user-images.githubusercontent.com/89263931/236975328-6a6717ed-b640-4556-af03-a4bcfb7f9d8c.png)

That's been fixed now.
![image](https://user-images.githubusercontent.com/89263931/236975399-cfa8a8f0-e9c6-4431-95c3-a77de2f3f2b5.png)

There is one more issue that I honestly am just 100% flummoxed by, and that's the fact that *something* in the stem length calculations for cross-staff trems is setting the stem the wrong length and causing the stem to flip at the point where the default stem length would be, rather than the notehead. From what I can tell the beam and trem layout code is essentially identical so this has to be some really deep-seated logic somewhere in the layout code that deals with stems like that but I have no idea why or where.
![image](https://user-images.githubusercontent.com/89263931/236976227-a38fbb9a-9990-405a-b2bb-2903a749561d.png)

If anyone has any ideas about this problem whatsoever I'd really love to hear them. I mean, all of the stem direction detection and stuff between two-note trems and regular cross-staff beams is essentially the same logic. I'm stumped.