### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/libmscore/stretchedbend.cpp
+++ b/src/engraving/libmscore/stretchedbend.cpp
@@ -766,10 +766,10 @@ bool StretchedBend::equalBendTypes(const StretchedBend* bend1, const StretchedBe
 //   prepareBends
 //---------------------------------------------------------
 
-void StretchedBend::prepareBends(std::vector<StretchedBend*>& bends)
+void StretchedBend::prepareBends(std::vector<StretchedBend*>& strechedBends)
 {
     std::unordered_map<Chord*, std::vector<StretchedBend*> > bendsInChords;
-    for (StretchedBend* bend : bends) {
+    for (StretchedBend* bend : strechedBends) {
         // filling segments after all ties are connected
         bend->createBendSegments();
         bendsInChords[toChord(bend->parent())].push_back(bend);

--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -4429,6 +4429,7 @@ void TLayout::layout(StretchedBend* item, LayoutContext& ctx)
 
 void TLayout::layoutStretched(StretchedBend* item, LayoutContext& ctx)
 {
+    UNUSED(ctx);
     item->fillStretchedSegments(true);
     item->setbbox(item->calculateBoundingRect());
     item->setPos(0.0, 0.0);

--- a/src/engraving/rendering/stable/tlayout.cpp
+++ b/src/engraving/rendering/stable/tlayout.cpp
@@ -4306,6 +4306,7 @@ void TLayout::layout(StretchedBend* item, LayoutContext& ctx)
 
 void TLayout::layoutStretched(StretchedBend* item, LayoutContext& ctx)
 {
+    UNUSED(ctx);
     item->fillStretchedSegments(true);
     item->setbbox(item->calculateBoundingRect());
     item->setPos(0.0, 0.0);

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -1970,6 +1970,9 @@ void TRead::read(Bend* b, XmlReader& e, ReadContext& ctx)
 
 void TRead::read(StretchedBend* b, XmlReader& xml, ReadContext& ctx)
 {
+    UNUSED(b);
+    UNUSED(xml);
+    UNUSED(ctx);
     // not implemented
 }
 

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -1967,6 +1967,9 @@ void TRead::read(Bend* b, XmlReader& e, ReadContext& ctx)
 
 void TRead::read(StretchedBend* b, XmlReader& xml, ReadContext& ctx)
 {
+    UNUSED(b);
+    UNUSED(xml);
+    UNUSED(ctx);
     // not implemented
 }
 

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -558,6 +558,9 @@ void TWrite::write(const Bend* item, XmlWriter& xml, WriteContext& ctx)
 
 void TWrite::write(const StretchedBend* item, XmlWriter& xml, WriteContext& ctx)
 {
+    UNUSED(item);
+    UNUSED(xml);
+    UNUSED(ctx);
     // not implemented
 }
 


### PR DESCRIPTION
* reg. declaration hides function parameter (C4457)
* reg. unreferenced formal parameter (C4100)