### PR TITLE
Don't add superfluous thin brackets for each instrument

### DIFF
--- a/src/engraving/libmscore/scoreorder.cpp
+++ b/src/engraving/libmscore/scoreorder.cpp
@@ -389,7 +389,7 @@ void ScoreOrder::setBracketsAndBarlines(Score* score)
     bool prvThnBracket { false };
     bool prvBarLineSpan { false };
     String prvSection;
-    int prvInstrument { 0 };
+    int prvInstrument { -1 };
     Staff* prvStaff { nullptr };
 
     Staff* thkBracketStaff { nullptr };
@@ -440,7 +440,7 @@ void ScoreOrder::setBracketsAndBarlines(Score* score)
                 thkBracketSpan += static_cast<int>(part->nstaves());
             }
 
-            if (!staffIdx || (ii.instrIndex != prvInstrument)) {
+            if (prvInstrument == -1 || (ii.instrIndex != prvInstrument)) {
                 if (thnBracketStaff && (thnBracketSpan > 1)) {
                     score->undoAddBracket(thnBracketStaff, 1, BracketType::SQUARE, thnBracketSpan);
                 }


### PR DESCRIPTION
Finalising a thin bracket should happen only when encountering a different instrument (i.e. the previous bracket will not grow any longer). Not for the first part of every staff.

This logic error already existed, but has surfaced only after ce01ab2243977d5e53a2c02f06098465703fc737.

Resolves: #18515