### PR TITLE
Switch to canvas coordinates when passing the drop to Measure

### DIFF
--- a/src/engraving/libmscore/chordrest.cpp
+++ b/src/engraving/libmscore/chordrest.cpp
@@ -400,6 +400,7 @@ EngravingItem* ChordRest::drop(EditData& data)
             delete ks;
         } else {
             // apply to all staves, at the beginning of the measure
+            data.pos = canvasPos(); // measure->drop() expects to receive canvas pos
             return m->drop(data);
         }
     }


### PR DESCRIPTION
Resolves: #18202 

When no ctrl modifier is pressed, the ChordRests passes the drop operation to the measure. That is intentional, and was done in 5b5182b14130b3041d82a3c9dc4a8636131c899e. However (for reasons that are completely obscure to me), the drop operation on _items_ registers the position in page coordinates, while the drop operation on _measures_ registers the position in canvas coordinates. I think only canvas coordinates should be used for these operations, but that's a change too big to make now, so I just made a quick fix. I'll come back to this.