### PR TITLE
removed wrong assert from updating note line

### DIFF
--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -2751,11 +2751,10 @@ void Note::horizontalDrag(EditData& ed)
 
 void Note::updateRelLine(int relLine, bool undoable)
 {
-    if (!staff()) {
+    if (!staff() || staffIdx() != chord()->staffIdx()) {
         return;
     }
     // int idx      = staffIdx() + chord()->staffMove();
-    assert(staffIdx() == chord()->staffIdx());
     staff_idx_t idx      = chord()->vStaffIdx();
 
     const Staff* staff  = score()->staff(idx);


### PR DESCRIPTION
assert stops the program when creating linked staff with trill
[trill.gp.zip](https://github.com/musescore/MuseScore/files/11947103/trill.gp.zip)
