### PR TITLE
capo_compat

### DIFF
--- a/src/engraving/libmscore/factory.cpp
+++ b/src/engraving/libmscore/factory.cpp
@@ -712,3 +712,5 @@ PlayTechAnnotation* Factory::createPlayTechAnnotation(Segment * parent, PlayingT
 
     return annotation;
 }
+
+CREATE_ITEM_IMPL(Capo, ElementType::CAPO, Segment, isAccessibleEnabled)

--- a/src/engraving/libmscore/factory.h
+++ b/src/engraving/libmscore/factory.h
@@ -268,6 +268,8 @@ public:
     static PlayTechAnnotation* createPlayTechAnnotation(Segment* parent, PlayingTechniqueType techniqueType, TextStyleType styleType,
                                                         bool isAccessibleEnabled = true);
 
+    static Capo* createCapo(Segment* parent, bool isAccessibleEnabled = true);
+
 private:
     static EngravingItem* doCreateItem(ElementType type, EngravingItem* parent);
 };

--- a/src/engraving/rw/compat/compatutils.h
+++ b/src/engraving/rw/compat/compatutils.h
@@ -55,6 +55,7 @@ private:
     static void resetRestVerticalOffset(MasterScore* masterScore);
     static void resetArticulationOffsets(MasterScore* masterScore);
     static void resetStemLengthsForTwoNoteTrems(MasterScore* masterScore);
+    static void replaceStaffTextWithCapo(MasterScore* masterScore);
 };
 }
 #endif // MU_ENGRAVING_COMPATUTILS_H

--- a/src/engraving/types/constants.h
+++ b/src/engraving/types/constants.h
@@ -83,6 +83,7 @@ struct Constants
 //       - A bunch of new options for dynamics
 //       - Clefs carry a "header" tag in the file (istead of trying to guess it from context)
 //       - New "Ornament" item with new properties and options
+//       - New "Capo" item
 
     constexpr static int DIVISION = 480;
     constexpr static BeatsPerSecond DEFAULT_TEMPO = 2.0; //default tempo is equal 120 bpm

--- a/src/palette/internal/palette.cpp
+++ b/src/palette/internal/palette.cpp
@@ -42,6 +42,7 @@
 #include "palettelayout.h"
 
 #include "palettecell.h"
+#include "palettecompat.h"
 
 #include "log.h"
 
@@ -316,6 +317,8 @@ bool Palette::read(XmlReader& e, bool pasteMode)
     if (m_type == Type::Unknown) {
         m_type = guessType();
     }
+
+    PaletteCompat::addNewItemsIfNeeded(*this, gpaletteScore);
 
     return true;
 }

--- a/src/palette/internal/palettecompat.h
+++ b/src/palette/internal/palettecompat.h
@@ -26,10 +26,15 @@
 #include "libmscore/engravingitem.h"
 
 namespace mu::palette {
+class Palette;
 class PaletteCompat
 {
 public:
     static void migrateOldPaletteItemIfNeeded(engraving::ElementPtr& element, engraving::Score* paletteScore);
+    static void addNewItemsIfNeeded(Palette& palette, engraving::Score* paletteScore);
+
+private:
+    static void addNewGuitarItems(Palette& guitarPalette, engraving::Score* paletteScore);
 };
 } // namespace mu::palette
 #endif // MU_PALETTE_PALETTECOMPAT_H

--- a/src/stubs/braille/qml/MuseScore/Braille/BrailleView.qml
+++ b/src/stubs/braille/qml/MuseScore/Braille/BrailleView.qml
@@ -29,13 +29,10 @@ Item {
     id: root
 
     property NavigationPanel navigationPanel: NavigationPanel {
-        name: "BrailleView"
-        enabled: root.enabled && root.visible
+        name: "BrailleViewStub"
+        enabled: false
         direction: NavigationPanel.Both
     }
 
-    StyledTextLabel {
-        anchors.centerIn: parent
-        text: "BrailleView stub"
-    }
+    visible: false
 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/18065

Known issue: it is currently impossible to delete Capo from the Guitar palette