### PR TITLE
Fix GH#17659: OGG export always at 48000 Hz

### DIFF
--- a/src/project/project.qrc
+++ b/src/project/project.qrc
@@ -20,6 +20,7 @@
         <file>qml/MuseScore/Project/internal/Export/PngSettingsPage.qml</file>
         <file>qml/MuseScore/Project/internal/Export/SvgSettingsPage.qml</file>
         <file>qml/MuseScore/Project/internal/Export/Mp3SettingsPage.qml</file>
+        <file>qml/MuseScore/Project/internal/Export/OggSettingsPage.qml</file>
         <file>qml/MuseScore/Project/internal/Export/AudioSettingsPage.qml</file>
         <file>qml/MuseScore/Project/internal/Export/MidiSettingsPage.qml</file>
         <file>qml/MuseScore/Project/internal/Export/MusicXmlSettingsPage.qml</file>

--- a/src/project/qml/MuseScore/Project/internal/Export/AudioSettingsPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/AudioSettingsPage.qml
@@ -30,9 +30,11 @@ ExportSettingsPage {
     id: root
 
     property bool showBitRateControl: false
+    property bool showSampleRateControl: true
 
     ExportOptionItem {
         id: sampleRateLabel
+        visible: root.showSampleRateControl
         text: qsTrc("project/export", "Sample rate:")
 
         StyledDropdown {

--- a/src/project/qml/MuseScore/Project/internal/Export/OggSettingsPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/OggSettingsPage.qml
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+
+AudioSettingsPage {
+    showSampleRateControl: false
+}

--- a/src/project/view/exportdialogmodel.cpp
+++ b/src/project/view/exportdialogmodel.cpp
@@ -82,7 +82,7 @@ ExportDialogModel::ExportDialogModel(QObject* parent)
         ExportType::makeWithSuffixes({ "ogg" },
                                      qtrc("project/export", "OGG audio"),
                                      qtrc("project/export", "OGG audio files"),
-                                     "AudioSettingsPage.qml"),
+                                     "OggSettingsPage.qml"),
         ExportType::makeWithSuffixes({ "flac" },
                                      qtrc("project/export", "FLAC audio"),
                                      qtrc("project/export", "FLAC audio files"),


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/17659

Fixed by disabling the corresponding part of the dialog, as apparently OGG Opus doesn't allow for setting a sample rate

See #17694