### PR TITLE
[4.1.0] Properly refresh braille when notation changes

### DIFF
--- a/src/braille/internal/notationbraille.cpp
+++ b/src/braille/internal/notationbraille.cpp
@@ -70,7 +70,9 @@ void NotationBraille::init()
 
     globalContext()->currentNotationChanged().onNotify(this, [this]() {
         if (notation()) {
-            doBraille(true);
+            notation()->notationChanged().onNotify(this, [this]() {
+                doBraille(true);
+            });
 
             notation()->interaction()->selectionChanged().onNotify(this, [this]() {
                 doBraille();


### PR DESCRIPTION
Backport PR #18308 to the 4.1.0 branch.