### PR TITLE
Correct playback transposing instruments and tpcs

### DIFF
--- a/src/engraving/libmscore/note.cpp
+++ b/src/engraving/libmscore/note.cpp
@@ -913,7 +913,12 @@ int Note::playingTpc() const
     int result = tpc();
 
     if (!concertPitch() && transposition()) {
-        result = transposeTpc(result);
+        int tpc1 = this->tpc1();
+        if (tpc1 == Tpc::TPC_INVALID) {
+            result = transposeTpc(result);
+        } else {
+            result = tpc1;
+        }
     }
 
     int steps = ottaveCapoFret();


### PR DESCRIPTION
Resolves: #18473
Resolves: https://github.com/musescore/MuseScore/issues/18472

<!-- Add a short description of and motivation for the changes here -->
There were couple of things.

1. note tpc2 were not recalculated after changing key signature. It isgenerally OK, but can be problem in cases where normal key signature is exchanged by enharmonic one (or vice versa), because enharmonic key signature also means different real transposition (not C-F, but C-Gbb).

2. `playingOctave()` is calculated from `tpc1`. But `playingTpc()` didn't use stored note tpc1, but recalculated it from tpc2. It is generally OK, because recalculated tpc should be same as stored tpc1, but in this situation, it led to trouble, because stored tpc were C, but recalculated tpc were B#, which is, in fact same tone, but in tonal system, it belongs to lower octave. But playingOctave was calculated from C, so it sounded octave higher.

First issue is fixed by resetting tpc, if enharmonic key signature is added, or removed from staff. Result may look contraintuitive on first sight sometimes, but is correct. 
G natural is exchanged by Abb: G is diminished fifth step in C# same, as Abb is diminished fifth in Db. 
It works correctly now for new scores, but MU 4.1 beta / nightly remain unchanged (incorrect tpc). I think, it is not a big problem. 4.0.2 files are OK.

Second (playback) issue is is fixed by using tpc1 in playingTpc by default. It fixes also cases, where tpcs remained incorrect.

https://github.com/musescore/MuseScore/assets/1646034/865b4f63-46b6-49fd-98e6-88ce9403f970

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
