### PR TITLE
uiconfiguration: fix DPI for bad screen metadata

### DIFF
--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -648,9 +648,16 @@ double UiConfiguration::physicalDpi() const
         return m_customDPI.value();
     }
 
+    constexpr double DEFAULT_DPI = 96;
     const QScreen* screen = mainWindow() ? mainWindow()->screen() : nullptr;
     if (!screen) {
-        constexpr double DEFAULT_DPI = 96;
+        return DEFAULT_DPI;
+    }
+
+    auto physicalSize = screen->physicalSize();
+    // Work around xrandr reporting a 1x1mm size if
+    // the screen doesn't have a valid physical size
+    if (physicalSize.height() <= 1 && physicalSize.width() <= 1) {
         return DEFAULT_DPI;
     }
 


### PR DESCRIPTION
Some screens don't report their physical size in their EDID, for instance the Samsung Neo G9 in its 5120x1440 configuration. When that happens, on Linux xrandr reports the physical size as 1mmx1mm, which is obviously invalid, and results in a computed DPI so high that the default view is a totally blank screen, and the max zoomed-out level still only covers a fraction of the score.

While it's possible for users to force the DPI via a command-line argument, having a sensible default value to begin with is much better, especially for nontechnical users.

While I only encountered the issue on Linux (due to not having Windows available in the first place) I deliberately left the check on the common codepath as I figured that a 1mm*1mm screen must be invalid no matter the platform.

Resolves: #16002.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
