### PR TITLE
fixed #18558: Crash when trying to open 2 cloud scores at the same time

### DIFF
--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -199,6 +199,7 @@ private:
     bool m_isProjectPublishing = false;
     bool m_isProjectUploading = false;
     bool m_isAudioSharing = false;
+    bool m_isProjectDownloading = false;
 
     framework::ProgressPtr m_uploadingProjectProgress = nullptr;
     framework::ProgressPtr m_uploadingAudioProgress = nullptr;


### PR DESCRIPTION
Resolves: #18558