### PR TITLE
[#18787] Fix y offset of ottava in Lines Palette

### DIFF
--- a/src/palette/internal/palettelayout.cpp
+++ b/src/palette/internal/palettelayout.cpp
@@ -1201,6 +1201,7 @@ void PaletteLayout::layout(Ottava* item, const Context& ctx)
 void PaletteLayout::layout(OttavaSegment* item, const Context& ctx)
 {
     layoutTextLineBaseSegment(item, ctx);
+    item->setOffset(PointF());
 }
 
 void PaletteLayout::layout(PalmMute* item, const Context& ctx)


### PR DESCRIPTION
Resolves: #18787

Hi! This PR fixes a regression of the ottava buttons in the Lines Palette not being vertically centered. I just added a `PointF` item offset to the `OttavaSegment` `PaletteLayout` method.

Before (current master branch):
<img width="293" alt="image" src="https://github.com/musescore/MuseScore/assets/11031519/e9ef6ded-0bdc-461a-9fdd-8486b54c09ae">


After (this PR):
<img width="295" alt="image" src="https://github.com/musescore/MuseScore/assets/11031519/9cfa4711-d08c-44de-9974-ac432a4264b8">



- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
