### PR TITLE
fixed #9966: Closing one of multiple projects leaves windows open

### DIFF
--- a/src/multiinstances/internal/ipc/ipcsocket.cpp
+++ b/src/multiinstances/internal/ipc/ipcsocket.cpp
@@ -50,11 +50,8 @@ bool IpcSocket::connect(const QString& serverName)
         m_lock = new IpcLock(serverName);
         m_socket = new QLocalSocket();
 
-        QObject::connect(m_socket, &QLocalSocket::errorOccurred, [this](QLocalSocket::LocalSocketError err) {
-            //! NOTE If the server is down, then we will try to connect to another or create a server ourselves
-            if (err == QLocalSocket::PeerClosedError) {
-                m_disconnected.notify();
-            }
+        QObject::connect(m_socket, &QLocalSocket::disconnected, [this]() {
+            m_disconnected.notify();
         });
 
         QObject::connect(m_socket, &QLocalSocket::readyRead, [this]() {

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -27,6 +27,7 @@
 
 #include "defer.h"
 #include "translation.h"
+#include "async/async.h"
 
 #include "engraving/infrastructure/mscio.h"
 #include "engraving/engravingerrors.h"
@@ -360,7 +361,10 @@ bool ProjectActionsController::closeOpenedProject(bool quitApp)
         globalContext()->setCurrentProject(nullptr);
 
         if (quitApp) {
-            dispatcher()->dispatch("quit", actions::ActionData::make_arg1<bool>(false));
+            //! NOTE: we need to call `quit` in the next event loop due to controlling the lifecycle of this method
+            async::Async::call(this, [this](){
+                dispatcher()->dispatch("quit", actions::ActionData::make_arg1<bool>(false));
+            });
         } else {
             Ret ret = openPageIfNeed(HOME_PAGE_URI);
             if (!ret) {


### PR DESCRIPTION
A cyclic dependency has occurred
ActionController::quit re-calls the ProjectActionsController::closeOpenedProject method which has not yet completed

Resolves: #9966