### PR TITLE
Fix special characters being lost in title frame texts when "cloning" to custom part

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/common/FrameSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/common/FrameSettings.qml
@@ -27,7 +27,7 @@ import MuseScore.UiComponents 1.0
 import MuseScore.Inspector 1.0
 
 Column {
-    id: frameSettings
+    id: root
 
     width: parent.width
     spacing: 12
@@ -37,21 +37,21 @@ Column {
     property int navigationRowStart: 0
     readonly property int navigationRowEnd: cornerRadiusSection.navigationRowEnd
 
-    required property QtObject frameTypePropertyItem
-    required property QtObject frameBorderColorPropertyItem
-    required property QtObject frameFillColorPropertyItem
-    required property QtObject frameThicknessPropertyItem
-    required property QtObject frameMarginPropertyItem
-    required property QtObject frameCornerRadiusPropertyItem
+    required property PropertyItem frameType
+    required property PropertyItem frameBorderColor
+    required property PropertyItem frameFillColor
+    required property PropertyItem frameThickness
+    required property PropertyItem frameMargin
+    required property PropertyItem frameCornerRadius
 
     FlatRadioButtonGroupPropertyView {
         id: frameSection
         titleText: qsTrc("inspector", "Frame")
-        propertyItem: frameSettings.frameTypePropertyItem ? frameSettings.frameTypePropertyItem : null
+        propertyItem: root.frameType ? root.frameType : null
 
         navigationName: "FrameMenu"
-        navigationPanel: frameSettings.navigationPanel
-        navigationRowStart: frameSettings.navigationRowStart
+        navigationPanel: root.navigationPanel
+        navigationRowStart: root.navigationRowStart
 
         model: [
             { text: qsTrc("inspector", "None"), value: TextTypes.FRAME_TYPE_NONE, titleRole: qsTrc("inspector", "None") },
@@ -71,14 +71,14 @@ Column {
             anchors.rightMargin: 2
 
             navigationName: "BorderColorMenu"
-            navigationPanel: frameSettings.navigationPanel
+            navigationPanel: root.navigationPanel
             navigationRowStart: frameSection.navigationRowEnd + 1
 
-            visible: frameSettings.frameBorderColorPropertyItem.isEnabled
+            visible: root.frameBorderColor ? root.frameBorderColor.isEnabled : false
             height: visible ? implicitHeight : 0
 
             titleText: qsTrc("inspector", "Border")
-            propertyItem: frameSettings.frameBorderColorPropertyItem
+            propertyItem: root.frameBorderColor
         }
 
         ColorSection {
@@ -88,14 +88,14 @@ Column {
             anchors.right: parent.right
 
             navigationName: "HighlightColorMenu"
-            navigationPanel: frameSettings.navigationPanel
+            navigationPanel: root.navigationPanel
             navigationRowStart: borderColorSection.navigationRowEnd + 1
 
-            visible: frameSettings.frameFillColorPropertyItem.isEnabled
+            visible: root.frameFillColor ? root.frameFillColor.isEnabled : false
             height: visible ? implicitHeight : 0
 
             titleText: qsTrc("inspector", "Fill color")
-            propertyItem: frameSettings.frameFillColorPropertyItem
+            propertyItem: root.frameFillColor
         }
     }
 
@@ -110,14 +110,14 @@ Column {
             anchors.rightMargin: 2
 
             navigationName: "Thickness"
-            navigationPanel: frameSettings.navigationPanel
+            navigationPanel: root.navigationPanel
             navigationRowStart: highlightColorSection.navigationRowEnd + 1
 
-            visible: frameSettings.frameThicknessPropertyItem.isEnabled
+            visible: root.frameThickness ? root.frameThickness.isEnabled : false
             height: visible ? implicitHeight : 0
 
             titleText: qsTrc("inspector", "Thickness")
-            propertyItem: frameSettings.frameThicknessPropertyItem
+            propertyItem: root.frameThickness
 
             step: 0.1
             minValue: 0
@@ -131,14 +131,14 @@ Column {
             anchors.right: parent.right
 
             navigationName: "Padding"
-            navigationPanel: frameSettings.navigationPanel
+            navigationPanel: root.navigationPanel
             navigationRowStart: thicknessSection.navigationRowEnd + 1
 
-            visible: frameSettings.frameMarginPropertyItem.isEnabled
+            visible: root.frameMargin ? root.frameMargin.isEnabled : false
             height: visible ? implicitHeight : 0
 
             titleText: qsTrc("inspector", "Padding")
-            propertyItem: frameSettings.frameMarginPropertyItem
+            propertyItem: root.frameMargin
 
             step: 0.1
             minValue: 0
@@ -153,14 +153,14 @@ Column {
         anchors.rightMargin: 2
 
         navigationName: "Corner radius"
-        navigationPanel: frameSettings.navigationPanel
+        navigationPanel: root.navigationPanel
         navigationRowStart: marginSection.navigationRowEnd + 1
 
-        visible: frameSettings.frameCornerRadiusPropertyItem.isEnabled
+        visible: root.frameCornerRadius ? root.frameCornerRadius.isEnabled : false
         height: visible ? implicitHeight : 0
 
         titleText: qsTrc("inspector", "Corner radius")
-        propertyItem: frameSettings.frameCornerRadiusPropertyItem
+        propertyItem: root.frameCornerRadius
 
         step: 1
         decimals: 2

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/dynamics/DynamicsSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/dynamics/DynamicsSettings.qml
@@ -121,12 +121,12 @@ Column {
                 navigationPanel: root.navigationPanel
                 navigationRowStart: dynamicAlignmentGroup.navigationRowEnd + 1
 
-                frameTypePropertyItem: root.model ? root.model.frameType : null
-                frameBorderColorPropertyItem: root.model ? root.model.frameBorderColor : null
-                frameFillColorPropertyItem: root.model ? root.model.frameFillColor : null
-                frameThicknessPropertyItem: root.model ? root.model.frameThickness : null
-                frameMarginPropertyItem: root.model ? root.model.frameMargin : null
-                frameCornerRadiusPropertyItem: root.model ? root.model.frameCornerRadius : null
+                frameType: root.model ? root.model.frameType : null
+                frameBorderColor: root.model ? root.model.frameBorderColor : null
+                frameFillColor: root.model ? root.model.frameFillColor : null
+                frameThickness: root.model ? root.model.frameThickness : null
+                frameMargin: root.model ? root.model.frameMargin : null
+                frameCornerRadius: root.model ? root.model.frameCornerRadius : null
             }
         }
     }

--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
@@ -107,12 +107,12 @@ Column {
         navigationPanel: root.navigationPanel
         navigationRowStart: subscriptOptionsButtonList.navigationRowEnd + 1
 
-        frameTypePropertyItem: root.model ? root.model.frameType : null
-        frameBorderColorPropertyItem: root.model ? root.model.frameBorderColor : null
-        frameFillColorPropertyItem: root.model ? root.model.frameFillColor : null
-        frameThicknessPropertyItem: root.model ? root.model.frameThickness : null
-        frameMarginPropertyItem: root.model ? root.model.frameMargin : null
-        frameCornerRadiusPropertyItem: root.model ? root.model.frameCornerRadius : null
+        frameType: root.model ? root.model.frameType : null
+        frameBorderColor: root.model ? root.model.frameBorderColor : null
+        frameFillColor: root.model ? root.model.frameFillColor : null
+        frameThickness: root.model ? root.model.frameThickness : null
+        frameMargin: root.model ? root.model.frameMargin : null
+        frameCornerRadius: root.model ? root.model.frameCornerRadius : null
     }
 
     SeparatorLine { anchors.margins: -12 }

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -96,31 +96,17 @@ void ExcerptNotation::fillWithDefaultInfo()
         topVerticalFrame->undoUnlink();
     }
 
-    auto setText = [&score](TextStyleType textType, const String& xmlText) {
-        TextBase* textItem = score->getText(textType);
-
-        if (!textItem && !xmlText.isEmpty()) {
-            textItem = score->addText(textType, nullptr /*destinationElement*/, false /*addToAllScores*/);
-        }
-
+    auto unlinkText = [&score](TextStyleType textType) {
+        engraving::Text* textItem = score->getText(textType);
         if (textItem) {
             textItem->undoUnlink();
-            textItem->setXmlText(xmlText);
         }
     };
 
-    auto getText = [&score](TextStyleType textType) {
-        if (mu::engraving::Text* t = score->getText(textType)) {
-            return t->xmlText();
-        }
-
-        return String();
-    };
-
-    setText(TextStyleType::TITLE, getText(TextStyleType::TITLE));
-    setText(TextStyleType::SUBTITLE, getText(TextStyleType::SUBTITLE));
-    setText(TextStyleType::COMPOSER, getText(TextStyleType::COMPOSER));
-    setText(TextStyleType::POET, getText(TextStyleType::POET));
+    unlinkText(TextStyleType::TITLE);
+    unlinkText(TextStyleType::SUBTITLE);
+    unlinkText(TextStyleType::COMPOSER);
+    unlinkText(TextStyleType::POET);
 }
 
 mu::engraving::Excerpt* ExcerptNotation::excerpt() const

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -96,31 +96,31 @@ void ExcerptNotation::fillWithDefaultInfo()
         topVerticalFrame->undoUnlink();
     }
 
-    auto setText = [&score](TextStyleType textType, const QString& text) {
+    auto setText = [&score](TextStyleType textType, const String& xmlText) {
         TextBase* textItem = score->getText(textType);
 
-        if (!textItem) {
+        if (!textItem && !xmlText.isEmpty()) {
             textItem = score->addText(textType, nullptr /*destinationElement*/, false /*addToAllScores*/);
         }
 
         if (textItem) {
             textItem->undoUnlink();
-            textItem->setPlainText(text);
+            textItem->setXmlText(xmlText);
         }
     };
 
-    auto getText = [&score](TextStyleType textType, const QString& defaultText) {
+    auto getText = [&score](TextStyleType textType) {
         if (mu::engraving::Text* t = score->getText(textType)) {
-            return t->plainText().toQString();
-        } else {
-            return defaultText;
+            return t->xmlText();
         }
+
+        return String();
     };
 
-    setText(TextStyleType::TITLE, getText(TextStyleType::TITLE, ""));
-    setText(TextStyleType::COMPOSER, getText(TextStyleType::COMPOSER, ""));
-    setText(TextStyleType::SUBTITLE, getText(TextStyleType::SUBTITLE, ""));
-    setText(TextStyleType::POET, getText(TextStyleType::POET, ""));
+    setText(TextStyleType::TITLE, getText(TextStyleType::TITLE));
+    setText(TextStyleType::SUBTITLE, getText(TextStyleType::SUBTITLE));
+    setText(TextStyleType::COMPOSER, getText(TextStyleType::COMPOSER));
+    setText(TextStyleType::POET, getText(TextStyleType::POET));
 }
 
 mu::engraving::Excerpt* ExcerptNotation::excerpt() const

--- a/src/notation/qml/MuseScore/NotationScene/SelectMeasuresCountDialog.qml
+++ b/src/notation/qml/MuseScore/NotationScene/SelectMeasuresCountDialog.qml
@@ -48,7 +48,7 @@ StyledDialogView {
             NavigationPanel {
                 id: measuresCountNavigationPanel
                 name: "MeasuresCountNavigationPanel"
-                enabled: parent.enabled && parent.visible
+                enabled: parent && parent.enabled && parent.visible
                 section: root.navigationSection
                 order: 1
                 direction: NavigationPanel.Horizontal
@@ -94,7 +94,7 @@ StyledDialogView {
             NavigationPanel {
                 id: buttonsNavigationPanel
                 name: "ButtonsNavigationPanel"
-                enabled: parent.enabled && parent.visible
+                enabled: parent && parent.enabled && parent.visible
                 section: root.navigationSection
                 order: 2
                 direction: NavigationPanel.Horizontal


### PR DESCRIPTION
Resolves: #18709 

(actually, it's not when _really_ cloning)

(I accidentally added some fixes for some QML warnings because I was annoyed by them)