### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -5781,7 +5781,7 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
             if (isSystemLine) {
                 Spanner* nsp = toSpanner(ne);
                 Spanner* sp = toSpanner(element);
-                int diff = sp->track2() - sp->track();
+                long long diff = sp->track2() - sp->track();
                 nsp->setTrack2(nsp->track() + diff);
                 nsp->computeStartElement();
                 nsp->computeEndElement();


### PR DESCRIPTION
reg. conversion from 'size_t' to 'int', possible loss of data (C4267)