### PR TITLE
Nullcheck for #17660

### DIFF
--- a/src/framework/ui/internal/navigationcontroller.cpp
+++ b/src/framework/ui/internal/navigationcontroller.cpp
@@ -672,6 +672,10 @@ void NavigationController::goToNextSection()
     if (!nextSec) { // active is last
         nextSec = firstEnabled(m_sections); // the first to be the next
     }
+    if (!nextSec) {
+        LOGI() << "no enabled sections!";
+        return;
+    }
 
     LOGI() << "nextSec: " << nextSec->name() << ", enabled: " << nextSec->enabled();
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/17660

This PR simply prevents a crash. If we want to ensure that the playback panel has proper sections set up for it that can be a different issue.