### PR TITLE
fix_draw_lines_when_exporting_svg_4.0.2

### DIFF
--- a/src/importexport/imagesexport/internal/svggenerator.cpp
+++ b/src/importexport/imagesexport/internal/svggenerator.cpp
@@ -1259,6 +1259,10 @@ void SvgPaintEngine::drawPolygon(const QPointF* points, int pointCount,
     }
 
     if (mode == PolylineMode) {
+        // fixes draw polyline
+        painter()->setBrush(Qt::NoBrush);
+        updateState(*this->state);
+
         stream() << SVG_POLYLINE << stateString
                  << SVG_POINTS;
         for (int i = 0; i < pointCount; ++i) {

--- a/src/importexport/imagesexport/internal/svgwriter.cpp
+++ b/src/importexport/imagesexport/internal/svgwriter.cpp
@@ -49,6 +49,8 @@ std::vector<INotationWriter::UnitType> SvgWriter::supportedUnitTypes() const
 
 mu::Ret SvgWriter::write(INotationPtr notation, QIODevice& destinationDevice, const Options& options)
 {
+    TRACEFUNC;
+
     IF_ASSERT_FAILED(notation) {
         return make_ret(Ret::Code::UnknownError);
     }


### PR DESCRIPTION
To reproduce:

1. create this simple score
<img width="745" alt="Screen Shot 2023-06-19 at 12 48 06" src="https://github.com/musescore/MuseScore/assets/67867444/abd2ea67-ef71-4137-855f-1dcf72f39517">

2. export an SVG file

3. notice that the pedal line in the SVG file is too thick (it inherited the brush style from the beam)
<img width="651" alt="Screen Shot 2023-06-19 at 12 58 16" src="https://github.com/musescore/MuseScore/assets/67867444/76b43b39-63b1-4f84-b06c-9693dc3e90b1">

