### PR TITLE
Introduce "Small accidental" option

### DIFF
--- a/src/inspector/models/notation/accidentals/accidentalsettingsmodel.cpp
+++ b/src/inspector/models/notation/accidentals/accidentalsettingsmodel.cpp
@@ -37,6 +37,7 @@ AccidentalSettingsModel::AccidentalSettingsModel(QObject* parent, IElementReposi
 void AccidentalSettingsModel::createProperties()
 {
     m_bracketType = buildPropertyItem(mu::engraving::Pid::ACCIDENTAL_BRACKET);
+    m_isSmall = buildPropertyItem(mu::engraving::Pid::SMALL);
 }
 
 void AccidentalSettingsModel::requestElements()
@@ -47,6 +48,7 @@ void AccidentalSettingsModel::requestElements()
 void AccidentalSettingsModel::loadProperties()
 {
     loadPropertyItem(m_bracketType);
+    loadPropertyItem(m_isSmall);
 }
 
 void AccidentalSettingsModel::resetProperties()
@@ -57,4 +59,9 @@ void AccidentalSettingsModel::resetProperties()
 PropertyItem* AccidentalSettingsModel::bracketType() const
 {
     return m_bracketType;
+}
+
+PropertyItem* AccidentalSettingsModel::isSmall() const
+{
+    return m_isSmall;
 }

--- a/src/inspector/models/notation/accidentals/accidentalsettingsmodel.h
+++ b/src/inspector/models/notation/accidentals/accidentalsettingsmodel.h
@@ -30,6 +30,8 @@ class AccidentalSettingsModel : public AbstractInspectorModel
     Q_OBJECT
 
     Q_PROPERTY(PropertyItem * bracketType READ bracketType CONSTANT)
+    Q_PROPERTY(PropertyItem * isSmall READ isSmall CONSTANT)
+
 public:
     explicit AccidentalSettingsModel(QObject* parent, IElementRepositoryService* repository);
 
@@ -39,9 +41,11 @@ public:
     void resetProperties() override;
 
     PropertyItem* bracketType() const;
+    PropertyItem* isSmall() const;
 
 private:
     PropertyItem* m_bracketType = nullptr;
+    PropertyItem* m_isSmall = nullptr;
 };
 }
 

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/accidentals/AccidentalSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/accidentals/AccidentalSettings.qml
@@ -58,4 +58,15 @@ Column {
             { iconCode: IconCode.BRACKET_PARENTHESES_SQUARE, value: AccidentalTypes.BRACKET_TYPE_SQUARE, title: qsTrc("inspector", "Brackets") }
         ]
     }
+
+    CheckBoxPropertyView {
+        id: smallAccidentalCheckBox
+
+        text: qsTrc("inspector", "Small accidental")
+        propertyItem: root.model ? root.model.isSmall : null
+
+        navigation.name: "SmallAccidentalBox"
+        navigation.panel: root.navigationPanel
+        navigation.row: bracketType.navigation.row + 1
+    }
 }


### PR DESCRIPTION
Resolves: #17306

Introducing "Small accidental" option, which has the same logic as the "Small notehead" option in terms of setting the whole chord VS individual items small.

https://github.com/musescore/MuseScore/assets/93707756/f604031e-f4ab-4175-b1b9-14f42568feb9

