### PR TITLE
Fix #13025: Added play option for chordlines/slides (fall, doit, etc.)

### DIFF
--- a/src/engraving/libmscore/chordline.cpp
+++ b/src/engraving/libmscore/chordline.cpp
@@ -278,6 +278,8 @@ PropertyValue ChordLine::getProperty(Pid propertyId) const
         return m_straight;
     case Pid::CHORD_LINE_WAVY:
         return m_wavy;
+    case Pid::PLAY:
+        return m_playChordLine;
     default:
         break;
     }
@@ -303,6 +305,9 @@ bool ChordLine::setProperty(Pid propertyId, const PropertyValue& val)
     case Pid::CHORD_LINE_WAVY:
         setWavy(val.toBool());
         break;
+    case Pid::PLAY:
+        setPlayChordLine(val.toBool());
+        break;
     default:
         return EngravingItem::setProperty(propertyId, val);
     }
@@ -321,6 +326,8 @@ PropertyValue ChordLine::propertyDefault(Pid pid) const
         return false;
     case Pid::CHORD_LINE_WAVY:
         return false;
+    case Pid::PLAY:
+        return true;
     default:
         break;
     }

--- a/src/engraving/libmscore/chordline.h
+++ b/src/engraving/libmscore/chordline.h
@@ -91,6 +91,9 @@ public:
     bool isToTheLeft() const { return m_chordLineType == ChordLineType::PLOP || m_chordLineType == ChordLineType::SCOOP; }
     bool isBelow() const { return m_chordLineType == ChordLineType::SCOOP || m_chordLineType == ChordLineType::FALL; }
 
+    bool playChordLine() const { return m_playChordLine; }
+    void setPlayChordLine(bool val) { m_playChordLine = val; }
+
     void setNote(Note* note);
     Note* note() const { return m_note; }
 
@@ -109,6 +112,7 @@ private:
     bool m_modified = false;
     double m_lengthX = 0.0;
     double m_lengthY = 0.0;
+    bool m_playChordLine = true;
     Note* m_note = nullptr;
 };
 } // namespace mu::engraving

--- a/src/engraving/playback/metaparsers/chordarticulationsparser.cpp
+++ b/src/engraving/playback/metaparsers/chordarticulationsparser.cpp
@@ -189,7 +189,7 @@ void ChordArticulationsParser::parseChordLine(const Chord* chord, const Renderin
 {
     const ChordLine* chordLine = chord->chordLine();
 
-    if (!chordLine) {
+    if (!chordLine || !chordLine->playChordLine()) {
         return;
     }
 

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -2574,6 +2574,8 @@ void TRead::read(ChordLine* l, XmlReader& e, ReadContext& ctx)
             l->setLengthX(e.readInt());
         } else if (tag == "lengthY") {
             l->setLengthY(e.readInt());
+        } else if (tag == "play") {
+            l->setPlayChordLine(e.readBool());
         } else if (tag == "offset" && l->score()->mscVersion() < 400) { // default positions has changed in 4.0 so ignore previous offset
             e.skipCurrentElement();
         } else if (!readItemProperties(l, e, ctx)) {

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -851,6 +851,7 @@ void TWrite::write(const ChordLine* item, XmlWriter& xml, WriteContext& ctx)
     writeProperty(item, xml, Pid::CHORD_LINE_TYPE);
     writeProperty(item, xml, Pid::CHORD_LINE_STRAIGHT);
     writeProperty(item, xml, Pid::CHORD_LINE_WAVY);
+    writeProperty(item, xml, Pid::PLAY);
     xml.tag("lengthX", item->lengthX(), 0.0);
     xml.tag("lengthY", item->lengthY(), 0.0);
     writeItemProperties(item, xml, ctx);


### PR DESCRIPTION
Resolves: #13025

Slides aren't working very well currently so users should be able to disable them without the parent note also being disabled.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
