### PR TITLE
Fix crash on reading specific files

### DIFF
--- a/src/engraving/rw/read400/read400.cpp
+++ b/src/engraving/rw/read400/read400.cpp
@@ -96,6 +96,8 @@ Err Read400::readScore(Score* score, XmlReader& e, rw::ReadInOutData* data)
         ex->setTracksMapping(ctx.tracks());
     }
 
+    ctx.clearOrphanedConnectors();
+
     if (data) {
         data->links = ctx.readLinks();
         data->settingsCompat = ctx.settingCompat();

--- a/src/engraving/rw/read400/readcontext.h
+++ b/src/engraving/rw/read400/readcontext.h
@@ -178,6 +178,7 @@ public:
     void addConnectorInfoLater(std::shared_ptr<read400::ConnectorInfoReader> c);   // add connector info to be checked after calling checkConnectors()
     void checkConnectors();
     void reconnectBrokenConnectors();
+    void clearOrphanedConnectors();
 
 private:
 

--- a/src/engraving/rw/read410/read410.cpp
+++ b/src/engraving/rw/read410/read410.cpp
@@ -98,6 +98,8 @@ Err Read410::readScore(Score* score, XmlReader& e, rw::ReadInOutData* data)
         ex->setTracksMapping(ctx.tracks());
     }
 
+    ctx.clearOrphanedConnectors();
+
     if (data) {
         data->links = ctx.readLinks();
         data->settingsCompat = ctx.settingCompat();

--- a/src/engraving/rw/read410/readcontext.h
+++ b/src/engraving/rw/read410/readcontext.h
@@ -178,6 +178,7 @@ public:
     void addConnectorInfoLater(std::shared_ptr<ConnectorInfoReader> c);   // add connector info to be checked after calling checkConnectors()
     void checkConnectors();
     void reconnectBrokenConnectors();
+    void clearOrphanedConnectors();
 
 private:
 


### PR DESCRIPTION
Resolves: #18155 
Resolves: #17901

At the end of `readScore()` we are [holding onto the links](https://github.com/musescore/MuseScore/blob/master/src/engraving/rw/read400/read400.cpp#L100C9-L100C39) (which are needed for reading the next excerpts), but when the current ReadContext goes out of scope and calls its destructor, it deletes the broken connectors, which may also delete links, thus invalidating the pointers were are holding. Solution is to delete them and null the pointers before saving the links.