### PR TITLE
Make SignTool on Windows more happy by specifying `/fd SHA256`

### DIFF
--- a/build/ci/windows/sign.bat
+++ b/build/ci/windows/sign.bat
@@ -47,14 +47,14 @@ IF %MODE% == "dir" (
         ECHO.
         ECHO "======================="
         ECHO "Signing %%f"
-        %SIGNTOOL% sign /f %SIGNCERT% /t %TIMESERVER1% /p %CERT_PASSWORD% "%%f"
+        %SIGNTOOL% sign /f %SIGNCERT% /t %TIMESERVER1% /p %CERT_PASSWORD% /fd SHA256 "%%f"
         IF ERRORLEVEL 1 (
             ECHO "signtool return error level: %ERRORLEVEL%, try use TIMESERVER2"
-            CALL %SIGNTOOL% sign /f %SIGNCERT% /t %TIMESERVER2% /p %CERT_PASSWORD% "%%f"
+            CALL %SIGNTOOL% sign /f %SIGNCERT% /t %TIMESERVER2% /p %CERT_PASSWORD% /fd SHA256 "%%f"
         )
         IF ERRORLEVEL 1 (
             ECHO "signtool return error level: %ERRORLEVEL%, try use TIMESERVER3"
-            %SIGNTOOL% sign /f %SIGNCERT% /t %TIMESERVER3% /p %CERT_PASSWORD% "%%f"
+            %SIGNTOOL% sign /f %SIGNCERT% /t %TIMESERVER3% /p %CERT_PASSWORD% /fd SHA256 "%%f"
         )
         IF ERRORLEVEL 1 (
             ECHO "signtool return error level: %ERRORLEVEL%, sign failed"
@@ -89,4 +89,3 @@ IF %MODE% == "file" (
         exit /b 1 
     )
 )
-


### PR DESCRIPTION
silences a warning.

The warning in question:
https://github.com/musescore/MuseScore/actions/runs/5347614389/jobs/9696346380#step:11:57

The docs:
https://learn.microsoft.com/en-us/dotnet/framework/tools/signtool-exe#sign-command-options