### PR TITLE
fixed #18001: New Score > "Cancel or "Done" or exiting from score wizard puts MuseScore window behind another window

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/NewScore/ChooseInstrumentsAndTemplatesPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/NewScore/ChooseInstrumentsAndTemplatesPage.qml
@@ -174,8 +174,6 @@ Item {
 
         ChooseInstrumentsPage {
             navigationSection: root.navigationSection
-
-            Component.onCompleted: focusOnFirst()
         }
     }
 

--- a/src/update/internal/updateservice.cpp
+++ b/src/update/internal/updateservice.cpp
@@ -71,7 +71,6 @@ mu::RetVal<ReleaseInfo> UpdateService::checkForUpdate()
     }
 
     QByteArray json = buff.data();
-    LOGD() << "json: " << json;
 
     RetVal<ReleaseInfo> releaseInfo = parseRelease(json);
     if (!releaseInfo.ret) {


### PR DESCRIPTION
Resolves: #18001

When opening the dialog, a control is selected for activation upon closing the dialog. This is done to restore navigation to the previous window. See PopupView::resolveNavigationParentControl.

However, if we activate the navigation for the control in the dialog before opening the window (for example, in Component.onCompleted), the parent of the window becomes the window itself, which is incorrect and Qt warns about it.

A simple rule is to initiate navigation in the dialog's only onNavigationActivateRequested handler.

Actually, the selection of the first instrument (which was added here https://github.com/musescore/MuseScore/pull/12393 and I reverted) doesn't work in 4.0.2, and I don't see any attached issue where this fix was implemented (it is just a commit).
So, I would suggest fixing the current issue, and if the selection of the first instrument is important to us, then we can fix it in a separate issue.

@HemantAntony FYI