### PR TITLE
fixed labels for stretched bend

### DIFF
--- a/src/engraving/libmscore/stretchedbend.cpp
+++ b/src/engraving/libmscore/stretchedbend.cpp
@@ -41,6 +41,13 @@ namespace mu::engraving {
 //   textFlags
 //---------------------------------------------------------
 
+static const char* stretchedBendlabel[] = {
+    "",     "\u00BC",   "\u00BD",   "\u00BE",  /// 0,   1/4, 1/2, 3/4
+    "full", "1\u00BC", "1\u00BD", "1\u00BE",   /// 1, 1+1/4...
+    "2",    "2\u00BC", "2\u00BD", "2\u00BE",   /// 2, ...
+    "3"                                        /// 3
+};
+
 static int textFlags = draw::AlignHCenter | draw::AlignBottom | draw::TextDontClip;
 
 //---------------------------------------------------------
@@ -249,7 +256,7 @@ void StretchedBend::layoutDraw(const bool layoutMode, mu::draw::Painter* painter
     for (const BendSegment& bendSegment : m_bendSegments) {
         const PointF& src = bendSegment.src;
         const PointF& dest = bendSegment.dest;
-        const String& text = String::fromUtf8(label[bendSegment.tone]);
+        const String& text = String::fromUtf8(stretchedBendlabel[bendSegment.tone]);
 
         switch (bendSegment.type) {
         case BendSegmentType::LINE_UP:


### PR DESCRIPTION
Wrong:
<img width="155" alt="Screenshot 2023-07-12 at 15 59 43" src="https://github.com/musescore/MuseScore/assets/24373905/1195d450-5f25-430e-9109-e205c9150c5a">

Correct:
<img width="174" alt="Screenshot 2023-07-12 at 16 00 05" src="https://github.com/musescore/MuseScore/assets/24373905/f803788b-37ab-4f07-bd99-7287a7096648">

regression after https://github.com/musescore/MuseScore/pull/17568
(was not included to build without define back then)
[bend+release.gp.zip](https://github.com/musescore/MuseScore/files/12028204/bend%2Brelease.gp.zip)

