### PR TITLE
Fix QML warnings and navigation order in some Properties panel sections

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/notation/notes/HeadSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/notes/HeadSettings.qml
@@ -70,8 +70,8 @@ FocusableItem {
         }
 
         CheckBoxPropertyView {
-            visible: root.model ? !root.model.isTrillCueNote : true
             id: hideNoteheadCheckBox
+            visible: root.model ? !root.model.isTrillCueNote : true
 
             text: qsTrc("inspector", "Hide notehead")
             propertyItem: root.model ? root.model.isHeadHidden : null
@@ -93,8 +93,8 @@ FocusableItem {
         }
 
         FlatRadioButtonGroupPropertyView {
-            visible: root.model ? !root.model.isTrillCueNote : true
             id: durationDotPosition
+            visible: root.model ? !root.model.isTrillCueNote : true
 
             titleText: qsTrc("inspector", "Duration dot position")
             propertyItem: root.model ? root.model.dotPosition : null
@@ -111,18 +111,20 @@ FocusableItem {
         }
 
         OffsetSection {
+            id: trillCueNoteOffsetSection
             visible: root.model ? root.model.isTrillCueNote : false
+
             titleText: qsTrc("inspector", "Notehead offset")
             propertyItem: root.model ? root.model.offset : null
 
             navigationName: "NoteHeadOffsetSection"
             navigationPanel: root.navigationPanel
-            navigationRowStart: noteDirectionSection.navigationRowEnd + 1
+            navigationRowStart: durationDotPosition.navigationRowEnd + 1
         }
 
         ExpandableBlank {
-            visible: root.model ? !root.model.isTrillCueNote : true
             id: showItem
+            visible: root.model ? !root.model.isTrillCueNote : true
 
             isExpanded: false
 
@@ -131,7 +133,7 @@ FocusableItem {
             width: parent.width
 
             navigation.panel: root.navigationPanel
-            navigation.row: durationDotPosition.navigationRowEnd + 1
+            navigation.row: trillCueNoteOffsetSection.navigationRowEnd + 1
 
             contentItemComponent: Column {
                 height: implicitHeight

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/ornaments/OrnamentSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/ornaments/OrnamentSettings.qml
@@ -47,6 +47,7 @@ Column {
     DropdownPropertyView {
         id: intervalAbove
         visible: root.model ? root.model.isIntervalAboveAvailable : false
+
         titleText: qsTrc("inspector", "Interval above")
         propertyItem: root.model ? root.model.intervalAbove : null
 
@@ -63,6 +64,7 @@ Column {
     DropdownPropertyView {
         id: intervalBelow
         visible: root.model ? root.model.isIntervalBelowAvailable : false
+
         titleText: qsTrc("inspector", "Interval below")
         propertyItem: root.model ? root.model.intervalBelow : null
 
@@ -79,6 +81,7 @@ Column {
     InspectorPropertyView {
         id: interval
         visible: root.model ? root.model.isFullIntervalChoiceAvailable : false
+
         titleText: qsTrc("inspector", "Interval")
         propertyItem: root.model ? root.model.intervalAbove : null
 
@@ -88,11 +91,14 @@ Column {
         }
 
         navigationName: "Interval"
-        navigationRowEnd: intervalType.navigation.row
+        navigationPanel: root.navigationPanel
+        navigationRowStart: intervalBelow.navigationRowEnd + 1
+        navigationRowEnd: intervalStep.navigation.row
 
         function focusOnFirst() {
             intervalType.navigation.requestActive()
         }
+
         Item {
             width: parent.width
             height: childrenRect.height
@@ -107,7 +113,7 @@ Column {
 
                 navigation.name: root.navigationName + " Dropdown"
                 navigation.panel: root.navigationPanel
-                navigation.row: root.navigationRowStart + 1
+                navigation.row: interval.navigationRowStart + 1
                 navigation.accessible.name: root.titleText + " " + currentText
 
                 model: root.model && root.model.isPerfectStep ? [
@@ -141,7 +147,7 @@ Column {
 
                 navigation.name: root.navigationName + " Dropdown"
                 navigation.panel: root.navigationPanel
-                navigation.row: root.navigationRowStart + 1
+                navigation.row: intervalType.navigation.row + 1
                 navigation.accessible.name: root.titleText + " " + currentText
 
                 model:  [
@@ -167,6 +173,7 @@ Column {
 
     DropdownPropertyView {
         id: showAccidental
+
         titleText: qsTrc("inspector", "Accidental visibility")
         propertyItem: root.model ? root.model.showAccidental : null
 
@@ -197,7 +204,8 @@ Column {
         propertyItem: root.model ? root.model.placement : null
 
         navigationPanel: root.navigationPanel
-        navigationRowStart: performanceSection.navigationRowEnd + 1
+        navigationRowStart: startOnUpperNote.navigation.row + 1
+
         model: [
             { text: qsTrc("inspector", "Auto"), value: ArticulationTypes.TYPE_AUTO },
             { text: qsTrc("inspector", "Above"), value: ArticulationTypes.TYPE_TOP },


### PR DESCRIPTION
For the following elements, the keyboard navigation order in the Properties panel was broken, and some QML warnings would be printed:
- Ornaments
- Note heads
- "Cue note heads" for trills