### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/appshell/view/internal/splashscreen/newinstanceloadingscreenview.cpp
+++ b/src/appshell/view/internal/splashscreen/newinstanceloadingscreenview.cpp
@@ -77,9 +77,9 @@ void NewInstanceLoadingScreenView::draw(QPainter* painter)
     painter->setPen(pen);
 
     QFontMetrics fontMetrics(font);
-    QRectF messageRect(0, 0, m_dialogSize.width(), m_dialogSize.height());
-    messageRect -= QMargins(8, 8, 8, 8);
+    QRectF messageRectangle(0, 0, m_dialogSize.width(), m_dialogSize.height());
+    messageRectangle -= QMargins(8, 8, 8, 8);
 
-    QString elidedText = fontMetrics.elidedText(m_message, Qt::ElideMiddle, messageRect.width());
-    painter->drawText(messageRect, Qt::AlignCenter | Qt::TextDontClip, elidedText);
+    QString elidedText = fontMetrics.elidedText(m_message, Qt::ElideMiddle, messageRectangle.width());
+    painter->drawText(messageRectangle, Qt::AlignCenter | Qt::TextDontClip, elidedText);
 }

--- a/src/braille/internal/louis.cpp
+++ b/src/braille/internal/louis.cpp
@@ -308,8 +308,8 @@ std::string braille_long_translate(const char* table_name, std::string txt)
     std::string buffer = braille_translate(table_name, lines.front());
 
     for (size_t i = 1; i < lines.size(); i++) {
-        std::string txt = lines[i] + " ";
-        buffer.append(braille_translate(table_name, txt));
+        std::string text = lines[i] + " ";
+        buffer.append(braille_translate(table_name, text));
     }
     return buffer;
 }

--- a/src/braille/internal/louis.cpp
+++ b/src/braille/internal/louis.cpp
@@ -116,7 +116,7 @@ FUNC(const SRC_UNIT* s, size_t n, DST_UNIT* resultbuf, size_t* lengthp)
            u8_uctomb will verify uc anyway.  */
 
         /* Store it in the output string.  */
-        count = u8_uctomb(result + length, uc, allocated - length);
+        count = u8_uctomb(result + length, uc, static_cast<int>(allocated - length));
         if (count == -1) {
             if (!(result == resultbuf || result == NULL)) {
                 free(result);
@@ -150,7 +150,7 @@ FUNC(const SRC_UNIT* s, size_t n, DST_UNIT* resultbuf, size_t* lengthp)
                        length * sizeof(DST_UNIT));
             }
             result = memory;
-            count = u8_uctomb(result + length, uc, allocated - length);
+            count = u8_uctomb(result + length, uc, static_cast<int>(allocated - length));
             if (count < 0) {
                 abort();
             }


### PR DESCRIPTION
* reg. declaration hides global declaration (C4459)
* reg. conversion from 'size_t' to 'int', possible loss of data (C4267)
* reg. declaration hides function parameter (C4457)