### PR TITLE
fix multiple clefs at the end of mmrest, when remove / insert precede…

### DIFF
--- a/src/engraving/rendering/dev/measurelayout.cpp
+++ b/src/engraving/rendering/dev/measurelayout.cpp
@@ -172,12 +172,16 @@ void MeasureLayout::createMMRest(LayoutContext& ctx, Measure* firstMeasure, Meas
     if (mmrMeasure) {
         // reuse existing mmrest
         if (mmrMeasure->ticks() != len) {
-            Segment* s = mmrMeasure->findSegmentR(SegmentType::EndBarLine, mmrMeasure->ticks());
+            Segment* bls = mmrMeasure->findSegmentR(SegmentType::EndBarLine, mmrMeasure->ticks());
+            Segment* cs = mmrMeasure->findSegment(SegmentType::Clef | SegmentType::HeaderClef, mmrMeasure->ticks());
             // adjust length
             mmrMeasure->setTicks(len);
-            // move existing end barline
-            if (s) {
-                s->setRtick(len);
+            // move existing end barline and clef
+            if (bls) {
+                bls->setRtick(len);
+            }
+            if (cs) {
+                cs->setRtick(len);
             }
         }
         MeasureLayout::removeSystemTrailer(mmrMeasure, ctx);


### PR DESCRIPTION
Fix multiple clefs at the end of mmrest, when remove / insert precedent measures

Resolves: #18740 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
