### PR TITLE
Fix #17761: Null check in Spanner::findStartChord()

### DIFF
--- a/src/engraving/libmscore/spanner.cpp
+++ b/src/engraving/libmscore/spanner.cpp
@@ -934,7 +934,7 @@ Chord* Spanner::findStartChord() const
 {
     assert(_anchor == Anchor::CHORD);
     ChordRest* cr = score()->findCR(tick(), track());
-    return cr->isChord() ? toChord(cr) : nullptr;
+    return cr && cr->isChord() ? toChord(cr) : nullptr;
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/17761

This was caused by slurs being anchored to a chordrest that is completely deleted (i.e. when they are in voice 2 and removed entirely). This can cause `score()->findCR` to return `nullptr` which then has `->isChord` called on it. This null check fixes the crash.

Note that the slur continues to float, attached to nothing. If we want to decide that the slur should be deleted along with the CR we can definitely do that, but for now I wanted to get this fix out as the crash is more important to fix.