### PR TITLE
Treble- and Bass-clef templates shouldn't have brackets attached to them

### DIFF
--- a/share/templates/01-General/01-Treble_Clef/01-Treble_Clef.mscx
+++ b/share/templates/01-General/01-Treble_Clef/01-Treble_Clef.mscx
@@ -69,8 +69,6 @@
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
-        <bracket type="1" span="2" col="2"/>
-        <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName>Piano</trackName>
       <Instrument id="piano">

--- a/share/templates/01-General/02-Bass_Clef/02-Bass_Clef.mscx
+++ b/share/templates/01-General/02-Bass_Clef/02-Bass_Clef.mscx
@@ -70,8 +70,6 @@
           <name>stdNormal</name>
           </StaffType>
         <defaultClef>F</defaultClef>
-        <bracket type="1" span="2" col="2"/>
-        <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName>Piano</trackName>
       <Instrument id="piano">


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/16793

Reeeeally simple fix here. I have modified these templates to match the sort of bracketing behavior as if you had added a single-staff instrument manually, which is to say, no bracket.