### PR TITLE
Fix #17651: Change beaming behavior for rests not at the start or end of a beam

### DIFF
--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -313,22 +313,22 @@ void Beam::setTremAnchors()
     }
 }
 
-void Beam::calcBeamBreaks(const ChordRest* cr, const ChordRest* prevCr, int level, bool& isBroken32, bool& isBroken64) const
+void Beam::calcBeamBreaks(const ChordRest* cr, const ChordRest* prevCr, int level, bool& isBroken16, bool& isBroken32) const
 {
     BeamMode beamMode = cr->beamMode();
-    if (cr->isRest() && (beamMode == BeamMode::MID || beamMode == BeamMode::BEGIN32 || beamMode == BeamMode::BEGIN64)) {
+    if (cr->isRest() && (beamMode == BeamMode::MID || beamMode == BeamMode::BEGIN16 || beamMode == BeamMode::BEGIN32)) {
         // when a rest has beamMode MID we can just ignore it entirely and allow any beams to continue through
         switch (beamMode) {
         case BeamMode::MID:
-            isBroken32 = isBroken64 = false;
+            isBroken16 = isBroken32 = false;
+            break;
+        case BeamMode::BEGIN16:
+            isBroken16 = level > 0;
+            isBroken32 = false;
             break;
         case BeamMode::BEGIN32:
-            isBroken32 = level > 0;
-            isBroken64 = false;
-            break;
-        case BeamMode::BEGIN64:
-            isBroken32 = false;
-            isBroken64 = level > 1;
+            isBroken16 = false;
+            isBroken32 = level > 1;
             break;
         default:
             // should be unreachable
@@ -340,13 +340,13 @@ void Beam::calcBeamBreaks(const ChordRest* cr, const ChordRest* prevCr, int leve
     const Groups& group = cr->staff()->group(cr->measure()->tick());
     BeamMode defaultBeamMode = group.endBeam(cr, prevCr);
 
-    bool isManuallyBroken32 = level >= 1 && beamMode == BeamMode::BEGIN32;
-    bool isManuallyBroken64 = level >= 2 && beamMode == BeamMode::BEGIN64;
-    bool isDefaultBroken32 = beamMode == BeamMode::AUTO && level >= 1 && defaultBeamMode == BeamMode::BEGIN32;
-    bool isDefaultBroken64 = beamMode == BeamMode::AUTO && level >= 2 && defaultBeamMode == BeamMode::BEGIN64;
+    bool isManuallyBroken16 = level >= 1 && beamMode == BeamMode::BEGIN16;
+    bool isManuallyBroken32 = level >= 2 && beamMode == BeamMode::BEGIN32;
+    bool isDefaultBroken16 = beamMode == BeamMode::AUTO && level >= 1 && defaultBeamMode == BeamMode::BEGIN16;
+    bool isDefaultBroken32 = beamMode == BeamMode::AUTO && level >= 2 && defaultBeamMode == BeamMode::BEGIN32;
 
+    isBroken16 = isManuallyBroken16 || isDefaultBroken16;
     isBroken32 = isManuallyBroken32 || isDefaultBroken32;
-    isBroken64 = isManuallyBroken64 || isDefaultBroken64;
 
     // deal with beam-embedded triplets by breaking beams as if they are their underlying durations
     // note that we use max(hooks, 1) here because otherwise we'd end up breaking the main (level 0) beam for
@@ -356,15 +356,15 @@ void Beam::calcBeamBreaks(const ChordRest* cr, const ChordRest* prevCr, int leve
             // this cr starts a tuplet
             int beams = std::max(TDuration(cr->tuplet()->ticks()).hooks(), 1);
             if (beams <= level) {
-                isBroken32 = level == 1;
-                isBroken64 = level >= 2;
+                isBroken16 = level == 1;
+                isBroken32 = level >= 2;
             }
         } else if (prevCr->tuplet() && prevCr->tuplet() != cr->tuplet()) {
             // this is a non-tuplet cr that is first after a tuplet
             int beams = std::max(TDuration(prevCr->tuplet()->ticks()).hooks(), 1);
             if (beams <= level) {
-                isBroken32 = level == 1;
-                isBroken64 = level >= 2;
+                isBroken16 = level == 1;
+                isBroken32 = level >= 2;
             }
         }
     }
@@ -838,9 +838,9 @@ ActionIconType Beam::actionIconTypeForBeamMode(BeamMode mode)
         return ActionIconType::BEAM_NONE;
     case BeamMode::BEGIN:
         return ActionIconType::BEAM_BREAK_LEFT;
-    case BeamMode::BEGIN32:
+    case BeamMode::BEGIN16:
         return ActionIconType::BEAM_BREAK_INNER_8TH;
-    case BeamMode::BEGIN64:
+    case BeamMode::BEGIN32:
         return ActionIconType::BEAM_BREAK_INNER_16TH;
     case BeamMode::MID:
         return ActionIconType::BEAM_JOIN;

--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -316,7 +316,26 @@ void Beam::setTremAnchors()
 void Beam::calcBeamBreaks(const ChordRest* cr, const ChordRest* prevCr, int level, bool& isBroken32, bool& isBroken64) const
 {
     BeamMode beamMode = cr->beamMode();
-
+    if (cr->isRest() && (beamMode == BeamMode::MID || beamMode == BeamMode::BEGIN32 || beamMode == BeamMode::BEGIN64)) {
+        // when a rest has beamMode MID we can just ignore it entirely and allow any beams to continue through
+        switch (beamMode) {
+        case BeamMode::MID:
+            isBroken32 = isBroken64 = false;
+            break;
+        case BeamMode::BEGIN32:
+            isBroken32 = level > 0;
+            isBroken64 = false;
+            break;
+        case BeamMode::BEGIN64:
+            isBroken32 = false;
+            isBroken64 = level > 1;
+            break;
+        default:
+            // should be unreachable
+            assert(false);
+        }
+        return;
+    }
     // get default beam mode -- based on time signature preferences
     const Groups& group = cr->staff()->group(cr->measure()->tick());
     BeamMode defaultBeamMode = group.endBeam(cr, prevCr);

--- a/src/engraving/libmscore/beam.cpp
+++ b/src/engraving/libmscore/beam.cpp
@@ -313,13 +313,13 @@ void Beam::setTremAnchors()
     }
 }
 
-void Beam::calcBeamBreaks(const ChordRest* chord, const ChordRest* prevChord, int level, bool& isBroken32, bool& isBroken64) const
+void Beam::calcBeamBreaks(const ChordRest* cr, const ChordRest* prevCr, int level, bool& isBroken32, bool& isBroken64) const
 {
-    BeamMode beamMode = chord->beamMode();
+    BeamMode beamMode = cr->beamMode();
 
     // get default beam mode -- based on time signature preferences
-    const Groups& group = chord->staff()->group(chord->measure()->tick());
-    BeamMode defaultBeamMode = group.endBeam(chord, prevChord);
+    const Groups& group = cr->staff()->group(cr->measure()->tick());
+    BeamMode defaultBeamMode = group.endBeam(cr, prevCr);
 
     bool isManuallyBroken32 = level >= 1 && beamMode == BeamMode::BEGIN32;
     bool isManuallyBroken64 = level >= 2 && beamMode == BeamMode::BEGIN64;
@@ -332,17 +332,17 @@ void Beam::calcBeamBreaks(const ChordRest* chord, const ChordRest* prevChord, in
     // deal with beam-embedded triplets by breaking beams as if they are their underlying durations
     // note that we use max(hooks, 1) here because otherwise we'd end up breaking the main (level 0) beam for
     // tuplets that take up non-beamed amounts of space (eg. 16th note quintuplets)
-    if (level > 0 && prevChord && chord->beamMode() == BeamMode::AUTO) {
-        if (chord->tuplet() && chord->tuplet() != prevChord->tuplet()) {
+    if (level > 0 && prevCr && cr->beamMode() == BeamMode::AUTO) {
+        if (cr->tuplet() && cr->tuplet() != prevCr->tuplet()) {
             // this cr starts a tuplet
-            int beams = std::max(TDuration(chord->tuplet()->ticks()).hooks(), 1);
+            int beams = std::max(TDuration(cr->tuplet()->ticks()).hooks(), 1);
             if (beams <= level) {
                 isBroken32 = level == 1;
                 isBroken64 = level >= 2;
             }
-        } else if (prevChord->tuplet() && prevChord->tuplet() != chord->tuplet()) {
+        } else if (prevCr->tuplet() && prevCr->tuplet() != cr->tuplet()) {
             // this is a non-tuplet cr that is first after a tuplet
-            int beams = std::max(TDuration(prevChord->tuplet()->ticks()).hooks(), 1);
+            int beams = std::max(TDuration(prevCr->tuplet()->ticks()).hooks(), 1);
             if (beams <= level) {
                 isBroken32 = level == 1;
                 isBroken64 = level >= 2;

--- a/src/engraving/libmscore/chordrest.cpp
+++ b/src/engraving/libmscore/chordrest.cpp
@@ -374,10 +374,10 @@ EngravingItem* ChordRest::drop(EditData& data)
             undoChangeProperty(Pid::BEAM_MODE, BeamMode::BEGIN);
             break;
         case ActionIconType::BEAM_BREAK_INNER_8TH:
-            undoChangeProperty(Pid::BEAM_MODE, BeamMode::BEGIN32);
+            undoChangeProperty(Pid::BEAM_MODE, BeamMode::BEGIN16);
             break;
         case ActionIconType::BEAM_BREAK_INNER_16TH:
-            undoChangeProperty(Pid::BEAM_MODE, BeamMode::BEGIN64);
+            undoChangeProperty(Pid::BEAM_MODE, BeamMode::BEGIN32);
             break;
         case ActionIconType::BEAM_JOIN:
             undoChangeProperty(Pid::BEAM_MODE, BeamMode::MID);

--- a/src/engraving/libmscore/groups.cpp
+++ b/src/engraving/libmscore/groups.cpp
@@ -186,8 +186,8 @@ BeamMode Groups::beamMode(int tick, DurationType d) const
         switch (action) {
         case 0: return BeamMode::AUTO;
         case 1: return BeamMode::BEGIN;
-        case 2: return BeamMode::BEGIN32;
-        case 3: return BeamMode::BEGIN64;
+        case 2: return BeamMode::BEGIN16;
+        case 3: return BeamMode::BEGIN32;
         default:
             LOGD("   Groups::beamMode: bad action %d", action);
             return BeamMode::AUTO;
@@ -254,9 +254,9 @@ void Groups::addStop(int pos, DurationType d, BeamMode bm)
     int action;
     if (bm == BeamMode::BEGIN) {
         action = 1;
-    } else if (bm == BeamMode::BEGIN32) {
+    } else if (bm == BeamMode::BEGIN16) {
         action = 2;
-    } else if (bm == BeamMode::BEGIN64) {
+    } else if (bm == BeamMode::BEGIN32) {
         action = 3;
     } else {
         return;

--- a/src/engraving/rw/read114/read114.cpp
+++ b/src/engraving/rw/read114/read114.cpp
@@ -3049,8 +3049,8 @@ Err Read114::readScore(Score* score, XmlReader& e, ReadInOutData* out)
                         case BeamMode::NONE:
                             break;
                         case BeamMode::MID:
+                        case BeamMode::BEGIN16:
                         case BeamMode::BEGIN32:
-                        case BeamMode::BEGIN64:
                             cr->setBeamMode(BeamMode::BEGIN);
                             break;
                         case BeamMode::INVALID:

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -2460,7 +2460,15 @@ bool TRead::readProperties(ChordRest* ch, XmlReader& e, ReadContext& ctx)
             }
         }
     } else if (tag == "BeamMode") {
-        ch->setBeamMode(TConv::fromXml(e.readAsciiText(), BeamMode::AUTO));
+        // 400 and previous used begin32/begin64 for beam mode
+        // 410 uses begin16/begin32
+        auto txt = e.readAsciiText();
+        if (txt == "begin64") {
+            txt = "begin32";
+        } else if (txt == "begin32") {
+            txt = "begin16";
+        }
+        ch->setBeamMode(TConv::fromXml(txt, BeamMode::AUTO));
     } else if (tag == "Articulation") {
         Articulation* atr = Factory::createArticulation(ch);
         atr->setTrack(ch->track());

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -304,13 +304,18 @@ enum class Orientation : signed char {
 
 // P_TYPE::BEAM_MODE
 //! Note: for historical reasons, these have strange names
+//!
 enum class BeamMode : signed char {
     INVALID = -1,
     AUTO,
     NONE,
     BEGIN,
+    // TODO:
+    // strange names aside, mscx files refer to BEGIN16 and BEGIN32 as begin32/begin64, which would describe the 3rd and 4th beams,
+    // which is wildly incorrect.These enum names are CORRECT, but I haven't touched the mscx files yet.
+    // changing this for the save files would necessitate some serious file version / import work. -A
+    BEGIN16,
     BEGIN32,
-    BEGIN64,
     MID,
     END
 };

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -1608,8 +1608,8 @@ static const std::vector<Item<BeamMode> > BEAMMODE_TYPES = {
     { BeamMode::MID, "mid" },
     { BeamMode::END, "end" },
     { BeamMode::NONE, "no" },
-    { BeamMode::BEGIN32, "begin32" },
-    { BeamMode::BEGIN64, "begin64" },
+    { BeamMode::BEGIN16, "begin32" },
+    { BeamMode::BEGIN32, "begin64" },
     { BeamMode::INVALID, "invalid" }
 };
 

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -1608,8 +1608,8 @@ static const std::vector<Item<BeamMode> > BEAMMODE_TYPES = {
     { BeamMode::MID, "mid" },
     { BeamMode::END, "end" },
     { BeamMode::NONE, "no" },
-    { BeamMode::BEGIN16, "begin32" },
-    { BeamMode::BEGIN32, "begin64" },
+    { BeamMode::BEGIN16, "begin16" },
+    { BeamMode::BEGIN32, "begin32" },
     { BeamMode::INVALID, "invalid" }
 };
 

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -2854,13 +2854,13 @@ void GPConverter::setBeamMode(const GPBeat* beat, ChordRest* cr, Measure* measur
         double fract = (double)tick.numerator() / tick.denominator() * measureDenom;
 
         if ((int)fract == fract && beat->beamMode() != GPBeat::BeamMode::BROKEN2_JOINED) {
-            /// keep auto direction for some beams, so BEGIN32/BEGIN64 modes work properly
+            /// keep auto direction for some beams, so BEGIN16/BEGIN32 modes work properly
             /// (forcing divide of beam groups, TODO-gp: make possible to show broken2 type from guitar pro
             beamMode = BeamMode::AUTO;
         } else if (cr->ticks() > Fraction(1, 32)) {
-            beamMode = BeamMode::BEGIN32;
+            beamMode = BeamMode::BEGIN16;
         } else {
-            beamMode = BeamMode::BEGIN64;
+            beamMode = BeamMode::BEGIN32;
         }
     }
 

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -377,8 +377,8 @@ void NotationActionController::init()
     registerAction("beam-auto", &Interaction::addBeamToSelectedChordRests, BeamMode::AUTO);
     registerAction("beam-none", &Interaction::addBeamToSelectedChordRests, BeamMode::NONE);
     registerAction("beam-break-left", &Interaction::addBeamToSelectedChordRests, BeamMode::BEGIN);
-    registerAction("beam-break-inner-8th", &Interaction::addBeamToSelectedChordRests, BeamMode::BEGIN32);
-    registerAction("beam-break-inner-16th", &Interaction::addBeamToSelectedChordRests, BeamMode::BEGIN64);
+    registerAction("beam-break-inner-8th", &Interaction::addBeamToSelectedChordRests, BeamMode::BEGIN16);
+    registerAction("beam-break-inner-16th", &Interaction::addBeamToSelectedChordRests, BeamMode::BEGIN32);
     registerAction("beam-join", &Interaction::addBeamToSelectedChordRests, BeamMode::MID);
 
     registerAction("add-brackets", &Interaction::addBracketsToSelection, BracketsType::Brackets);

--- a/src/palette/view/widgets/noteGroups.cpp
+++ b/src/palette/view/widgets/noteGroups.cpp
@@ -167,10 +167,10 @@ void NoteGroups::beamPropertyDropped(Chord* chord, ActionIcon* icon)
         updateBeams(chord, BeamMode::BEGIN);
         break;
     case ActionIconType::BEAM_BREAK_INNER_8TH:
-        updateBeams(chord, BeamMode::BEGIN32);
+        updateBeams(chord, BeamMode::BEGIN16);
         break;
     case ActionIconType::BEAM_BREAK_INNER_16TH:
-        updateBeams(chord, BeamMode::BEGIN64);
+        updateBeams(chord, BeamMode::BEGIN32);
         break;
     default:
         break;

--- a/src/plugins/api/apitypes.h
+++ b/src/plugins/api/apitypes.h
@@ -408,8 +408,8 @@ enum class BeamMode {
     MID = int(mu::engraving::BeamMode::MID),
     END = int(mu::engraving::BeamMode::END),
     NONE = int(mu::engraving::BeamMode::NONE),
-    BEGIN32 = int(mu::engraving::BeamMode::BEGIN32),
-    BEGIN64 = int(mu::engraving::BeamMode::BEGIN64),
+    BEGIN32 = int(mu::engraving::BeamMode::BEGIN16), // these names for the beam modes are deprecated! this beam mode begins a 16th beam
+    BEGIN64 = int(mu::engraving::BeamMode::BEGIN32), // this one begins a 32nd beam
     INVALID = int(mu::engraving::BeamMode::INVALID),
 };
 Q_ENUM_NS(BeamMode);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/17651

Rests inside beams need special handling, as their behavior is different from non-rest chords. A 16th beam can go through an 8th, for example. Additionally, while in the future we may want stems to be able to start and end on rests in the middle of a beam, right now we don't support that, so any number of rests surrounded on both sides by non-rests will neither start nor end any sub-beam within the beam.

I also used this opportunity to rename the BeamMode enums `BEGIN32` and `BEGIN64` as they don't describe what these two modes do, namely, begin a 16th beam (i.e. the beam next to the primary beam) and begin a 32nd beam (i.e. the beam two away from the primary beam). Right now we have no way to break or manipulate 64th beams (level 3) with the beam modes we have available right now, except by breaking at a higher level.

The BEGIN32/BEGIN64 renaming is in its own commit, so feel free to not merge it or request changes if it's more trouble than it's worth.