### PR TITLE
Include excerpt names in --score-media command JSON output

### DIFF
--- a/src/converter/internal/compat/notationmeta.h
+++ b/src/converter/internal/compat/notationmeta.h
@@ -41,6 +41,7 @@ private:
     static QString poet(const mu::engraving::Score* score);
     static QString timesig(const mu::engraving::Score* score);
     static std::pair<int, QString> tempo(const mu::engraving::Score* score);
+    static QJsonArray instrumentsJsonArray(const mu::engraving::Score* score);
     static QJsonArray partsJsonArray(const mu::engraving::Score* score);
     static QJsonObject pageFormatJson(const mu::engraving::Score* score);
     static QJsonObject typeDataJson(mu::engraving::Score* score);


### PR DESCRIPTION
Fix #17240. Looks like it might be caused by us after all.

@bentl, please confirm this is what you need for the website backend.

---

Sample output with [TestPartNames.mscz.zip](https://github.com/musescore/MuseScore/files/11537532/TestPartNames.mscz.zip)

```Bash
mscore --score-media TestPartNames.mscz | sed -E 's|"[A-Za-z0-9+/]{100,}=*"|"BASE64DATA"|g' | jq
```

<details>
<pre lang="JSON">
{
  "pngs": [
    "BASE64DATA"
  ],
  "svgs": [
    "BASE64DATA"
  ],
  "sposXML": "BASE64DATA",
  "mposXML": "BASE64DATA",
  "pdf": "BASE64DATA",
  "midi": "BASE64DATA",
  "mxml": "BASE64DATA",
  "metadata": {
    "composer": "Composer / arranger",
    "duration": 8,
    "fileVersion": 400,
    "hasHarmonies": "false",
    "hasLyrics": "false",
    "instruments": [  // INSTRUMENTS
      {
        "harmonyCount": 0,
        "hasDrumStaff": "false",
        "hasPitchedStaff": "true",
        "hasTabStaff": "false",
        "instrumentId": "flute",
        "isVisible": "true",
        "lyricCount": 0,
        "name": "Flute",
        "program": 73
      },
      {
        "harmonyCount": 0,
        "hasDrumStaff": "false",
        "hasPitchedStaff": "true",
        "hasTabStaff": "false",
        "instrumentId": "flute",
        "isVisible": "true",
        "lyricCount": 0,
        "name": "Flute",
        "program": 73
      },
      {
        "harmonyCount": 0,
        "hasDrumStaff": "false",
        "hasPitchedStaff": "true",
        "hasTabStaff": "false",
        "instrumentId": "flute",
        "isVisible": "true",
        "lyricCount": 0,
        "name": "Flute",
        "program": 73
      }
    ],
    "keysig": 0,
    "lyrics": "",
    "measures": 4,
    "mscoreVersion": "4.0.2",
    "pageFormat": {
      "height": 297,
      "twosided": "true",
      "width": 210
    },
    "pages": 1,
    "parts": [  // PARTS
      {
        "name": "Part 1"
      },
      {
        "name": "Part 2"
      },
      {
        "name": "Part 3"
      }
    ],
    "poet": "",
    "previousSource": "https://musescore.com/user/53589840/scores/10799875",
    "subtitle": "",
    "tempo": 0,
    "tempoText": "",
    "textFramesData": {
      "composers": [],
      "poets": [],
      "subtitles": [],
      "titles": [
        "Test Part Names"
      ]
    },
    "timesig": "4/4",
    "title": "Test Part Names"
  },
  "devinfo": {
    "version": "4.1.0-dev()"
  }
}
</pre>
</details>