### PR TITLE
Fix #12028: Fix messaging when opening non-existing scores

### DIFF
--- a/src/engraving/infrastructure/mscreader.cpp
+++ b/src/engraving/infrastructure/mscreader.cpp
@@ -258,25 +258,25 @@ Ret MscReader::ZipFileReader::open(IODevice* device, const path_t& filePath)
 {
     m_device = device;
     if (!m_device) {
-        m_device = new File(filePath);
-        m_selfDeviceOwner = true;
-
         if (!FileInfo::exists(filePath)) {
-            LOGD() << "not exists path: " << filePath;
+            LOGE() << "path does not exist: " << filePath;
             return make_ret(Err::FileNotFound, filePath);
         }
+
+        m_device = new File(filePath);
+        m_selfDeviceOwner = true;
     }
 
     if (!m_device->isOpen()) {
         if (!m_device->open(IODevice::ReadOnly)) {
-            LOGD() << "failed open file: " << filePath;
+            LOGE() << "failed open file: " << filePath;
             return make_ret(Err::FileOpenError, filePath);
         }
     }
 
     m_zip = new ZipReader(m_device);
 
-    return make_ret(Err::NoError, filePath);
+    return true;
 }
 
 void MscReader::ZipFileReader::close()
@@ -309,7 +309,7 @@ StringList MscReader::ZipFileReader::fileList() const
     StringList files;
     std::vector<ZipReader::FileInfo> fileInfoList = m_zip->fileInfoList();
     if (m_zip->hasError()) {
-        LOGD() << "failed read meta";
+        LOGE() << "failed read meta";
     }
 
     for (const ZipReader::FileInfo& fi : fileInfoList) {
@@ -338,7 +338,7 @@ ByteArray MscReader::ZipFileReader::fileData(const String& fileName) const
 
     ByteArray data = m_zip->fileData(fileName.toStdString());
     if (m_zip->hasError()) {
-        LOGD() << "failed read data";
+        LOGE() << "failed read data for filename " << fileName;
         return ByteArray();
     }
     return data;
@@ -352,13 +352,13 @@ Ret MscReader::DirReader::open(IODevice* device, const path_t& filePath)
     }
 
     if (!FileInfo::exists(filePath)) {
-        LOGD() << "not exists path: " << filePath;
+        LOGE() << "path does not exist: " << filePath;
         return make_ret(Err::FileNotFound, filePath);
     }
 
     m_rootPath = containerPath(filePath);
 
-    return make_ret(Err::NoError, filePath);
+    return make_ok();
 }
 
 void MscReader::DirReader::close()
@@ -406,7 +406,7 @@ ByteArray MscReader::DirReader::fileData(const String& fileName) const
     io::path_t filePath = m_rootPath + "/" + fileName;
     File file(filePath);
     if (!file.open(IODevice::ReadOnly)) {
-        LOGD() << "failed open file: " << filePath;
+        LOGE() << "failed open file: " << filePath;
         return ByteArray();
     }
 
@@ -417,23 +417,23 @@ Ret MscReader::XmlFileReader::open(IODevice* device, const path_t& filePath)
 {
     m_device = device;
     if (!m_device) {
-        m_device = new File(filePath);
-        m_selfDeviceOwner = true;
-
         if (!FileInfo::exists(filePath)) {
-            LOGD() << "not exists path: " << filePath;
+            LOGE() << "path does not exist: " << filePath;
             return make_ret(Err::FileNotFound, filePath);
         }
+
+        m_device = new File(filePath);
+        m_selfDeviceOwner = true;
     }
 
     if (!m_device->isOpen()) {
         if (!m_device->open(IODevice::ReadOnly)) {
-            LOGD() << "failed open file: " << filePath;
+            LOGE() << "failed open file: " << filePath;
             return make_ret(Err::FileOpenError, filePath);
         }
     }
 
-    return make_ret(Err::NoError, filePath);
+    return make_ok();
 }
 
 void MscReader::XmlFileReader::close()

--- a/src/engraving/infrastructure/mscreader.cpp
+++ b/src/engraving/infrastructure/mscreader.cpp
@@ -26,6 +26,7 @@
 #include "io/dir.h"
 #include "serialization/zipreader.h"
 #include "serialization/xmlstreamreader.h"
+#include "engraving/engravingerrors.h"
 
 #include "log.h"
 
@@ -65,7 +66,7 @@ const MscReader::Params& MscReader::params() const
     return m_params;
 }
 
-bool MscReader::open()
+Ret MscReader::open()
 {
     return reader()->open(m_params.device, m_params.filePath);
 }
@@ -253,24 +254,29 @@ MscReader::ZipFileReader::~ZipFileReader()
     }
 }
 
-bool MscReader::ZipFileReader::open(IODevice* device, const path_t& filePath)
+Ret MscReader::ZipFileReader::open(IODevice* device, const path_t& filePath)
 {
     m_device = device;
     if (!m_device) {
         m_device = new File(filePath);
         m_selfDeviceOwner = true;
+
+        if (!FileInfo::exists(filePath)) {
+            LOGD() << "not exists path: " << filePath;
+            return make_ret(Err::FileNotFound, filePath);
+        }
     }
 
     if (!m_device->isOpen()) {
         if (!m_device->open(IODevice::ReadOnly)) {
             LOGD() << "failed open file: " << filePath;
-            return false;
+            return make_ret(Err::FileOpenError, filePath);
         }
     }
 
     m_zip = new ZipReader(m_device);
 
-    return true;
+    return make_ret(Err::NoError, filePath);
 }
 
 void MscReader::ZipFileReader::close()
@@ -338,7 +344,7 @@ ByteArray MscReader::ZipFileReader::fileData(const String& fileName) const
     return data;
 }
 
-bool MscReader::DirReader::open(IODevice* device, const path_t& filePath)
+Ret MscReader::DirReader::open(IODevice* device, const path_t& filePath)
 {
     if (device) {
         NOT_SUPPORTED;
@@ -347,12 +353,12 @@ bool MscReader::DirReader::open(IODevice* device, const path_t& filePath)
 
     if (!FileInfo::exists(filePath)) {
         LOGD() << "not exists path: " << filePath;
-        return false;
+        return make_ret(Err::FileNotFound, filePath);
     }
 
     m_rootPath = containerPath(filePath);
 
-    return true;
+    return make_ret(Err::NoError, filePath);
 }
 
 void MscReader::DirReader::close()
@@ -407,22 +413,27 @@ ByteArray MscReader::DirReader::fileData(const String& fileName) const
     return file.readAll();
 }
 
-bool MscReader::XmlFileReader::open(IODevice* device, const path_t& filePath)
+Ret MscReader::XmlFileReader::open(IODevice* device, const path_t& filePath)
 {
     m_device = device;
     if (!m_device) {
         m_device = new File(filePath);
         m_selfDeviceOwner = true;
+
+        if (!FileInfo::exists(filePath)) {
+            LOGD() << "not exists path: " << filePath;
+            return make_ret(Err::FileNotFound, filePath);
+        }
     }
 
     if (!m_device->isOpen()) {
         if (!m_device->open(IODevice::ReadOnly)) {
             LOGD() << "failed open file: " << filePath;
-            return false;
+            return make_ret(Err::FileOpenError, filePath);
         }
     }
 
-    return true;
+    return make_ret(Err::NoError, filePath);
 }
 
 void MscReader::XmlFileReader::close()
@@ -453,13 +464,13 @@ StringList MscReader::XmlFileReader::fileList() const
     m_device->seek(0);
     XmlStreamReader xml(m_device);
     while (xml.readNextStartElement()) {
-        if ("files" != xml.name()) {
+        if (xml.name() != "files") {
             xml.skipCurrentElement();
             continue;
         }
 
         while (xml.readNextStartElement()) {
-            if ("file" != xml.name()) {
+            if (xml.name() != "file") {
                 xml.skipCurrentElement();
                 continue;
             }
@@ -511,13 +522,13 @@ ByteArray MscReader::XmlFileReader::fileData(const String& fileName) const
     m_device->seek(0);
     XmlStreamReader xml(m_device);
     while (xml.readNextStartElement()) {
-        if ("files" != xml.name()) {
+        if (xml.name() != "files") {
             xml.skipCurrentElement();
             continue;
         }
 
         while (xml.readNextStartElement()) {
-            if ("file" != xml.name()) {
+            if (xml.name() != "file") {
                 xml.skipCurrentElement();
                 continue;
             }

--- a/src/engraving/infrastructure/mscreader.h
+++ b/src/engraving/infrastructure/mscreader.h
@@ -22,6 +22,7 @@
 #ifndef MU_ENGRAVING_MSCREADER_H
 #define MU_ENGRAVING_MSCREADER_H
 
+#include "types/ret.h"
 #include "types/string.h"
 #include "io/path.h"
 #include "io/iodevice.h"
@@ -51,7 +52,7 @@ public:
     void setParams(const Params& params);
     const Params& params() const;
 
-    bool open();
+    Ret open();
     void close();
     bool isOpened() const;
 
@@ -77,7 +78,7 @@ private:
     struct IReader {
         virtual ~IReader() = default;
 
-        virtual bool open(io::IODevice* device, const io::path_t& filePath) = 0;
+        virtual Ret open(io::IODevice* device, const io::path_t& filePath) = 0;
         virtual void close() = 0;
         virtual bool isOpened() const = 0;
         //! NOTE In the case of reading from a directory,
@@ -92,7 +93,7 @@ private:
     struct ZipFileReader : public IReader
     {
         ~ZipFileReader() override;
-        bool open(io::IODevice* device, const io::path_t& filePath) override;
+        Ret open(io::IODevice* device, const io::path_t& filePath) override;
         void close() override;
         bool isOpened() const override;
         bool isContainer() const override;
@@ -107,7 +108,7 @@ private:
 
     struct DirReader : public IReader
     {
-        bool open(io::IODevice* device, const io::path_t& filePath) override;
+        Ret open(io::IODevice* device, const io::path_t& filePath) override;
         void close() override;
         bool isOpened() const override;
         bool isContainer() const override;
@@ -120,7 +121,7 @@ private:
 
     struct XmlFileReader : public IReader
     {
-        bool open(io::IODevice* device, const io::path_t& filePath) override;
+        Ret open(io::IODevice* device, const io::path_t& filePath) override;
         void close() override;
         bool isOpened() const override;
         bool isContainer() const override;

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -184,8 +184,9 @@ mu::Ret NotationProject::doLoad(const io::path_t& path, const io::path_t& styleP
     }
 
     MscReader reader(params);
-    if (!reader.open()) {
-        return make_ret(engraving::Err::FileOpenError);
+    Ret openResult = reader.open();
+    if (openResult != make_ret(mu::engraving::Err::NoError)) {
+        return openResult;
     }
 
     // Load engraving project

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -184,16 +184,16 @@ mu::Ret NotationProject::doLoad(const io::path_t& path, const io::path_t& styleP
     }
 
     MscReader reader(params);
-    Ret openResult = reader.open();
-    if (openResult != make_ret(mu::engraving::Err::NoError)) {
-        return openResult;
+    Ret ret = reader.open();
+    if (!ret) {
+        return ret;
     }
 
     // Load engraving project
     m_engravingProject->setFileInfoProvider(std::make_shared<ProjectFileInfoProvider>(this));
 
     SettingsCompat settingsCompat;
-    Ret ret = m_engravingProject->loadMscz(reader, settingsCompat, forceMode);
+    ret = m_engravingProject->loadMscz(reader, settingsCompat, forceMode);
     if (!ret) {
         return ret;
     }

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -107,7 +107,8 @@ private:
     bool askIfUserAgreesToOpenProjectWithIncompatibleVersion(const std::string& errorText);
     void warnFileTooNew(const io::path_t& filepath);
     bool askIfUserAgreesToOpenCorruptedProject(const String& projectName, const std::string& errorText);
-    void warnProjectCannotBeOpened(const String& projectName, const std::string& errorText);
+    void warnProjectCriticallyCorrupted(const String& projectName, const std::string& errorText);
+    void warnProjectCannotBeOpened(const Ret& ret, const io::path_t& filepath);
 
     framework::IInteractive::Button askAboutSavingScore(INotationProjectPtr project);
 


### PR DESCRIPTION
Resolves: #12028

Closes: #12173 

Not found: 
<img width="639" alt="Scherm­afbeelding 2023-07-04 om 01 07 39" src="https://github.com/musescore/MuseScore/assets/48658420/ee70ae3d-e4e8-47fb-a410-24fd1b3e4880">

No permission:
<img width="639" alt="Scherm­afbeelding 2023-07-04 om 01 12 24" src="https://github.com/musescore/MuseScore/assets/48658420/28241df8-42b8-4ba9-820a-984f81736ce2">

When an unknown error occurs, the dialog will look like this:
> **Cannot read file /Users/casper/Downloads/daft-punk-crash.mscz**
>
> An error occurred while reading this file.

But I've not been able to produce that, because I can't think of any other error.

@bkunda Please check if you agree with the copy :)