### PR TITLE
Fix the default Scores folder location from always auto generating

### DIFF
--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -151,7 +151,10 @@ void NotationConfiguration::init()
     settings()->valueChanged(USER_STYLES_PATH).onReceive(nullptr, [this](const Val& val) {
         m_userStylesPathChanged.send(val.toPath());
     });
-    fileSystem()->makePath(userStylesPath());
+
+    if (!userStylesPath().empty()) {
+        fileSystem()->makePath(userStylesPath());
+    }
 
     settings()->setDefaultValue(SELECTION_PROXIMITY, Val(2));
     settings()->setDefaultValue(IS_MIDI_INPUT_ENABLED, Val(true));

--- a/src/plugins/internal/pluginsconfiguration.cpp
+++ b/src/plugins/internal/pluginsconfiguration.cpp
@@ -50,8 +50,10 @@ void PluginsConfiguration::init()
     settings()->valueChanged(USER_PLUGINS_PATH).onReceive(nullptr, [this](const Val& val) {
         m_userPluginsPathChanged.send(val.toString());
     });
-    fileSystem()->makePath(userPluginsPath());
 
+    if (!userPluginsPath().empty()) {
+        fileSystem()->makePath(userPluginsPath());
+    }
     fileSystem()->makePath(pluginsDataPath());
 
     if (multiInstancesProvider()) {

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1294,7 +1294,11 @@ io::path_t ProjectActionsController::selectScoreOpeningFile()
     io::path_t defaultDir = configuration()->lastOpenedProjectsPath();
 
     if (defaultDir.empty()) {
-        defaultDir = configuration()->defaultProjectsPath();
+        defaultDir = configuration()->userProjectsPath();
+    }
+
+    if (defaultDir.empty()) {
+        defaultDir = configuration()->defaultUserProjectsPath();
     }
 
     io::path_t filePath = interactive()->selectOpeningFile(qtrc("project", "Open"), defaultDir, filter);

--- a/src/project/internal/projectconfiguration.h
+++ b/src/project/internal/projectconfiguration.h
@@ -60,9 +60,6 @@ public:
     void setUserTemplatesPath(const io::path_t& path) override;
     async::Channel<io::path_t> userTemplatesPathChanged() const override;
 
-    io::path_t defaultProjectsPath() const override;
-    void setDefaultProjectsPath(const io::path_t& path) override;
-
     io::path_t lastOpenedProjectsPath() const override;
     void setLastOpenedProjectsPath(const io::path_t& path) override;
 
@@ -72,6 +69,7 @@ public:
     io::path_t userProjectsPath() const override;
     void setUserProjectsPath(const io::path_t& path) override;
     async::Channel<io::path_t> userProjectsPathChanged() const override;
+    io::path_t defaultUserProjectsPath() const override;
 
     bool shouldAskSaveLocationType() const override;
     void setShouldAskSaveLocationType(bool shouldAsk) override;

--- a/src/project/iprojectconfiguration.h
+++ b/src/project/iprojectconfiguration.h
@@ -53,9 +53,6 @@ public:
     virtual void setUserTemplatesPath(const io::path_t& path) = 0;
     virtual async::Channel<io::path_t> userTemplatesPathChanged() const = 0;
 
-    virtual io::path_t defaultProjectsPath() const = 0;
-    virtual void setDefaultProjectsPath(const io::path_t& path) = 0;
-
     virtual io::path_t lastOpenedProjectsPath() const = 0;
     virtual void setLastOpenedProjectsPath(const io::path_t& path) = 0;
 
@@ -65,6 +62,7 @@ public:
     virtual io::path_t userProjectsPath() const = 0;
     virtual void setUserProjectsPath(const io::path_t& path) = 0;
     virtual async::Channel<io::path_t> userProjectsPathChanged() const = 0;
+    virtual io::path_t defaultUserProjectsPath() const = 0;
 
     virtual bool shouldAskSaveLocationType() const = 0;
     virtual void setShouldAskSaveLocationType(bool shouldAsk) = 0;

--- a/src/project/tests/mocks/projectconfigurationmock.h
+++ b/src/project/tests/mocks/projectconfigurationmock.h
@@ -43,9 +43,6 @@ public:
     MOCK_METHOD(void, setUserTemplatesPath, (const io::path_t&), (override));
     MOCK_METHOD(async::Channel<io::path_t>, userTemplatesPathChanged, (), (const, override));
 
-    MOCK_METHOD(io::path_t, defaultProjectsPath, (), (const, override));
-    MOCK_METHOD(void, setDefaultProjectsPath, (const io::path_t&), (override));
-
     MOCK_METHOD(io::path_t, lastOpenedProjectsPath, (), (const, override));
     MOCK_METHOD(void, setLastOpenedProjectsPath, (const io::path_t&), (override));
 
@@ -55,6 +52,7 @@ public:
     MOCK_METHOD(io::path_t, userProjectsPath, (), (const, override));
     MOCK_METHOD(void, setUserProjectsPath, (const io::path_t&), (override));
     MOCK_METHOD(async::Channel<io::path_t>, userProjectsPathChanged, (), (const, override));
+    MOCK_METHOD(io::path_t, defaultUserProjectsPath, (), (const, override));
 
     MOCK_METHOD(bool, shouldAskSaveLocationType, (), (const, override));
     MOCK_METHOD(void, setShouldAskSaveLocationType, (bool), (override));

--- a/src/stubs/project/projectconfigurationstub.cpp
+++ b/src/stubs/project/projectconfigurationstub.cpp
@@ -69,15 +69,6 @@ async::Channel<io::path_t> ProjectConfigurationStub::userTemplatesPathChanged() 
     return ch;
 }
 
-io::path_t ProjectConfigurationStub::defaultProjectsPath() const
-{
-    return io::path_t();
-}
-
-void ProjectConfigurationStub::setDefaultProjectsPath(const io::path_t&)
-{
-}
-
 io::path_t ProjectConfigurationStub::lastOpenedProjectsPath() const
 {
     return io::path_t();
@@ -109,6 +100,11 @@ async::Channel<io::path_t> ProjectConfigurationStub::userProjectsPathChanged() c
 {
     static async::Channel<io::path_t> ch;
     return ch;
+}
+
+io::path_t ProjectConfigurationStub::defaultUserProjectsPath() const
+{
+    return io::path_t();
 }
 
 bool ProjectConfigurationStub::shouldAskSaveLocationType() const

--- a/src/stubs/project/projectconfigurationstub.h
+++ b/src/stubs/project/projectconfigurationstub.h
@@ -43,9 +43,6 @@ public:
     void setUserTemplatesPath(const io::path_t& path) override;
     async::Channel<io::path_t> userTemplatesPathChanged() const override;
 
-    io::path_t defaultProjectsPath() const override;
-    void setDefaultProjectsPath(const io::path_t& path) override;
-
     io::path_t lastOpenedProjectsPath() const override;
     void setLastOpenedProjectsPath(const io::path_t& path) override;
 
@@ -55,6 +52,7 @@ public:
     io::path_t userProjectsPath() const override;
     void setUserProjectsPath(const io::path_t& path) override;
     async::Channel<io::path_t> userProjectsPathChanged() const override;
+    io::path_t defaultUserProjectsPath() const override;
 
     bool shouldAskSaveLocationType() const override;
     void setShouldAskSaveLocationType(bool shouldAsk) override;


### PR DESCRIPTION
# Resolves: #15567

## Fixes Included
- Fixes the default Scores user data folder from each being auto generated, when the user has defined a custom location for that folder in the Folder Preferences window.
- Fixes the default Scores folder path from being missing in the Folder Preferences window.
- Fixes the File Open Dialog from only checking the default Scores location, if no last opened projects path is found. Now it also checks the user defined location set in the Folder Preferences window. 
- Fixes the Styles, Templates, Plugins and Soundfonts folders from trying and failing to make their path, if the user enters a blank path (I put this check with Scores as well)

## Behavior not Changed 
The Cloud Scores folder is not changed from autogenerating as [cbjeukendrup](https://github.com/cbjeukendrup) is working on a pull request for changing things related to that folder, as mentioned in #15567. This is the last subfolder which will need to be changed to allow the MuseScore4 Documents folder to not auto generate, as requested in #15567. So as it currently stands, the MuseScore4 Documents folder still auto generates.

## Changes Explained
All five of the folders besides Scores, use a single Settings::Key value to hold both the default setting value and the user set setting value. Scores however, had the user scores folder path behavior split into two separate setting keys. Those keys being USER_PROJECTS_PATH and DEFAULT_PROJECTS_PATH. This split was causing bugs, including causing the default Scores path to be missing visually from the Folder Preferences window. I consolidated these two setting keys into one, choosing to migrate the functionality given to DEFAULT_PROJECTS_PATH over to USER_PROJECTS_PATH, since USER_PROJECTS_PATH matches the naming scheme. (For example: USER_TEMPLATES_PATH & USER_STYLES_PATH)

To accomplish this, I removed the DEFAULT_PROJECTS_PATH Settings::Key, and it's two associated functions, defaultProjectsPath() and setDefaultProjectsPath(), assigned the default location for Scores to USER_PROJECTS_PATH's defaultValue, and replaced the two calls to defaultProjectsPath() with calls to a new function, defaultUserProjectsPath(), which now grabs the default value from USER_PROJECTS_PATH. The two functions which now call this function instead of the original are ProjectActionsController::selectScoreOpeningFile and ProjectConfiguration::defaultSavingFilePath. Completing these changes, allowed me to fix the Scores folder path from being autogenerated, and in the process it fixed the default Scores folder path from being visually missing from the Folder Preferences window as well.

The only change made to the other four main autogenerating folders, is that they were trying to create their folder, even if the user entered in a blank folder path, so I added conditional logic to remove the warnings that were outputted as a result. This change was included with my fixes to Scores as well.

## Change Possibly Considered Unnecessary
While replacing the call to defaultProjectsPath() in selectScoreOpeningFile, I found that it wasn't checking the user defined location for Scores, like defaultSavingFilePath was, so I added that in. I though it was worthwhile to potentially include this short fix in the pull request, since it is closely related to the issue at hand, and helps more fully integrate the user defined path for Scores, while following behavior already present defaultSavingFilePath. I'm happy to remove this and make any other requested changes!

##
- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
