### PR TITLE
Fix entering system lines with control modifier

### DIFF
--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -557,7 +557,7 @@ void Score::cmdAddSpanner(Spanner* spanner, const PointF& pos, bool systemStaves
 
 void Score::cmdAddSpanner(Spanner* spanner, staff_idx_t staffIdx, Segment* startSegment, Segment* endSegment)
 {
-    track_idx_t track = spanner->systemFlag() ? 0 : staffIdx * VOICES; // system lines always on top staff
+    track_idx_t track = staffIdx * VOICES;
     spanner->setTrack(track);
     spanner->setTrack2(track);
     for (auto ss : spanner->spannerSegments()) {

--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -555,7 +555,7 @@ void Score::cmdAddSpanner(Spanner* spanner, const PointF& pos, bool systemStaves
 //    used when applying a spanner to a selection
 //---------------------------------------------------------
 
-void Score::cmdAddSpanner(Spanner* spanner, staff_idx_t staffIdx, Segment* startSegment, Segment* endSegment)
+void Score::cmdAddSpanner(Spanner* spanner, staff_idx_t staffIdx, Segment* startSegment, Segment* endSegment, bool ctrlModifier)
 {
     track_idx_t track = staffIdx * VOICES;
     spanner->setTrack(track);
@@ -573,7 +573,7 @@ void Score::cmdAddSpanner(Spanner* spanner, staff_idx_t staffIdx, Segment* start
         tick2 = endSegment->tick();
     }
     spanner->setTick2(tick2);
-    undoAddElement(spanner);
+    undoAddElement(spanner, true, ctrlModifier);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -5777,10 +5777,8 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
             if (isSystemLine) {
                 Spanner* nsp = toSpanner(ne);
                 Spanner* sp = toSpanner(element);
-                staff_idx_t staffIdx1 = sp->track() / VOICES;
-                staff_idx_t staffIdx2 = sp->track2() / VOICES;
-                int diff = static_cast<int>(staffIdx2 - staffIdx1);
-                nsp->setTrack2((staffIdx1 + diff) * VOICES + (sp->track2() % VOICES));
+                int diff = sp->track2() - sp->track();
+                nsp->setTrack2(nsp->track() + diff);
                 nsp->computeStartElement();
                 nsp->computeEndElement();
                 undo(new AddElement(nsp));

--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -5731,10 +5731,10 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
         || (et == ElementType::TEMPO_TEXT)
         || isSystemLine
         ) {
-        std::vector<Staff* > staffList;
+        std::list<Staff* > staffList;
 
         if (!addToLinkedStaves || (ctrlModifier && isSystemLine)) {
-            staffList.push_back(element->staff());
+            staffList = ostaff->staffList();
             if (ctrlModifier && isSystemLine) {
                 element->setSystemFlag(false);
             }

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -852,7 +852,7 @@ public:
     void removeSpanner(Spanner*);
     void addSpanner(Spanner*);
     void cmdAddSpanner(Spanner* spanner, const mu::PointF& pos, bool systemStavesOnly = false);
-    void cmdAddSpanner(Spanner* spanner, staff_idx_t staffIdx, Segment* startSegment, Segment* endSegment);
+    void cmdAddSpanner(Spanner* spanner, staff_idx_t staffIdx, Segment* startSegment, Segment* endSegment, bool ctrlModifier = false);
     void checkSpanner(const Fraction& startTick, const Fraction& lastTick, bool removeOrphans = true);
     const std::set<Spanner*>& unmanagedSpanners() const { return m_unmanagedSpanner; }
     void addUnmanagedSpanner(Spanner*);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1783,7 +1783,7 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
                 mu::engraving::Spanner* spanner = static_cast<mu::engraving::Spanner*>(element->clone());
                 spanner->setScore(score);
                 spanner->styleChanged();
-                score->cmdAddSpanner(spanner, i, startSegment, endSegment);
+                score->cmdAddSpanner(spanner, i, startSegment, endSegment, modifiers & Qt::ControlModifier);
             }
         } else if (element->isTextBase() && !element->isFingering() && !element->isSticking()) {
             mu::engraving::Segment* firstSegment = sel.startSegment();


### PR DESCRIPTION
Resolves: #18048

I had introduced that check in 6d933ae as part of a number of fixes related to system lines, but I think it turns out to be unnecessary now, given all the rest of the work that's been done to correct the behaviour of system lines in general.
