### PR TITLE
Improve cloning ornaments

### DIFF
--- a/src/engraving/libmscore/ornament.cpp
+++ b/src/engraving/libmscore/ornament.cpp
@@ -244,7 +244,6 @@ void Ornament::computeNotesAboveAndBelow(AccidentalState* accState)
 
         Note*& note = _notesAboveAndBelow.at(i);
         if (!note && above && _cueNoteChord) {
-            assert(_cueNoteChord->notes().size());
             note = _cueNoteChord->upNote();
         }
 

--- a/src/engraving/libmscore/ornament.cpp
+++ b/src/engraving/libmscore/ornament.cpp
@@ -49,6 +49,20 @@ Ornament::Ornament(const Ornament& o)
     _intervalBelow = o._intervalBelow;
     _showAccidental = o._showAccidental;
     _startOnUpperNote = o._startOnUpperNote;
+
+    if (o._cueNoteChord) {
+        _cueNoteChord = o._cueNoteChord->clone();
+    }
+
+    for (size_t i = 0; i < _accidentalsAboveAndBelow.size(); ++i) {
+        Accidental* oldAccidental = o._accidentalsAboveAndBelow[i];
+        if (!oldAccidental) {
+            continue;
+        }
+        Accidental* newAccidental = oldAccidental->clone();
+        newAccidental->setParent(this);
+        _accidentalsAboveAndBelow[i] = newAccidental;
+    }
 }
 
 Ornament::~Ornament()
@@ -229,6 +243,11 @@ void Ornament::computeNotesAboveAndBelow(AccidentalState* accState)
         }
 
         Note*& note = _notesAboveAndBelow.at(i);
+        if (!note && above && _cueNoteChord) {
+            assert(_cueNoteChord->notes().size());
+            note = _cueNoteChord->upNote();
+        }
+
         if (!note) {
             note = mainNote->clone();
         } else {


### PR DESCRIPTION
From the file @DmitryArefiev posted in the linked issue. See that not all the customizations done in the score are fully mapped to the part.

Score:
<img width="450" alt="0-score" src="https://github.com/musescore/MuseScore/assets/93707756/10e7e8d6-c441-4630-8beb-27aa42c690d5">

Part:
<img width="450" alt="image" src="https://github.com/musescore/MuseScore/assets/93707756/87284468-8d28-4c44-81f9-367afe424473">

This PR fixes that. 

Note: this only refers to the first generation of the part. Customizations done after that aren't mapped, which we know is a general problem.
