### PR TITLE
always use atonal key for drums

### DIFF
--- a/src/engraving/libmscore/edit.cpp
+++ b/src/engraving/libmscore/edit.cpp
@@ -4236,16 +4236,22 @@ void Score::restoreInitialKeySig()
         }
 
         Segment* keySegment = firstMeas->undoGetSegment(SegmentType::KeySig, startTick);
-        KeySig* newKeySig = Factory::createKeySig(keySegment);
-        newKeySig->setTrack(staff->idx() * VOICES);
-        newKeySig->setKey(transposedKey);
-        keySegment->add(newKeySig);
-        undoAddElement(newKeySig);
 
         KeySigEvent keySigEvent;
         keySigEvent.setConcertKey(concertKey);
         keySigEvent.setKey(transposedKey);
+        // use atonal KS for drums
+        if (instrument->useDrumset()) {
+            keySigEvent.setCustom(true);
+            keySigEvent.setMode(KeyMode::NONE);
+        }
+
+        KeySig* newKeySig = Factory::createKeySig(keySegment);
+        newKeySig->setTrack(staff->idx() * VOICES);
+        keySegment->add(newKeySig);
         newKeySig->setKeySigEvent(keySigEvent);
+        undoAddElement(newKeySig);
+
         staff->setKey(Fraction(0, 1), keySigEvent);
     }
 }

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -207,24 +207,30 @@ static void createMeasures(mu::engraving::Score* score, const ScoreCreateOptions
                     ts->setSig(timesig, scoreOptions.timesigType);
                     s->add(ts);
                     Part* part = staff->part();
-                    if (!part->instrument()->useDrumset()) {
+                    mu::engraving::KeySigEvent nKey;
+                    // use atonal keysig for drums
+                    if (part->instrument()->useDrumset()) {
+                        nKey.setConcertKey(Key::C);
+                        nKey.setCustom(true);
+                        nKey.setMode(KeyMode::NONE);
+                    } else {
                         //
                         // transpose key
                         //
-                        mu::engraving::KeySigEvent nKey = ks;
+                        nKey = ks;
                         mu::engraving::Interval v = part->instrument()->transpose();
                         if (!nKey.isAtonal() && !v.isZero() && !score->style().styleB(mu::engraving::Sid::concertPitch)) {
                             v.flip();
                             nKey.setKey(mu::engraving::transposeKey(nKey.concertKey(), v, part->preferSharpFlat()));
                         }
-                        staff->setKey(mu::engraving::Fraction(0, 1), nKey);
-                        mu::engraving::Segment* ss
-                            = measure->getSegment(mu::engraving::SegmentType::KeySig, mu::engraving::Fraction(0, 1));
-                        mu::engraving::KeySig* keysig = mu::engraving::Factory::createKeySig(ss);
-                        keysig->setTrack(staffIdx * mu::engraving::VOICES);
-                        keysig->setKeySigEvent(nKey);
-                        ss->add(keysig);
                     }
+                    staff->setKey(mu::engraving::Fraction(0, 1), nKey);
+                    mu::engraving::Segment* ss
+                        = measure->getSegment(mu::engraving::SegmentType::KeySig, mu::engraving::Fraction(0, 1));
+                    mu::engraving::KeySig* keysig = mu::engraving::Factory::createKeySig(ss);
+                    keysig->setTrack(staffIdx * mu::engraving::VOICES);
+                    keysig->setKeySigEvent(nKey);
+                    ss->add(keysig);
                 }
 
                 // determined if this staff is linked to previous so we can reuse rests


### PR DESCRIPTION
<!-- Add a short description of and motivation for the changes here -->
We should use atonal key sig for drum instruments. It is necessary, when changing instrument from pitched to unpitched.

"no keysig" is "missing definition of key"
"atonal keysig" is "defined non-key"

We should use later.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
