### PR TITLE
fix #19063 missing init key sig after removing first measure + cleanup

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -2995,10 +2995,7 @@ void Score::deleteMeasures(MeasureBase* mbStart, MeasureBase* mbEnd, bool preser
 
         // insert correct keysig if necessary
         if (mAfterSel && !mBeforeSel) {
-            Segment* s = mAfterSel->findSegment(SegmentType::KeySig, mAfterSel->tick());
-            if (!s) {
-                s = mAfterSel->undoGetSegment(SegmentType::KeySig, mAfterSel->tick());
-            }
+            Segment* s = mAfterSel->undoGetSegment(SegmentType::KeySig, mAfterSel->tick());
 
             bool userCustomizedKeySig = false;
             for (EngravingItem* e : s->elist()) {
@@ -3025,14 +3022,15 @@ void Score::deleteMeasures(MeasureBase* mbStart, MeasureBase* mbEnd, bool preser
                 KeySig* nks = (KeySig*)s->elementAt(staff2track(staffIdx));
                 if (!nks) {
                     nks = Factory::createKeySig(s);
+                    nks->setParent(s);
                     nks->setTrack(staffIdx * VOICES);
-                    nks->setKey(nkse.key());
+                    nks->setKeySigEvent(nkse);
                     score->undoAddElement(nks);
+                } else {
+                    nks->setGenerated(false);
+                    nks->setKeySigEvent(nkse);
+                    staff->setKey(mAfterSel->tick(), nkse);
                 }
-
-                nks->setGenerated(false);
-                nks->setKeySigEvent(nkse);
-                staff->setKey(mAfterSel->tick(), nkse);
             }
         }
     }


### PR DESCRIPTION
Resolves: #19063 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
newly created element needs to have parent element (segment) set

+ little cleanup 
<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
