### PR TITLE
Allow more flexibility for Spanners to compute start and end segment

### DIFF
--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -1504,6 +1504,12 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                 }
             }
         }
+        for (Segment& seg : nm->segments()) {
+            seg.checkEmpty();
+            if (seg.empty()) {
+                score->undoRemoveElement(&seg);
+            }
+        }
     }
 
     for (auto i : oscore->spanner()) {

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -565,7 +565,7 @@ public:
     Segment* tick2segmentMM(const Fraction& tick, bool first, SegmentType st) const;
     Segment* tick2segmentMM(const Fraction& tick) const;
     Segment* tick2segmentMM(const Fraction& tick, bool first) const;
-    Segment* tick2leftSegment(const Fraction& tick, bool useMMrest = false) const;
+    Segment* tick2leftSegment(const Fraction& tick, bool useMMrest = false, bool anySegmentType = false) const;
     Segment* tick2rightSegment(const Fraction& tick, bool useMMrest = false) const;
     Segment* tick2leftSegmentMM(const Fraction& tick) { return tick2leftSegment(tick, /* useMMRest */ true); }
 

--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -987,7 +987,11 @@ ChordRest* Spanner::findEndCR() const
 Segment* Spanner::startSegment() const
 {
     assert(score() != NULL);
-    return score()->tick2rightSegment(tick(), style().styleB(Sid::createMultiMeasureRests));
+    Segment* rightSegment = score()->tick2rightSegment(tick(), style().styleB(Sid::createMultiMeasureRests));
+    if (rightSegment && rightSegment->tick() < tick2()) {
+        return rightSegment;
+    }
+    return score()->tick2leftSegment(tick(), style().styleB(Sid::createMultiMeasureRests));
 }
 
 //---------------------------------------------------------
@@ -996,7 +1000,7 @@ Segment* Spanner::startSegment() const
 
 Segment* Spanner::endSegment() const
 {
-    return score()->tick2leftSegment(tick2(), style().styleB(Sid::createMultiMeasureRests));
+    return score()->tick2leftSegment(tick2(), style().styleB(Sid::createMultiMeasureRests), systemFlag());
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -205,16 +205,18 @@ Segment* Score::tick2segment(const Fraction& tick, bool first) const
 /// the first segment *before* this tick position
 //---------------------------------------------------------
 
-Segment* Score::tick2leftSegment(const Fraction& tick, bool useMMrest) const
+Segment* Score::tick2leftSegment(const Fraction& tick, bool useMMrest, bool anySegmentType) const
 {
     Measure* m = useMMrest ? tick2measureMM(tick) : tick2measure(tick);
     if (m == 0) {
         LOGD("tick2leftSegment(): not found tick %d", tick.ticks());
         return 0;
     }
+
     // loop over all segments
+    SegmentType segmentType = anySegmentType ? SegmentType::All : SegmentType::ChordRest;
     Segment* ps = 0;
-    for (Segment* s = m->first(SegmentType::ChordRest); s; s = s->next(SegmentType::ChordRest)) {
+    for (Segment* s = m->first(segmentType); s; s = s->next(segmentType)) {
         if (tick < s->tick()) {
             return ps;
         } else if (tick == s->tick()) {


### PR DESCRIPTION
Resolves: #18644 

As @cbjeukendrup said, the definitive solution to these kinds of bugs will come when we do #16796. In the meantime, this is still a good thing to do, i.e. make spanners more flexible when computing their start/end segment.
