### PR TITLE
Correctly use the selected file type after asking save path

### DIFF
--- a/src/autobot/internal/autobotinteractive.cpp
+++ b/src/autobot/internal/autobotinteractive.cpp
@@ -113,8 +113,8 @@ io::path_t AutobotInteractive::selectOpeningFile(const QString& title, const io:
     return m_real->selectOpeningFile(title, dir, filter);
 }
 
-io::path_t AutobotInteractive::selectSavingFile(const QString& title, const io::path_t& dir, const std::vector<std::string>& filter,
-                                                bool confirmOverwrite)
+IInteractive::FileDialogResult AutobotInteractive::selectSavingFile(const QString& title, const io::path_t& dir,
+                                                                    const std::vector<std::string>& filter, bool confirmOverwrite)
 {
     // return m_real->selectSavingFile(title, dir, filter, confirmOverwrite);
     QStringList filterList;
@@ -125,7 +125,10 @@ io::path_t AutobotInteractive::selectSavingFile(const QString& title, const io::
     LOGD() << title << " dir:" << dir << ", filter: " << filterList << ", confirmOverwrite: " << confirmOverwrite;
     m_real->open("musescore://autobot/selectfile?sync=true&filePath=" + dir.toStdString());
     m_selectedFilePath = dir;
-    return m_selectedFilePath;
+
+    FileDialogResult result;
+    result.path = m_selectedFilePath;
+    return result;
 }
 
 io::path_t AutobotInteractive::selectDirectory(const QString& title, const io::path_t& dir)

--- a/src/autobot/internal/autobotinteractive.h
+++ b/src/autobot/internal/autobotinteractive.h
@@ -75,8 +75,8 @@ public:
 
     // files
     io::path_t selectOpeningFile(const QString& title, const io::path_t& dir, const std::vector<std::string>& filter) override;
-    io::path_t selectSavingFile(const QString& title, const io::path_t& dir, const std::vector<std::string>& filter,
-                                bool confirmOverwrite = true) override;
+    FileDialogResult selectSavingFile(const QString& title, const io::path_t& dir, const std::vector<std::string>& filter,
+                                      bool confirmOverwrite = true) override;
 
     // dirs
     io::path_t selectDirectory(const QString& title, const io::path_t& dir) override;

--- a/src/diagnostics/internal/savediagnosticfilesscenario.cpp
+++ b/src/diagnostics/internal/savediagnosticfilesscenario.cpp
@@ -51,7 +51,7 @@ mu::Ret SaveDiagnosticFilesScenario::saveDiagnosticFiles()
     io::path_t path = interactive()->selectSavingFile(
         qtrc("diagnostics", "Save diagnostic files"),
         configuration()->diagnosticFilesDefaultSavingPath(),
-        { "(*.zip)" });
+        { "(*.zip)" }).path;
 
     if (path.empty()) {
         return make_ret(Ret::Code::Cancel);

--- a/src/framework/global/iinteractive.h
+++ b/src/framework/global/iinteractive.h
@@ -163,8 +163,14 @@ public:
 
     // files
     virtual io::path_t selectOpeningFile(const QString& title, const io::path_t& dir, const std::vector<std::string>& filter) = 0;
-    virtual io::path_t selectSavingFile(const QString& title, const io::path_t& path, const std::vector<std::string>& filter,
-                                        bool confirmOverwrite = true) = 0;
+
+    struct FileDialogResult {
+        io::path_t path;
+        size_t selectedFilterIndex = 0;
+    };
+
+    virtual FileDialogResult selectSavingFile(const QString& title, const io::path_t& path, const std::vector<std::string>& filter,
+                                              bool confirmOverwrite = true) = 0;
 
     // dirs
     virtual io::path_t selectDirectory(const QString& title, const io::path_t& dir) = 0;

--- a/src/framework/global/internal/interactive.cpp
+++ b/src/framework/global/internal/interactive.cpp
@@ -188,13 +188,18 @@ mu::io::path_t Interactive::selectOpeningFile(const QString& title, const io::pa
 #endif
 }
 
-io::path_t Interactive::selectSavingFile(const QString& title, const io::path_t& path, const std::vector<std::string>& filter,
-                                         bool confirmOverwrite)
+IInteractive::FileDialogResult Interactive::selectSavingFile(const QString& title, const io::path_t& path,
+                                                             const std::vector<std::string>& filter, bool confirmOverwrite)
 {
 #ifndef Q_OS_LINUX
+    FileDialogResult result;
+
     QFileDialog::Options options;
     options.setFlag(QFileDialog::DontConfirmOverwrite, !confirmOverwrite);
-    QString result = QFileDialog::getSaveFileName(nullptr, title, path.toQString(), filterToString(filter), nullptr, options);
+    QString selectedFilter;
+    result.path = QFileDialog::getSaveFileName(nullptr, title, path.toQString(), filterToString(filter), &selectedFilter, options);
+    result.selectedFilterIndex = mu::indexOf(filter, selectedFilter.toStdString());
+
     return result;
 #else
     return provider()->selectSavingFile(title.toStdString(), path, filter, confirmOverwrite).val;

--- a/src/framework/global/internal/interactive.h
+++ b/src/framework/global/internal/interactive.h
@@ -75,8 +75,8 @@ public:
 
     // files
     io::path_t selectOpeningFile(const QString& title, const io::path_t& dir, const std::vector<std::string>& filter) override;
-    io::path_t selectSavingFile(const QString& title, const io::path_t& path, const std::vector<std::string>& filter,
-                                bool confirmOverwrite = true) override;
+    FileDialogResult selectSavingFile(const QString& title, const io::path_t& path, const std::vector<std::string>& filter,
+                                      bool confirmOverwrite = true) override;
 
     // dirs
     io::path_t selectDirectory(const QString& title, const io::path_t& dir) override;

--- a/src/framework/global/tests/mocks/interactivemock.h
+++ b/src/framework/global/tests/mocks/interactivemock.h
@@ -53,7 +53,7 @@ public:
     MOCK_METHOD(Ret, showProgress, (const std::string&, framework::Progress*), (const, override));
 
     MOCK_METHOD(io::path_t, selectOpeningFile, (const QString&, const io::path_t&, const std::vector<std::string>&), (override));
-    MOCK_METHOD(io::path_t, selectSavingFile, (const QString&, const io::path_t&, const std::vector<std::string>&, bool), (override));
+    MOCK_METHOD(FileDialogResult, selectSavingFile, (const QString&, const io::path_t&, const std::vector<std::string>&, bool), (override));
     MOCK_METHOD(io::path_t, selectDirectory, (const QString&, const io::path_t&), (override));
     MOCK_METHOD(io::paths_t, selectMultipleDirectories, (const QString&, const io::path_t&, const io::paths_t&), (override));
     MOCK_METHOD(QColor, selectColor, (const QColor&, const QString&), (override));

--- a/src/framework/mpe/view/articulationsprofileeditormodel.cpp
+++ b/src/framework/mpe/view/articulationsprofileeditormodel.cpp
@@ -53,7 +53,7 @@ void ArticulationsProfileEditorModel::requestToOpenProfile()
 bool ArticulationsProfileEditorModel::requestToCreateProfile()
 {
     std::vector<std::string> filter = { /*qtrc*/ std::string("MPE articulations profile") + " " + PROFILE_EXTENSION };
-    io::path_t path = interactive()->selectSavingFile(/*qtrc*/ QString("Save MPE articulations profile"), "", filter);
+    io::path_t path = interactive()->selectSavingFile(/*qtrc*/ QString("Save MPE articulations profile"), "", filter).path;
 
     if (path.empty()) {
         return false;

--- a/src/framework/shortcuts/view/shortcutsmodel.cpp
+++ b/src/framework/shortcuts/view/shortcutsmodel.cpp
@@ -201,7 +201,7 @@ void ShortcutsModel::exportShortcutsToFile()
     io::path_t path = interactive()->selectSavingFile(
         qtrc("shortcuts", "Export shortcuts"),
         globalConfiguration()->homePath(),
-        shortcutsFileFilter());
+        shortcutsFileFilter()).path;
 
     if (path.empty()) {
         return;

--- a/src/framework/ui/iinteractiveprovider.h
+++ b/src/framework/ui/iinteractiveprovider.h
@@ -63,8 +63,9 @@ public:
 
     virtual RetVal<io::path_t> selectOpeningFile(const std::string& title, const io::path_t& dir,
                                                  const std::vector<std::string>& filter) = 0;
-    virtual RetVal<io::path_t> selectSavingFile(const std::string& title, const io::path_t& path, const std::vector<std::string>& filter,
-                                                bool confirmOverwrite) = 0;
+    virtual RetVal<framework::IInteractive::FileDialogResult> selectSavingFile(const std::string& title, const io::path_t& path,
+                                                                               const std::vector<std::string>& filter,
+                                                                               bool confirmOverwrite) = 0;
     virtual RetVal<io::path_t> selectDirectory(const std::string& title, const io::path_t& dir) = 0;
 
     virtual RetVal<Val> open(const UriQuery& uri) = 0;

--- a/src/framework/ui/qml/MuseScore/Ui/internal/FileDialog.qml
+++ b/src/framework/ui/qml/MuseScore/Ui/internal/FileDialog.qml
@@ -38,7 +38,13 @@ QtPlatform.FileDialog {
     }
 
     onAccepted: {
-        root.ret = { "errcode": 0, "value":  root.currentFile.toString() }
+        root.ret = {
+            "errcode": 0,
+            "value": {
+                "path": root.currentFile.toString(),
+                "selectedFilterIndex": root.selectedNameFilter.index
+            }
+        }
         root.close()
         root.closed()
     }

--- a/src/framework/ui/view/interactiveprovider.h
+++ b/src/framework/ui/view/interactiveprovider.h
@@ -78,8 +78,9 @@ public:
     Ret showProgress(const std::string& title, framework::Progress* progress) override;
 
     RetVal<io::path_t> selectOpeningFile(const std::string& title, const io::path_t& dir, const std::vector<std::string>& filter) override;
-    RetVal<io::path_t> selectSavingFile(const std::string& title, const io::path_t& path, const std::vector<std::string>& filter,
-                                        bool confirmOverwrite) override;
+    RetVal<framework::IInteractive::FileDialogResult> selectSavingFile(const std::string& title, const io::path_t& path,
+                                                                       const std::vector<std::string>& filter,
+                                                                       bool confirmOverwrite) override;
     RetVal<io::path_t> selectDirectory(const std::string& title, const io::path_t& dir) override;
 
     RetVal<Val> open(const UriQuery& uri) override;
@@ -155,8 +156,9 @@ private:
                                    int defBtn = int(framework::IInteractive::Button::NoButton),
                                    const framework::IInteractive::Options& options = {});
 
-    RetVal<io::path_t> openFileDialog(FileDialogType type, const std::string& title, const io::path_t& path,
-                                      const std::vector<std::string>& filter = {}, bool confirmOverwrite = true);
+    RetVal<framework::IInteractive::FileDialogResult> openFileDialog(FileDialogType type, const std::string& title, const io::path_t& path,
+                                                                     const std::vector<std::string>& filter = {},
+                                                                     bool confirmOverwrite = true);
 
     void closeObject(const ObjectInfo& obj);
 

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -1548,7 +1548,7 @@ mu::io::path_t NotationActionController::selectStyleFile(bool forLoad)
     std::vector<std::string> filter = { filterName + " (*.mss)" };
     return forLoad
            ? interactive()->selectOpeningFile(qtrc("notation", "Load style"), dir, filter)
-           : interactive()->selectSavingFile(qtrc("notation", "Save style"), dir, filter);
+           : interactive()->selectSavingFile(qtrc("notation", "Save style"), dir, filter).path;
 }
 
 void NotationActionController::loadStyle()

--- a/src/palette/internal/paletteprovider.cpp
+++ b/src/palette/internal/paletteprovider.cpp
@@ -920,7 +920,7 @@ QString PaletteProvider::getPaletteFilename(bool open, const QString& name) cons
     if (open) {
         fn = interactive()->selectOpeningFile(title, defaultPath, filter);
     } else {
-        fn = interactive()->selectSavingFile(title, defaultPath, filter);
+        fn = interactive()->selectSavingFile(title, defaultPath, filter).path;
     }
     return fn.toQString();
 }

--- a/src/palette/view/widgets/editdrumsetdialog.cpp
+++ b/src/palette/view/widgets/editdrumsetdialog.cpp
@@ -678,7 +678,7 @@ void EditDrumsetDialog::save()
 {
     std::vector<std::string> filter = { mu::trc("palette", "MuseScore drumset file") + " (*.drm)" };
     mu::io::path_t dir = notationConfiguration()->userStylesPath();
-    mu::io::path_t fname = interactive()->selectSavingFile(mu::qtrc("palette", "Save drumset"), dir, filter);
+    mu::io::path_t fname = interactive()->selectSavingFile(mu::qtrc("palette", "Save drumset"), dir, filter).path;
 
     if (fname.empty()) {
         return;

--- a/src/project/internal/exportprojectscenario.cpp
+++ b/src/project/internal/exportprojectscenario.cpp
@@ -88,7 +88,7 @@ mu::RetVal<mu::io::path_t> ExportProjectScenario::askExportPath(const INotationP
 
     RetVal<io::path_t> exportPath;
     exportPath.val = interactive()->selectSavingFile(qtrc("project/export", "Export"), defaultPath,
-                                                     exportType.filter(), isCreatingOnlyOneFile);
+                                                     exportType.filter(), isCreatingOnlyOneFile).path;
     exportPath.ret = !exportPath.val.empty();
 
     return exportPath;

--- a/src/project/internal/saveprojectscenario.h
+++ b/src/project/internal/saveprojectscenario.h
@@ -28,6 +28,7 @@
 #include "modularity/ioc.h"
 #include "iprojectconfiguration.h"
 #include "global/iinteractive.h"
+#include "io/ifilesystem.h"
 
 #include "cloud/musescorecom/imusescorecomservice.h"
 #include "cloud/audiocom/iaudiocomservice.h"
@@ -37,6 +38,7 @@ class SaveProjectScenario : public ISaveProjectScenario
 {
     INJECT(IProjectConfiguration, configuration)
     INJECT(framework::IInteractive, interactive)
+    INJECT(io::IFileSystem, fileSystem)
     INJECT(cloud::IMuseScoreComService, museScoreComService)
     INJECT(cloud::IAudioComService, audioComService)
 
@@ -59,6 +61,8 @@ public:
 private:
     RetVal<SaveLocationType> saveLocationType() const;
     RetVal<SaveLocationType> askSaveLocationType() const;
+
+    bool askAboutReplacingExistingFile(const io::path_t& filePath) const;
 
     /// \param isPublish:
     ///     false -> this is part of a "Save to cloud" action


### PR DESCRIPTION
Should resolve: #18321
Should resolve: https://github.com/musescore/MuseScore/issues/11615
Closes: #14365

Before, we determined the selected file type by looking at the path that the user entered in the file dialog. This is unreliable, since some OSs don't check if the entered filename extension matches the selected file type; if it didn't match, MuseScore would create a file of a different type from what was selected in the file dialog (in the dropdown).
Now, we will use the available APIs to check the _actually_ selected file type. Then, we adjust the name based on the selected file type. It may happen that we end up writing to a different path from what was selected in the file dialog, for example when an extension needs to be added or removed. 
In that case, the file dialog will not have had the ability to ask the user whether to replace the file that will _actually_ be replaced, because the file dialog only knows what the user has entered, not what we will make of it. In this situation, to be on the safe side, we ourselves check if the file exists and ask the user about replacing it. 
In the worst case, the user will see _two_ "replace file?" dialogs, namely the one from the file dialog about what the user has entered there, and the one from us about what we will make of that, but that's still better than overwriting a file when the user didn't want that. 
(Telling the file dialog that it should not show its own dialog is no option, because that needs to be told _before_ the dialog is opened, and we only know whether we will show our own dialog _after_ the dialog is closed. And on macOS, disabling the native "replace file?" dialog is not supported anyway.)

Testing checklist:
- [ ] all kinds of combinations of filenames+extensions and file types, on all OSs:
    - [ ] macOS
        On macOS, there is a preference in Finder that influences the behaviour: Finder > Preferences (or "Settings", nowadays) > Advanced > Show all file extensions (topmost option)
        - [ ] with the option disabled (default)
        - [ ] with the option enabled
    - [ ] Windows
    - [ ] Linux

I've already tested it on macOS, but not very systematically.