### PR TITLE
Fix crash and incorrect layout

### DIFF
--- a/src/engraving/layout/layoutsystem.cpp
+++ b/src/engraving/layout/layoutsystem.cpp
@@ -525,7 +525,7 @@ void LayoutSystem::justifySystem(System* system, double curSysWidth, double targ
             continue;
         }
         for (Segment& s : toMeasure(mb)->segments()) {
-            if (s.isChordRestType() && s.visible() && s.enabled() && !s.allElementsInvisible()) {
+            if (s.isChordRestType() && s.ticks() > Fraction(0, 1) && s.visible() && s.enabled() && !s.allElementsInvisible()) {
                 double springConst = 1 / s.stretch();
                 double width = s.width() - s.widthOffset();
                 double preTension = width * springConst;

--- a/src/engraving/layout/tlayout.cpp
+++ b/src/engraving/layout/tlayout.cpp
@@ -1399,6 +1399,10 @@ void TLayout::layout(Dynamic* item, LayoutContext& ctx)
         break;
     }
 
+    if (!itemToAlign) {
+        return;
+    }
+
     if (!itemToAlign->isChord()) {
         item->movePosX(itemToAlign->width() * 0.5);
         return;


### PR DESCRIPTION
Resolves: #17517

The crash was due to a forgotten nullcheck.

The horizontal justification error occurs because there exists a Segment of ChordRest-type with duration = 0 (which shouldn't be there). In turn, the reason why that segment exists is that it holds the "p" dynamic in the second to last measure, Cymbal staff. I don't think this state can be reached by editing in Musescore, so I would assume that the problem is migration-induced. It would probably need some more investigation. Anyway, I've inserted a check to ignore these spurious segments, which protects the layout.

