### PR TITLE
Fix crash introduced by GH#17531

### DIFF
--- a/src/engraving/libmscore/transpose.cpp
+++ b/src/engraving/libmscore/transpose.cpp
@@ -429,6 +429,9 @@ bool Score::transpose(TransposeMode mode, TransposeDirection direction, Key trKe
     }
 
     Segment* s1 = _selection.startSegment();
+    if (!s1) {
+        return result;
+    }
     // if range start on mmRest, get the actual segment instead
     if (s1->measure()->isMMRest()) {
         s1 = tick2segment(s1->tick(), true, s1->segmentType(), false);


### PR DESCRIPTION
Resolves: #17530 

Fixes a crash on trying to transpose single chord symbols (which is not supposed to do anything) or notes (which is supposed to work), i.e. transposing a list-selection, introduced by #17531