### PR TITLE
respect score "preferSharpFlat" setting of score, when initialise excerpt

### DIFF
--- a/src/engraving/libmscore/excerpt.cpp
+++ b/src/engraving/libmscore/excerpt.cpp
@@ -322,6 +322,7 @@ void Excerpt::createExcerpt(Excerpt* excerpt)
         p->setId(part->id());
         p->setInstrument(*part->instrument());
         p->setPartName(part->partName());
+        p->setPreferSharpFlat(part->preferSharpFlat());
 
         for (Staff* staff : part->staves()) {
             Staff* s = Factory::createStaff(p);


### PR DESCRIPTION
Resolves: #18655

Also related to #18425 (main "declared issue - playback" was already fixed by #18500 but in fact, playback is only symptom, not core of issue)

transposing pitch have to respect concert pitch and prefer settings, otherwise tpc(1, or 2) may be wrong

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
