### PR TITLE
[4.1.0] Create Windows Portable Nightly Builds and publish Portable builds to OSUOSL

### DIFF
--- a/.github/workflows/ci_windows_mu4.yml
+++ b/.github/workflows/ci_windows_mu4.yml
@@ -252,6 +252,9 @@ jobs:
         if [[ "$BUILD_MODE" == "testing_build" || "$BUILD_MODE" == "stable_build" ]]; then 
           DO_BUILD='true'  
         fi
+        if [[ "$BUILD_MODE" == "nightly_build" && "${{ github.repository }}" == "musescore/MuseScore" ]]; then 
+          DO_BUILD='true'
+        fi
 
         DO_PUBLISH='false'
         if [[ "${{ github.event.inputs.publish }}" == "on" || "$BUILD_MODE" == "nightly_build" ]]; then 

--- a/.github/workflows/ci_windows_mu4.yml
+++ b/.github/workflows/ci_windows_mu4.yml
@@ -254,7 +254,7 @@ jobs:
         fi
 
         DO_PUBLISH='false'
-        if [[ "${{ github.event.inputs.publish }}" == "on" ]]; then 
+        if [[ "${{ github.event.inputs.publish }}" == "on" || "$BUILD_MODE" == "nightly_build" ]]; then 
           DO_PUBLISH='true'
           if [ -z "${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }}" ]; then 
             echo "warning: not set OSUOSL_SSH_ENCRYPT_SECRET, publish disabled" 
@@ -337,7 +337,7 @@ jobs:
       if: env.DO_PUBLISH == 'true'
       shell: bash
       run: |
-        bash ./build/ci/tools/osuosl/publish.sh -s ${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }} --os windows -v 4
+        bash ./build/ci/tools/osuosl/publish.sh -s ${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }} --os windows -v 4 --arch x86_64-portable
     - name: Upload artifacts on GitHub
       if: env.DO_BUILD == 'true'
       uses: actions/upload-artifact@v3

--- a/.github/workflows/ci_windows_mu4.yml
+++ b/.github/workflows/ci_windows_mu4.yml
@@ -254,6 +254,13 @@ jobs:
         fi
 
         DO_PUBLISH='false'
+        if [[ "${{ github.event.inputs.publish }}" == "on" ]]; then 
+          DO_PUBLISH='true'
+          if [ -z "${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }}" ]; then 
+            echo "warning: not set OSUOSL_SSH_ENCRYPT_SECRET, publish disabled" 
+            DO_PUBLISH='false'
+          fi  
+        fi
 
         DO_UPDATE_TS='false'
         if [[ "$BUILD_MODE" == "testing_build" || "$BUILD_MODE" == "stable_build" ]]; then 
@@ -328,9 +335,9 @@ jobs:
         bash ./build/ci/tools/checksum.sh     
     - name: Publish package
       if: env.DO_PUBLISH == 'true'
+      shell: bash
       run: |
-        build\ci\windows\publish.bat --secret ${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }} 
-      shell: cmd
+        bash ./build/ci/tools/osuosl/publish.sh -s ${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }} --os windows -v 4
     - name: Upload artifacts on GitHub
       if: env.DO_BUILD == 'true'
       uses: actions/upload-artifact@v3

--- a/build/ci/tools/osuosl/publish.sh
+++ b/build/ci/tools/osuosl/publish.sh
@@ -118,7 +118,9 @@ if [ "$BUILD_MODE" == "nightly_build" ]; then
     echo "Delete old MuseScoreNightly files"
     number_to_keep=42 # includes the one we just uploaded and the symlink to it
     if [ "$OS" == "linux" ]; then
-      ((++number_to_keep)) # one extra for the zsync file
+        ((++number_to_keep)) # one extra for the zsync file
+    elif [ "$OS" == "windows" ]; then
+        ((number_to_keep *= 2)) # two nightlies each night, namely portable and normal
     fi
     ssh -i $SSH_KEY musescore-nightlies@ftp-osl.osuosl.org "cd ~/ftp/$FTP_PATH; ls MuseScoreNightly* -t | tail -n +${number_to_keep} | xargs rm -f"
 fi


### PR DESCRIPTION
See #18423, #18448, #18485

I propose we offer these builds on a "community support" basis (as opposed to "official support"): in principle, they are tested and maintained by the community, but the in-house team does help when necessary and when there is enough capacity. 