### PR TITLE
Fix #17648: Playback for surround audio

### DIFF
--- a/src/framework/audio/audiomodule.cpp
+++ b/src/framework/audio/audiomodule.cpp
@@ -194,10 +194,10 @@ void AudioModule::onInit(const framework::IApplication::RunMode& mode)
     m_soundFontRepository->init();
     m_registerAudioPluginsScenario->init();
 
-    m_audioOutputController->init();
-
     // Setup audio driver
     IAudioDriver::Spec spec = setupAudioDriver(mode);
+
+    m_audioOutputController->init();
 
     // Use actual channel count instead of configuration
     m_audioBuffer->init(spec.channels,

--- a/src/framework/audio/audiomodule.h
+++ b/src/framework/audio/audiomodule.h
@@ -62,7 +62,7 @@ public:
     void onDestroy() override;
 
 private:
-    void setupAudioDriver(const framework::IApplication::RunMode& mode);
+    IAudioDriver::Spec setupAudioDriver(const framework::IApplication::RunMode& mode);
     void setupAudioWorker(const IAudioDriver::Spec& activeSpec);
 
     std::shared_ptr<AudioConfiguration> m_configuration;

--- a/src/framework/audio/iaudiodriver.h
+++ b/src/framework/audio/iaudiodriver.h
@@ -52,7 +52,7 @@ public:
     {
         unsigned int sampleRate;      // frequency -- samples per second
         Format format;                // Audio data format
-        uint8_t channels;             // Number of channels: 1 mono, 2 stereo
+        uint8_t channels;             // Number of channels: 1 mono, 2 stereo, 6 surround
         uint16_t samples;             // Audio buffer size in sample FRAMES (total samples divided by channel count)
         Callback callback;            // Callback that feeds the audio device
         void* userdata;               // Userdata passed to callback (ignored for NULL callbacks).

--- a/src/framework/audio/iaudiodriver.h
+++ b/src/framework/audio/iaudiodriver.h
@@ -78,6 +78,7 @@ public:
     virtual async::Notification outputDeviceBufferSizeChanged() const = 0;
 
     virtual std::vector<unsigned int> availableOutputDeviceBufferSizes() const = 0;
+    virtual Spec activeSpec() const = 0;
 
     virtual void resume() = 0;
     virtual void suspend() = 0;

--- a/src/framework/audio/iaudiosource.h
+++ b/src/framework/audio/iaudiosource.h
@@ -48,7 +48,7 @@ public:
     virtual async::Channel<unsigned int> audioChannelsCountChanged() const = 0;
 
     //! move buffer forward for sampleCount samples
-    virtual samples_t process(float* buffer, samples_t samplesPerChannel) = 0;
+    virtual samples_t process(float* buffer, size_t bufferSize, samples_t samplesPerChannel) = 0;
 };
 
 using IAudioSourcePtr = std::shared_ptr<IAudioSource>;

--- a/src/framework/audio/iaudiosource.h
+++ b/src/framework/audio/iaudiosource.h
@@ -45,7 +45,8 @@ public:
     //! return substream count for this source: 1 for mono, 2 for stereo, 6 for surround
     virtual unsigned int audioChannelsCount() const = 0;
 
-    virtual async::Channel<unsigned int> audioChannelsCountChanged() const = 0;
+    //! Try to set audio channel count, returns false if failed
+    virtual bool setAudioChannelsCount(unsigned int channels) = 0;
 
     //! move buffer forward for sampleCount samples
     virtual samples_t process(float* buffer, size_t bufferSize, samples_t samplesPerChannel) = 0;

--- a/src/framework/audio/ifxprocessor.h
+++ b/src/framework/audio/ifxprocessor.h
@@ -40,7 +40,7 @@ public:
     virtual bool active() const = 0;
     virtual void setActive(bool active) = 0;
 
-    virtual void process(float* buffer, unsigned int sampleCount) = 0;
+    virtual void process(float* buffer, size_t bufferSize, unsigned int sampleCount) = 0;
 };
 
 using IFxProcessorPtr = std::shared_ptr<IFxProcessor>;

--- a/src/framework/audio/internal/audiobuffer.cpp
+++ b/src/framework/audio/internal/audiobuffer.cpp
@@ -142,7 +142,7 @@ void AudioBuffer::forward()
     samples_t framesToReserve = DEFAULT_SIZE / 2;
 
     while (reservedFrames(nextWriteIdx, currentReadIdx) < framesToReserve) {
-        m_source->process(m_data.data() + nextWriteIdx, m_renderStep);
+        m_source->process(m_data.data() + nextWriteIdx, m_data.size() - nextWriteIdx, m_renderStep);
 
         nextWriteIdx = incrementWriteIndex(nextWriteIdx, m_renderStep);
     }
@@ -152,6 +152,7 @@ void AudioBuffer::forward()
 
 void AudioBuffer::pop(float* dest, size_t sampleCount)
 {
+    // TODO: Check buffer size
     const auto currentReadIdx = m_readIndex.load(std::memory_order_relaxed);
     const auto currentWriteIdx = m_writeIndex.load(std::memory_order_acquire);
     if (currentReadIdx == currentWriteIdx) { // empty queue

--- a/src/framework/audio/internal/audiobuffer.cpp
+++ b/src/framework/audio/internal/audiobuffer.cpp
@@ -159,8 +159,12 @@ void AudioBuffer::forward()
     samples_t framesToReserve = m_data.size() / 2;
 
     while (reservedFrames(nextWriteIdx, currentReadIdx) < framesToReserve) {
-        m_source->process(m_data.data() + nextWriteIdx, m_data.size() - nextWriteIdx, m_renderStep);
-
+        samples_t num = m_source->process(m_data.data() + nextWriteIdx, m_data.size() - nextWriteIdx, m_renderStep);
+        if (num == 0) {
+            // Free audio worker thread if there is no progress
+            break;
+        }
+        // Increment by render step even if num is less, because otherwise we could write over the buffer end
         nextWriteIdx = incrementWriteIndex(nextWriteIdx, m_renderStep);
     }
 

--- a/src/framework/audio/internal/audiobuffer.cpp
+++ b/src/framework/audio/internal/audiobuffer.cpp
@@ -24,7 +24,7 @@
 #include "log.h"
 #include "audiosanitizer.h"
 
-#include<algorithm>
+#include <algorithm>
 
 using namespace mu::audio;
 

--- a/src/framework/audio/internal/audiobuffer.cpp
+++ b/src/framework/audio/internal/audiobuffer.cpp
@@ -111,6 +111,7 @@ static BaseBufferProfiler WRITE_PROFILE("WRITE_PROFILE", 0);
 
 void AudioBuffer::init(const audioch_t audioChannelsCount, const samples_t renderStep)
 {
+    // Prevent both write and read thread from accessing the data buffer as it might be reallocated
     std::scoped_lock lock(m_writeMutex, m_readMutex);
     m_samplesPerChannel = DEFAULT_SIZE_PER_CHANNEL;
     m_audioChannelsCount = audioChannelsCount;
@@ -131,6 +132,7 @@ void AudioBuffer::setAudioChannelsCount(const audioch_t audioChannelsCount)
 
 void AudioBuffer::setSource(std::shared_ptr<IAudioSource> source)
 {
+    // Source pointer is only used in write thread
     std::scoped_lock lock(m_writeMutex);
     if (m_source == source) {
         return;

--- a/src/framework/audio/internal/audiobuffer.cpp
+++ b/src/framework/audio/internal/audiobuffer.cpp
@@ -226,7 +226,6 @@ void AudioBuffer::setMinSamplesToReserve(size_t lag)
 
 void AudioBuffer::reset()
 {
-    std::scoped_lock lock(m_writeMutex, m_readMutex);
     m_readIndex.store(0, std::memory_order_release);
     m_writeIndex.store(0, std::memory_order_release);
 

--- a/src/framework/audio/internal/audiobuffer.h
+++ b/src/framework/audio/internal/audiobuffer.h
@@ -53,7 +53,7 @@ public:
     void setSource(std::shared_ptr<IAudioSource> source);
     void forward();
 
-    void pop(float* dest, size_t sampleCount);
+    void pop(float* dest, size_t byteCount);
     void setMinSamplesToReserve(size_t lag);
 
     void reset();

--- a/src/framework/audio/internal/audiobuffer.h
+++ b/src/framework/audio/internal/audiobuffer.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <memory>
 #include <atomic>
+#include <mutex>
 
 #include "iaudiosource.h"
 #include "audiotypes.h"
@@ -49,6 +50,7 @@ public:
     AudioBuffer() = default;
 
     void init(const audioch_t audioChannelsCount, const samples_t renderStep);
+    void setAudioChannelsCount(const audioch_t audioChannelsCount);
 
     void setSource(std::shared_ptr<IAudioSource> source);
     void forward();
@@ -74,6 +76,9 @@ private:
     samples_t m_renderStep = 0;
 
     std::shared_ptr<IAudioSource> m_source = nullptr;
+
+    std::mutex m_readMutex;
+    std::mutex m_writeMutex;
 };
 
 using AudioBufferPtr = std::shared_ptr<AudioBuffer>;

--- a/src/framework/audio/internal/audiooutputdevicecontroller.cpp
+++ b/src/framework/audio/internal/audiooutputdevicecontroller.cpp
@@ -41,6 +41,12 @@ void AudioOutputDeviceController::init()
     configuration()->audioOutputDeviceIdChanged().onNotify(this, [this]() {
         AudioDeviceID deviceId = configuration()->audioOutputDeviceId();
         audioDriver()->selectOutputDevice(deviceId);
+        IAudioDriver::Spec spec = audioDriver()->activeSpec();
+        async::Async::call(this, [spec](){
+            AudioEngine::instance()->setAudioChannelsCount(spec.channels);
+            AudioEngine::instance()->setSampleRate(spec.sampleRate);
+        }, AudioThread::ID);
+
     });
 
     configuration()->driverBufferSizeChanged().onNotify(this, [this]() {
@@ -72,10 +78,20 @@ void AudioOutputDeviceController::checkConnection()
 
     if (!preferredDeviceId.empty() && preferredDeviceId != currentDeviceId && containsDevice(devices, preferredDeviceId)) {
         audioDriver()->selectOutputDevice(preferredDeviceId);
+        IAudioDriver::Spec spec = audioDriver()->activeSpec();
+        async::Async::call(this, [spec](){
+            AudioEngine::instance()->setAudioChannelsCount(spec.channels);
+            AudioEngine::instance()->setSampleRate(spec.sampleRate);
+        }, AudioThread::ID);
         return;
     }
 
     if (!containsDevice(devices, currentDeviceId)) {
         audioDriver()->resetToDefaultOutputDevice();
+        IAudioDriver::Spec spec = audioDriver()->activeSpec();
+        async::Async::call(this, [spec](){
+            AudioEngine::instance()->setAudioChannelsCount(spec.channels);
+            AudioEngine::instance()->setSampleRate(spec.sampleRate);
+        }, AudioThread::ID);
     }
 }

--- a/src/framework/audio/internal/audiooutputdevicecontroller.cpp
+++ b/src/framework/audio/internal/audiooutputdevicecontroller.cpp
@@ -40,13 +40,12 @@ void AudioOutputDeviceController::init()
 
     configuration()->audioOutputDeviceIdChanged().onNotify(this, [this]() {
         AudioDeviceID deviceId = configuration()->audioOutputDeviceId();
-        audioDriver()->selectOutputDevice(deviceId);
-        IAudioDriver::Spec spec = audioDriver()->activeSpec();
-        async::Async::call(this, [spec](){
+        async::Async::call(this, [this, deviceId](){
+            audioDriver()->selectOutputDevice(deviceId);
+            IAudioDriver::Spec spec = audioDriver()->activeSpec();
             AudioEngine::instance()->setAudioChannelsCount(spec.channels);
             AudioEngine::instance()->setSampleRate(spec.sampleRate);
         }, AudioThread::ID);
-
     });
 
     configuration()->driverBufferSizeChanged().onNotify(this, [this]() {
@@ -77,9 +76,9 @@ void AudioOutputDeviceController::checkConnection()
     AudioDeviceList devices = audioDriver()->availableOutputDevices();
 
     if (!preferredDeviceId.empty() && preferredDeviceId != currentDeviceId && containsDevice(devices, preferredDeviceId)) {
-        audioDriver()->selectOutputDevice(preferredDeviceId);
-        IAudioDriver::Spec spec = audioDriver()->activeSpec();
-        async::Async::call(this, [spec](){
+        async::Async::call(this, [this, preferredDeviceId](){
+            audioDriver()->selectOutputDevice(preferredDeviceId);
+            IAudioDriver::Spec spec = audioDriver()->activeSpec();
             AudioEngine::instance()->setAudioChannelsCount(spec.channels);
             AudioEngine::instance()->setSampleRate(spec.sampleRate);
         }, AudioThread::ID);
@@ -87,9 +86,9 @@ void AudioOutputDeviceController::checkConnection()
     }
 
     if (!containsDevice(devices, currentDeviceId)) {
-        audioDriver()->resetToDefaultOutputDevice();
-        IAudioDriver::Spec spec = audioDriver()->activeSpec();
-        async::Async::call(this, [spec](){
+        async::Async::call(this, [this](){
+            audioDriver()->resetToDefaultOutputDevice();
+            IAudioDriver::Spec spec = audioDriver()->activeSpec();
             AudioEngine::instance()->setAudioChannelsCount(spec.channels);
             AudioEngine::instance()->setSampleRate(spec.sampleRate);
         }, AudioThread::ID);

--- a/src/framework/audio/internal/fx/reverb/reverbprocessor.cpp
+++ b/src/framework/audio/internal/fx/reverb/reverbprocessor.cpp
@@ -330,10 +330,14 @@ void ReverbProcessor::setActive(bool active)
     m_params.active = active;
 }
 
-void ReverbProcessor::process(float* buffer, unsigned int sampleCount)
+void ReverbProcessor::process(float* buffer, size_t bufferSize, unsigned int sampleCount)
 {
     if (m_processor._blockSize != static_cast<int>(sampleCount)) {
         setFormat(m_processor._audioChannelsCount, m_processor._sampleRate, sampleCount);
+    }
+
+    IF_ASSERT_FAILED(bufferSize >= sampleCount * m_processor._audioChannelsCount) {
+        return;
     }
 
     for (samples_t sampleIndex = 0; sampleIndex < sampleCount; ++sampleIndex) {

--- a/src/framework/audio/internal/fx/reverb/reverbprocessor.h
+++ b/src/framework/audio/internal/fx/reverb/reverbprocessor.h
@@ -45,7 +45,7 @@ public:
     bool active() const override;
     void setActive(bool active) override;
 
-    void process(float* buffer, unsigned int sampleCount) override;
+    void process(float* buffer, size_t bufferSize, unsigned int sampleCount) override;
 
 private:
     enum Params

--- a/src/framework/audio/internal/platform/lin/linuxaudiodriver.cpp
+++ b/src/framework/audio/internal/platform/lin/linuxaudiodriver.cpp
@@ -301,6 +301,11 @@ std::vector<unsigned int> LinuxAudioDriver::availableOutputDeviceBufferSizes() c
     return result;
 }
 
+IAudioDriver::Spec LinuxAudioDriver::activeSpec() const
+{
+    return s_format;
+}
+
 void LinuxAudioDriver::resume()
 {
 }

--- a/src/framework/audio/internal/platform/lin/linuxaudiodriver.h
+++ b/src/framework/audio/internal/platform/lin/linuxaudiodriver.h
@@ -56,6 +56,7 @@ public:
     async::Notification outputDeviceBufferSizeChanged() const override;
 
     std::vector<unsigned int> availableOutputDeviceBufferSizes() const override;
+    Spec activeSpec() const override;
 
     void resume() override;
     void suspend() override;

--- a/src/framework/audio/internal/platform/osx/osxaudiodriver.h
+++ b/src/framework/audio/internal/platform/osx/osxaudiodriver.h
@@ -68,6 +68,7 @@ public:
     async::Notification outputDeviceBufferSizeChanged() const override;
 
     std::vector<unsigned int> availableOutputDeviceBufferSizes() const override;
+    Spec activeSpec() const override;
 
 private:
     static void OnFillBuffer(void* context, OpaqueAudioQueue* queue, AudioQueueBuffer* buffer);

--- a/src/framework/audio/internal/platform/osx/osxaudiodriver.mm
+++ b/src/framework/audio/internal/platform/osx/osxaudiodriver.mm
@@ -358,6 +358,11 @@ std::vector<unsigned int> OSXAudioDriver::availableOutputDeviceBufferSizes() con
     return result;
 }
 
+IAudioDriver::Spec OSXAudioDriver::activeSpec() const
+{
+    return m_data->format;
+}
+
 bool OSXAudioDriver::audioQueueSetDeviceName(const AudioDeviceID& deviceId)
 {
     if (deviceId.empty() || deviceId == DEFAULT_DEVICE_ID) {

--- a/src/framework/audio/internal/platform/web/webaudiodriver.cpp
+++ b/src/framework/audio/internal/platform/web/webaudiodriver.cpp
@@ -95,10 +95,10 @@ bool WebAudioDriver::open(const Spec& spec, Spec* activeSpec)
 
     web::context = AudioContext.new_();
     unsigned int sampleRate = web::context["sampleRate"].as<int>();
-    *activeSpec = spec;
-    activeSpec->format = Format::AudioF32;
-    activeSpec->sampleRate = sampleRate;
-    web::format = activeSpec;
+    m_activeSpec = spec;
+    m_activeSpec.format = Format::AudioF32;
+    m_activeSpec.sampleRate = sampleRate;
+    web::format = &m_activeSpec;
 
     auto audioNode = web::context.call<val>("createScriptProcessor", spec.samples, 0, spec.channels);
     if (!audioNode.as<bool>()) {
@@ -147,6 +147,11 @@ mu::async::Notification WebAudioDriver::availableOutputDevicesChanged() const
 {
     NOT_SUPPORTED;
     return mu::async::Notification();
+}
+
+IAudioDriver::Spec WebAudioDriver::activeSpec() const
+{
+    return m_activeSpec;
 }
 
 void WebAudioDriver::resume()

--- a/src/framework/audio/internal/platform/web/webaudiodriver.h
+++ b/src/framework/audio/internal/platform/web/webaudiodriver.h
@@ -41,9 +41,11 @@ public:
     bool selectOutputDevice(const std::string& name) override;
     std::vector<std::string> availableOutputDevices() const override;
     async::Notification availableOutputDevicesChanged() const override;
+    Spec activeSpec() const override;
 
 private:
     bool m_opened = false;
+    Spec m_activeSpec;
 };
 }
 

--- a/src/framework/audio/internal/platform/win/wasapiaudioclient.cpp
+++ b/src/framework/audio/internal/platform/win/wasapiaudioclient.cpp
@@ -130,6 +130,22 @@ static void logWAVEFORMATEX(WAVEFORMATEX* format)
     LOGI() << "cbSize: " << format->cbSize;
 }
 
+static void logWAVEFORMATEXTENSIBLE(WAVEFORMATEXTENSIBLE* format)
+{
+    logWAVEFORMATEX(&format->Format);
+    if (format->Format.wBitsPerSample != 0) {
+        LOGI() << "Valid bits per sample: "
+               << format->Samples.wValidBitsPerSample;
+    } else {
+        LOGI() << "Samples per block: " << format->Samples.wSamplesPerBlock;
+    }
+    LOGI() << "Channel mask: " << format->dwChannelMask;
+
+    // LOGI() << "SubFormat GUID: " << format->SubFormat.Data1 << "." <<
+    // format->SubFormat.Data2 << "." << format->SubFormat.Data3 << "." <<
+    // format->SubFormat.Data4;
+}
+
 //
 //  ActivateCompleted()
 //
@@ -286,7 +302,8 @@ HRESULT WasapiAudioClient::configureDeviceInternal() noexcept
         check_hresult(m_audioClient->GetMixFormat(m_mixFormat.put()));
 
         LOGI() << "WASAPI: Mix format after getting from audio client:";
-        logWAVEFORMATEX(m_mixFormat.get());
+        WAVEFORMATEXTENSIBLE* extensibleMixFormat = (WAVEFORMATEXTENSIBLE*)m_mixFormat.get();
+        logWAVEFORMATEXTENSIBLE(extensibleMixFormat);
 
         m_mixFormat->wFormatTag = WAVE_FORMAT_IEEE_FLOAT;
         m_mixFormat->nChannels = 2;

--- a/src/framework/audio/internal/platform/win/wasapiaudioclient.cpp
+++ b/src/framework/audio/internal/platform/win/wasapiaudioclient.cpp
@@ -25,7 +25,6 @@
 #include "log.h"
 
 using namespace winrt;
-using namespace winrt::Windows::Foundation;
 
 WasapiAudioClient::WasapiAudioClient(HANDLE clientStartedEvent, HANDLE clientFailedToStartEvent, HANDLE clientStoppedEvent)
     : m_clientStartedEvent(clientStartedEvent), m_clientFailedToStartEvent(clientFailedToStartEvent), m_clientStoppedEvent(
@@ -141,9 +140,10 @@ static void logWAVEFORMATEXTENSIBLE(WAVEFORMATEXTENSIBLE* format)
     }
     LOGI() << "Channel mask: " << format->dwChannelMask;
 
-    // LOGI() << "SubFormat GUID: " << format->SubFormat.Data1 << "." <<
-    // format->SubFormat.Data2 << "." << format->SubFormat.Data3 << "." <<
-    // format->SubFormat.Data4;
+    PWSTR subFormatString;
+    StringFromIID(format->SubFormat, &subFormatString);
+
+    LOGI() << "SubFormat GUID: " << subFormatString;
 }
 
 //

--- a/src/framework/audio/internal/platform/win/wasapiaudiodriver.cpp
+++ b/src/framework/audio/internal/platform/win/wasapiaudiodriver.cpp
@@ -277,6 +277,11 @@ std::vector<unsigned int> WasapiAudioDriver::availableOutputDeviceBufferSizes() 
     return result;
 }
 
+IAudioDriver::Spec WasapiAudioDriver::activeSpec() const
+{
+    return m_activeSpec;
+}
+
 void WasapiAudioDriver::resume()
 {
 }

--- a/src/framework/audio/internal/platform/win/wasapiaudiodriver.cpp
+++ b/src/framework/audio/internal/platform/win/wasapiaudiodriver.cpp
@@ -136,6 +136,7 @@ bool WasapiAudioDriver::open(const Spec& spec, Spec* activeSpec)
 
     m_activeSpec = m_desiredSpec;
     m_activeSpec.sampleRate = s_data.wasapiClient->sampleRate();
+    m_activeSpec.channels = s_data.wasapiClient->channelCount();
     *activeSpec = m_activeSpec;
 
     m_isOpened = true;

--- a/src/framework/audio/internal/platform/win/wasapiaudiodriver.cpp
+++ b/src/framework/audio/internal/platform/win/wasapiaudiodriver.cpp
@@ -71,6 +71,7 @@ WasapiAudioDriver::WasapiAudioDriver()
 
         if (m_deviceId == DEFAULT_DEVICE_ID) {
             reopen();
+            m_outputDeviceChanged.notify();
         }
     });
 }
@@ -203,6 +204,7 @@ mu::async::Notification WasapiAudioDriver::outputDeviceChanged() const
 AudioDeviceList WasapiAudioDriver::availableOutputDevices() const
 {
     using namespace Windows::Devices::Enumeration;
+    using namespace winrt::Windows::Foundation;
     using namespace winrt::Windows::Media::Devices;
 
     AudioDeviceList result;

--- a/src/framework/audio/internal/platform/win/wasapiaudiodriver.h
+++ b/src/framework/audio/internal/platform/win/wasapiaudiodriver.h
@@ -24,6 +24,7 @@
 #define MU_AUDIO_WASAPIAUDIODRIVER_H
 
 #include <memory>
+#include <mutex>
 
 #include "async/asyncable.h"
 
@@ -70,6 +71,9 @@ private:
     async::Notification m_outputDeviceChanged;
     async::Notification m_availableOutputDevicesChanged;
     async::Notification m_outputDeviceBufferSizeChanged;
+
+    // Guards m_deviceId
+    mutable std::recursive_mutex m_mutex;
 
     Spec m_desiredSpec;
     Spec m_activeSpec;

--- a/src/framework/audio/internal/platform/win/wasapiaudiodriver.h
+++ b/src/framework/audio/internal/platform/win/wasapiaudiodriver.h
@@ -51,6 +51,7 @@ public:
     bool setOutputDeviceBufferSize(unsigned int bufferSize) override;
     async::Notification outputDeviceBufferSizeChanged() const override;
     std::vector<unsigned int> availableOutputDeviceBufferSizes() const override;
+    Spec activeSpec() const override;
     void resume() override;
     void suspend() override;
 

--- a/src/framework/audio/internal/soundtracks/soundtrackwriter.cpp
+++ b/src/framework/audio/internal/soundtracks/soundtrackwriter.cpp
@@ -136,7 +136,7 @@ Ret SoundTrackWriter::prepareInputBuffer()
     samples_t renderStep = config()->renderStep();
 
     while (inputBufferOffset < inputBufferMaxOffset && !m_isAborted) {
-        m_source->process(m_intermBuffer.data(), renderStep);
+        m_source->process(m_intermBuffer.data(), m_intermBuffer.size(), renderStep);
 
         size_t samplesToCopy = std::min(m_intermBuffer.size(), inputBufferMaxOffset - inputBufferOffset);
 

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
@@ -324,9 +324,13 @@ unsigned int FluidSynth::audioChannelsCount() const
     return FLUID_AUDIO_CHANNELS_PAIR * 2;
 }
 
-samples_t FluidSynth::process(float* buffer, samples_t samplesPerChannel)
+samples_t FluidSynth::process(float* buffer, size_t bufferSize, samples_t samplesPerChannel)
 {
     IF_ASSERT_FAILED(samplesPerChannel > 0) {
+        return 0;
+    }
+    unsigned int channelCount = audioChannelsCount();
+    IF_ASSERT_FAILED(bufferSize >= channelCount * samplesPerChannel) {
         return 0;
     }
 
@@ -343,8 +347,6 @@ samples_t FluidSynth::process(float* buffer, samples_t samplesPerChannel)
     }
 
     fluid_synth_tune_notes(m_fluid->synth, 0, 0, m_tuning.size(), m_tuning.keys.data(), m_tuning.pitches.data(), true);
-
-    unsigned int channelCount = audioChannelsCount();
 
     int result = fluid_synth_write_float(m_fluid->synth, samplesPerChannel,
                                          buffer, 0, channelCount,

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
@@ -359,9 +359,10 @@ samples_t FluidSynth::process(float* buffer, size_t bufferSize, samples_t sample
     return samplesPerChannel;
 }
 
-async::Channel<unsigned int> FluidSynth::audioChannelsCountChanged() const
+bool FluidSynth::setAudioChannelsCount(unsigned int /*channels*/)
 {
-    return m_streamsCountChanged;
+    // Different number of channels not implemented
+    return false;
 }
 
 void FluidSynth::toggleExpressionController()

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.h
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.h
@@ -63,7 +63,7 @@ public:
     void revokePlayingNotes() override; // all channels
 
     unsigned int audioChannelsCount() const override;
-    samples_t process(float* buffer, samples_t samplesPerChannel) override;
+    samples_t process(float* buffer, size_t bufferSize, samples_t samplesPerChannel) override;
     async::Channel<unsigned int> audioChannelsCountChanged() const override;
     void setSampleRate(unsigned int sampleRate) override;
 

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.h
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.h
@@ -64,7 +64,7 @@ public:
 
     unsigned int audioChannelsCount() const override;
     samples_t process(float* buffer, size_t bufferSize, samples_t samplesPerChannel) override;
-    async::Channel<unsigned int> audioChannelsCountChanged() const override;
+    bool setAudioChannelsCount(unsigned int channels) override;
     void setSampleRate(unsigned int sampleRate) override;
 
     bool isValid() const override;

--- a/src/framework/audio/internal/worker/abstractaudiosource.cpp
+++ b/src/framework/audio/internal/worker/abstractaudiosource.cpp
@@ -38,7 +38,8 @@ void AbstractAudioSource::setIsActive(bool isActive)
     m_isActive = isActive;
 }
 
-mu::async::Channel<unsigned int> AbstractAudioSource::audioChannelsCountChanged() const
+bool AbstractAudioSource::setAudioChannelsCount(unsigned int /*channels*/)
 {
-    return m_streamsCountChanged;
+    // Default implementation does not allow changing channel count
+    return false;
 }

--- a/src/framework/audio/internal/worker/abstractaudiosource.h
+++ b/src/framework/audio/internal/worker/abstractaudiosource.h
@@ -35,11 +35,10 @@ public:
     bool isActive() const override;
     void setIsActive(bool arg) override;
 
-    mu::async::Channel<unsigned int> audioChannelsCountChanged() const override;
+    bool setAudioChannelsCount(unsigned int channels) override;
 
 protected:
     unsigned int m_sampleRate = 1;
-    async::Channel<unsigned int> m_streamsCountChanged;
     bool m_isActive = false;
 };
 }

--- a/src/framework/audio/internal/worker/audioengine.cpp
+++ b/src/framework/audio/internal/worker/audioengine.cpp
@@ -125,6 +125,7 @@ void AudioEngine::setAudioChannelsCount(const audioch_t count)
     }
 
     m_mixer->setAudioChannelsCount(count);
+    m_buffer->setAudioChannelsCount(count);
 }
 
 RenderMode AudioEngine::mode() const

--- a/src/framework/audio/internal/worker/equaliser.cpp
+++ b/src/framework/audio/internal/worker/equaliser.cpp
@@ -43,8 +43,11 @@ void Equaliser::setActive(bool active)
     m_active = active;
 }
 
-void Equaliser::process(float* buffer, unsigned int sampleCount)
+void Equaliser::process(float* buffer, size_t bufferSize, unsigned int sampleCount)
 {
+    IF_ASSERT_FAILED(bufferSize >= sampleCount) {
+        return;
+    }
     for (unsigned int i = 0; i < sampleCount; ++i) {
         m_x[2] = m_x[1];
         m_x[1] = m_x[0];

--- a/src/framework/audio/internal/worker/equaliser.h
+++ b/src/framework/audio/internal/worker/equaliser.h
@@ -39,7 +39,7 @@ public:
     void setGain(float value);
     void setQ(float value);
 
-    void process(float* buffer, unsigned int sampleCount) override;
+    void process(float* buffer, size_t bufferSize, unsigned int sampleCount) override;
 
 private:
     void calculate();

--- a/src/framework/audio/internal/worker/eventaudiosource.cpp
+++ b/src/framework/audio/internal/worker/eventaudiosource.cpp
@@ -108,7 +108,7 @@ async::Channel<unsigned int> EventAudioSource::audioChannelsCountChanged() const
     return m_synth->audioChannelsCountChanged();
 }
 
-samples_t EventAudioSource::process(float* buffer, samples_t samplesPerChannel)
+samples_t EventAudioSource::process(float* buffer, size_t bufferSize, samples_t samplesPerChannel)
 {
     ONLY_AUDIO_WORKER_THREAD;
 
@@ -116,7 +116,7 @@ samples_t EventAudioSource::process(float* buffer, samples_t samplesPerChannel)
         return 0;
     }
 
-    return m_synth->process(buffer, samplesPerChannel);
+    return m_synth->process(buffer, bufferSize, samplesPerChannel);
 }
 
 void EventAudioSource::seek(const msecs_t newPositionMsecs)

--- a/src/framework/audio/internal/worker/eventaudiosource.cpp
+++ b/src/framework/audio/internal/worker/eventaudiosource.cpp
@@ -97,15 +97,15 @@ unsigned int EventAudioSource::audioChannelsCount() const
     return m_synth->audioChannelsCount();
 }
 
-async::Channel<unsigned int> EventAudioSource::audioChannelsCountChanged() const
+bool EventAudioSource::setAudioChannelsCount(unsigned int channels)
 {
     ONLY_AUDIO_WORKER_THREAD;
 
     IF_ASSERT_FAILED(m_synth) {
-        return {};
+        return false;
     }
 
-    return m_synth->audioChannelsCountChanged();
+    return m_synth->setAudioChannelsCount(channels);
 }
 
 samples_t EventAudioSource::process(float* buffer, size_t bufferSize, samples_t samplesPerChannel)

--- a/src/framework/audio/internal/worker/eventaudiosource.h
+++ b/src/framework/audio/internal/worker/eventaudiosource.h
@@ -46,7 +46,7 @@ public:
 
     void setSampleRate(unsigned int sampleRate) override;
     unsigned int audioChannelsCount() const override;
-    async::Channel<unsigned int> audioChannelsCountChanged() const override;
+    bool setAudioChannelsCount(unsigned int channels) override;
     samples_t process(float* buffer, size_t bufferSize, samples_t samplesPerChannel) override;
 
     void seek(const msecs_t newPositionMsecs) override;

--- a/src/framework/audio/internal/worker/eventaudiosource.h
+++ b/src/framework/audio/internal/worker/eventaudiosource.h
@@ -47,7 +47,7 @@ public:
     void setSampleRate(unsigned int sampleRate) override;
     unsigned int audioChannelsCount() const override;
     async::Channel<unsigned int> audioChannelsCountChanged() const override;
-    samples_t process(float* buffer, samples_t samplesPerChannel) override;
+    samples_t process(float* buffer, size_t bufferSize, samples_t samplesPerChannel) override;
 
     void seek(const msecs_t newPositionMsecs) override;
 

--- a/src/framework/audio/internal/worker/mixer.cpp
+++ b/src/framework/audio/internal/worker/mixer.cpp
@@ -114,11 +114,12 @@ Ret Mixer::removeChannel(const TrackId trackId)
     return make_ret(Err::InvalidTrackId);
 }
 
-void Mixer::setAudioChannelsCount(const audioch_t count)
+bool Mixer::setAudioChannelsCount(unsigned int channels)
 {
     ONLY_AUDIO_WORKER_THREAD;
 
-    m_audioChannelsCount = count;
+    m_audioChannelsCount = channels;
+    return true;
 }
 
 void Mixer::setSampleRate(unsigned int sampleRate)

--- a/src/framework/audio/internal/worker/mixer.cpp
+++ b/src/framework/audio/internal/worker/mixer.cpp
@@ -181,7 +181,7 @@ samples_t Mixer::process(float* outBuffer, size_t bufferSize, samples_t samplesP
             buffer = silent_buffer;
 
             if (channel) {
-                channel->process(buffer.data(), outBufferSize, samplesPerChannel);
+                channel->process(buffer.data(), buffer.size(), samplesPerChannel);
             }
 
             return buffer;

--- a/src/framework/audio/internal/worker/mixer.h
+++ b/src/framework/audio/internal/worker/mixer.h
@@ -66,14 +66,16 @@ public:
     // IAudioSource
     void setSampleRate(unsigned int sampleRate) override;
     unsigned int audioChannelsCount() const override;
-    samples_t process(float* outBuffer, samples_t samplesPerChannel) override;
+    samples_t process(float* outBuffer, size_t bufferSize, samples_t samplesPerChannel) override;
     void setIsActive(bool arg) override;
 
 private:
-    void mixOutputFromChannel(float* outBuffer, const float* inBuffer, unsigned int samplesCount, gain_t signalAmount = 1.f);
+    void mixOutputFromChannel(float* outBuffer, size_t outBufferSize, const float* inBuffer, unsigned int samplesCount,
+                              gain_t signalAmount = 1.f);
     void prepareAuxBuffers(size_t outBufferSize);
     void writeTrackToAuxBuffers(const AuxSendsParams& auxSends, const float* trackBuffer, samples_t samplesPerChannel);
-    void processAuxChannels(float* buffer, samples_t samplesPerChannel);
+    void processAuxChannels(float* buffer, size_t bufferSize, samples_t samplesPerChannel);
+
     void completeOutput(float* buffer, samples_t samplesPerChannel);
     void notifyAboutAudioSignalChanges(const audioch_t audioChannelNumber, const float linearRms) const;
 

--- a/src/framework/audio/internal/worker/mixer.h
+++ b/src/framework/audio/internal/worker/mixer.h
@@ -70,8 +70,8 @@ public:
     void setIsActive(bool arg) override;
 
 private:
-    void mixOutputFromChannel(float* outBuffer, size_t outBufferSize, const float* inBuffer, unsigned int samplesCount,
-                              gain_t signalAmount = 1.f);
+    void mixOutputFromChannel(float* outBuffer, size_t outBufferSize, audioch_t outChannels, const float* inBuffer,
+                              unsigned int samplesCount, audioch_t inChannels, gain_t signalAmount = 1.f);
     void prepareAuxBuffers(size_t outBufferSize);
     void writeTrackToAuxBuffers(const AuxSendsParams& auxSends, const float* trackBuffer, samples_t samplesPerChannel);
     void processAuxChannels(float* buffer, size_t bufferSize, samples_t samplesPerChannel);

--- a/src/framework/audio/internal/worker/mixer.h
+++ b/src/framework/audio/internal/worker/mixer.h
@@ -51,8 +51,6 @@ public:
     RetVal<MixerChannelPtr> addAuxChannel(const TrackId trackId);
     Ret removeChannel(const TrackId trackId);
 
-    void setAudioChannelsCount(const audioch_t count);
-
     void addClock(IClockPtr clock);
     void removeClock(IClockPtr clock);
 
@@ -66,6 +64,8 @@ public:
     // IAudioSource
     void setSampleRate(unsigned int sampleRate) override;
     unsigned int audioChannelsCount() const override;
+    bool setAudioChannelsCount(unsigned int channels) override;
+
     samples_t process(float* outBuffer, size_t bufferSize, samples_t samplesPerChannel) override;
     void setIsActive(bool arg) override;
 

--- a/src/framework/audio/internal/worker/mixer.h
+++ b/src/framework/audio/internal/worker/mixer.h
@@ -74,9 +74,9 @@ private:
                               unsigned int samplesCount, audioch_t inChannels, gain_t signalAmount = 1.f);
     void prepareAuxBuffers(size_t outBufferSize);
     void writeTrackToAuxBuffers(const AuxSendsParams& auxSends, const float* trackBuffer, samples_t samplesPerChannel);
-    void processAuxChannels(float* buffer, size_t bufferSize, samples_t samplesPerChannel);
+    void processAuxChannels(float* buffer, size_t bufferSize, audioch_t bufferChannels, samples_t samplesPerChannel);
 
-    void completeOutput(float* buffer, samples_t samplesPerChannel);
+    void completeOutput(float* buffer, samples_t samplesPerChannel, audioch_t channels);
     void notifyAboutAudioSignalChanges(const audioch_t audioChannelNumber, const float linearRms) const;
 
     std::vector<float> m_writeCacheBuff;

--- a/src/framework/audio/internal/worker/mixer.h
+++ b/src/framework/audio/internal/worker/mixer.h
@@ -70,13 +70,22 @@ public:
     void setIsActive(bool arg) override;
 
 private:
-    void mixOutputFromChannel(float* outBuffer, size_t outBufferSize, audioch_t outChannels, const float* inBuffer,
-                              unsigned int samplesCount, audioch_t inChannels, gain_t signalAmount = 1.f);
-    void prepareAuxBuffers(size_t outBufferSize);
-    void writeTrackToAuxBuffers(const AuxSendsParams& auxSends, const float* trackBuffer, samples_t samplesPerChannel);
-    void processAuxChannels(float* buffer, size_t bufferSize, audioch_t bufferChannels, samples_t samplesPerChannel);
+    template<typename T>
+    struct BufferViewT
+    {
+        T* const data;
+        const size_t size;
+        const audioch_t channels;
+    };
+    using BufferView = BufferViewT<float>;
+    using ConstBufferView = BufferViewT<const float>;
 
-    void completeOutput(float* buffer, samples_t samplesPerChannel, audioch_t channels);
+    void mixOutputFromChannel(BufferView outBuffer, ConstBufferView inBuffer, unsigned int samplesCount, gain_t signalAmount = 1.f);
+    void prepareAuxBuffers(size_t outBufferSize);
+    void writeTrackToAuxBuffers(const AuxSendsParams& auxSends, ConstBufferView trackBuffer, samples_t samplesPerChannel);
+    void processAuxChannels(BufferView buffer, samples_t samplesPerChannel);
+
+    void completeOutput(BufferView buffer, samples_t samplesPerChannel);
     void notifyAboutAudioSignalChanges(const audioch_t audioChannelNumber, const float linearRms) const;
 
     std::vector<float> m_writeCacheBuff;

--- a/src/framework/audio/internal/worker/mixerchannel.cpp
+++ b/src/framework/audio/internal/worker/mixerchannel.cpp
@@ -156,11 +156,11 @@ unsigned int MixerChannel::audioChannelsCount() const
     return m_audioSource ? m_audioSource->audioChannelsCount() : m_audioChannelsCount;
 }
 
-async::Channel<unsigned int> MixerChannel::audioChannelsCountChanged() const
+bool MixerChannel::setAudioChannelsCount(unsigned int channels)
 {
     ONLY_AUDIO_WORKER_THREAD;
 
-    return m_audioSource ? m_audioSource->audioChannelsCountChanged() : async::Channel<unsigned int>();
+    return m_audioSource ? m_audioSource->setAudioChannelsCount(channels) : false;
 }
 
 samples_t MixerChannel::process(float* buffer, size_t bufferSize, samples_t samplesPerChannel)

--- a/src/framework/audio/internal/worker/mixerchannel.h
+++ b/src/framework/audio/internal/worker/mixerchannel.h
@@ -53,7 +53,7 @@ public:
 
     void setSampleRate(unsigned int sampleRate) override;
     unsigned int audioChannelsCount() const override;
-    async::Channel<unsigned int> audioChannelsCountChanged() const override;
+    bool setAudioChannelsCount(unsigned int channels) override;
     samples_t process(float* buffer, size_t bufferSize, samples_t samplesPerChannel) override;
 
 private:

--- a/src/framework/audio/internal/worker/mixerchannel.h
+++ b/src/framework/audio/internal/worker/mixerchannel.h
@@ -54,10 +54,10 @@ public:
     void setSampleRate(unsigned int sampleRate) override;
     unsigned int audioChannelsCount() const override;
     async::Channel<unsigned int> audioChannelsCountChanged() const override;
-    samples_t process(float* buffer, samples_t samplesPerChannel) override;
+    samples_t process(float* buffer, size_t bufferSize, samples_t samplesPerChannel) override;
 
 private:
-    void completeOutput(float* buffer, unsigned int samplesCount) const;
+    void completeOutput(float* buffer, size_t bufferSize, unsigned int samplesCount) const;
     void notifyAboutAudioSignalChanges(const audioch_t audioChannelNumber, const float linearRms) const;
 
     TrackId m_trackId = -1;

--- a/src/framework/audio/internal/worker/noisesource.cpp
+++ b/src/framework/audio/internal/worker/noisesource.cpp
@@ -21,6 +21,8 @@
  */
 #include "noisesource.h"
 #include <random>
+
+#include "log.h"
 using namespace mu::audio;
 
 NoiseSource::NoiseSource()
@@ -37,9 +39,12 @@ unsigned int NoiseSource::audioChannelsCount() const
     return 1;
 }
 
-samples_t NoiseSource::process(float* buffer, samples_t samplesPerChannel)
+samples_t NoiseSource::process(float* buffer, size_t bufferSize, samples_t samplesPerChannel)
 {
     auto streams = audioChannelsCount();
+    IF_ASSERT_FAILED(bufferSize >= streams * samplesPerChannel) {
+        return 0;
+    }
     std::uniform_real_distribution<float> distribution{ -1.f, 1.f };
     std::random_device randomDevice{};
     std::mt19937 gen{ randomDevice() };

--- a/src/framework/audio/internal/worker/noisesource.h
+++ b/src/framework/audio/internal/worker/noisesource.h
@@ -38,7 +38,7 @@ public:
     void setType(Type type);
     unsigned int audioChannelsCount() const override;
 
-    samples_t process(float* buffer, samples_t samplesPerChannel) override;
+    samples_t process(float* buffer, size_t bufferSize, samples_t samplesPerChannel) override;
 
 private:
     float pinkFilter(float white);

--- a/src/framework/audio/internal/worker/sinesource.cpp
+++ b/src/framework/audio/internal/worker/sinesource.cpp
@@ -20,6 +20,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "sinesource.h"
+
+#include "log.h"
 #include <cmath>
 
 using namespace mu::audio;

--- a/src/framework/audio/internal/worker/sinesource.cpp
+++ b/src/framework/audio/internal/worker/sinesource.cpp
@@ -33,9 +33,13 @@ unsigned int SineSource::audioChannelsCount() const
     return 2;
 }
 
-samples_t SineSource::process(float* buffer, samples_t samplesPerChannel)
+samples_t SineSource::process(float* buffer, size_t bufferSize, samples_t samplesPerChannel)
 {
     auto streams = audioChannelsCount();
+    IF_ASSERT_FAILED(bufferSize >= streams * samplesPerChannel) {
+        return 0;
+    }
+
     for (unsigned int i = 0; i < samplesPerChannel; ++i) {
         m_phase += m_frequency / m_sampleRate * 2 * M_PI;
         if (m_phase > 2 * M_PI) {

--- a/src/framework/audio/internal/worker/sinesource.h
+++ b/src/framework/audio/internal/worker/sinesource.h
@@ -33,7 +33,7 @@ public:
 
     unsigned int audioChannelsCount() const override;
 
-    samples_t process(float* buffer, samples_t samplesPerChannel) override;
+    samples_t process(float* buffer, size_t bufferSize, samples_t samplesPerChannel) override;
 
 private:
     float m_frequency = 1000.f;

--- a/src/framework/musesampler/internal/musesamplerwrapper.cpp
+++ b/src/framework/musesampler/internal/musesamplerwrapper.cpp
@@ -92,9 +92,9 @@ unsigned int MuseSamplerWrapper::audioChannelsCount() const
     return AUDIO_CHANNELS_COUNT;
 }
 
-async::Channel<unsigned int> MuseSamplerWrapper::audioChannelsCountChanged() const
+bool MuseSamplerWrapper::setAudioChannelsCount(unsigned int /*channels*/)
 {
-    return m_audioChannelsCountChanged;
+    return false;
 }
 
 samples_t MuseSamplerWrapper::process(float* buffer, size_t bufferSize, audio::samples_t samplesPerChannel)

--- a/src/framework/musesampler/internal/musesamplerwrapper.cpp
+++ b/src/framework/musesampler/internal/musesamplerwrapper.cpp
@@ -97,7 +97,7 @@ async::Channel<unsigned int> MuseSamplerWrapper::audioChannelsCountChanged() con
     return m_audioChannelsCountChanged;
 }
 
-samples_t MuseSamplerWrapper::process(float* buffer, audio::samples_t samplesPerChannel)
+samples_t MuseSamplerWrapper::process(float* buffer, size_t bufferSize, audio::samples_t samplesPerChannel)
 {
     if (!m_samplerLib || !m_sampler || !m_track) {
         return 0;
@@ -124,7 +124,7 @@ samples_t MuseSamplerWrapper::process(float* buffer, audio::samples_t samplesPer
         }
     }
 
-    extractOutputSamples(samplesPerChannel, buffer);
+    extractOutputSamples(samplesPerChannel, buffer, bufferSize);
 
     if (active) {
         m_currentPosition += samplesPerChannel;
@@ -314,8 +314,11 @@ void MuseSamplerWrapper::setCurrentPosition(const audio::samples_t samples)
     LOGD() << "Seek a new playback position, newPosition: " << m_currentPosition;
 }
 
-void MuseSamplerWrapper::extractOutputSamples(audio::samples_t samples, float* output)
+void MuseSamplerWrapper::extractOutputSamples(audio::samples_t samples, float* output, size_t bufferSize)
 {
+    IF_ASSERT_FAILED(bufferSize >= samples * m_bus._num_channels) {
+        return;
+    }
     for (audio::samples_t sampleIndex = 0; sampleIndex < samples; ++sampleIndex) {
         size_t offset = sampleIndex * m_bus._num_channels;
 

--- a/src/framework/musesampler/internal/musesamplerwrapper.h
+++ b/src/framework/musesampler/internal/musesamplerwrapper.h
@@ -41,7 +41,7 @@ public:
     void setSampleRate(unsigned int sampleRate) override;
     unsigned int audioChannelsCount() const override;
     async::Channel<unsigned int> audioChannelsCountChanged() const override;
-    audio::samples_t process(float* buffer, audio::samples_t samplesPerChannel) override;
+    audio::samples_t process(float* buffer, size_t bufferSize, audio::samples_t samplesPerChannel) override;
 
     std::string name() const override;
     audio::AudioSourceType type() const override;
@@ -62,7 +62,7 @@ protected:
 
     void handleAuditionEvents(const MuseSamplerSequencer::EventType& event);
     void setCurrentPosition(const audio::samples_t samples);
-    void extractOutputSamples(audio::samples_t samples, float* output);
+    void extractOutputSamples(audio::samples_t samples, float* output, size_t bufferSize);
 
     async::Channel<unsigned int> m_audioChannelsCountChanged;
 

--- a/src/framework/musesampler/internal/musesamplerwrapper.h
+++ b/src/framework/musesampler/internal/musesamplerwrapper.h
@@ -40,7 +40,7 @@ public:
 
     void setSampleRate(unsigned int sampleRate) override;
     unsigned int audioChannelsCount() const override;
-    async::Channel<unsigned int> audioChannelsCountChanged() const override;
+    bool setAudioChannelsCount(unsigned int channels) override;
     audio::samples_t process(float* buffer, size_t bufferSize, audio::samples_t samplesPerChannel) override;
 
     std::string name() const override;

--- a/src/framework/vst/internal/fx/vstfxprocessor.cpp
+++ b/src/framework/vst/internal/fx/vstfxprocessor.cpp
@@ -87,12 +87,12 @@ void VstFxProcessor::setActive(bool active)
     m_params.active = active;
 }
 
-void VstFxProcessor::process(float* buffer, unsigned int sampleCount)
+void VstFxProcessor::process(float* buffer, size_t bufferSize, unsigned int sampleCount)
 {
     if (!buffer || !m_inited) {
         return;
     }
 
     m_vstAudioClient->setBlockSize(sampleCount);
-    m_vstAudioClient->process(buffer, sampleCount);
+    m_vstAudioClient->process(buffer, bufferSize, sampleCount);
 }

--- a/src/framework/vst/internal/fx/vstfxprocessor.h
+++ b/src/framework/vst/internal/fx/vstfxprocessor.h
@@ -24,7 +24,7 @@ public:
     void setSampleRate(unsigned int sampleRate) override;
     bool active() const override;
     void setActive(bool active) override;
-    void process(float* buffer, unsigned int sampleCount) override;
+    void process(float* buffer, size_t bufferSize, unsigned int sampleCount) override;
 
 private:
     bool m_inited = false;

--- a/src/framework/vst/internal/synth/vstsynthesiser.cpp
+++ b/src/framework/vst/internal/synth/vstsynthesiser.cpp
@@ -171,9 +171,9 @@ unsigned int VstSynthesiser::audioChannelsCount() const
     return config()->audioChannelsCount();
 }
 
-async::Channel<unsigned int> VstSynthesiser::audioChannelsCountChanged() const
+bool VstSynthesiser::setAudioChannelsCount(unsigned int /*channels*/)
 {
-    return m_streamsCountChanged;
+    return false;
 }
 
 audio::samples_t VstSynthesiser::process(float* buffer, size_t bufferSize, audio::samples_t samplesPerChannel)

--- a/src/framework/vst/internal/synth/vstsynthesiser.cpp
+++ b/src/framework/vst/internal/synth/vstsynthesiser.cpp
@@ -176,7 +176,7 @@ async::Channel<unsigned int> VstSynthesiser::audioChannelsCountChanged() const
     return m_streamsCountChanged;
 }
 
-audio::samples_t VstSynthesiser::process(float* buffer, audio::samples_t samplesPerChannel)
+audio::samples_t VstSynthesiser::process(float* buffer, size_t bufferSize, audio::samples_t samplesPerChannel)
 {
     if (!buffer) {
         return 0;
@@ -197,5 +197,5 @@ audio::samples_t VstSynthesiser::process(float* buffer, audio::samples_t samples
         }
     }
 
-    return m_vstAudioClient->process(buffer, samplesPerChannel);
+    return m_vstAudioClient->process(buffer, bufferSize, samplesPerChannel);
 }

--- a/src/framework/vst/internal/synth/vstsynthesiser.h
+++ b/src/framework/vst/internal/synth/vstsynthesiser.h
@@ -67,7 +67,7 @@ public:
     // IAudioSource
     void setSampleRate(unsigned int sampleRate) override;
     unsigned int audioChannelsCount() const override;
-    async::Channel<unsigned int> audioChannelsCountChanged() const override;
+    bool setAudioChannelsCount(unsigned int channels) override;
     audio::samples_t process(float* buffer, size_t bufferSize, audio::samples_t samplesPerChannel) override;
 
 private:
@@ -78,7 +78,6 @@ private:
 
     std::unique_ptr<VstAudioClient> m_vstAudioClient = nullptr;
 
-    async::Channel<unsigned int> m_streamsCountChanged;
     audio::samples_t m_samplesPerChannel = 0;
 
     VstSequencer m_sequencer;

--- a/src/framework/vst/internal/synth/vstsynthesiser.h
+++ b/src/framework/vst/internal/synth/vstsynthesiser.h
@@ -68,7 +68,7 @@ public:
     void setSampleRate(unsigned int sampleRate) override;
     unsigned int audioChannelsCount() const override;
     async::Channel<unsigned int> audioChannelsCountChanged() const override;
-    audio::samples_t process(float* buffer, audio::samples_t samplesPerChannel) override;
+    audio::samples_t process(float* buffer, size_t bufferSize, audio::samples_t samplesPerChannel) override;
 
 private:
     Ret init();

--- a/src/framework/vst/internal/vstaudioclient.cpp
+++ b/src/framework/vst/internal/vstaudioclient.cpp
@@ -83,7 +83,7 @@ void VstAudioClient::setVolumeGain(const audio::gain_t newVolumeGain)
     m_volumeGain = newVolumeGain;
 }
 
-audio::samples_t VstAudioClient::process(float* output, samples_t samplesPerChannel)
+audio::samples_t VstAudioClient::process(float* output, size_t bufferSize, samples_t samplesPerChannel)
 {
     IAudioProcessorPtr processor = pluginProcessor();
     if (!processor || !output) {
@@ -91,6 +91,10 @@ audio::samples_t VstAudioClient::process(float* output, samples_t samplesPerChan
     }
 
     if (!m_isActive) {
+        return 0;
+    }
+
+    IF_ASSERT_FAILED(bufferSize >= samplesPerChannel * m_audioChannelsCount) {
         return 0;
     }
 

--- a/src/framework/vst/internal/vstaudioclient.h
+++ b/src/framework/vst/internal/vstaudioclient.h
@@ -41,7 +41,7 @@ public:
     bool handleParamChange(const PluginParamInfo& param);
     void setVolumeGain(const audio::gain_t newVolumeGain);
 
-    audio::samples_t process(float* output, audio::samples_t samplesPerChannel);
+    audio::samples_t process(float* output, size_t bufferSize, audio::samples_t samplesPerChannel);
     void flush();
 
     void setBlockSize(unsigned int samples);

--- a/src/stubs/framework/audio/audiodriverstub.cpp
+++ b/src/stubs/framework/audio/audiodriverstub.cpp
@@ -96,6 +96,11 @@ std::vector<unsigned int> AudioDriverStub::availableOutputDeviceBufferSizes() co
     return {};
 }
 
+IAudioDriver::Spec AudioDriverStub::activeSpec() const
+{
+    return {};
+}
+
 void AudioDriverStub::resume()
 {
 }

--- a/src/stubs/framework/audio/audiodriverstub.h
+++ b/src/stubs/framework/audio/audiodriverstub.h
@@ -48,6 +48,7 @@ public:
     async::Notification outputDeviceBufferSizeChanged() const override;
 
     std::vector<unsigned int> availableOutputDeviceBufferSizes() const override;
+    Spec activeSpec() const override;
 
     void resume() override;
     void suspend() override;

--- a/src/stubs/framework/audio/synthesizerstub.cpp
+++ b/src/stubs/framework/audio/synthesizerstub.cpp
@@ -39,9 +39,9 @@ unsigned int SynthesizerStub::audioChannelsCount() const
     return 2;
 }
 
-mu::async::Channel<unsigned int> SynthesizerStub::audioChannelsCountChanged() const
+bool SynthesizerStub::setAudioChannelsCount(unsigned int /*channels*/)
 {
-    return async::Channel<unsigned int>();
+    return false;
 }
 
 samples_t SynthesizerStub::process(float*, size_t, samples_t)

--- a/src/stubs/framework/audio/synthesizerstub.cpp
+++ b/src/stubs/framework/audio/synthesizerstub.cpp
@@ -44,7 +44,7 @@ mu::async::Channel<unsigned int> SynthesizerStub::audioChannelsCountChanged() co
     return async::Channel<unsigned int>();
 }
 
-samples_t SynthesizerStub::process(float*, samples_t)
+samples_t SynthesizerStub::process(float*, size_t, samples_t)
 {
     return 0;
 }

--- a/src/stubs/framework/audio/synthesizerstub.h
+++ b/src/stubs/framework/audio/synthesizerstub.h
@@ -36,7 +36,7 @@ public:
 
     async::Channel<unsigned int> audioChannelsCountChanged() const override;
 
-    samples_t process(float* buffer, samples_t samplesPerChannel) override;
+    samples_t process(float* buffer, size_t bufferSize, samples_t samplesPerChannel) override;
 
     std::string name() const override;
     AudioSourceType type() const override;

--- a/src/stubs/framework/audio/synthesizerstub.h
+++ b/src/stubs/framework/audio/synthesizerstub.h
@@ -34,7 +34,7 @@ public:
 
     unsigned int audioChannelsCount() const override;
 
-    async::Channel<unsigned int> audioChannelsCountChanged() const override;
+    bool setAudioChannelsCount(unsigned int channels) override;
 
     samples_t process(float* buffer, size_t bufferSize, samples_t samplesPerChannel) override;
 


### PR DESCRIPTION
Resolves: #17648 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Playback for 5.1 audio output is high pitched because it was assumed that there are only 2 channels, thus overwriting the other channels with data meant for stereo output.
In this PR, I correctly forward the true channel count to the audio buffer and mixer. The two channels from instruments and effects are extended to the correct number in the mixer. The audio buffer is resized to match the necessary number of samples.
Output device changes are handled (both default output in Windows and in the preferences), but there is a short glitch when the number of channels changes (there is a delay until the channel count updates).

I tested on Windows 10, but some changes also impact Mac and Linux and have not been tested.
<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
