### PR TITLE
gp-import: fixed import of bend

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1932,7 +1932,7 @@ void GPConverter::addBend(const GPNote* gpnote, Note* note)
     const GPNote::Bend* gpBend = gpnote->bend();
 
     bool bendHasMiddleValue = true;
-    if (gpBend->middleOffset1 == 12 || gpBend->middleOffset2 == 12) {
+    if (gpBend->middleOffset1 == 12 && gpBend->middleOffset2 == 12) {
         bendHasMiddleValue = false;
     }
 


### PR DESCRIPTION
Due to wrong condition bend+release was not imported when it's offset was equal to 12.
Both offsets are 12 when it's pre-bend.
Both files are attached
[bends.zip](https://github.com/musescore/MuseScore/files/11837557/bends.zip)
