### PR TITLE
Fix #16519: L/R Arrow During Playback Moves From Playhead Current Location

### DIFF
--- a/src/notation/inotationplayback.h
+++ b/src/notation/inotationplayback.h
@@ -74,7 +74,7 @@ public:
 
     virtual const Tempo& tempo(muse::midi::tick_t tick) const = 0;
     virtual MeasureBeat beat(muse::midi::tick_t tick) const = 0;
-    virtual muse::midi::tick_t beatToTick(int measureIndex, int beatIndex) const = 0;
+    virtual muse::midi::tick_t beatToRawTick(int measureIndex, int beatIndex) const = 0;
 
     virtual double tempoMultiplier() const = 0;
     virtual void setTempoMultiplier(double multiplier) = 0;

--- a/src/notation/internal/notationplayback.cpp
+++ b/src/notation/internal/notationplayback.cpp
@@ -358,7 +358,7 @@ MeasureBeat NotationPlayback::beat(tick_t tick) const
     return measureBeat;
 }
 
-tick_t NotationPlayback::beatToTick(int measureIndex, int beatIndex) const
+tick_t NotationPlayback::beatToRawTick(int measureIndex, int beatIndex) const
 {
     return score() ? score()->sigmap()->bar2tick(measureIndex, beatIndex) : 0;
 }

--- a/src/notation/internal/notationplayback.h
+++ b/src/notation/internal/notationplayback.h
@@ -73,7 +73,7 @@ public:
 
     const Tempo& tempo(muse::midi::tick_t tick) const override;
     MeasureBeat beat(muse::midi::tick_t tick) const override;
-    muse::midi::tick_t beatToTick(int measureIndex, int beatIndex) const override;
+    muse::midi::tick_t beatToRawTick(int measureIndex, int beatIndex) const override;
 
     double tempoMultiplier() const override;
     void setTempoMultiplier(double multiplier) override;

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -215,7 +215,7 @@ void PlaybackController::seek(const midi::tick_t tick)
         return;
     }
 
-    seek(tickToSecs(tick));
+    seek(playedTickToSecs(tick));
 }
 
 void PlaybackController::seek(const audio::secs_t secs)
@@ -643,7 +643,7 @@ secs_t PlaybackController::playbackStartSecs() const
         if (!startTick.ret) {
             return 0;
         }
-        return tickToSecs(startTick.val);
+        return playedTickToSecs(startTick.val);
     }
 
     return 0;
@@ -805,8 +805,8 @@ void PlaybackController::updateLoop()
         return;
     }
 
-    secs_t fromSecs = tickToSecs(playbackTickFrom.val);
-    secs_t toSecs = tickToSecs(playbackTickTo.val);
+    secs_t fromSecs = playedTickToSecs(playbackTickFrom.val);
+    secs_t toSecs = playedTickToSecs(playbackTickTo.val);
     currentPlayer()->setLoop(secsToMilisecs(fromSecs), secsToMilisecs(toSecs));
 
     enableLoop();
@@ -1444,10 +1444,10 @@ secs_t PlaybackController::beatToSecs(int measureIndex, int beatIndex) const
         return 0;
     }
 
-    muse::midi::tick_t rawTick = notationPlayback()->beatToTick(measureIndex, beatIndex);
+    muse::midi::tick_t rawTick = notationPlayback()->beatToRawTick(measureIndex, beatIndex);
     muse::midi::tick_t playedTick = notationPlayback()->playPositionTickByRawTick(rawTick).val;
 
-    return tickToSecs(playedTick);
+    return playedTickToSecs(playedTick);
 }
 
 double PlaybackController::tempoMultiplier() const
@@ -1589,7 +1589,7 @@ bool PlaybackController::canReceiveAction(const ActionCode&) const
     return m_masterNotation != nullptr && m_masterNotation->hasParts();
 }
 
-muse::audio::secs_t PlaybackController::tickToSecs(int tick) const
+muse::audio::secs_t PlaybackController::playedTickToSecs(int tick) const
 {
     return secs_t(notationPlayback()->playedTickToSec(tick));
 }

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -366,6 +366,12 @@ void PlaybackController::seekElement(const notation::EngravingItem* element)
     seek(tick.val);
 }
 
+void PlaybackController::seekBeat(int measureIndex, int beatIndex)
+{
+    secs_t targetSecs = beatToSecs(measureIndex, beatIndex);
+    seek(targetSecs);
+}
+
 void PlaybackController::seekListSelection()
 {
     const std::vector<EngravingItem*>& elements = selection()->elements();
@@ -1434,7 +1440,14 @@ MeasureBeat PlaybackController::currentBeat() const
 
 secs_t PlaybackController::beatToSecs(int measureIndex, int beatIndex) const
 {
-    return notationPlayback() ? tickToSecs(notationPlayback()->beatToTick(measureIndex, beatIndex)) : secs_t { 0 };
+    if (!notationPlayback()) {
+        return 0;
+    }
+
+    muse::midi::tick_t rawTick = notationPlayback()->beatToTick(measureIndex, beatIndex);
+    muse::midi::tick_t playedTick = notationPlayback()->playPositionTickByRawTick(rawTick).val;
+
+    return tickToSecs(playedTick);
 }
 
 double PlaybackController::tempoMultiplier() const

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -202,7 +202,7 @@ private:
     void removeNonExistingTracks();
     void removeTrack(const engraving::InstrumentTrackId& instrumentTrackId);
 
-    muse::audio::secs_t tickToSecs(int tick) const;
+    muse::audio::secs_t playedTickToSecs(int tick) const;
 
     notation::INotationPtr m_notation;
     notation::IMasterNotationPtr m_masterNotation;

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -125,7 +125,7 @@ private:
 
     void updateCurrentTempo();
 
-    void seek(const muse::midi::tick_t tick);
+    void seekRawTick(const muse::midi::tick_t tick);
     void seek(const muse::audio::secs_t secs);
 
     bool isPaused() const;

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -87,6 +87,7 @@ public:
     void playElements(const std::vector<const notation::EngravingItem*>& elements) override;
     void playMetronome(int tick) override;
     void seekElement(const notation::EngravingItem* element) override;
+    void seekBeat(int measureIndex, int beatIndex) override;
 
     bool actionChecked(const muse::actions::ActionCode& actionCode) const override;
     muse::async::Channel<muse::actions::ActionCode> actionCheckedChanged() const override;
@@ -111,7 +112,6 @@ public:
     void setIsExportingAudio(bool exporting) override;
 
     bool canReceiveAction(const muse::actions::ActionCode& code) const override;
-
 private:
     muse::audio::IPlayerPtr currentPlayer() const;
 

--- a/src/playback/iplaybackcontroller.h
+++ b/src/playback/iplaybackcontroller.h
@@ -78,6 +78,7 @@ public:
     virtual void playElements(const std::vector<const notation::EngravingItem*>& elements) = 0;
     virtual void playMetronome(int tick) = 0;
     virtual void seekElement(const notation::EngravingItem* element) = 0;
+    virtual void seekBeat(int measureIndex, int beatIndex) = 0;
 
     virtual bool actionChecked(const muse::actions::ActionCode& actionCode) const = 0;
     virtual muse::async::Channel<muse::actions::ActionCode> actionCheckedChanged() const = 0;

--- a/src/playback/tests/mocks/playbackcontrollermock.h
+++ b/src/playback/tests/mocks/playbackcontrollermock.h
@@ -64,6 +64,7 @@ public:
     MOCK_METHOD(void, playElements, ((const std::vector<const notation::EngravingItem*>&)), (override));
     MOCK_METHOD(void, playMetronome, (int), (override));
     MOCK_METHOD(void, seekElement, (const notation::EngravingItem*), (override));
+    MOCK_METHOD(void, seekBeat, (int, int), (override));
 
     MOCK_METHOD(bool, actionChecked, (const muse::actions::ActionCode&), (const, override));
     MOCK_METHOD(muse::async::Channel<muse::actions::ActionCode>, actionCheckedChanged, (), (const, override));

--- a/src/stubs/playback/playbackcontrollerstub.cpp
+++ b/src/stubs/playback/playbackcontrollerstub.cpp
@@ -124,6 +124,10 @@ void PlaybackControllerStub::seekElement(const notation::EngravingItem*)
 {
 }
 
+void PlaybackControllerStub::seekBeat(int, int)
+{
+}
+
 bool PlaybackControllerStub::actionChecked(const ActionCode&) const
 {
     return false;

--- a/src/stubs/playback/playbackcontrollerstub.h
+++ b/src/stubs/playback/playbackcontrollerstub.h
@@ -60,6 +60,7 @@ public:
     void playElements(const std::vector<const notation::EngravingItem*>& elements) override;
     void playMetronome(int tick) override;
     void seekElement(const notation::EngravingItem* element) override;
+    void seekBeat(int measureIndex, int beatIndex) override;
 
     bool actionChecked(const muse::actions::ActionCode& actionCode) const override;
     muse::async::Channel<muse::actions::ActionCode> actionCheckedChanged() const override;


### PR DESCRIPTION
- Left/Right Arrow: Move between beats
- Left/Right Arrow + Ctrl/Command: Move between measures

Resolves: #16519
Resolves: https://github.com/musescore/MuseScore/issues/23795

Changed so that left and right arrows during playback move the playback cursor instead of the selection (which causes the playback cursor to move back to the selection)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
