### PR TITLE
Fix GH#18166: All expression texts not exported to MusicXML

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -5643,7 +5643,7 @@ static bool commonAnnotations(ExportMusicXml* exp, const EngravingItem* e, staff
     } else if (e->isTempoText()) {
         exp->tempoText(toTempoText(e), sstaff);
     } else if (e->isPlayTechAnnotation() || e->isCapo() || e->isStaffText() || e->isSystemText() || e->isTripletFeel() || e->isText()
-               || (e->isInstrumentChange() && e->visible())) {
+               || e->isExpression() || (e->isInstrumentChange() && e->visible())) {
         exp->words(toTextBase(e), sstaff);
     } else if (e->isDynamic()) {
         exp->dynamic(toDynamic(e), sstaff);


### PR DESCRIPTION
Resolves: #18166 for 4.1.0

See #18170, for master