### PR TITLE
fix crashes on revoice of revoiced accessibility info

### DIFF
--- a/src/framework/accessibility/internal/accessibilitycontroller.cpp
+++ b/src/framework/accessibility/internal/accessibilitycontroller.cpp
@@ -136,6 +136,10 @@ void AccessibilityController::unreg(IAccessible* aitem)
         m_lastFocused = nullptr;
     }
 
+    if (m_itemForRestoreFocus == item.item) {
+        m_itemForRestoreFocus = nullptr;
+    }
+
     if (m_children.contains(aitem)) {
         m_children.removeOne(aitem);
     }
@@ -353,7 +357,10 @@ void AccessibilityController::triggerRevoicingOfChangedName(IAccessible* item)
             m_lastFocused->setState(State::Focused, false);
         }
 
-        m_itemForRestoreFocus->setState(State::Focused, true);
+        if (m_itemForRestoreFocus) {
+            m_itemForRestoreFocus->setState(State::Focused, true);
+        }
+
         m_ignorePanelChangingVoice = false;
     });
 }


### PR DESCRIPTION
Resolves: #16437
Resolves: #16887

MuseScore crashes on certain operations when attempting to trigger the screen reader to revoice certain changed information.  This PR solves the crash by avoiding the bad pointer dereference.  The revoicing continues to not be correct in these cases (as it would have been anyhow), but it's certainly better than a crash.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
