### PR TITLE
Use new AppImage format with static libraries, to avoid libfuse2 installation

### DIFF
--- a/build/ci/linux/setup.sh
+++ b/build/ci/linux/setup.sh
@@ -46,6 +46,7 @@ echo "echo 'Setup MuseScore build environment'" >> $ENV_FILE
 # These are installed by default on Travis CI, but not on Docker
 apt_packages_basic=(
   # Alphabetical order please!
+  desktop-file-utils
   file
   git
   pkg-config

--- a/build/ci/linux/tools/make_appimage.sh
+++ b/build/ci/linux/tools/make_appimage.sh
@@ -44,13 +44,14 @@ function download_appimage_release()
   local -r github_repo_slug="$1" binary_name="$2" tag="$3"
   local -r appimage="${binary_name}-x86_64.AppImage"
   download_github_release "${github_repo_slug}" "${tag}" "${appimage}"
-  extract_appimage "${appimage}" "${binary_name}"
+  # extract_appimage "${appimage}" "${binary_name}"
+  mv "${appimage}" "${binary_name}"
 }
 
 if [[ ! -d $BUILD_TOOLS/appimagetool ]]; then
   mkdir $BUILD_TOOLS/appimagetool
   cd $BUILD_TOOLS/appimagetool
-  download_appimage_release AppImage/AppImageKit appimagetool continuous
+  download_appimage_release AppImage/appimagetool appimagetool continuous
   cd $ORIGIN_DIR
 fi
 export PATH="$BUILD_TOOLS/appimagetool:$PATH"


### PR DESCRIPTION
Resolves: #18633

This PR replaces the old appimagetool executables with the newer one, in which the needed libraries (such as libfuse2) are linked statically. The new AppImage will thus not require additional packages to be installed in the user's system.
By looking at the comment here: https://github.com/AppImage/appimagetool/pull/33 the statically linked runtime is at the moment still experimental, but the old runtime is not maintained anymore.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
