### PR TITLE
fix #18906 preserve keyList if removes all instruments

### DIFF
--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -62,12 +62,14 @@ void MasterNotationParts::setParts(const PartInstrumentList& partList, const Sco
 {
     TRACEFUNC;
 
+    mu::engraving::KeyList keyList = score()->keyList();
+
     endInteractionWithScore();
     startGlobalEdit();
 
     doSetScoreOrder(order);
     removeMissingParts(partList);
-    insertNewParts(partList);
+    insertNewParts(partList, keyList);
     updateSoloist(partList);
     sortParts(partList);
     setBracketsAndBarlines();

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -1016,12 +1016,11 @@ void NotationParts::removeMissingParts(const PartInstrumentList& newParts)
     doRemoveParts(partsToRemove);
 }
 
-void NotationParts::insertNewParts(const PartInstrumentList& parts)
+void NotationParts::insertNewParts(const PartInstrumentList& parts, const mu::engraving::KeyList& keyList)
 {
     TRACEFUNC;
 
     size_t partIdx = 0;
-    mu::engraving::KeyList keyList = score()->keyList();
 
     for (const PartInstrument& pi: parts) {
         if (pi.isExistingPart) {
@@ -1054,6 +1053,12 @@ void NotationParts::insertNewParts(const PartInstrumentList& parts)
 
         m_partChangedNotifier.itemAdded(part);
     }
+}
+
+void NotationParts::insertNewParts(const PartInstrumentList& parts)
+{
+    TRACEFUNC;
+    insertNewParts(parts, score()->keyList());
 }
 
 void NotationParts::updateSoloist(const PartInstrumentList& parts)

--- a/src/notation/internal/notationparts.h
+++ b/src/notation/internal/notationparts.h
@@ -110,6 +110,7 @@ private:
     void initStaff(Staff* staff, const InstrumentTemplate& templ, const mu::engraving::StaffType* staffType, size_t cleffIndex);
 
     void removeMissingParts(const PartInstrumentList& newParts);
+    void insertNewParts(const PartInstrumentList& parts, const mu::engraving::KeyList& keyList);
     void insertNewParts(const PartInstrumentList& parts);
     void updateSoloist(const PartInstrumentList& parts);
     void sortParts(const PartInstrumentList& parts);


### PR DESCRIPTION
preserve keyList if removes all instruments and add diferent one in instruments dialog

Resolves: #18906 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
score keyList is red from existing staves, but if user removes all staves in instruments dialog, there is nothing to read keyList from.

This PR just simply reads keyList in masternotationparts before removing instruments.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
