### PR TITLE
17698 fix incorrect percussion sounds on concert and brass band templates

### DIFF
--- a/share/templates/07-Band_and_Percussion/01-Concert_Band/01-Concert_Band.mscx
+++ b/share/templates/07-Band_and_Percussion/01-Concert_Band/01-Concert_Band.mscx
@@ -2215,7 +2215,7 @@ B. Tbn.</shortName>
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName>Percussion 1</trackName>
-      <Instrument id="drumset">
+      <Instrument id="percussion">
         <longName>Percussion 1</longName>
         <shortName>Perc. 1</shortName>
         <trackName>Percussion</trackName>
@@ -2435,7 +2435,7 @@ B. Tbn.</shortName>
         <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Percussion 2</trackName>
-      <Instrument id="drumset">
+      <Instrument id="percussion">
         <longName>Percussion 2</longName>
         <shortName>Perc. 2</shortName>
         <trackName>Percussion</trackName>

--- a/share/templates/07-Band_and_Percussion/03-Brass_Band/03-Brass_Band.mscx
+++ b/share/templates/07-Band_and_Percussion/03-Brass_Band/03-Brass_Band.mscx
@@ -1442,7 +1442,7 @@
         <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Percussion</trackName>
-      <Instrument id="drumset">
+      <Instrument id="percussion">
         <longName>Percussion</longName>
         <shortName>Perc.</shortName>
         <trackName>Percussion</trackName>


### PR DESCRIPTION
Resolves: #17698 

Percussion Instruments in Concert Band and Brass Band templates were set to Percussion Synthesizer. On investigation found that the instrument id of Percussion in the templates for Concert Band and Brass Band were set to drumset. In the Small Concert Band and European Concert Band templates with the correct behavior the id is percussion and not drumset. 

https://github.com/musescore/MuseScore/assets/41984034/2ff5816d-37f7-44fe-a6a8-96cc2e3c759d

@zacjansheski mentioned that this was working in MuseScore 3.x so we might need to investigate further if something caused the id to get overwritten. If that is the case maybe someone can point towards where I could potentially have a look. 

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
