### PR TITLE
Improved migration of old expressions to new Expression items

### DIFF
--- a/src/engraving/libmscore/dynamic.cpp
+++ b/src/engraving/libmscore/dynamic.cpp
@@ -48,16 +48,8 @@ namespace mu::engraving {
 //    see: http://en.wikipedia.org/wiki/File:Dynamic's_Note_Velocity.svg
 //-----------------------------------------------------------------------------
 
-struct Dyn {
-    DynamicType type;
-    int velocity;        ///< associated midi velocity (0-127, -1 = none)
-    int changeInVelocity;
-    bool accent;         ///< if true add velocity to current chord velocity
-    const char* text;    // utf8 text of dynamic
-};
-
 // variant with ligatures, works for both emmentaler and bravura:
-static Dyn dynList[] = {
+const std::vector<Dyn> Dynamic::dynList = {
     // dynamic:
     { DynamicType::OTHER,  -1, 0,   true, "" },
     { DynamicType::PPPPPP,  1, 0,   false,
@@ -399,7 +391,7 @@ void Dynamic::manageBarlineCollisions()
 void Dynamic::setDynamicType(const String& tag)
 {
     std::string utf8Tag = tag.toStdString();
-    int n = sizeof(dynList) / sizeof(*dynList);
+    size_t n = dynList.size();
     for (int i = 0; i < n; ++i) {
         if (TConv::toXml(DynamicType(i)).ascii() == utf8Tag || dynList[i].text == utf8Tag) {
             setDynamicType(DynamicType(i));

--- a/src/engraving/libmscore/dynamic.h
+++ b/src/engraving/libmscore/dynamic.h
@@ -29,6 +29,14 @@ namespace mu::engraving {
 class Measure;
 class Segment;
 
+struct Dyn {
+    DynamicType type;
+    int velocity;        ///< associated midi velocity (0-127, -1 = none)
+    int changeInVelocity;
+    bool accent;         ///< if true add velocity to current chord velocity
+    const char* text;    // utf8 text of dynamic
+};
+
 //-----------------------------------------------------------------------------
 //   @@ Dynamic
 ///    dynamics marker; determines midi velocity
@@ -103,6 +111,8 @@ public:
     bool acceptDrop(EditData& ed) const override;
     EngravingItem* drop(EditData& ed) override;
 
+    static const std::vector<Dyn>& dynamicList() { return dynList; }
+
 private:
 
     friend class layout::v0::TLayout;
@@ -122,6 +132,8 @@ private:
     DynamicSpeed _velChangeSpeed         { DynamicSpeed::NORMAL };
 
     mu::RectF drag(EditData&) override;
+
+    static const std::vector<Dyn> dynList;
 };
 } // namespace mu::engraving
 

--- a/src/engraving/rw/114/read114.cpp
+++ b/src/engraving/rw/114/read114.cpp
@@ -3163,10 +3163,6 @@ Err Read114::read(Score* score, XmlReader& e, ReadInOutData* out)
     masterScore->rebuildMidiMapping();
     masterScore->updateChannel();
 
-    for (Score* s : masterScore->scoreList()) {
-        CompatUtils::replaceStaffTextWithPlayTechniqueAnnotation(s);
-    }
-
     CompatUtils::assignInitialPartToExcerpts(masterScore->excerpts());
 
     return Err::NoError;

--- a/src/engraving/rw/206/read206.cpp
+++ b/src/engraving/rw/206/read206.cpp
@@ -3368,8 +3368,6 @@ bool Read206::readScore206(Score* score, XmlReader& e, ReadContext& ctx)
         ms->updateChannel();
     }
 
-    CompatUtils::replaceStaffTextWithPlayTechniqueAnnotation(score);
-
     if (score->isMaster()) {
         CompatUtils::assignInitialPartToExcerpts(score->masterScore()->excerpts());
     }

--- a/src/engraving/rw/302/read302.cpp
+++ b/src/engraving/rw/302/read302.cpp
@@ -255,8 +255,6 @@ bool Read302::readScore302(Score* score, XmlReader& e, ReadContext& ctx)
         staff->updateOttava();
     }
 
-    CompatUtils::replaceStaffTextWithPlayTechniqueAnnotation(score);
-
     if (score->isMaster()) {
         CompatUtils::assignInitialPartToExcerpts(score->masterScore()->excerpts());
     }

--- a/src/engraving/rw/400/measurerw.cpp
+++ b/src/engraving/rw/400/measurerw.cpp
@@ -519,21 +519,10 @@ void MeasureRW::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, int 
             StaffText* el = Factory::createStaffText(segment);
             el->setTrack(ctx.track());
             TRead::read(el, e, ctx);
-            if (el->textStyleType() != TextStyleType::EXPRESSION) {
-                if (el->systemFlag() && el->isTopSystemObject()) {
-                    el->setTrack(0); // original system object always goes on top
-                }
-                segment->add(el);
-            } else {
-                // Starting from version 4.1, Expressions have their own class.
-                // Map "old" expression objects into the "new" expression object.
-                Expression* expression = Factory::createExpression(segment);
-                expression->setTrack(ctx.track());
-                expression->setXmlText(el->xmlText());
-                expression->mapPropertiesFromOldExpressions(el);
-                segment->add(expression);
-                delete el;
+            if (el->systemFlag() && el->isTopSystemObject()) {
+                el->setTrack(0);     // original system object always goes on top
             }
+            segment->add(el);
         } else if (tag == "Sticking"
                    || tag == "SystemText"
                    || tag == "PlayTechAnnotation"

--- a/src/engraving/rw/compat/compatutils.h
+++ b/src/engraving/rw/compat/compatutils.h
@@ -28,6 +28,8 @@ namespace mu::engraving {
 class Score;
 class MasterScore;
 class Excerpt;
+class Dynamic;
+enum class DynamicType : char;
 }
 
 namespace mu::engraving::compat {
@@ -35,9 +37,12 @@ class CompatUtils
 {
 public:
     static void doCompatibilityConversions(MasterScore* masterScore);
-    static void replaceStaffTextWithPlayTechniqueAnnotation(Score* score);
+    static void replaceStaffTextWithPlayTechniqueAnnotation(MasterScore* score);
     static void assignInitialPartToExcerpts(const std::vector<Excerpt*>& excerpts);
     static void replaceOldWithNewOrnaments(MasterScore* score);
+    static void replaceOldWithNewExpressions(MasterScore* score);
+    static void reconstructTypeOfCustomDynamics(MasterScore* score);
+    static DynamicType reconstructDynamicTypeFromString(Dynamic* dynamic);
 };
 }
 #endif // MU_ENGRAVING_COMPATUTILS_H

--- a/src/engraving/tests/compat206_data/textstyles-ref.mscx
+++ b/src/engraving/tests/compat206_data/textstyles-ref.mscx
@@ -302,7 +302,8 @@
       <Measure>
         <voice>
           <Dynamic>
-            <subtype>other-dynamics</subtype>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
             <text>dyn <sym>dynamicForte</sym></text>
             </Dynamic>
           <Rest>
@@ -399,10 +400,10 @@
         </Measure>
       <Measure>
         <voice>
-          <StaffText>
-            <style>expression</style>
+          <Expression>
+            <placement>above</placement>
             <text>technique</text>
-            </StaffText>
+            </Expression>
           <Rest>
             <durationType>measure</durationType>
             <duration>4/4</duration>


### PR DESCRIPTION
Resolves: #17404 

Please merge #17515 before this. This branch is based onto that because I needed some things I've built there. Only the last commit is relevant to resolving the linked issue here. By the way, as @cbjeukendrup pointed out, the migration of play technique items is also not optimal, as it doesn't preserve linking in parts, so that as well may need a similar solution to this, at some point.

The best way to test this PR (besides verifying that it doesn't crash anymore on opening that file) is to create a file in 4.0 with lots of different expressions in score and parts and check that they are all mapped correctly and they stay linked.