### PR TITLE
Fix #17523: Change (note) select dialog "in selection" default state

### DIFF
--- a/src/notation/view/widgets/selectdialog.cpp
+++ b/src/notation/view/widgets/selectdialog.cpp
@@ -57,7 +57,11 @@ SelectDialog::SelectDialog(QWidget* parent)
 
     sameSubtype->setEnabled(m_element->subtype() != -1);
     subtype->setEnabled(m_element->subtype() != -1);
-    inSelection->setEnabled(!m_element->score()->selection().isSingle());
+
+    const auto isSingleSelection = m_element->score()->selection().isSingle();
+    inSelection->setCheckState(isSingleSelection ? Qt::CheckState::Unchecked : Qt::CheckState::Checked);
+    inSelection->setEnabled(!isSingleSelection);
+
     sameDuration->setEnabled(m_element->isRest());
 
     connect(buttonBox, &QDialogButtonBox::clicked, this, &SelectDialog::buttonClicked);

--- a/src/notation/view/widgets/selectnotedialog.cpp
+++ b/src/notation/view/widgets/selectnotedialog.cpp
@@ -88,7 +88,9 @@ SelectNoteDialog::SelectNoteDialog(QWidget* parent)
     name->setText(tpc2name(m_note->tpc(), mu::engraving::NoteSpellingType::STANDARD, mu::engraving::NoteCaseType::AUTO, false));
     sameName->setAccessibleName(sameName->text() + name->text());
 
-    inSelection->setEnabled(!m_note->score()->selection().isSingle());
+    const auto isSingleSelection = m_note->score()->selection().isSingle();
+    inSelection->setCheckState(isSingleSelection ? Qt::CheckState::Unchecked : Qt::CheckState::Checked);
+    inSelection->setEnabled(!isSingleSelection);
 
     connect(buttonBox, &QDialogButtonBox::clicked, this, &SelectNoteDialog::buttonClicked);
 


### PR DESCRIPTION
Resolves: #17523 

Changes the default state of "in selection" for the note selection dialog and the selection dialog. If it is a single selection, the default state is unchecked, as otherwise using this dialog serves no purpose. If multiple elements are selected the default state is checked to prevent user mistakes.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)

Regarding the CLA: My username on musescore.org (ivy0xa9) does not match my github username, but I think the real name is what matters?
