### PR TITLE
midi-render: fixed channel setup for different staves

### DIFF
--- a/src/engraving/compat/midi/midirender.cpp
+++ b/src/engraving/compat/midi/midirender.cpp
@@ -1191,6 +1191,7 @@ uint32_t MidiRenderer::getChannel(const Instrument* instr, const Note* note, Mid
 
     if (_context.eachStringHasChannel && instr->hasStrings()) {
         lookupData.string = note->string();
+        lookupData.staffIdx = note->staffIdx();
     }
 
     return _context.channels->getChannel(channel, lookupData);
@@ -1211,6 +1212,6 @@ uint32_t MidiRenderer::ChannelLookup::getChannel(uint32_t instrumentChannel, con
 
 bool MidiRenderer::ChannelLookup::LookupData::operator<(const MidiRenderer::ChannelLookup::LookupData& other) const
 {
-    return std::tie(string, effect) < std::tie(other.string, other.effect);
+    return std::tie(string, staffIdx, effect) < std::tie(other.string, other.staffIdx, other.effect);
 }
 }

--- a/src/engraving/compat/midi/midirender.h
+++ b/src/engraving/compat/midi/midirender.h
@@ -28,6 +28,7 @@
 #include "libmscore/instrument.h"
 #include "libmscore/measure.h"
 #include "libmscore/synthesizerstate.h"
+#include "types/types.h"
 #include "pitchwheelrenderer.h"
 
 namespace mu::engraving {
@@ -51,6 +52,7 @@ public:
             constexpr static int INVALID_STRING = -1;
 
             int32_t string = INVALID_STRING;
+            staff_idx_t staffIdx = 0;
             MidiInstrumentEffect effect = MidiInstrumentEffect::NONE;
 
             bool operator<(const LookupData& other) const;

--- a/src/engraving/tests/midirenderer_data/same_string_diff_staves.mscx
+++ b/src/engraving/tests/midirenderer_data/same_string_diff_staves.mscx
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.10">
+  <programVersion>4.2.0</programVersion>
+  <programRevision></programRevision>
+  <Score>
+    <Division>480</Division>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2023-06-22</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="originalFormat">gp</metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="1" span="2" col="0" visible="1"/>
+        <barLineSpan>2</barLineSpan>
+        </Staff>
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <defaultClef>F</defaultClef>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument id="piano">
+        <longName>Piano</longName>
+        <trackName></trackName>
+        <instrumentId>keyboard.piano</instrumentId>
+        <singleNoteDynamics>0</singleNoteDynamics>
+        <StringData>
+          <frets>24</frets>
+          <string>40</string>
+          <string>45</string>
+          <string>50</string>
+          <string>55</string>
+          <string>59</string>
+          <string>64</string>
+          </StringData>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>30</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="accent">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>144</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>169</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <controller ctrl="7" value="101"/>
+          <synti>Fluid</synti>
+          <midiPort>0</midiPort>
+          <midiChannel>1</midiChannel>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <KeySig>
+            <concertKey>3</concertKey>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Dynamic>
+            <subtype>mf</subtype>
+            <velocity>80</velocity>
+            </Dynamic>
+          <Tempo>
+            <tempo>1.433333</tempo>
+            <text><sym>metNoteQuarterUp</sym> = 86</text>
+            </Tempo>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>62</pitch>
+              <tpc>16</tpc>
+              <fret>12</fret>
+              <string>3</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>62</pitch>
+              <tpc>16</tpc>
+              <fret>12</fret>
+              <string>3</string>
+              </Note>
+            </Chord>
+          <Rest>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="2">
+      <Measure>
+        <voice>
+          <KeySig>
+            <concertKey>3</concertKey>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Dynamic>
+            <subtype>mf</subtype>
+            <velocity>80</velocity>
+            </Dynamic>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>35</pitch>
+              <tpc>19</tpc>
+              <fret>2</fret>
+              <string>3</string>
+              </Note>
+            </Chord>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/tests/midirenderer_tests.cpp
+++ b/src/engraving/tests/midirenderer_tests.cpp
@@ -46,8 +46,17 @@ static NPlayEvent noteEvent(int pitch, int volume, int channel)
 
 static void checkEventInterval(EventMap& events, int tickStart, int tickEnd, int pitch, int volume, int channel = DEFAULT_CHANNEL)
 {
-    EXPECT_EQ(events.find(tickStart)->second, noteEvent(pitch, volume, channel));
-    EXPECT_EQ(events.find(tickEnd)->second, noteEvent(pitch, NOTE_OFF_VOLUME, channel));
+    auto it1 = events.find(tickStart);
+    auto it2 = events.find(tickEnd);
+
+    EXPECT_TRUE(it1 != events.end());
+    EXPECT_TRUE(it2 != events.end());
+
+    EXPECT_EQ(it1->second, noteEvent(pitch, volume, channel));
+    EXPECT_EQ(it2->second, noteEvent(pitch, NOTE_OFF_VOLUME, channel));
+
+    events.erase(it1);
+    events.erase(it2);
 }
 
 static EventMap renderMidiEvents(const String& fileName, bool eachStringHasChannel = false, bool instrumentsHaveEffects = false)
@@ -362,6 +371,19 @@ TEST_F(MidiRenderer_Tests, slideInAndOut)
     checkEventInterval(events, 720, 798, 61, glissVol);
     checkEventInterval(events, 799, 877, 62, glissVol);
     checkEventInterval(events, 879, 957, 63, glissVol);
+}
+
+TEST_F(MidiRenderer_Tests, sameStringDifferentStaves)
+{
+    constexpr int defVol = 80; // mf
+
+    EventMap events = getNoteOnEvents(renderMidiEvents(u"same_string_diff_staves.mscx", true));
+
+    EXPECT_EQ(events.size(), 6);
+
+    checkEventInterval(events, 0, 239, 62, defVol, DEFAULT_CHANNEL);
+    checkEventInterval(events, 240, 479, 62, defVol, DEFAULT_CHANNEL);
+    checkEventInterval(events, 0, 1919, 35, defVol, DEFAULT_CHANNEL + 1);
 }
 
 /*****************************************************************************


### PR DESCRIPTION
When there is instrument with several staves and 2 notes on different staves and the same string are playing together,
it creates problems when MidiRenderer::Context has eachStringHasChannel = true
So extra lookup parameter (staffIdx) is added

[test-file.zip](https://github.com/musescore/MuseScore/files/11833918/test-file.zip)
