### PR TITLE
add "a Tempo" in the Tempo palette

### DIFF
--- a/src/engraving/libmscore/engravingitem.h
+++ b/src/engraving/libmscore/engravingitem.h
@@ -324,6 +324,10 @@ public:
 
     virtual int subtype() const { return -1; }                    // for select gui
 
+    // Index to a set of properties if the same element type can represent
+    // different set of properties
+    virtual int propset() const { return subtype(); }
+
     virtual void draw(mu::draw::Painter*) const {}
     void drawAt(mu::draw::Painter* p, const PointF& pt) const { p->translate(pt); draw(p); p->translate(-pt); }
 

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -703,10 +703,10 @@ void Score::rebuildTempoAndTimeSigMaps(Measure* measure)
                     }
 
                     int ticks = tt->segment()->tick().ticks();
-                    BeatsPerSecond tempo = tt->isRestorePrevious()
-                            ? tempomap()->tempo(ticks)
-                            : tt->tempo();
-                            
+                    BeatsPerSecond tempo = tt->isRestorePrevious() && tt->followText()
+                                           ? tempomap()->tempo(ticks)
+                                           : tt->tempo();
+
                     tempomap()->setTempo(ticks, tempo);
                 }
             }

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -701,7 +701,13 @@ void Score::rebuildTempoAndTimeSigMaps(Measure* measure)
                     if (tt->isRelative()) {
                         tt->updateRelative();
                     }
-                    tempomap()->setTempo(tt->segment()->tick().ticks(), tt->tempo());
+
+                    int ticks = tt->segment()->tick().ticks();
+                    BeatsPerSecond tempo = tt->isRestorePrevious()
+                            ? tempomap()->tempo(ticks)
+                            : tt->tempo();
+                            
+                    tempomap()->setTempo(ticks, tempo);
                 }
             }
             if (stretch != 0.0 && stretch != 1.0) {

--- a/src/engraving/libmscore/tempotext.cpp
+++ b/src/engraving/libmscore/tempotext.cpp
@@ -70,6 +70,11 @@ TempoText::TempoText(Segment* parent)
     _isRelative     = false;
 }
 
+int TempoText::propset() const
+{
+    return static_cast<int>(_tempoTextType);
+}
+
 void TempoText::setTempoTextType(TempoTextType ttt)
 {
     _tempoTextType = ttt;

--- a/src/engraving/libmscore/tempotext.cpp
+++ b/src/engraving/libmscore/tempotext.cpp
@@ -63,10 +63,17 @@ TempoText::TempoText(Segment* parent)
     : TextBase(ElementType::TEMPO_TEXT, parent, TextStyleType::TEMPO, ElementFlag::SYSTEM | ElementFlag::ON_STAFF)
 {
     initElementStyle(&tempoStyle);
-    _tempo      = 2.0;        // propertyDefault(P_TEMPO).toDouble();
-    _followText = false;
-    _relative   = 1.0;
-    _isRelative = false;
+    _tempoTextType  = TempoTextType::NORMAL;
+    _tempo          = 2.0;        // propertyDefault(P_TEMPO).toDouble();
+    _followText     = false;
+    _relative       = 1.0;
+    _isRelative     = false;
+}
+
+void TempoText::setTempoTextType(TempoTextType ttt)
+{
+    _tempoTextType = ttt;
+    score()->setUpTempoMapLater();
 }
 
 double TempoText::tempoBpm() const

--- a/src/engraving/libmscore/tempotext.h
+++ b/src/engraving/libmscore/tempotext.h
@@ -27,6 +27,12 @@
 #include "textbase.h"
 
 namespace mu::engraving {
+enum class TempoTextType : signed char
+{
+    NORMAL,
+    RESTORE_PREVIOUS,
+};
+
 //-------------------------------------------------------------------
 //   @@ TempoText
 ///    Tempo marker which determines the midi tempo.
@@ -48,12 +54,18 @@ public:
     Segment* segment() const { return toSegment(explicitParent()); }
     Measure* measure() const { return toMeasure(explicitParent()->explicitParent()); }
 
+    TempoTextType tempoTextType() const { return _tempoTextType; }
+    void setTempoTextType(TempoTextType);
+
     BeatsPerSecond tempo() const { return _tempo; }
     double tempoBpm() const;
     void setTempo(BeatsPerSecond v);
     void undoSetTempo(double v);
     bool isRelative() { return _isRelative; }
     void setRelative(double v) { _isRelative = true; _relative = v; }
+
+    bool isRestorePrevious() const { return _tempoTextType == TempoTextType::RESTORE_PREVIOUS; }
+    void setRestorePrevious() { setTempoTextType(TempoTextType::RESTORE_PREVIOUS); }
 
     bool followText() const { return _followText; }
     void setFollowText(bool v) { _followText = v; }
@@ -80,7 +92,8 @@ protected:
 
     void updateScore();
     void updateTempo();
-
+    
+    TempoTextType _tempoTextType;
     BeatsPerSecond _tempo;             // beats per second
     bool _followText;         // parse text to determine tempo
     double _relative;

--- a/src/engraving/libmscore/tempotext.h
+++ b/src/engraving/libmscore/tempotext.h
@@ -51,6 +51,8 @@ public:
 
     TempoText* clone() const override { return new TempoText(*this); }
 
+    virtual int propset() const override;
+
     Segment* segment() const { return toSegment(explicitParent()); }
     Measure* measure() const { return toMeasure(explicitParent()->explicitParent()); }
 
@@ -92,7 +94,7 @@ protected:
 
     void updateScore();
     void updateTempo();
-    
+
     TempoTextType _tempoTextType;
     BeatsPerSecond _tempo;             // beats per second
     bool _followText;         // parse text to determine tempo

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -486,6 +486,8 @@ void TRead::read(TempoText* t, XmlReader& e, ReadContext& ctx)
             t->setTempo(TConv::fromXml(e.readAsciiText(), Constants::DEFAULT_TEMPO));
         } else if (tag == "followText") {
             t->setFollowText(e.readInt());
+        } else if (tag == "restorePrevious") {
+            t->setTempoTextType(e.readInt() ? TempoTextType::RESTORE_PREVIOUS : TempoTextType::NORMAL);
         } else if (!readProperties(static_cast<TextBase*>(t), e, ctx)) {
             e.unknown();
         }

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -2609,6 +2609,9 @@ void TWrite::write(const TempoText* item, XmlWriter& xml, WriteContext& ctx)
     if (item->followText()) {
         xml.tag("followText", item->followText());
     }
+    if (item->isRestorePrevious()) {
+        xml.tag("restorePrevious", true);
+    }
     writeProperties(static_cast<const TextBase*>(item), xml, ctx, true);
     xml.endElement();
 }

--- a/src/inspector/models/abstractinspectormodel.cpp
+++ b/src/inspector/models/abstractinspectormodel.cpp
@@ -24,6 +24,8 @@
 
 #include "types/texttypes.h"
 
+#include "libmscore/tempotext.h"
+
 #include "log.h"
 
 using namespace mu::inspector;
@@ -109,6 +111,11 @@ static QMap<mu::engraving::HairpinType, InspectorModelType> HAIRPIN_ELEMENT_MODE
 
 static QMap<mu::engraving::LayoutBreakType, InspectorModelType> LAYOUT_BREAK_ELEMENT_MODEL_TYPES = {
     { mu::engraving::LayoutBreakType::SECTION, InspectorModelType::TYPE_SECTIONBREAK }
+};
+
+static QMap<mu::engraving::TempoTextType, InspectorModelType> TEMPO_TEXT_ELEMENT_MODEL_TYPES = {
+    { mu::engraving::TempoTextType::NORMAL, InspectorModelType::TYPE_TEMPO },
+    { mu::engraving::TempoTextType::RESTORE_PREVIOUS, InspectorModelType::TYPE_TEMPO_RESTORE_PREVIOUS },
 };
 
 AbstractInspectorModel::AbstractInspectorModel(QObject* parent, IElementRepositoryService* repository,

--- a/src/inspector/models/abstractinspectormodel.cpp
+++ b/src/inspector/models/abstractinspectormodel.cpp
@@ -190,13 +190,18 @@ InspectorModelType AbstractInspectorModel::modelType() const
 InspectorModelType AbstractInspectorModel::modelTypeByElementKey(const ElementKey& elementKey)
 {
     if (elementKey.type == mu::engraving::ElementType::HAIRPIN || elementKey.type == mu::engraving::ElementType::HAIRPIN_SEGMENT) {
-        return HAIRPIN_ELEMENT_MODEL_TYPES.value(static_cast<mu::engraving::HairpinType>(elementKey.subtype),
+        return HAIRPIN_ELEMENT_MODEL_TYPES.value(static_cast<mu::engraving::HairpinType>(elementKey.propset),
                                                  InspectorModelType::TYPE_UNDEFINED);
     }
 
     if (elementKey.type == mu::engraving::ElementType::LAYOUT_BREAK) {
-        return LAYOUT_BREAK_ELEMENT_MODEL_TYPES.value(static_cast<mu::engraving::LayoutBreakType>(elementKey.subtype),
+        return LAYOUT_BREAK_ELEMENT_MODEL_TYPES.value(static_cast<mu::engraving::LayoutBreakType>(elementKey.propset),
                                                       InspectorModelType::TYPE_UNDEFINED);
+    }
+
+    if (elementKey.type == mu::engraving::ElementType::TEMPO_TEXT) {
+        return TEMPO_TEXT_ELEMENT_MODEL_TYPES.value(static_cast<mu::engraving::TempoTextType>(elementKey.propset),
+                                                    InspectorModelType::TYPE_UNDEFINED);
     }
 
     return NOTATION_ELEMENT_MODEL_TYPES.value(elementKey.type, InspectorModelType::TYPE_UNDEFINED);

--- a/src/inspector/models/abstractinspectormodel.h
+++ b/src/inspector/models/abstractinspectormodel.h
@@ -76,6 +76,7 @@ public:
         TYPE_HOOK,
         TYPE_FERMATA,
         TYPE_TEMPO,
+        TYPE_TEMPO_RESTORE_PREVIOUS,
         TYPE_GLISSANDO,
         TYPE_BARLINE,
         TYPE_BREATH,

--- a/src/inspector/models/inspectorlistmodel.cpp
+++ b/src/inspector/models/inspectorlistmodel.cpp
@@ -98,7 +98,7 @@ void InspectorListModel::setElementList(const QList<mu::engraving::EngravingItem
         ElementKeySet newElementKeySet;
 
         for (const mu::engraving::EngravingItem* element : selectedElementList) {
-            newElementKeySet << ElementKey(element->type(), element->subtype());
+            newElementKeySet << ElementKey(element->type(), element->propset());
         }
 
         buildModelsForSelectedElements(newElementKeySet, selectionState == SelectionState::RANGE, selectedElementList);

--- a/src/inspector/models/inspectormodelcreator.cpp
+++ b/src/inspector/models/inspectormodelcreator.cpp
@@ -95,7 +95,8 @@ AbstractInspectorModel* InspectorModelCreator::newInspectorModel(InspectorModelT
     case InspectorModelType::TYPE_FERMATA:
         return new FermataSettingsModel(parent, repository);
     case InspectorModelType::TYPE_TEMPO:
-        return new TempoSettingsModel(parent, repository);
+    case InspectorModelType::TYPE_TEMPO_RESTORE_PREVIOUS:
+        return new TempoSettingsModel(parent, repository, modelType);
     case InspectorModelType::TYPE_GLISSANDO:
         return new GlissandoSettingsModel(parent, repository);
     case InspectorModelType::TYPE_BARLINE:

--- a/src/inspector/models/notation/tempos/temposettingsmodel.cpp
+++ b/src/inspector/models/notation/tempos/temposettingsmodel.cpp
@@ -27,18 +27,26 @@
 
 using namespace mu::inspector;
 
-TempoSettingsModel::TempoSettingsModel(QObject* parent, IElementRepositoryService* repository)
+TempoSettingsModel::TempoSettingsModel(QObject* parent, IElementRepositoryService* repository, InspectorModelType modelType)
     : AbstractInspectorModel(parent, repository)
 {
-    setModelType(InspectorModelType::TYPE_TEMPO);
-    setTitle(qtrc("inspector", "Tempo"));
+    Q_ASSERT(modelType == InspectorModelType::TYPE_TEMPO || modelType == InspectorModelType::TYPE_TEMPO_RESTORE_PREVIOUS);
+
+    setModelType(modelType);
+
+    if (modelType == InspectorModelType::TYPE_TEMPO) {
+        setTitle(qtrc("inspector", "Tempo"));
+    } else {
+        setTitle(qtrc("inspector", "Restore previous tempo (a tempo)"));
+    }
+
     setIcon(ui::IconCode::Code::METRONOME);
     createProperties();
 }
 
 void TempoSettingsModel::createProperties()
 {
-    m_isDefaultTempoForced
+    m_isFollowText
         = buildPropertyItem(mu::engraving::Pid::TEMPO_FOLLOW_TEXT, [this](const mu::engraving::Pid pid, const QVariant& newValue) {
         onPropertyValueChanged(pid, newValue);
 
@@ -55,19 +63,19 @@ void TempoSettingsModel::requestElements()
 
 void TempoSettingsModel::loadProperties()
 {
-    loadPropertyItem(m_isDefaultTempoForced);
+    loadPropertyItem(m_isFollowText);
     loadPropertyItem(m_tempo, formatDoubleFunc);
 }
 
 void TempoSettingsModel::resetProperties()
 {
-    m_isDefaultTempoForced->resetToDefault();
+    m_isFollowText->resetToDefault();
     m_tempo->resetToDefault();
 }
 
-PropertyItem* TempoSettingsModel::isDefaultTempoForced() const
+PropertyItem* TempoSettingsModel::isFollowText() const
 {
-    return m_isDefaultTempoForced;
+    return m_isFollowText;
 }
 
 PropertyItem* TempoSettingsModel::tempo() const

--- a/src/inspector/models/notation/tempos/temposettingsmodel.h
+++ b/src/inspector/models/notation/tempos/temposettingsmodel.h
@@ -29,22 +29,22 @@ class TempoSettingsModel : public AbstractInspectorModel
 {
     Q_OBJECT
 
-    Q_PROPERTY(PropertyItem * isDefaultTempoForced READ isDefaultTempoForced CONSTANT)
+    Q_PROPERTY(PropertyItem * followText READ isFollowText CONSTANT)
     Q_PROPERTY(PropertyItem * tempo READ tempo CONSTANT)
 
 public:
-    explicit TempoSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit TempoSettingsModel(QObject* parent, IElementRepositoryService* repository, InspectorModelType modelType);
 
     void createProperties() override;
     void requestElements() override;
     void loadProperties() override;
     void resetProperties() override;
 
-    PropertyItem* isDefaultTempoForced() const;
+    PropertyItem* isFollowText() const;
     PropertyItem* tempo() const;
 
 private:
-    PropertyItem* m_isDefaultTempoForced = nullptr;
+    PropertyItem* m_isFollowText = nullptr;
     PropertyItem* m_tempo = nullptr;
 };
 }

--- a/src/inspector/types/commontypes.h
+++ b/src/inspector/types/commontypes.h
@@ -33,18 +33,18 @@ namespace mu::inspector {
 struct ElementKey
 {
     mu::engraving::ElementType type = mu::engraving::ElementType::INVALID;
-    int subtype = -1;
+    int propset = -1;
 
     ElementKey() = default;
 
-    ElementKey(mu::engraving::ElementType type, int subtype = -1)
-        : type(type), subtype(subtype)
+    ElementKey(mu::engraving::ElementType type, int propset = -1)
+        : type(type), propset(propset)
     {
     }
 
     bool operator==(const ElementKey& key) const
     {
-        return type == key.type && subtype == key.subtype;
+        return type == key.type && propset == key.propset;
     }
 
     bool operator!=(const ElementKey& key) const
@@ -58,8 +58,8 @@ using ElementKeySet = QSet<ElementKey>;
 
 inline uint qHash(const ElementKey& key)
 {
-    QString subtypePart = key.subtype >= 0 ? QString::number(key.subtype) : "";
-    return qHash(QString::number(static_cast<int>(key.type)) + subtypePart);
+    QString propsetPart = key.propset >= 0 ? QString::number(key.propset) : "";
+    return qHash(QString::number(static_cast<int>(key.type)) + propsetPart);
 }
 
 class CommonTypes

--- a/src/inspector/view/inspector_resources.qrc
+++ b/src/inspector/view/inspector_resources.qrc
@@ -64,6 +64,7 @@
         <file>qml/MuseScore/Inspector/notation/lines/VibratoSettings.qml</file>
         <file>qml/MuseScore/Inspector/notation/lines/SlurAndTieSettings.qml</file>
         <file>qml/MuseScore/Inspector/notation/tempos/TempoSettings.qml</file>
+        <file>qml/MuseScore/Inspector/notation/tempos/TempoRestorePreviousSettings.qml</file>
         <file>qml/MuseScore/Inspector/notation/sectionbreaks/SectionBreakSettings.qml</file>
         <file>qml/MuseScore/Inspector/notation/markers/MarkerSettings.qml</file>
         <file>qml/MuseScore/Inspector/notation/jumps/JumpSettings.qml</file>

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/NotationInspectorSectionLoader.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/NotationInspectorSectionLoader.qml
@@ -91,6 +91,7 @@ Loader {
             case Inspector.TYPE_SLUR:
             case Inspector.TYPE_TIE: return slurAndTieComp
             case Inspector.TYPE_TEMPO: return tempoComp
+            case Inspector.TYPE_TEMPO_RESTORE_PREVIOUS: return tempoRestorePreviousComp
             case Inspector.TYPE_BARLINE: return barlineComp
             case Inspector.TYPE_SECTIONBREAK: return sectionBreakComp
             case Inspector.TYPE_MARKER: return markerComp
@@ -175,6 +176,11 @@ Loader {
     Component {
         id: tempoComp
         TempoSettings { }
+    }
+
+    Component {
+        id: tempoRestorePreviousComp
+        TempoRestorePreviousSettings { }
     }
 
     Component {

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/tempos/TempoRestorePreviousSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/tempos/TempoRestorePreviousSettings.qml
@@ -67,7 +67,7 @@ Column {
     }
 
     SpinBoxPropertyView {
-        titleText: qsTrc("inspector", "Specific tempo")
+        titleText: qsTrc("inspector", "Tempo")
         propertyItem: root.model ? root.model.tempo : null
         enabled: root.model ? !root.model.isEmpty && setSpecificTempoCheckBox.checked : false
 

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/tempos/TempoRestorePreviousSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/tempos/TempoRestorePreviousSettings.qml
@@ -44,6 +44,9 @@ Column {
     }
 
     CheckBox {
+        // Same as CheckBoxPropertyView, except that this view shows
+        // the negation of the boolean model property
+
         id: setSpecificTempoCheckBox
         property PropertyItem followText: root.model ? root.model.followText : null
 

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/tempos/TempoRestorePreviousSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/tempos/TempoRestorePreviousSettings.qml
@@ -71,7 +71,7 @@ Column {
         propertyItem: root.model ? root.model.tempo : null
         enabled: root.model ? !root.model.isEmpty && setSpecificTempoCheckBox.checked : false
 
-        measureUnitsSymbol: qsTrc("inspector", " BPM")
+        measureUnitsSymbol: qsTrc("inspector", "BPM")
 
         navigationName: "Override"
         navigationPanel: root.navigationPanel

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/tempos/TempoRestorePreviousSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/tempos/TempoRestorePreviousSettings.qml
@@ -71,7 +71,7 @@ Column {
         propertyItem: root.model ? root.model.tempo : null
         enabled: root.model ? !root.model.isEmpty && setSpecificTempoCheckBox.checked : false
 
-        measureUnitsSymbol: qsTrc("inspector", "BPM")
+        measureUnitsSymbol: qsTrc("inspector", " BPM")
 
         navigationName: "Override"
         navigationPanel: root.navigationPanel

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/tempos/TempoRestorePreviousSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/tempos/TempoRestorePreviousSettings.qml
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+
+import MuseScore.Ui 1.0
+import MuseScore.UiComponents 1.0
+import MuseScore.Inspector 1.0
+
+import "../../common"
+
+Column {
+    id: root
+
+    property QtObject model: null
+
+    property NavigationPanel navigationPanel: null
+    property int navigationRowStart: 1
+
+    objectName: "TempoRestorePreviousSettings"
+
+    spacing: 12
+
+    function focusOnFirst() {
+        setSpecificTempoCheckBox.navigation.requestActive()
+    }
+
+    CheckBox {
+        id: setSpecificTempoCheckBox
+        property PropertyItem followText: root.model ? root.model.followText : null
+
+        text: qsTrc("inspector", "Set specific tempo")
+
+        width: parent.width
+
+        visible: followText && followText.isVisible
+        enabled: followText && followText.isEnabled
+
+        isIndeterminate: followText && followText.isUndefined
+        checked: !isIndeterminate && followText && !Boolean(followText.value)
+        onClicked: {
+            if (followText) {
+                followText.value = checked
+            }
+        }
+        navigation.name: "SetSpecificTempoCheckBox"
+        navigation.panel: root.navigationPanel
+        navigation.row: root.navigationRowStart + 1
+    }
+
+    SpinBoxPropertyView {
+        titleText: qsTrc("inspector", "Specific tempo")
+        propertyItem: root.model ? root.model.tempo : null
+        enabled: root.model ? !root.model.isEmpty && setSpecificTempoCheckBox.checked : false
+
+        measureUnitsSymbol: qsTrc("inspector", "BPM")
+
+        navigationName: "Override"
+        navigationPanel: root.navigationPanel
+        navigationRowStart: setSpecificTempoCheckBox.navigation.row + 1
+    }
+}

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/tempos/TempoSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/tempos/TempoSettings.qml
@@ -58,7 +58,7 @@ Column {
         propertyItem: root.model ? root.model.tempo : null
         enabled: root.model ? !root.model.isEmpty && !followWrittenTempoCheckbox.checked : false
 
-        measureUnitsSymbol: qsTrc("inspector", " BPM")
+        measureUnitsSymbol: qsTrc("inspector", "BPM")
 
         navigationName: "Override"
         navigationPanel: root.navigationPanel

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/tempos/TempoSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/tempos/TempoSettings.qml
@@ -46,7 +46,7 @@ Column {
     CheckBoxPropertyView {
         id: followWrittenTempoCheckbox
         text: qsTrc("inspector", "Follow written tempo")
-        propertyItem: root.model ? root.model.isDefaultTempoForced : null
+        propertyItem: root.model ? root.model.followText : null
 
         navigation.name: "FollowCheckBox"
         navigation.panel: root.navigationPanel

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/tempos/TempoSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/tempos/TempoSettings.qml
@@ -58,7 +58,7 @@ Column {
         propertyItem: root.model ? root.model.tempo : null
         enabled: root.model ? !root.model.isEmpty && !followWrittenTempoCheckbox.checked : false
 
-        measureUnitsSymbol: qsTrc("inspector", "BPM")
+        measureUnitsSymbol: qsTrc("inspector", " BPM")
 
         navigationName: "Override"
         navigationPanel: root.navigationPanel

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -1492,6 +1492,12 @@ PalettePtr PaletteCreator::newTempoPalette(bool defaultPalette)
         sp->appendElement(item, pair.second, 1.3)->yoffset = 0.4;
     }
 
+    auto aTempoTxt = makeElement<TempoText>(gpaletteScore);
+    aTempoTxt->setFollowText(false);
+    aTempoTxt->setXmlText("a tempo");
+    aTempoTxt->setRestorePrevious();
+    sp->appendElement(aTempoTxt, "a tempo", 1.3);
+
     auto stxt = makeElement<SystemText>(gpaletteScore);
     stxt->setTextStyleType(TextStyleType::TEMPO);
     stxt->setXmlText(String::fromAscii(QT_TRANSLATE_NOOP("palette", "Swing")));

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -1493,7 +1493,7 @@ PalettePtr PaletteCreator::newTempoPalette(bool defaultPalette)
     }
 
     auto aTempoTxt = makeElement<TempoText>(gpaletteScore);
-    aTempoTxt->setFollowText(false);
+    aTempoTxt->setFollowText(true);
     aTempoTxt->setXmlText("a tempo");
     aTempoTxt->setRestorePrevious();
     sp->appendElement(aTempoTxt, "a tempo", 1.3);


### PR DESCRIPTION
Aims to provide "a Tempo" text mark to reset the tempo after a gradual change. At the moment it is a simple tempo text that defaults to 120 BPM and can be edited to whatever the user wants.

It is already better than present situation, but I'd prefer the item to automatically pick-up the tempo prior to previous gradual change.

Duplicate of #15563, just rebased (conflict-free), to get the tests to run