### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/engraving/rw/400/write400.cpp
+++ b/src/engraving/rw/400/write400.cpp
@@ -37,6 +37,7 @@ using namespace mu::engraving::rw400;
 
 bool Write400::writeScore(Score* score, io::IODevice* device, bool onlySelection, rw::WriteInOutData* out)
 {
+    UNUSED(out);
     XmlWriter xml(device);
     WriteContext ctx;
     xml.startDocument();


### PR DESCRIPTION
reg. unreferenced formal parameter (C410)