### PR TITLE
Fix #18563 Crash on deleting harp pedal diagram with MM rests

### DIFF
--- a/src/notation/view/internal/harppedalpopupmodel.cpp
+++ b/src/notation/view/internal/harppedalpopupmodel.cpp
@@ -132,6 +132,10 @@ QRectF HarpPedalPopupModel::staffPos() const
 {
     // Just need top & bottom y.  Don't need x pos
     Measure* measure = m_item->findMeasure();
+    if (!measure->system()) {
+        return QRectF();
+    }
+
     auto harpIdxList = m_item->part()->staveIdxList();
     std::list<engraving::StaffLines*> staves;
     for (auto idx : harpIdxList) {


### PR DESCRIPTION
Resolves: #18563

This is a surface-level solution, but I think it's worth doing it anyway (and it can be ported to 4.1.1), cause measures _can_ have a null system in certain situations, so it's better to add the null-check. In this case, the measure that the harp diagram is applied to becomes "reabsorbed" by the MM-rest so it's not laid out anymore, so it will not have a system.

A deeper solution would be to avoid calling this code when deleting the harp diagram (this is basically the popup trying to recalculate its position on the canvas, which is unnecessary cause it will disappear immediately after) but I don't really know how to do that. Maybe @cbjeukendrup or @RomanPudashkin can help?