### PR TITLE
Implemented coloured log

### DIFF
--- a/src/autobot/internal/api/logapi.cpp
+++ b/src/autobot/internal/api/logapi.cpp
@@ -52,20 +52,20 @@ void LogApi::debug(const QString& message)
 
 void LogApi::error(const QString& tag, const QString& message)
 {
-    LOGE_T(tag.toStdString())() << message;
+    LOGE_T(tag.toStdString(), haw::logger::Red)() << message;
 }
 
 void LogApi::warn(const QString& tag, const QString& message)
 {
-    LOGW_T(tag.toStdString())() << message;
+    LOGW_T(tag.toStdString(), haw::logger::Yellow)() << message;
 }
 
 void LogApi::info(const QString& tag, const QString& message)
 {
-    LOGI_T(tag.toStdString())() << message;
+    LOGI_T(tag.toStdString(), haw::logger::Green)() << message;
 }
 
 void LogApi::debug(const QString& tag, const QString& message)
 {
-    LOGD_T(tag.toStdString())() << message;
+    LOGD_T(tag.toStdString(), haw::logger::None)() << message;
 }

--- a/src/framework/draw/utils/drawlogger.cpp
+++ b/src/framework/draw/utils/drawlogger.cpp
@@ -33,7 +33,7 @@ void DrawObjectsLogger::beginObject(const std::string& name)
     std::string gap;
     gap.resize(m_objects.size());
 #ifdef LOG_STREAM
-    LOG_STREAM(haw::logger::Logger::DEBG, DRAW_OBJ_TAG, "")() << "Begin: " << gap << name;
+    LOG_STREAM(haw::logger::Logger::DEBG, DRAW_OBJ_TAG, "", haw::logger::None)() << "Begin: " << gap << name;
 #else
     UNUSED(pagePos);
 #endif
@@ -48,7 +48,7 @@ void DrawObjectsLogger::endObject()
     std::string gap;
     gap.resize(m_objects.size());
 #ifdef LOG_STREAM
-    LOG_STREAM(haw::logger::Logger::DEBG, DRAW_OBJ_TAG, "")() << "End:   " << gap << m_objects.top();
+    LOG_STREAM(haw::logger::Logger::DEBG, DRAW_OBJ_TAG, "", haw::logger::None)() << "End:   " << gap << m_objects.top();
 #endif
 
     m_objects.pop();

--- a/src/framework/global/globalmodule.cpp
+++ b/src/framework/global/globalmodule.cpp
@@ -134,8 +134,8 @@ void GlobalModule::onPreInit(const IApplication::RunMode& mode)
     using namespace haw::profiler;
     struct MyPrinter : public Profiler::Printer
     {
-        void printDebug(const std::string& str) override { LOG_STREAM(Logger::DEBG, "Profiler", "")() << str; }
-        void printInfo(const std::string& str) override { LOG_STREAM(Logger::INFO, "Profiler", "")() << str; }
+        void printDebug(const std::string& str) override { LOG_STREAM(Logger::DEBG, "Profiler", "", None)() << str; }
+        void printInfo(const std::string& str) override { LOG_STREAM(Logger::INFO, "Profiler", "", None)() << str; }
     };
 
     Profiler::Options profOpt;

--- a/src/framework/global/thirdparty/haw_logger/logger/log_base.h
+++ b/src/framework/global/thirdparty/haw_logger/logger/log_base.h
@@ -24,19 +24,19 @@
 
 #define IF_LOGLEVEL(level)  if (haw::logger::Logger::instance()->isLevel(level))
 
-#define LOG_STREAM(type, tag, funcInfo) haw::logger::LogInput(type, tag, funcInfo).stream
-#define LOG(type, tag)  LOG_STREAM(type, tag, FUNCNAME(FUNC_INFO) + ": ")
+#define LOG_STREAM(type, tag, funcInfo, color) haw::logger::LogInput(type, tag, funcInfo, color).stream
+#define LOG(type, tag, color)  LOG_STREAM(type, tag, FUNCNAME(FUNC_INFO) + ": ", color)
 
-#define LOGE_T(tag) IF_LOGLEVEL(haw::logger::Normal) LOG(haw::logger::Logger::ERRR, tag)
-#define LOGW_T(tag) IF_LOGLEVEL(haw::logger::Normal) LOG(haw::logger::Logger::WARN, tag)
-#define LOGI_T(tag) IF_LOGLEVEL(haw::logger::Normal) LOG(haw::logger::Logger::INFO, tag)
-#define LOGD_T(tag) IF_LOGLEVEL(haw::logger::Debug) LOG(haw::logger::Logger::DEBG, tag)
+#define LOGE_T(tag, color) IF_LOGLEVEL(haw::logger::Normal) LOG(haw::logger::Logger::ERRR, tag, color)
+#define LOGW_T(tag, color) IF_LOGLEVEL(haw::logger::Normal) LOG(haw::logger::Logger::WARN, tag, color)
+#define LOGI_T(tag, color) IF_LOGLEVEL(haw::logger::Normal) LOG(haw::logger::Logger::INFO, tag, color)
+#define LOGD_T(tag, color) IF_LOGLEVEL(haw::logger::Debug) LOG(haw::logger::Logger::DEBG, tag, color)
 
-#define LOGE LOGE_T(LOG_TAG)
-#define LOGW LOGW_T(LOG_TAG)
-#define LOGI LOGI_T(LOG_TAG)
-#define LOGD LOGD_T(LOG_TAG)
-#define LOGN if (0) LOGD_T(LOG_TAG) // compiling, but no output
+#define LOGE LOGE_T(LOG_TAG, haw::logger::Red)
+#define LOGW LOGW_T(LOG_TAG, haw::logger::Yellow)
+#define LOGI LOGI_T(LOG_TAG, haw::logger::Green)
+#define LOGD LOGD_T(LOG_TAG, haw::logger::None)
+#define LOGN if (0) LOGD_T(LOG_TAG, haw::logger::None) // compiling, but no output
 
 //! Helps
 #define DEPRECATED LOGD() << "This function deprecated!!"

--- a/src/framework/global/thirdparty/haw_logger/logger/logdefdest.cpp
+++ b/src/framework/global/thirdparty/haw_logger/logger/logdefdest.cpp
@@ -2,12 +2,25 @@
 
 #include <iostream>
 #include <cassert>
+#include <unordered_map>
 
 #ifdef _WIN32
 #include <Windows.h>
 #endif
 
 using namespace haw::logger;
+
+static const std::unordered_map<Color, std::string> COLOR_CODES = {
+    { None,    "\033[0m" },
+    { Black,   "\033[1;30m" },
+    { Red,     "\033[1;31m" },
+    { Green,   "\033[1;32m" },
+    { Yellow,  "\033[1;33m" },
+    { Blue,    "\033[1;34m" },
+    { Magenta, "\033[1;35m" },
+    { Cyan,    "\033[1;36m" },
+    { White,   "\033[1;37m" }
+};
 
 MemLogDest::MemLogDest(const LogLayout& l)
     : LogDest(l)
@@ -75,12 +88,16 @@ std::string ConsoleLogDest::name() const
 
 void ConsoleLogDest::write(const LogMsg& logMsg)
 {
+    std::string msg;
+    msg.reserve(100);
+    msg.append(COLOR_CODES.at(logMsg.color));
+    msg.append(m_layout.output(logMsg));
+    msg.append("\033[0m");
     #ifdef _WIN32
-    std::string stemp = m_layout.output(logMsg);
-    std::wstring temp = std::wstring(stemp.begin(), stemp.end());
+    std::wstring temp = std::wstring(msg.begin(), msg.end());
     OutputDebugString(temp.c_str());
     OutputDebugString(L"\n");
     #else
-    std::cout << m_layout.output(logMsg) << std::endl;
+    std::cout << msg << std::endl;
     #endif
 }

--- a/src/framework/global/thirdparty/haw_logger/logger/logger.cpp
+++ b/src/framework/global/thirdparty/haw_logger/logger/logger.cpp
@@ -424,8 +424,8 @@ void Logger::setIsCatchQtMsg(bool arg)
 
 #endif
 
-LogInput::LogInput(const Type& type, const std::string& tag, const std::string& funcInfo)
-    : m_msg(type, tag), m_funcInfo(funcInfo)
+LogInput::LogInput(const Type& type, const std::string& tag, const std::string& funcInfo, const Color& color)
+    : m_msg(type, tag, color), m_funcInfo(funcInfo)
 {
 }
 

--- a/src/framework/global/thirdparty/haw_logger/logger/logger.h
+++ b/src/framework/global/thirdparty/haw_logger/logger/logger.h
@@ -24,6 +24,18 @@ enum Level {
     Full    = 3
 };
 
+enum Color {
+    None,
+    Black,
+    Red,
+    Green,
+    Yellow,
+    Blue,
+    Magenta,
+    Cyan,
+    White
+};
+
 struct Date
 {
     int day = 0;
@@ -65,6 +77,10 @@ public:
         : type(l), tag(t), datetime(DateTime::now()),
         thread(std::this_thread::get_id()) {}
 
+    LogMsg(const Type& l, const std::string& t, const Color& color)
+        : type(l), tag(t), datetime(DateTime::now()),
+        thread(std::this_thread::get_id()), color(color) {}
+
     LogMsg(const Type& l, const std::string& t, const std::string& m)
         : type(l), tag(t), message(m), datetime(DateTime::now()),
         thread(std::this_thread::get_id()) {}
@@ -74,6 +90,7 @@ public:
     std::string message;
     DateTime datetime;
     std::thread::id thread;
+    Color color = None;
 };
 
 //! Layout ---------------------------------
@@ -181,7 +198,7 @@ private:
 class LogInput
 {
 public:
-    explicit LogInput(const Type& type, const std::string& tag, const std::string& funcInfo);
+    explicit LogInput(const Type& type, const std::string& tag, const std::string& funcInfo, const Color& color);
     ~LogInput();
 
     Stream& stream();


### PR DESCRIPTION
Presenting, coloured log:

This commit adds a bunch of functions in addition to the `LOGI`, `LOGD`, `LOGW`, `LOGE` functions. Using the following functions, you can print output in colours:
![Screenshot from 2023-07-08 14-16-37](https://github.com/musescore/MuseScore/assets/88136054/94e5b7d1-d8b1-4aae-88f6-d3e1c70230dd)

Before these logs are added to the `.log` file, the control characters associated with this are removed. So there will be no changes to the `.log` file

Using these functions, can make it easier to see output. Also, these coloured outputs have been emboldened. They look like the following in Ubuntu 22.04 LTS:
![Screenshot from 2023-07-08 13-17-29](https://github.com/musescore/MuseScore/assets/88136054/e11c791b-c8c6-4b33-be7b-cb18b7ebf884)

In Windows, they look like:
![image](https://github.com/musescore/MuseScore/assets/88136054/869d6f1f-d6a8-4f16-99d0-137263fa310e)


<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)