### PR TITLE
Enable to not bundle qt qml files in installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ option(MUE_ENABLE_CUSTOM_ALLOCATOR "Enable custom allocator (used for engraving)
 # === Compile ===
 option(MUE_COMPILE_BUILD_64 "Build 64 bit version of editor" ON)
 option(MUE_COMPILE_BUILD_MACOS_APPLE_SILICON "Build for Apple Silicon architecture. Only applicable on Macs with Apple Silicon, and requires suitable Qt version." OFF)
+option(MUE_COMPILE_INSTALL_QTQML_FILES "Whether to bundle qml files along with the installation (relevant on MacOS only)" ON)
 option(MUE_COMPILE_USE_PCH "Use precompiled headers." ON)
 option(MUE_COMPILE_USE_UNITY "Use unity build." ON)
 option(MUE_COMPILE_USE_CCACHE "Try use ccache" ON)

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -449,15 +449,17 @@ elseif(OS_IS_MAC)
             DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME}fonts
     )
 
-    install(DIRECTORY
-            ${QT_INSTALL_QML}
-            DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME}
-            REGEX ".*QtWebkit.*" EXCLUDE
-            REGEX ".*QtTest.*" EXCLUDE
-            REGEX ".*QtSensors.*" EXCLUDE
-            REGEX ".*QtMultimedia.*" EXCLUDE
-            REGEX ".*QtAudioEngine.*" EXCLUDE
-            REGEX ".*_debug\\.dylib" EXCLUDE)
+    if(MUE_COMPILE_INSTALL_QTQML_FILES)
+        install(DIRECTORY
+                ${QT_INSTALL_QML}
+                DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME}
+                REGEX ".*QtWebkit.*" EXCLUDE
+                REGEX ".*QtTest.*" EXCLUDE
+                REGEX ".*QtSensors.*" EXCLUDE
+                REGEX ".*QtMultimedia.*" EXCLUDE
+                REGEX ".*QtAudioEngine.*" EXCLUDE
+                REGEX ".*_debug\\.dylib" EXCLUDE)
+    endif()
 
 ###########################################
 # Wasm


### PR DESCRIPTION
Resolves: #18665

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
