### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/framework/global/dataformatter.cpp
+++ b/src/framework/global/dataformatter.cpp
@@ -100,5 +100,5 @@ String DataFormatter::formatFileSize(size_t size)
     }
 
     //: Used to indicate file size. Ideally, keep the translation short; feel free to use an abbreviation.
-    return mtrc("global", "%n bytes", "", size);
+    return mtrc("global", "%n byte(s)", nullptr, int(size));
 }


### PR DESCRIPTION
reg. conversion from 'size_t' to 'int', possible loss of data (C4267)