### PR TITLE
Fix crash related to fixing time sigs when deleting measures

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -2955,7 +2955,7 @@ void Score::deleteMeasures(MeasureBase* mbStart, MeasureBase* mbEnd, bool preser
         if (mAfterSel) {
             Segment* s = mAfterSel->findSegment(SegmentType::TimeSig, mAfterSel->tick());
 
-            for (staff_idx_t staffIdx = 0; staffIdx < nstaves(); ++staffIdx) {
+            for (staff_idx_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
                 if (s && s->element(staffIdx * VOICES)) {
                     continue;
                 }


### PR DESCRIPTION
When iterating over all part scores to apply the changes, we used the number of staves from the master score for each part score, rather than the number of staves for that particular part score, which caused a read out of bounds because part scores typically have less staves than the master score.

Resolves: #17726 