### PR TITLE
Only show "Loading new file" splash screen when really doing that

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -166,21 +166,19 @@ int App::run(int argc, char** argv)
 #ifdef MUE_BUILD_APPSHELL_MODULE
     SplashScreen* splashScreen = nullptr;
     if (runMode == framework::IApplication::RunMode::GuiApp) {
-        SplashScreen::SplashScreenType type = SplashScreen::Default;
-        QString fileName;
-
-        if (!multiInstancesProvider()->isMainInstance()) {
+        if (multiInstancesProvider()->isMainInstance()) {
+            splashScreen = new SplashScreen(SplashScreen::Default);
+        } else {
             project::ProjectFile file = startupScenario()->startupScoreFile();
-
             if (file.isValid()) {
-                type = SplashScreen::ForNewInstance;
-                fileName = file.displayName(true /* includingExtension */);
+                splashScreen = new SplashScreen(SplashScreen::ForNewInstance, file.displayName(true /* includingExtension */));
             } else if (startupScenario()->isStartWithNewFileAsSecondaryInstance()) {
-                type = SplashScreen::ForNewInstance;
+                splashScreen = new SplashScreen(SplashScreen::ForNewInstance);
             }
         }
+    }
 
-        splashScreen = new SplashScreen(type, fileName);
+    if (splashScreen) {
         splashScreen->show();
     }
 #endif

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -166,13 +166,21 @@ int App::run(int argc, char** argv)
 #ifdef MUE_BUILD_APPSHELL_MODULE
     SplashScreen* splashScreen = nullptr;
     if (runMode == framework::IApplication::RunMode::GuiApp) {
-        if (multiInstancesProvider()->isMainInstance()) {
-            splashScreen = new SplashScreen(SplashScreen::Default);
-        } else {
-            QString fileName = startupScenario()->startupScoreFile().displayName(true /* includingExtension */);
-            splashScreen = new SplashScreen(SplashScreen::ForNewInstance, fileName);
+        SplashScreen::SplashScreenType type = SplashScreen::Default;
+        QString fileName;
+
+        if (!multiInstancesProvider()->isMainInstance()) {
+            project::ProjectFile file = startupScenario()->startupScoreFile();
+
+            if (file.isValid()) {
+                type = SplashScreen::ForNewInstance;
+                fileName = file.displayName(true /* includingExtension */);
+            } else if (startupScenario()->isStartWithNewFileAsSecondaryInstance()) {
+                type = SplashScreen::ForNewInstance;
+            }
         }
 
+        splashScreen = new SplashScreen(type, fileName);
         splashScreen->show();
     }
 #endif

--- a/src/appshell/internal/istartupscenario.h
+++ b/src/appshell/internal/istartupscenario.h
@@ -36,6 +36,8 @@ public:
 
     virtual void setStartupType(const std::optional<std::string>& type) = 0;
 
+    virtual bool isStartWithNewFileAsSecondaryInstance() const = 0;
+
     virtual const project::ProjectFile& startupScoreFile() const = 0;
     virtual void setStartupScoreFile(const std::optional<project::ProjectFile>& file) = 0;
 

--- a/src/appshell/internal/startupscenario.cpp
+++ b/src/appshell/internal/startupscenario.cpp
@@ -60,6 +60,19 @@ void StartupScenario::setStartupType(const std::optional<std::string>& type)
     m_startupTypeStr = type ? type.value() : "";
 }
 
+bool StartupScenario::isStartWithNewFileAsSecondaryInstance() const
+{
+    if (m_startupScoreFile.isValid()) {
+        return false;
+    }
+
+    if (!m_startupTypeStr.empty()) {
+        return modeTypeTromString(m_startupTypeStr) == StartupModeType::StartWithNewScore;
+    }
+
+    return false;
+}
+
 const mu::project::ProjectFile& StartupScenario::startupScoreFile() const
 {
     return m_startupScoreFile;

--- a/src/appshell/internal/startupscenario.h
+++ b/src/appshell/internal/startupscenario.h
@@ -48,6 +48,8 @@ public:
 
     void setStartupType(const std::optional<std::string>& type) override;
 
+    bool isStartWithNewFileAsSecondaryInstance() const override;
+
     const project::ProjectFile& startupScoreFile() const override;
     void setStartupScoreFile(const std::optional<project::ProjectFile>& file) override;
 


### PR DESCRIPTION
Resolves: #18129 

- When the user just manually opens a new instance*, just show the normal splash screen
- Only when a new instance is opened because the user clicked "new file" inside an existing instance, then we show the "Loading new file" splash screen

\* On Windows, the user can trivially launch new instances manually, by just clicking on the app icon another time. 
On macOS, this is also possible, by typing `open -n /path/to/MuseScore 4.app` in Terminal. 