### PR TITLE
Fix #18267: Use staff-dependent spatium for beam layout, not style-dependent

### DIFF
--- a/src/engraving/layout/v0/beamtremololayout.cpp
+++ b/src/engraving/layout/v0/beamtremololayout.cpp
@@ -68,7 +68,7 @@ BeamTremoloLayout::BeamTremoloLayout(EngravingItem* e)
         isGrace = m_trem->chord1()->isGrace();
     }
     m_element = e;
-    m_spatium = e->style().spatium();
+    m_spatium = e->spatium();
     m_tick = m_element->tick();
     m_beamSpacing = e->style().styleB(Sid::useWideBeams) ? 4 : 3;
     m_beamDist = (m_beamSpacing / 4.0) * m_spatium * e->mag()


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/18267

This is a small bug introduced in the layout refactor.