### PR TITLE
Correct autoplace for expression when not snapping to dynamic

### DIFF
--- a/src/engraving/layout/v0/tlayout.cpp
+++ b/src/engraving/layout/v0/tlayout.cpp
@@ -1535,7 +1535,12 @@ void TLayout::layout(Expression* item, LayoutContext& ctx)
 
     item->setSnappedDynamic(nullptr);
 
-    if (!item->autoplace() || !item->snapToDynamics()) {
+    if (!item->autoplace()) {
+        return;
+    }
+
+    if (!item->snapToDynamics()) {
+        item->autoplaceSegmentElement();
         return;
     }
 


### PR DESCRIPTION
Resolves: #18351