### PR TITLE
fixed #17906: Opening parts, then returning to score, score is zoomed in very far

### DIFF
--- a/src/notation/view/abstractnotationpaintview.cpp
+++ b/src/notation/view/abstractnotationpaintview.cpp
@@ -81,6 +81,8 @@ AbstractNotationPaintView::~AbstractNotationPaintView()
         m_notation->accessibility()->setMapToScreenFunc(nullptr);
         m_notation->interaction()->setGetViewRectFunc(nullptr);
     }
+
+    clear();
 }
 
 void AbstractNotationPaintView::load()
@@ -101,6 +103,8 @@ void AbstractNotationPaintView::load()
         emit verticalScrollChanged();
         emit viewportChanged();
     });
+
+    redraw();
 }
 
 void AbstractNotationPaintView::initBackground()
@@ -1177,13 +1181,11 @@ void AbstractNotationPaintView::dropEvent(QDropEvent* event)
 
 void AbstractNotationPaintView::setNotation(INotationPtr notation)
 {
-    clear();
     m_notation = notation;
     m_continuousPanel->setNotation(m_notation);
     m_playbackCursor->setNotation(m_notation);
     m_loopInMarker->setNotation(m_notation);
     m_loopOutMarker->setNotation(m_notation);
-    redraw();
 }
 
 void AbstractNotationPaintView::setReadonly(bool readonly)


### PR DESCRIPTION
Resolves: #17906

It was broken in this PR https://github.com/musescore/MuseScore/pull/17858