### PR TITLE
Fix #15421: Prevent crash when adding tie behind a currently active slur

### DIFF
--- a/src/engraving/libmscore/noteentry.cpp
+++ b/src/engraving/libmscore/noteentry.cpp
@@ -308,9 +308,9 @@ Note* Score::addPitch(NoteVal& nval, bool addFlag, InputState* externalInputStat
         // extend slur
         //
         ChordRest* e = searchNote(is.tick(), is.track());
-        if (e) {
+        EngravingItem* ee = is.slur()->startElement();
+        if (e && ee) {
             Fraction stick = Fraction(0, 1);
-            EngravingItem* ee = is.slur()->startElement();
             if (ee->isChordRest()) {
                 stick = toChordRest(ee)->tick();
             } else if (ee->isNote()) {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/15421

In input mode, a tie creates a new note to be tied to. Replacing chords with slurs attached to them is generally no problem, the slurs reconnect themselves, but when the start chord of a slur that is currently active in terms of note input mode is replaced in this way, we segfault hard. This adds a nullcheck, the ultimate result of which is that the slur will be removed, the same as if you were to edit anything impossible to add to the slur.

For example, new score, `F` `F` `G` `left arrow` `left arrow` `S` `left arrow` `E`

The slur, since it was never finalized and other things are being edited outside of that slur's purview, it is removed. This is how I understand it to work!