### PR TITLE
vst_compat_fix

### DIFF
--- a/src/framework/audio/CMakeLists.txt
+++ b/src/framework/audio/CMakeLists.txt
@@ -85,6 +85,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/iaudiosource.h
     ${CMAKE_CURRENT_LIST_DIR}/synthtypes.h
     ${CMAKE_CURRENT_LIST_DIR}/audiotypes.h
+    ${CMAKE_CURRENT_LIST_DIR}/audioutils.h
     ${CMAKE_CURRENT_LIST_DIR}/iplayer.h
     ${CMAKE_CURRENT_LIST_DIR}/itracks.h
     ${CMAKE_CURRENT_LIST_DIR}/iaudiooutput.h

--- a/src/framework/audio/audiotypes.h
+++ b/src/framework/audio/audiotypes.h
@@ -161,17 +161,6 @@ using AudioResourceMetaSet = std::set<AudioResourceMeta>;
 
 static const AudioResourceId MUSE_REVERB_ID("Muse Reverb");
 
-inline AudioResourceMeta makeReverbMeta()
-{
-    AudioResourceMeta meta;
-    meta.id = MUSE_REVERB_ID;
-    meta.type = AudioResourceType::MusePlugin;
-    meta.vendor = "Muse";
-    meta.hasNativeEditorSupport = true;
-
-    return meta;
-}
-
 enum class AudioPluginType {
     Undefined = -1,
     Instrument,
@@ -185,22 +174,6 @@ struct AudioPluginInfo {
     bool enabled = false;
     int errorCode = 0;
 };
-
-inline AudioPluginType audioPluginTypeFromCategoriesString(const String& categoriesStr)
-{
-    static const std::map<String, AudioPluginType> STRING_TO_PLUGIN_TYPE_MAP = {
-        { u"Fx", AudioPluginType::Fx },
-        { u"Instrument", AudioPluginType::Instrument },
-    };
-
-    for (auto it = STRING_TO_PLUGIN_TYPE_MAP.cbegin(); it != STRING_TO_PLUGIN_TYPE_MAP.cend(); ++it) {
-        if (categoriesStr.contains(it->first)) {
-            return it->second;
-        }
-    }
-
-    return AudioPluginType::Undefined;
-}
 
 enum class AudioFxType {
     Undefined = -1,

--- a/src/framework/audio/audioutils.h
+++ b/src/framework/audio/audioutils.h
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2023 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_AUDIO_AUDIOUTILS_H
+#define MU_AUDIO_AUDIOUTILS_H
+
+#include "audiotypes.h"
+
+namespace mu::audio {
+inline AudioResourceMeta makeReverbMeta()
+{
+    AudioResourceMeta meta;
+    meta.id = MUSE_REVERB_ID;
+    meta.type = AudioResourceType::MusePlugin;
+    meta.vendor = "Muse";
+    meta.hasNativeEditorSupport = true;
+
+    return meta;
+}
+
+inline AudioPluginType audioPluginTypeFromCategoriesString(const String& categoriesStr)
+{
+    static const std::vector<std::pair<String, AudioPluginType> > STRING_TO_PLUGIN_TYPE_LIST = {
+        { u"Instrument", AudioPluginType::Instrument },
+        { u"Fx", AudioPluginType::Fx },
+    };
+
+    for (auto it = STRING_TO_PLUGIN_TYPE_LIST.cbegin(); it != STRING_TO_PLUGIN_TYPE_LIST.cend(); ++it) {
+        if (categoriesStr.contains(it->first)) {
+            return it->second;
+        }
+    }
+
+    return AudioPluginType::Undefined;
+}
+}
+
+#endif // MU_AUDIO_AUDIOUTILS_H

--- a/src/framework/audio/internal/fx/musefxresolver.cpp
+++ b/src/framework/audio/internal/fx/musefxresolver.cpp
@@ -24,7 +24,7 @@
 
 #include "reverb/reverbprocessor.h"
 
-#include "log.h"
+#include "audio/audioutils.h"
 
 using namespace mu::audio;
 using namespace mu::audio::fx;

--- a/src/framework/audio/internal/plugins/knownaudiopluginsregister.cpp
+++ b/src/framework/audio/internal/plugins/knownaudiopluginsregister.cpp
@@ -22,6 +22,7 @@
 
 #include "knownaudiopluginsregister.h"
 
+#include "audioutils.h"
 #include "serialization/json.h"
 
 #include "log.h"

--- a/src/framework/audio/internal/plugins/registeraudiopluginsscenario.cpp
+++ b/src/framework/audio/internal/plugins/registeraudiopluginsscenario.cpp
@@ -24,6 +24,7 @@
 
 #include <QApplication>
 
+#include "audioutils.h"
 #include "audioerrors.h"
 #include "translation.h"
 #include "log.h"

--- a/src/framework/audio/tests/CMakeLists.txt
+++ b/src/framework/audio/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ set(MODULE_TEST_SRC
 
     ${CMAKE_CURRENT_LIST_DIR}/knownaudiopluginsregistertest.cpp
     ${CMAKE_CURRENT_LIST_DIR}/registeraudiopluginsscenariotest.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/audioutilstest.cpp
 )
 
 set(MODULE_TEST_LINK audio)

--- a/src/framework/audio/tests/audioutilstest.cpp
+++ b/src/framework/audio/tests/audioutilstest.cpp
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2023 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "audio/audioutils.h"
+
+using namespace mu::audio;
+
+namespace mu::audio {
+class Audio_AudioUtilsTest : public ::testing::Test
+{
+public:
+};
+}
+
+TEST_F(Audio_AudioUtilsTest, AudioPluginTypeFromCategoriesString)
+{
+    EXPECT_EQ(AudioPluginType::Fx, audioPluginTypeFromCategoriesString(u"Fx|Delay"));
+    EXPECT_EQ(AudioPluginType::Fx, audioPluginTypeFromCategoriesString(u"Test|Fx"));
+
+    EXPECT_EQ(AudioPluginType::Instrument, audioPluginTypeFromCategoriesString(u"Instrument|Test"));
+    EXPECT_EQ(AudioPluginType::Instrument, audioPluginTypeFromCategoriesString(u"Test|Instrument"));
+
+    //! NOTE: "Instrument" has the highest priority for compatibility reasons
+    EXPECT_EQ(AudioPluginType::Instrument, audioPluginTypeFromCategoriesString(u"Instrument|Fx|Test"));
+    EXPECT_EQ(AudioPluginType::Instrument, audioPluginTypeFromCategoriesString(u"Fx|Instrument|Test"));
+
+    EXPECT_EQ(AudioPluginType::Undefined, audioPluginTypeFromCategoriesString(u"Test"));
+    EXPECT_EQ(AudioPluginType::Undefined, audioPluginTypeFromCategoriesString(u"FX|Test"));
+    EXPECT_EQ(AudioPluginType::Undefined, audioPluginTypeFromCategoriesString(u"INSTRUMENT|Test"));
+}

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -23,6 +23,7 @@
 
 #include "playbacktypes.h"
 
+#include "audio/audioutils.h"
 #include "containers.h"
 #include "defer.h"
 #include "log.h"


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/18525

Regression after: https://github.com/musescore/MuseScore/pull/16990/commits/01bdffe756c1d4b42a0e953ae1e3647199930612 (see the old implementation inside vstmodulesmetaregister.cpp)