### PR TITLE
Fix build on my Mac

### DIFF
--- a/build/cmake/GetCompilerInfo.cmake
+++ b/build/cmake/GetCompilerInfo.cmake
@@ -1,6 +1,29 @@
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-CLA-applies
+#
+# MuseScore
+# Music Composition & Notation
+#
+# Copyright (C) 2023 MuseScore BVBA and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # Compiler definition
 # MuseScore-specific, defines typical configurations
+
+if (COMPILER_INFO_DETECTED)
+    return()
+endif()
 
 include(GetPlatformInfo)
 
@@ -36,3 +59,5 @@ endif()
 if (MSVC)
    set (MINGW false)
 endif (MSVC)
+
+set(COMPILER_INFO_DETECTED 1)

--- a/build/cmake/GetPlatformInfo.cmake
+++ b/build/cmake/GetPlatformInfo.cmake
@@ -1,3 +1,26 @@
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-CLA-applies
+#
+# MuseScore
+# Music Composition & Notation
+#
+# Copyright (C) 2023 MuseScore BVBA and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+if (PLATFORM_DETECTED)
+    return()
+endif()
 
 if(${CMAKE_CXX_COMPILER} MATCHES "/em\\+\\+(-[a-zA-Z0-9.])?$")
     set(OS_IS_WASM 1)
@@ -11,14 +34,13 @@ else()
     message(FATAL_ERROR "Unsupported platform: ${CMAKE_HOST_SYSTEM_NAME}")
 endif()
 
-if (NOT ARCH_DETECTED)
-    # architecture detection
-    # based on QT5 processor detection code
-    # qtbase/blobs/master/src/corelib/global/qprocessordetection.h
+# architecture detection
+# based on QT5 processor detection code
+# qtbase/blobs/master/src/corelib/global/qprocessordetection.h
 
-    # we only have binary blobs compatible with x86_64, aarch64, and armv7l
+# we only have binary blobs compatible with x86_64, aarch64, and armv7l
 
-    set(archdetect_c_code "
+set(archdetect_c_code "
     #if defined(__arm__) || defined(__TARGET_ARCH_ARM) || defined(_M_ARM) || defined(__aarch64__) || defined(__ARM64__)
         #if defined(__aarch64__) || defined(__ARM64__)
             #error cmake_ARCH aarch64
@@ -31,35 +53,31 @@ if (NOT ARCH_DETECTED)
     #error cmake_ARCH unknown
     ")
 
-    if(CMAKE_C_COMPILER_LOADED)
-        set(TA_EXTENSION "c")
-    elseif(CMAKE_CXX_COMPILER_LOADED)
-        set(TA_EXTENSION "cpp")
-    elseif(CMAKE_FORTRAN_COMPILER_LOADED)
-        set(TA_EXTENSION "F90")
-    else()
-        message(FATAL_ERROR "You must enable a C, CXX, or Fortran compiler to use TargetArch.cmake")
-    endif()
+if(CMAKE_C_COMPILER_LOADED)
+    set(TA_EXTENSION "c")
+elseif(CMAKE_CXX_COMPILER_LOADED)
+    set(TA_EXTENSION "cpp")
+elseif(CMAKE_FORTRAN_COMPILER_LOADED)
+    set(TA_EXTENSION "F90")
+else()
+    message(FATAL_ERROR "You must enable a C, CXX, or Fortran compiler to use TargetArch.cmake")
+endif()
 
-    file(WRITE "${CMAKE_BINARY_DIR}/arch.${TA_EXTENSION}" "${archdetect_c_code}")
+file(WRITE "${CMAKE_BINARY_DIR}/arch.${TA_EXTENSION}" "${archdetect_c_code}")
 
-    try_run(
-        run_result_unused
-        compile_result_unused
-        "${CMAKE_BINARY_DIR}"
-        "${CMAKE_BINARY_DIR}/arch.${TA_EXTENSION}"
-        COMPILE_OUTPUT_VARIABLE ARCH
-        CMAKE_FLAGS ${TA_CMAKE_FLAGS}
-    )
+try_run(
+    run_result_unused
+    compile_result_unused
+    "${CMAKE_BINARY_DIR}"
+    "${CMAKE_BINARY_DIR}/arch.${TA_EXTENSION}"
+    COMPILE_OUTPUT_VARIABLE ARCH
+    CMAKE_FLAGS ${TA_CMAKE_FLAGS}
+)
 
-    string(REGEX MATCH "cmake_ARCH ([a-zA-Z0-9_]+)" ARCH "${ARCH}")
+string(REGEX MATCH "cmake_ARCH ([a-zA-Z0-9_]+)" ARCH "${ARCH}")
 
-    string(REPLACE "cmake_ARCH " "" ARCH "${ARCH}")
-    message(STATUS "Detected CPU Architecture: ${ARCH}")
-
-    set(ARCH_DETECTED ON)
-
-endif(NOT ARCH_DETECTED)
+string(REPLACE "cmake_ARCH " "" ARCH "${ARCH}")
+message(STATUS "Detected CPU Architecture: ${ARCH}")
 
 if(${ARCH} MATCHES "armv7l")
     set(ARCH_IS_ARMV7L 1)
@@ -71,3 +89,5 @@ else()
     set(ARCH_IS_X86_64 1)
     message(WARNING "Architecture could not be detected. Using x86_64 as a fallback.")
 endif()
+
+set(PLATFORM_DETECTED 1)

--- a/src/framework/global/CMakeLists.txt
+++ b/src/framework/global/CMakeLists.txt
@@ -171,9 +171,8 @@ else()
             SKIP_PRECOMPILE_HEADERS ON
         )
         find_library(AppKit NAMES AppKit)
-        set(MODULE_LINK ${MODULE_LINK} ${AppKit})
+        list(APPEND MODULE_LINK ${AppKit})
     endif()
-
 endif()
 
 set(FS_LIB )
@@ -196,11 +195,11 @@ else ()
     set(Z_LIB z)
 endif ()
 
-set(MODULE_INCLUDE
+list(APPEND MODULE_INCLUDE
     ${Z_INCLUDE}
     )
 
-set(MODULE_LINK
+list(APPEND MODULE_LINK
     ${FS_LIB}
     ${Z_LIB}
 )

--- a/src/framework/global/CMakeLists.txt
+++ b/src/framework/global/CMakeLists.txt
@@ -159,6 +159,8 @@ else()
         ${CMAKE_CURRENT_LIST_DIR}/deprecated/qzipwriter_p.h
         )
 
+    include(GetPlatformInfo)
+
     if (OS_IS_MAC)
         set(MODULE_SRC ${MODULE_SRC}
             ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosinteractivehelper.mm


### PR DESCRIPTION
It turns out that #17729 causes trouble on my machine, because after `set(MODULE_LINK ${MODULE_LINK} ${AppKit})`, we do `set(MODULE_LINK ${FS_LIB} ${Z_LIB})`, so `${AppKit}` is lost and thus we don't link to AppKit, so the build fails. So, we just append `${FS_LIB} ${Z_LIB}` to `MODULE_LINK` instead of overwriting the current value. And while at it, let's use the "modern" `list(APPEND` syntax.

Also, don't leave to chance whether `GetPlatformInfo` has been included before checking `OS_IS_MAC`.

And run the contents of `GetPlatformInfo` and `GetCompilerInfo` only once per scope.

And add some missing license headers. (Actually, it looks like Vasily forgot .cmake files when doing the big license headers overhaul a few years ago; we could add them one by one whenever touching a .cmake file.)