### PR TITLE
Fix #17965:  Aux send knob grays out when bypassed

### DIFF
--- a/src/framework/audio/qml/MuseScore/Audio/KnobControl.qml
+++ b/src/framework/audio/qml/MuseScore/Audio/KnobControl.qml
@@ -36,6 +36,8 @@ Dial {
 
     property alias mouseArea: mouseArea
 
+    property color accentColor: null
+
     implicitWidth: root.radius * 2
     implicitHeight: implicitWidth
 
@@ -63,9 +65,9 @@ Dial {
         readonly property real outerArcLineWidth: 3
         readonly property real innerArcLineWidth: 2
 
-        readonly property color valueArcColor: ui.theme.accentColor
         readonly property color outerArcColor: Utils.colorWithAlpha(ui.theme.buttonColor, 0.7)
         readonly property color innerArcColor: Utils.colorWithAlpha(ui.theme.fontPrimaryColor, 0.5)
+        property color valueArcColor: accentColor
 
         readonly property real startValueArcAngle: root.isBalanceKnob ? 0 : -140
 

--- a/src/playback/qml/MuseScore/Playback/internal/AuxSendControl.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/AuxSendControl.qml
@@ -73,6 +73,29 @@ Item {
             onNewValueRequested: function(newValue) {
                 root.auxSendItemModel.audioSignalPercentage = newValue
             }
+
+
+            states: [
+                State {
+                    name: "ON"
+                    when: root.auxSendItemModel.isActive
+
+                    PropertyChanges {
+                        target: audioSignalAmountKnob
+                        accentColor: ui.theme.accentColor
+                    }
+                },
+
+                State {
+                    name: "OFF"
+                    when: !root.auxSendItemModel.isActive
+
+                    PropertyChanges {
+                        target: audioSignalAmountKnob
+                        accentColor: Utils.colorWithAlpha(ui.theme.fontPrimaryColor, 0.4)
+                    }
+                }
+            ]
         }
 
         FlatButton {

--- a/src/playback/qml/MuseScore/Playback/internal/MixerBalanceSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerBalanceSection.qml
@@ -53,6 +53,7 @@ MixerPanelSection {
                 value: channelItem.balance
                 stepSize: 1
                 isBalanceKnob: true
+                accentColor: ui.theme.accentColor
 
                 navigation.panel: channelItem.panel
                 navigation.row: root.navigationRowStart


### PR DESCRIPTION
Resolves: #17965 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Hi all, this is my first time looking at this codebase and submitting my first PR.

I was skeptical on creating a new property whether it was appropriate, but however I was able to make it similar to how the `FlatButton` handles its colors through states. This could still work without states considering its boolean nature, but I'm not sure how that would work.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
