### PR TITLE
fix #18197 #18212 correct instrument change and key signatures behaviour

### DIFF
--- a/src/engraving/layout/v0/measurelayout.cpp
+++ b/src/engraving/layout/v0/measurelayout.cpp
@@ -1694,6 +1694,21 @@ void MeasureLayout::removeSystemHeader(Measure* m)
         seg->setEnabled(false);
     }
     m->setHeader(false);
+
+    // remove all "generated" key signatures
+    Segment* kSeg = m->findFirstR(SegmentType::KeySig, Fraction(0, 1));
+    if (!kSeg) {
+        return;
+    }
+    for (EngravingItem* e : kSeg->elist()) {
+        if (e && e->generated()) {
+            kSeg->elist().at(e->track()) = 0;
+        }
+    }
+    kSeg->checkEmpty();
+    if (kSeg->empty()) {
+        m->remove(kSeg);
+    }
 }
 
 void MeasureLayout::addSystemTrailer(Measure* m, Measure* nm, LayoutContext& ctx)

--- a/src/engraving/layout/v0/measurelayout.cpp
+++ b/src/engraving/layout/v0/measurelayout.cpp
@@ -1792,33 +1792,29 @@ void MeasureLayout::addSystemTrailer(Measure* m, Measure* nm, LayoutContext& ctx
                 m->add(s);
             }
 
-            if (staffIsPitchedAtNextMeas) {
-                KeySig* ks = toKeySig(s->element(track));
-                KeySigEvent key2 = staff->keySigEvent(m->endTick());
-                bool needCourtesy = staff->key(m->tick()) != key2.key();
+            KeySig* keySig = nullptr;
+            EngravingItem* keySigElem = s->element(track);
+            if (keySigElem && keySigElem->isKeySig()) {
+                keySig = toKeySig(keySigElem);
+            }
 
-                if (needCourtesy) {
-                    if (!ks) {
-                        ks = Factory::createKeySig(s);
-                        ks->setTrack(track);
-                        ks->setGenerated(true);
-                        ks->setParent(s);
-                        s->add(ks);
-                        s->setTrailer(true);
-                    }
-                    ks->setKeySigEvent(key2);
-                    TLayout::layout(ks, ctx);
-                    //s->createShape(track / VOICES);
-                    s->setEnabled(true);
-                } else if (ks) {
-                    s->remove(ks);
+            KeySigEvent key2 = staff->keySigEvent(m->endTick());
+            bool needsCourtesy = staff->key(m->tick()) != key2.key();
+
+            if (staffIsPitchedAtNextMeas && needsCourtesy) {
+                if (!keySig) {
+                    keySig = Factory::createKeySig(s);
+                    keySig->setTrack(track);
+                    keySig->setGenerated(true);
+                    keySig->setParent(s);
+                    s->add(keySig);
+                    s->setTrailer(true);
                 }
-            } else { /// !staffIsPitchedAtNextMeas
-                KeySig* keySig = nullptr;
-                EngravingItem* keySigElem = s->element(track);
-                if (keySigElem && keySigElem->isKeySig()) {
-                    keySig = toKeySig(keySigElem);
-                }
+                keySig->setKeySigEvent(key2);
+                TLayout::layout(keySig, ctx);
+                //s->createShape(track / VOICES);
+                s->setEnabled(true);
+            } else { /// !staffIsPitchedAtNextMeas || !needsCourtesy
                 if (keySig) {
                     s->remove(keySig);
                 }

--- a/src/engraving/layout/v0/measurelayout.cpp
+++ b/src/engraving/layout/v0/measurelayout.cpp
@@ -1795,22 +1795,24 @@ void MeasureLayout::addSystemTrailer(Measure* m, Measure* nm, LayoutContext& ctx
             if (staffIsPitchedAtNextMeas) {
                 KeySig* ks = toKeySig(s->element(track));
                 KeySigEvent key2 = staff->keySigEvent(m->endTick());
+                bool needCourtesy = staff->key(m->tick()) != key2.key();
 
-                if (!ks) {
-                    ks = Factory::createKeySig(s);
-                    ks->setTrack(track);
-                    ks->setGenerated(true);
-                    ks->setParent(s);
-                    s->add(ks);
-                    s->setTrailer(true);
+                if (needCourtesy) {
+                    if (!ks) {
+                        ks = Factory::createKeySig(s);
+                        ks->setTrack(track);
+                        ks->setGenerated(true);
+                        ks->setParent(s);
+                        s->add(ks);
+                        s->setTrailer(true);
+                    }
+                    ks->setKeySigEvent(key2);
+                    TLayout::layout(ks, ctx);
+                    //s->createShape(track / VOICES);
+                    s->setEnabled(true);
+                } else if (ks) {
+                    s->remove(ks);
                 }
-                //else if (!(ks->keySigEvent() == key2)) {
-                //      score()->undo(new ChangeKeySig(ks, key2, ks->showCourtesy()));
-                //      }
-                ks->setKeySigEvent(key2);
-                TLayout::layout(ks, ctx);
-                //s->createShape(track / VOICES);
-                s->setEnabled(true);
             } else { /// !staffIsPitchedAtNextMeas
                 KeySig* keySig = nullptr;
                 EngravingItem* keySigElem = s->element(track);

--- a/src/engraving/libmscore/instrchange.cpp
+++ b/src/engraving/libmscore/instrchange.cpp
@@ -117,7 +117,7 @@ void InstrumentChange::setupInstrument(const Instrument* instrument)
                     Segment* seg = segment()->prev1(SegmentType::KeySig);
                     voice_idx_t voice = part->staff(i)->idx() * VOICES;
                     KeySig* ksig = toKeySig(seg->element(voice));
-                    bool forInstChange = ksig && ksig->tick() != tickStart;
+                    bool forInstChange = !(ksig && ksig->tick() == tickStart && !ksig->generated());
                     ks.setForInstrumentChange(forInstChange);
                     Key cKey = part->staff(i)->concertKey(tickStart);
                     ks.setConcertKey(cKey);


### PR DESCRIPTION
Resolves: #18197
Resolves: #18212 

- instrument change key signature were sometimes incorectly set as stnadard key signature, if there were local key signature (or instrument change) in previous measures in different staff
- if head measure (first measure of system) became standard measure (for example after line break change) header flag were removed, but key signatures remain hidden there and if user added local key signature to souch measure, all key signatures in other staves in this measure reappeared
- add courtesy key signatures only if key in next system differs

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
