### PR TITLE
Revert "Fix #18389: Block output to muted mixer channels"

### DIFF
--- a/src/framework/audio/internal/worker/mixerchannel.cpp
+++ b/src/framework/audio/internal/worker/mixerchannel.cpp
@@ -169,7 +169,7 @@ samples_t MixerChannel::process(float* buffer, samples_t samplesPerChannel)
 
     samples_t processedSamplesCount = samplesPerChannel;
 
-    if (m_audioSource && !m_params.muted) {
+    if (m_audioSource) {
         processedSamplesCount = m_audioSource->process(buffer, samplesPerChannel);
     }
 


### PR DESCRIPTION
Reverts musescore/MuseScore#18827

Resolves: https://github.com/musescore/MuseScore/issues/18865

I'll think about how to apply this optimization later