### PR TITLE
 Fix #11377: No search results found hint added

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/NewScore/TitleListView.qml
+++ b/src/project/qml/MuseScore/Project/internal/NewScore/TitleListView.qml
@@ -132,4 +132,16 @@ Item {
             }
         }
     }
+
+    StyledTextLabel {
+        id: noResultsFoundHint
+
+        anchors.fill: parent
+
+        font: ui.theme.bodyBoldFont
+
+        text: qsTrc("global", "No results found")
+
+        visible: view.count < 1
+    }
 }


### PR DESCRIPTION
Resolves: #11377

Previously, a "New Score->Create from template" search yielding no results would give the user no feedback. This change ensures that a "No results found" message displays under the "Category" and "Template" columns.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
