### PR TITLE
Prevent crash when (dis)connecting audio devices on macOS

### DIFF
--- a/src/framework/audio/internal/platform/osx/osxaudiodriver.h
+++ b/src/framework/audio/internal/platform/osx/osxaudiodriver.h
@@ -22,8 +22,9 @@
 #ifndef MU_AUDIO_OSXAUDIODRIVER_H
 #define MU_AUDIO_OSXAUDIODRIVER_H
 
-#include <memory>
 #include <map>
+#include <memory>
+#include <mutex>
 
 #include <MacTypes.h>
 
@@ -83,6 +84,7 @@ private:
 
     std::shared_ptr<Data> m_data = nullptr;
     std::map<unsigned int, std::string> m_outputDevices = {}, m_inputDevices = {};
+    mutable std::mutex m_devicesMutex;
     async::Notification m_outputDeviceChanged;
     async::Notification m_availableOutputDevicesChanged;
     AudioDeviceID m_deviceId;

--- a/src/framework/audio/internal/platform/osx/osxaudiodriver.mm
+++ b/src/framework/audio/internal/platform/osx/osxaudiodriver.mm
@@ -186,6 +186,8 @@ bool OSXAudioDriver::isOpened() const
 
 AudioDeviceList OSXAudioDriver::availableOutputDevices() const
 {
+    std::lock_guard lock(m_devicesMutex);
+
     AudioDeviceList deviceList;
     deviceList.push_back({ DEFAULT_DEVICE_ID, trc("audio", "System default") });
 
@@ -212,6 +214,8 @@ mu::audio::AudioDeviceID OSXAudioDriver::outputDevice() const
 
 void OSXAudioDriver::updateDeviceMap()
 {
+    std::lock_guard lock(m_devicesMutex);
+
     UInt32 propertySize;
     OSStatus result;
     std::vector<AudioObjectID> audioObjects = {};
@@ -363,6 +367,8 @@ bool OSXAudioDriver::audioQueueSetDeviceName(const AudioDeviceID& deviceId)
     if (deviceId.empty() || deviceId == DEFAULT_DEVICE_ID) {
         return true; //default device used
     }
+
+    std::lock_guard lock(m_devicesMutex);
 
     uint deviceIdInt = QString::fromStdString(deviceId).toInt();
     auto index = std::find_if(m_outputDevices.begin(), m_outputDevices.end(), [&deviceIdInt](auto& d) {


### PR DESCRIPTION
The block that's passed to `AudioObjectAddPropertyListener` is apparently not always called in the main thread, so members that are used in the methods called from this block need to be protected using a mutex.

Resolves: #17662

The problem is: this can't really been tested because the problem cannot be reproduced reliably. The best thing we can do, is to try if it does not introduce any (performance) regressions.