### PR TITLE
Fix GH#15426: Bring back the Save button (master)

### DIFF
--- a/src/appshell/view/publish/publishtoolbarmodel.cpp
+++ b/src/appshell/view/publish/publishtoolbarmodel.cpp
@@ -36,7 +36,8 @@ void PublishToolBarModel::load()
         "print",
         "file-publish",
         "file-share-audio",
-        "file-export"
+        "file-export",
+        "file-save"
     };
 
     ToolBarItemList items;

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -2790,6 +2790,15 @@ const muse::ui::ToolConfig& NotationUiActions::defaultNoteInputBarConfig()
     static ToolConfig config;
     if (!config.isValid()) {
         config.items = {
+            { "file-new", false },
+            { "file-open", false },
+            //{ "file-export", false }, // not in Mu3's file operations toolbar
+            { "file-save", false },
+            { "file-publish", false },
+            { "print", false },
+            //{ "undo", false }, // needs more work, to enable/disable as appropriate
+            //{ "redo", false }, // needs more work, to enable/disable as appropriate
+            { "", true },
             { "note-input", true },
             { "pad-note-1024", false },
             { "pad-note-512", false },

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -61,19 +61,22 @@ const UiActionList ProjectUiActions::m_actions = {
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "Save &as…"),
-             TranslatableString("action", "Save as…")
+             TranslatableString("action", "Save as…"),
+             IconCode::Code::SAVE
              ),
     UiAction("file-save-a-copy",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "Save a cop&y…"),
-             TranslatableString("action", "Save a copy…")
+             TranslatableString("action", "Save a copy…"),
+             IconCode::Code::SAVE
              ),
     UiAction("file-save-selection",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "Save se&lection…"),
-             TranslatableString("action", "Save selection…")
+             TranslatableString("action", "Save selection…"),
+             IconCode::Code::SAVE
              ),
     UiAction("file-save-to-cloud",
              mu::context::UiCtxAny,


### PR DESCRIPTION
and also add the Save icon to "Save as", "Save a copy" and "Save selection"

Resolves: #15426
Resolves: #18896

1. ![Screenshot 2023-08-02 111420](https://github.com/musescore/MuseScore/assets/1786669/f31b3760-6326-47cf-ad32-7e896947b020)
2. ![Screenshot 2023-08-02 130118](https://github.com/musescore/MuseScore/assets/1786669/e5e5f830-dd8c-4ca2-adb1-608a6008b906)
3. ![image](https://github.com/musescore/MuseScore/assets/1786669/84184839-1c94-4f1e-b330-d77a7228b6c8)

See also the (lengthy and heated!) discussion in https://musescore.org/en/node/338612