### PR TITLE
Consolidate staff/chord anchors into trinary above/below/auto

### DIFF
--- a/src/engraving/layout/v0/chordlayout.cpp
+++ b/src/engraving/layout/v0/chordlayout.cpp
@@ -731,10 +731,9 @@ void ChordLayout::layoutArticulations(Chord* item, LayoutContext& ctx)
 
     Articulation* prevArticulation = nullptr;
     for (Articulation* a : item->_articulations) {
-        if (item->measure()->hasVoices(a->staffIdx(), item->tick(), item->actualTicks())
-            && !(a->anchor() == ArticulationAnchor::TOP_CHORD || a->anchor() == ArticulationAnchor::BOTTOM_CHORD)) {
+        if (item->measure()->hasVoices(a->staffIdx(), item->tick(), item->actualTicks()) && a->anchor() == ArticulationAnchor::AUTO) {
             a->setUp(item->up());         // if there are voices place articulation at stem
-        } else if (a->anchor() == ArticulationAnchor::CHORD) {
+        } else if (a->anchor() == ArticulationAnchor::AUTO) {
             if (a->symId() >= SymId::articMarcatoAbove && a->symId() <= SymId::articMarcatoTenutoBelow) {
                 a->setUp(true);         // Gould, p. 117: strong accents above staff
             } else if (item->isGrace() && item->up() && !a->layoutCloseToNote() && item->downNote()->line() < 6) {
@@ -743,7 +742,7 @@ void ChordLayout::layoutArticulations(Chord* item, LayoutContext& ctx)
                 a->setUp(!item->up());         // place articulation at note head
             }
         } else {
-            a->setUp(a->anchor() == ArticulationAnchor::TOP_STAFF || a->anchor() == ArticulationAnchor::TOP_CHORD);
+            a->setUp(a->anchor() == ArticulationAnchor::TOP);
         }
 
         if (!a->layoutCloseToNote()) {
@@ -946,8 +945,7 @@ void ChordLayout::layoutArticulations2(Chord* item, LayoutContext& ctx, bool lay
     // add space for staccato and tenuto marks which may have been previously laid out
     for (Articulation* a : item->_articulations) {
         ArticulationAnchor aa = a->anchor();
-        if (a->layoutCloseToNote() && a->visible()
-            && aa != ArticulationAnchor::TOP_STAFF && aa != ArticulationAnchor::BOTTOM_STAFF) {
+        if (a->layoutCloseToNote() && a->visible() && aa == ArticulationAnchor::AUTO) {
             if (a->up()) {
                 chordTopY = a->y() - a->height() - minDist;
             } else {
@@ -961,7 +959,7 @@ void ChordLayout::layoutArticulations2(Chord* item, LayoutContext& ctx, bool lay
             continue;
         }
         ArticulationAnchor aa = a->anchor();
-        if (!a->layoutCloseToNote() || aa == ArticulationAnchor::TOP_STAFF || aa == ArticulationAnchor::BOTTOM_STAFF) {
+        if (!a->layoutCloseToNote()) {
             continue;
         }
         if (a->up()) {
@@ -999,9 +997,7 @@ void ChordLayout::layoutArticulations2(Chord* item, LayoutContext& ctx, bool lay
             stacc = nullptr;
         }
         ArticulationAnchor aa = a->anchor();
-        if (aa == ArticulationAnchor::TOP_STAFF
-            || aa == ArticulationAnchor::BOTTOM_STAFF
-            || !a->layoutCloseToNote()) {
+        if (!a->layoutCloseToNote()) {
             TLayout::layout(a, ctx);
             if (a->up()) {
                 a->setPos(!item->up() || !a->isBasicArticulation() ? headSideX : stemSideX, staffTopY + kearnHeight);

--- a/src/engraving/libmscore/articulation.cpp
+++ b/src/engraving/libmscore/articulation.cpp
@@ -63,7 +63,7 @@ Articulation::Articulation(ChordRest* parent, ElementType type)
     : EngravingItem(type, parent, ElementFlag::MOVABLE)
 {
     _symId         = SymId::noSym;
-    _anchor        = ArticulationAnchor::TOP_STAFF;
+    _anchor        = ArticulationAnchor::AUTO;
     _direction     = DirectionV::AUTO;
     _up            = true;
     _ornamentStyle = OrnamentStyle::DEFAULT;
@@ -717,10 +717,10 @@ void Articulation::setupShowOnTabStyles()
 
 void Articulation::styleChanged()
 {
-    bool isGolpeThumb = _symId == SymId::guitarGolpe && _anchor == ArticulationAnchor::BOTTOM_STAFF;
+    bool isGolpeThumb = _symId == SymId::guitarGolpe && _anchor == ArticulationAnchor::BOTTOM;
     EngravingItem::styleChanged();
     if (isGolpeThumb) {
-        setAnchor(ArticulationAnchor::BOTTOM_STAFF);
+        setAnchor(ArticulationAnchor::BOTTOM);
     }
 }
 

--- a/src/engraving/libmscore/articulation.h
+++ b/src/engraving/libmscore/articulation.h
@@ -54,11 +54,9 @@ DECLARE_FLAGS(ArticulationCategories, ArticulationCategory)
 DECLARE_OPERATORS_FOR_FLAGS(ArticulationCategories)
 
 enum class ArticulationAnchor : char {
-    TOP_STAFF,        // anchor is always placed at top of staff
-    BOTTOM_STAFF,     // anchor is always placed at bottom of staff
-    CHORD,            // anchor depends on chord direction, away from stem
-    TOP_CHORD,        // attribute is always placed at top of chord
-    BOTTOM_CHORD,     // attribute is placed at bottom of chord
+    TOP,        // attribute is always placed at top
+    BOTTOM,     // attribute is placed at bottom
+    AUTO,       // anchor depends on chord direction, away from stem
 };
 
 enum class ArticulationStemSideAlign : char

--- a/src/engraving/libmscore/chord.cpp
+++ b/src/engraving/libmscore/chord.cpp
@@ -2078,13 +2078,13 @@ EngravingItem* Chord::drop(EditData& data)
                 if (pf == PropertyFlags::STYLED) {
                     continue;
                 }
-                if (a->anchor() == ArticulationAnchor::TOP_STAFF || a->anchor() == ArticulationAnchor::TOP_CHORD) {
+                if (a->anchor() == ArticulationAnchor::TOP) {
                     if (aboveBelow < 0) {
                         mixed = true;
                         break;
                     }
                     ++aboveBelow;
-                } else if (a->anchor() == ArticulationAnchor::BOTTOM_STAFF || a->anchor() == ArticulationAnchor::BOTTOM_CHORD) {
+                } else if (a->anchor() == ArticulationAnchor::BOTTOM) {
                     if (aboveBelow > 0) {
                         mixed = true;
                         break;
@@ -2094,9 +2094,9 @@ EngravingItem* Chord::drop(EditData& data)
             }
             if (!mixed && aboveBelow != 0) {
                 if (aboveBelow > 0) {
-                    atr->setAnchor(ArticulationAnchor::TOP_CHORD);
+                    atr->setAnchor(ArticulationAnchor::TOP);
                 } else {
-                    atr->setAnchor(ArticulationAnchor::BOTTOM_CHORD);
+                    atr->setAnchor(ArticulationAnchor::BOTTOM);
                 }
                 atr->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
             }
@@ -2299,7 +2299,7 @@ void Chord::updateArticulations(const std::set<SymId>& newArticulationIds, Artic
     Articulation* accent = nullptr;
     Articulation* marcato = nullptr;
     Articulation* tenuto = nullptr;
-    ArticulationAnchor overallAnchor = ArticulationAnchor::CHORD;
+    ArticulationAnchor overallAnchor = ArticulationAnchor::AUTO;
     bool mixedDirections = false;
     if (!_articulations.empty()) {
         std::vector<Articulation*> articsToRemove;
@@ -2329,10 +2329,10 @@ void Chord::updateArticulations(const std::set<SymId>& newArticulationIds, Artic
         // take an inventory of which articulations are already present
         for (Articulation* artic : _articulations) {
             PropertyFlags pf = artic->propertyFlags(Pid::ARTICULATION_ANCHOR);
-            if (!mixedDirections && pf == PropertyFlags::UNSTYLED && artic->anchor() != ArticulationAnchor::CHORD) {
-                if (overallAnchor != ArticulationAnchor::CHORD && artic->anchor() != overallAnchor) {
+            if (!mixedDirections && pf == PropertyFlags::UNSTYLED && artic->anchor() != ArticulationAnchor::AUTO) {
+                if (overallAnchor != ArticulationAnchor::AUTO && artic->anchor() != overallAnchor) {
                     mixedDirections = true;
-                    overallAnchor = ArticulationAnchor::CHORD;
+                    overallAnchor = ArticulationAnchor::AUTO;
                 } else {
                     overallAnchor = artic->anchor();
                 }
@@ -2399,7 +2399,7 @@ void Chord::updateArticulations(const std::set<SymId>& newArticulationIds, Artic
         for (const SymId& id : newArtics) {
             Articulation* newArticulation = Factory::createArticulation(score()->dummy()->chord());
             newArticulation->setSymId(id);
-            if (overallAnchor != ArticulationAnchor::CHORD) {
+            if (overallAnchor != ArticulationAnchor::AUTO) {
                 newArticulation->setAnchor(overallAnchor);
                 newArticulation->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
             }

--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -2243,20 +2243,14 @@ void Score::cmdFlip()
             flipOnce(artic, [artic]() {
                 ArticulationAnchor articAnchor = artic->anchor();
                 switch (articAnchor) {
-                case ArticulationAnchor::TOP_CHORD:
-                    articAnchor = ArticulationAnchor::BOTTOM_CHORD;
+                case ArticulationAnchor::TOP:
+                    articAnchor = ArticulationAnchor::BOTTOM;
                     break;
-                case ArticulationAnchor::BOTTOM_CHORD:
-                    articAnchor = ArticulationAnchor::TOP_CHORD;
+                case ArticulationAnchor::BOTTOM:
+                    articAnchor = ArticulationAnchor::TOP;
                     break;
-                case ArticulationAnchor::CHORD:
-                    articAnchor = artic->up() ? ArticulationAnchor::BOTTOM_CHORD : ArticulationAnchor::TOP_CHORD;
-                    break;
-                case ArticulationAnchor::TOP_STAFF:
-                    articAnchor = ArticulationAnchor::BOTTOM_STAFF;
-                    break;
-                case ArticulationAnchor::BOTTOM_STAFF:
-                    articAnchor = ArticulationAnchor::TOP_STAFF;
+                case ArticulationAnchor::AUTO:
+                    articAnchor = artic->up() ? ArticulationAnchor::BOTTOM : ArticulationAnchor::TOP;
                     break;
                 }
                 PropertyFlags pf = artic->propertyFlags(Pid::ARTICULATION_ANCHOR);

--- a/src/engraving/rw/206/read206.cpp
+++ b/src/engraving/rw/206/read206.cpp
@@ -2167,17 +2167,15 @@ static void setFermataPlacement(EngravingItem* el, ArticulationAnchor anchor, Di
         el->setPlacement(PlacementV::BELOW);
     } else {
         switch (anchor) {
-        case ArticulationAnchor::TOP_STAFF:
-        case ArticulationAnchor::TOP_CHORD:
+        case ArticulationAnchor::TOP:
             el->setPlacement(PlacementV::ABOVE);
             break;
 
-        case ArticulationAnchor::BOTTOM_STAFF:
-        case ArticulationAnchor::BOTTOM_CHORD:
+        case ArticulationAnchor::BOTTOM:
             el->setPlacement(PlacementV::BELOW);
             break;
 
-        case ArticulationAnchor::CHORD:
+        case ArticulationAnchor::AUTO:
             break;
         default:
             break;
@@ -2189,7 +2187,7 @@ EngravingItem* Read206::readArticulation(EngravingItem* parent, XmlReader& e, Re
 {
     EngravingItem* el = nullptr;
     SymId sym = SymId::fermataAbove;            // default -- backward compatibility (no type = ufermata in 1.2)
-    ArticulationAnchor anchor  = ArticulationAnchor::TOP_STAFF;
+    ArticulationAnchor anchor  = ArticulationAnchor::TOP;
     DirectionV direction = DirectionV::AUTO;
     track_idx_t track = parent->track();
     double timeStretch = 0.0;

--- a/src/engraving/rw/206/read206.cpp
+++ b/src/engraving/rw/206/read206.cpp
@@ -2289,7 +2289,7 @@ EngravingItem* Read206::readArticulation(EngravingItem* parent, XmlReader& e, Re
         } else if (tag == "anchor") {
             useDefaultPlacement = false;
             if (!el || el->isFermata()) {
-                anchor = ArticulationAnchor(e.readInt());
+                anchor = CompatUtils::translateToNewArticulationAnchor(e.readInt());
             } else {
                 readProperties(el, e, ctx);
             }

--- a/src/engraving/rw/400/tread.cpp
+++ b/src/engraving/rw/400/tread.cpp
@@ -135,7 +135,7 @@
 
 #include "../xmlreader.h"
 #include "../206/read206.h"
-
+#include "../compat/compatutils.h"
 #include "readcontext.h"
 #include "connectorinforeader.h"
 
@@ -1851,7 +1851,17 @@ bool TRead::readProperties(Articulation* a, XmlReader& xml, ReadContext& ctx)
     } else if (tag == "channel") {
         a->setChannelName(xml.attribute("name"));
         xml.readNext();
-    } else if (TRead::readProperty(a, tag, xml, ctx, Pid::ARTICULATION_ANCHOR)) {
+    } else if (tag == "anchor") {
+        if (ctx.mscVersion() <= 400) {
+            int v = xml.readInt();
+            ArticulationAnchor aa = compat::CompatUtils::translateToNewArticulationAnchor(v);
+            a->setAnchor(aa);
+            if (a->isStyled(Pid::ARTICULATION_ANCHOR)) {
+                a->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
+            }
+        } else {
+            TRead::readProperty(a, tag, xml, ctx, Pid::ARTICULATION_ANCHOR);
+        }
     } else if (tag == "direction") {
         TRead::readProperty(a, xml, ctx, Pid::DIRECTION);
     } else if (tag == "ornamentStyle") {

--- a/src/engraving/rw/compat/compatutils.cpp
+++ b/src/engraving/rw/compat/compatutils.cpp
@@ -367,3 +367,21 @@ DynamicType CompatUtils::reconstructDynamicTypeFromString(Dynamic* dynamic)
     }
     return DynamicType::OTHER;
 }
+
+ArticulationAnchor CompatUtils::translateToNewArticulationAnchor(int anchor)
+{
+    switch (anchor) {
+    case 0: // ArticulationAnchor::TOP_STAFF
+    case 3: // ArticulationAnchor::TOP_CHORD
+        return ArticulationAnchor::TOP;
+        break;
+    case 1: // ArticulationAnchor::BOTTOM_STAFF
+    case 4: // ArticulationAnchor::BOTTOM_CHORD
+        return ArticulationAnchor::BOTTOM;
+        break;
+    case 2: // ArticulationAnchor::CHORD
+    default:
+        return ArticulationAnchor::AUTO;
+        break;
+    }
+}

--- a/src/engraving/rw/compat/compatutils.h
+++ b/src/engraving/rw/compat/compatutils.h
@@ -24,6 +24,8 @@
 
 #include <vector>
 
+#include "libmscore/articulation.h"
+
 namespace mu::engraving {
 class Score;
 class MasterScore;
@@ -43,6 +45,7 @@ public:
     static void replaceOldWithNewExpressions(MasterScore* score);
     static void reconstructTypeOfCustomDynamics(MasterScore* score);
     static DynamicType reconstructDynamicTypeFromString(Dynamic* dynamic);
+    static ArticulationAnchor translateToNewArticulationAnchor(int anchor);
 };
 }
 #endif // MU_ENGRAVING_COMPATUTILS_H

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -220,9 +220,9 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
 
     { Sid::articulationMag,         "articulationMag",         PropertyValue(1.0) },
     { Sid::articulationPosAbove,    "articulationPosAbove",    PointF(0.0, 0.0) },
-    { Sid::articulationAnchorDefault, "articulationAnchorDefault", int(ArticulationAnchor::CHORD) },
-    { Sid::articulationAnchorLuteFingering, "articulationAnchorLuteFingering", int(ArticulationAnchor::BOTTOM_CHORD) },
-    { Sid::articulationAnchorOther, "articulationAnchorOther", int(ArticulationAnchor::TOP_STAFF) },
+    { Sid::articulationAnchorDefault, "articulationAnchorDefault", int(ArticulationAnchor::AUTO) },
+    { Sid::articulationAnchorLuteFingering, "articulationAnchorLuteFingering", int(ArticulationAnchor::BOTTOM) },
+    { Sid::articulationAnchorOther, "articulationAnchorOther", int(ArticulationAnchor::TOP) },
     { Sid::articulationStemHAlign,  "articulationStemHAlign",  int(ArticulationStemSideAlign::AVERAGE) },
     { Sid::articulationKeepTogether, "articulationKeepTogether", true },
     { Sid::lastSystemFillLimit,     "lastSystemFillLimit",     PropertyValue(0.3) },

--- a/src/engraving/tests/compat206_data/articulations-double-ref.mscx
+++ b/src/engraving/tests/compat206_data/articulations-double-ref.mscx
@@ -450,7 +450,7 @@
               <direction>down</direction>
               <subtype>articAccentStaccatoBelow</subtype>
               <ornamentStyle>baroque</ornamentStyle>
-              <anchor>4</anchor>
+              <anchor>1</anchor>
               <linkedMain/>
               </Articulation>
             <Note>
@@ -2263,7 +2263,7 @@
                 <direction>down</direction>
                 <subtype>articAccentStaccatoBelow</subtype>
                 <ornamentStyle>baroque</ornamentStyle>
-                <anchor>4</anchor>
+                <anchor>1</anchor>
                 <linked>
                   <indexDiff>1</indexDiff>
                   </linked>

--- a/src/engraving/tests/compat206_data/articulations-ref.mscx
+++ b/src/engraving/tests/compat206_data/articulations-ref.mscx
@@ -296,7 +296,7 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>articAccentAbove</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>72</pitch>
@@ -307,7 +307,7 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>articAccentAbove</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>60</pitch>
@@ -342,7 +342,7 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>articStaccatoAbove</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>72</pitch>
@@ -353,7 +353,7 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>articStaccatoAbove</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>60</pitch>
@@ -437,7 +437,7 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>articTenutoAbove</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>72</pitch>
@@ -448,7 +448,7 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>articTenutoAbove</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>60</pitch>
@@ -575,7 +575,6 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>guitarFadeIn</subtype>
-              <anchor>3</anchor>
               </Articulation>
             <Note>
               <pitch>72</pitch>
@@ -586,7 +585,6 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>guitarFadeIn</subtype>
-              <anchor>3</anchor>
               </Articulation>
             <Note>
               <pitch>60</pitch>
@@ -624,7 +622,6 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>guitarFadeOut</subtype>
-              <anchor>3</anchor>
               </Articulation>
             <Note>
               <pitch>72</pitch>
@@ -635,7 +632,6 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>guitarFadeOut</subtype>
-              <anchor>3</anchor>
               </Articulation>
             <Note>
               <pitch>60</pitch>
@@ -670,7 +666,7 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>wiggleSawtooth</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>72</pitch>
@@ -681,7 +677,7 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>wiggleSawtooth</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>60</pitch>
@@ -716,7 +712,7 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>wiggleSawtoothWide</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>72</pitch>
@@ -727,7 +723,7 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>wiggleSawtoothWide</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>60</pitch>
@@ -762,7 +758,7 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>wiggleVibratoLargeFaster</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>72</pitch>
@@ -773,7 +769,7 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>wiggleVibratoLargeFaster</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>60</pitch>
@@ -811,7 +807,7 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>wiggleVibratoLargeSlowest</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>72</pitch>
@@ -822,7 +818,7 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>wiggleVibratoLargeSlowest</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>60</pitch>

--- a/src/engraving/tests/rhythmicGrouping_data/groupShortenNotes-ref.mscx
+++ b/src/engraving/tests/rhythmicGrouping_data/groupShortenNotes-ref.mscx
@@ -95,7 +95,7 @@
             <durationType>eighth</durationType>
             <Articulation>
               <subtype>articTenutoAbove</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>71</pitch>
@@ -106,7 +106,7 @@
             <durationType>eighth</durationType>
             <Articulation>
               <subtype>articAccentAbove</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <Spanner type="Tie">
@@ -172,7 +172,7 @@
             <durationType>eighth</durationType>
             <Articulation>
               <subtype>articTenutoAbove</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>71</pitch>
@@ -183,7 +183,7 @@
             <durationType>eighth</durationType>
             <Articulation>
               <subtype>articAccentAbove</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <Spanner type="Tie">
@@ -239,7 +239,7 @@
             <durationType>eighth</durationType>
             <Articulation>
               <subtype>articTenutoAbove</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>71</pitch>
@@ -250,7 +250,7 @@
             <durationType>eighth</durationType>
             <Articulation>
               <subtype>articTenutoAbove</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>71</pitch>
@@ -337,7 +337,7 @@
             <durationType>eighth</durationType>
             <Articulation>
               <subtype>articAccentAbove</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>71</pitch>
@@ -364,7 +364,7 @@
             <durationType>eighth</durationType>
             <Articulation>
               <subtype>articTenutoAbove</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>71</pitch>
@@ -375,7 +375,7 @@
             <durationType>eighth</durationType>
             <Articulation>
               <subtype>articTenutoAbove</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>71</pitch>
@@ -462,7 +462,7 @@
             <durationType>eighth</durationType>
             <Articulation>
               <subtype>articAccentAbove</subtype>
-              <anchor>3</anchor>
+              <anchor>0</anchor>
               </Articulation>
             <Note>
               <pitch>71</pitch>

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -2832,7 +2832,7 @@ void GPConverter::addGolpe(const GPBeat* beat, ChordRest* cr)
     art->setSymId(SymId::guitarGolpe);
 
     if (beat->golpe() == GPBeat::Golpe::Thumb) {
-        art->setAnchor(ArticulationAnchor::BOTTOM_STAFF);
+        art->setAnchor(ArticulationAnchor::BOTTOM);
     }
 
     if (!_score->toggleArticulation(static_cast<Chord*>(cr)->upNote(), art)) {

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -1093,7 +1093,7 @@ void GuitarPro::applyBeatEffects(Chord* chord, int beatEffect)
         if (version >= 400) {
             Articulation* a = Factory::createArticulation(chord);
             a->setSymId(SymId::guitarFadeIn);
-            a->setAnchor(ArticulationAnchor::TOP_STAFF);
+            a->setAnchor(ArticulationAnchor::TOP);
             a->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
             chord->add(a);
         }
@@ -2640,7 +2640,7 @@ bool GuitarPro3::read(IODevice* io)
                         beatEffects -= 200;
                         Articulation* art = Factory::createArticulation(cr);
                         art->setSymId(SymId::guitarFadeOut);
-                        art->setAnchor(ArticulationAnchor::TOP_STAFF);
+                        art->setAnchor(ArticulationAnchor::TOP);
                         art->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
                         if (!score->toggleArticulation(cr, art)) {
                             delete art;

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -3048,9 +3048,8 @@ void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technic
                 } else {
                     mxmlArtic += " type=\"down\"";
                 }
-            } else if (a->anchor() != ArticulationAnchor::CHORD) {
-                if (a->anchor() == ArticulationAnchor::TOP_CHORD
-                    || a->anchor() == ArticulationAnchor::TOP_STAFF) {
+            } else if (a->anchor() != ArticulationAnchor::AUTO) {
+                if (a->anchor() == ArticulationAnchor::TOP) {
                     mxmlArtic += " placement=\"above\"";
                 } else {
                     mxmlArtic += " placement=\"below\"";
@@ -3100,9 +3099,8 @@ void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technic
         QString direction;
 
         QString attr;
-        if (!a->isStyled(Pid::ARTICULATION_ANCHOR) && a->anchor() != ArticulationAnchor::CHORD) {
-            placement
-                = (a->anchor() == ArticulationAnchor::BOTTOM_STAFF || a->anchor() == ArticulationAnchor::BOTTOM_CHORD) ? "below" : "above";
+        if (!a->isStyled(Pid::ARTICULATION_ANCHOR) && a->anchor() != ArticulationAnchor::AUTO) {
+            placement = (a->anchor() == ArticulationAnchor::BOTTOM) ? "below" : "above";
         } else if (!a->isStyled(Pid::DIRECTION) && a->direction() != DirectionV::AUTO) {
             direction = (a->direction() == DirectionV::DOWN) ? "down" : "up";
         }

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -1047,10 +1047,10 @@ static void addArticulationToChord(const Notation& notation, ChordRest* cr)
     // when setting anchor, assume type up/down without explicit placement
     // implies placement above/below
     if (place == "above" || (dir == "up" && place == "")) {
-        na->setAnchor(ArticulationAnchor::TOP_CHORD);
+        na->setAnchor(ArticulationAnchor::TOP);
         na->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
     } else if (place == "below" || (dir == "down" && place == "")) {
-        na->setAnchor(ArticulationAnchor::BOTTOM_CHORD);
+        na->setAnchor(ArticulationAnchor::BOTTOM);
         na->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
     }
 

--- a/src/inspector/types/articulationtypes.h
+++ b/src/inspector/types/articulationtypes.h
@@ -31,11 +31,9 @@ class ArticulationTypes
 
 public:
     enum class Placement {
-        TYPE_ABOVE_STAFF,
-        TYPE_BELOW_STAFF,
-        TYPE_CHORD_AUTO,
-        TYPE_ABOVE_CHORD,
-        TYPE_BELOW_CHORD
+        TYPE_TOP,
+        TYPE_BOTTOM,
+        TYPE_AUTO
     };
 
     enum class Style {

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/articulations/ArticulationSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/articulations/ArticulationSettings.qml
@@ -54,11 +54,9 @@ Column {
         navigationRowStart: root.navigationRowStart
 
         model: [
-            { text: qsTrc("inspector", "Above staff"), value: ArticulationTypes.TYPE_ABOVE_STAFF },
-            { text: qsTrc("inspector", "Below staff"), value: ArticulationTypes.TYPE_BELOW_STAFF },
-            { text: qsTrc("inspector", "Chord automatic"), value: ArticulationTypes.TYPE_CHORD_AUTO },
-            { text: qsTrc("inspector", "Above chord"), value: ArticulationTypes.TYPE_ABOVE_CHORD },
-            { text: qsTrc("inspector", "Below chord"), value: ArticulationTypes.TYPE_BELOW_CHORD }
+            { text: qsTrc("inspector", "Above"), value: ArticulationTypes.TYPE_TOP },
+            { text: qsTrc("inspector", "Auto"), value: ArticulationTypes.TYPE_AUTO },
+            { text: qsTrc("inspector", "Below"), value: ArticulationTypes.TYPE_BOTTOM }
         ]
     }
 }

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/ornaments/OrnamentSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/ornaments/OrnamentSettings.qml
@@ -198,13 +198,10 @@ Column {
 
         navigationPanel: root.navigationPanel
         navigationRowStart: performanceSection.navigationRowEnd + 1
-
         model: [
-            { text: qsTrc("inspector", "Above staff"), value: ArticulationTypes.TYPE_ABOVE_STAFF },
-            { text: qsTrc("inspector", "Below staff"), value: ArticulationTypes.TYPE_BELOW_STAFF },
-            { text: qsTrc("inspector", "Chord automatic"), value: ArticulationTypes.TYPE_CHORD_AUTO },
-            { text: qsTrc("inspector", "Above chord"), value: ArticulationTypes.TYPE_ABOVE_CHORD },
-            { text: qsTrc("inspector", "Below chord"), value: ArticulationTypes.TYPE_BELOW_CHORD }
+            { text: qsTrc("inspector", "Above"), value: ArticulationTypes.TYPE_TOP },
+            { text: qsTrc("inspector", "Auto"), value: ArticulationTypes.TYPE_AUTO },
+            { text: qsTrc("inspector", "Below"), value: ArticulationTypes.TYPE_BOTTOM }
         ]
     }
 }


### PR DESCRIPTION
Previously, (in 4.0 and below) there were five options for articulation anchors: above staff, below staff, above chord, below chord, and chord. The majority of articulations that exist ignore these and decide whether they place inside or outside the staff based on what sort of articulation they are. This PR consolidates articulations into above, below, and auto. Note that this is different from "direction" in code, which right now is not exposed but may be in the future, so we're keeping them separate still.