### PR TITLE
Potentially fix infinite loop in multi-measure repeat playback rendering

### DIFF
--- a/src/engraving/libmscore/measure.cpp
+++ b/src/engraving/libmscore/measure.cpp
@@ -2864,7 +2864,12 @@ MeasureRepeat* Measure::measureRepeatElement(staff_idx_t staffIdx) const
                 }
             }
         }
-        m = m->nextMeasure();
+        Measure* nm = m->nextMeasure();
+        if (nm && nm->measureRepeatCount(staffIdx) == m->measureRepeatCount(staffIdx) + 1) {
+            m = nm;
+        } else {
+            break;
+        }
     }
     return nullptr;
 }

--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -417,6 +417,10 @@ void PlaybackModel::processMeasureRepeat(const int tickPositionOffset, const Mea
         return;
     }
 
+    IF_ASSERT_FAILED(referringMeasure != currentMeasure) {
+        return;
+    }
+
     int currentMeasureTick = currentMeasure->tick().ticks();
     int referringMeasureTick = referringMeasure->tick().ticks();
     int repeatPositionTickOffset = currentMeasureTick - referringMeasureTick;


### PR DESCRIPTION
I could not reproduce this myself; only by creating a purposefully corrupted score by modifying the MSCX, by replacing the `MeasureRepeat` with an ordinary `Rest`.

Stack trace from Sentry (the only info we have): 
[4c8228cc485a4f8fab3aaac85a62a85f-symbolicated.crash.txt](https://github.com/musescore/MuseScore/files/12065351/4c8228cc485a4f8fab3aaac85a62a85f-symbolicated.crash.txt)
