### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/build/cmake/SetupCompileWarnings.cmake
+++ b/build/cmake/SetupCompileWarnings.cmake
@@ -52,7 +52,7 @@ function(target_no_warning TARGET WNAME)
     elseif(WNAME STREQUAL "-Wno-attributes")
 
     elseif(WNAME STREQUAL "-w")
-        set(MSVC_Warning /w)
+        set(MSVC_Warning /W0)
 
     # Only MSVC warnings
     elseif(WNAME STREQUAL "-WMSVC-no-translation-unit-is-empty")

--- a/src/engraving/layout/v0/beamlayout.cpp
+++ b/src/engraving/layout/v0/beamlayout.cpp
@@ -993,7 +993,7 @@ void BeamLayout::createBeamSegments(Beam* item, const std::vector<ChordRest*>& c
                     if (startCr == endCr && startCr->isChord()) {
                         bool isBeamletBefore = calcIsBeamletBefore(item,
                                                                    toChord(startCr),
-                                                                   beamletIndex,
+                                                                   static_cast<int>(beamletIndex),
                                                                    level,
                                                                    previousBreak16,
                                                                    previousBreak32);

--- a/src/engraving/layout/v0/beamlayout.cpp
+++ b/src/engraving/layout/v0/beamlayout.cpp
@@ -942,7 +942,6 @@ void BeamLayout::createBeamSegments(Beam* item, const std::vector<ChordRest*>& c
         for (size_t i = 0; i < numCr; i++) {
             ChordRest* chordRest = chordRests[i];
             ChordRest* prevChordRest = i < 1 ? nullptr : chordRests[i - 1];
-            ChordRest* nextChordRest = i + 1 >= numCr ? nullptr : chordRests[i + 1];
 
             if (level < chordRest->beams()) {
                 levelHasBeam = true;

--- a/src/engraving/libmscore/stringdata.cpp
+++ b/src/engraving/libmscore/stringdata.cpp
@@ -437,7 +437,7 @@ int StringData::fret(int pitch, int string, int pitchOffset) const
 void StringData::sortChordNotesUseSameString(const Chord* chord, int pitchOffset) const
 {
     int capoFret = chord->staff()->part()->capoFret();
-    std::unordered_map<int, Note*> usedStrings;
+    std::unordered_map<size_t, Note*> usedStrings;
     std::unordered_map<int, std::vector<int> > fretTable;
 
     for (auto note: chord->notes()) {


### PR DESCRIPTION
* reg. conversion from 'size_t' to 'int', possible loss of data (C4267)
* reg. overriding '/W4' with '/w' (D9025)
* reg.  local variable is initialized but not referenced (C4189)