### PR TITLE
Revert the use of static runtime AppImage

### DIFF
--- a/build/ci/linux/tools/make_appimage.sh
+++ b/build/ci/linux/tools/make_appimage.sh
@@ -44,14 +44,14 @@ function download_appimage_release()
   local -r github_repo_slug="$1" binary_name="$2" tag="$3"
   local -r appimage="${binary_name}-x86_64.AppImage"
   download_github_release "${github_repo_slug}" "${tag}" "${appimage}"
-  # extract_appimage "${appimage}" "${binary_name}"
-  mv "${appimage}" "${binary_name}"
+  extract_appimage "${appimage}" "${binary_name}"
+  # mv "${appimage}" "${binary_name}" # use this instead of the previous line for the static runtime AppImage
 }
 
 if [[ ! -d $BUILD_TOOLS/appimagetool ]]; then
   mkdir $BUILD_TOOLS/appimagetool
   cd $BUILD_TOOLS/appimagetool
-  download_appimage_release AppImage/appimagetool appimagetool continuous
+  download_appimage_release AppImage/AppImageKit appimagetool continuous # use AppImage/appimagetool for the static runtime AppImage
   cd $ORIGIN_DIR
 fi
 export PATH="$BUILD_TOOLS/appimagetool:$PATH"


### PR DESCRIPTION
This PR reverts the commit introducing the use of static runtime AppImage, because of the bad interplay between this new runtime and the AppImageLauncher. See https://github.com/musescore/MuseScore/issues/18830
When the crash is solved upstream ( https://github.com/TheAssassin/AppImageLauncher/issues/585 ), we can enable again the new runtime (which does not require the installation of additional libraries, such as libfuse2, to run)
I left as comments the (reverted) changes required for the use of the static runtime appimagetool, for future reference.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
