### PR TITLE
gp-import: fixed segment tick for empty measure

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -424,6 +424,10 @@ void GPConverter::fixEmptyMeasures()
             for (size_t i = 0; i < lastIndex; ++i) {
                 segItemPairs.at(i).first->remove(segItemPairs.at(i).second);
             }
+
+            Segment* segment = toSegment(segItemPairs.at(lastIndex).first);
+            segment->setRtick(Fraction(0, 1));
+
             Rest* rest = toRest(segItemPairs.at(lastIndex).second);
             rest->setTicks(_lastMeasure->ticks());
             rest->setDurationType(DurationType::V_MEASURE);

--- a/src/importexport/guitarpro/tests/data/fret-diagram.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram.gp-ref.mscx
@@ -90,9 +90,6 @@
             <tempo>1.683333</tempo>
             <text><sym>metNoteQuarterUp</sym> = 101</text>
             </Tempo>
-          <location>
-            <fractions>1/1</fractions>
-            </location>
           <Rest>
             <durationType>measure</durationType>
             <duration>12/8</duration>

--- a/src/importexport/guitarpro/tests/data/fret-diagram.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram.gpx-ref.mscx
@@ -90,9 +90,6 @@
             <tempo>1.683333</tempo>
             <text><sym>metNoteQuarterUp</sym> = 101</text>
             </Tempo>
-          <location>
-            <fractions>1/1</fractions>
-            </location>
           <Rest>
             <durationType>measure</durationType>
             <duration>12/8</duration>

--- a/src/importexport/guitarpro/tests/data/mmrest.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/mmrest.gp-ref.mscx
@@ -115,9 +115,6 @@
         </Measure>
       <Measure>
         <voice>
-          <location>
-            <fractions>3/4</fractions>
-            </location>
           <Rest>
             <durationType>measure</durationType>
             <duration>4/4</duration>
@@ -126,9 +123,6 @@
         </Measure>
       <Measure>
         <voice>
-          <location>
-            <fractions>3/4</fractions>
-            </location>
           <Rest>
             <durationType>measure</durationType>
             <duration>4/4</duration>


### PR DESCRIPTION
while deleting the extra rests during import from guitar pro, relative segment position wasn't change, it should be set to initial (0, 1), when segment has only 1 full-measure rest

before fix:
<img width="644" alt="Screenshot 2023-06-22 at 16 42 41" src="https://github.com/musescore/MuseScore/assets/24373905/d5714ced-bffc-40e0-a06b-7d5987ac91d3">

after fix:
<img width="604" alt="Screenshot 2023-06-22 at 16 42 54" src="https://github.com/musescore/MuseScore/assets/24373905/ba9e3f7f-d976-40d0-8b3b-c7c671582b80">
[mmrest.gp.zip](https://github.com/musescore/MuseScore/files/11834592/mmrest.gp.zip)

