### PR TITLE
Don't write track for tuplets

### DIFF
--- a/src/engraving/rw/400/twrite.cpp
+++ b/src/engraving/rw/400/twrite.cpp
@@ -331,8 +331,8 @@ void TWrite::writeItemProperties(const EngravingItem* item, XmlWriter& xml, Writ
         }
     }
     if ((ctx.writeTrack() || item->track() != ctx.curTrack())
-        && (item->track() != mu::nidx) && !item->isBeam()) {
-        // Writing track number for beams is redundant as it is calculated
+        && (item->track() != mu::nidx) && !item->isBeam() && !item->isTuplet()) {
+        // Writing track number for beams and tuplets is redundant as it is calculated
         // during layout.
         int t = static_cast<int>(item->track()) + ctx.trackDiff();
         xml.tag("track", t);


### PR DESCRIPTION
Resolves: #16679 

Just like beams, the track of tuplets is calculated during layout, so we shouldn't write it. This was causing the crash because the track difference was being summed twice (once as the difference between the origin and destination staff of the copy-paste operation, once as the written property of the tuplet).