### PR TITLE
fix #14230: Replace the used instrument id by the correct family name.

### DIFF
--- a/share/instruments/orders.xml
+++ b/share/instruments/orders.xml
@@ -180,7 +180,7 @@
             <family>voice-groups</family>
         </section>
         <section id="guitars" thinBrackets="false">
-            <family>plucked-strings</family>
+            <family>guitars</family>
         </section>
         <family>drums</family>
         <unsorted/>


### PR DESCRIPTION
Resolves: #14230 

The `family` tag in `orders.xml` should refer to a corresponding `family` tag in `instruments.xml` (or defined in the `Order` section itself) but it was referring to an `instrument id`. 
I checked `orders.xml` for similar typos but this was the only one I found.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
