### PR TITLE
fixed #15870: Crash when declining update then using search bar in New Score dialog

### DIFF
--- a/src/update/internal/updatescenario.cpp
+++ b/src/update/internal/updatescenario.cpp
@@ -62,7 +62,7 @@ static ReleaseInfo releaseInfoFromValMap(const ValMap& map)
 
 void UpdateScenario::delayedInit()
 {
-    if (configuration()->needCheckForUpdate()) {
+    if (configuration()->needCheckForUpdate() && multiInstancesProvider()->instances().size() == 1) {
         QTimer::singleShot(AUTO_CHECK_UPDATE_INTERVAL, [this]() {
             doCheckForUpdate(false);
         });


### PR DESCRIPTION
Resolves: #15870
