### PR TITLE
Fix #17147: Deleting whole inner tuplet of nested tuplets corrupts score 

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -3304,10 +3304,12 @@ ChordRest* Score::deleteRange(Segment* s1, Segment* s2, track_idx_t track1, trac
                         tick = s->tick();
                     }
                     currentTuplet = cr1->tuplet();
-                    if (currentTuplet && ((currentTuplet->tick()) >= stick1) && ((currentTuplet->tick() + currentTuplet->actualTicks()) <= tick2)) {
+                    if (currentTuplet && ((currentTuplet->tick()) >= stick1)
+                        && ((currentTuplet->tick() + currentTuplet->actualTicks()) <= tick2)) {
                         // Find highest-level complete tuplet contained in range
                         Tuplet* t = cr1->tuplet();
-                        while (t->tuplet() && ((t->tuplet()->tick()) >= stick1) && ((t->tuplet()->tick() + t->tuplet()->actualTicks()) <= tick2)) {
+                        while (t->tuplet() && ((t->tuplet()->tick()) >= stick1)
+                               && ((t->tuplet()->tick() + t->tuplet()->actualTicks()) <= tick2)) {
                             t = t->tuplet();
                         }
                         cmdDeleteTuplet(t, false);
@@ -3328,7 +3330,8 @@ ChordRest* Score::deleteRange(Segment* s1, Segment* s2, track_idx_t track1, trac
                     Tuplet* t = cr1->tuplet();
                     if (t && ((t->tick()) >= stick1) && (((t->tick() + t->actualTicks()) <= tick2) || fullMeasure)) { // If deleting a complete tuplet
                         // Find highest-level complete tuplet contained in range
-                        while (t->tuplet() && ((t->tuplet()->tick()) >= stick1) && ((t->tuplet()->tick() + t->tuplet()->actualTicks()) <= tick2)) {
+                        while (t->tuplet() && ((t->tuplet()->tick()) >= stick1)
+                               && ((t->tuplet()->tick() + t->tuplet()->actualTicks()) <= tick2)) {
                             t = t->tuplet();
                         }
                         cmdDeleteTuplet(t, false);

--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -3269,7 +3269,7 @@ ChordRest* Score::deleteRange(Segment* s1, Segment* s2, track_idx_t track1, trac
             }
             Fraction f;
             Fraction tick  = Fraction(-1, 1);
-            Tuplet* tuplet = 0;
+            Tuplet* currentTuplet = 0;
             for (Segment* s = s1; s && (s->tick() < stick2); s = s->next1()) {
                 if (s->element(track) && s->isBreathType()) {
                     deleteItem(s->element(track));
@@ -3303,8 +3303,8 @@ ChordRest* Score::deleteRange(Segment* s1, Segment* s2, track_idx_t track1, trac
                         f = Fraction(0, 1);
                         tick = s->tick();
                     }
-                    tuplet = cr1->tuplet();
-                    if (tuplet && ((tuplet->tick()) >= stick1) && ((tuplet->tick() + tuplet->actualTicks()) <= tick2)) {
+                    currentTuplet = cr1->tuplet();
+                    if (currentTuplet && ((currentTuplet->tick()) >= stick1) && ((currentTuplet->tick() + currentTuplet->actualTicks()) <= tick2)) {
                         // Find highest-level complete tuplet contained in range
                         Tuplet* t = cr1->tuplet();
                         while (t->tuplet() && ((t->tuplet()->tick()) >= stick1) && ((t->tuplet()->tick() + t->tuplet()->actualTicks()) <= tick2)) {
@@ -3312,7 +3312,7 @@ ChordRest* Score::deleteRange(Segment* s1, Segment* s2, track_idx_t track1, trac
                         }
                         cmdDeleteTuplet(t, false);
                         f += t->ticks();
-                        tuplet = t->tuplet();
+                        currentTuplet = t->tuplet();
                         continue;
                     }
                 }
@@ -3321,9 +3321,9 @@ ChordRest* Score::deleteRange(Segment* s1, Segment* s2, track_idx_t track1, trac
                     continue;
                 }
 
-                if (tuplet != cr1->tuplet()) {
+                if (currentTuplet != cr1->tuplet()) {
                     if (f.isValid()) { // Set rests for the previous tuplet we were dealing with
-                        setRest(tick, track, f, false, tuplet);
+                        setRest(tick, track, f, false, currentTuplet);
                     }
                     Tuplet* t = cr1->tuplet();
                     if (t && ((t->tick()) >= stick1) && (((t->tick() + t->actualTicks()) <= tick2) || fullMeasure)) { // If deleting a complete tuplet
@@ -3334,12 +3334,12 @@ ChordRest* Score::deleteRange(Segment* s1, Segment* s2, track_idx_t track1, trac
                         cmdDeleteTuplet(t, false);
                         tick = t->tick();
                         f = t->ticks();
-                        tuplet = t->tuplet();
+                        currentTuplet = t->tuplet();
                         continue;
                     }
                     // Not deleting a complete tuplet
                     tick = cr1->tick();
-                    tuplet = cr1->tuplet();
+                    currentTuplet = cr1->tuplet();
                     removeChordRest(cr1, true);
                     f = cr1->ticks();
                 } else {
@@ -3364,7 +3364,7 @@ ChordRest* Score::deleteRange(Segment* s1, Segment* s2, track_idx_t track1, trac
                         }
                     }
                 } else {
-                    Rest* r = setRest(tick, track, f, false, tuplet);
+                    Rest* r = setRest(tick, track, f, false, currentTuplet);
                     if (!cr) {
                         cr = r;
                     }

--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -3300,20 +3300,19 @@ ChordRest* Score::deleteRange(Segment* s1, Segment* s2, track_idx_t track1, trac
                         f = offset;
                         tick = s->measure()->tick();
                     } else {
+                        f = Fraction(0, 1);
                         tick = s->tick();
-                        f    = Fraction(0, 1);
                     }
                     tuplet = cr1->tuplet();
-                    if (tuplet && (tuplet->tick() == tick) && ((tuplet->tick() + tuplet->actualTicks()) <= tick2)) {
-                        // remove complete top level tuplet
-
+                    if (tuplet && ((tuplet->tick()) >= stick1) && ((tuplet->tick() + tuplet->actualTicks()) <= tick2)) {
+                        // Find highest-level complete tuplet contained in range
                         Tuplet* t = cr1->tuplet();
-                        while (t->tuplet()) {
+                        while (t->tuplet() && ((t->tuplet()->tick()) >= stick1) && ((t->tuplet()->tick() + t->tuplet()->actualTicks()) <= tick2)) {
                             t = t->tuplet();
                         }
                         cmdDeleteTuplet(t, false);
                         f += t->ticks();
-                        tuplet = 0;
+                        tuplet = t->tuplet();
                         continue;
                     }
                 }
@@ -3321,22 +3320,24 @@ ChordRest* Score::deleteRange(Segment* s1, Segment* s2, track_idx_t track1, trac
                     deleteItem(e);
                     continue;
                 }
-                if (tuplet != cr1->tuplet()) {
-                    Tuplet* t = cr1->tuplet();
-                    if (t && (((t->tick() + t->actualTicks()) <= tick2) || fullMeasure)) {
-                        // remove complete top level tuplet
 
-                        while (t->tuplet()) {
+                if (tuplet != cr1->tuplet()) {
+                    if (f.isValid()) { // Set rests for the previous tuplet we were dealing with
+                        setRest(tick, track, f, false, tuplet);
+                    }
+                    Tuplet* t = cr1->tuplet();
+                    if (t && ((t->tick()) >= stick1) && (((t->tick() + t->actualTicks()) <= tick2) || fullMeasure)) { // If deleting a complete tuplet
+                        // Find highest-level complete tuplet contained in range
+                        while (t->tuplet() && ((t->tuplet()->tick()) >= stick1) && ((t->tuplet()->tick() + t->tuplet()->actualTicks()) <= tick2)) {
                             t = t->tuplet();
                         }
                         cmdDeleteTuplet(t, false);
-                        f += t->ticks();
-                        tuplet = 0;
+                        tick = t->tick();
+                        f = t->ticks();
+                        tuplet = t->tuplet();
                         continue;
                     }
-                    if (f.isValid()) {
-                        setRest(tick, track, f, false, tuplet);
-                    }
+                    // Not deleting a complete tuplet
                     tick = cr1->tick();
                     tuplet = cr1->tuplet();
                     removeChordRest(cr1, true);


### PR DESCRIPTION
Resolves: #17147

First PR :)

Fixes file corruption when deleting a part of nested tuplets. The existing code for `deleteRange()` doesn't seem to consider this case.

I added checks for finding the highest-level complete tuplet _contained within the range selection_ for deletion. `setRest()` now runs whenever we move to a new tuplet since it deals with one tuplet at a time. 

I tested it manually on a variety of tuplet combinations and range selections (see attached), but I'm not sure if I'm supposed to add a unit test (maybe in `Engraving_SelectionRangeDeleteTests`?) for this. Let me know if there are any issues. 
[delete nested tuplet.mscz.zip](https://github.com/musescore/MuseScore/files/12170296/delete.nested.tuplet.mscz.zip)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
