### PR TITLE
keysig setKey clarifying

### DIFF
--- a/src/engraving/libmscore/keysig.cpp
+++ b/src/engraving/libmscore/keysig.cpp
@@ -149,16 +149,16 @@ EngravingItem* KeySig::drop(EditData& data)
 //   setKey
 //---------------------------------------------------------
 
-void KeySig::setKey(Key key)
+void KeySig::setKey(Key cKey)
 {
     KeySigEvent e;
-    e.setConcertKey(key);
+    e.setConcertKey(cKey);
     if (staff() && !score()->styleB(Sid::concertPitch)) {
         Interval v = staff()->part()->instrument(tick())->transpose();
         if (!v.isZero()) {
             v.flip();
-            key = transposeKey(key, v, staff()->part()->preferSharpFlat());
-            e.setKey(key);
+            Key tKey = transposeKey(cKey, v, staff()->part()->preferSharpFlat());
+            e.setKey(tKey);
         }
     }
     setKeySigEvent(e);

--- a/src/engraving/libmscore/keysig.h
+++ b/src/engraving/libmscore/keysig.h
@@ -54,7 +54,7 @@ public:
 
     //@ sets the key of the key signature (concert key and transposing key)
     void setKey(Key cKey, Key tKey);
-    void setKey(Key key);
+    void setKey(Key cKey);
 
     Segment* segment() const { return (Segment*)explicitParent(); }
     Measure* measure() const { return explicitParent() ? (Measure*)explicitParent()->explicitParent() : nullptr; }


### PR DESCRIPTION
It was not obvious, if `key` parameter in `KeySig::setKey(Key key)` should be concert key, or transposing key, which may be confusing.

This tiny change `KeySig::setKey(Key cKey)` makes it clear (I hope).

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
