### PR TITLE
Fix #16849: Fix crash when searching in Palettes

### DIFF
--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -59,7 +59,6 @@ PopupView::~PopupView()
     if (m_window) {
         m_window->setOnHidden(std::function<void()>());
     }
-    m_contentItem->deleteLater();
 
     if (m_closeController) {
         delete m_closeController;


### PR DESCRIPTION
Resolves: #16849

Items created in QML are managed by the QML engine, so they can't be deleted from C++ code. The destructor of PopupView deletes the object and it should only delete objects with Cpp ownership.

I'm not sure whether this also fixes other issues than #16849.

Steps to reproduce the original issue:
1. Add several notes and select all of them.
2. Click on the search box in the palettes tab.
3. Quickly type words that should display some results.
4. The program will randomly crash.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
