### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/layout/v0/chordlayout.cpp
+++ b/src/engraving/layout/v0/chordlayout.cpp
@@ -959,7 +959,6 @@ void ChordLayout::layoutArticulations2(Chord* item, LayoutContext& ctx, bool lay
         if (layoutOnCrossBeamSide && !a->isOnCrossBeamSide()) {
             continue;
         }
-        ArticulationAnchor aa = a->anchor();
         if (!a->layoutCloseToNote()) {
             continue;
         }
@@ -997,7 +996,6 @@ void ChordLayout::layoutArticulations2(Chord* item, LayoutContext& ctx, bool lay
         } else {
             stacc = nullptr;
         }
-        ArticulationAnchor aa = a->anchor();
         if (!a->layoutCloseToNote()) {
             TLayout::layout(a, ctx);
             if (a->up()) {

--- a/src/engraving/rw/206/read206.cpp
+++ b/src/engraving/rw/206/read206.cpp
@@ -1832,6 +1832,7 @@ bool Read206::readChordProperties206(XmlReader& e, ReadContext& ctx, Chord* ch)
 
 static void convertDoubleArticulations(Chord* chord, XmlReader& e, ReadContext& ctx)
 {
+    UNUSED(e);
     std::vector<Articulation*> pairableArticulations;
     for (Articulation* a : chord->articulations()) {
         if (a->isStaccato() || a->isTenuto()

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -424,7 +424,7 @@ void GPConverter::fixEmptyMeasures()
 {
     // Get all ChordRest elems and sort them by staves
     // Also store root Segment ptr will need it later to delete some rest elems
-    std::map<int, std::vector<std::pair<Segment*, EngravingItem*> > > elems;
+    std::map<track_idx_t, std::vector<std::pair<Segment*, EngravingItem*> > > elems;
 
     auto ntracks = _score->ntracks();
     auto type = SegmentType::ChordRest;


### PR DESCRIPTION
* reg. unreferenced formal parameter (C4100)
* reg. local variable is initialized but not referenced (C4189)
* reg. conversion from 'size_t' to 'int', possible loss of data (C4267)