### PR TITLE
Fix #18440 - Delete augmentation dots when necessary

### DIFF
--- a/src/engraving/layout/v0/chordlayout.cpp
+++ b/src/engraving/layout/v0/chordlayout.cpp
@@ -2172,6 +2172,10 @@ void ChordLayout::placeDots(const std::vector<Chord*>& chords, const std::vector
         if (c->dots() > 0) {
             chord = c;
             break;
+        } else {
+            for (Note* note : c->notes()) {
+                note->setDotRelativeLine(0); // this manages the deletion of dots
+            }
         }
     }
     if (!chord || chord->staff()->isTabStaff(chord->tick())) {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/18440

Small bug was preventing augmentation dots from getting deleted when the chord's duration is changed

(This PR is a small addendum to https://github.com/musescore/MuseScore/pull/17988)