### PR TITLE
Fix #19061: Center title text horizontally in the edit MIDI mapping dialog

### DIFF
--- a/src/framework/shortcuts/qml/MuseScore/Shortcuts/EditMidiMappingDialog.qml
+++ b/src/framework/shortcuts/qml/MuseScore/Shortcuts/EditMidiMappingDialog.qml
@@ -62,7 +62,7 @@ StyledDialogView {
             spacing: 24
 
             Row {
-                width: parent.width
+                anchors.horizontalCenter: parent.horizontalCenter
 
                 spacing: 8
 


### PR DESCRIPTION
Resolves: #19061

![image](https://github.com/musescore/MuseScore/assets/73422868/bb46e04a-77e9-4359-b5b4-8e2b32d089c4)

Seems this issue was introduced with https://github.com/musescore/MuseScore/commit/da1672b569391bebe64e8efa5c00544d7f2eb605.

Also, is the text vertically centred with the icon?

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
