### PR TITLE
Also include the top menubar on FreeBSD.

### DIFF
--- a/src/appshell/appshellmodule.cpp
+++ b/src/appshell/appshellmodule.cpp
@@ -164,7 +164,7 @@ void AppShellModule::registerUiTypes()
 
 #if defined(Q_OS_MACOS)
     qmlRegisterType<AppMenuModel>("MuseScore.AppShell", 1, 0, "PlatformAppMenuModel");
-#elif defined(Q_OS_LINUX)
+#elif defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     qmlRegisterType<AppMenuModel>("MuseScore.AppShell", 1, 0, "PlatformAppMenuModel");
     qmlRegisterType<NavigableAppMenuModel>("MuseScore.AppShell", 1, 0, "AppMenuModel");
 #else


### PR DESCRIPTION
Include top menu bar in FreeBSD.
Note (to self) the shadows on the menus are too big under openbox (openbox does not do  compositing I suppose that is a main part of the issue) both on Linux and FreeBSD).