### PR TITLE
[MusicXML] Properly export Persian key accidentals

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -2136,6 +2136,10 @@ static double accSymId2alter(SymId id)
         break;
     case SymId::accidentalDoubleSharp:                     res =  2;
         break;
+    case SymId::accidentalSori:                            res =  0.5;
+        break;
+    case SymId::accidentalKoron:                           res =  -0.5;
+        break;
     default: LOGD("accSymId2alter: unsupported sym %s", SymNames::nameForSymId(id).ascii());
     }
     return res;


### PR DESCRIPTION

This PR adds the missing `key-alter` values for Persian [sori](https://en.wikipedia.org/wiki/Sori_(music)) and [koron](https://en.wikipedia.org/wiki/Koron_(music)) key accidentals to MusicXML export.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
