### PR TITLE
Fix trill cue note on wrong staff upon reordering parts

### DIFF
--- a/src/engraving/libmscore/ornament.cpp
+++ b/src/engraving/libmscore/ornament.cpp
@@ -75,6 +75,19 @@ void Ornament::remove(EngravingItem* e)
     }
 }
 
+void Ornament::setTrack(track_idx_t val)
+{
+    for (Note* note : _notesAboveAndBelow) {
+        if (note) {
+            note->setTrack(val);
+        }
+    }
+    if (_cueNoteChord) {
+        _cueNoteChord->setTrack(val);
+    }
+    _track = val;
+}
+
 void Ornament::draw(draw::Painter* painter) const
 {
     Articulation::draw(painter);
@@ -359,15 +372,16 @@ void Ornament::updateCueNote()
     // If needed, create cue note
     if (!_cueNoteChord) {
         _cueNoteChord = Factory::createChord(parentChord->segment());
-        _cueNoteChord->setTrack(track());
         _cueNoteChord->setSmall(true);
         cueNote->setHeadHasParentheses(true);
         cueNote->setHeadType(NoteHeadType::HEAD_QUARTER);
         _cueNoteChord->add(cueNote);
         cueNote->setParent(_cueNoteChord);
     }
-    cueNote->setIsTrillCueNote(true);
+    _cueNoteChord->setTrack(track());
     _cueNoteChord->setParent(parentChord->segment());
+    cueNote->updateLine();
+    cueNote->setIsTrillCueNote(true);
 }
 
 Shape Ornament::shape() const

--- a/src/engraving/libmscore/ornament.h
+++ b/src/engraving/libmscore/ornament.h
@@ -76,6 +76,8 @@ public:
     Note* noteAbove() const { return _notesAboveAndBelow[0]; }
     Note* noteBelow() const { return _notesAboveAndBelow[1]; }
 
+    void setTrack(track_idx_t val) override;
+
 private:
     void updateAccidentalsAboveAndBelow();
     void updateCueNote();


### PR DESCRIPTION
Resolves: #17771 
