### PR TITLE
Fix crash when Ctrl+Shift+Dragging Hairpin

### DIFF
--- a/src/engraving/layout/v0/tlayout.cpp
+++ b/src/engraving/layout/v0/tlayout.cpp
@@ -2414,7 +2414,9 @@ void TLayout::layout(HairpinSegment* item, LayoutContext& ctx)
     Dynamic* sd = nullptr;
     Dynamic* ed = nullptr;
     double dymax = item->hairpin()->placeBelow() ? -10000.0 : 10000.0;
-    if (item->autoplace() && !ctx.conf().isPaletteMode()) {
+    if (item->autoplace() && !ctx.conf().isPaletteMode()
+        && item->explicitParent() // TODO: remove this line (this might happen when Ctrl+Shift+Dragging an item)
+        ) {
         Segment* start = item->hairpin()->startSegment();
         Segment* end = item->hairpin()->endSegment();
         // Try to fit between adjacent dynamics


### PR DESCRIPTION
Resolves: #18286 

@igorkorsukov I think that we should ultimately replace the calls to `EngravingItem::layout()->layoutItem` inside the `NotationInteraction::startDrop` methods with something like `PaletteLayout`. These layout calls are very similar to palette layout: they should lay out a stand-alone item without any access to a parent item (the only difference with Palettes is that in this case the item does have a real score unlike `gpaletteScore`, but it still does not have a parent).