### PR TITLE
prefersharpflat none by default for older scores

### DIFF
--- a/src/engraving/rw/read114/read114.cpp
+++ b/src/engraving/rw/read114/read114.cpp
@@ -2529,6 +2529,7 @@ static void readInstrument(Instrument* i, Part* p, XmlReader& e, ReadContext& ct
 
 static void readPart(Part* part, XmlReader& e, ReadContext& ctx)
 {
+    part->setPreferSharpFlat(PreferSharpFlat::NONE);
     while (e.readNextStartElement()) {
         const AsciiStringView tag(e.name());
         if (tag == "Staff") {

--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -750,6 +750,7 @@ static void readStaff(Staff* staff, XmlReader& e, ReadContext& ctx)
 
 void Read206::readPart206(Part* part, XmlReader& e, ReadContext& ctx)
 {
+    part->setPreferSharpFlat(PreferSharpFlat::NONE);
     while (e.readNextStartElement()) {
         const AsciiStringView tag(e.name());
         if (tag == "Instrument") {

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -3280,6 +3280,7 @@ void TRead::read(PalmMute* p, XmlReader& e, ReadContext& ctx)
 void TRead::read(Part* p, XmlReader& e, ReadContext& ctx)
 {
     p->setId(e.intAttribute("id", 0));
+    p->setPreferSharpFlat(PreferSharpFlat::NONE);
 
     while (e.readNextStartElement()) {
         if (!readProperties(p, e, ctx)) {
@@ -3324,7 +3325,7 @@ bool TRead::readProperties(Part* p, XmlReader& e, ReadContext& ctx)
         } else if (val == "flats") {
             p->setPreferSharpFlat(PreferSharpFlat::FLATS);
         } else {
-            p->setPreferSharpFlat(PreferSharpFlat::AUTO);
+            p->setPreferSharpFlat(PreferSharpFlat::NONE);
         }
     } else {
         return false;

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -1718,6 +1718,7 @@ void MusicXMLParserPass1::partList(MusicXmlPartGroupList& partGroupList)
 static void createPart(Score* score, const QString& id, PartMap& pm)
 {
     Part* part = new Part(score);
+    part->setPreferSharpFlat(PreferSharpFlat::NONE);
     pm.insert(id, part);
     score->appendPart(part);
     Staff* staff = Factory::createStaff(part);


### PR DESCRIPTION
Resolves: #18425

The default for staff property "prefer sharps or flats for transposing instruments" has changed to a new "auto" setting that aims to simplify spellings, but this isn't compatible with older scores and leads to incorrect playback due to tpc confusion and also incorrect notation upon toggling concert pitch on/off.  This PR forces older scores to default to "none" instead of "auto".

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
