### PR TITLE
Rename family "Lauds" to "Laúds" in the instruments list for consistency 

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -344,7 +344,7 @@
             <name>Bandurrias</name>
       </Family>
       <Family id="lauds">
-            <name>Lauds</name>
+            <name>Laúds</name>
       </Family>
       <Family id="strings">
             <name>Strings</name>
@@ -13166,7 +13166,7 @@
                   <genre>popular</genre>
             </Instrument>
             <Instrument id="laud">
-                  <family>lauds</family>
+                  <family>Laúds</family>
                   <trackName>Laúd</trackName>
                   <longName>Laúd</longName>
                   <shortName>Laúd</shortName>
@@ -13194,7 +13194,7 @@
             </Instrument>
             <Instrument id="laud-tablature">
                   <init>laud</init>
-                  <family>lauds</family>
+                  <family>Laúds</family>
                   <trackName>Laúd (tablature)</trackName>
                   <longName>Laúd</longName>
                   <description>Spanish lute similar to the bandurria. (Tablature).</description>


### PR DESCRIPTION
Resolves: #17758 

The singular "Laúd" was used in the instruments list already, just not on the 'family'. Updated `instruments.xml` for consistency. 

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
