### PR TITLE
Fix #17599: Alt+Left/Right Navigates to Gradual Tempo Changes

### DIFF
--- a/src/engraving/libmscore/segment.cpp
+++ b/src/engraving/libmscore/segment.cpp
@@ -1711,7 +1711,7 @@ Spanner* Segment::firstSpanner(staff_idx_t activeStaff)
                 continue;
             }
             if (s->startSegment() == this) {
-                if (e->staffIdx() == activeStaff || (e->isMeasure() && activeStaff == 0)) {
+                if (e->staffIdx() == activeStaff || activeStaff == 0) {
                     return s;
                 }
             }
@@ -1736,7 +1736,7 @@ Spanner* Segment::lastSpanner(staff_idx_t activeStaff)
                 continue;
             }
             if (s->startSegment() == this) {
-                if (e->staffIdx() == activeStaff || (e->isMeasure() && activeStaff == 0)) {
+                if (e->staffIdx() == activeStaff || activeStaff == 0) {
                     return s;
                 }
             }


### PR DESCRIPTION
Resolves: #17599

Removed a condition in `segment.cpp` that checks `e->isMeasure()` in `Segment::firstSpanner` and `Segment::lastSpanner`.

Not sure if this has any unintended side effects.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
