### PR TITLE
Fix wrong harmony import for gp files

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -2423,7 +2423,7 @@ void GPConverter::addHarmonicMark(const GPBeat* gpbeat, ChordRest* cr)
     }
 }
 
-void GPConverter::addFretDiagram(const GPBeat* gpnote, ChordRest* cr, const Context& ctx)
+void GPConverter::addFretDiagram(const GPBeat* gpnote, ChordRest* cr, const Context& ctx, bool asHarmony)
 {
     int GPTrackIdx = static_cast<int>(ctx.curTrack);
     int diaId = gpnote->diagramIdx(GPTrackIdx, ctx.masterBarIndex);
@@ -2450,11 +2450,14 @@ void GPConverter::addFretDiagram(const GPBeat* gpnote, ChordRest* cr, const Cont
     GPTrack::Diagram diagram = trackIt->second->diagram().at(diaId);
 
     /// currently importing fret diagrams as chord names
-    if (true) {
-        StaffText* staffText = Factory::createStaffText(cr->segment());
-        staffText->setTrack(cr->track());
-        staffText->setPlainText(diagram.name);
-        cr->segment()->add(staffText);
+    if (asHarmony) {
+        Harmony* h = Factory::createHarmony(cr->segment());
+        h->setTrack(cr->track());
+        h->setParent(cr->segment());
+        h->setHarmonyType(HarmonyType::STANDARD);
+        h->setHarmony(diagram.name); // F#dim7
+        h->setPlainText(h->harmonyName());
+        cr->segment()->add(h);
         return;
     }
 

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.h
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.h
@@ -127,7 +127,7 @@ private:
     void addBarline(const GPMasterBar* mB, Measure* measure);
 
     void addTie(const GPNote* gpnote, Note* note, TieMap& ties);
-    void addFretDiagram(const GPBeat* gpnote, ChordRest* note, const Context& ctx);
+    void addFretDiagram(const GPBeat* gpnote, ChordRest* note, const Context& ctx, bool asHarmony = true);
     ChordRest* addChordRest(const GPBeat* beats, const Context& ctx);
     void addOrnament(const GPNote* gpnote, Note* note);
     void addVibratoLeftHand(const GPNote* gpnote, Note* note);

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -3004,6 +3004,7 @@ static Err importScore(MasterScore* score, mu::io::IODevice* io)
 
     score->loadStyle(u":/engraving/styles/gp-style.mss");
 
+    score->checkChordList();
     io->seek(0);
     char header[5];
     io->read((uint8_t*)(header), 4);

--- a/src/importexport/guitarpro/tests/data/beams-stems-ledger-lines.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/beams-stems-ledger-lines.gp-ref.mscx
@@ -91,9 +91,11 @@
             <subtype>f</subtype>
             <velocity>96</velocity>
             </Dynamic>
-          <StaffText>
-            <text>Dadd11/F#</text>
-            </StaffText>
+          <Harmony>
+            <root>16</root>
+            <name>add11</name>
+            <base>20</base>
+            </Harmony>
           <RehearsalMark>
             <text>Verse 1</text>
             </RehearsalMark>
@@ -443,9 +445,11 @@
             <subtype>f</subtype>
             <velocity>96</velocity>
             </Dynamic>
-          <StaffText>
-            <text>Gadd9/E</text>
-            </StaffText>
+          <Harmony>
+            <root>15</root>
+            <name>add9</name>
+            <base>18</base>
+            </Harmony>
           <Beam>
             <l1>-16</l1>
             <l2>-16</l2>

--- a/src/importexport/guitarpro/tests/data/beams-stems-ledger-lines.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/beams-stems-ledger-lines.gpx-ref.mscx
@@ -91,9 +91,11 @@
             <subtype>f</subtype>
             <velocity>96</velocity>
             </Dynamic>
-          <StaffText>
-            <text>Dadd11/F#</text>
-            </StaffText>
+          <Harmony>
+            <root>16</root>
+            <name>add11</name>
+            <base>20</base>
+            </Harmony>
           <RehearsalMark>
             <text>Verse 1</text>
             </RehearsalMark>
@@ -443,9 +445,11 @@
             <subtype>f</subtype>
             <velocity>96</velocity>
             </Dynamic>
-          <StaffText>
-            <text>Gadd9/E</text>
-            </StaffText>
+          <Harmony>
+            <root>15</root>
+            <name>add9</name>
+            <base>18</base>
+            </Harmony>
           <Beam>
             <l1>-16</l1>
             <l2>-16</l2>

--- a/src/importexport/guitarpro/tests/data/chordnames_keyboard.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/chordnames_keyboard.gp-ref.mscx
@@ -99,9 +99,9 @@
             <subtype>mf</subtype>
             <velocity>80</velocity>
             </Dynamic>
-          <StaffText>
-            <text>G</text>
-            </StaffText>
+          <Harmony>
+            <root>15</root>
+            </Harmony>
           <Tempo>
             <tempo>2</tempo>
             <text><sym>metNoteQuarterUp</sym> = 120</text>

--- a/src/importexport/guitarpro/tests/data/fret-diagram.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram.gp-ref.mscx
@@ -423,9 +423,11 @@
               <string>1</string>
               </Note>
             </Chord>
-          <StaffText>
-            <text>Asus4/E</text>
-            </StaffText>
+          <Harmony>
+            <root>17</root>
+            <name>sus4</name>
+            <base>18</base>
+            </Harmony>
           <Beam>
             <l1>-20</l1>
             <l2>-20</l2>

--- a/src/importexport/guitarpro/tests/data/fret-diagram.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram.gpx-ref.mscx
@@ -423,9 +423,11 @@
               <string>1</string>
               </Note>
             </Chord>
-          <StaffText>
-            <text>Asus4/E</text>
-            </StaffText>
+          <Harmony>
+            <root>17</root>
+            <name>sus4</name>
+            <base>18</base>
+            </Harmony>
           <Beam>
             <l1>-20</l1>
             <l2>-20</l2>

--- a/src/importexport/guitarpro/tests/data/fret-diagram_2instruments.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram_2instruments.gp-ref.mscx
@@ -153,9 +153,10 @@
             <subtype>mf</subtype>
             <velocity>80</velocity>
             </Dynamic>
-          <StaffText>
-            <text>Em</text>
-            </StaffText>
+          <Harmony>
+            <root>18</root>
+            <name>m</name>
+            </Harmony>
           <Tempo>
             <tempo>2</tempo>
             <text><sym>metNoteQuarterUp</sym> = 120</text>
@@ -173,9 +174,10 @@
         </Measure>
       <Measure>
         <voice>
-          <StaffText>
-            <text>Am</text>
-            </StaffText>
+          <Harmony>
+            <root>17</root>
+            <name>m</name>
+            </Harmony>
           <Chord>
             <durationType>whole</durationType>
             <Note>
@@ -189,9 +191,10 @@
         </Measure>
       <Measure>
         <voice>
-          <StaffText>
-            <text>Em</text>
-            </StaffText>
+          <Harmony>
+            <root>18</root>
+            <name>m</name>
+            </Harmony>
           <Chord>
             <durationType>whole</durationType>
             <Note>

--- a/src/importexport/guitarpro/tests/data/fret-diagram_2instruments.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram_2instruments.gpx-ref.mscx
@@ -153,9 +153,10 @@
             <subtype>mf</subtype>
             <velocity>80</velocity>
             </Dynamic>
-          <StaffText>
-            <text>Em</text>
-            </StaffText>
+          <Harmony>
+            <root>18</root>
+            <name>m</name>
+            </Harmony>
           <Tempo>
             <tempo>2</tempo>
             <text><sym>metNoteQuarterUp</sym> = 120</text>


### PR DESCRIPTION
This PR fixes an issue with harmony elements during gp import.
Before, they were added as staff text elements and wasn't transposable because of that.
Now they are added as harmony elements and can be transposed. 

related to #17530 and #17531 