### PR TITLE
Fix #18577: Harp pedal pitch feedback uses tpc instead of MIDI pitch

### DIFF
--- a/src/engraving/libmscore/harppedaldiagram.cpp
+++ b/src/engraving/libmscore/harppedaldiagram.cpp
@@ -70,32 +70,32 @@ static const ElementStyle harpPedalTextDiagramStyle {
 };
 
 // HarpPedalDiagram
-void HarpPedalDiagram::setPlayablePitches()
+void HarpPedalDiagram::setPlayableTpcs()
 {
-    std::set<int> playablePitches;
-    static const std::map<HarpStringType, int> string2pitch = {
+    std::set<int> playableTpcs;
+    static const std::map<HarpStringType, int> string2step = {
         { HarpStringType::C, 0 },
-        { HarpStringType::D, 2 },
-        { HarpStringType::E, 4 },
-        { HarpStringType::F, 5 },
-        { HarpStringType::G, 7 },
-        { HarpStringType::A, 9 },
-        { HarpStringType::B, 11 }
+        { HarpStringType::D, 1 },
+        { HarpStringType::E, 2 },
+        { HarpStringType::F, 3 },
+        { HarpStringType::G, 4 },
+        { HarpStringType::A, 5 },
+        { HarpStringType::B, 6 }
     };
-    static const std::map<PedalPosition, int> position2delta = {
-        { PedalPosition::FLAT, -1 },
-        { PedalPosition::NATURAL, 0 },
-        { PedalPosition::SHARP, 1 }
+    static const std::map<PedalPosition, AccidentalVal> position2accidentalVal = {
+        { PedalPosition::FLAT, AccidentalVal::FLAT },
+        { PedalPosition::NATURAL, AccidentalVal::NATURAL },
+        { PedalPosition::SHARP, AccidentalVal::SHARP }
     };
 
     for (size_t i = 0; i < _pedalState.size(); i++) {
-        int stringPitch = string2pitch.at(HarpStringType(i));
-        int delta = position2delta.at(_pedalState[i]);
-        int resPitch = (stringPitch + delta + 12) % 12;
-        playablePitches.insert(resPitch);
+        int stringStep = string2step.at(HarpStringType(i));
+        AccidentalVal accidentalVal = position2accidentalVal.at(_pedalState[i]);
+        int resTpc = step2tpc(stringStep, accidentalVal);
+        playableTpcs.insert(resTpc);
     }
 
-    _playablePitches = playablePitches;
+    _playableTpcs = playableTpcs;
 }
 
 HarpPedalDiagram::HarpPedalDiagram(Segment* parent)
@@ -106,7 +106,7 @@ HarpPedalDiagram::HarpPedalDiagram(Segment* parent)
         = std::array<PedalPosition, HARP_STRING_NO> { PedalPosition::NATURAL, PedalPosition::NATURAL, PedalPosition::NATURAL,
                                                       PedalPosition::NATURAL,
                                                       PedalPosition::NATURAL, PedalPosition::NATURAL, PedalPosition::NATURAL };
-    setPlayablePitches();
+    setPlayableTpcs();
 }
 
 HarpPedalDiagram::HarpPedalDiagram(const HarpPedalDiagram& h)
@@ -114,13 +114,13 @@ HarpPedalDiagram::HarpPedalDiagram(const HarpPedalDiagram& h)
 {
     _pedalState = h._pedalState;
     _isDiagram = h._isDiagram;
-    setPlayablePitches();
+    setPlayableTpcs();
 }
 
 void HarpPedalDiagram::setPedalState(std::array<PedalPosition, HARP_STRING_NO> state)
 {
     _pedalState = state;
-    setPlayablePitches();
+    setPlayableTpcs();
 }
 
 void HarpPedalDiagram::setIsDiagram(bool diagram)
@@ -140,7 +140,7 @@ void HarpPedalDiagram::setIsDiagram(bool diagram)
 void HarpPedalDiagram::setPedal(HarpStringType harpString, PedalPosition pedal)
 {
     _pedalState.at(harpString) = pedal;
-    setPlayablePitches();
+    setPlayableTpcs();
 }
 
 String HarpPedalDiagram::createDiagramText()
@@ -244,9 +244,9 @@ void HarpPedalDiagram::updateDiagramText()
     undoChangeProperty(Pid::TEXT, createDiagramText(), PropertyFlags::STYLED);
 }
 
-bool HarpPedalDiagram::isPitchPlayable(int pitch)
+bool HarpPedalDiagram::isTpcPlayable(int tpc)
 {
-    return _playablePitches.find(pitch % 12) != _playablePitches.cend();
+    return _playableTpcs.find(tpc) != _playableTpcs.cend();
 }
 
 PropertyValue HarpPedalDiagram::getProperty(Pid propertyId) const

--- a/src/engraving/libmscore/harppedaldiagram.h
+++ b/src/engraving/libmscore/harppedaldiagram.h
@@ -76,18 +76,18 @@ public:
 
     void setPedal(HarpStringType harpString, PedalPosition pedal);
 
-    void setPlayablePitches();
+    void setPlayableTpcs();
 
     String createDiagramText();
     void updateDiagramText();
 
-    bool isPitchPlayable(int pitch);
+    bool isTpcPlayable(int tpc);
 
 private:
 
     std::array<PedalPosition, HARP_STRING_NO> _pedalState;
 
-    std::set<int> _playablePitches;
+    std::set<int> _playableTpcs;
 
     bool _isDiagram = true;
 };

--- a/src/engraving/rendering/dev/tdraw.cpp
+++ b/src/engraving/rendering/dev/tdraw.cpp
@@ -2201,7 +2201,7 @@ void TDraw::draw(const Note* item, Painter* painter)
         if (item->chord() && item->chord()->segment() && item->staff() && !item->score()->printing()
             && !item->staff()->isDrumStaff(item->chord()->tick())) {
             HarpPedalDiagram* prevDiagram = item->part()->currentHarpDiagram(item->chord()->segment()->tick());
-            if (prevDiagram && !prevDiagram->isPitchPlayable(item->ppitch())) {
+            if (prevDiagram && !prevDiagram->isTpcPlayable(item->tpc())) {
                 painter->setPen(item->selected() ? config->criticalSelectedColor() : config->criticalColor());
             }
         }

--- a/src/engraving/rendering/single/singledraw.cpp
+++ b/src/engraving/rendering/single/singledraw.cpp
@@ -522,7 +522,7 @@ void SingleDraw::draw(const Note* item, Painter* painter)
         if (item->chord() && item->chord()->segment() && item->staff() && !item->score()->printing()
             && !item->staff()->isDrumStaff(item->chord()->tick())) {
             HarpPedalDiagram* prevDiagram = item->part()->currentHarpDiagram(item->chord()->segment()->tick());
-            if (prevDiagram && !prevDiagram->isPitchPlayable(item->ppitch())) {
+            if (prevDiagram && !prevDiagram->isTpcPlayable(item->tpc())) {
                 painter->setPen(item->selected() ? config->criticalSelectedColor() : config->criticalColor());
             }
         }

--- a/src/engraving/rendering/stable/tdraw.cpp
+++ b/src/engraving/rendering/stable/tdraw.cpp
@@ -2200,7 +2200,7 @@ void TDraw::draw(const Note* item, Painter* painter)
         if (item->chord() && item->chord()->segment() && item->staff() && !item->score()->printing()
             && !item->staff()->isDrumStaff(item->chord()->tick())) {
             HarpPedalDiagram* prevDiagram = item->part()->currentHarpDiagram(item->chord()->segment()->tick());
-            if (prevDiagram && !prevDiagram->isPitchPlayable(item->ppitch())) {
+            if (prevDiagram && !prevDiagram->isTpcPlayable(item->tpc())) {
                 painter->setPen(item->selected() ? config->criticalSelectedColor() : config->criticalColor());
             }
         }

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -2834,7 +2834,7 @@ void TRead::read(HarpPedalDiagram* h, XmlReader& xml, ReadContext& ctx)
                     xml.unknown();
                 }
             }
-            h->setPlayablePitches();
+            h->setPlayableTpcs();
         } else if (!readProperties(h, xml, ctx)) {
             xml.unknown();
         }

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -2863,7 +2863,7 @@ void TRead::read(HarpPedalDiagram* h, XmlReader& xml, ReadContext& ctx)
                     xml.unknown();
                 }
             }
-            h->setPlayablePitches();
+            h->setPlayableTpcs();
         } else if (!readProperties(h, xml, ctx)) {
             xml.unknown();
         }

--- a/src/engraving/tests/harpdiagram_tests.cpp
+++ b/src/engraving/tests/harpdiagram_tests.cpp
@@ -30,6 +30,7 @@
 #include "libmscore/part.h"
 #include "libmscore/segment.h"
 #include "libmscore/undo.h"
+#include "libmscore/pitchspelling.h"
 
 #include "utils/scorerw.h"
 #include "utils/scorecomp.h"
@@ -68,8 +69,9 @@ TEST_F(Engraving_HarpDiagramTests, harpdiagram)
     diagram->setPedal(HarpStringType::C, PedalPosition::SHARP);
 
     d = toHarpPedalDiagram((ScoreRW::writeReadElement(diagram)));
-    EXPECT_FALSE(d->isPitchPlayable(60));
-    EXPECT_TRUE(d->isPitchPlayable(61));
+    EXPECT_FALSE(d->isTpcPlayable(Tpc::TPC_C));
+    EXPECT_TRUE(d->isTpcPlayable(Tpc::TPC_C_S));
+    EXPECT_FALSE(d->isTpcPlayable(Tpc::TPC_D_B));
     delete d;
 }
 


### PR DESCRIPTION
Resolves: #18577 

<!-- Add a short description of and motivation for the changes here -->

The check for playable pitches used MIDI pitch numbers so it couldn’t see any difference between f. e. an F♯ and a G♭. Using the Tpc (tonal pitch class) enum instead solves this issue.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
