### PR TITLE
Fix: My account -> My accounts

### DIFF
--- a/src/cloud/qml/MuseScore/Cloud/AccountInfoButton.qml
+++ b/src/cloud/qml/MuseScore/Cloud/AccountInfoButton.qml
@@ -39,7 +39,7 @@ PageTabButton {
     spacing: 22
     leftPadding: spacing
 
-    title: Boolean(root.cloudInfo) ? root.cloudInfo.userName : qsTrc("cloud", "My account")
+    title: Boolean(root.cloudInfo) ? root.cloudInfo.userName : qsTrc("cloud", "My accounts")
     iconComponent: AccountAvatar {
         url: Boolean(root.cloudInfo) ? root.cloudInfo.userAvatarUrl : null
         side: 32


### PR DESCRIPTION
Fix: My account -> My accounts
In MuseScore 4.1, there are two accounts:
1. MuseScore.com
2. Audio.com
so, it should be in the plural.

Greetings,
Gootector

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
