### PR TITLE
fixed #16774: Update announcement popup (for new releases) has poor UX / UI

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -6,7 +6,7 @@ on:
       mode:
         description: 'Mode: stable, testing'
         required: true
-        default: 'stable'
+        default: 'testing'
       tag:
         description: 'Release tag (latest stable by default)'
         required: false

--- a/build/ci/learn/make_youtube_playlist_info.py
+++ b/build/ci/learn/make_youtube_playlist_info.py
@@ -1,4 +1,23 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-CLA-applies
+#
+# MuseScore
+# Music Composition & Notation
+#
+# Copyright (C) 2021 MuseScore BVBA and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import io
 import sys

--- a/build/ci/release/correct_release_info.py
+++ b/build/ci/release/correct_release_info.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-CLA-applies
+#
+# MuseScore
+# Music Composition & Notation
+#
+# Copyright (C) 2021 MuseScore BVBA and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import sys
+import json
+import markdown
+
+RELEASE_INFO_FILE = sys.argv[1]
+
+print("=== Load json ===")
+
+json_file = open(RELEASE_INFO_FILE, "r+")
+release_info_json = json.load(json_file)
+json_file.close()
+
+print("=== Make html version of body ===")
+
+release_body_markdown = release_info_json["body"]
+
+release_body_html = markdown.markdown(release_body_markdown)
+
+# Correct result of Markdown parser
+# Escape single quotes
+release_body_html = release_body_html.replace("'", "`")
+
+# Correct new lines next to <ul> and </ul>
+release_body_html = release_body_html.replace("\n<ul>\n", "<ul>")
+release_body_html = release_body_html.replace("\n</ul>\n", "</ul>")
+
+release_info_json["body"] = "'" + release_body_html + "'"
+release_info_json["bodyMarkdown"] = release_body_markdown
+
+release_info_json_updated = json.dumps(release_info_json)
+
+print("=== Write json ===")
+
+json_file = open(RELEASE_INFO_FILE, "w")
+json_file.write(release_info_json_updated)
+json_file.close()

--- a/build/ci/release/make_release_info_file.sh
+++ b/build/ci/release/make_release_info_file.sh
@@ -49,3 +49,8 @@ RELEASE_INFO=$(curl \
 mkdir -p $ARTIFACTS_DIR
 echo $RELEASE_INFO > $ARTIFACTS_DIR/release_info.json
 cat $ARTIFACTS_DIR/release_info.json
+
+pip install markdown
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+python3 $HERE/correct_release_info.py ${ARTIFACTS_DIR}/release_info.json

--- a/src/update/internal/updatescenario.cpp
+++ b/src/update/internal/updatescenario.cpp
@@ -40,7 +40,6 @@ using namespace mu::framework;
 static ValMap releaseInfoToValMap(const ReleaseInfo& info)
 {
     return {
-        { "title", Val(info.title) },
         { "notes", Val(info.notes) },
         { "fileName", Val(info.fileName) },
         { "fileUrl", Val(info.fileUrl) },
@@ -51,7 +50,6 @@ static ValMap releaseInfoToValMap(const ReleaseInfo& info)
 static ReleaseInfo releaseInfoFromValMap(const ValMap& map)
 {
     ReleaseInfo info;
-    info.title = map.at("title").toString();
     info.notes = map.at("notes").toString();
     info.fileName = map.at("fileName").toString();
     info.fileUrl = map.at("fileUrl").toString();
@@ -172,7 +170,6 @@ void UpdateScenario::showNoUpdateMsg()
 void UpdateScenario::showReleaseInfo(const ReleaseInfo& info)
 {
     QStringList params = {
-        "title=" + QString::fromStdString(info.title),
         "notes=" + QString::fromStdString(info.notes)
     };
 

--- a/src/update/internal/updateservice.cpp
+++ b/src/update/internal/updateservice.cpp
@@ -71,6 +71,7 @@ mu::RetVal<ReleaseInfo> UpdateService::checkForUpdate()
     }
 
     QByteArray json = buff.data();
+    LOGD() << "json: " << json;
 
     RetVal<ReleaseInfo> releaseInfo = parseRelease(json);
     if (!releaseInfo.ret) {
@@ -154,7 +155,7 @@ mu::RetVal<ReleaseInfo> UpdateService::parseRelease(const QByteArray& json) cons
 
     QJsonObject release = jsonDoc.object();
     result.val.title = release.value("name").toString().toStdString();
-    result.val.notes = release.value("body").toString().toStdString();
+    result.val.notes = release.value("bodyMarkdown").toString().toStdString();
 
     QString tagName = release.value("tag_name").toString();
     result.val.version = tagName.replace("v", "").toStdString();

--- a/src/update/internal/updateservice.cpp
+++ b/src/update/internal/updateservice.cpp
@@ -159,9 +159,7 @@ mu::RetVal<ReleaseInfo> UpdateService::parseRelease(const QByteArray& json) cons
     QString version = tagName.replace("v", "");
     result.val.version = version.toStdString();
 
-    result.val.notes = QString("### MuseScore %1\n\n%2")
-                       .arg(version, release.value("bodyMarkdown").toString())
-                       .toStdString();
+    result.val.notes = release.value("bodyMarkdown").toString().toStdString();
 
     std::string fileSuffix = platformFileSuffix();
 

--- a/src/update/internal/updateservice.cpp
+++ b/src/update/internal/updateservice.cpp
@@ -154,11 +154,14 @@ mu::RetVal<ReleaseInfo> UpdateService::parseRelease(const QByteArray& json) cons
     result.ret = make_ok();
 
     QJsonObject release = jsonDoc.object();
-    result.val.title = release.value("name").toString().toStdString();
-    result.val.notes = release.value("bodyMarkdown").toString().toStdString();
 
     QString tagName = release.value("tag_name").toString();
-    result.val.version = tagName.replace("v", "").toStdString();
+    QString version = tagName.replace("v", "");
+    result.val.version = version.toStdString();
+
+    result.val.notes = QString("### MuseScore %1\n\n%2")
+                       .arg(version, release.value("bodyMarkdown").toString())
+                       .toStdString();
 
     std::string fileSuffix = platformFileSuffix();
 

--- a/src/update/qml/MuseScore/Update/ReleaseInfoDialog.qml
+++ b/src/update/qml/MuseScore/Update/ReleaseInfoDialog.qml
@@ -36,7 +36,7 @@ StyledDialogView {
     contentWidth: 644
     contentHeight: 474
 
-    margins: 24
+    margins: 22
 
     onNavigationActivateRequested: {
         buttons.focusOnFirst()
@@ -70,13 +70,30 @@ StyledDialogView {
              }
          }
 
-        StyledTextLabel {
-            id: releaseTitleLabel
-
+        Column {
             Layout.alignment: Qt.AlignTop
 
-            text: qsTrc("update", "A new version of MuseScore is available!")
-            font: ui.theme.headerBoldFont
+            spacing: 8
+
+            StyledTextLabel {
+                id: releaseTitleLabel
+
+                text: qsTrc("update", "A new version of MuseScore is available!")
+                font: ui.theme.headerBoldFont
+            }
+
+            StyledTextLabel {
+                id: releaseNotesLabel
+
+                text: qsTrc("update", "Release notes")
+                font: ui.theme.largeBodyBoldFont
+                horizontalAlignment: Qt.AlignLeft
+            }
+        }
+
+        SeparatorLine {
+            Layout.leftMargin: -root.margins
+            Layout.rightMargin: -root.margins
         }
 
         ReleaseNotesView {
@@ -84,6 +101,11 @@ StyledDialogView {
 
             Layout.fillWidth: true
             Layout.fillHeight: true
+        }
+
+        SeparatorLine {
+            Layout.leftMargin: -root.margins
+            Layout.rightMargin: -root.margins
         }
 
         ReleaseInfoBottomPanel {

--- a/src/update/qml/MuseScore/Update/ReleaseInfoDialog.qml
+++ b/src/update/qml/MuseScore/Update/ReleaseInfoDialog.qml
@@ -31,7 +31,6 @@ import "internal"
 StyledDialogView {
     id: root
 
-    property alias title: releaseTitleLabel.text
     property alias notes: view.notes
 
     contentWidth: 644
@@ -76,6 +75,7 @@ StyledDialogView {
 
             Layout.alignment: Qt.AlignTop
 
+            text: qsTrc("update", "A new version of MuseScore is available!")
             font: ui.theme.headerBoldFont
         }
 

--- a/src/update/qml/MuseScore/Update/internal/ReleaseNotesView.qml
+++ b/src/update/qml/MuseScore/Update/internal/ReleaseNotesView.qml
@@ -64,7 +64,7 @@ ColumnLayout {
             horizontalAlignment: Text.AlignLeft
             font: ui.theme.largeBodyFont
             wrapMode: Text.WordWrap
-            lineHeight: 2.0
+            textFormat: Text.MarkdownText
         }
     }
 

--- a/src/update/qml/MuseScore/Update/internal/ReleaseNotesView.qml
+++ b/src/update/qml/MuseScore/Update/internal/ReleaseNotesView.qml
@@ -37,33 +37,10 @@ Item {
         readonly property int sideMargin: 24
     }
 
-    StyledTextLabel {
-        id: titleLabel
-        anchors.left: parent.left
-        anchors.right: parent.right
-
-        text: qsTrc("update", "Release notes")
-
-        horizontalAlignment: Qt.AlignLeft
-        font: ui.theme.bodyBoldFont
-    }
-
-    SeparatorLine {
-        anchors.leftMargin: -prv.sideMargin
-        anchors.rightMargin: -prv.sideMargin
-        anchors.bottom: flickable.top
-        anchors.bottomMargin: 16
-    }
-
     StyledFlickable {
         id: flickable
 
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.top: titleLabel.bottom
-        anchors.topMargin: 32
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: 16
+        anchors.fill: parent
 
         contentHeight: notesLabel.implicitHeight
 
@@ -77,6 +54,7 @@ Item {
             font: ui.theme.largeBodyFont
             wrapMode: Text.WordWrap
             textFormat: Text.MarkdownText
+            lineHeight: 1.2
         }
 
         ScrollBar.vertical: scrollBar
@@ -88,12 +66,5 @@ Item {
         anchors.right: flickable.right
         anchors.rightMargin: -prv.sideMargin
         anchors.bottom: flickable.bottom
-    }
-
-    SeparatorLine {
-        anchors.top: flickable.bottom
-        anchors.topMargin: 16
-        anchors.leftMargin: -prv.sideMargin
-        anchors.rightMargin: -prv.sideMargin
     }
 }

--- a/src/update/qml/MuseScore/Update/internal/ReleaseNotesView.qml
+++ b/src/update/qml/MuseScore/Update/internal/ReleaseNotesView.qml
@@ -21,25 +21,26 @@
  */
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
+import QtQuick.Controls 2.15
 
 import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
 
-ColumnLayout {
+Item {
     id: root
 
     property alias notes: notesLabel.text
 
-    spacing: 16
-
     QtObject {
         id: prv
 
-        readonly property int sideMargin: 36
+        readonly property int sideMargin: 24
     }
 
     StyledTextLabel {
-        Layout.fillWidth: true
+        id: titleLabel
+        anchors.left: parent.left
+        anchors.right: parent.right
 
         text: qsTrc("update", "Release notes")
 
@@ -47,11 +48,22 @@ ColumnLayout {
         font: ui.theme.bodyBoldFont
     }
 
-    SeparatorLine { Layout.leftMargin: -prv.sideMargin; Layout.rightMargin: -prv.sideMargin }
+    SeparatorLine {
+        anchors.leftMargin: -prv.sideMargin
+        anchors.rightMargin: -prv.sideMargin
+        anchors.bottom: flickable.top
+        anchors.bottomMargin: 16
+    }
 
     StyledFlickable {
-        Layout.fillWidth: true
-        Layout.fillHeight: true
+        id: flickable
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: titleLabel.bottom
+        anchors.topMargin: 32
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: 16
 
         contentHeight: notesLabel.implicitHeight
 
@@ -66,7 +78,22 @@ ColumnLayout {
             wrapMode: Text.WordWrap
             textFormat: Text.MarkdownText
         }
+
+        ScrollBar.vertical: scrollBar
     }
 
-    SeparatorLine { Layout.leftMargin: -prv.sideMargin; Layout.rightMargin: -prv.sideMargin }
+    StyledScrollBar {
+        id: scrollBar
+        anchors.top: flickable.top
+        anchors.right: flickable.right
+        anchors.rightMargin: -prv.sideMargin
+        anchors.bottom: flickable.bottom
+    }
+
+    SeparatorLine {
+        anchors.top: flickable.bottom
+        anchors.topMargin: 16
+        anchors.leftMargin: -prv.sideMargin
+        anchors.rightMargin: -prv.sideMargin
+    }
 }

--- a/src/update/updatetypes.h
+++ b/src/update/updatetypes.h
@@ -26,7 +26,6 @@
 
 namespace mu::update {
 struct ReleaseInfo {
-    std::string title;
     std::string notes;
     std::string fileName;
     std::string fileUrl;


### PR DESCRIPTION
Resolves: #16774

The idea is to convert from markdown to HTML on the CI side and overwrite the data in the "body" in json. Old versions will receive the HTML version of the text and display it correctly in the dialog. The original markdown text will be stored in json under the key "bodyMarkdown" for the new versions of MuseScore.

For testing need to enable `checkForUpdateTestingMode` in `DevTools->Settings`

On this branch
![image](https://github.com/musescore/MuseScore/assets/10116828/988c6bb3-30ba-4b8b-b016-ee949fe8d3a9)


4.0.2
![image](https://github.com/musescore/MuseScore/assets/10116828/2ac167da-d1dc-42be-a104-9e60b5f8f1ff)


