### PR TITLE
Partial fix #17623: Null check for stemside artic placement on stemless chords

### DIFF
--- a/src/engraving/layout/v0/chordlayout.cpp
+++ b/src/engraving/layout/v0/chordlayout.cpp
@@ -756,7 +756,7 @@ void ChordLayout::layoutArticulations(Chord* item, LayoutContext& ctx)
         bool headSide = bottom == item->up();
         double y = 0.0;
         double x;
-        if (!headSide || !a->isBasicArticulation()) {
+        if ((!headSide || !a->isBasicArticulation()) && item->stem()) {
             switch (articulationHAlign) {
             case ArticulationStemSideAlign::STEM:
                 x = item->stem()->width() * .5;


### PR DESCRIPTION
Partially resolves: https://github.com/musescore/MuseScore/issues/17623

The Szymanowski score was a simple null check, so I'm pushing that here. The other example score from that issue is related to some major changes that are taking place, and the fix for that one will be folded into a different PR in the near future.