### PR TITLE
Writing the result of running the program to stderr in case of an error

### DIFF
--- a/src/app/app.h
+++ b/src/app/app.h
@@ -23,6 +23,8 @@
 #ifndef MU_APP_APP_H
 #define MU_APP_APP_H
 
+#include <optional>
+
 #include <QList>
 
 #include "modularity/imodulesetup.h"
@@ -72,16 +74,18 @@ public:
 
     void addModule(modularity::IModuleSetup* module);
 
-    int run(int argc, char** argv);
+    Ret run(int argc, char** argv);
 
 private:
     void applyCommandLineOptions(const CommandLineParser::Options& options, framework::IApplication::RunMode runMode);
-    int processConverter(const CommandLineParser::ConverterTask& task);
-    int processDiagnostic(const CommandLineParser::Diagnostic& task);
-    int processAudioPluginRegistration(const CommandLineParser::AudioPluginRegistration& task);
+    Ret processConverter(const CommandLineParser::ConverterTask& task);
+    Ret processDiagnostic(const CommandLineParser::Diagnostic& task);
+    Ret processAudioPluginRegistration(const CommandLineParser::AudioPluginRegistration& task);
     void processAutobot(const CommandLineParser::Autobot& task);
 
     QList<modularity::IModuleSetup*> m_modules;
+
+    std::optional<Ret> m_ret;
 };
 }
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -340,7 +340,13 @@ int main(int argc, char** argv)
 
 #endif
 
-    int code = app.run(argcFinal, argvFinal);
-    LOGI() << "Goodbye!! code: " << code;
-    return code;
+    mu::Ret ret = app.run(argcFinal, argvFinal);
+    LOGI() << "Goodbye!! code: " << ret.code();
+
+    if (!ret) {
+        std::cerr << ret.toJson();
+        return 1;
+    }
+
+    return 0;
 }

--- a/src/framework/global/types/ret.cpp
+++ b/src/framework/global/types/ret.cpp
@@ -22,6 +22,8 @@
 
 #include "types/ret.h"
 
+#include "serialization/json.h"
+
 using namespace mu;
 
 Ret::Ret(bool arg)
@@ -88,4 +90,12 @@ std::any Ret::data(const std::string& key) const
 std::string Ret::toString() const
 {
     return "[" + std::to_string(m_code) + "] " + m_text;
+}
+
+std::string Ret::toJson() const
+{
+    JsonObject rootObj;
+    rootObj["code"] = m_code;
+    rootObj["message"] = m_text;
+    return JsonDocument(rootObj).toJson().constChar();
 }

--- a/src/framework/global/types/ret.h
+++ b/src/framework/global/types/ret.h
@@ -127,6 +127,7 @@ public:
     inline bool operator!() const { return !success(); }
 
     std::string toString() const;
+    std::string toJson() const;
 
 private:
     int m_code = int(Code::Undefined);


### PR DESCRIPTION
On some operating systems, such as Unix/Linux, the exit code is limited to an unsigned 8-bit number (0 to 255). We return codes much greater than 255. 
Now we are returning only 0 or 1. The error code is output to stderr as json