### PR TITLE
Fix old project migration bugs

### DIFF
--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -3447,13 +3447,6 @@ Err Read206::readScore(Score* score, XmlReader& e, ReadInOutData* out)
 
     compat::CompatUtils::doCompatibilityConversions(score->masterScore());
 
-    // fix positions
-    //    offset = saved offset - layout position
-    score->doLayout();
-    for (auto i : ctx.fixOffsets()) {
-        i.first->setOffset(i.second - i.first->pos());
-    }
-
     return Err::NoError;
 }
 

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -215,10 +215,12 @@ mu::Ret NotationProject::doLoad(const io::path_t& path, const io::path_t& styleP
 
     // Migration
     if (migrator()) {
+        masterScore->lockUpdates(false); // because migration needs a second layout
         ret = migrator()->migrateEngravingProjectIfNeed(m_engravingProject);
         if (!ret) {
             return ret;
         }
+        masterScore->lockUpdates(true);
     }
 
     // Load style if present

--- a/src/project/internal/projectmigrator.cpp
+++ b/src/project/internal/projectmigrator.cpp
@@ -142,7 +142,6 @@ Ret ProjectMigrator::migrateProject(engraving::EngravingProjectPtr project, cons
         return make_ret(Ret::Code::InternalError);
     }
 
-    score->lockUpdates(false);
     score->startCmd();
 
     bool ok = true;

--- a/src/project/internal/projectmigrator.cpp
+++ b/src/project/internal/projectmigrator.cpp
@@ -142,6 +142,7 @@ Ret ProjectMigrator::migrateProject(engraving::EngravingProjectPtr project, cons
         return make_ret(Ret::Code::InternalError);
     }
 
+    score->lockUpdates(false);
     score->startCmd();
 
     bool ok = true;


### PR DESCRIPTION
Resolves: #17982 

The bug happens because the position of some items (in this case hairpins) is reset when migrating from version 2.x, but we don't call a new layout after that, so the items aren't rendered properly until a relayout happens. `ProjectMigrator::migrateProject` should be responsible for calling this layout. In fact, I think it was designed to do so as it calls `score->endCmd()`, but was being blocked by `_updatesLocked`.
In turn, there was a pointless layout call being made at the end of `Read206`, which I've removed.