### PR TITLE
[4.1.0] Import hidden instruments as hidden staves

### DIFF
--- a/src/engraving/rw/read114/read114.cpp
+++ b/src/engraving/rw/read114/read114.cpp
@@ -3161,6 +3161,13 @@ Err Read114::readScore(Score* score, XmlReader& e, ReadInOutData* out)
 
     for (Part* p : masterScore->parts()) {
         p->updateHarmonyChannels(false);
+        if (!p->show()) {
+            // convert hidden instruments into hidden staves, to preserve playback
+            p->setShow(true);
+            for (Staff* s : p->staves()) {
+                s->setVisible(false);
+            }
+        }
     }
 
     masterScore->rebuildMidiMapping();

--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -3362,6 +3362,13 @@ bool Read206::readScore206(Score* score, XmlReader& e, ReadContext& ctx)
 
     for (Part* p : score->parts()) {
         p->updateHarmonyChannels(false);
+        if (!p->show()) {
+            // convert hidden instruments into hidden staves, to preserve playback
+            p->setShow(true);
+            for (Staff* s : p->staves()) {
+                s->setVisible(false);
+            }
+        }
     }
 
     if (score->isMaster()) {

--- a/src/engraving/rw/read302/read302.cpp
+++ b/src/engraving/rw/read302/read302.cpp
@@ -237,6 +237,13 @@ bool Read302::readScore302(Score* score, XmlReader& e, ReadContext& ctx)
 
     for (Part* p : score->_parts) {
         p->updateHarmonyChannels(false);
+        if (!p->show()) {
+            // convert hidden instruments into hidden staves, to preserve playback
+            p->setShow(true);
+            for (Staff* s : p->staves()) {
+                s->setVisible(false);
+            }
+        }
     }
 
     score->masterScore()->rebuildMidiMapping();

--- a/src/engraving/tests/compat206_data/lidemptytext-ref.mscx
+++ b/src/engraving/tests/compat206_data/lidemptytext-ref.mscx
@@ -78,8 +78,8 @@
           <name>stdNormal</name>
           </StaffType>
         <defaultClef>F8vb</defaultClef>
+        <isStaffVisible>0</isStaffVisible>
         </Staff>
-      <show>0</show>
       <trackName>Bass</trackName>
       <Instrument id="contrabass">
         <trackName>Contrabass</trackName>


### PR DESCRIPTION
See #18229

Resolves: #10951 (partially)

MU4 treats hidden instruments as muted with no possibility of unmuting, which breaks older (3.x and earlier) scores that use invisible playback staves. The change in this PR acts on import, setting the instrument itself to show but marking the staves of the instrument as invisible. This allows existing scores to both look and sound as before.

Rebased (actually cherry-picked) version of @MarcSabatella's #13293