### PR TITLE
fix #18968 - correct tpc2 when pasting note to chordrest

### DIFF
--- a/src/engraving/libmscore/chordrest.cpp
+++ b/src/engraving/libmscore/chordrest.cpp
@@ -250,6 +250,11 @@ EngravingItem* ChordRest::drop(EditData& data)
 
     case ElementType::NOTE: {
         Note* note = toNote(e);
+        // calculate correct transposed tpc
+        Interval v = staff()->transpose(tick());
+        v.flip();
+        note->setTpc2(transposeTpc(note->tpc1(), v, true));
+
         Segment* seg = segment();
         score()->undoRemoveElement(this);
         Chord* chord = Factory::createChord(score()->dummy()->segment());


### PR DESCRIPTION
Resolves: #18968 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
When pasting note to chordrest between instruments with different transposition, tpc2 needs to be recalculated.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
