### PR TITLE
Correct off-by-one error in `SpannerFilter::isPlayable`

### DIFF
--- a/src/engraving/playback/filters/spannerfilter.cpp
+++ b/src/engraving/playback/filters/spannerfilter.cpp
@@ -42,7 +42,7 @@ bool SpannerFilter::isPlayable(const EngravingItem* item, const RenderingContext
     int spannerTo = spannerFrom + spannerDurationTicks;
 
     if (spannerDurationTicks == 0
-        || spannerTo < ctx.nominalPositionStartTick
+        || spannerTo <= ctx.nominalPositionStartTick
         || spannerFrom >= ctx.nominalPositionEndTick) {
         return false;
     }
@@ -54,13 +54,6 @@ int SpannerFilter::spannerActualDurationTicks(const Spanner* spanner, const int 
 {
     if (spanner->type() == ElementType::TRILL) {
         return spanner->endSegment()->tick().ticks() - spanner->tick().ticks() - 1;
-    }
-
-    if (spanner->type() == ElementType::PEDAL) {
-        const Pedal* pedal = toPedal(spanner);
-        if (pedal->endHookType() == HookType::HOOK_45) {
-            return nominalDurationTicks - Constants::DIVISION / 4;
-        }
     }
 
     if (spanner->type() == ElementType::SLUR) {

--- a/src/engraving/playback/filters/spannerfilter.cpp
+++ b/src/engraving/playback/filters/spannerfilter.cpp
@@ -52,10 +52,6 @@ bool SpannerFilter::isPlayable(const EngravingItem* item, const RenderingContext
 
 int SpannerFilter::spannerActualDurationTicks(const Spanner* spanner, const int nominalDurationTicks)
 {
-    if (spanner->type() == ElementType::TRILL) {
-        return spanner->endSegment()->tick().ticks() - spanner->tick().ticks() - 1;
-    }
-
     if (spanner->type() == ElementType::SLUR) {
         EngravingItem* startItem = spanner->startElement();
         EngravingItem* endItem = spanner->endElement();


### PR DESCRIPTION
This immediately fixes #16757, which occurred when a chord right after the end of a pedal line was counted as intersecting its duration.

This commit also reverts the subtraction by `Constants::DIVISION / 4` for the duration of a pedal line ending in an angled hook. This subtraction was introduced in order to fix #12869, but it has caused other issues such as #16001 and is probably unneeded given the fix to `isPlayable`.

Resolves: #16757
Resolves: #16001
Resolves: https://github.com/musescore/MuseScore/issues/19322
Resolves: https://github.com/musescore/MuseScore/issues/18835

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes – ~~TODO, mainly due to tooling. Adds `.cache` and `compile_commands.json` to `.gitignore` since clangd expects a `compile_commands.json` file in either `.` or `build/` and creates a `.cache` directory in `build`. Also specifies the path to the Uncrustify config for VSCode. These can be moved to a separate PR if desired.~~ moved to #18767
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
