### PR TITLE
[Crash Fix] Remove invalid 2-note trems when connecting them

### DIFF
--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -1988,6 +1988,13 @@ void Measure::connectTremolo()
                         break;
                     }
                 }
+
+                if (!tremolo->chord2()) {
+                    // this is an invalid tremolo! a continued tremolo was started on one note without a valid next note in that measure
+                    // remove the tremolo entirely
+                    c->setTremolo(nullptr);
+                    score()->removeElement(tremolo);
+                }
             }
         }
     }


### PR DESCRIPTION
This crash was reported in a comment: https://github.com/musescore/MuseScore/issues/17623#issuecomment-1586343144

There is a method in `Measure` that connects two-note tremolos to their appropriate partners, so I added logic in there that removes the trem altogether if no second chord could be found!