### PR TITLE
gp-import: fixed segments while removing extra rests

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -417,14 +417,14 @@ void GPConverter::fixEmptyMeasures()
             // Keep only one rest element in a bar and make its duration V_MEASURE
             // that way layout can recognize this bar as "empty"
             // and properly render mmrests
-            size_t lastIndex = segItemPairs.size() - 1;
             if (segItemPairs.empty()) {
                 continue;
             }
-            for (size_t i = 0; i < lastIndex; ++i) {
+            for (size_t i = 1; i < segItemPairs.size(); ++i) {
                 segItemPairs.at(i).first->remove(segItemPairs.at(i).second);
             }
-            Rest* rest = toRest(segItemPairs.at(lastIndex).second);
+
+            Rest* rest = toRest(segItemPairs.at(0).second);
             rest->setTicks(_lastMeasure->ticks());
             rest->setDurationType(DurationType::V_MEASURE);
         }

--- a/src/importexport/guitarpro/tests/data/fret-diagram.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram.gp-ref.mscx
@@ -90,9 +90,6 @@
             <tempo>1.683333</tempo>
             <text><sym>metNoteQuarterUp</sym> = 101</text>
             </Tempo>
-          <location>
-            <fractions>1/1</fractions>
-            </location>
           <Rest>
             <durationType>measure</durationType>
             <duration>12/8</duration>

--- a/src/importexport/guitarpro/tests/data/fret-diagram.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram.gpx-ref.mscx
@@ -90,9 +90,6 @@
             <tempo>1.683333</tempo>
             <text><sym>metNoteQuarterUp</sym> = 101</text>
             </Tempo>
-          <location>
-            <fractions>1/1</fractions>
-            </location>
           <Rest>
             <durationType>measure</durationType>
             <duration>12/8</duration>

--- a/src/importexport/guitarpro/tests/data/mmrest.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/mmrest.gp-ref.mscx
@@ -115,9 +115,6 @@
         </Measure>
       <Measure>
         <voice>
-          <location>
-            <fractions>3/4</fractions>
-            </location>
           <Rest>
             <durationType>measure</durationType>
             <duration>4/4</duration>
@@ -126,9 +123,6 @@
         </Measure>
       <Measure>
         <voice>
-          <location>
-            <fractions>3/4</fractions>
-            </location>
           <Rest>
             <durationType>measure</durationType>
             <duration>4/4</duration>


### PR DESCRIPTION
fix the same thing as https://github.com/musescore/MuseScore/pull/18113 but without regression