### PR TITLE
Fix default visibility when publishing existing cloud score

### DIFF
--- a/src/project/internal/saveprojectscenario.cpp
+++ b/src/project/internal/saveprojectscenario.cpp
@@ -241,7 +241,9 @@ RetVal<CloudProjectInfo> SaveProjectScenario::doAskCloudLocation(INotationProjec
         switch (scoreInfo.ret.code()) {
         case int(Ret::Code::Ok):
             defaultName = scoreInfo.val.title;
-            defaultVisibility = scoreInfo.val.visibility;
+            if (!isPublish) {
+                defaultVisibility = scoreInfo.val.visibility;
+            }
             break;
 
         case int(cloud::Err::AccountNotActivated):


### PR DESCRIPTION
Should be set to "Public". We did already have Public as the default for publishing scores, but since 4fe785991483367c90029112f56bf560034dbe81 that would be overridden by the visibility of the existing online score. So we shouldn't do that when publishing.