### PR TITLE
default_playback_profile_for_old_scores

### DIFF
--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -236,6 +236,8 @@ mu::Ret NotationProject::doLoad(const io::path_t& path, const io::path_t& styleP
     // Load audio settings
     ret = m_projectAudioSettings->read(reader);
     if (!ret) {
+        m_projectAudioSettings->makeDefault();
+
         // Apply compat audio settings
         if (!settingsCompat.audioSettings.empty()) {
             for (const auto& audioCompat : settingsCompat.audioSettings) {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/18584

Caused by https://github.com/musescore/MuseScore/pull/16222 (previously we implicitly initialized m_activeSoundProfileName inside ProjectAudioSettings::read for older projects)