### PR TITLE
Fix #15212: Smooth panning advanced setting

### DIFF
--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -119,6 +119,9 @@ public:
     virtual bool isAutomaticallyPanEnabled() const = 0;
     virtual void setIsAutomaticallyPanEnabled(bool enabled) = 0;
 
+    virtual bool isSmoothPanning() const = 0;
+    virtual void setIsSmoothPanning(bool value) = 0;
+
     virtual bool isPlayRepeatsEnabled() const = 0;
     virtual void setIsPlayRepeatsEnabled(bool enabled) = 0;
     virtual async::Notification isPlayRepeatsChanged() const = 0;

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -59,6 +59,7 @@ static const Settings::Key USER_STYLES_PATH(module_name, "application/paths/mySt
 
 static const Settings::Key IS_MIDI_INPUT_ENABLED(module_name, "io/midi/enableInput");
 static const Settings::Key IS_AUTOMATICALLY_PAN_ENABLED(module_name, "application/playback/panPlayback");
+static const Settings::Key PLAYBACK_SMOOTH_PANNING(module_name, "application/playback/smoothPan");
 static const Settings::Key IS_PLAY_REPEATS_ENABLED(module_name, "application/playback/playRepeats");
 static const Settings::Key IS_PLAY_CHORD_SYMBOLS_ENABLED(module_name, "application/playback/playChordSymbols");
 static const Settings::Key IS_METRONOME_ENABLED(module_name, "application/playback/metronomeEnabled");
@@ -163,6 +164,10 @@ void NotationConfiguration::init()
     settings()->setDefaultValue(IS_PLAY_CHORD_SYMBOLS_ENABLED, Val(true));
     settings()->setDefaultValue(IS_METRONOME_ENABLED, Val(false));
     settings()->setDefaultValue(IS_COUNT_IN_ENABLED, Val(false));
+
+    settings()->setDefaultValue(PLAYBACK_SMOOTH_PANNING, Val(false));
+    settings()->setDescription(PLAYBACK_SMOOTH_PANNING, trc("notation", "Smooth panning"));
+    settings()->setCanBeManuallyEdited(PLAYBACK_SMOOTH_PANNING, true);
 
     settings()->valueChanged(IS_PLAY_CHORD_SYMBOLS_ENABLED).onReceive(nullptr, [this](const Val&) {
         m_isPlayChordSymbolsChanged.notify();
@@ -538,6 +543,16 @@ bool NotationConfiguration::isAutomaticallyPanEnabled() const
 void NotationConfiguration::setIsAutomaticallyPanEnabled(bool enabled)
 {
     settings()->setSharedValue(IS_AUTOMATICALLY_PAN_ENABLED, Val(enabled));
+}
+
+bool NotationConfiguration::isSmoothPanning() const
+{
+    return settings()->value(PLAYBACK_SMOOTH_PANNING).toBool();
+}
+
+void NotationConfiguration::setIsSmoothPanning(bool value)
+{
+    settings()->setSharedValue(PLAYBACK_SMOOTH_PANNING, Val(value));
 }
 
 bool NotationConfiguration::isPlayRepeatsEnabled() const

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -122,6 +122,9 @@ public:
     bool isAutomaticallyPanEnabled() const override;
     void setIsAutomaticallyPanEnabled(bool enabled) override;
 
+    bool isSmoothPanning() const override;
+    void setIsSmoothPanning(bool value) override;
+
     bool isPlayRepeatsEnabled() const override;
     void setIsPlayRepeatsEnabled(bool enabled) override;
     async::Notification isPlayRepeatsChanged() const override;

--- a/src/notation/view/abstractnotationpaintview.cpp
+++ b/src/notation/view/abstractnotationpaintview.cpp
@@ -860,6 +860,18 @@ bool AbstractNotationPaintView::adjustCanvasPosition(const RectF& logicRect, boo
     return moveCanvasToPosition(pos);
 }
 
+bool AbstractNotationPaintView::adjustCanvasPositionSmoothPan(const RectF& cursorRect)
+{
+    RectF viewRect = viewport();
+    PointF pos(cursorRect.x() - (viewRect.width() / 2), viewRect.y());
+
+    if (!viewport().intersects(cursorRect)) {
+        pos.setY(cursorRect.y() - (viewRect.height() / 2));
+    }
+
+    return moveCanvasToPosition(pos);
+}
+
 bool AbstractNotationPaintView::ensureViewportInsideScrollableArea()
 {
     TRACEFUNC;
@@ -1284,11 +1296,16 @@ void AbstractNotationPaintView::movePlaybackCursor(midi::tick_t tick)
         return;
     }
 
-    if (configuration()->isAutomaticallyPanEnabled() && m_autoScrollEnabled) {
-        bool adjustVertically = needAdjustCanvasVerticallyWhilePlayback(newCursorRect);
-
-        if (adjustCanvasPosition(newCursorRect, adjustVertically)) {
+    if (configuration()->isAutomaticallyPanEnabled()) {
+        if (configuration()->isSmoothPanning() && adjustCanvasPositionSmoothPan(newCursorRect)) {
             return;
+        }
+
+        if (m_autoScrollEnabled) {
+            bool adjustVertically = needAdjustCanvasVerticallyWhilePlayback(newCursorRect);
+            if (adjustCanvasPosition(newCursorRect, adjustVertically)) {
+                return;
+            }
         }
     }
 

--- a/src/notation/view/abstractnotationpaintview.h
+++ b/src/notation/view/abstractnotationpaintview.h
@@ -230,6 +230,7 @@ private:
     qreal verticalScrollableSize() const;
 
     bool adjustCanvasPosition(const RectF& logicRect, bool adjustVertically = true);
+    bool adjustCanvasPositionSmoothPan(const RectF& cursorRect);
 
     void onNoteInputStateChanged();
 


### PR DESCRIPTION
Resolves: #15212

Smooth panning advanced setting that used to be in MuseScore 3

Some things I am not sure about:
- I am not sure about how to change the order of the advanced preferences items, is this only possible if we list all the advanced preferences manually?
- The screen is slightly jittery when playing back, which is most likely because I am moving the screen to the cursor instead of moving the screen independently. Im not sure if this was the case in MuseScore 3.
- Should I add the other advanced preferences (that used to be in MuseScore 3) relating to smooth panning (cursor position on screen, cursor visibility, etc.)?

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
