### PR TITLE
Fix crash on opening StaffText dialog

### DIFF
--- a/src/inspector/types/texttypes.h
+++ b/src/inspector/types/texttypes.h
@@ -77,6 +77,7 @@ public:
         TEXT_TYPE_MEASURE_NUMBER,
         TEXT_TYPE_MMREST_RANGE,
         TEXT_TYPE_TEMPO,
+        TEXT_TYPE_TEMPO_CHANGE,
         TEXT_TYPE_METRONOME,
         TEXT_TYPE_REPEAT_LEFT,       // align to start of measure
         TEXT_TYPE_REPEAT_RIGHT,      // align to end of measure

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -1786,27 +1786,27 @@ bool NotationActionController::isNotNoteInputMode() const
 
 void NotationActionController::openTupletOtherDialog()
 {
-    interactive()->open("musescore://notation/othertupletdialog");
+    interactive()->open("musescore://notation/othertupletdialog?sync=false");
 }
 
 void NotationActionController::openStaffTextPropertiesDialog()
 {
-    interactive()->open("musescore://notation/stafftextproperties");
+    interactive()->open("musescore://notation/stafftextproperties?sync=false");
 }
 
 void NotationActionController::openMeasurePropertiesDialog()
 {
-    interactive()->open("musescore://notation/measureproperties");
+    interactive()->open("musescore://notation/measureproperties?sync=false");
 }
 
 void NotationActionController::openEditGridSizeDialog()
 {
-    interactive()->open("musescore://notation/editgridsize");
+    interactive()->open("musescore://notation/editgridsize?sync=false");
 }
 
 void NotationActionController::openRealizeChordSymbolsDialog()
 {
-    interactive()->open("musescore://notation/realizechordsymbols");
+    interactive()->open("musescore://notation/realizechordsymbols?sync=false");
 }
 
 void NotationActionController::toggleScoreConfig(ScoreConfigType configType)


### PR DESCRIPTION
Resolves: #17804 

First of all, there was a mismatch of the enum in `inspector/types/texttypes.h` with the corresponding enum of `engraving/types/types.h`, so the option was being activated for System Text, but it should be activated for Staff Text.

About the crash, I'm definitely not experienced in this area, but it seemed to be happen because the QML panel calling this dialog was being closed while the dialog is open. So I just used `open()` instead of `exec()`, and it seems to fix it.