### PR TITLE
Make synthesizers aware of track ID

### DIFF
--- a/src/framework/audio/internal/abstractsynthesizer.cpp
+++ b/src/framework/audio/internal/abstractsynthesizer.cpp
@@ -54,6 +54,16 @@ async::Channel<AudioInputParams> AbstractSynthesizer::paramsChanged() const
     return m_paramsChanges;
 }
 
+TrackId AbstractSynthesizer::trackId() const
+{
+    return m_trackId;
+}
+
+void AbstractSynthesizer::setTrackId(TrackId trackId)
+{
+    m_trackId = trackId;
+}
+
 void AbstractSynthesizer::setup(const mpe::PlaybackData& playbackData)
 {
     ONLY_AUDIO_WORKER_THREAD;

--- a/src/framework/audio/internal/abstractsynthesizer.h
+++ b/src/framework/audio/internal/abstractsynthesizer.h
@@ -45,6 +45,9 @@ public:
     const audio::AudioInputParams& params() const override;
     async::Channel<audio::AudioInputParams> paramsChanged() const override;
 
+    TrackId trackId() const override;
+    void setTrackId(TrackId trackId) override;
+
     void setup(const mpe::PlaybackData& playbackData) override;
     void revokePlayingNotes() override;
 
@@ -65,6 +68,8 @@ protected:
     async::Channel<audio::AudioInputParams> m_paramsChanges;
 
     samples_t m_sampleRate = 0;
+
+    TrackId m_trackId = -1;
 };
 }
 

--- a/src/framework/audio/internal/synthesizers/synthresolver.cpp
+++ b/src/framework/audio/internal/synthesizers/synthresolver.cpp
@@ -66,7 +66,9 @@ ISynthesizerPtr SynthResolver::resolveSynth(const TrackId trackId, const AudioIn
         return nullptr;
     }
 
-    return resolver->resolveSynth(trackId, params);
+    ISynthesizerPtr synth = resolver->resolveSynth(trackId, params);
+    synth->setTrackId(trackId);
+    return synth;
 }
 
 ISynthesizerPtr SynthResolver::resolveDefaultSynth(const TrackId trackId) const

--- a/src/framework/audio/isynthesizer.h
+++ b/src/framework/audio/isynthesizer.h
@@ -44,6 +44,9 @@ public:
     virtual msecs_t playbackPosition() const = 0;
     virtual void setPlaybackPosition(const msecs_t newPosition) = 0;
 
+    virtual TrackId trackId() const = 0;
+    virtual void setTrackId(TrackId trackId) = 0;
+
     virtual void revokePlayingNotes() = 0;
     virtual void flushSound() = 0;
 };

--- a/src/stubs/framework/audio/synthesizerstub.cpp
+++ b/src/stubs/framework/audio/synthesizerstub.cpp
@@ -74,6 +74,16 @@ async::Channel<audio::AudioInputParams> SynthesizerStub::paramsChanged() const
     return ch;
 }
 
+TrackId SynthesizerStub::trackId() const
+{
+    return m_trackId;
+}
+
+void SynthesizerStub::setTrackId(TrackId trackId)
+{
+    m_trackId = trackId;
+}
+
 msecs_t SynthesizerStub::playbackPosition() const
 {
     return 0;

--- a/src/stubs/framework/audio/synthesizerstub.h
+++ b/src/stubs/framework/audio/synthesizerstub.h
@@ -46,6 +46,9 @@ public:
     const audio::AudioInputParams& params() const override;
     async::Channel<audio::AudioInputParams> paramsChanged() const override;
 
+    TrackId trackId() const override;
+    void setTrackId(TrackId trackId) override;
+
     msecs_t playbackPosition() const override;
     void setPlaybackPosition(const msecs_t newPosition) override;
 
@@ -58,6 +61,8 @@ public:
 
 private:
     audio::AudioInputParams m_params;
+
+    TrackId m_trackId = -1;
 };
 }
 


### PR DESCRIPTION
This is my first step of implementing piano keyboard visualization (#14428) and maybe fixing this MIDI output issue:
#12552

Making `FluidSynth` know the track ID of MIDI events will help solve the issue because in the next PR, I'll probably make it send the events using `async::Channel` and a module outside framework such as `notation` will listen to the channel. From there, the events will be sent to a MIDI device because it's possible to get information about tracks there (metronome track, chord track, etc.).

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [ ] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
