### PR TITLE
Score padding reduced

### DIFF
--- a/src/notation/view/abstractnotationpaintview.cpp
+++ b/src/notation/view/abstractnotationpaintview.cpp
@@ -32,7 +32,7 @@ using namespace mu::ui;
 using namespace mu::draw;
 using namespace mu::notation;
 
-static constexpr qreal SCROLL_LIMIT_OFF_OFFSET = 0.75;
+static constexpr qreal SCROLL_LIMIT_OFF_OFFSET = 0.33;
 static constexpr qreal SCROLL_LIMIT_ON_OFFSET = 0.02;
 
 AbstractNotationPaintView::AbstractNotationPaintView(QQuickItem* parent)


### PR DESCRIPTION
Resolves: #11363

Hello, Score pading reduced from 75% down to 33%

Old:
![Screenshot_20230604_135314](https://github.com/musescore/MuseScore/assets/46960941/c0cf9f67-9d90-433c-9681-6139bab97e84)


New:
![Screenshot_20230604_134702](https://github.com/musescore/MuseScore/assets/46960941/c76f3fa5-8db3-493e-aeda-62582b34a9f4)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
