### PR TITLE
Update languages update upload/download URL for 4.1

### DIFF
--- a/build/ci/translation/s3_packandsend.py
+++ b/build/ci/translation/s3_packandsend.py
@@ -13,7 +13,7 @@ import zipfile
 #needs to be equal or smaller than the cron
 period = 300
 outputDir = "share/locale/"
-s3Urls = ["s3://extensions.musescore.org/4.0/languages/"]
+s3Urls = ["s3://extensions.musescore.org/4.1/languages/"]
 
 def processTsFile(prefix, langCode, data):
     print("Processing " + langCode)
@@ -123,5 +123,3 @@ if translationChanged:
     for s3Url in s3Urls:
         push_json = subprocess.Popen(['s3cmd','put','--acl-public', '--guess-mime-type', outputDir + 'details.json', s3Url + 'details.json'])
         push_json.communicate()
-
-

--- a/src/languages/internal/languagesconfiguration.cpp
+++ b/src/languages/internal/languagesconfiguration.cpp
@@ -34,7 +34,7 @@ using namespace mu::languages;
 
 static const Settings::Key LANGUAGE_KEY("languages", "language");
 
-static const QString LANGUAGES_SERVER_URL("http://extensions.musescore.org/4.0/languages/");
+static const QString LANGUAGES_SERVER_URL("http://extensions.musescore.org/4.1/languages/");
 
 void LanguagesConfiguration::init()
 {


### PR DESCRIPTION
*After* this, we can push strings to Transifex

There are similar URLs for the Learn page (`LearnConfiguration` and `ci_learn_update_playlists.yml`) and the sound font (`DownloadSoundFont.cmake`), but I'm not updating those now, because they are unrelated and there is no reason to update them now.