### PR TITLE
fixed calculating measure index for mmrests

### DIFF
--- a/src/engraving/libmscore/measurebase.cpp
+++ b/src/engraving/libmscore/measurebase.cpp
@@ -607,8 +607,12 @@ int MeasureBase::measureIndex() const
 {
     int idx = 0;
     MeasureBase* m = score()->firstMeasure();
+    Measure* mmRestFirst = nullptr;
+    if (isMeasure() && toMeasure(this)->isMMRest()) {
+        mmRestFirst = toMeasure(this)->mmRestFirst();
+    }
     while (m) {
-        if (m == this) {
+        if (m == this || m == mmRestFirst) {
             return idx;
         }
         m = m->next();


### PR DESCRIPTION
took into account mmrests, see the same implementation in `MeasureBase::index()`