### PR TITLE
Remove wrong check from PaletteCompat

### DIFF
--- a/src/palette/internal/palettecompat.cpp
+++ b/src/palette/internal/palettecompat.cpp
@@ -41,10 +41,6 @@ using namespace mu::engraving;
 
 void PaletteCompat::migrateOldPaletteItemIfNeeded(ElementPtr& element, Score* paletteScore)
 {
-    if (paletteScore->mscVersion() >= 410) {
-        return;
-    }
-
     EngravingItem* item = element.get();
 
     if (item->isArticulation()) {


### PR DESCRIPTION
The palette score version is now always >= 410 so the check is actually doing the opposite of what it was intended for. In fact, it is unnecessary to do this check in the first place.