### PR TITLE
[engraving] Added LayoutData... Step 32

### DIFF
--- a/src/engraving/layout/dev/tlayout.cpp
+++ b/src/engraving/layout/dev/tlayout.cpp
@@ -401,6 +401,10 @@ static void layoutAccidental(const Accidental* item, const LayoutContext& ctx, A
         return;
     }
 
+    if (item->accidentalType() == AccidentalType::NONE) {
+        return;
+    }
+
     // Single?
     SymId singleSym = accidentalSingleSym(item);
     if (singleSym != SymId::noSym && ctx.engravingFont()->isValid(singleSym)) {
@@ -465,79 +469,47 @@ void TLayout::layout(ActionIcon* item, LayoutContext&)
     }
 }
 
-void TLayout::layout(Ambitus* item, LayoutContext& ctx)
+static void layoutAmbitus(const Ambitus* item, const LayoutContext& ctx, Ambitus::LayoutData& data)
 {
-    int bottomLine, topLine;
-
-    const double headWdt = item->headWidth();
     const double spatium = item->spatium();
-    const Fraction tick = item->segment()->tick();
-    const Staff* stf = ctx.dom().staff(item->staffIdx());
-    const double lineDist = stf->lineDistance(tick) * spatium;
-    const int numOfLines = stf->lines(tick);
-    const ClefType clf = stf->clef(tick);
-    const Key key = stf->key(tick);
+    const double headWdt = item->headWidth();
 
     //
     // NOTEHEADS Y POS
     //
+    {
+        const Fraction tick = item->segment()->tick();
+        const Staff* stf = ctx.dom().staff(item->staffIdx());
+        const ClefType clf = stf->clef(tick);
+        const Key key = stf->key(tick);
+        const double lineDist = stf->lineDistance(tick) * spatium;
 
-    double xAccidOffTop    = 0;
-    double xAccidOffBottom = 0;
+        // top notehead
+        if (item->topPitch() == INVALID_PITCH || item->topTpc() == Tpc::TPC_INVALID) {
+            data.topPos.setY(0.0); // if uninitialized, set to top staff line
+        } else {
+            int topLine = Ambitus::staffLine(item->topTpc(), item->topPitch(), clf);
+            data.topPos.setY(topLine * lineDist * 0.5);
+            // compute accidental
+            AccidentalType accidType = Ambitus::accidentalType(item->topTpc(), key);
+            item->topAccidental()->setAccidentalType(accidType);
+            layoutAccidental(item->topAccidental(), ctx, data.topAcc);
+            data.topAcc.pos.setY(data.topPos.y());
+        }
 
-    // top notehead
-    if (item->topPitch() == INVALID_PITCH || item->topTpc() == Tpc::TPC_INVALID) {
-        item->setTopPosY(0.0);  // if uninitialized, set to top staff line
-    } else {
-        topLine = absStep(item->topTpc(), item->topPitch());
-        topLine = relStep(topLine, clf);
-        item->setTopPosY(topLine * lineDist * 0.5);
-        // compute accidental
-        AccidentalType accidType;
-        // if (13 <= (tpc - key) <= 19) there is no accidental)
-        if (item->topTpc() - int(key) >= 13 && item->topTpc() - int(key) <= 19) {
-            accidType = AccidentalType::NONE;
+        // bottom notehead
+        if (item->bottomPitch() == INVALID_PITCH || item->bottomTpc() == Tpc::TPC_INVALID) {
+            const int numOfLines = stf->lines(tick);
+            data.bottomPos.setY((numOfLines - 1) * lineDist);         // if uninitialized, set to last staff line
         } else {
-            AccidentalVal accidVal = tpc2alter(item->topTpc());
-            accidType = Accidental::value2subtype(accidVal);
-            if (accidType == AccidentalType::NONE) {
-                accidType = AccidentalType::NATURAL;
-            }
+            int bottomLine = Ambitus::staffLine(item->bottomTpc(), item->bottomPitch(), clf);
+            data.bottomPos.setY(bottomLine * lineDist * 0.5);
+            // compute accidental
+            AccidentalType accidType = Ambitus::accidentalType(item->bottomTpc(), key);
+            item->bottomAccidental()->setAccidentalType(accidType);
+            layoutAccidental(item->bottomAccidental(), ctx, data.bottomAcc);
+            data.bottomAcc.pos.setY(data.bottomPos.y());
         }
-        item->topAccidental()->setAccidentalType(accidType);
-        if (accidType != AccidentalType::NONE) {
-            layout(item->topAccidental(), ctx);
-        } else {
-            item->topAccidental()->setbbox(RectF());
-        }
-        item->topAccidental()->setPosY(item->topPos().y());
-    }
-
-    // bottom notehead
-    if (item->bottomPitch() == INVALID_PITCH || item->bottomTpc() == Tpc::TPC_INVALID) {
-        item->setBottomPosY((numOfLines - 1) * lineDist);             // if uninitialized, set to last staff line
-    } else {
-        bottomLine  = absStep(item->bottomTpc(), item->bottomPitch());
-        bottomLine  = relStep(bottomLine, clf);
-        item->setBottomPosY(bottomLine * lineDist * 0.5);
-        // compute accidental
-        AccidentalType accidType;
-        if (item->bottomTpc() - int(key) >= 13 && item->bottomTpc() - int(key) <= 19) {
-            accidType = AccidentalType::NONE;
-        } else {
-            AccidentalVal accidVal = tpc2alter(item->bottomTpc());
-            accidType = Accidental::value2subtype(accidVal);
-            if (accidType == AccidentalType::NONE) {
-                accidType = AccidentalType::NATURAL;
-            }
-        }
-        item->bottomAccidental()->setAccidentalType(accidType);
-        if (accidType != AccidentalType::NONE) {
-            layout(item->bottomAccidental(), ctx);
-        } else {
-            item->bottomAccidental()->setbbox(RectF());
-        }
-        item->bottomAccidental()->setPosY(item->bottomPos().y());
     }
 
     //
@@ -545,72 +517,85 @@ void TLayout::layout(Ambitus* item, LayoutContext& ctx)
     //
     // Note: manages colliding accidentals
     //
-    double accNoteDist = item->point(ctx.conf().styleS(Sid::accidentalNoteDistance));
-    xAccidOffTop      = item->topAccidental()->width() + accNoteDist;
-    xAccidOffBottom   = item->bottomAccidental()->width() + accNoteDist;
+    {
+        double accNoteDist = item->point(ctx.conf().styleS(Sid::accidentalNoteDistance));
+        double xAccidOffTop = data.topAcc.bbox.width() + accNoteDist;
+        double xAccidOffBottom = data.bottomAcc.bbox.width() + accNoteDist;
 
-    // if top accidental extends down more than bottom accidental extends up,
-    // AND ambitus is not leaning right, bottom accidental needs to be displaced
-    bool collision
-        =(item->topAccidental()->ipos().y() + item->topAccidental()->bbox().y() + item->topAccidental()->height()
-          > item->bottomAccidental()->ipos().y() + item->bottomAccidental()->bbox().y())
-          && item->direction() != DirectionH::RIGHT;
-    if (collision) {
-        // displace bottom accidental (also attempting to 'undercut' flats)
-        xAccidOffBottom = xAccidOffTop
-                          + ((item->bottomAccidental()->accidentalType() == AccidentalType::FLAT
-                              || item->bottomAccidental()->accidentalType() == AccidentalType::FLAT2
-                              || item->bottomAccidental()->accidentalType() == AccidentalType::NATURAL)
-                             ? item->bottomAccidental()->width() * 0.5 : item->bottomAccidental()->width());
+        // if top accidental extends down more than bottom accidental extends up,
+        // AND ambitus is not leaning right, bottom accidental needs to be displaced
+        bool collision = (item->direction() != DirectionH::RIGHT)
+                         && (data.topAcc.pos.y() + data.topAcc.bbox.y() + data.topAcc.bbox.height()
+                             > data.bottomAcc.pos.y() + data.bottomAcc.bbox.y());
+        if (collision) {
+            // displace bottom accidental (also attempting to 'undercut' flats)
+            AccidentalType bottomAccType = item->bottomAccidental()->accidentalType();
+            xAccidOffBottom = xAccidOffTop + ((bottomAccType == AccidentalType::FLAT
+                                               || bottomAccType == AccidentalType::FLAT2
+                                               || bottomAccType == AccidentalType::NATURAL)
+                                              ? data.bottomAcc.bbox.width() * 0.5 : data.bottomAcc.bbox.width());
+        }
+
+        switch (item->direction()) {
+        case DirectionH::AUTO:                   // noteheads one above the other
+            // left align noteheads and right align accidentals 'hanging' on the left
+            data.topPos.setX(0.0);
+            data.bottomPos.setX(0.0);
+            data.topAcc.pos.setX(-xAccidOffTop);
+            data.bottomAcc.pos.setX(-xAccidOffBottom);
+            break;
+        case DirectionH::LEFT:                   // top notehead at the left of bottom notehead
+            // place top notehead at left margin; bottom notehead at right of top head;
+            // top accid. 'hanging' on left of top head and bottom accid. 'hanging' at left of bottom head
+            data.topPos.setX(0.0);
+            data.bottomPos.setX(headWdt);
+            data.topAcc.pos.setX(-xAccidOffTop);
+            data.bottomAcc.pos.setX(collision ? -xAccidOffBottom : headWdt - xAccidOffBottom);
+            break;
+        case DirectionH::RIGHT:                  // top notehead at the right of bottom notehead
+            // bottom notehead at left margin; top notehead at right of bottomnotehead
+            // top accid. 'hanging' on left of top head and bottom accid. 'hanging' at left of bottom head
+            data.topPos.setX(headWdt);
+            data.bottomPos.setX(0.0);
+            data.topAcc.pos.setX(headWdt - xAccidOffTop);
+            data.bottomAcc.pos.setX(-xAccidOffBottom);
+            break;
+        }
     }
 
-    switch (item->direction()) {
-    case DirectionH::AUTO:                       // noteheads one above the other
-        // left align noteheads and right align accidentals 'hanging' on the left
-        item->setTopPosX(0.0);
-        item->setBottomPosX(0.0);
-        item->topAccidental()->setPosX(-xAccidOffTop);
-        item->bottomAccidental()->setPosX(-xAccidOffBottom);
-        break;
-    case DirectionH::LEFT:                       // top notehead at the left of bottom notehead
-        // place top notehead at left margin; bottom notehead at right of top head;
-        // top accid. 'hanging' on left of top head and bottom accid. 'hanging' at left of bottom head
-        item->setTopPosX(0.0);
-        item->setBottomPosX(headWdt);
-        item->topAccidental()->setPosX(-xAccidOffTop);
-        item->bottomAccidental()->setPosX(collision ? -xAccidOffBottom : headWdt - xAccidOffBottom);
-        break;
-    case DirectionH::RIGHT:                      // top notehead at the right of bottom notehead
-        // bottom notehead at left margin; top notehead at right of bottomnotehead
-        // top accid. 'hanging' on left of top head and bottom accid. 'hanging' at left of bottom head
-        item->setBottomPosX(0.0);
-        item->setTopPosX(headWdt);
-        item->bottomAccidental()->setPosX(-xAccidOffBottom);
-        item->topAccidental()->setPosX(headWdt - xAccidOffTop);
-        break;
-    }
-
+    // LINE
     // compute line from top note centre to bottom note centre
-    LineF fullLine(item->topPos().x() + headWdt * 0.5,
-                   item->topPos().y(),
-                   item->bottomPos().x() + headWdt * 0.5,
-                   item->bottomPos().y());
-    // shorten line on each side by offsets
-    double yDelta = item->bottomPos().y() - item->topPos().y();
-    if (yDelta != 0.0) {
-        double off = spatium * Ambitus::LINEOFFSET_DEFAULT;
-        PointF p1 = fullLine.pointAt(off / yDelta);
-        PointF p2 = fullLine.pointAt(1 - (off / yDelta));
-        item->setLine(LineF(p1, p2));
-    } else {
-        item->setLine(fullLine);
+    {
+        LineF fullLine(data.topPos.x() + headWdt * 0.5,
+                       data.topPos.y(),
+                       data.bottomPos.x() + headWdt * 0.5,
+                       data.bottomPos.y());
+        // shorten line on each side by offsets
+        double yDelta = data.bottomPos.y() - data.topPos.y();
+        if (!RealIsNull(yDelta)) {
+            double off = spatium * Ambitus::LINEOFFSET_DEFAULT;
+            PointF p1 = fullLine.pointAt(off / yDelta);
+            PointF p2 = fullLine.pointAt(1 - (off / yDelta));
+            data.line = LineF(p1, p2);
+        } else {
+            data.line = fullLine;
+        }
     }
 
-    RectF headRect(0, -0.5 * spatium, headWdt, 1 * spatium);
-    item->setbbox(headRect.translated(item->topPos()).united(headRect.translated(item->bottomPos()))
-                  .united(item->topAccidental()->bbox().translated(item->topAccidental()->ipos()))
-                  .united(item->bottomAccidental()->bbox().translated(item->bottomAccidental()->ipos()))
-                  );
+    // BBOX
+    {
+        RectF headRect(0, -0.5 * spatium, headWdt, 1 * spatium);
+        data.bbox = headRect.translated(data.topPos).united(headRect.translated(data.bottomPos))
+                    .united(data.topAcc.bbox.translated(data.topAcc.pos))
+                    .united(data.bottomAcc.bbox.translated(data.bottomAcc.pos));
+    }
+}
+
+void TLayout::layout(Ambitus* item, LayoutContext& ctx)
+{
+    Ambitus::LayoutData data;
+    layoutAmbitus(item, ctx, data);
+    item->setLayoutData(data);
 }
 
 void TLayout::layout(Arpeggio* item, LayoutContext& ctx)

--- a/src/engraving/layout/dev/tlayout.cpp
+++ b/src/engraving/layout/dev/tlayout.cpp
@@ -457,8 +457,12 @@ void TLayout::layout(Accidental* item, LayoutContext& ctx)
 
 void TLayout::layout(ActionIcon* item, LayoutContext&)
 {
-    FontMetrics fontMetrics(item->iconFont());
-    item->setbbox(fontMetrics.boundingRect(Char(item->icon())));
+    if (!item->layoutData().isValid()) {
+        ActionIcon::LayoutData data;
+        FontMetrics fontMetrics(item->iconFont());
+        data.bbox = fontMetrics.boundingRect(Char(item->icon()));
+        item->setLayoutData(data);
+    }
 }
 
 void TLayout::layout(Ambitus* item, LayoutContext& ctx)

--- a/src/engraving/layout/dev/tlayout.cpp
+++ b/src/engraving/layout/dev/tlayout.cpp
@@ -468,46 +468,29 @@ void TLayout::layout(ActionIcon* item, LayoutContext&)
 void TLayout::layout(Ambitus* item, LayoutContext& ctx)
 {
     int bottomLine, topLine;
-    ClefType clf;
-    double headWdt = item->headWidth();
-    Key key;
-    double lineDist;
-    int numOfLines;
-    Segment* segm = item->segment();
-    double _spatium = item->spatium();
-    const Staff* stf = nullptr;
-    if (segm && item->track() != mu::nidx) {
-        Fraction tick    = segm->tick();
-        stf         = ctx.dom().staff(item->staffIdx());
-        lineDist    = stf->lineDistance(tick) * _spatium;
-        numOfLines  = stf->lines(tick);
-        clf         = stf->clef(tick);
-    } else {                              // for use in palettes
-        lineDist    = _spatium;
-        numOfLines  = 3;
-        clf         = ClefType::G;
-    }
+
+    const double headWdt = item->headWidth();
+    const double spatium = item->spatium();
+    const Fraction tick = item->segment()->tick();
+    const Staff* stf = ctx.dom().staff(item->staffIdx());
+    const double lineDist = stf->lineDistance(tick) * spatium;
+    const int numOfLines = stf->lines(tick);
+    const ClefType clf = stf->clef(tick);
+    const Key key = stf->key(tick);
 
     //
     // NOTEHEADS Y POS
     //
-    // if pitch == INVALID_PITCH or tpc == Tpc::TPC_INVALID, set to some default:
-    // for use in palettes and when actual range cannot be calculated (new ambitus or no notes in staff)
-    //
+
     double xAccidOffTop    = 0;
     double xAccidOffBottom = 0;
-    if (stf) {
-        key = stf->key(segm->tick());
-    } else {
-        key = Key::C;
-    }
 
     // top notehead
     if (item->topPitch() == INVALID_PITCH || item->topTpc() == Tpc::TPC_INVALID) {
         item->setTopPosY(0.0);  // if uninitialized, set to top staff line
     } else {
-        topLine  = absStep(item->topTpc(), item->topPitch());
-        topLine  = relStep(topLine, clf);
+        topLine = absStep(item->topTpc(), item->topPitch());
+        topLine = relStep(topLine, clf);
         item->setTopPosY(topLine * lineDist * 0.5);
         // compute accidental
         AccidentalType accidType;
@@ -615,7 +598,7 @@ void TLayout::layout(Ambitus* item, LayoutContext& ctx)
     // shorten line on each side by offsets
     double yDelta = item->bottomPos().y() - item->topPos().y();
     if (yDelta != 0.0) {
-        double off = _spatium * Ambitus::LINEOFFSET_DEFAULT;
+        double off = spatium * Ambitus::LINEOFFSET_DEFAULT;
         PointF p1 = fullLine.pointAt(off / yDelta);
         PointF p2 = fullLine.pointAt(1 - (off / yDelta));
         item->setLine(LineF(p1, p2));
@@ -623,7 +606,7 @@ void TLayout::layout(Ambitus* item, LayoutContext& ctx)
         item->setLine(fullLine);
     }
 
-    RectF headRect(0, -0.5 * _spatium, headWdt, 1 * _spatium);
+    RectF headRect(0, -0.5 * spatium, headWdt, 1 * spatium);
     item->setbbox(headRect.translated(item->topPos()).united(headRect.translated(item->bottomPos()))
                   .united(item->topAccidental()->bbox().translated(item->topAccidental()->ipos()))
                   .united(item->bottomAccidental()->bbox().translated(item->bottomAccidental()->ipos()))

--- a/src/engraving/layout/dev/tlayout.h
+++ b/src/engraving/layout/dev/tlayout.h
@@ -339,9 +339,6 @@ private:
 
     friend class SlurTieLayout;
 
-    static void layoutSingleGlyphAccidental(Accidental* item, LayoutContext& ctx);
-    static void layoutMultiGlyphAccidental(Accidental* item, LayoutContext& ctx);
-
     static double layoutWidth(const BarLine* item, LayoutContext& ctx);
 
     static void adjustLayoutWithoutImages(VBox* item, LayoutContext& ctx);

--- a/src/engraving/layout/stable/tlayout.cpp
+++ b/src/engraving/layout/stable/tlayout.cpp
@@ -267,7 +267,7 @@ void TLayout::layoutSingleGlyphAccidental(Accidental* item, LayoutContext& ctx)
         }
     }
 
-    SymElement e(s, 0.0, 0.0);
+    Accidental::LayoutData::Sym e(s, 0.0, 0.0);
     item->addElement(e);
     r.unite(item->symBbox(s));
     item->setbbox(r);
@@ -295,14 +295,14 @@ void TLayout::layoutMultiGlyphAccidental(Accidental* item, LayoutContext& ctx)
         case AccidentalBracket::NONE: // can't happen
             break;
         }
-        SymElement se(id, 0.0, item->bracket() == AccidentalBracket::BRACE ? item->spatium() * 0.4 : 0.0);
+        Accidental::LayoutData::Sym se(id, 0.0, item->bracket() == AccidentalBracket::BRACE ? item->spatium() * 0.4 : 0.0);
         item->addElement(se);
         r.unite(item->symBbox(id));
         x += item->symAdvance(id) + margin;
     }
 
     SymId s = item->symId();
-    SymElement e(s, x, 0.0);
+    Accidental::LayoutData::Sym e(s, x, 0.0);
     item->addElement(e);
     r.unite(item->symBbox(s).translated(x, 0.0));
 
@@ -323,7 +323,7 @@ void TLayout::layoutMultiGlyphAccidental(Accidental* item, LayoutContext& ctx)
         case AccidentalBracket::NONE: // can't happen
             break;
         }
-        SymElement se(id, x, item->bracket() == AccidentalBracket::BRACE ? item->spatium() * 0.4 : 0.0);
+        Accidental::LayoutData::Sym se(id, x, item->bracket() == AccidentalBracket::BRACE ? item->spatium() * 0.4 : 0.0);
         item->addElement(se);
         r.unite(item->symBbox(id).translated(x, 0.0));
     }

--- a/src/engraving/libmscore/accidental.cpp
+++ b/src/engraving/libmscore/accidental.cpp
@@ -372,6 +372,7 @@ void Accidental::setLayoutData(const LayoutData& data)
 {
     m_layoutData = data;
     setbbox(data.bbox);
+    setPos(data.pos);
 }
 
 void Accidental::draw(mu::draw::Painter* painter) const

--- a/src/engraving/libmscore/accidental.cpp
+++ b/src/engraving/libmscore/accidental.cpp
@@ -51,7 +51,7 @@ struct Acc {
 };
 
 // NOTE: keep this in sync with AccidentalType enum in types.h, watch out for isMicrotonal()
-static Acc accList[] = {
+static const Acc ACC_LIST[] = {
     Acc(AccidentalVal::NATURAL,    0,   SymId::noSym),                  // NONE
     Acc(AccidentalVal::FLAT,       0,   SymId::accidentalFlat),         // FLAT
     Acc(AccidentalVal::NATURAL,    0,   SymId::accidentalNatural),      // NATURAL
@@ -232,7 +232,7 @@ static Acc accList[] = {
 
 AccidentalVal sym2accidentalVal(SymId id)
 {
-    for (const Acc& a : accList) {
+    for (const Acc& a : ACC_LIST) {
         if (a.sym == id) {
             return a.offset;
         }
@@ -264,7 +264,7 @@ TranslatableString Accidental::subtypeUserName() const
 
 SymId Accidental::symId() const
 {
-    return accList[int(accidentalType())].sym;
+    return ACC_LIST[int(accidentalType())].sym;
 }
 
 bool Accidental::parentNoteHasParentheses() const
@@ -279,7 +279,7 @@ bool Accidental::parentNoteHasParentheses() const
 
 AccidentalVal Accidental::subtype2value(AccidentalType st)
 {
-    return accList[int(st)].offset;
+    return ACC_LIST[int(st)].offset;
 }
 
 //---------------------------------------------------------
@@ -288,7 +288,7 @@ AccidentalVal Accidental::subtype2value(AccidentalType st)
 
 AsciiStringView Accidental::subtype2name(AccidentalType st)
 {
-    return SymNames::nameForSymId(accList[int(st)].sym);
+    return SymNames::nameForSymId(ACC_LIST[int(st)].sym);
 }
 
 //---------------------------------------------------------
@@ -297,7 +297,7 @@ AsciiStringView Accidental::subtype2name(AccidentalType st)
 
 SymId Accidental::subtype2symbol(AccidentalType st)
 {
-    return accList[int(st)].sym;
+    return ACC_LIST[int(st)].sym;
 }
 
 //---------------------------------------------------------
@@ -306,7 +306,7 @@ SymId Accidental::subtype2symbol(AccidentalType st)
 
 double Accidental::subtype2centOffset(AccidentalType st)
 {
-    return accList[int(st)].centOffset;
+    return ACC_LIST[int(st)].centOffset;
 }
 
 //---------------------------------------------------------
@@ -320,7 +320,7 @@ AccidentalType Accidental::name2subtype(const AsciiStringView& tag)
         // LOGD("no symbol found");
     } else {
         int i = 0;
-        for (const Acc& acc : accList) {
+        for (const Acc& acc : ACC_LIST) {
             if (acc.sym == symId) {
                 return AccidentalType(i);
             }
@@ -381,7 +381,7 @@ void Accidental::draw(mu::draw::Painter* painter) const
     }
 
     painter->setPen(curColor());
-    for (const SymElement& e : el) {
+    for (const SymElement& e : m_syms) {
         score()->engravingFont()->draw(e.sym, painter, magS(), PointF(e.x, e.y));
     }
 }
@@ -454,7 +454,7 @@ void Accidental::undoSetSmall(bool val)
 PropertyValue Accidental::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
-    case Pid::ACCIDENTAL_TYPE:    return int(_accidentalType);
+    case Pid::ACCIDENTAL_TYPE:    return int(m_accidentalType);
     case Pid::SMALL:              return m_isSmall;
     case Pid::ACCIDENTAL_BRACKET: return int(bracket());
     case Pid::ACCIDENTAL_ROLE:    return role();
@@ -493,10 +493,10 @@ bool Accidental::setProperty(Pid propertyId, const PropertyValue& v)
         m_isSmall = v.toBool();
         break;
     case Pid::ACCIDENTAL_BRACKET:
-        _bracket = AccidentalBracket(v.toInt());
+        m_bracket = AccidentalBracket(v.toInt());
         break;
     case Pid::ACCIDENTAL_ROLE:
-        _role = v.value<AccidentalRole>();
+        m_role = v.value<AccidentalRole>();
         break;
     default:
         return EngravingItem::setProperty(propertyId, v);

--- a/src/engraving/libmscore/accidental.cpp
+++ b/src/engraving/libmscore/accidental.cpp
@@ -368,9 +368,11 @@ AccidentalType Accidental::value2subtype(AccidentalVal v)
     return AccidentalType::NONE;
 }
 
-//---------------------------------------------------------
-//   draw
-//---------------------------------------------------------
+void Accidental::setLayoutData(const LayoutData& data)
+{
+    m_layoutData = data;
+    setbbox(data.bbox);
+}
 
 void Accidental::draw(mu::draw::Painter* painter) const
 {
@@ -381,7 +383,7 @@ void Accidental::draw(mu::draw::Painter* painter) const
     }
 
     painter->setPen(curColor());
-    for (const SymElement& e : m_syms) {
+    for (const LayoutData::Sym& e : m_layoutData.syms) {
         score()->engravingFont()->draw(e.sym, painter, magS(), PointF(e.x, e.y));
     }
 }

--- a/src/engraving/libmscore/accidental.h
+++ b/src/engraving/libmscore/accidental.h
@@ -51,18 +51,6 @@ enum class AccidentalBracket : char {
 };
 
 //---------------------------------------------------------
-//   SymElement
-//---------------------------------------------------------
-
-struct SymElement {
-    SymId sym;
-    double x;
-    double y;
-    SymElement(SymId _sym, double _x, double _y)
-        : sym(_sym), x(_x), y(_y) {}
-};
-
-//---------------------------------------------------------
 //   @@ Accidental
 //   @P role        enum  (Accidental.AUTO, .USER) (read only)
 //   @P isSmall     bool
@@ -100,9 +88,6 @@ public:
     void setSmall(bool val) { m_isSmall = val; }
 
     SymId symId() const;
-    const std::vector<SymElement>& syms() const { return m_syms; }
-    void clearElements() { m_syms.clear(); }
-    void addElement(const SymElement& e) { m_syms.push_back(e); }
 
     bool acceptDrop(EditData&) const override;
     EngravingItem* drop(EditData&) override;
@@ -129,17 +114,42 @@ public:
 
     void computeMag();
 
+    struct LayoutData {
+        struct Sym {
+            SymId sym;
+            double x;
+            double y;
+            Sym(SymId _sym, double _x, double _y)
+                : sym(_sym), x(_x), y(_y) {}
+        };
+
+        std::vector<Sym> syms;
+        RectF bbox;
+
+        bool isValid() const { return !syms.empty(); }
+        void invalidate() { syms.clear(); }
+    };
+
+    const LayoutData& layoutData() const { return m_layoutData; }
+    void setLayoutData(const LayoutData& data);
+
+    //! -- Old interface --
+    void clearElements() { m_layoutData.syms.clear(); }
+    void addElement(const LayoutData::Sym& s) { m_layoutData.syms.push_back(s); }
+    //! -----------
+
 private:
 
     friend class Factory;
 
     Accidental(EngravingItem* parent);
 
-    std::vector<SymElement> m_syms;
     AccidentalType m_accidentalType = AccidentalType::NONE;
     AccidentalBracket m_bracket = AccidentalBracket::NONE;
     AccidentalRole m_role = AccidentalRole::AUTO;
     bool m_isSmall = false;
+
+    LayoutData m_layoutData;
 };
 
 extern AccidentalVal sym2accidentalVal(SymId id);

--- a/src/engraving/libmscore/accidental.h
+++ b/src/engraving/libmscore/accidental.h
@@ -127,7 +127,6 @@ public:
         RectF bbox;
 
         bool isValid() const { return !syms.empty(); }
-        void invalidate() { syms.clear(); }
     };
 
     const LayoutData& layoutData() const { return m_layoutData; }

--- a/src/engraving/libmscore/accidental.h
+++ b/src/engraving/libmscore/accidental.h
@@ -125,6 +125,7 @@ public:
 
         std::vector<Sym> syms;
         RectF bbox;
+        PointF pos;
 
         bool isValid() const { return !syms.empty(); }
     };

--- a/src/engraving/libmscore/accidental.h
+++ b/src/engraving/libmscore/accidental.h
@@ -77,21 +77,32 @@ public:
 
     Accidental* clone() const override { return new Accidental(*this); }
 
+    Note* note() const { return (explicitParent() && explicitParent()->isNote()) ? toNote(explicitParent()) : 0; }
+
     // Score Tree functions
     EngravingObject* scanParent() const override;
 
     TranslatableString subtypeUserName() const override;
     void setSubtype(const AsciiStringView& s);
-    void setAccidentalType(AccidentalType t) { _accidentalType = t; }
+    int subtype() const override { return (int)m_accidentalType; }
 
-    AccidentalType accidentalType() const { return _accidentalType; }
-    AccidentalRole role() const { return _role; }
+    void setAccidentalType(AccidentalType t) { m_accidentalType = t; }
+    AccidentalType accidentalType() const { return m_accidentalType; }
 
-    int subtype() const override { return (int)_accidentalType; }
+    void setRole(AccidentalRole r) { m_role = r; }
+    AccidentalRole role() const { return m_role; }
 
-    const std::vector<SymElement>& elements() const { return el; }
-    void clearElements() { el.clear(); }
-    void addElement(const SymElement& e) { el.push_back(e); }
+    AccidentalBracket bracket() const { return m_bracket; }
+    void setBracket(AccidentalBracket val) { m_bracket = val; }
+    bool parentNoteHasParentheses() const;
+
+    bool isSmall() const { return m_isSmall; }
+    void setSmall(bool val) { m_isSmall = val; }
+
+    SymId symId() const;
+    const std::vector<SymElement>& syms() const { return m_syms; }
+    void clearElements() { m_syms.clear(); }
+    void addElement(const SymElement& e) { m_syms.push_back(e); }
 
     bool acceptDrop(EditData&) const override;
     EngravingItem* drop(EditData&) override;
@@ -99,18 +110,6 @@ public:
     void draw(mu::draw::Painter*) const override;
     bool isEditable() const override { return true; }
     void startEdit(EditData&) override { setGenerated(false); }
-
-    SymId symId() const;
-    Note* note() const { return (explicitParent() && explicitParent()->isNote()) ? toNote(explicitParent()) : 0; }
-
-    AccidentalBracket bracket() const { return _bracket; }
-    void setBracket(AccidentalBracket val) { _bracket = val; }
-    bool parentNoteHasParentheses() const;
-
-    void setRole(AccidentalRole r) { _role = r; }
-
-    bool isSmall() const { return m_isSmall; }
-    void setSmall(bool val) { m_isSmall = val; }
 
     void undoSetSmall(bool val);
 
@@ -136,11 +135,11 @@ private:
 
     Accidental(EngravingItem* parent);
 
-    std::vector<SymElement> el;
-    AccidentalType _accidentalType { AccidentalType::NONE };
-    bool m_isSmall                    { false };
-    AccidentalBracket _bracket     { AccidentalBracket::NONE };
-    AccidentalRole _role           { AccidentalRole::AUTO };
+    std::vector<SymElement> m_syms;
+    AccidentalType m_accidentalType = AccidentalType::NONE;
+    AccidentalBracket m_bracket = AccidentalBracket::NONE;
+    AccidentalRole m_role = AccidentalRole::AUTO;
+    bool m_isSmall = false;
 };
 
 extern AccidentalVal sym2accidentalVal(SymId id);

--- a/src/engraving/libmscore/actionicon.cpp
+++ b/src/engraving/libmscore/actionicon.cpp
@@ -22,16 +22,14 @@
 
 #include "actionicon.h"
 
-#include "draw/fontmetrics.h"
-
 #include "property.h"
 
 #include "log.h"
 
 using namespace mu;
 using namespace mu::draw;
+using namespace mu::engraving;
 
-namespace mu::engraving {
 ActionIcon::ActionIcon(EngravingItem* score)
     : EngravingItem(ElementType::ACTION_ICON, score)
 {
@@ -63,6 +61,7 @@ void ActionIcon::setAction(const std::string& actionCode, char16_t icon)
 {
     m_actionCode = actionCode;
     m_icon = icon;
+    m_layoutData.invalidate();
 }
 
 double ActionIcon::fontSize() const
@@ -105,4 +104,9 @@ bool ActionIcon::setProperty(Pid pid, const PropertyValue& v)
     }
     return true;
 }
+
+void ActionIcon::setLayoutData(const LayoutData& data)
+{
+    m_layoutData = data;
+    setbbox(data.bbox);
 }

--- a/src/engraving/libmscore/actionicon.h
+++ b/src/engraving/libmscore/actionicon.h
@@ -90,11 +90,23 @@ public:
 
     static constexpr double DEFAULT_FONT_SIZE = 16.0;
 
+    struct LayoutData {
+        RectF bbox;
+
+        bool isValid() const { return bbox.isValid(); }
+        void invalidate() { bbox = RectF(); }
+    };
+
+    const LayoutData& layoutData() const { return m_layoutData; }
+    void setLayoutData(const LayoutData& data);
+
 private:
-    ActionIconType m_actionType { ActionIconType::UNDEFINED };
+    ActionIconType m_actionType = ActionIconType::UNDEFINED;
     std::string m_actionCode;
     char16_t m_icon = 0;
     mu::draw::Font m_iconFont;
+
+    LayoutData m_layoutData;
 };
 }
 

--- a/src/engraving/libmscore/ambitus.cpp
+++ b/src/engraving/libmscore/ambitus.cpp
@@ -42,7 +42,6 @@
 using namespace mu;
 using namespace mu::engraving;
 
-namespace mu::engraving {
 const Spatium Ambitus::LINEWIDTH_DEFAULT = Spatium(0.12);
 //---------------------------------------------------------
 //   Ambitus
@@ -81,10 +80,6 @@ Ambitus::Ambitus(const Ambitus& a)
     m_topTpc = a.m_topTpc;
     m_bottomPitch = a.m_bottomPitch;
     m_bottomTpc = a.m_bottomTpc;
-
-    m_topPos = a.m_topPos;
-    m_bottomPos = a.m_bottomPos;
-    m_line = a.m_line;
 }
 
 Ambitus::~Ambitus()
@@ -110,7 +105,7 @@ void Ambitus::initFrom(Ambitus* a)
 {
     m_noteHeadGroup   = a->m_noteHeadGroup;
     m_noteHeadType    = a->m_noteHeadType;
-    m_direction             = a->m_direction;
+    m_direction       = a->m_direction;
     m_hasLine         = a->m_hasLine;
     m_lineWidth       = a->m_lineWidth;
     m_topPitch        = a->m_topPitch;
@@ -162,15 +157,15 @@ void Ambitus::setTrack(track_idx_t t)
 void Ambitus::setTopPitch(int val, bool applyLogic)
 {
     if (!applyLogic) {
-        m_topPitch   = val;
+        m_topPitch = val;
         return;
     }
 
-    int deltaPitch    = val - topPitch();
+    int deltaPitch = val - topPitch();
     // if deltaPitch is not an integer number of octaves, adjust tpc
     // (to avoid 'wild' tpc changes with octave changes)
     if (deltaPitch % PITCH_DELTA_OCTAVE != 0) {
-        int newTpc        = topTpc() + deltaPitch * TPC_DELTA_SEMITONE;
+        int newTpc = topTpc() + deltaPitch * TPC_DELTA_SEMITONE;
         // reduce newTpc into acceptable range via enharmonic
         while (newTpc < Tpc::TPC_MIN) {
             newTpc += TPC_DELTA_ENHARMONIC;
@@ -178,9 +173,9 @@ void Ambitus::setTopPitch(int val, bool applyLogic)
         while (newTpc > Tpc::TPC_MAX) {
             newTpc -= TPC_DELTA_ENHARMONIC;
         }
-        m_topTpc     = newTpc;
+        m_topTpc = newTpc;
     }
-    m_topPitch   = val;
+    m_topPitch = val;
     normalize();
 }
 
@@ -191,11 +186,11 @@ void Ambitus::setBottomPitch(int val, bool applyLogic)
         return;
     }
 
-    int deltaPitch    = val - bottomPitch();
+    int deltaPitch = val - bottomPitch();
     // if deltaPitch is not an integer number of octaves, adjust tpc
     // (to avoid 'wild' tpc changes with octave changes)
     if (deltaPitch % PITCH_DELTA_OCTAVE != 0) {
-        int newTpc        = bottomTpc() + deltaPitch * TPC_DELTA_SEMITONE;
+        int newTpc = bottomTpc() + deltaPitch * TPC_DELTA_SEMITONE;
         // reduce newTpc into acceptable range via enharmonic
         while (newTpc < Tpc::TPC_MIN) {
             newTpc += TPC_DELTA_ENHARMONIC;
@@ -203,9 +198,9 @@ void Ambitus::setBottomPitch(int val, bool applyLogic)
         while (newTpc > Tpc::TPC_MAX) {
             newTpc -= TPC_DELTA_ENHARMONIC;
         }
-        m_bottomTpc  = newTpc;
+        m_bottomTpc = newTpc;
     }
-    m_bottomPitch= val;
+    m_bottomPitch = val;
     normalize();
 }
 
@@ -223,14 +218,14 @@ void Ambitus::setTopTpc(int val, bool applyLogic)
         return;
     }
 
-    int octave        = topPitch() / PITCH_DELTA_OCTAVE;
-    int deltaTpc      = val - topTpc();
+    int octave = topPitch() / PITCH_DELTA_OCTAVE;
+    int deltaTpc = val - topTpc();
     // get new pitch according to tpc change
-    int newPitch      = topPitch() + deltaTpc * TPC_DELTA_SEMITONE;
+    int newPitch = topPitch() + deltaTpc * TPC_DELTA_SEMITONE;
     // reduce pitch to the same octave as original pitch
-    newPitch          = (octave * PITCH_DELTA_OCTAVE) + (newPitch % PITCH_DELTA_OCTAVE);
-    m_topPitch   = newPitch;
-    m_topTpc     = val;
+    newPitch = (octave * PITCH_DELTA_OCTAVE) + (newPitch % PITCH_DELTA_OCTAVE);
+    m_topPitch = newPitch;
+    m_topTpc = val;
     normalize();
 }
 
@@ -241,14 +236,14 @@ void Ambitus::setBottomTpc(int val, bool applyLogic)
         return;
     }
 
-    int octave        = bottomPitch() / PITCH_DELTA_OCTAVE;
-    int deltaTpc      = val - bottomTpc();
+    int octave = bottomPitch() / PITCH_DELTA_OCTAVE;
+    int deltaTpc = val - bottomTpc();
     // get new pitch according to tpc change
-    int newPitch      = bottomPitch() + deltaTpc * TPC_DELTA_SEMITONE;
+    int newPitch = bottomPitch() + deltaTpc * TPC_DELTA_SEMITONE;
     // reduce pitch to the same octave as original pitch
-    newPitch          = (octave * PITCH_DELTA_OCTAVE) + (newPitch % PITCH_DELTA_OCTAVE);
-    m_bottomPitch= newPitch;
-    m_bottomTpc  = val;
+    newPitch = (octave * PITCH_DELTA_OCTAVE) + (newPitch % PITCH_DELTA_OCTAVE);
+    m_bottomPitch = newPitch;
+    m_bottomTpc = val;
     normalize();
 }
 
@@ -263,36 +258,36 @@ void Ambitus::draw(mu::draw::Painter* painter) const
     double _spatium = spatium();
     double lw = lineWidth().val() * _spatium;
     painter->setPen(Pen(curColor(), lw, PenStyle::SolidLine, PenCapStyle::FlatCap));
-    drawSymbol(noteHead(), painter, m_topPos);
-    drawSymbol(noteHead(), painter, m_bottomPos);
+    drawSymbol(noteHead(), painter, m_layoutData.topPos);
+    drawSymbol(noteHead(), painter, m_layoutData.bottomPos);
     if (m_hasLine) {
-        painter->drawLine(m_line);
+        painter->drawLine(m_layoutData.line);
     }
 
     // draw ledger lines (if not in a palette)
     if (segment() && track() != mu::nidx) {
-        Fraction tick  = segment()->tick();
-        Staff* staff   = score()->staff(staffIdx());
+        Fraction tick = segment()->tick();
+        Staff* staff = score()->staff(staffIdx());
         double lineDist = staff->lineDistance(tick);
         int numOfLines = staff->lines(tick);
-        double step     = lineDist * _spatium;
-        double stepTolerance    = step * 0.1;
+        double step = lineDist * _spatium;
+        double stepTolerance = step * 0.1;
         double ledgerLineLength = style().styleS(Sid::ledgerLineLength).val() * _spatium;
-        double ledgerLineWidth  = style().styleS(Sid::ledgerLineWidth).val() * _spatium;
+        double ledgerLineWidth = style().styleS(Sid::ledgerLineWidth).val() * _spatium;
         painter->setPen(Pen(curColor(), ledgerLineWidth, PenStyle::SolidLine, PenCapStyle::FlatCap));
 
-        if (m_topPos.y() - stepTolerance <= -step) {
-            double xMin = m_topPos.x() - ledgerLineLength;
-            double xMax = m_topPos.x() + headWidth() + ledgerLineLength;
-            for (double y = -step; y >= m_topPos.y() - stepTolerance; y -= step) {
+        if (m_layoutData.topPos.y() - stepTolerance <= -step) {
+            double xMin = m_layoutData.topPos.x() - ledgerLineLength;
+            double xMax = m_layoutData.topPos.x() + headWidth() + ledgerLineLength;
+            for (double y = -step; y >= m_layoutData.topPos.y() - stepTolerance; y -= step) {
                 painter->drawLine(mu::PointF(xMin, y), mu::PointF(xMax, y));
             }
         }
 
-        if (m_bottomPos.y() + stepTolerance >= numOfLines * step) {
-            double xMin = m_bottomPos.x() - ledgerLineLength;
-            double xMax = m_bottomPos.x() + headWidth() + ledgerLineLength;
-            for (double y = numOfLines * step; y <= m_bottomPos.y() + stepTolerance; y += step) {
+        if (m_layoutData.bottomPos.y() + stepTolerance >= numOfLines * step) {
+            double xMin = m_layoutData.bottomPos.x() - ledgerLineLength;
+            double xMax = m_layoutData.bottomPos.x() + headWidth() + ledgerLineLength;
+            for (double y = numOfLines * step; y <= m_layoutData.bottomPos.y() + stepTolerance; y += step) {
                 painter->drawLine(mu::PointF(xMin, y), mu::PointF(xMax, y));
             }
         }
@@ -371,18 +366,14 @@ mu::PointF Ambitus::pagePos() const
 //---------------------------------------------------------
 //   normalize
 //
-//    makes sure _topPitch is not < _bottomPitch
+//    makes sure topPitch is not < bottomPitch
 //---------------------------------------------------------
 
 void Ambitus::normalize()
 {
     if (m_topPitch < m_bottomPitch) {
-        int temp    = m_topPitch;
-        m_topPitch   = m_bottomPitch;
-        m_bottomPitch= temp;
-        temp        = m_topTpc;
-        m_topTpc     = m_bottomTpc;
-        m_bottomTpc  = temp;
+        std::swap(m_topPitch, m_bottomPitch);
+        std::swap(m_topTpc, m_bottomTpc);
     }
 }
 
@@ -612,4 +603,37 @@ String Ambitus::accessibleInfo() const
            .arg(tpc2name(topTpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, false) + String::number(topOctave()),
                 tpc2name(bottomTpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, false) + String::number(bottomOctave()));
 }
+
+AccidentalType Ambitus::accidentalType(int tpc, Key key)
+{
+    AccidentalType accidType = AccidentalType::NONE;
+    // if (13 <= (tpc - key) <= 19) there is no accidental)
+    if (tpc - int(key) >= 13 && tpc - int(key) <= 19) {
+        accidType = AccidentalType::NONE;
+    } else {
+        AccidentalVal accidVal = tpc2alter(tpc);
+        accidType = Accidental::value2subtype(accidVal);
+        if (accidType == AccidentalType::NONE) {
+            accidType = AccidentalType::NATURAL;
+        }
+    }
+
+    return accidType;
+}
+
+//! TODO Seems to need to be moved to utilities
+int Ambitus::staffLine(int tpc, int pitch, ClefType clf)
+{
+    int line = absStep(tpc, pitch);
+    line = relStep(line, clf);
+    return line;
+}
+
+void Ambitus::setLayoutData(const LayoutData& data)
+{
+    m_layoutData = data;
+    setbbox(data.bbox);
+
+    m_topAccidental->setLayoutData(data.topAcc);
+    m_bottomAccidental->setLayoutData(data.bottomAcc);
 }

--- a/src/engraving/libmscore/ambitus.cpp
+++ b/src/engraving/libmscore/ambitus.cpp
@@ -51,46 +51,46 @@ const Spatium Ambitus::LINEWIDTH_DEFAULT = Spatium(0.12);
 Ambitus::Ambitus(Segment* parent)
     : EngravingItem(ElementType::AMBITUS, parent, ElementFlag::ON_STAFF)
 {
-    _noteHeadGroup    = NOTEHEADGROUP_DEFAULT;
-    _noteHeadType     = NOTEHEADTYPE_DEFAULT;
-    _dir              = DIR_DEFAULT;
-    _hasLine          = HASLINE_DEFAULT;
-    _lineWidth        = LINEWIDTH_DEFAULT;
-    _topPitch         = INVALID_PITCH;
-    _bottomPitch      = INVALID_PITCH;
-    _topTpc           = Tpc::TPC_INVALID;
-    _bottomTpc        = Tpc::TPC_INVALID;
+    m_noteHeadGroup    = NOTEHEADGROUP_DEFAULT;
+    m_noteHeadType     = NOTEHEADTYPE_DEFAULT;
+    m_direction        = DIRECTION_DEFAULT;
+    m_hasLine          = HASLINE_DEFAULT;
+    m_lineWidth        = LINEWIDTH_DEFAULT;
+    m_topPitch         = INVALID_PITCH;
+    m_bottomPitch      = INVALID_PITCH;
+    m_topTpc           = Tpc::TPC_INVALID;
+    m_bottomTpc        = Tpc::TPC_INVALID;
 
-    _topAccid = Factory::createAccidental(this, false);
-    _bottomAccid = Factory::createAccidental(this, false);
-    _topAccid->setParent(this);
-    _bottomAccid->setParent(this);
+    m_topAccidental = Factory::createAccidental(this, false);
+    m_bottomAccidental = Factory::createAccidental(this, false);
+    m_topAccidental->setParent(this);
+    m_bottomAccidental->setParent(this);
 }
 
 Ambitus::Ambitus(const Ambitus& a)
     : EngravingItem(a)
 {
-    _noteHeadGroup = a._noteHeadGroup;
-    _noteHeadType = a._noteHeadType;
-    _dir = a._dir;
-    _hasLine = a._hasLine;
-    _lineWidth = a._lineWidth;
-    _topAccid = a._topAccid->clone();
-    _bottomAccid = a._bottomAccid->clone();
-    _topPitch = a._topPitch;
-    _topTpc = a._topTpc;
-    _bottomPitch = a._bottomPitch;
-    _bottomTpc = a._bottomTpc;
+    m_noteHeadGroup = a.m_noteHeadGroup;
+    m_noteHeadType = a.m_noteHeadType;
+    m_direction = a.m_direction;
+    m_hasLine = a.m_hasLine;
+    m_lineWidth = a.m_lineWidth;
+    m_topAccidental = a.m_topAccidental->clone();
+    m_bottomAccidental = a.m_bottomAccidental->clone();
+    m_topPitch = a.m_topPitch;
+    m_topTpc = a.m_topTpc;
+    m_bottomPitch = a.m_bottomPitch;
+    m_bottomTpc = a.m_bottomTpc;
 
-    _topPos = a._topPos;
-    _bottomPos = a._bottomPos;
-    _line = a._line;
+    m_topPos = a.m_topPos;
+    m_bottomPos = a.m_bottomPos;
+    m_line = a.m_line;
 }
 
 Ambitus::~Ambitus()
 {
-    delete _topAccid;
-    delete _bottomAccid;
+    delete m_topAccidental;
+    delete m_bottomAccidental;
 }
 
 //---------------------------------------------------------
@@ -108,15 +108,15 @@ double Ambitus::mag() const
 
 void Ambitus::initFrom(Ambitus* a)
 {
-    _noteHeadGroup   = a->_noteHeadGroup;
-    _noteHeadType    = a->_noteHeadType;
-    _dir             = a->_dir;
-    _hasLine         = a->_hasLine;
-    _lineWidth       = a->_lineWidth;
-    _topPitch        = a->_topPitch;
-    _bottomPitch     = a->_bottomPitch;
-    _topTpc          = a->_topTpc;
-    _bottomTpc       = a->_bottomTpc;
+    m_noteHeadGroup   = a->m_noteHeadGroup;
+    m_noteHeadType    = a->m_noteHeadType;
+    m_direction             = a->m_direction;
+    m_hasLine         = a->m_hasLine;
+    m_lineWidth       = a->m_lineWidth;
+    m_topPitch        = a->m_topPitch;
+    m_bottomPitch     = a->m_bottomPitch;
+    m_topTpc          = a->m_topTpc;
+    m_bottomTpc       = a->m_bottomTpc;
 }
 
 //---------------------------------------------------------
@@ -135,17 +135,17 @@ void Ambitus::setTrack(track_idx_t t)
     // if not initialized and there is a segment and a staff,
     // initialize pitches and tpc's to first and last staff line
     // (for use in palettes)
-    if (_topPitch == INVALID_PITCH || _topTpc == Tpc::TPC_INVALID
-        || _bottomPitch == INVALID_PITCH || _bottomTpc == Tpc::TPC_INVALID) {
+    if (m_topPitch == INVALID_PITCH || m_topTpc == Tpc::TPC_INVALID
+        || m_bottomPitch == INVALID_PITCH || m_bottomTpc == Tpc::TPC_INVALID) {
         if (segm && stf) {
             Ambitus::Ranges ranges = estimateRanges();
-            _topTpc = ranges.topTpc;
-            _bottomTpc = ranges.bottomTpc;
-            _topPitch = ranges.topPitch;
-            _bottomPitch = ranges.bottomPitch;
+            m_topTpc = ranges.topTpc;
+            m_bottomTpc = ranges.bottomTpc;
+            m_topPitch = ranges.topPitch;
+            m_bottomPitch = ranges.bottomPitch;
 
-            _topAccid->setTrack(t);
-            _bottomAccid->setTrack(t);
+            m_topAccidental->setTrack(t);
+            m_bottomAccidental->setTrack(t);
         }
 //            else {
 //                  _topPitch = _bottomPitch = INVALID_PITCH;
@@ -162,7 +162,7 @@ void Ambitus::setTrack(track_idx_t t)
 void Ambitus::setTopPitch(int val, bool applyLogic)
 {
     if (!applyLogic) {
-        _topPitch   = val;
+        m_topPitch   = val;
         return;
     }
 
@@ -178,16 +178,16 @@ void Ambitus::setTopPitch(int val, bool applyLogic)
         while (newTpc > Tpc::TPC_MAX) {
             newTpc -= TPC_DELTA_ENHARMONIC;
         }
-        _topTpc     = newTpc;
+        m_topTpc     = newTpc;
     }
-    _topPitch   = val;
+    m_topPitch   = val;
     normalize();
 }
 
 void Ambitus::setBottomPitch(int val, bool applyLogic)
 {
     if (!applyLogic) {
-        _bottomPitch = val;
+        m_bottomPitch = val;
         return;
     }
 
@@ -203,9 +203,9 @@ void Ambitus::setBottomPitch(int val, bool applyLogic)
         while (newTpc > Tpc::TPC_MAX) {
             newTpc -= TPC_DELTA_ENHARMONIC;
         }
-        _bottomTpc  = newTpc;
+        m_bottomTpc  = newTpc;
     }
-    _bottomPitch= val;
+    m_bottomPitch= val;
     normalize();
 }
 
@@ -219,7 +219,7 @@ void Ambitus::setBottomPitch(int val, bool applyLogic)
 void Ambitus::setTopTpc(int val, bool applyLogic)
 {
     if (!applyLogic) {
-        _topTpc = val;
+        m_topTpc = val;
         return;
     }
 
@@ -229,15 +229,15 @@ void Ambitus::setTopTpc(int val, bool applyLogic)
     int newPitch      = topPitch() + deltaTpc * TPC_DELTA_SEMITONE;
     // reduce pitch to the same octave as original pitch
     newPitch          = (octave * PITCH_DELTA_OCTAVE) + (newPitch % PITCH_DELTA_OCTAVE);
-    _topPitch   = newPitch;
-    _topTpc     = val;
+    m_topPitch   = newPitch;
+    m_topTpc     = val;
     normalize();
 }
 
 void Ambitus::setBottomTpc(int val, bool applyLogic)
 {
     if (!applyLogic) {
-        _bottomTpc = val;
+        m_bottomTpc = val;
         return;
     }
 
@@ -247,8 +247,8 @@ void Ambitus::setBottomTpc(int val, bool applyLogic)
     int newPitch      = bottomPitch() + deltaTpc * TPC_DELTA_SEMITONE;
     // reduce pitch to the same octave as original pitch
     newPitch          = (octave * PITCH_DELTA_OCTAVE) + (newPitch % PITCH_DELTA_OCTAVE);
-    _bottomPitch= newPitch;
-    _bottomTpc  = val;
+    m_bottomPitch= newPitch;
+    m_bottomTpc  = val;
     normalize();
 }
 
@@ -263,10 +263,10 @@ void Ambitus::draw(mu::draw::Painter* painter) const
     double _spatium = spatium();
     double lw = lineWidth().val() * _spatium;
     painter->setPen(Pen(curColor(), lw, PenStyle::SolidLine, PenCapStyle::FlatCap));
-    drawSymbol(noteHead(), painter, _topPos);
-    drawSymbol(noteHead(), painter, _bottomPos);
-    if (_hasLine) {
-        painter->drawLine(_line);
+    drawSymbol(noteHead(), painter, m_topPos);
+    drawSymbol(noteHead(), painter, m_bottomPos);
+    if (m_hasLine) {
+        painter->drawLine(m_line);
     }
 
     // draw ledger lines (if not in a palette)
@@ -281,18 +281,18 @@ void Ambitus::draw(mu::draw::Painter* painter) const
         double ledgerLineWidth  = style().styleS(Sid::ledgerLineWidth).val() * _spatium;
         painter->setPen(Pen(curColor(), ledgerLineWidth, PenStyle::SolidLine, PenCapStyle::FlatCap));
 
-        if (_topPos.y() - stepTolerance <= -step) {
-            double xMin = _topPos.x() - ledgerLineLength;
-            double xMax = _topPos.x() + headWidth() + ledgerLineLength;
-            for (double y = -step; y >= _topPos.y() - stepTolerance; y -= step) {
+        if (m_topPos.y() - stepTolerance <= -step) {
+            double xMin = m_topPos.x() - ledgerLineLength;
+            double xMax = m_topPos.x() + headWidth() + ledgerLineLength;
+            for (double y = -step; y >= m_topPos.y() - stepTolerance; y -= step) {
                 painter->drawLine(mu::PointF(xMin, y), mu::PointF(xMax, y));
             }
         }
 
-        if (_bottomPos.y() + stepTolerance >= numOfLines * step) {
-            double xMin = _bottomPos.x() - ledgerLineLength;
-            double xMax = _bottomPos.x() + headWidth() + ledgerLineLength;
-            for (double y = numOfLines * step; y <= _bottomPos.y() + stepTolerance; y += step) {
+        if (m_bottomPos.y() + stepTolerance >= numOfLines * step) {
+            double xMin = m_bottomPos.x() - ledgerLineLength;
+            double xMax = m_bottomPos.x() + headWidth() + ledgerLineLength;
+            for (double y = numOfLines * step; y <= m_bottomPos.y() + stepTolerance; y += step) {
                 painter->drawLine(mu::PointF(xMin, y), mu::PointF(xMax, y));
             }
         }
@@ -307,12 +307,12 @@ void Ambitus::scanElements(void* data, void (* func)(void*, EngravingItem*), boo
 {
     UNUSED(all);
     func(data, this);
-    if (_topAccid->accidentalType() != AccidentalType::NONE) {
-        func(data, _topAccid);
+    if (m_topAccidental->accidentalType() != AccidentalType::NONE) {
+        func(data, m_topAccidental);
     }
 
-    if (_bottomAccid->accidentalType() != AccidentalType::NONE) {
-        func(data, _bottomAccid);
+    if (m_bottomAccidental->accidentalType() != AccidentalType::NONE) {
+        func(data, m_bottomAccidental);
     }
 }
 
@@ -325,13 +325,13 @@ SymId Ambitus::noteHead() const
     int hg = 1;
     NoteHeadType ht  = NoteHeadType::HEAD_QUARTER;
 
-    if (_noteHeadType != NoteHeadType::HEAD_AUTO) {
-        ht = _noteHeadType;
+    if (m_noteHeadType != NoteHeadType::HEAD_AUTO) {
+        ht = m_noteHeadType;
     }
 
-    SymId t = Note::noteHead(hg, _noteHeadGroup, ht);
+    SymId t = Note::noteHead(hg, m_noteHeadGroup, ht);
     if (t == SymId::noSym) {
-        LOGD("invalid notehead %d/%d", int(_noteHeadGroup), int(_noteHeadType));
+        LOGD("invalid notehead %d/%d", int(m_noteHeadGroup), int(m_noteHeadType));
         t = Note::noteHead(0, NoteHeadGroup::HEAD_NORMAL, ht);
     }
     return t;
@@ -376,13 +376,13 @@ mu::PointF Ambitus::pagePos() const
 
 void Ambitus::normalize()
 {
-    if (_topPitch < _bottomPitch) {
-        int temp    = _topPitch;
-        _topPitch   = _bottomPitch;
-        _bottomPitch= temp;
-        temp        = _topTpc;
-        _topTpc     = _bottomTpc;
-        _bottomTpc  = temp;
+    if (m_topPitch < m_bottomPitch) {
+        int temp    = m_topPitch;
+        m_topPitch   = m_bottomPitch;
+        m_bottomPitch= temp;
+        temp        = m_topTpc;
+        m_topTpc     = m_bottomTpc;
+        m_bottomTpc  = temp;
     }
 }
 
@@ -560,7 +560,7 @@ PropertyValue Ambitus::propertyDefault(Pid id) const
     case Pid::HEAD_TYPE:
         return int(NOTEHEADTYPE_DEFAULT);
     case Pid::MIRROR_HEAD:
-        return int(DIR_DEFAULT);
+        return int(DIRECTION_DEFAULT);
     case Pid::GHOST:
         return HASLINE_DEFAULT;
     case Pid::LINE_WIDTH_SPATIUM:

--- a/src/engraving/libmscore/ambitus.h
+++ b/src/engraving/libmscore/ambitus.h
@@ -28,10 +28,12 @@
 #include "pitchspelling.h"
 
 #include "types/types.h"
+#include "libmscore/types.h"
 #include "types/dimension.h"
 
+#include "accidental.h"
+
 namespace mu::engraving {
-class Accidental;
 class Factory;
 
 //---------------------------------------------------------
@@ -76,19 +78,6 @@ public:
     int topTpc() const { return m_topTpc; }
     int bottomTpc() const { return m_bottomTpc; }
 
-    PointF topPos() const { return m_topPos; }
-    void setTopPos(const PointF& p) { m_topPos = p; }
-    void setTopPosX(double p) { m_topPos.setX(p); }
-    void setTopPosY(double p) { m_topPos.setY(p); }
-
-    PointF bottomPos() const { return m_bottomPos; }
-    void setBottomPos(const PointF& p) { m_bottomPos = p; }
-    void setBottomPosX(double p) { m_bottomPos.setX(p); }
-    void setBottomPosY(double p) { m_bottomPos.setY(p); }
-
-    LineF line() const { return m_line; }
-    void setLine(const LineF& l) { m_line = l; }
-
     Accidental* topAccidental() const { return m_topAccidental; }
     Accidental* bottomAccidental() const { return m_bottomAccidental; }
 
@@ -126,6 +115,38 @@ public:
     EngravingItem* nextSegmentElement() override;
     EngravingItem* prevSegmentElement() override;
 
+    static AccidentalType accidentalType(int tpc, Key key);
+    static int staffLine(int tpc, int pitch, ClefType clf);
+
+    struct LayoutData {
+        Accidental::LayoutData topAcc;
+        Accidental::LayoutData bottomAcc;
+
+        PointF topPos;          // position of top note symbol
+        PointF bottomPos;       // position of bottom note symbol
+        LineF line;             // the drawn line
+
+        RectF bbox;
+    };
+
+    const LayoutData& layoutData() const { return m_layoutData; }
+    void setLayoutData(const LayoutData& data);
+
+    //! -- Old interface --
+    PointF topPos() const { return m_layoutData.topPos; }
+    void setTopPos(const PointF& p) { m_layoutData.topPos = p; }
+    void setTopPosX(double p) { m_layoutData.topPos.setX(p); }
+    void setTopPosY(double p) { m_layoutData.topPos.setY(p); }
+
+    PointF bottomPos() const { return m_layoutData.bottomPos; }
+    void setBottomPos(const PointF& p) { m_layoutData.bottomPos = p; }
+    void setBottomPosX(double p) { m_layoutData.bottomPos.setX(p); }
+    void setBottomPosY(double p) { m_layoutData.bottomPos.setY(p); }
+
+    LineF line() const { return m_layoutData.line; }
+    void setLine(const LineF& l) { m_layoutData.line = l; }
+    //! -------------------
+
 private:
 
     friend class Factory;
@@ -154,9 +175,7 @@ private:
     int m_topTpc = Tpc::TPC_INVALID, m_bottomTpc = Tpc::TPC_INVALID;
 
     // internally managed, to optimize layout / drawing
-    PointF m_topPos;       // position of top note symbol
-    PointF m_bottomPos;    // position of bottom note symbol
-    LineF m_line;          // the drawn line
+    LayoutData m_layoutData;
 };
 } // namespace mu::engraving
 

--- a/src/engraving/libmscore/ambitus.h
+++ b/src/engraving/libmscore/ambitus.h
@@ -48,7 +48,7 @@ public:
 
     static constexpr NoteHeadGroup NOTEHEADGROUP_DEFAULT = NoteHeadGroup::HEAD_NORMAL;
     static constexpr NoteHeadType NOTEHEADTYPE_DEFAULT = NoteHeadType::HEAD_AUTO;
-    static constexpr DirectionH DIR_DEFAULT = DirectionH::AUTO;
+    static constexpr DirectionH DIRECTION_DEFAULT = DirectionH::AUTO;
     static constexpr bool HASLINE_DEFAULT = true;
     static const Spatium LINEWIDTH_DEFAULT;
     static constexpr double LINEOFFSET_DEFAULT = 0.8;               // the distance between notehead and line
@@ -64,39 +64,39 @@ public:
     void initFrom(Ambitus* a);
 
     // getters and setters
-    NoteHeadGroup noteHeadGroup() const { return _noteHeadGroup; }
-    NoteHeadType noteHeadType() const { return _noteHeadType; }
-    DirectionH direction() const { return _dir; }
-    bool hasLine() const { return _hasLine; }
-    Spatium lineWidth() const { return _lineWidth; }
-    int topOctave() const { return (_topPitch / 12) - 1; }
-    int bottomOctave() const { return (_bottomPitch / 12) - 1; }
-    int topPitch() const { return _topPitch; }
-    int bottomPitch() const { return _bottomPitch; }
-    int topTpc() const { return _topTpc; }
-    int bottomTpc() const { return _bottomTpc; }
+    NoteHeadGroup noteHeadGroup() const { return m_noteHeadGroup; }
+    NoteHeadType noteHeadType() const { return m_noteHeadType; }
+    DirectionH direction() const { return m_direction; }
+    bool hasLine() const { return m_hasLine; }
+    Spatium lineWidth() const { return m_lineWidth; }
+    int topOctave() const { return (m_topPitch / 12) - 1; }
+    int bottomOctave() const { return (m_bottomPitch / 12) - 1; }
+    int topPitch() const { return m_topPitch; }
+    int bottomPitch() const { return m_bottomPitch; }
+    int topTpc() const { return m_topTpc; }
+    int bottomTpc() const { return m_bottomTpc; }
 
-    PointF topPos() const { return _topPos; }
-    void setTopPos(const PointF& p) { _topPos = p; }
-    void setTopPosX(double p) { _topPos.setX(p); }
-    void setTopPosY(double p) { _topPos.setY(p); }
+    PointF topPos() const { return m_topPos; }
+    void setTopPos(const PointF& p) { m_topPos = p; }
+    void setTopPosX(double p) { m_topPos.setX(p); }
+    void setTopPosY(double p) { m_topPos.setY(p); }
 
-    PointF bottomPos() const { return _bottomPos; }
-    void setBottomPos(const PointF& p) { _bottomPos = p; }
-    void setBottomPosX(double p) { _bottomPos.setX(p); }
-    void setBottomPosY(double p) { _bottomPos.setY(p); }
+    PointF bottomPos() const { return m_bottomPos; }
+    void setBottomPos(const PointF& p) { m_bottomPos = p; }
+    void setBottomPosX(double p) { m_bottomPos.setX(p); }
+    void setBottomPosY(double p) { m_bottomPos.setY(p); }
 
-    LineF line() const { return _line; }
-    void setLine(const LineF& l) { _line = l; }
+    LineF line() const { return m_line; }
+    void setLine(const LineF& l) { m_line = l; }
 
-    Accidental* topAccidental() const { return _topAccid; }
-    Accidental* bottomAccidental() const { return _bottomAccid; }
+    Accidental* topAccidental() const { return m_topAccidental; }
+    Accidental* bottomAccidental() const { return m_bottomAccidental; }
 
-    void setNoteHeadGroup(NoteHeadGroup val) { _noteHeadGroup = val; }
-    void setNoteHeadType(NoteHeadType val) { _noteHeadType  = val; }
-    void setDirection(DirectionH val) { _dir = val; }
-    void setHasLine(bool val) { _hasLine = val; }
-    void setLineWidth(Spatium val) { _lineWidth = val; }
+    void setNoteHeadGroup(NoteHeadGroup val) { m_noteHeadGroup = val; }
+    void setNoteHeadType(NoteHeadType val) { m_noteHeadType  = val; }
+    void setDirection(DirectionH val) { m_direction = val; }
+    void setHasLine(bool val) { m_hasLine = val; }
+    void setLineWidth(Spatium val) { m_lineWidth = val; }
     void setTopPitch(int val, bool applyLogic = true);
     void setBottomPitch(int val, bool applyLogic = true);
     void setTopTpc(int val, bool applyLogic = true);
@@ -108,13 +108,13 @@ public:
     double headWidth() const;
 
     // re-implemented virtual functions
-    void      draw(mu::draw::Painter* painter) const override;
+    void draw(mu::draw::Painter* painter) const override;
 
-    mu::PointF pagePos() const override;        ///< position in page coordinates
-    void      scanElements(void* data, void (* func)(void*, EngravingItem*), bool all=true) override;
-    void      setTrack(track_idx_t val) override;
+    mu::PointF pagePos() const override;        // position in page coordinates
+    void scanElements(void* data, void (* func)(void*, EngravingItem*), bool all=true) override;
+    void setTrack(track_idx_t val) override;
 
-    String    accessibleInfo() const override;
+    String accessibleInfo() const override;
 
     void remove(EngravingItem*) override;
 
@@ -143,20 +143,20 @@ private:
 
     Ranges estimateRanges() const;                // scan staff up to next section break and update range pitches
 
-    NoteHeadGroup _noteHeadGroup;
-    NoteHeadType _noteHeadType;
-    DirectionH _dir;
-    bool _hasLine;
-    Spatium _lineWidth;
-    Accidental* _topAccid = nullptr;
-    Accidental* _bottomAccid = nullptr;
-    int _topPitch, _bottomPitch;
-    int _topTpc, _bottomTpc;
+    NoteHeadGroup m_noteHeadGroup = NOTEHEADGROUP_DEFAULT;
+    NoteHeadType m_noteHeadType = NOTEHEADTYPE_DEFAULT;
+    DirectionH m_direction = DIRECTION_DEFAULT;
+    bool m_hasLine = HASLINE_DEFAULT;
+    Spatium m_lineWidth;
+    Accidental* m_topAccidental = nullptr;
+    Accidental* m_bottomAccidental = nullptr;
+    int m_topPitch = INVALID_PITCH, m_bottomPitch = INVALID_PITCH;
+    int m_topTpc = Tpc::TPC_INVALID, m_bottomTpc = Tpc::TPC_INVALID;
 
     // internally managed, to optimize layout / drawing
-    PointF _topPos;       // position of top note symbol
-    PointF _bottomPos;    // position of bottom note symbol
-    LineF _line;          // the drawn line
+    PointF m_topPos;       // position of top note symbol
+    PointF m_bottomPos;    // position of bottom note symbol
+    LineF m_line;          // the drawn line
 };
 } // namespace mu::engraving
 

--- a/src/engraving/libmscore/scoretree.cpp
+++ b/src/engraving/libmscore/scoretree.cpp
@@ -504,12 +504,12 @@ EngravingObjectList Ambitus::scanChildren() const
 {
     EngravingObjectList children;
 
-    Accidental* topAccid = const_cast<Accidental*>(_topAccid);
+    Accidental* topAccid = const_cast<Accidental*>(m_topAccidental);
     if (topAccid && topAccid->accidentalType() != AccidentalType::NONE) {
         children.push_back(topAccid);
     }
 
-    Accidental* bottomAccid = const_cast<Accidental*>(_bottomAccid);
+    Accidental* bottomAccid = const_cast<Accidental*>(m_bottomAccidental);
     if (bottomAccid && bottomAccid->accidentalType() != AccidentalType::NONE) {
         children.push_back(bottomAccid);
     }

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -373,7 +373,7 @@ void TWrite::write(const Ambitus* item, XmlWriter& xml, WriteContext& ctx)
     xml.startElement(item);
     xml.tagProperty(Pid::HEAD_GROUP, int(item->noteHeadGroup()), int(Ambitus::NOTEHEADGROUP_DEFAULT));
     xml.tagProperty(Pid::HEAD_TYPE,  int(item->noteHeadType()),  int(Ambitus::NOTEHEADTYPE_DEFAULT));
-    xml.tagProperty(Pid::MIRROR_HEAD, int(item->direction()),    int(Ambitus::DIR_DEFAULT));
+    xml.tagProperty(Pid::MIRROR_HEAD, int(item->direction()),    int(Ambitus::DIRECTION_DEFAULT));
     xml.tag("hasLine",    item->hasLine(), true);
     xml.tagProperty(Pid::LINE_WIDTH_SPATIUM, item->lineWidth(), Ambitus::LINEWIDTH_DEFAULT);
     xml.tag("topPitch",   item->topPitch());

--- a/src/framework/global/types/translatablestring.h
+++ b/src/framework/global/types/translatablestring.h
@@ -74,7 +74,7 @@ public:
 
         String res = isTranslatable() ? mtrc(context, str, disambiguation, n) : str;
 
-        for (auto arg : args) {
+        for (const auto& arg : args) {
             arg->apply(res);
         }
 
@@ -90,7 +90,7 @@ public:
 
         QString res = isTranslatable() ? qtrc(context, str, disambiguation, n) : str.toQString();
 
-        for (auto arg : args) {
+        for (const auto& arg : args) {
             arg->apply(res);
         }
 

--- a/src/palette/internal/palettelayout.cpp
+++ b/src/palette/internal/palettelayout.cpp
@@ -265,7 +265,7 @@ compat::DummyElement* PaletteLayout::Context::dummyParent() const
 void PaletteLayout::layout(Accidental* item, const Context&)
 {
     SymId s = item->symId();
-    if (item->elements().empty()) {
+    if (item->syms().empty()) {
         SymElement e(s, 0.0, 0.0);
         item->addElement(e);
     }

--- a/src/palette/internal/palettelayout.cpp
+++ b/src/palette/internal/palettelayout.cpp
@@ -264,14 +264,14 @@ compat::DummyElement* PaletteLayout::Context::dummyParent() const
 
 void PaletteLayout::layout(Accidental* item, const Context&)
 {
-    SymId s = item->symId();
-    if (item->syms().empty()) {
-        SymElement e(s, 0.0, 0.0);
-        item->addElement(e);
+    if (!item->layoutData().isValid()) {
+        Accidental::LayoutData data;
+        SymId symId = item->symId();
+        Accidental::LayoutData::Sym s(symId, 0.0, 0.0);
+        data.syms.push_back(s);
+        data.bbox = item->symBbox(symId);
+        item->setLayoutData(data);
     }
-
-    RectF bbox = item->symBbox(s);
-    item->setbbox(bbox);
 }
 
 void PaletteLayout::layout(ActionIcon* item, const Context&)


### PR DESCRIPTION
The idea is to:
* Explicitly separate properties that are calculated and set during layout
* During the layout, do not change the items themselves, but fill in the layout data with the calculated properties, and then set this data (this approach has great potential in the future, for example, if we just need to calculate something, then it is not necessary to change the state of the items for this)
* Add layout data caching. Now caching is done for ActionIcon as an example. For others, not done, not everything is simple... but this approach brings us one step closer to caching - not doing what should not be done, not be doing the same thing over and over again... 