### PR TITLE
Fix unpredictable behavior of braille export ui

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/Export/ExportOptionsView.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/ExportOptionsView.qml
@@ -125,6 +125,7 @@ Column {
     Loader {
         id: pageLoader
         width: parent.width
+        visible: status === Loader.Ready
 
         function refresh() {
             if (!root.exportModel.selectedExportType.settingsPagePath) {


### PR DESCRIPTION
Resolves: [this fix](https://github.com/musescore/MuseScore/pull/17126#issuecomment-1542056234) suggested by @jessjwilliamson 

The Braille menu for export options previously had unpredictable behavior and blank space in the UI. This change fixes this behavior.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
