### PR TITLE
remove empty shortcut for top-staff command

### DIFF
--- a/src/framework/shortcuts/data/shortcuts-Mac.xml
+++ b/src/framework/shortcuts/data/shortcuts-Mac.xml
@@ -360,10 +360,6 @@
     <seq>Ctrl+Alt+Up</seq>
     </SC>
   <SC>
-    <key>top-staff</key>
-    <seq></seq>
-    </SC>
-  <SC>
     <key>first-element</key>
     <seq>Ctrl+Home</seq>
     </SC>

--- a/src/framework/shortcuts/data/shortcuts.xml
+++ b/src/framework/shortcuts/data/shortcuts.xml
@@ -360,10 +360,6 @@
     <seq>Ctrl+Alt+Up</seq>
     </SC>
   <SC>
-    <key>top-staff</key>
-    <seq></seq>
-    </SC>
-  <SC>
     <key>first-element</key>
     <seq>Ctrl+Home</seq>
     </SC>

--- a/src/framework/shortcuts/data/shortcuts_AZERTY.xml
+++ b/src/framework/shortcuts/data/shortcuts_AZERTY.xml
@@ -369,10 +369,6 @@
     <seq>Ctrl+Alt+Up</seq>
     </SC>
   <SC>
-    <key>top-staff</key>
-    <seq></seq>
-    </SC>
-  <SC>
     <key>first-element</key>
     <seq>Ctrl+Home</seq>
     </SC>


### PR DESCRIPTION
Resolves: #15033

The top-staff command has a spurious empty shortcut defined for it, which causes certain keyboards to trigger this command inadvertently (e.g., Swedish Mac keyboards triggering it on pressing "A").  This PR simply removes the top-staff entry from the shortcut files - commands with no shortcuts aren't supposed to be present in this file at all.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
