### PR TITLE
Cleanup of dot positioning code and manual direction bugfix

### DIFF
--- a/src/engraving/layout/v0/chordlayout.h
+++ b/src/engraving/layout/v0/chordlayout.h
@@ -63,6 +63,7 @@ public:
     static void layoutChords1(LayoutContext& ctx, Segment* segment, staff_idx_t staffIdx);
     static double layoutChords2(std::vector<Note*>& notes, bool up, LayoutContext& ctx);
     static void layoutChords3(const MStyle& style, const std::vector<Chord*>&, const std::vector<Note*>&, const Staff*, LayoutContext& ctx);
+    static void getNoteListForDots(Chord* c, std::vector<Note*>&, std::vector<Note*>&, std::vector<int>&);
     static void updateGraceNotes(Measure* measure, LayoutContext& ctx);
     static void repositionGraceNotesAfter(Segment* segment, size_t tracks);
     static void appendGraceNotes(Chord* chord);
@@ -83,6 +84,8 @@ private:
     static void layoutTablature(Chord* item, LayoutContext& ctx);
 
     static void layoutNote2(Note* note, LayoutContext& ctx);
+
+    static void placeDots(const std::vector<Chord*>& chords, const std::vector<Note*>& notes);
 };
 }
 

--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -1981,77 +1981,14 @@ void Note::setHeadHasParentheses(bool hasParentheses)
 }
 
 //---------------------------------------------------------
-//   getNoteListForDots
-//      This method populates three lists: one for chord notes that need to be checked from the top down,
-//      one for chords from the bottom up, and one for spaces (where the dot will be in that space)
-//---------------------------------------------------------
-
-void Note::getNoteListForDots(std::vector<Note*>& topDownNotes, std::vector<Note*>& bottomUpNotes, std::vector<int>& anchoredDots)
-{
-    Chord* c = chord();
-    bool hasVoices = c->measure()->hasVoices(c->staffIdx(), c->tick(), c->ticks());
-    if (!hasVoices) {
-        // only this voice, so topDownNotes is just the notes in the chord
-        for (Note* note : c->notes()) {
-            if (note->line() & 1) {
-                int newOffset = 0;
-                bool adjustDown = (c->voice() & 1) && !c->up();
-                if (!anchoredDots.empty() && anchoredDots.back() == note->line()) {
-                    if (anchoredDots.size() >= 2 && anchoredDots[anchoredDots.size() - 2] == note->line() + (adjustDown ? 2 : -2)) {
-                        newOffset = adjustDown ? -2 : 2;
-                    } else {
-                        newOffset = adjustDown ? 2 : -2;
-                    }
-                }
-                anchoredDots.push_back(note->line() + newOffset);
-            } else {
-                topDownNotes.push_back(note);
-            }
-        }
-    } else {
-        // Get a list of notes in this staff that adjust dots from top down,
-        // bottom up, and also start our locked-in dot list by adding all lines where dots are
-        // guaranteed
-        Measure* m = c->measure();
-        size_t firstVoice = c->track() - c->voice();
-        for (size_t i = firstVoice; i < firstVoice + VOICES; ++i) {
-            if (Chord* voiceChord = m->findChord(c->tick(), i)) {
-                bool startFromTop = !((voiceChord->voice() & 1) && !voiceChord->up());
-                if (startFromTop) {
-                    for (Note* note : voiceChord->notes()) {
-                        if (note->line() & 1) {
-                            anchoredDots.push_back(note->line());
-                        } else {
-                            topDownNotes.push_back(note);
-                        }
-                    }
-                } else {
-                    for (Note* note : voiceChord->notes()) {
-                        if (note->line() & 1) {
-                            anchoredDots.push_back(note->line());
-                        } else {
-                            bottomUpNotes.push_back(note);
-                        }
-                    }
-                }
-            }
-        }
-    }
-    // our two lists now contain only notes that are on lines
-    std::sort(topDownNotes.begin(), topDownNotes.end(),
-              [](Note* n1, Note* n2) { return n1->line() < n2->line(); });
-    std::sort(bottomUpNotes.begin(), bottomUpNotes.end(),
-              [](Note* n1, Note* n2) { return n1->line() > n2->line(); });
-}
-
-//---------------------------------------------------------
 //   setDotY
+//    dotMove is number of staff spaces/lines to move from the note's
+//    space or line
 //---------------------------------------------------------
 
-void Note::setDotY(DirectionV pos)
+void Note::setDotRelativeLine(int dotMove)
 {
-    double y = 0;
-    bool onLine = !(line() & 1);
+    double y = dotMove / 2.0;
     if (staff()->isTabStaff(chord()->tick())) {
         // with TAB's, dotPosX is not set:
         // get dot X from width of fret text and use TAB default spacing
@@ -2063,11 +2000,9 @@ void Note::setDotY(DirectionV pos)
                 // if fret marks above lines, raise the dots by half line distance
                 y = -0.5;
             }
-            if (pos == DirectionV::AUTO) {
+            if (dotMove == 0) {
                 bool oddVoice = voice() & 1;
                 y = oddVoice ? 0.5 : -0.5;
-            } else if (pos == DirectionV::UP) {
-                y = -0.5;
             } else {
                 y = 0.5;
             }
@@ -2076,56 +2011,7 @@ void Note::setDotY(DirectionV pos)
         else {
             return;
         }
-    } else if (onLine) {
-        // NON-TAB
-        std::vector<Note*> topDownNotes;
-        std::vector<Note*> bottomUpNotes;
-        std::vector<int> anchoredDots;
-
-        // construct combined chords using the notes from overlapping chords
-        getNoteListForDots(topDownNotes, bottomUpNotes, anchoredDots);
-
-        bool finished = false;
-        for (Note* note : topDownNotes) {
-            int dotMove = -1;
-            if (mu::contains(anchoredDots, note->line() + dotMove)) {
-                dotMove = 1; // if the desired space is taken, adjust downwards
-            }
-            if (note == this) {
-                y = dotMove / 2.0;
-                finished = true;
-                break;
-            }
-            anchoredDots.push_back(note->line() + dotMove);
-        }
-        if (!finished) {
-            for (Note* note : bottomUpNotes) {
-                int dotMove = 1;
-                if (mu::contains(anchoredDots, note->line() + dotMove)) {
-                    dotMove = -1; // if the desired space is taken, adjust upwards
-                }
-                if (note == this) {
-                    y = dotMove / 2.0;
-                    finished = true;
-                    break;
-                }
-                anchoredDots.push_back(note->line() + dotMove);
-            }
-        }
-    } else {
-        // on a space; usually this means the dot is on this same line, but there is an exception
-        // for a unison within the same chord.
-        for (Note* note : chord()->notes()) {
-            if (note == this) {
-                break;
-            }
-            if (note->line() == m_line) {
-                bool adjustDown = (chord()->voice() & 1) && !chord()->up();
-                y = adjustDown ? 1.0 : -1.0;
-            }
-        }
     }
-
     y *= spatium() * staff()->lineDistance(tick());
 
     // apply to dots

--- a/src/engraving/libmscore/note.h
+++ b/src/engraving/libmscore/note.h
@@ -332,6 +332,8 @@ public:
 
     DirectionV userDotPosition() const { return m_userDotPosition; }
     void setUserDotPosition(DirectionV d) { m_userDotPosition = d; }
+    DirectionV dotPosition() const { return m_dotPosition; }
+    void setDotPosition(DirectionV d) { m_dotPosition = d; }
     bool dotIsUp() const;                 // actual dot position
 
     void reset() override;
@@ -387,7 +389,7 @@ public:
     bool mark() const { return m_mark; }
     void setMark(bool v) const { m_mark = v; }
     void setScore(Score* s) override;
-    void setDotY(DirectionV);
+    void setDotRelativeLine(int);
 
     void setHeadHasParentheses(bool hasParentheses);
     bool headHasParentheses() const { return m_hasHeadParentheses; }
@@ -492,8 +494,9 @@ private:
     SlideType m_slideToType = SlideType::Undefined;
     SlideType m_slideFromType = SlideType::Undefined;
 
-    DirectionH m_userMirror = DirectionH::AUTO;        // user override of mirror
-    DirectionV m_userDotPosition = DirectionV::AUTO;   // user override of dot position
+    DirectionH m_userMirror = DirectionH::AUTO;        ///< user override of mirror
+    DirectionV m_userDotPosition = DirectionV::AUTO;   ///< user override of dot position
+    DirectionV m_dotPosition = DirectionV::AUTO;       // used as an intermediate step when resolving dot conflicts
 
     NoteHeadScheme m_headScheme = NoteHeadScheme::HEAD_AUTO;
     NoteHeadGroup m_headGroup = NoteHeadGroup::HEAD_NORMAL;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/17749

Took @mike-spa's advice in (https://github.com/musescore/MuseScore/pull/17763#issuecomment-1566873892) on this one and used this as an opportunity to finally optimize some of the dot repositioning code. Now the dot repositioning check happens once per staff rather than once per note. It wasn't much of a workhorse before but every little helps!

I moved all of the positioning logic into `ChordLayout::layoutChords3` instead of `Note::setDotY`. There was also a method in `Note` called `getNoteListForDots` which did not belong in the note class at all, so that has also been moved to the `ChordLayout` class. I love our newly refactored layout system :D
