### PR TITLE
Fixed crash when restoring mu navigation in app menu

### DIFF
--- a/src/appshell/view/navigableappmenumodel.cpp
+++ b/src/appshell/view/navigableappmenumodel.cpp
@@ -79,6 +79,7 @@ void NavigableAppMenuModel::load()
 void NavigableAppMenuModel::handleMenuItem(const QString& itemId)
 {
     resetNavigation();
+    restoreMUNavigationSystemState();
 
     AppMenuModel::handleMenuItem(itemId);
 }
@@ -463,18 +464,31 @@ void NavigableAppMenuModel::saveMUNavigationSystemState()
     bool muNavigationIsHighlight = navigationController()->isHighlight();
     m_needActivateLastMUNavigationControl = muNavigationIsHighlight;
 
-    ui::INavigationControl* activeControl = navigationController()->activeControl();
-    if (activeControl) {
-        m_lastActiveMUNavigationControl = activeControl;
-        activeControl->setActive(false);
+    INavigationSection* section = navigationController()->activeSection();
+    INavigationPanel* panel = navigationController()->activePanel();
+    INavigationControl* control = navigationController()->activeControl();
+    m_lastActiveMUNavigationState = {
+        section ? section->name().toStdString() : "",
+        panel ? panel->name().toStdString() : "",
+        control ? control->name().toStdString() : ""
+    };
+
+    if (control) {
+        control->setActive(false);
     }
 }
 
 void NavigableAppMenuModel::restoreMUNavigationSystemState()
 {
-    if (m_lastActiveMUNavigationControl) {
-        m_lastActiveMUNavigationControl->requestActive();
-        m_lastActiveMUNavigationControl = nullptr;
+    if (m_lastActiveMUNavigationState.has_value()) {
+        MUNavigationSystemState state = m_lastActiveMUNavigationState.value();
+
+        bool ok = navigationController()->requestActivateByName(state.sectionName, state.panelName, state.controlName);
+        if (!ok) {
+            navigationController()->resetNavigation();
+        }
+
+        m_lastActiveMUNavigationState.reset();
     }
 
     navigationController()->setIsHighlight(m_needActivateLastMUNavigationControl);

--- a/src/appshell/view/navigableappmenumodel.h
+++ b/src/appshell/view/navigableappmenumodel.h
@@ -22,6 +22,8 @@
 #ifndef MU_APPSHELL_NAVIGABLEAPPMENUMODEL_H
 #define MU_APPSHELL_NAVIGABLEAPPMENUMODEL_H
 
+#include <optional>
+
 #include <QObject>
 
 #include "appmenumodel.h"
@@ -86,6 +88,12 @@ private:
     void resetNavigation();
     void navigateToFirstMenu();
 
+    struct MUNavigationSystemState {
+        std::string sectionName;
+        std::string panelName;
+        std::string controlName;
+    };
+
     void saveMUNavigationSystemState();
     void restoreMUNavigationSystemState();
 
@@ -100,7 +108,7 @@ private:
     QString m_openedMenuId;
 
     bool m_needActivateHighlight = true;
-    ui::INavigationControl* m_lastActiveMUNavigationControl = nullptr;
+    std::optional<MUNavigationSystemState> m_lastActiveMUNavigationState;
     bool m_needActivateLastMUNavigationControl = false;
 
     QWindow* m_appWindow = nullptr;

--- a/src/framework/ui/inavigationcontroller.h
+++ b/src/framework/ui/inavigationcontroller.h
@@ -42,6 +42,8 @@ public:
     virtual bool requestActivateByName(const std::string& section, const std::string& panel, const std::string& controlName) = 0;
     virtual bool requestActivateByIndex(const std::string& section, const std::string& panel, const INavigation::Index& controlIndex) = 0;
 
+    virtual void resetNavigation() = 0;
+
     virtual INavigationSection* activeSection() const = 0;
     virtual INavigationPanel* activePanel() const = 0;
     virtual INavigationControl* activeControl() const = 0;

--- a/src/framework/ui/internal/navigationcontroller.cpp
+++ b/src/framework/ui/internal/navigationcontroller.cpp
@@ -367,7 +367,7 @@ void NavigationController::resetIfNeed(QObject* watched)
 
     auto activeCtrl = activeControl();
     if (activeCtrl && activeCtrl != m_defaultNavigationControl && watched == qApp) {
-        resetActive();
+        resetNavigation();
     }
 
     setIsHighlight(false);
@@ -429,7 +429,7 @@ void NavigationController::navigateTo(NavigationController::NavigationType type)
     setIsHighlight(true);
 }
 
-void NavigationController::resetActive()
+void NavigationController::resetNavigation()
 {
     MYLOG() << "===";
     INavigationSection* activeSec = this->activeSection();
@@ -456,6 +456,8 @@ void NavigationController::resetActive()
             m_defaultNavigationControl->setActive(true);
             m_navigationChanged.notify();
         }
+    } else {
+        doActivateFirst();
     }
 }
 

--- a/src/framework/ui/internal/navigationcontroller.h
+++ b/src/framework/ui/internal/navigationcontroller.h
@@ -67,6 +67,8 @@ public:
 
     void setDefaultNavigationControl(INavigationControl* control) override;
 
+    void resetNavigation() override;
+
     async::Notification navigationChanged() const override;
 
     bool isHighlight() const override;
@@ -133,7 +135,6 @@ private:
     void doActivateLast();
 
     void resetIfNeed(QObject* watched);
-    void resetActive();
 
     std::set<INavigationSection*> m_sections;
     async::Notification m_navigationChanged;


### PR DESCRIPTION
Fixed a crash when clicking on a menu item deletes the current control and after restoration mu navigation, trying to call the method from invalid pointer. 

For example, when navigating through the mixer, press Alt, go to the View menu and turn off the Mixer.
The crash occurs in some cases, navigation fails in some