### PR TITLE
VTests: fail early if build fails

### DIFF
--- a/build/ci/vtests/build_and_pack.sh
+++ b/build/ci/vtests/build_and_pack.sh
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+trap 'echo Build failed; exit 1' ERR
+
 BUILD_TOOLS=$HOME/build_tools
 ARTIFACTS_DIR=build.artifacts
 BUILD_DIR=build.release

--- a/build/ci/vtests/generate_pngs.sh
+++ b/build/ci/vtests/generate_pngs.sh
@@ -19,14 +19,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+trap 'echo Generate PNGs failed; exit 1' ERR
+
 REF_BIN=./musescore_reference/app/bin/mscore4portable
 CUR_BIN=./musescore_current/app/bin/mscore4portable
 
 chmod +x $REF_BIN
-chmod +x ./musescore_reference/app/bin/crashpad_handler
+# chmod +x ./musescore_reference/app/bin/crashpad_handler
 
 chmod +x $CUR_BIN
-chmod +x ./musescore_current/app/bin/crashpad_handler
+# chmod +x ./musescore_current/app/bin/crashpad_handler
 
 echo reference version:
 $REF_BIN --long-version


### PR DESCRIPTION
As seen in https://github.com/musescore/MuseScore/actions/runs/5680802801?pr=18820, the "Build" job of the VTests workflow could succeed even when the build actually failed. The error would only manifest in the "Generate and compare PNGs" step, where it is difficult to understand what went wrong. 