### PR TITLE
[engraving] Added AccidentalRenderer. Step 38

### DIFF
--- a/src/engraving/engravingmodule.cpp
+++ b/src/engraving/engravingmodule.cpp
@@ -85,7 +85,9 @@ Versions:
 *
 * see layout/README.h
 */
-    ioc()->registerExport<rendering::IScoreRenderer>(moduleName(), new rendering::dev::ScoreRenderer());
+    auto devRenderer = std::make_shared<rendering::dev::ScoreRenderer>();
+    devRenderer->setup();
+    ioc()->registerExport<rendering::IScoreRenderer>(moduleName(), devRenderer);
     //ioc()->registerExport<rendering::IScoreRenderer>(moduleName(), new layout::stable::ScoreRenderer());
 
     ioc()->registerExport<rendering::ISingleRenderer>(moduleName(), new rendering::single::SingleRenderer());

--- a/src/engraving/rendering/dev/accidentalrenderer.cpp
+++ b/src/engraving/rendering/dev/accidentalrenderer.cpp
@@ -1,0 +1,153 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2023 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "accidentalrenderer.h"
+
+#include "infrastructure/rtti.h"
+
+#include "libmscore/accidental.h"
+#include "libmscore/note.h"
+
+#include "layoutcontext.h"
+
+using namespace mu::engraving;
+using namespace mu::engraving::rendering::dev;
+using namespace mu::engraving::rtti;
+
+void AccidentalRenderer::layout(EngravingItem* item, LayoutContext& ctx) const
+{
+    layoutAccidental(item_cast<Accidental*>(item), ctx);
+}
+
+static SymId accidentalSingleSym(const Accidental* item)
+{
+    // if the accidental is standard (doubleflat, flat, natural, sharp or double sharp)
+    // and it has either no bracket or parentheses, then we have glyphs straight from smufl.
+
+    if (item->bracket() == AccidentalBracket::PARENTHESIS && !item->parentNoteHasParentheses()) {
+        switch (item->accidentalType()) {
+        case AccidentalType::FLAT:      return SymId::accidentalFlatParens;
+        case AccidentalType::FLAT2:     return SymId::accidentalDoubleFlatParens;
+        case AccidentalType::NATURAL:   return SymId::accidentalNaturalParens;
+        case AccidentalType::SHARP:     return SymId::accidentalSharpParens;
+        case AccidentalType::SHARP2:    return SymId::accidentalDoubleSharpParens;
+        default:
+            break;
+        }
+    }
+    return SymId::noSym;
+}
+
+static std::pair<SymId, SymId> accidentalBracketSyms(AccidentalBracket type)
+{
+    switch (type) {
+    case AccidentalBracket::PARENTHESIS: return { SymId::accidentalParensLeft, SymId::accidentalParensRight };
+    case AccidentalBracket::BRACKET: return { SymId::accidentalBracketLeft, SymId::accidentalBracketRight };
+    case AccidentalBracket::BRACE: return { SymId::accidentalCombiningOpenCurlyBrace, SymId::accidentalCombiningCloseCurlyBrace };
+    case AccidentalBracket::NONE: return { SymId::noSym, SymId::noSym };
+    }
+    return { SymId::noSym, SymId::noSym };
+}
+
+void AccidentalRenderer::layoutAccidental(const Accidental* item, const LayoutContext& ctx, Accidental::LayoutData& data)
+{
+    // TODO: remove Accidental in layout
+    // don't show accidentals for tab or slash notation
+    if (item->onTabStaff() || (item->note() && item->note()->fixed())) {
+        data.isSkipDraw = true;
+        return;
+    }
+
+    if (item->accidentalType() == AccidentalType::NONE) {
+        return;
+    }
+
+    // Single?
+    SymId singleSym = accidentalSingleSym(item);
+    if (singleSym != SymId::noSym && ctx.engravingFont()->isValid(singleSym)) {
+        Accidental::LayoutData::Sym s(singleSym, 0.0, 0.0);
+        data.syms.push_back(s);
+
+        data.bbox.unite(item->symBbox(singleSym));
+    }
+    // Multi
+    else {
+        double margin = ctx.conf().styleMM(Sid::bracketedAccidentalPadding);
+        double x = 0.0;
+
+        std::pair<SymId, SymId> bracketSyms;
+        bool isNeedBracket = item->bracket() != AccidentalBracket::NONE && !item->parentNoteHasParentheses();
+        if (isNeedBracket) {
+            bracketSyms = accidentalBracketSyms(item->bracket());
+        }
+
+        // Left
+        if (bracketSyms.first != SymId::noSym) {
+            Accidental::LayoutData::Sym ls(bracketSyms.first, 0.0,
+                                           item->bracket() == AccidentalBracket::BRACE ? item->spatium() * 0.4 : 0.0);
+            data.syms.push_back(ls);
+            data.bbox.unite(item->symBbox(bracketSyms.first));
+
+            x += item->symAdvance(bracketSyms.first) + margin;
+        }
+
+        // Main
+        SymId mainSym = item->symId();
+        Accidental::LayoutData::Sym ms(mainSym, x, 0.0);
+        data.syms.push_back(ms);
+        data.bbox.unite(item->symBbox(mainSym).translated(x, 0.0));
+
+        // Right
+        if (bracketSyms.second != SymId::noSym) {
+            x += item->symAdvance(mainSym) + margin;
+
+            Accidental::LayoutData::Sym rs(bracketSyms.second, x,
+                                           item->bracket() == AccidentalBracket::BRACE ? item->spatium() * 0.4 : 0.0);
+            data.syms.push_back(rs);
+            data.bbox.unite(item->symBbox(bracketSyms.second).translated(x, 0.0));
+        }
+    }
+}
+
+void AccidentalRenderer::layoutAccidental(Accidental* item, const LayoutContext& ctx)
+{
+    Accidental::LayoutData data;
+    layoutAccidental(item, ctx, data);
+    item->setLayoutData(data);
+}
+
+void AccidentalRenderer::draw(const EngravingItem* item, draw::Painter* painter) const
+{
+    draw(item_cast<const Accidental*>(item), painter);
+}
+
+void AccidentalRenderer::draw(const Accidental* item, draw::Painter* painter)
+{
+    TRACE_DRAW_ITEM;
+    if (item->layoutData().isSkipDraw) {
+        return;
+    }
+
+    painter->setPen(item->curColor());
+    for (const Accidental::LayoutData::Sym& e : item->layoutData().syms) {
+        item->drawSymbol(e.sym, painter, PointF(e.x, e.y));
+    }
+}

--- a/src/engraving/rendering/dev/accidentalrenderer.h
+++ b/src/engraving/rendering/dev/accidentalrenderer.h
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2023 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_ENGRAVING_ACCIDENTALRENDERER_H
+#define MU_ENGRAVING_ACCIDENTALRENDERER_H
+
+#include "iitemrenderer.h"
+
+#include "libmscore/accidental.h"
+
+namespace mu::engraving::rendering::dev {
+class AccidentalRenderer : public IItemRenderer
+{
+public:
+    AccidentalRenderer() = default;
+
+    void layout(EngravingItem* item, LayoutContext& ctx) const override;
+    void draw(const EngravingItem* item, draw::Painter* painter) const override;
+
+    static void layoutAccidental(Accidental* item, const LayoutContext& ctx);
+    static void layoutAccidental(const Accidental* item, const LayoutContext& ctx, Accidental::LayoutData& data);
+
+    static void draw(const Accidental* item, draw::Painter* painter);
+};
+}
+
+#endif // MU_ENGRAVING_ACCIDENTALRENDERER_H

--- a/src/engraving/rendering/dev/chordlayout.cpp
+++ b/src/engraving/rendering/dev/chordlayout.cpp
@@ -62,6 +62,8 @@
 #include "slurtielayout.h"
 #include "beamlayout.h"
 
+#include "accidentalrenderer.h"
+
 using namespace mu::engraving;
 using namespace mu::engraving::rendering::dev;
 
@@ -2304,7 +2306,7 @@ void ChordLayout::layoutChords3(const MStyle& style, const std::vector<Chord*>& 
             prevLine = note->line();
             prevSubtype = ac->subtype();
             ac->computeMag();
-            TLayout::layout(ac, ctx);
+            AccidentalRenderer::layoutAccidental(ac, ctx);
             if (!ac->visible() || note->fixed()) {
                 ac->setPos(ac->bbox().x() - ac->width(), 0.0);
             } else {

--- a/src/engraving/rendering/dev/iitemrenderer.h
+++ b/src/engraving/rendering/dev/iitemrenderer.h
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2023 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_ENGRAVING_IITEMRENDERER_H
+#define MU_ENGRAVING_IITEMRENDERER_H
+
+namespace mu::draw {
+class Painter;
+}
+
+namespace mu::engraving {
+class EngravingItem;
+}
+
+namespace mu::engraving::rendering::dev {
+class LayoutContext;
+class IItemRenderer
+{
+public:
+    virtual ~IItemRenderer() = default;
+
+    virtual void layout(EngravingItem* item, LayoutContext& ctx) const = 0;
+    virtual void draw(const EngravingItem* item, draw::Painter* painter) const = 0;
+};
+}
+
+#endif // MU_ENGRAVING_IITEMRENDERER_H

--- a/src/engraving/rendering/dev/itemrenderersregister.cpp
+++ b/src/engraving/rendering/dev/itemrenderersregister.cpp
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2023 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "itemrenderersregister.h"
+
+using namespace mu::engraving;
+using namespace mu::engraving::rendering;
+using namespace mu::engraving::rendering::dev;
+
+ItemRenderersRegister* ItemRenderersRegister::instance()
+{
+    static ItemRenderersRegister r;
+    return &r;
+}
+
+void ItemRenderersRegister::reg(ElementType type, std::shared_ptr<IItemRenderer> r)
+{
+    m_map.insert({ type, r });
+}
+
+const std::shared_ptr<IItemRenderer>& ItemRenderersRegister::renderer(ElementType type) const
+{
+    auto it = m_map.find(type);
+    if (it == m_map.end()) {
+        static std::shared_ptr<IItemRenderer> null;
+        return null;
+    }
+    return it->second;
+}

--- a/src/engraving/rendering/dev/itemrenderersregister.h
+++ b/src/engraving/rendering/dev/itemrenderersregister.h
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2023 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_ENGRAVING_ITEMRENDERERSREGISTER_H
+#define MU_ENGRAVING_ITEMRENDERERSREGISTER_H
+
+#include <unordered_map>
+
+#include "types/types.h"
+#include "iitemrenderer.h"
+
+namespace mu::engraving::rendering::dev {
+class ItemRenderersRegister
+{
+public:
+
+    static ItemRenderersRegister* instance();
+
+    void reg(ElementType type, std::shared_ptr<IItemRenderer> r);
+    const std::shared_ptr<IItemRenderer>& renderer(ElementType type) const;
+
+private:
+    ItemRenderersRegister() = default;
+
+    std::unordered_map<ElementType, std::shared_ptr<IItemRenderer> > m_map;
+};
+}
+
+#endif // MU_ENGRAVING_ITEMRENDERERSREGISTER_H

--- a/src/engraving/rendering/dev/rendering.cmake
+++ b/src/engraving/rendering/dev/rendering.cmake
@@ -45,4 +45,10 @@ set(RENDERING_DEV_SRC
     ${CMAKE_CURRENT_LIST_DIR}/arpeggiolayout.h
     ${CMAKE_CURRENT_LIST_DIR}/horizontalspacing.cpp
     ${CMAKE_CURRENT_LIST_DIR}/horizontalspacing.h
+
+    ${CMAKE_CURRENT_LIST_DIR}/iitemrenderer.h
+    ${CMAKE_CURRENT_LIST_DIR}/itemrenderersregister.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/itemrenderersregister.h
+    ${CMAKE_CURRENT_LIST_DIR}/accidentalrenderer.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/accidentalrenderer.h
 )

--- a/src/engraving/rendering/dev/scorerenderer.cpp
+++ b/src/engraving/rendering/dev/scorerenderer.cpp
@@ -37,10 +37,19 @@
 
 #include "paint.h"
 
+#include "itemrenderersregister.h"
+#include "accidentalrenderer.h"
+
 #include "log.h"
 
 using namespace mu::engraving;
 using namespace mu::engraving::rendering::dev;
+
+void ScoreRenderer::setup()
+{
+    ItemRenderersRegister* r = ItemRenderersRegister::instance();
+    r->reg(ElementType::ACCIDENTAL, std::make_shared<AccidentalRenderer>());
+}
 
 void ScoreRenderer::layoutScore(Score* score, const Fraction& st, const Fraction& et) const
 {
@@ -70,12 +79,23 @@ void ScoreRenderer::paintItem(draw::Painter& painter, const EngravingItem* item)
 void ScoreRenderer::doLayoutItem(EngravingItem* item)
 {
     LayoutContext ctx(item->score());
-    TLayout::layoutItem(item, ctx);
+
+    auto renderer = ItemRenderersRegister::instance()->renderer(item->type());
+    if (renderer) {
+        renderer->layout(item, ctx);
+    } else {
+        TLayout::layoutItem(item, ctx);
+    }
 }
 
 void ScoreRenderer::doDrawItem(const EngravingItem* item, draw::Painter* p)
 {
-    TDraw::drawItem(item, p);
+    auto renderer = ItemRenderersRegister::instance()->renderer(item->type());
+    if (renderer) {
+        renderer->draw(item, p);
+    } else {
+        TDraw::drawItem(item, p);
+    }
 }
 
 void ScoreRenderer::layoutText1(TextBase* item, bool base)

--- a/src/engraving/rendering/dev/scorerenderer.h
+++ b/src/engraving/rendering/dev/scorerenderer.h
@@ -33,6 +33,8 @@ class ScoreRenderer : public IScoreRenderer
 {
 public:
 
+    void setup();
+
     // Main interface
     void layoutScore(Score* score, const Fraction& st, const Fraction& et) const override;
 

--- a/src/engraving/rendering/dev/tdraw.cpp
+++ b/src/engraving/rendering/dev/tdraw.cpp
@@ -24,7 +24,6 @@
 #include "style/style.h"
 #include "types/typesconv.h"
 
-#include "libmscore/accidental.h"
 #include "libmscore/actionicon.h"
 #include "libmscore/ambitus.h"
 #include "libmscore/arpeggio.h"
@@ -47,8 +46,6 @@ using namespace mu::draw;
 void TDraw::drawItem(const EngravingItem* item, draw::Painter* painter)
 {
     switch (item->type()) {
-    case ElementType::ACCIDENTAL:   draw(item_cast<const Accidental*>(item), painter);
-        break;
     case ElementType::ACTION_ICON:  draw(item_cast<const ActionIcon*>(item), painter);
         break;
     case ElementType::AMBITUS:      draw(item_cast<const Ambitus*>(item), painter);
@@ -63,19 +60,6 @@ void TDraw::drawItem(const EngravingItem* item, draw::Painter* painter)
         break;
     default:
         item->draw(painter);
-    }
-}
-
-void TDraw::draw(const Accidental* item, draw::Painter* painter)
-{
-    TRACE_DRAW_ITEM;
-    if (item->layoutData().isSkipDraw) {
-        return;
-    }
-
-    painter->setPen(item->curColor());
-    for (const Accidental::LayoutData::Sym& e : item->layoutData().syms) {
-        item->drawSymbol(e.sym, painter, PointF(e.x, e.y));
     }
 }
 

--- a/src/engraving/rendering/dev/tdraw.h
+++ b/src/engraving/rendering/dev/tdraw.h
@@ -172,7 +172,6 @@ public:
     static void drawItem(const EngravingItem* item, draw::Painter* painter);      // factory
 
 private:
-    static void draw(const Accidental* item, draw::Painter* painter);
     static void draw(const ActionIcon* item, draw::Painter* painter);
     static void draw(const Ambitus* item, draw::Painter* painter);
     static void draw(const Arpeggio* item, draw::Painter* painter);

--- a/src/engraving/rendering/dev/tlayout.h
+++ b/src/engraving/rendering/dev/tlayout.h
@@ -173,7 +173,6 @@ public:
 
     static void layoutItem(EngravingItem* item, LayoutContext& ctx);  // factory
 
-    static void layout(Accidental* item, LayoutContext& ctx);
     static void layout(ActionIcon* item, LayoutContext& ctx);
     static void layout(Ambitus* item, LayoutContext& ctx);
     static void layout(Arpeggio* item, LayoutContext& ctx);


### PR DESCRIPTION
This PR shows an example of an approach we can use

We add `ItemNameRenderer`, which combines layout and draw, this gives the following advantages:
* We more simply and clearly see what is done in the layout and, accordingly, what we can use in the draw
* Semantically, we show that layout and draw are two stages of a single rendering action (position and draw)
* Semantically, for each item, we have a rendering service for this item.
* We can register these renderers in the register by type
* We can make a development version of not the entire rendering subsystem, but only certain elements (although this approach can be very difficult to manage, we need to keep this in mind)