### PR TITLE
fix #18212 do not add unnecessary courtesy keysigs

### DIFF
--- a/src/engraving/layout/v0/measurelayout.cpp
+++ b/src/engraving/layout/v0/measurelayout.cpp
@@ -1780,22 +1780,22 @@ void MeasureLayout::addSystemTrailer(Measure* m, Measure* nm, LayoutContext& ctx
             if (staffIsPitchedAtNextMeas) {
                 KeySig* ks = toKeySig(s->element(track));
                 KeySigEvent key2 = staff->keySigEvent(m->endTick());
+                bool needCourtesy = staff->key(m->tick()) != key2.key();
 
-                if (!ks) {
-                    ks = Factory::createKeySig(s);
-                    ks->setTrack(track);
-                    ks->setGenerated(true);
-                    ks->setParent(s);
-                    s->add(ks);
-                    s->setTrailer(true);
+                if (needCourtesy) {
+                    if (!ks) {
+                        ks = Factory::createKeySig(s);
+                        ks->setTrack(track);
+                        ks->setGenerated(true);
+                        ks->setParent(s);
+                        s->add(ks);
+                        s->setTrailer(true);
+                    }
+                    ks->setKeySigEvent(key2);
+                    TLayout::layout(ks, ctx);
+                    //s->createShape(track / VOICES);
+                    s->setEnabled(true);
                 }
-                //else if (!(ks->keySigEvent() == key2)) {
-                //      score()->undo(new ChangeKeySig(ks, key2, ks->showCourtesy()));
-                //      }
-                ks->setKeySigEvent(key2);
-                TLayout::layout(ks, ctx);
-                //s->createShape(track / VOICES);
-                s->setEnabled(true);
             } else { /// !staffIsPitchedAtNextMeas
                 KeySig* keySig = nullptr;
                 EngravingItem* keySigElem = s->element(track);


### PR DESCRIPTION
Resolves: #18212 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
add curtesy keysigs, only if key after linebreak differs

undeleteable keysigs are fixed in #18279

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
