### PR TITLE
Fix #14700: Shortcut input now has accented border

### DIFF
--- a/src/framework/shortcuts/qml/MuseScore/Shortcuts/EditMidiMappingDialog.qml
+++ b/src/framework/shortcuts/qml/MuseScore/Shortcuts/EditMidiMappingDialog.qml
@@ -97,6 +97,8 @@ StyledDialogView {
 
                     Layout.fillWidth: true
 
+                    background.border.color: ui.theme.accentColor
+
                     readOnly: true
 
                     currentText: model.mappingTitle

--- a/src/framework/shortcuts/qml/MuseScore/Shortcuts/EditShortcutDialog.qml
+++ b/src/framework/shortcuts/qml/MuseScore/Shortcuts/EditShortcutDialog.qml
@@ -121,6 +121,8 @@ StyledDialogView {
 
                         Layout.fillWidth: true
 
+                        background.border.color: ui.theme.accentColor
+
                         hint: qsTrc("shortcuts", "Type to set shortcut")
                         readOnly: true
                         currentText: model.newSequence


### PR DESCRIPTION
Resolves: #14700

Dialog's text input field now has a border colour consistent with focused text input fields.