### PR TITLE
fixed crash on creating linked trill

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -47,6 +47,7 @@
 #include "libmscore/tie.h"
 #include "libmscore/timesig.h"
 #include "libmscore/tremolo.h"
+#include "libmscore/trill.h"
 #include "libmscore/tripletfeel.h"
 #include "libmscore/tuplet.h"
 #include "libmscore/volta.h"
@@ -1737,6 +1738,22 @@ void GPConverter::addTrill(const GPNote* gpnote, Note* note)
 void GPConverter::addTrill(const GPBeat* gpbeat, ChordRest* cr)
 {
     buildContiniousElement(cr, m_trillElements, ElementType::TRILL, LineImportType::TRILL, gpbeat->trill(), true);
+
+    if (!cr->isChord()) {
+        return;
+    }
+
+    SLine* lineElem = m_trillElements[cr->track()];
+    if (lineElem) {
+        Trill* trill = dynamic_cast<Trill*>(lineElem);
+
+        if (!trill) {
+            LOGE() << "trill not found";
+            return;
+        }
+
+        trill->setTrillType(TrillType::TRILL_LINE);
+    }
 }
 
 void GPConverter::addOrnament(const GPNote* gpnote, Note* note)

--- a/src/importexport/guitarpro/tests/data/trill.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/trill.gp-ref.mscx
@@ -119,6 +119,9 @@
           <Spanner type="Trill">
             <Trill>
               <subtype>trill</subtype>
+              <Ornament>
+                <subtype>ornamentTrill</subtype>
+                </Ornament>
               </Trill>
             <next>
               <location>

--- a/src/importexport/guitarpro/tests/data/trill.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/trill.gpx-ref.mscx
@@ -119,6 +119,9 @@
           <Spanner type="Trill">
             <Trill>
               <subtype>trill</subtype>
+              <Ornament>
+                <subtype>ornamentTrill</subtype>
+                </Ornament>
               </Trill>
             <next>
               <location>


### PR DESCRIPTION
can be reproduced on creating linked staff for this file:
[trill-1.gp.zip](https://github.com/musescore/MuseScore/files/11636468/trill-1.gp.zip)
