### PR TITLE
[palette] Added layout for Chord (fixed bug 18337)

### DIFF
--- a/src/palette/internal/palettelayout.cpp
+++ b/src/palette/internal/palettelayout.cpp
@@ -87,6 +87,7 @@
 #include "engraving/layout/v0/tlayout.h"
 #include "engraving/layout/v0/tremololayout.h"
 #include "engraving/layout/v0/arpeggiolayout.h"
+#include "engraving/layout/v0/chordlayout.h"
 
 #include "log.h"
 
@@ -199,9 +200,12 @@ void PaletteLayout::layoutItem(EngravingItem* item)
         break;
     case ElementType::VOLTA:        layout(toVolta(item), ctx);
         break;
+    // drumset
+    case ElementType::CHORD:        layout(toChord(item), ctx);
+        break;
     default:
+        LOGE() << "Not handled: " << item->typeName();
         IF_ASSERT_FAILED(false) {
-            LOGE() << "Not handled: " << item->typeName();
             layout::v0::LayoutContext ctxv0(item->score());
             layout::v0::TLayout::layoutItem(item, ctxv0);
         }
@@ -630,6 +634,12 @@ void PaletteLayout::layout(Breath* item, const Context&)
 void PaletteLayout::layout(Capo* item, const Context& ctx)
 {
     layoutTextBase(item, ctx);
+}
+
+void PaletteLayout::layout(Chord* item, const Context& ctx)
+{
+    layout::v0::LayoutContext ctxv0(ctx.dontUseScore());
+    layout::v0::ChordLayout::layout(item, ctxv0);
 }
 
 void PaletteLayout::layout(ChordLine* item, const Context& ctx)

--- a/src/palette/internal/palettelayout.h
+++ b/src/palette/internal/palettelayout.h
@@ -43,6 +43,7 @@ class Bracket;
 class Breath;
 
 class Capo;
+class Chord;
 class ChordLine;
 class Clef;
 
@@ -157,6 +158,7 @@ public:
     static void layout(engraving::Breath* item, const Context&);
 
     static void layout(engraving::Capo* item, const Context& ctx);
+    static void layout(engraving::Chord* item, const Context& ctx);
     static void layout(engraving::ChordLine* item, const Context& ctx);
     static void layout(engraving::Clef* item, const Context& ctx);
 


### PR DESCRIPTION
In fact, https://github.com/musescore/MuseScore/issues/18337 has already been fixed, the drumset is displayed correctly.
This is a technical edit.