### PR TITLE
Fix FileIO::write in Plugin API

### DIFF
--- a/src/plugins/api/util.cpp
+++ b/src/plugins/api/util.cpp
@@ -88,7 +88,11 @@ bool FileIO::write(const QString& data)
         return false;
     }
 
-    QFile file(mSource);
+    QUrl url(mSource);
+
+    QString source = (url.isValid() && url.isLocalFile()) ? url.toLocalFile() : mSource;
+
+    QFile file(source);
     if (!file.open(QFile::WriteOnly | QFile::Truncate)) {
         return false;
     }


### PR DESCRIPTION
Minimal plugin example to test writing to a file:

```QML
import QtQuick 2.2
import MuseScore 3.0
import FileIO 3.0

MuseScore {
    title: "Save hello.txt to /tmp"
    description: qsTr("Saves file hello.txt to /tmp or %LocalAppData%\Temp.")
    version: "1.0"

    onRun: {
        outputFile.write("Hello, world!");
    }

    FileIO {
        id: outputFile
        source: tempPath() + "/hello.txt"
    }
}
```