### PR TITLE
Fix GH#18019 and fix GH#18121

### DIFF
--- a/src/palette/internal/palettecell.cpp
+++ b/src/palette/internal/palettecell.cpp
@@ -115,6 +115,7 @@ const char* PaletteCell::translationContext() const
     case ElementType::BREATH:
     case ElementType::FERMATA:
     case ElementType::MEASURE_REPEAT:
+    case ElementType::ORNAMENT:
     case ElementType::SYMBOL:
         return "engraving/sym";
     case ElementType::TIMESIG:

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -794,17 +794,17 @@ PalettePtr PaletteCreator::newOrnamentsPalette(bool defaultPalette)
     sp->setVisible(false);
 
     static const SymIdList defaultOrnaments {
-        SymId::ornamentTurnInverted,
         SymId::ornamentTurn,
+        SymId::ornamentTurnInverted,
         SymId::ornamentTrill,
         SymId::ornamentShortTrill,
         SymId::ornamentMordent
     };
 
     static const SymIdList masterOrnaments {
+        SymId::ornamentTurn,
         SymId::ornamentTurnInverted,
         SymId::ornamentTurnSlash,
-        SymId::ornamentTurn,
         SymId::ornamentTrill,
         SymId::ornamentShortTrill,
         SymId::ornamentMordent,


### PR DESCRIPTION
* Translations for most ornaments don't work, all except "Trill line", "Up mordent" and "Down mordent"
Resolves: #18019
* Turn should come before inverted turn in Ornaments palette
Resolves: #18121 