### PR TITLE
Adjust part instrument IDs in MEI importer

### DIFF
--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -2321,6 +2321,13 @@ bool MeiImporter::buildScoreParts(pugi::xml_node scoreDefNode)
     pugi::xml_node staffGrpNode = scoreDefNode.select_node("./staffGrp").node();
 
     bool success = this->readStaffGrps(staffGrpNode, staffSpan, 0, idx);
+    
+    // Update parts instruments IDs for playback
+    for (const Part* part : m_score->parts()) {
+        for (const auto& pair : part->instruments()) {
+            pair.second->updateInstrumentId();
+        }
+    }
 
     return success;
 }

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -2321,7 +2321,7 @@ bool MeiImporter::buildScoreParts(pugi::xml_node scoreDefNode)
     pugi::xml_node staffGrpNode = scoreDefNode.select_node("./staffGrp").node();
 
     bool success = this->readStaffGrps(staffGrpNode, staffSpan, 0, idx);
-    
+
     // Update parts instruments IDs for playback
     for (const Part* part : m_score->parts()) {
         for (const auto& pair : part->instruments()) {

--- a/src/importexport/mei/tests/data/accid-01.mscx
+++ b/src/importexport/mei/tests/data/accid-01.mscx
@@ -28,10 +28,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="voice">
         <longName>Voice</longName>
         <shortName>Vo.</shortName>
         <trackName></trackName>
+        <instrumentId>voice.vocals</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/accid-02.mscx
+++ b/src/importexport/mei/tests/data/accid-02.mscx
@@ -28,10 +28,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="voice">
         <longName>Voice</longName>
         <shortName>Vo.</shortName>
         <trackName></trackName>
+        <instrumentId>voice.vocals</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/beam-01.mscx
+++ b/src/importexport/mei/tests/data/beam-01.mscx
@@ -28,10 +28,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="oboe">
         <longName>Oboe</longName>
         <shortName>Ob.</shortName>
         <trackName></trackName>
+        <instrumentId>wind.reed.oboe</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/beam-02.mscx
+++ b/src/importexport/mei/tests/data/beam-02.mscx
@@ -28,10 +28,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="oboe">
         <longName>Oboe</longName>
         <shortName>Ob.</shortName>
         <trackName></trackName>
+        <instrumentId>wind.reed.oboe</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/beam-03.mscx
+++ b/src/importexport/mei/tests/data/beam-03.mscx
@@ -28,12 +28,13 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Clarinet in B♭</longName>
         <shortName>Cl. in B♭</shortName>
         <trackName></trackName>
         <transposeDiatonic>-1</transposeDiatonic>
         <transposeChromatic>-2</transposeChromatic>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/breaks-01.mscx
+++ b/src/importexport/mei/tests/data/breaks-01.mscx
@@ -35,10 +35,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName></trackName>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/breath-01.mscx
+++ b/src/importexport/mei/tests/data/breath-01.mscx
@@ -30,10 +30,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="viola">
         <longName>Viola</longName>
         <shortName>Vla.</shortName>
         <trackName></trackName>
+        <instrumentId>strings.viola</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -45,10 +46,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="violoncello">
         <longName>Violoncello</longName>
         <shortName>Vc.</shortName>
         <trackName></trackName>
+        <instrumentId>strings.cello</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/chord-label-01.mscx
+++ b/src/importexport/mei/tests/data/chord-label-01.mscx
@@ -28,10 +28,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="trombone">
         <longName>Trombone</longName>
         <shortName>Tbn.</shortName>
         <trackName></trackName>
+        <instrumentId>brass.trombone</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/clef-01.mscx
+++ b/src/importexport/mei/tests/data/clef-01.mscx
@@ -28,9 +28,10 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Staff 1</longName>
         <trackName></trackName>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/cross-staff-01.mscx
+++ b/src/importexport/mei/tests/data/cross-staff-01.mscx
@@ -35,10 +35,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName></trackName>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/dir-01.mscx
+++ b/src/importexport/mei/tests/data/dir-01.mscx
@@ -30,10 +30,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="oboe">
         <longName>Oboe</longName>
         <shortName>Ob.</shortName>
         <trackName></trackName>
+        <instrumentId>wind.reed.oboe</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -45,10 +46,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="bassoon">
         <longName>Bassoon</longName>
         <shortName>Bsn.</shortName>
         <trackName></trackName>
+        <instrumentId>wind.reed.bassoon</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/dynamic-01.mscx
+++ b/src/importexport/mei/tests/data/dynamic-01.mscx
@@ -28,10 +28,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="oboe">
         <longName>Oboe</longName>
         <shortName>Ob.</shortName>
         <trackName></trackName>
+        <instrumentId>wind.reed.oboe</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/ending-01.mscx
+++ b/src/importexport/mei/tests/data/ending-01.mscx
@@ -30,10 +30,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="violin">
         <longName>Violin</longName>
         <shortName>Vln.</shortName>
         <trackName></trackName>
+        <instrumentId>strings.violin</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -45,10 +46,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="violoncello">
         <longName>Violoncello</longName>
         <shortName>Vc.</shortName>
         <trackName></trackName>
+        <instrumentId>strings.cello</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/fermata-01.mscx
+++ b/src/importexport/mei/tests/data/fermata-01.mscx
@@ -30,10 +30,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="viola">
         <longName>Viola</longName>
         <shortName>Vla.</shortName>
         <trackName></trackName>
+        <instrumentId>strings.viola</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -45,10 +46,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="violoncello">
         <longName>Violoncello</longName>
         <shortName>Vc.</shortName>
         <trackName></trackName>
+        <instrumentId>strings.cello</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/gracenote-01.mscx
+++ b/src/importexport/mei/tests/data/gracenote-01.mscx
@@ -28,10 +28,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="oboe">
         <longName>Oboe</longName>
         <shortName>Ob.</shortName>
         <trackName></trackName>
+        <instrumentId>wind.reed.oboe</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/gracenote-02.mscx
+++ b/src/importexport/mei/tests/data/gracenote-02.mscx
@@ -28,10 +28,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="oboe">
         <longName>Oboe</longName>
         <shortName>Ob.</shortName>
         <trackName></trackName>
+        <instrumentId>wind.reed.oboe</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/hairpin-01.mscx
+++ b/src/importexport/mei/tests/data/hairpin-01.mscx
@@ -35,10 +35,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName></trackName>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/jump-01.mscx
+++ b/src/importexport/mei/tests/data/jump-01.mscx
@@ -28,10 +28,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName></trackName>
+        <instrumentId>wind.flutes.flute</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/jump-02.mscx
+++ b/src/importexport/mei/tests/data/jump-02.mscx
@@ -28,10 +28,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName></trackName>
+        <instrumentId>wind.flutes.flute</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/key-signature-01.mscx
+++ b/src/importexport/mei/tests/data/key-signature-01.mscx
@@ -28,12 +28,13 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Clarinet in B♭</longName>
         <shortName>Cl. in B♭</shortName>
         <trackName></trackName>
         <transposeDiatonic>-1</transposeDiatonic>
         <transposeChromatic>-2</transposeChromatic>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -52,10 +53,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName></trackName>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/measure-01.mscx
+++ b/src/importexport/mei/tests/data/measure-01.mscx
@@ -28,10 +28,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="violin">
         <longName>Violin</longName>
         <shortName>Vln.</shortName>
         <trackName></trackName>
+        <instrumentId>strings.violin</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/measure-02.mscx
+++ b/src/importexport/mei/tests/data/measure-02.mscx
@@ -30,10 +30,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="violin">
         <longName>Violin</longName>
         <shortName>Vln.</shortName>
         <trackName></trackName>
+        <instrumentId>strings.violin</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -46,10 +47,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Violin 2</longName>
         <shortName>Vln. 2</shortName>
         <trackName></trackName>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -62,10 +64,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="viola">
         <longName>Viola</longName>
         <shortName>Vla.</shortName>
         <trackName></trackName>
+        <instrumentId>strings.viola</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -77,10 +80,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="violoncello">
         <longName>Violoncello</longName>
         <shortName>Vc.</shortName>
         <trackName></trackName>
+        <instrumentId>strings.cello</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/metadata-01.mscx
+++ b/src/importexport/mei/tests/data/metadata-01.mscx
@@ -28,10 +28,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="oboe">
         <longName>Oboe</longName>
         <shortName>Ob.</shortName>
         <trackName></trackName>
+        <instrumentId>wind.reed.oboe</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/octave-01.mscx
+++ b/src/importexport/mei/tests/data/octave-01.mscx
@@ -35,10 +35,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName></trackName>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/page-head-01.mscx
+++ b/src/importexport/mei/tests/data/page-head-01.mscx
@@ -28,10 +28,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName></trackName>
+        <instrumentId>wind.flutes.flute</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/page-head-02.mscx
+++ b/src/importexport/mei/tests/data/page-head-02.mscx
@@ -28,10 +28,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName></trackName>
+        <instrumentId>wind.flutes.flute</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/roman-numeral-01.mscx
+++ b/src/importexport/mei/tests/data/roman-numeral-01.mscx
@@ -35,10 +35,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName></trackName>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/score-01.mscx
+++ b/src/importexport/mei/tests/data/score-01.mscx
@@ -30,12 +30,13 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Horn in F</longName>
         <shortName>Hn. in F</shortName>
         <trackName></trackName>
         <transposeDiatonic>-4</transposeDiatonic>
         <transposeChromatic>-7</transposeChromatic>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -48,12 +49,13 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Trumpet in B♭</longName>
         <shortName>Tpt. in B♭</shortName>
         <trackName></trackName>
         <transposeDiatonic>-1</transposeDiatonic>
         <transposeChromatic>-2</transposeChromatic>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -66,12 +68,13 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Bass Trumpet in E♭</longName>
         <shortName>B. Tpt. in E♭</shortName>
         <trackName></trackName>
         <transposeDiatonic>-5</transposeDiatonic>
         <transposeChromatic>-9</transposeChromatic>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -84,10 +87,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="alto-trombone">
         <longName>Alto Trombone</longName>
         <shortName>A. Tbn.</shortName>
         <trackName></trackName>
+        <instrumentId>brass.trombone.alto</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -100,10 +104,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="trombone">
         <longName>Trombone</longName>
         <shortName>Tbn.</shortName>
         <trackName></trackName>
+        <instrumentId>brass.trombone</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -116,10 +121,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="contrabass-trombone">
         <longName>Contrabass Trombone</longName>
         <shortName>Cb. Tbn.</shortName>
         <trackName></trackName>
+        <instrumentId>brass.trombone.contrabass</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -132,10 +138,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="bass-trombone">
         <longName>Bass Trombone</longName>
         <shortName>B. Tbn.</shortName>
         <trackName></trackName>
+        <instrumentId>brass.trombone.bass</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -148,10 +155,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="tuba">
         <longName>Tuba</longName>
         <shortName>Tba.</shortName>
         <trackName></trackName>
+        <instrumentId>brass.tuba</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -163,10 +171,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="tuba">
         <longName>B♭ Contrabass Tuba</longName>
         <shortName>B♭ Cb. Tb.</shortName>
         <trackName></trackName>
+        <instrumentId>brass.tuba</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -185,12 +194,13 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="celesta">
         <longName>Celesta</longName>
         <shortName>Cel.</shortName>
         <trackName></trackName>
         <transposeDiatonic>7</transposeDiatonic>
         <transposeChromatic>12</transposeChromatic>
+        <instrumentId>keyboard.celesta</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -204,10 +214,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="strings">
         <longName>Violins</longName>
         <shortName>Vlns.</shortName>
         <trackName></trackName>
+        <instrumentId>strings.group</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -220,10 +231,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="viola">
         <longName>Viola</longName>
         <shortName>Vla.</shortName>
         <trackName></trackName>
+        <instrumentId>strings.viola</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -236,10 +248,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="violoncello">
         <longName>Violoncello</longName>
         <shortName>Vc.</shortName>
         <trackName></trackName>
+        <instrumentId>strings.cello</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -251,12 +264,13 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="contrabass">
         <longName>Contrabass</longName>
         <shortName>Cb.</shortName>
         <trackName></trackName>
         <transposeDiatonic>-7</transposeDiatonic>
         <transposeChromatic>-12</transposeChromatic>
+        <instrumentId>strings.contrabass</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/score-02.mscx
+++ b/src/importexport/mei/tests/data/score-02.mscx
@@ -29,10 +29,11 @@
         <bracket type="0" span="1" col="0" visible="1"/>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="soprano">
         <longName>Soprano</longName>
         <shortName>S.</shortName>
         <trackName></trackName>
+        <instrumentId>voice.soprano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -53,10 +54,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName></trackName>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -82,10 +84,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="organ">
         <longName>Organ</longName>
         <shortName>Org.</shortName>
         <trackName></trackName>
+        <instrumentId>keyboard.organ</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -111,10 +114,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="organ">
         <longName>Organ</longName>
         <shortName>Org.</shortName>
         <trackName></trackName>
+        <instrumentId>keyboard.organ</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -126,10 +130,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="timpani">
         <longName>Timpani</longName>
         <shortName>Timp.</shortName>
         <trackName></trackName>
+        <instrumentId>drum.timpani</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -142,10 +147,11 @@
         <bracket type="0" span="2" col="0" visible="1"/>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="violin">
         <longName>Violin</longName>
         <shortName>Vln.</shortName>
         <trackName></trackName>
+        <instrumentId>strings.violin</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -157,10 +163,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="violoncello">
         <longName>Violoncello</longName>
         <shortName>Vc.</shortName>
         <trackName></trackName>
+        <instrumentId>strings.cello</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/slur-01.mscx
+++ b/src/importexport/mei/tests/data/slur-01.mscx
@@ -28,10 +28,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="oboe">
         <longName>Oboe</longName>
         <shortName>Ob.</shortName>
         <trackName></trackName>
+        <instrumentId>wind.reed.oboe</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/slur-02.mscx
+++ b/src/importexport/mei/tests/data/slur-02.mscx
@@ -35,10 +35,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName></trackName>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/stem-01.mscx
+++ b/src/importexport/mei/tests/data/stem-01.mscx
@@ -28,8 +28,9 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <trackName></trackName>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/tempo-01.mscx
+++ b/src/importexport/mei/tests/data/tempo-01.mscx
@@ -30,10 +30,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="violin">
         <longName>Violin</longName>
         <shortName>Vln.</shortName>
         <trackName></trackName>
+        <instrumentId>strings.violin</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -45,10 +46,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="viola">
         <longName>Viola</longName>
         <shortName>Vla.</shortName>
         <trackName></trackName>
+        <instrumentId>strings.viola</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/tie-01.mscx
+++ b/src/importexport/mei/tests/data/tie-01.mscx
@@ -35,10 +35,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Piano</longName>
         <shortName>Pno.</shortName>
         <trackName></trackName>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/time-signature-01.mscx
+++ b/src/importexport/mei/tests/data/time-signature-01.mscx
@@ -28,9 +28,10 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Staff 1</longName>
         <trackName></trackName>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/time-signature-02.mscx
+++ b/src/importexport/mei/tests/data/time-signature-02.mscx
@@ -28,12 +28,13 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Clarinet in B♭</longName>
         <shortName>Cl. in B♭</shortName>
         <trackName></trackName>
         <transposeDiatonic>-1</transposeDiatonic>
         <transposeChromatic>-2</transposeChromatic>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -45,10 +46,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="trombone">
         <longName>Trombone</longName>
         <shortName>Tbn.</shortName>
         <trackName></trackName>
+        <instrumentId>brass.trombone</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/transpose-01.mscx
+++ b/src/importexport/mei/tests/data/transpose-01.mscx
@@ -30,10 +30,11 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName></trackName>
+        <instrumentId>wind.flutes.flute</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -45,12 +46,13 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Clarinet in B♭</longName>
         <shortName>Cl. in B♭</shortName>
         <trackName></trackName>
         <transposeDiatonic>-1</transposeDiatonic>
         <transposeChromatic>-2</transposeChromatic>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -64,12 +66,13 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Horn in F</longName>
         <shortName>Hn. in F</shortName>
         <trackName></trackName>
         <transposeDiatonic>-4</transposeDiatonic>
         <transposeChromatic>-7</transposeChromatic>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -82,12 +85,13 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <longName>Cornet in B♭</longName>
         <shortName>Cnt. in B♭</shortName>
         <trackName></trackName>
         <transposeDiatonic>-1</transposeDiatonic>
         <transposeChromatic>-2</transposeChromatic>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>
@@ -99,10 +103,11 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="trombone">
         <longName>Trombone</longName>
         <shortName>Tbn.</shortName>
         <trackName></trackName>
+        <instrumentId>brass.trombone</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/tuplet-01.mscx
+++ b/src/importexport/mei/tests/data/tuplet-01.mscx
@@ -28,8 +28,9 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <trackName></trackName>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/tuplet-02.mscx
+++ b/src/importexport/mei/tests/data/tuplet-02.mscx
@@ -28,8 +28,9 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <trackName></trackName>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>

--- a/src/importexport/mei/tests/data/tuplet-03.mscx
+++ b/src/importexport/mei/tests/data/tuplet-03.mscx
@@ -28,8 +28,9 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="piano">
         <trackName></trackName>
+        <instrumentId>keyboard.piano</instrumentId>
         <Channel>
           </Channel>
         </Instrument>


### PR DESCRIPTION
This PR updates the part instrument IDs in the MEI importer. This fixes playback not working with MEI imported files.

The reference tests files are being updated accordingly.