### PR TITLE
fix #17691 - Instrument change copy paste

### DIFF
--- a/src/engraving/libmscore/chordrest.cpp
+++ b/src/engraving/libmscore/chordrest.cpp
@@ -327,14 +327,21 @@ EngravingItem* ChordRest::drop(EditData& data)
             ic->setParent(segment());
             ic->setTrack(trackZeroVoice(track()));
 
-            const Instrument* instr = part()->instrument(tick());
-            IF_ASSERT_FAILED(instr) {
+            const Instrument* prevInstr = part()->instrument(tick());
+            const Instrument instr = *ic->instrument();
+
+            IF_ASSERT_FAILED(prevInstr) {
                 delete e;
                 return nullptr;
             }
 
-            ic->setInstrument(*instr);
+            // temporarily set previous instrument, for correct transposition calculation
+            ic->setInstrument(*prevInstr);
             score()->undoAddElement(ic);
+
+            if (!fromPalette) {
+                ic->setupInstrument(&instr);
+            }
             return e;
         }
     case ElementType::FIGURED_BASS:

--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -3187,7 +3187,7 @@ void Score::deleteAnnotationsFromRange(Segment* s1, Segment* s2, track_idx_t tra
                 if (!filter.canSelect(annotation)) {
                     continue;
                 }
-                if (!annotation->systemFlag() && annotation->track() == track) {
+                if (!annotation->systemFlag() && annotation->track() == track && !(annotation->type() == ElementType::INSTRUMENT_CHANGE)) {
                     deleteItem(annotation);
                 }
             }


### PR DESCRIPTION
Resolves: #17691 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
1. st issue was in fact casued by PR #14802, which fixed adding from palette, but broke copy paste
Now it distinguish between adding from palette and pasting, to cover both cases.

2. nd issue is fixed by adding exception for "instrument change" annotation, to prevent deleting it, when deleting range selection


https://github.com/musescore/MuseScore/assets/1646034/c302648f-718f-4a7b-8c51-826c122b3128



(Incorrect transposing is not covered here, as it is fixed in #17601)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
