### PR TITLE
Adjust spanners and IDs in MEI exporter

### DIFF
--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -70,6 +70,9 @@ using namespace mu::engraving;
 // Number of spaces for the XML indentation. Set to 0 for tabs
 #define MEI_INDENT 3
 
+// Use counter-based IDs for layer elements
+#define MEI_COUNTER_BASED_IDS true
+
 /**
  * Write the Score to the destination file.
  * Return false on error.
@@ -2064,12 +2067,15 @@ std::string MeiExporter::getLayerXmlId()
 
 std::string MeiExporter::getLayerXmlIdFor(layerElementCounter elementType)
 {
-    // m (Measure) / s (Staff) / l (Layer) / ? Layer element type
-    // The layer element abbreviation is given in the MeiExporter::s_layerXmlIdMap
-    return String("m%1s%2l%3%4%5").arg(m_measureCounter).arg(m_staffCounter).arg(m_layerCounter).arg(MeiExporter::s_layerXmlIdMap.at(
-                                                                                                         elementType)).arg(++(
-                                                                                                                               m_layerCounterFor
-                                                                                                                               .at(
-                                                                                                                                   elementType)))
-           .toStdString();
+    String id;
+    if (MEI_COUNTER_BASED_IDS) {
+        // m (Measure) / s (Staff) / l (Layer) / ? Layer element type
+        // The layer element abbreviation is given in the MeiExporter::s_layerXmlIdMap
+        id = String("m%1s%2l%3%4%5").arg(m_measureCounter).arg(m_staffCounter).arg(m_layerCounter).arg(MeiExporter::s_layerXmlIdMap.at(
+                                                                                                           elementType)).arg(++(
+                                                                                                                                 m_layerCounterFor
+                                                                                                                                 .at(
+                                                                                                                                     elementType)));
+    }
+    return id.toStdString();
 }

--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -71,7 +71,7 @@ using namespace mu::engraving;
 #define MEI_INDENT 3
 
 // Use counter-based IDs for layer elements
-#define MEI_COUNTER_BASED_IDS true
+#define MEI_COUNTER_BASED_IDS false
 
 /**
  * Write the Score to the destination file.

--- a/src/importexport/mei/internal/meiexporter.h
+++ b/src/importexport/mei/internal/meiexporter.h
@@ -126,6 +126,7 @@ private:
     std::pair<libmei::xsdPositiveInteger_List, double> findTstampFor(const engraving::EngravingItem* item);
     bool isNode(pugi::xml_node node, const String& name);
     pugi::xml_node getLastChordRest(pugi::xml_node node);
+    void addNodeToOpenControlEvents(pugi::xml_node node, const engraving::Spanner* spanner, const std::string& startid);
     void addEndidToControlEvents();
 
     /**

--- a/src/importexport/mei/tests/data/accid-01.mei
+++ b/src/importexport/mei/tests/data/accid-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:09:39" />
+            <date isodate="2023-08-11T14:50:27" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -39,53 +39,53 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="mat6gg1" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <note xml:id="s1l1_t0_1" dur="4" pname="a" oct="4" />
-                           <note xml:id="s1l1_t1_4" dur="4" pname="a" oct="4" />
-                           <note xml:id="s1l1_t1_2" dur="4" pname="a" oct="4" />
-                           <note xml:id="s1l1_t3_4" dur="4" pname="b" oct="4" />
+                           <note xml:id="n1vvxea5" dur="4" pname="a" oct="4" />
+                           <note xml:id="nu9xqct" dur="4" pname="a" oct="4" />
+                           <note xml:id="n1uqjzyk" dur="4" pname="a" oct="4" />
+                           <note xml:id="nee7bul" dur="4" pname="b" oct="4" />
                         </layer>
                         <layer xml:id="m1s1l2" n="2">
-                           <note xml:id="s1l2_t0_1" dur="4" pname="f" oct="4">
-                              <accid xml:id="m1s1l2a1" accid.ges="s" />
+                           <note xml:id="niqqv88" dur="4" pname="f" oct="4">
+                              <accid accid.ges="s" />
                            </note>
-                           <note xml:id="s1l2_t1_4" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l2_t1_2" dur="4" pname="f" oct="4">
-                              <accid xml:id="m1s1l2a2" accid.ges="s" />
+                           <note xml:id="n1svsv96" dur="4" pname="e" oct="4" />
+                           <note xml:id="n16050n7" dur="4" pname="f" oct="4">
+                              <accid accid.ges="s" />
                            </note>
-                           <note xml:id="s1l2_t3_4" dur="4" pname="f" oct="4">
-                              <accid xml:id="m1s1l2a3" accid.ges="s" />
+                           <note xml:id="n1wol7y" dur="4" pname="f" oct="4">
+                              <accid accid.ges="s" />
                            </note>
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" right="end" n="2">
+                  <measure xml:id="mw7xdt8" right="end" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <note xml:id="s1l1_t1_1" dur="4" pname="g" oct="4">
-                              <accid xml:id="m2s1l1a1" accid="n" />
+                           <note xml:id="ngr62x1" dur="4" pname="g" oct="4">
+                              <accid accid="n" />
                            </note>
-                           <note xml:id="s1l1_t5_4" dur="4" pname="f" oct="4">
-                              <accid xml:id="m2s1l1a2" accid.ges="s" />
+                           <note xml:id="n1k2ht2o" dur="4" pname="f" oct="4">
+                              <accid accid.ges="s" />
                            </note>
-                           <note xml:id="s1l1_t3_2" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t7_4" dur="4" pname="b" oct="4" />
+                           <note xml:id="n3tl8gy" dur="4" pname="e" oct="4" />
+                           <note xml:id="n189kcmn" dur="4" pname="b" oct="4" />
                         </layer>
                         <layer xml:id="m2s1l2" n="2">
-                           <note xml:id="s1l2_t1_1" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l2_t5_4" dur="4" pname="d" oct="4">
-                              <accid xml:id="m2s1l2a1" accid="s" />
+                           <note xml:id="n1013jq2" dur="4" pname="e" oct="4" />
+                           <note xml:id="n1misoi0" dur="4" pname="d" oct="4">
+                              <accid accid="s" />
                            </note>
-                           <note xml:id="s1l2_t3_2" dur="4" pname="b" oct="3" />
-                           <note xml:id="s1l2_t7_4" dur="4" pname="g" oct="4">
-                              <accid xml:id="m2s1l2a2" accid="s" />
+                           <note xml:id="n162mdpz" dur="4" pname="b" oct="3" />
+                           <note xml:id="n1dbkfl9" dur="4" pname="g" oct="4">
+                              <accid accid="s" />
                            </note>
                         </layer>
                      </staff>
-                     <slur xml:id="m2sl1" startid="#s1l1_t1_1" endid="#s1l1_t5_4" />
-                     <fermata xml:id="m2fm1" startid="#s1l1_t3_2" />
+                     <slur xml:id="s5thic2" startid="#ngr62x1" endid="#n1k2ht2o" />
+                     <fermata xml:id="fn0ng21" startid="#n3tl8gy" />
                   </measure>
                </section>
             </score>

--- a/src/importexport/mei/tests/data/accid-01.mscx
+++ b/src/importexport/mei/tests/data/accid-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:09:39&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:50:27&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/accid-02.mei
+++ b/src/importexport/mei/tests/data/accid-02.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:09:40" />
+            <date isodate="2023-08-11T14:50:34" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -39,38 +39,38 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m1qmvc7q" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <note xml:id="s1l1_t0_1" dur="4" pname="f" oct="4">
-                              <accid xml:id="m1s1l1a1" accid.ges="s" />
+                           <note xml:id="nssxvo2" dur="4" pname="f" oct="4">
+                              <accid accid.ges="s" />
                            </note>
-                           <note xml:id="s1l1_t1_4" dur="4" pname="f" oct="4">
-                              <accid xml:id="m1s1l1a2" accid="s" />
+                           <note xml:id="ne4my69" dur="4" pname="f" oct="4">
+                              <accid accid="s" />
                            </note>
-                           <note xml:id="s1l1_t1_2" dur="4" pname="f" oct="4">
-                              <accid xml:id="m1s1l1a3" accid="x" />
+                           <note xml:id="nq96ye1" dur="4" pname="f" oct="4">
+                              <accid accid="x" />
                            </note>
-                           <note xml:id="s1l1_t3_4" dur="4" pname="f" oct="4">
-                              <accid xml:id="m1s1l1a4" accid="ss" />
+                           <note xml:id="nkrvj69" dur="4" pname="f" oct="4">
+                              <accid accid="ss" />
                            </note>
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" right="end" n="2">
+                  <measure xml:id="m1fdbhz6" right="end" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <note xml:id="s1l1_t1_1" dur="4" pname="a" oct="4">
-                              <accid xml:id="m2s1l1a1" accid="n" />
+                           <note xml:id="n1kv2xwk" dur="4" pname="a" oct="4">
+                              <accid accid="n" />
                            </note>
-                           <note xml:id="s1l1_t5_4" dur="4" pname="a" oct="4">
-                              <accid xml:id="m2s1l1a2" accid="f" />
+                           <note xml:id="n1ktkawl" dur="4" pname="a" oct="4">
+                              <accid accid="f" />
                            </note>
-                           <note xml:id="s1l1_t3_2" dur="4" pname="a" oct="4">
-                              <accid xml:id="m2s1l1a3" accid="nf" />
+                           <note xml:id="nz6925q" dur="4" pname="a" oct="4">
+                              <accid accid="nf" />
                            </note>
-                           <note xml:id="s1l1_t7_4" dur="4" pname="a" oct="4">
-                              <accid xml:id="m2s1l1a4" accid="ff" />
+                           <note xml:id="nlpi0gu" dur="4" pname="a" oct="4">
+                              <accid accid="ff" />
                            </note>
                         </layer>
                      </staff>

--- a/src/importexport/mei/tests/data/accid-02.mscx
+++ b/src/importexport/mei/tests/data/accid-02.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:09:40&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:50:34&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/beam-01.mei
+++ b/src/importexport/mei/tests/data/beam-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:09:44" />
+            <date isodate="2023-08-11T14:50:54" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -39,74 +39,74 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m1oc7la4" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <beam xml:id="m1s1l1b1">
-                              <note xml:id="s1l1_t0_1" dur="8" pname="c" oct="5" />
-                              <note xml:id="s1l1_t1_8" dur="8" pname="d" oct="5" />
-                              <note xml:id="s1l1_t1_4" dur="8" pname="c" oct="5" />
-                              <note xml:id="s1l1_t3_8" dur="8" pname="b" oct="4" />
+                           <beam>
+                              <note xml:id="n1vqivb0" dur="8" pname="c" oct="5" />
+                              <note xml:id="n1yzh6zn" dur="8" pname="d" oct="5" />
+                              <note xml:id="nker71v" dur="8" pname="c" oct="5" />
+                              <note xml:id="n1c8bust" dur="8" pname="b" oct="4" />
                            </beam>
-                           <beam xml:id="m1s1l1b2">
-                              <note xml:id="s1l1_t1_2" dur="16" pname="c" oct="5" />
-                              <note xml:id="s1l1_t9_16" dur="16" pname="d" oct="5" />
-                              <note xml:id="s1l1_t5_8" dur="16" pname="c" oct="5" />
-                              <note xml:id="s1l1_t11_16" dur="16" pname="b" oct="4" />
+                           <beam>
+                              <note xml:id="nrwf4cn" dur="16" pname="c" oct="5" />
+                              <note xml:id="nlj09wy" dur="16" pname="d" oct="5" />
+                              <note xml:id="n1g3w5gm" dur="16" pname="c" oct="5" />
+                              <note xml:id="n5v8tch" dur="16" pname="b" oct="4" />
                            </beam>
-                           <beam xml:id="m1s1l1b3">
-                              <note xml:id="s1l1_t3_4" dur="16" pname="c" oct="5" />
-                              <note xml:id="s1l1_t13_16" dur="16" pname="d" oct="5" />
-                              <note xml:id="s1l1_t7_8" dur="16" pname="c" oct="5" />
-                              <note xml:id="s1l1_t15_16" dur="16" pname="b" oct="4" />
+                           <beam>
+                              <note xml:id="nmps2t9" dur="16" pname="c" oct="5" />
+                              <note xml:id="n9wv4fd" dur="16" pname="d" oct="5" />
+                              <note xml:id="nwhc024" dur="16" pname="c" oct="5" />
+                              <note xml:id="nl12hmo" dur="16" pname="b" oct="4" />
                            </beam>
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" right="end" n="2">
+                  <measure xml:id="m12x0iq6" right="end" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <beam xml:id="m2s1l1b1">
-                              <note xml:id="s1l1_t1_1" dur="32" pname="c" oct="5" />
-                              <note xml:id="s1l1_t33_32" dur="32" pname="d" oct="5" />
-                              <note xml:id="s1l1_t17_16" dur="32" pname="c" oct="5" />
-                              <note xml:id="s1l1_t35_32" dur="32" pname="b" oct="4" />
-                              <note xml:id="s1l1_t9_8" dur="32" pname="c" oct="5" />
-                              <note xml:id="s1l1_t37_32" dur="32" pname="d" oct="5" />
-                              <note xml:id="s1l1_t19_16" dur="32" pname="c" oct="5" />
-                              <note xml:id="s1l1_t39_32" dur="32" pname="b" oct="4" />
+                           <beam>
+                              <note xml:id="nd26oh3" dur="32" pname="c" oct="5" />
+                              <note xml:id="n1ng5txb" dur="32" pname="d" oct="5" />
+                              <note xml:id="n1owy8tn" dur="32" pname="c" oct="5" />
+                              <note xml:id="nvwddrl" dur="32" pname="b" oct="4" />
+                              <note xml:id="n1wxs8q9" dur="32" pname="c" oct="5" />
+                              <note xml:id="nggtyqi" dur="32" pname="d" oct="5" />
+                              <note xml:id="n11mkzob" dur="32" pname="c" oct="5" />
+                              <note xml:id="ndbt6my" dur="32" pname="b" oct="4" />
                            </beam>
-                           <beam xml:id="m2s1l1b2">
-                              <note xml:id="s1l1_t5_4" dur="64" pname="c" oct="5" />
-                              <note xml:id="s1l1_t81_64" dur="64" pname="d" oct="5" />
-                              <note xml:id="s1l1_t41_32" dur="64" pname="c" oct="5" />
-                              <note xml:id="s1l1_t83_64" dur="64" pname="b" oct="4" />
-                              <note xml:id="s1l1_t21_16" dur="64" pname="c" oct="5" />
-                              <note xml:id="s1l1_t85_64" dur="64" pname="d" oct="5" />
-                              <note xml:id="s1l1_t43_32" dur="64" pname="c" oct="5" />
-                              <note xml:id="s1l1_t87_64" dur="64" pname="b" oct="4" />
-                              <note xml:id="s1l1_t11_8" dur="64" pname="c" oct="5" />
-                              <note xml:id="s1l1_t89_64" dur="64" pname="d" oct="5" />
-                              <note xml:id="s1l1_t45_32" dur="64" pname="c" oct="5" />
-                              <note xml:id="s1l1_t91_64" dur="64" pname="b" oct="4" />
-                              <note xml:id="s1l1_t23_16" dur="64" pname="c" oct="5" />
-                              <note xml:id="s1l1_t93_64" dur="64" pname="d" oct="5" />
-                              <note xml:id="s1l1_t47_32" dur="64" pname="c" oct="5" />
-                              <note xml:id="s1l1_t95_64" dur="64" pname="b" oct="4" />
+                           <beam>
+                              <note xml:id="n1rtpip5" dur="64" pname="c" oct="5" />
+                              <note xml:id="n1sx8xvg" dur="64" pname="d" oct="5" />
+                              <note xml:id="n1vie4r6" dur="64" pname="c" oct="5" />
+                              <note xml:id="ns8ko6o" dur="64" pname="b" oct="4" />
+                              <note xml:id="nznuse2" dur="64" pname="c" oct="5" />
+                              <note xml:id="nqc3uyo" dur="64" pname="d" oct="5" />
+                              <note xml:id="n105ln32" dur="64" pname="c" oct="5" />
+                              <note xml:id="n54ikam" dur="64" pname="b" oct="4" />
+                              <note xml:id="nxaxxcg" dur="64" pname="c" oct="5" />
+                              <note xml:id="nbivqzk" dur="64" pname="d" oct="5" />
+                              <note xml:id="n1igqapg" dur="64" pname="c" oct="5" />
+                              <note xml:id="n1s09kev" dur="64" pname="b" oct="4" />
+                              <note xml:id="n2uuxzm" dur="64" pname="c" oct="5" />
+                              <note xml:id="nha4azt" dur="64" pname="d" oct="5" />
+                              <note xml:id="n1qhqi8f" dur="64" pname="c" oct="5" />
+                              <note xml:id="n1xxrfjm" dur="64" pname="b" oct="4" />
                            </beam>
-                           <beam xml:id="m2s1l1b3">
-                              <note xml:id="s1l1_t3_2" dur="8" pname="c" oct="5" />
-                              <note xml:id="s1l1_t13_8" dur="8" pname="d" oct="5" />
+                           <beam>
+                              <note xml:id="noajxvx" dur="8" pname="c" oct="5" />
+                              <note xml:id="n1mxoa0f" dur="8" pname="d" oct="5" />
                            </beam>
-                           <beam xml:id="m2s1l1b4">
-                              <note xml:id="s1l1_t7_4" dur="16" pname="c" oct="5" />
-                              <note xml:id="s1l1_t29_16" dur="16" pname="b" oct="4" />
-                              <note xml:id="s1l1_t15_8" dur="32" pname="c" oct="5" />
-                              <note xml:id="s1l1_t61_32" dur="32" pname="d" oct="5" />
-                              <note xml:id="s1l1_t31_16" dur="64" pname="c" oct="5" />
-                              <note xml:id="s1l1_t125_64" dur="64" pname="b" oct="4" />
-                              <note xml:id="s1l1_t63_32" dur="64" pname="c" oct="5" />
-                              <note xml:id="s1l1_t127_64" dur="64" pname="d" oct="5" />
+                           <beam>
+                              <note xml:id="n1j9hwtq" dur="16" pname="c" oct="5" />
+                              <note xml:id="n1et78mc" dur="16" pname="b" oct="4" />
+                              <note xml:id="njdrw86" dur="32" pname="c" oct="5" />
+                              <note xml:id="n1ebwops" dur="32" pname="d" oct="5" />
+                              <note xml:id="n189hiue" dur="64" pname="c" oct="5" />
+                              <note xml:id="n1jmeqmp" dur="64" pname="b" oct="4" />
+                              <note xml:id="nsh2m1v" dur="64" pname="c" oct="5" />
+                              <note xml:id="n4o3h7b" dur="64" pname="d" oct="5" />
                            </beam>
                         </layer>
                      </staff>

--- a/src/importexport/mei/tests/data/beam-01.mscx
+++ b/src/importexport/mei/tests/data/beam-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:09:44&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:50:54&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/beam-02.mei
+++ b/src/importexport/mei/tests/data/beam-02.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:09:45" />
+            <date isodate="2023-08-11T14:51:00" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -39,80 +39,80 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m1cjrjkc" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <note xml:id="s1l1_t0_1" type="mscore-beam-none" dur="8" pname="c" oct="5" />
-                           <note xml:id="s1l1_t1_8" type="mscore-beam-none" dur="8" pname="d" oct="5" />
-                           <beam xml:id="m1s1l1b1">
-                              <note xml:id="s1l1_t1_4" dur="8" pname="c" oct="5" />
-                              <note xml:id="s1l1_t3_8" dur="8" pname="b" oct="4" />
-                              <note xml:id="s1l1_t1_2" type="mscore-beam-mid" dur="16" pname="c" oct="5" />
-                              <note xml:id="s1l1_t9_16" dur="16" pname="d" oct="5" />
+                           <note xml:id="nll6m9v" type="mscore-beam-none" dur="8" pname="c" oct="5" />
+                           <note xml:id="n8bki5z" type="mscore-beam-none" dur="8" pname="d" oct="5" />
+                           <beam>
+                              <note xml:id="n16x37ae" dur="8" pname="c" oct="5" />
+                              <note xml:id="n1ljghjy" dur="8" pname="b" oct="4" />
+                              <note xml:id="ny8r2yk" type="mscore-beam-mid" dur="16" pname="c" oct="5" />
+                              <note xml:id="n1gloyvp" dur="16" pname="d" oct="5" />
                            </beam>
-                           <beam xml:id="m1s1l1b2">
-                              <note xml:id="s1l1_t5_8" type="mscore-beam-begin" dur="16" pname="c" oct="5" />
-                              <note xml:id="s1l1_t11_16" dur="16" pname="b" oct="4" />
+                           <beam>
+                              <note xml:id="n1n92rml" type="mscore-beam-begin" dur="16" pname="c" oct="5" />
+                              <note xml:id="n1tfdo3n" dur="16" pname="b" oct="4" />
                            </beam>
-                           <beam xml:id="m1s1l1b3">
-                              <note xml:id="s1l1_t3_4" dur="16" pname="c" oct="5" />
-                              <note xml:id="s1l1_t13_16" dur="16" pname="d" oct="5" breaksec="1" />
-                              <note xml:id="s1l1_t7_8" dur="16" pname="c" oct="5" />
-                              <note xml:id="s1l1_t15_16" dur="16" pname="b" oct="4" />
+                           <beam>
+                              <note xml:id="naawzoa" dur="16" pname="c" oct="5" />
+                              <note xml:id="n1ee5stl" dur="16" pname="d" oct="5" breaksec="1" />
+                              <note xml:id="nwycje3" dur="16" pname="c" oct="5" />
+                              <note xml:id="nle968c" dur="16" pname="b" oct="4" />
                            </beam>
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" right="end" n="2">
+                  <measure xml:id="m14o08v9" right="end" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <beam xml:id="m2s1l1b1">
-                              <note xml:id="s1l1_t1_1" dur="32" pname="c" oct="5" />
-                              <note xml:id="s1l1_t33_32" dur="32" pname="d" oct="5" breaksec="1" />
-                              <note xml:id="s1l1_t17_16" dur="32" pname="c" oct="5" />
-                              <note xml:id="s1l1_t35_32" dur="32" pname="b" oct="4" />
-                              <note xml:id="s1l1_t9_8" dur="32" pname="c" oct="5" />
-                              <note xml:id="s1l1_t37_32" dur="32" pname="d" oct="5" breaksec="2" />
-                              <note xml:id="s1l1_t19_16" dur="32" pname="c" oct="5" />
-                              <note xml:id="s1l1_t39_32" dur="32" pname="b" oct="4" />
+                           <beam>
+                              <note xml:id="nucm59r" dur="32" pname="c" oct="5" />
+                              <note xml:id="nkb6lln" dur="32" pname="d" oct="5" breaksec="1" />
+                              <note xml:id="n1ihrfc2" dur="32" pname="c" oct="5" />
+                              <note xml:id="n5jh9sf" dur="32" pname="b" oct="4" />
+                              <note xml:id="nxnn9ad" dur="32" pname="c" oct="5" />
+                              <note xml:id="n1ctry5c" dur="32" pname="d" oct="5" breaksec="2" />
+                              <note xml:id="n1irtndi" dur="32" pname="c" oct="5" />
+                              <note xml:id="n1i3a4gi" dur="32" pname="b" oct="4" />
                            </beam>
-                           <beam xml:id="m2s1l1b2">
-                              <note xml:id="s1l1_t5_4" dur="64" pname="c" oct="5" />
-                              <note xml:id="s1l1_t81_64" dur="64" pname="d" oct="5" />
-                              <note xml:id="s1l1_t41_32" dur="64" pname="c" oct="5" />
-                              <note xml:id="s1l1_t83_64" dur="64" pname="b" oct="4" />
+                           <beam>
+                              <note xml:id="n18w82nd" dur="64" pname="c" oct="5" />
+                              <note xml:id="n1f59gvu" dur="64" pname="d" oct="5" />
+                              <note xml:id="nsghjbc" dur="64" pname="c" oct="5" />
+                              <note xml:id="n1m5t0zr" dur="64" pname="b" oct="4" />
                            </beam>
-                           <beam xml:id="m2s1l1b3">
-                              <note xml:id="s1l1_t21_16" type="mscore-beam-begin" dur="64" pname="c" oct="5" />
-                              <note xml:id="s1l1_t85_64" dur="64" pname="d" oct="5" />
-                              <note xml:id="s1l1_t43_32" dur="64" pname="c" oct="5" />
-                              <note xml:id="s1l1_t87_64" dur="64" pname="b" oct="4" />
+                           <beam>
+                              <note xml:id="n4ngt5a" type="mscore-beam-begin" dur="64" pname="c" oct="5" />
+                              <note xml:id="nlhuwyx" dur="64" pname="d" oct="5" />
+                              <note xml:id="n1tttu6q" dur="64" pname="c" oct="5" />
+                              <note xml:id="nr802n7" dur="64" pname="b" oct="4" />
                            </beam>
-                           <note xml:id="s1l1_t11_8" type="mscore-beam-none" dur="64" pname="c" oct="5" />
-                           <note xml:id="s1l1_t89_64" type="mscore-beam-none" dur="64" pname="d" oct="5" />
-                           <beam xml:id="m2s1l1b4">
-                              <note xml:id="s1l1_t45_32" dur="64" pname="c" oct="5" />
-                              <note xml:id="s1l1_t91_64" dur="64" pname="b" oct="4" breaksec="2" />
-                              <note xml:id="s1l1_t23_16" dur="64" pname="c" oct="5" />
-                              <note xml:id="s1l1_t93_64" dur="64" pname="d" oct="5" breaksec="1" />
-                              <note xml:id="s1l1_t47_32" dur="64" pname="c" oct="5" />
-                              <note xml:id="s1l1_t95_64" dur="64" pname="b" oct="4" />
+                           <note xml:id="nesj8ir" type="mscore-beam-none" dur="64" pname="c" oct="5" />
+                           <note xml:id="nt1rs3z" type="mscore-beam-none" dur="64" pname="d" oct="5" />
+                           <beam>
+                              <note xml:id="nbvd3a1" dur="64" pname="c" oct="5" />
+                              <note xml:id="n10q5n1o" dur="64" pname="b" oct="4" breaksec="2" />
+                              <note xml:id="n143z9cp" dur="64" pname="c" oct="5" />
+                              <note xml:id="n1b4rd89" dur="64" pname="d" oct="5" breaksec="1" />
+                              <note xml:id="nlr0pi8" dur="64" pname="c" oct="5" />
+                              <note xml:id="n17n1kc" dur="64" pname="b" oct="4" />
                            </beam>
-                           <beam xml:id="m2s1l1b5">
-                              <note xml:id="s1l1_t3_2" dur="8" pname="c" oct="5" />
-                              <note xml:id="s1l1_t13_8" dur="8" pname="d" oct="5" />
-                              <note xml:id="s1l1_t7_4" type="mscore-beam-mid" dur="16" pname="c" oct="5" />
-                              <note xml:id="s1l1_t29_16" dur="16" pname="b" oct="4" />
+                           <beam>
+                              <note xml:id="n1ancyv8" dur="8" pname="c" oct="5" />
+                              <note xml:id="nvp9yz0" dur="8" pname="d" oct="5" />
+                              <note xml:id="n15x2mjd" type="mscore-beam-mid" dur="16" pname="c" oct="5" />
+                              <note xml:id="n19d0stc" dur="16" pname="b" oct="4" />
                            </beam>
-                           <beam xml:id="m2s1l1b6">
-                              <note xml:id="s1l1_t15_8" type="mscore-beam-begin" dur="32" pname="c" oct="5" />
-                              <note xml:id="s1l1_t61_32" dur="32" pname="d" oct="5" />
+                           <beam>
+                              <note xml:id="n1sfhyzp" type="mscore-beam-begin" dur="32" pname="c" oct="5" />
+                              <note xml:id="n13shkcn" dur="32" pname="d" oct="5" />
                            </beam>
-                           <beam xml:id="m2s1l1b7">
-                              <note xml:id="s1l1_t31_16" type="mscore-beam-begin" dur="64" pname="c" oct="5" />
-                              <note xml:id="s1l1_t125_64" dur="64" pname="b" oct="4" />
-                              <note xml:id="s1l1_t63_32" dur="64" pname="c" oct="5" />
-                              <note xml:id="s1l1_t127_64" dur="64" pname="d" oct="5" />
+                           <beam>
+                              <note xml:id="nsug8aq" type="mscore-beam-begin" dur="64" pname="c" oct="5" />
+                              <note xml:id="n1mrmqvw" dur="64" pname="b" oct="4" />
+                              <note xml:id="ng9raad" dur="64" pname="c" oct="5" />
+                              <note xml:id="n1fnlr7z" dur="64" pname="d" oct="5" />
                            </beam>
                         </layer>
                      </staff>

--- a/src/importexport/mei/tests/data/beam-02.mscx
+++ b/src/importexport/mei/tests/data/beam-02.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:09:45&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:51:00&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/beam-03.mei
+++ b/src/importexport/mei/tests/data/beam-03.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:09:46" />
+            <date isodate="2023-08-11T14:51:06" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -39,96 +39,96 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" right="end" n="1">
+                  <measure xml:id="m1xv0sir" right="end" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <beam xml:id="m1s1l1b1">
-                              <note xml:id="s1l1_t0_1" dur="64" pname="g" oct="4" breaksec="1" />
-                              <graceGrp xml:id="m1s1l1g1" grace="acc">
-                                 <beam xml:id="m1s1l1b2">
-                                    <note xml:id="m1s1l1n1" dur="32" pname="b" oct="4" breaksec="1" />
-                                    <note xml:id="m1s1l1n2" dur="32" pname="b" oct="4" />
-                                    <note xml:id="m1s1l1n3" dur="32" pname="b" oct="4" />
-                                    <note xml:id="m1s1l1n4" dur="32" pname="b" oct="4" breaksec="1" />
-                                    <note xml:id="m1s1l1n5" dur="32" pname="b" oct="4" />
-                                    <note xml:id="m1s1l1n6" dur="32" pname="b" oct="4" />
+                           <beam>
+                              <note xml:id="n4c8j9l" dur="64" pname="g" oct="4" breaksec="1" />
+                              <graceGrp grace="acc">
+                                 <beam>
+                                    <note xml:id="n1cvhhm8" dur="32" pname="b" oct="4" breaksec="1" />
+                                    <note xml:id="n1fuvlf8" dur="32" pname="b" oct="4" />
+                                    <note xml:id="nmrv9tj" dur="32" pname="b" oct="4" />
+                                    <note xml:id="nsnekx2" dur="32" pname="b" oct="4" breaksec="1" />
+                                    <note xml:id="n1etc0qn" dur="32" pname="b" oct="4" />
+                                    <note xml:id="n8e7lg" dur="32" pname="b" oct="4" />
                                  </beam>
                               </graceGrp>
-                              <note xml:id="s1l1_t1_64" dur="64" pname="b" oct="4" breaksec="2" />
-                              <note xml:id="s1l1_t1_32" dur="64" pname="d" oct="5" />
-                              <note xml:id="s1l1_t3_64" dur="64" pname="d" oct="5" />
-                              <note xml:id="s1l1_t1_16" dur="64" pname="d" oct="5" />
-                              <note xml:id="s1l1_t5_64" dur="64" pname="b" oct="4" />
-                              <note xml:id="s1l1_t3_32" dur="64" pname="c" oct="5" breaksec="2">
-                                 <accid xml:id="m1s1l1a1" accid.ges="s" />
+                              <note xml:id="n1uuk73i" dur="64" pname="b" oct="4" breaksec="2" />
+                              <note xml:id="n3dn07d" dur="64" pname="d" oct="5" />
+                              <note xml:id="nkya9h1" dur="64" pname="d" oct="5" />
+                              <note xml:id="nbsaaco" dur="64" pname="d" oct="5" />
+                              <note xml:id="n5wz98m" dur="64" pname="b" oct="4" />
+                              <note xml:id="n1db47iw" dur="64" pname="c" oct="5" breaksec="2">
+                                 <accid accid.ges="s" />
                               </note>
-                              <note xml:id="s1l1_t7_64" dur="64" pname="d" oct="5" />
-                              <note xml:id="s1l1_t1_8" dur="64" pname="b" oct="4" />
-                              <note xml:id="s1l1_t9_64" dur="64" pname="a" oct="4" breaksec="1" />
-                              <note xml:id="s1l1_t5_32" dur="64" pname="f" oct="4">
-                                 <accid xml:id="m1s1l1a2" accid.ges="s" />
+                              <note xml:id="ntq6p5a" dur="64" pname="d" oct="5" />
+                              <note xml:id="n1xf43ac" dur="64" pname="b" oct="4" />
+                              <note xml:id="n1t3mcc" dur="64" pname="a" oct="4" breaksec="1" />
+                              <note xml:id="n1l25qne" dur="64" pname="f" oct="4">
+                                 <accid accid.ges="s" />
                               </note>
                            </beam>
-                           <rest xml:id="s1l1_t11_64" dur="64" />
-                           <beam xml:id="m1s1l1b3">
-                              <chord xml:id="s1l1_t3_16" dur="64" breaksec="1">
-                                 <note xml:id="m1s1l1n7" pname="e" oct="4" />
-                                 <note xml:id="m1s1l1n8" pname="g" oct="4" />
+                           <rest xml:id="rj4hhca" dur="64" />
+                           <beam>
+                              <chord xml:id="c12tutzl" dur="64" breaksec="1">
+                                 <note xml:id="nddbzb" pname="e" oct="4" />
+                                 <note xml:id="n19l535h" pname="g" oct="4" />
                               </chord>
-                              <graceGrp xml:id="m1s1l1g2" grace="acc">
-                                 <beam xml:id="m1s1l1b4">
-                                    <note xml:id="m1s1l1n9" dur="32" pname="b" oct="4" breaksec="1" />
-                                    <note xml:id="m1s1l1n10" dur="32" pname="b" oct="4" />
-                                    <note xml:id="m1s1l1n11" dur="32" pname="b" oct="4" />
-                                    <note xml:id="m1s1l1n12" dur="32" pname="b" oct="4" breaksec="1" />
-                                    <note xml:id="m1s1l1n13" dur="32" pname="b" oct="4" />
-                                    <note xml:id="m1s1l1n14" dur="32" pname="b" oct="4" />
+                              <graceGrp grace="acc">
+                                 <beam>
+                                    <note xml:id="n1y8yw3c" dur="32" pname="b" oct="4" breaksec="1" />
+                                    <note xml:id="nw5kwwz" dur="32" pname="b" oct="4" />
+                                    <note xml:id="noz29xv" dur="32" pname="b" oct="4" />
+                                    <note xml:id="nr8mo4y" dur="32" pname="b" oct="4" breaksec="1" />
+                                    <note xml:id="n1apo5ur" dur="32" pname="b" oct="4" />
+                                    <note xml:id="noj2mvr" dur="32" pname="b" oct="4" />
                                  </beam>
                               </graceGrp>
-                              <chord xml:id="s1l1_t13_64" dur="64" breaksec="2">
-                                 <note xml:id="m1s1l1n15" pname="g" oct="4" />
-                                 <note xml:id="m1s1l1n16" pname="b" oct="4" />
+                              <chord xml:id="c12tj7a3" dur="64" breaksec="2">
+                                 <note xml:id="n2sivfk" pname="g" oct="4" />
+                                 <note xml:id="n1l2kmcn" pname="b" oct="4" />
                               </chord>
-                              <chord xml:id="s1l1_t7_32" dur="64">
-                                 <note xml:id="m1s1l1n17" pname="b" oct="4" />
-                                 <note xml:id="m1s1l1n18" pname="d" oct="5" />
+                              <chord xml:id="ceat4vl" dur="64">
+                                 <note xml:id="n12ch662" pname="b" oct="4" />
+                                 <note xml:id="n1r96y20" pname="d" oct="5" />
                               </chord>
-                              <chord xml:id="s1l1_t15_64" dur="64">
-                                 <note xml:id="m1s1l1n19" pname="b" oct="4" />
-                                 <note xml:id="m1s1l1n20" pname="d" oct="5" />
+                              <chord xml:id="c1esogo2" dur="64">
+                                 <note xml:id="n1e5do8b" pname="b" oct="4" />
+                                 <note xml:id="n11mfx7r" pname="d" oct="5" />
                               </chord>
-                              <chord xml:id="s1l1_t1_4" dur="64">
-                                 <note xml:id="m1s1l1n21" pname="b" oct="4" />
-                                 <note xml:id="m1s1l1n22" pname="d" oct="5" />
+                              <chord xml:id="ci5tqxj" dur="64">
+                                 <note xml:id="n1qj2hdo" pname="b" oct="4" />
+                                 <note xml:id="n1texv5p" pname="d" oct="5" />
                               </chord>
-                              <chord xml:id="s1l1_t17_64" dur="64">
-                                 <note xml:id="m1s1l1n23" pname="g" oct="4" />
-                                 <note xml:id="m1s1l1n24" pname="b" oct="4" />
+                              <chord xml:id="c1gjm4tj" dur="64">
+                                 <note xml:id="nvi7mdg" pname="g" oct="4" />
+                                 <note xml:id="ni715pd" pname="b" oct="4" />
                               </chord>
-                              <chord xml:id="s1l1_t9_32" dur="64" breaksec="2">
-                                 <note xml:id="m1s1l1n25" pname="a" oct="4" />
-                                 <note xml:id="m1s1l1n26" pname="c" oct="5">
-                                    <accid xml:id="m1s1l1a3" accid.ges="s" />
+                              <chord xml:id="cl919r6" dur="64" breaksec="2">
+                                 <note xml:id="n1dz21ij" pname="a" oct="4" />
+                                 <note xml:id="n149cn2r" pname="c" oct="5">
+                                    <accid accid.ges="s" />
                                  </note>
                               </chord>
-                              <chord xml:id="s1l1_t19_64" dur="64">
-                                 <note xml:id="m1s1l1n27" pname="b" oct="4" />
-                                 <note xml:id="m1s1l1n28" pname="d" oct="5" />
+                              <chord xml:id="c1sb2c9h" dur="64">
+                                 <note xml:id="nexpyg3" pname="b" oct="4" />
+                                 <note xml:id="nva8v9o" pname="d" oct="5" />
                               </chord>
-                              <chord xml:id="s1l1_t5_16" dur="64">
-                                 <note xml:id="m1s1l1n29" pname="g" oct="4" />
-                                 <note xml:id="m1s1l1n30" pname="b" oct="4" />
+                              <chord xml:id="c1s95934" dur="64">
+                                 <note xml:id="n1e2po7u" pname="g" oct="4" />
+                                 <note xml:id="nmkux78" pname="b" oct="4" />
                               </chord>
-                              <rest xml:id="s1l1_t21_64" type="mscore-beam-mid" dur="64" breaksec="2" />
-                              <chord xml:id="s1l1_t11_32" dur="64">
-                                 <note xml:id="m1s1l1n31" pname="d" oct="4" />
-                                 <note xml:id="m1s1l1n32" pname="f" oct="4">
-                                    <accid xml:id="m1s1l1a4" accid.ges="s" />
+                              <rest xml:id="r1isy8kp" type="mscore-beam-mid" dur="64" breaksec="2" />
+                              <chord xml:id="c1z0iy91" dur="64">
+                                 <note xml:id="n1posvb2" pname="d" oct="4" />
+                                 <note xml:id="n73hvll" pname="f" oct="4">
+                                    <accid accid.ges="s" />
                                  </note>
                               </chord>
                            </beam>
-                           <rest xml:id="s1l1_t23_64" dur="8" />
-                           <rest xml:id="s1l1_t31_64" dur="64" />
+                           <rest xml:id="rtksbu4" dur="8" />
+                           <rest xml:id="r1ves4t" dur="64" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/beam-03.mscx
+++ b/src/importexport/mei/tests/data/beam-03.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:09:46&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:51:06&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/breaks-01.mei
+++ b/src/importexport/mei/tests/data/breaks-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:09:47" />
+            <date isodate="2023-08-11T14:51:13" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -39,213 +39,213 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="mq9w44a" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <rest xml:id="s1l1_t0_1" dur="4" />
-                           <note xml:id="s1l1_t1_4" dur="4" pname="c" oct="5" />
-                           <note xml:id="s1l1_t1_2" dur="4" pname="b" oct="4" />
-                           <note xml:id="s1l1_t3_4" dur="4" pname="a" oct="4" />
+                           <rest xml:id="r1rcmlku" dur="4" />
+                           <note xml:id="n182hzs" dur="4" pname="c" oct="5" />
+                           <note xml:id="nrnz93w" dur="4" pname="b" oct="4" />
+                           <note xml:id="nknu120" dur="4" pname="a" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s2" n="2">
                         <layer xml:id="m1s2l1" n="1">
-                           <rest xml:id="s2l1_t0_1" dur="4" />
-                           <note xml:id="s2l1_t1_4" dur="4" pname="c" oct="3" />
-                           <note xml:id="s2l1_t1_2" dur="4" pname="g" oct="3" />
-                           <note xml:id="s2l1_t3_4" dur="4" pname="d" oct="3" />
+                           <rest xml:id="r1suv84g" dur="4" />
+                           <note xml:id="n1v7j2xt" dur="4" pname="c" oct="3" />
+                           <note xml:id="nem50yz" dur="4" pname="g" oct="3" />
+                           <note xml:id="n87rp3t" dur="4" pname="d" oct="3" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="m97nau9" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <note xml:id="s1l1_t1_1" dur="2" pname="g" oct="4" />
-                           <rest xml:id="s1l1_t3_2" dur="4" />
-                           <note xml:id="s1l1_t7_4" dur="4" pname="g" oct="4" />
+                           <note xml:id="n10w4mzw" dur="2" pname="g" oct="4" />
+                           <rest xml:id="rbdj4sv" dur="4" />
+                           <note xml:id="n114dm4h" dur="4" pname="g" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s2" n="2">
                         <layer xml:id="m2s2l1" n="1">
-                           <note xml:id="s2l1_t1_1" dur="2" pname="g" oct="2" />
-                           <rest xml:id="s2l1_t3_2" dur="4" />
-                           <note xml:id="s2l1_t7_4" dur="4" pname="c" oct="3" />
+                           <note xml:id="n1sgoj8j" dur="2" pname="g" oct="2" />
+                           <rest xml:id="r1jv68sp" dur="4" />
+                           <note xml:id="n1xira8g" dur="4" pname="c" oct="3" />
                         </layer>
                      </staff>
-                     <fermata xml:id="m2fm1" startid="#s1l1_t1_1" />
-                     <fermata xml:id="m2fm2" startid="#s2l1_t1_1" />
+                     <fermata xml:id="f44stdf" startid="#n10w4mzw" />
+                     <fermata xml:id="f1ury5cr" startid="#n1sgoj8j" />
                   </measure>
-                  <measure xml:id="m3" n="3">
+                  <measure xml:id="mgev384" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <note xml:id="s1l1_t2_1" dur="4" pname="a" oct="4" />
-                           <note xml:id="s1l1_t9_4" dur="4" pname="b" oct="4" />
-                           <note xml:id="s1l1_t5_2" dur="2" pname="c" oct="5" />
+                           <note xml:id="n1kyaz70" dur="4" pname="a" oct="4" />
+                           <note xml:id="naxfzvy" dur="4" pname="b" oct="4" />
+                           <note xml:id="njgcc2v" dur="2" pname="c" oct="5" />
                         </layer>
                      </staff>
                      <staff xml:id="m3s2" n="2">
                         <layer xml:id="m3s2l1" n="1">
-                           <beam xml:id="m3s2l1b1">
-                              <note xml:id="s2l1_t2_1" dur="8" pname="f" oct="3" />
-                              <note xml:id="s2l1_t17_8" dur="8" pname="e" oct="3" />
+                           <beam>
+                              <note xml:id="nmw1ywd" dur="8" pname="f" oct="3" />
+                              <note xml:id="nmkzejq" dur="8" pname="e" oct="3" />
                            </beam>
-                           <note xml:id="s2l1_t9_4" dur="4" pname="d" oct="3" />
-                           <note xml:id="s2l1_t5_2" dur="2" pname="c" oct="3" />
+                           <note xml:id="n18979ar" dur="4" pname="d" oct="3" />
+                           <note xml:id="nwmlg8j" dur="2" pname="c" oct="3" />
                         </layer>
                      </staff>
-                     <fermata xml:id="m3fm1" startid="#s1l1_t5_2" />
-                     <fermata xml:id="m3fm2" startid="#s2l1_t5_2" />
+                     <fermata xml:id="f1usjm8l" startid="#njgcc2v" />
+                     <fermata xml:id="f1l5i2px" startid="#nwmlg8j" />
                   </measure>
-                  <measure xml:id="m4" n="4">
+                  <measure xml:id="m1a5txm0" n="4">
                      <staff xml:id="m4s1" n="1">
                         <layer xml:id="m4s1l1" n="1">
-                           <rest xml:id="s1l1_t3_1" dur="4" />
-                           <note xml:id="s1l1_t13_4" dur="4" pname="d" oct="5" />
-                           <note xml:id="s1l1_t7_2" dur="4" pname="c" oct="5" />
-                           <note xml:id="s1l1_t15_4" dur="4" pname="b" oct="4" />
+                           <rest xml:id="rjizomp" dur="4" />
+                           <note xml:id="n1lk6gc0" dur="4" pname="d" oct="5" />
+                           <note xml:id="n95sj2g" dur="4" pname="c" oct="5" />
+                           <note xml:id="niga7pg" dur="4" pname="b" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m4s2" n="2">
                         <layer xml:id="m4s2l1" n="1">
-                           <rest xml:id="s2l1_t3_1" dur="4" />
-                           <note xml:id="s2l1_t13_4" dur="4" pname="g" oct="2" />
-                           <note xml:id="s2l1_t7_2" dur="4" pname="a" oct="2" />
-                           <beam xml:id="m4s2l1b1">
-                              <note xml:id="s2l1_t15_4" dur="8" pname="b" oct="2" />
-                              <note xml:id="s2l1_t31_8" dur="8" pname="c" oct="3" />
+                           <rest xml:id="rutko9y" dur="4" />
+                           <note xml:id="n193g4zm" dur="4" pname="g" oct="2" />
+                           <note xml:id="nzghu2u" dur="4" pname="a" oct="2" />
+                           <beam>
+                              <note xml:id="nntbky6" dur="8" pname="b" oct="2" />
+                              <note xml:id="nopqi4u" dur="8" pname="c" oct="3" />
                            </beam>
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m5" n="5">
+                  <measure xml:id="m1i46xoe" n="5">
                      <staff xml:id="m5s1" n="1">
                         <layer xml:id="m5s1l1" n="1">
-                           <note xml:id="s1l1_t4_1" dur="4" pname="a" oct="4" />
-                           <note xml:id="s1l1_t17_4" dur="4" pname="b" oct="4" />
-                           <note xml:id="s1l1_t9_2" dur="2" pname="a" oct="4" />
+                           <note xml:id="ni1brma" dur="4" pname="a" oct="4" />
+                           <note xml:id="nzk2nsn" dur="4" pname="b" oct="4" />
+                           <note xml:id="ng7dosx" dur="2" pname="a" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m5s2" n="2">
                         <layer xml:id="m5s2l1" n="1">
-                           <note xml:id="s2l1_t4_1" dur="4" pname="d" oct="3" />
-                           <note xml:id="s2l1_t17_4" dur="4" pname="g" oct="2" />
-                           <note xml:id="s2l1_t9_2" dur="4" pname="c" oct="3" />
-                           <note xml:id="s2l1_t19_4" dur="4" pname="d" oct="3" />
+                           <note xml:id="n1e6e5qh" dur="4" pname="d" oct="3" />
+                           <note xml:id="ns2deqq" dur="4" pname="g" oct="2" />
+                           <note xml:id="n11s100v" dur="4" pname="c" oct="3" />
+                           <note xml:id="n1bzmfi" dur="4" pname="d" oct="3" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m6" n="6">
+                  <measure xml:id="mmfkci1" n="6">
                      <staff xml:id="m6s1" n="1">
                         <layer xml:id="m6s1l1" n="1">
-                           <note xml:id="s1l1_t5_1" dur="2" pname="g" oct="4" />
-                           <rest xml:id="s1l1_t11_2" dur="4" />
-                           <note xml:id="s1l1_t23_4" dur="4" pname="c" oct="5" />
+                           <note xml:id="n1vw3dv4" dur="2" pname="g" oct="4" />
+                           <rest xml:id="r1wcshm" dur="4" />
+                           <note xml:id="nspc0k6" dur="4" pname="c" oct="5" />
                         </layer>
                      </staff>
                      <staff xml:id="m6s2" n="2">
                         <layer xml:id="m6s2l1" n="1">
-                           <note xml:id="s2l1_t5_1" dur="2" pname="g" oct="2" />
-                           <rest xml:id="s2l1_t11_2" dur="4" />
-                           <note xml:id="s2l1_t23_4" dur="4" pname="e" oct="3" />
+                           <note xml:id="n1qn2uip" dur="2" pname="g" oct="2" />
+                           <rest xml:id="r16sqyef" dur="4" />
+                           <note xml:id="n2p73dn" dur="4" pname="e" oct="3" />
                         </layer>
                      </staff>
-                     <fermata xml:id="m6fm1" startid="#s1l1_t5_1" />
-                     <fermata xml:id="m6fm2" startid="#s2l1_t5_1" />
+                     <fermata xml:id="fsgobdm" startid="#n1vw3dv4" />
+                     <fermata xml:id="fwta297" startid="#n1qn2uip" />
                   </measure>
-                  <measure xml:id="m7" n="7">
+                  <measure xml:id="m2lumdv" n="7">
                      <staff xml:id="m7s1" n="1">
                         <layer xml:id="m7s1l1" n="1">
-                           <note xml:id="s1l1_t6_1" dur="4" pname="b" oct="4" />
-                           <note xml:id="s1l1_t25_4" dur="4" pname="c" oct="5" />
-                           <note xml:id="s1l1_t13_2" dur="2" pname="d" oct="5" />
+                           <note xml:id="n1mi3y13" dur="4" pname="b" oct="4" />
+                           <note xml:id="nqwknb3" dur="4" pname="c" oct="5" />
+                           <note xml:id="n1x2jg1w" dur="2" pname="d" oct="5" />
                         </layer>
                      </staff>
                      <staff xml:id="m7s2" n="2">
                         <layer xml:id="m7s2l1" n="1">
-                           <note xml:id="s2l1_t6_1" dur="4" pname="d" oct="3" />
-                           <note xml:id="s2l1_t25_4" dur="4" pname="c" oct="3" />
-                           <note xml:id="s2l1_t13_2" dur="2" pname="g" oct="3" />
+                           <note xml:id="nqp2dgg" dur="4" pname="d" oct="3" />
+                           <note xml:id="n85ojyb" dur="4" pname="c" oct="3" />
+                           <note xml:id="n1qsigl8" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
-                     <fermata xml:id="m7fm1" startid="#s1l1_t13_2" />
-                     <fermata xml:id="m7fm2" startid="#s2l1_t13_2" />
+                     <fermata xml:id="fm8vpg7" startid="#n1x2jg1w" />
+                     <fermata xml:id="f1bjixyt" startid="#n1qsigl8" />
                   </measure>
-                  <measure xml:id="m8" n="8">
+                  <measure xml:id="mzwij6m" n="8">
                      <staff xml:id="m8s1" n="1">
                         <layer xml:id="m8s1l1" n="1">
-                           <rest xml:id="s1l1_t7_1" dur="4" />
-                           <note xml:id="s1l1_t29_4" dur="4" pname="d" oct="5" />
-                           <beam xml:id="m8s1l1b1">
-                              <note xml:id="s1l1_t15_2" dur="8" pname="e" oct="5" />
-                              <note xml:id="s1l1_t61_8" dur="8" pname="d" oct="5" />
+                           <rest xml:id="rmoyo2" dur="4" />
+                           <note xml:id="n1q06doc" dur="4" pname="d" oct="5" />
+                           <beam>
+                              <note xml:id="n1l8yw5e" dur="8" pname="e" oct="5" />
+                              <note xml:id="nsourmg" dur="8" pname="d" oct="5" />
                            </beam>
-                           <note xml:id="s1l1_t31_4" dur="4" pname="c" oct="5" />
+                           <note xml:id="n1founj6" dur="4" pname="c" oct="5" />
                         </layer>
                      </staff>
                      <staff xml:id="m8s2" n="2">
                         <layer xml:id="m8s2l1" n="1">
-                           <rest xml:id="s2l1_t7_1" dur="4" />
-                           <note xml:id="s2l1_t29_4" dur="4" pname="g" oct="2" />
-                           <note xml:id="s2l1_t15_2" dur="4" pname="c" oct="3" />
-                           <beam xml:id="m8s2l1b1">
-                              <note xml:id="s2l1_t31_4" dur="8" pname="e" oct="3" />
-                              <note xml:id="s2l1_t63_8" dur="8" pname="c" oct="3" />
+                           <rest xml:id="rmu2uxz" dur="4" />
+                           <note xml:id="n10qscmx" dur="4" pname="g" oct="2" />
+                           <note xml:id="n1pqxxfb" dur="4" pname="c" oct="3" />
+                           <beam>
+                              <note xml:id="n1h5a7t" dur="8" pname="e" oct="3" />
+                              <note xml:id="n7ldqsj" dur="8" pname="c" oct="3" />
                            </beam>
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m9" n="9">
+                  <measure xml:id="m1ddinyu" n="9">
                      <staff xml:id="m9s1" n="1">
                         <layer xml:id="m9s1l1" n="1">
-                           <note xml:id="s1l1_t8_1" dur="2" pname="d" oct="5" />
-                           <rest xml:id="s1l1_t17_2" dur="4" />
-                           <note xml:id="s1l1_t35_4" dur="4" pname="g" oct="4" />
+                           <note xml:id="n1s7emil" dur="2" pname="d" oct="5" />
+                           <rest xml:id="r1gw6yli" dur="4" />
+                           <note xml:id="n1vzqg1s" dur="4" pname="g" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m9s2" n="2">
                         <layer xml:id="m9s2l1" n="1">
-                           <note xml:id="s2l1_t8_1" dur="2" pname="g" oct="3" />
-                           <rest xml:id="s2l1_t17_2" dur="4" />
-                           <note xml:id="s2l1_t35_4" dur="4" pname="c" oct="3" />
+                           <note xml:id="nx88dbt" dur="2" pname="g" oct="3" />
+                           <rest xml:id="r1a63kuk" dur="4" />
+                           <note xml:id="n3aj1lf" dur="4" pname="c" oct="3" />
                         </layer>
                      </staff>
-                     <fermata xml:id="m9fm1" startid="#s1l1_t8_1" />
-                     <fermata xml:id="m9fm2" startid="#s2l1_t8_1" />
+                     <fermata xml:id="f1xtc2l4" startid="#n1s7emil" />
+                     <fermata xml:id="f1qn0rq5" startid="#nx88dbt" />
                   </measure>
-                  <measure xml:id="m10" n="10">
+                  <measure xml:id="m14l0kjk" n="10">
                      <staff xml:id="m10s1" n="1">
                         <layer xml:id="m10s1l1" n="1">
-                           <note xml:id="s1l1_t9_1" dur="4" pname="a" oct="4" />
-                           <note xml:id="s1l1_t37_4" dur="4" pname="b" oct="4" />
-                           <note xml:id="s1l1_t19_2" dur="4" pname="c" oct="5" />
-                           <note xml:id="s1l1_t39_4" dur="4" pname="e" oct="5" />
+                           <note xml:id="nb9m7cg" dur="4" pname="a" oct="4" />
+                           <note xml:id="nrmg3u3" dur="4" pname="b" oct="4" />
+                           <note xml:id="nct14t1" dur="4" pname="c" oct="5" />
+                           <note xml:id="n1u100ct" dur="4" pname="e" oct="5" />
                         </layer>
                      </staff>
                      <staff xml:id="m10s2" n="2">
                         <layer xml:id="m10s2l1" n="1">
-                           <note xml:id="s2l1_t9_1" dur="4" pname="f" oct="3" />
-                           <note xml:id="s2l1_t37_4" dur="4" pname="d" oct="3" />
-                           <note xml:id="s2l1_t19_2" dur="4" pname="e" oct="3" />
-                           <note xml:id="s2l1_t39_4" dur="4" pname="c" oct="3" />
+                           <note xml:id="nux1zmb" dur="4" pname="f" oct="3" />
+                           <note xml:id="n3efwul" dur="4" pname="d" oct="3" />
+                           <note xml:id="nwaicl6" dur="4" pname="e" oct="3" />
+                           <note xml:id="nd6d2lw" dur="4" pname="c" oct="3" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m11" right="end" n="11">
+                  <measure xml:id="mcmnkze" right="end" n="11">
                      <staff xml:id="m11s1" n="1">
                         <layer xml:id="m11s1l1" n="1">
-                           <note xml:id="s1l1_t10_1" dur="2" pname="d" oct="5" />
-                           <note xml:id="s1l1_t21_2" dur="2" pname="c" oct="5" />
+                           <note xml:id="nqpb1zv" dur="2" pname="d" oct="5" />
+                           <note xml:id="n1m3rbb4" dur="2" pname="c" oct="5" />
                         </layer>
                      </staff>
                      <staff xml:id="m11s2" n="2">
                         <layer xml:id="m11s2l1" n="1">
-                           <note xml:id="s2l1_t10_1" dur="4" pname="f" oct="3" />
-                           <note xml:id="s2l1_t41_4" dur="4" pname="g" oct="3" />
-                           <note xml:id="s2l1_t21_2" dur="2" pname="c" oct="3" />
+                           <note xml:id="nmqy42z" dur="4" pname="f" oct="3" />
+                           <note xml:id="nybdybh" dur="4" pname="g" oct="3" />
+                           <note xml:id="n1ylj57c" dur="2" pname="c" oct="3" />
                         </layer>
                      </staff>
-                     <fermata xml:id="m11fm1" startid="#s1l1_t21_2" />
-                     <fermata xml:id="m11fm2" startid="#s2l1_t21_2" />
+                     <fermata xml:id="fvt9cd9" startid="#n1m3rbb4" />
+                     <fermata xml:id="f160ju5r" startid="#n1ylj57c" />
                   </measure>
                </section>
             </score>

--- a/src/importexport/mei/tests/data/breaks-01.mscx
+++ b/src/importexport/mei/tests/data/breaks-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Rein</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Ach Gott und Herr&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Rein&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:09:47&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Ach Gott und Herr&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Rein&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:51:13&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/breath-01.mei
+++ b/src/importexport/mei/tests/data/breath-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:09:48" />
+            <date isodate="2023-08-11T14:51:19" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -46,95 +46,95 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" metcon="false" n="1">
+                  <measure xml:id="mzf2odj" metcon="false" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <rest xml:id="s1l1_t0_1" dur="4" />
+                           <rest xml:id="rp7gcn" dur="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s2" n="2">
                         <layer xml:id="m1s2l1" n="1">
-                           <rest xml:id="s2l1_t0_1" dur="4" />
+                           <rest xml:id="r1soe0n0" dur="4" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="mv0cui5" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <note xml:id="s1l1_t1_4" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t1_2" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t3_4" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t1_1" dur="4" pname="b" oct="3" />
+                           <note xml:id="n1x0czh2" dur="4" pname="c" oct="4" />
+                           <note xml:id="n1t2hxkc" dur="4" pname="e" oct="4" />
+                           <note xml:id="n19gmhps" dur="4" pname="g" oct="4" />
+                           <note xml:id="ncsync" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s2" n="2">
                         <layer xml:id="m2s2l1" n="1">
-                           <note xml:id="s2l1_t1_4" dur="2" pname="c" oct="3" />
-                           <note xml:id="s2l1_t3_4" dur="2" pname="g" oct="2" />
+                           <note xml:id="n16smjdq" dur="2" pname="c" oct="3" />
+                           <note xml:id="n1dsn2tl" dur="2" pname="g" oct="2" />
                         </layer>
                      </staff>
-                     <breath xml:id="m2bt1" startid="#s1l1_t1_4" />
-                     <breath xml:id="m2bt2" startid="#s1l1_t1_1" glyph.auth="smufl" glyph.name="breathMarkUpbow" />
-                     <breath xml:id="m2bt3" startid="#s2l1_t1_4" />
+                     <breath xml:id="bkfjn7f" startid="#n1x0czh2" />
+                     <breath xml:id="bb93j7i" startid="#ncsync" glyph.auth="smufl" glyph.name="breathMarkUpbow" />
+                     <breath xml:id="bt93nqa" startid="#n16smjdq" />
                   </measure>
-                  <measure xml:id="m3" n="3">
+                  <measure xml:id="mthvh9f" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <note xml:id="s1l1_t5_4" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t3_2" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t7_4" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t2_1" dur="4" pname="b" oct="3" />
+                           <note xml:id="n78o72a" dur="4" pname="c" oct="4" />
+                           <note xml:id="n1q3bgmi" dur="4" pname="e" oct="4" />
+                           <note xml:id="n11rk39v" dur="4" pname="g" oct="4" />
+                           <note xml:id="n1xi704l" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m3s2" n="2">
                         <layer xml:id="m3s2l1" n="1">
-                           <note xml:id="s2l1_t5_4" dur="2" pname="c" oct="3" />
-                           <note xml:id="s2l1_t7_4" dur="2" pname="g" oct="2" />
+                           <note xml:id="n1y8fxxo" dur="2" pname="c" oct="3" />
+                           <note xml:id="nfa3a4t" dur="2" pname="g" oct="2" />
                         </layer>
                      </staff>
-                     <caesura xml:id="m3cs1" startid="#s1l1_t5_4" glyph.auth="smufl" glyph.name="caesuraCurved" />
-                     <caesura xml:id="m3cs2" startid="#s1l1_t3_2" />
-                     <caesura xml:id="m3cs3" startid="#s1l1_t2_1" glyph.auth="smufl" glyph.name="caesuraShort" />
-                     <caesura xml:id="m3cs4" startid="#s2l1_t5_4" />
+                     <caesura xml:id="csoibna" startid="#n78o72a" glyph.auth="smufl" glyph.name="caesuraCurved" />
+                     <caesura xml:id="c1sbyhff" startid="#n1q3bgmi" />
+                     <caesura xml:id="cmbip06" startid="#n1xi704l" glyph.auth="smufl" glyph.name="caesuraShort" />
+                     <caesura xml:id="c1d2aebh" startid="#n1y8fxxo" />
                   </measure>
-                  <measure xml:id="m4" n="4">
+                  <measure xml:id="mp4731w" n="4">
                      <staff xml:id="m4s1" n="1">
                         <layer xml:id="m4s1l1" n="1">
-                           <note xml:id="s1l1_t9_4" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t5_2" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t11_4" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t3_1" dur="4" pname="b" oct="3" />
+                           <note xml:id="nze48jy" dur="4" pname="c" oct="4" />
+                           <note xml:id="n11akada" dur="4" pname="e" oct="4" />
+                           <note xml:id="nkyy2ca" dur="4" pname="g" oct="4" />
+                           <note xml:id="n1urqw50" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m4s2" n="2">
                         <layer xml:id="m4s2l1" n="1">
-                           <note xml:id="s2l1_t9_4" dur="2" pname="c" oct="3" />
-                           <note xml:id="s2l1_t11_4" dur="2" pname="g" oct="2" />
+                           <note xml:id="n10n7j8" dur="2" pname="c" oct="3" />
+                           <note xml:id="nrpzau9" dur="2" pname="g" oct="2" />
                         </layer>
                      </staff>
-                     <caesura xml:id="m4cs1" startid="#s1l1_t5_2" glyph.auth="smufl" glyph.name="chantCaesura" />
+                     <caesura xml:id="c1j4wn46" startid="#n11akada" glyph.auth="smufl" glyph.name="chantCaesura" />
                   </measure>
                   <scoreDef meter.count="6" meter.unit="8" />
-                  <measure xml:id="m5" right="end" n="5">
+                  <measure xml:id="mnijfsd" right="end" n="5">
                      <staff xml:id="m5s1" n="1">
                         <layer xml:id="m5s1l1" n="1">
-                           <note xml:id="s1l1_t13_4" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t7_2" dur="8" pname="e" oct="4" />
-                           <note xml:id="s1l1_t29_8" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t31_8" dur="8" pname="g" oct="3" />
+                           <note xml:id="n133n6rf" dur="4" pname="c" oct="4" />
+                           <note xml:id="n1z0gafg" dur="8" pname="e" oct="4" />
+                           <note xml:id="n1tylffb" dur="4" pname="g" oct="4" />
+                           <note xml:id="n1k5df3b" dur="8" pname="g" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m5s2" n="2">
                         <layer xml:id="m5s2l1" n="1">
-                           <note xml:id="s2l1_t13_4" dots="1" dur="4" pname="c" oct="3" />
-                           <note xml:id="s2l1_t29_8" dots="1" dur="4" pname="g" oct="2" />
+                           <note xml:id="n105osyq" dots="1" dur="4" pname="c" oct="3" />
+                           <note xml:id="nz5si71" dots="1" dur="4" pname="g" oct="2" />
                         </layer>
                      </staff>
-                     <caesura xml:id="m5cs1" startid="#s1l1_t13_4" glyph.auth="smufl" glyph.name="chantCaesura" />
-                     <caesura xml:id="m5cs2" startid="#s1l1_t7_2" glyph.auth="smufl" glyph.name="caesuraThick" />
-                     <caesura xml:id="m5cs3" startid="#s1l1_t29_8" glyph.auth="smufl" glyph.name="caesuraThick" />
-                     <caesura xml:id="m5cs4" startid="#s1l1_t31_8" glyph.auth="smufl" glyph.name="caesuraThick" />
-                     <caesura xml:id="m5cs5" startid="#s2l1_t13_4" glyph.auth="smufl" glyph.name="caesuraThick" />
+                     <caesura xml:id="c1xlsqgr" startid="#n133n6rf" glyph.auth="smufl" glyph.name="chantCaesura" />
+                     <caesura xml:id="cfvwysy" startid="#n1z0gafg" glyph.auth="smufl" glyph.name="caesuraThick" />
+                     <caesura xml:id="c13mj4gz" startid="#n1tylffb" glyph.auth="smufl" glyph.name="caesuraThick" />
+                     <caesura xml:id="clqaqjx" startid="#n1k5df3b" glyph.auth="smufl" glyph.name="caesuraThick" />
+                     <caesura xml:id="c16kirlk" startid="#n105osyq" glyph.auth="smufl" glyph.name="caesuraThick" />
                   </measure>
                </section>
             </score>

--- a/src/importexport/mei/tests/data/breath-01.mscx
+++ b/src/importexport/mei/tests/data/breath-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:09:48&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:51:19&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/chord-label-01.mei
+++ b/src/importexport/mei/tests/data/chord-label-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:09:51" />
+            <date isodate="2023-08-11T14:51:31" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -39,150 +39,150 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m1n62k5j" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <chord xml:id="s1l1_t0_1" dur="2">
-                              <note xml:id="m1s1l1n1" pname="e" oct="2" />
-                              <note xml:id="m1s1l1n2" pname="b" oct="2" />
-                              <note xml:id="m1s1l1n3" pname="d" oct="3">
-                                 <accid xml:id="m1s1l1a1" accid="s" />
+                           <chord xml:id="ce1pgdr" dur="2">
+                              <note xml:id="n1wmy1hl" pname="e" oct="2" />
+                              <note xml:id="ndd6g30" pname="b" oct="2" />
+                              <note xml:id="n1txs7w4" pname="d" oct="3">
+                                 <accid accid="s" />
                               </note>
-                              <note xml:id="m1s1l1n4" pname="g" oct="3">
-                                 <accid xml:id="m1s1l1a2" accid="s" />
+                              <note xml:id="n1va2xz9" pname="g" oct="3">
+                                 <accid accid="s" />
                               </note>
                            </chord>
-                           <chord xml:id="s1l1_t1_2" dur="2">
-                              <note xml:id="m1s1l1n5" pname="d" oct="2" />
-                              <note xml:id="m1s1l1n6" pname="b" oct="2">
-                                 <accid xml:id="m1s1l1a3" accid="f" />
+                           <chord xml:id="c1li1ln8" dur="2">
+                              <note xml:id="n1t0ugcu" pname="d" oct="2" />
+                              <note xml:id="ndbyuws" pname="b" oct="2">
+                                 <accid accid="f" />
                               </note>
-                              <note xml:id="m1s1l1n7" pname="d" oct="3">
-                                 <accid xml:id="m1s1l1a4" accid="n" />
+                              <note xml:id="nj3mw95" pname="d" oct="3">
+                                 <accid accid="n" />
                               </note>
-                              <note xml:id="m1s1l1n8" pname="f" oct="3">
-                                 <accid xml:id="m1s1l1a5" accid="n" />
+                              <note xml:id="n1mfuxos" pname="f" oct="3">
+                                 <accid accid="n" />
                               </note>
                            </chord>
                         </layer>
                      </staff>
-                     <harm xml:id="m1hr1" startid="#s1l1_t0_1">E^7</harm>
-                     <harm xml:id="m1hr2" startid="#s1l1_t1_2">Bb/D</harm>
+                     <harm xml:id="h13odusg" startid="#ce1pgdr">E^7</harm>
+                     <harm xml:id="h33umgw" startid="#c1li1ln8">Bb/D</harm>
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="m1i2auik" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <rest xml:id="s1l1_t1_1" dur="4" />
-                           <chord xml:id="s1l1_t5_4" dur="4">
-                              <note xml:id="m2s1l1n1" pname="e" oct="2" />
-                              <note xml:id="m2s1l1n2" pname="b" oct="2" />
-                              <note xml:id="m2s1l1n3" pname="d" oct="3" />
-                              <note xml:id="m2s1l1n4" pname="g" oct="3">
-                                 <accid xml:id="m2s1l1a1" accid="s" />
+                           <rest xml:id="r1x2jngi" dur="4" />
+                           <chord xml:id="ck8a9w3" dur="4">
+                              <note xml:id="n1j1003f" pname="e" oct="2" />
+                              <note xml:id="n1bpds2n" pname="b" oct="2" />
+                              <note xml:id="ngpxgrm" pname="d" oct="3" />
+                              <note xml:id="n8itekh" pname="g" oct="3">
+                                 <accid accid="s" />
                               </note>
                            </chord>
-                           <chord xml:id="s1l1_t3_2" dur="2">
-                              <note xml:id="m2s1l1n5" pname="d" oct="2">
-                                 <accid xml:id="m2s1l1a2" accid="f" />
+                           <chord xml:id="cla9a5l" dur="2">
+                              <note xml:id="n1rg2veq" pname="d" oct="2">
+                                 <accid accid="f" />
                               </note>
-                              <note xml:id="m2s1l1n6" pname="a" oct="2">
-                                 <accid xml:id="m2s1l1a3" accid="f" />
+                              <note xml:id="nn6d3cd" pname="a" oct="2">
+                                 <accid accid="f" />
                               </note>
-                              <note xml:id="m2s1l1n7" pname="d" oct="3">
-                                 <accid xml:id="m2s1l1a4" accid="f" />
+                              <note xml:id="n1sunfo7" pname="d" oct="3">
+                                 <accid accid="f" />
                               </note>
-                              <note xml:id="m2s1l1n8" pname="f" oct="3" />
-                              <note xml:id="m2s1l1n9" pname="a" oct="3">
-                                 <accid xml:id="m2s1l1a5" accid="f" />
+                              <note xml:id="nr2mf1s" pname="f" oct="3" />
+                              <note xml:id="n14wh0pt" pname="a" oct="3">
+                                 <accid accid="f" />
                               </note>
                            </chord>
                         </layer>
                      </staff>
-                     <harm xml:id="m2hr1" startid="#s1l1_t1_1">EM</harm>
-                     <harm xml:id="m2hr2" startid="#s1l1_t5_4">E7</harm>
-                     <harm xml:id="m2hr3" startid="#s1l1_t3_2">not a chord</harm>
+                     <harm xml:id="h1c0dmjp" startid="#r1x2jngi">EM</harm>
+                     <harm xml:id="h1jis26n" startid="#ck8a9w3">E7</harm>
+                     <harm xml:id="hkvfebu" startid="#cla9a5l">not a chord</harm>
                   </measure>
-                  <measure xml:id="m3" n="3">
+                  <measure xml:id="m13aeql2" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <chord xml:id="s1l1_t2_1" dur="2">
-                              <note xml:id="m3s1l1n1" pname="b" oct="2">
-                                 <accid xml:id="m3s1l1a1" accid="ff" />
+                           <chord xml:id="c16xft9c" dur="2">
+                              <note xml:id="nkp85c3" pname="b" oct="2">
+                                 <accid accid="ff" />
                               </note>
-                              <note xml:id="m3s1l1n2" pname="d" oct="3">
-                                 <accid xml:id="m3s1l1a2" accid="f" />
+                              <note xml:id="n1r0jdq3" pname="d" oct="3">
+                                 <accid accid="f" />
                               </note>
-                              <note xml:id="m3s1l1n3" pname="f" oct="3">
-                                 <accid xml:id="m3s1l1a3" accid="f" />
+                              <note xml:id="n1vqf819" pname="f" oct="3">
+                                 <accid accid="f" />
                               </note>
-                              <note xml:id="m3s1l1n4" pname="b" oct="3">
-                                 <accid xml:id="m3s1l1a4" accid="ff" />
+                              <note xml:id="n12i51dj" pname="b" oct="3">
+                                 <accid accid="ff" />
                               </note>
                            </chord>
-                           <chord xml:id="s1l1_t5_2" dur="2">
-                              <note xml:id="m3s1l1n5" pname="g" oct="2">
-                                 <accid xml:id="m3s1l1a5" accid="f" />
+                           <chord xml:id="c1gy7hnm" dur="2">
+                              <note xml:id="nbg7hk9" pname="g" oct="2">
+                                 <accid accid="f" />
                               </note>
-                              <note xml:id="m3s1l1n6" pname="g" oct="3">
-                                 <accid xml:id="m3s1l1a6" accid="f" />
+                              <note xml:id="n1erio7j" pname="g" oct="3">
+                                 <accid accid="f" />
                               </note>
-                              <note xml:id="m3s1l1n7" pname="b" oct="3">
-                                 <accid xml:id="m3s1l1a7" accid="ff" />
+                              <note xml:id="nl5rsf3" pname="b" oct="3">
+                                 <accid accid="ff" />
                               </note>
                            </chord>
                         </layer>
                         <layer xml:id="m3s1l2" n="2">
-                           <note xml:id="s1l2_t2_1" dur="2" pname="c" oct="3" />
-                           <note xml:id="s1l2_t5_2" dur="4" pname="d" oct="3">
-                              <accid xml:id="m3s1l2a1" accid="f" />
+                           <note xml:id="n1yj7kly" dur="2" pname="c" oct="3" />
+                           <note xml:id="n7wax1i" dur="4" pname="d" oct="3">
+                              <accid accid="f" />
                            </note>
-                           <note xml:id="s1l2_t11_4" dur="4" pname="e" oct="3">
-                              <accid xml:id="m3s1l2a2" accid="f" />
+                           <note xml:id="n1p6ucuy" dur="4" pname="e" oct="3">
+                              <accid accid="f" />
                            </note>
                         </layer>
                      </staff>
-                     <harm xml:id="m3hr1" startid="#s1l1_t2_1">Bbb</harm>
-                     <harm xml:id="m3hr2" startid="#s1l1_t5_2">Gb-</harm>
-                     <harm xml:id="m3hr3" startid="#s1l2_t11_4">Eb0</harm>
+                     <harm xml:id="hs3epla" startid="#c16xft9c">Bbb</harm>
+                     <harm xml:id="hta9dzc" startid="#c1gy7hnm">Gb-</harm>
+                     <harm xml:id="hesozve" startid="#n1p6ucuy">Eb0</harm>
                   </measure>
-                  <measure xml:id="m4" right="end" n="4">
+                  <measure xml:id="m5rxr9c" right="end" n="4">
                      <staff xml:id="m4s1" n="1">
                         <layer xml:id="m4s1l1" n="1">
-                           <chord xml:id="s1l1_t3_1" dur="1">
-                              <note xml:id="m4s1l1n1" pname="d" oct="2">
-                                 <accid xml:id="m4s1l1a1" accid="f" />
+                           <chord xml:id="cnx0jer" dur="1">
+                              <note xml:id="nzkgdgm" pname="d" oct="2">
+                                 <accid accid="f" />
                               </note>
-                              <note xml:id="m4s1l1n2" pname="f" oct="3">
-                                 <accid xml:id="m4s1l1a2" accid="n" />
+                              <note xml:id="n1i3jaas" pname="f" oct="3">
+                                 <accid accid="n" />
                               </note>
                            </chord>
                         </layer>
                         <layer xml:id="m4s1l2" n="2">
-                           <note xml:id="s1l2_t3_1" dur="2" pname="c" oct="3" />
-                           <note xml:id="s1l2_t7_2" dur="2" pname="b" oct="2">
-                              <accid xml:id="m4s1l2a1" accid="f" />
+                           <note xml:id="n1hxdolq" dur="2" pname="c" oct="3" />
+                           <note xml:id="ng0pl5s" dur="2" pname="b" oct="2">
+                              <accid accid="f" />
                            </note>
                         </layer>
                         <layer xml:id="m4s1l3" n="3">
-                           <note xml:id="s1l3_t3_1" dur="2" pname="e" oct="4">
-                              <accid xml:id="m4s1l3a1" accid="f" />
+                           <note xml:id="n1g03w2v" dur="2" pname="e" oct="4">
+                              <accid accid="f" />
                            </note>
-                           <note xml:id="s1l3_t7_2" dur="2" pname="d" oct="4">
-                              <accid xml:id="m4s1l3a2" accid="f" />
+                           <note xml:id="n143sgv5" dur="2" pname="d" oct="4">
+                              <accid accid="f" />
                            </note>
                         </layer>
                         <layer xml:id="m4s1l4" n="4">
-                           <note xml:id="s1l4_t3_1" dur="2" pname="a" oct="3">
-                              <accid xml:id="m4s1l4a1" accid="f" />
+                           <note xml:id="n1i1lz9f" dur="2" pname="a" oct="3">
+                              <accid accid="f" />
                            </note>
-                           <note xml:id="s1l4_t7_2" dur="2" pname="a" oct="3">
-                              <accid xml:id="m4s1l4a2" accid="n" />
+                           <note xml:id="n1shftah" dur="2" pname="a" oct="3">
+                              <accid accid="n" />
                            </note>
                         </layer>
                      </staff>
-                     <harm xml:id="m4hr1" startid="#s1l1_t3_1">Db9Maj7</harm>
-                     <harm xml:id="m4hr2" startid="#s1l2_t7_2">Bbono5ma7</harm>
-                     <harm xml:id="m4hr3" startid="#s1l4_t7_2">Bb-Maj7/Db</harm>
+                     <harm xml:id="hjkk6k0" startid="#cnx0jer">Db9Maj7</harm>
+                     <harm xml:id="h1apzsdh" startid="#ng0pl5s">Bbono5ma7</harm>
+                     <harm xml:id="h1ybbeae" startid="#n1shftah">Bb-Maj7/Db</harm>
                   </measure>
                </section>
             </score>

--- a/src/importexport/mei/tests/data/chord-label-01.mscx
+++ b/src/importexport/mei/tests/data/chord-label-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:09:51&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:51:31&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/clef-01.mei
+++ b/src/importexport/mei/tests/data/clef-01.mei
@@ -8,7 +8,7 @@
             <title>Clefs</title>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:09:52" />
+            <date isodate="2023-08-11T14:51:37" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -30,146 +30,146 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m10vi231" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <note xml:id="s1l1_t0_1" dur="1" pname="g" oct="4" />
-                           <clef xml:id="m1s1l1z1" shape="G" line="2" dis="8" dis.place="above" />
+                           <note xml:id="n1lavsmx" dur="1" pname="g" oct="4" />
+                           <clef xml:id="c1fepbps" shape="G" line="2" dis="8" dis.place="above" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="m99jjek" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <note xml:id="s1l1_t1_1" dur="1" pname="g" oct="5" />
-                           <clef xml:id="m2s1l1z1" shape="G" line="2" dis="15" dis.place="above" />
+                           <note xml:id="n10n4e7z" dur="1" pname="g" oct="5" />
+                           <clef xml:id="c1cv2kbh" shape="G" line="2" dis="15" dis.place="above" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m3" n="3">
+                  <measure xml:id="mxn0u1p" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <note xml:id="s1l1_t2_1" dur="1" pname="g" oct="6" />
-                           <clef xml:id="m3s1l1z1" shape="G" line="2" dis="8" dis.place="below" />
+                           <note xml:id="n1bf4pst" dur="1" pname="g" oct="6" />
+                           <clef xml:id="cod1oy7" shape="G" line="2" dis="8" dis.place="below" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m4" n="4">
+                  <measure xml:id="m13t4998" n="4">
                      <staff xml:id="m4s1" n="1">
                         <layer xml:id="m4s1l1" n="1">
-                           <note xml:id="s1l1_t3_1" dur="1" pname="g" oct="3" />
-                           <clef xml:id="m4s1l1z1" shape="G" line="1" />
+                           <note xml:id="n1rer54m" dur="1" pname="g" oct="3" />
+                           <clef xml:id="ck4sn4e" shape="G" line="1" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m5" n="5">
+                  <measure xml:id="m1ei7loh" n="5">
                      <staff xml:id="m5s1" n="1">
                         <layer xml:id="m5s1l1" n="1">
-                           <note xml:id="s1l1_t4_1" dur="1" pname="g" oct="4" />
-                           <clef xml:id="m5s1l1z1" shape="GG" line="2" />
+                           <note xml:id="nsc0ny6" dur="1" pname="g" oct="4" />
+                           <clef xml:id="c10htukn" shape="GG" line="2" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m6" n="6">
+                  <measure xml:id="mr72v07" n="6">
                      <staff xml:id="m6s1" n="1">
                         <layer xml:id="m6s1l1" n="1">
-                           <note xml:id="s1l1_t5_1" dur="1" pname="g" oct="3" />
-                           <clef xml:id="m6s1l1z1" shape="C" line="1" />
+                           <note xml:id="n1xk47u8" dur="1" pname="g" oct="3" />
+                           <clef xml:id="c1y2z7sj" shape="C" line="1" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m7" n="7">
+                  <measure xml:id="mrc6b72" n="7">
                      <staff xml:id="m7s1" n="1">
                         <layer xml:id="m7s1l1" n="1">
-                           <note xml:id="s1l1_t6_1" dur="1" pname="c" oct="4" />
-                           <clef xml:id="m7s1l1z1" shape="C" line="2" />
+                           <note xml:id="n1li70bq" dur="1" pname="c" oct="4" />
+                           <clef xml:id="c2v7qp7" shape="C" line="2" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m8" n="8">
+                  <measure xml:id="m19g834m" n="8">
                      <staff xml:id="m8s1" n="1">
                         <layer xml:id="m8s1l1" n="1">
-                           <note xml:id="s1l1_t7_1" dur="1" pname="c" oct="4" />
-                           <clef xml:id="m8s1l1z1" shape="C" line="3" />
+                           <note xml:id="nll9e96" dur="1" pname="c" oct="4" />
+                           <clef xml:id="cc9aphh" shape="C" line="3" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m9" n="9">
+                  <measure xml:id="m1f28c9j" n="9">
                      <staff xml:id="m9s1" n="1">
                         <layer xml:id="m9s1l1" n="1">
-                           <note xml:id="s1l1_t8_1" dur="1" pname="c" oct="4" />
-                           <clef xml:id="m9s1l1z1" shape="C" line="4" />
+                           <note xml:id="n12mvmi1" dur="1" pname="c" oct="4" />
+                           <clef xml:id="c1ucw6js" shape="C" line="4" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m10" n="10">
+                  <measure xml:id="m17d47f2" n="10">
                      <staff xml:id="m10s1" n="1">
                         <layer xml:id="m10s1l1" n="1">
-                           <note xml:id="s1l1_t9_1" dur="1" pname="c" oct="4" />
-                           <clef xml:id="m10s1l1z1" shape="C" line="5" />
+                           <note xml:id="ng0sd0b" dur="1" pname="c" oct="4" />
+                           <clef xml:id="c1wlo6v7" shape="C" line="5" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m11" n="11">
+                  <measure xml:id="mo8rl2h" n="11">
                      <staff xml:id="m11s1" n="1">
                         <layer xml:id="m11s1l1" n="1">
-                           <note xml:id="s1l1_t10_1" dur="1" pname="c" oct="4" />
-                           <clef xml:id="m11s1l1z1" shape="F" line="4" />
+                           <note xml:id="n1pl141h" dur="1" pname="c" oct="4" />
+                           <clef xml:id="cgpfgu2" shape="F" line="4" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m12" n="12">
+                  <measure xml:id="m1w3zyx" n="12">
                      <staff xml:id="m12s1" n="1">
                         <layer xml:id="m12s1l1" n="1">
-                           <note xml:id="s1l1_t11_1" dur="1" pname="f" oct="3" />
-                           <clef xml:id="m12s1l1z1" shape="F" line="4" dis="8" dis.place="above" />
+                           <note xml:id="no704j5" dur="1" pname="f" oct="3" />
+                           <clef xml:id="c32xlzz" shape="F" line="4" dis="8" dis.place="above" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m13" n="13">
+                  <measure xml:id="m1dk0ame" n="13">
                      <staff xml:id="m13s1" n="1">
                         <layer xml:id="m13s1l1" n="1">
-                           <note xml:id="s1l1_t12_1" dur="1" pname="f" oct="4" />
-                           <clef xml:id="m13s1l1z1" shape="F" line="4" dis="15" dis.place="above" />
+                           <note xml:id="n10nsveq" dur="1" pname="f" oct="4" />
+                           <clef xml:id="c1cflihm" shape="F" line="4" dis="15" dis.place="above" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m14" n="14">
+                  <measure xml:id="mgzyoy5" n="14">
                      <staff xml:id="m14s1" n="1">
                         <layer xml:id="m14s1l1" n="1">
-                           <note xml:id="s1l1_t13_1" dur="1" pname="f" oct="5" />
-                           <clef xml:id="m14s1l1z1" shape="F" line="4" dis="8" dis.place="below" />
+                           <note xml:id="nmrekih" dur="1" pname="f" oct="5" />
+                           <clef xml:id="cohw8zf" shape="F" line="4" dis="8" dis.place="below" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m15" n="15">
+                  <measure xml:id="m1q3zn8z" n="15">
                      <staff xml:id="m15s1" n="1">
                         <layer xml:id="m15s1l1" n="1">
-                           <note xml:id="s1l1_t14_1" dur="1" pname="f" oct="2" />
-                           <clef xml:id="m15s1l1z1" shape="F" line="4" dis="15" dis.place="below" />
+                           <note xml:id="nxv9tml" dur="1" pname="f" oct="2" />
+                           <clef xml:id="c1yq37iu" shape="F" line="4" dis="15" dis.place="below" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m16" n="16">
+                  <measure xml:id="mhsym8n" n="16">
                      <staff xml:id="m16s1" n="1">
                         <layer xml:id="m16s1l1" n="1">
-                           <note xml:id="s1l1_t15_1" dur="1" pname="f" oct="1" />
-                           <clef xml:id="m16s1l1z1" shape="F" line="3" />
+                           <note xml:id="n8vb82c" dur="1" pname="f" oct="1" />
+                           <clef xml:id="c1oviza9" shape="F" line="3" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m17" n="17">
+                  <measure xml:id="m1ana82i" n="17">
                      <staff xml:id="m17s1" n="1">
                         <layer xml:id="m17s1l1" n="1">
-                           <note xml:id="s1l1_t16_1" dur="1" pname="f" oct="3" />
-                           <clef xml:id="m17s1l1z1" shape="F" line="5" />
+                           <note xml:id="ncths4h" dur="1" pname="f" oct="3" />
+                           <clef xml:id="ckrpmha" shape="F" line="5" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m18" right="end" n="18">
+                  <measure xml:id="m1y0vz9p" right="end" n="18">
                      <staff xml:id="m18s1" n="1">
                         <layer xml:id="m18s1l1" n="1">
-                           <note xml:id="s1l1_t17_1" dur="1" pname="f" oct="3" />
+                           <note xml:id="n1gotq6n" dur="1" pname="f" oct="3" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/clef-01.mscx
+++ b/src/importexport/mei/tests/data/clef-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer"></metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Clefs&lt;/title&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:09:52&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Clefs&lt;/title&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:51:37&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/cross-staff-01.mei
+++ b/src/importexport/mei/tests/data/cross-staff-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:09:54" />
+            <date isodate="2023-08-11T14:51:50" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -44,77 +44,77 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m11ee0h6" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <mRest xml:id="s1l1_t0_1" />
+                           <mRest xml:id="m1e641zh" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s2" n="2">
                         <layer xml:id="m1s2l1" n="1">
-                           <beam xml:id="m1s2l1b1">
-                              <note xml:id="s2l1_t0_1" dur="16" staff="1" pname="b" oct="4" />
-                              <note xml:id="s2l1_t1_16" dur="16" pname="b" oct="2" />
-                              <note xml:id="s2l1_t1_8" dur="16" pname="b" oct="2" />
-                              <note xml:id="s2l1_t3_16" dur="16" staff="1" pname="d" oct="4" />
+                           <beam>
+                              <note xml:id="n1p18dci" dur="16" staff="1" pname="b" oct="4" />
+                              <note xml:id="n187uhng" dur="16" pname="b" oct="2" />
+                              <note xml:id="nzcgtxp" dur="16" pname="b" oct="2" />
+                              <note xml:id="nk6ops8" dur="16" staff="1" pname="d" oct="4" />
                            </beam>
-                           <beam xml:id="m1s2l1b2">
-                              <note xml:id="s2l1_t1_4" dur="16" staff="1" pname="b" oct="4" />
-                              <note xml:id="s2l1_t5_16" dur="16" pname="b" oct="2" />
-                              <note xml:id="s2l1_t3_8" dur="16" pname="b" oct="2" />
-                              <note xml:id="s2l1_t7_16" dur="16" staff="1" pname="d" oct="4" />
+                           <beam>
+                              <note xml:id="ntcjc22" dur="16" staff="1" pname="b" oct="4" />
+                              <note xml:id="n1mngjsa" dur="16" pname="b" oct="2" />
+                              <note xml:id="n1jcv1hh" dur="16" pname="b" oct="2" />
+                              <note xml:id="n7q5lbi" dur="16" staff="1" pname="d" oct="4" />
                            </beam>
-                           <beam xml:id="m1s2l1b3">
-                              <note xml:id="s2l1_t1_2" dur="16" staff="1" pname="b" oct="4" />
-                              <note xml:id="s2l1_t9_16" dur="16" pname="b" oct="2" />
-                              <note xml:id="s2l1_t5_8" dur="16" staff="1" pname="d" oct="4" />
+                           <beam>
+                              <note xml:id="nw10ccu" dur="16" staff="1" pname="b" oct="4" />
+                              <note xml:id="n19gk865" dur="16" pname="b" oct="2" />
+                              <note xml:id="n1272h95" dur="16" staff="1" pname="d" oct="4" />
                            </beam>
-                           <rest xml:id="s2l1_t11_16" type="mscore-beam-none" dur="16" staff="1" />
-                           <beam xml:id="m1s2l1b4">
-                              <note xml:id="s2l1_t3_4" dur="16" staff="1" pname="b" oct="4" />
-                              <note xml:id="s2l1_t13_16" dur="16" pname="b" oct="2" />
+                           <rest xml:id="rf4j9x2" type="mscore-beam-none" dur="16" staff="1" />
+                           <beam>
+                              <note xml:id="npacqi" dur="16" staff="1" pname="b" oct="4" />
+                              <note xml:id="nzntqhi" dur="16" pname="b" oct="2" />
                            </beam>
-                           <rest xml:id="s2l1_t7_8" type="mscore-beam-none" dur="16" staff="1" />
-                           <chord xml:id="s2l1_t15_16" dur="16" staff="1" stem.dir="up">
-                              <note xml:id="m1s2l1n1" pname="g" oct="3" />
-                              <note xml:id="m1s2l1n2" pname="b" oct="3" />
-                              <note xml:id="m1s2l1n3" pname="d" oct="4" />
+                           <rest xml:id="rnnqhfv" type="mscore-beam-none" dur="16" staff="1" />
+                           <chord xml:id="cddiqiv" dur="16" staff="1" stem.dir="up">
+                              <note xml:id="n5jfee8" pname="g" oct="3" />
+                              <note xml:id="nwpobph" pname="b" oct="3" />
+                              <note xml:id="n1vmxjaz" pname="d" oct="4" />
                            </chord>
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" right="end" n="2">
+                  <measure xml:id="mm4bewe" right="end" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <beam xml:id="m2s1l1b1">
-                              <note xml:id="s1l1_t1_1" dur="16" pname="b" oct="4" />
-                              <note xml:id="s1l1_t17_16" dur="16" staff="2" pname="b" oct="3" />
-                              <note xml:id="s1l1_t9_8" dur="16" pname="b" oct="4" />
-                              <note xml:id="s1l1_t19_16" dur="16" staff="2" pname="b" oct="3" />
+                           <beam>
+                              <note xml:id="n2fzn9a" dur="16" pname="b" oct="4" />
+                              <note xml:id="nypnlzd" dur="16" staff="2" pname="b" oct="3" />
+                              <note xml:id="n1jw2hju" dur="16" pname="b" oct="4" />
+                              <note xml:id="noh701w" dur="16" staff="2" pname="b" oct="3" />
                            </beam>
-                           <beam xml:id="m2s1l1b2">
-                              <note xml:id="s1l1_t5_4" dur="16" staff="2" pname="b" oct="3" />
-                              <note xml:id="s1l1_t21_16" dur="16" pname="b" oct="4" />
-                              <note xml:id="s1l1_t11_8" dur="16" staff="2" pname="b" oct="3" />
-                              <note xml:id="s1l1_t23_16" dur="16" pname="b" oct="4" />
+                           <beam>
+                              <note xml:id="n1z0w4uo" dur="16" staff="2" pname="b" oct="3" />
+                              <note xml:id="n6xgfx1" dur="16" pname="b" oct="4" />
+                              <note xml:id="nh9x4hc" dur="16" staff="2" pname="b" oct="3" />
+                              <note xml:id="n1cpwh79" dur="16" pname="b" oct="4" />
                            </beam>
-                           <beam xml:id="m2s1l1b3">
-                              <note xml:id="s1l1_t3_2" dur="16" pname="b" oct="4" />
-                              <note xml:id="s1l1_t25_16" dur="16" staff="2" pname="b" oct="3" />
-                              <note xml:id="s1l1_t13_8" dur="16" staff="2" pname="b" oct="3" />
-                              <note xml:id="s1l1_t27_16" dur="16" pname="b" oct="4" />
+                           <beam>
+                              <note xml:id="n1wvsk9i" dur="16" pname="b" oct="4" />
+                              <note xml:id="n131u565" dur="16" staff="2" pname="b" oct="3" />
+                              <note xml:id="nopzsd1" dur="16" staff="2" pname="b" oct="3" />
+                              <note xml:id="n1y26qk1" dur="16" pname="b" oct="4" />
                            </beam>
-                           <beam xml:id="m2s1l1b4">
-                              <note xml:id="s1l1_t7_4" dur="16" staff="2" pname="b" oct="3" />
-                              <note xml:id="s1l1_t29_16" dur="16" pname="b" oct="4" />
-                              <note xml:id="s1l1_t15_8" dur="16" pname="b" oct="4" />
-                              <note xml:id="s1l1_t31_16" dur="16" staff="2" pname="b" oct="3" />
+                           <beam>
+                              <note xml:id="n1o7whi1" dur="16" staff="2" pname="b" oct="3" />
+                              <note xml:id="neyzag0" dur="16" pname="b" oct="4" />
+                              <note xml:id="n1p8uc7d" dur="16" pname="b" oct="4" />
+                              <note xml:id="ni1ybvp" dur="16" staff="2" pname="b" oct="3" />
                            </beam>
                         </layer>
                      </staff>
                      <staff xml:id="m2s2" n="2">
                         <layer xml:id="m2s2l1" n="1">
-                           <mRest xml:id="s2l1_t1_1" />
+                           <mRest xml:id="m17y66iu" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/cross-staff-01.mscx
+++ b/src/importexport/mei/tests/data/cross-staff-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:09:54&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:51:50&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/dir-01.mei
+++ b/src/importexport/mei/tests/data/dir-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:09:56" />
+            <date isodate="2023-08-11T14:51:56" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -46,55 +46,55 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m1jreum9" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <mRest xml:id="s1l1_t0_1" />
+                           <mRest xml:id="mrkn6rf" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s2" n="2">
                         <layer xml:id="m1s2l1" n="1">
-                           <mRest xml:id="s2l1_t0_1" />
+                           <mRest xml:id="muoflm6" />
                         </layer>
                      </staff>
-                     <dir xml:id="m1dr1" type="mscore-staff-text" startid="#s1l1_t0_1">Staff text</dir>
-                     <dir xml:id="m1dr2" startid="#s2l1_t0_1">expression</dir>
+                     <dir xml:id="du9jefs" type="mscore-staff-text" startid="#mrkn6rf">Staff text</dir>
+                     <dir xml:id="d1bz5iph" startid="#muoflm6">expression</dir>
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="mou62ga" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <mRest xml:id="s1l1_t1_1" />
+                           <mRest xml:id="m1g8qzk0" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s2" n="2">
                         <layer xml:id="m2s2l1" n="1">
-                           <mRest xml:id="s2l1_t1_1" />
+                           <mRest xml:id="mogb023" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m3" n="3">
+                  <measure xml:id="mzoz4qx" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <mRest xml:id="s1l1_t2_1" />
+                           <mRest xml:id="mwek1l9" />
                         </layer>
                      </staff>
                      <staff xml:id="m3s2" n="2">
                         <layer xml:id="m3s2l1" n="1">
-                           <mRest xml:id="s2l1_t2_1" />
+                           <mRest xml:id="mtzukeh" />
                         </layer>
                      </staff>
-                     <dir xml:id="m3dr1" type="mscore-playtech-annotation" startid="#s1l1_t2_1" place="below">tremolo</dir>
-                     <dir xml:id="m3dr2" type="mscore-playtech-annotation" startid="#s2l1_t2_1">legato</dir>
+                     <dir xml:id="d1ukq7ad" type="mscore-playtech-annotation" startid="#mwek1l9" place="below">tremolo</dir>
+                     <dir xml:id="d9jr1ki" type="mscore-playtech-annotation" startid="#mtzukeh">legato</dir>
                   </measure>
-                  <measure xml:id="m4" right="end" n="4">
+                  <measure xml:id="mvrfsn6" right="end" n="4">
                      <staff xml:id="m4s1" n="1">
                         <layer xml:id="m4s1l1" n="1">
-                           <mRest xml:id="s1l1_t3_1" />
+                           <mRest xml:id="m1uxv1xq" />
                         </layer>
                      </staff>
                      <staff xml:id="m4s2" n="2">
                         <layer xml:id="m4s2l1" n="1">
-                           <mRest xml:id="s2l1_t3_1" />
+                           <mRest xml:id="m1bii3jk" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/dir-01.mscx
+++ b/src/importexport/mei/tests/data/dir-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:09:56&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:51:56&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/dynamic-01.mei
+++ b/src/importexport/mei/tests/data/dynamic-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:09:57" />
+            <date isodate="2023-08-11T14:52:02" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -39,46 +39,46 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m1uhe4sl" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <note xml:id="s1l1_t0_1" dur="2" pname="c" oct="5" />
-                           <beam xml:id="m1s1l1b1">
-                              <note xml:id="s1l1_t1_2" dur="8" pname="d" oct="5" />
-                              <note xml:id="s1l1_t5_8" dur="8" pname="e" oct="5" />
-                              <note xml:id="s1l1_t3_4" dur="8" pname="f" oct="5" />
-                              <note xml:id="s1l1_t7_8" dur="8" pname="e" oct="5" />
+                           <note xml:id="nrgzdcj" dur="2" pname="c" oct="5" />
+                           <beam>
+                              <note xml:id="n6si3n7" dur="8" pname="d" oct="5" />
+                              <note xml:id="n7c44ti" dur="8" pname="e" oct="5" />
+                              <note xml:id="nvtsktx" dur="8" pname="f" oct="5" />
+                              <note xml:id="nbt46w7" dur="8" pname="e" oct="5" />
                            </beam>
                         </layer>
                         <layer xml:id="m1s1l2" n="2">
-                           <note xml:id="s1l2_t0_1" dur="1" pname="c" oct="4" />
+                           <note xml:id="ns8t4tw" dur="1" pname="c" oct="4" />
                         </layer>
                      </staff>
-                     <dynam xml:id="m1dn1" label="p" startid="#s1l1_t0_1" place="above">p</dynam>
-                     <dynam xml:id="m1dn2" label="mp" startid="#s1l1_t1_2">mp</dynam>
-                     <dynam xml:id="m1dn3" label="sffz" startid="#s1l1_t5_8">sffz</dynam>
-                     <dynam xml:id="m1dn4" label="sfz" startid="#s1l1_t3_4">sfz</dynam>
-                     <dynam xml:id="m1dn5" label="pp" startid="#s1l2_t0_1">pp</dynam>
+                     <dynam xml:id="dvuqhls" label="p" startid="#nrgzdcj" place="above">p</dynam>
+                     <dynam xml:id="d1hg5le3" label="mp" startid="#n6si3n7">mp</dynam>
+                     <dynam xml:id="d1n0kf96" label="sffz" startid="#n7c44ti">sffz</dynam>
+                     <dynam xml:id="d1btxom9" label="sfz" startid="#nvtsktx">sfz</dynam>
+                     <dynam xml:id="d1rbma6l" label="pp" startid="#ns8t4tw">pp</dynam>
                   </measure>
-                  <measure xml:id="m2" right="end" n="2">
+                  <measure xml:id="m428gem" right="end" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <note xml:id="s1l1_t1_1" dur="4" pname="d" oct="5" />
-                           <chord xml:id="s1l1_t5_4" dur="4">
-                              <note xml:id="m2s1l1n1" pname="f" oct="4" />
-                              <note xml:id="m2s1l1n2" pname="c" oct="5" />
-                              <note xml:id="m2s1l1n3" pname="f" oct="5" />
+                           <note xml:id="noxjpqs" dur="4" pname="d" oct="5" />
+                           <chord xml:id="c1bio1o2" dur="4">
+                              <note xml:id="n1ypjje7" pname="f" oct="4" />
+                              <note xml:id="nkuy9t" pname="c" oct="5" />
+                              <note xml:id="n167vjzz" pname="f" oct="5" />
                            </chord>
-                           <chord xml:id="s1l1_t3_2" dur="2">
-                              <note xml:id="m2s1l1n4" pname="b" oct="4" />
-                              <note xml:id="m2s1l1n5" pname="d" oct="5" />
-                              <note xml:id="m2s1l1n6" pname="f" oct="5" />
+                           <chord xml:id="c19y1p0c" dur="2">
+                              <note xml:id="n10rwr2q" pname="b" oct="4" />
+                              <note xml:id="n5zaicj" pname="d" oct="5" />
+                              <note xml:id="ni76au9" pname="f" oct="5" />
                            </chord>
                         </layer>
                      </staff>
-                     <dynam xml:id="m2dn1" label="mp" startid="#s1l1_t1_1">sempre mp e <lb />dolce</dynam>
-                     <dynam xml:id="m2dn2" label="p" startid="#s1l1_t5_4">p e sempre<lb />dolce</dynam>
-                     <dynam xml:id="m2dn3" label="ff" startid="#s1l1_t3_2">molto ff</dynam>
+                     <dynam xml:id="d1pv19cd" label="mp" startid="#noxjpqs">sempre mp e <lb />dolce</dynam>
+                     <dynam xml:id="da76h31" label="p" startid="#c1bio1o2">p e sempre<lb />dolce</dynam>
+                     <dynam xml:id="dqa2pt" label="ff" startid="#c19y1p0c">molto ff</dynam>
                   </measure>
                </section>
             </score>

--- a/src/importexport/mei/tests/data/dynamic-01.mscx
+++ b/src/importexport/mei/tests/data/dynamic-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:09:57&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:52:02&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/ending-01.mei
+++ b/src/importexport/mei/tests/data/ending-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:09:58" />
+            <date isodate="2023-08-11T14:52:08" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -46,157 +46,157 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m1smv0tl" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <note xml:id="s1l1_t0_1" dur="1" pname="g" oct="4" />
+                           <note xml:id="niroceo" dur="1" pname="g" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s2" n="2">
                         <layer xml:id="m1s2l1" n="1">
-                           <note xml:id="s2l1_t0_1" dur="1" pname="b" oct="2" />
+                           <note xml:id="nj5abn7" dur="1" pname="b" oct="2" />
                         </layer>
                      </staff>
-                     <tempo xml:id="m1dn1" type="mscore-infer-from-text" startid="#s1l1_t0_1" midi.bpm="320.000000">
+                     <tempo xml:id="t1sz2k2m" type="mscore-infer-from-text" startid="#niroceo" midi.bpm="320.000000">
                         <rend glyph.auth="smufl"></rend> = 160</tempo>
                   </measure>
-                  <ending xml:id="e1" label="1." type="mscore-ending-1">
-                     <measure xml:id="m2" type="mscore-repeat-2" right="rptend" n="2">
+                  <ending xml:id="e56vjvc" label="1." type="mscore-ending-1">
+                     <measure xml:id="m1n5h024" type="mscore-repeat-2" right="rptend" n="2">
                         <staff xml:id="m2s1" n="1">
                            <layer xml:id="m2s1l1" n="1">
-                              <note xml:id="s1l1_t1_1" dur="1" pname="a" oct="4" />
+                              <note xml:id="n1ngr1a2" dur="1" pname="a" oct="4" />
                            </layer>
                         </staff>
                         <staff xml:id="m2s2" n="2">
                            <layer xml:id="m2s2l1" n="1">
-                              <note xml:id="s2l1_t1_1" dur="1" pname="c" oct="3" />
+                              <note xml:id="n1fcgpv7" dur="1" pname="c" oct="3" />
                            </layer>
                         </staff>
                      </measure>
                   </ending>
-                  <ending xml:id="e2" label="2." type="mscore-ending-2" lendsym="none">
-                     <measure xml:id="m3" left="rptstart" n="3">
+                  <ending xml:id="eg6c3mu" label="2." type="mscore-ending-2" lendsym="none">
+                     <measure xml:id="m8gswqi" left="rptstart" n="3">
                         <staff xml:id="m3s1" n="1">
                            <layer xml:id="m3s1l1" n="1">
-                              <note xml:id="s1l1_t2_1" dur="1" pname="b" oct="4" />
+                              <note xml:id="n1krclkp" dur="1" pname="b" oct="4" />
                            </layer>
                         </staff>
                         <staff xml:id="m3s2" n="2">
                            <layer xml:id="m3s2l1" n="1">
-                              <note xml:id="s2l1_t2_1" dur="1" pname="d" oct="3" />
+                              <note xml:id="n1kncbt8" dur="1" pname="d" oct="3" />
                            </layer>
                         </staff>
                      </measure>
                   </ending>
-                  <measure xml:id="m4" n="4">
+                  <measure xml:id="m1xghqbk" n="4">
                      <staff xml:id="m4s1" n="1">
                         <layer xml:id="m4s1l1" n="1">
-                           <note xml:id="s1l1_t3_1" dur="1" pname="c" oct="5" />
+                           <note xml:id="nlo886t" dur="1" pname="c" oct="5" />
                         </layer>
                      </staff>
                      <staff xml:id="m4s2" n="2">
                         <layer xml:id="m4s2l1" n="1">
-                           <note xml:id="s2l1_t3_1" dur="1" pname="e" oct="3" />
+                           <note xml:id="n1tsl1wu" dur="1" pname="e" oct="3" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m5" n="5">
+                  <measure xml:id="m1vq7qse" n="5">
                      <staff xml:id="m5s1" n="1">
                         <layer xml:id="m5s1l1" n="1">
-                           <mRest xml:id="s1l1_t4_1" />
+                           <mRest xml:id="mb52esf" />
                         </layer>
                      </staff>
                      <staff xml:id="m5s2" n="2">
                         <layer xml:id="m5s2l1" n="1">
-                           <mRest xml:id="s2l1_t4_1" />
+                           <mRest xml:id="m1okkxu7" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m6" n="6">
+                  <measure xml:id="m1qfn0e8" n="6">
                      <staff xml:id="m6s1" n="1">
                         <layer xml:id="m6s1l1" n="1">
-                           <mRest xml:id="s1l1_t5_1" />
+                           <mRest xml:id="mg5avp1" />
                         </layer>
                      </staff>
                      <staff xml:id="m6s2" n="2">
                         <layer xml:id="m6s2l1" n="1">
-                           <mRest xml:id="s2l1_t5_1" />
+                           <mRest xml:id="m7j197d" />
                         </layer>
                      </staff>
                   </measure>
-                  <ending xml:id="e3" label="1st 3rd 5th" type="mscore-ending-1 mscore-ending-3 mscore-ending-5" lform="dotted">
-                     <measure xml:id="m7" n="7">
+                  <ending xml:id="e1p0627b" label="1st 3rd 5th" type="mscore-ending-1 mscore-ending-3 mscore-ending-5" lform="dotted">
+                     <measure xml:id="m5bvbt4" n="7">
                         <staff xml:id="m7s1" n="1">
                            <layer xml:id="m7s1l1" n="1">
-                              <note xml:id="s1l1_t6_1" dur="1" pname="g" oct="4" />
+                              <note xml:id="n37h3x" dur="1" pname="g" oct="4" />
                            </layer>
                         </staff>
                         <staff xml:id="m7s2" n="2">
                            <layer xml:id="m7s2l1" n="1">
-                              <note xml:id="s2l1_t6_1" dur="1" pname="b" oct="2" />
+                              <note xml:id="n1w4s2y6" dur="1" pname="b" oct="2" />
                            </layer>
                         </staff>
                      </measure>
-                     <measure xml:id="m8" type="mscore-repeat-4" right="rptend" n="8">
+                     <measure xml:id="m7c31e7" type="mscore-repeat-4" right="rptend" n="8">
                         <staff xml:id="m8s1" n="1">
                            <layer xml:id="m8s1l1" n="1">
-                              <note xml:id="s1l1_t7_1" dur="1" pname="a" oct="4" />
+                              <note xml:id="n90xyss" dur="1" pname="a" oct="4" />
                            </layer>
                         </staff>
                         <staff xml:id="m8s2" n="2">
                            <layer xml:id="m8s2l1" n="1">
-                              <note xml:id="s2l1_t7_1" dur="1" pname="c" oct="3" />
+                              <note xml:id="netnfj8" dur="1" pname="c" oct="3" />
                            </layer>
                         </staff>
                      </measure>
                   </ending>
-                  <ending xml:id="e4" label="2nd 4th 6th" type="mscore-ending-2 mscore-ending-4 mscore-ending-6" lform="dashed">
-                     <measure xml:id="m9" n="9">
+                  <ending xml:id="e464h6d" label="2nd 4th 6th" type="mscore-ending-2 mscore-ending-4 mscore-ending-6" lform="dashed">
+                     <measure xml:id="m1sguhcf" n="9">
                         <staff xml:id="m9s1" n="1">
                            <layer xml:id="m9s1l1" n="1">
-                              <note xml:id="s1l1_t8_1" dur="1" pname="d" oct="5" />
+                              <note xml:id="n1iznqn4" dur="1" pname="d" oct="5" />
                            </layer>
                         </staff>
                         <staff xml:id="m9s2" n="2">
                            <layer xml:id="m9s2l1" n="1">
-                              <note xml:id="s2l1_t8_1" dur="1" pname="f" oct="3" />
+                              <note xml:id="ndqg3ag" dur="1" pname="f" oct="3" />
                            </layer>
                         </staff>
                      </measure>
-                     <measure xml:id="m10" type="mscore-repeat-3" right="rptend" n="10">
+                     <measure xml:id="mtgkatu" type="mscore-repeat-3" right="rptend" n="10">
                         <staff xml:id="m10s1" n="1">
                            <layer xml:id="m10s1l1" n="1">
-                              <note xml:id="s1l1_t9_1" dur="1" pname="c" oct="5" />
+                              <note xml:id="n1mbbtf7" dur="1" pname="c" oct="5" />
                            </layer>
                         </staff>
                         <staff xml:id="m10s2" n="2">
                            <layer xml:id="m10s2l1" n="1">
-                              <note xml:id="s2l1_t9_1" dur="1" pname="e" oct="3" />
+                              <note xml:id="nz536ag" dur="1" pname="e" oct="3" />
                            </layer>
                         </staff>
                      </measure>
                   </ending>
-                  <measure xml:id="m11" left="rptstart" n="11">
+                  <measure xml:id="m1g0477x" left="rptstart" n="11">
                      <staff xml:id="m11s1" n="1">
                         <layer xml:id="m11s1l1" n="1">
-                           <note xml:id="s1l1_t10_1" dur="1" pname="d" oct="5" />
+                           <note xml:id="n3mkxtn" dur="1" pname="d" oct="5" />
                         </layer>
                      </staff>
                      <staff xml:id="m11s2" n="2">
                         <layer xml:id="m11s2l1" n="1">
-                           <note xml:id="s2l1_t10_1" dur="1" pname="f" oct="3" />
+                           <note xml:id="n1iwlhm2" dur="1" pname="f" oct="3" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m12" type="mscore-repeat-3" right="rptend" n="12">
+                  <measure xml:id="m2rgla2" type="mscore-repeat-3" right="rptend" n="12">
                      <staff xml:id="m12s1" n="1">
                         <layer xml:id="m12s1l1" n="1">
-                           <note xml:id="s1l1_t11_1" dur="1" pname="e" oct="5" />
+                           <note xml:id="n1hc28e0" dur="1" pname="e" oct="5" />
                         </layer>
                      </staff>
                      <staff xml:id="m12s2" n="2">
                         <layer xml:id="m12s2l1" n="1">
-                           <note xml:id="s2l1_t11_1" dur="1" pname="g" oct="3" />
+                           <note xml:id="n1ojjse5" dur="1" pname="g" oct="3" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/ending-01.mscx
+++ b/src/importexport/mei/tests/data/ending-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:09:58&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:52:08&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/fermata-01.mei
+++ b/src/importexport/mei/tests/data/fermata-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:46:42" />
+            <date isodate="2023-08-11T14:52:15" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -46,167 +46,167 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" metcon="false" n="1">
+                  <measure xml:id="m110s9yb" metcon="false" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <rest xml:id="s1l1_t0_1" dur="4" />
+                           <rest xml:id="r16fphgk" dur="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s2" n="2">
                         <layer xml:id="m1s2l1" n="1">
-                           <rest xml:id="s2l1_t0_1" dur="4" />
+                           <rest xml:id="r18d58nb" dur="4" />
                         </layer>
                      </staff>
-                     <fermata xml:id="m1fm1" staff="1" tstamp="2.000000" />
+                     <fermata xml:id="fzo78nu" staff="1" tstamp="2.000000" />
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="m1qulie6" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <note xml:id="s1l1_t1_4" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t1_2" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t3_4" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t1_1" dur="4" pname="b" oct="3" />
+                           <note xml:id="n1h0rvw1" dur="4" pname="c" oct="4" />
+                           <note xml:id="n9r8ty2" dur="4" pname="e" oct="4" />
+                           <note xml:id="nfkjs2e" dur="4" pname="g" oct="4" />
+                           <note xml:id="nqskwva" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s2" n="2">
                         <layer xml:id="m2s2l1" n="1">
-                           <note xml:id="s2l1_t1_4" dur="2" pname="c" oct="3" />
-                           <note xml:id="s2l1_t3_4" dur="2" pname="g" oct="2" />
+                           <note xml:id="nk5ue42" dur="2" pname="c" oct="3" />
+                           <note xml:id="n1wnv9wo" dur="2" pname="g" oct="2" />
                         </layer>
                      </staff>
-                     <fermata xml:id="m2fm1" startid="#s1l1_t1_2" />
-                     <fermata xml:id="m2fm2" startid="#s2l1_t3_4" />
+                     <fermata xml:id="fi33eun" startid="#n9r8ty2" />
+                     <fermata xml:id="f4h0gm8" startid="#n1wnv9wo" />
                   </measure>
-                  <measure xml:id="m3" n="3">
+                  <measure xml:id="maprncz" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <note xml:id="s1l1_t5_4" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t3_2" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t7_4" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t2_1" dur="4" pname="b" oct="3" />
+                           <note xml:id="n7p3ne0" dur="4" pname="c" oct="4" />
+                           <note xml:id="n1iesm4e" dur="4" pname="e" oct="4" />
+                           <note xml:id="n8uuoi3" dur="4" pname="g" oct="4" />
+                           <note xml:id="nyodxzh" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m3s2" n="2">
                         <layer xml:id="m3s2l1" n="1">
-                           <note xml:id="s2l1_t5_4" dur="2" pname="c" oct="3" />
-                           <note xml:id="s2l1_t7_4" dur="2" pname="g" oct="2" />
+                           <note xml:id="n1nqzcfb" dur="2" pname="c" oct="3" />
+                           <note xml:id="n1ljfreg" dur="2" pname="g" oct="2" />
                         </layer>
                      </staff>
-                     <fermata xml:id="m3fm1" startid="#s1l1_t5_4" shape="angular" />
-                     <fermata xml:id="m3fm2" startid="#s1l1_t3_2" shape="square" />
+                     <fermata xml:id="f1ezejmd" startid="#n7p3ne0" shape="angular" />
+                     <fermata xml:id="f1htovas" startid="#n1iesm4e" shape="square" />
                   </measure>
-                  <measure xml:id="m4" n="4">
+                  <measure xml:id="m1m2ebbc" n="4">
                      <staff xml:id="m4s1" n="1">
                         <layer xml:id="m4s1l1" n="1">
-                           <note xml:id="s1l1_t9_4" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t5_2" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t11_4" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t3_1" dur="4" pname="b" oct="3" />
+                           <note xml:id="n1nsneqs" dur="4" pname="c" oct="4" />
+                           <note xml:id="n82ze2g" dur="4" pname="e" oct="4" />
+                           <note xml:id="n1jifwyj" dur="4" pname="g" oct="4" />
+                           <note xml:id="nsbpefc" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m4s2" n="2">
                         <layer xml:id="m4s2l1" n="1">
-                           <note xml:id="s2l1_t9_4" dur="2" pname="c" oct="3" />
-                           <note xml:id="s2l1_t11_4" dur="2" pname="g" oct="2" />
+                           <note xml:id="n12ttdf3" dur="2" pname="c" oct="3" />
+                           <note xml:id="n1dce1yl" dur="2" pname="g" oct="2" />
                         </layer>
                      </staff>
-                     <fermata xml:id="m4fm1" startid="#s1l1_t9_4" />
-                     <fermata xml:id="m4fm2" startid="#s1l1_t5_2" />
-                     <fermata xml:id="m4fm3" startid="#s1l1_t11_4" place="below" />
-                     <fermata xml:id="m4fm4" startid="#s1l1_t3_1" place="below" />
+                     <fermata xml:id="f1ukl3lu" startid="#n1nsneqs" />
+                     <fermata xml:id="fxn3fec" startid="#n82ze2g" />
+                     <fermata xml:id="fkgq0pg" startid="#n1jifwyj" place="below" />
+                     <fermata xml:id="f1jt3as0" startid="#nsbpefc" place="below" />
                   </measure>
-                  <measure xml:id="m5" n="5">
+                  <measure xml:id="mrpg72a" n="5">
                      <staff xml:id="m5s1" n="1">
                         <layer xml:id="m5s1l1" n="1">
-                           <note xml:id="s1l1_t13_4" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t7_2" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t15_4" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t4_1" dur="4" pname="b" oct="3" />
+                           <note xml:id="n1jlxl91" dur="4" pname="c" oct="4" />
+                           <note xml:id="n1jv0zjm" dur="4" pname="e" oct="4" />
+                           <note xml:id="n1u2ixab" dur="4" pname="g" oct="4" />
+                           <note xml:id="nk81tmp" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m5s2" n="2">
                         <layer xml:id="m5s2l1" n="1">
-                           <note xml:id="s2l1_t13_4" dur="2" pname="c" oct="3" />
-                           <note xml:id="s2l1_t15_4" dur="2" pname="g" oct="2" />
+                           <note xml:id="n16pd7st" dur="2" pname="c" oct="3" />
+                           <note xml:id="n1moi55d" dur="2" pname="g" oct="2" />
                         </layer>
                      </staff>
-                     <fermata xml:id="m5fm1" startid="#s2l1_t13_4" shape="angular" place="below" />
+                     <fermata xml:id="fwm1z9u" startid="#n16pd7st" shape="angular" place="below" />
                   </measure>
-                  <measure xml:id="m6" n="6">
+                  <measure xml:id="ma58sa4" n="6">
                      <staff xml:id="m6s1" n="1">
                         <layer xml:id="m6s1l1" n="1">
-                           <note xml:id="s1l1_t17_4" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t9_2" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t19_4" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t5_1" dur="4" pname="b" oct="3" />
+                           <note xml:id="nns2a8o" dur="4" pname="c" oct="4" />
+                           <note xml:id="n1blhh1z" dur="4" pname="e" oct="4" />
+                           <note xml:id="ng6v427" dur="4" pname="g" oct="4" />
+                           <note xml:id="nr31gvo" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m6s2" n="2">
                         <layer xml:id="m6s2l1" n="1">
-                           <note xml:id="s2l1_t17_4" dur="2" pname="c" oct="3" />
-                           <note xml:id="s2l1_t19_4" dur="2" pname="g" oct="2" />
+                           <note xml:id="n17rbcoc" dur="2" pname="c" oct="3" />
+                           <note xml:id="n1n0uak2" dur="2" pname="g" oct="2" />
                         </layer>
                      </staff>
-                     <fermata xml:id="m6fm1" startid="#s1l1_t9_2" glyph.auth="smufl" glyph.name="fermataLongHenzeAbove" />
-                     <fermata xml:id="m6fm2" startid="#s1l1_t19_4" glyph.auth="smufl" glyph.name="fermataShortHenzeAbove" />
-                     <fermata xml:id="m6fm3" startid="#s2l1_t19_4" glyph.auth="smufl" glyph.name="fermataShortHenzeAbove" />
-                     <fermata xml:id="m6fm4" staff="1" tstamp="5.000000" shape="angular" />
+                     <fermata xml:id="ffflrtn" startid="#n1blhh1z" glyph.auth="smufl" glyph.name="fermataLongHenzeAbove" />
+                     <fermata xml:id="f1guncru" startid="#ng6v427" glyph.auth="smufl" glyph.name="fermataShortHenzeAbove" />
+                     <fermata xml:id="fp4mpiu" startid="#n1n0uak2" glyph.auth="smufl" glyph.name="fermataShortHenzeAbove" />
+                     <fermata xml:id="fkv7j99" staff="1" tstamp="5.000000" shape="angular" />
                   </measure>
-                  <measure xml:id="m7" n="7">
+                  <measure xml:id="m13kw3nr" n="7">
                      <staff xml:id="m7s1" n="1">
                         <layer xml:id="m7s1l1" n="1">
-                           <note xml:id="s1l1_t21_4" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t11_2" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t23_4" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t6_1" dur="4" pname="b" oct="3" />
+                           <note xml:id="n1b74ywh" dur="4" pname="c" oct="4" />
+                           <note xml:id="n19spk43" dur="4" pname="e" oct="4" />
+                           <note xml:id="ntvxsq0" dur="4" pname="g" oct="4" />
+                           <note xml:id="n1ygwjwy" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m7s2" n="2">
                         <layer xml:id="m7s2l1" n="1">
-                           <note xml:id="s2l1_t21_4" dur="2" pname="c" oct="3" />
-                           <note xml:id="s2l1_t23_4" dur="2" pname="g" oct="2" />
+                           <note xml:id="n18gwl56" dur="2" pname="c" oct="3" />
+                           <note xml:id="n1ix144u" dur="2" pname="g" oct="2" />
                         </layer>
                      </staff>
-                     <fermata xml:id="m7fm1" startid="#s1l1_t11_2" glyph.auth="smufl" glyph.name="fermataVeryShortAbove" />
-                     <fermata xml:id="m7fm2" staff="1" tstamp="5.000000" />
-                     <fermata xml:id="m7fm3" staff="2" tstamp="5.000000" place="below" />
+                     <fermata xml:id="f1dqs1if" startid="#n19spk43" glyph.auth="smufl" glyph.name="fermataVeryShortAbove" />
+                     <fermata xml:id="f9edv42" staff="1" tstamp="5.000000" />
+                     <fermata xml:id="fu09pdz" staff="2" tstamp="5.000000" place="below" />
                   </measure>
                   <scoreDef meter.count="6" meter.unit="8" />
-                  <measure xml:id="m8" n="8">
+                  <measure xml:id="m1a4wupt" n="8">
                      <staff xml:id="m8s1" n="1">
                         <layer xml:id="m8s1l1" n="1">
-                           <note xml:id="s1l1_t25_4" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t13_2" dur="8" pname="e" oct="4" />
-                           <note xml:id="s1l1_t53_8" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t55_8" dur="8" pname="g" oct="3" />
+                           <note xml:id="n1crbjtg" dur="4" pname="c" oct="4" />
+                           <note xml:id="n1ypjqfq" dur="8" pname="e" oct="4" />
+                           <note xml:id="nm9xjje" dur="4" pname="g" oct="4" />
+                           <note xml:id="n1g9iiax" dur="8" pname="g" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m8s2" n="2">
                         <layer xml:id="m8s2l1" n="1">
-                           <note xml:id="s2l1_t25_4" dots="1" dur="4" pname="c" oct="3" />
-                           <note xml:id="s2l1_t53_8" dots="1" dur="4" pname="g" oct="2" />
+                           <note xml:id="n16araw5" dots="1" dur="4" pname="c" oct="3" />
+                           <note xml:id="n130j8q7" dots="1" dur="4" pname="g" oct="2" />
                         </layer>
                      </staff>
-                     <fermata xml:id="m8fm1" startid="#s1l1_t13_2" />
-                     <fermata xml:id="m8fm2" staff="1" tstamp="7.000000" shape="square" />
+                     <fermata xml:id="fpgie99" startid="#n1ypjqfq" />
+                     <fermata xml:id="fy27rdt" staff="1" tstamp="7.000000" shape="square" />
                   </measure>
-                  <measure xml:id="m9" right="end" n="9">
+                  <measure xml:id="mzfndk8" right="end" n="9">
                      <staff xml:id="m9s1" n="1">
                         <layer xml:id="m9s1l1" n="1">
-                           <note xml:id="s1l1_t7_1" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t29_4" dur="8" pname="e" oct="4" />
-                           <note xml:id="s1l1_t59_8" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t61_8" dur="8" pname="g" oct="3" />
+                           <note xml:id="ntxc3nk" dur="4" pname="c" oct="4" />
+                           <note xml:id="n14f18vf" dur="8" pname="e" oct="4" />
+                           <note xml:id="n9x3rkx" dur="4" pname="g" oct="4" />
+                           <note xml:id="ngvopyg" dur="8" pname="g" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m9s2" n="2">
                         <layer xml:id="m9s2l1" n="1">
-                           <note xml:id="s2l1_t7_1" dots="1" dur="4" pname="c" oct="3" />
-                           <note xml:id="s2l1_t59_8" dots="1" dur="4" pname="g" oct="2" />
+                           <note xml:id="n1yw1061" dots="1" dur="4" pname="c" oct="3" />
+                           <note xml:id="ns98aqt" dots="1" dur="4" pname="g" oct="2" />
                         </layer>
                      </staff>
-                     <fermata xml:id="m9fm1" startid="#s1l1_t29_4" />
-                     <fermata xml:id="m9fm2" staff="1" tstamp="7.000000" />
+                     <fermata xml:id="feb84zc" startid="#n14f18vf" />
+                     <fermata xml:id="f103qszv" staff="1" tstamp="7.000000" />
                   </measure>
                </section>
             </score>

--- a/src/importexport/mei/tests/data/fermata-01.mscx
+++ b/src/importexport/mei/tests/data/fermata-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:46:42&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:52:15&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/gracenote-01.mei
+++ b/src/importexport/mei/tests/data/gracenote-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:00" />
+            <date isodate="2023-08-11T14:52:21" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -39,86 +39,86 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="mzonbws" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <graceGrp xml:id="m1s1l1g1" grace="unacc">
-                              <note xml:id="m1s1l1n1" dur="8" pname="d" oct="5" />
+                           <graceGrp grace="unacc">
+                              <note xml:id="nxlwdja" dur="8" pname="d" oct="5" />
                            </graceGrp>
-                           <note xml:id="s1l1_t0_1" dur="4" pname="c" oct="5" />
-                           <graceGrp xml:id="m1s1l1g2" grace="acc">
-                              <note xml:id="m1s1l1n2" dur="8" pname="d" oct="5" />
+                           <note xml:id="n1624qws" dur="4" pname="c" oct="5" />
+                           <graceGrp grace="acc">
+                              <note xml:id="nrqgo5w" dur="8" pname="d" oct="5" />
                            </graceGrp>
-                           <note xml:id="s1l1_t1_4" dur="4" pname="c" oct="5" />
-                           <graceGrp xml:id="m1s1l1g3" grace="acc">
-                              <note xml:id="m1s1l1n3" dur="4" pname="d" oct="5" />
+                           <note xml:id="nat0pjx" dur="4" pname="c" oct="5" />
+                           <graceGrp grace="acc">
+                              <note xml:id="n1o6k89a" dur="4" pname="d" oct="5" />
                            </graceGrp>
-                           <note xml:id="s1l1_t1_2" dur="4" pname="c" oct="5" />
-                           <graceGrp xml:id="m1s1l1g4" grace="acc">
-                              <note xml:id="m1s1l1n4" dur="16" pname="d" oct="5" />
+                           <note xml:id="n4yf2nw" dur="4" pname="c" oct="5" />
+                           <graceGrp grace="acc">
+                              <note xml:id="n1org7fe" dur="16" pname="d" oct="5" />
                            </graceGrp>
-                           <note xml:id="s1l1_t3_4" dur="4" pname="c" oct="5" />
+                           <note xml:id="nr9ysnf" dur="4" pname="c" oct="5" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="m94481w" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <graceGrp xml:id="m2s1l1g1" grace="acc">
-                              <note xml:id="m2s1l1n1" dur="32" pname="d" oct="5" />
+                           <graceGrp grace="acc">
+                              <note xml:id="ngolj96" dur="32" pname="d" oct="5" />
                            </graceGrp>
-                           <note xml:id="s1l1_t1_1" dur="4" pname="c" oct="5" />
-                           <graceGrp xml:id="m2s1l1g2" grace="unacc">
-                              <beam xml:id="m2s1l1b1">
-                                 <note xml:id="m2s1l1n2" dur="8" pname="e" oct="5" />
-                                 <note xml:id="m2s1l1n3" dur="8" pname="d" oct="5" />
+                           <note xml:id="nhd647y" dur="4" pname="c" oct="5" />
+                           <graceGrp grace="unacc">
+                              <beam>
+                                 <note xml:id="nuzoxq9" dur="8" pname="e" oct="5" />
+                                 <note xml:id="n3ks6ab" dur="8" pname="d" oct="5" />
                               </beam>
                            </graceGrp>
-                           <note xml:id="s1l1_t5_4" dur="4" pname="c" oct="5" />
-                           <graceGrp xml:id="m2s1l1g3" grace="unacc">
-                              <note xml:id="m2s1l1n4" dur="8" pname="e" oct="5" />
-                              <note xml:id="m2s1l1n5" type="mscore-beam-none" dur="8" pname="d" oct="5" />
+                           <note xml:id="ne8g66c" dur="4" pname="c" oct="5" />
+                           <graceGrp grace="unacc">
+                              <note xml:id="nmxiag2" dur="8" pname="e" oct="5" />
+                              <note xml:id="np34wj8" type="mscore-beam-none" dur="8" pname="d" oct="5" />
                            </graceGrp>
-                           <note xml:id="s1l1_t3_2" dur="4" pname="c" oct="5" />
-                           <graceGrp xml:id="m2s1l1g4" grace="acc">
-                              <beam xml:id="m2s1l1b2">
-                                 <note xml:id="m2s1l1n6" dur="8" pname="e" oct="5" />
-                                 <note xml:id="m2s1l1n7" dur="8" pname="d" oct="5" />
+                           <note xml:id="nbxxx9u" dur="4" pname="c" oct="5" />
+                           <graceGrp grace="acc">
+                              <beam>
+                                 <note xml:id="naosm2m" dur="8" pname="e" oct="5" />
+                                 <note xml:id="n14n1rtj" dur="8" pname="d" oct="5" />
                               </beam>
                            </graceGrp>
-                           <note xml:id="s1l1_t7_4" dur="4" pname="c" oct="5" />
+                           <note xml:id="njveceb" dur="4" pname="c" oct="5" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m3" right="end" n="3">
+                  <measure xml:id="m1790ud6" right="end" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <graceGrp xml:id="m3s1l1g1" grace="acc">
-                              <note xml:id="m3s1l1n1" dur="8" pname="d" oct="5" />
+                           <graceGrp grace="acc">
+                              <note xml:id="n1xx73pv" dur="8" pname="d" oct="5" />
                            </graceGrp>
-                           <beam xml:id="m3s1l1b1">
-                              <note xml:id="s1l1_t2_1" dur="8" pname="c" oct="5" />
-                              <graceGrp xml:id="m3s1l1g2" grace="acc">
-                                 <beam xml:id="m3s1l1b2">
-                                    <note xml:id="m3s1l1n2" dur="8" pname="e" oct="5" />
-                                    <note xml:id="m3s1l1n3" dur="8" pname="d" oct="5" />
+                           <beam>
+                              <note xml:id="n1fw9s0c" dur="8" pname="c" oct="5" />
+                              <graceGrp grace="acc">
+                                 <beam>
+                                    <note xml:id="nqm3z6o" dur="8" pname="e" oct="5" />
+                                    <note xml:id="n1rnmzub" dur="8" pname="d" oct="5" />
                                  </beam>
                               </graceGrp>
-                              <note xml:id="s1l1_t17_8" dur="8" pname="c" oct="5" />
-                              <graceGrp xml:id="m3s1l1g3" grace="acc">
-                                 <note xml:id="m3s1l1n4" dur="4" pname="d" oct="5" />
+                              <note xml:id="nrmqnai" dur="8" pname="c" oct="5" />
+                              <graceGrp grace="acc">
+                                 <note xml:id="ndb6dwe" dur="4" pname="d" oct="5" />
                               </graceGrp>
-                              <note xml:id="s1l1_t9_4" dur="8" pname="c" oct="5" />
-                              <graceGrp xml:id="m3s1l1g4" grace="acc">
-                                 <beam xml:id="m3s1l1b3">
-                                    <note xml:id="m3s1l1n5" dur="16" pname="f" oct="5" />
-                                    <note xml:id="m3s1l1n6" dur="16" pname="e" oct="5" />
+                              <note xml:id="nin0n2b" dur="8" pname="c" oct="5" />
+                              <graceGrp grace="acc">
+                                 <beam>
+                                    <note xml:id="n161x521" dur="16" pname="f" oct="5" />
+                                    <note xml:id="n4ps5k4" dur="16" pname="e" oct="5" />
                                  </beam>
-                                 <note xml:id="m3s1l1n7" dur="4" pname="d" oct="5" />
+                                 <note xml:id="n1b6sj26" dur="4" pname="d" oct="5" />
                               </graceGrp>
-                              <note xml:id="s1l1_t19_8" dur="8" pname="c" oct="5" />
+                              <note xml:id="n1u2j3yy" dur="8" pname="c" oct="5" />
                            </beam>
-                           <note xml:id="s1l1_t5_2" dur="2" pname="c" oct="5" />
+                           <note xml:id="ncdlzbi" dur="2" pname="c" oct="5" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/gracenote-01.mscx
+++ b/src/importexport/mei/tests/data/gracenote-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:00&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:52:21&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/gracenote-02.mei
+++ b/src/importexport/mei/tests/data/gracenote-02.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:01" />
+            <date isodate="2023-08-11T14:52:27" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -39,121 +39,121 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="mtv536c" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <graceGrp xml:id="m1s1l1g1" grace="unacc">
-                              <note xml:id="m1s1l1n1" dur="8" pname="d" oct="5" />
+                           <graceGrp grace="unacc">
+                              <note xml:id="n13zrhtw" dur="8" pname="d" oct="5" />
                            </graceGrp>
-                           <note xml:id="s1l1_t0_1" dur="4" pname="c" oct="5" />
-                           <graceGrp xml:id="m1s1l1g2" attach="pre" grace="unknown">
-                              <beam xml:id="m1s1l1b1">
-                                 <note xml:id="m1s1l1n2" dur="8" pname="g" oct="4" />
-                                 <note xml:id="m1s1l1n3" dur="16" pname="a" oct="4" />
-                                 <note xml:id="m1s1l1n4" dur="16" pname="b" oct="4" />
+                           <note xml:id="nxw7xq8" dur="4" pname="c" oct="5" />
+                           <graceGrp attach="pre" grace="unknown">
+                              <beam>
+                                 <note xml:id="n37urfd" dur="8" pname="g" oct="4" />
+                                 <note xml:id="n1t0pki2" dur="16" pname="a" oct="4" />
+                                 <note xml:id="nqtxwdg" dur="16" pname="b" oct="4" />
                               </beam>
                            </graceGrp>
-                           <graceGrp xml:id="m1s1l1g3" grace="acc">
-                              <chord xml:id="m1s1l1c1" dur="8">
-                                 <note xml:id="m1s1l1n5" pname="d" oct="5" />
-                                 <note xml:id="m1s1l1n6" pname="f" oct="5">
-                                    <accid xml:id="m1s1l1a1" accid="s" />
+                           <graceGrp grace="acc">
+                              <chord xml:id="c1mij8b2" dur="8">
+                                 <note xml:id="n1wknz54" pname="d" oct="5" />
+                                 <note xml:id="n16rcevi" pname="f" oct="5">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m1s1l1n7" pname="a" oct="5" />
+                                 <note xml:id="n5pzmb7" pname="a" oct="5" />
                               </chord>
                            </graceGrp>
-                           <note xml:id="s1l1_t1_4" dur="4" pname="c" oct="5" />
-                           <graceGrp xml:id="m1s1l1g4" grace="acc">
-                              <note xml:id="m1s1l1n8" dur="4" pname="d" oct="5" />
+                           <note xml:id="n1wpxhen" dur="4" pname="c" oct="5" />
+                           <graceGrp grace="acc">
+                              <note xml:id="nb5ocjr" dur="4" pname="d" oct="5" />
                            </graceGrp>
-                           <note xml:id="s1l1_t1_2" dur="4" pname="c" oct="5" />
-                           <graceGrp xml:id="m1s1l1g5" grace="acc">
-                              <note xml:id="m1s1l1n9" dur="16" pname="b" oct="4" />
+                           <note xml:id="n1p7ssvq" dur="4" pname="c" oct="5" />
+                           <graceGrp grace="acc">
+                              <note xml:id="n1dxtd69" dur="16" pname="b" oct="4" />
                            </graceGrp>
-                           <note xml:id="s1l1_t3_4" dur="4" pname="c" oct="5" />
+                           <note xml:id="n6w3jj7" dur="4" pname="c" oct="5" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="m15jwold" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <chord xml:id="s1l1_t1_1" dur="2">
-                              <note xml:id="m2s1l1n1" pname="c" oct="5" />
-                              <note xml:id="m2s1l1n2" pname="e" oct="5" />
+                           <chord xml:id="c11lpok2" dur="2">
+                              <note xml:id="n1qw1hrx" pname="c" oct="5" />
+                              <note xml:id="nuoo2ed" pname="e" oct="5" />
                            </chord>
-                           <graceGrp xml:id="m2s1l1g1" grace="acc">
-                              <chord xml:id="m2s1l1c1" dur="8">
-                                 <note xml:id="m2s1l1n3" pname="d" oct="5" />
-                                 <note xml:id="m2s1l1n4" pname="f" oct="5" />
+                           <graceGrp grace="acc">
+                              <chord xml:id="c1vthzc6" dur="8">
+                                 <note xml:id="n1rwvk0l" pname="d" oct="5" />
+                                 <note xml:id="ndann1h" pname="f" oct="5" />
                               </chord>
                            </graceGrp>
-                           <chord xml:id="s1l1_t3_2" dur="2">
-                              <note xml:id="m2s1l1n5" pname="c" oct="5" />
-                              <note xml:id="m2s1l1n6" pname="e" oct="5" />
+                           <chord xml:id="c1bjgjmi" dur="2">
+                              <note xml:id="n1ibrbok" pname="c" oct="5" />
+                              <note xml:id="n8le3x6" pname="e" oct="5" />
                            </chord>
                         </layer>
                         <layer xml:id="m2s1l2" n="2">
-                           <graceGrp xml:id="m2s1l2g1" grace="unacc">
-                              <chord xml:id="m2s1l2c1" dur="8">
-                                 <note xml:id="m2s1l2n1" pname="e" oct="4" />
-                                 <note xml:id="m2s1l2n2" pname="g" oct="4" />
+                           <graceGrp grace="unacc">
+                              <chord xml:id="cc8fjz1" dur="8">
+                                 <note xml:id="n12f58l1" pname="e" oct="4" />
+                                 <note xml:id="n12xnq01" pname="g" oct="4" />
                               </chord>
                            </graceGrp>
-                           <chord xml:id="s1l2_t1_1" dur="2">
-                              <note xml:id="m2s1l2n3" pname="d" oct="4" />
-                              <note xml:id="m2s1l2n4" pname="f" oct="4" />
+                           <chord xml:id="c1bjkozp" dur="2">
+                              <note xml:id="n1djsx93" pname="d" oct="4" />
+                              <note xml:id="n1bbkxzf" pname="f" oct="4" />
                            </chord>
-                           <chord xml:id="s1l2_t3_2" dur="2">
-                              <note xml:id="m2s1l2n5" pname="d" oct="4" />
-                              <note xml:id="m2s1l2n6" pname="f" oct="4" />
+                           <chord xml:id="cz318lj" dur="2">
+                              <note xml:id="n1xp5d6o" pname="d" oct="4" />
+                              <note xml:id="nldz3w6" pname="f" oct="4" />
                            </chord>
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m3" n="3">
+                  <measure xml:id="m1ml06sn" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <graceGrp xml:id="m3s1l1g1" grace="acc">
-                              <beam xml:id="m3s1l1b1">
-                                 <note xml:id="m3s1l1n1" dur="16" pname="e" oct="5" />
-                                 <note xml:id="m3s1l1n2" dur="16" pname="d" oct="5" />
+                           <graceGrp grace="acc">
+                              <beam>
+                                 <note xml:id="nu4i1da" dur="16" pname="e" oct="5" />
+                                 <note xml:id="n1fs2g4d" dur="16" pname="d" oct="5" />
                               </beam>
                            </graceGrp>
-                           <note xml:id="s1l1_t2_1" dur="2" pname="c" oct="5" />
-                           <graceGrp xml:id="m3s1l1g2" grace="acc">
-                              <beam xml:id="m3s1l1b2">
-                                 <note xml:id="m3s1l1n3" dur="32" pname="a" oct="5">
-                                    <accid xml:id="m3s1l1a1" accid="s" />
+                           <note xml:id="n299oie" dur="2" pname="c" oct="5" />
+                           <graceGrp grace="acc">
+                              <beam>
+                                 <note xml:id="ndz9qng" dur="32" pname="a" oct="5">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m3s1l1n4" dur="32" pname="g" oct="5">
-                                    <accid xml:id="m3s1l1a2" accid="s" />
+                                 <note xml:id="n1j1krav" dur="32" pname="g" oct="5">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m3s1l1n5" dur="32" pname="f" oct="5">
-                                    <accid xml:id="m3s1l1a3" accid="s" />
+                                 <note xml:id="nw2t371" dur="32" pname="f" oct="5">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m3s1l1n6" dur="32" pname="d" oct="5">
-                                    <accid xml:id="m3s1l1a4" accid="s" />
+                                 <note xml:id="ntexygr" dur="32" pname="d" oct="5">
+                                    <accid accid="s" />
                                  </note>
                               </beam>
                            </graceGrp>
-                           <note xml:id="s1l1_t5_2" dur="2" pname="c" oct="5" />
+                           <note xml:id="n1l2ge9u" dur="2" pname="c" oct="5" />
                         </layer>
                         <layer xml:id="m3s1l2" n="2">
-                           <note xml:id="s1l2_t2_1" dur="1" pname="f" oct="4" />
+                           <note xml:id="nsir2h3" dur="1" pname="f" oct="4" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m4" n="4">
+                  <measure xml:id="mdh9u0f" n="4">
                      <staff xml:id="m4s1" n="1">
                         <layer xml:id="m4s1l1" n="1">
-                           <mRest xml:id="s1l1_t3_1" />
+                           <mRest xml:id="m1an2hah" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m5" right="end" n="5">
+                  <measure xml:id="m14b1b31" right="end" n="5">
                      <staff xml:id="m5s1" n="1">
                         <layer xml:id="m5s1l1" n="1">
-                           <mRest xml:id="s1l1_t4_1" />
+                           <mRest xml:id="m1s6rcb5" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/gracenote-02.mscx
+++ b/src/importexport/mei/tests/data/gracenote-02.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:01&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:52:27&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/hairpin-01.mei
+++ b/src/importexport/mei/tests/data/hairpin-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-08T22:14:36" />
+            <date isodate="2023-08-11T14:52:33" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -44,217 +44,217 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m13eggds" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <note xml:id="s1l1_t0_1" dur="4" pname="c" oct="5" />
-                           <note xml:id="s1l1_t1_4" dur="4" pname="b" oct="4" />
-                           <note xml:id="s1l1_t1_2" dur="4" pname="a" oct="4" />
-                           <note xml:id="s1l1_t3_4" dur="4" pname="b" oct="4" />
+                           <note xml:id="n1ms8to4" dur="4" pname="c" oct="5" />
+                           <note xml:id="n1andpxj" dur="4" pname="b" oct="4" />
+                           <note xml:id="n1n2q0nd" dur="4" pname="a" oct="4" />
+                           <note xml:id="natuzn3" dur="4" pname="b" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s2" n="2">
                         <layer xml:id="m1s2l1" n="1">
-                           <mRest xml:id="s2l1_t0_1" />
+                           <mRest xml:id="mfs9r97" />
                         </layer>
                      </staff>
-                     <hairpin xml:id="m1hp1" form="cres" startid="#s1l1_t1_2" endid="#s1l1_t5_4" />
+                     <hairpin xml:id="h1dor5os" form="cres" startid="#n1n2q0nd" endid="#n14xf1ls" />
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="mcatpri" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <note xml:id="s1l1_t1_1" dur="4" pname="c" oct="5" />
-                           <note xml:id="s1l1_t5_4" dur="4" pname="d" oct="5" />
-                           <note xml:id="s1l1_t3_2" dur="4" pname="e" oct="5" />
-                           <note xml:id="s1l1_t7_4" dur="4" pname="f" oct="5" />
+                           <note xml:id="n1hqbwq6" dur="4" pname="c" oct="5" />
+                           <note xml:id="n14xf1ls" dur="4" pname="d" oct="5" />
+                           <note xml:id="nspxw9k" dur="4" pname="e" oct="5" />
+                           <note xml:id="nqo32gg" dur="4" pname="f" oct="5" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s2" n="2">
                         <layer xml:id="m2s2l1" n="1">
-                           <mRest xml:id="s2l1_t1_1" />
+                           <mRest xml:id="m1sz0e05" />
                         </layer>
                      </staff>
-                     <dynam xml:id="m2dn1" label="f" startid="#s1l1_t3_2">f</dynam>
-                     <hairpin xml:id="m2hp1" form="dim" startid="#s1l1_t3_2" endid="#s1l1_t9_4" />
+                     <dynam xml:id="d1eogas6" label="f" startid="#nspxw9k">f</dynam>
+                     <hairpin xml:id="hniw3gu" form="dim" startid="#nspxw9k" endid="#n1w9pjbk" />
                   </measure>
-                  <measure xml:id="m3" n="3">
+                  <measure xml:id="mzs8qux" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <note xml:id="s1l1_t2_1" dur="4" pname="g" oct="5" />
-                           <note xml:id="s1l1_t9_4" dur="4" pname="a" oct="5" />
-                           <note xml:id="s1l1_t5_2" dur="2" pname="b" oct="5" />
+                           <note xml:id="nsksevx" dur="4" pname="g" oct="5" />
+                           <note xml:id="n1w9pjbk" dur="4" pname="a" oct="5" />
+                           <note xml:id="n1sgkp79" dur="2" pname="b" oct="5" />
                         </layer>
                      </staff>
                      <staff xml:id="m3s2" n="2">
                         <layer xml:id="m3s2l1" n="1">
-                           <mRest xml:id="s2l1_t2_1" />
+                           <mRest xml:id="m1uf1dp9" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m4" n="4">
+                  <measure xml:id="moduufb" n="4">
                      <staff xml:id="m4s1" n="1">
                         <layer xml:id="m4s1l1" n="1">
-                           <mRest xml:id="s1l1_t3_1" />
+                           <mRest xml:id="mtaf6eq" />
                         </layer>
                      </staff>
                      <staff xml:id="m4s2" n="2">
                         <layer xml:id="m4s2l1" n="1">
-                           <note xml:id="s2l1_t3_1" dur="4" pname="c" oct="3" />
-                           <note xml:id="s2l1_t13_4" dur="4" pname="d" oct="3" />
-                           <note xml:id="s2l1_t7_2" dur="4" pname="e" oct="3" />
-                           <note xml:id="s2l1_t15_4" dur="4" pname="d" oct="3" />
+                           <note xml:id="nldn980" dur="4" pname="c" oct="3" />
+                           <note xml:id="nnkw2h2" dur="4" pname="d" oct="3" />
+                           <note xml:id="n1ev5pao" dur="4" pname="e" oct="3" />
+                           <note xml:id="n1v5qqi1" dur="4" pname="d" oct="3" />
                         </layer>
                      </staff>
-                     <dir xml:id="m4dr1" type="mscore-hairpin mscore-cresc" startid="#s2l1_t7_2" extender="true" endid="#s2l1_t17_4">cresc.</dir>
+                     <dir xml:id="d1yivsdb" type="mscore-hairpin mscore-cresc" startid="#n1ev5pao" extender="true" endid="#n11epc2m">cresc.</dir>
                   </measure>
-                  <measure xml:id="m5" n="5">
+                  <measure xml:id="m1e50bnv" n="5">
                      <staff xml:id="m5s1" n="1">
                         <layer xml:id="m5s1l1" n="1">
-                           <mRest xml:id="s1l1_t4_1" />
+                           <mRest xml:id="mgxhdug" />
                         </layer>
                      </staff>
                      <staff xml:id="m5s2" n="2">
                         <layer xml:id="m5s2l1" n="1">
-                           <note xml:id="s2l1_t4_1" dur="4" pname="c" oct="3" />
-                           <note xml:id="s2l1_t17_4" dur="4" pname="b" oct="2" />
-                           <note xml:id="s2l1_t9_2" dur="4" pname="a" oct="2" />
-                           <note xml:id="s2l1_t19_4" dur="4" pname="g" oct="2" />
+                           <note xml:id="n18fdkqo" dur="4" pname="c" oct="3" />
+                           <note xml:id="n11epc2m" dur="4" pname="b" oct="2" />
+                           <note xml:id="n1h73eje" dur="4" pname="a" oct="2" />
+                           <note xml:id="naukxk7" dur="4" pname="g" oct="2" />
                         </layer>
                      </staff>
-                     <dynam xml:id="m5dn1" label="f" startid="#s2l1_t9_2">f</dynam>
-                     <dir xml:id="m5dr1" type="mscore-hairpin mscore-decresc" startid="#s2l1_t9_2" extender="true" endid="#s2l1_t21_4">dim.</dir>
+                     <dynam xml:id="d16couhq" label="f" startid="#n1h73eje">f</dynam>
+                     <dir xml:id="dxfp0cj" type="mscore-hairpin mscore-decresc" startid="#n1h73eje" extender="true" endid="#n4ihxav">dim.</dir>
                   </measure>
-                  <measure xml:id="m6" n="6">
+                  <measure xml:id="m1suce6e" n="6">
                      <staff xml:id="m6s1" n="1">
                         <layer xml:id="m6s1l1" n="1">
-                           <mRest xml:id="s1l1_t5_1" />
+                           <mRest xml:id="m1xxk5zx" />
                         </layer>
                      </staff>
                      <staff xml:id="m6s2" n="2">
                         <layer xml:id="m6s2l1" n="1">
-                           <note xml:id="s2l1_t5_1" dur="4" pname="f" oct="2" />
-                           <note xml:id="s2l1_t21_4" dur="4" pname="e" oct="2" />
-                           <note xml:id="s2l1_t11_2" dur="2" pname="d" oct="2" />
+                           <note xml:id="ng3pe1m" dur="4" pname="f" oct="2" />
+                           <note xml:id="n4ihxav" dur="4" pname="e" oct="2" />
+                           <note xml:id="n1ea84qe" dur="2" pname="d" oct="2" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m7" n="7">
+                  <measure xml:id="mdcd5z7" n="7">
                      <staff xml:id="m7s1" n="1">
                         <layer xml:id="m7s1l1" n="1">
-                           <note xml:id="s1l1_t6_1" dur="2" pname="c" oct="6" />
-                           <rest xml:id="s1l1_t13_2" dur="2" />
+                           <note xml:id="n1fam44t" dur="2" pname="c" oct="6" />
+                           <rest xml:id="rcvk6nd" dur="2" />
                         </layer>
                      </staff>
                      <staff xml:id="m7s2" n="2">
                         <layer xml:id="m7s2l1" n="1">
-                           <note xml:id="s2l1_t6_1" dur="2" pname="c" oct="2" />
-                           <rest xml:id="s2l1_t13_2" dur="2" />
+                           <note xml:id="n1gxiuud" dur="2" pname="c" oct="2" />
+                           <rest xml:id="rxyukb6" dur="2" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m8" n="8">
+                  <measure xml:id="me9cs80" n="8">
                      <staff xml:id="m8s1" n="1">
                         <layer xml:id="m8s1l1" n="1">
-                           <note xml:id="s1l1_t7_1" dur="4" pname="c" oct="5" />
-                           <note xml:id="s1l1_t29_4" dur="4" pname="b" oct="4" />
-                           <note xml:id="s1l1_t15_2" dur="4" pname="a" oct="4" />
-                           <note xml:id="s1l1_t31_4" dur="4" pname="b" oct="4" />
+                           <note xml:id="nrcwa43" dur="4" pname="c" oct="5" />
+                           <note xml:id="nmgjbnw" dur="4" pname="b" oct="4" />
+                           <note xml:id="n9ff3t1" dur="4" pname="a" oct="4" />
+                           <note xml:id="ndncteg" dur="4" pname="b" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m8s2" n="2">
                         <layer xml:id="m8s2l1" n="1">
-                           <mRest xml:id="s2l1_t7_1" />
+                           <mRest xml:id="mks294k" />
                         </layer>
                      </staff>
-                     <hairpin xml:id="m8hp1" form="cres" startid="#s1l1_t15_2" lform="dashed" place="above" endid="#s1l1_t33_4" />
+                     <hairpin xml:id="hjs1sym" form="cres" startid="#n9ff3t1" lform="dashed" place="above" endid="#n2tj1jf" />
                   </measure>
-                  <measure xml:id="m9" n="9">
+                  <measure xml:id="moaa1gv" n="9">
                      <staff xml:id="m9s1" n="1">
                         <layer xml:id="m9s1l1" n="1">
-                           <note xml:id="s1l1_t8_1" dur="4" pname="c" oct="5" />
-                           <note xml:id="s1l1_t33_4" dur="4" pname="d" oct="5" />
-                           <note xml:id="s1l1_t17_2" dur="4" pname="e" oct="5" />
-                           <note xml:id="s1l1_t35_4" dur="4" pname="f" oct="5" />
+                           <note xml:id="nth4qu2" dur="4" pname="c" oct="5" />
+                           <note xml:id="n2tj1jf" dur="4" pname="d" oct="5" />
+                           <note xml:id="nq8sgb7" dur="4" pname="e" oct="5" />
+                           <note xml:id="n17b9s2c" dur="4" pname="f" oct="5" />
                         </layer>
                      </staff>
                      <staff xml:id="m9s2" n="2">
                         <layer xml:id="m9s2l1" n="1">
-                           <mRest xml:id="s2l1_t8_1" />
+                           <mRest xml:id="m1okzahl" />
                         </layer>
                      </staff>
-                     <hairpin xml:id="m9hp1" form="dim" startid="#s1l1_t17_2" lform="dotted" place="above" endid="#s1l1_t37_4" />
+                     <hairpin xml:id="hhnn0kt" form="dim" startid="#nq8sgb7" lform="dotted" place="above" endid="#n19df3r8" />
                   </measure>
-                  <measure xml:id="m10" n="10">
+                  <measure xml:id="m1vhuhz5" n="10">
                      <staff xml:id="m10s1" n="1">
                         <layer xml:id="m10s1l1" n="1">
-                           <note xml:id="s1l1_t9_1" dur="4" pname="g" oct="5" />
-                           <note xml:id="s1l1_t37_4" dur="4" pname="a" oct="5" />
-                           <note xml:id="s1l1_t19_2" dur="2" pname="b" oct="5" />
+                           <note xml:id="n10xvfkz" dur="4" pname="g" oct="5" />
+                           <note xml:id="n19df3r8" dur="4" pname="a" oct="5" />
+                           <note xml:id="n1imuqfs" dur="2" pname="b" oct="5" />
                         </layer>
                      </staff>
                      <staff xml:id="m10s2" n="2">
                         <layer xml:id="m10s2l1" n="1">
-                           <mRest xml:id="s2l1_t9_1" />
+                           <mRest xml:id="m9962ud" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m11" n="11">
+                  <measure xml:id="m1o34upj" n="11">
                      <staff xml:id="m11s1" n="1">
                         <layer xml:id="m11s1l1" n="1">
-                           <mRest xml:id="s1l1_t10_1" />
+                           <mRest xml:id="m1tmp2q7" />
                         </layer>
                      </staff>
                      <staff xml:id="m11s2" n="2">
                         <layer xml:id="m11s2l1" n="1">
-                           <note xml:id="s2l1_t10_1" dur="4" pname="c" oct="3" />
-                           <note xml:id="s2l1_t41_4" dur="4" pname="d" oct="3" />
-                           <note xml:id="s2l1_t21_2" dur="4" pname="e" oct="3" />
-                           <note xml:id="s2l1_t43_4" dur="4" pname="d" oct="3" />
+                           <note xml:id="n1vp2iid" dur="4" pname="c" oct="3" />
+                           <note xml:id="noxyswc" dur="4" pname="d" oct="3" />
+                           <note xml:id="n1ahnf5i" dur="4" pname="e" oct="3" />
+                           <note xml:id="ntcvrux" dur="4" pname="d" oct="3" />
                         </layer>
                      </staff>
-                     <hairpin xml:id="m11hp1" form="cres" startid="#s2l1_t21_2" place="above" endid="#s2l1_t45_4" />
+                     <hairpin xml:id="heiz76k" form="cres" startid="#n1ahnf5i" place="above" endid="#nsqyndt" />
                   </measure>
-                  <measure xml:id="m12" n="12">
+                  <measure xml:id="mjmh4f6" n="12">
                      <staff xml:id="m12s1" n="1">
                         <layer xml:id="m12s1l1" n="1">
-                           <mRest xml:id="s1l1_t11_1" />
+                           <mRest xml:id="mkvaady" />
                         </layer>
                      </staff>
                      <staff xml:id="m12s2" n="2">
                         <layer xml:id="m12s2l1" n="1">
-                           <note xml:id="s2l1_t11_1" dur="4" pname="c" oct="3" />
-                           <note xml:id="s2l1_t45_4" dur="4" pname="b" oct="2" />
-                           <note xml:id="s2l1_t23_2" dur="4" pname="a" oct="2" />
-                           <note xml:id="s2l1_t47_4" dur="4" pname="g" oct="2" />
+                           <note xml:id="n11dbwm8" dur="4" pname="c" oct="3" />
+                           <note xml:id="nsqyndt" dur="4" pname="b" oct="2" />
+                           <note xml:id="n13xf9ul" dur="4" pname="a" oct="2" />
+                           <note xml:id="n3ccbzy" dur="4" pname="g" oct="2" />
                         </layer>
                      </staff>
-                     <dir xml:id="m12dr1" type="mscore-hairpin mscore-decresc" startid="#s2l1_t23_2" extender="true" lform="dotted" place="above" endid="#s2l1_t13_1">diminuendo</dir>
+                     <dir xml:id="d1h5zlat" type="mscore-hairpin mscore-decresc" startid="#n13xf9ul" extender="true" lform="dotted" place="above" endid="#nfbqb4p">diminuendo</dir>
                   </measure>
-                  <measure xml:id="m13" n="13">
+                  <measure xml:id="m15y798u" n="13">
                      <staff xml:id="m13s1" n="1">
                         <layer xml:id="m13s1l1" n="1">
-                           <mRest xml:id="s1l1_t12_1" />
+                           <mRest xml:id="m1tt4284" />
                         </layer>
                      </staff>
                      <staff xml:id="m13s2" n="2">
                         <layer xml:id="m13s2l1" n="1">
-                           <note xml:id="s2l1_t12_1" dur="4" pname="f" oct="2" />
-                           <note xml:id="s2l1_t49_4" dur="4" pname="e" oct="2" />
-                           <note xml:id="s2l1_t25_2" dur="2" pname="d" oct="2" />
+                           <note xml:id="nniyj35" dur="4" pname="f" oct="2" />
+                           <note xml:id="n18hrjtg" dur="4" pname="e" oct="2" />
+                           <note xml:id="n1dyffqv" dur="2" pname="d" oct="2" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m14" right="end" n="14">
+                  <measure xml:id="m6hho9m" right="end" n="14">
                      <staff xml:id="m14s1" n="1">
                         <layer xml:id="m14s1l1" n="1">
-                           <note xml:id="s1l1_t13_1" dur="2" pname="c" oct="6" />
-                           <rest xml:id="s1l1_t27_2" dur="2" />
+                           <note xml:id="njvyk6n" dur="2" pname="c" oct="6" />
+                           <rest xml:id="ry8ar5n" dur="2" />
                         </layer>
                      </staff>
                      <staff xml:id="m14s2" n="2">
                         <layer xml:id="m14s2l1" n="1">
-                           <note xml:id="s2l1_t13_1" dur="2" pname="c" oct="2" />
-                           <rest xml:id="s2l1_t27_2" dur="2" />
+                           <note xml:id="nfbqb4p" dur="2" pname="c" oct="2" />
+                           <rest xml:id="r1o9geiq" dur="2" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/hairpin-01.mscx
+++ b/src/importexport/mei/tests/data/hairpin-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-08T22:14:36&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:52:33&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/jump-01.mei
+++ b/src/importexport/mei/tests/data/jump-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:03" />
+            <date isodate="2023-08-11T14:52:39" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -39,92 +39,92 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m1d6ya8h" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <note xml:id="s1l1_t0_1" dur="1" pname="c" oct="4" />
+                           <note xml:id="n11d3ef" dur="1" pname="c" oct="4" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="m1qxox9a" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <note xml:id="s1l1_t1_1" dur="1" pname="d" oct="4" />
+                           <note xml:id="n912k7" dur="1" pname="d" oct="4" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m2rp1" type="mscore-jump-dc-al-double-coda" func="daCapo" tstamp="0.000000">D.C. al Double Coda</repeatMark>
+                     <repeatMark xml:id="r1275fyx" type="mscore-jump-dc-al-double-coda" func="daCapo" tstamp="0.000000">D.C. al Double Coda</repeatMark>
                   </measure>
-                  <measure xml:id="m3" n="3">
+                  <measure xml:id="m19nftig" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <note xml:id="s1l1_t2_1" dur="1" pname="e" oct="4" />
+                           <note xml:id="n7oozff" dur="1" pname="e" oct="4" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m4" n="4">
+                  <measure xml:id="mxzzrfr" n="4">
                      <staff xml:id="m4s1" n="1">
                         <layer xml:id="m4s1l1" n="1">
-                           <note xml:id="s1l1_t3_1" dur="1" pname="d" oct="4" />
+                           <note xml:id="ny90sao" dur="1" pname="d" oct="4" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m5" n="5">
+                  <measure xml:id="m13rrcsl" n="5">
                      <staff xml:id="m5s1" n="1">
                         <layer xml:id="m5s1l1" n="1">
-                           <note xml:id="s1l1_t4_1" dur="1" pname="c" oct="4" />
+                           <note xml:id="no6otrq" dur="1" pname="c" oct="4" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m5rp1" func="segno" tstamp="0.000000" />
+                     <repeatMark xml:id="r1mdylt7" func="segno" tstamp="0.000000" />
                   </measure>
-                  <measure xml:id="m6" n="6">
+                  <measure xml:id="md370gx" n="6">
                      <staff xml:id="m6s1" n="1">
                         <layer xml:id="m6s1l1" n="1">
-                           <note xml:id="s1l1_t5_1" dur="1" pname="e" oct="4" />
+                           <note xml:id="nls7c2u" dur="1" pname="e" oct="4" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m7" n="7">
+                  <measure xml:id="m1t2qsvv" n="7">
                      <staff xml:id="m7s1" n="1">
                         <layer xml:id="m7s1l1" n="1">
-                           <note xml:id="s1l1_t6_1" dur="1" pname="g" oct="4" />
+                           <note xml:id="nomf9x9" dur="1" pname="g" oct="4" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m7rp1" type="mscore-marker-to-coda" func="coda" tstamp="0.000000">To Coda</repeatMark>
+                     <repeatMark xml:id="r1uhpszs" type="mscore-marker-to-coda" func="coda" tstamp="0.000000">To Coda</repeatMark>
                   </measure>
-                  <measure xml:id="m8" n="8">
+                  <measure xml:id="m16isenw" n="8">
                      <staff xml:id="m8s1" n="1">
                         <layer xml:id="m8s1l1" n="1">
-                           <note xml:id="s1l1_t7_1" dur="1" pname="b" oct="4" />
+                           <note xml:id="n1h8545z" dur="1" pname="b" oct="4" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m9" n="9">
+                  <measure xml:id="m1hcikey" n="9">
                      <staff xml:id="m9s1" n="1">
                         <layer xml:id="m9s1l1" n="1">
-                           <note xml:id="s1l1_t8_1" dur="1" pname="c" oct="5" />
+                           <note xml:id="nxtfrph" dur="1" pname="c" oct="5" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m9rp1" type="mscore-jump-ds-al-coda" func="dalSegno" tstamp="0.000000">D.S. al Coda</repeatMark>
+                     <repeatMark xml:id="rvl0b39" type="mscore-jump-ds-al-coda" func="dalSegno" tstamp="0.000000">D.S. al Coda</repeatMark>
                   </measure>
-                  <measure xml:id="m10" n="10">
+                  <measure xml:id="m13tc1db" n="10">
                      <staff xml:id="m10s1" n="1">
                         <layer xml:id="m10s1l1" n="1">
-                           <note xml:id="s1l1_t9_1" dur="1" pname="g" oct="4" />
+                           <note xml:id="nr8xosg" dur="1" pname="g" oct="4" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m11" n="11">
+                  <measure xml:id="mk68fev" n="11">
                      <staff xml:id="m11s1" n="1">
                         <layer xml:id="m11s1l1" n="1">
-                           <note xml:id="s1l1_t10_1" dur="1" pname="d" oct="5" />
+                           <note xml:id="n160z06z" dur="1" pname="d" oct="5" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m11rp1" func="coda" tstamp="0.000000" />
+                     <repeatMark xml:id="r10or82b" func="coda" tstamp="0.000000" />
                   </measure>
-                  <measure xml:id="m12" right="end" n="12">
+                  <measure xml:id="m8fddfg" right="end" n="12">
                      <staff xml:id="m12s1" n="1">
                         <layer xml:id="m12s1l1" n="1">
-                           <note xml:id="s1l1_t11_1" dur="1" pname="c" oct="5" />
+                           <note xml:id="n1k5nyqp" dur="1" pname="c" oct="5" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/jump-01.mscx
+++ b/src/importexport/mei/tests/data/jump-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:03&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:52:39&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/jump-02.mei
+++ b/src/importexport/mei/tests/data/jump-02.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:04" />
+            <date isodate="2023-08-11T14:52:45" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -39,294 +39,294 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="mq0b0m9" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <mRest xml:id="s1l1_t0_1" />
+                           <mRest xml:id="m17vywhl" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="mee22q" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <mRest xml:id="s1l1_t1_1" />
+                           <mRest xml:id="magjrcq" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m2rp1" func="segno" tstamp="0.000000" />
+                     <repeatMark xml:id="rcffupx" func="segno" tstamp="0.000000" />
                   </measure>
-                  <measure xml:id="m3" n="3">
+                  <measure xml:id="m147n12q" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <mRest xml:id="s1l1_t2_1" />
+                           <mRest xml:id="m12b8re7" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m3rp1" func="coda" tstamp="0.000000" />
+                     <repeatMark xml:id="r5pepc5" func="coda" tstamp="0.000000" />
                   </measure>
-                  <measure xml:id="m4" n="4">
+                  <measure xml:id="m1wtunea" n="4">
                      <staff xml:id="m4s1" n="1">
                         <layer xml:id="m4s1l1" n="1">
-                           <mRest xml:id="s1l1_t3_1" />
+                           <mRest xml:id="m14ylxt4" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m4rp1" func="fine" tstamp="0.000000" />
+                     <repeatMark xml:id="r1g457ok" func="fine" tstamp="0.000000" />
                   </measure>
-                  <measure xml:id="m5" n="5">
+                  <measure xml:id="mh0e6nx" n="5">
                      <staff xml:id="m5s1" n="1">
                         <layer xml:id="m5s1l1" n="1">
-                           <mRest xml:id="s1l1_t4_1" />
+                           <mRest xml:id="m1vhjzml" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m6" n="6">
+                  <measure xml:id="m194qwma" n="6">
                      <staff xml:id="m6s1" n="1">
                         <layer xml:id="m6s1l1" n="1">
-                           <mRest xml:id="s1l1_t5_1" />
+                           <mRest xml:id="mlv5uz7" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m6rp1" type="mscore-marker-to-coda" func="coda" tstamp="0.000000">To Coda</repeatMark>
+                     <repeatMark xml:id="r1f7agup" type="mscore-marker-to-coda" func="coda" tstamp="0.000000">To Coda</repeatMark>
                   </measure>
-                  <measure xml:id="m7" n="7">
+                  <measure xml:id="moy1md4" n="7">
                      <staff xml:id="m7s1" n="1">
                         <layer xml:id="m7s1l1" n="1">
-                           <mRest xml:id="s1l1_t6_1" />
+                           <mRest xml:id="m1tngm0r" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m8" n="8">
+                  <measure xml:id="m2445q6" n="8">
                      <staff xml:id="m8s1" n="1">
                         <layer xml:id="m8s1l1" n="1">
-                           <mRest xml:id="s1l1_t7_1" />
+                           <mRest xml:id="mz96drd" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m8rp1" func="daCapo" tstamp="0.000000" />
+                     <repeatMark xml:id="rqzyhoe" func="daCapo" tstamp="0.000000" />
                   </measure>
-                  <measure xml:id="m9" n="9">
+                  <measure xml:id="mglhatt" n="9">
                      <staff xml:id="m9s1" n="1">
                         <layer xml:id="m9s1l1" n="1">
-                           <mRest xml:id="s1l1_t8_1" />
+                           <mRest xml:id="m1pjd3r" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m10" n="10">
+                  <measure xml:id="mbwl4s3" n="10">
                      <staff xml:id="m10s1" n="1">
                         <layer xml:id="m10s1l1" n="1">
-                           <mRest xml:id="s1l1_t9_1" />
+                           <mRest xml:id="m1wtn1lz" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m10rp1" type="mscore-jump-dc-al-fine" func="daCapo" tstamp="0.000000">D.C. al Fine</repeatMark>
+                     <repeatMark xml:id="r8bjppz" type="mscore-jump-dc-al-fine" func="daCapo" tstamp="0.000000">D.C. al Fine</repeatMark>
                   </measure>
-                  <measure xml:id="m11" n="11">
+                  <measure xml:id="m8vs4ge" n="11">
                      <staff xml:id="m11s1" n="1">
                         <layer xml:id="m11s1l1" n="1">
-                           <mRest xml:id="s1l1_t10_1" />
+                           <mRest xml:id="m1id3zk7" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m12" n="12">
+                  <measure xml:id="mkvtli5" n="12">
                      <staff xml:id="m12s1" n="1">
                         <layer xml:id="m12s1l1" n="1">
-                           <mRest xml:id="s1l1_t11_1" />
+                           <mRest xml:id="magwjf3" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m13" n="13">
+                  <measure xml:id="mrzsvyq" n="13">
                      <staff xml:id="m13s1" n="1">
                         <layer xml:id="m13s1l1" n="1">
-                           <mRest xml:id="s1l1_t12_1" />
+                           <mRest xml:id="m19j03ff" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m13rp1" type="mscore-jump-dc-al-coda" func="daCapo" tstamp="0.000000">D.C. al Coda</repeatMark>
+                     <repeatMark xml:id="r1mmym64" type="mscore-jump-dc-al-coda" func="daCapo" tstamp="0.000000">D.C. al Coda</repeatMark>
                   </measure>
-                  <measure xml:id="m14" n="14">
+                  <measure xml:id="mia16k9" n="14">
                      <staff xml:id="m14s1" n="1">
                         <layer xml:id="m14s1l1" n="1">
-                           <mRest xml:id="s1l1_t13_1" />
+                           <mRest xml:id="mzfbv97" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m15" n="15">
+                  <measure xml:id="mv0gzmp" n="15">
                      <staff xml:id="m15s1" n="1">
                         <layer xml:id="m15s1l1" n="1">
-                           <mRest xml:id="s1l1_t14_1" />
+                           <mRest xml:id="m1qxqnfq" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m15rp1" type="mscore-jump-ds-al-coda" func="dalSegno" tstamp="0.000000">D.S. al Coda</repeatMark>
+                     <repeatMark xml:id="r11iw6ja" type="mscore-jump-ds-al-coda" func="dalSegno" tstamp="0.000000">D.S. al Coda</repeatMark>
                   </measure>
-                  <measure xml:id="m16" n="16">
+                  <measure xml:id="ma0vwly" n="16">
                      <staff xml:id="m16s1" n="1">
                         <layer xml:id="m16s1l1" n="1">
-                           <mRest xml:id="s1l1_t15_1" />
+                           <mRest xml:id="m1xsei73" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m17" n="17">
+                  <measure xml:id="m19yihwd" n="17">
                      <staff xml:id="m17s1" n="1">
                         <layer xml:id="m17s1l1" n="1">
-                           <mRest xml:id="s1l1_t16_1" />
+                           <mRest xml:id="mul8jwz" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m17rp1" type="mscore-jump-ds-al-fine" func="dalSegno" tstamp="0.000000">D.S. al Fine</repeatMark>
+                     <repeatMark xml:id="r1mbewl2" type="mscore-jump-ds-al-fine" func="dalSegno" tstamp="0.000000">D.S. al Fine</repeatMark>
                   </measure>
-                  <measure xml:id="m18" n="18">
+                  <measure xml:id="mtaqn7c" n="18">
                      <staff xml:id="m18s1" n="1">
                         <layer xml:id="m18s1l1" n="1">
-                           <mRest xml:id="s1l1_t17_1" />
+                           <mRest xml:id="mcsrt0q" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m19" n="19">
+                  <measure xml:id="m6upixg" n="19">
                      <staff xml:id="m19s1" n="1">
                         <layer xml:id="m19s1l1" n="1">
-                           <mRest xml:id="s1l1_t18_1" />
+                           <mRest xml:id="mp0hmii" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m19rp1" func="dalSegno" tstamp="0.000000" />
+                     <repeatMark xml:id="r19olli1" func="dalSegno" tstamp="0.000000" />
                   </measure>
-                  <measure xml:id="m20" n="20">
+                  <measure xml:id="m1879ew5" n="20">
                      <staff xml:id="m20s1" n="1">
                         <layer xml:id="m20s1l1" n="1">
-                           <mRest xml:id="s1l1_t19_1" />
+                           <mRest xml:id="m1kh4i4h" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m21" n="21">
+                  <measure xml:id="m1cimrtk" n="21">
                      <staff xml:id="m21s1" n="1">
                         <layer xml:id="m21s1l1" n="1">
-                           <mRest xml:id="s1l1_t20_1" />
+                           <mRest xml:id="m1ohl0o3" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m21rp1" type="mscore-marker-segno-variation" func="segno" tstamp="0.000000" />
+                     <repeatMark xml:id="r19gaqv8" type="mscore-marker-segno-variation" func="segno" tstamp="0.000000" />
                   </measure>
-                  <measure xml:id="m22" n="22">
+                  <measure xml:id="mv2kkx2" n="22">
                      <staff xml:id="m22s1" n="1">
                         <layer xml:id="m22s1l1" n="1">
-                           <mRest xml:id="s1l1_t21_1" />
+                           <mRest xml:id="mx6fj46" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m22rp1" type="mscore-marker-varied-coda" func="coda" tstamp="0.000000" />
+                     <repeatMark xml:id="r27n4ba" type="mscore-marker-varied-coda" func="coda" tstamp="0.000000" />
                   </measure>
-                  <measure xml:id="m23" n="23">
+                  <measure xml:id="m1p8go0p" n="23">
                      <staff xml:id="m23s1" n="1">
                         <layer xml:id="m23s1l1" n="1">
-                           <mRest xml:id="s1l1_t22_1" />
+                           <mRest xml:id="m45onci" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m24" n="24">
+                  <measure xml:id="m13pfudn" n="24">
                      <staff xml:id="m24s1" n="1">
                         <layer xml:id="m24s1l1" n="1">
-                           <mRest xml:id="s1l1_t23_1" />
+                           <mRest xml:id="m1luj6rb" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m25" n="25">
+                  <measure xml:id="m1isn0xd" n="25">
                      <staff xml:id="m25s1" n="1">
                         <layer xml:id="m25s1l1" n="1">
-                           <mRest xml:id="s1l1_t24_1" />
+                           <mRest xml:id="mf88e0i" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m25rp1" type="mscore-jump-dc-al-double-coda" func="daCapo" tstamp="0.000000">D.C. al Double Coda</repeatMark>
+                     <repeatMark xml:id="rb0e9jx" type="mscore-jump-dc-al-double-coda" func="daCapo" tstamp="0.000000">D.C. al Double Coda</repeatMark>
                   </measure>
-                  <measure xml:id="m26" n="26">
+                  <measure xml:id="m4wju9q" n="26">
                      <staff xml:id="m26s1" n="1">
                         <layer xml:id="m26s1l1" n="1">
-                           <mRest xml:id="s1l1_t25_1" />
+                           <mRest xml:id="m1jphy9v" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m27" n="27">
+                  <measure xml:id="m96zldb" n="27">
                      <staff xml:id="m27s1" n="1">
                         <layer xml:id="m27s1l1" n="1">
-                           <mRest xml:id="s1l1_t26_1" />
+                           <mRest xml:id="mrf9b58" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m28" n="28">
+                  <measure xml:id="m1sj3ntv" n="28">
                      <staff xml:id="m28s1" n="1">
                         <layer xml:id="m28s1l1" n="1">
-                           <mRest xml:id="s1l1_t27_1" />
+                           <mRest xml:id="mdx816j" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m28rp1" type="mscore-jump-ds-al-double-coda" func="dalSegno" tstamp="0.000000">D.S. al Double Coda</repeatMark>
+                     <repeatMark xml:id="r1rlyijq" type="mscore-jump-ds-al-double-coda" func="dalSegno" tstamp="0.000000">D.S. al Double Coda</repeatMark>
                   </measure>
-                  <measure xml:id="m29" n="29">
+                  <measure xml:id="m14x5idk" n="29">
                      <staff xml:id="m29s1" n="1">
                         <layer xml:id="m29s1l1" n="1">
-                           <mRest xml:id="s1l1_t28_1" />
+                           <mRest xml:id="mlrmu8" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m30" n="30">
+                  <measure xml:id="mh2nh76" n="30">
                      <staff xml:id="m30s1" n="1">
                         <layer xml:id="m30s1l1" n="1">
-                           <mRest xml:id="s1l1_t29_1" />
+                           <mRest xml:id="ms9s3p0" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m31" n="31">
+                  <measure xml:id="m14xoo13" n="31">
                      <staff xml:id="m31s1" n="1">
                         <layer xml:id="m31s1l1" n="1">
-                           <mRest xml:id="s1l1_t30_1" />
+                           <mRest xml:id="m1nfqh13" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m31rp1" type="mscore-jump-dal-segno-segno" func="dalSegno" tstamp="0.000000">Dal Segno Segno</repeatMark>
+                     <repeatMark xml:id="r9pug6" type="mscore-jump-dal-segno-segno" func="dalSegno" tstamp="0.000000">Dal Segno Segno</repeatMark>
                   </measure>
-                  <measure xml:id="m32" n="32">
+                  <measure xml:id="mykxmdc" n="32">
                      <staff xml:id="m32s1" n="1">
                         <layer xml:id="m32s1l1" n="1">
-                           <mRest xml:id="s1l1_t31_1" />
+                           <mRest xml:id="m1057c8c" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m33" n="33">
+                  <measure xml:id="mxn1lb1" n="33">
                      <staff xml:id="m33s1" n="1">
                         <layer xml:id="m33s1l1" n="1">
-                           <mRest xml:id="s1l1_t32_1" />
+                           <mRest xml:id="m1u8it3z" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m34" n="34">
+                  <measure xml:id="muwykl0" n="34">
                      <staff xml:id="m34s1" n="1">
                         <layer xml:id="m34s1l1" n="1">
-                           <mRest xml:id="s1l1_t33_1" />
+                           <mRest xml:id="m1phn5hx" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m34rp1" type="mscore-jump-dss-al-coda" func="dalSegno" tstamp="0.000000">D.S.S. al Coda</repeatMark>
+                     <repeatMark xml:id="rgajmz3" type="mscore-jump-dss-al-coda" func="dalSegno" tstamp="0.000000">D.S.S. al Coda</repeatMark>
                   </measure>
-                  <measure xml:id="m35" n="35">
+                  <measure xml:id="mrhoh70" n="35">
                      <staff xml:id="m35s1" n="1">
                         <layer xml:id="m35s1l1" n="1">
-                           <mRest xml:id="s1l1_t34_1" />
+                           <mRest xml:id="mfhl2t7" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m36" n="36">
+                  <measure xml:id="mzgpp41" n="36">
                      <staff xml:id="m36s1" n="1">
                         <layer xml:id="m36s1l1" n="1">
-                           <mRest xml:id="s1l1_t35_1" />
+                           <mRest xml:id="mnffeub" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m36rp1" type="mscore-jump-dss-al-double-coda" func="dalSegno" tstamp="0.000000">D.S.S. al Double Coda</repeatMark>
+                     <repeatMark xml:id="ra4t4wq" type="mscore-jump-dss-al-double-coda" func="dalSegno" tstamp="0.000000">D.S.S. al Double Coda</repeatMark>
                   </measure>
-                  <measure xml:id="m37" n="37">
+                  <measure xml:id="m1cd5cwt" n="37">
                      <staff xml:id="m37s1" n="1">
                         <layer xml:id="m37s1l1" n="1">
-                           <mRest xml:id="s1l1_t36_1" />
+                           <mRest xml:id="m1ne5z0r" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m38" n="38">
+                  <measure xml:id="m1pjap4h" n="38">
                      <staff xml:id="m38s1" n="1">
                         <layer xml:id="m38s1l1" n="1">
-                           <mRest xml:id="s1l1_t37_1" />
+                           <mRest xml:id="m14xsxp6" />
                         </layer>
                      </staff>
-                     <repeatMark xml:id="m38rp1" type="mscore-jump-dss-al-fine" func="dalSegno" tstamp="0.000000">D.S.S. al Fine</repeatMark>
+                     <repeatMark xml:id="rp8uic0" type="mscore-jump-dss-al-fine" func="dalSegno" tstamp="0.000000">D.S.S. al Fine</repeatMark>
                   </measure>
-                  <measure xml:id="m39" right="end" n="39">
+                  <measure xml:id="m1yvuz2f" right="end" n="39">
                      <staff xml:id="m39s1" n="1">
                         <layer xml:id="m39s1l1" n="1">
-                           <mRest xml:id="s1l1_t38_1" />
+                           <mRest xml:id="m1swk88t" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/jump-02.mscx
+++ b/src/importexport/mei/tests/data/jump-02.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:04&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:52:45&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/key-signature-01.mei
+++ b/src/importexport/mei/tests/data/key-signature-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:05" />
+            <date isodate="2023-08-11T14:52:51" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -49,29 +49,29 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m1luku1g" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <note xml:id="s1l1_t0_1" dur="1" pname="a" oct="4" />
+                           <note xml:id="nmpms87" dur="1" pname="a" oct="4" />
                         </layer>
                         <layer xml:id="m1s1l2" n="2">
-                           <note xml:id="s1l2_t0_1" dur="1" pname="d" oct="4" />
+                           <note xml:id="nmn0j2x" dur="1" pname="d" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s2" n="2">
                         <layer xml:id="m1s2l1" n="1">
-                           <mRest xml:id="s2l1_t0_1" />
+                           <mRest xml:id="m1nc2slx" />
                         </layer>
                         <layer xml:id="m1s2l2" n="2">
-                           <note xml:id="s2l2_t0_1" dur="1" pname="e" oct="4" />
+                           <note xml:id="n9v4ms9" dur="1" pname="e" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s3" n="3">
                         <layer xml:id="m1s3l1" n="1">
-                           <mRest xml:id="s3l1_t0_1" />
+                           <mRest xml:id="m138euud" />
                         </layer>
                         <layer xml:id="m1s3l2" n="2">
-                           <note xml:id="s3l2_t0_1" dur="1" pname="c" oct="3" />
+                           <note xml:id="n1oxhgac" dur="1" pname="c" oct="3" />
                         </layer>
                      </staff>
                   </measure>
@@ -82,31 +82,31 @@
                         <staffDef n="3" keysig="3f" />
                      </staffGrp>
                   </scoreDef>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="m1rg09ln" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <note xml:id="s1l1_t1_1" dur="1" pname="a" oct="4" />
+                           <note xml:id="n1n13czy" dur="1" pname="a" oct="4" />
                         </layer>
                         <layer xml:id="m2s1l2" n="2">
-                           <note xml:id="s1l2_t1_1" dur="1" pname="d" oct="4" />
+                           <note xml:id="n1yxfigg" dur="1" pname="d" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s2" n="2">
                         <layer xml:id="m2s2l1" n="1">
-                           <mRest xml:id="s2l1_t1_1" />
+                           <mRest xml:id="m18vj4b5" />
                         </layer>
                         <layer xml:id="m2s2l2" n="2">
-                           <note xml:id="s2l2_t1_1" dur="1" pname="e" oct="4">
-                              <accid xml:id="m2s2l2a1" accid.ges="f" />
+                           <note xml:id="n124yf7q" dur="1" pname="e" oct="4">
+                              <accid accid.ges="f" />
                            </note>
                         </layer>
                      </staff>
                      <staff xml:id="m2s3" n="3">
                         <layer xml:id="m2s3l1" n="1">
-                           <mRest xml:id="s3l1_t1_1" />
+                           <mRest xml:id="m1hy3itq" />
                         </layer>
                         <layer xml:id="m2s3l2" n="2">
-                           <note xml:id="s3l2_t1_1" dur="1" pname="c" oct="3" />
+                           <note xml:id="nlkft73" dur="1" pname="c" oct="3" />
                         </layer>
                      </staff>
                   </measure>
@@ -117,29 +117,29 @@
                         <staffDef n="3" keysig="0" />
                      </staffGrp>
                   </scoreDef>
-                  <measure xml:id="m3" right="end" n="3">
+                  <measure xml:id="m514l6d" right="end" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <note xml:id="s1l1_t2_1" dots="1" dur="2" pname="a" oct="4" />
+                           <note xml:id="n1evsei9" dots="1" dur="2" pname="a" oct="4" />
                         </layer>
                         <layer xml:id="m3s1l2" n="2">
-                           <note xml:id="s1l2_t2_1" dots="1" dur="2" pname="d" oct="4" />
+                           <note xml:id="n1x3wga" dots="1" dur="2" pname="d" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m3s2" n="2">
                         <layer xml:id="m3s2l1" n="1">
-                           <mRest xml:id="s2l1_t2_1" />
+                           <mRest xml:id="m1w9csg5" />
                         </layer>
                         <layer xml:id="m3s2l2" n="2">
-                           <note xml:id="s2l2_t2_1" dots="1" dur="2" pname="e" oct="4" />
+                           <note xml:id="n155ckkw" dots="1" dur="2" pname="e" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m3s3" n="3">
                         <layer xml:id="m3s3l1" n="1">
-                           <mRest xml:id="s3l1_t2_1" />
+                           <mRest xml:id="m1gkxhdn" />
                         </layer>
                         <layer xml:id="m3s3l2" n="2">
-                           <note xml:id="s3l2_t2_1" dots="1" dur="2" pname="c" oct="3" />
+                           <note xml:id="na7klj" dots="1" dur="2" pname="c" oct="3" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/key-signature-01.mscx
+++ b/src/importexport/mei/tests/data/key-signature-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:05&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:52:51&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/measure-01.mei
+++ b/src/importexport/mei/tests/data/measure-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:07" />
+            <date isodate="2023-08-11T14:53:04" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -39,73 +39,73 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" metcon="false">
+                  <measure xml:id="m1cdidqp" metcon="false">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <note xml:id="s1l1_t0_1" dur="4" pname="g" oct="4" />
+                           <note xml:id="n1yz5z9l" dur="4" pname="g" oct="4" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" n="1">
+                  <measure xml:id="ms79q1" n="1">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <note xml:id="s1l1_t1_4" dur="2" pname="g" oct="4" />
-                           <note xml:id="s1l1_t3_4" dur="4" pname="d" oct="5" />
+                           <note xml:id="n3c1ths" dur="2" pname="g" oct="4" />
+                           <note xml:id="npqdmlo" dur="4" pname="d" oct="5" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m3" n="2">
+                  <measure xml:id="m1jemaai" n="2">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <note xml:id="s1l1_t1_1" dots="1" dur="4" pname="b" oct="4" />
-                           <note xml:id="s1l1_t11_8" type="mscore-beam-none" dur="8" pname="a" oct="4" />
-                           <note xml:id="s1l1_t3_2" dur="4" pname="g" oct="4" />
+                           <note xml:id="neyegj" dots="1" dur="4" pname="b" oct="4" />
+                           <note xml:id="n80fo22" type="mscore-beam-none" dur="8" pname="a" oct="4" />
+                           <note xml:id="ng3zozv" dur="4" pname="g" oct="4" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m4" n="3">
+                  <measure xml:id="mcu5zej" n="3">
                      <staff xml:id="m4s1" n="1">
                         <layer xml:id="m4s1l1" n="1">
-                           <note xml:id="s1l1_t7_4" dots="1" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t17_8" type="mscore-beam-none" dur="8" pname="a" oct="4" />
-                           <note xml:id="s1l1_t9_4" dur="4" pname="b" oct="4" />
+                           <note xml:id="n12kjauk" dots="1" dur="4" pname="g" oct="4" />
+                           <note xml:id="nbn4bcc" type="mscore-beam-none" dur="8" pname="a" oct="4" />
+                           <note xml:id="n1pmtkrc" dur="4" pname="b" oct="4" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m5" metcon="false" n="4">
+                  <measure xml:id="mojcxm1" metcon="false" n="4">
                      <staff xml:id="m5s1" n="1">
                         <layer xml:id="m5s1l1" n="1">
-                           <note xml:id="s1l1_t5_2" dur="2" pname="a" oct="4" />
+                           <note xml:id="n7d7658" dur="2" pname="a" oct="4" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m6" metcon="false">
+                  <measure xml:id="m1ldz6o3" metcon="false">
                      <staff xml:id="m6s1" n="1">
                         <layer xml:id="m6s1l1" n="1">
-                           <note xml:id="s1l1_t3_1" dur="4" pname="b" oct="4" />
+                           <note xml:id="n100aznw" dur="4" pname="b" oct="4" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m7" n="5">
+                  <measure xml:id="m1s0q3k3" n="5">
                      <staff xml:id="m7s1" n="1">
                         <layer xml:id="m7s1l1" n="1">
-                           <note xml:id="s1l1_t13_4" dur="2" pname="d" oct="5" />
-                           <note xml:id="s1l1_t15_4" dur="4" pname="c" oct="5" />
+                           <note xml:id="n16y0l6n" dur="2" pname="d" oct="5" />
+                           <note xml:id="n374iko" dur="4" pname="c" oct="5" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m8" n="6">
+                  <measure xml:id="m11eoenp" n="6">
                      <staff xml:id="m8s1" n="1">
                         <layer xml:id="m8s1l1" n="1">
-                           <note xml:id="s1l1_t4_1" dur="4" pname="b" oct="4" />
-                           <note xml:id="s1l1_t17_4" dur="2" pname="a" oct="4" />
+                           <note xml:id="ni0o84b" dur="4" pname="b" oct="4" />
+                           <note xml:id="n1t762ep" dur="2" pname="a" oct="4" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m9" right="end" metcon="false" n="7">
+                  <measure xml:id="m1h50n2w" right="end" metcon="false" n="7">
                      <staff xml:id="m9s1" n="1">
                         <layer xml:id="m9s1l1" n="1">
-                           <note xml:id="s1l1_t19_4" dur="2" pname="g" oct="4" />
+                           <note xml:id="n1kdz5jj" dur="2" pname="g" oct="4" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/measure-01.mscx
+++ b/src/importexport/mei/tests/data/measure-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:07&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:53:04&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/measure-02.mei
+++ b/src/importexport/mei/tests/data/measure-02.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:09" />
+            <date isodate="2023-08-11T14:53:10" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -56,245 +56,245 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" left="rptstart" metcon="false">
+                  <measure xml:id="m1ymqo4d" left="rptstart" metcon="false">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <rest xml:id="s1l1_t0_1" dur="4" />
+                           <rest xml:id="ryqpxf7" dur="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s2" n="2">
                         <layer xml:id="m1s2l1" n="1">
-                           <rest xml:id="s2l1_t0_1" dur="4" />
+                           <rest xml:id="r11vupue" dur="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s3" n="3">
                         <layer xml:id="m1s3l1" n="1">
-                           <rest xml:id="s3l1_t0_1" dur="4" />
+                           <rest xml:id="r1c5t8o9" dur="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s4" n="4">
                         <layer xml:id="m1s4l1" n="1">
-                           <rest xml:id="s4l1_t0_1" dur="4" />
+                           <rest xml:id="r1ff7qjd" dur="4" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" type="mscore-repeat-2" right="rptend" n="1">
+                  <measure xml:id="m66bjes" type="mscore-repeat-2" right="rptend" n="1">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <note xml:id="s1l1_t1_4" dots="1" dur="2" pname="c" oct="4" />
+                           <note xml:id="ncy4p46" dots="1" dur="2" pname="c" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s2" n="2">
                         <layer xml:id="m2s2l1" n="1">
-                           <note xml:id="s2l1_t1_4" dots="1" dur="2" pname="c" oct="4" />
+                           <note xml:id="n1l01fpx" dots="1" dur="2" pname="c" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s3" n="3">
                         <layer xml:id="m2s3l1" n="1">
-                           <note xml:id="s3l1_t1_4" dots="1" dur="2" pname="c" oct="3" />
+                           <note xml:id="nwzaj0m" dots="1" dur="2" pname="c" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s4" n="4">
                         <layer xml:id="m2s4l1" n="1">
-                           <note xml:id="s4l1_t1_4" dots="1" dur="2" pname="c" oct="2" />
+                           <note xml:id="nf87711" dots="1" dur="2" pname="c" oct="2" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m3" left="rptstart" right="dbl" n="2">
+                  <measure xml:id="m18dc5bo" left="rptstart" right="dbl" n="2">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <note xml:id="s1l1_t1_1" dots="1" dur="2" pname="d" oct="4" />
+                           <note xml:id="nllv2om" dots="1" dur="2" pname="d" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m3s2" n="2">
                         <layer xml:id="m3s2l1" n="1">
-                           <note xml:id="s2l1_t1_1" dots="1" dur="2" pname="d" oct="4" />
+                           <note xml:id="n1fck12e" dots="1" dur="2" pname="d" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m3s3" n="3">
                         <layer xml:id="m3s3l1" n="1">
-                           <note xml:id="s3l1_t1_1" dots="1" dur="2" pname="d" oct="3" />
+                           <note xml:id="n1cd8ahp" dots="1" dur="2" pname="d" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m3s4" n="4">
                         <layer xml:id="m3s4l1" n="1">
-                           <note xml:id="s4l1_t1_1" dots="1" dur="2" pname="d" oct="2" />
+                           <note xml:id="nmn0fdq" dots="1" dur="2" pname="d" oct="2" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m4" type="mscore-repeat-2" right="rptend" n="3">
+                  <measure xml:id="mcrcv0y" type="mscore-repeat-2" right="rptend" n="3">
                      <staff xml:id="m4s1" n="1">
                         <layer xml:id="m4s1l1" n="1">
-                           <note xml:id="s1l1_t7_4" dots="1" dur="2" pname="e" oct="4" />
+                           <note xml:id="n2mpbrb" dots="1" dur="2" pname="e" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m4s2" n="2">
                         <layer xml:id="m4s2l1" n="1">
-                           <note xml:id="s2l1_t7_4" dots="1" dur="2" pname="e" oct="4" />
+                           <note xml:id="n2jdzil" dots="1" dur="2" pname="e" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m4s3" n="3">
                         <layer xml:id="m4s3l1" n="1">
-                           <note xml:id="s3l1_t7_4" dots="1" dur="2" pname="e" oct="3" />
+                           <note xml:id="n1ksawgy" dots="1" dur="2" pname="e" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m4s4" n="4">
                         <layer xml:id="m4s4l1" n="1">
-                           <note xml:id="s4l1_t7_4" dots="1" dur="2" pname="e" oct="2" />
+                           <note xml:id="n1c6l10j" dots="1" dur="2" pname="e" oct="2" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m5" left="rptstart" metcon="false" n="4">
+                  <measure xml:id="m1we9eem" left="rptstart" metcon="false" n="4">
                      <staff xml:id="m5s1" n="1">
                         <layer xml:id="m5s1l1" n="1">
-                           <note xml:id="s1l1_t5_2" dur="2" pname="f" oct="4" />
+                           <note xml:id="n1awqufv" dur="2" pname="f" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m5s2" n="2">
                         <layer xml:id="m5s2l1" n="1">
-                           <note xml:id="s2l1_t5_2" dur="2" pname="f" oct="4" />
+                           <note xml:id="ndheb8i" dur="2" pname="f" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m5s3" n="3">
                         <layer xml:id="m5s3l1" n="1">
-                           <note xml:id="s3l1_t5_2" dur="2" pname="f" oct="3" />
+                           <note xml:id="n17jdk6f" dur="2" pname="f" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m5s4" n="4">
                         <layer xml:id="m5s4l1" n="1">
-                           <note xml:id="s4l1_t5_2" dur="2" pname="f" oct="2" />
+                           <note xml:id="n1q11vgr" dur="2" pname="f" oct="2" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m6" right="dashed" metcon="false">
+                  <measure xml:id="mpqepdo" right="dashed" metcon="false">
                      <staff xml:id="m6s1" n="1">
                         <layer xml:id="m6s1l1" n="1">
-                           <note xml:id="s1l1_t3_1" dur="4" pname="f" oct="4" />
+                           <note xml:id="n1calpfu" dur="4" pname="f" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m6s2" n="2">
                         <layer xml:id="m6s2l1" n="1">
-                           <note xml:id="s2l1_t3_1" dur="4" pname="f" oct="4" />
+                           <note xml:id="n2s0tw8" dur="4" pname="f" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m6s3" n="3">
                         <layer xml:id="m6s3l1" n="1">
-                           <note xml:id="s3l1_t3_1" dur="4" pname="f" oct="3" />
+                           <note xml:id="n1erlzgf" dur="4" pname="f" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m6s4" n="4">
                         <layer xml:id="m6s4l1" n="1">
-                           <note xml:id="s4l1_t3_1" dur="4" pname="f" oct="2" />
+                           <note xml:id="nxjmkt8" dur="4" pname="f" oct="2" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m7" right="heavy" n="5">
+                  <measure xml:id="msjk0go" right="heavy" n="5">
                      <staff xml:id="m7s1" n="1">
                         <layer xml:id="m7s1l1" n="1">
-                           <note xml:id="s1l1_t13_4" dots="1" dur="2" pname="g" oct="4" />
+                           <note xml:id="n1muoj4r" dots="1" dur="2" pname="g" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m7s2" n="2">
                         <layer xml:id="m7s2l1" n="1">
-                           <note xml:id="s2l1_t13_4" dots="1" dur="2" pname="g" oct="4" />
+                           <note xml:id="n1h3u9v4" dots="1" dur="2" pname="g" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m7s3" n="3">
                         <layer xml:id="m7s3l1" n="1">
-                           <note xml:id="s3l1_t13_4" dots="1" dur="2" pname="g" oct="3" />
+                           <note xml:id="nl7uqup" dots="1" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m7s4" n="4">
                         <layer xml:id="m7s4l1" n="1">
-                           <note xml:id="s4l1_t13_4" dots="1" dur="2" pname="g" oct="2" />
+                           <note xml:id="n3axv29" dots="1" dur="2" pname="g" oct="2" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m8" right="dbl" n="6">
+                  <measure xml:id="m1eq5jm4" right="dbl" n="6">
                      <staff xml:id="m8s1" n="1">
                         <layer xml:id="m8s1l1" n="1">
-                           <note xml:id="s1l1_t4_1" dots="1" dur="2" pname="a" oct="4" />
+                           <note xml:id="nr9lypi" dots="1" dur="2" pname="a" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m8s2" n="2">
                         <layer xml:id="m8s2l1" n="1">
-                           <note xml:id="s2l1_t4_1" dots="1" dur="2" pname="a" oct="4" />
+                           <note xml:id="nodrq7o" dots="1" dur="2" pname="a" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m8s3" n="3">
                         <layer xml:id="m8s3l1" n="1">
-                           <note xml:id="s3l1_t4_1" dots="1" dur="2" pname="a" oct="3" />
+                           <note xml:id="n6q6fe7" dots="1" dur="2" pname="a" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m8s4" n="4">
                         <layer xml:id="m8s4l1" n="1">
-                           <note xml:id="s4l1_t4_1" dots="1" dur="2" pname="a" oct="2" />
+                           <note xml:id="nw67jpe" dots="1" dur="2" pname="a" oct="2" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m9" right="dblheavy" n="7">
+                  <measure xml:id="mcxgzb1" right="dblheavy" n="7">
                      <staff xml:id="m9s1" n="1">
                         <layer xml:id="m9s1l1" n="1">
-                           <note xml:id="s1l1_t19_4" dots="1" dur="2" pname="b" oct="4" />
+                           <note xml:id="n1o7ulfd" dots="1" dur="2" pname="b" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m9s2" n="2">
                         <layer xml:id="m9s2l1" n="1">
-                           <note xml:id="s2l1_t19_4" dots="1" dur="2" pname="b" oct="4" />
+                           <note xml:id="n1uyabvy" dots="1" dur="2" pname="b" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m9s3" n="3">
                         <layer xml:id="m9s3l1" n="1">
-                           <note xml:id="s3l1_t19_4" dots="1" dur="2" pname="b" oct="3" />
+                           <note xml:id="n1ljg0jg" dots="1" dur="2" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m9s4" n="4">
                         <layer xml:id="m9s4l1" n="1">
-                           <note xml:id="s4l1_t19_4" dots="1" dur="2" pname="b" oct="2" />
+                           <note xml:id="n1u9197t" dots="1" dur="2" pname="b" oct="2" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m10" right="dotted" n="8">
+                  <measure xml:id="m1rjc9r1" right="dotted" n="8">
                      <staff xml:id="m10s1" n="1">
                         <layer xml:id="m10s1l1" n="1">
-                           <note xml:id="s1l1_t11_2" dots="1" dur="2" pname="c" oct="5" />
+                           <note xml:id="nj7a2li" dots="1" dur="2" pname="c" oct="5" />
                         </layer>
                      </staff>
                      <staff xml:id="m10s2" n="2">
                         <layer xml:id="m10s2l1" n="1">
-                           <note xml:id="s2l1_t11_2" dots="1" dur="2" pname="c" oct="5" />
+                           <note xml:id="n5cp1ym" dots="1" dur="2" pname="c" oct="5" />
                         </layer>
                      </staff>
                      <staff xml:id="m10s3" n="3">
                         <layer xml:id="m10s3l1" n="1">
-                           <note xml:id="s3l1_t11_2" dots="1" dur="2" pname="c" oct="4" />
+                           <note xml:id="n1kwqf7b" dots="1" dur="2" pname="c" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m10s4" n="4">
                         <layer xml:id="m10s4l1" n="1">
-                           <note xml:id="s4l1_t11_2" dots="1" dur="2" pname="c" oct="3" />
+                           <note xml:id="n1hhew9z" dots="1" dur="2" pname="c" oct="3" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m11" right="end" metcon="false" n="9">
+                  <measure xml:id="mqlwmqi" right="end" metcon="false" n="9">
                      <staff xml:id="m11s1" n="1">
                         <layer xml:id="m11s1l1" n="1">
-                           <note xml:id="s1l1_t25_4" dur="2" pname="c" oct="4" />
+                           <note xml:id="n1a17diz" dur="2" pname="c" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m11s2" n="2">
                         <layer xml:id="m11s2l1" n="1">
-                           <note xml:id="s2l1_t25_4" dur="2" pname="c" oct="4" />
+                           <note xml:id="ns4gq0p" dur="2" pname="c" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m11s3" n="3">
                         <layer xml:id="m11s3l1" n="1">
-                           <note xml:id="s3l1_t25_4" dur="2" pname="c" oct="4" />
+                           <note xml:id="n5q7uon" dur="2" pname="c" oct="4" />
                         </layer>
                      </staff>
                      <staff xml:id="m11s4" n="4">
                         <layer xml:id="m11s4l1" n="1">
-                           <note xml:id="s4l1_t25_4" dur="2" pname="c" oct="2" />
+                           <note xml:id="n14kbe4t" dur="2" pname="c" oct="2" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/measure-02.mscx
+++ b/src/importexport/mei/tests/data/measure-02.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:09&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:53:10&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/metadata-01.mei
+++ b/src/importexport/mei/tests/data/metadata-01.mei
@@ -14,7 +14,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:10" />
+            <date isodate="2023-08-11T14:53:16" />
             <availability>
                <distributor>Public domain</distributor>
             </availability>
@@ -45,10 +45,10 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" right="end" n="1">
+                  <measure xml:id="m1tv41uh" right="end" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <mRest xml:id="s1l1_t0_1" />
+                           <mRest xml:id="mrs5w9t" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/metadata-01.mscx
+++ b/src/importexport/mei/tests/data/metadata-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer of the piece</metaTag>
     <metaTag name="copyright">Public domain</metaTag>
     <metaTag name="lyricist">Metastasio</metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Metadata test (title)&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;arranger&quot;&gt;Arranger of the piece&lt;/persName&gt;&lt;persName role=&quot;composer&quot;&gt;Composer of the piece&lt;/persName&gt;&lt;persName role=&quot;lyricist&quot;&gt;Metastasio&lt;/persName&gt;&lt;persName role=&quot;translator&quot;&gt;Deepl&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:10&quot;/&gt;&lt;availability&gt;&lt;distributor&gt;Public domain&lt;/distributor&gt;&lt;/availability&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Metadata test (title)&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;arranger&quot;&gt;Arranger of the piece&lt;/persName&gt;&lt;persName role=&quot;composer&quot;&gt;Composer of the piece&lt;/persName&gt;&lt;persName role=&quot;lyricist&quot;&gt;Metastasio&lt;/persName&gt;&lt;persName role=&quot;translator&quot;&gt;Deepl&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:53:16&quot;/&gt;&lt;availability&gt;&lt;distributor&gt;Public domain&lt;/distributor&gt;&lt;/availability&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/octava-01.mei
+++ b/src/importexport/mei/tests/data/octava-01.mei
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-basic.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-basic.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev+basic">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Untitled score</title>
+            <respStmt>
+               <persName role="composer">Composer / arranger</persName>
+            </respStmt>
+         </titleStmt>
+         <pubStmt>
+            <date isodate="2023-08-11T14:53:22" />
+         </pubStmt>
+      </fileDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef>
+                  <pgHead>
+                     <rend halign="center" valign="top">
+                        <rend type="title" fontsize="x-large">Untitled score</rend>
+                        <lb />
+                        <rend type="subtitle" fontsize="large">Subtitle</rend>
+                     </rend>
+                     <rend halign="right" valign="bottom">
+                        <rend type="composer">Composer / arranger</rend>
+                     </rend>
+                  </pgHead>
+                  <staffGrp>
+                     <staffGrp bar.thru="true" symbol="brace">
+                        <label>Piano</label>
+                        <labelAbbr>Pno.</labelAbbr>
+                        <staffDef n="1" lines="5" meter.count="4" meter.unit="4">
+                           <clef shape="G" line="2" />
+                        </staffDef>
+                        <staffDef n="2" lines="5" meter.count="4" meter.unit="4">
+                           <clef shape="F" line="4" />
+                        </staffDef>
+                     </staffGrp>
+                  </staffGrp>
+               </scoreDef>
+               <section xml:id="s1">
+                  <measure xml:id="mirc9t8" n="1">
+                     <staff xml:id="m1s1" n="1">
+                        <layer xml:id="m1s1l1" n="1">
+                           <note xml:id="n1xoex0c" dur="4" pname="c" oct="6" />
+                           <note xml:id="nhemcqc" dur="4" pname="b" oct="5" />
+                           <note xml:id="n14afflk" dur="4" pname="a" oct="4" oct.ges="5" />
+                           <note xml:id="n1mr21jx" dur="4" pname="b" oct="4" oct.ges="5" />
+                        </layer>
+                     </staff>
+                     <staff xml:id="m1s2" n="2">
+                        <layer xml:id="m1s2l1" n="1">
+                           <mRest xml:id="mbmf4aa" />
+                        </layer>
+                     </staff>
+                     <octave xml:id="o1pqq9gw" dis="8" dis.place="above" startid="#n14afflk" endid="#nnn9bu2" />
+                  </measure>
+                  <measure xml:id="m1smpbur" n="2">
+                     <staff xml:id="m2s1" n="1">
+                        <layer xml:id="m2s1l1" n="1">
+                           <note xml:id="n1fd24af" dur="4" pname="c" oct="5" oct.ges="6" />
+                           <note xml:id="nnn9bu2" dur="4" pname="d" oct="5" oct.ges="6" />
+                           <note xml:id="n16ncub5" dur="4" pname="e" oct="4" oct.ges="6" />
+                           <note xml:id="n1aco1r1" dur="4" pname="f" oct="4" oct.ges="6" />
+                        </layer>
+                     </staff>
+                     <staff xml:id="m2s2" n="2">
+                        <layer xml:id="m2s2l1" n="1">
+                           <mRest xml:id="m7fvait" />
+                        </layer>
+                     </staff>
+                     <octave xml:id="ozpgzyl" dis="15" dis.place="above" startid="#n16ncub5" lform="solid" endid="#nufwsna" />
+                  </measure>
+                  <measure xml:id="m1h5ai48" n="3">
+                     <staff xml:id="m3s1" n="1">
+                        <layer xml:id="m3s1l1" n="1">
+                           <note xml:id="n1bny9cd" dur="4" pname="g" oct="4" oct.ges="6" />
+                           <note xml:id="n15uwza7" dur="4" pname="a" oct="4" oct.ges="6" />
+                           <note xml:id="nufwsna" dur="2" pname="b" oct="4" oct.ges="6" />
+                        </layer>
+                     </staff>
+                     <staff xml:id="m3s2" n="2">
+                        <layer xml:id="m3s2l1" n="1">
+                           <mRest xml:id="m1kivali" />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure xml:id="mk4kqwj" n="4">
+                     <staff xml:id="m4s1" n="1">
+                        <layer xml:id="m4s1l1" n="1">
+                           <mRest xml:id="mmdh4oi" />
+                        </layer>
+                     </staff>
+                     <staff xml:id="m4s2" n="2">
+                        <layer xml:id="m4s2l1" n="1">
+                           <note xml:id="nhdweke" dur="4" pname="c" oct="2" />
+                           <note xml:id="n2xx4oi" dur="4" pname="d" oct="2" />
+                           <note xml:id="ntbb9ux" dur="4" pname="e" oct="3" oct.ges="2" />
+                           <note xml:id="n12bhd0i" dur="4" pname="d" oct="3" oct.ges="2" />
+                        </layer>
+                     </staff>
+                     <octave xml:id="o1py2wsi" dis="8" dis.place="below" startid="#ntbb9ux" lform="dotted" endid="#n1e8igt" />
+                  </measure>
+                  <measure xml:id="m1ckqz7o" n="5">
+                     <staff xml:id="m5s1" n="1">
+                        <layer xml:id="m5s1l1" n="1">
+                           <mRest xml:id="m1mrvoty" />
+                        </layer>
+                     </staff>
+                     <staff xml:id="m5s2" n="2">
+                        <layer xml:id="m5s2l1" n="1">
+                           <note xml:id="na9pss1" dur="4" pname="c" oct="3" oct.ges="2" />
+                           <note xml:id="n1e8igt" dur="4" pname="b" oct="2" oct.ges="1" />
+                           <note xml:id="n1berik3" dur="4" pname="a" oct="3" oct.ges="1" />
+                           <note xml:id="n4dprro" dur="4" pname="g" oct="3" oct.ges="1" />
+                        </layer>
+                     </staff>
+                     <octave xml:id="o1xlny20" dis="15" dis.place="below" startid="#n1berik3" lendsym="none" endid="#n1vv9pku" />
+                  </measure>
+                  <measure xml:id="mzv8ba3" n="6">
+                     <staff xml:id="m6s1" n="1">
+                        <layer xml:id="m6s1l1" n="1">
+                           <mRest xml:id="m1l2y2ll" />
+                        </layer>
+                     </staff>
+                     <staff xml:id="m6s2" n="2">
+                        <layer xml:id="m6s2l1" n="1">
+                           <note xml:id="nuwkeif" dur="4" pname="f" oct="3" oct.ges="1" />
+                           <note xml:id="n9gl9bo" dur="4" pname="e" oct="3" oct.ges="1" />
+                           <note xml:id="n1vv9pku" dur="2" pname="d" oct="3" oct.ges="1" />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure xml:id="m1kpsuxe" right="end" n="7">
+                     <staff xml:id="m7s1" n="1">
+                        <layer xml:id="m7s1l1" n="1">
+                           <note xml:id="nr6lxxg" dur="2" pname="c" oct="4" oct.ges="7" />
+                           <rest xml:id="r1xlox0x" dur="2" />
+                        </layer>
+                     </staff>
+                     <staff xml:id="m7s2" n="2">
+                        <layer xml:id="m7s2l1" n="1">
+                           <note xml:id="natazm8" dur="2" pname="c" oct="4" oct.ges="1" />
+                           <rest xml:id="r1ovcvak" dur="2" />
+                        </layer>
+                     </staff>
+                     <octave xml:id="o2dads4" dis="22" dis.place="above" startid="#nr6lxxg" endid="#r1xlox0x" />
+                     <octave xml:id="o8hvyqi" dis="22" dis.place="below" startid="#natazm8" endid="#r1ovcvak" />
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
+</mei>

--- a/src/importexport/mei/tests/data/page-head-01.mei
+++ b/src/importexport/mei/tests/data/page-head-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:11" />
+            <date isodate="2023-08-11T14:53:28" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -37,24 +37,24 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="maj80e4" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <mRest xml:id="s1l1_t0_1" />
+                           <mRest xml:id="m1ebitev" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="mejrl04" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <mRest xml:id="s1l1_t1_1" />
+                           <mRest xml:id="m1av3pua" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m3" right="end" n="3">
+                  <measure xml:id="ml9eojw" right="end" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <mRest xml:id="s1l1_t2_1" />
+                           <mRest xml:id="msgweml" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/page-head-01.mscx
+++ b/src/importexport/mei/tests/data/page-head-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:11&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:53:28&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/page-head-02.mei
+++ b/src/importexport/mei/tests/data/page-head-02.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:12" />
+            <date isodate="2023-08-11T14:53:34" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -45,24 +45,24 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m1n6o508" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <mRest xml:id="s1l1_t0_1" />
+                           <mRest xml:id="m1gyuain" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="ml5jwus" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <mRest xml:id="s1l1_t1_1" />
+                           <mRest xml:id="mz6zu6x" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m3" right="end" n="3">
+                  <measure xml:id="m19d8l9" right="end" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <mRest xml:id="s1l1_t2_1" />
+                           <mRest xml:id="m1b3mep7" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/page-head-02.mscx
+++ b/src/importexport/mei/tests/data/page-head-02.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:12&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:53:34&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/roman-numeral-01.mei
+++ b/src/importexport/mei/tests/data/roman-numeral-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:13" />
+            <date isodate="2023-08-11T14:53:40" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -44,34 +44,34 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m1mueqpj" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <beam xml:id="m1s1l1b1">
-                              <chord xml:id="s1l1_t0_1" dur="8">
-                                 <note xml:id="m1s1l1n1" pname="d" oct="4" />
-                                 <note xml:id="m1s1l1n2" pname="e" oct="4" />
+                           <beam>
+                              <chord xml:id="cmy6svr" dur="8">
+                                 <note xml:id="n1yc2657" pname="d" oct="4" />
+                                 <note xml:id="ngxsfwi" pname="e" oct="4" />
                               </chord>
-                              <chord xml:id="s1l1_t1_8" dur="8">
-                                 <note xml:id="m1s1l1n3" pname="d" oct="4">
-                                    <accid xml:id="m1s1l1a1" accid="f" />
+                              <chord xml:id="c1mddrsx" dur="8">
+                                 <note xml:id="n1sm3uri" pname="d" oct="4">
+                                    <accid accid="f" />
                                  </note>
-                                 <note xml:id="m1s1l1n4" pname="f" oct="4">
-                                    <accid xml:id="m1s1l1a2" accid="n" />
+                                 <note xml:id="ntoit5" pname="f" oct="4">
+                                    <accid accid="n" />
                                  </note>
                               </chord>
                            </beam>
-                           <beam xml:id="m1s1l1b2">
-                              <chord xml:id="s1l1_t1_4" dur="8">
-                                 <note xml:id="m1s1l1n5" pname="c" oct="4" />
-                                 <note xml:id="m1s1l1n6" pname="f" oct="4">
-                                    <accid xml:id="m1s1l1a3" accid="s" />
+                           <beam>
+                              <chord xml:id="c1i5zxee" dur="8">
+                                 <note xml:id="nptznae" pname="c" oct="4" />
+                                 <note xml:id="n1l7h9mi" pname="f" oct="4">
+                                    <accid accid="s" />
                                  </note>
                               </chord>
-                              <chord xml:id="s1l1_t3_8" dur="8">
-                                 <note xml:id="m1s1l1n7" pname="b" oct="3" />
-                                 <note xml:id="m1s1l1n8" pname="g" oct="4">
-                                    <accid xml:id="m1s1l1a4" accid="n" />
+                              <chord xml:id="ccssazm" dur="8">
+                                 <note xml:id="n117b6gw" pname="b" oct="3" />
+                                 <note xml:id="n943r96" pname="g" oct="4">
+                                    <accid accid="n" />
                                  </note>
                               </chord>
                            </beam>
@@ -79,188 +79,188 @@
                      </staff>
                      <staff xml:id="m1s2" n="2">
                         <layer xml:id="m1s2l1" n="1">
-                           <beam xml:id="m1s2l1b1">
-                              <chord xml:id="s2l1_t0_1" dur="8">
-                                 <note xml:id="m1s2l1n1" pname="g" oct="3">
-                                    <accid xml:id="m1s2l1a1" accid="s" />
+                           <beam>
+                              <chord xml:id="cbq6jqg" dur="8">
+                                 <note xml:id="n92sam5" pname="g" oct="3">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m1s2l1n2" pname="b" oct="3" />
+                                 <note xml:id="nojssbr" pname="b" oct="3" />
                               </chord>
-                              <note xml:id="s2l1_t1_8" dur="8" pname="g" oct="3">
-                                 <accid xml:id="m1s2l1a2" accid="n" />
+                              <note xml:id="nqvsdrq" dur="8" pname="g" oct="3">
+                                 <accid accid="n" />
                               </note>
                            </beam>
-                           <beam xml:id="m1s2l1b2">
-                              <note xml:id="s2l1_t1_4" dur="8" pname="f" oct="3">
-                                 <accid xml:id="m1s2l1a3" accid="s" />
+                           <beam>
+                              <note xml:id="n1dpgx51" dur="8" pname="f" oct="3">
+                                 <accid accid="s" />
                               </note>
-                              <note xml:id="s2l1_t3_8" dur="8" pname="f" oct="3">
-                                 <accid xml:id="m1s2l1a4" accid="n" />
+                              <note xml:id="nor72bw" dur="8" pname="f" oct="3">
+                                 <accid accid="n" />
                               </note>
                            </beam>
                         </layer>
                         <layer xml:id="m1s2l2" n="2">
-                           <beam xml:id="m1s2l2b1">
-                              <chord xml:id="s2l2_t0_1" dur="8">
-                                 <note xml:id="m1s2l2n1" pname="e" oct="2" />
-                                 <note xml:id="m1s2l2n2" pname="e" oct="3" />
+                           <beam>
+                              <chord xml:id="cfp4mbz" dur="8">
+                                 <note xml:id="n1ewnd1n" pname="e" oct="2" />
+                                 <note xml:id="n1hxdu7c" pname="e" oct="3" />
                               </chord>
-                              <chord xml:id="s2l2_t1_8" dur="8">
-                                 <note xml:id="m1s2l2n3" pname="e" oct="2">
-                                    <accid xml:id="m1s2l2a1" accid="f" />
+                              <chord xml:id="coo81qj" dur="8">
+                                 <note xml:id="nosyy29" pname="e" oct="2">
+                                    <accid accid="f" />
                                  </note>
-                                 <note xml:id="m1s2l2n4" pname="e" oct="3">
-                                    <accid xml:id="m1s2l2a2" accid="f" />
+                                 <note xml:id="n1vh34io" pname="e" oct="3">
+                                    <accid accid="f" />
                                  </note>
                               </chord>
                            </beam>
-                           <beam xml:id="m1s2l2b2">
-                              <chord xml:id="s2l2_t1_4" dur="8">
-                                 <note xml:id="m1s2l2n5" pname="d" oct="2" />
-                                 <note xml:id="m1s2l2n6" pname="d" oct="3" />
+                           <beam>
+                              <chord xml:id="c1ume9sq" dur="8">
+                                 <note xml:id="n1maxygw" pname="d" oct="2" />
+                                 <note xml:id="ngo7get" pname="d" oct="3" />
                               </chord>
-                              <chord xml:id="s2l2_t3_8" dur="8">
-                                 <note xml:id="m1s2l2n7" pname="c" oct="2">
-                                    <accid xml:id="m1s2l2a3" accid="s" />
+                              <chord xml:id="c18zaam0" dur="8">
+                                 <note xml:id="n1qb629k" pname="c" oct="2">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m1s2l2n8" pname="c" oct="3">
-                                    <accid xml:id="m1s2l2a4" accid="s" />
+                                 <note xml:id="n1pxxd47" pname="c" oct="3">
+                                    <accid accid="s" />
                                  </note>
                               </chord>
                            </beam>
                         </layer>
                      </staff>
-                     <harm xml:id="m1hr1" type="mscore-roman" startid="#s2l2_t0_1">E.I7{</harm>
-                     <harm xml:id="m1hr2" type="mscore-roman" startid="#s2l2_t1_8">bVII7(b9)</harm>
-                     <harm xml:id="m1hr3" type="mscore-roman" startid="#s2l2_t1_4">V7(-5)/bIII</harm>
-                     <harm xml:id="m1hr4" type="mscore-roman" startid="#s2l2_t3_8">VI7(b5b4)</harm>
+                     <harm xml:id="h11isqcg" type="mscore-roman" startid="#cfp4mbz">E.I7{</harm>
+                     <harm xml:id="hqd5b29" type="mscore-roman" startid="#coo81qj">bVII7(b9)</harm>
+                     <harm xml:id="h1ouzwgk" type="mscore-roman" startid="#c1ume9sq">V7(-5)/bIII</harm>
+                     <harm xml:id="h1c6oiqa" type="mscore-roman" startid="#c18zaam0">VI7(b5b4)</harm>
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="m1msh5yn" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <beam xml:id="m2s1l1b1">
-                              <chord xml:id="s1l1_t1_2" dur="8">
-                                 <note xml:id="m2s1l1n1" pname="c" oct="4">
-                                    <accid xml:id="m2s1l1a1" accid="n" />
+                           <beam>
+                              <chord xml:id="cuvdbax" dur="8">
+                                 <note xml:id="nprwva9" pname="c" oct="4">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m2s1l1n2" pname="f" oct="4">
-                                    <accid xml:id="m2s1l1a2" accid="s" />
+                                 <note xml:id="ncqzgfl" pname="f" oct="4">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m2s1l1n3" pname="g" oct="4">
-                                    <accid xml:id="m2s1l1a3" accid="s" />
+                                 <note xml:id="nx2z3zl" pname="g" oct="4">
+                                    <accid accid="s" />
                                  </note>
                               </chord>
-                              <chord xml:id="s1l1_t5_8" dur="8">
-                                 <note xml:id="m2s1l1n4" pname="b" oct="3" />
-                                 <note xml:id="m2s1l1n5" pname="f" oct="4">
-                                    <accid xml:id="m2s1l1a4" accid="n" />
+                              <chord xml:id="cak03ue" dur="8">
+                                 <note xml:id="n1t2lez1" pname="b" oct="3" />
+                                 <note xml:id="n9njtzr" pname="f" oct="4">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m2s1l1n6" pname="a" oct="4" />
+                                 <note xml:id="ntol9xq" pname="a" oct="4" />
                               </chord>
                            </beam>
-                           <beam xml:id="m2s1l1b2">
-                              <chord xml:id="s1l1_t3_4" dur="8">
-                                 <note xml:id="m2s1l1n7" pname="a" oct="3">
-                                    <accid xml:id="m2s1l1a5" accid="s" />
+                           <beam>
+                              <chord xml:id="cc63sgn" dur="8">
+                                 <note xml:id="npb69gz" pname="a" oct="3">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m2s1l1n8" pname="e" oct="4" />
-                                 <note xml:id="m2s1l1n9" pname="a" oct="4">
-                                    <accid xml:id="m2s1l1a6" accid="s" />
+                                 <note xml:id="n1i4c8aa" pname="e" oct="4" />
+                                 <note xml:id="n2227jn" pname="a" oct="4">
+                                    <accid accid="s" />
                                  </note>
                               </chord>
-                              <chord xml:id="s1l1_t7_8" dur="8">
-                                 <note xml:id="m2s1l1n10" pname="a" oct="3">
-                                    <accid xml:id="m2s1l1a7" accid="n" />
+                              <chord xml:id="c1c89c1g" dur="8">
+                                 <note xml:id="n1g3x5xf" pname="a" oct="3">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m2s1l1n11" pname="e" oct="4">
-                                    <accid xml:id="m2s1l1a8" accid="f" />
+                                 <note xml:id="nqs3sbx" pname="e" oct="4">
+                                    <accid accid="f" />
                                  </note>
-                                 <note xml:id="m2s1l1n12" pname="b" oct="4" />
+                                 <note xml:id="n16n6aa3" pname="b" oct="4" />
                               </chord>
                            </beam>
                         </layer>
                      </staff>
                      <staff xml:id="m2s2" n="2">
                         <layer xml:id="m2s2l1" n="1">
-                           <beam xml:id="m2s2l1b1">
-                              <chord xml:id="s2l1_t1_2" dur="8">
-                                 <note xml:id="m2s2l1n1" pname="g" oct="2">
-                                    <accid xml:id="m2s2l1a1" accid="s" />
+                           <beam>
+                              <chord xml:id="cviqpqu" dur="8">
+                                 <note xml:id="n1uv49k5" pname="g" oct="2">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m2s2l1n2" pname="g" oct="3">
-                                    <accid xml:id="m2s2l1a2" accid="s" />
+                                 <note xml:id="nwf8kqr" pname="g" oct="3">
+                                    <accid accid="s" />
                                  </note>
                               </chord>
-                              <chord xml:id="s2l1_t5_8" dur="8">
-                                 <note xml:id="m2s2l1n3" pname="g" oct="2">
-                                    <accid xml:id="m2s2l1a3" accid="n" />
+                              <chord xml:id="c1tr709o" dur="8">
+                                 <note xml:id="nga45oi" pname="g" oct="2">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m2s2l1n4" pname="g" oct="3">
-                                    <accid xml:id="m2s2l1a4" accid="n" />
+                                 <note xml:id="n27ijwo" pname="g" oct="3">
+                                    <accid accid="n" />
                                  </note>
                               </chord>
                            </beam>
-                           <beam xml:id="m2s2l1b2">
-                              <chord xml:id="s2l1_t3_4" dur="8">
-                                 <note xml:id="m2s2l1n5" pname="f" oct="2">
-                                    <accid xml:id="m2s2l1a5" accid="s" />
+                           <beam>
+                              <chord xml:id="c1l0sgf" dur="8">
+                                 <note xml:id="n11frvun" pname="f" oct="2">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m2s2l1n6" pname="f" oct="3">
-                                    <accid xml:id="m2s2l1a6" accid="s" />
+                                 <note xml:id="n3xs6ic" pname="f" oct="3">
+                                    <accid accid="s" />
                                  </note>
                               </chord>
-                              <chord xml:id="s2l1_t7_8" dur="8">
-                                 <note xml:id="m2s2l1n7" pname="f" oct="2">
-                                    <accid xml:id="m2s2l1a7" accid="n" />
+                              <chord xml:id="chf5i2s" dur="8">
+                                 <note xml:id="n1536sio" pname="f" oct="2">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m2s2l1n8" pname="f" oct="3">
-                                    <accid xml:id="m2s2l1a8" accid="n" />
+                                 <note xml:id="nqk78vc" pname="f" oct="3">
+                                    <accid accid="n" />
                                  </note>
                               </chord>
                            </beam>
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m3" n="3">
+                  <measure xml:id="m5v26e" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <beam xml:id="m3s1l1b1">
-                              <chord xml:id="s1l1_t1_1" dur="8">
-                                 <note xml:id="m3s1l1n1" pname="e" oct="4">
-                                    <accid xml:id="m3s1l1a1" accid="n" />
+                           <beam>
+                              <chord xml:id="c1mndf20" dur="8">
+                                 <note xml:id="npz8s8u" pname="e" oct="4">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m3s1l1n2" pname="b" oct="4">
-                                    <accid xml:id="m3s1l1a2" accid="f" />
+                                 <note xml:id="n1q5m78y" pname="b" oct="4">
+                                    <accid accid="f" />
                                  </note>
-                                 <note xml:id="m3s1l1n3" pname="c" oct="5" />
+                                 <note xml:id="nbas9vr" pname="c" oct="5" />
                               </chord>
-                              <chord xml:id="s1l1_t9_8" dur="8">
-                                 <note xml:id="m3s1l1n4" pname="d" oct="4">
-                                    <accid xml:id="m3s1l1a3" accid="s" />
+                              <chord xml:id="c1a0q8r8" dur="8">
+                                 <note xml:id="n1h3kgb5" pname="d" oct="4">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m3s1l1n5" pname="a" oct="4" />
-                                 <note xml:id="m3s1l1n6" pname="c" oct="5">
-                                    <accid xml:id="m3s1l1a4" accid="s" />
+                                 <note xml:id="n1q1g39l" pname="a" oct="4" />
+                                 <note xml:id="nk5nq9o" pname="c" oct="5">
+                                    <accid accid="s" />
                                  </note>
                               </chord>
                            </beam>
-                           <beam xml:id="m3s1l1b2">
-                              <chord xml:id="s1l1_t5_4" dur="8">
-                                 <note xml:id="m3s1l1n7" pname="d" oct="4">
-                                    <accid xml:id="m3s1l1a5" accid="n" />
+                           <beam>
+                              <chord xml:id="ccre3i2" dur="8">
+                                 <note xml:id="npnlqie" pname="d" oct="4">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m3s1l1n8" pname="a" oct="4">
-                                    <accid xml:id="m3s1l1a6" accid="f" />
+                                 <note xml:id="n1h6hxjm" pname="a" oct="4">
+                                    <accid accid="f" />
                                  </note>
-                                 <note xml:id="m3s1l1n9" pname="d" oct="5" />
+                                 <note xml:id="no3vwct" pname="d" oct="5" />
                               </chord>
-                              <chord xml:id="s1l1_t11_8" dur="8">
-                                 <note xml:id="m3s1l1n10" pname="d" oct="4">
-                                    <accid xml:id="m3s1l1a7" accid="f" />
+                              <chord xml:id="c36rknm" dur="8">
+                                 <note xml:id="n1jlfsxx" pname="d" oct="4">
+                                    <accid accid="f" />
                                  </note>
-                                 <note xml:id="m3s1l1n11" pname="g" oct="4" />
-                                 <note xml:id="m3s1l1n12" pname="e" oct="5">
-                                    <accid xml:id="m3s1l1a8" accid="f" />
+                                 <note xml:id="n1g94wuj" pname="g" oct="4" />
+                                 <note xml:id="n72z2tg" pname="e" oct="5">
+                                    <accid accid="f" />
                                  </note>
                               </chord>
                            </beam>
@@ -268,341 +268,341 @@
                      </staff>
                      <staff xml:id="m3s2" n="2">
                         <layer xml:id="m3s2l1" n="1">
-                           <beam xml:id="m3s2l1b1">
-                              <chord xml:id="s2l1_t1_1" dur="8">
-                                 <note xml:id="m3s2l1n1" pname="c" oct="3" />
-                                 <note xml:id="m3s2l1n2" pname="c" oct="4" />
+                           <beam>
+                              <chord xml:id="c136d7js" dur="8">
+                                 <note xml:id="n1gi7wxd" pname="c" oct="3" />
+                                 <note xml:id="n1gxudhv" pname="c" oct="4" />
                               </chord>
-                              <chord xml:id="s2l1_t9_8" dur="8">
-                                 <note xml:id="m3s2l1n3" pname="b" oct="2">
-                                    <accid xml:id="m3s2l1a1" accid="n" />
+                              <chord xml:id="ciax3pj" dur="8">
+                                 <note xml:id="n11i98lb" pname="b" oct="2">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m3s2l1n4" pname="b" oct="3">
-                                    <accid xml:id="m3s2l1a2" accid="n" />
+                                 <note xml:id="n1pazn1i" pname="b" oct="3">
+                                    <accid accid="n" />
                                  </note>
                               </chord>
                            </beam>
-                           <beam xml:id="m3s2l1b2">
-                              <chord xml:id="s2l1_t5_4" dur="8">
-                                 <note xml:id="m3s2l1n5" pname="b" oct="2">
-                                    <accid xml:id="m3s2l1a3" accid="f" />
+                           <beam>
+                              <chord xml:id="c1tjvi0m" dur="8">
+                                 <note xml:id="n1mroh6t" pname="b" oct="2">
+                                    <accid accid="f" />
                                  </note>
-                                 <note xml:id="m3s2l1n6" pname="b" oct="3">
-                                    <accid xml:id="m3s2l1a4" accid="f" />
+                                 <note xml:id="nc84jme" pname="b" oct="3">
+                                    <accid accid="f" />
                                  </note>
                               </chord>
-                              <chord xml:id="s2l1_t11_8" dur="8">
-                                 <note xml:id="m3s2l1n7" pname="a" oct="2">
-                                    <accid xml:id="m3s2l1a5" accid="n" />
+                              <chord xml:id="c1yyfm9x" dur="8">
+                                 <note xml:id="n1k8qz5u" pname="a" oct="2">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m3s2l1n8" pname="a" oct="3">
-                                    <accid xml:id="m3s2l1a6" accid="n" />
+                                 <note xml:id="n1jng5ob" pname="a" oct="3">
+                                    <accid accid="n" />
                                  </note>
                               </chord>
                            </beam>
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m4" n="4">
+                  <measure xml:id="m1ky13m5" n="4">
                      <staff xml:id="m4s1" n="1">
                         <layer xml:id="m4s1l1" n="1">
-                           <beam xml:id="m4s1l1b1">
-                              <chord xml:id="s1l1_t3_2" dur="8">
-                                 <note xml:id="m4s1l1n1" pname="e" oct="4">
-                                    <accid xml:id="m4s1l1a1" accid="n" />
+                           <beam>
+                              <chord xml:id="c1xrr9sz" dur="8">
+                                 <note xml:id="nklomku" pname="e" oct="4">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m4s1l1n2" pname="g" oct="4">
-                                    <accid xml:id="m4s1l1a2" accid="s" />
+                                 <note xml:id="n1bb5y4u" pname="g" oct="4">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m4s1l1n3" pname="c" oct="5">
-                                    <accid xml:id="m4s1l1a3" accid="n" />
+                                 <note xml:id="nux0zvd" pname="c" oct="5">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m4s1l1n4" pname="e" oct="5">
-                                    <accid xml:id="m4s1l1a4" accid="n" />
+                                 <note xml:id="n1wie9fs" pname="e" oct="5">
+                                    <accid accid="n" />
                                  </note>
                               </chord>
-                              <chord xml:id="s1l1_t13_8" dur="8">
-                                 <note xml:id="m4s1l1n5" pname="f" oct="4" />
-                                 <note xml:id="m4s1l1n6" pname="a" oct="4">
-                                    <accid xml:id="m4s1l1a5" accid="n" />
+                              <chord xml:id="cpqgpn9" dur="8">
+                                 <note xml:id="n1usl2tk" pname="f" oct="4" />
+                                 <note xml:id="n1jkdp6n" pname="a" oct="4">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m4s1l1n7" pname="b" oct="4" />
-                                 <note xml:id="m4s1l1n8" pname="f" oct="5" />
+                                 <note xml:id="nivglxi" pname="b" oct="4" />
+                                 <note xml:id="n1xeg6ul" pname="f" oct="5" />
                               </chord>
                            </beam>
-                           <beam xml:id="m4s1l1b2">
-                              <chord xml:id="s1l1_t7_4" dur="8">
-                                 <note xml:id="m4s1l1n9" pname="f" oct="4">
-                                    <accid xml:id="m4s1l1a6" accid="s" />
+                           <beam>
+                              <chord xml:id="coj5usf" dur="8">
+                                 <note xml:id="nch4m2d" pname="f" oct="4">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m4s1l1n10" pname="a" oct="4">
-                                    <accid xml:id="m4s1l1a7" accid="s" />
+                                 <note xml:id="n1xyn6wi" pname="a" oct="4">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m4s1l1n11" pname="e" oct="5" />
-                                 <note xml:id="m4s1l1n12" pname="f" oct="5">
-                                    <accid xml:id="m4s1l1a8" accid="s" />
+                                 <note xml:id="n18haqxv" pname="e" oct="5" />
+                                 <note xml:id="n1esmo6a" pname="f" oct="5">
+                                    <accid accid="s" />
                                  </note>
                               </chord>
-                              <chord xml:id="s1l1_t15_8" dur="8">
-                                 <note xml:id="m4s1l1n13" pname="g" oct="4">
-                                    <accid xml:id="m4s1l1a9" accid="n" />
+                              <chord xml:id="c18vo3yk" dur="8">
+                                 <note xml:id="n1yqaj5p" pname="g" oct="4">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m4s1l1n14" pname="a" oct="4">
-                                    <accid xml:id="m4s1l1a10" accid="n" />
+                                 <note xml:id="nge9eg3" pname="a" oct="4">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m4s1l1n15" pname="b" oct="4" />
-                                 <note xml:id="m4s1l1n16" pname="e" oct="5">
-                                    <accid xml:id="m4s1l1a11" accid="f" />
+                                 <note xml:id="nos4c2m" pname="b" oct="4" />
+                                 <note xml:id="nuvzsw5" pname="e" oct="5">
+                                    <accid accid="f" />
                                  </note>
-                                 <note xml:id="m4s1l1n17" pname="g" oct="5" />
+                                 <note xml:id="nnflcsl" pname="g" oct="5" />
                               </chord>
                            </beam>
                         </layer>
                      </staff>
                      <staff xml:id="m4s2" n="2">
                         <layer xml:id="m4s2l1" n="1">
-                           <beam xml:id="m4s2l1b1">
-                              <chord xml:id="s2l1_t3_2" dur="8">
-                                 <note xml:id="m4s2l1n1" pname="a" oct="2">
-                                    <accid xml:id="m4s2l1a1" accid="f" />
+                           <beam>
+                              <chord xml:id="coi5l0z" dur="8">
+                                 <note xml:id="n5azuxn" pname="a" oct="2">
+                                    <accid accid="f" />
                                  </note>
-                                 <note xml:id="m4s2l1n2" pname="g" oct="3">
-                                    <accid xml:id="m4s2l1a2" accid="f" />
+                                 <note xml:id="nxkspma" pname="g" oct="3">
+                                    <accid accid="f" />
                                  </note>
-                                 <note xml:id="m4s2l1n3" pname="a" oct="3">
-                                    <accid xml:id="m4s2l1a3" accid="f" />
+                                 <note xml:id="n1x8uugh" pname="a" oct="3">
+                                    <accid accid="f" />
                                  </note>
                               </chord>
-                              <chord xml:id="s2l1_t13_8" dur="8">
-                                 <note xml:id="m4s2l1n4" pname="g" oct="2">
-                                    <accid xml:id="m4s2l1a4" accid="n" />
+                              <chord xml:id="c1icqjae" dur="8">
+                                 <note xml:id="n1q4qc8b" pname="g" oct="2">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m4s2l1n5" pname="f" oct="3" />
-                                 <note xml:id="m4s2l1n6" pname="g" oct="3">
-                                    <accid xml:id="m4s2l1a5" accid="n" />
+                                 <note xml:id="noq4tns" pname="f" oct="3" />
+                                 <note xml:id="nohvdvf" pname="g" oct="3">
+                                    <accid accid="n" />
                                  </note>
                               </chord>
                            </beam>
-                           <beam xml:id="m4s2l1b2">
-                              <chord xml:id="s2l1_t7_4" dur="8">
-                                 <note xml:id="m4s2l1n7" pname="g" oct="2">
-                                    <accid xml:id="m4s2l1a6" accid="f" />
+                           <beam>
+                              <chord xml:id="ctirhrj" dur="8">
+                                 <note xml:id="ndjq8f2" pname="g" oct="2">
+                                    <accid accid="f" />
                                  </note>
-                                 <note xml:id="m4s2l1n8" pname="e" oct="3">
-                                    <accid xml:id="m4s2l1a7" accid="n" />
+                                 <note xml:id="nvhwzkg" pname="e" oct="3">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m4s2l1n9" pname="g" oct="3">
-                                    <accid xml:id="m4s2l1a8" accid="f" />
+                                 <note xml:id="n53kg5u" pname="g" oct="3">
+                                    <accid accid="f" />
                                  </note>
                               </chord>
-                              <chord xml:id="s2l1_t15_8" dur="8">
-                                 <note xml:id="m4s2l1n10" pname="f" oct="2">
-                                    <accid xml:id="m4s2l1a9" accid="n" />
+                              <chord xml:id="c1o1fjjd" dur="8">
+                                 <note xml:id="n1eslr2h" pname="f" oct="2">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m4s2l1n11" pname="e" oct="3">
-                                    <accid xml:id="m4s2l1a10" accid="f" />
+                                 <note xml:id="n1gqp8zy" pname="e" oct="3">
+                                    <accid accid="f" />
                                  </note>
-                                 <note xml:id="m4s2l1n12" pname="f" oct="3">
-                                    <accid xml:id="m4s2l1a11" accid="n" />
+                                 <note xml:id="nz6y71t" pname="f" oct="3">
+                                    <accid accid="n" />
                                  </note>
                               </chord>
                            </beam>
                         </layer>
                      </staff>
-                     <harm xml:id="m4hr1" type="mscore-roman" startid="#s1l1_t3_2">I.bVI+6</harm>
-                     <harm xml:id="m4hr2" type="mscore-roman" startid="#s1l1_t13_8">v%43(-3)</harm>
-                     <harm xml:id="m4hr3" type="mscore-roman" startid="#s1l1_t7_4">V7/V</harm>
-                     <harm xml:id="m4hr4" type="mscore-roman" startid="#s1l1_t15_8">bI+6(+4)</harm>
+                     <harm xml:id="h1874to2" type="mscore-roman" startid="#c1xrr9sz">I.bVI+6</harm>
+                     <harm xml:id="h1v3iy05" type="mscore-roman" startid="#cpqgpn9">v%43(-3)</harm>
+                     <harm xml:id="hwsyu0q" type="mscore-roman" startid="#coj5usf">V7/V</harm>
+                     <harm xml:id="h154c0h8" type="mscore-roman" startid="#c18vo3yk">bI+6(+4)</harm>
                   </measure>
-                  <measure xml:id="m5" n="5">
+                  <measure xml:id="mx37hco" n="5">
                      <staff xml:id="m5s1" n="1">
                         <layer xml:id="m5s1l1" n="1">
-                           <beam xml:id="m5s1l1b1">
-                              <chord xml:id="s1l1_t2_1" dur="8">
-                                 <note xml:id="m5s1l1n1" pname="g" oct="4">
-                                    <accid xml:id="m5s1l1a1" accid="s" />
+                           <beam>
+                              <chord xml:id="c43d8gh" dur="8">
+                                 <note xml:id="n1649079" pname="g" oct="4">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m5s1l1n2" pname="c" oct="5" />
-                                 <note xml:id="m5s1l1n3" pname="g" oct="5">
-                                    <accid xml:id="m5s1l1a2" accid="s" />
+                                 <note xml:id="n1g84qf5" pname="c" oct="5" />
+                                 <note xml:id="n1iltgu5" pname="g" oct="5">
+                                    <accid accid="s" />
                                  </note>
                               </chord>
-                              <chord xml:id="s1l1_t17_8" dur="8">
-                                 <note xml:id="m5s1l1n4" pname="g" oct="4">
-                                    <accid xml:id="m5s1l1a3" accid="n" />
+                              <chord xml:id="cwhajaw" dur="8">
+                                 <note xml:id="nlx9om" pname="g" oct="4">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m5s1l1n5" pname="a" oct="4" />
-                                 <note xml:id="m5s1l1n6" pname="c" oct="5">
-                                    <accid xml:id="m5s1l1a4" accid="s" />
+                                 <note xml:id="no3g9an" pname="a" oct="4" />
+                                 <note xml:id="n6zdiuy" pname="c" oct="5">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m5s1l1n7" pname="a" oct="5" />
+                                 <note xml:id="n1h3f22" pname="a" oct="5" />
                               </chord>
                            </beam>
-                           <beam xml:id="m5s1l1b2">
-                              <chord xml:id="s1l1_t9_4" dur="8">
-                                 <note xml:id="m5s1l1n8" pname="a" oct="4">
-                                    <accid xml:id="m5s1l1a5" accid="s" />
+                           <beam>
+                              <chord xml:id="ckslsmb" dur="8">
+                                 <note xml:id="nt7261" pname="a" oct="4">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m5s1l1n9" pname="d" oct="5" />
-                                 <note xml:id="m5s1l1n10" pname="f" oct="5">
-                                    <accid xml:id="m5s1l1a6" accid="s" />
+                                 <note xml:id="njj4chv" pname="d" oct="5" />
+                                 <note xml:id="nm4llsn" pname="f" oct="5">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m5s1l1n11" pname="a" oct="5">
-                                    <accid xml:id="m5s1l1a7" accid="s" />
+                                 <note xml:id="n1ampkqt" pname="a" oct="5">
+                                    <accid accid="s" />
                                  </note>
                               </chord>
-                              <chord xml:id="s1l1_t19_8" dur="8">
-                                 <note xml:id="m5s1l1n12" pname="b" oct="4" />
-                                 <note xml:id="m5s1l1n13" pname="d" oct="5">
-                                    <accid xml:id="m5s1l1a8" accid="s" />
+                              <chord xml:id="c1ss475g" dur="8">
+                                 <note xml:id="nfao4e6" pname="b" oct="4" />
+                                 <note xml:id="n1rf8rrq" pname="d" oct="5">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m5s1l1n14" pname="f" oct="5">
-                                    <accid xml:id="m5s1l1a9" accid.ges="s" />
+                                 <note xml:id="n1nhe0a8" pname="f" oct="5">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="m5s1l1n15" pname="b" oct="5" />
+                                 <note xml:id="n1mxazs8" pname="b" oct="5" />
                               </chord>
                            </beam>
                         </layer>
                      </staff>
                      <staff xml:id="m5s2" n="2">
                         <layer xml:id="m5s2l1" n="1">
-                           <beam xml:id="m5s2l1b1">
-                              <chord xml:id="s2l1_t2_1" dur="8">
-                                 <note xml:id="m5s2l1n1" pname="e" oct="2" />
-                                 <note xml:id="m5s2l1n2" pname="d" oct="3" />
-                                 <note xml:id="m5s2l1n3" pname="e" oct="3">
-                                    <accid xml:id="m5s2l1a1" accid="n" />
+                           <beam>
+                              <chord xml:id="c1djk3s0" dur="8">
+                                 <note xml:id="ndbh4vl" pname="e" oct="2" />
+                                 <note xml:id="nhl3k73" pname="d" oct="3" />
+                                 <note xml:id="n1nx9d1t" pname="e" oct="3">
+                                    <accid accid="n" />
                                  </note>
                               </chord>
-                              <chord xml:id="s2l1_t17_8" dur="8">
-                                 <note xml:id="m5s2l1n4" pname="e" oct="2">
-                                    <accid xml:id="m5s2l1a2" accid="f" />
+                              <chord xml:id="coe4rhe" dur="8">
+                                 <note xml:id="n73rgz2" pname="e" oct="2">
+                                    <accid accid="f" />
                                  </note>
-                                 <note xml:id="m5s2l1n5" pname="d" oct="3">
-                                    <accid xml:id="m5s2l1a3" accid="f" />
+                                 <note xml:id="ne7qhwn" pname="d" oct="3">
+                                    <accid accid="f" />
                                  </note>
-                                 <note xml:id="m5s2l1n6" pname="e" oct="3">
-                                    <accid xml:id="m5s2l1a4" accid="f" />
+                                 <note xml:id="n1exmwx4" pname="e" oct="3">
+                                    <accid accid="f" />
                                  </note>
                               </chord>
                            </beam>
-                           <beam xml:id="m5s2l1b2">
-                              <chord xml:id="s2l1_t9_4" dur="8">
-                                 <note xml:id="m5s2l1n7" pname="d" oct="2" />
-                                 <note xml:id="m5s2l1n8" pname="c" oct="3" />
-                                 <note xml:id="m5s2l1n9" pname="d" oct="3">
-                                    <accid xml:id="m5s2l1a5" accid="n" />
+                           <beam>
+                              <chord xml:id="c1kk682t" dur="8">
+                                 <note xml:id="n7g1tzk" pname="d" oct="2" />
+                                 <note xml:id="ne4gbxe" pname="c" oct="3" />
+                                 <note xml:id="n1819q3q" pname="d" oct="3">
+                                    <accid accid="n" />
                                  </note>
                               </chord>
-                              <chord xml:id="s2l1_t19_8" dur="8">
-                                 <note xml:id="m5s2l1n10" pname="d" oct="2">
-                                    <accid xml:id="m5s2l1a6" accid="f" />
+                              <chord xml:id="c1066e1z" dur="8">
+                                 <note xml:id="n1no4gn7" pname="d" oct="2">
+                                    <accid accid="f" />
                                  </note>
-                                 <note xml:id="m5s2l1n11" pname="c" oct="3">
-                                    <accid xml:id="m5s2l1a7" accid="f" />
+                                 <note xml:id="nsrdhr0" pname="c" oct="3">
+                                    <accid accid="f" />
                                  </note>
-                                 <note xml:id="m5s2l1n12" pname="d" oct="3">
-                                    <accid xml:id="m5s2l1a8" accid="f" />
+                                 <note xml:id="n11ls9cf" pname="d" oct="3">
+                                    <accid accid="f" />
                                  </note>
                               </chord>
                            </beam>
                         </layer>
                      </staff>
-                     <harm xml:id="m5hr1" type="mscore-roman" startid="#s2l1_t2_1">N7(+6)</harm>
-                     <harm xml:id="m5hr2" type="mscore-roman" startid="#s2l1_t17_8">I7(+#6#4)</harm>
-                     <harm xml:id="m5hr3" type="mscore-roman" startid="#s2l1_t9_4">V7(v##6)/III</harm>
-                     <harm xml:id="m5hr4" type="mscore-roman" startid="#s2l1_t19_8">bII7(+#6##3##1)/V/V/V</harm>
+                     <harm xml:id="h19k4fue" type="mscore-roman" startid="#c1djk3s0">N7(+6)</harm>
+                     <harm xml:id="h1janxng" type="mscore-roman" startid="#coe4rhe">I7(+#6#4)</harm>
+                     <harm xml:id="h974j5y" type="mscore-roman" startid="#c1kk682t">V7(v##6)/III</harm>
+                     <harm xml:id="hjfstls" type="mscore-roman" startid="#c1066e1z">bII7(+#6##3##1)/V/V/V</harm>
                   </measure>
-                  <measure xml:id="m6" right="end" n="6">
+                  <measure xml:id="m17w0b7o" right="end" n="6">
                      <staff xml:id="m6s1" n="1">
                         <layer xml:id="m6s1l1" n="1">
-                           <beam xml:id="m6s1l1b1">
-                              <chord xml:id="s1l1_t5_2" dur="8">
-                                 <note xml:id="m6s1l1n1" pname="c" oct="5">
-                                    <accid xml:id="m6s1l1a1" accid="n" />
+                           <beam>
+                              <chord xml:id="c10gqwpm" dur="8">
+                                 <note xml:id="nckcjlj" pname="c" oct="5">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m6s1l1n2" pname="e" oct="5" />
-                                 <note xml:id="m6s1l1n3" pname="b" oct="5">
-                                    <accid xml:id="m6s1l1a2" accid="f" />
+                                 <note xml:id="ncxcni6" pname="e" oct="5" />
+                                 <note xml:id="nxcbich" pname="b" oct="5">
+                                    <accid accid="f" />
                                  </note>
-                                 <note xml:id="m6s1l1n4" pname="c" oct="6" />
+                                 <note xml:id="n1jdzjhk" pname="c" oct="6" />
                               </chord>
-                              <chord xml:id="s1l1_t21_8" dur="8">
-                                 <note xml:id="m6s1l1n5" pname="c" oct="5">
-                                    <accid xml:id="m6s1l1a3" accid="s" />
+                              <chord xml:id="chs45cy" dur="8">
+                                 <note xml:id="nq67t0b" pname="c" oct="5">
+                                    <accid accid="s" />
                                  </note>
-                                 <note xml:id="m6s1l1n6" pname="e" oct="5">
-                                    <accid xml:id="m6s1l1a4" accid="f" />
+                                 <note xml:id="nsf42jh" pname="e" oct="5">
+                                    <accid accid="f" />
                                  </note>
-                                 <note xml:id="m6s1l1n7" pname="f" oct="5" />
-                                 <note xml:id="m6s1l1n8" pname="a" oct="5" />
-                                 <note xml:id="m6s1l1n9" pname="c" oct="6">
-                                    <accid xml:id="m6s1l1a5" accid="s" />
+                                 <note xml:id="n5kygch" pname="f" oct="5" />
+                                 <note xml:id="nlqbopr" pname="a" oct="5" />
+                                 <note xml:id="nib29j2" pname="c" oct="6">
+                                    <accid accid="s" />
                                  </note>
                               </chord>
                            </beam>
-                           <chord xml:id="s1l1_t11_4" dur="8">
-                              <note xml:id="m6s1l1n10" pname="d" oct="5" />
-                              <note xml:id="m6s1l1n11" pname="f" oct="5" />
-                              <note xml:id="m6s1l1n12" pname="a" oct="5">
-                                 <accid xml:id="m6s1l1a6" accid="f" />
+                           <chord xml:id="cg7p1d9" dur="8">
+                              <note xml:id="n1mouz8e" pname="d" oct="5" />
+                              <note xml:id="nixawc7" pname="f" oct="5" />
+                              <note xml:id="n1kz1wyb" pname="a" oct="5">
+                                 <accid accid="f" />
                               </note>
-                              <note xml:id="m6s1l1n13" pname="b" oct="5">
-                                 <accid xml:id="m6s1l1a7" accid.ges="f" />
+                              <note xml:id="nict01" pname="b" oct="5">
+                                 <accid accid.ges="f" />
                               </note>
-                              <note xml:id="m6s1l1n14" pname="d" oct="6" />
+                              <note xml:id="nbcuvla" pname="d" oct="6" />
                            </chord>
-                           <rest xml:id="s1l1_t23_8" type="mscore-beam-none" dur="8" />
+                           <rest xml:id="rwaq027" type="mscore-beam-none" dur="8" />
                         </layer>
                      </staff>
                      <staff xml:id="m6s2" n="2">
                         <layer xml:id="m6s2l1" n="1">
-                           <beam xml:id="m6s2l1b1">
-                              <chord xml:id="s2l1_t5_2" dur="8">
-                                 <note xml:id="m6s2l1n1" pname="c" oct="2">
-                                    <accid xml:id="m6s2l1a1" accid="n" />
+                           <beam>
+                              <chord xml:id="c18b26o0" dur="8">
+                                 <note xml:id="na269gj" pname="c" oct="2">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m6s2l1n2" pname="b" oct="2">
-                                    <accid xml:id="m6s2l1a2" accid="f" />
+                                 <note xml:id="nyjd5v7" pname="b" oct="2">
+                                    <accid accid="f" />
                                  </note>
-                                 <note xml:id="m6s2l1n3" pname="c" oct="3">
-                                    <accid xml:id="m6s2l1a3" accid="n" />
+                                 <note xml:id="n327rcx" pname="c" oct="3">
+                                    <accid accid="n" />
                                  </note>
                               </chord>
-                              <chord xml:id="s2l1_t21_8" dur="8">
-                                 <note xml:id="m6s2l1n4" pname="b" oct="1">
-                                    <accid xml:id="m6s2l1a4" accid="n" />
+                              <chord xml:id="c1uxt5we" dur="8">
+                                 <note xml:id="n1lu6qlu" pname="b" oct="1">
+                                    <accid accid="n" />
                                  </note>
-                                 <note xml:id="m6s2l1n5" pname="a" oct="2" />
-                                 <note xml:id="m6s2l1n6" pname="b" oct="2">
-                                    <accid xml:id="m6s2l1a5" accid="n" />
+                                 <note xml:id="ncj1rm6" pname="a" oct="2" />
+                                 <note xml:id="n44b8xa" pname="b" oct="2">
+                                    <accid accid="n" />
                                  </note>
                               </chord>
                            </beam>
-                           <chord xml:id="s2l1_t11_4" dur="8">
-                              <note xml:id="m6s2l1n7" pname="b" oct="1">
-                                 <accid xml:id="m6s2l1a6" accid="f" />
+                           <chord xml:id="c119yffs" dur="8">
+                              <note xml:id="npnjw1p" pname="b" oct="1">
+                                 <accid accid="f" />
                               </note>
-                              <note xml:id="m6s2l1n8" pname="b" oct="2">
-                                 <accid xml:id="m6s2l1a7" accid="f" />
+                              <note xml:id="n3gehji" pname="b" oct="2">
+                                 <accid accid="f" />
                               </note>
-                              <note xml:id="m6s2l1n9" pname="f" oct="3" />
-                              <note xml:id="m6s2l1n10" pname="a" oct="3">
-                                 <accid xml:id="m6s2l1a8" accid="f" />
+                              <note xml:id="n1j7sozp" pname="f" oct="3" />
+                              <note xml:id="n1t5ondq" pname="a" oct="3">
+                                 <accid accid="f" />
                               </note>
-                              <note xml:id="m6s2l1n11" pname="b" oct="3">
-                                 <accid xml:id="m6s2l1a9" accid="f" />
+                              <note xml:id="n1pm4npx" pname="b" oct="3">
+                                 <accid accid="f" />
                               </note>
-                              <note xml:id="m6s2l1n12" pname="d" oct="4" />
+                              <note xml:id="n117dah0" pname="d" oct="4" />
                            </chord>
-                           <rest xml:id="s2l1_t23_8" type="mscore-beam-none" dur="8" />
+                           <rest xml:id="r1adsi1c" type="mscore-beam-none" dur="8" />
                         </layer>
                      </staff>
-                     <caesura xml:id="m6cs1" startid="#s1l1_t11_4" />
-                     <harm xml:id="m6hr1" type="mscore-roman" startid="#s2l1_t5_2">V7/V/V</harm>
-                     <harm xml:id="m6hr2" type="mscore-roman" startid="#s2l1_t21_8">Fr(+#5)</harm>
-                     <harm xml:id="m6hr3" type="mscore-roman" startid="#s2l1_t11_4">V7|HC}</harm>
-                     <caesura xml:id="m6cs2" startid="#s2l1_t11_4" />
+                     <caesura xml:id="ct7c3el" startid="#cg7p1d9" />
+                     <harm xml:id="hpsp4ra" type="mscore-roman" startid="#c18b26o0">V7/V/V</harm>
+                     <harm xml:id="hbo8vux" type="mscore-roman" startid="#c1uxt5we">Fr(+#5)</harm>
+                     <harm xml:id="h1blah3y" type="mscore-roman" startid="#c119yffs">V7|HC}</harm>
+                     <caesura xml:id="crg1jce" startid="#c119yffs" />
                   </measure>
                </section>
             </score>

--- a/src/importexport/mei/tests/data/roman-numeral-01.mscx
+++ b/src/importexport/mei/tests/data/roman-numeral-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:13&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:53:40&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/score-01.mei
+++ b/src/importexport/mei/tests/data/score-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:14" />
+            <date isodate="2023-08-11T14:53:46" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -113,157 +113,157 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m68kmlq" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <mRest xml:id="s1l1_t0_1" />
+                           <mRest xml:id="miofnlo" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s2" n="2">
                         <layer xml:id="m1s2l1" n="1">
-                           <mRest xml:id="s2l1_t0_1" />
+                           <mRest xml:id="mrsaxm3" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s3" n="3">
                         <layer xml:id="m1s3l1" n="1">
-                           <mRest xml:id="s3l1_t0_1" />
+                           <mRest xml:id="m6vx529" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s4" n="4">
                         <layer xml:id="m1s4l1" n="1">
-                           <mRest xml:id="s4l1_t0_1" />
+                           <mRest xml:id="msb238d" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s5" n="5">
                         <layer xml:id="m1s5l1" n="1">
-                           <mRest xml:id="s5l1_t0_1" />
+                           <mRest xml:id="m1g3dcx4" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s6" n="6">
                         <layer xml:id="m1s6l1" n="1">
-                           <mRest xml:id="s6l1_t0_1" />
+                           <mRest xml:id="m1f3587c" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s7" n="7">
                         <layer xml:id="m1s7l1" n="1">
-                           <mRest xml:id="s7l1_t0_1" />
+                           <mRest xml:id="mcok5a6" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s8" n="8">
                         <layer xml:id="m1s8l1" n="1">
-                           <mRest xml:id="s8l1_t0_1" />
+                           <mRest xml:id="m1w570mp" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s9" n="9">
                         <layer xml:id="m1s9l1" n="1">
-                           <mRest xml:id="s9l1_t0_1" />
+                           <mRest xml:id="m1tucpc3" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s10" n="10">
                         <layer xml:id="m1s10l1" n="1">
-                           <mRest xml:id="s10l1_t0_1" />
+                           <mRest xml:id="m1nf6lku" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s11" n="11">
                         <layer xml:id="m1s11l1" n="1">
-                           <mRest xml:id="s11l1_t0_1" />
+                           <mRest xml:id="mkugsrc" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s12" n="12">
                         <layer xml:id="m1s12l1" n="1">
-                           <mRest xml:id="s12l1_t0_1" />
+                           <mRest xml:id="m1j22q0h" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s13" n="13">
                         <layer xml:id="m1s13l1" n="1">
-                           <mRest xml:id="s13l1_t0_1" />
+                           <mRest xml:id="m1j9eusq" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s14" n="14">
                         <layer xml:id="m1s14l1" n="1">
-                           <mRest xml:id="s14l1_t0_1" />
+                           <mRest xml:id="m1akvgd2" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s15" n="15">
                         <layer xml:id="m1s15l1" n="1">
-                           <mRest xml:id="s15l1_t0_1" />
+                           <mRest xml:id="m1ej1tc8" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" right="end" n="2">
+                  <measure xml:id="m8h45yf" right="end" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <mRest xml:id="s1l1_t1_1" />
+                           <mRest xml:id="mmvcsza" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s2" n="2">
                         <layer xml:id="m2s2l1" n="1">
-                           <mRest xml:id="s2l1_t1_1" />
+                           <mRest xml:id="mns7usa" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s3" n="3">
                         <layer xml:id="m2s3l1" n="1">
-                           <mRest xml:id="s3l1_t1_1" />
+                           <mRest xml:id="m1n72omr" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s4" n="4">
                         <layer xml:id="m2s4l1" n="1">
-                           <mRest xml:id="s4l1_t1_1" />
+                           <mRest xml:id="m1exhp7g" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s5" n="5">
                         <layer xml:id="m2s5l1" n="1">
-                           <mRest xml:id="s5l1_t1_1" />
+                           <mRest xml:id="m1a8hdrr" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s6" n="6">
                         <layer xml:id="m2s6l1" n="1">
-                           <mRest xml:id="s6l1_t1_1" />
+                           <mRest xml:id="m1awvzi9" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s7" n="7">
                         <layer xml:id="m2s7l1" n="1">
-                           <mRest xml:id="s7l1_t1_1" />
+                           <mRest xml:id="m8fwucx" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s8" n="8">
                         <layer xml:id="m2s8l1" n="1">
-                           <mRest xml:id="s8l1_t1_1" />
+                           <mRest xml:id="msp3hnq" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s9" n="9">
                         <layer xml:id="m2s9l1" n="1">
-                           <mRest xml:id="s9l1_t1_1" />
+                           <mRest xml:id="m19vqqbk" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s10" n="10">
                         <layer xml:id="m2s10l1" n="1">
-                           <mRest xml:id="s10l1_t1_1" />
+                           <mRest xml:id="m10f58g7" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s11" n="11">
                         <layer xml:id="m2s11l1" n="1">
-                           <mRest xml:id="s11l1_t1_1" />
+                           <mRest xml:id="m10cedzr" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s12" n="12">
                         <layer xml:id="m2s12l1" n="1">
-                           <mRest xml:id="s12l1_t1_1" />
+                           <mRest xml:id="m1mtu5j0" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s13" n="13">
                         <layer xml:id="m2s13l1" n="1">
-                           <mRest xml:id="s13l1_t1_1" />
+                           <mRest xml:id="mghmjgj" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s14" n="14">
                         <layer xml:id="m2s14l1" n="1">
-                           <mRest xml:id="s14l1_t1_1" />
+                           <mRest xml:id="majar5x" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s15" n="15">
                         <layer xml:id="m2s15l1" n="1">
-                           <mRest xml:id="s15l1_t1_1" />
+                           <mRest xml:id="m1ny6qkp" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/score-01.mscx
+++ b/src/importexport/mei/tests/data/score-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:14&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:53:46&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/score-02.mei
+++ b/src/importexport/mei/tests/data/score-02.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:16" />
+            <date isodate="2023-08-11T14:53:54" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -96,127 +96,127 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m110hsbh" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <mRest xml:id="s1l1_t0_1" />
+                           <mRest xml:id="m1o3wj2l" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s2" n="2">
                         <layer xml:id="m1s2l1" n="1">
-                           <mRest xml:id="s2l1_t0_1" />
+                           <mRest xml:id="m142i4xx" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s3" n="3">
                         <layer xml:id="m1s3l1" n="1">
-                           <mRest xml:id="s3l1_t0_1" />
+                           <mRest xml:id="m1dd7j99" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s4" n="4">
                         <layer xml:id="m1s4l1" n="1">
-                           <mRest xml:id="s4l1_t0_1" />
+                           <mRest xml:id="mxchtzl" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s5" n="5">
                         <layer xml:id="m1s5l1" n="1">
-                           <mRest xml:id="s5l1_t0_1" />
+                           <mRest xml:id="mauexcc" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s6" n="6">
                         <layer xml:id="m1s6l1" n="1">
-                           <mRest xml:id="s6l1_t0_1" />
+                           <mRest xml:id="moxc4ym" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s7" n="7">
                         <layer xml:id="m1s7l1" n="1">
-                           <mRest xml:id="s7l1_t0_1" />
+                           <mRest xml:id="m51rgi6" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s8" n="8">
                         <layer xml:id="m1s8l1" n="1">
-                           <mRest xml:id="s8l1_t0_1" />
+                           <mRest xml:id="mugay3z" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s9" n="9">
                         <layer xml:id="m1s9l1" n="1">
-                           <mRest xml:id="s9l1_t0_1" />
+                           <mRest xml:id="m1mbk37d" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s10" n="10">
                         <layer xml:id="m1s10l1" n="1">
-                           <mRest xml:id="s10l1_t0_1" />
+                           <mRest xml:id="m146cnjb" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s11" n="11">
                         <layer xml:id="m1s11l1" n="1">
-                           <mRest xml:id="s11l1_t0_1" />
+                           <mRest xml:id="m1ewfcgc" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s12" n="12">
                         <layer xml:id="m1s12l1" n="1">
-                           <mRest xml:id="s12l1_t0_1" />
+                           <mRest xml:id="mtxhrkj" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" right="end" n="2">
+                  <measure xml:id="m4xslfq" right="end" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <mRest xml:id="s1l1_t1_1" />
+                           <mRest xml:id="m7j5f47" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s2" n="2">
                         <layer xml:id="m2s2l1" n="1">
-                           <mRest xml:id="s2l1_t1_1" />
+                           <mRest xml:id="mineazm" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s3" n="3">
                         <layer xml:id="m2s3l1" n="1">
-                           <mRest xml:id="s3l1_t1_1" />
+                           <mRest xml:id="mmrg3y0" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s4" n="4">
                         <layer xml:id="m2s4l1" n="1">
-                           <mRest xml:id="s4l1_t1_1" />
+                           <mRest xml:id="mtlkbjw" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s5" n="5">
                         <layer xml:id="m2s5l1" n="1">
-                           <mRest xml:id="s5l1_t1_1" />
+                           <mRest xml:id="mbej7b" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s6" n="6">
                         <layer xml:id="m2s6l1" n="1">
-                           <mRest xml:id="s6l1_t1_1" />
+                           <mRest xml:id="m1a35yvq" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s7" n="7">
                         <layer xml:id="m2s7l1" n="1">
-                           <mRest xml:id="s7l1_t1_1" />
+                           <mRest xml:id="m1e625az" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s8" n="8">
                         <layer xml:id="m2s8l1" n="1">
-                           <mRest xml:id="s8l1_t1_1" />
+                           <mRest xml:id="mkrv7bw" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s9" n="9">
                         <layer xml:id="m2s9l1" n="1">
-                           <mRest xml:id="s9l1_t1_1" />
+                           <mRest xml:id="m176z6ux" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s10" n="10">
                         <layer xml:id="m2s10l1" n="1">
-                           <mRest xml:id="s10l1_t1_1" />
+                           <mRest xml:id="m37600l" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s11" n="11">
                         <layer xml:id="m2s11l1" n="1">
-                           <mRest xml:id="s11l1_t1_1" />
+                           <mRest xml:id="m15j9vqm" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s12" n="12">
                         <layer xml:id="m2s12l1" n="1">
-                           <mRest xml:id="s12l1_t1_1" />
+                           <mRest xml:id="ml3e53g" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/score-02.mscx
+++ b/src/importexport/mei/tests/data/score-02.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:16&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:53:54&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/slur-01.mei
+++ b/src/importexport/mei/tests/data/slur-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:17" />
+            <date isodate="2023-08-11T14:54:00" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -39,106 +39,106 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m10iifs4" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <note xml:id="s1l1_t0_1" dur="4" pname="c" oct="5" />
-                           <note xml:id="s1l1_t1_4" dur="4" pname="d" oct="5" />
+                           <note xml:id="n12hau96" dur="4" pname="c" oct="5" />
+                           <note xml:id="n1ncga0z" dur="4" pname="d" oct="5" />
                         </layer>
                         <layer xml:id="m1s1l2" n="2">
-                           <note xml:id="s1l2_t0_1" dur="4" pname="a" oct="4" />
-                           <note xml:id="s1l2_t1_4" dur="4" pname="f" oct="4" />
+                           <note xml:id="n19n3s8g" dur="4" pname="a" oct="4" />
+                           <note xml:id="nhf3jcf" dur="4" pname="f" oct="4" />
                         </layer>
                      </staff>
-                     <slur xml:id="m1sl1" startid="#s1l1_t0_1" endid="#s1l1_t1_4" />
+                     <slur xml:id="s1drgy7q" startid="#n12hau96" endid="#n1ncga0z" />
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="m1x3mog7" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <note xml:id="s1l1_t1_2" dur="4" pname="c" oct="5" />
-                           <note xml:id="s1l1_t3_4" dur="4" pname="d" oct="5" />
+                           <note xml:id="n1a77pix" dur="4" pname="c" oct="5" />
+                           <note xml:id="n1x5f5bv" dur="4" pname="d" oct="5" />
                         </layer>
                         <layer xml:id="m2s1l2" n="2">
-                           <note xml:id="s1l2_t1_2" dur="4" pname="a" oct="4" />
-                           <note xml:id="s1l2_t3_4" dur="4" pname="f" oct="4" />
+                           <note xml:id="n1m3807z" dur="4" pname="a" oct="4" />
+                           <note xml:id="n1wtyw1h" dur="4" pname="f" oct="4" />
                         </layer>
                      </staff>
-                     <slur xml:id="m2sl1" startid="#s1l2_t1_2" endid="#s1l2_t3_4" />
+                     <slur xml:id="svfcjr3" startid="#n1m3807z" endid="#n1wtyw1h" />
                   </measure>
-                  <measure xml:id="m3" n="3">
+                  <measure xml:id="m12fjj57" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <note xml:id="s1l1_t1_1" dur="4" pname="c" oct="5" />
-                           <note xml:id="s1l1_t5_4" dur="4" pname="d" oct="5" />
+                           <note xml:id="n1x3hq2x" dur="4" pname="c" oct="5" />
+                           <note xml:id="nf4n3cz" dur="4" pname="d" oct="5" />
                         </layer>
                         <layer xml:id="m3s1l2" n="2">
-                           <note xml:id="s1l2_t1_1" dur="4" pname="a" oct="4" />
-                           <note xml:id="s1l2_t5_4" dur="4" pname="f" oct="4" />
+                           <note xml:id="n6w8pe0" dur="4" pname="a" oct="4" />
+                           <note xml:id="novf7kr" dur="4" pname="f" oct="4" />
                         </layer>
                      </staff>
-                     <slur xml:id="m3sl1" startid="#s1l1_t1_1" endid="#s1l1_t5_4" />
-                     <slur xml:id="m3sl2" startid="#s1l2_t1_1" endid="#s1l2_t5_4" />
+                     <slur xml:id="s1ab6vqb" startid="#n1x3hq2x" endid="#nf4n3cz" />
+                     <slur xml:id="s1ougv38" startid="#n6w8pe0" endid="#novf7kr" />
                   </measure>
-                  <measure xml:id="m4" n="4">
+                  <measure xml:id="m1aagn5h" n="4">
                      <staff xml:id="m4s1" n="1">
                         <layer xml:id="m4s1l1" n="1">
-                           <graceGrp xml:id="m4s1l1g1" grace="acc">
-                              <note xml:id="m4s1l1n1" dur="16" pname="a" oct="4" />
+                           <graceGrp grace="acc">
+                              <note xml:id="noau8k" dur="16" pname="a" oct="4" />
                            </graceGrp>
-                           <note xml:id="s1l1_t3_2" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t7_4" dur="4" pname="a" oct="4" />
+                           <note xml:id="n1xxpnhv" dur="4" pname="g" oct="4" />
+                           <note xml:id="n1v30q6c" dur="4" pname="a" oct="4" />
                         </layer>
                      </staff>
-                     <slur xml:id="m4sl1" startid="#s1l1_t3_2" endid="#s1l1_t7_4" />
+                     <slur xml:id="syw37t1" startid="#n1xxpnhv" endid="#n1v30q6c" />
                   </measure>
-                  <measure xml:id="m5" n="5">
+                  <measure xml:id="m181xv9l" n="5">
                      <staff xml:id="m5s1" n="1">
                         <layer xml:id="m5s1l1" n="1">
-                           <note xml:id="s1l1_t2_1" dur="4" pname="c" oct="5" />
-                           <graceGrp xml:id="m5s1l1g1" grace="acc">
-                              <note xml:id="m5s1l1n1" dur="16" pname="e" oct="5" />
+                           <note xml:id="n1rcei5y" dur="4" pname="c" oct="5" />
+                           <graceGrp grace="acc">
+                              <note xml:id="n1khol7p" dur="16" pname="e" oct="5" />
                            </graceGrp>
-                           <note xml:id="s1l1_t9_4" dur="4" pname="d" oct="5" />
+                           <note xml:id="n1ufkbce" dur="4" pname="d" oct="5" />
                         </layer>
                      </staff>
-                     <slur xml:id="m5sl1" startid="#s1l1_t2_1" endid="#s1l1_t9_4" />
+                     <slur xml:id="s1ljmfrq" startid="#n1rcei5y" endid="#n1ufkbce" />
                   </measure>
-                  <measure xml:id="m6" n="6">
+                  <measure xml:id="m1egdv9v" n="6">
                      <staff xml:id="m6s1" n="1">
                         <layer xml:id="m6s1l1" n="1">
-                           <note xml:id="s1l1_t5_2" dur="4" pname="c" oct="5" />
-                           <note xml:id="s1l1_t11_4" dur="4" pname="f" oct="5" />
+                           <note xml:id="np1l4cc" dur="4" pname="c" oct="5" />
+                           <note xml:id="nkjssrw" dur="4" pname="f" oct="5" />
                         </layer>
                         <layer xml:id="m6s1l2" n="2">
-                           <note xml:id="s1l2_t5_2" dur="4" pname="a" oct="4" />
-                           <note xml:id="s1l2_t11_4" dur="4" pname="f" oct="4" />
+                           <note xml:id="n703r8c" dur="4" pname="a" oct="4" />
+                           <note xml:id="n19b1xyj" dur="4" pname="f" oct="4" />
                         </layer>
                      </staff>
-                     <slur xml:id="m6sl1" startid="#s1l1_t5_2" curvedir="above" endid="#s1l2_t11_4" />
+                     <slur xml:id="s1ub3s6" startid="#np1l4cc" curvedir="above" endid="#n19b1xyj" />
                   </measure>
-                  <measure xml:id="m7" n="7">
+                  <measure xml:id="m1eb907q" n="7">
                      <staff xml:id="m7s1" n="1">
                         <layer xml:id="m7s1l1" n="1">
-                           <note xml:id="s1l1_t3_1" dur="4" pname="c" oct="5" />
-                           <note xml:id="s1l1_t13_4" dur="4" pname="d" oct="5" />
+                           <note xml:id="n77sm86" dur="4" pname="c" oct="5" />
+                           <note xml:id="n1xjtjdl" dur="4" pname="d" oct="5" />
                         </layer>
                         <layer xml:id="m7s1l2" n="2">
-                           <note xml:id="s1l2_t3_1" dur="4" pname="a" oct="4" />
-                           <note xml:id="s1l2_t13_4" dur="4" pname="f" oct="4" />
+                           <note xml:id="n11l809t" dur="4" pname="a" oct="4" />
+                           <note xml:id="n104zj0p" dur="4" pname="f" oct="4" />
                         </layer>
                      </staff>
-                     <slur xml:id="m7sl1" startid="#s1l1_t3_1" endid="#s1l1_t15_4" />
-                     <slur xml:id="m7sl2" startid="#s1l2_t3_1" endid="#s1l2_t15_4" />
+                     <slur xml:id="s1j00pz" startid="#n77sm86" endid="#n17l2zf4" />
+                     <slur xml:id="snd70iu" startid="#n11l809t" endid="#n1rah6bf" />
                   </measure>
-                  <measure xml:id="m8" right="end" n="8">
+                  <measure xml:id="mboaezt" right="end" n="8">
                      <staff xml:id="m8s1" n="1">
                         <layer xml:id="m8s1l1" n="1">
-                           <note xml:id="s1l1_t7_2" dur="4" pname="c" oct="5" />
-                           <note xml:id="s1l1_t15_4" dur="4" pname="d" oct="5" />
+                           <note xml:id="n1jf0wlj" dur="4" pname="c" oct="5" />
+                           <note xml:id="n17l2zf4" dur="4" pname="d" oct="5" />
                         </layer>
                         <layer xml:id="m8s1l2" n="2">
-                           <note xml:id="s1l2_t7_2" dur="4" pname="a" oct="4" />
-                           <note xml:id="s1l2_t15_4" dur="4" pname="f" oct="4" />
+                           <note xml:id="nu03xr4" dur="4" pname="a" oct="4" />
+                           <note xml:id="n1rah6bf" dur="4" pname="f" oct="4" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/slur-01.mscx
+++ b/src/importexport/mei/tests/data/slur-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:17&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:54:00&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/slur-02.mei
+++ b/src/importexport/mei/tests/data/slur-02.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:18" />
+            <date isodate="2023-08-11T14:54:09" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -44,154 +44,154 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m1phsrbh" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <beam xml:id="m1s1l1b1">
-                              <note xml:id="s1l1_t0_1" type="mscore-beam-begin" dur="16" pname="g" oct="6">
-                                 <accid xml:id="m1s1l1a1" accid.ges="s" />
+                           <beam>
+                              <note xml:id="nxnkach" type="mscore-beam-begin" dur="16" pname="g" oct="6">
+                                 <accid accid.ges="s" />
                               </note>
-                              <tuplet xml:id="m1s1l1t1" num="3" numbase="2">
-                                 <note xml:id="s1l1_t1_16" type="mscore-beam-mid" dur="32" pname="f" oct="6">
-                                    <accid xml:id="m1s1l1a2" accid.ges="s" />
+                              <tuplet xml:id="t1cf7bjb" num="3" numbase="2">
+                                 <note xml:id="n5t82mu" type="mscore-beam-mid" dur="32" pname="f" oct="6">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t1_12" type="mscore-beam-mid" dur="32" pname="c" oct="6">
-                                    <accid xml:id="m1s1l1a3" accid.ges="s" />
+                                 <note xml:id="n1gzbbkk" type="mscore-beam-mid" dur="32" pname="c" oct="6">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t5_48" dur="32" pname="a" oct="5">
-                                    <accid xml:id="m1s1l1a4" accid.ges="s" />
+                                 <note xml:id="nscbnac" dur="32" pname="a" oct="5">
+                                    <accid accid.ges="s" />
                                  </note>
                               </tuplet>
                            </beam>
-                           <beam xml:id="m1s1l1b2">
-                              <note xml:id="s1l1_t1_8" type="mscore-beam-begin" dur="16" pname="d" oct="6">
-                                 <accid xml:id="m1s1l1a5" accid.ges="s" />
+                           <beam>
+                              <note xml:id="n1oj99xm" type="mscore-beam-begin" dur="16" pname="d" oct="6">
+                                 <accid accid.ges="s" />
                               </note>
-                              <tuplet xml:id="m1s1l1t2" num="3" numbase="2">
-                                 <note xml:id="s1l1_t3_16" type="mscore-beam-mid" dur="32" pname="c" oct="6">
-                                    <accid xml:id="m1s1l1a6" accid.ges="s" />
+                              <tuplet xml:id="th31g4c" num="3" numbase="2">
+                                 <note xml:id="nior9z1" type="mscore-beam-mid" dur="32" pname="c" oct="6">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t5_24" type="mscore-beam-mid" dur="32" pname="a" oct="5">
-                                    <accid xml:id="m1s1l1a7" accid.ges="s" />
+                                 <note xml:id="n1iunlj7" type="mscore-beam-mid" dur="32" pname="a" oct="5">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t11_48" dur="32" pname="f" oct="5">
-                                    <accid xml:id="m1s1l1a8" accid.ges="s" />
-                                 </note>
-                              </tuplet>
-                           </beam>
-                           <beam xml:id="m1s1l1b3">
-                              <note xml:id="s1l1_t1_4" type="mscore-beam-begin" dur="16" pname="b" oct="5" />
-                              <tuplet xml:id="m1s1l1t3" num="3" numbase="2">
-                                 <note xml:id="s1l1_t5_16" type="mscore-beam-mid" dur="32" pname="a" oct="5">
-                                    <accid xml:id="m1s1l1a9" accid.ges="s" />
-                                 </note>
-                                 <note xml:id="s1l1_t1_3" type="mscore-beam-mid" dur="32" pname="f" oct="5">
-                                    <accid xml:id="m1s1l1a10" accid.ges="s" />
-                                 </note>
-                                 <note xml:id="s1l1_t17_48" dur="32" pname="c" oct="5">
-                                    <accid xml:id="m1s1l1a11" accid.ges="s" />
+                                 <note xml:id="n1uqu85c" dur="32" pname="f" oct="5">
+                                    <accid accid.ges="s" />
                                  </note>
                               </tuplet>
                            </beam>
-                           <beam xml:id="m1s1l1b4">
-                              <note xml:id="s1l1_t3_8" type="mscore-beam-begin" dur="16" pname="g" oct="5">
-                                 <accid xml:id="m1s1l1a12" accid.ges="s" />
+                           <beam>
+                              <note xml:id="n8tlcju" type="mscore-beam-begin" dur="16" pname="b" oct="5" />
+                              <tuplet xml:id="t12k8j4r" num="3" numbase="2">
+                                 <note xml:id="n13hp0eq" type="mscore-beam-mid" dur="32" pname="a" oct="5">
+                                    <accid accid.ges="s" />
+                                 </note>
+                                 <note xml:id="niqr6zt" type="mscore-beam-mid" dur="32" pname="f" oct="5">
+                                    <accid accid.ges="s" />
+                                 </note>
+                                 <note xml:id="n12pzu31" dur="32" pname="c" oct="5">
+                                    <accid accid.ges="s" />
+                                 </note>
+                              </tuplet>
+                           </beam>
+                           <beam>
+                              <note xml:id="n158ixas" type="mscore-beam-begin" dur="16" pname="g" oct="5">
+                                 <accid accid.ges="s" />
                               </note>
-                              <tuplet xml:id="m1s1l1t4" num="3" numbase="2">
-                                 <note xml:id="s1l1_t7_16" type="mscore-beam-mid" dur="32" pname="f" oct="5">
-                                    <accid xml:id="m1s1l1a13" accid.ges="s" />
+                              <tuplet xml:id="th5gsvw" num="3" numbase="2">
+                                 <note xml:id="n113gg9z" type="mscore-beam-mid" dur="32" pname="f" oct="5">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t11_24" type="mscore-beam-mid" dur="32" pname="c" oct="5">
-                                    <accid xml:id="m1s1l1a14" accid.ges="s" />
+                                 <note xml:id="nqcoqqj" type="mscore-beam-mid" dur="32" pname="c" oct="5">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t23_48" dur="32" pname="a" oct="4">
-                                    <accid xml:id="m1s1l1a15" accid.ges="s" />
-                                 </note>
-                              </tuplet>
-                           </beam>
-                           <beam xml:id="m1s1l1b5">
-                              <tuplet xml:id="m1s1l1t5" num="6" numbase="4">
-                                 <note xml:id="s1l1_t1_2" type="mscore-beam-begin" dur="32" pname="d" oct="5" stem.dir="up">
-                                    <accid xml:id="m1s1l1a16" accid.ges="s" />
-                                 </note>
-                                 <note xml:id="s1l1_t25_48" type="mscore-beam-mid" dur="32" pname="c" oct="5" stem.dir="up">
-                                    <accid xml:id="m1s1l1a17" accid.ges="s" />
-                                 </note>
-                                 <note xml:id="s1l1_t13_24" type="mscore-beam-mid" dur="32" pname="a" oct="4" stem.dir="up">
-                                    <accid xml:id="m1s1l1a18" accid.ges="s" />
-                                 </note>
-                                 <note xml:id="s1l1_t9_16" type="mscore-beam-mid" dur="32" pname="f" oct="4" stem.dir="up">
-                                    <accid xml:id="m1s1l1a19" accid.ges="s" />
-                                 </note>
-                                 <note xml:id="s1l1_t7_12" type="mscore-beam-mid" dur="32" pname="b" oct="4" stem.dir="up" />
-                                 <note xml:id="s1l1_t29_48" dur="32" pname="a" oct="4" stem.dir="up">
-                                    <accid xml:id="m1s1l1a20" accid.ges="s" />
+                                 <note xml:id="ned4qpd" dur="32" pname="a" oct="4">
+                                    <accid accid.ges="s" />
                                  </note>
                               </tuplet>
                            </beam>
-                           <beam xml:id="m1s1l1b6">
-                              <tuplet xml:id="m1s1l1t6" num="6" numbase="4">
-                                 <note xml:id="s1l1_t5_8" type="mscore-beam-begin" dur="32" pname="f" oct="4" stem.dir="up">
-                                    <accid xml:id="m1s1l1a21" accid.ges="s" />
+                           <beam>
+                              <tuplet xml:id="tmljxn5" num="6" numbase="4">
+                                 <note xml:id="n1hh0z9n" type="mscore-beam-begin" dur="32" pname="d" oct="5" stem.dir="up">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t31_48" type="mscore-beam-mid" dur="32" pname="c" oct="4" stem.dir="up">
-                                    <accid xml:id="m1s1l1a22" accid.ges="s" />
+                                 <note xml:id="n1lwbvb" type="mscore-beam-mid" dur="32" pname="c" oct="5" stem.dir="up">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t2_3" type="mscore-beam-mid" dur="32" pname="g" oct="4" stem.dir="up">
-                                    <accid xml:id="m1s1l1a23" accid.ges="s" />
+                                 <note xml:id="nal6ylf" type="mscore-beam-mid" dur="32" pname="a" oct="4" stem.dir="up">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t11_16" type="mscore-beam-mid" dur="32" pname="f" oct="4" stem.dir="up">
-                                    <accid xml:id="m1s1l1a24" accid.ges="s" />
+                                 <note xml:id="n1twa8l" type="mscore-beam-mid" dur="32" pname="f" oct="4" stem.dir="up">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t17_24" type="mscore-beam-mid" dur="32" pname="c" oct="4" stem.dir="up">
-                                    <accid xml:id="m1s1l1a25" accid.ges="s" />
-                                 </note>
-                                 <note xml:id="s1l1_t35_48" dur="32" pname="a" oct="3" stem.dir="up">
-                                    <accid xml:id="m1s1l1a26" accid.ges="s" />
+                                 <note xml:id="nqtky4a" type="mscore-beam-mid" dur="32" pname="b" oct="4" stem.dir="up" />
+                                 <note xml:id="n1n47f99" dur="32" pname="a" oct="4" stem.dir="up">
+                                    <accid accid.ges="s" />
                                  </note>
                               </tuplet>
                            </beam>
-                           <beam xml:id="m1s1l1b7">
-                              <tuplet xml:id="m1s1l1t7" num="6" numbase="4">
-                                 <note xml:id="s1l1_t3_4" type="mscore-beam-begin" dur="32" staff="2" pname="d" oct="4">
-                                    <accid xml:id="m1s1l1a27" accid.ges="s" />
+                           <beam>
+                              <tuplet xml:id="tnjht6f" num="6" numbase="4">
+                                 <note xml:id="n13gg0nr" type="mscore-beam-begin" dur="32" pname="f" oct="4" stem.dir="up">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t37_48" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="4">
-                                    <accid xml:id="m1s1l1a28" accid.ges="s" />
+                                 <note xml:id="nws4ncb" type="mscore-beam-mid" dur="32" pname="c" oct="4" stem.dir="up">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t19_24" type="mscore-beam-mid" dur="32" staff="2" pname="a" oct="3">
-                                    <accid xml:id="m1s1l1a29" accid.ges="s" />
+                                 <note xml:id="n174pn4z" type="mscore-beam-mid" dur="32" pname="g" oct="4" stem.dir="up">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t13_16" type="mscore-beam-mid" dur="32" staff="2" pname="f" oct="3">
-                                    <accid xml:id="m1s1l1a30" accid.ges="s" />
+                                 <note xml:id="n18go9e6" type="mscore-beam-mid" dur="32" pname="f" oct="4" stem.dir="up">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t5_6" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="3">
-                                    <accid xml:id="m1s1l1a31" accid.ges="s" />
+                                 <note xml:id="ncx7dqc" type="mscore-beam-mid" dur="32" pname="c" oct="4" stem.dir="up">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t41_48" dur="32" staff="2" pname="a" oct="3">
-                                    <accid xml:id="m1s1l1a32" accid.ges="s" />
+                                 <note xml:id="nwyqdnt" dur="32" pname="a" oct="3" stem.dir="up">
+                                    <accid accid.ges="s" />
                                  </note>
                               </tuplet>
                            </beam>
-                           <beam xml:id="m1s1l1b8">
-                              <tuplet xml:id="m1s1l1t8" num="6" numbase="4">
-                                 <note xml:id="s1l1_t7_8" type="mscore-beam-begin" dur="32" staff="2" pname="d" oct="4">
-                                    <accid xml:id="m1s1l1a33" accid.ges="s" />
+                           <beam>
+                              <tuplet xml:id="t18tp8e6" num="6" numbase="4">
+                                 <note xml:id="n181jne1" type="mscore-beam-begin" dur="32" staff="2" pname="d" oct="4">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t43_48" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="4">
-                                    <accid xml:id="m1s1l1a34" accid.ges="s" />
+                                 <note xml:id="n1g8i39z" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="4">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t11_12" type="mscore-beam-mid" dur="32" staff="2" pname="a" oct="3">
-                                    <accid xml:id="m1s1l1a35" accid.ges="s" />
+                                 <note xml:id="nofmkua" type="mscore-beam-mid" dur="32" staff="2" pname="a" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t15_16" type="mscore-beam-mid" dur="32" staff="2" pname="f" oct="3">
-                                    <accid xml:id="m1s1l1a36" accid.ges="s" />
+                                 <note xml:id="njj7om4" type="mscore-beam-mid" dur="32" staff="2" pname="f" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t23_24" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="3">
-                                    <accid xml:id="m1s1l1a37" accid.ges="s" />
+                                 <note xml:id="n6vzthv" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t47_48" dur="32" staff="2" pname="a" oct="3">
-                                    <accid xml:id="m1s1l1a38" accid.ges="s" />
+                                 <note xml:id="n1k32dod" dur="32" staff="2" pname="a" oct="3">
+                                    <accid accid.ges="s" />
+                                 </note>
+                              </tuplet>
+                           </beam>
+                           <beam>
+                              <tuplet xml:id="tyegdr2" num="6" numbase="4">
+                                 <note xml:id="n1tzfb53" type="mscore-beam-begin" dur="32" staff="2" pname="d" oct="4">
+                                    <accid accid.ges="s" />
+                                 </note>
+                                 <note xml:id="nfajnu" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="4">
+                                    <accid accid.ges="s" />
+                                 </note>
+                                 <note xml:id="npsr3c0" type="mscore-beam-mid" dur="32" staff="2" pname="a" oct="3">
+                                    <accid accid.ges="s" />
+                                 </note>
+                                 <note xml:id="n13g6wzh" type="mscore-beam-mid" dur="32" staff="2" pname="f" oct="3">
+                                    <accid accid.ges="s" />
+                                 </note>
+                                 <note xml:id="n14c7eod" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="3">
+                                    <accid accid.ges="s" />
+                                 </note>
+                                 <note xml:id="n3xaoeq" dur="32" staff="2" pname="a" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
                               </tuplet>
                            </beam>
@@ -199,236 +199,236 @@
                      </staff>
                      <staff xml:id="m1s2" n="2">
                         <layer xml:id="m1s2l1" n="1">
-                           <note xml:id="s2l1_t0_1" type="mscore-beam-none" dur="8" pname="f" oct="2">
-                              <accid xml:id="m1s2l1a1" accid.ges="s" />
+                           <note xml:id="n1q79ura" type="mscore-beam-none" dur="8" pname="f" oct="2">
+                              <accid accid.ges="s" />
                            </note>
-                           <beam xml:id="m1s2l1b1">
-                              <chord xml:id="s2l1_t1_8" type="mscore-beam-begin" dur="16">
-                                 <note xml:id="m1s2l1n1" pname="c" oct="3">
-                                    <accid xml:id="m1s2l1a2" accid.ges="s" />
+                           <beam>
+                              <chord xml:id="c33kuiq" type="mscore-beam-begin" dur="16">
+                                 <note xml:id="nzp7z2z" pname="c" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="m1s2l1n2" pname="f" oct="3">
-                                    <accid xml:id="m1s2l1a3" accid.ges="s" />
+                                 <note xml:id="no4aojx" pname="f" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="m1s2l1n3" pname="a" oct="3">
-                                    <accid xml:id="m1s2l1a4" accid.ges="s" />
+                                 <note xml:id="n6ded74" pname="a" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
                               </chord>
-                              <tuplet xml:id="m1s2l1t1" num="3" numbase="2">
-                                 <chord xml:id="s2l1_t3_16" type="mscore-beam-mid" dur="32">
-                                    <note xml:id="m1s2l1n4" pname="c" oct="3">
-                                       <accid xml:id="m1s2l1a5" accid.ges="s" />
+                              <tuplet xml:id="t1sesr97" num="3" numbase="2">
+                                 <chord xml:id="ctn1316" type="mscore-beam-mid" dur="32">
+                                    <note xml:id="n1xzdfbq" pname="c" oct="3">
+                                       <accid accid.ges="s" />
                                     </note>
-                                    <note xml:id="m1s2l1n5" pname="f" oct="3">
-                                       <accid xml:id="m1s2l1a6" accid.ges="s" />
+                                    <note xml:id="n1h6bm64" pname="f" oct="3">
+                                       <accid accid.ges="s" />
                                     </note>
-                                    <note xml:id="m1s2l1n6" pname="a" oct="3">
-                                       <accid xml:id="m1s2l1a7" accid.ges="s" />
-                                    </note>
-                                 </chord>
-                                 <chord xml:id="s2l1_t5_24" type="mscore-beam-mid" dur="32">
-                                    <note xml:id="m1s2l1n7" pname="c" oct="3">
-                                       <accid xml:id="m1s2l1a8" accid.ges="s" />
-                                    </note>
-                                    <note xml:id="m1s2l1n8" pname="f" oct="3">
-                                       <accid xml:id="m1s2l1a9" accid.ges="s" />
-                                    </note>
-                                    <note xml:id="m1s2l1n9" pname="a" oct="3">
-                                       <accid xml:id="m1s2l1a10" accid.ges="s" />
+                                    <note xml:id="np9tmzl" pname="a" oct="3">
+                                       <accid accid.ges="s" />
                                     </note>
                                  </chord>
-                                 <chord xml:id="s2l1_t11_48" dur="32">
-                                    <note xml:id="m1s2l1n10" pname="c" oct="3">
-                                       <accid xml:id="m1s2l1a11" accid.ges="s" />
+                                 <chord xml:id="cnqov6u" type="mscore-beam-mid" dur="32">
+                                    <note xml:id="nkmnzya" pname="c" oct="3">
+                                       <accid accid.ges="s" />
                                     </note>
-                                    <note xml:id="m1s2l1n11" pname="f" oct="3">
-                                       <accid xml:id="m1s2l1a12" accid.ges="s" />
+                                    <note xml:id="n1qy7z64" pname="f" oct="3">
+                                       <accid accid.ges="s" />
                                     </note>
-                                    <note xml:id="m1s2l1n12" pname="a" oct="3">
-                                       <accid xml:id="m1s2l1a13" accid.ges="s" />
+                                    <note xml:id="n1aog6d2" pname="a" oct="3">
+                                       <accid accid.ges="s" />
+                                    </note>
+                                 </chord>
+                                 <chord xml:id="co4efjx" dur="32">
+                                    <note xml:id="n1ottd9r" pname="c" oct="3">
+                                       <accid accid.ges="s" />
+                                    </note>
+                                    <note xml:id="n3h7unv" pname="f" oct="3">
+                                       <accid accid.ges="s" />
+                                    </note>
+                                    <note xml:id="n19vwqkr" pname="a" oct="3">
+                                       <accid accid.ges="s" />
                                     </note>
                                  </chord>
                               </tuplet>
                            </beam>
-                           <beam xml:id="m1s2l1b2">
-                              <chord xml:id="s2l1_t1_4" type="mscore-beam-begin" dur="8">
-                                 <note xml:id="m1s2l1n13" pname="f" oct="3">
-                                    <accid xml:id="m1s2l1a14" accid.ges="s" />
+                           <beam>
+                              <chord xml:id="c1fzyq3j" type="mscore-beam-begin" dur="8">
+                                 <note xml:id="nafnl79" pname="f" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="m1s2l1n14" pname="a" oct="3">
-                                    <accid xml:id="m1s2l1a15" accid.ges="s" />
+                                 <note xml:id="n15g60wb" pname="a" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="m1s2l1n15" pname="c" oct="4">
-                                    <accid xml:id="m1s2l1a16" accid.ges="s" />
+                                 <note xml:id="n1fr4uxr" pname="c" oct="4">
+                                    <accid accid.ges="s" />
                                  </note>
                               </chord>
-                              <chord xml:id="s2l1_t3_8" dur="8">
-                                 <note xml:id="m1s2l1n16" pname="c" oct="3">
-                                    <accid xml:id="m1s2l1a17" accid.ges="s" />
+                              <chord xml:id="c1yyiui3" dur="8">
+                                 <note xml:id="n1j2nrki" pname="c" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="m1s2l1n17" pname="f" oct="3">
-                                    <accid xml:id="m1s2l1a18" accid.ges="s" />
+                                 <note xml:id="n9sxmfy" pname="f" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="m1s2l1n18" pname="a" oct="3">
-                                    <accid xml:id="m1s2l1a19" accid.ges="s" />
+                                 <note xml:id="nlodio6" pname="a" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
                               </chord>
                            </beam>
-                           <chord xml:id="s2l1_t1_2" type="mscore-beam-none" dur="8" stem.dir="down">
-                              <note xml:id="m1s2l1n19" pname="f" oct="2">
-                                 <accid xml:id="m1s2l1a20" accid.ges="s" />
+                           <chord xml:id="cd1tped" type="mscore-beam-none" dur="8" stem.dir="down">
+                              <note xml:id="nx2d9rm" pname="f" oct="2">
+                                 <accid accid.ges="s" />
                               </note>
-                              <note xml:id="m1s2l1n20" pname="c" oct="3">
-                                 <accid xml:id="m1s2l1a21" accid.ges="s" />
+                              <note xml:id="n1kc4ws4" pname="c" oct="3">
+                                 <accid accid.ges="s" />
                               </note>
-                              <note xml:id="m1s2l1n21" pname="a" oct="3">
-                                 <accid xml:id="m1s2l1a22" accid.ges="s" />
+                              <note xml:id="ntku1me" pname="a" oct="3">
+                                 <accid accid.ges="s" />
                               </note>
                            </chord>
-                           <rest xml:id="s2l1_t5_8" type="mscore-beam-none" dur="8" />
-                           <rest xml:id="s2l1_t3_4" type="mscore-beam-none" dur="8" />
-                           <note xml:id="s2l1_t7_8" type="mscore-beam-none" dur="8" pname="c" oct="2">
-                              <accid xml:id="m1s2l1a23" accid.ges="s" />
+                           <rest xml:id="r1smqhmc" type="mscore-beam-none" dur="8" />
+                           <rest xml:id="rjpaj8g" type="mscore-beam-none" dur="8" />
+                           <note xml:id="n1nvcscz" type="mscore-beam-none" dur="8" pname="c" oct="2">
+                              <accid accid.ges="s" />
                            </note>
                         </layer>
                      </staff>
-                     <slur xml:id="m1sl1" startid="#s1l1_t0_1" endid="#s1l1_t5_48" />
-                     <slur xml:id="m1sl2" startid="#s1l1_t0_1" endid="#s1l1_t23_48" />
-                     <slur xml:id="m1sl3" startid="#s1l1_t1_8" lform="dotted" endid="#s1l1_t11_48" />
-                     <slur xml:id="m1sl4" startid="#s1l1_t1_4" lform="dotted" endid="#s1l1_t17_48" />
-                     <slur xml:id="m1sl5" startid="#s1l1_t3_8" curvedir="above" lform="dotted" endid="#s1l1_t23_48" />
-                     <slur xml:id="m1sl6" startid="#s1l1_t1_2" curvedir="below" lform="dashed" endid="#s1l1_t29_48" />
-                     <slur xml:id="m1sl7" startid="#s1l1_t1_2" curvedir="above" endid="#s1l1_t71_48" />
-                     <slur xml:id="m1sl8" startid="#s1l1_t9_16" curvedir="above" lform="dashed" endid="#s1l1_t2_3" />
-                     <slur xml:id="m1sl9" startid="#s1l1_t5_8" curvedir="below" lform="dashed" endid="#s1l1_t35_48" />
-                     <slur xml:id="m1sl10" startid="#s1l1_t11_16" curvedir="above" lform="dashed" endid="#s1l1_t19_24" />
-                     <slur xml:id="m1sl11" startid="#s1l1_t3_4" curvedir="below" lform="dashed" endid="#s1l1_t41_48" />
-                     <slur xml:id="m1sl12" startid="#s1l1_t13_16" curvedir="above" lform="dashed" endid="#s1l1_t11_12" />
-                     <slur xml:id="m1sl13" startid="#s1l1_t7_8" curvedir="below" lform="dashed" endid="#s1l1_t47_48" />
-                     <slur xml:id="m1sl14" startid="#s2l1_t0_1" curvedir="below" lform="dashed" endid="#s2l1_t11_48" />
-                     <slur xml:id="m1sl15" startid="#s2l1_t1_8" curvedir="above" endid="#s2l1_t3_8" />
-                     <slur xml:id="m1sl16" startid="#s2l1_t1_4" curvedir="below" lform="dashed" endid="#s2l1_t3_8" />
+                     <slur xml:id="sxpu2fs" startid="#nxnkach" endid="#nscbnac" />
+                     <slur xml:id="s88jkbp" startid="#nxnkach" endid="#ned4qpd" />
+                     <slur xml:id="s1vdkvoo" startid="#n1oj99xm" lform="dotted" endid="#n1uqu85c" />
+                     <slur xml:id="s1hbyb6l" startid="#n8tlcju" lform="dotted" endid="#n12pzu31" />
+                     <slur xml:id="s1pk9agb" startid="#n158ixas" curvedir="above" lform="dotted" endid="#ned4qpd" />
+                     <slur xml:id="s1f6nwhp" startid="#n1hh0z9n" curvedir="below" lform="dashed" endid="#n1n47f99" />
+                     <slur xml:id="sdbs90" startid="#n1hh0z9n" curvedir="above" endid="#n1gymv66" />
+                     <slur xml:id="sdw14vy" startid="#n1twa8l" curvedir="above" lform="dashed" endid="#n174pn4z" />
+                     <slur xml:id="sedvjdg" startid="#n13gg0nr" curvedir="below" lform="dashed" endid="#nwyqdnt" />
+                     <slur xml:id="s1nmagch" startid="#n18go9e6" curvedir="above" lform="dashed" endid="#nofmkua" />
+                     <slur xml:id="s1888lec" startid="#n181jne1" curvedir="below" lform="dashed" endid="#n1k32dod" />
+                     <slur xml:id="s8nf2uh" startid="#njj7om4" curvedir="above" lform="dashed" endid="#npsr3c0" />
+                     <slur xml:id="s6wd36" startid="#n1tzfb53" curvedir="below" lform="dashed" endid="#n3xaoeq" />
+                     <slur xml:id="sm5ep9t" startid="#n1q79ura" curvedir="below" lform="dashed" endid="#co4efjx" />
+                     <slur xml:id="s4vjjwf" startid="#c33kuiq" curvedir="above" endid="#c1yyiui3" />
+                     <slur xml:id="smbrt4d" startid="#c1fzyq3j" curvedir="below" lform="dashed" endid="#c1yyiui3" />
                   </measure>
-                  <measure xml:id="m2" right="end" n="2">
+                  <measure xml:id="m1d9g788" right="end" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <beam xml:id="m2s1l1b1">
-                              <tuplet xml:id="m2s1l1t1" num="6" numbase="4">
-                                 <note xml:id="s1l1_t1_1" type="mscore-beam-begin" dur="32" staff="2" pname="d" oct="4">
-                                    <accid xml:id="m2s1l1a1" accid.ges="s" />
+                           <beam>
+                              <tuplet xml:id="t1fb1luu" num="6" numbase="4">
+                                 <note xml:id="n19i31e0" type="mscore-beam-begin" dur="32" staff="2" pname="d" oct="4">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t49_48" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="4">
-                                    <accid xml:id="m2s1l1a2" accid.ges="s" />
+                                 <note xml:id="n1v5kaja" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="4">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t25_24" type="mscore-beam-mid" dur="32" staff="2" pname="a" oct="3">
-                                    <accid xml:id="m2s1l1a3" accid.ges="s" />
+                                 <note xml:id="n6dp973" type="mscore-beam-mid" dur="32" staff="2" pname="a" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t17_16" type="mscore-beam-mid" dur="32" staff="2" pname="f" oct="3">
-                                    <accid xml:id="m2s1l1a4" accid.ges="s" />
+                                 <note xml:id="noff6es" type="mscore-beam-mid" dur="32" staff="2" pname="f" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t13_12" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="3">
-                                    <accid xml:id="m2s1l1a5" accid.ges="s" />
+                                 <note xml:id="n148w7yy" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t53_48" dur="32" staff="2" pname="a" oct="3">
-                                    <accid xml:id="m2s1l1a6" accid.ges="s" />
-                                 </note>
-                              </tuplet>
-                           </beam>
-                           <beam xml:id="m2s1l1b2">
-                              <tuplet xml:id="m2s1l1t2" num="6" numbase="4">
-                                 <note xml:id="s1l1_t9_8" type="mscore-beam-begin" dur="32" staff="2" pname="d" oct="4">
-                                    <accid xml:id="m2s1l1a7" accid.ges="s" />
-                                 </note>
-                                 <note xml:id="s1l1_t55_48" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="4">
-                                    <accid xml:id="m2s1l1a8" accid.ges="s" />
-                                 </note>
-                                 <note xml:id="s1l1_t7_6" type="mscore-beam-mid" dur="32" staff="2" pname="a" oct="3">
-                                    <accid xml:id="m2s1l1a9" accid.ges="s" />
-                                 </note>
-                                 <note xml:id="s1l1_t19_16" type="mscore-beam-mid" dur="32" staff="2" pname="f" oct="3">
-                                    <accid xml:id="m2s1l1a10" accid.ges="s" />
-                                 </note>
-                                 <note xml:id="s1l1_t29_24" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="3">
-                                    <accid xml:id="m2s1l1a11" accid.ges="s" />
-                                 </note>
-                                 <note xml:id="s1l1_t59_48" dur="32" staff="2" pname="a" oct="3">
-                                    <accid xml:id="m2s1l1a12" accid.ges="s" />
+                                 <note xml:id="n13v77kd" dur="32" staff="2" pname="a" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
                               </tuplet>
                            </beam>
-                           <beam xml:id="m2s1l1b3">
-                              <tuplet xml:id="m2s1l1t3" num="6" numbase="4">
-                                 <note xml:id="s1l1_t5_4" type="mscore-beam-begin" dur="32" staff="2" pname="d" oct="4">
-                                    <accid xml:id="m2s1l1a13" accid.ges="s" />
+                           <beam>
+                              <tuplet xml:id="t3xknwy" num="6" numbase="4">
+                                 <note xml:id="n436pug" type="mscore-beam-begin" dur="32" staff="2" pname="d" oct="4">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t61_48" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="4">
-                                    <accid xml:id="m2s1l1a14" accid.ges="s" />
+                                 <note xml:id="n1wemq0r" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="4">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t31_24" type="mscore-beam-mid" dur="32" staff="2" pname="a" oct="3">
-                                    <accid xml:id="m2s1l1a15" accid.ges="s" />
+                                 <note xml:id="ntmuvq0" type="mscore-beam-mid" dur="32" staff="2" pname="a" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t21_16" type="mscore-beam-mid" dur="32" staff="2" pname="f" oct="3">
-                                    <accid xml:id="m2s1l1a16" accid.ges="s" />
+                                 <note xml:id="nbgttkw" type="mscore-beam-mid" dur="32" staff="2" pname="f" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t4_3" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="3">
-                                    <accid xml:id="m2s1l1a17" accid.ges="s" />
+                                 <note xml:id="n12rscwf" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
-                                 <note xml:id="s1l1_t65_48" dur="32" staff="2" pname="a" oct="3">
-                                    <accid xml:id="m2s1l1a18" accid.ges="s" />
-                                 </note>
-                              </tuplet>
-                           </beam>
-                           <beam xml:id="m2s1l1b4">
-                              <tuplet xml:id="m2s1l1t4" num="6" numbase="4">
-                                 <note xml:id="s1l1_t11_8" type="mscore-beam-begin" dur="32" staff="2" pname="d" oct="4">
-                                    <accid xml:id="m2s1l1a19" accid.ges="s" />
-                                 </note>
-                                 <note xml:id="s1l1_t67_48" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="4">
-                                    <accid xml:id="m2s1l1a20" accid.ges="s" />
-                                 </note>
-                                 <note xml:id="s1l1_t17_12" type="mscore-beam-mid" dur="32" staff="2" pname="a" oct="3">
-                                    <accid xml:id="m2s1l1a21" accid.ges="s" />
-                                 </note>
-                                 <note xml:id="s1l1_t23_16" type="mscore-beam-mid" dur="32" staff="2" pname="f" oct="3">
-                                    <accid xml:id="m2s1l1a22" accid.ges="s" />
-                                 </note>
-                                 <note xml:id="s1l1_t35_24" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="3">
-                                    <accid xml:id="m2s1l1a23" accid.ges="s" />
-                                 </note>
-                                 <note xml:id="s1l1_t71_48" dur="32" staff="2" pname="c" oct="4">
-                                    <accid xml:id="m2s1l1a24" accid.ges="s" />
+                                 <note xml:id="n1s160e4" dur="32" staff="2" pname="a" oct="3">
+                                    <accid accid.ges="s" />
                                  </note>
                               </tuplet>
                            </beam>
-                           <note xml:id="s1l1_t3_2" dur="2" pname="a" oct="4">
-                              <accid xml:id="m2s1l1a25" accid.ges="s" />
+                           <beam>
+                              <tuplet xml:id="toqa1b0" num="6" numbase="4">
+                                 <note xml:id="n1n9vex1" type="mscore-beam-begin" dur="32" staff="2" pname="d" oct="4">
+                                    <accid accid.ges="s" />
+                                 </note>
+                                 <note xml:id="n14cveu6" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="4">
+                                    <accid accid.ges="s" />
+                                 </note>
+                                 <note xml:id="n10qs215" type="mscore-beam-mid" dur="32" staff="2" pname="a" oct="3">
+                                    <accid accid.ges="s" />
+                                 </note>
+                                 <note xml:id="nbav1wo" type="mscore-beam-mid" dur="32" staff="2" pname="f" oct="3">
+                                    <accid accid.ges="s" />
+                                 </note>
+                                 <note xml:id="n13bhyvq" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="3">
+                                    <accid accid.ges="s" />
+                                 </note>
+                                 <note xml:id="nac7nlb" dur="32" staff="2" pname="a" oct="3">
+                                    <accid accid.ges="s" />
+                                 </note>
+                              </tuplet>
+                           </beam>
+                           <beam>
+                              <tuplet xml:id="t1fk1j91" num="6" numbase="4">
+                                 <note xml:id="nsixsde" type="mscore-beam-begin" dur="32" staff="2" pname="d" oct="4">
+                                    <accid accid.ges="s" />
+                                 </note>
+                                 <note xml:id="nnvdz5l" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="4">
+                                    <accid accid.ges="s" />
+                                 </note>
+                                 <note xml:id="n1r21xcg" type="mscore-beam-mid" dur="32" staff="2" pname="a" oct="3">
+                                    <accid accid.ges="s" />
+                                 </note>
+                                 <note xml:id="n1ezsnpi" type="mscore-beam-mid" dur="32" staff="2" pname="f" oct="3">
+                                    <accid accid.ges="s" />
+                                 </note>
+                                 <note xml:id="n86rjey" type="mscore-beam-mid" dur="32" staff="2" pname="c" oct="3">
+                                    <accid accid.ges="s" />
+                                 </note>
+                                 <note xml:id="n1gymv66" dur="32" staff="2" pname="c" oct="4">
+                                    <accid accid.ges="s" />
+                                 </note>
+                              </tuplet>
+                           </beam>
+                           <note xml:id="n3oguuq" dur="2" pname="a" oct="4">
+                              <accid accid.ges="s" />
                            </note>
                         </layer>
                      </staff>
                      <staff xml:id="m2s2" n="2">
                         <layer xml:id="m2s2l1" n="1">
-                           <chord xml:id="s2l1_t1_1" dots="1" dur="4">
-                              <note xml:id="m2s2l1n1" pname="f" oct="1">
-                                 <accid xml:id="m2s2l1a1" accid="n" />
+                           <chord xml:id="ccdpven" dots="1" dur="4">
+                              <note xml:id="n1gm7lg4" pname="f" oct="1">
+                                 <accid accid="n" />
                               </note>
-                              <note xml:id="m2s2l1n2" pname="f" oct="2">
-                                 <accid xml:id="m2s2l1a2" accid.ges="s" />
+                              <note xml:id="n1ktajnp" pname="f" oct="2">
+                                 <accid accid.ges="s" />
                               </note>
                            </chord>
-                           <note xml:id="s2l1_t11_8" type="mscore-beam-none" dur="8" pname="c" oct="2">
-                              <accid xml:id="m2s2l1a3" accid.ges="s" />
+                           <note xml:id="nuvrdzy" type="mscore-beam-none" dur="8" pname="c" oct="2">
+                              <accid accid.ges="s" />
                            </note>
-                           <note xml:id="s2l1_t3_2" dur="2" pname="f" oct="1">
-                              <accid xml:id="m2s2l1a4" accid="s" />
+                           <note xml:id="n1112hvr" dur="2" pname="f" oct="1">
+                              <accid accid="s" />
                            </note>
                         </layer>
                      </staff>
-                     <slur xml:id="m2sl1" startid="#s1l1_t1_1" curvedir="below" lform="dashed" endid="#s1l1_t53_48" />
-                     <slur xml:id="m2sl2" startid="#s1l1_t9_8" curvedir="below" lform="dashed" endid="#s1l1_t59_48" />
-                     <slur xml:id="m2sl3" startid="#s1l1_t5_4" curvedir="below" lform="dashed" endid="#s1l1_t65_48" />
-                     <slur xml:id="m2sl4" startid="#s1l1_t11_8" curvedir="below" lform="dashed" endid="#s1l1_t71_48" />
-                     <fermata xml:id="m2fm1" startid="#s1l1_t3_2" />
-                     <fermata xml:id="m2fm2" startid="#s2l1_t3_2" place="below" />
+                     <slur xml:id="s1fr9h9o" startid="#n19i31e0" curvedir="below" lform="dashed" endid="#n13v77kd" />
+                     <slur xml:id="skn562w" startid="#n436pug" curvedir="below" lform="dashed" endid="#n1s160e4" />
+                     <slur xml:id="s1wk4te5" startid="#n1n9vex1" curvedir="below" lform="dashed" endid="#nac7nlb" />
+                     <slur xml:id="sbphd9l" startid="#nsixsde" curvedir="below" lform="dashed" endid="#n1gymv66" />
+                     <fermata xml:id="focr7cp" startid="#n3oguuq" />
+                     <fermata xml:id="f510p5p" startid="#n1112hvr" place="below" />
                   </measure>
                </section>
             </score>

--- a/src/importexport/mei/tests/data/slur-02.mscx
+++ b/src/importexport/mei/tests/data/slur-02.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:18&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:54:09&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/stem-01.mei
+++ b/src/importexport/mei/tests/data/stem-01.mei
@@ -8,7 +8,7 @@
             <title />
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:19" />
+            <date isodate="2023-08-11T14:54:15" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -29,62 +29,62 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m1vpdeqs" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <beam xml:id="m1s1l1b1">
-                              <note xml:id="s1l1_t0_1" dur="16" pname="c" oct="5" />
-                              <note xml:id="s1l1_t1_16" dur="16" pname="b" oct="4" />
-                              <note xml:id="s1l1_t1_8" dur="16" pname="c" oct="5" />
-                              <note xml:id="s1l1_t3_16" dur="16" pname="d" oct="5" />
+                           <beam>
+                              <note xml:id="nd657gv" dur="16" pname="c" oct="5" />
+                              <note xml:id="n3jtdu9" dur="16" pname="b" oct="4" />
+                              <note xml:id="n19s94xb" dur="16" pname="c" oct="5" />
+                              <note xml:id="nbfpypk" dur="16" pname="d" oct="5" />
                            </beam>
-                           <beam xml:id="m1s1l1b2">
-                              <note xml:id="s1l1_t1_4" dur="16" pname="c" oct="5" stem.dir="up" />
-                              <note xml:id="s1l1_t5_16" dur="16" pname="b" oct="4" stem.dir="up" />
-                              <note xml:id="s1l1_t3_8" dur="16" pname="c" oct="5" stem.dir="up" />
-                              <note xml:id="s1l1_t7_16" dur="16" pname="d" oct="5" stem.dir="up" />
+                           <beam>
+                              <note xml:id="n1wa00sg" dur="16" pname="c" oct="5" stem.dir="up" />
+                              <note xml:id="n1vh7npu" dur="16" pname="b" oct="4" stem.dir="up" />
+                              <note xml:id="ny2mnp7" dur="16" pname="c" oct="5" stem.dir="up" />
+                              <note xml:id="n1ujuwo5" dur="16" pname="d" oct="5" stem.dir="up" />
                            </beam>
-                           <note xml:id="s1l1_t1_2" dur="4" pname="e" oct="5" />
-                           <note xml:id="s1l1_t3_4" dur="4" pname="e" oct="4" />
+                           <note xml:id="n1piglfn" dur="4" pname="e" oct="5" />
+                           <note xml:id="n1ykvqq9" dur="4" pname="e" oct="4" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="m1hff1y1" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <beam xml:id="m2s1l1b1">
-                              <note xml:id="s1l1_t1_1" dur="8" pname="e" oct="5" stem.dir="down" />
-                              <note xml:id="s1l1_t9_8" dur="8" pname="e" oct="4" stem.dir="down" />
+                           <beam>
+                              <note xml:id="nvyxu93" dur="8" pname="e" oct="5" stem.dir="down" />
+                              <note xml:id="nsxxlvn" dur="8" pname="e" oct="4" stem.dir="down" />
                            </beam>
-                           <note xml:id="s1l1_t5_4" type="mscore-beam-none" dur="8" pname="e" oct="5" />
-                           <note xml:id="s1l1_t11_8" type="mscore-beam-none" dur="8" pname="e" oct="4" />
-                           <note xml:id="s1l1_t3_2" type="mscore-beam-none" dur="8" pname="e" oct="5" stem.dir="down" />
-                           <note xml:id="s1l1_t13_8" type="mscore-beam-none" dur="8" pname="e" oct="4" stem.dir="up" />
-                           <note xml:id="s1l1_t7_4" type="mscore-beam-none" dur="8" pname="e" oct="5" stem.dir="up" />
-                           <note xml:id="s1l1_t15_8" dur="8" pname="e" oct="4" stem.dir="down" />
+                           <note xml:id="n2fxcky" type="mscore-beam-none" dur="8" pname="e" oct="5" />
+                           <note xml:id="n1jx1o8r" type="mscore-beam-none" dur="8" pname="e" oct="4" />
+                           <note xml:id="nby31rf" type="mscore-beam-none" dur="8" pname="e" oct="5" stem.dir="down" />
+                           <note xml:id="n1yqghcs" type="mscore-beam-none" dur="8" pname="e" oct="4" stem.dir="up" />
+                           <note xml:id="nxlcpke" type="mscore-beam-none" dur="8" pname="e" oct="5" stem.dir="up" />
+                           <note xml:id="ncrw2hl" dur="8" pname="e" oct="4" stem.dir="down" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m3" right="end" n="3">
+                  <measure xml:id="muimas1" right="end" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <note xml:id="s1l1_t2_1" dur="4" pname="e" oct="4" stem.len="0.000000" />
-                           <note xml:id="s1l1_t9_4" dur="4" pname="e" oct="5" stem.len="0.000000" />
-                           <chord xml:id="s1l1_t5_2" type="mscore-beam-none" dur="8">
-                              <note xml:id="m3s1l1n1" pname="e" oct="5" />
-                              <note xml:id="m3s1l1n2" pname="g" oct="5" />
+                           <note xml:id="nekme74" dur="4" pname="e" oct="4" stem.len="0.000000" />
+                           <note xml:id="n2zero2" dur="4" pname="e" oct="5" stem.len="0.000000" />
+                           <chord xml:id="c14ojaey" type="mscore-beam-none" dur="8">
+                              <note xml:id="n1xjn0sp" pname="e" oct="5" />
+                              <note xml:id="n15p4jjf" pname="g" oct="5" />
                            </chord>
-                           <chord xml:id="s1l1_t21_8" type="mscore-beam-none" dur="8">
-                              <note xml:id="m3s1l1n3" pname="e" oct="4" />
-                              <note xml:id="m3s1l1n4" pname="g" oct="4" />
+                           <chord xml:id="c1wnppn4" type="mscore-beam-none" dur="8">
+                              <note xml:id="n3z50so" pname="e" oct="4" />
+                              <note xml:id="n1mdoapv" pname="g" oct="4" />
                            </chord>
-                           <chord xml:id="s1l1_t11_4" type="mscore-beam-none" dur="8" stem.dir="up">
-                              <note xml:id="m3s1l1n5" pname="e" oct="5" />
-                              <note xml:id="m3s1l1n6" pname="g" oct="5" />
+                           <chord xml:id="cql1g8h" type="mscore-beam-none" dur="8" stem.dir="up">
+                              <note xml:id="ntvmflq" pname="e" oct="5" />
+                              <note xml:id="n1y09tz2" pname="g" oct="5" />
                            </chord>
-                           <chord xml:id="s1l1_t23_8" type="mscore-beam-none" dur="8" stem.dir="down">
-                              <note xml:id="m3s1l1n7" pname="e" oct="4" />
-                              <note xml:id="m3s1l1n8" pname="g" oct="4" />
+                           <chord xml:id="c4zo5an" type="mscore-beam-none" dur="8" stem.dir="down">
+                              <note xml:id="n1aaaojp" pname="e" oct="4" />
+                              <note xml:id="n19njqm4" pname="g" oct="4" />
                            </chord>
                         </layer>
                      </staff>

--- a/src/importexport/mei/tests/data/stem-01.mscx
+++ b/src/importexport/mei/tests/data/stem-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer"></metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title/&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:19&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title/&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:54:15&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/tempo-01.mei
+++ b/src/importexport/mei/tests/data/tempo-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:20" />
+            <date isodate="2023-08-11T14:54:21" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -46,308 +46,308 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m125pgf3" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <note xml:id="s1l1_t0_1" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t1_4" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t1_2" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t3_4" dur="4" pname="b" oct="3" />
+                           <note xml:id="n1tvv7rf" dur="4" pname="c" oct="4" />
+                           <note xml:id="n1nl28gv" dur="4" pname="e" oct="4" />
+                           <note xml:id="n1t65xx9" dur="4" pname="g" oct="4" />
+                           <note xml:id="n7itcqf" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s2" n="2">
                         <layer xml:id="m1s2l1" n="1">
-                           <note xml:id="s2l1_t0_1" dur="2" pname="c" oct="4" />
-                           <note xml:id="s2l1_t1_2" dur="2" pname="g" oct="3" />
+                           <note xml:id="n10ho83e" dur="2" pname="c" oct="4" />
+                           <note xml:id="nrmm3ez" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
-                     <tempo xml:id="m1dn1" type="mscore-infer-from-text" startid="#s1l1_t0_1" midi.bpm="80.000000">
+                     <tempo xml:id="t19ctd6p" type="mscore-infer-from-text" startid="#n1tvv7rf" midi.bpm="80.000000">
                         <rend glyph.auth="smufl"></rend> = 80</tempo>
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="m1yzdfof" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <note xml:id="s1l1_t1_1" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t5_4" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t3_2" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t7_4" dur="4" pname="b" oct="3" />
+                           <note xml:id="n1bhkdyq" dur="4" pname="c" oct="4" />
+                           <note xml:id="n1jcthsq" dur="4" pname="e" oct="4" />
+                           <note xml:id="n1bjpmzs" dur="4" pname="g" oct="4" />
+                           <note xml:id="n1emup33" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s2" n="2">
                         <layer xml:id="m2s2l1" n="1">
-                           <note xml:id="s2l1_t1_1" dur="2" pname="c" oct="4" />
-                           <note xml:id="s2l1_t3_2" dur="2" pname="g" oct="3" />
+                           <note xml:id="nykxuk" dur="2" pname="c" oct="4" />
+                           <note xml:id="n1oc3itk" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
-                     <tempo xml:id="m2dn1" type="mscore-infer-from-text" startid="#s1l1_t1_1" midi.bpm="120.000000">
+                     <tempo xml:id="t1qcdn3j" type="mscore-infer-from-text" startid="#n1bhkdyq" midi.bpm="120.000000">
                         <rend glyph.auth="smufl"></rend> = 120</tempo>
                   </measure>
-                  <measure xml:id="m3" n="3">
+                  <measure xml:id="m1h89rz0" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <note xml:id="s1l1_t2_1" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t9_4" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t5_2" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t11_4" dur="4" pname="b" oct="3" />
+                           <note xml:id="n1oa6z4q" dur="4" pname="c" oct="4" />
+                           <note xml:id="n458jr2" dur="4" pname="e" oct="4" />
+                           <note xml:id="ncc1bry" dur="4" pname="g" oct="4" />
+                           <note xml:id="n19j3n51" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m3s2" n="2">
                         <layer xml:id="m3s2l1" n="1">
-                           <note xml:id="s2l1_t2_1" dur="2" pname="c" oct="4" />
-                           <note xml:id="s2l1_t5_2" dur="2" pname="g" oct="3" />
+                           <note xml:id="n16mv9vm" dur="2" pname="c" oct="4" />
+                           <note xml:id="n1rf6jms" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
-                     <tempo xml:id="m3dn1" type="mscore-infer-from-text" startid="#s1l1_t2_1" midi.bpm="160.000000">
+                     <tempo xml:id="td9e89e" type="mscore-infer-from-text" startid="#n1oa6z4q" midi.bpm="160.000000">
                         <rend glyph.auth="smufl"></rend> = 80</tempo>
                   </measure>
-                  <measure xml:id="m4" n="4">
+                  <measure xml:id="m13fajcg" n="4">
                      <staff xml:id="m4s1" n="1">
                         <layer xml:id="m4s1l1" n="1">
-                           <note xml:id="s1l1_t3_1" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t13_4" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t7_2" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t15_4" dur="4" pname="b" oct="3" />
+                           <note xml:id="n13wfzmo" dur="4" pname="c" oct="4" />
+                           <note xml:id="nxhosjx" dur="4" pname="e" oct="4" />
+                           <note xml:id="n12y9ym1" dur="4" pname="g" oct="4" />
+                           <note xml:id="n1y9ibaw" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m4s2" n="2">
                         <layer xml:id="m4s2l1" n="1">
-                           <note xml:id="s2l1_t3_1" dur="2" pname="c" oct="4" />
-                           <note xml:id="s2l1_t7_2" dur="2" pname="g" oct="3" />
+                           <note xml:id="n1f9b14h" dur="2" pname="c" oct="4" />
+                           <note xml:id="nt1fnmr" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
-                     <tempo xml:id="m4dn1" startid="#s1l1_t3_1" midi.bpm="172.000000">Vivace</tempo>
+                     <tempo xml:id="t1ydvqo1" startid="#n13wfzmo" midi.bpm="172.000000">Vivace</tempo>
                   </measure>
-                  <measure xml:id="m5" n="5">
+                  <measure xml:id="mti300x" n="5">
                      <staff xml:id="m5s1" n="1">
                         <layer xml:id="m5s1l1" n="1">
-                           <note xml:id="s1l1_t4_1" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t17_4" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t9_2" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t19_4" dur="4" pname="b" oct="3" />
+                           <note xml:id="n1jwj581" dur="4" pname="c" oct="4" />
+                           <note xml:id="n20socd" dur="4" pname="e" oct="4" />
+                           <note xml:id="n1e3if3i" dur="4" pname="g" oct="4" />
+                           <note xml:id="ndq2xrt" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m5s2" n="2">
                         <layer xml:id="m5s2l1" n="1">
-                           <note xml:id="s2l1_t4_1" dur="2" pname="c" oct="4" />
-                           <note xml:id="s2l1_t9_2" dur="2" pname="g" oct="3" />
+                           <note xml:id="n1or8891" dur="2" pname="c" oct="4" />
+                           <note xml:id="nk9ewxf" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
-                     <tempo xml:id="m5dn1" startid="#s1l1_t4_1" midi.bpm="187.000000">Presto</tempo>
+                     <tempo xml:id="t13pakdc" startid="#n1jwj581" midi.bpm="187.000000">Presto</tempo>
                   </measure>
-                  <measure xml:id="m6" n="6">
+                  <measure xml:id="m86cvw0" n="6">
                      <staff xml:id="m6s1" n="1">
                         <layer xml:id="m6s1l1" n="1">
-                           <note xml:id="s1l1_t5_1" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t21_4" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t11_2" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t23_4" dur="4" pname="b" oct="3" />
+                           <note xml:id="ntyy4dw" dur="4" pname="c" oct="4" />
+                           <note xml:id="n1el29gw" dur="4" pname="e" oct="4" />
+                           <note xml:id="n1l7r6x8" dur="4" pname="g" oct="4" />
+                           <note xml:id="n1ciauj9" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m6s2" n="2">
                         <layer xml:id="m6s2l1" n="1">
-                           <note xml:id="s2l1_t5_1" dur="2" pname="c" oct="4" />
-                           <note xml:id="s2l1_t11_2" dur="2" pname="g" oct="3" />
+                           <note xml:id="n1wvgdtj" dur="2" pname="c" oct="4" />
+                           <note xml:id="nxo2jts" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
-                     <tempo xml:id="m6dn1" type="mscore-infer-from-text" startid="#s1l1_t5_1" midi.bpm="120.000000">
+                     <tempo xml:id="t1pqrmiv" type="mscore-infer-from-text" startid="#ntyy4dw" midi.bpm="120.000000">
                         <rend glyph.auth="smufl"></rend> = <rend glyph.auth="smufl"></rend>
                      </tempo>
                   </measure>
-                  <measure xml:id="m7" n="7">
+                  <measure xml:id="mw97pc7" n="7">
                      <staff xml:id="m7s1" n="1">
                         <layer xml:id="m7s1l1" n="1">
-                           <note xml:id="s1l1_t6_1" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t25_4" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t13_2" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t27_4" dur="4" pname="b" oct="3" />
+                           <note xml:id="n1v3yffv" dur="4" pname="c" oct="4" />
+                           <note xml:id="ndanfqh" dur="4" pname="e" oct="4" />
+                           <note xml:id="n1ta9h50" dur="4" pname="g" oct="4" />
+                           <note xml:id="nk7vt42" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m7s2" n="2">
                         <layer xml:id="m7s2l1" n="1">
-                           <note xml:id="s2l1_t6_1" dur="2" pname="c" oct="4" />
-                           <note xml:id="s2l1_t13_2" dur="2" pname="g" oct="3" />
+                           <note xml:id="n4nnrpj" dur="2" pname="c" oct="4" />
+                           <note xml:id="nzl59q9" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
-                     <tempo xml:id="m7dn1" type="mscore-infer-from-text" startid="#s1l1_t6_1" midi.bpm="120.000000">
+                     <tempo xml:id="t1egyk2b" type="mscore-infer-from-text" startid="#n1v3yffv" midi.bpm="120.000000">
                         <rend glyph.auth="smufl"></rend> = <rend glyph.auth="smufl"></rend>
                      </tempo>
                   </measure>
-                  <measure xml:id="m8" n="8">
+                  <measure xml:id="mbbtc5t" n="8">
                      <staff xml:id="m8s1" n="1">
                         <layer xml:id="m8s1l1" n="1">
-                           <note xml:id="s1l1_t7_1" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t29_4" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t15_2" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t31_4" dur="4" pname="b" oct="3" />
+                           <note xml:id="n7yeykm" dur="4" pname="c" oct="4" />
+                           <note xml:id="np9x205" dur="4" pname="e" oct="4" />
+                           <note xml:id="n19yq3br" dur="4" pname="g" oct="4" />
+                           <note xml:id="n6nfplc" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m8s2" n="2">
                         <layer xml:id="m8s2l1" n="1">
-                           <note xml:id="s2l1_t7_1" dur="2" pname="c" oct="4" />
-                           <note xml:id="s2l1_t15_2" dur="2" pname="g" oct="3" />
+                           <note xml:id="n1kg5kgx" dur="2" pname="c" oct="4" />
+                           <note xml:id="nowkwf8" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
-                     <tempo xml:id="m8dn1" startid="#s1l1_t7_1" midi.bpm="92.000000">Andante (<rend glyph.auth="smufl"></rend> = 120)</tempo>
+                     <tempo xml:id="t16u6fwq" startid="#n7yeykm" midi.bpm="92.000000">Andante (<rend glyph.auth="smufl"></rend> = 120)</tempo>
                   </measure>
-                  <measure xml:id="m9" n="9">
+                  <measure xml:id="mdoorsi" n="9">
                      <staff xml:id="m9s1" n="1">
                         <layer xml:id="m9s1l1" n="1">
-                           <note xml:id="s1l1_t8_1" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t33_4" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t17_2" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t35_4" dur="4" pname="b" oct="3" />
+                           <note xml:id="n1gcf7s0" dur="4" pname="c" oct="4" />
+                           <note xml:id="ncac85s" dur="4" pname="e" oct="4" />
+                           <note xml:id="n9sezdo" dur="4" pname="g" oct="4" />
+                           <note xml:id="n1vshpj1" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m9s2" n="2">
                         <layer xml:id="m9s2l1" n="1">
-                           <note xml:id="s2l1_t8_1" dur="2" pname="c" oct="4" />
-                           <note xml:id="s2l1_t17_2" dur="2" pname="g" oct="3" />
+                           <note xml:id="n1feeddq" dur="2" pname="c" oct="4" />
+                           <note xml:id="n1a68few" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m10" n="10">
+                  <measure xml:id="m1q78bvy" n="10">
                      <staff xml:id="m10s1" n="1">
                         <layer xml:id="m10s1l1" n="1">
-                           <note xml:id="s1l1_t9_1" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t37_4" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t19_2" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t39_4" dur="4" pname="b" oct="3" />
+                           <note xml:id="n1q978pn" dur="4" pname="c" oct="4" />
+                           <note xml:id="n1e3vc63" dur="4" pname="e" oct="4" />
+                           <note xml:id="n1gdralm" dur="4" pname="g" oct="4" />
+                           <note xml:id="n1jynlsc" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m10s2" n="2">
                         <layer xml:id="m10s2l1" n="1">
-                           <note xml:id="s2l1_t9_1" dur="2" pname="c" oct="4" />
-                           <note xml:id="s2l1_t19_2" dur="2" pname="g" oct="3" />
+                           <note xml:id="nv7xb1t" dur="2" pname="c" oct="4" />
+                           <note xml:id="n18dmckz" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m11" n="11">
+                  <measure xml:id="m1iv19l9" n="11">
                      <staff xml:id="m11s1" n="1">
                         <layer xml:id="m11s1l1" n="1">
-                           <note xml:id="s1l1_t10_1" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t41_4" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t21_2" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t43_4" dur="4" pname="b" oct="3" />
+                           <note xml:id="ntxrxfe" dur="4" pname="c" oct="4" />
+                           <note xml:id="nygm8dc" dur="4" pname="e" oct="4" />
+                           <note xml:id="n1uo5ip4" dur="4" pname="g" oct="4" />
+                           <note xml:id="n1czpu50" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m11s2" n="2">
                         <layer xml:id="m11s2l1" n="1">
-                           <note xml:id="s2l1_t10_1" dur="2" pname="c" oct="4" />
-                           <note xml:id="s2l1_t21_2" dur="2" pname="g" oct="3" />
+                           <note xml:id="n1972ba9" dur="2" pname="c" oct="4" />
+                           <note xml:id="n1qeqm3x" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m12" n="12">
+                  <measure xml:id="mlez124" n="12">
                      <staff xml:id="m12s1" n="1">
                         <layer xml:id="m12s1l1" n="1">
-                           <note xml:id="s1l1_t11_1" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t45_4" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t23_2" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t47_4" dur="4" pname="b" oct="3" />
+                           <note xml:id="n1k00eln" dur="4" pname="c" oct="4" />
+                           <note xml:id="n19mjakx" dur="4" pname="e" oct="4" />
+                           <note xml:id="nkxg640" dur="4" pname="g" oct="4" />
+                           <note xml:id="nerfy9e" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m12s2" n="2">
                         <layer xml:id="m12s2l1" n="1">
-                           <note xml:id="s2l1_t11_1" dur="2" pname="c" oct="4" />
-                           <note xml:id="s2l1_t23_2" dur="2" pname="g" oct="3" />
+                           <note xml:id="n1w8v54n" dur="2" pname="c" oct="4" />
+                           <note xml:id="n7kifqj" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m13" n="13">
+                  <measure xml:id="m82rjgs" n="13">
                      <staff xml:id="m13s1" n="1">
                         <layer xml:id="m13s1l1" n="1">
-                           <note xml:id="s1l1_t12_1" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t49_4" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t25_2" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t51_4" dur="4" pname="b" oct="3" />
+                           <note xml:id="n139bhyx" dur="4" pname="c" oct="4" />
+                           <note xml:id="n16m04cw" dur="4" pname="e" oct="4" />
+                           <note xml:id="n6d1jk4" dur="4" pname="g" oct="4" />
+                           <note xml:id="n8pwt5c" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m13s2" n="2">
                         <layer xml:id="m13s2l1" n="1">
-                           <note xml:id="s2l1_t12_1" dur="2" pname="c" oct="4" />
-                           <note xml:id="s2l1_t25_2" dur="2" pname="g" oct="3" />
+                           <note xml:id="ngsfpjk" dur="2" pname="c" oct="4" />
+                           <note xml:id="nopyavo" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
-                     <tempo xml:id="m13dn1" startid="#s1l1_t12_1" midi.bpm="144.000000">Allegro<lb />molto</tempo>
+                     <tempo xml:id="t4t06bt" startid="#n139bhyx" midi.bpm="144.000000">Allegro<lb />molto</tempo>
                   </measure>
-                  <measure xml:id="m14" n="14">
+                  <measure xml:id="m1fq65a7" n="14">
                      <staff xml:id="m14s1" n="1">
                         <layer xml:id="m14s1l1" n="1">
-                           <note xml:id="s1l1_t13_1" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t53_4" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t27_2" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t55_4" dur="4" pname="b" oct="3" />
+                           <note xml:id="n1amebe5" dur="4" pname="c" oct="4" />
+                           <note xml:id="nmjnl8c" dur="4" pname="e" oct="4" />
+                           <note xml:id="nred3y8" dur="4" pname="g" oct="4" />
+                           <note xml:id="n18otw9" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m14s2" n="2">
                         <layer xml:id="m14s2l1" n="1">
-                           <note xml:id="s2l1_t13_1" dur="2" pname="c" oct="4" />
-                           <note xml:id="s2l1_t27_2" dur="2" pname="g" oct="3" />
+                           <note xml:id="n110lgxs" dur="2" pname="c" oct="4" />
+                           <note xml:id="nzgcaps" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
-                     <tempo xml:id="m14dn1" startid="#s1l1_t53_4" midi.bpm="172.000000">Vivace</tempo>
+                     <tempo xml:id="tm7hfns" startid="#nmjnl8c" midi.bpm="172.000000">Vivace</tempo>
                   </measure>
-                  <measure xml:id="m15" n="15">
+                  <measure xml:id="m6uij9w" n="15">
                      <staff xml:id="m15s1" n="1">
                         <layer xml:id="m15s1l1" n="1">
-                           <note xml:id="s1l1_t14_1" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t57_4" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t29_2" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t59_4" dur="4" pname="b" oct="3" />
+                           <note xml:id="nrfvyf4" dur="4" pname="c" oct="4" />
+                           <note xml:id="nineb8n" dur="4" pname="e" oct="4" />
+                           <note xml:id="nrf9l9q" dur="4" pname="g" oct="4" />
+                           <note xml:id="n13sotb5" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m15s2" n="2">
                         <layer xml:id="m15s2l1" n="1">
-                           <note xml:id="s2l1_t14_1" dur="2" pname="c" oct="4" />
-                           <note xml:id="s2l1_t29_2" dur="2" pname="g" oct="3" />
+                           <note xml:id="n1u69lj7" dur="2" pname="c" oct="4" />
+                           <note xml:id="nswwoun" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m16" n="16">
+                  <measure xml:id="m19spco8" n="16">
                      <staff xml:id="m16s1" n="1">
                         <layer xml:id="m16s1l1" n="1">
-                           <note xml:id="s1l1_t15_1" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t61_4" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t31_2" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t63_4" dur="4" pname="b" oct="3" />
+                           <note xml:id="n1u5r1qt" dur="4" pname="c" oct="4" />
+                           <note xml:id="n1701dye" dur="4" pname="e" oct="4" />
+                           <note xml:id="n1sow0rx" dur="4" pname="g" oct="4" />
+                           <note xml:id="n13t3gzp" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m16s2" n="2">
                         <layer xml:id="m16s2l1" n="1">
-                           <note xml:id="s2l1_t15_1" dur="2" pname="c" oct="4" />
-                           <note xml:id="s2l1_t31_2" dur="2" pname="g" oct="3" />
+                           <note xml:id="nywkjo" dur="2" pname="c" oct="4" />
+                           <note xml:id="n12s39xi" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m17" n="17">
+                  <measure xml:id="myqg3ka" n="17">
                      <staff xml:id="m17s1" n="1">
                         <layer xml:id="m17s1l1" n="1">
-                           <note xml:id="s1l1_t16_1" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t65_4" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t33_2" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t67_4" dur="4" pname="b" oct="3" />
+                           <note xml:id="n4gmtar" dur="4" pname="c" oct="4" />
+                           <note xml:id="n1nqjhkn" dur="4" pname="e" oct="4" />
+                           <note xml:id="n46h9pl" dur="4" pname="g" oct="4" />
+                           <note xml:id="n5ktu6d" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m17s2" n="2">
                         <layer xml:id="m17s2l1" n="1">
-                           <note xml:id="s2l1_t16_1" dur="2" pname="c" oct="4" />
-                           <note xml:id="s2l1_t33_2" dur="2" pname="g" oct="3" />
+                           <note xml:id="nzwjpwg" dur="2" pname="c" oct="4" />
+                           <note xml:id="n1ux4dba" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m18" right="end" n="18">
+                  <measure xml:id="mrv1kf9" right="end" n="18">
                      <staff xml:id="m18s1" n="1">
                         <layer xml:id="m18s1l1" n="1">
-                           <note xml:id="s1l1_t17_1" dur="4" pname="c" oct="4" />
-                           <note xml:id="s1l1_t69_4" dur="4" pname="e" oct="4" />
-                           <note xml:id="s1l1_t35_2" dur="4" pname="g" oct="4" />
-                           <note xml:id="s1l1_t71_4" dur="4" pname="b" oct="3" />
+                           <note xml:id="nlkxy0o" dur="4" pname="c" oct="4" />
+                           <note xml:id="nih5fh7" dur="4" pname="e" oct="4" />
+                           <note xml:id="n1wvj4j" dur="4" pname="g" oct="4" />
+                           <note xml:id="n1elfqev" dur="4" pname="b" oct="3" />
                         </layer>
                      </staff>
                      <staff xml:id="m18s2" n="2">
                         <layer xml:id="m18s2l1" n="1">
-                           <note xml:id="s2l1_t17_1" dur="2" pname="c" oct="4" />
-                           <note xml:id="s2l1_t35_2" dur="2" pname="g" oct="3" />
+                           <note xml:id="nwg7vp9" dur="2" pname="c" oct="4" />
+                           <note xml:id="n1tq1emt" dur="2" pname="g" oct="3" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/tempo-01.mscx
+++ b/src/importexport/mei/tests/data/tempo-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:20&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:54:21&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/tie-01.mei
+++ b/src/importexport/mei/tests/data/tie-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:21" />
+            <date isodate="2023-08-11T14:54:27" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -44,88 +44,88 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m15hfppn" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <rest xml:id="s1l1_t0_1" dur="16" />
-                           <beam xml:id="m1s1l1b1">
-                              <note xml:id="s1l1_t1_16" dur="16" pname="c" oct="5" />
-                              <note xml:id="s1l1_t1_8" dur="16" pname="g" oct="4" />
-                              <note xml:id="s1l1_t3_16" dur="16" pname="e" oct="4" />
+                           <rest xml:id="rznumim" dur="16" />
+                           <beam>
+                              <note xml:id="n4r2wip" dur="16" pname="c" oct="5" />
+                              <note xml:id="n20xtwd" dur="16" pname="g" oct="4" />
+                              <note xml:id="nyow3yo" dur="16" pname="e" oct="4" />
                            </beam>
-                           <chord xml:id="s1l1_t1_4" dur="4">
-                              <note xml:id="m1s1l1n1" pname="c" oct="4" />
-                              <note xml:id="m1s1l1n2" pname="e" oct="4" />
-                              <note xml:id="m1s1l1n3" pname="g" oct="4" />
-                              <note xml:id="m1s1l1n4" pname="c" oct="5" />
+                           <chord xml:id="cyxp7c6" dur="4">
+                              <note xml:id="n1s6kmbt" pname="c" oct="4" />
+                              <note xml:id="n1jwxrvj" pname="e" oct="4" />
+                              <note xml:id="ng2bykb" pname="g" oct="4" />
+                              <note xml:id="n1knbq7h" pname="c" oct="5" />
                            </chord>
                         </layer>
                      </staff>
                      <staff xml:id="m1s2" n="2">
                         <layer xml:id="m1s2l1" n="1">
-                           <mRest xml:id="s2l1_t0_1" />
+                           <mRest xml:id="m1r960bj" />
                         </layer>
                      </staff>
-                     <tie xml:id="m1ti1" startid="#s1l1_t1_16" curvedir="above" endid="#m1s1l1n4" />
-                     <tie xml:id="m1ti2" startid="#s1l1_t1_8" curvedir="above" endid="#m1s1l1n3" />
-                     <tie xml:id="m1ti3" startid="#s1l1_t3_16" lform="dotted" endid="#m1s1l1n2" />
-                     <tie xml:id="m1ti4" startid="#m1s1l1n1" lform="dashed" endid="#m2s1l1n1" />
-                     <tie xml:id="m1ti5" startid="#m1s1l1n2" lform="dotted" endid="#m2s1l1n2" />
-                     <tie xml:id="m1ti6" startid="#m1s1l1n3" endid="#m2s1l1n3" />
-                     <tie xml:id="m1ti7" startid="#m1s1l1n4" endid="#m2s1l1n4" />
+                     <tie xml:id="t8agmui" startid="#n4r2wip" curvedir="above" endid="#n1knbq7h" />
+                     <tie xml:id="txk0b" startid="#n20xtwd" curvedir="above" endid="#ng2bykb" />
+                     <tie xml:id="t1svmikp" startid="#nyow3yo" lform="dotted" endid="#n1jwxrvj" />
+                     <tie xml:id="t1gmiqnr" startid="#n1s6kmbt" lform="dashed" endid="#n1txktcp" />
+                     <tie xml:id="t1jsqmt8" startid="#n1jwxrvj" lform="dotted" endid="#n1sarm1h" />
+                     <tie xml:id="t192njbk" startid="#ng2bykb" endid="#n1ws2r51" />
+                     <tie xml:id="t1sv8xxu" startid="#n1knbq7h" endid="#n107nooj" />
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="medbfal" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <chord xml:id="s1l1_t1_2" dur="4">
-                              <note xml:id="m2s1l1n1" pname="c" oct="4" />
-                              <note xml:id="m2s1l1n2" pname="e" oct="4" />
-                              <note xml:id="m2s1l1n3" pname="g" oct="4" />
-                              <note xml:id="m2s1l1n4" pname="c" oct="5" />
+                           <chord xml:id="c1duegqi" dur="4">
+                              <note xml:id="n1txktcp" pname="c" oct="4" />
+                              <note xml:id="n1sarm1h" pname="e" oct="4" />
+                              <note xml:id="n1ws2r51" pname="g" oct="4" />
+                              <note xml:id="n107nooj" pname="c" oct="5" />
                            </chord>
-                           <chord xml:id="s1l1_t3_4" dur="4">
-                              <note xml:id="m2s1l1n5" pname="c" oct="4" />
-                              <note xml:id="m2s1l1n6" pname="e" oct="4" />
-                              <note xml:id="m2s1l1n7" pname="g" oct="4" />
-                              <note xml:id="m2s1l1n8" pname="c" oct="5" />
+                           <chord xml:id="c10ss3qn" dur="4">
+                              <note xml:id="n10m6l4h" pname="c" oct="4" />
+                              <note xml:id="nfrpgyk" pname="e" oct="4" />
+                              <note xml:id="nutljvw" pname="g" oct="4" />
+                              <note xml:id="n138c9a2" pname="c" oct="5" />
                            </chord>
                         </layer>
                      </staff>
                      <staff xml:id="m2s2" n="2">
                         <layer xml:id="m2s2l1" n="1">
-                           <mRest xml:id="s2l1_t1_2" />
+                           <mRest xml:id="mg8kcsi" />
                         </layer>
                      </staff>
-                     <tie xml:id="m2ti1" startid="#m2s1l1n5" lform="dashed" endid="#m3s1l1n1" />
-                     <tie xml:id="m2ti2" startid="#m2s1l1n6" lform="dotted" endid="#m3s1l1n2" />
-                     <tie xml:id="m2ti3" startid="#m2s1l1n7" endid="#m3s1l1n3" />
-                     <tie xml:id="m2ti4" startid="#m2s1l1n8" endid="#m3s1l1n4" />
+                     <tie xml:id="t18lz0e4" startid="#n10m6l4h" lform="dashed" endid="#nsiio7j" />
+                     <tie xml:id="tpbm6pt" startid="#nfrpgyk" lform="dotted" endid="#n1860de0" />
+                     <tie xml:id="t6ra7pa" startid="#nutljvw" endid="#na1020w" />
+                     <tie xml:id="t1b1jb92" startid="#n138c9a2" endid="#naonwnf" />
                   </measure>
-                  <measure xml:id="m3" right="end" n="3">
+                  <measure xml:id="m1fnxvbi" right="end" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <chord xml:id="s1l1_t1_1" dur="4">
-                              <note xml:id="m3s1l1n1" pname="c" oct="4" />
-                              <note xml:id="m3s1l1n2" pname="e" oct="4" />
-                              <note xml:id="m3s1l1n3" pname="g" oct="4" />
-                              <note xml:id="m3s1l1n4" pname="c" oct="5" />
+                           <chord xml:id="c1hsz5rq" dur="4">
+                              <note xml:id="nsiio7j" pname="c" oct="4" />
+                              <note xml:id="n1860de0" pname="e" oct="4" />
+                              <note xml:id="na1020w" pname="g" oct="4" />
+                              <note xml:id="naonwnf" pname="c" oct="5" />
                            </chord>
-                           <beam xml:id="m3s1l1b1">
-                              <note xml:id="s1l1_t5_4" dur="16" pname="e" oct="4" />
-                              <note xml:id="s1l1_t21_16" dur="16" pname="g" oct="4" />
-                              <note xml:id="s1l1_t11_8" dur="16" pname="c" oct="5" />
+                           <beam>
+                              <note xml:id="n110j8gp" dur="16" pname="e" oct="4" />
+                              <note xml:id="n1f90ozx" dur="16" pname="g" oct="4" />
+                              <note xml:id="nw5atoz" dur="16" pname="c" oct="5" />
                            </beam>
-                           <rest xml:id="s1l1_t23_16" dur="16" />
+                           <rest xml:id="r1ie874s" dur="16" />
                         </layer>
                      </staff>
                      <staff xml:id="m3s2" n="2">
                         <layer xml:id="m3s2l1" n="1">
-                           <mRest xml:id="s2l1_t1_1" />
+                           <mRest xml:id="m2q0bof" />
                         </layer>
                      </staff>
-                     <tie xml:id="m3ti1" startid="#m3s1l1n2" lform="dotted" endid="#s1l1_t5_4" />
-                     <tie xml:id="m3ti2" startid="#m3s1l1n3" curvedir="above" endid="#s1l1_t21_16" />
-                     <tie xml:id="m3ti3" startid="#m3s1l1n4" endid="#s1l1_t11_8" />
+                     <tie xml:id="t18l6fg3" startid="#n1860de0" lform="dotted" endid="#n110j8gp" />
+                     <tie xml:id="t497zlb" startid="#na1020w" curvedir="above" endid="#n1f90ozx" />
+                     <tie xml:id="t5rvqg7" startid="#naonwnf" endid="#nw5atoz" />
                   </measure>
                </section>
             </score>

--- a/src/importexport/mei/tests/data/tie-01.mscx
+++ b/src/importexport/mei/tests/data/tie-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:21&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:54:27&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/time-signature-01.mei
+++ b/src/importexport/mei/tests/data/time-signature-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:23" />
+            <date isodate="2023-08-11T14:54:33" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -33,86 +33,86 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="msi0v3b" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <note xml:id="s1l1_t0_1" dur="1" pname="g" oct="4" />
+                           <note xml:id="n92rcwp" dur="1" pname="g" oct="4" />
                         </layer>
                      </staff>
                   </measure>
                   <scoreDef meter.count="2" meter.unit="4" />
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="mjf4khp" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <note xml:id="s1l1_t1_1" dur="2" pname="a" oct="4" stem.dir="up" />
+                           <note xml:id="n1y5d16w" dur="2" pname="a" oct="4" stem.dir="up" />
                         </layer>
                      </staff>
                   </measure>
                   <scoreDef meter.count="3" meter.unit="4" />
-                  <measure xml:id="m3" n="3">
+                  <measure xml:id="m1hyy44h" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <note xml:id="s1l1_t3_2" dots="1" dur="2" pname="b" oct="4" stem.dir="down" />
+                           <note xml:id="n8wgnrk" dots="1" dur="2" pname="b" oct="4" stem.dir="down" />
                         </layer>
                      </staff>
                   </measure>
                   <scoreDef meter.count="4" meter.unit="4" />
-                  <measure xml:id="m4" n="4">
+                  <measure xml:id="m1781jzb" n="4">
                      <staff xml:id="m4s1" n="1">
                         <layer xml:id="m4s1l1" n="1">
-                           <note xml:id="s1l1_t9_4" dur="1" pname="c" oct="5" />
+                           <note xml:id="n1rn1qyi" dur="1" pname="c" oct="5" />
                         </layer>
                      </staff>
                   </measure>
                   <scoreDef meter.count="5" meter.unit="4" />
-                  <measure xml:id="m5" n="5">
+                  <measure xml:id="mrs15zs" n="5">
                      <staff xml:id="m5s1" n="1">
                         <layer xml:id="m5s1l1" n="1">
-                           <note xml:id="s1l1_t13_4" dur="1" pname="g" oct="4" />
-                           <note xml:id="s1l1_t17_4" dur="4" pname="g" oct="4" stem.dir="up" />
+                           <note xml:id="n1t1bdaf" dur="1" pname="g" oct="4" />
+                           <note xml:id="n1nk1cjw" dur="4" pname="g" oct="4" stem.dir="up" />
                         </layer>
                      </staff>
                   </measure>
                   <scoreDef meter.count="6" meter.unit="4" />
-                  <measure xml:id="m6" n="6">
+                  <measure xml:id="m16hotqd" n="6">
                      <staff xml:id="m6s1" n="1">
                         <layer xml:id="m6s1l1" n="1">
-                           <note xml:id="s1l1_t9_2" dur="1" pname="a" oct="4" />
-                           <note xml:id="s1l1_t11_2" dur="2" pname="a" oct="4" stem.dir="up" />
+                           <note xml:id="nftdx6" dur="1" pname="a" oct="4" />
+                           <note xml:id="n9kcrv5" dur="2" pname="a" oct="4" stem.dir="up" />
                         </layer>
                      </staff>
                   </measure>
                   <scoreDef meter.count="3" meter.unit="8" />
-                  <measure xml:id="m7" n="7">
+                  <measure xml:id="m1hp0g0d" n="7">
                      <staff xml:id="m7s1" n="1">
                         <layer xml:id="m7s1l1" n="1">
-                           <note xml:id="s1l1_t6_1" dots="1" dur="4" pname="b" oct="4" stem.dir="down" />
+                           <note xml:id="n1heyg3p" dots="1" dur="4" pname="b" oct="4" stem.dir="down" />
                         </layer>
                      </staff>
                   </measure>
                   <scoreDef meter.count="6" meter.unit="8" />
-                  <measure xml:id="m8" n="8">
+                  <measure xml:id="m4v7pqs" n="8">
                      <staff xml:id="m8s1" n="1">
                         <layer xml:id="m8s1l1" n="1">
-                           <note xml:id="s1l1_t51_8" dots="1" dur="2" pname="c" oct="5" stem.dir="down" />
+                           <note xml:id="n1qxgiuc" dots="1" dur="2" pname="c" oct="5" stem.dir="down" />
                         </layer>
                      </staff>
                   </measure>
                   <scoreDef meter.count="9" meter.unit="8" />
-                  <measure xml:id="m9" n="9">
+                  <measure xml:id="m1byfbm4" n="9">
                      <staff xml:id="m9s1" n="1">
                         <layer xml:id="m9s1l1" n="1">
-                           <note xml:id="s1l1_t57_8" dur="1" pname="g" oct="4" />
-                           <note xml:id="s1l1_t65_8" dur="8" pname="g" oct="4" stem.dir="up" />
+                           <note xml:id="n169dnyf" dur="1" pname="g" oct="4" />
+                           <note xml:id="nvyulon" dur="8" pname="g" oct="4" stem.dir="up" />
                         </layer>
                      </staff>
                   </measure>
                   <scoreDef meter.count="12" meter.unit="8" />
-                  <measure xml:id="m10" n="10">
+                  <measure xml:id="muxu9b" n="10">
                      <staff xml:id="m10s1" n="1">
                         <layer xml:id="m10s1l1" n="1">
-                           <note xml:id="s1l1_t33_4" dur="1" pname="a" oct="4" />
-                           <note xml:id="s1l1_t37_4" dur="2" pname="a" oct="4" stem.dir="up" />
+                           <note xml:id="nvsucav" dur="1" pname="a" oct="4" />
+                           <note xml:id="n1e8hxao" dur="2" pname="a" oct="4" stem.dir="up" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/time-signature-01.mscx
+++ b/src/importexport/mei/tests/data/time-signature-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Leon Vinken</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Time Signature 1&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Leon Vinken&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:23&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Time Signature 1&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Leon Vinken&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:54:33&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/time-signature-02.mei
+++ b/src/importexport/mei/tests/data/time-signature-02.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:24" />
+            <date isodate="2023-08-11T14:54:39" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -44,15 +44,15 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="m1udwisy" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <mRest xml:id="s1l1_t0_1" />
+                           <mRest xml:id="m1se76j6" />
                         </layer>
                      </staff>
                      <staff xml:id="m1s2" n="2">
                         <layer xml:id="m1s2l1" n="1">
-                           <mRest xml:id="s2l1_t0_1" />
+                           <mRest xml:id="m1w7x40x" />
                         </layer>
                      </staff>
                   </measure>
@@ -62,15 +62,15 @@
                         <staffDef n="2" meter.count="3" meter.unit="4" />
                      </staffGrp>
                   </scoreDef>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="m15c4kr" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <mRest xml:id="s1l1_t3_4" />
+                           <mRest xml:id="m118ury3" />
                         </layer>
                      </staff>
                      <staff xml:id="m2s2" n="2">
                         <layer xml:id="m2s2l1" n="1">
-                           <mRest xml:id="s2l1_t3_4" />
+                           <mRest xml:id="m1dl6ejk" />
                         </layer>
                      </staff>
                   </measure>
@@ -80,28 +80,28 @@
                         <staffDef n="2" />
                      </staffGrp>
                   </scoreDef>
-                  <measure xml:id="m3" n="3">
+                  <measure xml:id="m1bp277z" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <mRest xml:id="s1l1_t3_2" />
+                           <mRest xml:id="mmr0oxr" />
                         </layer>
                      </staff>
                      <staff xml:id="m3s2" n="2">
                         <layer xml:id="m3s2l1" n="1">
-                           <mRest xml:id="s2l1_t3_2" />
+                           <mRest xml:id="mqazjtt" />
                         </layer>
                      </staff>
                   </measure>
                   <scoreDef meter.count="4" meter.unit="4" />
-                  <measure xml:id="m4" n="4">
+                  <measure xml:id="mv9pxxt" n="4">
                      <staff xml:id="m4s1" n="1">
                         <layer xml:id="m4s1l1" n="1">
-                           <mRest xml:id="s1l1_t9_4" />
+                           <mRest xml:id="m1n5jpbz" />
                         </layer>
                      </staff>
                      <staff xml:id="m4s2" n="2">
                         <layer xml:id="m4s2l1" n="1">
-                           <mRest xml:id="s2l1_t9_4" />
+                           <mRest xml:id="mszj461" />
                         </layer>
                      </staff>
                   </measure>
@@ -111,28 +111,28 @@
                         <staffDef n="2" meter.count="4" meter.unit="8" />
                      </staffGrp>
                   </scoreDef>
-                  <measure xml:id="m5" n="5">
+                  <measure xml:id="m1ke1zp2" n="5">
                      <staff xml:id="m5s1" n="1">
                         <layer xml:id="m5s1l1" n="1">
-                           <mRest xml:id="s1l1_t13_4" />
+                           <mRest xml:id="m1fnay8u" />
                         </layer>
                      </staff>
                      <staff xml:id="m5s2" n="2">
                         <layer xml:id="m5s2l1" n="1">
-                           <mRest xml:id="s2l1_t13_4" />
+                           <mRest xml:id="mgqolcz" />
                         </layer>
                      </staff>
                   </measure>
                   <scoreDef meter.count="3" meter.unit="4" />
-                  <measure xml:id="m6" right="end" n="6">
+                  <measure xml:id="m1ugj75w" right="end" n="6">
                      <staff xml:id="m6s1" n="1">
                         <layer xml:id="m6s1l1" n="1">
-                           <mRest xml:id="s1l1_t15_4" />
+                           <mRest xml:id="mnr71lf" />
                         </layer>
                      </staff>
                      <staff xml:id="m6s2" n="2">
                         <layer xml:id="m6s2l1" n="1">
-                           <mRest xml:id="s2l1_t15_4" />
+                           <mRest xml:id="m1msxel2" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/time-signature-02.mscx
+++ b/src/importexport/mei/tests/data/time-signature-02.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:24&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:54:39&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/transpose-01.mei
+++ b/src/importexport/mei/tests/data/transpose-01.mei
@@ -11,7 +11,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:25" />
+            <date isodate="2023-08-11T14:54:46" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -63,260 +63,260 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="mqnlyuq" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <note xml:id="s1l1_t0_1" dur="2" pname="c" oct="5" />
-                           <note xml:id="s1l1_t1_2" dur="4" pname="g" oct="4" />
-                           <beam xml:id="m1s1l1b1">
-                              <note xml:id="s1l1_t3_4" dur="8" pname="a" oct="4" />
-                              <note xml:id="s1l1_t7_8" dur="8" pname="b" oct="4" />
+                           <note xml:id="nera4q4" dur="2" pname="c" oct="5" />
+                           <note xml:id="nl4p5ba" dur="4" pname="g" oct="4" />
+                           <beam>
+                              <note xml:id="nhyqr7i" dur="8" pname="a" oct="4" />
+                              <note xml:id="n1snqbzg" dur="8" pname="b" oct="4" />
                            </beam>
                         </layer>
                      </staff>
                      <staff xml:id="m1s2" n="2">
                         <layer xml:id="m1s2l1" n="1">
-                           <note xml:id="s2l1_t0_1" dur="2" pname="d" oct="5" />
-                           <note xml:id="s2l1_t1_2" dur="4" pname="a" oct="4" />
-                           <beam xml:id="m1s2l1b1">
-                              <note xml:id="s2l1_t3_4" dur="8" pname="b" oct="4" />
-                              <note xml:id="s2l1_t7_8" dur="8" pname="c" oct="5">
-                                 <accid xml:id="m1s2l1a1" accid.ges="s" />
+                           <note xml:id="nbi6t11" dur="2" pname="d" oct="5" />
+                           <note xml:id="nuu22zp" dur="4" pname="a" oct="4" />
+                           <beam>
+                              <note xml:id="nc1fes7" dur="8" pname="b" oct="4" />
+                              <note xml:id="n189z8nb" dur="8" pname="c" oct="5">
+                                 <accid accid.ges="s" />
                               </note>
                            </beam>
                         </layer>
                      </staff>
                      <staff xml:id="m1s3" n="3">
                         <layer xml:id="m1s3l1" n="1">
-                           <note xml:id="s3l1_t0_1" dur="2" pname="g" oct="5" />
-                           <note xml:id="s3l1_t1_2" dur="4" pname="d" oct="5" />
-                           <beam xml:id="m1s3l1b1">
-                              <note xml:id="s3l1_t3_4" dur="8" pname="e" oct="5" />
-                              <note xml:id="s3l1_t7_8" dur="8" pname="f" oct="5">
-                                 <accid xml:id="m1s3l1a1" accid.ges="s" />
+                           <note xml:id="n10ran9l" dur="2" pname="g" oct="5" />
+                           <note xml:id="n1avhl7" dur="4" pname="d" oct="5" />
+                           <beam>
+                              <note xml:id="n13s2y36" dur="8" pname="e" oct="5" />
+                              <note xml:id="n1kdbqaf" dur="8" pname="f" oct="5">
+                                 <accid accid.ges="s" />
                               </note>
                            </beam>
                         </layer>
                      </staff>
                      <staff xml:id="m1s4" n="4">
                         <layer xml:id="m1s4l1" n="1">
-                           <note xml:id="s4l1_t0_1" dur="2" pname="d" oct="5" />
-                           <note xml:id="s4l1_t1_2" dur="4" pname="a" oct="4" />
-                           <beam xml:id="m1s4l1b1">
-                              <note xml:id="s4l1_t3_4" dur="8" pname="b" oct="4" />
-                              <note xml:id="s4l1_t7_8" dur="8" pname="c" oct="5">
-                                 <accid xml:id="m1s4l1a1" accid.ges="s" />
+                           <note xml:id="ncuobrk" dur="2" pname="d" oct="5" />
+                           <note xml:id="n1msl7vo" dur="4" pname="a" oct="4" />
+                           <beam>
+                              <note xml:id="nokvmuo" dur="8" pname="b" oct="4" />
+                              <note xml:id="n19hc13q" dur="8" pname="c" oct="5">
+                                 <accid accid.ges="s" />
                               </note>
                            </beam>
                         </layer>
                      </staff>
                      <staff xml:id="m1s5" n="5">
                         <layer xml:id="m1s5l1" n="1">
-                           <note xml:id="s5l1_t0_1" dur="2" pname="c" oct="4" />
-                           <note xml:id="s5l1_t1_2" dur="4" pname="g" oct="3" />
-                           <beam xml:id="m1s5l1b1">
-                              <note xml:id="s5l1_t3_4" dur="8" pname="a" oct="3" />
-                              <note xml:id="s5l1_t7_8" dur="8" pname="b" oct="3" />
+                           <note xml:id="nypeab2" dur="2" pname="c" oct="4" />
+                           <note xml:id="nh6lui1" dur="4" pname="g" oct="3" />
+                           <beam>
+                              <note xml:id="n15hj5ye" dur="8" pname="a" oct="3" />
+                              <note xml:id="n8am48i" dur="8" pname="b" oct="3" />
                            </beam>
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="mfb1nn6" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <beam xml:id="m2s1l1b1">
-                              <note xml:id="s1l1_t1_1" dur="8" pname="c" oct="5" />
-                              <note xml:id="s1l1_t9_8" dur="8" pname="b" oct="4" />
-                              <note xml:id="s1l1_t5_4" dur="8" pname="a" oct="4">
-                                 <accid xml:id="m2s1l1a1" accid="s" />
+                           <beam>
+                              <note xml:id="n116r3lw" dur="8" pname="c" oct="5" />
+                              <note xml:id="ni6nsrz" dur="8" pname="b" oct="4" />
+                              <note xml:id="n1lk0761" dur="8" pname="a" oct="4">
+                                 <accid accid="s" />
                               </note>
-                              <note xml:id="s1l1_t11_8" dur="8" pname="a" oct="4">
-                                 <accid xml:id="m2s1l1a2" accid="n" />
+                              <note xml:id="n1n1tmij" dur="8" pname="a" oct="4">
+                                 <accid accid="n" />
                               </note>
                            </beam>
-                           <beam xml:id="m2s1l1b2">
-                              <note xml:id="s1l1_t3_2" dur="8" pname="g" oct="4">
-                                 <accid xml:id="m2s1l1a3" accid="s" />
+                           <beam>
+                              <note xml:id="n1gefkcj" dur="8" pname="g" oct="4">
+                                 <accid accid="s" />
                               </note>
-                              <note xml:id="s1l1_t13_8" dur="8" pname="g" oct="4">
-                                 <accid xml:id="m2s1l1a4" accid="n" />
+                              <note xml:id="n152o62e" dur="8" pname="g" oct="4">
+                                 <accid accid="n" />
                               </note>
-                              <note xml:id="s1l1_t7_4" dur="8" pname="g" oct="4">
-                                 <accid xml:id="m2s1l1a5" accid="s" />
+                              <note xml:id="nisxtwt" dur="8" pname="g" oct="4">
+                                 <accid accid="s" />
                               </note>
-                              <note xml:id="s1l1_t15_8" dur="8" pname="g" oct="4">
-                                 <accid xml:id="m2s1l1a6" accid="x" />
+                              <note xml:id="n1thnwdu" dur="8" pname="g" oct="4">
+                                 <accid accid="x" />
                               </note>
                            </beam>
                         </layer>
                      </staff>
                      <staff xml:id="m2s2" n="2">
                         <layer xml:id="m2s2l1" n="1">
-                           <beam xml:id="m2s2l1b1">
-                              <note xml:id="s2l1_t1_1" dur="8" pname="d" oct="5" />
-                              <note xml:id="s2l1_t9_8" dur="8" pname="c" oct="5">
-                                 <accid xml:id="m2s2l1a1" accid.ges="s" />
+                           <beam>
+                              <note xml:id="novz8rp" dur="8" pname="d" oct="5" />
+                              <note xml:id="n1qhngq0" dur="8" pname="c" oct="5">
+                                 <accid accid.ges="s" />
                               </note>
-                              <note xml:id="s2l1_t5_4" dur="8" pname="b" oct="4">
-                                 <accid xml:id="m2s2l1a2" accid="s" />
+                              <note xml:id="n1dj9v5s" dur="8" pname="b" oct="4">
+                                 <accid accid="s" />
                               </note>
-                              <note xml:id="s2l1_t11_8" dur="8" pname="b" oct="4">
-                                 <accid xml:id="m2s2l1a3" accid="n" />
+                              <note xml:id="n1a4jpry" dur="8" pname="b" oct="4">
+                                 <accid accid="n" />
                               </note>
                            </beam>
-                           <beam xml:id="m2s2l1b2">
-                              <note xml:id="s2l1_t3_2" dur="8" pname="a" oct="4">
-                                 <accid xml:id="m2s2l1a4" accid="s" />
+                           <beam>
+                              <note xml:id="n1hmy54d" dur="8" pname="a" oct="4">
+                                 <accid accid="s" />
                               </note>
-                              <note xml:id="s2l1_t13_8" dur="8" pname="a" oct="4">
-                                 <accid xml:id="m2s2l1a5" accid="n" />
+                              <note xml:id="nyc8u1y" dur="8" pname="a" oct="4">
+                                 <accid accid="n" />
                               </note>
-                              <note xml:id="s2l1_t7_4" dur="8" pname="a" oct="4">
-                                 <accid xml:id="m2s2l1a6" accid="s" />
+                              <note xml:id="n15ce54w" dur="8" pname="a" oct="4">
+                                 <accid accid="s" />
                               </note>
-                              <note xml:id="s2l1_t15_8" dur="8" pname="a" oct="4">
-                                 <accid xml:id="m2s2l1a7" accid="x" />
+                              <note xml:id="nawutlp" dur="8" pname="a" oct="4">
+                                 <accid accid="x" />
                               </note>
                            </beam>
                         </layer>
                      </staff>
                      <staff xml:id="m2s3" n="3">
                         <layer xml:id="m2s3l1" n="1">
-                           <beam xml:id="m2s3l1b1">
-                              <note xml:id="s3l1_t1_1" dur="8" pname="g" oct="5" />
-                              <note xml:id="s3l1_t9_8" dur="8" pname="f" oct="5">
-                                 <accid xml:id="m2s3l1a1" accid.ges="s" />
+                           <beam>
+                              <note xml:id="n1u2os2z" dur="8" pname="g" oct="5" />
+                              <note xml:id="n1eflwzv" dur="8" pname="f" oct="5">
+                                 <accid accid.ges="s" />
                               </note>
-                              <note xml:id="s3l1_t5_4" dur="8" pname="e" oct="5">
-                                 <accid xml:id="m2s3l1a2" accid="s" />
+                              <note xml:id="n1dwhpdu" dur="8" pname="e" oct="5">
+                                 <accid accid="s" />
                               </note>
-                              <note xml:id="s3l1_t11_8" dur="8" pname="e" oct="5">
-                                 <accid xml:id="m2s3l1a3" accid="n" />
+                              <note xml:id="nmnn9fj" dur="8" pname="e" oct="5">
+                                 <accid accid="n" />
                               </note>
                            </beam>
-                           <beam xml:id="m2s3l1b2">
-                              <note xml:id="s3l1_t3_2" dur="8" pname="d" oct="5">
-                                 <accid xml:id="m2s3l1a4" accid="s" />
+                           <beam>
+                              <note xml:id="n7ib3bd" dur="8" pname="d" oct="5">
+                                 <accid accid="s" />
                               </note>
-                              <note xml:id="s3l1_t13_8" dur="8" pname="d" oct="5">
-                                 <accid xml:id="m2s3l1a5" accid="n" />
+                              <note xml:id="n1vy649g" dur="8" pname="d" oct="5">
+                                 <accid accid="n" />
                               </note>
-                              <note xml:id="s3l1_t7_4" dur="8" pname="d" oct="5">
-                                 <accid xml:id="m2s3l1a6" accid="s" />
+                              <note xml:id="nhfxijr" dur="8" pname="d" oct="5">
+                                 <accid accid="s" />
                               </note>
-                              <note xml:id="s3l1_t15_8" dur="8" pname="d" oct="5">
-                                 <accid xml:id="m2s3l1a7" accid="x" />
+                              <note xml:id="n2g2ur5" dur="8" pname="d" oct="5">
+                                 <accid accid="x" />
                               </note>
                            </beam>
                         </layer>
                      </staff>
                      <staff xml:id="m2s4" n="4">
                         <layer xml:id="m2s4l1" n="1">
-                           <beam xml:id="m2s4l1b1">
-                              <note xml:id="s4l1_t1_1" dur="8" pname="d" oct="5" />
-                              <note xml:id="s4l1_t9_8" dur="8" pname="c" oct="5">
-                                 <accid xml:id="m2s4l1a1" accid.ges="s" />
+                           <beam>
+                              <note xml:id="nwylyem" dur="8" pname="d" oct="5" />
+                              <note xml:id="nd228b1" dur="8" pname="c" oct="5">
+                                 <accid accid.ges="s" />
                               </note>
-                              <note xml:id="s4l1_t5_4" dur="8" pname="b" oct="4">
-                                 <accid xml:id="m2s4l1a2" accid="s" />
+                              <note xml:id="nagx725" dur="8" pname="b" oct="4">
+                                 <accid accid="s" />
                               </note>
-                              <note xml:id="s4l1_t11_8" dur="8" pname="b" oct="4">
-                                 <accid xml:id="m2s4l1a3" accid="n" />
+                              <note xml:id="n7e5iu3" dur="8" pname="b" oct="4">
+                                 <accid accid="n" />
                               </note>
                            </beam>
-                           <beam xml:id="m2s4l1b2">
-                              <note xml:id="s4l1_t3_2" dur="8" pname="a" oct="4">
-                                 <accid xml:id="m2s4l1a4" accid="s" />
+                           <beam>
+                              <note xml:id="nfsvf2o" dur="8" pname="a" oct="4">
+                                 <accid accid="s" />
                               </note>
-                              <note xml:id="s4l1_t13_8" dur="8" pname="a" oct="4">
-                                 <accid xml:id="m2s4l1a5" accid="n" />
+                              <note xml:id="n1ma0f66" dur="8" pname="a" oct="4">
+                                 <accid accid="n" />
                               </note>
-                              <note xml:id="s4l1_t7_4" dur="8" pname="a" oct="4">
-                                 <accid xml:id="m2s4l1a6" accid="s" />
+                              <note xml:id="n15v8uom" dur="8" pname="a" oct="4">
+                                 <accid accid="s" />
                               </note>
-                              <note xml:id="s4l1_t15_8" dur="8" pname="a" oct="4">
-                                 <accid xml:id="m2s4l1a7" accid="x" />
+                              <note xml:id="ngo4hjv" dur="8" pname="a" oct="4">
+                                 <accid accid="x" />
                               </note>
                            </beam>
                         </layer>
                      </staff>
                      <staff xml:id="m2s5" n="5">
                         <layer xml:id="m2s5l1" n="1">
-                           <beam xml:id="m2s5l1b1">
-                              <note xml:id="s5l1_t1_1" dur="8" pname="c" oct="4" />
-                              <note xml:id="s5l1_t9_8" dur="8" pname="b" oct="3" />
-                              <note xml:id="s5l1_t5_4" dur="8" pname="a" oct="3">
-                                 <accid xml:id="m2s5l1a1" accid="s" />
+                           <beam>
+                              <note xml:id="n1a70dsr" dur="8" pname="c" oct="4" />
+                              <note xml:id="n15l4dy8" dur="8" pname="b" oct="3" />
+                              <note xml:id="n1uixstx" dur="8" pname="a" oct="3">
+                                 <accid accid="s" />
                               </note>
-                              <note xml:id="s5l1_t11_8" dur="8" pname="a" oct="3">
-                                 <accid xml:id="m2s5l1a2" accid="n" />
+                              <note xml:id="ndu566f" dur="8" pname="a" oct="3">
+                                 <accid accid="n" />
                               </note>
                            </beam>
-                           <beam xml:id="m2s5l1b2">
-                              <note xml:id="s5l1_t3_2" dur="8" pname="g" oct="3">
-                                 <accid xml:id="m2s5l1a3" accid="s" />
+                           <beam>
+                              <note xml:id="nyfy6lm" dur="8" pname="g" oct="3">
+                                 <accid accid="s" />
                               </note>
-                              <note xml:id="s5l1_t13_8" dur="8" pname="g" oct="3">
-                                 <accid xml:id="m2s5l1a4" accid="n" />
+                              <note xml:id="n1krrnzp" dur="8" pname="g" oct="3">
+                                 <accid accid="n" />
                               </note>
-                              <note xml:id="s5l1_t7_4" dur="8" pname="g" oct="3">
-                                 <accid xml:id="m2s5l1a5" accid="s" />
+                              <note xml:id="n1qjbge2" dur="8" pname="g" oct="3">
+                                 <accid accid="s" />
                               </note>
-                              <note xml:id="s5l1_t15_8" dur="8" pname="g" oct="3">
-                                 <accid xml:id="m2s5l1a6" accid="x" />
+                              <note xml:id="n19duzp9" dur="8" pname="g" oct="3">
+                                 <accid accid="x" />
                               </note>
                            </beam>
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m3" right="end" n="3">
+                  <measure xml:id="mccjdd2" right="end" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <note xml:id="s1l1_t2_1" dur="2" pname="c" oct="5">
-                              <accid xml:id="m3s1l1a1" accid="f" />
+                           <note xml:id="n7sp5a1" dur="2" pname="c" oct="5">
+                              <accid accid="f" />
                            </note>
-                           <note xml:id="s1l1_t5_2" dur="2" pname="c" oct="5">
-                              <accid xml:id="m3s1l1a2" accid="n" />
+                           <note xml:id="n7r8xpf" dur="2" pname="c" oct="5">
+                              <accid accid="n" />
                            </note>
                         </layer>
                      </staff>
                      <staff xml:id="m3s2" n="2">
                         <layer xml:id="m3s2l1" n="1">
-                           <note xml:id="s2l1_t2_1" dur="2" pname="d" oct="5">
-                              <accid xml:id="m3s2l1a1" accid="f" />
+                           <note xml:id="nv5z6bn" dur="2" pname="d" oct="5">
+                              <accid accid="f" />
                            </note>
-                           <note xml:id="s2l1_t5_2" dur="2" pname="d" oct="5">
-                              <accid xml:id="m3s2l1a2" accid="n" />
+                           <note xml:id="nqj43o3" dur="2" pname="d" oct="5">
+                              <accid accid="n" />
                            </note>
                         </layer>
                      </staff>
                      <staff xml:id="m3s3" n="3">
                         <layer xml:id="m3s3l1" n="1">
-                           <note xml:id="s3l1_t2_1" dur="2" pname="g" oct="5">
-                              <accid xml:id="m3s3l1a1" accid="f" />
+                           <note xml:id="n1x3qqsb" dur="2" pname="g" oct="5">
+                              <accid accid="f" />
                            </note>
-                           <note xml:id="s3l1_t5_2" dur="2" pname="g" oct="5">
-                              <accid xml:id="m3s3l1a2" accid="n" />
+                           <note xml:id="n18aor7b" dur="2" pname="g" oct="5">
+                              <accid accid="n" />
                            </note>
                         </layer>
                      </staff>
                      <staff xml:id="m3s4" n="4">
                         <layer xml:id="m3s4l1" n="1">
-                           <note xml:id="s4l1_t2_1" dur="2" pname="d" oct="5">
-                              <accid xml:id="m3s4l1a1" accid="f" />
+                           <note xml:id="n1atzzuc" dur="2" pname="d" oct="5">
+                              <accid accid="f" />
                            </note>
-                           <note xml:id="s4l1_t5_2" dur="2" pname="d" oct="5">
-                              <accid xml:id="m3s4l1a2" accid="n" />
+                           <note xml:id="nd4pzxn" dur="2" pname="d" oct="5">
+                              <accid accid="n" />
                            </note>
                         </layer>
                      </staff>
                      <staff xml:id="m3s5" n="5">
                         <layer xml:id="m3s5l1" n="1">
-                           <note xml:id="s5l1_t2_1" dur="2" pname="c" oct="4">
-                              <accid xml:id="m3s5l1a1" accid="f" />
+                           <note xml:id="nxpa7k8" dur="2" pname="c" oct="4">
+                              <accid accid="f" />
                            </note>
-                           <note xml:id="s5l1_t5_2" dur="2" pname="c" oct="4">
-                              <accid xml:id="m3s5l1a2" accid="n" />
+                           <note xml:id="n1udntro" dur="2" pname="c" oct="4">
+                              <accid accid="n" />
                            </note>
                         </layer>
                      </staff>

--- a/src/importexport/mei/tests/data/transpose-01.mscx
+++ b/src/importexport/mei/tests/data/transpose-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:25&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Untitled score&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Composer / arranger&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:54:46&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/tuplet-01.mei
+++ b/src/importexport/mei/tests/data/tuplet-01.mei
@@ -8,7 +8,7 @@
             <title />
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:26" />
+            <date isodate="2023-08-11T14:54:52" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -29,97 +29,97 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="mgdiw0y" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <beam xml:id="m1s1l1b1">
-                              <tuplet xml:id="m1s1l1t1" num="3" numbase="2">
-                                 <note xml:id="s1l1_t0_1" dur="8" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t1_12" dur="8" pname="d" oct="5" />
-                                 <note xml:id="s1l1_t1_6" dur="8" pname="b" oct="4" />
+                           <beam>
+                              <tuplet xml:id="t1dxkbuc" num="3" numbase="2">
+                                 <note xml:id="nv3eezm" dur="8" pname="c" oct="5" />
+                                 <note xml:id="nklr3ed" dur="8" pname="d" oct="5" />
+                                 <note xml:id="ndn1r6w" dur="8" pname="b" oct="4" />
                               </tuplet>
                            </beam>
-                           <beam xml:id="m1s1l1b2">
-                              <tuplet xml:id="m1s1l1t2" num="5" numbase="4">
-                                 <note xml:id="s1l1_t1_4" dur="16" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t3_10" dur="16" pname="d" oct="5" />
-                                 <note xml:id="s1l1_t7_20" dur="16" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t2_5" dur="16" pname="b" oct="4" />
-                                 <note xml:id="s1l1_t9_20" dur="16" pname="d" oct="5" />
+                           <beam>
+                              <tuplet xml:id="t12ouxow" num="5" numbase="4">
+                                 <note xml:id="n1h5nj7r" dur="16" pname="c" oct="5" />
+                                 <note xml:id="n18l59c6" dur="16" pname="d" oct="5" />
+                                 <note xml:id="n12v1ocz" dur="16" pname="c" oct="5" />
+                                 <note xml:id="n1xxls2v" dur="16" pname="b" oct="4" />
+                                 <note xml:id="n14nj3hc" dur="16" pname="d" oct="5" />
                               </tuplet>
                            </beam>
-                           <tuplet xml:id="m1s1l1t3" num="3" numbase="2">
-                              <note xml:id="s1l1_t1_2" dur="4" pname="c" oct="5" />
-                              <note xml:id="s1l1_t2_3" dur="4" pname="b" oct="4" />
-                              <beam xml:id="m1s1l1b3">
-                                 <note xml:id="s1l1_t5_6" dur="8" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t11_12" dur="8" pname="d" oct="5" />
+                           <tuplet xml:id="tibt5zk" num="3" numbase="2">
+                              <note xml:id="nbr8tq4" dur="4" pname="c" oct="5" />
+                              <note xml:id="n9dupw" dur="4" pname="b" oct="4" />
+                              <beam>
+                                 <note xml:id="n1994t6c" dur="8" pname="c" oct="5" />
+                                 <note xml:id="n2u2c78" dur="8" pname="d" oct="5" />
                               </beam>
                            </tuplet>
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="m1xxaxpb" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <beam xml:id="m2s1l1b1">
-                              <tuplet xml:id="m2s1l1t1" num="6" numbase="4">
-                                 <note xml:id="s1l1_t1_1" dur="32" pname="a" oct="4" />
-                                 <note xml:id="s1l1_t49_48" dur="32" pname="g" oct="4" />
-                                 <note xml:id="s1l1_t25_24" dur="32" pname="a" oct="4" />
-                                 <note xml:id="s1l1_t17_16" dur="32" pname="b" oct="4" />
-                                 <note xml:id="s1l1_t13_12" dur="32" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t53_48" dur="32" pname="b" oct="4" />
+                           <beam>
+                              <tuplet xml:id="t81yt3h" num="6" numbase="4">
+                                 <note xml:id="n1t4focn" dur="32" pname="a" oct="4" />
+                                 <note xml:id="n8kp7v6" dur="32" pname="g" oct="4" />
+                                 <note xml:id="nifckfw" dur="32" pname="a" oct="4" />
+                                 <note xml:id="nmt8sms" dur="32" pname="b" oct="4" />
+                                 <note xml:id="nhz5x27" dur="32" pname="c" oct="5" />
+                                 <note xml:id="n1cmlx8w" dur="32" pname="b" oct="4" />
                               </tuplet>
-                              <tuplet xml:id="m2s1l1t2" num="6" numbase="4">
-                                 <note xml:id="s1l1_t9_8" dur="32" pname="a" oct="4" />
-                                 <note xml:id="s1l1_t55_48" dur="32" pname="g" oct="4" />
-                                 <note xml:id="s1l1_t7_6" dur="32" pname="a" oct="4" />
-                                 <note xml:id="s1l1_t19_16" dur="32" pname="b" oct="4" />
-                                 <note xml:id="s1l1_t29_24" dur="32" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t59_48" dur="32" pname="b" oct="4" />
+                              <tuplet xml:id="t15tk7m0" num="6" numbase="4">
+                                 <note xml:id="ngk5dkv" dur="32" pname="a" oct="4" />
+                                 <note xml:id="n1ftahgu" dur="32" pname="g" oct="4" />
+                                 <note xml:id="n1dnhu0v" dur="32" pname="a" oct="4" />
+                                 <note xml:id="n1gi4vmz" dur="32" pname="b" oct="4" />
+                                 <note xml:id="n1qx32yd" dur="32" pname="c" oct="5" />
+                                 <note xml:id="ntzaodf" dur="32" pname="b" oct="4" />
                               </tuplet>
                            </beam>
-                           <tuplet xml:id="m2s1l1t3" num="6" numbase="4">
-                              <beam xml:id="m2s1l1b2">
-                                 <note xml:id="s1l1_t5_4" dur="32" pname="a" oct="4" />
-                                 <note xml:id="s1l1_t61_48" dur="32" pname="g" oct="4" />
-                                 <note xml:id="s1l1_t31_24" dur="32" pname="a" oct="4" />
+                           <tuplet xml:id="t1ckf88r" num="6" numbase="4">
+                              <beam>
+                                 <note xml:id="nqv6n5l" dur="32" pname="a" oct="4" />
+                                 <note xml:id="n1fy60xy" dur="32" pname="g" oct="4" />
+                                 <note xml:id="n1glic1g" dur="32" pname="a" oct="4" />
                               </beam>
-                              <beam xml:id="m2s1l1b3">
-                                 <note xml:id="s1l1_t21_16" type="mscore-beam-begin" dur="32" pname="b" oct="4" />
-                                 <note xml:id="s1l1_t4_3" dur="32" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t65_48" dur="32" pname="b" oct="4" />
-                              </beam>
-                           </tuplet>
-                           <tuplet xml:id="m2s1l1t4" num="6" numbase="4">
-                              <beam xml:id="m2s1l1b4">
-                                 <note xml:id="s1l1_t11_8" type="mscore-beam-begin" dur="32" pname="a" oct="4" />
-                                 <note xml:id="s1l1_t67_48" dur="32" pname="g" oct="4" />
-                                 <note xml:id="s1l1_t17_12" dur="32" pname="a" oct="4" />
-                              </beam>
-                              <beam xml:id="m2s1l1b5">
-                                 <note xml:id="s1l1_t23_16" type="mscore-beam-begin" dur="32" pname="b" oct="4" />
-                                 <note xml:id="s1l1_t35_24" dur="32" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t71_48" dur="32" pname="b" oct="4" />
+                              <beam>
+                                 <note xml:id="n10qz2tt" type="mscore-beam-begin" dur="32" pname="b" oct="4" />
+                                 <note xml:id="n1ry0vus" dur="32" pname="c" oct="5" />
+                                 <note xml:id="nahl0ig" dur="32" pname="b" oct="4" />
                               </beam>
                            </tuplet>
-                           <tuplet xml:id="m2s1l1t5" num="3" numbase="2">
-                              <note xml:id="s1l1_t3_2" dur="4" pname="c" oct="5" />
-                              <rest xml:id="s1l1_t5_3" dur="4" />
-                              <beam xml:id="m2s1l1b6">
-                                 <note xml:id="s1l1_t11_6" dur="8" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t23_12" dur="8" pname="b" oct="4" />
+                           <tuplet xml:id="thtxbz8" num="6" numbase="4">
+                              <beam>
+                                 <note xml:id="n1dt1qa1" type="mscore-beam-begin" dur="32" pname="a" oct="4" />
+                                 <note xml:id="nngtlz8" dur="32" pname="g" oct="4" />
+                                 <note xml:id="n1q6c0hx" dur="32" pname="a" oct="4" />
+                              </beam>
+                              <beam>
+                                 <note xml:id="nd5jbqd" type="mscore-beam-begin" dur="32" pname="b" oct="4" />
+                                 <note xml:id="ng87uba" dur="32" pname="c" oct="5" />
+                                 <note xml:id="n1l56m30" dur="32" pname="b" oct="4" />
+                              </beam>
+                           </tuplet>
+                           <tuplet xml:id="t1ikepox" num="3" numbase="2">
+                              <note xml:id="n1rn792o" dur="4" pname="c" oct="5" />
+                              <rest xml:id="rd37vqz" dur="4" />
+                              <beam>
+                                 <note xml:id="n6q6jcu" dur="8" pname="c" oct="5" />
+                                 <note xml:id="n5ftnm4" dur="8" pname="b" oct="4" />
                               </beam>
                            </tuplet>
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m3" right="end" n="3">
+                  <measure xml:id="m16wn8gq" right="end" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <note xml:id="s1l1_t2_1" dur="2" pname="c" oct="5" />
-                           <rest xml:id="s1l1_t5_2" dur="2" />
+                           <note xml:id="ncyyeem" dur="2" pname="c" oct="5" />
+                           <rest xml:id="raj65hx" dur="2" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/tuplet-01.mscx
+++ b/src/importexport/mei/tests/data/tuplet-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer"></metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title/&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:26&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title/&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:54:52&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/tuplet-02.mei
+++ b/src/importexport/mei/tests/data/tuplet-02.mei
@@ -8,7 +8,7 @@
             <title />
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:27" />
+            <date isodate="2023-08-11T14:54:58" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -29,99 +29,99 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="mzwx4m1" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <tuplet xml:id="m1s1l1t1" num="3" numbase="2">
-                              <beam xml:id="m1s1l1b1">
-                                 <note xml:id="s1l1_t0_1" dur="8" pname="d" oct="5" />
-                                 <note xml:id="s1l1_t1_12" dur="8" pname="d" oct="5" />
+                           <tuplet xml:id="tu0b3ah" num="3" numbase="2">
+                              <beam>
+                                 <note xml:id="n1ih09hv" dur="8" pname="d" oct="5" />
+                                 <note xml:id="n1h0g4jq" dur="8" pname="d" oct="5" />
                               </beam>
-                              <beam xml:id="m1s1l1b2">
-                                 <note xml:id="s1l1_t1_6" type="mscore-beam-begin" dur="8" pname="d" oct="5" />
-                                 <note xml:id="s1l1_t1_4" dur="8" pname="d" oct="5" />
+                              <beam>
+                                 <note xml:id="nomedtn" type="mscore-beam-begin" dur="8" pname="d" oct="5" />
+                                 <note xml:id="ntmb6i8" dur="8" pname="d" oct="5" />
                               </beam>
-                              <rest xml:id="s1l1_t1_3" dur="2" />
-                              <note xml:id="s1l1_t2_3" dur="4" pname="d" oct="5" />
-                              <note xml:id="s1l1_t5_6" dur="4" pname="d" oct="5" />
+                              <rest xml:id="r1rl7yax" dur="2" />
+                              <note xml:id="n1nooisc" dur="4" pname="d" oct="5" />
+                              <note xml:id="n5ek7si" dur="4" pname="d" oct="5" />
                            </tuplet>
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="mivq3wj" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <beam xml:id="m2s1l1b1">
-                              <tuplet xml:id="m2s1l1t1" num="3" numbase="2">
-                                 <note xml:id="s1l1_t1_1" dur="16" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t25_24" dur="16" pname="d" oct="5" />
-                                 <note xml:id="s1l1_t13_12" dur="16" pname="c" oct="5" />
+                           <beam>
+                              <tuplet xml:id="t1i8f9zy" num="3" numbase="2">
+                                 <note xml:id="n1y90lg5" dur="16" pname="c" oct="5" />
+                                 <note xml:id="nh6gv13" dur="16" pname="d" oct="5" />
+                                 <note xml:id="nujwqgo" dur="16" pname="c" oct="5" />
                               </tuplet>
                            </beam>
-                           <beam xml:id="m2s1l1b2">
-                              <tuplet xml:id="m2s1l1t2" num="3" numbase="2">
-                                 <note xml:id="s1l1_t9_8" type="mscore-beam-begin" dur="16" pname="d" oct="5" />
-                                 <note xml:id="s1l1_t7_6" dur="16" pname="e" oct="5" />
-                                 <note xml:id="s1l1_t29_24" dur="16" pname="d" oct="5" />
+                           <beam>
+                              <tuplet xml:id="t27ot0c" num="3" numbase="2">
+                                 <note xml:id="nh0ehye" type="mscore-beam-begin" dur="16" pname="d" oct="5" />
+                                 <note xml:id="n1lzg8vg" dur="16" pname="e" oct="5" />
+                                 <note xml:id="n7t7j93" dur="16" pname="d" oct="5" />
                               </tuplet>
                            </beam>
-                           <beam xml:id="m2s1l1b3">
-                              <tuplet xml:id="m2s1l1t3" num="3" numbase="2">
-                                 <note xml:id="s1l1_t5_4" dur="16" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t31_24" dur="16" pname="d" oct="5" />
-                                 <note xml:id="s1l1_t4_3" dur="16" pname="c" oct="5" />
+                           <beam>
+                              <tuplet xml:id="t1rnqp1h" num="3" numbase="2">
+                                 <note xml:id="nesu0lc" dur="16" pname="c" oct="5" />
+                                 <note xml:id="n10v9nid" dur="16" pname="d" oct="5" />
+                                 <note xml:id="nxf38n7" dur="16" pname="c" oct="5" />
                               </tuplet>
-                              <tuplet xml:id="m2s1l1t4" num="3" numbase="2">
-                                 <note xml:id="s1l1_t11_8" dur="16" pname="d" oct="5" />
-                                 <note xml:id="s1l1_t17_12" dur="16" pname="e" oct="5" />
-                                 <note xml:id="s1l1_t35_24" dur="16" pname="d" oct="5" />
+                              <tuplet xml:id="t1tkr7su" num="3" numbase="2">
+                                 <note xml:id="n1ee7sk6" dur="16" pname="d" oct="5" />
+                                 <note xml:id="n2s274q" dur="16" pname="e" oct="5" />
+                                 <note xml:id="nta6nhs" dur="16" pname="d" oct="5" />
                               </tuplet>
                            </beam>
-                           <beam xml:id="m2s1l1b4">
-                              <tuplet xml:id="m2s1l1t5" num="3" numbase="2">
-                                 <note xml:id="s1l1_t3_2" dur="16" pname="e" oct="5" />
-                                 <note xml:id="s1l1_t37_24" dur="16" pname="f" oct="5" />
-                                 <note xml:id="s1l1_t19_12" dur="16" pname="e" oct="5" />
+                           <beam>
+                              <tuplet xml:id="tmc629v" num="3" numbase="2">
+                                 <note xml:id="nirkgvu" dur="16" pname="e" oct="5" />
+                                 <note xml:id="n1gi5yqi" dur="16" pname="f" oct="5" />
+                                 <note xml:id="n1r78f48" dur="16" pname="e" oct="5" />
                               </tuplet>
-                              <note xml:id="s1l1_t13_8" dur="8" pname="d" oct="5" />
+                              <note xml:id="n18oi5aw" dur="8" pname="d" oct="5" />
                            </beam>
-                           <beam xml:id="m2s1l1b5">
-                              <note xml:id="s1l1_t7_4" dur="8" pname="e" oct="5" />
-                              <tuplet xml:id="m2s1l1t6" num="3" numbase="2">
-                                 <note xml:id="s1l1_t15_8" dur="16" pname="f" oct="5" />
-                                 <note xml:id="s1l1_t23_12" dur="16" pname="g" oct="5" />
-                                 <note xml:id="s1l1_t47_24" dur="16" pname="f" oct="5" />
+                           <beam>
+                              <note xml:id="ni8h3fr" dur="8" pname="e" oct="5" />
+                              <tuplet xml:id="tkem6ue" num="3" numbase="2">
+                                 <note xml:id="n137cs0x" dur="16" pname="f" oct="5" />
+                                 <note xml:id="ng1jve7" dur="16" pname="g" oct="5" />
+                                 <note xml:id="n3ct119" dur="16" pname="f" oct="5" />
                               </tuplet>
                            </beam>
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m3" right="end" n="3">
+                  <measure xml:id="mp2axse" right="end" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <beam xml:id="m3s1l1b1">
-                              <note xml:id="s1l1_t2_1" dur="8" pname="e" oct="5" />
-                              <note xml:id="s1l1_t17_8" dur="16" pname="d" oct="5" />
-                              <note xml:id="s1l1_t35_16" dur="16" pname="d" oct="5" />
+                           <beam>
+                              <note xml:id="n6i24a2" dur="8" pname="e" oct="5" />
+                              <note xml:id="nufkt1h" dur="16" pname="d" oct="5" />
+                              <note xml:id="nicc5lb" dur="16" pname="d" oct="5" />
                            </beam>
-                           <beam xml:id="m3s1l1b2">
-                              <note xml:id="s1l1_t9_4" dur="8" pname="c" oct="5" />
-                              <tuplet xml:id="m3s1l1t1" num="3" numbase="2">
-                                 <note xml:id="s1l1_t19_8" dur="16" pname="d" oct="5" />
-                                 <note xml:id="s1l1_t29_12" dur="16" pname="e" oct="5" />
-                                 <note xml:id="s1l1_t59_24" dur="16" pname="d" oct="5" />
+                           <beam>
+                              <note xml:id="n18le3no" dur="8" pname="c" oct="5" />
+                              <tuplet xml:id="t1x4q6ks" num="3" numbase="2">
+                                 <note xml:id="ndzoh9k" dur="16" pname="d" oct="5" />
+                                 <note xml:id="nqo5pl5" dur="16" pname="e" oct="5" />
+                                 <note xml:id="n3esi7p" dur="16" pname="d" oct="5" />
                               </tuplet>
-                              <tuplet xml:id="m3s1l1t2" num="3" numbase="2">
-                                 <note xml:id="s1l1_t5_2" type="mscore-beam-mid" dur="16" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t61_24" dur="16" pname="d" oct="5" />
-                                 <note xml:id="s1l1_t31_12" dur="16" pname="c" oct="5" />
+                              <tuplet xml:id="t1xtmgp8" num="3" numbase="2">
+                                 <note xml:id="n13khj6u" type="mscore-beam-mid" dur="16" pname="c" oct="5" />
+                                 <note xml:id="n2di44i" dur="16" pname="d" oct="5" />
+                                 <note xml:id="nqvhjhc" dur="16" pname="c" oct="5" />
                               </tuplet>
-                              <note xml:id="s1l1_t21_8" dur="8" pname="b" oct="4" />
+                              <note xml:id="n1tk2ux6" dur="8" pname="b" oct="4" />
                            </beam>
-                           <beam xml:id="m3s1l1b3">
-                              <note xml:id="s1l1_t11_4" dur="8" pname="d" oct="5" />
-                              <note xml:id="s1l1_t23_8" dur="8" pname="c" oct="5">
-                                 <accid xml:id="m3s1l1a1" accid="s" />
+                           <beam>
+                              <note xml:id="n21cmm6" dur="8" pname="d" oct="5" />
+                              <note xml:id="n11mlqfw" dur="8" pname="c" oct="5">
+                                 <accid accid="s" />
                               </note>
                            </beam>
                         </layer>

--- a/src/importexport/mei/tests/data/tuplet-02.mscx
+++ b/src/importexport/mei/tests/data/tuplet-02.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer"></metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title/&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:27&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title/&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:54:58&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>

--- a/src/importexport/mei/tests/data/tuplet-03.mei
+++ b/src/importexport/mei/tests/data/tuplet-03.mei
@@ -8,7 +8,7 @@
             <title />
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-08-02T11:10:28" />
+            <date isodate="2023-08-11T14:55:05" />
          </pubStmt>
       </fileDesc>
    </meiHead>
@@ -29,99 +29,99 @@
                   </staffGrp>
                </scoreDef>
                <section xml:id="s1">
-                  <measure xml:id="m1" n="1">
+                  <measure xml:id="mte5hse" n="1">
                      <staff xml:id="m1s1" n="1">
                         <layer xml:id="m1s1l1" n="1">
-                           <beam xml:id="m1s1l1b1">
-                              <tuplet xml:id="m1s1l1t1" num="3" numbase="2" bracket.place="below" num.format="ratio" num.place="below">
-                                 <note xml:id="s1l1_t0_1" dur="8" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t1_12" dur="8" pname="d" oct="5" />
-                                 <note xml:id="s1l1_t1_6" dur="8" pname="b" oct="4" />
+                           <beam>
+                              <tuplet xml:id="tmyydmf" num="3" numbase="2" bracket.place="below" num.format="ratio" num.place="below">
+                                 <note xml:id="n1f04j3p" dur="8" pname="c" oct="5" />
+                                 <note xml:id="nmm2j9v" dur="8" pname="d" oct="5" />
+                                 <note xml:id="n15rtd0u" dur="8" pname="b" oct="4" />
                               </tuplet>
                            </beam>
-                           <beam xml:id="m1s1l1b2">
-                              <tuplet xml:id="m1s1l1t2" num="3" numbase="2" bracket.place="above" num.place="above">
-                                 <note xml:id="s1l1_t1_4" dur="8" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t1_3" dur="8" pname="d" oct="5" />
-                                 <note xml:id="s1l1_t5_12" dur="8" pname="b" oct="4" />
+                           <beam>
+                              <tuplet xml:id="t1adxib7" num="3" numbase="2" bracket.place="above" num.place="above">
+                                 <note xml:id="n1bs16co" dur="8" pname="c" oct="5" />
+                                 <note xml:id="n17qtkga" dur="8" pname="d" oct="5" />
+                                 <note xml:id="nk77hkp" dur="8" pname="b" oct="4" />
                               </tuplet>
                            </beam>
-                           <beam xml:id="m1s1l1b3">
-                              <tuplet xml:id="m1s1l1t3" num="3" numbase="2" bracket.visible="true">
-                                 <note xml:id="s1l1_t1_2" dur="8" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t7_12" dur="8" pname="d" oct="5" />
-                                 <note xml:id="s1l1_t2_3" dur="8" pname="b" oct="4" />
+                           <beam>
+                              <tuplet xml:id="t1acoyah" num="3" numbase="2" bracket.visible="true">
+                                 <note xml:id="n1cchnwt" dur="8" pname="c" oct="5" />
+                                 <note xml:id="noey36r" dur="8" pname="d" oct="5" />
+                                 <note xml:id="nghuz6x" dur="8" pname="b" oct="4" />
                               </tuplet>
                            </beam>
-                           <tuplet xml:id="m1s1l1t4" num="3" numbase="2" bracket.visible="false">
-                              <note xml:id="s1l1_t3_4" type="mscore-beam-none" dur="8" pname="c" oct="5" />
-                              <note xml:id="s1l1_t5_6" type="mscore-beam-none" dur="8" pname="d" oct="5" />
-                              <note xml:id="s1l1_t11_12" dur="8" pname="b" oct="4" />
+                           <tuplet xml:id="t1p69km3" num="3" numbase="2" bracket.visible="false">
+                              <note xml:id="no3va87" type="mscore-beam-none" dur="8" pname="c" oct="5" />
+                              <note xml:id="n7t24j4" type="mscore-beam-none" dur="8" pname="d" oct="5" />
+                              <note xml:id="norzgcz" dur="8" pname="b" oct="4" />
                            </tuplet>
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m2" n="2">
+                  <measure xml:id="m1axaflu" n="2">
                      <staff xml:id="m2s1" n="1">
                         <layer xml:id="m2s1l1" n="1">
-                           <beam xml:id="m2s1l1b1">
-                              <tuplet xml:id="m2s1l1t1" num="6" numbase="4" bracket.visible="true">
-                                 <note xml:id="s1l1_t1_1" dur="32" pname="a" oct="4" />
-                                 <note xml:id="s1l1_t49_48" dur="32" pname="g" oct="4" />
-                                 <note xml:id="s1l1_t25_24" dur="32" pname="a" oct="4" />
-                                 <note xml:id="s1l1_t17_16" dur="32" pname="b" oct="4" />
-                                 <note xml:id="s1l1_t13_12" dur="32" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t53_48" dur="32" pname="b" oct="4" />
+                           <beam>
+                              <tuplet xml:id="t13j26w9" num="6" numbase="4" bracket.visible="true">
+                                 <note xml:id="nmbr4vl" dur="32" pname="a" oct="4" />
+                                 <note xml:id="nyx2ck8" dur="32" pname="g" oct="4" />
+                                 <note xml:id="ncrpzvp" dur="32" pname="a" oct="4" />
+                                 <note xml:id="ntniz7n" dur="32" pname="b" oct="4" />
+                                 <note xml:id="nbg3ujp" dur="32" pname="c" oct="5" />
+                                 <note xml:id="n19ifrmt" dur="32" pname="b" oct="4" />
                               </tuplet>
-                              <tuplet xml:id="m2s1l1t2" num="6" numbase="4" bracket.place="below" bracket.visible="true" num.place="below" num.visible="false">
-                                 <note xml:id="s1l1_t9_8" dur="32" pname="a" oct="4" />
-                                 <note xml:id="s1l1_t55_48" dur="32" pname="g" oct="4" />
-                                 <note xml:id="s1l1_t7_6" dur="32" pname="a" oct="4" />
-                                 <note xml:id="s1l1_t19_16" dur="32" pname="b" oct="4" />
-                                 <note xml:id="s1l1_t29_24" dur="32" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t59_48" dur="32" pname="b" oct="4" />
+                              <tuplet xml:id="tx9xua0" num="6" numbase="4" bracket.place="below" bracket.visible="true" num.place="below" num.visible="false">
+                                 <note xml:id="n17aqvtd" dur="32" pname="a" oct="4" />
+                                 <note xml:id="nw4upb3" dur="32" pname="g" oct="4" />
+                                 <note xml:id="n1qk8dsa" dur="32" pname="a" oct="4" />
+                                 <note xml:id="ndh2xbc" dur="32" pname="b" oct="4" />
+                                 <note xml:id="nptyykt" dur="32" pname="c" oct="5" />
+                                 <note xml:id="nzan34g" dur="32" pname="b" oct="4" />
                               </tuplet>
                            </beam>
-                           <tuplet xml:id="m2s1l1t3" num="6" numbase="4" num.format="ratio">
-                              <beam xml:id="m2s1l1b2">
-                                 <note xml:id="s1l1_t5_4" dur="32" pname="a" oct="4" />
-                                 <note xml:id="s1l1_t61_48" dur="32" pname="g" oct="4" />
-                                 <note xml:id="s1l1_t31_24" dur="32" pname="a" oct="4" />
+                           <tuplet xml:id="t1v61xxl" num="6" numbase="4" num.format="ratio">
+                              <beam>
+                                 <note xml:id="nk0d2ys" dur="32" pname="a" oct="4" />
+                                 <note xml:id="n19yazmm" dur="32" pname="g" oct="4" />
+                                 <note xml:id="na21qs6" dur="32" pname="a" oct="4" />
                               </beam>
-                              <beam xml:id="m2s1l1b3">
-                                 <note xml:id="s1l1_t21_16" type="mscore-beam-begin" dur="32" pname="b" oct="4" />
-                                 <note xml:id="s1l1_t4_3" dur="32" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t65_48" dur="32" pname="b" oct="4" />
-                              </beam>
-                           </tuplet>
-                           <tuplet xml:id="m2s1l1t4" num="6" numbase="4" bracket.place="below" bracket.visible="false" num.place="below" num.visible="false">
-                              <beam xml:id="m2s1l1b4">
-                                 <note xml:id="s1l1_t11_8" type="mscore-beam-begin" dur="32" pname="a" oct="4" />
-                                 <note xml:id="s1l1_t67_48" dur="32" pname="g" oct="4" />
-                                 <note xml:id="s1l1_t17_12" dur="32" pname="a" oct="4" />
-                              </beam>
-                              <beam xml:id="m2s1l1b5">
-                                 <note xml:id="s1l1_t23_16" type="mscore-beam-begin" dur="32" pname="b" oct="4" />
-                                 <note xml:id="s1l1_t35_24" dur="32" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t71_48" dur="32" pname="b" oct="4" />
+                              <beam>
+                                 <note xml:id="n1xboni6" type="mscore-beam-begin" dur="32" pname="b" oct="4" />
+                                 <note xml:id="n1nv3c8x" dur="32" pname="c" oct="5" />
+                                 <note xml:id="n17gdvs3" dur="32" pname="b" oct="4" />
                               </beam>
                            </tuplet>
-                           <tuplet xml:id="m2s1l1t5" num="3" numbase="2" bracket.place="above" num.format="ratio" num.place="above">
-                              <note xml:id="s1l1_t3_2" dur="4" pname="c" oct="5" />
-                              <rest xml:id="s1l1_t5_3" dur="4" />
-                              <beam xml:id="m2s1l1b6">
-                                 <note xml:id="s1l1_t11_6" dur="8" pname="c" oct="5" />
-                                 <note xml:id="s1l1_t23_12" dur="8" pname="b" oct="4" />
+                           <tuplet xml:id="t1wg5srb" num="6" numbase="4" bracket.place="below" bracket.visible="false" num.place="below" num.visible="false">
+                              <beam>
+                                 <note xml:id="nn9z704" type="mscore-beam-begin" dur="32" pname="a" oct="4" />
+                                 <note xml:id="n1jd8yan" dur="32" pname="g" oct="4" />
+                                 <note xml:id="n1du0zh1" dur="32" pname="a" oct="4" />
+                              </beam>
+                              <beam>
+                                 <note xml:id="nsnj0k7" type="mscore-beam-begin" dur="32" pname="b" oct="4" />
+                                 <note xml:id="n1f8ouap" dur="32" pname="c" oct="5" />
+                                 <note xml:id="nbikys5" dur="32" pname="b" oct="4" />
+                              </beam>
+                           </tuplet>
+                           <tuplet xml:id="t61826k" num="3" numbase="2" bracket.place="above" num.format="ratio" num.place="above">
+                              <note xml:id="n1d54hnh" dur="4" pname="c" oct="5" />
+                              <rest xml:id="r13p76gi" dur="4" />
+                              <beam>
+                                 <note xml:id="n4j6c6g" dur="8" pname="c" oct="5" />
+                                 <note xml:id="n14ey57w" dur="8" pname="b" oct="4" />
                               </beam>
                            </tuplet>
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="m3" right="end" n="3">
+                  <measure xml:id="m7j561u" right="end" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <note xml:id="s1l1_t2_1" dur="2" pname="c" oct="5" />
-                           <rest xml:id="s1l1_t5_2" dur="2" />
+                           <note xml:id="n1uby8dv" dur="2" pname="c" oct="5" />
+                           <rest xml:id="rs3kou0" dur="2" />
                         </layer>
                      </staff>
                   </measure>

--- a/src/importexport/mei/tests/data/tuplet-03.mscx
+++ b/src/importexport/mei/tests/data/tuplet-03.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer"></metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="lyricist"></metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title/&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-02T11:10:28&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title/&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:55:05&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>


### PR DESCRIPTION
This PR fixes MEI export of spanner object where the start and end are the same object in MuseScore (e.g., a hairpin under a single note). These were missing the `@endid` in the generated MEI output.

The PR also removes xml:ids for MEI layer element for which the xml:id is not preserved in the import / export round-trip. All the test files are being updated accordingly.