### PR TITLE
Home > Scores: display a dash instead of nothing if file size can't be retrieved

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/CloudScoresListView.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/CloudScoresListView.qml
@@ -198,7 +198,7 @@ ScoresListView {
 
             delegate: StyledTextLabel {
                 id: sizeLabel
-                text: score.fileSize ?? ""
+                text: Boolean(score.fileSize) ? score.fileSize : "-"
 
                 font: ui.theme.largeBodyFont
                 horizontalAlignment: Text.AlignLeft
@@ -210,7 +210,7 @@ ScoresListView {
                         row: navigationRow
                         column: navigationColumnStart
                         enabled: sizeLabel.visible && sizeLabel.enabled && !sizeLabel.isEmpty
-                        accessible.name: sizeColumn.header + ": " + sizeLabel.text
+                        accessible.name: sizeColumn.header + ": " + (Boolean(score.fileSize) ? score.fileSize : qsTrc("global", "Unknown"))
                         accessible.role: MUAccessible.StaticText
 
                         onActiveChanged: {

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/RecentScoresView.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/RecentScoresView.qml
@@ -149,7 +149,7 @@ ScoresView {
 
                     delegate: StyledTextLabel {
                         id: sizeLabel
-                        text: score.fileSize ?? ""
+                        text: Boolean(score.fileSize) ? score.fileSize : "-"
 
                         font: ui.theme.largeBodyFont
                         horizontalAlignment: Text.AlignLeft
@@ -161,7 +161,7 @@ ScoresView {
                                 row: navigationRow
                                 column: navigationColumnStart
                                 enabled: sizeLabel.visible && sizeLabel.enabled && !sizeLabel.isEmpty
-                                accessible.name: sizeColumn.header + ": " + sizeLabel.text
+                                accessible.name: sizeColumn.header + ": " + (Boolean(score.fileSize) ? score.fileSize : qsTrc("global", "Unknown"))
                                 accessible.role: MUAccessible.StaticText
 
                                 onActiveChanged: {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/pull/18853#issuecomment-1671059224