### PR TITLE
Fix crash when selecting all and trying to drag in score with ottava line without segments

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -912,7 +912,8 @@ void NotationInteraction::startDrag(const std::vector<EngravingItem*>& elems,
         bool draggable = isDraggable(e);
 
         if (!draggable && e->isSpanner()) {
-            draggable = isDraggable(toSpanner(e)->frontSegment());
+            Spanner* s = toSpanner(e);
+            draggable = !s->segmentsEmpty() && isDraggable(s->frontSegment());
         }
 
         if (!draggable) {


### PR DESCRIPTION
Check if segments list is not empty before taking front. Segments list of ottava line can apparently be empty on TAB staves. Since it seems to be quite common to check if the segments list is not empty, I think this is a correct situation, so this can be considered a real fix and not "fixing the symptoms only". But opinions are welcome. 

Resolves: #18232