### PR TITLE
Add EngravingItem::_uid for preserving MEI IDs

### DIFF
--- a/src/engraving/libmscore/engravingitem.h
+++ b/src/engraving/libmscore/engravingitem.h
@@ -270,7 +270,7 @@ public:
     bool skipDraw() const { return _skipDraw; }
     void setSkipDraw(bool val) { _skipDraw = val; }
     const String& uid() const { return _uid; }
-    void setUid(String val) { _uid = val; }
+    void setUid(const String& val) { _uid = val; }
 
     virtual PointF pagePos() const;            ///< position in page coordinates
     virtual PointF canvasPos() const;          ///< position in canvas coordinates

--- a/src/engraving/libmscore/engravingitem.h
+++ b/src/engraving/libmscore/engravingitem.h
@@ -149,6 +149,7 @@ class EngravingItem : public EngravingObject
     ///< valid after call to layout()
 
     bool m_colorsInversionEnabled = true;
+    String _uid;    ///< Unique ID from MEI imported files, not copied in copy constructor
 
 protected:
     mutable int _z;
@@ -268,6 +269,8 @@ public:
     virtual void move(const PointF& s) { _pos += s; }
     bool skipDraw() const { return _skipDraw; }
     void setSkipDraw(bool val) { _skipDraw = val; }
+    const String& uid() const { return _uid; }
+    void setUid(String val) { _uid = val; }
 
     virtual PointF pagePos() const;            ///< position in page coordinates
     virtual PointF canvasPos() const;          ///< position in canvas coordinates


### PR DESCRIPTION
This PR is adding a EngravingItem member for preserving MEI xml:ids when the files are loading and edited in MuseScore.

This is meant to be as light way as possible and, as it is, the xml:ids would be preserved only in memory and not in the MuseScore files.

Because the xml:ids are meant to be unique, the member is deliberately not copied in the copy constructor. For new objects, including copied ones, a new xml:id will be generated on export.
