### PR TITLE
Fix #13281: Implement [Apply current palette element] command

### DIFF
--- a/src/palette/internal/paletteuiactions.cpp
+++ b/src/palette/internal/paletteuiactions.cpp
@@ -56,6 +56,12 @@ const UiActionList PaletteUiActions::m_actions = {
              TranslatableString("action", "Edit drumset…"),
              TranslatableString("action", "Edit drumset…")
              ),
+    UiAction("apply-current-palette-element",
+             mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             TranslatableString("action", "Apply current palette element"),
+             TranslatableString("action", "Apply current palette element")
+             ),
     UiAction("show-keys",
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_NOTATION_TEXT_EDITING,

--- a/src/palette/qml/MuseScore/Palette/PalettesPanel.qml
+++ b/src/palette/qml/MuseScore/Palette/PalettesPanel.qml
@@ -65,6 +65,9 @@ Item {
         onPaletteSearchRequested: {
             palettesPanelHeader.startSearch()
         }
+        onApplyCurrentPaletteElementRequested: {
+            root.applyCurrentPaletteElement()
+        }
     }
 
     ColumnLayout {

--- a/src/palette/qml/MuseScore/Palette/internal/Palette.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/Palette.qml
@@ -526,9 +526,9 @@ StyledGridView {
             }
 
             onClicked: {
-                if (!paletteView.paletteController.applyPaletteElement(paletteCell.modelIndex, ui.keyboardModifiers())) {
-                    updateSelection()
-                }
+                paletteView.paletteController.applyPaletteElement(paletteCell.modelIndex, ui.keyboardModifiers())
+
+                updateSelection()
             }
 
             onDoubleClicked: {

--- a/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
@@ -116,6 +116,7 @@ StyledListView {
             // in search and no cell selected: apply the first found element
             const parentIndex = paletteTreeDelegateModel.modelIndex(0);
             index = paletteModel.index(0, 0, parentIndex);
+            paletteSelectionModel.select(index, ItemSelectionModel.Select);
         }
 
         paletteController.applyPaletteElement(index, Qt.NoModifier);

--- a/src/palette/qml/MuseScore/Palette/internal/PalettesPanelHeader.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PalettesPanelHeader.qml
@@ -190,5 +190,7 @@ Item {
         visible: root.isSearchOpened
 
         Keys.onEscapePressed: root.endSearch()
+
+        onAccepted: applyCurrentPaletteElement()
     }
 }

--- a/src/palette/view/paletterootmodel.cpp
+++ b/src/palette/view/paletterootmodel.cpp
@@ -29,6 +29,9 @@ PaletteRootModel::PaletteRootModel(QObject* parent)
     dispatcher()->reg(this, "palette-search", [this]() {
         emit paletteSearchRequested();
     });
+    dispatcher()->reg(this, "apply-current-palette-element", [this]() {
+        emit applyCurrentPaletteElementRequested();
+    });
 }
 
 PaletteRootModel::~PaletteRootModel()

--- a/src/palette/view/paletterootmodel.h
+++ b/src/palette/view/paletterootmodel.h
@@ -49,6 +49,7 @@ public:
 
 signals:
     void paletteSearchRequested();
+    void applyCurrentPaletteElementRequested();
 };
 }
 


### PR DESCRIPTION
Resolves: #13281 
Resolves: #18675 

Been a while since doing a pull-request...

This is an attempt at superseding #13779 (draft), to re-implement functionality lost from MuseScore 3 for applying palette element via shortcut command.

1) Apply current palette element will work after selecting a palette element with the mouse or keyboard, and it will continue to work however many times the user executes the command

Similarly, not needing this command's shortcut to be defined:

2) On completion of search (I.e., pressing [enter/return]), the first element showing will apply the command given a valid score-selection. This should fulfill #18675 and will also highlight the first element on the palette to give visual feedback that it is the current selected palette item (MS3 did not do this)


Has been tested well enough it seems


Aside: Afterwards, MS4's gotta get customized names of palette items to be searchable, and also let the search command bring to view a palette that is a non-selected tab or not showing at all.


P.S.:
Demonstration of 3.x behavior with the searching ability allowed for the command to work within palette search:

https://github.com/musescore/MuseScore/assets/7139517/ff828c12-8be6-4f30-b376-34a901a6665d

Updated demonstration of version 4 performing points (1) + (2):

https://github.com/musescore/MuseScore/assets/7139517/6a5304a4-a330-4b4b-930b-2a624b4cc38e






<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
