### PR TITLE
Fix losing spaces when in-between symbols

### DIFF
--- a/src/engraving/libmscore/textbase.cpp
+++ b/src/engraving/libmscore/textbase.cpp
@@ -246,15 +246,12 @@ void TextCursor::updateCursorFormat()
 {
     TextBlock* block = &_text->_layout[_row];
     size_t col = hasSelection() ? selectColumn() : column();
-    const CharFormat* format = block->formatAt(static_cast<int>(col));
+    // Get format at the LEFT of the cursor position
+    const CharFormat* format = block->formatAt(std::max(static_cast<int>(col) - 1, 0));
     if (!format) {
         init();
     } else {
-        CharFormat updated = *format;
-        if (updated.fontFamily() == "ScoreText") {
-            updated.setFontFamily(_format.fontFamily());
-        }
-        setFormat(updated);
+        setFormat(*format);
     }
 }
 

--- a/src/engraving/tests/textbase_tests.cpp
+++ b/src/engraving/tests/textbase_tests.cpp
@@ -81,9 +81,10 @@ TEST_F(Engraving_TextBaseTests, dynamicAddTextAfter)
     MasterScore* score = ScoreRW::readScore(u"test.mscx");
     Dynamic* dynamic = addDynamic(score);
     EditData ed;
+    ed.s = String(u" ma non troppo");
     dynamic->startEdit(ed);
     dynamic->cursor()->moveCursorToEnd();
-    score->undo(new InsertText(dynamic->cursor(), String(u" ma non troppo")), &ed);
+    dynamic->edit(ed);
     dynamic->endEdit(ed);
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"dynamicAddTextAfter.mscx", TEXTBASE_DATA_DIR + u"dynamicAddTextAfter-ref.mscx"));
 }
@@ -126,7 +127,7 @@ TEST_F(Engraving_TextBaseTests, getFontStyleProperty)
     staffText->cursor()->movePosition(TextCursor::MoveOperation::End, TextCursor::MoveMode::KeepAnchor);
     EXPECT_EQ(staffText->getProperty(Pid::FONT_STYLE), PropertyValue::fromValue(0));
     staffText->cursor()->movePosition(TextCursor::MoveOperation::WordLeft, TextCursor::MoveMode::MoveAnchor);
-    EXPECT_EQ(staffText->getProperty(Pid::FONT_STYLE), PropertyValue::fromValue(static_cast<int>(FontStyle::Bold)));
+    EXPECT_EQ(staffText->getProperty(Pid::FONT_STYLE), PropertyValue::fromValue(static_cast<int>(FontStyle::Normal)));
     staffText->cursor()->movePosition(TextCursor::MoveOperation::NextWord, TextCursor::MoveMode::KeepAnchor);
     EXPECT_EQ(staffText->getProperty(Pid::FONT_STYLE), PropertyValue::fromValue(static_cast<int>(FontStyle::Bold)));
     staffText->endEdit(ed);


### PR DESCRIPTION
Resolves: #15629

So the idea of the solution is simple: if you type a "space" in between symbols, we insert the special "non-breaking" space character, instead of the normal space (which will get lost when parsing the xml, see my comment on the issue for context).

In order to do that, it was necessary to change a couple of things:
1) When clicking on a piece of text, the cursor should get the format from the _left_ of the current position (Musescore currently does this wrong so it needed to be fixed anyway).
2) We must let the cursor carry the "ScoreText" font family and reset it to "normal" text only when needed, otherwise we don't have a way of knowing when we are indeed in between symbols.

Update: the unit test failures were expected (the first test was failing because it was editing the text without passing by TextBase::edit(), which in the real world can't happen, and the second because of the change I described in point 1.)