### PR TITLE
Don't use backticks delimiter syntax for translatable strings

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/CloudScoresView.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/CloudScoresView.qml
@@ -150,7 +150,7 @@ ScoresView {
                 anchors.rightMargin: root.sideMargin
 
                 title: qsTrc("project", "You don't have any online scores yet")
-                body: qsTrc("project", `Scores will appear here when you save a file to the cloud, or publish a score on <a href="https://musescore.com">musescore.com</a>.`)
+                body: qsTrc("project", "Scores will appear here when you save a file to the cloud, or publish a score on <a href=\"https://musescore.com\">musescore.com</a>.")
             }
         }
     }
@@ -175,7 +175,7 @@ ScoresView {
                     width: parent.width
 
                     title: qsTrc("project", "You are not signed in")
-                    body: qsTrc("project", `Login or create a new account on <a href="https://musescore.com">musescore.com</a> to view online scores.`)
+                    body: qsTrc("project", "Login or create a new account on <a href=\"https://musescore.com\">musescore.com</a> to view online scores.")
                 }
 
                 Row {


### PR DESCRIPTION
lupdate is too stupid to understand it, apparently

Resolves: comment on Discord about string missing on Transifex