### PR TITLE
X and <> symbols changed for tabs

### DIFF
--- a/fonts/fonts_tablature.xml
+++ b/fonts/fonts_tablature.xml
@@ -124,7 +124,7 @@
       <fret value="15" letter="1">q</fret>
       <fret value="16" letter="1">r</fret>
       <mark value="x">X</mark>
-      <mark value="ghost">×</mark>
+      <mark value="ghost">⨯</mark>
       <mark value="slash" number="1">/</mark>
       <mark value="slash" number="2">//</mark>
       <mark value="slash" number="3">///</mark>
@@ -254,7 +254,7 @@
       <fret value="15" letter="1">q</fret>
       <fret value="16" letter="1">r</fret>
       <mark value="x">X</mark>
-      <mark value="ghost">×</mark>
+      <mark value="ghost">⨯</mark>
       <mark value="slash" number="1">/</mark>
       <mark value="slash" number="2">//</mark>
       <mark value="slash" number="3">///</mark>

--- a/src/engraving/layout/v0/tlayout.cpp
+++ b/src/engraving/layout/v0/tlayout.cpp
@@ -3546,11 +3546,12 @@ void TLayout::layout(Note* item, LayoutContext&)
             if (item->negativeFretUsed()) {
                 item->setFretString(u"-" + item->fretString());
             }
-
+            // Don't use regular less than or more than symbols
+            // they are not centered. Use these instead! ＜＞
             if (item->displayFret() == Note::DisplayFretOption::ArtificialHarmonic) {
-                item->setFretString(String(u"%1 <%2>").arg(item->fretString(), String::number(item->harmonicFret())));
+                item->setFretString(String(u"%1 ＜%2＞").arg(item->fretString(), String::number(item->harmonicFret())));
             } else if (item->displayFret() == Note::DisplayFretOption::NaturalHarmonic) {
-                item->setFretString(String(u"<%1>").arg(String::number(item->harmonicFret())));
+                item->setFretString(String(u"＜%1＞").arg(String::number(item->harmonicFret())));
             }
         }
 


### PR DESCRIPTION
X and <> symbols wasn't centred.
<img width="870" alt="image" src="https://user-images.githubusercontent.com/101250347/187180537-9a0a8fdc-8cae-42c2-a947-41ac6f1b4a3e.png">

I've changed the symbols
<img width="870" alt="image" src="https://github.com/musescore/MuseScore/assets/16940972/95cb0943-6da6-4697-a111-95272c5fab2f">
