### PR TITLE
Fix crash when exporting to MusicXML after toggling MMRests

### DIFF
--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -2737,7 +2737,7 @@ EngravingItem* Score::move(const String& cmd)
         }
         if (ftm) {
             if (score()->styleB(Sid::createMultiMeasureRests) && ftm->hasMMRest()) {
-                ftm = ftm->mmRest1();
+                ftm = ftm->coveringMMRestOrThis();
             }
             el = !cr ? ftm->first()->nextChordRest(0, false) : ftm->first()->nextChordRest(trackZeroVoice(cr->track()), false);
         }

--- a/src/engraving/libmscore/line.cpp
+++ b/src/engraving/libmscore/line.cpp
@@ -1051,9 +1051,9 @@ PointF SLine::linePos(Grip grip, System** sys) const
                 }
             }
         }
-        if (score()->styleB(Sid::createMultiMeasureRests)) {
-            m = m->mmRest1();
-        }
+
+        m = m->coveringMMRestOrThis();
+
         assert(m->system());
         *sys = m->system();
     }

--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -2729,27 +2729,36 @@ Measure* Measure::mmRestLast() const
 }
 
 //---------------------------------------------------------
-//   mmRest1
-//    return the multi measure rest this measure is covered
-//    by
+//   coveringMMRestOrThis
+//    if multi-measure rests are enabled,
+//        and this measure is covered by an MMRest,
+//            return that MMRest.
+//    otherwise, return the measure itself.
 //---------------------------------------------------------
 
-const Measure* Measure::mmRest1() const
+const Measure* Measure::coveringMMRestOrThis() const
 {
+    if (!score()->styleB(Sid::createMultiMeasureRests)) {
+        return this;
+    }
+
     if (m_mmRest) {
         return m_mmRest;
     }
+
     if (m_mmRestCount != -1) {
-        // return const_cast<Measure*>(this);
         return this;
     }
+
     const Measure* m = this;
     while (m && !m->m_mmRest) {
         m = m->prevMeasure();
     }
+
     if (m) {
-        return const_cast<Measure*>(m->m_mmRest);
+        return m->m_mmRest;
     }
+
     return 0;
 }
 

--- a/src/engraving/libmscore/measure.h
+++ b/src/engraving/libmscore/measure.h
@@ -304,7 +304,7 @@ public:
     bool hasMMRest() const { return m_mmRest != 0; }
     bool isMMRest() const { return m_mmRestCount > 0; }
     Measure* mmRest() const { return m_mmRest; }
-    const Measure* mmRest1() const;
+    const Measure* coveringMMRestOrThis() const;
     void setMMRest(Measure* m) { m_mmRest = m; }
     int mmRestCount() const { return m_mmRestCount; }            // number of measures m_mmRest spans
     void setMMRestCount(int n) { m_mmRestCount = n; }

--- a/src/engraving/libmscore/measurebase.cpp
+++ b/src/engraving/libmscore/measurebase.cpp
@@ -570,7 +570,7 @@ MeasureBase* MeasureBase::prevMM() const
     if (_prev
         && _prev->isMeasure()
         && score()->styleB(Sid::createMultiMeasureRests)) {
-        return const_cast<Measure*>(toMeasure(_prev)->mmRest1());
+        return const_cast<Measure*>(toMeasure(_prev)->coveringMMRestOrThis());
     }
     return _prev;
 }

--- a/src/engraving/libmscore/score.cpp
+++ b/src/engraving/libmscore/score.cpp
@@ -1953,13 +1953,7 @@ Measure* Score::lastMeasure() const
 Measure* Score::lastMeasureMM() const
 {
     Measure* m = lastMeasure();
-    if (m && styleB(Sid::createMultiMeasureRests)) {
-        Measure* m1 = const_cast<Measure*>(toMeasure(m->mmRest1()));
-        if (m1) {
-            return m1;
-        }
-    }
-    return m;
+    return m ? const_cast<Measure*>(m->coveringMMRestOrThis()) : nullptr;
 }
 
 //---------------------------------------------------------
@@ -4655,7 +4649,7 @@ ChordRest* Score::cmdNextPrevSystem(ChordRest* cr, bool next)
 {
     auto newCR = cr;
     auto currentMeasure = cr->measure();
-    auto currentSystem = currentMeasure->system() ? currentMeasure->system() : currentMeasure->mmRest1()->system();
+    auto currentSystem = currentMeasure->system() ? currentMeasure->system() : currentMeasure->coveringMMRestOrThis()->system();
     if (!currentSystem) {
         return cr;
     }
@@ -4666,7 +4660,9 @@ ChordRest* Score::cmdNextPrevSystem(ChordRest* cr, bool next)
     if (next) {
         if ((destinationMeasure = currentSystem->lastMeasure()->nextMeasure())) {
             // There is a next system present: get it and accommodate for MMRest
-            currentSystem = destinationMeasure->system() ? destinationMeasure->system() : destinationMeasure->mmRest1()->system();
+            currentSystem = destinationMeasure->system()
+                            ? destinationMeasure->system()
+                            : destinationMeasure->coveringMMRestOrThis()->system();
             if ((destinationMeasure = currentSystem->firstMeasure())) {
                 if ((newCR = destinationMeasure->first()->nextChordRest(trackZeroVoice(cr->track()), false))) {
                     cr = newCR;
@@ -4700,7 +4696,9 @@ ChordRest* Score::cmdNextPrevSystem(ChordRest* cr, bool next)
                     return cr;
                 }
             }
-            if (!(currentSystem = destinationMeasure->system() ? destinationMeasure->system() : destinationMeasure->mmRest1()->system())) {
+            if (!(currentSystem = destinationMeasure->system()
+                                  ? destinationMeasure->system()
+                                  : destinationMeasure->coveringMMRestOrThis()->system())) {
                 return cr;
             }
             destinationMeasure = currentSystem->firstMeasure();
@@ -4836,7 +4834,7 @@ EngravingItem* Score::getScoreElementOfMeasureBase(MeasureBase* mb) const
         } else if ((currentMeasure = mb->findMeasure())) {
             // Accommodate for MMRest
             if (score()->styleB(Sid::createMultiMeasureRests) && currentMeasure->hasMMRest()) {
-                currentMeasure = currentMeasure->mmRest1();
+                currentMeasure = currentMeasure->coveringMMRestOrThis();
             }
             if ((cr = currentMeasure->first()->nextChordRest(0, false))) {
                 el = cr;
@@ -4898,7 +4896,7 @@ ChordRest* Score::cmdTopStaff(ChordRest* cr)
     if (destinationMeasure) {
         // Accommodate for MMRest
         if (score()->styleB(Sid::createMultiMeasureRests) && destinationMeasure->hasMMRest()) {
-            destinationMeasure = destinationMeasure->mmRest1();
+            destinationMeasure = destinationMeasure->coveringMMRestOrThis();
         }
         // Get first ChordRest of top staff
         cr = destinationMeasure->first()->nextChordRest(0, false);

--- a/src/engraving/libmscore/scoretree.cpp
+++ b/src/engraving/libmscore/scoretree.cpp
@@ -173,7 +173,7 @@ EngravingObject* Measure::scanParent() const
     if (isMMRest()) {  // this is MMR
         return system();
     } else if (m_mmRestCount < 0) {  // this is part of MMR
-        return const_cast<Measure*>(mmRest1());
+        return const_cast<Measure*>(coveringMMRestOrThis());
     }
     // for a normal measure
     return system();

--- a/src/engraving/libmscore/select.cpp
+++ b/src/engraving/libmscore/select.cpp
@@ -559,7 +559,7 @@ void Selection::updateSelectedElements()
             return;
         }
 
-        if (s2 && s2 == s2->measure()->first() && !(s2->measure()->prevMeasure() && s2->measure()->prevMeasure()->mmRest1())) {
+        if (s2 && s2 == s2->measure()->first() && !(s2->measure()->prevMeasure() && s2->measure()->prevMeasure()->coveringMMRestOrThis())) {
             // we want the last segment of the previous measure (unless it's part of a MMrest)
             s2 = s2->prev1();
         }

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2637,7 +2637,7 @@ void NotationInteraction::selectEmptyTrailingMeasure()
     }
     if (ftm) {
         if (score()->styleB(mu::engraving::Sid::createMultiMeasureRests) && ftm->hasMMRest()) {
-            ftm = ftm->mmRest1();
+            ftm = ftm->coveringMMRestOrThis();
         }
         EngravingItem* el
             = !cr ? ftm->first()->nextChordRest(0, false) : ftm->first()->nextChordRest(mu::engraving::trackZeroVoice(cr->track()), false);

--- a/src/notation/internal/notationselectionrange.cpp
+++ b/src/notation/internal/notationselectionrange.cpp
@@ -173,7 +173,7 @@ mu::engraving::Segment* NotationSelectionRange::rangeStartSegment() const
     }
 
     if (!startSegment->measure()->system()) {
-        const Measure* mmr = startSegment->measure()->mmRest1();
+        const Measure* mmr = startSegment->measure()->coveringMMRestOrThis();
         if (!mmr || mmr->system()) {
             return nullptr;
         }
@@ -226,7 +226,7 @@ const
         mu::engraving::System* nextSegmentSystem = nextSegment->measure()->system();
 
         if (!nextSegmentSystem) {
-            const Measure* mmr = nextSegment->measure()->mmRest1();
+            const Measure* mmr = nextSegment->measure()->coveringMMRestOrThis();
             if (mmr) {
                 nextSegmentSystem = mmr->system();
             }


### PR DESCRIPTION
The problem: when MMRests are disabled, measures still keep a reference to their MMRest measure (in order to preserve that MMRest measure and its properties). This means that the `mmRest1` method might return this MMRest, even when MMRests are disabled (so the method would be expected to return the measure itself). This is fixed by checking inside that method if MMRests are actually enabled.

Additionally, this commit gives that method a slightly nicer name: `coveringMMRestOrThis()`.

Resolves: #17819