### PR TITLE
Fix gcc compiler warnings

### DIFF
--- a/src/braille/internal/louis.cpp
+++ b/src/braille/internal/louis.cpp
@@ -70,9 +70,11 @@ u8_uctomb(uint8_t* s, ucs4_t uc, int n)
             case 4: s[3] = 0x80 | (uc & 0x3f);
                 uc = uc >> 6;
                 uc |= 0x10000;
+            // FALLTHROUGH
             case 3: s[2] = 0x80 | (uc & 0x3f);
                 uc = uc >> 6;
                 uc |= 0x800;
+            // FALLTHROUGH
             case 2: s[1] = 0x80 | (uc & 0x3f);
                 uc = uc >> 6;
                 uc |= 0xc0;

--- a/src/engraving/layout/v0/beamtremololayout.cpp
+++ b/src/engraving/layout/v0/beamtremololayout.cpp
@@ -553,7 +553,7 @@ bool BeamTremoloLayout::calculateAnchors(const std::vector<ChordRest*>& chordRes
         dictator = m_up ? std::min(pointer, dictator) : std::max(pointer, dictator);
         pointer = dictator;
     } else {
-        if (dictator > pointer != (isStartDictator ? startNote > endNote : endNote > startNote)) {
+        if ((dictator > pointer) != (isStartDictator ? startNote > endNote : endNote > startNote)) {
             dictator = pointer - slant;
         } else {
             pointer = dictator + slant;

--- a/src/importexport/guitarpro/internal/gtp/gpbeat.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpbeat.cpp
@@ -29,6 +29,8 @@ void GPBeat::addHarmonicMarkType(GPBeat::HarmonicMarkType type)
     case GPBeat::HarmonicMarkType::FeedBack:
         _harmonicMarkInfo.feedback = true;
         break;
+    case GPBeat::HarmonicMarkType::None:
+        break;
     }
 }
 

--- a/src/stubs/playback/playbackconfigurationstub.cpp
+++ b/src/stubs/playback/playbackconfigurationstub.cpp
@@ -79,7 +79,7 @@ mu::async::Channel<mu::audio::aux_channel_idx_t, bool> PlaybackConfigurationStub
     return {};
 }
 
-bool PlaybackConfigurationStub::isAuxChannelVisible(audio::aux_channel_idx_t index) const
+bool PlaybackConfigurationStub::isAuxChannelVisible(audio::aux_channel_idx_t) const
 {
     return false;
 }

--- a/thirdparty/lame/libmp3lame/quantize.c
+++ b/thirdparty/lame/libmp3lame/quantize.c
@@ -1734,6 +1734,9 @@ VBR_new_iteration_loop(lame_internal_flags * gfc, const FLOAT pe[2][2],
         int     mean_bits, fullframebits;
         fullframebits = ResvFrameBegin(gfc, &mean_bits);
         assert(used_bits <= fullframebits);
+#ifdef NDEBUG
+        (void)fullframebits;
+#endif
         for (gr = 0; gr < cfg->mode_gr; gr++) {
             for (ch = 0; ch < cfg->channels_out; ch++) {
                 gr_info const *const cod_info = &l3_side->tt[gr][ch];


### PR DESCRIPTION
as observed on GitHub CI

* reg. variable set but not used [-Wunused-but-set-variable]
* reg. this statement may fall through [-Wimplicit-fallthrough=]
* reg. enumeration value not handled in switch [-Wswitch]
* reg. unused parameter [-Wunused-parameter]
* reg. suggest parentheses around comparison in operand of ‘!=’ [-Wparentheses]