### PR TITLE
Fix translatable "Title Case" strings to "Sentence case"

### DIFF
--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -1036,8 +1036,8 @@ static const std::vector<Item<TextStyleType> > TEXTSTYLE_TYPES = {
     { TextStyleType::GLISSANDO,         "glissando",            TranslatableString("engraving", "Glissando") },
     { TextStyleType::PEDAL,             "pedal",                TranslatableString("engraving", "Pedal") },
     { TextStyleType::BEND,              "bend",                 TranslatableString("engraving", "Bend") },
-    { TextStyleType::LET_RING,          "let_ring",             TranslatableString("engraving", "Let Ring") },
-    { TextStyleType::PALM_MUTE,         "palm_mute",            TranslatableString("engraving", "Palm Mute") },
+    { TextStyleType::LET_RING,          "let_ring",             TranslatableString("engraving", "Let ring") },
+    { TextStyleType::PALM_MUTE,         "palm_mute",            TranslatableString("engraving", "Palm mute") },
 
     { TextStyleType::USER1,             "user_1",               TranslatableString("engraving", "User-1") },
     { TextStyleType::USER2,             "user_2",               TranslatableString("engraving", "User-2") },

--- a/src/framework/vst/vsterrors.h
+++ b/src/framework/vst/vsterrors.h
@@ -46,9 +46,9 @@ inline Ret make_ret(Err e)
     case Err::Undefined: return Ret(retCode);
     case Err::UnknownError: return Ret(retCode);
     case Err::NoPluginModule: return Ret(retCode, trc("vst", "Could not create VstModule"));
-    case Err::NoPluginFactory: return Ret(retCode, trc("vst", "Could not get Vst Plugin Factory from file"));
-    case Err::NoPluginProvider: return Ret(retCode, trc("vst", "No VST3 Audio Module Class found"));
-    case Err::NoPluginController: return Ret(retCode, trc("vst", "No VST3 Editor Controller Class found"));
+    case Err::NoPluginFactory: return Ret(retCode, trc("vst", "Could not get VST plugin factory from file"));
+    case Err::NoPluginProvider: return Ret(retCode, trc("vst", "No VST3 audio module class found"));
+    case Err::NoPluginController: return Ret(retCode, trc("vst", "No VST3 editor controller class found"));
     case Err::NoPluginWithId: return Ret(retCode, trc("vst", "VST3 plugin is not found"));
     }
 

--- a/src/framework/vst/vsterrors.h
+++ b/src/framework/vst/vsterrors.h
@@ -45,11 +45,11 @@ inline Ret make_ret(Err e)
     switch (e) {
     case Err::Undefined: return Ret(retCode);
     case Err::UnknownError: return Ret(retCode);
-    case Err::NoPluginModule: return Ret(retCode, trc("vst", "Could not create VstModule"));
-    case Err::NoPluginFactory: return Ret(retCode, trc("vst", "Could not get VST plugin factory from file"));
-    case Err::NoPluginProvider: return Ret(retCode, trc("vst", "No VST3 audio module class found"));
-    case Err::NoPluginController: return Ret(retCode, trc("vst", "No VST3 editor controller class found"));
-    case Err::NoPluginWithId: return Ret(retCode, trc("vst", "VST3 plugin is not found"));
+    case Err::NoPluginModule: return Ret(retCode, "Could not create VstModule");
+    case Err::NoPluginFactory: return Ret(retCode, "Could not get VST plugin factory from file");
+    case Err::NoPluginProvider: return Ret(retCode, "No VST3 audio module class found");
+    case Err::NoPluginController: return Ret(retCode, "No VST3 editor controller class found");
+    case Err::NoPluginWithId: return Ret(retCode, "VST3 plugin is not found");
     }
 
     return Ret(retCode);

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -518,7 +518,7 @@ const UiActionList NotationUiActions::m_actions = {
     UiAction("find",
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_ANY,
-             TranslatableString("action", "&Find / Go To"),
+             TranslatableString("action", "&Find / Go to"),
              TranslatableString("action", "Find / Go to")
              ),
     UiAction("staff-properties",

--- a/src/notation/qml/MuseScore/NotationScene/internal/HarpPedalPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/HarpPedalPopup.qml
@@ -92,13 +92,13 @@ StyledPopupView {
     function getNoteName(string, state) {
 
         var noteNames = [
-                [qsTrc("notation", "D Flat"), qsTrc("notation", "D Natural"), qsTrc("notation", "D Sharp")],
-                [qsTrc("notation", "C Flat"), qsTrc("notation", "C Natural"), qsTrc("notation", "C Sharp")],
-                [qsTrc("notation", "B Flat"), qsTrc("notation", "B Natural"), qsTrc("notation", "B Sharp")],
-                [qsTrc("notation", "E Flat"), qsTrc("notation", "E Natural"), qsTrc("notation", "E Sharp")],
-                [qsTrc("notation", "F Flat"), qsTrc("notation", "F Natural"), qsTrc("notation", "F Sharp")],
-                [qsTrc("notation", "G Flat"), qsTrc("notation", "G Natural"), qsTrc("notation", "G Sharp")],
-                [qsTrc("notation", "A Flat"), qsTrc("notation", "A Natural"), qsTrc("notation", "A Sharp")]
+                [qsTrc("notation", "D flat"), qsTrc("notation", "D natural"), qsTrc("notation", "D sharp")],
+                [qsTrc("notation", "C flat"), qsTrc("notation", "C natural"), qsTrc("notation", "C sharp")],
+                [qsTrc("notation", "B flat"), qsTrc("notation", "B natural"), qsTrc("notation", "B sharp")],
+                [qsTrc("notation", "E flat"), qsTrc("notation", "E natural"), qsTrc("notation", "E sharp")],
+                [qsTrc("notation", "F flat"), qsTrc("notation", "F natural"), qsTrc("notation", "F sharp")],
+                [qsTrc("notation", "G flat"), qsTrc("notation", "G natural"), qsTrc("notation", "G sharp")],
+                [qsTrc("notation", "A flat"), qsTrc("notation", "A natural"), qsTrc("notation", "A sharp")]
         ]
 
         return noteNames[string][state]
@@ -121,7 +121,7 @@ StyledPopupView {
             direction: NavigationPanel.Vertical
             section: root.notationViewNavigationSection
             order: root.navigationOrderStart
-            accessible.name: qsTrc("notation", "Pedal Settings buttons")
+            accessible.name: qsTrc("notation", "Pedal settings buttons")
         }
 
         // Accidental symbols

--- a/src/palette/internal/palette.cpp
+++ b/src/palette/internal/palette.cpp
@@ -512,8 +512,8 @@ bool Palette::writeToFile(const QString& p) const
 
 void Palette::showWritingPaletteError(const QString& path) const
 {
-    std::string title = trc("palette", "Writing Palette file");
-    std::string message = qtrc("palette", "Writing Palette file\n%1\nfailed.").arg(path).toStdString();
+    std::string title = trc("palette", "Writing palette file");
+    std::string message = qtrc("palette", "Writing palette file\n%1\nfailed.").arg(path).toStdString();
     interactive()->error(title, message);
 }
 

--- a/src/palette/internal/paletteprovider.cpp
+++ b/src/palette/internal/paletteprovider.cpp
@@ -898,11 +898,11 @@ QString PaletteProvider::getPaletteFilename(bool open, const QString& name) cons
                  .arg(QCoreApplication::applicationName());
 #endif
     if (open) {
-        title  = mu::qtrc("palette", "Load Palette");
-        filter = { mu::trc("palette", "MuseScore Palette") + " (*.mpal)" };
+        title  = mu::qtrc("palette", "Load palette");
+        filter = { mu::trc("palette", "MuseScore palette") + " (*.mpal)" };
     } else {
-        title  = mu::qtrc("palette", "Save Palette");
-        filter = { mu::trc("palette", "MuseScore Palette") + " (*.mpal)" };
+        title  = mu::qtrc("palette", "Save palette");
+        filter = { mu::trc("palette", "MuseScore palette") + " (*.mpal)" };
     }
 
     QFileInfo myPalettes(wd);

--- a/src/palette/qml/MuseScore/Palette/internal/PalettesPanelHeader.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PalettesPanelHeader.qml
@@ -117,7 +117,7 @@ Item {
         navigation.panel: navPanel
         navigation.order: 1
 
-        text: qsTrc("palette", "Add Palettes")
+        text: qsTrc("palette", "Add palettes")
         visible: !root.isSearchOpened
         enabled: visible
 
@@ -157,7 +157,7 @@ Item {
         navigation.panel: navPanel
         navigation.order: 2
 
-        toolTipTitle: qsTrc("palette", "Search Palettes")
+        toolTipTitle: qsTrc("palette", "Search palettes")
 
         icon: IconCode.SEARCH
         visible: !root.isSearchOpened

--- a/src/palette/view/palettespanelcontextmenumodel.cpp
+++ b/src/palette/view/palettespanelcontextmenumodel.cpp
@@ -61,7 +61,7 @@ MenuItem* PalettesPanelContextMenuModel::createIsSingleClickToOpenPaletteItem()
     item->setId(QString::fromStdString(TOGGLE_SINGLE_CLICK_CODE));
 
     UiAction action;
-    action.title = TranslatableString("palette", "Single-click to open a Palette");
+    action.title = TranslatableString("palette", "Single-click to open a palette");
     action.code = TOGGLE_SINGLE_CLICK_CODE;
     action.checkable = Checkable::Yes;
     item->setAction(action);
@@ -93,7 +93,7 @@ MenuItem* PalettesPanelContextMenuModel::createIsSinglePaletteItem()
     item->setId(QString::fromStdString(TOGGLE_SINGLE_PALETTE_CODE));
 
     UiAction action;
-    action.title = TranslatableString("palette", "Open only one Palette at a time");
+    action.title = TranslatableString("palette", "Open only one palette at a time");
     action.code = TOGGLE_SINGLE_PALETTE_CODE;
     action.checkable = Checkable::Yes;
     item->setAction(action);
@@ -125,8 +125,8 @@ MenuItem* PalettesPanelContextMenuModel::createExpandCollapseAllItem(bool expand
     item->setId(QString::fromStdString(expand ? EXPAND_ALL_CODE : COLLAPSE_ALL_CODE));
 
     UiAction action;
-    action.title = expand ? TranslatableString("palette", "Expand all Palettes")
-                   : TranslatableString("palette", "Collapse all Palettes");
+    action.title = expand ? TranslatableString("palette", "Expand all palettes")
+                   : TranslatableString("palette", "Collapse all palettes");
     action.code = expand ? EXPAND_ALL_CODE : COLLAPSE_ALL_CODE;
     item->setAction(action);
 


### PR DESCRIPTION
Following a discussion on Discord, see https://discord.com/channels/818804595450445834/939880479887327302/1123170640208347207 ff.

Changes 16 strings in .cpp files, 3 in .h files (which may not be translatable at all) and 24 in .qml files
Leaves 123 in .ui files untouched (so far) and won't touch those from https://github.com/musescore/MuseScore/blob/aef9f79948c7edcf544c3d403cf242ef9f880227/src/palette/view/widgets/specialcharactersdialog.cpp#L97-L404 , as these are not ours.