### PR TITLE
Fix date and time macros crash

### DIFF
--- a/src/engraving/libmscore/page.cpp
+++ b/src/engraving/libmscore/page.cpp
@@ -455,14 +455,14 @@ String Page::replaceTextMacros(const String& s) const
             }
             break;
             case 'm':
-                if (score()->dirty()) {
+                if (score()->dirty() || !masterScore()->saved()) {
                     d += Time::currentTime().toString(DateFormat::ISODate);
                 } else {
                     d += masterScore()->fileInfo()->lastModified().time().toString(DateFormat::ISODate);
                 }
                 break;
             case 'M':
-                if (score()->dirty()) {
+                if (score()->dirty() || !masterScore()->saved()) {
                     d += Date::currentDate().toString(DateFormat::ISODate);
                 } else {
                     d += masterScore()->fileInfo()->lastModified().date().toString(DateFormat::ISODate);

--- a/src/framework/global/types/datetime.cpp
+++ b/src/framework/global/types/datetime.cpp
@@ -36,9 +36,9 @@ static Date dateFromTM(const std::tm& tm)
 
 static void toTM(std::tm& tm, const Date& d)
 {
-    tm.tm_year = d.year() - 1900;
-    tm.tm_mon = d.month() - 1;
-    tm.tm_mday = d.day();
+    tm.tm_year = std::max(d.year() - 1900, 0);
+    tm.tm_mon = std::max(d.month() - 1, 0);
+    tm.tm_mday = std::max(d.day(), 1);
 }
 
 static Time timeFromTM(const std::tm& tm)
@@ -48,9 +48,9 @@ static Time timeFromTM(const std::tm& tm)
 
 static void toTM(std::tm& tm, const Time& t)
 {
-    tm.tm_hour = t.hour();
-    tm.tm_min = t.minute();
-    tm.tm_sec = t.second();
+    tm.tm_hour = std::max(t.hour(), 0);
+    tm.tm_min = std::max(t.minute(), 0);
+    tm.tm_sec = std::max(t.second(), 0);
 }
 
 static DateTime datetimeFromTM(const std::tm& tm)

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -345,7 +345,7 @@ mu::Ret NotationProject::createNew(const ProjectCreateOptions& projectOptions)
         excerpt->notation()->viewState()->makeDefault();
     }
 
-    masterScore->setSaved(true);
+    masterScore->setSaved(false);
 
     m_isNewlyCreated = true;
 


### PR DESCRIPTION
Resolves: #17137 

I've done a low-level and a high-level solution here. 

At the low level, the crash is happening when calling `std::strftime` [here](https://github.com/musescore/MuseScore/blob/master/src/framework/global/types/datetime.cpp#LL73C1-L73C1) and [here](https://github.com/musescore/MuseScore/blob/master/src/framework/global/types/datetime.cpp#L84). It crashes because we are passing an `std::tm` with invalid (negative) values which we get from `QDate` and `QTime`, and apparently `std::strftime` doesn't like them (I'm guessing the previous implementation used some Qt equivalent which accepted them, hence why it wasn't crashing). So I've inserted some checks in the conversion function to make sure that we don't create invalid time and dates, which should protect also for future cases.

At the high level, we actually shouldn't even get here when the score has never been saved. `score()->dirty()` doesn't help because it just checks the undo stack (which is empty at the start), so I've used `masterScore()->saved()` instead. By the way, I'm not sure why in NotationProject::createNew we were setting the newly created score as saved, so I've changed that. Hope that makes sense.