### PR TITLE
Enable signing for Windows Portable builds

### DIFF
--- a/.github/workflows/ci_windows_mu4.yml
+++ b/.github/workflows/ci_windows_mu4.yml
@@ -318,7 +318,9 @@ jobs:
       if: env.DO_BUILD == 'true'
       shell: cmd
       run: |      
-        build\ci\windows\package.bat --portable ON 
+        IF ${{ secrets.WIN_SIGN_CERTIFICATE_ENCRYPT_SECRET != 0 }} == true ( SET S_S=${{ secrets.WIN_SIGN_CERTIFICATE_ENCRYPT_SECRET }} ) ELSE ( SET S_S="''" )
+        IF ${{ secrets.WIN_SIGN_CERTIFICATE_PASSWORD != 0 }} == true ( SET S_P=${{ secrets.WIN_SIGN_CERTIFICATE_PASSWORD }} ) ELSE ( SET S_P="''" )
+        build\ci\windows\package.bat --portable ON --signsecret %S_S% --signpass %S_P%
     - name: Checksum 
       if: env.DO_BUILD == 'true'
       run: |

--- a/build/ci/windows/package.bat
+++ b/build/ci/windows/package.bat
@@ -54,6 +54,16 @@ IF %BUILD_MODE% == stable_build  ( SET PACKAGE_TYPE="msi") ELSE (
 SET DO_SIGN=OFF
 IF %PACKAGE_TYPE% == "msi" ( 
     SET DO_SIGN=ON
+)
+IF %PACKAGE_TYPE% == "portable" ( 
+    IF %BUILD_MODE% == testing_build (
+        SET DO_SIGN=ON
+    )
+    IF %BUILD_MODE% == stable_build (
+        SET DO_SIGN=ON
+    )
+)
+IF %DO_SIGN% == ON (
     IF %SIGN_CERTIFICATE_ENCRYPT_SECRET% == "" ( 
         SET DO_SIGN=OFF
         ECHO "warning: not set SIGN_CERTIFICATE_ENCRYPT_SECRET"


### PR DESCRIPTION
In https://github.com/musescore/MuseScore/issues/18071#issuecomment-1600436033, it was reported that the Windows Portable builds are not signed. This PR would enable signing for them.

Not yet tested, because I first wanted to ask if it wouldn't cause problems or if there is a reason that it was disabled. 