### PR TITLE
[4.1.1] Don't reset horizontal align of text in TBox during each layout

### DIFF
--- a/src/engraving/layout/v0/tlayout.cpp
+++ b/src/engraving/layout/v0/tlayout.cpp
@@ -4524,7 +4524,7 @@ void TLayout::layout1TextBase(TextBase* item, LayoutContext& ctx)
         if (item->layoutToParentWidth()) {
             if (item->explicitParent()->isTBox()) {
                 // hack: vertical alignment is always TOP
-                item->setAlign(AlignV::TOP);
+                item->setAlign({ item->align().horizontal, AlignV::TOP });
             } else if (item->explicitParent()->isBox()) {
                 // consider inner margins of frame
                 Box* b = toBox(item->explicitParent());


### PR DESCRIPTION
See #18736 