### PR TITLE
fix #15866 - correct playback of drum palette

### DIFF
--- a/src/palette/view/widgets/drumsetpalette.cpp
+++ b/src/palette/view/widgets/drumsetpalette.cpp
@@ -196,7 +196,7 @@ void DrumsetPalette::previewSound(const Chord* chord, bool newChordSelected, con
 
     Chord* preview = chord->clone();
     preview->setParent(inputState.segment);
-    preview->setStaffIdx(engraving::track2staff(inputState.currentTrack));
+    preview->setTrack(inputState.currentTrack);
 
     playback()->playElements({ preview });
 


### PR DESCRIPTION
Resolves: #15866  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
children notes of Chord needs correct track set

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x ] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
