### PR TITLE
[build] Returned USE_SYSTEM_FREETYPE option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ option(MUE_COMPILE_USE_PCH "Use precompiled headers." ON)
 option(MUE_COMPILE_USE_UNITY "Use unity build." ON)
 option(MUE_COMPILE_USE_CCACHE "Try use ccache" ON)
 option(MUE_COMPILE_USE_SHARED_LIBS_IN_DEBUG "Build shared libs if possible in debug" OFF)
+option(MUE_COMPILE_USE_SYSTEM_FREETYPE "Try use system freetype" OFF) # Important for the maintainer of Linux distributions
 
 # === Debug ===
 option(MUE_ENABLE_LOGGER_DEBUGLEVEL "Enable logging debug level" ON)

--- a/build/cmake/SetupFreeType.cmake
+++ b/build/cmake/SetupFreeType.cmake
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-CLA-applies
+#
+# MuseScore
+# Music Composition & Notation
+#
+# Copyright (C) 2023 MuseScore BVBA and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+if (MUE_COMPILE_USE_SYSTEM_FREETYPE)
+    find_package(Freetype)
+    if (FREETYPE_FOUND)
+        message(STATUS "Found freetype: ${FREETYPE_VERSION_STRING}")
+    else()
+        message(WARNING "Set MUE_COMPILE_USE_SYSTEM_FREETYPE=ON, but system freetype not found, built-in will be used")
+    endif()
+endif()
+
+if (NOT FREETYPE_FOUND)
+    add_subdirectory(${THIRDPARTY_DIR}/freetype freetype)
+    set(FREETYPE_LIBRARIES freetype)
+    set(FREETYPE_INCLUDE_DIRS ${THIRDPARTY_DIR}/freetype/include)
+endif()

--- a/src/framework/draw/CMakeLists.txt
+++ b/src/framework/draw/CMakeLists.txt
@@ -83,9 +83,9 @@ else()
         ${CMAKE_CURRENT_LIST_DIR}/internal/qimagepainterprovider.h
         )
 
-    add_subdirectory(${THIRDPARTY_DIR}/freetype freetype)
-    set(MODULE_INCLUDE ${THIRDPARTY_DIR}/freetype/include)
-    set(MODULE_LINK freetype)
+    include(SetupFreeType)
+    set(MODULE_INCLUDE ${FREETYPE_INCLUDE_DIRS})
+    set(MODULE_LINK ${FREETYPE_LIBRARIES})
 
 endif()
 


### PR DESCRIPTION
https://github.com/musescore/MuseScore/issues/18795 
At the request of the Linux distribution maintainer

We should also update the built-in version of freetype
