### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/engraving/libmscore/textedit.cpp
+++ b/src/engraving/libmscore/textedit.cpp
@@ -731,7 +731,7 @@ void ChangeText::removeText(EditData* ed)
     TextCursor tc = _cursor;
     TextBlock& l  = _cursor.curLine();
     size_t column = _cursor.column();
-    format = *l.formatAt(column + s.size() - 1);
+    format = *l.formatAt(static_cast<int>(column + s.size()) - 1);
 
     for (size_t n = 0; n < s.size(); ++n) {
         l.remove(static_cast<int>(column), &_cursor);


### PR DESCRIPTION
reg. conversion from 'size_t' to 'int', possible loss of data (C4267)