### PR TITLE
Fix #18570: Palette properties dialog, prevent invalid values

### DIFF
--- a/src/palette/qml/MuseScore/Palette/PaletteCellPropertiesDialog.qml
+++ b/src/palette/qml/MuseScore/Palette/PaletteCellPropertiesDialog.qml
@@ -84,7 +84,7 @@ StyledDialogView {
                         //: Abbreviation of "spatium"
                         measureUnit: qsTrc("global", "sp") },
                     { title: qsTrc("palette", "Y"), value: propertiesModel.yOffset, incrementStep: 1, measureUnit: qsTrc("global", "sp") },
-                    { title: qsTrc("palette", "Content scale"), value: propertiesModel.scaleFactor, incrementStep: 0.1 }
+                    { title: qsTrc("palette", "Content scale"), value: propertiesModel.scaleFactor, minValue: 0.1, incrementStep: 0.1 }
                 ]
 
                 function setValue(index, value) {
@@ -110,7 +110,7 @@ StyledDialogView {
                         currentValue: modelData["value"]
                         measureUnitsSymbol: Boolean(modelData["measureUnit"]) ? modelData["measureUnit"] : ""
                         step: modelData["incrementStep"]
-                        minValue: (qsTrc("palette", "Content scale")) ? step : -999
+                        minValue: modelData["minValue"]
 
                         onValueEdited: function(newValue) {
                             repeater.setValue(model.index, newValue)

--- a/src/palette/qml/MuseScore/Palette/PaletteCellPropertiesDialog.qml
+++ b/src/palette/qml/MuseScore/Palette/PaletteCellPropertiesDialog.qml
@@ -110,6 +110,7 @@ StyledDialogView {
                         currentValue: modelData["value"]
                         measureUnitsSymbol: Boolean(modelData["measureUnit"]) ? modelData["measureUnit"] : ""
                         step: modelData["incrementStep"]
+                        minValue: (qsTrc("palette", "Content scale")) ? step : -999
 
                         onValueEdited: function(newValue) {
                             repeater.setValue(model.index, newValue)

--- a/src/palette/qml/MuseScore/Palette/PaletteCellPropertiesDialog.qml
+++ b/src/palette/qml/MuseScore/Palette/PaletteCellPropertiesDialog.qml
@@ -80,10 +80,10 @@ StyledDialogView {
                 id: repeater
 
                 model: [
-                    { title: qsTrc("palette", "X"), value: propertiesModel.xOffset, incrementStep: 1,
+                    { title: qsTrc("palette", "X"), value: propertiesModel.xOffset, minValue: -999, incrementStep: 1,
                         //: Abbreviation of "spatium"
                         measureUnit: qsTrc("global", "sp") },
-                    { title: qsTrc("palette", "Y"), value: propertiesModel.yOffset, incrementStep: 1, measureUnit: qsTrc("global", "sp") },
+                    { title: qsTrc("palette", "Y"), value: propertiesModel.yOffset, minValue: -999, incrementStep: 1, measureUnit: qsTrc("global", "sp") },
                     { title: qsTrc("palette", "Content scale"), value: propertiesModel.scaleFactor, minValue: 0.1, incrementStep: 0.1 }
                 ]
 

--- a/src/palette/qml/MuseScore/Palette/PalettePropertiesDialog.qml
+++ b/src/palette/qml/MuseScore/Palette/PalettePropertiesDialog.qml
@@ -88,12 +88,16 @@ StyledDialogView {
 
                 function setValue(index, value) {
                     if (index === 0) {
+                        propertiesModel.cellWidth = 0
                         propertiesModel.cellWidth = value
                     } else if (index === 1) {
+                        propertiesModel.cellHeight = 0
                         propertiesModel.cellHeight = value
                     } else if (index === 2) {
+                        propertiesModel.elementOffset = 0
                         propertiesModel.elementOffset = value
                     } else if (index === 3) {
+                        propertiesModel.scaleFactor = 0
                         propertiesModel.scaleFactor = value
                     }
                 }
@@ -113,10 +117,10 @@ StyledDialogView {
                         step: modelData["incrementStep"]
 
                         onValueEdited: function(newValue) {
-                            if (newValue > 0) {
-                                repeater.setValue(model.index, newValue)
-                            } else {
+                            if (newValue <= 0) {
                                 repeater.setValue(model.index, step)
+                            } else if (newValue != currentValue) {
+                                repeater.setValue(model.index, newValue)
                             }
                         }
                     }

--- a/src/palette/qml/MuseScore/Palette/PalettePropertiesDialog.qml
+++ b/src/palette/qml/MuseScore/Palette/PalettePropertiesDialog.qml
@@ -113,7 +113,11 @@ StyledDialogView {
                         step: modelData["incrementStep"]
 
                         onValueEdited: function(newValue) {
-                            repeater.setValue(model.index, newValue)
+                            if (newValue > 0) {
+                                repeater.setValue(model.index, newValue)
+                            } else {
+                                repeater.setValue(model.index, step)
+                            }
                         }
                     }
                 }

--- a/src/palette/qml/MuseScore/Palette/PalettePropertiesDialog.qml
+++ b/src/palette/qml/MuseScore/Palette/PalettePropertiesDialog.qml
@@ -88,16 +88,12 @@ StyledDialogView {
 
                 function setValue(index, value) {
                     if (index === 0) {
-                        propertiesModel.cellWidth = 0
                         propertiesModel.cellWidth = value
                     } else if (index === 1) {
-                        propertiesModel.cellHeight = 0
                         propertiesModel.cellHeight = value
                     } else if (index === 2) {
-                        propertiesModel.elementOffset = 0
                         propertiesModel.elementOffset = value
                     } else if (index === 3) {
-                        propertiesModel.scaleFactor = 0
                         propertiesModel.scaleFactor = value
                     }
                 }
@@ -115,6 +111,7 @@ StyledDialogView {
                         currentValue: modelData["value"]
                         measureUnitsSymbol: Boolean(modelData["measureUnit"]) ? modelData["measureUnit"] : ""
                         step: modelData["incrementStep"]
+                        minValue: step
 
                         onValueEdited: function(newValue) {
                             if (newValue <= 0) {

--- a/src/palette/qml/MuseScore/Palette/PalettePropertiesDialog.qml
+++ b/src/palette/qml/MuseScore/Palette/PalettePropertiesDialog.qml
@@ -114,11 +114,7 @@ StyledDialogView {
                         minValue: step
 
                         onValueEdited: function(newValue) {
-                            if (newValue <= 0) {
-                                repeater.setValue(model.index, step)
-                            } else if (newValue != currentValue) {
-                                repeater.setValue(model.index, newValue)
-                            }
+                            repeater.setValue(model.index, newValue)
                         }
                     }
                 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/18570

PalettePropertiesDialog.qml
Added if statement replacing new value with increment step if new value is less than or equal 0.

There was an issue with the value not being set to the increment step if the current value is the same as the increment step (i.e., If the width was 36 and then set to -5, the value would be replaced with 1, but if the width was 1 and then set to -5, the value would not be replaced with 1, it is instead replaced with -5.00)

This was solved by setting each palette property to 0 before setting to the desired value. There may be a better solution to this issue (but I am not sure since this is my first contribution)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
