### PR TITLE
17567 added vertical center offset to anchor for lock button to solve alignment issue

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/notation/images/ImageSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/images/ImageSettings.qml
@@ -69,6 +69,7 @@ Column {
 
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: heightControl.verticalCenter
+            anchors.verticalCenterOffset: 14
 
             height: 20
             width: 20

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/images/ImageSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/images/ImageSettings.qml
@@ -68,11 +68,11 @@ Column {
             id: lockButton
 
             anchors.horizontalCenter: parent.horizontalCenter
-            anchors.verticalCenter: heightControl.verticalCenter
-            anchors.verticalCenterOffset: 14
 
             height: 20
             width: 20
+
+            y: heightControl.spinBox.y + (heightControl.spinBox.height - height) / 2
 
             icon: checked ? IconCode.LOCK_CLOSED : IconCode.LOCK_OPEN
 


### PR DESCRIPTION
Resolves: #17567 

The lock button in image properties viewer was not placed properly in comparison to the design. This was caused by the lock button being anchored to the `heightControl` SpinBox vertical center, however it should be aligned with the center of the icon of this SpinBox and not the center of the SpinBox itself. A `verticalCenterOffset` (selected by judging visually) was added to bring the lock button to the correct place. 

![lockbutton_align_fix](https://github.com/musescore/MuseScore/assets/41984034/93300913-0b08-461f-8920-718356f6df3c)

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
