### PR TITLE
Add support for additional tools

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+    CompilationDatabase: build.tooldata/

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 build.release
 build.debug
 build.install
+build.tooldata
 build.qtc
 build-*
 win32build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -48,5 +48,6 @@
         "qcombobox": "cpp"
     },
     "cmake.buildDirectory": "${workspaceRoot}/build.debug",
-    "cmake.configureOnOpen": true
+    "cmake.configureOnOpen": true,
+    "uncrustify.configPath.linux": "tools/codestyle/uncrustify_musescore.cfg"
 }

--- a/ninja_build.sh
+++ b/ninja_build.sh
@@ -135,6 +135,36 @@ case $TARGET in
     clean)
         rm -rf build.debug build.release
         ;; 
+    
+    compile_commands)
+        # Generate compile_commands.json file (https://clang.llvm.org/docs/JSONCompilationDatabase.html)
+        mkdir -p build.tooldata
+        cd build.tooldata
+        cmake .. -GNinja \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
+            -DMUE_COMPILE_USE_UNITY=OFF \
+            -DCMAKE_BUILD_TYPE="Debug" \
+            -DCMAKE_INSTALL_PREFIX="${MUSESCORE_INSTALL_DIR}" \
+            -DMUSESCORE_INSTALL_SUFFIX="${MUSESCORE_INSTALL_SUFFIX}" \
+            -DMUSESCORE_BUILD_CONFIGURATION="${MUSESCORE_BUILD_CONFIGURATION}" \
+            -DMUSESCORE_BUILD_MODE="${MUSESCORE_BUILD_MODE}" \
+            -DCMAKE_BUILD_NUMBER="${MUSESCORE_BUILD_NUMBER}" \
+            -DMUSESCORE_REVISION="${MUSESCORE_REVISION}" \
+            -DMUE_RUN_LRELEASE="${MUSESCORE_RUN_LRELEASE}" \
+            -DMUE_BUILD_VST_MODULE="${MUSESCORE_BUILD_VST_MODULE}" \
+            -DMUE_BUILD_VIDEOEXPORT_MODULE="${MUSESCORE_BUILD_VIDEOEXPORT_MODULE}" \
+            -DMUE_LEARN_YOUTUBE_API_KEY="${MUSESCORE_YOUTUBE_API_KEY}" \
+            -DMUE_BUILD_UPDATE_MODULE="${MUSESCORE_BUILD_UPDATE_MODULE}" \
+            -DMUE_DOWNLOAD_SOUNDFONT="${MUSESCORE_DOWNLOAD_SOUNDFONT}" \
+            -DMUE_BUILD_UNIT_TESTS="${MUSESCORE_BUILD_UNIT_TESTS}" \
+            -DMUE_BUILD_CRASHPAD_CLIENT="${MUSESCORE_BUILD_CRASHPAD_CLIENT}" \
+            -DMUE_CRASH_REPORT_URL="${MUSESCORE_CRASHREPORT_URL}" \
+            -DMUE_LOGGER_DEBUGLEVEL_ENABLED="${MUSESCORE_DEBUGLEVEL_ENABLED}" \
+            -DVST3_SDK_PATH="${MUSESCORE_VST3_SDK_PATH}" \
+            -DCMAKE_SKIP_RPATH="${MUSESCORE_NO_RPATH}" \
+
+
+        ;;
 
     revision)
 	    git rev-parse --short=7 HEAD | tr -d '\n' > local_build_revision.env


### PR DESCRIPTION
This adds the following:

* A `compile_commands` target for the ninja_build.sh script. This generates a `compile_commands.json` file, which is used by tools such as clangd, in a new target directory called `build.tooldata`. Unity builds must be disabled for the database to be complete; see [this Discord comment by Casper Jeukendrup](https://discord.com/channels/818804595450445834/939880479887327302/1001483416753143818) for more info.
* Additionally, a configuration file for clangd has been created to tell it to find the file in the `build.tooldata` directory.
* Add a one-line change to the workspace settings for VSCode, telling it where to find the Uncrustify config.

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable) – N/A
