### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/infrastructure/debugpaint.cpp
+++ b/src/engraving/infrastructure/debugpaint.cpp
@@ -72,7 +72,7 @@ void DebugPaint::paintElementDebug(mu::draw::Painter& painter, const EngravingIt
 
     if (!item->bbox().isEmpty()) {
         // Draw shape
-        if (configuration()->debuggingOptions().colorElementShapes
+        if (engravingConfiguration()->debuggingOptions().colorElementShapes
             && !item->isPage() && !item->isSystem() && !item->isStaffLines() && !item->isBox()) {
             PainterPath path;
             path.setFillRule(PainterPath::FillRule::WindingFill);
@@ -88,8 +88,8 @@ void DebugPaint::paintElementDebug(mu::draw::Painter& painter, const EngravingIt
         }
 
         // Draw bbox
-        if (isDiagnosticSelected || configuration()->debuggingOptions().showElementBoundingRects) {
-            double scaling = painter.worldTransform().m11() / configuration()->guiScaling();
+        if (isDiagnosticSelected || engravingConfiguration()->debuggingOptions().showElementBoundingRects) {
+            double scaling = painter.worldTransform().m11() / engravingConfiguration()->guiScaling();
             draw::Pen borderPen(DEBUG_ELTREE_SELECTED_COLOR, (item->selected() ? 2.0 : 1.0) / scaling);
 
             painter.setPen(borderPen);
@@ -135,11 +135,11 @@ void DebugPaint::paintPageDebug(Painter& painter, const Page* page)
         return;
     }
 
-    double scaling = painter.worldTransform().m11() / configuration()->guiScaling();
+    double scaling = painter.worldTransform().m11() / engravingConfiguration()->guiScaling();
 
     painter.save();
 
-    auto options = configuration()->debuggingOptions();
+    auto options = engravingConfiguration()->debuggingOptions();
 
     if (options.showSystemBoundingRects) {
         painter.setBrush(BrushStyle::NoBrush);

--- a/src/engraving/infrastructure/debugpaint.h
+++ b/src/engraving/infrastructure/debugpaint.h
@@ -35,7 +35,7 @@ class Page;
 class PaintDebugger;
 class DebugPaint
 {
-    INJECT_STATIC(IEngravingConfiguration, configuration)
+    INJECT_STATIC(IEngravingConfiguration, engravingConfiguration)
     INJECT_STATIC(diagnostics::IEngravingElementsProvider, elementsProvider)
 
 public:

--- a/src/notation/internal/notationviewstate.cpp
+++ b/src/notation/internal/notationviewstate.cpp
@@ -124,7 +124,7 @@ async::Channel<Transform, NotationPaintView*> NotationViewState::matrixChanged()
 
 void NotationViewState::setMatrix(const Transform& matrix, NotationPaintView* sender)
 {
-    int newZoomPercentage = configuration()->zoomPercentageFromScaling(matrix.m11());
+    int newZoomPercentage = notationConfiguration()->zoomPercentageFromScaling(matrix.m11());
     if (m_matrix == matrix && m_zoomPercentage.val == newZoomPercentage) {
         return;
     }

--- a/src/notation/internal/notationviewstate.h
+++ b/src/notation/internal/notationviewstate.h
@@ -32,7 +32,7 @@ namespace mu::notation {
 class Notation;
 class NotationViewState : public INotationViewState, public async::Asyncable
 {
-    INJECT_STATIC(INotationConfiguration, configuration)
+    INJECT_STATIC(INotationConfiguration, notationConfiguration)
 
 public:
     explicit NotationViewState(Notation* notation);

--- a/src/palette/internal/palettecelliconengine.cpp
+++ b/src/palette/internal/palettecelliconengine.cpp
@@ -71,7 +71,7 @@ void PaletteCellIconEngine::paintCell(Painter& painter, const RectF& rect, bool 
         return;
     }
 
-    painter.setPen(configuration()->elementsColor());
+    painter.setPen(paletteConfiguration()->elementsColor());
 
     if (element->isActionIcon()) {
         paintActionIcon(painter, rect, element);
@@ -79,7 +79,7 @@ void PaletteCellIconEngine::paintCell(Painter& painter, const RectF& rect, bool 
     }
 
     const bool drawStaff = m_cell->drawStaff;
-    const qreal spatium = configuration()->paletteSpatium() * m_extraMag * m_cell->mag;
+    const qreal spatium = paletteConfiguration()->paletteSpatium() * m_extraMag * m_cell->mag;
 
     PointF origin = rect.center(); // draw element at center of cell by default
     if (drawStaff) {
@@ -96,7 +96,7 @@ void PaletteCellIconEngine::paintCell(Painter& painter, const RectF& rect, bool 
 void PaletteCellIconEngine::paintBackground(Painter& painter, const RectF& rect, bool selected, bool current) const
 {
     if (current || selected) {
-        QColor c(configuration()->accentColor());
+        QColor c(paletteConfiguration()->accentColor());
         c.setAlpha(selected ? 100 : 60);
         painter.fillRect(rect, c);
     }
@@ -128,7 +128,7 @@ qreal PaletteCellIconEngine::paintStaff(Painter& painter, const RectF& rect, qre
 {
     painter.save();
 
-    Color staffLinesColor(configuration()->elementsColor());
+    Color staffLinesColor(paletteConfiguration()->elementsColor());
     staffLinesColor.setAlpha(127);//reduce alpha of staff lines to half
     Pen pen(staffLinesColor);
     pen.setWidthF(engraving::DefaultStyle::defaultStyle().styleS(Sid::staffLineWidth).val() * spatium);
@@ -208,7 +208,7 @@ void PaletteCellIconEngine::paintPaletteElement(void* context, EngravingItem* el
     element->setColorsInverionEnabled(ctx->colorsInversionEnabled);
 
     if (!ctx->useElementColors) {
-        Color color = configuration()->elementsColor();
+        Color color = paletteConfiguration()->elementsColor();
         element->setProperty(Pid::COLOR, color);
         element->setProperty(Pid::FRAME_FG_COLOR, color);
     }

--- a/src/palette/internal/palettecelliconengine.h
+++ b/src/palette/internal/palettecelliconengine.h
@@ -36,7 +36,7 @@ class Painter;
 namespace mu::palette {
 class PaletteCellIconEngine : public QIconEngine
 {
-    INJECT_STATIC(IPaletteConfiguration, configuration)
+    INJECT_STATIC(IPaletteConfiguration, paletteConfiguration)
 
 public:
     explicit PaletteCellIconEngine(PaletteCellConstPtr cell, qreal extraMag = 1.0);

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -565,7 +565,7 @@ PalettePtr PaletteCreator::newLayoutPalette()
     sp->appendActionIcon(ActionIconType::VFRAME, "insert-vbox");
     sp->appendActionIcon(ActionIconType::HFRAME, "insert-hbox");
     sp->appendActionIcon(ActionIconType::TFRAME, "insert-textframe");
-    if (configuration()->enableExperimental()) {
+    if (paletteConfiguration()->enableExperimental()) {
         sp->appendActionIcon(ActionIconType::FFRAME, "insert-fretframe");
     }
     sp->appendActionIcon(ActionIconType::STAFF_TYPE_CHANGE, "insert-staff-type-change");

--- a/src/palette/internal/palettecreator.h
+++ b/src/palette/internal/palettecreator.h
@@ -31,7 +31,7 @@
 namespace mu::palette {
 class PaletteCreator
 {
-    INJECT_STATIC(IPaletteConfiguration, configuration)
+    INJECT_STATIC(IPaletteConfiguration, paletteConfiguration)
 
 public:
     static PalettePtr newTempoPalette(bool defaultPalette = false);


### PR DESCRIPTION
reg. declaration of `s_configuration` hides global declaration (C4459)

Alternative to #17671