### PR TITLE
fixed #18001: New Score > "Cancel or "Done" or exiting from score wizard puts MuseScore window behind another window. 4.1

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/NewScore/ChooseInstrumentsAndTemplatesPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/NewScore/ChooseInstrumentsAndTemplatesPage.qml
@@ -174,8 +174,6 @@ Item {
 
         ChooseInstrumentsPage {
             navigationSection: root.navigationSection
-
-            Component.onCompleted: focusOnFirst()
         }
     }
 

--- a/src/update/internal/updateservice.cpp
+++ b/src/update/internal/updateservice.cpp
@@ -71,7 +71,6 @@ mu::RetVal<ReleaseInfo> UpdateService::checkForUpdate()
     }
 
     QByteArray json = buff.data();
-    LOGD() << "json: " << json;
 
     RetVal<ReleaseInfo> releaseInfo = parseRelease(json);
     if (!releaseInfo.ret) {


### PR DESCRIPTION
see #18365