### PR TITLE
fixed layout of ghost note together with bend

### DIFF
--- a/src/engraving/layout/v0/tlayout.cpp
+++ b/src/engraving/layout/v0/tlayout.cpp
@@ -3652,7 +3652,7 @@ void TLayout::layout2(Note* item, LayoutContext& ctx)
         if (e->isSymbol()) {
             e->setMag(item->mag());
             Shape noteShape = item->shape();
-            mu::remove_if(noteShape, [e](ShapeElement& s) { return s.toItem == e; });
+            mu::remove_if(noteShape, [e](ShapeElement& s) { return s.toItem == e || s.toItem->isBend() || s.toItem->isStretchedBend(); });
             LedgerLine* ledger = item->line() < -1 || item->line() > item->staff()->lines(item->tick())
                                  ? item->chord()->ledgerLines() : nullptr;
             if (ledger) {


### PR DESCRIPTION
avoided adding bends to note shape while layouting brackets for ghost note

<img width="204" alt="Screenshot 2023-05-22 at 13 45 03" src="https://github.com/musescore/MuseScore/assets/24373905/c03d9cdc-7f79-4795-8cc7-799302443ad5">
