### PR TITLE
Add implementation for the MEI importer and exporter

### DIFF
--- a/src/importexport/mei/internal/meiconverter.cpp
+++ b/src/importexport/mei/internal/meiconverter.cpp
@@ -176,7 +176,7 @@ libmei::data_BARRENDITION Convert::barlineToMEI(const engraving::BarLineType bar
     case (engraving::BarLineType::HEAVY): return libmei::BARRENDITION_heavy;
     case (engraving::BarLineType::DOUBLE_HEAVY): return libmei::BARRENDITION_dblheavy;
     case (engraving::BarLineType::REVERSE_END):
-        LOGD("Unsupported engraving::BarLineType::REVERSE_END");
+        LOGD() << "Unsupported engraving::BarLineType::REVERSE_END";
         return libmei::BARRENDITION_dbl;
     default:
         return libmei::BARRENDITION_single;
@@ -500,7 +500,7 @@ libmei::Clef Convert::clefToMEI(engraving::ClefType clef)
         meiClef.SetShape(libmei::CLEFSHAPE_GG);
         break;
     default:
-        LOGD("Unsupported clef shape");
+        LOGD() << "Unsupported clef shape";
         meiClef.SetShape(libmei::CLEFSHAPE_F);
     }
 

--- a/src/importexport/mei/internal/meiconverter.cpp
+++ b/src/importexport/mei/internal/meiconverter.cpp
@@ -631,7 +631,9 @@ void Convert::dynamFromMEI(engraving::Dynamic* dynamic, const StringList& meiLin
         { 'n', engraving::SymId::dynamicNiente },
     };
 
-    assert(dynamic);
+    IF_ASSERT_FAILED(dynamic) {
+        return;
+    }
 
     warning = false;
 
@@ -741,7 +743,9 @@ libmei::Dynam Convert::dynamToMEI(const engraving::Dynamic* dynamic, StringList&
 
 void Convert::endingFromMEI(engraving::Volta* volta, const libmei::Ending& meiEnding, bool& warning)
 {
-    assert(volta);
+    IF_ASSERT_FAILED(volta) {
+        return;
+    }
 
     warning = false;
     // @type used for storing endings
@@ -926,7 +930,9 @@ std::pair<libmei::graceGrpLog_ATTACH, libmei::data_GRACE> Convert::gracegrpToMEI
 
 void Convert::harmFromMEI(engraving::Harmony* harmony, const StringList& meiLines, const libmei::Harm& meiHarm, bool& warning)
 {
-    assert(harmony);
+    IF_ASSERT_FAILED(harmony) {
+        return;
+    }
 
     warning = false;
 
@@ -1374,7 +1380,12 @@ Convert::PitchStruct Convert::pitchFromMEI(const libmei::Note& meiNote, const li
 std::pair<libmei::Note, libmei::Accid> Convert::pitchToMEI(const engraving::Note* note, const engraving::Accidental* accid,
                                                            const engraving::Interval& interval)
 {
-    assert(note);
+    libmei::Note meiNote;
+    libmei::Accid meiAccid;
+
+    IF_ASSERT_FAILED(note) {
+        return { meiNote, meiAccid };
+    }
 
     Convert::PitchStruct pitch;
     pitch.pitch = note->pitch();
@@ -1386,9 +1397,6 @@ std::pair<libmei::Note, libmei::Accid> Convert::pitchToMEI(const engraving::Note
         // Not needed because relying on accidType
         // pitch.accidRole = accid->role();
     }
-
-    libmei::Note meiNote;
-    libmei::Accid meiAccid;
 
     meiNote.SetPname(static_cast<libmei::data_PITCHNAME>(engraving::tpc2step(pitch.tpc2) + 1));
 
@@ -1448,9 +1456,12 @@ Convert::StaffStruct Convert::staffFromMEI(const libmei::StaffDef& meiStaffDef, 
 
 libmei::StaffDef Convert::staffToMEI(const engraving::Staff* staff)
 {
-    assert(staff);
-
     libmei::StaffDef meiStaffDef;
+
+    IF_ASSERT_FAILED(staff) {
+        return;
+    }
+
     // @n
     meiStaffDef.SetN(static_cast<int>(staff->idx() + 1));
     // @trans.*
@@ -1511,7 +1522,9 @@ std::pair<libmei::data_STEMDIRECTION, double> Convert::stemToMEI(const engraving
 
 void Convert::tempoFromMEI(engraving::TempoText* tempoText, const StringList& meiLines, const libmei::Tempo& meiTempo, bool& warning)
 {
-    assert(tempoText);
+    IF_ASSERT_FAILED(tempoText) {
+        return;
+    }
 
     warning = false;
 
@@ -1701,7 +1714,9 @@ void Convert::textToMEI(textWithSmufl& textBlocks, const String& text)
 
 void Convert::tupletFromMEI(engraving::Tuplet* tuplet, const libmei::Tuplet& meiTuplet, bool& warning)
 {
-    assert(tuplet);
+    IF_ASSERT_FAILED(tuplet) {
+        return;
+    }
 
     warning = false;
     if (!meiTuplet.HasNum() || !meiTuplet.HasNumbase()) {

--- a/src/importexport/mei/internal/meiconverter.cpp
+++ b/src/importexport/mei/internal/meiconverter.cpp
@@ -1459,7 +1459,7 @@ libmei::StaffDef Convert::staffToMEI(const engraving::Staff* staff)
     libmei::StaffDef meiStaffDef;
 
     IF_ASSERT_FAILED(staff) {
-        return;
+        return meiStaffDef;
     }
 
     // @n

--- a/src/importexport/mei/internal/meiconverter.cpp
+++ b/src/importexport/mei/internal/meiconverter.cpp
@@ -621,7 +621,7 @@ libmei::data_DURATION Convert::durToMEI(const engraving::DurationType duration)
 void Convert::dynamFromMEI(engraving::Dynamic* dynamic, const StringList& meiLines, const libmei::Dynam& meiDynam, bool& warning)
 {
     // The letters in the MEI to be mapped to SMuFL symbols in the xmlText
-    static std::map<Char, engraving::SymId> dynMap = {
+    static const std::map<Char, engraving::SymId> DYN_MAP = {
         { 'p', engraving::SymId::dynamicPiano },
         { 'm', engraving::SymId::dynamicMezzo },
         { 'f', engraving::SymId::dynamicForte },
@@ -665,7 +665,7 @@ void Convert::dynamFromMEI(engraving::Dynamic* dynamic, const StringList& meiLin
             // If the word is only dynamic letters, convert them to SMuFL symbols one by one
             if (word.toStdString().find_first_not_of("fpmrszn") == std::string::npos) {
                 for (size_t i = 0; i < word.size(); i++) {
-                    line += u"<sym>" + String::fromAscii(engraving::SymNames::nameForSymId(dynMap.at(word.at(i))).ascii()) + u"</sym>";
+                    line += u"<sym>" + String::fromAscii(engraving::SymNames::nameForSymId(DYN_MAP.at(word.at(i))).ascii()) + u"</sym>";
                 }
             }
             // Otherwise keep it as is
@@ -684,7 +684,7 @@ void Convert::dynamFromMEI(engraving::Dynamic* dynamic, const StringList& meiLin
 libmei::Dynam Convert::dynamToMEI(const engraving::Dynamic* dynamic, StringList& meiLines)
 {
     // The SMuFL unicode points in the plainText to be mapped to letters in the MEI
-    static std::map<char16_t, Char> dynMap = {
+    static const std::map<char16_t, Char> DYN_MAP = {
         { u'\uE520', 'p' },
         { u'\uE521', 'm' },
         { u'\uE522', 'f' },
@@ -711,11 +711,11 @@ libmei::Dynam Convert::dynamToMEI(const engraving::Dynamic* dynamic, StringList&
     String plainText = dynamic->plainText();
     for (size_t i = 0; i < plainText.size(); i++) {
         char16_t c = plainText.at(i).unicode();
-        if (c < u'\uE000' || c > u'\uF8FF' || !dynMap.count(c)) {
+        if (c < u'\uE000' || c > u'\uF8FF' || !DYN_MAP.count(c)) {
             meiText += c;
             continue;
         }
-        meiText += dynMap.at(c);
+        meiText += DYN_MAP.at(c);
 
         /*
         char16_t c = plainText.at(i).unicode();

--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -54,7 +54,10 @@
 
 #include "log.h"
 
+#include "meiconverter.h"
+
 #include "thirdparty/libmei/cmn.h"
+#include "thirdparty/libmei/harmony.h"
 #include "thirdparty/libmei/shared.h"
 
 using namespace mu::iex::mei;
@@ -72,6 +75,18 @@ bool MeiExporter::write(QIODevice& destinationDevice)
 {
     // Still using QTextStream since we have a QIODevice
     QTextStream out(&destinationDevice);
+
+    m_hasSections = false;
+
+    m_sectionCounter = 0;
+    m_endingCounter = 0;
+    m_measureCounter = 0;
+    m_staffCounter = 0;
+    m_layerCounter = 0;
+    m_measureCounterFor.resize(UNSPECIFIED_M + 1);
+    this->resetMeasureIDs();
+    m_layerCounterFor.resize(UNSPECIFIED_L + 1);
+    this->resetLayerIDs();
 
     try {
         pugi::xml_document meiDoc;
@@ -101,7 +116,12 @@ bool MeiExporter::write(QIODevice& destinationDevice)
         libmei::meiVersion_MEIVERSION meiVersion = libmei::meiVersion_MEIVERSION_5_0_0_devplusbasic;
         m_mei.append_attribute("meiversion") = (converter.MeiVersionMeiversionToStr(meiVersion)).c_str();
 
-        // TODO: actual export
+        this->writeHeader();
+
+        this->writeScore();
+
+        // Currently not used. To be enabled for unfolding MuseScore Jumps into `@jumpto` MEI attribute if it becomes available on MEI repeatMark
+        // this->addJumpToRepeatMarks();
 
         unsigned int output_flags = pugi::format_default;
 
@@ -118,4 +138,1647 @@ bool MeiExporter::write(QIODevice& destinationDevice)
 
     out.flush();
     return true;
+}
+
+//---------------------------------------------------------
+//   convert
+//---------------------------------------------------------
+
+/**
+ * Write the MEI header.
+ * Look for the meiHead custom meta tag (given when importing an MEI file into MuseScore).
+ * Otherwise, generate the header using the common meta tags.
+ */
+
+bool MeiExporter::writeHeader()
+{
+    String headStr = m_score->metaTag(u"meiHead");
+    if (headStr.size() > 0) {
+        pugi::xml_document docHead;
+        docHead.load_string(headStr.toStdString().c_str());
+        m_mei.append_copy(docHead.first_child());
+    } else {
+        // create header
+        pugi::xml_node meiHead = m_mei.append_child("meiHead");
+        pugi::xml_node fileDesc = meiHead.append_child("fileDesc");
+        pugi::xml_node titleStmt = fileDesc.append_child("titleStmt");
+        pugi::xml_node title = titleStmt.append_child("title");
+        if (!m_score->metaTag(u"workTitle").isEmpty()) {
+            title.text().set(m_score->metaTag(u"workTitle").toStdString().c_str());
+        }
+
+        pugi::xml_node respStmt;
+        StringList persNames;
+        // the creator types commonly found in MusicXML
+        persNames << u"arranger" << u"composer" << u"lyricist" << u"translator";
+        for (String tagName : persNames) {
+            String persName = m_score->metaTag(tagName);
+            if (!persName.isEmpty()) {
+                if (!respStmt) {
+                    respStmt = titleStmt.append_child("respStmt");
+                }
+                pugi::xml_node persNameNode = respStmt.append_child("persName");
+                persNameNode.text().set(persName.toStdString().c_str());
+                persNameNode.append_attribute("role") = tagName.toStdString().c_str();
+            }
+        }
+
+        pugi::xml_node pubStmt = fileDesc.append_child("pubStmt");
+        pugi::xml_node date = pubStmt.append_child("date");
+
+        // date
+        String dateStr = DateTime::currentDateTime().toString();
+        date.append_attribute("isodate") = dateStr.toStdString().c_str();
+
+        if (!m_score->metaTag(u"copyright").isEmpty()) {
+            pugi::xml_node availability = pubStmt.append_child("availability");
+            pugi::xml_node distributor = availability.append_child("distributor");
+            distributor.text().set(m_score->metaTag(u"copyright").toStdString().c_str());
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Write the MEI score.
+ * First write the initial scoreDef, and then loop through pages and systems.
+ * Layout information (sb and pb) is written only when the corresponding output option is selected.
+ */
+
+bool MeiExporter::writeScore()
+{
+    pugi::xml_node music = m_mei.append_child("music");
+    m_currentNode = music.append_child("body");
+    m_currentNode = m_currentNode.append_child("mdiv");
+    m_currentNode = m_currentNode.append_child("score");
+
+    this->writeScoreDef();
+
+    m_currentNode = m_currentNode.append_child();
+    libmei::Section meiSection;
+    meiSection.Write(m_currentNode, this->getSectionXmlId());
+
+    int measureN = 0;
+    bool isFirst = true;
+    bool wasPreviousIrregular = true;
+
+    bool exportLayout = configuration()->meiExportLayout();
+    bool pageBreak = false;
+    bool lineBreak = false;
+    //bool sectionBreak = false; // not implemented, but we should had additional sections elements where m_hasSections is true
+
+    for (const Page* page : m_score->pages()) {
+        bool firstSystem = true;
+        if (exportLayout) {
+            libmei::Pb pb;
+            if (pageBreak) {
+                pb.SetType(BREAK_TYPE);
+            }
+            pb.Write(m_currentNode.append_child());
+        }
+        for (const System* system : page->systems()) {
+            if (exportLayout && !firstSystem) {
+                libmei::Sb sb;
+                if (lineBreak) {
+                    sb.SetType(BREAK_TYPE);
+                }
+                sb.Write(m_currentNode.append_child());
+            }
+            for (const MeasureBase* mBase : system->measures()) {
+                if (mBase->isMeasure()) {
+                    const Measure* measure = static_cast<const Measure*>(mBase);
+                    this->writeEnding(measure);
+                    this->writeMeasure(measure, measureN, isFirst, wasPreviousIrregular);
+                    this->writeEndingEnd(measure);
+                    firstSystem = false;
+                }
+                lineBreak = mBase->lineBreak();
+                pageBreak = mBase->pageBreak();
+                //sectionBreak = mBase->sectionBreak(); // see comment above
+            }
+        }
+    }
+
+    // non critical assert
+    assert(this->isCurrentNode(libmei::Section()));
+    m_currentNode = m_currentNode.parent();
+
+    return true;
+}
+
+/**
+ * Write the initial score definition.
+ */
+
+bool MeiExporter::writeScoreDef()
+{
+    m_currentNode = m_currentNode.append_child("scoreDef");
+
+    // If we have a VBox on the first measure, assume it to be a title frame and use it for the pgHead
+    MeasureBase* mBase = m_score->measures()->first();
+    if (mBase->isVBox()) {
+        this->writePgHead(toVBox(mBase));
+    }
+
+    m_currentNode = m_currentNode.append_child("staffGrp");
+
+    // Number of staffGrp closing at each staff
+    std::vector<int> staffGrpEnds(m_score->staves().size(), 0);
+
+    const Measure* measure = nullptr;
+    for (MeasureBase* mBase = m_score->measures()->first(); mBase != nullptr; mBase = mBase->next()) {
+        if (!measure && mBase->isMeasure()) {
+            // the first actuall measure we are going built the scoreDef from
+            measure = static_cast<const Measure*>(mBase);
+        }
+        // Also check here if we have multiple sections in the score
+        if (mBase->sectionBreak()) {
+            m_hasSections = true;
+            break;
+        }
+    }
+
+    for (Part* part : m_score->parts()) {
+        // For parts with more than one staff, write the label in the staffGrp
+        Part* staffGrpPart = (part->nstaves() > 1) ? part : nullptr;
+        // Otherwise write the label in the staffDef
+        bool isStaffDefPart = (part->nstaves() == 1) ? true : false;
+        for (Staff* staff : part->staves()) {
+            this->writeStaffGrpStart(staff, staffGrpEnds, staffGrpPart);
+            this->writeStaffDef(staff, measure, part, isStaffDefPart);
+            this->writeStaffGrpEnd(staff, staffGrpEnds);
+            // We pass the part only for the first staff of the staffGrp, so set it to null after
+            staffGrpPart = nullptr;
+        }
+    }
+
+    m_currentNode = m_currentNode.parent();
+    m_currentNode = m_currentNode.parent();
+
+    return true;
+}
+
+/**
+ * Write the page header.
+ * Uses the first MuseScore vBox.
+ */
+
+bool MeiExporter::writePgHead(const VBox* vBox)
+{
+    IF_ASSERT_FAILED(vBox) {
+        return false;
+    }
+
+    m_currentNode = m_currentNode.append_child();
+
+    libmei::PgHead pgHead;
+    pgHead.Write(m_currentNode);
+
+    std::list<std::pair<libmei::Rend, String> > cells[CellCount];
+
+    // For each text in the frame create an MEI Rend
+    // Convert::textToMEI set the size of the Rend looking at the TextStyleType
+    // It also places them (cell) accordingly
+    for (const EngravingItem* element : vBox->el()) {
+        if (element->isText()) {
+            const Text* text = toText(element);
+            auto [meiRend, cell, rendText] = Convert::textToMEI(text);
+            cells[cell].push_back(std::make_pair(meiRend, rendText));
+        }
+    }
+
+    // Each cell is now a list of pairs of Rend and the corresponding text content
+    // The text content is plain text but can be mutliple lines separated with a "\n"
+    for (int cell = TopLeft; cell < CellCount; cell++) {
+        if (cells[cell].empty()) {
+            continue;
+        }
+        // if the cell is not empty, create a cell Rend an place it accordingly
+        pugi::xml_node cellNode = m_currentNode.append_child();
+        libmei::Rend meiRendCell;
+        if (cell < 3) {
+            meiRendCell.SetValign(libmei::VERTICALALIGNMENT_top);
+        } else if (cell < 6) {
+            meiRendCell.SetValign(libmei::VERTICALALIGNMENT_middle);
+        } else {
+            meiRendCell.SetValign(libmei::VERTICALALIGNMENT_bottom);
+        }
+        if ((cell % 3) == 0) {
+            meiRendCell.SetHalign(libmei::HORIZONTALALIGNMENT_left);
+        } else if ((cell % 3) == 1) {
+            meiRendCell.SetHalign(libmei::HORIZONTALALIGNMENT_center);
+        } else {
+            meiRendCell.SetHalign(libmei::HORIZONTALALIGNMENT_right);
+        }
+        meiRendCell.Write(cellNode);
+        // In the cell, write each Rend
+        bool isFirst = true;
+        for (auto& pair : cells[cell]) {
+            // If we have more than one Rend in the cell-list, add an <lb/>
+            if (!isFirst) {
+                cellNode.append_child("lb");
+            }
+            pugi::xml_node rendNode = cellNode.append_child();
+            pair.first.Write(rendNode);
+            // Each Rend (as plain text) can itself be multi-line, split it with <lb/>
+            StringList lines = pair.second.split(u"\n");
+            this->writeLines(rendNode, lines);
+            isFirst = false;
+        }
+    }
+
+    m_currentNode = m_currentNode.parent();
+
+    return true;
+}
+
+/**
+ * Write a list of string as lines separated with line breaks
+ */
+
+bool MeiExporter::writeLines(pugi::xml_node node, const StringList& lines)
+{
+    if (lines.size() > 0) {
+        node.text().set(lines[0].toStdString().c_str());
+    }
+    for (size_t index = 1; index < lines.size(); index++) {
+        node.append_child("lb");
+        pugi::xml_node textNode = node.append_child(pugi::node_pcdata);
+        textNode.text() = lines[index].toStdString().c_str();
+    }
+    return true;
+}
+
+/**
+ * Write a list of string as lines separated with line breaks.
+ * For each line group the SMuFL symbols into <rend> with a @glyph.num
+ * Convert line by line MuseScore plain text (without <sym>) into text segmented text blocks
+ */
+
+bool MeiExporter::writeLinesWithSMuFL(pugi::xml_node node, const StringList& lines)
+{
+    bool isFirst = true;
+    for (size_t index = 0; index < lines.size(); index++) {
+        if (!isFirst) {
+            node.append_child("lb");
+        }
+
+        Convert::textWithSmufl lineBlocks;
+        Convert::textToMEI(lineBlocks, lines.at(index));
+
+        bool isFirstBlock = true;
+        for (auto& block : lineBlocks) {
+            if (block.first) {
+                pugi::xml_node rendText = node.append_child();
+                libmei::Rend meiRend;
+                meiRend.SetGlyphAuth("smufl");
+                meiRend.Write(rendText);
+                rendText.text() = block.second.toStdString().c_str();
+            } else {
+                if (isFirst && isFirstBlock) {
+                    node.text().set(block.second.toStdString().c_str());
+                } else {
+                    pugi::xml_node textNode = node.append_child(pugi::node_pcdata);
+                    textNode.text() = block.second.toStdString().c_str();
+                }
+            }
+            isFirstBlock = false;
+        }
+        isFirst = false;
+    }
+    return true;
+}
+
+/**
+ * Write a score definition change.
+ * The scoreDef is preprended to the m_currentNode that currently holds the measure.
+ * The changes are encoded in the scoreDef element if that is possible.
+ * Otherwise, staffGrp with staffDef are encoded (e.g., when changing a key signature with transposing instruments)
+ */
+
+bool MeiExporter::writeScoreDefChange()
+{
+    if (!m_timeSig && !m_keySig) {
+        return true;
+    }
+
+    // First check that the timesig change is the same at all staves
+    const TimeSig* scoreDefTimeSig = nullptr;
+    if (m_timeSig) {
+        for (size_t staff = 0; staff < m_score->nstaves(); staff++) {
+            const TimeSig* current = dynamic_cast<const TimeSig*>(m_timeSig->element(staff2track(staff)));
+            if (scoreDefTimeSig) {
+                // Compare the current and the previous one, stop if they are different
+                if (!current || (*current) != (*scoreDefTimeSig)) {
+                    scoreDefTimeSig = nullptr;
+                    break;
+                }
+            }
+            scoreDefTimeSig = current;
+            // The first staff had none, that will be different than any other one in the segment anyway
+            if (!scoreDefTimeSig) {
+                break;
+            }
+        }
+    }
+
+    // Same for keysig changes (likely to be different with transposing instruments)
+    const KeySig* scoreDefKeySig = nullptr;
+    if (m_keySig) {
+        for (size_t staff = 0; staff < m_score->nstaves(); staff++) {
+            const KeySig* current = dynamic_cast<const KeySig*>(m_keySig->element(staff2track(staff)));
+            if (scoreDefKeySig) {
+                if (!current || (current->key() != scoreDefKeySig->key())) {
+                    scoreDefKeySig = nullptr;
+                    break;
+                }
+            }
+            scoreDefKeySig = current;
+            // The first staff had none, same as for time sig
+            if (!scoreDefKeySig) {
+                break;
+            }
+        }
+    }
+
+    // m_currentNode is the last measure and we need to prepend the scoreDef
+    pugi::xml_node scoreDefNode = m_currentNode.parent().insert_child_before("scoreDef", m_currentNode);
+    libmei::ScoreDef meiScoreDef;
+
+    // Single timesig change
+    if (scoreDefTimeSig) {
+        libmei::StaffDef timeSigDef = Convert::meterToMEI(scoreDefTimeSig->sig(), scoreDefTimeSig->timeSigType());
+        meiScoreDef.SetMeterSym(timeSigDef.GetMeterSym());
+        meiScoreDef.SetMeterUnit(timeSigDef.GetMeterUnit());
+        meiScoreDef.SetMeterCount(timeSigDef.GetMeterCount());
+    }
+    // Single keysig change
+    if (scoreDefKeySig) {
+        //libmei::StaffDef keySigDef = Convert::keyToMEI(scoreDefKeySig->sig());
+        meiScoreDef.SetKeysig(Convert::keyToMEI(scoreDefKeySig->key()));
+    }
+    // Otherwise, add staffGrp/staffDef
+    if ((!scoreDefTimeSig && m_timeSig) || (!scoreDefKeySig && m_keySig)) {
+        pugi::xml_node staffGrpNode = scoreDefNode.append_child("staffGrp");
+        for (size_t staff = 0; staff < m_score->nstaves(); staff++) {
+            pugi::xml_node staffDefNode = staffGrpNode.append_child();
+            libmei::StaffDef meiStaffDef;
+            if (!scoreDefTimeSig && m_timeSig) {
+                const TimeSig* timeSig = dynamic_cast<const TimeSig*>(m_timeSig->element(staff2track(staff)));
+                if (timeSig) {
+                    meiStaffDef = Convert::meterToMEI(timeSig->sig(), timeSig->timeSigType());
+                }
+            }
+            if (!scoreDefKeySig && m_keySig) {
+                const KeySig* keySig = dynamic_cast<const KeySig*>(m_keySig->element(staff2track(staff)));
+                if (keySig) {
+                    meiStaffDef.SetKeysig(Convert::keyToMEI(keySig->key()));
+                }
+            }
+            meiStaffDef.SetN(static_cast<int>(staff + 1));
+            meiStaffDef.Write(staffDefNode);
+        }
+    }
+
+    meiScoreDef.Write(scoreDefNode);
+
+    return true;
+}
+
+/**
+ * Write a staffGrp (opening).
+ * Increments in ends the ending position of the staffGrp to be closed by MeiExporter::writeStaffGrpEnd.
+ */
+
+bool MeiExporter::writeStaffGrpStart(const Staff* staff, std::vector<int>& ends, const Part* staffGrpPart)
+{
+    IF_ASSERT_FAILED(staff) {
+        return false;
+    }
+
+    for (size_t j = 0; j < staff->bracketLevels() + 1; j++) {
+        if (staff->bracketType(j) != BracketType::NO_BRACKET) {
+            libmei::StaffGrp meiStaffGrp = Convert::bracketToMEI(staff->bracketType(j), staff->barLineSpan());
+            // mark at which staff we will need to close the staffGrp
+            int end = static_cast<int>(staff->idx() + staff->bracketSpan(j)) - 1;
+            ends.at(end)++;
+            //
+            m_currentNode = m_currentNode.append_child();
+            meiStaffGrp.Write(m_currentNode);
+            // If we have a part and reached the latest level, write the label and labelAbbr
+            if (staffGrpPart && j == staff->bracketLevels()) {
+                this->writeLabel(m_currentNode, staffGrpPart);
+            }
+        }
+    }
+    return true;
+}
+
+/**
+ * Write a staffGrp (closing).
+ * Looks in ends how many staffGrp levels need to be closed for the corresponding staffIdx.
+ */
+
+bool MeiExporter::writeStaffGrpEnd(const Staff* staff, std::vector<int>& ends)
+{
+    IF_ASSERT_FAILED(staff) {
+        return false;
+    }
+
+    size_t idx = staff->idx();
+    for (int i = 0; i < ends.at(idx); i++) {
+        m_currentNode = m_currentNode.parent();
+    }
+
+    return true;
+}
+
+/**
+ * Write the initial staff definitions.
+ */
+
+bool MeiExporter::writeStaffDef(const Staff* staff, const Measure* measure, const Part* part, bool isPart)
+{
+    IF_ASSERT_FAILED(staff && measure && part) {
+        return false;
+    }
+
+    libmei::StaffDef meiStaffDef = Convert::staffToMEI(staff);
+    pugi::xml_node staffDefNode = m_currentNode.append_child();
+
+    if (isPart) {
+        this->writeLabel(staffDefNode, part);
+    }
+
+    if (measure) {
+        Fraction tick = measure->tick();
+
+        track_idx_t startTrack = staff2track(staff->idx());
+        track_idx_t endTrack = startTrack + VOICES;
+
+        // clef
+        Segment* clefSeg = measure->findSegment(SegmentType::HeaderClef, tick);
+        if (clefSeg) {
+            for (track_idx_t track = startTrack; track < endTrack; ++track) {
+                Clef* clef = static_cast<Clef*>(clefSeg->element(track));
+                if (clef) {
+                    libmei::Clef meiClef = Convert::clefToMEI(clef->clefType());
+                    pugi::xml_node clefNode = staffDefNode.append_child();
+                    meiClef.Write(clefNode);
+                    break;
+                }
+            }
+        }
+        // time signature
+        Segment* timeSigSeg = measure->findSegment(SegmentType::TimeSig, tick);
+        if (timeSigSeg) {
+            for (track_idx_t track = startTrack; track < endTrack; ++track) {
+                TimeSig* timeSig = static_cast<TimeSig*>(timeSigSeg->element(track));
+                if (timeSig) {
+                    libmei::StaffDef timeSigDef = Convert::meterToMEI(timeSig->sig(), timeSig->timeSigType());
+                    meiStaffDef.SetMeterSym(timeSigDef.GetMeterSym());
+                    meiStaffDef.SetMeterUnit(timeSigDef.GetMeterUnit());
+                    meiStaffDef.SetMeterCount(timeSigDef.GetMeterCount());
+                    break;
+                }
+            }
+        }
+        // key signature
+        Segment* keySigSeg = measure->findSegment(SegmentType::KeySig, tick);
+        if (keySigSeg) {
+            for (track_idx_t track = startTrack; track < endTrack; ++track) {
+                KeySig* keySig = static_cast<KeySig*>(keySigSeg->element(track));
+                // For the initial staffDef we do not write @key.sig="0"
+                if (keySig && keySig->key() != Key::C) {
+                    meiStaffDef.SetKeysig(Convert::keyToMEI(keySig->key()));
+                    break;
+                }
+            }
+        }
+    }
+
+    meiStaffDef.Write(staffDefNode);
+
+    return true;
+}
+
+/**
+ * Write label and label abbreviations.
+ */
+
+bool MeiExporter::writeLabel(pugi::xml_node node, const Part* part)
+{
+    IF_ASSERT_FAILED(part) {
+        return false;
+    }
+
+    const Instrument* instrument = part->instrument();
+    if (instrument && instrument->longNames().size() > 0) {
+        libmei::Label meiLabel;
+        pugi::xml_node labelNode = node.append_child();
+        meiLabel.Write(labelNode);
+        labelNode.text().set(instrument->nameAsPlainText().toStdString().c_str());
+    }
+    if (instrument && instrument->shortNames().size() > 0) {
+        libmei::LabelAbbr meiLabelAbbr;
+        pugi::xml_node labelAbbrNode = node.append_child();
+        meiLabelAbbr.Write(labelAbbrNode);
+        labelAbbrNode.text().set(instrument->abbreviatureAsPlainText().toStdString().c_str());
+    }
+
+    return true;
+}
+
+/**
+ * Write an ending (opening).
+ * Performs a lookup of voltas spanning the measure with MeiExporter::findVoltasInMeasure
+ */
+
+bool MeiExporter::writeEnding(const Measure* measure)
+{
+    std::list<const Volta*> voltas = this->findVoltasInMeasure(measure);
+    auto voltaIter = std::find_if(voltas.begin(), voltas.end(), [measure](const Volta* volta) { return volta->startMeasure() == measure; });
+
+    if (voltaIter != voltas.end()) {
+        libmei::Ending meiEnding = Convert::endingToMEI(*voltaIter);
+        m_currentNode = m_currentNode.append_child();
+        meiEnding.Write(m_currentNode, this->getEndingXmlId());
+    }
+    return true;
+}
+
+/**
+ * Write an ending (closing).
+ * Performs a lookup of voltas spanning the measure with MeiExporter::findVoltasInMeasure
+ */
+
+bool MeiExporter::writeEndingEnd(const Measure* measure)
+{
+    std::list<const Volta*> voltas = this->findVoltasInMeasure(measure);
+    auto voltaIter = std::find_if(voltas.begin(), voltas.end(), [measure](const Volta* volta) { return volta->endMeasure() == measure; });
+
+    if (voltaIter != voltas.end()) {
+        // non critical assert
+        assert(this->isCurrentNode(libmei::Ending()));
+        m_currentNode = m_currentNode.parent();
+    }
+    return true;
+}
+
+/**
+ * Write a measure and its content.
+ * Write the staves and the control events.
+ * Prepends a scoreDef change if a changing key signature or time signature is encountered in the content.
+ */
+
+bool MeiExporter::writeMeasure(const Measure* measure, int& measureN, bool& isFirst, bool& wasPreviousIrregular)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    bool success = true;
+
+    libmei::Measure meiMeasure = Convert::measureToMEI(measure, measureN, wasPreviousIrregular);
+    m_currentNode = m_currentNode.append_child();
+    meiMeasure.Write(m_currentNode, this->getMeasureXmlId());
+
+    // Reset keySig and timeSig change
+    m_keySig = nullptr;
+    m_timeSig = nullptr;
+
+    for (Staff* staff : m_score->staves()) {
+        this->writeStaff(staff, measure);
+    }
+
+    for (EngravingItem* item : measure->el()) {
+        switch (item->type()) {
+        case ElementType::JUMP: success = success && this->writeRepeatMark(toJump(item), measure);
+            break;
+        case ElementType::MARKER: success = success && this->writeRepeatMark(toMarker(item), measure);
+            break;
+        default: break;
+        }
+    }
+
+    for (auto controlEvent : m_startingControlEventMap) {
+        if (controlEvent.first->isBreath()) {
+            success = success && this->writeBreath(dynamic_cast<const Breath*>(controlEvent.first), controlEvent.second);
+        } else if (controlEvent.first->isDynamic()) {
+            success = success && this->writeDynam(dynamic_cast<const Dynamic*>(controlEvent.first), controlEvent.second);
+        } else if (controlEvent.first->isFermata()) {
+            success = success && this->writeFermata(dynamic_cast<const Fermata*>(controlEvent.first), controlEvent.second);
+        } else if (controlEvent.first->isHarmony()) {
+            success = success && this->writeHarm(dynamic_cast<const Harmony*>(controlEvent.first), controlEvent.second);
+        } else if (controlEvent.first->isTempoText()) {
+            success = success && this->writeTempo(dynamic_cast<const TempoText*>(controlEvent.first), controlEvent.second);
+        }
+    }
+    m_startingControlEventMap.clear();
+
+    for (auto controlEvent : m_tstampControlEventMap) {
+        if (controlEvent.first->isFermata()) {
+            success = success && this->writeFermata(dynamic_cast<const Fermata*>(controlEvent.first), controlEvent.second.first,
+                                                    controlEvent.second.second);
+        }
+    }
+    m_tstampControlEventMap.clear();
+
+    // This will preprend the scoreDef
+    if (!isFirst) {
+        this->writeScoreDefChange();
+    }
+    isFirst = false;
+
+    m_currentNode = m_currentNode.parent();
+
+    return success;
+}
+
+/**
+ * Write a staff and its content.
+ * Checks if each voice has some content.
+ */
+
+bool MeiExporter::writeStaff(const Staff* staff, const Measure* measure)
+{
+    IF_ASSERT_FAILED(staff && measure) {
+        return false;
+    }
+
+    m_currentNode = m_currentNode.append_child();
+
+    libmei::Staff meiStaff;
+    meiStaff.SetN(static_cast<int>(staff->idx() + 1));
+    meiStaff.Write(m_currentNode, this->getStaffXmlId());
+
+    track_idx_t startTrack = staff2track(staff->idx());
+    track_idx_t endTrack = startTrack + VOICES;
+    for (track_idx_t track = startTrack; track < endTrack; ++track) {
+        writeLayer(track, staff, measure);
+    }
+
+    m_currentNode = m_currentNode.parent();
+
+    return true;
+}
+
+/**
+ * Write a layer (i.e., voice) and its content.
+ */
+
+bool MeiExporter::writeLayer(track_idx_t track, const Staff* staff, const Measure* measure)
+{
+    IF_ASSERT_FAILED(staff) {
+        return false;
+    }
+
+    // If there is no voice, only increase the layer@n
+    if (!measure->hasVoice(track)) {
+        this->getLayerXmlId();
+        return true;
+    }
+
+    m_currentNode = m_currentNode.append_child();
+    libmei::Layer meiLayer;
+    meiLayer.SetN(static_cast<int>(track2voice(track) + 1));
+    meiLayer.Write(m_currentNode, this->getLayerXmlId());
+
+    for (Segment* seg = measure->first(); seg; seg = seg->next()) {
+        if (seg->segmentType() == SegmentType::EndBarLine) {
+            this->addFermataToMap(track, seg, measure);
+        }
+
+        // Do not go any further than the measure tick (ignore EndBarLine, KeySigAnnounce, TimeSigAnnounce)
+        const EngravingItem* item = seg->element(track);
+        if (!item || item->generated()) {
+            continue;
+        }
+
+        if (item->isClef()) {
+            this->writeClef(dynamic_cast<const Clef*>(item));
+        } else if (item->isChord()) {
+            this->writeChord(dynamic_cast<const Chord*>(item), staff);
+        } else if (item->isRest()) {
+            this->writeRest(dynamic_cast<const Rest*>(item), staff);
+        } else if (item->isBarLine()) {
+            //
+        } else if (item->isKeySig()) {
+            if (m_keySig && (seg != m_keySig)) {
+                LOGD() << "MeiExporter::writeLayer unexpected KeySig segment";
+            }
+            m_keySig = seg;
+        } else if (item->isTimeSig()) {
+            if (m_timeSig && (seg != m_timeSig)) {
+                LOGD() << "MeiExporter::writeLayer unexpected TimeSig segment";
+            }
+            m_timeSig = seg;
+        } else {
+            LOGD() << "MeiExporter::writeLayer unknown segment type " << item->typeName();
+        }
+    }
+
+    m_currentNode = m_currentNode.parent();
+
+    return true;
+}
+
+//---------------------------------------------------------
+// write MEI layer elements
+//---------------------------------------------------------
+
+/**
+ * Open and close beam and tuplet elements for a ChordRest.
+ * When both a beam and a tuplet is opening and closing, check which is the appropriate nesting order.
+ * By default, nest the tuplet within the beam.
+ * Closing beam and tuplet only change the bool parameters and actually closing the elements is happening in MeiExporter::writeBeamAndTupletEnd
+ */
+
+bool MeiExporter::writeBeamAndTuplet(const ChordRest* chordRest, bool& closingBeam, bool& closingTuplet, bool& closingBeamInTuplet)
+{
+    IF_ASSERT_FAILED(chordRest) {
+        return false;
+    }
+
+    const Beam* beam = (chordRest->beam()) ? toBeam(chordRest->beam()) : nullptr;
+    const Tuplet* tuplet = (chordRest->tuplet()) ? toTuplet(chordRest->tuplet()) : nullptr;
+    const Beam* beamInTuplet = nullptr;
+
+    if (beam && tuplet) {
+        if ((beam->elements().front() == chordRest) && ((tuplet->elements().front() == chordRest))) {
+            if (beam->elements().size() < tuplet->elements().size()) {
+                beamInTuplet = beam;
+                beam = nullptr;
+            }
+        }
+    }
+    if (beam) {
+        this->writeBeam(beam, chordRest, closingBeam);
+    }
+    if (tuplet) {
+        this->writeTuplet(tuplet, chordRest, closingTuplet);
+    }
+    if (beamInTuplet) {
+        this->writeBeam(beamInTuplet, chordRest, closingBeamInTuplet);
+    }
+
+    // Case when the beam was open within the tuplet but not at the beginning (fewer elements)
+    // We need to close it first since it is nested in the tuplet
+    if (closingTuplet && closingBeam && beam->elements().size() < tuplet->elements().size()) {
+        closingBeam = false;
+        closingBeamInTuplet = true;
+    }
+
+    return true;
+}
+
+/**
+ * Close beam and tuplet elements according to the parameters calculated in MeiExporter::writeBeamAndTuplet
+ */
+
+bool MeiExporter::writeBeamAndTupletEnd(bool closingBeam, bool closingTuplet, bool closingBeamInTuplet)
+{
+    // non critical asserts
+    if (closingBeamInTuplet) {
+        assert(isCurrentNode(libmei::Beam()));
+        m_currentNode = m_currentNode.parent();
+    }
+
+    if (closingTuplet) {
+        assert(isCurrentNode(libmei::Tuplet()));
+        m_currentNode = m_currentNode.parent();
+    }
+
+    if (closingBeam) {
+        assert(isCurrentNode(libmei::Beam()));
+        m_currentNode = m_currentNode.parent();
+    }
+
+    return true;
+}
+
+/**
+ * Write a beam if the ChordRest is the first element of the beam.
+ * If the ChordRest is the last, sets the closing flag to true.
+ * Also set the MEI `@breaksec` on the previous element when the BeamMode is BEGIN16 or BEGIN32
+ */
+
+bool MeiExporter::writeBeam(const Beam* beam, const ChordRest* chordRest, bool& closing)
+{
+    IF_ASSERT_FAILED(beam && chordRest) {
+        return false;
+    }
+
+    if (beam->elements().front() == chordRest) {
+        libmei::Beam meiBeam;
+        m_currentNode = m_currentNode.append_child();
+        meiBeam.Write(m_currentNode, this->getLayerXmlIdFor(BEAM_L));
+    } else if ((chordRest->beamMode() == BeamMode::BEGIN16) || (chordRest->beamMode() == BeamMode::BEGIN32)) {
+        pugi::xml_node lastInBeam = this->getLastChordRest(m_currentNode);
+        // We have already written one chord/rest element in the beam, the last one is the one we need to modify
+        if (lastInBeam) {
+            // Create the attribute class to modify the already created XML element
+            libmei::InstBeamSecondary beamSecondary;
+            beamSecondary.SetBreaksec(Convert::breaksecToMEI(chordRest->beamMode()));
+            beamSecondary.WriteBeamSecondary(lastInBeam);
+        }
+    }
+
+    if (beam->elements().back() == chordRest) {
+        closing = true;
+    }
+
+    return true;
+}
+
+/**
+ * Write a clef.
+ */
+
+bool MeiExporter::writeClef(const Clef* clef)
+{
+    IF_ASSERT_FAILED(clef) {
+        return false;
+    }
+
+    if (clef->isHeader()) {
+        return true;
+    }
+
+    pugi::xml_node clefNode = m_currentNode.append_child();
+    libmei::Clef meiClef = Convert::clefToMEI(clef->clefType());
+    meiClef.Write(clefNode, this->getLayerXmlIdFor(UNSPECIFIED_L));
+
+    return true;
+}
+
+/**
+ * Write a chord (chord or note).
+ * If the Chord is a chord, write its notes with MeiExporter::writeNote.
+ * Also write the beam and tuplet (opening and closing) and fill the control event list pointing to it.
+ */
+
+bool MeiExporter::writeChord(const Chord* chord, const Staff* staff)
+{
+    IF_ASSERT_FAILED(chord && staff) {
+        return false;
+    }
+
+    if (chord->graceNotes().size() > 0) {
+        this->writeGraceGrp(chord, staff);
+    }
+
+    bool closingBeam = false;
+    bool closingTuplet = false;
+    bool closingBeamInTuplet = false;
+    this->writeBeamAndTuplet(chord, closingBeam, closingTuplet, closingBeamInTuplet);
+
+    bool isChord = (chord->notes().size() > 1);
+    if (isChord) {
+        // We need to create a <chord> before writing the notes
+        m_currentNode = m_currentNode.append_child();
+        libmei::Chord meiChord;
+        meiChord.SetDur(Convert::durToMEI(chord->durationType().type()));
+        if (chord->dots()) {
+            meiChord.SetDots(chord->dots());
+        }
+        this->writeBeamTypeAtt(chord, meiChord);
+        this->writeStaffIdenAtt(chord, staff, meiChord);
+        this->writeStemAtt(chord, meiChord);
+        std::string xmlId = this->getLayerXmlIdFor(CHORD_L, (chord->isGrace() ? nullptr : chord->segment()));
+        meiChord.Write(m_currentNode, xmlId);
+        this->fillControlEventMap(xmlId, chord);
+    }
+
+    for (const Note* note : chord->notes()) {
+        this->writeNote(note, chord, staff, isChord);
+    }
+
+    if (isChord) {
+        // This is the end of the <chord> - non critical assert
+        assert(isCurrentNode(libmei::Chord()));
+        m_currentNode = m_currentNode.parent();
+    }
+
+    this->writeBeamAndTupletEnd(closingBeam, closingTuplet, closingBeamInTuplet);
+
+    if (chord->graceNotes().size() > 0) {
+        this->writeGraceGrp(chord, staff, true);
+    }
+
+    return true;
+}
+
+/**
+ * Write a graceGrp placed before or after the chord / note.
+ * Loop through the notes of the group and write them.
+ */
+
+bool MeiExporter::writeGraceGrp(const Chord* chord, const Staff* staff, bool isAfter)
+{
+    IF_ASSERT_FAILED(chord) {
+        return false;
+    }
+
+    GraceNotesGroup& graceNotes = (isAfter) ? chord->graceNotesAfter() : chord->graceNotesBefore();
+
+    if (graceNotes.empty()) {
+        return true;
+    }
+
+    m_currentNode = m_currentNode.append_child();
+
+    libmei::GraceGrp meiGraceGrp;
+    auto [meiAttach, meiGrace] = Convert::gracegrpToMEI(isAfter, graceNotes.front()->noteType());
+    meiGraceGrp.SetAttach(meiAttach);
+    meiGraceGrp.SetGrace(meiGrace);
+    meiGraceGrp.Write(m_currentNode, this->getLayerXmlIdFor(GRACEGRP_L));
+
+    for (auto graceChord : graceNotes) {
+        this->writeChord(graceChord, staff);
+    }
+
+    // non critical assert
+    assert(isCurrentNode(meiGraceGrp));
+    m_currentNode = m_currentNode.parent();
+
+    return true;
+}
+
+/**
+ * Write a note (single note or chord note).
+ * For single notes, also writes the duration and the beam and stem attributes.
+ */
+
+bool MeiExporter::writeNote(const Note* note, const Chord* chord, const Staff* staff, bool isChord)
+{
+    IF_ASSERT_FAILED(note && chord && staff) {
+        return false;
+    }
+
+    Interval interval = staff->part()->instrument()->transpose();
+    auto [meiNote, meiAccid] = Convert::pitchToMEI(note, note->accidental(), interval);
+    pugi::xml_node noteNode = m_currentNode.append_child();
+    if (!isChord) {
+        meiNote.SetDur(Convert::durToMEI(chord->durationType().type()));
+        if (chord->dots()) {
+            meiNote.SetDots(chord->dots());
+        }
+        this->writeBeamTypeAtt(chord, meiNote);
+        this->writeStaffIdenAtt(chord, staff, meiNote);
+        this->writeStemAtt(chord, meiNote);
+    }
+    std::string xmlId = this->getLayerXmlIdFor(NOTE_L, (isChord || chord->isGrace() ? nullptr : chord->segment()));
+    meiNote.Write(noteNode, xmlId);
+    if (!isChord) {
+        this->fillControlEventMap(xmlId, chord);
+    }
+
+    if (meiAccid.HasAccid() || meiAccid.HasAccidGes()) {
+        pugi::xml_node accidNode = noteNode.append_child();
+        meiAccid.Write(accidNode, this->getLayerXmlIdFor(ACCID_L));
+    }
+
+    return true;
+}
+
+/**
+ * Write a rest (rest and mRest).
+ */
+
+bool MeiExporter::writeRest(const Rest* rest, const Staff* staff)
+{
+    IF_ASSERT_FAILED(rest) {
+        return false;
+    }
+
+    // measure rest
+    if (rest->durationType() == DurationType::V_MEASURE) {
+        pugi::xml_node mRestNode = m_currentNode.append_child();
+        libmei::MRest meiMRest;
+        meiMRest.Write(mRestNode, this->getLayerXmlIdFor(UNSPECIFIED_L));
+    } else {
+        bool closingBeam = false;
+        bool closingTuplet = false;
+        bool closingBeamInTuplet = false;
+        this->writeBeamAndTuplet(rest, closingBeam, closingTuplet, closingBeamInTuplet);
+
+        pugi::xml_node restNode = m_currentNode.append_child();
+        libmei::Rest meiRest;
+        meiRest.SetDur(Convert::durToMEI(rest->durationType().type()));
+        if (rest->dots()) {
+            meiRest.SetDots(rest->dots());
+        }
+        this->writeBeamTypeAtt(rest, meiRest);
+        this->writeStaffIdenAtt(rest, staff, meiRest);
+        std::string xmlId = this->getLayerXmlIdFor(REST_L, rest->segment());
+        meiRest.Write(restNode, xmlId);
+        this->fillControlEventMap(xmlId, rest);
+
+        this->writeBeamAndTupletEnd(closingBeam, closingTuplet, closingBeamInTuplet);
+    }
+
+    return true;
+}
+
+/**
+ * Write a tuplet if the ChordRest is the first element of the tuplet.
+ * If the ChordRest is the last, sets the closing flag to true.
+ */
+
+bool MeiExporter::writeTuplet(const Tuplet* tuplet, const EngravingItem* item, bool& closing)
+{
+    IF_ASSERT_FAILED(tuplet && item) {
+        return false;
+    }
+
+    if (tuplet->elements().front() == item) {
+        // recursive call for hanling nested tuplets
+        // nearly works except for closing which is happening to early (after the first note)
+        // when a nested tuplet is ending at the same time as its parent
+        /**
+        if (tuplet->tuplet()) {
+            writeTuplet(toTuplet(tuplet->tuplet()), tuplet, closing);
+        }
+        if (item->isTuplet()) {
+            LOGD() << "MeiExporter::writeTuplet nested tuplet export not fully supported";
+        }
+        */
+        libmei::Tuplet meiTuplet = Convert::tupletToMEI(tuplet);
+        m_currentNode = m_currentNode.append_child();
+        meiTuplet.Write(m_currentNode, this->getLayerXmlIdFor(TUPLET_L));
+    } else if (tuplet->elements().back() == item) {
+        closing = true;
+    }
+
+    return true;
+}
+
+//---------------------------------------------------------
+// write MEI control events
+//---------------------------------------------------------
+
+/**
+ * Write a breath (i.e., breath or caesura).
+ */
+
+bool MeiExporter::writeBreath(const Breath* breath, const std::string& startid)
+{
+    IF_ASSERT_FAILED(breath) {
+        return false;
+    }
+
+    pugi::xml_node breathNode = m_currentNode.append_child();
+    if (breath->isCaesura()) {
+        libmei::Caesura meiCaesura = Convert::caesuraToMEI(breath);
+        meiCaesura.SetStartid(startid);
+        meiCaesura.Write(breathNode, this->getMeasureXmlIdFor(CAESURA_M));
+    } else {
+        libmei::Breath meiBreath = Convert::breathToMEI(breath);
+        meiBreath.SetStartid(startid);
+        meiBreath.Write(breathNode, this->getMeasureXmlIdFor(BREATH_M));
+    }
+
+    return true;
+}
+
+/**
+ * Write a dynam and its text content.
+ */
+
+bool MeiExporter::writeDynam(const Dynamic* dynamic, const std::string& startid)
+{
+    IF_ASSERT_FAILED(dynamic) {
+        return false;
+    }
+
+    StringList meiLines;
+
+    pugi::xml_node dynamNode = m_currentNode.append_child();
+    libmei::Dynam meiDynam = Convert::dynamToMEI(dynamic, meiLines);
+    meiDynam.SetStartid(startid);
+    meiDynam.Write(dynamNode, this->getMeasureXmlIdFor(DYNAM_M));
+
+    this->writeLines(dynamNode, meiLines);
+
+    return true;
+}
+
+/**
+ * Write a fermata.
+ */
+
+bool MeiExporter::writeFermata(const Fermata* fermata, const std::string& startid)
+{
+    IF_ASSERT_FAILED(fermata) {
+        return false;
+    }
+
+    pugi::xml_node fermataNode = m_currentNode.append_child();
+    libmei::Fermata meiFermata = Convert::fermataToMEI(fermata);
+    meiFermata.SetStartid(startid);
+
+    meiFermata.Write(fermataNode, this->getMeasureXmlIdFor(FERMATA_M));
+
+    return true;
+}
+
+/**
+ * Write a fermata with a staffNs and tsamp
+ */
+
+bool MeiExporter::writeFermata(const Fermata* fermata, const libmei::xsdPositiveInteger_List& staffNs, double tstamp)
+{
+    IF_ASSERT_FAILED(fermata) {
+        return false;
+    }
+
+    pugi::xml_node fermataNode = m_currentNode.append_child();
+    libmei::Fermata meiFermata = Convert::fermataToMEI(fermata);
+    meiFermata.SetStaff(staffNs);
+    meiFermata.SetTstamp(tstamp);
+
+    meiFermata.Write(fermataNode, this->getMeasureXmlIdFor(FERMATA_M));
+
+    return true;
+}
+
+/**
+ * Write a harm and its text content.
+ */
+
+bool MeiExporter::writeHarm(const Harmony* harmony, const std::string& startid)
+{
+    IF_ASSERT_FAILED(harmony) {
+        return false;
+    }
+
+    StringList meiLines;
+
+    pugi::xml_node dynamNode = m_currentNode.append_child();
+    libmei::Harm meiHarm = Convert::harmToMEI(harmony, meiLines);
+    meiHarm.SetStartid(startid);
+    meiHarm.Write(dynamNode, this->getMeasureXmlIdFor(HARM_M));
+
+    this->writeLines(dynamNode, meiLines);
+
+    return true;
+}
+
+/**
+ * Write a repeatMark from a Jump.
+ */
+
+bool MeiExporter::writeRepeatMark(const Jump* jump, const Measure* measure)
+{
+    IF_ASSERT_FAILED(jump && measure) {
+        return false;
+    }
+
+    pugi::xml_node repeatMarkNode = m_currentNode.append_child();
+    String text;
+    libmei::RepeatMark meiRepeatMark = Convert::jumpToMEI(jump, text);
+
+    if (text.size() > 0) {
+        repeatMarkNode.text().set(text.toStdString().c_str());
+    }
+
+    meiRepeatMark.SetTstamp(0.0);
+    std::string xmlId = this->getMeasureXmlIdFor(REPEATMARK_M);
+    meiRepeatMark.Write(repeatMarkNode, xmlId);
+
+    // Currently not used - builds a post-processing list to be processing in MeiExporter::addJumpToRepeatMarks
+    // this->addToRepeatMarkList(static_cast<const TextBase*>(jump), repeatMarkNode, xmlId);
+
+    return true;
+}
+
+/**
+ * Write a repeatMark from a Marker.
+ */
+
+bool MeiExporter::writeRepeatMark(const Marker* marker, const Measure* measure)
+{
+    IF_ASSERT_FAILED(marker && measure) {
+        return false;
+    }
+
+    pugi::xml_node repeatMarkNode = m_currentNode.append_child();
+    String text;
+    libmei::RepeatMark meiRepeatMark = Convert::markerToMEI(marker, text);
+
+    if (text.size() > 0) {
+        repeatMarkNode.text().set(text.toStdString().c_str());
+    }
+
+    meiRepeatMark.SetTstamp(0.0);
+    std::string xmlId = this->getMeasureXmlIdFor(REPEATMARK_M);
+    meiRepeatMark.Write(repeatMarkNode, xmlId);
+
+    // Currently not used.
+    // this->addToRepeatMarkList(dynamic_cast<const TextBase*>(marker), repeatMarkNode, xmlId);
+
+    return true;
+}
+
+/**
+ * Write a tempo and its text content.
+ */
+
+bool MeiExporter::writeTempo(const TempoText* tempoText, const std::string& startid)
+{
+    IF_ASSERT_FAILED(tempoText) {
+        return false;
+    }
+
+    StringList meiLines;
+
+    pugi::xml_node tempoNode = m_currentNode.append_child();
+    libmei::Tempo meiTempo = Convert::tempoToMEI(tempoText, meiLines);
+    meiTempo.SetStartid(startid);
+    meiTempo.Write(tempoNode, this->getMeasureXmlIdFor(DYNAM_M));
+
+    this->writeLinesWithSMuFL(tempoNode, meiLines);
+
+    return true;
+}
+
+//---------------------------------------------------------
+// write MEI attribute classes
+//---------------------------------------------------------
+
+/**
+ * Write the beam attributes for a ChordRest (i.e., chord, note, rest or space).
+ * Uses the `@type` attribute for storing MuseScore beaming added flags.
+ */
+
+bool MeiExporter::writeBeamTypeAtt(const ChordRest* chordRest, libmei::AttTyped& typeAtt)
+{
+    IF_ASSERT_FAILED(chordRest) {
+        return false;
+    }
+
+    // Make sure we do not add a @type for notes / rests longer the 8th with a hanging beam flag
+    if (int(chordRest->durationType().type()) < int(DurationType::V_EIGHTH)) {
+        return true;
+    }
+
+    switch (chordRest->beamMode()) {
+    // BeamMode::BEGIN16 and BEGIN32 is handled in MeiExporter::writeBeam, which will add MEI a @breaksec to the previous element
+    // This is BeamMode in MuseScore is on the first note _after_ the break, whereas it is on the last note _before_ it in MEI.
+    case (BeamMode::BEGIN):
+    case (BeamMode::MID):
+    case (BeamMode::NONE):
+        typeAtt.SetType(Convert::beamToMEI(chordRest->beamMode(), BEAM_ELEMENT_TYPE));
+        break;
+    default:
+        break;
+    }
+
+    return true;
+}
+
+/**
+ * Write the cross-staff attribute (@staff) for a ChordRest (i.e., chord, note, rest or space).
+ */
+
+bool MeiExporter::writeStaffIdenAtt(const ChordRest* chordRest, const Staff* staff, libmei::AttStaffIdent& staffIdentAtt)
+{
+    if (chordRest->staffMove() != 0) {
+        staff_idx_t staffN = staff->idx() + chordRest->staffMove() + 1;
+        libmei::xsdPositiveInteger_List staffNs;
+        staffNs.push_back(static_cast<int>(staffN));
+        staffIdentAtt.SetStaff(staffNs);
+    }
+
+    return true;
+}
+
+/**
+ * Write the stem attributes for a Chord (i.e., chord or note).
+ */
+
+bool MeiExporter::writeStemAtt(const Chord* chord, libmei::AttStems& stemsAtt)
+{
+    IF_ASSERT_FAILED(chord) {
+        return false;
+    }
+
+    auto [meiStemDir, meiStemLen] = Convert::stemToMEI(chord->stemDirection(), chord->noStem());
+    stemsAtt.SetStemDir(meiStemDir);
+    stemsAtt.SetStemLen(meiStemLen);
+
+    return true;
+}
+
+bool MeiExporter::isCurrentNode(const libmei::Element& element)
+{
+    return element.m_name == std::string(m_currentNode.name());
+}
+
+/**
+ * When writing a measure, find voltas (endings) spanning over it.
+ * This will then be use to check if the measure is the beginning or the end or a volta.
+ */
+
+std::list<const Volta*> MeiExporter::findVoltasInMeasure(const Measure* measure)
+{
+    std::list<const Volta*> voltas;
+    auto spanners = m_score->spannerMap().findOverlapping(measure->tick().ticks(), measure->endTick().ticks());
+    for (auto interval : spanners) {
+        Spanner* spanner = interval.value;
+        if (spanner && spanner->isVolta()) {
+            voltas.push_back(toVolta(spanner));
+        }
+    }
+    return voltas;
+}
+
+/**
+ * Go through the list of annotations pointing to the ChordRest and map their element to the xmlId.
+ * When writing the annotation (i.e., control events) the map is used to generate the `@startid` of the control event.
+ * The value in the map already contains the `#`
+ * Also add Breath attached to a ChordRest, which are not represented as annotations but di
+ */
+
+void MeiExporter::fillControlEventMap(const std::string& xmlId, const engraving::ChordRest* chordRest)
+{
+    IF_ASSERT_FAILED(chordRest) {
+        return;
+    }
+
+    track_idx_t trackIdx = chordRest->track();
+
+    for (const EngravingItem* element : chordRest->segment()->annotations()) {
+        if (element->track() == trackIdx) {
+            m_startingControlEventMap[element] = "#" + xmlId;
+        }
+    }
+    // Breath a handled differently
+    const Breath* breath = chordRest->hasBreathMark();
+    if (breath) {
+        m_startingControlEventMap[breath] = "#" + xmlId;
+    }
+}
+
+/**
+ * Retrieve the `@startid` for a control event.
+ * The map has been filled previously by MeiExporter::addToStartIdMap.
+ */
+
+std::string MeiExporter::findStartIdFor(const engraving::EngravingItem* item)
+{
+    std::string xmlId;
+    if (m_startingControlEventMap.count(item)) {
+        xmlId = m_startingControlEventMap.at(item);
+    }
+    return xmlId;
+}
+
+/**
+ * Keep a list of Mei::Exporter::RepeatMark for post-processing jumps.
+ * This code is currently not used.
+ * During the post-processing, if a m_jumpToXmlId can be determined, it will be added to the XML m_node.
+ * See MeiExporter::addJumpToRepeatMarks
+ */
+
+void MeiExporter::addToRepeatMarkList(const EngravingItem* repeatMark, pugi::xml_node node, const std::string& xmlId)
+{
+    IF_ASSERT_FAILED(repeatMark) {
+        return;
+    }
+
+    m_repeatMarks.push_back(MeiExporter::RepeatMark());
+    RepeatMark& repeatMarkItem = m_repeatMarks.back();
+    repeatMarkItem.m_repeatMark = repeatMark;
+    repeatMarkItem.m_node = node;
+    repeatMarkItem.m_xmlId = xmlId;
+}
+
+/**
+ * Add `@jumpto` to repeatMark MEI elements by unfolding MuseScore jumps.
+ * This code is currently unused because `@jumpto` is not available in MEI.
+ * The principle is to post-process the list of m_repeatMarks.
+ * For each mark, we lookup the `@jumpto` xmlId, which can then be written to the repeatMark node
+ */
+
+void MeiExporter::addJumpToRepeatMarks()
+{
+    if (m_repeatMarks.size() < 1) {
+        return;
+    }
+
+    for (RepeatMark& item : m_repeatMarks) {
+        if (item.m_repeatMark->isJump()) {
+            // For each jump, lookup the Marker that has the label matching the jumpTo
+            const Jump* jump = toJump(item.m_repeatMark);
+            item.m_jumptToLabel = jump->jumpTo().toStdString();
+            auto jumpTo = std::find_if(m_repeatMarks.begin(), m_repeatMarks.end(), [jump](RepeatMark& item) {
+                if (!item.m_repeatMark->isMarker()) {
+                    return false;
+                }
+                const Marker* marker = toMarker(item.m_repeatMark);
+                // Found it
+                return marker->label() == jump->jumpTo();
+            });
+            if (jumpTo != m_repeatMarks.end()) {
+                // This is the xmlId we need to add to the (jump) repeatMark
+                item.m_jumpToXmlId = jumpTo->m_xmlId;
+            }
+
+            // Try to see if we have a playUntil Marker and a continueAt Marker
+            auto playUntil = std::find_if(m_repeatMarks.begin(), m_repeatMarks.end(), [jump](RepeatMark& item) {
+                if (!item.m_repeatMark->isMarker()) {
+                    return false;
+                }
+                const Marker* marker = toMarker(item.m_repeatMark);
+                return marker->label() == jump->playUntil();
+            });
+            auto continueAt = std::find_if(m_repeatMarks.begin(), m_repeatMarks.end(), [jump](RepeatMark& item) {
+                if (!item.m_repeatMark->isMarker()) {
+                    return false;
+                }
+                const Marker* marker = toMarker(item.m_repeatMark);
+                return marker->label() == jump->continueAt();
+            });
+            // If yes, make the playUntil repeatMark jump to the continueAt
+            if (playUntil != m_repeatMarks.end() && continueAt != m_repeatMarks.end()) {
+                playUntil->m_jumpToXmlId = continueAt->m_xmlId;
+            }
+        }
+    }
+    // Add the jumpto attribute for all the repeatMarks for which we filled a jumpToXmlId
+    for (RepeatMark& item : m_repeatMarks) {
+        if (item.m_jumpToXmlId.size() > 0) {
+            item.m_node.append_attribute("jumpto") = item.m_jumpToXmlId.c_str();
+        }
+    }
+}
+
+/**
+ * Check if the Segment (barLineEnd type) has a Fermata annotation for the given track.
+ * Add the Fermata to the m_tstampControlEventMap with the appropriate @staff and @tstamp values.
+ */
+
+bool MeiExporter::addFermataToMap(const track_idx_t track, const Segment* segment, const Measure* measure)
+{
+    IF_ASSERT_FAILED(segment) {
+        return false;
+    }
+
+    for (const auto& annotation : segment->annotations()) {
+        if (annotation->isFermata() && track == annotation->track()) {
+            staff_idx_t staffN = track2staff(track) + 1;
+            libmei::xsdPositiveInteger_List staffNs;
+            staffNs.push_back(static_cast<int>(staffN));
+            double tstamp = Convert::tstampFromFraction(measure->ticks(), measure->timesig());
+            m_tstampControlEventMap[toFermata(annotation)] = std::make_pair(staffNs, tstamp);
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Return true if the node name matches the name parameter.
+ */
+
+bool MeiExporter::isNode(pugi::xml_node node, const String& name)
+{
+    if (!node) {
+        return false;
+    }
+
+    String nodeName = String(node.name());
+    return nodeName == name;
+}
+
+/**
+ * Return the last element in node that is a ChordRest (chord, note, or rest)
+ */
+
+pugi::xml_node MeiExporter::getLastChordRest(pugi::xml_node node)
+{
+    pugi::xml_node chordRest;
+
+    for (pugi::xml_node child : node.children()) {
+        if (this->isNode(child, u"chord") || this->isNode(child, u"note") || this->isNode(child, u"rest")) {
+            chordRest = child;
+        }
+    }
+    return chordRest;
+}
+
+//---------------------------------------------------------
+// geneate XML:IDs
+//---------------------------------------------------------
+
+/**
+ * Reset all the sub-counters for measure elements (i.e., control events).
+ */
+
+void MeiExporter::resetMeasureIDs()
+{
+    std::fill(m_measureCounterFor.begin(), m_measureCounterFor.end(), 0);
+}
+
+/**
+ * Reset all the sub-counters for layer elements (e.g., accid, chord, note, etc.).
+ */
+
+void MeiExporter::resetLayerIDs()
+{
+    std::fill(m_layerCounterFor.begin(), m_layerCounterFor.end(), 0);
+}
+
+/**
+ * Return the current @xml:id for a section.
+ */
+
+std::string MeiExporter::getSectionXmlId()
+{
+    return String("s%1").arg(++m_sectionCounter).toStdString();
+}
+
+/**
+ * Return the current @xml:id for an ending.
+ */
+
+std::string MeiExporter::getEndingXmlId()
+{
+    return String("e%1").arg(++m_endingCounter).toStdString();
+}
+
+/**
+ * Return the current @xml:id for a measure.
+ * Reset the staff counter and the measure sub-counters
+ */
+
+std::string MeiExporter::getMeasureXmlId()
+{
+    // Reset the staff counter when a new measure starts
+    m_staffCounter = 0;
+    // Reset the measure sub-counters when a new measure starts
+    this->resetMeasureIDs();
+    return String("m%1").arg(++m_measureCounter).toStdString();
+}
+
+/**
+ * Return the current @xml:id for a measure element (i.e., a control event).
+ */
+
+std::string MeiExporter::getMeasureXmlIdFor(measureElementCounter elementType)
+{
+    // m (Measure) / ? Measure element type
+    // The measure element abbreviation is given in the MeiExporter::s_measureXmlIdMap
+    return String("m%1%2%3").arg(m_measureCounter).arg(MeiExporter::s_measureXmlIdMap.at(elementType)).arg(++(m_measureCounterFor.
+                                                                                                              at(elementType))).
+           toStdString();
+}
+
+/**
+ * Return the current @xml:id for a staff.
+ * Reset the layer counters
+ */
+
+std::string MeiExporter::getStaffXmlId()
+{
+    // Reset the layer counter when a new staff starts
+    m_layerCounter = 0;
+    return String("m%1s%2").arg(m_measureCounter).arg(++m_staffCounter).toStdString();
+}
+
+/**
+ * Return the current @xml:id for a layer.
+ * Reset the layer sub-counters
+ */
+
+std::string MeiExporter::getLayerXmlId()
+{
+    // Reset the layer sub-counters when a new layer starts
+    this->resetLayerIDs();
+    return String("m%1s%2l%3").arg(m_measureCounter).arg(m_staffCounter).arg(++m_layerCounter).toStdString();
+}
+
+/**
+ * Return the current @xml:id for a layer element.
+ */
+
+std::string MeiExporter::getLayerXmlIdFor(layerElementCounter elementType, const Segment* segment)
+{
+    // If we have a segment, generate a track and time-based xml:id
+    if (segment) {
+        //return String("m%1s%2l%3t-%4-%5").arg(m_measureCounter).arg(m_staffCounter).arg(m_layerCounter).arg(segment->tick().numerator()).arg(segment->tick().denominator()).toStdString();
+        return String("s%1l%2_t%3_%4").arg(m_staffCounter).arg(m_layerCounter).arg(segment->tick().numerator()).arg(
+            segment->tick().denominator()).toStdString();
+    }
+    // m (Measure) / s (Staff) / l (Layer) / ? Layer element type
+    // The layer element abbreviation is given in the MeiExporter::s_layerXmlIdMap
+    return String("m%1s%2l%3%4%5").arg(m_measureCounter).arg(m_staffCounter).arg(m_layerCounter).arg(MeiExporter::s_layerXmlIdMap.at(
+                                                                                                         elementType)).arg(++(
+                                                                                                                               m_layerCounterFor
+                                                                                                                               .at(
+                                                                                                                                   elementType)))
+           .toStdString();
 }

--- a/src/importexport/mei/internal/meiexporter.h
+++ b/src/importexport/mei/internal/meiexporter.h
@@ -38,6 +38,29 @@ class Staff;
 }
 
 namespace mu::iex::mei {
+enum measureElementCounter {
+    BREATH_M = 0,
+    CAESURA_M,
+    DYNAM_M,
+    FERMATA_M,
+    HARM_M,
+    REPEATMARK_M,
+    SLUR_M,
+    TEMPO_M,
+    UNSPECIFIED_M
+};
+
+enum layerElementCounter {
+    ACCID_L = 0,
+    BEAM_L,
+    CHORD_L,
+    GRACEGRP_L,
+    NOTE_L,
+    REST_L,
+    TUPLET_L,
+    UNSPECIFIED_L,
+};
+
 /**
  * Class of exporting Music Encoding Initiative (MEI) files
  */
@@ -51,11 +74,145 @@ public:
     bool write(QIODevice& destinationDevice);
 
 private:
+    bool writeHeader();
+    bool writeScore();
+    bool writeScoreDef();
+    bool writePgHead(const engraving::VBox* vBox);
+    bool writeLines(pugi::xml_node node, const StringList& lines);
+    bool writeLinesWithSMuFL(pugi::xml_node node, const StringList& lines);
+    bool writeScoreDefChange();
+    bool writeStaffGrpStart(const engraving::Staff* staff, std::vector<int>& ends, const engraving::Part* part);
+    bool writeStaffGrpEnd(const engraving::Staff* staff, std::vector<int>& ends);
+    bool writeStaffDef(const engraving::Staff* staff, const engraving::Measure* measure, const engraving::Part* part, bool isPart);
+    bool writeLabel(pugi::xml_node node, const engraving::Part* part);
+    bool writeEnding(const engraving::Measure* measure);
+    bool writeEndingEnd(const engraving::Measure* measure);
+    bool writeMeasure(const engraving::Measure* measure, int& measureN, bool& isFirst, bool& wasLastIrregular);
+    bool writeStaff(const engraving::Staff* staff, const engraving::Measure* measure);
+    bool writeLayer(engraving::track_idx_t track, const engraving::Staff* staff, const engraving::Measure* measure);
+
+    /**
+     * Methods for writing MEI elements within a <layer>
+     */
+    bool writeBeamAndTuplet(const engraving::ChordRest* chordRest, bool& closingBeam, bool& closingTuplet, bool& closingBeamInTuplet);
+    bool writeBeamAndTupletEnd(bool closingBeam, bool closingTuplet, bool closingBeamInTuplet);
+    bool writeBeam(const engraving::Beam* beam, const engraving::ChordRest* chordRest, bool& closing);
+    bool writeClef(const engraving::Clef* clef);
+    bool writeChord(const engraving::Chord* chord, const engraving::Staff* staff);
+    bool writeGraceGrp(const engraving::Chord* chord, const engraving::Staff* staff, bool isAfter = false);
+    bool writeNote(const engraving::Note* note, const engraving::Chord* chord, const engraving::Staff* staff, bool isChord);
+    bool writeRest(const engraving::Rest* rest, const engraving::Staff* staff);
+    bool writeTuplet(const engraving::Tuplet* tuplet, const engraving::EngravingItem* item, bool& closing);
+
+    /**
+     * Methods for writing MEI control events (within <measure>)
+     */
+    bool writeBreath(const engraving::Breath* breath, const std::string& startid);
+    bool writeDynam(const engraving::Dynamic* dynamic, const std::string& startid);
+    bool writeFermata(const engraving::Fermata* fermata, const std::string& startid);
+    bool writeFermata(const engraving::Fermata* fermata, const libmei::xsdPositiveInteger_List& staffNs, double tstamp);
+    bool writeHarm(const engraving::Harmony* harmony, const std::string& startid);
+    bool writeRepeatMark(const engraving::Jump* jump, const engraving::Measure* measure);
+    bool writeRepeatMark(const engraving::Marker* marker, const engraving::Measure* measure);
+    bool writeTempo(const engraving::TempoText* tempoText, const std::string& startid);
+
+    /**
+     * Methods for writing specific MEI attribute classes within elements
+     */
+    bool writeBeamTypeAtt(const engraving::ChordRest* chordRest, libmei::AttTyped& typeAtt);
+    bool writeStaffIdenAtt(const engraving::ChordRest* chordRest, const engraving::Staff* staff, libmei::AttStaffIdent& staffIdentAtt);
+    bool writeStemAtt(const engraving::Chord* chord, libmei::AttStems& stemsAtt);
+
+    /**
+     * Helper methods
+     */
+    bool isCurrentNode(const libmei::Element& element);
+    std::list<const engraving::Volta*> findVoltasInMeasure(const engraving::Measure* measure);
+    void fillControlEventMap(const std::string& xmlId, const engraving::ChordRest* chordRest);
+    std::string findStartIdFor(const engraving::EngravingItem* item);
+    void addToRepeatMarkList(const engraving::EngravingItem* repeatMark, pugi::xml_node node, const std::string& xmlId);
+    void addJumpToRepeatMarks();
+    bool addFermataToMap(engraving::track_idx_t track, const engraving::Segment* segment, const engraving::Measure* measure);
+    std::pair<libmei::xsdPositiveInteger_List, double> findTstampFor(const engraving::EngravingItem* item);
+    bool isNode(pugi::xml_node node, const String& name);
+    pugi::xml_node getLastChordRest(pugi::xml_node node);
+
+    /**
+     * Methods for generating @xml:ids
+     */
+    void resetMeasureIDs();
+    void resetLayerIDs();
+    std::string getSectionXmlId();
+    std::string getEndingXmlId();
+    std::string getMeasureXmlId();
+    std::string getMeasureXmlIdFor(measureElementCounter elementType);
+    std::string getStaffXmlId();
+    std::string getLayerXmlId();
+    std::string getLayerXmlIdFor(layerElementCounter elementType, const engraving::Segment* segment = nullptr);
+
+    /** A structure of holding a list of repeat marks to be post-process in addJumpToRepeatMarks (currently unused) */
+    struct RepeatMark {
+        const engraving::EngravingItem* m_repeatMark = nullptr;
+        pugi::xml_node m_node;
+        std::string m_xmlId;
+        std::string m_jumptToLabel;
+        std::string m_jumpToXmlId;
+    };
+
     /** The Score pointer */
     engraving::Score* m_score = nullptr;
 
     /** MEI xml element */
     pugi::xml_node m_mei;
+    /** Current xml element */
+    pugi::xml_node m_currentNode;
+
+    /** When writing layers, keep a pointer to the keySig segment (if any) to prepend a scoreDef if necessary */
+    const engraving::Segment* m_keySig;
+    /** Same for the timeSig segment */
+    const engraving::Segment* m_timeSig;
+    /** A flag indicating that we have mulitple sections in the file */
+    bool m_hasSections;
+
+    std::map<const engraving::EngravingItem*, std::string> m_startingControlEventMap;
+    std::map<const engraving::EngravingItem*, std::pair<libmei::xsdPositiveInteger_List, double> > m_tstampControlEventMap;
+
+    std::list<MeiExporter::RepeatMark> m_repeatMarks;
+
+    /** Counters for generating xml:ids */
+    int m_sectionCounter;
+    int m_endingCounter;
+    int m_measureCounter;
+    int m_staffCounter;
+    int m_layerCounter;
+    /** Sub counters by elementType */
+    std::vector<int> m_measureCounterFor;
+    std::vector<int> m_layerCounterFor;
+
+    /** map of abbreviations for control events within measure */
+    inline static std::map<measureElementCounter, String> s_measureXmlIdMap = {
+        { BREATH_M, u"bt" },
+        { CAESURA_M, u"cs" },
+        { DYNAM_M, u"dn" },
+        { FERMATA_M, u"fm" },
+        { HARM_M, u"hr" },
+        { REPEATMARK_M, u"rp" },
+        { SLUR_M, u"sl" },
+        { TEMPO_M, u"tp" },
+        { UNSPECIFIED_M, u"z" }
+    };
+
+    /** map of abbreviations for element within layers */
+    inline static std::map<layerElementCounter, String> s_layerXmlIdMap = {
+        { ACCID_L, u"a" },
+        { BEAM_L, u"b" },
+        { CHORD_L, u"c" },
+        { GRACEGRP_L, u"g" },
+        { NOTE_L, u"n" },
+        { REST_L, u"r" },
+        { TUPLET_L, u"t" },
+        { UNSPECIFIED_L, u"z" }
+    };
 };
 } // namespace
 

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -328,7 +328,7 @@ bool MeiImporter::addGraceNotesToChord(engraving::ChordRest* chordRest, bool isA
                     break;
                 default:
                     LOGD() << "MeiImporter::addGraceNotesToChord unsupported grace duration type " <<
-                    int(graceChord->durationType().type());
+                        int(graceChord->durationType().type());
                     break;
                 }
                 graceChord->setNoteType(noteType);

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -327,7 +327,8 @@ bool MeiImporter::addGraceNotesToChord(engraving::ChordRest* chordRest, bool isA
                 case (DurationType::V_32ND): noteType = NoteType::GRACE32_AFTER;
                     break;
                 default:
-                    LOGD() << "MeiImporter::addGraceNotesToChord unsupported grace duration type " << int(graceChord->durationType().type());
+                    LOGD() << "MeiImporter::addGraceNotesToChord unsupported grace duration type " <<
+                    int(graceChord->durationType().type());
                     break;
                 }
                 graceChord->setNoteType(noteType);

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -47,7 +47,7 @@
 #include "libmscore/timesig.h"
 #include "libmscore/tuplet.h"
 
-#include "io/file.h"
+#include "meiconverter.h"
 
 #include "thirdparty/libmei/cmn.h"
 #include "thirdparty/libmei/shared.h"
@@ -69,12 +69,26 @@ using namespace mu::engraving;
 
 bool MeiImporter::read(const io::path_t& path)
 {
+    m_lastMeasure = nullptr;
+    m_tuplet = nullptr;
+    m_beamBeginMode = BeamMode::AUTO;
+    m_graceBeamBeginMode = BeamMode::AUTO;
+
+    m_readingGraceNotes = GraceNone;
+    m_lastChord = nullptr;
+
+    m_readingEnding = false;
+    m_endingStart = nullptr;
+    m_endingEnd = nullptr;
+
+    Convert::logs.clear();
+
     pugi::xml_document doc;
     pugi::xml_parse_result result = doc.load_file(
         path.toStdString().c_str(), (pugi::parse_comments | pugi::parse_default) & ~pugi::parse_eol);
 
     if (!result) {
-        LOGD() << "Cannot open file <%s>", qPrintable(path.toString());
+        LOGD() << "Cannot open file <" << qPrintable(path.toString()) << ">";
         return false;
     }
 
@@ -87,7 +101,1863 @@ bool MeiImporter::read(const io::path_t& path)
 
     bool success = true;
 
-    // TODO: actual import
+    success = success && this->readMeiHead(root);
+
+    success = success && this->readScore(root);
 
     return success;
+}
+
+//---------------------------------------------------------
+// helper methods
+//---------------------------------------------------------
+
+/**
+ * Add a message together with a printout of the node to the log list.
+ */
+
+void MeiImporter::addLog(const std::string& msg, pugi::xml_node node)
+{
+    String nodeStr = u"&lt;";
+    nodeStr += String(node.name());
+    for (auto attribute : node.attributes()) {
+        nodeStr += String(" %1='%2'").arg(String(attribute.name()), String(attribute.value()));
+    }
+    nodeStr += u" /&gt;";
+    Convert::logs.push_back(String("Could not convert the %1 from %2").arg(String::fromStdString(msg), nodeStr));
+}
+
+/**
+ * Return true if the node name matches the name parameter.
+ */
+
+bool MeiImporter::isNode(pugi::xml_node node, const String& name)
+{
+    if (!node) {
+        return false;
+    }
+
+    String nodeName = String(node.name());
+    return nodeName == name;
+}
+
+/**
+ * Return the MuseScore staff index for the corresponding MEI staff `@n`
+ * Actually useful only when reading files not written by MuseScore and that can have not continuous staff numbers
+ */
+
+int MeiImporter::getStaffIndex(int staffN)
+{
+    if (m_staffNs.find(staffN) == m_staffNs.end()) {
+        return 0;
+    }
+    return static_cast<int>(std::distance(m_staffNs.begin(), m_staffNs.find(staffN)));
+}
+
+/**
+ * Return the voice index (0 to 3) for the corresponding MEI layer `@n`
+ * Actually useful only when reading files not written by MuseScore
+ */
+
+int MeiImporter::getVoiceIndex(int staffIdx, int layerN)
+{
+    if (!m_staffLayerNs.count(staffIdx)) {
+        return 0;
+    }
+    const std::set<int>& layerNs = m_staffLayerNs.at(staffIdx);
+    if (layerNs.find(layerN) == layerNs.end()) {
+        return 0;
+    }
+    return static_cast<int>(std::distance(layerNs.begin(), layerNs.find(layerN)));
+}
+
+/**
+ * Add a new ChordRest object to a measure and called when reading a <chord>, <note> or <rest>, including grace notes.
+ * When reading grace notes, add the object to the m_graceNotes list, which will eventually be added to the appropriate Chord.
+ * When reading tuplet, increase the ticks value to the corrected ratio, and not at all when reading grace notes.
+ */
+
+ChordRest* MeiImporter::addChordRest(pugi::xml_node node, Measure* measure, int track, const libmei::Element& meiElement, int& ticks,
+                                     bool isRest)
+{
+    IF_ASSERT_FAILED(measure) {
+        return nullptr;
+    }
+
+    bool warning = false;
+
+    libmei::AttAugmentDots const* augmentDotsAtt = dynamic_cast<libmei::AttAugmentDots const*>(&meiElement);
+    libmei::AttDurationLog const* durationLogAtt = dynamic_cast<libmei::AttDurationLog const*>(&meiElement);
+    libmei::AttStaffIdent const* staffIdentAtt = dynamic_cast<libmei::AttStaffIdent const*>(&meiElement);
+    libmei::AttTyped const* typedAtt = dynamic_cast<libmei::AttTyped const*>(&meiElement);
+
+    IF_ASSERT_FAILED(augmentDotsAtt && durationLogAtt && staffIdentAtt && typedAtt) {
+        return nullptr;
+    }
+
+    // No assert because att.beam.secondary is not available on MEI `<space>`
+    libmei::AttBeamSecondary const* beamSecondaryAtt = dynamic_cast<libmei::AttBeamSecondary const*>(&meiElement);
+
+    TDuration duration;
+    duration.setType(Convert::durFromMEI(durationLogAtt->GetDur(), warning));
+    if (warning) {
+        this->addLog("duration", node);
+    }
+
+    if (augmentDotsAtt->HasDots()) {
+        duration.setDots(augmentDotsAtt->GetDots());
+    }
+
+    Segment* segment = nullptr;
+    // For grace notes we use a dummy segment, otherwise a ChordRest segement with the appropriate ticks value
+    if (m_readingGraceNotes) {
+        segment = m_score->dummy()->segment();
+    } else {
+        segment = measure->getSegment(SegmentType::ChordRest, Fraction::fromTicks(ticks) + measure->tick());
+    }
+
+    ChordRest* chordRest = nullptr;
+    if (isRest) {
+        chordRest = Factory::createRest(segment);
+    } else {
+        chordRest = Factory::createChord(segment);
+    }
+
+    if (m_startIdChordRests.count(meiElement.m_xmlId)) {
+        m_startIdChordRests[meiElement.m_xmlId] = chordRest;
+    }
+
+    // Handle cross-staff notation
+    if (staffIdentAtt->HasStaff()) {
+        int staffN = staffIdentAtt->GetStaff().front();
+        int staffMoveIdx = this->getStaffIndex(staffN);
+        int staffMove = (staffMoveIdx - static_cast<int>(track2staff(track)));
+        // Limit staff move to one staff - also, boundaries should be OK since we use getStaffIndex and track2staff previously
+        if (staffMove == -1 || staffMove == 1) {
+            chordRest->setStaffMove(staffMove);
+        }
+    }
+
+    chordRest->setTrack(track);
+    chordRest->setTicks(duration.fraction());
+    chordRest->setDurationType(TDuration(duration));
+
+    if (m_readingGraceNotes) {
+        // non critical assert
+        assert(chordRest->isChord());
+        m_graceNotes.push_front(toChord(chordRest));
+    } else {
+        if (m_graceNotes.size() > 0) {
+            // pre grace groups have to be added to the chord - if it is a rest they will be ignored (deleted)
+            this->addGraceNotesToChord(chordRest);
+        }
+        segment->add(chordRest);
+        // Keep a pointer to the last chord read for adding post grace groups
+        if (chordRest->isChord()) {
+            m_lastChord = static_cast<Chord*>(chordRest);
+        }
+    }
+
+    BeamMode beamMode = Convert::beamFromMEI(typedAtt->GetType(), BEAM_ELEMENT_TYPE, warning);
+    if (beamMode != BeamMode::AUTO) {
+        chordRest->setBeamMode(beamMode);
+    }
+    // Set BeamMode::BEGIN16 or BeamMode::BEGIN32 (we have a distinct flag for grace notes for handling nested beams)
+    else {
+        if (!m_readingGraceNotes) {
+            chordRest->setBeamMode(m_beamBeginMode);
+            m_beamBeginMode = BeamMode::AUTO;
+        } else {
+            chordRest->setBeamMode(m_graceBeamBeginMode);
+            m_graceBeamBeginMode = BeamMode::AUTO;
+        }
+    }
+
+    Fraction chordTicks = chordRest->ticks();
+    // For tuplet add the ChordRest to it and adjust the tick advance to the ratio
+    if (m_tuplet) {
+        m_tuplet->add(chordRest);
+        chordRest->setTuplet(m_tuplet);
+        // For tuplets the tick advance is adjusted to the ratio
+        chordTicks /= m_tuplet->ratio();
+    }
+    // For grace notes, no tick advance
+    if (!m_readingGraceNotes) {
+        ticks += chordTicks.ticks();
+        // Check if we have an AttBeamSecondary and read it for the next ChordRest
+        if (beamSecondaryAtt) {
+            m_beamBeginMode = Convert::breaksecFromMEI(beamSecondaryAtt->GetBreaksec(), warning);
+        }
+    } else {
+        // Check if we have an AttBeamSecondary and read it for the next ChordRest
+        if (beamSecondaryAtt) {
+            m_graceBeamBeginMode = Convert::breaksecFromMEI(beamSecondaryAtt->GetBreaksec(), warning);
+        }
+    }
+
+    return chordRest;
+}
+
+/**
+ * Add grace notes to a ChordRest When a grace group was previously read and added to MeiImpoter::m_graceNotes
+ * Ignore (delete) the grace notes if the ChordRest is a Rest.
+ * Look at m_graceNoteType for setting the acciaccatura note type (when grace notes preceed only)
+ */
+
+bool MeiImporter::addGraceNotesToChord(engraving::ChordRest* chordRest, bool isAfter)
+{
+    IF_ASSERT_FAILED(chordRest) {
+        return false;
+    }
+
+    if (!chordRest->isChord()) {
+        this->clearGraceNotes();
+        return false;
+    } else {
+        if (isAfter) {
+            NoteType noteType = NoteType::GRACE8_AFTER;
+            // For after grace notes, the order of insertion is flipped
+            m_graceNotes.reverse();
+            for (auto graceChord : m_graceNotes) {
+                switch (graceChord->durationType().type()) {
+                case (DurationType::V_EIGHTH): noteType = NoteType::GRACE8_AFTER;
+                    break;
+                case (DurationType::V_16TH): noteType = NoteType::GRACE16_AFTER;
+                    break;
+                case (DurationType::V_32ND): noteType = NoteType::GRACE32_AFTER;
+                    break;
+                default:
+                    LOGD() << "MeiImporter::addGraceNotesToChord unsupported grace duration type " << int(graceChord->durationType().type());
+                    break;
+                }
+                graceChord->setNoteType(noteType);
+                chordRest->add(graceChord);
+            }
+        } else {
+            for (auto graceChord : m_graceNotes) {
+                NoteType noteType = NoteType::APPOGGIATURA;
+                if (m_graceNoteType == NoteType::ACCIACCATURA) {
+                    noteType = NoteType::ACCIACCATURA;
+                } else {
+                    switch (graceChord->durationType().type()) {
+                    case (DurationType::V_QUARTER): noteType = NoteType::GRACE4;
+                        break;
+                    case (DurationType::V_EIGHTH): noteType = NoteType::APPOGGIATURA;
+                        break;
+                    case (DurationType::V_16TH): noteType = NoteType::GRACE16;
+                        break;
+                    case (DurationType::V_32ND): noteType = NoteType::GRACE32;
+                        break;
+                    default:
+                        LOGD("MeiImporter::addGraceNotesToChord unsupported grace duration type %d",
+                             int(graceChord->durationType().type()));
+                        break;
+                    }
+                }
+                graceChord->setNoteType(noteType);
+                chordRest->add(graceChord);
+            }
+        }
+        m_graceNotes.clear();
+        return true;
+    }
+}
+
+/**
+ * Create a annotation (MEI control event with @startid).
+ * Do a lookup in the m_startIdChordRests map with the @startid value to retrieve the ChordRest to which the annotation points to.
+ * If there is not @startid but a @tstamp (MEI not written by MuseScore), try to find the corresponding ChordRest
+ * Create the EngravingItem according to the MEI element name (e.g., "dynam", "fermata")
+ * Return nullptr if the lookup fails.
+ */
+
+EngravingItem* MeiImporter::addAnnotation(const libmei::Element& meiElement, Measure* measure)
+{
+    libmei::AttStartId const* startIdAtt = dynamic_cast<libmei::AttStartId const*>(&meiElement);
+    IF_ASSERT_FAILED(measure && startIdAtt) {
+        return nullptr;
+    }
+
+    ChordRest* chordRest = nullptr;
+    if (startIdAtt->HasStartid()) {
+        std::string startId = startIdAtt->GetStartid();
+        // Basic check for the @stardid validity
+        if (startId.size() < 1 || startId.at(0) != '#') {
+            Convert::logs.push_back(String("Could not find element for @startid '%1'").arg(String::fromStdString(startIdAtt->GetStartid())));
+            return nullptr;
+        }
+        startId.erase(0, 1);
+
+        // The startid corresponding ChordRest should have been added to the m_startIdChordRests previously
+        if (!m_startIdChordRests.count(startId) || !m_startIdChordRests.at(startId)) {
+            Convert::logs.push_back(String("Could not find element for @startid '%1'").arg(String::fromStdString(startIdAtt->GetStartid())));
+            return nullptr;
+        }
+        chordRest = m_startIdChordRests.at(startId);
+    } else {
+        // No @startid, try a lookup based on the @tstamp. This is only for files not written via MuseScore
+        libmei::AttTimestampLog const* timestampLogAtt = dynamic_cast<libmei::AttTimestampLog const*>(&meiElement);
+        libmei::AttStaffIdent const* staffIdentAtt = dynamic_cast<libmei::AttStaffIdent const*>(&meiElement);
+        libmei::AttLayerIdent const* layerIdentAtt = dynamic_cast<libmei::AttLayerIdent const*>(&meiElement);
+
+        IF_ASSERT_FAILED(timestampLogAtt && staffIdentAtt && layerIdentAtt) {
+            return nullptr;
+        }
+
+        // If no @tstamp (invalid), put it on 1.0;
+        double tstampValue = timestampLogAtt->HasTstamp() ? : 1.0;
+        Fraction tstampFraction = Convert::tstampToFraction(tstampValue, measure->timesig());
+        int staffIdx = (staffIdentAtt->HasStaff() && staffIdentAtt->GetStaff().size() > 0) ? this->getStaffIndex(
+            staffIdentAtt->GetStaff().at(0)) : 0;
+        int layer = (layerIdentAtt->HasLayer()) ? this->getVoiceIndex(staffIdx, layerIdentAtt->GetLayer()) : 0;
+
+        chordRest = measure->findChordRest(measure->tick() + tstampFraction, staffIdx * VOICES + layer);
+        if (!chordRest) {
+            Convert::logs.push_back(String("Could not find element corresponding to @tstamp '%1'").arg(timestampLogAtt->GetTstamp()));
+            return nullptr;
+        }
+    }
+
+    Segment* segment = chordRest->segment();
+    EngravingItem* item = nullptr;
+
+    if (meiElement.m_name == "breath" || meiElement.m_name == "caesura") {
+        // For Breath we need to add a specific segment and add the breath to it (and not to the ChordRest one)
+        segment = measure->getSegment(SegmentType::Breath, segment->tick() + chordRest->actualTicks());
+        item = Factory::createBreath(segment);
+    } else if (meiElement.m_name == "dynam") {
+        item = Factory::createDynamic(chordRest->segment());
+    } else if (meiElement.m_name == "fermata") {
+        item = Factory::createFermata(chordRest->segment());
+    } else if (meiElement.m_name == "harm") {
+        item = Factory::createHarmony(chordRest->segment());
+    } else if (meiElement.m_name == "tempo") {
+        item = Factory::createTempoText(chordRest->segment());
+    }
+
+    item->setTrack(chordRest->track());
+    segment->add(item);
+
+    return item;
+}
+
+/**
+ * Clear grace notes that cannot be properly attached to a Chord.
+ * Actually delete  the grace notes (Chord) because these have no parent.
+ */
+
+void MeiImporter::clearGraceNotes()
+{
+    for (auto graceChord : m_graceNotes) {
+        delete graceChord;
+    }
+    m_graceNotes.clear();
+    m_readingGraceNotes = GraceNone;
+}
+
+//---------------------------------------------------------
+// parsing methods
+//---------------------------------------------------------
+
+/**
+ * Read the <meiHead> and stores it as a custom MuseScore metatag
+ * Also
+ */
+
+bool MeiImporter::readMeiHead(pugi::xml_node root)
+{
+    pugi::xml_node headNode = root.select_node("//meiHead").node();
+    // Store the MEI header in a custom meta tag
+
+    // Critical error
+    if (!headNode) {
+        return false;
+    }
+
+    pugi::xml_document docHeader;
+    docHeader.append_copy(headNode);
+    unsigned int output_flags = pugi::format_default | pugi::format_no_declaration | pugi::format_raw;
+
+    std::stringstream strStream;
+    docHeader.save(strStream, "", output_flags);
+    m_score->setMetaTag(u"meiHead", String::fromStdString(strStream.str()));
+
+    pugi::xml_node workTitleNode = root.select_node("//meiHead/fileDesc/titleStmt/title").node();
+    if (workTitleNode) {
+        m_score->setMetaTag(u"workTitle", String(workTitleNode.text().as_string()));
+    }
+
+    StringList persNames;
+    // the creator types commonly found in MusicXML
+    persNames << u"arranger" << u"composer" << u"lyricist" << u"translator";
+    for (String tagName : persNames) {
+        String xpath = String("//meiHead/fileDesc/titleStmt/respStmt/persName[@role='%1']").arg(tagName);
+        pugi::xml_node persNameNode = root.select_node(xpath.toStdString().c_str()).node();
+        if (persNameNode) {
+            m_score->setMetaTag(tagName, String(persNameNode.text().as_string()));
+        }
+    }
+
+    pugi::xml_node copyrightNode = root.select_node("//meiHead/fileDesc/pubStmt/availability/distributor").node();
+    if (copyrightNode) {
+        m_score->setMetaTag(u"copyright", String(copyrightNode.text().as_string()));
+    }
+
+    return true;
+}
+
+/**
+ * Read the MEI score.
+ * Previously builds a map of IDs being referred to (e.g., through `@startid` or `@endid`)
+ * Also builds a map for staff@n and layer@n when reading MEI files not produced with MuseScore.
+ * Reads the intitial scoreDef before reading the section elements.
+ */
+
+bool MeiImporter::readScore(pugi::xml_node root)
+{
+    pugi::xml_node scoreNode = root.select_node("./music//score").node();
+
+    if (!scoreNode) {
+        return false;
+    }
+
+    pugi::xml_node scoreDefNode = scoreNode.select_node("./scoreDef").node();
+
+    bool success = true;
+
+    success = success && this->buildIdMap(scoreNode);
+
+    success = success && this->buildStaffLayerMap(scoreNode);
+
+    success = success && this->readScoreDef(scoreDefNode, true);
+
+    m_ticks = Fraction(0, 1);
+    m_lastMeasureN = 0;
+    m_lastMeasure = nullptr;
+
+    pugi::xpath_node_set sections = scoreNode.select_nodes("./section");
+    for (pugi::xpath_node xpathNode : sections) {
+        success = success && this->readSectionElements(xpathNode.node());
+    }
+
+    return success;
+}
+
+/**
+ * Read a scoreDef (initial or intermediate).
+ * For the intial scoreDef, also tries to build the part structure from the scoreDef relying on staffGrp@label and staffDef@label.
+ * Sets the time signature and key signature to the global m_timeSigs and m_keySigs maps.
+ * Uses the SCOREDEF_IDX index position for global (scoreDef) time signature and key signatures.
+ * Since the map are ordered, these will have priority over the ones read in MeiImporter::readStaffDef.
+ */
+
+bool MeiImporter::readScoreDef(pugi::xml_node scoreDefNode, bool isInitial)
+{
+    bool warning = false;
+    libmei::ScoreDef meiScoreDef;
+
+    // Critical error
+    if (!scoreDefNode) {
+        return false;
+    }
+
+    bool success = true;
+
+    if (isInitial) {
+        success = readPgHead(scoreDefNode.child("pgHead"));
+    }
+
+    meiScoreDef.Read(scoreDefNode);
+
+    if (meiScoreDef.HasMeterSym() || meiScoreDef.HasMeterCount()) {
+        m_timeSigs[SCOREDEF_IDX] = Convert::meterFromMEI(meiScoreDef, warning);
+        if (warning) {
+            this->addLog("meter signature", scoreDefNode);
+        }
+    }
+    if (meiScoreDef.HasKeysig()) {
+        m_keySigs[SCOREDEF_IDX] = Convert::keyFromMEI(meiScoreDef.GetKeysig(), warning);
+        if (warning) {
+            this->addLog("key signature", scoreDefNode);
+        }
+    }
+
+    if (isInitial) {
+        success = success && this->buildScoreParts(scoreDefNode);
+    }
+
+    success = success && this->readStaffDefs(scoreDefNode);
+
+    // If we have a time signature, pick the first one, which will be SCOREDEF_IDX one (if given)
+    // Otherwise, it picks the first staffDef one and we expect it to be the same for all staves
+    if (!m_timeSigs.empty()) {
+        m_currentTimeSig = m_timeSigs.begin()->second.first;
+    }
+
+    return success;
+}
+
+/**
+ * Read the pgHead into a MuseScore initial vBox.
+ */
+
+bool MeiImporter::readPgHead(pugi::xml_node pgHeadNode)
+{
+    if (!pgHeadNode) {
+        return this->buildTextFrame();
+    }
+
+    bool warning;
+
+    VBox* vBox = nullptr;
+
+    // first level MEI /rend are positioning <rend> elements, which are ignored since positioning is based on
+    // second level MEI /rend @label based on text styles ("title", "subtitle", "composer", etc).
+    pugi::xpath_node_set rends = pgHeadNode.select_nodes("./rend/rend");
+
+    for (pugi::xpath_node rendXpathNode : rends) {
+        pugi::xml_node rendNode = rendXpathNode.node();
+        if (!rendNode) {
+            continue;
+        }
+        libmei::Rend meiRend;
+        meiRend.Read(rendNode);
+
+        // Read the string content (first level), including <lb>
+        StringList lines;
+        this->readLines(rendNode, lines);
+
+        TextStyleType textStyle = Convert::textFromMEI(meiRend, warning);
+        if (warning) {
+            this->addLog("text label", rendNode);
+        }
+
+        if (!vBox) {
+            vBox = Factory::createVBox(m_score->dummy()->system());
+        }
+
+        Text* text = Factory::createText(vBox, textStyle);
+        text->setPlainText(lines.join(u"\n"));
+        vBox->add(text);
+    }
+
+    if (vBox) {
+        m_score->measures()->add(vBox);
+    }
+
+    return true;
+}
+
+/**
+ * Read the lines of a textual mixed content.
+ */
+
+bool MeiImporter::readLines(pugi::xml_node parentNode, StringList& lines)
+{
+    for (pugi::xml_node child : parentNode.children()) {
+        if (child.type() == pugi::node_pcdata) {
+            lines.push_back(String(child.text().as_string()));
+        } else if (!this->isNode(child, u"lb")) {
+            this->addLog("skipping child element", child);
+        }
+    }
+    return true;
+}
+
+/**
+ * Read the lines of a textual mixed content.
+ * For each line, read <rend> with @glyph.auth as XML symbols.
+ * Read the text content line by line and convert each line into MuseScore xmlText (with <sym>)
+ * The method does not parse the content of <rend> recursively.
+ */
+
+bool MeiImporter::readLinesWithSmufl(pugi::xml_node parentNode, StringList& lines)
+{
+    // A list of segmented text or smufl text blocks
+    Convert::textWithSmufl lineBlocks;
+    String line;
+
+    for (pugi::xml_node child : parentNode.children()) {
+        // Plain text, add it as is to the text block list
+        if (child.type() == pugi::node_pcdata) {
+            lineBlocks.push_back(std::make_pair(false, String(child.text().as_string())));
+        }
+        // A rend, check is the content is smufl
+        else if (this->isNode(child, u"rend")) {
+            libmei::Rend meiRend;
+            meiRend.Read(child);
+            bool isSmufl = (meiRend.HasGlyphAuth() && meiRend.GetGlyphAuth() == "smufl");
+            // If smufl, add its text as smufl, otherwise as text
+            lineBlocks.push_back(std::make_pair(isSmufl, String(child.first_child().text().as_string())));
+        }
+        // A line break, already convert the current text blocks
+        else if (this->isNode(child, u"lb")) {
+            Convert::textFromMEI(line, lineBlocks);
+            lines.push_back(line);
+            lineBlocks.clear();
+        } else {
+            this->addLog("skipping child element", child);
+        }
+    }
+
+    // At the end, convert the remaining text blocks
+    Convert::textFromMEI(line, lineBlocks);
+    lines.push_back(line);
+
+    return true;
+}
+
+/**
+ * Read the staff definition.
+ * Stores clef, time signature and key signature into the corresponding global maps.
+ */
+
+bool MeiImporter::readStaffDefs(pugi::xml_node parentNode)
+{
+    bool warning = false;
+
+    pugi::xpath_node_set staffDefs = parentNode.select_nodes(".//staffDef");
+    // No critical error here if not staffDefs is empty because we can all this from an empty <scoreDef> change
+
+    for (pugi::xpath_node staffDefXpathNode : staffDefs) {
+        libmei::StaffDef meiStaffDef;
+        meiStaffDef.Read(staffDefXpathNode.node());
+
+        // Mapped index from MEI staff@n to MuseScore index
+        const int staffIdx = this->getStaffIndex(meiStaffDef.GetN());
+
+        pugi::xml_node clefNode = staffDefXpathNode.node().select_node(".//clef").node();
+        if (clefNode) {
+            libmei::Clef meiClef;
+            meiClef.Read(clefNode);
+            m_clefs[staffIdx] = Convert::clefFromMEI(meiClef, warning);
+            if (warning) {
+                this->addLog("clef", clefNode);
+            }
+            //staff->setDefaultClefType(ClefTypeList(Convert::clefFromMEI(meiClef)));
+        } else if (meiStaffDef.HasClefShape() && meiStaffDef.HasClefLine()) {
+            m_clefs[staffIdx] = Convert::clefFromMEI(meiStaffDef, warning);
+            if (warning) {
+                this->addLog("clef", staffDefXpathNode.node());
+            }
+            //staff->setDefaultClefType(ClefTypeList(Convert::clefFromMEI(meiStaffDef)));
+        }
+        //m_clefs[meiStaffDef.GetN()] = staff->defaultClefType();
+
+        if (meiStaffDef.HasMeterSym() || meiStaffDef.HasMeterCount()) {
+            m_timeSigs[staffIdx] = Convert::meterFromMEI(meiStaffDef, warning);
+            if (warning) {
+                this->addLog("meter signature", staffDefXpathNode.node());
+            }
+        }
+        if (meiStaffDef.HasKeysig()) {
+            m_keySigs[staffIdx] = Convert::keyFromMEI(meiStaffDef.GetKeysig(), warning);
+            if (warning) {
+                this->addLog("key signature", staffDefXpathNode.node());
+            }
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Read the staffGrp.
+ */
+
+bool MeiImporter::readStaffGrps(pugi::xml_node parentNode, int& staffSpan, int column, size_t& idx)
+{
+    pugi::xpath_node_set children = parentNode.select_nodes("./*");
+
+    bool success = true;
+
+    // Loop through all staffDef and staffGrp
+    for (pugi::xpath_node child : children) {
+        if (isNode(child.node(), u"staffDef")) {
+            staffSpan++;
+            idx++;
+        } else if (isNode(child.node(), u"staffGrp")) {
+            Staff* staff = m_score->staff(idx);
+            libmei::StaffGrp meiStaffGrp;
+            meiStaffGrp.Read(child.node());
+            Convert::BracketStruct bracketSt = Convert::bracketFromMEI(meiStaffGrp);
+            staff->setBracketType(column, bracketSt.bracketType);
+
+            int childStaffSpan = 0;
+            // Recursive call
+            success = success && this->readStaffGrps(child.node(), childStaffSpan, column + 1, idx);
+
+            // Now we know the spanning of the group
+            staff->setBracketSpan(column, childStaffSpan);
+            // We can also set the barline spanning - staff by staff since this is what MuseScore seems to do by default
+            if (bracketSt.barLineSpan > 0) {
+                size_t staffIdxStart = idx - static_cast<size_t>(childStaffSpan);
+                size_t staffIdxEnd = idx - 1;
+                for (size_t staffIdx = staffIdxStart; staffIdx < staffIdxEnd; staffIdx++) {
+                    Staff* currentStaff = m_score->staff(staffIdx);
+                    if (currentStaff) {
+                        currentStaff->setBarLineSpan(1);
+                    }
+                }
+            }
+
+            staffSpan += childStaffSpan;
+        }
+    }
+
+    return success;
+}
+
+/**
+ * Read section content, including through a recursive call for nested section elements.
+ */
+
+bool MeiImporter::readSectionElements(pugi::xml_node parentNode)
+{
+    bool success = true;
+
+    pugi::xpath_node_set elements = parentNode.select_nodes("./*");
+    for (pugi::xpath_node xpathNode : elements) {
+        std::string elementName = std::string(xpathNode.node().name());
+        if (elementName == "section") {
+            success = success && this->readSectionElements(xpathNode.node());
+        } else if (elementName == "ending") {
+            success = success && this->readEnding(xpathNode.node());
+        } else if (elementName == "measure") {
+            success = success && this->readMeasure(xpathNode.node());
+        } else if (elementName == "pb") {
+            success = success && this->readPb(xpathNode.node());
+        } else if (elementName == "sb") {
+            success = success && this->readSb(xpathNode.node());
+        } else if (elementName == "scoreDef") {
+            success = success && this->readScoreDef(xpathNode.node(), false);
+        }
+    }
+
+    // Post-processing adjustment for the last barLine.
+    if (m_score->measures()->last() && m_score->measures()->last()->isMeasure()) {
+        Measure* measure = static_cast<Measure*>(m_score->measures()->last());
+        if (!measure->endBarLine()) {
+            this->addEndBarLineToMeasure(measure, BarLineType::NORMAL);
+        }
+    }
+
+    return success;
+}
+
+/**
+ * Read ending and its content.
+ * Spanning of the ending is set using m_endingStart and m_endingEnd measures
+ */
+
+bool MeiImporter::readEnding(pugi::xml_node endingNode)
+{
+    bool success = true;
+
+    bool warning;
+    libmei::Ending meiEnding;
+    meiEnding.Read(endingNode);
+
+    m_readingEnding = true;
+
+    success = success && this->readSectionElements(endingNode);
+
+    if (!m_endingStart || !m_endingEnd) {
+        success = false;
+    } else {
+        Volta* volta = Factory::createVolta(m_score->dummy());
+        Convert::endingFromMEI(volta, meiEnding, warning);
+        volta->setTrack(0);
+        volta->setTrack2(0);
+        volta->setTick(m_endingStart->tick());
+        volta->setTick2(m_endingEnd->tick() + m_endingEnd->ticks());
+        m_score->addElement(volta);
+    }
+
+    m_readingEnding = false;
+    m_endingStart = nullptr;
+    m_endingEnd = nullptr;
+
+    return success;
+}
+
+/**
+ * Read measure and its content.
+ * Sets m_endingStart and m_endingEnd pointers as appropriate.
+ * Try to manage measure offest looking at MEI measure@n (num-like values).
+ * Ajust various flags (end barline, repeat counts).
+ * Reads measure control events.
+ */
+
+bool MeiImporter::readMeasure(pugi::xml_node measureNode)
+{
+    bool success = true;
+
+    bool warning;
+    libmei::Measure meiMeasure;
+    meiMeasure.Read(measureNode);
+    Convert::MeasureStruct measureSt = Convert::measureFromMEI(meiMeasure, warning);
+
+    Measure* measure = Factory::createMeasure(m_score->dummy()->system());
+    measure->setTick(m_ticks);
+    measure->setTimesig(m_currentTimeSig);
+
+    if (m_readingEnding) {
+        if (!m_endingStart) {
+            m_endingStart = measure;
+        }
+        m_endingEnd = measure;
+    }
+
+    // Try to manage measure offsets
+    if (measureSt.n) {
+        m_lastMeasureN++;
+        // The offset might be positive or negative
+        // For example, two measure 9a and 9b, with the second with a -1 offset
+        if (measureSt.n != m_lastMeasureN) {
+            measure->setNoOffset(measureSt.n - m_lastMeasureN);
+            m_lastMeasureN = measureSt.n;
+        }
+    }
+    measure->setIrregular(measureSt.irregular);
+
+    int measureTicks = 0;
+    success = success & this->readStaves(measureNode, measure, measureTicks);
+    // Make sure we correct empty content because this would crash MuseScore
+    if (measureTicks == 0) {
+        measureTicks = m_currentTimeSig.ticks();
+        LOGD() << "MeiImporter::readMeasure empty content in " << meiMeasure.GetN();
+    }
+    measure->setTicks(Fraction::fromTicks(measureTicks));
+
+    success = success & this->readControlEvents(measureNode, measure);
+
+    measure->setRepeatStart(measureSt.repeatStart);
+    if (measureSt.repeatEnd) {
+        measure->setRepeatEnd(true);
+    } else if (measureSt.endBarLineType != engraving::BarLineType::NORMAL) {
+        this->addEndBarLineToMeasure(measure, measureSt.endBarLineType);
+    }
+
+    if (measureSt.repeatCount) {
+        measure->setRepeatCount(measureSt.repeatCount);
+    }
+
+    m_score->measures()->add(measure);
+    m_ticks += measure->ticks();
+
+    m_lastMeasure = measure;
+
+    return success;
+}
+
+/**
+ * Read page begin.
+ * Only pb with a BREAK_TYPE `@type` will be imported as user added breaks
+ */
+
+bool MeiImporter::readPb(pugi::xml_node pbNode)
+{
+    if (!configuration()->meiImportLayout()) {
+        return true;
+    }
+
+    libmei::Pb meiPb;
+    meiPb.Read(pbNode);
+
+    if (meiPb.HasType() && Convert::hasTypeValue(meiPb.GetType(), BREAK_TYPE)) {
+        this->addLayoutBreakToMeasure(m_lastMeasure, engraving::LayoutBreakType::PAGE);
+    }
+
+    return true;
+}
+
+/**
+ * Read system begin.
+ * Only sb with a BREAK_TYPE `@type` will be imported as user added breaks
+ */
+
+bool MeiImporter::readSb(pugi::xml_node pbNode)
+{
+    if (!configuration()->meiImportLayout()) {
+        return true;
+    }
+
+    libmei::Sb meiSb;
+    meiSb.Read(pbNode);
+
+    if (meiSb.HasType() && Convert::hasTypeValue(meiSb.GetType(), BREAK_TYPE)) {
+        this->addLayoutBreakToMeasure(m_lastMeasure, engraving::LayoutBreakType::LINE);
+    }
+
+    return true;
+}
+
+/**
+ * Read all staves of a measure and their content.
+ * Lookup (and clear) the time signature and key signature maps to add them if necessary.
+ */
+
+bool MeiImporter::readStaves(pugi::xml_node parentNode, Measure* measure, int& measureTicks)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    bool success = true;
+
+    pugi::xpath_node_set staves = parentNode.select_nodes("./staff");
+    // Critical error
+    if (staves.empty()) {
+        success = false;
+    }
+
+    for (pugi::xpath_node xpathNode : staves) {
+        libmei::Staff meiStaff;
+        meiStaff.Read(xpathNode.node());
+        const int staffIdx = this->getStaffIndex(meiStaff.GetN());
+
+        // Either the staffDef specific value (if any), the scoreDef one (if any) or nothing
+        int timeSigIdx = m_timeSigs.count(staffIdx) ? staffIdx : m_timeSigs.count(SCOREDEF_IDX) ? SCOREDEF_IDX : MEI_UNSET;
+        if (timeSigIdx != MEI_UNSET) {
+            Segment* segment = measure->getSegment(SegmentType::TimeSig, Fraction::fromTicks(0) + measure->tick());
+            TimeSig* timeSig = Factory::createTimeSig(segment);
+            timeSig->setTrack(staffIdx * VOICES);
+            timeSig->setSig(m_timeSigs.at(timeSigIdx).first, m_timeSigs.at(timeSigIdx).second);
+            segment->add(timeSig);
+            // Erase the staffDef specific values (add them only for this staff).
+            m_timeSigs.erase(staffIdx);
+        }
+
+        int keySigIdx = m_keySigs.count(staffIdx) ? staffIdx : m_keySigs.count(SCOREDEF_IDX) ? SCOREDEF_IDX : MEI_UNSET;
+        if (keySigIdx != MEI_UNSET) {
+            Segment* segment = measure->getSegment(SegmentType::KeySig, Fraction::fromTicks(0) + measure->tick());
+            KeySigEvent ksEvent;
+            ksEvent.setKey(m_keySigs.at(keySigIdx));
+            KeySig* keySig = Factory::createKeySig(segment);
+            keySig->setTrack(staffIdx * VOICES);
+            keySig->setKeySigEvent(ksEvent);
+            segment->add(keySig);
+            m_keySigs.erase(staffIdx);
+        }
+
+        if (m_clefs.count(staffIdx)) {
+            Segment* segment = measure->getSegment(SegmentType::HeaderClef, Fraction::fromTicks(0) + measure->tick());
+            Clef* clef = Factory::createClef(segment);
+            clef->setClefType(m_clefs.at(staffIdx));
+            clef->setTrack(staffIdx * VOICES);
+            segment->add(clef);
+            m_clefs.erase(staffIdx);
+        }
+
+        success = success && this->readLayers(xpathNode.node(), measure, staffIdx, measureTicks);
+    }
+
+    // Erase the scoreDef values (add them only for this measure)
+    m_timeSigs.erase(SCOREDEF_IDX);
+    m_keySigs.erase(SCOREDEF_IDX);
+
+    return success;
+}
+
+/**
+ * Read the layer and its content.
+ * Also read grace notes not within a graceGrp for MEI files not written by MuseScore.
+ * Relies on the m_lastChord pointer for adding grace notes to the correct ChordRest
+ */
+
+bool MeiImporter::readLayers(pugi::xml_node parentNode, Measure* measure, int staffN, int& measureTicks)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    bool success = true;
+
+    pugi::xpath_node_set layers = parentNode.select_nodes("./layer");
+    // Critical error
+    if (layers.empty()) {
+        success = false;
+    }
+
+    size_t i = 0;
+    for (pugi::xpath_node xpathNode : layers) {
+        // We cannot have more than 4 voices in Musescore
+        if (i >= VOICES) {
+            Convert::logs.push_back(String("More than %1 layers in a staff in not supported. Their content will not be imported.").arg(
+                                        VOICES));
+            break;
+        }
+        libmei::Layer meiLayer;
+        meiLayer.Read(xpathNode.node());
+
+        m_lastChord = nullptr;
+        int ticks = 0;
+        int track = staffN * VOICES + static_cast<int>(i);
+        success = success && this->readElements(xpathNode.node(), measure, track, ticks);
+        measureTicks = std::max(measureTicks, ticks);
+        i++;
+        this->clearGraceNotes();
+    }
+
+    return success;
+}
+
+/**
+ * Read the layer content, including through a recursive call for nested elements.
+ */
+
+bool MeiImporter::readElements(pugi::xml_node parentNode, Measure* measure, int track, int& ticks)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    bool success = true;
+
+    pugi::xpath_node_set elements = parentNode.select_nodes("./*");
+    for (pugi::xpath_node xpathNode : elements) {
+        std::string elementName = std::string(xpathNode.node().name());
+        if (elementName == "beam") {
+            success = success && this->readBeam(xpathNode.node(), measure, track, ticks);
+        } else if (elementName == "chord") {
+            success = success && this->readChord(xpathNode.node(), measure, track, ticks);
+        } else if (elementName == "clef" && !m_readingGraceNotes) {
+            success = success && this->readClef(xpathNode.node(), measure, track, ticks);
+        } else if (elementName == "graceGrp" && !m_readingGraceNotes) {
+            success = success && this->readGraceGrp(xpathNode.node(), measure, track, ticks);
+        } else if (elementName == "mRest" && !m_readingGraceNotes) {
+            success = success && this->readMRest(xpathNode.node(), measure, track, ticks);
+        } else if (elementName == "note") {
+            success = success && this->readNote(xpathNode.node(), measure, track, ticks);
+        } else if (elementName == "rest" && !m_readingGraceNotes) {
+            success = success && this->readRest(xpathNode.node(), measure, track, ticks);
+        } else if (elementName == "tuplet" && !m_readingGraceNotes) {
+            success = success && this->readTuplet(xpathNode.node(), measure, track, ticks);
+        } else {
+            success = success && this->readElements(xpathNode.node(), measure, track, ticks);
+        }
+    }
+    return success;
+}
+
+/**
+ * Read a beam.
+ * Set MuseScore flags based on custom `@type` values.
+ */
+
+bool MeiImporter::readBeam(pugi::xml_node beamNode, engraving::Measure* measure, int track, int& ticks)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    bool success = true;
+
+    libmei::Beam meiBeam;
+    meiBeam.Read(beamNode);
+
+    success = readElements(beamNode, measure, track, ticks);
+
+    // Reset the beam BEGIN16 and BEGIN32 mode
+    if (!m_readingGraceNotes) {
+        m_beamBeginMode = BeamMode::AUTO;
+    } else {
+        m_graceBeamBeginMode = BeamMode::AUTO;
+    }
+
+    return success;
+}
+
+/**
+ * Read a chord and its content (note elements).
+ */
+
+bool MeiImporter::readChord(pugi::xml_node chordNode, engraving::Measure* measure, int track, int& ticks)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    libmei::Chord meiChord;
+    meiChord.Read(chordNode);
+
+    int chordTicks = ticks;
+
+    // Support for @grace without <graceGrp>
+    this->readGracedAtt(meiChord);
+    Chord* chord = static_cast<Chord*>(addChordRest(chordNode, measure, track, meiChord, ticks, false));
+    this->readStemsAtt(chord, meiChord);
+
+    pugi::xpath_node_set notes = chordNode.select_nodes(".//note");
+    for (pugi::xpath_node xpathNode : notes) {
+        this->readNote(xpathNode.node(), measure, track, chordTicks, chord);
+    }
+
+    return true;
+}
+
+/*
+ * Read a clef.
+ */
+
+bool MeiImporter::readClef(pugi::xml_node clefNode, engraving::Measure* measure, int track, int& ticks)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    bool warning = false;
+    libmei::Clef meiClef;
+    meiClef.Read(clefNode);
+
+    Segment* segment = measure->getSegment(SegmentType::Clef, Fraction::fromTicks(ticks) + measure->tick());
+    Clef* clef = Factory::createClef(segment);
+    clef->setClefType(ClefTypeList(Convert::clefFromMEI(meiClef, warning)));
+    if (warning) {
+        this->addLog("clef", clefNode);
+    }
+
+    clef->setTrack(track);
+    //clef->setGenerated(true);
+    segment->add(clef);
+
+    return true;
+}
+
+/**
+ * Read a <graceGrp> and adjust the MeiImporter::m_readingGraceNotes flag.
+ * For <graceGrp> with @attach="pre", add the grace notes read recursively (through readElements) to m_lastChord (if any)
+ * Otherwise, only reset the flag and adding the grace notes will be performed in MeiImporter::addChordRest when the next <chord> / <note> is read
+ */
+
+bool MeiImporter::readGraceGrp(pugi::xml_node graceGrpNode, engraving::Measure* measure, int track, int& ticks)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    libmei::GraceGrp meiGraceGrp;
+    meiGraceGrp.Read(graceGrpNode);
+
+    bool warning = false;
+    auto [isAfter, noteType] = Convert::gracegrpFromMEI(meiGraceGrp.GetAttach(), meiGraceGrp.GetGrace(), warning);
+    m_graceNoteType = noteType;
+
+    m_readingGraceNotes = GraceAsGrp;
+
+    this->readElements(graceGrpNode, measure, track, ticks);
+
+    if (isAfter) {
+        if (m_lastChord) {
+            this->addGraceNotesToChord(m_lastChord, true);
+        } else {
+            this->clearGraceNotes();
+        }
+    }
+
+    m_readingGraceNotes = GraceNone;
+
+    return true;
+}
+
+/**
+ * Read a mRest.
+ */
+
+bool MeiImporter::readMRest(pugi::xml_node mRestNode, engraving::Measure* measure, int track, int& ticks)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    libmei::MRest meiMRest;
+    meiMRest.Read(mRestNode);
+
+    TDuration duration;
+
+    Segment* segment = measure->getSegment(SegmentType::ChordRest, Fraction::fromTicks(ticks) + measure->tick());
+    Rest* rest = Factory::createRest(segment, TDuration(DurationType::V_MEASURE));
+    rest->setTicks(m_currentTimeSig);
+    rest->setDurationType(DurationType::V_MEASURE);
+    rest->setTrack(track);
+    segment->add(rest);
+
+    // The duration is the duration according to the timesig
+    ticks += rest->ticks().ticks();
+
+    return true;
+}
+
+/**
+ * Read a note.
+ */
+
+bool MeiImporter::readNote(pugi::xml_node noteNode, engraving::Measure* measure, int track, int& ticks, engraving::Chord* chord)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    bool warning = false;
+    libmei::Note meiNote;
+    meiNote.Read(noteNode);
+
+    // Support for @grace without <graceGrp>
+    if (!chord) {
+        this->readGracedAtt(meiNote);
+    }
+
+    pugi::xml_node accidNode = noteNode.select_node(".//accid").node();
+    libmei::Accid meiAccid;
+    if (accidNode) {
+        meiAccid.Read(accidNode);
+    } else {
+        // Support for non MEI-Basic accid and accid.ges encoded in <note> - this is not accademic...
+        meiAccid.Read(noteNode);
+    }
+
+    Staff* staff = m_score->staff(track2staff(track));
+    engraving::Interval interval = staff->part()->instrument()->transpose();
+
+    Convert::PitchStruct pitchSt = Convert::pitchFromMEI(meiNote, meiAccid, interval, warning);
+    if (warning) {
+        this->addLog("pitch", noteNode);
+        this->addLog("accidental", accidNode);
+    }
+
+    if (!chord) {
+        chord = static_cast<Chord*>(addChordRest(noteNode, measure, track, meiNote, ticks, false));
+        this->readStemsAtt(chord, meiNote);
+    }
+
+    Note* note = Factory::createNote(chord);
+
+    int tpc1 = mu::engraving::transposeTpc(pitchSt.tpc2, interval, true);
+    note->setPitch(pitchSt.pitch, tpc1, pitchSt.tpc2);
+
+    Accidental* accid = Factory::createAccidental(note);
+    accid->setAccidentalType(pitchSt.accidType);
+    //accid->setBracket(AccidentalBracket::BRACKET); // Not supported in MEI-Basic
+    accid->setRole(pitchSt.accidRole);
+    note->add(accid);
+
+    note->setTrack(track);
+    chord->add(note);
+
+    return true;
+}
+
+/**
+ * Read a rest.
+ */
+
+bool MeiImporter::readRest(pugi::xml_node restNode, engraving::Measure* measure, int track, int& ticks)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    libmei::Rest meiRest;
+    meiRest.Read(restNode);
+
+    Rest* rest = static_cast<Rest*>(addChordRest(restNode, measure, track, meiRest, ticks, true));
+
+    UNUSED(rest);
+    //ticks += rest->ticks().ticks();
+
+    return true;
+}
+
+/**
+ * Read a tuplet.
+ */
+
+bool MeiImporter::readTuplet(pugi::xml_node tupletNode, engraving::Measure* measure, int track, int& ticks)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    if (m_tuplet) {
+        Convert::logs.push_back(u"Nested tuplets are not supported");
+        return false;
+    }
+
+    bool warning = false;
+    bool success = true;
+
+    int startTicks = ticks;
+    libmei::Tuplet meiTuplet;
+    meiTuplet.Read(tupletNode);
+
+    m_tuplet = Factory::createTuplet(measure);
+    Convert::tupletFromMEI(m_tuplet, meiTuplet, warning);
+    if (warning) {
+        this->addLog("tuplet", tupletNode);
+    }
+
+    m_tuplet->setTrack(track);
+    m_tuplet->setParent(measure);
+
+    success = readElements(tupletNode, measure, track, ticks);
+
+    Fraction tupletTicks = Fraction::fromTicks(ticks - startTicks);
+
+    TDuration d;
+    d.setVal((tupletTicks / m_tuplet->ratio().denominator()).ticks());
+
+    m_tuplet->setBaseLen(d);
+    m_tuplet->setTick(Fraction::fromTicks(startTicks) + measure->tick());
+    m_tuplet->setTicks(tupletTicks);
+
+    m_tuplet = nullptr;
+
+    return success;
+}
+
+//---------------------------------------------------------
+// read MEI control events
+//---------------------------------------------------------
+
+/**
+ * Loop through the content of the MEI <measure> and read the control events
+ */
+
+bool MeiImporter::readControlEvents(pugi::xml_node parentNode, Measure* measure)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    bool success = true;
+
+    pugi::xpath_node_set elements = parentNode.select_nodes("./*");
+    for (pugi::xpath_node xpathNode : elements) {
+        std::string elementName = std::string(xpathNode.node().name());
+        if (elementName == "breath") {
+            success = success && this->readBreath(xpathNode.node(), measure);
+        } else if (elementName == "caesura") {
+            success = success && this->readCaesura(xpathNode.node(), measure);
+        } else if (elementName == "dynam") {
+            success = success && this->readDynam(xpathNode.node(), measure);
+        } else if (elementName == "fermata") {
+            success = success && this->readFermata(xpathNode.node(), measure);
+        } else if (elementName == "harm") {
+            success = success && this->readHarm(xpathNode.node(), measure);
+        } else if (elementName == "repeatMark") {
+            success = success && this->readRepeatMark(xpathNode.node(), measure);
+        } else if (elementName == "tempo") {
+            success = success && this->readTempo(xpathNode.node(), measure);
+        }
+    }
+    return success;
+}
+
+/**
+ * Read a breath.
+ */
+
+bool MeiImporter::readBreath(pugi::xml_node breathNode, engraving::Measure* measure)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    bool warning;
+    libmei::Breath meiBreath;
+    meiBreath.Read(breathNode);
+
+    Breath* breath = static_cast<Breath*>(this->addAnnotation(meiBreath, measure));
+    if (!breath) {
+        // Warning message given in MeiExpoter::addAnnotation
+        return true;
+    }
+
+    Convert::breathFromMEI(breath, meiBreath, warning);
+
+    return true;
+}
+
+/**
+ * Read a caesura (
+ */
+
+bool MeiImporter::readCaesura(pugi::xml_node caesuraNode, engraving::Measure* measure)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    bool warning;
+    libmei::Caesura meiCaesura;
+    meiCaesura.Read(caesuraNode);
+
+    Breath* breath = static_cast<Breath*>(this->addAnnotation(meiCaesura, measure));
+    if (!breath) {
+        // Warning message given in MeiExpoter::addAnnotation
+        return true;
+    }
+
+    Convert::caesuraFromMEI(breath, meiCaesura, warning);
+
+    return true;
+}
+
+/**
+ * Read a dynam.
+ */
+
+bool MeiImporter::readDynam(pugi::xml_node dynamNode, engraving::Measure* measure)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    bool warning;
+    libmei::Dynam meiDynam;
+    meiDynam.Read(dynamNode);
+
+    Dynamic* dynamic = static_cast<Dynamic*>(this->addAnnotation(meiDynam, measure));
+    if (!dynamic) {
+        // Warning message given in MeiExpoter::addAnnotation
+        return true;
+    }
+
+    StringList meiLines;
+    this->readLines(dynamNode, meiLines);
+
+    Convert::dynamFromMEI(dynamic, meiLines, meiDynam, warning);
+
+    return true;
+}
+
+/**
+ * Read a fermata.
+ */
+
+bool MeiImporter::readFermata(pugi::xml_node fermataNode, engraving::Measure* measure)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    bool warning;
+    libmei::Fermata meiFermata;
+    meiFermata.Read(fermataNode);
+
+    Fermata* fermata = nullptr;
+    if (meiFermata.HasTstamp()) {
+        Fraction fermataPos = Convert::tstampToFraction(meiFermata.GetTstamp(), measure->timesig());
+        if (fermataPos == measure->ticks()) {
+            Segment* segment = measure->getSegment(SegmentType::EndBarLine, measure->tick() + measure->ticks());
+            fermata = Factory::createFermata(segment);
+            const int staffIdx
+                = (meiFermata.HasStaff() && meiFermata.GetStaff().size() > 0) ? this->getStaffIndex(meiFermata.GetStaff().at(0)) : 0;
+            fermata->setTrack(staffIdx * VOICES);
+            segment->add(fermata);
+        }
+    }
+
+    if (!fermata) {
+        fermata = static_cast<Fermata*>(this->addAnnotation(meiFermata, measure));
+    }
+
+    if (!fermata) {
+        // Warning message given in MeiExpoter::addAnnotation
+        return true;
+    }
+
+    Convert::fermataFromMEI(fermata, meiFermata, warning);
+
+    return true;
+}
+
+/**
+ * Read a harm.
+ */
+
+bool MeiImporter::readHarm(pugi::xml_node harmNode, engraving::Measure* measure)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    bool warning;
+    libmei::Harm meiHarm;
+    meiHarm.Read(harmNode);
+
+    Harmony* harmony = static_cast<Harmony*>(this->addAnnotation(meiHarm, measure));
+    if (!harmony) {
+        // Warning message given in MeiExpoter::addAnnotation
+        return true;
+    }
+
+    StringList meiLines;
+    this->readLines(harmNode, meiLines);
+
+    Convert::harmFromMEI(harmony, meiLines, meiHarm, warning);
+
+    return true;
+}
+
+/**
+ * Read a repeatMark and create a Jump or a Marker as appropriate.
+ * For Jump, default values for jumpTo, playUntil and continueAt are used.
+ * Similarly, default value for label is used for Marker.
+ */
+
+bool MeiImporter::readRepeatMark(pugi::xml_node repeatMarkNode, engraving::Measure* measure)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    bool warning;
+    libmei::RepeatMark meiRepeatMark;
+    meiRepeatMark.Read(repeatMarkNode);
+
+    EngravingItem* item = nullptr;
+    if (Convert::elementTypeFor(meiRepeatMark) == ElementType::JUMP) {
+        item = Factory::createJump(measure);
+        Convert::jumpFromMEI(dynamic_cast<Jump*>(item), meiRepeatMark, warning);
+    } else {
+        item = Factory::createMarker(measure);
+        Convert::markerFromMEI(dynamic_cast<Marker*>(item), meiRepeatMark, warning);
+    }
+    item->setTrack(0);
+    measure->add(item);
+
+    return true;
+}
+
+/**
+ * Read a tempo.
+ */
+
+bool MeiImporter::readTempo(pugi::xml_node tempoNode, engraving::Measure* measure)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    bool warning;
+    libmei::Tempo meiTempo;
+    meiTempo.Read(tempoNode);
+
+    TempoText* tempoText = static_cast<TempoText*>(this->addAnnotation(meiTempo, measure));
+    if (!tempoText) {
+        // Warning message given in MeiExpoter::addAnnotation
+        return true;
+    }
+
+    StringList meiLines;
+    this->readLinesWithSmufl(tempoNode, meiLines);
+
+    Convert::tempoFromMEI(tempoText, meiLines, meiTempo, warning);
+
+    return true;
+}
+
+//---------------------------------------------------------
+// read MEI attribute classes
+//---------------------------------------------------------
+
+/**
+ * Check the presence of `@grace` on <chord> and <note> to see if we have grace encoded not as <graceGrp>
+ * Used only when importing files not generated from MuseScore since these will use <graceGrp>.
+ * Always set the grace notes not within a <graceGrp> as attached to a following <chord> / <note>.
+ * Grace notes at the end of a measure and not in a <graceGrp> will be dropped.
+ */
+
+bool MeiImporter::readGracedAtt(libmei::AttGraced& gracedAtt)
+{
+    // if we are inside a graceGrp, ignore @grace on the chord/node
+    if (m_readingGraceNotes == GraceAsGrp) {
+        return true;
+    }
+    if (gracedAtt.HasGrace()) {
+        m_readingGraceNotes = GraceAsNote;
+        bool warning = false;
+        auto [isAfter, noteType] = Convert::gracegrpFromMEI(libmei::graceGrpLog_ATTACH_post, gracedAtt.GetGrace(), warning);
+        m_graceNoteType = noteType;
+    } else {
+        m_readingGraceNotes = GraceNone;
+    }
+
+    return true;
+}
+
+/**
+ * Read the stem direction attributes on <chord> and <note>.
+ * Attribute read are `@stem.dir` and `@stem.len` when `0.0` is converted as stem less.
+ */
+
+bool MeiImporter::readStemsAtt(engraving::Chord* chord, libmei::AttStems& stemsAtt)
+{
+    IF_ASSERT_FAILED(chord) {
+        return false;
+    }
+
+    bool warning = false;
+
+    auto [direction, noStem] = Convert::stemFromMEI(stemsAtt, warning);
+    chord->setStemDirection(direction);
+    chord->setNoStem(noStem);
+
+    return true;
+}
+
+//---------------------------------------------------------
+// content extraction methods
+//---------------------------------------------------------
+
+/**
+ * Build a map of xml:id and corresponding EngravingItem elements.
+ * After building the map, all values are `nullptr`.
+ * They will be assigned a object when the element with the corresponding `xml:id` is read in MeiImporter::addChordRest
+ */
+bool MeiImporter::buildIdMap(pugi::xml_node scoreNode)
+{
+    pugi::xpath_node_set nodesWithStartid = scoreNode.select_nodes("//@startid");
+
+    for (pugi::xpath_node elementXpathNode : nodesWithStartid) {
+        std::string id = elementXpathNode.attribute().value();
+        if (id.size() < 1 || id.at(0) != '#') {
+            continue;
+        }
+        m_startIdChordRests[id.erase(0, 1)] = nullptr;
+    }
+
+    return true;
+}
+
+/**
+ * Create a mapping for <staff> `@n` and <layer> `@n`.
+ * Usefull only when reading MEI files where the sequence of `@n` is not starting from 1 or not sequential.
+ * Not really useful when reading MEI files generated from MuseScore since these will have sequential numbers starting with 1.
+ */
+
+bool MeiImporter::buildStaffLayerMap(pugi::xml_node node)
+{
+    pugi::xpath_node_set staves = node.select_nodes("//staff");
+    // Critical error
+    if (staves.empty()) {
+        return false;
+    }
+
+    for (pugi::xpath_node staffXpathNode : staves) {
+        pugi::xml_node staff = staffXpathNode.node();
+        int staffN = staff.attribute("n") ? staff.attribute("n").as_int() : 1;
+        m_staffNs.insert(staffN);
+    }
+
+    pugi::xpath_node_set layers = node.select_nodes("//layer");
+    // Critical error
+    if (layers.empty()) {
+        return false;
+    }
+
+    for (pugi::xpath_node layerXpathNode : layers) {
+        pugi::xml_node layer = layerXpathNode.node();
+        int layerN = layer.attribute("n") ? layer.attribute("n").as_int() : 1;
+        pugi::xml_node staff = layer.parent();
+        if (!staff) {
+            continue;
+        }
+        const int staffN = staff.attribute("n") ? staff.attribute("n").as_int() : 1;
+        const int staffIdx = this->getStaffIndex(staffN);
+        m_staffLayerNs[staffIdx].insert(layerN);
+    }
+
+    return true;
+}
+
+/**
+ * Build a title frame from the metaTag values.
+ */
+
+bool MeiImporter::buildTextFrame()
+{
+    VBox* vBox = nullptr;
+
+    if (!m_score->metaTag(u"workTitle").isEmpty()) {
+        this->addTextToTitleFrame(vBox, m_score->metaTag(u"workTitle"), TextStyleType::TITLE);
+    }
+
+    StringList creators;
+    if (!m_score->metaTag(u"composer").isEmpty()) {
+        creators << m_score->metaTag(u"composer");
+    }
+    if (!m_score->metaTag(u"arranger").isEmpty()) {
+        creators << m_score->metaTag(u"arranger");
+    }
+    if (!creators.empty()) {
+        this->addTextToTitleFrame(vBox, creators.join(u"\n"), TextStyleType::COMPOSER);
+    }
+
+    StringList textCreators;
+    if (!m_score->metaTag(u"lyricist").isEmpty()) {
+        textCreators << m_score->metaTag(u"lyricist");
+    }
+    if (!m_score->metaTag(u"translator").isEmpty()) {
+        textCreators << m_score->metaTag(u"translator");
+    }
+    if (!textCreators.empty()) {
+        this->addTextToTitleFrame(vBox, textCreators.join(u"\n"), TextStyleType::POET);
+    }
+
+    if (vBox) {
+        vBox->setTick(Fraction(0, 1));
+        m_score->measures()->add(vBox);
+    }
+
+    return true;
+}
+
+/**
+ * Build the score parts from the scoreDef staffGrp@label and staffDef@label.
+ */
+
+bool MeiImporter::buildScoreParts(pugi::xml_node scoreDefNode)
+{
+    bool warning = false;
+
+    // First try to build the list of parts from the labels
+    pugi::xpath_node_set labels = scoreDefNode.select_nodes(".//label");
+    for (pugi::xpath_node labelXpathNode : labels) {
+        pugi::xml_node labelNode = labelXpathNode.node();
+        if (!labelNode) {
+            continue;
+        }
+
+        Part* part = new Part(m_score);
+        part->setLongName(String(labelNode.text().as_string()));
+
+        pugi::xml_node labelAbbrNode = labelNode.select_node("./following-sibling::labelAbbr").node();
+        if (labelAbbrNode) {
+            part->setShortName(String(labelAbbrNode.text().as_string()));
+        }
+
+        m_score->appendPart(part);
+
+        // If the label is a child of a staffGrp, the part contains all the child staffDefs
+        if (isNode(labelNode.parent(), u"staffGrp")) {
+            pugi::xpath_node_set staffDefs = labelNode.parent().select_nodes(".//staffDef");
+            for (pugi::xpath_node staffDefXpathNode : staffDefs) {
+                libmei::StaffDef meiStaffDef;
+                meiStaffDef.Read(staffDefXpathNode.node());
+                m_staffParts[meiStaffDef.GetN()] = part;
+            }
+        }
+        // Otherwise the parent must be a staffDef and it is a part with a single staff
+        else if (isNode(labelNode.parent(), u"staffDef")) {
+            libmei::StaffDef meiStaffDef;
+            meiStaffDef.Read(labelNode.parent());
+            m_staffParts[meiStaffDef.GetN()] = part;
+        } else {
+            LOGD() << "MeiImporter::readStaffDefs unknown label part " << labelNode.text();
+        }
+    }
+
+    pugi::xpath_node_set staffDefs = scoreDefNode.select_nodes(".//staffDef");
+    // Critical error
+    if (staffDefs.empty()) {
+        return false;
+    }
+
+    for (pugi::xpath_node staffDefXpathNode : staffDefs) {
+        libmei::StaffDef meiStaffDef;
+        meiStaffDef.Read(staffDefXpathNode.node());
+        Convert::StaffStruct staffSt = Convert::staffFromMEI(meiStaffDef, warning);
+        if (warning) {
+            this->addLog("staff definition", staffDefXpathNode.node());
+        }
+
+        Part* part = nullptr;
+        // Try to get the corresponding part from the map
+        if (m_staffParts.count(meiStaffDef.GetN()) > 0) {
+            part = m_staffParts.at(meiStaffDef.GetN());
+        }
+        // If not found, create a new part and add it to the score
+        else {
+            part = new Part(m_score);
+            m_score->appendPart(part);
+        }
+        Staff* staff = Factory::createStaff(part);
+        // Mapped index from MEI staff@n to MuseScore index
+        const int staffIdx = this->getStaffIndex(meiStaffDef.GetN());
+        staff->setId(staffIdx);
+        staff->setLines(Fraction(0, 1), staffSt.lines);
+        part->instrument()->setTranspose(staffSt.interval);
+
+        m_score->appendStaff(staff);
+    }
+
+    int staffSpan = 0;
+    size_t idx = 0;
+    // Start from the top (default) staffGrp
+    pugi::xml_node staffGrpNode = scoreDefNode.select_node("./staffGrp").node();
+
+    bool success = this->readStaffGrps(staffGrpNode, staffSpan, 0, idx);
+
+    return success;
+}
+
+//---------------------------------------------------------
+// content creation helper methods
+//---------------------------------------------------------
+
+/**
+ * Add an end barline to a measure.
+ */
+
+void MeiImporter::addEndBarLineToMeasure(engraving::Measure* measure, engraving::BarLineType barLineType)
+{
+    IF_ASSERT_FAILED(measure) {
+        return;
+    }
+
+    // Here we could check if this is the last measure and not add END because mscore sets it automatically
+    Segment* segment = measure->getSegment(SegmentType::EndBarLine, measure->endTick());
+    for (staff_idx_t staffIdx = 0; staffIdx < m_score->nstaves(); staffIdx++) {
+        BarLine* barLine = Factory::createBarLine(segment);
+        barLine->setTrack(staffIdx * VOICES);
+        barLine->setBarLineType(barLineType);
+        barLine->setSpanStaff(m_score->staff(staffIdx)->barLineSpan());
+        segment->add(barLine);
+    }
+}
+
+/**
+ * Add a layout break to a measure.
+ */
+
+void MeiImporter::addLayoutBreakToMeasure(engraving::Measure* measure, engraving::LayoutBreakType layoutBreakType)
+{
+    if (!measure) {
+        LOGD() << "MeiImporter::addLayoutBreakToMeasure no measure to add the break";
+        return;
+    }
+
+    LayoutBreak* layoutBreak = Factory::createLayoutBreak(measure);
+    layoutBreak->setLayoutBreakType(layoutBreakType);
+    layoutBreak->setTrack(mu::nidx); // this are system elements
+    measure->add(layoutBreak);
+}
+
+/**
+ *  Add some text with a textStyleType to a vBox.
+ */
+
+void MeiImporter::addTextToTitleFrame(VBox*& vBox, const String& str, TextStyleType textStyleType)
+{
+    if (!str.isEmpty()) {
+        if (vBox == nullptr) {
+            vBox = Factory::createVBox(m_score->dummy()->system());
+        }
+        Text* text = Factory::createText(vBox, textStyleType);
+        text->setPlainText(str);
+        vBox->add(text);
+    }
 }

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -406,7 +406,7 @@ EngravingItem* MeiImporter::addAnnotation(const libmei::Element& meiElement, Mea
         }
 
         // If no @tstamp (invalid), put it on 1.0;
-        double tstampValue = timestampLogAtt->HasTstamp() ? : 1.0;
+        double tstampValue = timestampLogAtt->HasTstamp() ? timestampLogAtt->GetTstamp() : 1.0;
         Fraction tstampFraction = Convert::tstampToFraction(tstampValue, measure->timesig());
         int staffIdx = (staffIdentAtt->HasStaff() && staffIdentAtt->GetStaff().size() > 0) ? this->getStaffIndex(
             staffIdentAtt->GetStaff().at(0)) : 0;

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -74,7 +74,7 @@ bool MeiImporter::read(const io::path_t& path)
         path.toStdString().c_str(), (pugi::parse_comments | pugi::parse_default) & ~pugi::parse_eol);
 
     if (!result) {
-        LOGD("Cannot open file <%s>", qPrintable(path.toString()));
+        LOGD() << "Cannot open file <%s>", qPrintable(path.toString());
         return false;
     }
 

--- a/src/importexport/mei/internal/meiimporter.h
+++ b/src/importexport/mei/internal/meiimporter.h
@@ -30,6 +30,8 @@
 #include "io/ifilesystem.h"
 #include "io/path.h"
 
+#include "thirdparty/pugixml.hpp"
+
 namespace mu::engraving {
 class Fraction;
 class Measure;
@@ -58,7 +60,120 @@ public:
     void convert();
 
 private:
+    /**
+     * Methods for parsing the MEI tree and converting data
+     */
+    bool readMeiHead(pugi::xml_node root);
+    bool readScore(pugi::xml_node root);
+    bool readScoreDef(pugi::xml_node scoreDefNode, bool isInitial);
+    bool readPgHead(pugi::xml_node pgHeadNode);
+    bool readLines(pugi::xml_node parentNode, StringList& lines);
+    bool readLinesWithSmufl(pugi::xml_node parentNode, StringList& lines);
+    bool readStaffDefs(pugi::xml_node parentNode);
+    bool readStaffGrps(pugi::xml_node parentNode, int& staffSpan, int column, size_t& idx);
+    bool readSectionElements(pugi::xml_node parentNode);
+    bool readEnding(pugi::xml_node endingNode);
+    bool readMeasure(pugi::xml_node measureNode);
+    bool readPb(pugi::xml_node pbNode);
+    bool readSb(pugi::xml_node sbNode);
+    bool readStaves(pugi::xml_node parentNode, engraving::Measure* measure, int& measureTicks);
+    bool readLayers(pugi::xml_node parentNode, engraving::Measure* measure, int staffIdx, int& measureTicks);
+
+    /**
+     * Methods for parsing MEI elements within a <layer>
+     */
+    bool readElements(pugi::xml_node parentNode, engraving::Measure* measure, int track, int& ticks);
+    bool readBeam(pugi::xml_node beamNode, engraving::Measure* measure, int track, int& ticks);
+    bool readClef(pugi::xml_node clefNode, engraving::Measure* measure, int track, int& ticks);
+    bool readChord(pugi::xml_node chordNode, engraving::Measure* measure, int track, int& ticks);
+    bool readGraceGrp(pugi::xml_node graceGrpNode, engraving::Measure* measure, int track, int& ticks);
+    bool readMRest(pugi::xml_node mRestNode, engraving::Measure* measure, int track, int& ticks);
+    bool readNote(pugi::xml_node noteNode, engraving::Measure* measure, int track, int& ticks, engraving::Chord* chord = nullptr);
+    bool readRest(pugi::xml_node restNode, engraving::Measure* measure, int track, int& ticks);
+    bool readTuplet(pugi::xml_node tupletNode, engraving::Measure* measure, int track, int& ticks);
+
+    /**
+     * Methods for parsing MEI control events (within <measure>)
+     */
+    bool readControlEvents(pugi::xml_node parentNode, engraving::Measure* measure);
+    bool readBreath(pugi::xml_node breathNode, engraving::Measure* measure);
+    bool readCaesura(pugi::xml_node caesuraNode, engraving::Measure* measure);
+    bool readDynam(pugi::xml_node dynamNode, engraving::Measure* measure);
+    bool readFermata(pugi::xml_node fermataNode, engraving::Measure* measure);
+    bool readHarm(pugi::xml_node harmNode, engraving::Measure* measure);
+    bool readRepeatMark(pugi::xml_node repeatMarkNode, engraving::Measure* measure);
+    bool readTempo(pugi::xml_node tempoNode, engraving::Measure* measure);
+
+    /**
+     * Methods for parsing specific MEI attribute classes within elements
+     */
+    bool readGracedAtt(libmei::AttGraced& gracedAtt);
+    bool readStemsAtt(engraving::Chord* chord, libmei::AttStems& stemsAtt);
+
+    /**
+     * Methods for extracting content from the MEI
+     */
+    bool buildIdMap(pugi::xml_node scoreNode);
+    bool buildStaffLayerMap(pugi::xml_node root);
+    bool buildTextFrame();
+    bool buildScoreParts(pugi::xml_node scoreDefNode);
+
+    /**
+     * Helper methods for content creation
+     */
+    void addEndBarLineToMeasure(engraving::Measure* measure, engraving::BarLineType barLineType);
+    void addLayoutBreakToMeasure(engraving::Measure* measure, engraving::LayoutBreakType layoutBreakType);
+    void addTextToTitleFrame(VBox*& vBox, const String& str, TextStyleType textStyleType);
+
+    /**
+     * Helper methods
+     */
+    int getStaffIndex(int staffN);
+    int getVoiceIndex(int staffIdx, int layerN);
+    void addLog(const std::string& msg, pugi::xml_node node);
+    bool isNode(pugi::xml_node node, const String& name);
+    engraving::ChordRest* addChordRest(pugi::xml_node node, Measure* measure, int track, const libmei::Element& meiElement, int& ticks,
+                                       bool isRest);
+    bool addGraceNotesToChord(engraving::ChordRest* chordRest, bool isAfter = false);
+    engraving::EngravingItem* addAnnotation(const libmei::Element& meiElement, Measure* measure);
+    void clearGraceNotes();
+
+    /** The Score pointer */
     engraving::Score* m_score = nullptr;
+
+    Fraction m_ticks;
+    int m_lastMeasureN;
+    engraving::Measure* m_lastMeasure;
+
+    /** map of MuseScore indexes and clef, timesig and keysig */
+    std::map<int, engraving::ClefTypeList> m_clefs;
+    std::map<int, std::pair<engraving::Fraction, engraving::TimeSigType> > m_timeSigs;
+    std::map<int, engraving::Key> m_keySigs;
+    /** the current time signature */
+    engraving::Fraction m_currentTimeSig = engraving::Fraction(4, 4);
+
+    /* Set for mapping between MEI staff@n and MuseScore staff indexes */
+    std::set<int> m_staffNs;
+    /* A map of sets for mapping between MEI layer@ in MuseScore voice indexes */
+    std::map<int, std::set<int> > m_staffLayerNs;
+    /* A map for original staffN and MuseScore parts */
+    std::map<int, engraving::Part*> m_staffParts;
+
+    /* A map for startId and corresponding engraving::Segment */
+    std::map<std::string, engraving::ChordRest*> m_startIdChordRests;
+
+    engraving::Tuplet* m_tuplet;
+    engraving::BeamMode m_beamBeginMode;
+    engraving::BeamMode m_graceBeamBeginMode;
+    engraving::Chord* m_lastChord;
+
+    std::list<engraving::Chord*> m_graceNotes;
+    GraceReading m_readingGraceNotes;
+    engraving::NoteType m_graceNoteType;
+
+    bool m_readingEnding;
+    engraving::Measure* m_endingStart;
+    engraving::Measure* m_endingEnd;
 };
 } // namespace
 


### PR DESCRIPTION
This PR incorporates the implementation for the MeiImporter and MeiExporter classes.

The `MeiExporter` class is where the `mu::engraving::Score` object is parsed and where corresponding libmei objects are created and added to the tree. The `MeiImporter` is the mirror of it. It parses the MEI tree and create MuseScore object and builds the `mu::engraving::Score`. In other words, these classes focus on the high level structural aspect of the export and the import. They perform essentially looping and mapping tasks. For example, going through the list of measures in the score, or generating the MEI `scoreDef` structure from the MuseScore parts and the opposite.

Both the `MeiImporter` and the `MeiExporter` class use the `MeiConverter` (already merged) class for actually converting object or attributes.

The status (MuseScore and generated MEI files) corresponding to this PR is available in the https://github.com/rism-digital/musescore-mei-tests

The PR also integrates the suggested changes made by @igorkorsukov in https://github.com/musescore/MuseScore/pull/18745