### PR TITLE
Fix crash when selecting the last measure in a certain score

### DIFF
--- a/src/notation/internal/notationselectionrange.cpp
+++ b/src/notation/internal/notationselectionrange.cpp
@@ -223,8 +223,17 @@ const
         mu::engraving::System* currentSegmentSystem = segment->measure()->system();
 
         mu::engraving::Segment* nextSegment = segment->next1MMenabled();
-        mu::engraving::System* nextSegmentSystem = nextSegment->measure()->system();
+        if (!nextSegment) {
+            RangeSection section;
+            section.system = currentSegmentSystem;
+            section.startSegment = startSegment;
+            section.endSegment = segment;
 
+            sections.push_back(section);
+            break;
+        }
+
+        mu::engraving::System* nextSegmentSystem = nextSegment->measure()->system();
         if (!nextSegmentSystem) {
             const Measure* mmr = nextSegment->measure()->mmRest1();
             if (mmr) {


### PR DESCRIPTION
Resolves: #17829

In this score, the last segment is not the last enabled segment. So, even though `segment` is not yet equal to `rangeEndSegment`, `nextSegment` is nullptr, because apparently there is no next _enabled_ segment.

I'm not sure if it is an expected situation that the last segment of a score is not enabled, especially because in this case it seems to be a remnant of a courtesy key signature for a next measure that is not present anymore. But apparently that can happen. Still, I wonder if that _should_ be possible to happen; or are we fixing a symptom of some problem rather than the problem itself? For example, should we instead do something in the reading code to remove that weird courtesy key signature?