### PR TITLE
Added vtest as gtest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ set(CMAKE_MODULE_PATH
 ###########################################
 # Setup option and build settings
 ###########################################
+include(GetPaths)
+
 set(MUSESCORE_BUILD_CONFIGURATION "app" CACHE STRING "Build configuration")
 # Possible MUSESCORE_BUILD_CONFIGURATION values:
 # - app             - for desktop app
@@ -103,6 +105,7 @@ option(MUE_INSTALL_SOUNDFONT "Install sound font" ON)
 
 # === Tests ===
 option(MUE_BUILD_UNIT_TESTS "Build unit tests" ON)
+set(MUE_VTEST_MSCORE_REF_BIN "${CMAKE_CURRENT_LIST_DIR}/../MU_ORIGIN/MuseScore/build.debug/install/${INSTALL_SUBDIR}/mscore" CACHE PATH "Path to mscore ref bin")
 option(MUE_BUILD_ASAN "Enable Address Sanitizer" OFF)
 option(MUE_BUILD_CRASHPAD_CLIENT "Build crashpad client" ON)
 set(MUE_CRASH_REPORT_URL "" CACHE STRING "URL where to send crash reports")
@@ -208,3 +211,8 @@ endif(OS_IS_LIN)
 if (OS_IS_WIN)
     include(Packaging)
 endif(OS_IS_WIN)
+
+###########################################
+# Add VTest target
+###########################################
+add_subdirectory(vtest)

--- a/build/cmake/GetPaths.cmake
+++ b/build/cmake/GetPaths.cmake
@@ -1,0 +1,9 @@
+include(GetPlatformInfo)
+
+if (OS_IS_MAC)
+    set(INSTALL_SUBDIR ${CMAKE_PROJECT_NAME}.app/Contents/MacOS/)
+    set(INSTALL_BIN_DIR ${CMAKE_INSTALL_PREFIX}/${INSTALL_SUBDIR})
+else()
+    set(INSTALL_SUBDIR bin)
+    set(INSTALL_BIN_DIR ${CMAKE_INSTALL_PREFIX}/${INSTALL_SUBDIR})
+endif()

--- a/vtest/CMakeLists.txt
+++ b/vtest/CMakeLists.txt
@@ -4,7 +4,7 @@
 # MuseScore
 # Music Composition & Notation
 #
-# Copyright (C) 2022 MuseScore BVBA and others
+# Copyright (C) 2021 MuseScore BVBA and others
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -18,12 +18,26 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-set(MODULE_TEST draw_tests)
+set(MODULE_TEST vtests)
 
 set(MODULE_TEST_SRC
-    ${CMAKE_CURRENT_LIST_DIR}/painter_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/vtest_gtest_runner.cpp
 )
 
-set(MODULE_TEST_LINK draw)
+set(MODULE_TEST_DEF
+    -DVTEST_ROOT_DIR="${CMAKE_CURRENT_LIST_DIR}"
+    -DVTEST_MSCORE_REF_BIN="${MUE_VTEST_MSCORE_REF_BIN}"
+    -DVTEST_MSCORE_BIN="${INSTALL_BIN_DIR}/mscore"
+    )
 
-include(${PROJECT_SOURCE_DIR}/src/framework/testing/gtest.cmake)
+set(ADD_VTEST OFF)
+if (MUE_BUILD_UNIT_TESTS)
+    set(ADD_VTEST ON)
+    if (NOT EXISTS "${MUE_VTEST_MSCORE_REF_BIN}")
+        set(ADD_VTEST OFF)
+    endif()
+endif()
+
+if (ADD_VTEST)
+    include(SetupGTest)
+endif()

--- a/vtest/vtest_gtest_runner.cpp
+++ b/vtest/vtest_gtest_runner.cpp
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2022 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include <QProcess>
+#include <QTextStream>
+
+static const QString ROOT_DIR(VTEST_ROOT_DIR);
+static const QString MSCORE_REF_BIN(VTEST_MSCORE_REF_BIN);
+static const QString MSCORE_BIN(VTEST_MSCORE_BIN);
+static const QString REF_DIR("./reference_pngs");
+static const QString CURRENT_DIR("./current_pngs");
+
+class Engraving_VTest : public ::testing::Test
+{
+public:
+};
+
+static int run_command(const QString& name, const QStringList& args)
+{
+    QString path = ROOT_DIR + "/" + name;
+
+    QProcess p;
+    p.start(path, args);
+
+    QObject::connect(&p, &QProcess::readyReadStandardOutput, [&p]() {
+        QByteArray ba = p.readAllStandardOutput();
+        QTextStream outputText(stdout);
+        outputText << QString(ba);
+    });
+
+    if (!p.waitForFinished(60000 * 5)) {
+        return -1;
+    }
+
+    int code = p.exitCode();
+    return code;
+}
+
+TEST_F(Engraving_VTest, 1_GenerateRef)
+{
+    ASSERT_EQ(run_command("vtest-generate-pngs.sh",
+                          { "--mscore", MSCORE_REF_BIN,
+                            "--output-dir", REF_DIR
+                          }), 0);
+}
+
+TEST_F(Engraving_VTest, 2_GenerateCurrentAndCompare)
+{
+    // GenerateCurrent
+    ASSERT_EQ(run_command("vtest-generate-pngs.sh",
+                          { "--mscore", MSCORE_BIN,
+                            "--output-dir", CURRENT_DIR
+                          }), 0);
+
+    // Compare
+    ASSERT_EQ(run_command("vtest-compare-pngs.sh",
+                          { "--gen-gif", "0"
+                          }), 0);
+}


### PR DESCRIPTION
For the convenience of running locally.
Now it’s not convenient that we first need to build the current binary file, that is, after changing the code, it’s not enough just to run the test.
It would be nice to fix this in the future.

![image](https://github.com/musescore/MuseScore/assets/3818029/e4bc406e-8804-4db2-8320-62fae4e076ed)
