### PR TITLE
Fix #14377: "Follow system theme" on Linux

### DIFF
--- a/src/framework/ui/internal/platform/linux/linuxplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/linux/linuxplatformtheme.cpp
@@ -28,26 +28,52 @@
 using namespace mu::ui;
 using namespace mu::async;
 
+static const QLatin1String service("org.freedesktop.portal.Desktop");
+static const QLatin1String path("/org/freedesktop/portal/desktop");
+static const QLatin1String interface("org.freedesktop.portal.Settings");
+static const QLatin1String settingGroup("org.freedesktop.appearance");
+static const QLatin1String settingSignal("SettingChanged");
+static const QLatin1String colorSchemeSetting("color-scheme");
+
 LinuxPlatformTheme::LinuxPlatformTheme()
 {
 }
 
 void LinuxPlatformTheme::startListening()
 {
+    QDBusConnection::sessionBus().connect(service, path, interface, settingSignal, this,
+                                          SLOT(processSettingChange(QString,QString,QDBusVariant)));
+    m_isSystemThemeDark = isSystemThemeCurrentlyDark();
+    m_isListening = true;
 }
 
 void LinuxPlatformTheme::stopListening()
 {
+    QDBusConnection::sessionBus().disconnect(service, path, interface, settingSignal, this,
+                                             SLOT(processSettingChange(QString,QString,QDBusVariant)));
+    m_isListening = false;
 }
 
 bool LinuxPlatformTheme::isFollowSystemThemeAvailable() const
 {
-    return false;
+    const QDBusConnection connection = QDBusConnection::sessionBus();
+
+    const auto iface = connection.interface();
+    if (!iface->isServiceRegistered(service)) {
+        return false;
+    }
+
+    QDBusReply<QVariant> reply = getSystemTheme();
+    return reply.isValid();
 }
 
 bool LinuxPlatformTheme::isSystemThemeDark() const
 {
-    return false;
+    if (m_isListening) {
+        return m_isSystemThemeDark;
+    }
+
+    return isSystemThemeCurrentlyDark();
 }
 
 bool LinuxPlatformTheme::isGlobalMenuAvailable() const
@@ -71,4 +97,32 @@ void LinuxPlatformTheme::applyPlatformStyleOnAppForTheme(const ThemeCode&)
 
 void LinuxPlatformTheme::applyPlatformStyleOnWindowForTheme(QWindow*, const ThemeCode&)
 {
+}
+
+void LinuxPlatformTheme::processSettingChange(const QString& group, const QString& key, const QDBusVariant& value)
+{
+    if (group == settingGroup && key == colorSchemeSetting) {
+        m_isSystemThemeDark = (value.variant().toUInt() == 1);
+        m_platformThemeChanged.notify();
+    }
+}
+
+bool LinuxPlatformTheme::isSystemThemeCurrentlyDark() const
+{
+    QDBusReply<QVariant> reply = getSystemTheme();
+
+    if (reply.isValid()) {
+        const QDBusVariant dbusVariant = qvariant_cast<QDBusVariant>(reply.value());
+        return dbusVariant.variant().toUInt() == 1;
+    }
+
+    return false;
+}
+
+QDBusReply<QVariant> LinuxPlatformTheme::getSystemTheme() const
+{
+    auto message = QDBusMessage::createMethodCall(service, path, interface, QStringLiteral("Read"));
+    message << settingGroup << colorSchemeSetting;
+
+    return QDBusConnection::sessionBus().call(message);
 }

--- a/src/framework/ui/internal/platform/linux/linuxplatformtheme.h
+++ b/src/framework/ui/internal/platform/linux/linuxplatformtheme.h
@@ -23,11 +23,16 @@
 #ifndef MU_UI_LINUXPLATFORMTHEME_H
 #define MU_UI_LINUXPLATFORMTHEME_H
 
+#include <QtDBus/QDBusReply>
+
 #include "internal/iplatformtheme.h"
 
+class QDBusVariant;
+
 namespace mu::ui {
-class LinuxPlatformTheme : public IPlatformTheme
+class LinuxPlatformTheme : public QObject, public IPlatformTheme
 {
+    Q_OBJECT
 public:
     LinuxPlatformTheme();
 
@@ -44,8 +49,16 @@ public:
     void applyPlatformStyleOnAppForTheme(const ThemeCode& themeCode) override;
     void applyPlatformStyleOnWindowForTheme(QWindow* window, const ThemeCode& themeCode) override;
 
+private slots:
+    void processSettingChange(const QString& group, const QString& key, const QDBusVariant& value);
+
 private:
+    bool isSystemThemeCurrentlyDark() const;
+    QDBusReply<QVariant> getSystemTheme() const;
+
     async::Notification m_platformThemeChanged;
+    bool m_isListening = false;
+    bool m_isSystemThemeDark = false;
 };
 }
 


### PR DESCRIPTION
Resolves: #14377
Resolves: #16966

Uses the [org.freedesktop.portal.Settings](https://flatpak.github.io/xdg-desktop-portal/#gdbus-org.freedesktop.portal.Settings) dbus API to query the `org.freedesktop.appearance color-scheme` setting.

`LinuxPlatformTheme` inherits from `QObject`. This is required because the only way of connecting a D-Bus signal to a slot using `QDBusConnection::connect()` is using the old method (`SLOT()`).

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
