### PR TITLE
fix #18425 - part containing key with more than 6 accidentals

### DIFF
--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -1279,6 +1279,11 @@ void TRead::read(KeySig* s, XmlReader& e, ReadContext& ctx)
     if (sig.custom() && sig.customKeyDefs().empty()) {
         sig.setMode(KeyMode::NONE);
     }
+    // if there are more than 6 accidentals in transposing key, it cannot be PreferSharpFlat::AUTO
+    if (p && !s->concertPitch() && (sig.key() > 6 || sig.key() < -6)
+        && p->preferSharpFlat() == PreferSharpFlat::AUTO && !p->instrument(s->tick())->transpose().isZero()) {
+        p->setPreferSharpFlat(PreferSharpFlat::NONE);
+    }
 
     s->setKeySigEvent(sig);
 }

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -1284,6 +1284,11 @@ void TRead::read(KeySig* s, XmlReader& e, ReadContext& ctx)
     if (sig.custom() && sig.customKeyDefs().empty()) {
         sig.setMode(KeyMode::NONE);
     }
+    // if there are more than 6 accidentals in transposing key, it cannot be PreferSharpFlat::AUTO
+    if (p && !s->concertPitch() && (sig.key() > 6 || sig.key() < -6)
+        && p->preferSharpFlat() == PreferSharpFlat::AUTO && !p->instrument(s->tick())->transpose().isZero()) {
+        p->setPreferSharpFlat(PreferSharpFlat::NONE);
+    }
 
     s->setKeySigEvent(sig);
 }

--- a/src/importexport/bb/internal/bb.cpp
+++ b/src/importexport/bb/internal/bb.cpp
@@ -561,6 +561,10 @@ Err importBB(MasterScore* score, const QString& name)
         Interval v = staff->part()->instrument(tick)->transpose();
         if (!v.isZero() && !score->style().styleB(Sid::concertPitch)) {
             cKey = transposeKey(key, v);
+            // if there are more than 6 accidentals in transposing key, it cannot be PreferSharpFlat::AUTO
+            if ((key > 6 || key < -6) && staff->part()->preferSharpFlat() == PreferSharpFlat::AUTO) {
+                staff->part()->setPreferSharpFlat(PreferSharpFlat::NONE);
+            }
         }
         ke.setConcertKey(cKey);
         ke.setKey(key);

--- a/src/importexport/capella/internal/capella.cpp
+++ b/src/importexport/capella/internal/capella.cpp
@@ -870,8 +870,13 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
             Key tKey = Key(o->signature);
             Key cKey = tKey;
             Interval v = score->staff(staffIdx)->part()->instrument(tick)->transpose();
-            if (!v.isZero() && score->style().styleB(mu::engraving::Sid::concertPitch)) {
+            if (!v.isZero() && !score->style().styleB(mu::engraving::Sid::concertPitch)) {
                 cKey = transposeKey(tKey, v);
+                // if there are more than 6 accidentals in transposing key, it cannot be PreferSharpFlat::AUTO
+                Part* part = score->staff(staffIdx)->part();
+                if ((tKey > 6 || tKey < -6) && part->preferSharpFlat() == PreferSharpFlat::AUTO) {
+                    part->setPreferSharpFlat(PreferSharpFlat::NONE);
+                }
             }
             okey.setConcertKey(cKey);
             okey.setKey(tKey);

--- a/src/importexport/midi/internal/midiimport/importmidi.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi.cpp
@@ -334,6 +334,10 @@ void MTrack::processMeta(int tick, const MidiEvent& mm)
         Interval v = staff->part()->instrument(t)->transpose();
         if (!v.isZero() && !cs->style().styleB(Sid::concertPitch)) {
             cKey = transposeKey(tKey, v);
+            // if there are more than 6 accidentals in transposing key, it cannot be PreferSharpFlat::AUTO
+            if ((tKey > 6 || tKey < -6) && staff->part()->preferSharpFlat() == PreferSharpFlat::AUTO) {
+                staff->part()->setPreferSharpFlat(PreferSharpFlat::NONE);
+            }
         }
         ke.setConcertKey(cKey);
         ke.setKey(tKey);

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -3826,6 +3826,11 @@ void MusicXMLParserPass2::key(const QString& partId, Measure* measure, const Fra
             Interval v = _pass1.getPart(partId)->instrument()->transpose();
             if (!v.isZero() && !_score->style().styleB(Sid::concertPitch)) {
                 cKey = transposeKey(tKey, v);
+                // if there are more than 6 accidentals in transposing key, it cannot be PreferSharpFlat::AUTO
+                Part* part = _pass1.getPart(partId);
+                if ((tKey > 6 || tKey < -6) && part->preferSharpFlat() == PreferSharpFlat::AUTO) {
+                    part->setPreferSharpFlat(PreferSharpFlat::NONE);
+                }
             }
             key.setConcertKey(cKey);
             key.setKey(tKey);

--- a/src/importexport/ove/internal/importove.cpp
+++ b/src/importexport/ove/internal/importove.cpp
@@ -841,6 +841,10 @@ void OveToMScore::convertSignatures()
                             Interval v = staff.part()->instrument(tick)->transpose();
                             if (!v.isZero() && !m_score->style().styleB(Sid::concertPitch)) {
                                 cKey = transposeKey(key, v);
+                                // if there are more than 6 accidentals in transposing key, it cannot be PreferSharpFlat::AUTO
+                                if ((key > 6 || key < -6) && staff.part()->preferSharpFlat() == PreferSharpFlat::AUTO) {
+                                    staff.part()->setPreferSharpFlat(PreferSharpFlat::NONE);
+                                }
                             }
                             ke.setConcertKey(cKey);
                             ke.setKey(key);


### PR DESCRIPTION
part containing transposing key with more than 6 accidentals may not be PreferSharpFlat::AUTO

I also fixed small typo in capella.cpp

Resolves: #18425 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
