### PR TITLE
Fix GH#15890: Lyrics elision shortcut not working

### DIFF
--- a/src/engraving/libmscore/textedit.cpp
+++ b/src/engraving/libmscore/textedit.cpp
@@ -690,7 +690,7 @@ bool TextBase::edit(EditData& ed)
             }
         }
         if (ctrlPressed && altPressed) {
-            if (ed.key == Key_Minus) {
+            if (ed.key == Key_Minus || ed.key == Key_Underscore) {
                 insertSym(ed, SymId::lyricsElision);
                 return true;
             }


### PR DESCRIPTION
Resolves: #15890

Works on Windows (11) and a German QWERTZ keyboard, needs to get tested on other setups