### PR TITLE
Rename eighth icons to 8th

### DIFF
--- a/src/framework/ui/view/iconcodes.h
+++ b/src/framework/ui/view/iconcodes.h
@@ -201,7 +201,7 @@ public:
         CLEF_TREBLE = 0xF31A,
 
         AUTO_TEXT = 0xF329,
-        NOTE_HEAD_EIGHTH = 0xF33A,
+        BEAM_NONE = 0xF33A,
         BEAM_BREAK_LEFT = 0xF33B,
         BEAM_JOIN = 0xF33D,
         BEAM_BREAK_INNER_8TH = 0xF33E,
@@ -381,7 +381,7 @@ public:
 
         STOP_FILL = 0xF447,
 
-        QUAVER_REST = 0xF44C,
+        REST_8TH = 0xF44C,
 
         SHARE_AUDIO = 0xF44F,
 

--- a/src/inspector/models/notation/rests/restsettingsproxymodel.cpp
+++ b/src/inspector/models/notation/rests/restsettingsproxymodel.cpp
@@ -34,7 +34,7 @@ RestSettingsProxyModel::RestSettingsProxyModel(QObject* parent, IElementReposito
 {
     setModelType(InspectorModelType::TYPE_REST);
     setTitle(qtrc("inspector", "Rest"));
-    setIcon(ui::IconCode::Code::QUAVER_REST);
+    setIcon(ui::IconCode::Code::REST_8TH);
 
     QList<AbstractInspectorModel*> models;
     for (InspectorModelType modelType : REST_PART_TYPES) {

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/beams/BeamTypeSelector.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/beams/BeamTypeSelector.qml
@@ -58,7 +58,7 @@ InspectorPropertyView {
 
             model: [
                 { value: Beam.MODE_AUTO, iconCode: IconCode.AUTO_TEXT, hint: qsTrc("inspector", "Auto") },
-                { value: Beam.MODE_NONE, iconCode: IconCode.NOTE_HEAD_EIGHTH, hint: qsTrc("inspector", "No beam") },
+                { value: Beam.MODE_NONE, iconCode: IconCode.BEAM_NONE, hint: qsTrc("inspector", "No beam") },
                 { value: Beam.MODE_BEGIN, iconCode: IconCode.BEAM_BREAK_LEFT, hint: qsTrc("inspector", "Break beam left") },
                 { value: Beam.MODE_BEGIN32, iconCode: IconCode.BEAM_BREAK_INNER_8TH, hint: qsTrc("inspector", "Break inner beams (8th)") },
                 { value: Beam.MODE_BEGIN64, iconCode: IconCode.BEAM_BREAK_INNER_16TH, hint: qsTrc("inspector", "Break inner beams (16th)") },

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -775,7 +775,7 @@ const UiActionList NotationUiActions::m_actions = {
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "No beam"),
              TranslatableString("action", "No beam"),
-             IconCode::Code::NOTE_HEAD_EIGHTH
+             IconCode::Code::BEAM_NONE
              ),
     UiAction("beam-break-left",
              mu::context::UiCtxNotationOpened,


### PR DESCRIPTION
Resolves: None

While working on https://github.com/musescore/MuseScore/pull/15849, I added the `QUAVER_REST` icon, but it's now bugging me because some other icons use `EIGHTH` and others yet use `8TH` (which was an oversight of mine in that PR). This PR aims to introduce a little consistency with the naming of these icons by *only* using `8TH`.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
