### PR TITLE
Completely block opening files from newer versions

### DIFF
--- a/src/engraving/engravingerrors.h
+++ b/src/engraving/engravingerrors.h
@@ -81,8 +81,7 @@ inline Ret make_ret(Err err, const io::path_t& filePath = "")
         break;
     case Err::FileTooNew:
         text = mtrc("engraving", "This file was saved using a newer version of MuseScore. "
-                                 "Visit the <a href=\"%1\">MuseScore website</a> to obtain the latest version.")
-               .arg(u"https://musescore.org");
+                                 "Please visit <a href=\"https://musescore.org\">musescore.org</a> to obtain the latest version.");
         break;
     case Err::FileOld300Format:
         text = mtrc("engraving", "This file was last saved in a development version of 3.0.");

--- a/src/framework/global/io/path.cpp
+++ b/src/framework/global/io/path.cpp
@@ -21,6 +21,10 @@
  */
 #include "path.h"
 
+#ifndef NO_QT_SUPPORT
+#include <QDir>
+#endif
+
 #include "stringutils.h"
 #include "fileinfo.h"
 
@@ -272,4 +276,13 @@ std::string mu::io::pathsToString(const paths_t& ps, const std::string& delim)
     }
 
     return result;
+}
+
+path_t mu::io::toNativeSeparators(const path_t& path)
+{
+#ifndef NO_QT_SUPPORT
+    return QDir::toNativeSeparators(path.toQString());
+#else
+    return path;
+#endif
 }

--- a/src/framework/global/io/path.h
+++ b/src/framework/global/io/path.h
@@ -109,6 +109,8 @@ bool isAbsolute(const path_t& path);
 bool isAllowedFileName(const path_t& fn);
 path_t escapeFileName(const path_t& fn);
 
+path_t toNativeSeparators(const path_t& path);
+
 paths_t pathsFromString(const std::string& str, const std::string& delim = ";");
 std::string pathsToString(const paths_t& ps, const std::string& delim = ";");
 }

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -238,7 +238,7 @@ RetVal<INotationProjectPtr> ProjectActionsController::loadProject(const io::path
             return ret;
         }
 
-        if (checkCanIgnoreError(ret, io::filename(loadPath).toString())) {
+        if (checkCanIgnoreError(ret, loadPath)) {
             ret = project->load(loadPath, "" /*stylePath*/, true /*forceMode*/, format);
         }
 
@@ -1375,7 +1375,7 @@ void ProjectActionsController::showScoreDownloadError(const Ret& ret)
     interactive()->warning(title, message);
 }
 
-bool ProjectActionsController::checkCanIgnoreError(const Ret& ret, const String& projectName)
+bool ProjectActionsController::checkCanIgnoreError(const Ret& ret, const io::path_t& filepath)
 {
     if (ret) {
         return true;
@@ -1383,13 +1383,15 @@ bool ProjectActionsController::checkCanIgnoreError(const Ret& ret, const String&
 
     switch (static_cast<engraving::Err>(ret.code())) {
     case engraving::Err::FileTooOld:
-    case engraving::Err::FileTooNew:
     case engraving::Err::FileOld300Format:
         return askIfUserAgreesToOpenProjectWithIncompatibleVersion(ret.text());
+    case engraving::Err::FileTooNew:
+        warnFileTooNew(filepath);
+        return false;
     case engraving::Err::FileCorrupted:
-        return askIfUserAgreesToOpenCorruptedProject(projectName, ret.text());
+        return askIfUserAgreesToOpenCorruptedProject(io::filename(filepath).toString(), ret.text());
     default:
-        warnProjectCannotBeOpened(projectName, ret.text());
+        warnProjectCannotBeOpened(io::filename(filepath).toString(), ret.text());
         return false;
     }
 }
@@ -1404,6 +1406,13 @@ bool ProjectActionsController::askIfUserAgreesToOpenProjectWithIncompatibleVersi
     }, openAnywayBtn.btn).button();
 
     return btn == openAnywayBtn.btn;
+}
+
+void ProjectActionsController::warnFileTooNew(const io::path_t& filepath)
+{
+    interactive()->error(qtrc("project", "Cannot read file %1").arg(filepath.toQString()).toStdString(),
+                         trc("project", "This file was saved using a newer version of MuseScore. "
+                                        "Please visit <a href=\"https://musescore.org\">musescore.org</a> to obtain the latest version."));
 }
 
 bool ProjectActionsController::askIfUserAgreesToOpenCorruptedProject(const String& projectName, const std::string& errorText)

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1410,7 +1410,7 @@ bool ProjectActionsController::askIfUserAgreesToOpenProjectWithIncompatibleVersi
 
 void ProjectActionsController::warnFileTooNew(const io::path_t& filepath)
 {
-    interactive()->error(qtrc("project", "Cannot read file %1").arg(filepath.toQString()).toStdString(),
+    interactive()->error(qtrc("project", "Cannot read file %1").arg(io::toNativeSeparators(filepath).toQString()).toStdString(),
                          trc("project", "This file was saved using a newer version of MuseScore. "
                                         "Please visit <a href=\"https://musescore.org\">musescore.org</a> to obtain the latest version."));
 }

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -103,8 +103,9 @@ private:
 
     void showScoreDownloadError(const Ret& ret);
 
-    bool checkCanIgnoreError(const Ret& ret, const String& projectName);
+    bool checkCanIgnoreError(const Ret& ret, const io::path_t& filepath);
     bool askIfUserAgreesToOpenProjectWithIncompatibleVersion(const std::string& errorText);
+    void warnFileTooNew(const io::path_t& filepath);
     bool askIfUserAgreesToOpenCorruptedProject(const String& projectName, const std::string& errorText);
     void warnProjectCannotBeOpened(const String& projectName, const std::string& errorText);
 


### PR DESCRIPTION
Basically remove the "Open anyway" button

Resolves: #18083 

<img width="639" alt="Scherm­afbeelding 2023-07-03 om 01 29 32" src="https://github.com/musescore/MuseScore/assets/48658420/39d1880d-910f-4651-b234-f536217ffb1c">

Here is a fake too-new MuseScore file to test it: [too_new.mscz.zip](https://github.com/musescore/MuseScore/files/11931731/too_new.mscz.zip)
