### PR TITLE
More accurate tempo change

### DIFF
--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -609,7 +609,7 @@ void Score::setUpTempoMap()
 
             std::map<int, double> tempoCurve = TConv::easingValueCurve(tempoChange->ticks().ticks(),
                                                                        4 /*stepsCount*/,
-                                                                       newBps.val - currentBps.val,
+                                                                       (newBps.val - currentBps.val) / 2,
                                                                        tempoChange->easingMethod());
 
             for (const auto& pair : tempoCurve) {

--- a/src/engraving/tests/tempomap_tests.cpp
+++ b/src/engraving/tests/tempomap_tests.cpp
@@ -172,7 +172,7 @@ TEST_F(Engraving_TempoMapTests, GRADUAL_TEMPO_CHANGE_ACCELERANDO)
     // [GIVEN] Expected tempomap
     std::map<int, BeatsPerSecond> expectedTempoMap = {
         { 0, BeatsPerSecond::fromBPM(BeatsPerMinute(120.f)) }, // beginning of the first measure
-        { 6 * 4 * Constants::DIVISION, BeatsPerSecond::fromBPM(BeatsPerMinute(159.6f)) } // beginning of the last measure
+        { 6 * 4 * Constants::DIVISION, BeatsPerSecond::fromBPM(BeatsPerMinute(139.8f)) } // beginning of the last measure
     };
 
     // [WHEN] We request score's tempomap its size matches with our expectations
@@ -201,7 +201,7 @@ TEST_F(Engraving_TempoMapTests, GRADUAL_TEMPO_CHANGE_RALLENTANDO)
     // [GIVEN] Expected tempomap
     std::map<int, BeatsPerSecond> expectedTempoMap = {
         { 0, BeatsPerSecond::fromBPM(BeatsPerMinute(120.f)) }, // beginning of the first measure
-        { 6 * 4 * Constants::DIVISION, BeatsPerSecond::fromBPM(BeatsPerMinute(90.f)) } // beginning of the last measure
+        { 6 * 4 * Constants::DIVISION, BeatsPerSecond::fromBPM(BeatsPerMinute(105.f)) } // beginning of the last measure
     };
 
     // [WHEN] We request score's tempomap its size matches with our expectations
@@ -237,12 +237,12 @@ TEST_F(Engraving_TempoMapTests, GRADUAL_TEMPO_CHANGE_DOESNT_OVERWRITE_OTHER_TEMP
     std::map<int, BeatsPerSecond> expectedTempoMap = {
         // ritardando (beginning of the first measure)
         { 0, BeatsPerSecond::fromBPM(BeatsPerMinute(120.f)) },
-        { 960, BeatsPerSecond::fromBPM(BeatsPerMinute(112.5f)) },
+        { 960, BeatsPerSecond::fromBPM(BeatsPerMinute(116.25f)) },
         // tempo marking (80 BPM, the first measure)
         { 1440, BeatsPerSecond::fromBPM(BeatsPerMinute(80.f)) },
         // ritardando (the second measure)
-        { 1920, BeatsPerSecond::fromBPM(BeatsPerMinute(105.f)) },
-        { 2880, BeatsPerSecond::fromBPM(BeatsPerMinute(97.5f)) },
+        { 1920, BeatsPerSecond::fromBPM(BeatsPerMinute(112.5f)) },
+        { 2880, BeatsPerSecond::fromBPM(BeatsPerMinute(108.75f)) },
         // presto (beginning of the third measure)
         { 3840, BeatsPerSecond::fromBPM(BeatsPerMinute(187.2f)) },
     };

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -1208,7 +1208,8 @@ static std::map<int /*tickPosition*/, T> buildEasedValueCurve(const int ticksDur
     float durationStep = static_cast<float>(ticksDuration) / static_cast<float>(stepsCount);
 
     for (int i = 0; i <= stepsCount; ++i) {
-        result.emplace(i * durationStep, easingFactor(i / static_cast<float>(stepsCount), method) * amplitude);
+        result.emplace(static_cast<float>(i) * durationStep, easingFactor(static_cast<float>(i) / (static_cast<float>(stepsCount)),
+                                                                          method) * amplitude);
     }
 
     return result;


### PR DESCRIPTION
Made more accurate tempo change
Original issue
<img width="1718" alt="image" src="https://github.com/musescore/MuseScore/assets/16940972/b93c8861-550c-4bfe-88e6-fd37dd08bb0a">
<img width="712" alt="image" src="https://github.com/musescore/MuseScore/assets/16940972/607e4dbc-60e8-49d3-9023-e27a3528f923">

