### PR TITLE
Fixed gp7 tuning string for ver 7.0.0

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
@@ -19,7 +19,6 @@ void GP67DomBuilder::buildGPDomModel(XmlDomElement* domElem)
                masterBars,       bars,             voices,
                beats,            notes,            rhythms;
 
-    // Currently ignored
     XmlDomNode gpversion, encoding;
 
     std::map<String, XmlDomNode*> nodeMap =
@@ -61,7 +60,7 @@ void GP67DomBuilder::buildGPDomModel(XmlDomElement* domElem)
     buildGPScore(&scoreNode);
     buildGPMasterTracks(&masterTrack);
     buildGPAudioTracks(&audioTracks);
-    buildGPTracks(&eachTrack);
+    buildGPTracks(&eachTrack, &gpversion);
 }
 
 std::unique_ptr<GPDomModel> GP67DomBuilder::getGPDomModel()
@@ -142,12 +141,12 @@ void GP67DomBuilder::buildGPAudioTracks(XmlDomNode* audioTrack)
     }
 }
 
-void GP67DomBuilder::buildGPTracks(XmlDomNode* tracksNode)
+void GP67DomBuilder::buildGPTracks(XmlDomNode* tracksNode, XmlDomNode* versionNode)
 {
     std::map<int, std::unique_ptr<GPTrack> > tracks;
     XmlDomNode currentNode = tracksNode->firstChild();
     while (!currentNode.isNull()) {
-        tracks.insert(createGPTrack(&currentNode));
+        tracks.insert(createGPTrack(&currentNode, versionNode));
         currentNode = currentNode.nextSibling();
     }
 
@@ -1196,9 +1195,10 @@ void GP67DomBuilder::readBeatProperties(const XmlDomNode& propertiesNode, GPBeat
     }
 }
 
-void GP67DomBuilder::readTrackProperties(XmlDomNode* propertiesNode, GPTrack* track) const
+void GP67DomBuilder::readTrackProperties(XmlDomNode* propertiesNode, GPTrack* track, bool ignoreTuningFlats) const
 {
     GPTrack::StaffProperty property;
+    property.ignoreFlats = ignoreTuningFlats;
 
     auto propertyNode = propertiesNode->firstChild();
 

--- a/src/importexport/guitarpro/internal/gtp/gp67dombuilder.h
+++ b/src/importexport/guitarpro/internal/gtp/gp67dombuilder.h
@@ -22,7 +22,7 @@ protected:
     void buildGPScore(XmlDomNode* scoreNode);
     void buildGPMasterTracks(XmlDomNode* masterTrack);
     void buildGPAudioTracks(XmlDomNode* audioTrack);
-    void buildGPTracks(XmlDomNode* tracksNode);
+    void buildGPTracks(XmlDomNode* tracksNode, XmlDomNode* versionNode);
     void buildGPMasterBars(XmlDomNode* masterBars);
     void buildGPBars(XmlDomNode* bars);
     void buildGPVoices(XmlDomNode* voicesNode);
@@ -33,7 +33,7 @@ protected:
     void breakLyricsOnBeatsIfNeed();
     bool isLyricsOnBeats() const;
 
-    virtual std::pair<int, std::unique_ptr<GPTrack> > createGPTrack(XmlDomNode* trackNode) = 0;
+    virtual std::pair<int, std::unique_ptr<GPTrack> > createGPTrack(XmlDomNode* trackNode, XmlDomNode* versionNode) = 0;
 
     std::unique_ptr<GPMasterTracks> createGPMasterTrack(XmlDomNode* metadata);
     std::unique_ptr<GPMasterBar> createGPMasterBar(XmlDomNode* masterBarNode);
@@ -54,7 +54,7 @@ protected:
     GPMasterBar::KeySig readKeySig(XmlDomNode* keyNode) const;
     bool readUseFlats(XmlDomNode* keyNode) const;
     GPMasterBar::TimeSig readTimeSig(XmlDomNode* timeNode) const;
-    void readTrackProperties(XmlDomNode* propertiesNode, GPTrack* track) const;
+    void readTrackProperties(XmlDomNode* propertiesNode, GPTrack* track, bool ignoreTuningFlats) const;
     void readBeatProperties(const XmlDomNode& propertiesNode, GPBeat* beat) const;
     void readDiagram(const XmlDomNode& items, GPTrack* track) const;
     void readLyrics(const XmlDomNode& items, GPTrack* track) const;

--- a/src/importexport/guitarpro/internal/gtp/gp6dombuilder.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gp6dombuilder.cpp
@@ -5,7 +5,7 @@
 #include "global/log.h"
 
 namespace mu::iex::guitarpro {
-std::pair<int, std::unique_ptr<GPTrack> > GP6DomBuilder::createGPTrack(XmlDomNode* trackNode)
+std::pair<int, std::unique_ptr<GPTrack> > GP6DomBuilder::createGPTrack(XmlDomNode* trackNode, XmlDomNode* versionNode)
 {
     static const std::set<String> sUnusedNodes = {
         u"Color",                                        // we dont use icon color for the tracks
@@ -50,7 +50,7 @@ std::pair<int, std::unique_ptr<GPTrack> > GP6DomBuilder::createGPTrack(XmlDomNod
         } else if (nodeName == u"ShortName") {
             track->setShortName(trackChildNode.toElement().text());
         } else if (nodeName == u"Properties") {
-            readTrackProperties(&trackChildNode, track.get());
+            readTrackProperties(&trackChildNode, track.get(), false);
         } else if (nodeName == u"Instrument") {
             setUpInstrument(&trackChildNode, track.get());
         } else if (nodeName == u"Lyrics") {

--- a/src/importexport/guitarpro/internal/gtp/gp6dombuilder.h
+++ b/src/importexport/guitarpro/internal/gtp/gp6dombuilder.h
@@ -10,7 +10,7 @@ public:
     GP6DomBuilder() = default;
 
 private:
-    virtual std::pair<int, std::unique_ptr<GPTrack> > createGPTrack(XmlDomNode* trackNode);
+    virtual std::pair<int, std::unique_ptr<GPTrack> > createGPTrack(XmlDomNode* trackNode, XmlDomNode* versionNode);
     void setUpInstrument(XmlDomNode* trackChildNode, GPTrack* track);
     GPTrack::SoundAutomation readRsePickUp(XmlDomNode& rseNode) const;
 };

--- a/src/importexport/guitarpro/internal/gtp/gp7dombuilder.h
+++ b/src/importexport/guitarpro/internal/gtp/gp7dombuilder.h
@@ -11,7 +11,7 @@ public:
     GP7DomBuilder() = default;
 
 private:
-    std::pair<int, std::unique_ptr<GPTrack> > createGPTrack(XmlDomNode* trackNode) override;
+    std::pair<int, std::unique_ptr<GPTrack> > createGPTrack(XmlDomNode* trackNode, XmlDomNode* versionNode) override;
 
     int readMidiChannel(XmlDomNode* trackChildNode) const;
     int readMidiProgramm(XmlDomNode* trackChildNode) const;

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1115,8 +1115,16 @@ void GPConverter::setUpTrack(const std::unique_ptr<GPTrack>& tR)
         part->staff(0)->insertCapoParams({ 0, 1 }, params);
         part->setCapoFret(capoFret);
         auto tunning = staffProperty[0].tunning;
+        bool usePresetTable = staffProperty[0].ignoreFlats;
 
-        bool useFlats = staffProperty[0].useFlats;
+        std::array<uint64_t, 3> flatPresets{ 0x3f3a36312c27, 0x3c37332e2924, 0x3f3a36312c25 };
+
+        uint64_t k = 0;
+        for (size_t i = 0; i < tunning.size(); ++i) {
+            k |= (uint64_t)tunning[i] << 8 * i;
+        }
+        bool useFlats
+            = usePresetTable ? std::find(flatPresets.begin(), flatPresets.end(), k) != flatPresets.end() : staffProperty[0].useFlats;
         auto fretCount = staffProperty[0].fretCount;
 
         if (tunning.empty()) {

--- a/src/importexport/guitarpro/internal/gtp/gptrack.h
+++ b/src/importexport/guitarpro/internal/gtp/gptrack.h
@@ -24,6 +24,7 @@ public:
         int capoFret{ 0 };
         std::vector<int> tunning;
         bool useFlats{ false };
+        bool ignoreFlats{ false };
     };
 
     struct InstrumentString {


### PR DESCRIPTION
There is a bug in GP version 7.0.0.
All tracks marked to use flats for tuning string, but the real behaviour is that we should use presets instead.
