### PR TITLE
Fix the "Replace existing online score" option 

### DIFF
--- a/src/cloud/musescorecom/musescorecomservice.cpp
+++ b/src/cloud/musescorecom/musescorecomservice.cpp
@@ -150,7 +150,7 @@ mu::Ret MuseScoreComService::downloadAccountInfo()
     QJsonObject user = document.object();
 
     AccountInfo info;
-    info.id = user.value("id").toInt();
+    info.id = QString::number(user.value("id").toInt());
     info.userName = user.value("name").toString();
     QString profileUrl = user.value("profile_url").toString();
     info.profileUrl = QUrl(profileUrl);


### PR DESCRIPTION
Fix MuseScore.com authorization after cab067919e2f887fd3094e1d89e9c31aea8133ed: 
User id was not set correctly (int vs QString). This causes the User id to be some invalid character rather than a number, so in `MuseScoreComService::doUploadScore`, the check `scoreInfo.val.owner.id != accountInfo().val.id.toInt()` fails. This causes trouble with uploading scores.

Resolves: apparently there is no issue about it, but @Tantacrul reported it on Discord

Cherry-picked from #17764 