### PR TITLE
Added channels handling to event map

### DIFF
--- a/src/engraving/compat/midi/event.cpp
+++ b/src/engraving/compat/midi/event.cpp
@@ -248,19 +248,49 @@ void EventMap::fixupMIDI()
 
     free((void*)info);
 }
-EventMap::events_multimap_t &EventMap::operator[](std::size_t idx)
+
+EventMap::events_multimap_t& EventMap::operator[](std::size_t idx)
 {
-    if (idx == size()) {
-        _channels.emplace_back();
-        return _channels[idx];
+    if (size() == 0) {
+        for (size_t i = 0; i <= _lastIndex; ++i) {
+            _channels.emplace_back();
+        }
     }
-    if (idx > size()) {
+    if (idx > _lastIndex) {
+        _lastIndex = idx;
+    }
+    if (idx >= size()) {
         auto diff = idx - size();
         do {
             _channels.emplace_back();
         } while (diff-- != 0);
     }
-    _lastIndex = idx;
     return _channels[idx];
+}
+
+const EventMap::events_multimap_t& EventMap::operator[](std::size_t idx) const
+{
+    assert(idx < size());
+    return _channels[idx];
+}
+
+void EventMap::mergePitchWheelEvents(EventMap& pitchWheelEvents)
+{
+    for (size_t i = 0; i < size(); ++i) {
+        for (const auto& eventPair : _channels[i]) {
+            const auto& event = eventPair.second;
+            const auto& tick = eventPair.first;
+            if (event.type() == ME_NOTEON && event.velo() != 0) {
+                const auto& pwEvent = findLess(pitchWheelEvents[i], tick);
+                if (pwEvent != pitchWheelEvents[i].end()
+                    && pwEvent->second.type() == ME_PITCHBEND) {
+                    PitchWheelSpecs specs;
+                    NPlayEvent pwReset(ME_PITCHBEND, i, specs.mLimit % 128, specs.mLimit / 128);
+                    _channels[i].insert(std::pair<int, NPlayEvent>(tick - 1, pwReset));
+                }
+            }
+        }
+        _channels[i].merge(pitchWheelEvents[i]);
+    }
 }
 }

--- a/src/engraving/compat/midi/event.cpp
+++ b/src/engraving/compat/midi/event.cpp
@@ -215,14 +215,14 @@ void EventMap::fixupMIDI()
     };
 
     /* track info for each channel (on the heap, 0-initialised) */
-    struct channelInfo* info = (struct channelInfo*)calloc(_lastIndex + 1, sizeof(struct channelInfo));
+    struct channelInfo* info = (struct channelInfo*)calloc(size(), sizeof(struct channelInfo));
 
     for (auto& mm : _channels) {
         auto it = mm.begin();
         while (it != mm.end()) {
             NPlayEvent& event = it->second;
             /* ME_NOTEOFF is never emitted, no need to check for it */
-            if (event.type() == ME_NOTEON && !event.isMuted()) {
+            if (event.type() == ME_NOTEON) {
                 uint8_t np = info[event.channel()].nowPlaying[event.pitch()];
                 if (event.velo() == 0) {
                     /* already off (should not happen) or still playing? */
@@ -252,12 +252,7 @@ void EventMap::fixupMIDI()
 EventMap::events_multimap_t& EventMap::operator[](std::size_t idx)
 {
     if (size() == 0) {
-        for (size_t i = 0; i <= _lastIndex; ++i) {
-            _channels.emplace_back();
-        }
-    }
-    if (idx > _lastIndex) {
-        _lastIndex = idx;
+        _channels.emplace_back();
     }
     if (idx >= size()) {
         auto diff = idx - size();
@@ -268,11 +263,11 @@ EventMap::events_multimap_t& EventMap::operator[](std::size_t idx)
     return _channels[idx];
 }
 
-const EventMap::events_multimap_t& EventMap::operator[](std::size_t idx) const
-{
-    assert(idx < size());
-    return _channels[idx];
-}
+//const EventMap::events_multimap_t& EventMap::operator[](std::size_t idx) const
+//{
+//    assert(idx < size());
+//    return _channels[idx];
+//}
 
 void EventMap::mergePitchWheelEvents(EventMap& pitchWheelEvents)
 {

--- a/src/engraving/compat/midi/event.h
+++ b/src/engraving/compat/midi/event.h
@@ -181,12 +181,12 @@ class EventMap
     OBJECT_ALLOCATOR(engraving, EventMap)
 
     using events_multimap_t = std::multimap<int, NPlayEvent>;
-    size_t _lastIndex = 15;
+//    size_t _lastIndex = 15;
     std::vector<events_multimap_t> _channels;
 public:
     [[nodiscard]] size_t size() const { return _channels.size(); }
     events_multimap_t& operator[](std::size_t idx);
-    const events_multimap_t& operator[](std::size_t idx) const;
+//    const events_multimap_t& operator[](std::size_t idx) const;
     void fixupMIDI();
     void mergePitchWheelEvents(EventMap& pitchWheelEvents);
 };

--- a/src/engraving/compat/midi/event.h
+++ b/src/engraving/compat/midi/event.h
@@ -176,19 +176,23 @@ public:
     void insertNote(int channel, Note*);
 };
 
-class EventMap : public std::multimap<int, NPlayEvent>
+class EventMap
 {
     OBJECT_ALLOCATOR(engraving, EventMap)
 
-    int _highestChannel = 15;
+    using events_multimap_t = std::multimap<int, NPlayEvent>;
+    size_t _lastIndex = 0;
+    std::vector<events_multimap_t> _channels;
 public:
+    [[nodiscard]] size_t size() const { return _channels.size(); }
+    events_multimap_t& operator[](std::size_t idx);
     void fixupMIDI();
-    void registerChannel(int c)
-    {
-        if (c > _highestChannel) {
-            _highestChannel = c;
-        }
-    }
+//    void registerChannel(int c)
+//    {
+//        if (c > _highestChannel) {
+//            _highestChannel = c;
+//        }
+//    }
 };
 
 typedef EventList::iterator iEvent;

--- a/src/engraving/compat/midi/event.h
+++ b/src/engraving/compat/midi/event.h
@@ -181,18 +181,14 @@ class EventMap
     OBJECT_ALLOCATOR(engraving, EventMap)
 
     using events_multimap_t = std::multimap<int, NPlayEvent>;
-    size_t _lastIndex = 0;
+    size_t _lastIndex = 15;
     std::vector<events_multimap_t> _channels;
 public:
     [[nodiscard]] size_t size() const { return _channels.size(); }
     events_multimap_t& operator[](std::size_t idx);
+    const events_multimap_t& operator[](std::size_t idx) const;
     void fixupMIDI();
-//    void registerChannel(int c)
-//    {
-//        if (c > _highestChannel) {
-//            _highestChannel = c;
-//        }
-//    }
+    void mergePitchWheelEvents(EventMap& pitchWheelEvents);
 };
 
 typedef EventList::iterator iEvent;

--- a/src/engraving/compat/midi/midirender.cpp
+++ b/src/engraving/compat/midi/midirender.cpp
@@ -212,12 +212,6 @@ static void playNote(EventMap& events, const Note* note, PlayNoteParams params, 
     if (params.offTime > 0 && params.offTime < params.onTime) {
         return;
     }
-    // We need to set Pitch Value to initial in case previous note was with bendUp
-    if (params.onTime - params.offset - 1 > 0) {
-        PitchWheelSpecs specs;
-        NPlayEvent pwReset(ME_PITCHBEND, params.channel, specs.mLimit % 128, specs.mLimit / 128);
-        events[params.channel].insert(std::pair<int, NPlayEvent>(std::max(0, params.onTime - params.offset - 1), pwReset));
-    }
 
     events[params.channel].insert(std::pair<int, NPlayEvent>(std::max(0, params.onTime - params.offset), ev));
     // adds portamento for continuous glissando
@@ -545,7 +539,6 @@ static void renderHarmony(EventMap& events, Measure const* m, Harmony* h, int ti
         return;
     }
 
-//    events.registerChannel(channel->channel());
     if (!staff->isPrimaryStaff()) {
         return;
     }
@@ -606,7 +599,6 @@ void MidiRenderer::collectGraceBeforeChordEvents(Chord* chord, EventMap& events,
 
                 Instrument* instr = st->part()->instrument(chord->tick());
                 int channel = getChannel(instr, note, effect);
-//                events.registerChannel(channel);
                 params.channel = channel;
 
                 if (note->noteType() == NoteType::ACCIACCATURA) {
@@ -737,7 +729,6 @@ void MidiRenderer::doCollectMeasureEvents(EventMap& events, Measure const* m, co
                 }
 
                 int channel = getChannel(instr, note, effect);
-//                events.registerChannel(channel);
                 params.channel = channel;
 
                 if (_context.eachStringHasChannel && instr->hasStrings()) {
@@ -750,7 +741,6 @@ void MidiRenderer::doCollectMeasureEvents(EventMap& events, Measure const* m, co
                 for (Chord* c : chord->graceNotesAfter()) {
                     for (const Note* note : c->notes()) {
                         int channel = getChannel(instr, note, effect);
-//                        events.registerChannel(channel);
                         CollectNoteParams params;
                         params.channel = channel;
                         params.velocityMultiplier = veloMultiplier;
@@ -1184,7 +1174,8 @@ void MidiRenderer::renderScore(EventMap& events, const Context& ctx)
     // create sustain pedal events
     renderSpanners(events, pitchWheelRender);
 
-//    EventMap pitchWheelEvents = pitchWheelRender.renderPitchWheel();
+    EventMap pitchWheelEvents = pitchWheelRender.renderPitchWheel();
+    events.mergePitchWheelEvents(pitchWheelEvents);
 //    events->merge(pitchWheelEvents);
 
     if (ctx.metronome) {

--- a/src/engraving/compat/midi/midirender.h
+++ b/src/engraving/compat/midi/midirender.h
@@ -76,24 +76,24 @@ public:
 
     explicit MidiRenderer(Score* s);
 
-    void renderScore(EventMap* events, const Context& ctx);
+    void renderScore(EventMap& events, const Context& ctx);
 
     static const int ARTICULATION_CONV_FACTOR { 100000 };
 
 private:
 
-    void renderStaff(EventMap* events, const Staff* sctx, PitchWheelRenderer& pitchWheelRenderer);
+    void renderStaff(EventMap& events, const Staff* sctx, PitchWheelRenderer& pitchWheelRenderer);
 
-    void renderSpanners(EventMap* events, PitchWheelRenderer& pitchWheelRenderer);
-    void doRenderSpanners(EventMap* events, Spanner* s, uint32_t channel, PitchWheelRenderer& pitchWheelRenderer,
+    void renderSpanners(EventMap& events, PitchWheelRenderer& pitchWheelRenderer);
+    void doRenderSpanners(EventMap& events, Spanner* s, uint32_t channel, PitchWheelRenderer& pitchWheelRenderer,
                           MidiInstrumentEffect effect);
 
-    void renderMetronome(EventMap* events);
-    void renderMetronome(EventMap* events, Measure const* m);
+    void renderMetronome(EventMap& events);
+    void renderMetronome(EventMap& events, Measure const* m);
 
-    void collectMeasureEvents(EventMap* events, Measure const* m, const Staff* sctx, int tickOffset,
+    void collectMeasureEvents(EventMap& events, Measure const* m, const Staff* sctx, int tickOffset,
                               PitchWheelRenderer& pitchWheelRenderer);
-    void doCollectMeasureEvents(EventMap* events, Measure const* m, const Staff* sctx, int tickOffset,
+    void doCollectMeasureEvents(EventMap& events, Measure const* m, const Staff* sctx, int tickOffset,
                                 PitchWheelRenderer& pitchWheelRenderer);
 
     struct ChordParams {
@@ -103,7 +103,7 @@ private:
     };
 
     ChordParams collectChordParams(const Chord* chord) const;
-    void collectGraceBeforeChordEvents(Chord* chord, EventMap* events, double veloMultiplier, Staff* st, int tickOffset,
+    void collectGraceBeforeChordEvents(Chord* chord, EventMap& events, double veloMultiplier, Staff* st, int tickOffset,
                                        PitchWheelRenderer& pitchWheelRenderer,  MidiInstrumentEffect effect);
 
     uint32_t getChannel(const Instrument* instr, const Note* note, MidiInstrumentEffect effect);

--- a/src/engraving/compat/midi/pitchwheelrenderer.cpp
+++ b/src/engraving/compat/midi/pitchwheelrenderer.cpp
@@ -106,7 +106,7 @@ void PitchWheelRenderer::renderChannelPitchWheel(EventMap& pitchWheelEvents,
                 if (staffInfoValid) {
                     evb.setOriginatingStaff(staffIdx);
                 }
-                pitchWheelEvents.emplace_hint(pitchWheelEvents.end(), std::make_pair(tick, evb));
+                pitchWheelEvents[channel].emplace_hint(pitchWheelEvents[channel].end(), std::make_pair(tick, evb));
             }
 
             prevPitch = finalPitch;

--- a/src/engraving/libmscore/rendermidi.cpp
+++ b/src/engraving/libmscore/rendermidi.cpp
@@ -1517,7 +1517,7 @@ void Score::createPlayEvents(Measure const* start, Measure const* const end)
     }
 }
 
-void Score::renderMidi(EventMap* events, const MidiRenderer::Context& ctx, bool expandRepeats)
+void Score::renderMidi(EventMap& events, const MidiRenderer::Context& ctx, bool expandRepeats)
 {
     masterScore()->setExpandRepeats(expandRepeats);
     MidiRenderer(this).renderScore(events, ctx);

--- a/src/engraving/libmscore/score.h
+++ b/src/engraving/libmscore/score.h
@@ -648,7 +648,7 @@ public:
     void cmdPaste(const IMimeData* ms, MuseScoreView* view, Fraction scale = Fraction(1, 1));
     bool pasteStaff(XmlReader&, Segment* dst, staff_idx_t staffIdx, Fraction scale = Fraction(1, 1));
     void pasteSymbols(XmlReader& e, ChordRest* dst);
-    void renderMidi(EventMap* events, const MidiRenderer::Context& ctx, bool expandRepeats);
+    void renderMidi(EventMap& events, const MidiRenderer::Context& ctx, bool expandRepeats);
 
     static void transposeChord(Chord* c, const Fraction& tick);
 

--- a/src/engraving/rendering/stable/tlayout.cpp
+++ b/src/engraving/rendering/stable/tlayout.cpp
@@ -3546,10 +3546,11 @@ void TLayout::layout(Note* item, LayoutContext&)
             if (item->negativeFretUsed()) {
                 item->setFretString(u"-" + item->fretString());
             }
-
             if (item->displayFret() == Note::DisplayFretOption::ArtificialHarmonic) {
                 item->setFretString(String(u"%1 <%2>").arg(item->fretString(), String::number(item->harmonicFret())));
+                item->setFretString(String(u"%1 <%2>").arg(item->fretString(), String::number(item->harmonicFret())));
             } else if (item->displayFret() == Note::DisplayFretOption::NaturalHarmonic) {
+                item->setFretString(String(u"<%1>").arg(String::number(item->harmonicFret())));
                 item->setFretString(String(u"<%1>").arg(String::number(item->harmonicFret())));
             }
         }

--- a/src/engraving/tests/pitchwheelrender_tests.cpp
+++ b/src/engraving/tests/pitchwheelrender_tests.cpp
@@ -29,6 +29,7 @@
 
 using namespace mu;
 using namespace mu::engraving;
+static int DEFAULT_CHANNEL = 0;
 
 class PitchWheelRender_Tests : public ::testing::Test
 {
@@ -99,14 +100,12 @@ TEST_F(PitchWheelRender_Tests, simpleLinear)
     render.addPitchWheelFunction(func, 0, 0, MidiInstrumentEffect::NONE);
 
     EventMap events = render.renderPitchWheel();
+    EXPECT_EQ(events[DEFAULT_CHANNEL].begin()->second.channel(), 0);
 
-    EXPECT_EQ(events.begin()->second.channel(), 0);
+    EXPECT_EQ(events[DEFAULT_CHANNEL].size(), 10);
 
-    EXPECT_EQ(events.size(), 10);
-
-    EXPECT_EQ(pitch(events.find(10)->second), 8202);
-    EXPECT_EQ(pitch(events.find(90)->second), 8282);
-//    EXPECT_EQ(pitch(events.find(100)->second), 8192);
+    EXPECT_EQ(pitch(events[DEFAULT_CHANNEL].find(10)->second), 8202);
+    EXPECT_EQ(pitch(events[DEFAULT_CHANNEL].find(90)->second), 8282);
 }
 
 TEST_F(PitchWheelRender_Tests, twoReverseFunctions)
@@ -161,14 +160,10 @@ TEST_F(PitchWheelRender_Tests, channelTest)
     render.addPitchWheelFunction(func, 1, 0, MidiInstrumentEffect::NONE);
 
     EventMap events = render.renderPitchWheel();
-    std::set<int> channels;
-    for (const auto& ev : events) {
-        channels.insert(ev.second.channel());
-    }
 
-    EXPECT_EQ(channels.size(), 2);
-    EXPECT_EQ(channels.count(0), 1);
-    EXPECT_EQ(channels.count(1), 1);
+    EXPECT_EQ(events.size(), 2);
+    EXPECT_EQ(events[0].count(0), 1);
+    EXPECT_EQ(events[1].count(0), 1);
 }
 
 TEST_F(PitchWheelRender_Tests, twoConnectedFunctions)
@@ -212,9 +207,9 @@ TEST_F(PitchWheelRender_Tests, twoConnectedFunctions)
 
     EventMap events = render.renderPitchWheel();
 
-    EXPECT_EQ(events.size(), 6);
+    EXPECT_EQ(events[0].size(), 6);
     std::set<int> expectedValues = { 8192, 8202, 8212, 8222, 8232, 8242 };
-    for (const auto& ev : events) {
+    for (const auto& ev : events[DEFAULT_CHANNEL]) {
         EXPECT_TRUE(expectedValues.count(pitch(ev.second)) > 0);
     }
 }
@@ -260,9 +255,9 @@ TEST_F(PitchWheelRender_Tests, twoDevidedFunctions)
 
     EventMap events = render.renderPitchWheel();
 
-    EXPECT_EQ(events.size(), 5);
+    EXPECT_EQ(events[0].size(), 5);
     std::multimap<int, int> expectedValues = { { 0, 8192 }, { 10, 8202 }, { 20, 8212 }, { 40, 8222 }, { 50, 8232 } };
-    for (const auto& ev : events) {
+    for (const auto& ev : events[DEFAULT_CHANNEL]) {
         auto it = expectedValues.find(ev.first);
         EXPECT_TRUE(it != expectedValues.end());
         EXPECT_EQ(it->second, pitch(ev.second));
@@ -309,10 +304,10 @@ TEST_F(PitchWheelRender_Tests, twoOverlappedFunctions)
 
     EventMap events = render.renderPitchWheel();
 
-    EXPECT_EQ(events.size(), 4);
+    EXPECT_EQ(events[DEFAULT_CHANNEL].size(), 4);
     std::multimap<int, int> pitches;
     std::multimap<int, int> expectedValues = { { 0, 8192 }, { 10, 8202 }, { 20, 8222 }, { 30, 8212 } };
-    for (const auto& ev : events) {
+    for (const auto& ev : events[DEFAULT_CHANNEL]) {
         auto it = expectedValues.find(ev.first);
         EXPECT_TRUE(it != expectedValues.end());
         EXPECT_EQ(it->second, pitch(ev.second));
@@ -365,7 +360,7 @@ TEST_F(PitchWheelRender_Tests, threeDevidedFunctions)
 
     std::multimap<int, int> pitches;
     std::multimap<int, int> expectedValues = { { 10, 8202 }, { 20, 8192 }, { 30, 8212 }, { 40, 8192 }, { 60, 8222 } };
-    for (const auto& ev : events) {
+    for (const auto& ev : events[DEFAULT_CHANNEL]) {
         auto it = expectedValues.find(ev.first);
         EXPECT_TRUE(it != expectedValues.end());
         EXPECT_EQ(it->second, pitch(ev.second));
@@ -418,7 +413,7 @@ TEST_F(PitchWheelRender_Tests, threeOverLappedFunctions)
 
     std::multimap<int, int> pitches;
     std::multimap<int, int> expectedValues = { { 0, 8202 }, { 20, 8212 }, { 40, 8222 }, { 50, 8212 }, { 60, 8202 }, { 70, 8192 } };
-    for (const auto& ev : events) {
+    for (const auto& ev : events[DEFAULT_CHANNEL]) {
         auto it = expectedValues.find(ev.first);
         EXPECT_TRUE(it != expectedValues.end());
         EXPECT_EQ(it->second, pitch(ev.second));

--- a/src/engraving/tests/pitchwheelrender_tests.cpp
+++ b/src/engraving/tests/pitchwheelrender_tests.cpp
@@ -135,7 +135,7 @@ TEST_F(PitchWheelRender_Tests, twoReverseFunctions)
     render.addPitchWheelFunction(func, 0, 0, MidiInstrumentEffect::NONE);
 
     EventMap events = render.renderPitchWheel();
-    EXPECT_EQ(events.size(), 1);
+    EXPECT_EQ(events[DEFAULT_CHANNEL].size(), 1);
 }
 
 TEST_F(PitchWheelRender_Tests, channelTest)
@@ -161,7 +161,7 @@ TEST_F(PitchWheelRender_Tests, channelTest)
 
     EventMap events = render.renderPitchWheel();
 
-    EXPECT_EQ(events.size(), 2);
+    EXPECT_EQ(events[0].size(), 3);
     EXPECT_EQ(events[0].count(0), 1);
     EXPECT_EQ(events[1].count(0), 1);
 }

--- a/src/importexport/midi/internal/midiexport/exportmidi.cpp
+++ b/src/importexport/midi/internal/midiexport/exportmidi.cpp
@@ -234,7 +234,7 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
     ctx.instrumentsHaveEffects = false;
     ctx.metronome = false;
     ctx.synthState = synthState;
-    m_score->renderMidi(&events, ctx, midiExpandRepeats);
+    m_score->renderMidi(events, ctx, midiExpandRepeats);
 
     m_pauseMap.calculate(m_score);
     writeHeader();
@@ -298,64 +298,67 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
                     ev.setEData(data);
                     track.insert(0, ev);
                 }
+                for (size_t e = 0; e < events.size(); ++e) {
+                    auto& m = events[e];
+                    for (auto& i : m) {
+                        const NPlayEvent& event = i.second;
 
-                for (auto i = events.begin(); i != events.end(); ++i) {
-                    const NPlayEvent& event = i->second;
-
-                    if (event.isMuted()) {
-                        continue;
-                    }
-                    if (event.discard() == staffIdx + 1 && event.velo() > 0) {
-                        // turn note off so we can restrike it in another track
-                        track.insert(m_pauseMap.addPauseTicks(i->first), MidiEvent(ME_NOTEON, channel,
-                                                                                   event.pitch(), 0));
-                    }
-
-                    staff_idx_t equivalentStaffIdx = staffIdx;
-                    for (Staff* st : m_score->masterScore()->staves()) {
-                        if (staff->id() == st->id()) {
-                            equivalentStaffIdx = st->idx();
+                        if (event.isMuted()) {
+                            continue;
                         }
-                    }
+                        if (event.discard() == staffIdx + 1 && event.velo() > 0) {
+                            // turn note off so we can restrike it in another track
+                            track.insert(m_pauseMap.addPauseTicks(i.first), MidiEvent(ME_NOTEON, channel,
+                                                                                       event.pitch(), 0));
+                        }
 
-                    if (event.getOriginatingStaff() != equivalentStaffIdx) {
-                        continue;
-                    }
+                        staff_idx_t equivalentStaffIdx = staffIdx;
+                        for (Staff* st : m_score->masterScore()->staves()) {
+                            if (staff->id() == st->id()) {
+                                equivalentStaffIdx = st->idx();
+                            }
+                        }
 
-                    if (event.discard() && event.velo() == 0) {
-                        // ignore noteoff but restrike noteon
-                        continue;
-                    }
+                        if (event.getOriginatingStaff() != equivalentStaffIdx) {
+                            continue;
+                        }
 
-                    if (!exportRPNs && event.type() == ME_CONTROLLER && event.portamento()) {
-                        // ignore portamento control events if exportRPN isn't switched on
-                        continue;
-                    }
+                        if (event.discard() && event.velo() == 0) {
+                            // ignore noteoff but restrike noteon
+                            continue;
+                        }
 
-                    char eventPort    = m_score->masterScore()->midiPort(event.channel());
-                    char eventChannel = m_score->masterScore()->midiChannel(event.channel());
-                    if (port != eventPort || channel != eventChannel) {
-                        continue;
-                    }
+                        if (!exportRPNs && event.type() == ME_CONTROLLER && event.portamento()) {
+                            // ignore portamento control events if exportRPN isn't switched on
+                            continue;
+                        }
 
-                    if (event.type() == ME_NOTEON) {
-                        // use the note values instead of the event values if portamento is suppressed
-                        if (!exportRPNs && event.portamento()) {
-                            track.insert(m_pauseMap.addPauseTicks(i->first), MidiEvent(ME_NOTEON, channel,
-                                                                                       event.note()->pitch(), event.velo()));
+                        char eventPort    = m_score->masterScore()->midiPort(event.channel());
+                        char eventChannel = m_score->masterScore()->midiChannel(event.channel());
+                        if (port != eventPort || channel != eventChannel) {
+                            continue;
+                        }
+
+                        if (event.type() == ME_NOTEON) {
+                            // use the note values instead of the event values if portamento is suppressed
+                            if (!exportRPNs && event.portamento()) {
+                                track.insert(m_pauseMap.addPauseTicks(i.first), MidiEvent(ME_NOTEON, channel,
+                                                                                           event.note()->pitch(), event.velo()));
+                            } else {
+                                track.insert(m_pauseMap.addPauseTicks(i.first), MidiEvent(ME_NOTEON, channel,
+                                                                                           event.pitch(), event.velo()));
+                            }
+                        } else if (event.type() == ME_CONTROLLER) {
+                            track.insert(m_pauseMap.addPauseTicks(i.first), MidiEvent(ME_CONTROLLER, channel,
+                                                                                       event.controller(), event.value()));
+                        } else if (event.type() == ME_PITCHBEND) {
+                            track.insert(m_pauseMap.addPauseTicks(i.first), MidiEvent(ME_PITCHBEND, channel,
+                                                                                       event.dataA(), event.dataB()));
                         } else {
-                            track.insert(m_pauseMap.addPauseTicks(i->first), MidiEvent(ME_NOTEON, channel,
-                                                                                       event.pitch(), event.velo()));
+                            LOGD("writeMidi: unknown midi event 0x%02x", event.type());
                         }
-                    } else if (event.type() == ME_CONTROLLER) {
-                        track.insert(m_pauseMap.addPauseTicks(i->first), MidiEvent(ME_CONTROLLER, channel,
-                                                                                   event.controller(), event.value()));
-                    } else if (event.type() == ME_PITCHBEND) {
-                        track.insert(m_pauseMap.addPauseTicks(i->first), MidiEvent(ME_PITCHBEND, channel,
-                                                                                   event.dataA(), event.dataB()));
-                    } else {
-                        LOGD("writeMidi: unknown midi event 0x%02x", event.type());
                     }
+
                 }
             }
         }

--- a/src/importexport/midi/internal/midiexport/exportmidi.cpp
+++ b/src/importexport/midi/internal/midiexport/exportmidi.cpp
@@ -309,7 +309,7 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
                         if (event.discard() == staffIdx + 1 && event.velo() > 0) {
                             // turn note off so we can restrike it in another track
                             track.insert(m_pauseMap.addPauseTicks(i.first), MidiEvent(ME_NOTEON, channel,
-                                                                                       event.pitch(), 0));
+                                                                                      event.pitch(), 0));
                         }
 
                         staff_idx_t equivalentStaffIdx = staffIdx;
@@ -343,22 +343,21 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
                             // use the note values instead of the event values if portamento is suppressed
                             if (!exportRPNs && event.portamento()) {
                                 track.insert(m_pauseMap.addPauseTicks(i.first), MidiEvent(ME_NOTEON, channel,
-                                                                                           event.note()->pitch(), event.velo()));
+                                                                                          event.note()->pitch(), event.velo()));
                             } else {
                                 track.insert(m_pauseMap.addPauseTicks(i.first), MidiEvent(ME_NOTEON, channel,
-                                                                                           event.pitch(), event.velo()));
+                                                                                          event.pitch(), event.velo()));
                             }
                         } else if (event.type() == ME_CONTROLLER) {
                             track.insert(m_pauseMap.addPauseTicks(i.first), MidiEvent(ME_CONTROLLER, channel,
-                                                                                       event.controller(), event.value()));
+                                                                                      event.controller(), event.value()));
                         } else if (event.type() == ME_PITCHBEND) {
                             track.insert(m_pauseMap.addPauseTicks(i.first), MidiEvent(ME_PITCHBEND, channel,
-                                                                                       event.dataA(), event.dataB()));
+                                                                                      event.dataA(), event.dataB()));
                         } else {
                             LOGD("writeMidi: unknown midi event 0x%02x", event.type());
                         }
                     }
-
                 }
             }
         }


### PR DESCRIPTION
Related to #18180 
After fixing midi export for pitch wheel events downside was unnecessary "pitch wheel reset" events before every note on.
This PR fixes this problem.