### PR TITLE
Fix #18570: Palette properties dialog allow only values of at least one increment

### DIFF
--- a/src/palette/qml/MuseScore/Palette/PalettePropertiesDialog.qml
+++ b/src/palette/qml/MuseScore/Palette/PalettePropertiesDialog.qml
@@ -113,7 +113,11 @@ StyledDialogView {
                         step: modelData["incrementStep"]
 
                         onValueEdited: function(newValue) {
-                            repeater.setValue(model.index, newValue)
+                            if (newValue > 0) {
+                                repeater.setValue(model.index, newValue)
+                            } else {
+                                repeater.setValue(model.index, step)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Resolves: #18570
PalettePropertiesDialog.qml
Added if statement replacing new value with increment step if new value is less than or equal 0.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
