### PR TITLE
Develop mei tests roundtrip

### DIFF
--- a/src/engraving/tests/utils/scorerw.cpp
+++ b/src/engraving/tests/utils/scorerw.cpp
@@ -105,6 +105,29 @@ bool ScoreRW::saveScore(Score* score, const String& name)
     return rw::RWRegister::writer()->writeScore(score, &file, false);
 }
 
+bool ScoreRW::saveScore(Score* score, const String& name, ExportFunc exportFunc)
+{
+    File file(name);
+    if (file.exists()) {
+        file.remove();
+    }
+
+    if (!file.open(IODevice::ReadWrite)) {
+        return false;
+    }
+
+    io::path_t path =  name;
+    Err rv = exportFunc(score, path);
+
+    if (rv != Err::NoError) {
+        LOGE() << "can't load score, path: " << path;
+        return false;
+    }
+    else {
+        return true;
+    }
+}
+
 EngravingItem* ScoreRW::writeReadElement(EngravingItem* element)
 {
     //

--- a/src/engraving/tests/utils/scorerw.h
+++ b/src/engraving/tests/utils/scorerw.h
@@ -40,9 +40,11 @@ public:
     static String rootPath();
 
     using ImportFunc = std::function<Err(MasterScore* score, const io::path_t& path)>;
+    using ExportFunc = std::function<Err(Score* score, const io::path_t& path)>;
 
     static MasterScore* readScore(const String& path, bool isAbsolutePath = false, ImportFunc importFunc = nullptr);
     static bool saveScore(Score* score, const String& name);
+    static bool saveScore(Score* score, const String& name, ExportFunc exportFunc);
     static EngravingItem* writeReadElement(EngravingItem* element);
     static bool saveMimeData(ByteArray mimeData, const String& saveName);
 

--- a/src/importexport/mei/internal/meiconverter.cpp
+++ b/src/importexport/mei/internal/meiconverter.cpp
@@ -966,6 +966,7 @@ libmei::Fermata Convert::fermataToMEI(const engraving::Fermata* fermata)
         break;
     case (engraving::SymId::fermataShortBelow): meiFermata.SetShape(libmei::fermataVis_SHAPE_angular);
         below = true;
+        break;
     case (engraving::SymId::fermataLongHenzeAbove):
     case (engraving::SymId::fermataVeryLongAbove):
     case (engraving::SymId::fermataShortHenzeAbove):

--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -72,11 +72,8 @@ using namespace mu::engraving;
  * Return false on error.
  */
 
-bool MeiExporter::write(QIODevice& destinationDevice)
+bool MeiExporter::write(std::string& meiData)
 {
-    // Still using QTextStream since we have a QIODevice
-    QTextStream out(&destinationDevice);
-
     m_hasSections = false;
 
     m_sectionCounter = 0;
@@ -130,7 +127,7 @@ bool MeiExporter::write(QIODevice& destinationDevice)
         std::string indent = MEI_INDENT ? std::string(MEI_INDENT, ' ') : "\t";
         std::stringstream strStream;
         meiDoc.save(strStream, indent.c_str(), output_flags);
-        out << String::fromStdString(strStream.str());
+        meiData = strStream.str();
     }
     catch (char* str) {
         UNUSED(str);
@@ -138,7 +135,6 @@ bool MeiExporter::write(QIODevice& destinationDevice)
         return false;
     }
 
-    out.flush();
     return true;
 }
 

--- a/src/importexport/mei/internal/meiexporter.h
+++ b/src/importexport/mei/internal/meiexporter.h
@@ -73,7 +73,7 @@ class MeiExporter
 
 public:
     MeiExporter(engraving::Score* s) { m_score = s; }
-    bool write(QIODevice& destinationDevice);
+    bool write(std::string& meiData);
 
 private:
     bool writeHeader();

--- a/src/importexport/mei/internal/meiwriter.cpp
+++ b/src/importexport/mei/internal/meiwriter.cpp
@@ -70,11 +70,11 @@ mu::Ret MeiWriter::write(notation::INotationPtr notation, QIODevice& destination
     }
 }
 
-Err MeiWriter::writeScore(mu::engraving::MasterScore* score, const io::path_t& path)
+Err MeiWriter::writeScore(mu::engraving::Score* score, const io::path_t& path)
 {
     MeiExporter exporter(score);
     std::string meiData;
-    if (exporter.write(meiData) && !io::File::writeFile(path, ByteArray(meiData.c_str(), meiData.size()))) {
+    if (exporter.write(meiData) && (io::File::writeFile(path, ByteArray(meiData.c_str(), meiData.size())) == make_ok())) {
         return Err::NoError;
     } else {
         return Err::UnknownError;

--- a/src/importexport/mei/internal/meiwriter.h
+++ b/src/importexport/mei/internal/meiwriter.h
@@ -23,6 +23,7 @@
 #define MU_IMPORTEXPORT_MEIWRITER_H
 
 #include "project/inotationwriter.h"
+#include "engravingerrors.h"
 
 namespace mu::iex::mei {
 class MeiWriter : public project::INotationWriter
@@ -33,6 +34,7 @@ public:
 
     Ret write(notation::INotationPtr notation, QIODevice& destinationDevice, const Options& options = Options()) override;
     Ret writeList(const notation::INotationPtrList& notations, QIODevice& destinationDevice, const Options& options = Options()) override;
+    mu::engraving::Err writeScore(mu::engraving::MasterScore* score, const io::path_t& path);
 };
 } // namespace
 

--- a/src/importexport/mei/internal/meiwriter.h
+++ b/src/importexport/mei/internal/meiwriter.h
@@ -34,7 +34,7 @@ public:
 
     Ret write(notation::INotationPtr notation, QIODevice& destinationDevice, const Options& options = Options()) override;
     Ret writeList(const notation::INotationPtrList& notations, QIODevice& destinationDevice, const Options& options = Options()) override;
-    mu::engraving::Err writeScore(mu::engraving::MasterScore* score, const io::path_t& path);
+    mu::engraving::Err writeScore(mu::engraving::Score* score, const io::path_t& path);
 };
 } // namespace
 

--- a/src/importexport/mei/tests/mei_tests.cpp
+++ b/src/importexport/mei/tests/mei_tests.cpp
@@ -33,11 +33,13 @@
 #include "modularity/ioc.h"
 #include "importexport/mei/imeiconfiguration.h"
 #include "importexport/mei/internal/meireader.h"
+#include "importexport/mei/internal/meiwriter.h"
 
 using namespace mu;
 using namespace mu::engraving;
 
 static const String MEI_DIR(u"data/");
+static const String TMP_DIR(u"tmp/");
 
 namespace mu::iex::mei {
 class Mei_Tests : public ::testing::Test
@@ -58,6 +60,12 @@ void Mei_Tests::meiReadTest(const char* file, const char* ext)
         return meiReader.import(score, path);
     };
 
+    auto exportFunc = [](Score* score, const io::path_t& path) -> Err {
+        MeiWriter meiWriter;
+        return meiWriter.writeScore(score, path);
+    };
+
+    // Load the .mei file
     MasterScore* score = ScoreRW::readScore(MEI_DIR + fileName + u"." + String::fromUtf8(ext), false, importFunc);
     EXPECT_TRUE(score);
 
@@ -68,8 +76,18 @@ void Mei_Tests::meiReadTest(const char* file, const char* ext)
         return;
     }
 
-    EXPECT_TRUE(ScoreComp::saveCompareScore(score, fileName + u".mscx", MEI_DIR + fileName + u".mscx"));
+    // Save the .mei file to the ./tmp directory for round trip testing
+    bool output = ScoreRW::saveScore(score, ScoreRW::rootPath() + u"/" + TMP_DIR + fileName + u".mei", exportFunc);
+    EXPECT_TRUE(output);
     delete score;
+
+    // Reload the generated .mei file
+    MasterScore* score2 = ScoreRW::readScore(TMP_DIR + fileName + u".mei", false, importFunc);
+    EXPECT_TRUE(score2);
+
+    // Compare with the reference MuseScore file
+    EXPECT_TRUE(ScoreComp::saveCompareScore(score2, fileName + u".mscx", MEI_DIR + fileName + u".mscx"));
+    delete score2;
 }
 
 TEST_F(Mei_Tests, meiAccid01) {


### PR DESCRIPTION
This PR adds a ScoreRW::saveScore methods that takes an `exportFunc` parameter for writing a temporary file using a specific exporter.

This allows for round-trip (import and export) testing in the unit test.

It used in the MEI tests as follow:
* Import a test MEI file
* Export it again to MEI 
* Re-import it
* Compare with the MuseScore reference file