### PR TITLE
Fix PalmMute crash

### DIFF
--- a/src/engraving/libmscore/chordtextlinebase.cpp
+++ b/src/engraving/libmscore/chordtextlinebase.cpp
@@ -55,6 +55,7 @@ PointF ChordTextLineBase::linePos(Grip grip, System** sys) const
     if (grip == Grip::START) {
         ChordRest* c = toChordRest(startElement());
         if (!c) {
+            *sys = s;
             return PointF();
         }
         s = c->segment()->system();


### PR DESCRIPTION
Resolves: #17622

The crash happened because in `ChordTextLine::linePos()` in the early-return case we were not setting the system to `null` so it ended up pointing to garbage.

Side note: the linePos() method (which returns the starting or ending point of any spanner line) is implemented in 3 classes: SLine, Pedal and ChordTextLineBase. There is a lot of repeated code among the three, so that probably needs rethinking at some point. In general starting/ending points of spanners is one of the most fragile and janky things in Musescore. Probably worth taking a second look at this when we do the big "anchors" work.