### PR TITLE
Fix #18204: Audio plugin scanning dialog is not centred

### DIFF
--- a/src/appshell/view/internal/splashscreen/splashscreen.cpp
+++ b/src/appshell/view/internal/splashscreen/splashscreen.cpp
@@ -87,7 +87,7 @@ void SplashScreen::setSize(const QSize& size)
         resize(m_view->size());
 
         if (screen()) {
-            move(screen()->geometry().center() - QPoint(size.width() / 2, size.height() / 2));
+            move(screen()->availableGeometry().center() - QPoint(size.width() / 2, size.height() / 2));
         }
     }
 }

--- a/src/framework/ui/qml/MuseScore/Ui/internal/ProgressDialog.qml
+++ b/src/framework/ui/qml/MuseScore/Ui/internal/ProgressDialog.qml
@@ -63,6 +63,8 @@ StyledDialogView {
 
         spacing: 16
 
+        onHeightChanged: root.updateGeometryOnHeightChange = true
+
         StyledTextLabel {
             id: titleLabel
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledDialogView.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/StyledDialogView.qml
@@ -41,6 +41,7 @@ DialogView {
     property alias navigationSection: navSec
 
     property bool closeOnEscape : true
+    property bool updateGeometryOnHeightChange: false
 
     contentWidth: 240
     contentHeight: contentBody.childrenRect.height
@@ -49,6 +50,13 @@ DialogView {
         navSec.requestActive()
         root.navigationActivateRequested()
         accessibilityActiveTimer.start()
+    }
+
+    onHeightChanged: {
+        if (root.updateGeometryOnHeightChange) {
+            root.updateGeometry()
+            root.updateGeometryOnHeightChange = false
+        }
     }
 
     signal navigationActivateRequested()

--- a/src/framework/uicomponents/view/dialogview.cpp
+++ b/src/framework/uicomponents/view/dialogview.cpp
@@ -72,16 +72,19 @@ void DialogView::updateGeometry()
     const QWindow* qMainWindow = mainWindow()->qWindow();
     bool mainWindowVisible = qMainWindow->isVisible();
     QRect referenceRect = qMainWindow->geometry();
+    int frameHeight = frameless() ? 0 : DIALOG_WINDOW_FRAME_HEIGHT;
 
     if (referenceRect.isEmpty() || !mainWindowVisible) {
         referenceRect = anchorRect;
     }
 
     QRect dlgRect = viewGeometry();
+    qreal dlgActualWidth = contentItem()->width();
+    qreal dlgActualHeight = contentItem()->height() + frameHeight;
 
     // position the dialog in the center of the main window
-    dlgRect.moveLeft(referenceRect.x() + (referenceRect.width() - dlgRect.width()) / 2);
-    dlgRect.moveTop(referenceRect.y() + (referenceRect.height() - dlgRect.height()) / 2 + DIALOG_WINDOW_FRAME_HEIGHT);
+    dlgRect.moveLeft(referenceRect.x() + (referenceRect.width() - dlgActualWidth) / 2);
+    dlgRect.moveTop(referenceRect.y() + (referenceRect.height() - dlgActualHeight) / 2);
 
     dlgRect.moveLeft(dlgRect.x() + m_localPos.x());
     dlgRect.moveTop(dlgRect.y() + m_localPos.y());
@@ -91,25 +94,25 @@ void DialogView::updateGeometry()
     int titleBarHeight = QApplication::style()->pixelMetric(QStyle::PM_TitleBarHeight);
 
     if (dlgRect.left() <= anchorRect.left()) {
-        dlgRect.moveLeft(anchorRect.left() + DIALOG_WINDOW_FRAME_HEIGHT);
+        dlgRect.moveLeft(anchorRect.left() + frameHeight);
     }
 
     if (dlgRect.top() - titleBarHeight <= anchorRect.top()) {
-        dlgRect.moveTop(anchorRect.top() + titleBarHeight + DIALOG_WINDOW_FRAME_HEIGHT);
+        dlgRect.moveTop(anchorRect.top() + titleBarHeight + frameHeight);
     }
 
     if (dlgRect.right() >= anchorRect.right()) {
-        dlgRect.moveRight(anchorRect.right() - DIALOG_WINDOW_FRAME_HEIGHT);
+        dlgRect.moveRight(anchorRect.right() - frameHeight);
     }
 
     if (dlgRect.bottom() >= anchorRect.bottom()) {
-        dlgRect.moveBottom(anchorRect.bottom() - DIALOG_WINDOW_FRAME_HEIGHT);
+        dlgRect.moveBottom(anchorRect.bottom() - frameHeight);
     }
 
     // if after moving the dialog does not fit on the screen, then adjust the size of the dialog
     if (!anchorRect.contains(dlgRect)) {
-        anchorRect -= QMargins(DIALOG_WINDOW_FRAME_HEIGHT, DIALOG_WINDOW_FRAME_HEIGHT + titleBarHeight,
-                               DIALOG_WINDOW_FRAME_HEIGHT, DIALOG_WINDOW_FRAME_HEIGHT);
+        anchorRect -= QMargins(frameHeight, frameHeight + titleBarHeight,
+                               frameHeight, frameHeight);
         dlgRect = anchorRect.intersected(dlgRect);
     }
 
@@ -118,8 +121,9 @@ void DialogView::updateGeometry()
     setContentWidth(dlgRect.width());
     setContentHeight(dlgRect.height());
 
-    //! NOTE ok will be if they call accept
-    setErrCode(Ret::Code::Cancel);
+    if (m_window) {
+        m_window->show(resolveScreen(), dlgRect, m_openPolicy != OpenPolicy::NoActivateFocus);
+    }
 }
 
 QRect DialogView::viewGeometry() const

--- a/src/framework/uicomponents/view/dialogview.h
+++ b/src/framework/uicomponents/view/dialogview.h
@@ -43,13 +43,13 @@ public:
     Q_INVOKABLE void accept();
     Q_INVOKABLE void reject(int code = -1);
 
+    Q_INVOKABLE void updateGeometry() override;
+
 private:
     bool isDialog() const override;
     void onHidden() override;
 
     QScreen* resolveScreen() const override;
-
-    void updateGeometry() override;
 
     QRect viewGeometry() const override;
 


### PR DESCRIPTION
This commit centres both the Audio plugin scanning dialog and the splash-screen (which wasn't centred vertically)

Resolves: #18204 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
