### PR TITLE
Fix initial positioning of element edit popups (harp pedal, capo, ...)

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/NotationView.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NotationView.qml
@@ -142,8 +142,8 @@ FocusScope {
                         contextMenuLoader.close()
                     }
 
-                    onShowElementPopupRequested: function (popupType, viewPos, elemSize) {
-                        Qt.callLater(popUpLoader.show, popupType, viewPos, elemSize)
+                    onShowElementPopupRequested: function (popupType, elementRect) {
+                        Qt.callLater(popUpLoader.show, popupType, elementRect)
                     }
 
                     onHideElementPopupRequested: {

--- a/src/notation/qml/MuseScore/NotationScene/internal/CapoPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/CapoPopup.qml
@@ -38,17 +38,17 @@ StyledPopupView {
 
     showArrow: false
 
-    function updatePosition(pos, size) {
+    function updatePosition(elementRect) {
         var h = Math.max(root.contentHeight, capoModel.capoIsOn ? 360 : 160)
-        root.x = pos.x + size.x + 12
-        root.y = pos.y - h / 2
+        root.x = elementRect.x + elementRect.width + 12
+        root.y = elementRect.y - h / 2
     }
 
     CapoSettingsModel {
         id: capoModel
 
         onItemRectChanged: function(rect) {
-            updatePosition(Qt.point(rect.x, rect.y), Qt.point(rect.width, rect.height))
+            updatePosition(rect)
         }
     }
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/ElementPopupLoader.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/ElementPopupLoader.qml
@@ -79,12 +79,12 @@ Item {
         }
     }
 
-    function show(elementType, viewPos, size) {
+    function show(elementType, elementRect) {
         if (isPopupOpened) {
             prv.closeOpenedPopup()
         }
         opened()
-        var popup = loader.createPopup(prv.componentByType(elementType), viewPos, size)
+        var popup = loader.createPopup(prv.componentByType(elementType), elementRect)
         prv.openPopup(popup)
     }
 
@@ -96,10 +96,10 @@ Item {
     Loader {
         id: loader
 
-        function createPopup(comp, pos, size) {
+        function createPopup(comp, elementRect) {
             loader.sourceComponent = comp
             loader.item.parent = container
-            loader.item.updatePosition(pos, size)
+            loader.item.updatePosition(elementRect)
 
             //! NOTE: All navigation panels in popups must be in the notation view section.
             //        This is necessary so that popups do not activate navigation in the new section,

--- a/src/notation/qml/MuseScore/NotationScene/internal/HarpPedalPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/HarpPedalPopup.qml
@@ -54,27 +54,31 @@ StyledPopupView {
     showArrow: false
 
     function updatePosition(elementRect) {
-        // Default: open above position of diagram
-        setOpensUpward(true)
-        root.x = (elementRect.x + elementRect.width / 2) - contentWidth / 2
-        root.y = elementRect.y - elementRect.height - contentHeight
+        root.x = elementRect.x + (elementRect.width - contentWidth) / 2
 
-        // For diagrams below stave, position above stave to not obscure it
-        if (harpModel.belowStave) {
-            root.y = harpModel.staffPos.y - elementRect.height - contentHeight
-        }
+        const marginFromElement = 12
+
+        // Above diagram
+        let yUp = Math.min(elementRect.y - contentHeight - marginFromElement,
+                           harpModel.staffPos.y - contentHeight - marginFromElement)
+        let yDown = Math.max(elementRect.y + elementRect.height + marginFromElement,
+                             harpModel.staffPos.y + harpModel.staffPos.height + marginFromElement)
 
         // not enough room on window to open above so open below stave
-        var globPos = mapToItem(ui.rootItem, Qt.point(root.x, root.y))
+        let opensUp = true
+        let globPos = root.parent.mapToItem(ui.rootItem, Qt.point(root.x, yUp))
         if (globPos.y < 0) {
-            setOpensUpward(false)
-            root.y = harpModel.staffPos.y + harpModel.staffPos.height + 10
+            opensUp = false;
+            globPos = root.parent.mapToItem(ui.rootItem, Qt.point(root.x, yDown))
         }
 
         // not enough room below stave to open so open above
-        if (root.y > ui.rootItem.height) {
-            root.y = elementRect.y - elementRect.height
+        if (globPos + contentHeight > ui.rootItem.height) {
+            opensUp = true;
         }
+
+        setOpensUpward(opensUp)
+        root.y = opensUp ? yUp : yDown
     }
 
     function checkPedalState(string, state) {

--- a/src/notation/qml/MuseScore/NotationScene/internal/HarpPedalPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/HarpPedalPopup.qml
@@ -33,8 +33,8 @@ StyledPopupView {
     HarpPedalPopupModel {
         id: harpModel
 
-        onIsDiagramChanged: {
-            updatePosition(harpModel.itemRect)
+        onItemRectChanged: function(rect) {
+            updatePosition(rect)
         }
     }
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/HarpPedalPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/HarpPedalPopup.qml
@@ -34,8 +34,7 @@ StyledPopupView {
         id: harpModel
 
         onIsDiagramChanged: {
-            var rect = harpModel.itemRect
-            updatePosition(Qt.point(rect.x, rect.y), Qt.point(rect.width, rect.height))
+            updatePosition(harpModel.itemRect)
         }
     }
 
@@ -48,23 +47,21 @@ StyledPopupView {
     property int navigationOrderEnd: isDiagramNavPanel.order
 
     contentWidth: menuItems.width
-
     contentHeight: menuItems.height
 
     margins: 0
 
     showArrow: false
 
-    function updatePosition(pos, size) {
-
+    function updatePosition(elementRect) {
         // Default: open above position of diagram
         setOpensUpward(true)
-        root.x = (pos.x + size.x / 2) - contentWidth / 2
-        root.y = pos.y - size.y - contentHeight
+        root.x = (elementRect.x + elementRect.width / 2) - contentWidth / 2
+        root.y = elementRect.y - elementRect.height - contentHeight
 
         // For diagrams below stave, position above stave to not obscure it
         if (harpModel.belowStave) {
-            root.y = harpModel.staffPos.y - size.y - contentHeight
+            root.y = harpModel.staffPos.y - elementRect.height - contentHeight
         }
 
         // not enough room on window to open above so open below stave
@@ -76,7 +73,7 @@ StyledPopupView {
 
         // not enough room below stave to open so open above
         if (root.y > ui.rootItem.height) {
-            root.y = pos.y - size.y
+            root.y = elementRect.y - elementRect.height
         }
     }
 

--- a/src/notation/view/abstractnotationpaintview.cpp
+++ b/src/notation/view/abstractnotationpaintview.cpp
@@ -493,21 +493,13 @@ void AbstractNotationPaintView::hideContextMenu()
     }
 }
 
-void AbstractNotationPaintView::showElementPopup(const ElementType& elementType, const QPointF& pos, const RectF& size)
+void AbstractNotationPaintView::showElementPopup(const ElementType& elementType, const RectF& elementRect)
 {
     TRACEFUNC;
 
-    QPointF _pos = pos;
-    if (_pos.isNull()) {
-        _pos = QPointF(width() / 2, height() / 2);
-    }
-
-    RectF elemRect = fromLogical(size);
-    QPointF elemSize = QPointF(elemRect.width(), elemRect.height());
-
     PopupModelType modelType = AbstractElementPopupModel::modelTypeFromElement(elementType);
 
-    emit showElementPopupRequested(modelType, pos, elemSize);
+    emit showElementPopupRequested(modelType, fromLogical(elementRect).toQRectF());
 }
 
 void AbstractNotationPaintView::hideElementPopup()
@@ -519,14 +511,14 @@ void AbstractNotationPaintView::hideElementPopup()
     }
 }
 
-void AbstractNotationPaintView::toggleElementPopup(const ElementType& elementType, const QPointF& pos, const RectF& size)
+void AbstractNotationPaintView::toggleElementPopup(const ElementType& elementType, const RectF& elementRect)
 {
     if (m_isPopupOpen) {
         hideElementPopup();
         return;
     }
 
-    showElementPopup(elementType, pos, size);
+    showElementPopup(elementType, elementRect);
 }
 
 void AbstractNotationPaintView::paint(QPainter* qp)

--- a/src/notation/view/abstractnotationpaintview.h
+++ b/src/notation/view/abstractnotationpaintview.h
@@ -119,9 +119,9 @@ public:
     void showContextMenu(const ElementType& elementType, const QPointF& pos) override;
     void hideContextMenu() override;
 
-    void showElementPopup(const ElementType& elementType, const QPointF& pos, const RectF& size) override;
+    void showElementPopup(const ElementType& elementType, const RectF& elementRect) override;
     void hideElementPopup() override;
-    void toggleElementPopup(const ElementType& elementType, const QPointF& pos, const RectF& size) override;
+    void toggleElementPopup(const ElementType& elementType, const RectF& elementRect) override;
 
     INotationInteractionPtr notationInteraction() const override;
     INotationPlaybackPtr notationPlayback() const override;
@@ -147,7 +147,7 @@ signals:
     void showContextMenuRequested(int elementType, const QPointF& viewPos);
     void hideContextMenuRequested();
 
-    void showElementPopupRequested(mu::notation::PopupModelType modelType, const QPointF& viewPos, const QPointF& elemSize);
+    void showElementPopupRequested(mu::notation::PopupModelType modelType, const QRectF& elementRect);
     void hideElementPopupRequested();
     void isPopupOpenChanged(bool isPopupOpen);
 

--- a/src/notation/view/internal/harppedalpopupmodel.cpp
+++ b/src/notation/view/internal/harppedalpopupmodel.cpp
@@ -119,15 +119,6 @@ bool HarpPedalPopupModel::isDiagram() const
     return m_isDiagram;
 }
 
-bool HarpPedalPopupModel::belowStave() const
-{
-    if (!m_item) {
-        return false;
-    }
-
-    return m_item->getProperty(mu::engraving::Pid::PLACEMENT) == mu::engraving::PlacementV::BELOW;
-}
-
 QRectF HarpPedalPopupModel::staffPos() const
 {
     // Just need top & bottom y.  Don't need x pos

--- a/src/notation/view/internal/harppedalpopupmodel.h
+++ b/src/notation/view/internal/harppedalpopupmodel.h
@@ -40,7 +40,6 @@ class HarpPedalPopupModel : public AbstractElementPopupModel
     Q_PROPERTY(
         QVector<mu::notation::HarpPedalPopupModel::Position> pedalState READ pedalState WRITE setDiagramPedalState NOTIFY pedalStateChanged)
     Q_PROPERTY(QRectF staffPos READ staffPos CONSTANT)
-    Q_PROPERTY(bool belowStave READ belowStave CONSTANT)
 
 public:
     enum class Position {
@@ -57,8 +56,6 @@ public:
     bool isDiagram() const;
 
     QRectF staffPos() const;
-
-    bool belowStave() const;
 
     QVector<Position> pedalState() const;
 

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -112,8 +112,7 @@ void NotationViewInputController::onNotationChanged()
         m_view->hideElementPopup();
 
         if (AbstractElementPopupModel::supportsPopup(type)) {
-            m_view->showElementPopup(type, m_view->fromLogical(selectedItem->canvasPos()).toQPointF(),
-                                     selectedItem->canvasBoundingRect());
+            m_view->showElementPopup(type, selectedItem->canvasBoundingRect());
         }
     });
 }
@@ -1116,6 +1115,6 @@ void NotationViewInputController::togglePopupForItemIfSupports(const EngravingIt
     ElementType type = item->type();
 
     if (AbstractElementPopupModel::supportsPopup(type)) {
-        m_view->toggleElementPopup(type, m_view->fromLogical(item->canvasPos()).toQPointF(), item->canvasBoundingRect());
+        m_view->toggleElementPopup(type, item->canvasBoundingRect());
     }
 }

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -71,9 +71,9 @@ public:
     virtual void showContextMenu(const ElementType& elementType, const QPointF& pos) = 0;
     virtual void hideContextMenu() = 0;
 
-    virtual void showElementPopup(const ElementType& elementType, const QPointF& pos, const RectF& size) = 0;
+    virtual void showElementPopup(const ElementType& elementType, const RectF& elementRect) = 0;
     virtual void hideElementPopup() = 0;
-    virtual void toggleElementPopup(const ElementType& elementType, const QPointF& pos, const RectF& size) = 0;
+    virtual void toggleElementPopup(const ElementType& elementType, const RectF& elementRect) = 0;
 
     virtual INotationInteractionPtr notationInteraction() const = 0;
     virtual INotationPlaybackPtr notationPlayback() const = 0;


### PR DESCRIPTION
This issue came up for the first time in https://github.com/musescore/MuseScore/pull/17904#issuecomment-1587930434, and our GSoC contributor discovered it in more extreme forms while working on #18436 