### PR TITLE
use list selection for updateMutestatuses

### DIFF
--- a/src/appshell/qml/Preferences/CanvasPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/CanvasPreferencesPage.qml
@@ -56,7 +56,6 @@ PreferencesPage {
             onDefaultZoomLevelChangeRequested: function(zoomLevel) {
                 preferencesModel.setDefaultZoomLevel(zoomLevel)
             }
-
             onMouseZoomPrecisionChangeRequested: function(zoomPrecision) {
                 preferencesModel.mouseZoomPrecision = zoomPrecision
             }
@@ -84,13 +83,16 @@ PreferencesPage {
 
         MiscellaneousSection {
             selectionProximity: preferencesModel.selectionProximity
-
+            useSelectionForMuteStatuses:preferencesModel.useSelectionForMuteStatuses
             navigation.section: root.navigationSection
             navigation.order: root.navigationOrderStart + 3
 
             onSelectionProximityChangeRequested: function(proximity) {
                 preferencesModel.selectionProximity = proximity
             }
+            onUseSelectionForMuteStatusesChangeRequested: function(muteNotSelected) {
+                preferencesModel.useSelectionForMuteStatuses= muteNotSelected
+             }
         }
     }
 }

--- a/src/appshell/qml/Preferences/internal/MiscellaneousSection.qml
+++ b/src/appshell/qml/Preferences/internal/MiscellaneousSection.qml
@@ -30,8 +30,11 @@ BaseSection {
     title: qsTrc("appshell/preferences", "Miscellaneous")
 
     property alias selectionProximity: selectionProximityControl.currentValue
+    property alias useSelectionForMuteStatuses: useSelectionForMuteStatusesBox.checked
 
     signal selectionProximityChangeRequested(int proximity)
+    signal useSelectionForMuteStatusesChangeRequested(bool limit)
+
 
     IncrementalPropertyControlWithTitle {
         id: selectionProximityControl
@@ -55,4 +58,20 @@ BaseSection {
             root.selectionProximityChangeRequested(newValue)
         }
     }
+    CheckBox {
+        id: useSelectionForMuteStatusesBox
+        width: parent.width
+
+        text: qsTrc("appshell/preferences", "Auto mute parts with no selected elements")
+
+        navigation.name: "useSelectionForMuteStatusesBox"
+        navigation.panel: root.navigation
+        navigation.row: 2
+        navigation.column: 0
+        onClicked: {
+            root.useSelectionForMuteStatusesChangeRequested(!checked)
+
+        }
+
+}
 }

--- a/src/appshell/view/preferences/canvaspreferencesmodel.cpp
+++ b/src/appshell/view/preferences/canvaspreferencesmodel.cpp
@@ -70,6 +70,11 @@ int CanvasPreferencesModel::scrollPagesOrientation() const
     return static_cast<int>(notationConfiguration()->canvasOrientation().val);
 }
 
+bool CanvasPreferencesModel::useSelectionForMuteStatuses() const
+{
+    return notationConfiguration()->useSelectionForMuteStatuses();
+}
+
 bool CanvasPreferencesModel::limitScrollArea() const
 {
     return notationConfiguration()->isLimitCanvasScrollArea();
@@ -118,6 +123,15 @@ void CanvasPreferencesModel::setScrollPagesOrientation(int orientation)
     }
 
     notationConfiguration()->setCanvasOrientation(static_cast<framework::Orientation>(orientation));
+}
+
+void CanvasPreferencesModel::setUseSelectionForMuteStatuses(bool muteNotSelected)
+{
+    if (useSelectionForMuteStatuses() == muteNotSelected) {
+        return;
+    }
+    notationConfiguration()->setUseSelectionForMuteStatuses(muteNotSelected);
+    emit useSelectionForMuteStatusesChanged(muteNotSelected);
 }
 
 void CanvasPreferencesModel::setLimitScrollArea(bool limit)

--- a/src/appshell/view/preferences/canvaspreferencesmodel.h
+++ b/src/appshell/view/preferences/canvaspreferencesmodel.h
@@ -41,7 +41,8 @@ class CanvasPreferencesModel : public QObject, public async::Asyncable
 
     Q_PROPERTY(int scrollPagesOrientation READ scrollPagesOrientation WRITE setScrollPagesOrientation NOTIFY scrollPagesOrientationChanged)
     Q_PROPERTY(bool limitScrollArea READ limitScrollArea WRITE setLimitScrollArea NOTIFY limitScrollAreaChanged)
-
+    Q_PROPERTY(
+        bool useSelectionForMuteStatuses READ useSelectionForMuteStatuses WRITE setUseSelectionForMuteStatuses NOTIFY useSelectionForMuteStatusesChanged)
     Q_PROPERTY(int selectionProximity READ selectionProximity WRITE setSelectionProximity NOTIFY selectionProximityChanged)
 
 public:
@@ -58,6 +59,7 @@ public:
 
     int scrollPagesOrientation() const;
     bool limitScrollArea() const;
+    bool useSelectionForMuteStatuses() const;
 
     int selectionProximity() const;
 
@@ -66,6 +68,7 @@ public slots:
 
     void setScrollPagesOrientation(int orientation);
     void setLimitScrollArea(bool limit);
+    void setUseSelectionForMuteStatuses(bool muteNotSelected);
 
     void setSelectionProximity(int proximity);
 
@@ -75,7 +78,7 @@ signals:
     void scrollPagesOrientationChanged();
     void limitScrollAreaChanged();
     void selectionProximityChanged(int selectionProximity);
-
+    void useSelectionForMuteStatusesChanged(bool checked);
 private:
     void setupConnections();
 

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -142,7 +142,6 @@ public:
     virtual bool isLimitCanvasScrollArea() const = 0;
     virtual void setIsLimitCanvasScrollArea(bool limited) = 0;
     virtual async::Notification isLimitCanvasScrollAreaChanged() const = 0;
-
     virtual bool colorNotesOutsideOfUsablePitchRange() const = 0;
     virtual void setColorNotesOutsideOfUsablePitchRange(bool value) = 0;
 
@@ -183,6 +182,8 @@ public:
 
     virtual io::path_t styleFileImportPath() const = 0;
     virtual void setStyleFileImportPath(const io::path_t& path) = 0;
+    virtual bool useSelectionForMuteStatuses() const = 0;
+    virtual void setUseSelectionForMuteStatuses(const bool muteNotSelected) const = 0;
 };
 }
 

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -72,7 +72,6 @@ static const Settings::Key IS_LIMIT_CANVAS_SCROLL_AREA_KEY(module_name, "ui/canv
 static const Settings::Key COLOR_NOTES_OUTSIDE_OF_USABLE_PITCH_RANGE(module_name, "score/note/warnPitchRange");
 static const Settings::Key REALTIME_DELAY(module_name, "io/midi/realtimeDelay");
 static const Settings::Key NOTE_DEFAULT_PLAY_DURATION(module_name, "score/note/defaultPlayDuration");
-
 static const Settings::Key FIRST_SCORE_ORDER_LIST_KEY(module_name, "application/paths/scoreOrderList1");
 static const Settings::Key SECOND_SCORE_ORDER_LIST_KEY(module_name, "application/paths/scoreOrderList2");
 
@@ -87,12 +86,13 @@ static const Settings::Key NEED_TO_SHOW_ADD_FIGURED_BASS_ERROR_MESSAGE_KEY(modul
 static const Settings::Key PIANO_KEYBOARD_NUMBER_OF_KEYS(module_name,  "pianoKeyboard/numberOfKeys");
 
 static const Settings::Key STYLE_FILE_IMPORT_PATH_KEY(module_name, "import/style/styleFile");
-
+static const Settings::Key USE_LIST_SELECTION_FOR_MUTESTATUSES(module_name, "ui/canvas/misc/useSelectionForMuteStatus");
 static constexpr int DEFAULT_GRID_SIZE_SPATIUM = 2;
 
 void NotationConfiguration::init()
 {
     settings()->setDefaultValue(BACKGROUND_USE_COLOR, Val(true));
+    settings()->setDefaultValue(USE_LIST_SELECTION_FOR_MUTESTATUSES, Val(false));
     settings()->valueChanged(BACKGROUND_USE_COLOR).onReceive(nullptr, [this](const Val&) {
         m_backgroundChanged.notify();
     });
@@ -174,7 +174,6 @@ void NotationConfiguration::init()
     settings()->valueChanged(IS_LIMIT_CANVAS_SCROLL_AREA_KEY).onReceive(this, [this](const Val&) {
         m_isLimitCanvasScrollAreaChanged.notify();
     });
-
     settings()->setDefaultValue(COLOR_NOTES_OUTSIDE_OF_USABLE_PITCH_RANGE, Val(true));
     settings()->setDefaultValue(REALTIME_DELAY, Val(750));
     settings()->setDefaultValue(NOTE_DEFAULT_PLAY_DURATION, Val(500));
@@ -839,4 +838,14 @@ mu::io::path_t NotationConfiguration::styleFileImportPath() const
 void NotationConfiguration::setStyleFileImportPath(const io::path_t& path)
 {
     settings()->setSharedValue(STYLE_FILE_IMPORT_PATH_KEY, Val(path.toStdString()));
+}
+
+bool NotationConfiguration::useSelectionForMuteStatuses() const
+{
+    return settings()->value(USE_LIST_SELECTION_FOR_MUTESTATUSES).toBool();
+}
+
+void NotationConfiguration::setUseSelectionForMuteStatuses(const bool muteNotSelected) const
+{
+    settings()->setSharedValue(USE_LIST_SELECTION_FOR_MUTESTATUSES, Val(muteNotSelected));
 }

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -145,6 +145,7 @@ public:
     bool isLimitCanvasScrollArea() const override;
     void setIsLimitCanvasScrollArea(bool limited) override;
     async::Notification isLimitCanvasScrollAreaChanged() const override;
+//    async::Notification useSelectionForMuteStatusesChanged() const override;
 
     bool colorNotesOutsideOfUsablePitchRange() const override;
     void setColorNotesOutsideOfUsablePitchRange(bool value) override;
@@ -165,7 +166,6 @@ public:
 
     io::paths_t userScoreOrderListPaths() const override;
     void setUserScoreOrderListPaths(const io::paths_t& paths) override;
-
     bool isSnappedToGrid(framework::Orientation gridOrientation) const override;
     void setIsSnappedToGrid(framework::Orientation gridOrientation, bool isSnapped) override;
 
@@ -186,6 +186,8 @@ public:
 
     io::path_t styleFileImportPath() const override;
     void setStyleFileImportPath(const io::path_t& path) override;
+    bool useSelectionForMuteStatuses() const override;
+    void setUseSelectionForMuteStatuses(const bool muteNotSelected) const override;
 
 private:
     io::path_t firstScoreOrderListPath() const;
@@ -200,6 +202,7 @@ private:
     async::Channel<io::path_t> m_userStylesPathChanged;
     async::Notification m_scoreOrderListPathsChanged;
     async::Notification m_isLimitCanvasScrollAreaChanged;
+    async::Notification m_useSelectionForMuteStatusesChanged;
     async::Notification m_isPlayRepeatsChanged;
     async::Notification m_isPlayChordSymbolsChanged;
     ValCh<int> m_pianoKeyboardNumberOfKeys;


### PR DESCRIPTION
 Make auto mute parts with no selected elements a setting
 in ui/canvas/misc/useSelectionForMuteStatus


Just an  extra easy way to choose which instruments to playback

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
