### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/libmscore/system.cpp
+++ b/src/engraving/libmscore/system.cpp
@@ -1037,8 +1037,8 @@ void System::layout2(LayoutContext& ctx)
                 ChordRest* ecr = sp->endCR();
                 staff_idx_t idx = sp->vStaffIdx();
                 if (scr && ecr && (scr->vStaffIdx() != idx || ecr->vStaffIdx() != idx)) {
-                    LayoutContext ctx(score());
-                    TLayout::layoutSystem(sp, this, ctx);
+                    LayoutContext cntx(score());
+                    TLayout::layoutSystem(sp, this, cntx);
                 }
             }
         }

--- a/src/framework/audio/internal/worker/mixer.cpp
+++ b/src/framework/audio/internal/worker/mixer.cpp
@@ -185,7 +185,7 @@ samples_t Mixer::process(float* outBuffer, samples_t samplesPerChannel)
         mixOutputFromChannel(outBuffer, trackBuffer.data(), samplesPerChannel);
         masterChannelSampleCount = std::max(samplesPerChannel, masterChannelSampleCount);
 
-        const AuxSendsParams& auxSends = m_trackChannels.at(trackIdx)->outputParams().auxSends;
+        const AuxSendsParams& auxSends = m_trackChannels.at(static_cast<TrackId>(trackIdx))->outputParams().auxSends;
         writeTrackToAuxBuffers(auxSends, trackBuffer.data(), samplesPerChannel);
     }
 


### PR DESCRIPTION
* reg. conversion from 'size_t' to 'const int', possible loss of data (C4267)
* reg. declaration hides function parameter (C4457)
