### PR TITLE
Correct scaling errors of ChordLine objects

### DIFF
--- a/src/engraving/libmscore/chordline.cpp
+++ b/src/engraving/libmscore/chordline.cpp
@@ -198,12 +198,11 @@ std::vector<PointF> ChordLine::gripsPositions(const EditData&) const
         return {};
     }
 
-    double sp = spatium();
     auto n   = m_path.elementCount();
     PointF cp(pagePos());
     if (m_straight) {
         // limit the number of grips to one
-        double offset = 0.5 * sp;
+        double offset = 0.5;
         PointF p;
 
         if (m_chordLineType == ChordLineType::FALL) {
@@ -217,7 +216,7 @@ std::vector<PointF> ChordLine::gripsPositions(const EditData&) const
         }
 
         // translate on the length and height - stops the grips from going past boundaries of slide
-        p += (cp + PointF(m_path.elementAt(1).x * sp, m_path.elementAt(1).y * sp));
+        p += (cp + PointF(m_path.elementAt(1).x, m_path.elementAt(1).y));
         return { p };
     } else {
         std::vector<PointF> grips(n);

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -2541,6 +2541,9 @@ void TRead::read(ChordLine* l, XmlReader& e, ReadContext& ctx)
                     int type = e.intAttribute("type");
                     double x  = e.doubleAttribute("x");
                     double y  = e.doubleAttribute("y");
+                    double spatium = ctx.spatium();
+                    x *= spatium;
+                    y *= spatium;
                     switch (PainterPath::ElementType(type)) {
                     case PainterPath::ElementType::MoveToElement:
                         path.moveTo(x, y);

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -2530,6 +2530,9 @@ void TRead::read(ChordLine* l, XmlReader& e, ReadContext& ctx)
                     int type = e.intAttribute("type");
                     double x  = e.doubleAttribute("x");
                     double y  = e.doubleAttribute("y");
+                    double spatium = ctx.spatium();
+                    x *= spatium;
+                    y *= spatium;
                     switch (PainterPath::ElementType(type)) {
                     case PainterPath::ElementType::MoveToElement:
                         path.moveTo(x, y);

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -857,7 +857,10 @@ void TWrite::write(const ChordLine* item, XmlWriter& xml, WriteContext& ctx)
         xml.startElement("Path");
         for (size_t i = 0; i < n; ++i) {
             const PainterPath::Element& e = path.elementAt(i);
-            xml.tag("Element", { { "type", int(e.type) }, { "x", e.x }, { "y", e.y } });
+            double spatium = item->spatium();
+            double x = e.x / spatium;
+            double y = e.y / spatium;
+            xml.tag("Element", { { "type", int(e.type) }, { "x", x }, { "y", y } });
         }
         xml.endElement();
     }


### PR DESCRIPTION
Resolves: #18480 

This issue only affects slides whose anchor points have been manually moved. It is caused by the fact that ChordLine objects used to have wrong scaling calculations with respect to the spatium, which I fixed in #16292. The fix, however, had side effects in reading/writing the offset values. This now fixes it.