### PR TITLE
Fix crash when trying to export "potential" (not-yet-initialized) part scores

### DIFF
--- a/src/project/internal/exportprojectscenario.h
+++ b/src/project/internal/exportprojectscenario.h
@@ -66,11 +66,18 @@ private:
         ReplaceAll
     };
 
+    /// When the user is trying to export a part that is a "potential excerpt", the corresponding score
+    /// is not initialized yet, so we can't be certain about the page count. We should not initialize
+    /// these scores either, until the user really starts the export, because initializing these scores
+    /// means making changes to the file, which can't be done without the user's consent.
+    bool guessIsCreatingOnlyOneFile(const notation::INotationPtrList& notations, INotationWriter::UnitType unitType) const;
     size_t exportFileCount(const notation::INotationPtrList& notations, INotationWriter::UnitType unitType) const;
 
     bool isMainNotation(notation::INotationPtr notation) const;
+    notation::IMasterNotationPtr masterNotation() const;
 
-    io::path_t completeExportPath(const io::path_t& basePath, notation::INotationPtr notation, bool isMain, int pageIndex = -1) const;
+    io::path_t completeExportPath(const io::path_t& basePath, notation::INotationPtr notation, bool isMain, bool isExportingOnlyOneScore,
+                                  int pageIndex = -1) const;
 
     bool shouldReplaceFile(const QString& filename) const;
     bool askForRetry(const QString& filename) const;

--- a/src/project/view/exportdialogmodel.cpp
+++ b/src/project/view/exportdialogmodel.cpp
@@ -375,21 +375,6 @@ bool ExportDialogModel::exportScores()
 
     m_exportPath = exportPath.val;
 
-    ExcerptNotationList excerptsToInit;
-    ExcerptNotationList potentialExcerpts = masterNotation()->potentialExcerpts();
-
-    for (const INotationPtr& notation : notations) {
-        auto it = std::find_if(potentialExcerpts.cbegin(), potentialExcerpts.cend(), [notation](const IExcerptNotationPtr& excerpt) {
-            return excerpt->notation() == notation;
-        });
-
-        if (it != potentialExcerpts.cend()) {
-            excerptsToInit.push_back(*it);
-        }
-    }
-
-    masterNotation()->initExcerpts(excerptsToInit);
-
     QMetaObject::invokeMethod(qApp, [this, notations]() {
         exportProjectScenario()->exportScores(notations, m_exportPath, m_selectedUnitType,
                                               shouldDestinationFolderBeOpenedOnExport());

--- a/src/project/view/exportdialogmodel.cpp
+++ b/src/project/view/exportdialogmodel.cpp
@@ -354,15 +354,16 @@ bool ExportDialogModel::exportScores()
     }
 
     INotationProjectPtr project = context()->currentProject();
-    io::path_t filename;
-    if (project && project->path() == exportProjectScenario()->exportInfo().projectPath) {
-        filename = io::filename(m_exportPath);
-    } else {
-        filename = io::filename(project->path());
-    }
+    io::path_t filename = io::filename(project->path());
+    // TODO: only restore filename if exactly the same notations are selected and the same unit type.
+    // These settings may namely cause extra things to be added to the name, but these extra things
+    // are not applicable to other values of these settings.
+    //if (project && project->path() == exportProjectScenario()->exportInfo().projectPath) {
+    //    filename = io::filename(m_exportPath);
+    //}
     io::path_t defaultPath;
     if (m_exportPath != "" && filename != "") {
-        defaultPath = io::absolutePath(m_exportPath)
+        defaultPath = io::absoluteDirpath(m_exportPath)
                       .appendingComponent(io::filename(filename, false))
                       .appendingSuffix(m_selectedExportType.suffixes[0]);
     }


### PR DESCRIPTION
Resolves: #18045 

See the commit messages for explanation (also about intended behaviour)