### PR TITLE
fixed reading note slides, added midirender slides tests

### DIFF
--- a/src/engraving/libmscore/rendermidi.cpp
+++ b/src/engraving/libmscore/rendermidi.cpp
@@ -1146,7 +1146,7 @@ static void createSlideInNotePlayEvents(Note* note, int prevChordTicks, NoteEven
     }
 }
 
-static void createSlideOutNotePlayEvents(Note* note, NoteEventList* el, int onTime)
+static void createSlideOutNotePlayEvents(Note* note, NoteEventList* el, int onTime, bool hasTremolo)
 {
     if (!note->isSlideOutNote()) {
         return;
@@ -1157,7 +1157,9 @@ static void createSlideOutNotePlayEvents(Note* note, NoteEventList* el, int onTi
     const int slideDuration = allSlidesDuration / slideNotes;
     int slideOn = NoteEvent::NOTE_LENGTH - allSlidesDuration;
     double velocity = !note->ghost() ? NoteEvent::DEFAULT_VELOCITY_MULTIPLIER : NoteEvent::GHOST_VELOCITY_MULTIPLIER;
-    el->push_back(NoteEvent(0, onTime, slideOn, velocity, !note->tieBack()));
+    if (!hasTremolo) {
+        el->push_back(NoteEvent(0, onTime, slideOn, velocity, !note->tieBack()));
+    }
 
     int pitch = 0;
     int pitchOffset = note->slide().is(Note::SlideType::Doit) ? 1 : -1;
@@ -1209,7 +1211,7 @@ static std::vector<NoteEventList> renderChord(Chord* chord, Chord* prevChord, in
         Note* note = chord->notes()[i];
         NoteEventList* el = &ell[i];
 
-        createSlideOutNotePlayEvents(note, el, ontime);
+        createSlideOutNotePlayEvents(note, el, ontime, tremolo);
         if (arpeggio) {
             continue;       // don't add extra events and apply gateTime to arpeggio
         }

--- a/src/engraving/rw/400/tread.cpp
+++ b/src/engraving/rw/400/tread.cpp
@@ -3148,6 +3148,24 @@ bool TRead::readProperties(Note* n, XmlReader& e, ReadContext& ctx)
         cl->setNote(n);
         TRead::read(cl, e, ctx);
         n->chord()->add(cl);
+
+        auto convertSlideType = [](ChordLineType type) {
+            switch (type) {
+            case ChordLineType::FALL:
+                return Note::SlideType::Fall;
+            case ChordLineType::DOIT:
+                return Note::SlideType::Doit;
+            case ChordLineType::SCOOP:
+                return Note::SlideType::Lift;
+            case ChordLineType::PLOP:
+                return Note::SlideType::Plop;
+            default:
+                return Note::SlideType::Undefined;
+            }
+        };
+
+        Note::Slide sl{ convertSlideType(cl->chordLineType()) };
+        n->attachSlide(sl);
     } else if (readItemProperties(n, e, ctx)) {
     } else {
         return false;

--- a/src/engraving/tests/midirenderer_data/slide_in_from_above.mscx
+++ b/src/engraving/tests/midirenderer_data/slide_in_from_above.mscx
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.00">
+  <programVersion>4.0.0</programVersion>
+  <programRevision>2c34155</programRevision>
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2023-05-27</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="originalFormat">gp</metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Nylon Guitar</trackName>
+      <Instrument id="cavaquinho">
+        <longName>Nylon Guitar</longName>
+        <shortName>n.guit.</shortName>
+        <trackName></trackName>
+        <transposeDiatonic>-7</transposeDiatonic>
+        <transposeChromatic>-12</transposeChromatic>
+        <instrumentId>pluck.guitar</instrumentId>
+        <singleNoteDynamics>0</singleNoteDynamics>
+        <StringData>
+          <frets>24</frets>
+          <string>52</string>
+          <string>57</string>
+          <string>62</string>
+          <string>67</string>
+          <string>71</string>
+          <string>76</string>
+          </StringData>
+        <Channel>
+          <program value="24"/>
+          <controller ctrl="7" value="95"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <KeySig>
+            <accidental>0</accidental>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Dynamic>
+            <subtype>mf</subtype>
+            <velocity>80</velocity>
+            </Dynamic>
+          <Tempo>
+            <tempo>2</tempo>
+            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            </Tempo>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>1</fret>
+              <string>1</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>1</fret>
+              <string>1</string>
+              <ChordLine>
+                <subtype>3</subtype>
+                <straight>1</straight>
+                </ChordLine>
+              </Note>
+            </Chord>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/tests/midirenderer_data/slide_out_from_below.mscx
+++ b/src/engraving/tests/midirenderer_data/slide_out_from_below.mscx
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.00">
+  <programVersion>4.0.0</programVersion>
+  <programRevision>2c34155</programRevision>
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2023-05-27</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="originalFormat">gp</metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Nylon Guitar</trackName>
+      <Instrument id="cavaquinho">
+        <longName>Nylon Guitar</longName>
+        <shortName>n.guit.</shortName>
+        <trackName></trackName>
+        <transposeDiatonic>-7</transposeDiatonic>
+        <transposeChromatic>-12</transposeChromatic>
+        <instrumentId>pluck.guitar</instrumentId>
+        <singleNoteDynamics>0</singleNoteDynamics>
+        <StringData>
+          <frets>24</frets>
+          <string>52</string>
+          <string>57</string>
+          <string>62</string>
+          <string>67</string>
+          <string>71</string>
+          <string>76</string>
+          </StringData>
+        <Channel>
+          <program value="24"/>
+          <controller ctrl="7" value="95"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <KeySig>
+            <accidental>0</accidental>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Dynamic>
+            <subtype>mf</subtype>
+            <velocity>80</velocity>
+            </Dynamic>
+          <Tempo>
+            <tempo>2</tempo>
+            <text><sym>metNoteQuarterUp</sym> = 120</text>
+            </Tempo>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>1</fret>
+              <string>1</string>
+              <ChordLine>
+                <subtype>2</subtype>
+                <straight>1</straight>
+                </ChordLine>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>1</fret>
+              <string>1</string>
+              </Note>
+            </Chord>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/tests/midirenderer_data/tremolo_and_slide_in.mscx
+++ b/src/engraving/tests/midirenderer_data/tremolo_and_slide_in.mscx
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.00">
+  <programVersion>4.0.0</programVersion>
+  <programRevision>2c34155</programRevision>
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2023-05-28</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="originalFormat">gp</metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Guitar</trackName>
+      <Instrument id="guitar-steel">
+        <longName>Guitar</longName>
+        <shortName>dist.guit.</shortName>
+        <trackName></trackName>
+        <transposeDiatonic>-7</transposeDiatonic>
+        <transposeChromatic>-12</transposeChromatic>
+        <instrumentId>pluck.guitar.acoustic</instrumentId>
+        <singleNoteDynamics>0</singleNoteDynamics>
+        <StringData>
+          <frets>24</frets>
+          <string>52</string>
+          <string>57</string>
+          <string>62</string>
+          <string>67</string>
+          <string>71</string>
+          <string>76</string>
+          </StringData>
+        <Channel>
+          <program value="30"/>
+          <controller ctrl="7" value="67"/>
+          <synti>Fluid</synti>
+          <midiPort>0</midiPort>
+          <midiChannel>4</midiChannel>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <KeySig>
+            <accidental>0</accidental>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            </Dynamic>
+          <Tempo>
+            <tempo>2.25</tempo>
+            <text><sym>metNoteQuarterUp</sym> = 135</text>
+            </Tempo>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <pitch>59</pitch>
+              <tpc>19</tpc>
+              <fret>19</fret>
+              <string>5</string>
+              </Note>
+            <Tremolo>
+              <subtype>r8</subtype>
+              </Tremolo>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <pitch>59</pitch>
+              <tpc>19</tpc>
+              <fret>19</fret>
+              <string>5</string>
+              <ChordLine>
+                <subtype>4</subtype>
+                <straight>1</straight>
+                </ChordLine>
+              </Note>
+            </Chord>
+          <Rest>
+            <durationType>quarter</durationType>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/tests/midirenderer_data/tremolo_and_slide_out.mscx
+++ b/src/engraving/tests/midirenderer_data/tremolo_and_slide_out.mscx
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.00">
+  <programVersion>4.0.0</programVersion>
+  <programRevision>2c34155</programRevision>
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2023-05-28</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="originalFormat">gp</metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Guitar</trackName>
+      <Instrument id="guitar-steel">
+        <longName>Guitar</longName>
+        <shortName>dist.guit.</shortName>
+        <trackName></trackName>
+        <transposeDiatonic>-7</transposeDiatonic>
+        <transposeChromatic>-12</transposeChromatic>
+        <instrumentId>pluck.guitar.acoustic</instrumentId>
+        <singleNoteDynamics>0</singleNoteDynamics>
+        <StringData>
+          <frets>24</frets>
+          <string>52</string>
+          <string>57</string>
+          <string>62</string>
+          <string>67</string>
+          <string>71</string>
+          <string>76</string>
+          </StringData>
+        <Channel>
+          <program value="30"/>
+          <controller ctrl="7" value="67"/>
+          <synti>Fluid</synti>
+          <midiPort>0</midiPort>
+          <midiChannel>4</midiChannel>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <KeySig>
+            <accidental>0</accidental>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            </Dynamic>
+          <Tempo>
+            <tempo>2.25</tempo>
+            <text><sym>metNoteQuarterUp</sym> = 135</text>
+            </Tempo>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>59</pitch>
+              <tpc>19</tpc>
+              <fret>19</fret>
+              <string>5</string>
+              <ChordLine>
+                <subtype>1</subtype>
+                <straight>1</straight>
+                </ChordLine>
+              </Note>
+            <Tremolo>
+              <subtype>r8</subtype>
+              </Tremolo>
+            </Chord>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/tests/midirenderer_tests.cpp
+++ b/src/engraving/tests/midirenderer_tests.cpp
@@ -245,14 +245,7 @@ TEST_F(MidiRenderer_Tests, tremoloAndGlissando)
     checkEventInterval(events, 960, 1439, 55, defVol);
 }
 
-/*****************************************************************************
-
-    DISABLED TESTS BELOW
-
-*****************************************************************************/
-
-/// TODO: enable after fixing slides midi rendering
-TEST_F(MidiRenderer_Tests, DISABLED_slideInFromBelow)
+TEST_F(MidiRenderer_Tests, slideInFromBelow)
 {
     constexpr int defVol = 80; // mf
     constexpr int glissVol = defVol * NoteEvent::GLISSANDO_VELOCITY_MULTIPLIER;
@@ -263,13 +256,28 @@ TEST_F(MidiRenderer_Tests, DISABLED_slideInFromBelow)
 
     checkEventInterval(events, 0, 239, 60, defVol);
     checkEventInterval(events, 240, 318, 57, glissVol);
-    checkEventInterval(events, 318, 398, 58, glissVol);
+    checkEventInterval(events, 320, 398, 58, glissVol);
     checkEventInterval(events, 400, 478, 59, glissVol);
     checkEventInterval(events, 480, 959, 60, defVol);
 }
 
-/// TODO: enable after fixing slides midi rendering
-TEST_F(MidiRenderer_Tests, DISABLED_slideOutFromAbove)
+TEST_F(MidiRenderer_Tests, slideInFromAbove)
+{
+    constexpr int defVol = 80; // mf
+    constexpr int glissVol = defVol * NoteEvent::GLISSANDO_VELOCITY_MULTIPLIER;
+
+    EventMap events = renderMidiEvents(u"slide_in_from_above.mscx");
+
+    EXPECT_EQ(events.size(), 10);
+
+    checkEventInterval(events, 0, 239, 60, defVol);
+    checkEventInterval(events, 240, 318, 63, glissVol);
+    checkEventInterval(events, 320, 398, 62, glissVol);
+    checkEventInterval(events, 400, 478, 61, glissVol);
+    checkEventInterval(events, 480, 959, 60, defVol);
+}
+
+TEST_F(MidiRenderer_Tests, slideOutFromAbove)
 {
     constexpr int defVol = 80; // mf
     constexpr int glissVol = defVol * NoteEvent::GLISSANDO_VELOCITY_MULTIPLIER;
@@ -280,7 +288,66 @@ TEST_F(MidiRenderer_Tests, DISABLED_slideOutFromAbove)
 
     checkEventInterval(events, 0, 239, 60, defVol);
     checkEventInterval(events, 240, 318, 59, glissVol);
-    checkEventInterval(events, 318, 397, 58, glissVol);
+    checkEventInterval(events, 319, 397, 58, glissVol);
     checkEventInterval(events, 399, 477, 57, glissVol);
     checkEventInterval(events, 480, 959, 60, defVol);
+}
+
+TEST_F(MidiRenderer_Tests, slideOutFromBelow)
+{
+    constexpr int defVol = 80; // mf
+    constexpr int glissVol = defVol * NoteEvent::GLISSANDO_VELOCITY_MULTIPLIER;
+
+    EventMap events = renderMidiEvents(u"slide_out_from_below.mscx");
+
+    EXPECT_EQ(events.size(), 10);
+
+    checkEventInterval(events, 0, 239, 60, defVol);
+    checkEventInterval(events, 240, 318, 61, glissVol);
+    checkEventInterval(events, 319, 397, 62, glissVol);
+    checkEventInterval(events, 399, 477, 63, glissVol);
+    checkEventInterval(events, 480, 959, 60, defVol);
+}
+
+TEST_F(MidiRenderer_Tests, tremoloSlideIn)
+{
+    constexpr int defVol = 96; // f
+    constexpr int glissVol = defVol * NoteEvent::GLISSANDO_VELOCITY_MULTIPLIER;
+
+    EventMap events = renderMidiEvents(u"tremolo_and_slide_in.mscx");
+
+    EXPECT_EQ(events.size(), 16);
+
+    checkEventInterval(events, 0, 119, 59, defVol);
+    checkEventInterval(events, 120, 239, 59, defVol);
+    checkEventInterval(events, 240, 359, 59, defVol);
+    checkEventInterval(events, 360, 479, 59, defVol);
+    checkEventInterval(events, 480, 638, 56, glissVol);
+    checkEventInterval(events, 640, 798, 57, glissVol);
+    checkEventInterval(events, 800, 958, 58, glissVol);
+    checkEventInterval(events, 960, 1439, 59, defVol);
+}
+
+/*****************************************************************************
+
+    DISABLED TESTS BELOW
+
+*****************************************************************************/
+
+TEST_F(MidiRenderer_Tests, DISABLED_tremoloSlideOut)
+{
+    constexpr int defVol = 96; // f
+    constexpr int glissVol = defVol * NoteEvent::GLISSANDO_VELOCITY_MULTIPLIER;
+
+    EventMap events = renderMidiEvents(u"tremolo_and_slide_out.mscx");
+
+    EXPECT_EQ(events.size(), 14);
+
+    checkEventInterval(events, 0, 239, 59, defVol);
+    checkEventInterval(events, 240, 479, 59, defVol);
+    checkEventInterval(events, 480, 719, 59, defVol);
+    checkEventInterval(events, 720, 959, 59, defVol);
+    checkEventInterval(events, 960, 1277, 58, glissVol);
+    checkEventInterval(events, 1278, 1595, 57, glissVol);
+    checkEventInterval(events, 1597, 1919, 56, glissVol);
 }

--- a/src/engraving/tests/midirenderer_tests.cpp
+++ b/src/engraving/tests/midirenderer_tests.cpp
@@ -328,13 +328,7 @@ TEST_F(MidiRenderer_Tests, tremoloSlideIn)
     checkEventInterval(events, 960, 1439, 59, defVol);
 }
 
-/*****************************************************************************
-
-    DISABLED TESTS BELOW
-
-*****************************************************************************/
-
-TEST_F(MidiRenderer_Tests, DISABLED_tremoloSlideOut)
+TEST_F(MidiRenderer_Tests, tremoloSlideOut)
 {
     constexpr int defVol = 96; // f
     constexpr int glissVol = defVol * NoteEvent::GLISSANDO_VELOCITY_MULTIPLIER;
@@ -349,5 +343,11 @@ TEST_F(MidiRenderer_Tests, DISABLED_tremoloSlideOut)
     checkEventInterval(events, 720, 959, 59, defVol);
     checkEventInterval(events, 960, 1277, 58, glissVol);
     checkEventInterval(events, 1278, 1595, 57, glissVol);
-    checkEventInterval(events, 1597, 1919, 56, glissVol);
+    checkEventInterval(events, 1597, 1914, 56, glissVol);
 }
+
+/*****************************************************************************
+
+    DISABLED TESTS BELOW
+
+*****************************************************************************/

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1900,7 +1900,7 @@ void GPConverter::addSingleSlide(const GPNote* gpnote, Note* note)
             note->chord()->add(cl);
             cl->setNote(note);
 
-            Note::Slide sl{ type.second, nullptr };
+            Note::Slide sl{ type.second };
             note->attachSlide(sl);
         }
     }

--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -1142,7 +1142,7 @@ bool GuitarPro5::readNoteEffects(Note* note)
             sld->setStraight(true);
             note->chord()->add(sld);
             sld->setNote(note);
-            Note::Slide sl{ convertSlideType(slideType), nullptr };
+            Note::Slide sl{ convertSlideType(slideType) };
             note->attachSlide(sl);
         }
 


### PR DESCRIPTION
* slides were not being exported to midi - fixed that
compare midi-export from guitar pro and MU files:
[all-slides.zip](https://github.com/musescore/MuseScore/files/11583140/all-slides.zip)

* fixed midi rendering of tremolo and slide together
[tremolo+slide.zip](https://github.com/musescore/MuseScore/files/11583249/tremolo%2Bslide.zip)
