### PR TITLE
fix #18611 - respect atonal key sig when inserting first measure 

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -4138,7 +4138,9 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
                 KeySig* nks = Factory::copyKeySig(*ks);
                 Segment* s  = newMeasure->undoGetSegmentR(SegmentType::KeySig, Fraction(0, 1));
                 nks->setParent(s);
-                nks->setKey(nks->concertKey());  // to set correct (transposing) key
+                if (!nks->isAtonal()) {
+                    nks->setKey(nks->concertKey());  // to set correct (transposing) key
+                }
                 undoAddElement(nks);
             }
             for (Clef* clef : clefList) {


### PR DESCRIPTION
respect atonal key signature when inserting measure  at the begining of the score

Resolves: #18611  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
