### PR TITLE
Correct Marching Snare Instrument IDs in Templates

### DIFF
--- a/share/templates/07-Band_and_Percussion/06-Battery_Percussion/06-Battery_Percussion.mscx
+++ b/share/templates/07-Band_and_Percussion/06-Battery_Percussion/06-Battery_Percussion.mscx
@@ -30,7 +30,7 @@
         <barLineSpan>3</barLineSpan>
         </Staff>
       <trackName>Snare Drum</trackName>
-      <Instrument id="snare-drum">
+      <Instrument id="marching-snare">
         <longName>Snare Drum</longName>
         <shortName>S.D.</shortName>
         <trackName>Snare Drum</trackName>

--- a/share/templates/07-Band_and_Percussion/07-Large_Pit_Percussion/07-Large_Pit_Percussion.mscx
+++ b/share/templates/07-Band_and_Percussion/07-Large_Pit_Percussion/07-Large_Pit_Percussion.mscx
@@ -1999,7 +1999,7 @@
         <barLineSpan>3</barLineSpan>
         </Staff>
       <trackName>Snare Drum</trackName>
-      <Instrument id="snare-drum">
+      <Instrument id="marching-snare">
         <longName>Snare Drum</longName>
         <shortName>S.D.</shortName>
         <trackName>Snare Drum</trackName>

--- a/share/templates/07-Band_and_Percussion/08-Small_Pit_Percussion/08-Small_Pit_Percussion.mscx
+++ b/share/templates/07-Band_and_Percussion/08-Small_Pit_Percussion/08-Small_Pit_Percussion.mscx
@@ -1100,7 +1100,7 @@
         <barLineSpan>3</barLineSpan>
         </Staff>
       <trackName>Snare Drum</trackName>
-      <Instrument id="snare-drum">
+      <Instrument id="marching-snare">
         <longName>Snare Drum</longName>
         <shortName>S.D.</shortName>
         <trackName>Snare Drum</trackName>


### PR DESCRIPTION
Resolves:  https://github.com/musescore/MuseScore/issues/18514

Instrument IDs for marching snare instruments should match across templates

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
