### PR TITLE
Fix #17502: Exclude tab staves from clef change recalculation shenanigans

### DIFF
--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -2766,7 +2766,10 @@ void Note::updateRelLine(int relLine, bool undoable)
 
     const Staff* staff  = score()->staff(idx);
     const StaffType* st = staff->staffTypeForElement(this);
-
+    if (st->isTabStaff()) {
+        // tab staff is already correct, and the following relStep method doesn't apply whatsoever to tab staves
+        return;
+    }
     ClefType clef = staff->clef(chord()->tick());
     int line      = relStep(relLine, clef);
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/17502

There is a fleet of methods to deal with recalculating the staff line based on clef, but none of them apply to tab staves.