### PR TITLE
Extend MusicXML color support

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -660,6 +660,8 @@ static QString color2xml(const EngravingItem* el)
 {
     if (el->color() != engravingConfiguration()->defaultColor()) {
         return QString(" color=\"%1\"").arg(QString::fromStdString(el->color().toString()).toUpper());
+    } else if (el->isSLine() && ((SLine*)el)->lineColor() != engravingConfiguration()->defaultColor()) {
+        return QString(" color=\"%1\"").arg(QString::fromStdString(((SLine*)el)->lineColor().toString()).toUpper());
     } else {
         return "";
     }
@@ -712,18 +714,25 @@ static QString slurTieLineStyle(const SlurTie* s)
     QString lineType;
     QString rest;
     switch (s->styleType()) {
+    case SlurStyleType::Dashed:
+    case SlurStyleType::WideDashed:
+        lineType = "dashed";
+        break;
     case SlurStyleType::Dotted:
         lineType = "dotted";
         break;
-    case SlurStyleType::Dashed:
-        lineType = "dashed";
-        break;
+    case SlurStyleType::Solid:
     default:
         lineType = "";
     }
     if (!lineType.isEmpty()) {
         rest = QString(" line-type=\"%1\"").arg(lineType);
     }
+    if (s->slurDirection() != engraving::DirectionV::AUTO) {
+        rest += QString(" orientation=\"%1\"").arg(s->up() ? "over" : "under");
+        rest += QString(" placement=\"%1\"").arg(s->up() ? "above" : "below");
+    }
+    rest += color2xml(s);
     return rest;
 }
 
@@ -845,10 +854,8 @@ void SlurHandler::doSlurStart(const Slur* s, Notations& notations, XmlWriter& xm
     int i = findSlur(s);
     // compose tag
     QString tagName = "slur";
-    tagName += slurTieLineStyle(s);   // define line type
-    tagName += color2xml(s);
-    tagName += QString(" type=\"start\" placement=\"%1\"")
-               .arg(s->up() ? "above" : "below");
+    tagName += QString(" type=\"start\"");
+    tagName += slurTieLineStyle(s);
     tagName += ExportMusicXml::positioningAttributes(s, true);
 
     if (i >= 0) {
@@ -940,8 +947,10 @@ static void glissando(const Glissando* gli, int number, bool start, Notations& n
         break;
     }
     tagName += QString(" number=\"%1\" type=\"%2\"").arg(number).arg(start ? "start" : "stop");
-    tagName += color2xml(gli);
-    tagName += ExportMusicXml::positioningAttributes(gli, start);
+    if (start) {
+        tagName += color2xml(gli);
+        tagName += ExportMusicXml::positioningAttributes(gli, start);
+    }
     notations.tag(xml, gli);
     if (start && gli->showText() && gli->text() != "") {
         xml.tagRaw(tagName, gli->text());
@@ -1778,10 +1787,11 @@ static void ending(XmlWriter& xml, Volta* v, bool left)
     }
     QString voltaXml = QString("ending number=\"%1\" type=\"%2\"").arg(number, type);
     voltaXml += ExportMusicXml::positioningAttributes(v, left);
-    if (!v->visible()) {
-        voltaXml += " print-object=\"no\"";
-    }
     if (left) {
+        if (!v->visible()) {
+            voltaXml += " print-object=\"no\"";
+        }
+        voltaXml += color2xml(v);
         xml.tagRaw(voltaXml, v->text().toXmlEscaped());
     } else {
         xml.tagRaw(voltaXml);
@@ -1846,14 +1856,14 @@ static QString normalBarlineStyle(const BarLine* bl)
         return "regular";
     case BarLineType::DOUBLE:
         return "light-light";
-    case BarLineType::END_REPEAT:
     case BarLineType::REVERSE_END:
-        return "light-heavy";
+        return "heavy-light";
     case BarLineType::BROKEN:
         return "dashed";
     case BarLineType::DOTTED:
         return "dotted";
     case BarLineType::END:
+    case BarLineType::END_REPEAT:
     case BarLineType::END_START_REPEAT:
         return "light-heavy";
     case BarLineType::HEAVY:
@@ -1943,8 +1953,10 @@ static void fermata(const Fermata* const a, XmlWriter& xml)
         xml.tagRaw(tagName, "double-dot");
     } else if (id == SymId::fermataShortHenzeAbove || id == SymId::fermataShortHenzeBelow) {
         xml.tagRaw(tagName, "half-curve");
+    } else if (id == SymId::curlewSign) {
+        xml.tagRaw(tagName, "curlew");
     } else {
-        LOGD("unknown fermata sim id %d", static_cast<int>(id));
+        LOGD("unsupported fermata SymId %d", static_cast<int>(id));
     }
 }
 
@@ -1992,15 +2004,17 @@ void ExportMusicXml::barlineRight(const Measure* const m, const track_idx_t stra
     const Measure* mmRLst = mmR1->isMMRest() ? mmR1->mmRestLast() : 0;   // last measure of replaced sequence of empty measures
     // note: use barlinetype as found in multi measure rest for last measure of replaced sequence
     BarLineType bst = m == mmRLst ? mmR1->endBarLineType() : m->endBarLineType();
-    bool visible = m->endBarLineVisible();
+    const bool visible = m->endBarLineVisible();
+    QString color = "";
 
     bool needBarStyle = (bst != BarLineType::NORMAL && bst != BarLineType::START_REPEAT) || !visible;
     Volta* volta = findVolta(m, false, strack);
     // detect short and tick barlines
     QString special = "";
-    if (bst == BarLineType::NORMAL) {
-        const BarLine* bl = m->endBarLine();
-        if (bl && !bl->spanStaff()) {
+    const BarLine* bl = m->endBarLine();
+    if (bl) {
+        color = color2xml(bl);
+        if (bst == BarLineType::NORMAL && !bl->spanStaff()) {
             if (bl->spanFrom() == BARLINE_SPAN_TICK1_FROM && bl->spanTo() == BARLINE_SPAN_TICK1_TO) {
                 special = "tick";
             }
@@ -2020,38 +2034,40 @@ void ExportMusicXml::barlineRight(const Measure* const m, const track_idx_t stra
     // no need to take mmrest into account, MS does not create mmrests for measure with fermatas
     const auto hasFermata = barlineHasFermata(m->endBarLine(), strack, etrack);
 
-    if (!needBarStyle && !volta && special.isEmpty() && !hasFermata) {
+    if (!needBarStyle && !volta && special.isEmpty() && !hasFermata && color.isEmpty()) {
         return;
     }
 
     _xml.startElement("barline", { { "location", "right" } });
+    QString tagName = "bar-style";
+    tagName += color;
     if (needBarStyle) {
         if (!visible) {
-            _xml.tag("bar-style", QString("none"));
+            _xml.tagRaw(tagName, "none");
         } else {
             switch (bst) {
             case BarLineType::DOUBLE:
-                _xml.tag("bar-style", QString("light-light"));
+                _xml.tagRaw(tagName, "light-light");
                 break;
-            case BarLineType::END_REPEAT:
             case BarLineType::REVERSE_END:
-                _xml.tag("bar-style", QString("light-heavy"));
+                _xml.tagRaw(tagName, "heavy-light");
                 break;
             case BarLineType::BROKEN:
-                _xml.tag("bar-style", QString("dashed"));
+                _xml.tagRaw(tagName, "dashed");
                 break;
             case BarLineType::DOTTED:
-                _xml.tag("bar-style", QString("dotted"));
+                _xml.tagRaw(tagName, "dotted");
                 break;
             case BarLineType::END:
+            case BarLineType::END_REPEAT:
             case BarLineType::END_START_REPEAT:
-                _xml.tag("bar-style", QString("light-heavy"));
+                _xml.tagRaw(tagName, "light-heavy");
                 break;
             case BarLineType::HEAVY:
-                _xml.tag("bar-style", QString("heavy"));
+                _xml.tagRaw(tagName, "heavy");
                 break;
             case BarLineType::DOUBLE_HEAVY:
-                _xml.tag("bar-style", QString("heavy-heavy"));
+                _xml.tagRaw(tagName, "heavy-heavy");
                 break;
             default:
                 LOGD("ExportMusicXml::bar(): bar subtype %d not supported", int(bst));
@@ -2059,7 +2075,9 @@ void ExportMusicXml::barlineRight(const Measure* const m, const track_idx_t stra
             }
         }
     } else if (!special.isEmpty()) {
-        _xml.tag("bar-style", special);
+        _xml.tagRaw(tagName, special);
+    } else if (!color.isEmpty()) {
+        _xml.tagRaw(tagName, "regular");
     }
 
     writeBarlineFermata(m->endBarLine(), _xml, strack, etrack);
@@ -2681,13 +2699,15 @@ static void tupletTypeAndDots(const QString& type, const int dots, XmlWriter& xm
 static void tupletActualAndNormal(const Tuplet* const t, XmlWriter& xml)
 {
     xml.startElement("tuplet-actual");
-    xml.tag("tuplet-number", t->ratio().numerator());
+    XmlWriter::Attributes tNumAttrs;
+    addColorAttr(t, tNumAttrs);
+    xml.tag("tuplet-number", tNumAttrs, t->ratio().numerator());
     int dots { 0 };
     const auto s = tick2xml(t->baseLen().ticks(), &dots);
     tupletTypeAndDots(s, dots, xml);
     xml.endElement();
     xml.startElement("tuplet-normal");
-    xml.tag("tuplet-number", t->ratio().denominator());
+    xml.tag("tuplet-number", tNumAttrs, t->ratio().denominator());
     tupletTypeAndDots(s, dots, xml);
     xml.endElement();
 }
@@ -2712,9 +2732,15 @@ static void tupletStart(const Tuplet* const t, const int number, const bool need
     tupletTag += t->hasBracket() ? "\"yes\"" : "\"no\"";
     if (t->numberType() == TupletNumberType::SHOW_RELATION) {
         tupletTag += " show-number=\"both\"";
-    }
-    if (t->numberType() == TupletNumberType::NO_TEXT) {
+    } else if (t->numberType() == TupletNumberType::NO_TEXT) {
         tupletTag += " show-number=\"none\"";
+    }
+    if (t->direction() != engraving::DirectionV::AUTO) {
+        if (t->direction() == engraving::DirectionV::UP) {
+            tupletTag += " placement=\"above\"";
+        } else if (t->direction() == engraving::DirectionV::DOWN) {
+            tupletTag += " placement=\"below\"";
+        }
     }
     if (needActualAndNormal) {
         xml.startElementRaw(tupletTag);
@@ -2791,9 +2817,19 @@ static void writeAccidental(XmlWriter& xml, const QString& tagName, const Accide
                 attrs = { { "smufl", accidentalType2SmuflMxmlString(acc->accidentalType()) } };
             }
             QString tag = tagName;
-            if (acc->bracket() != AccidentalBracket::NONE) {
+            if (acc->bracket() == AccidentalBracket::BRACKET) {
+                attrs.emplace_back(std::make_pair("bracket", "yes"));
+            } else if (acc->bracket() == AccidentalBracket::PARENTHESIS) {
                 attrs.emplace_back(std::make_pair("parentheses", "yes"));
             }
+            if (tagName == "accidental-mark") {
+                if (acc->placeAbove()) {
+                    attrs.emplace_back(std::make_pair("placement", "above"));
+                } else if (acc->placeBelow()) {
+                    attrs.emplace_back(std::make_pair("placement", "below"));
+                }
+            }
+            addColorAttr(acc, attrs);
             xml.tag(AsciiStringView(tag.toStdString()), attrs, s);
         }
     }
@@ -2808,7 +2844,7 @@ static void wavyLineStart(const Trill* tr, const int number, Notations& notation
     // mscore only supports wavy-line with trill-mark
     notations.tag(xml, tr);
     ornaments.tag(xml);
-    xml.tag("trill-mark");
+    xml.tagRaw("trill-mark" + color2xml(tr));
     writeAccidental(xml, "accidental-mark", tr->accidental());
     QString tagName = "wavy-line type=\"start\"";
     tagName += QString(" number=\"%1\"").arg(number + 1);
@@ -3290,6 +3326,7 @@ void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technic
                     mxmlArtic += " placement=\"below\"";
                 }
             }
+            mxmlArtic += color2xml(a);
 
             notations.tag(_xml, a);
             articulations.tag(_xml);
@@ -3313,9 +3350,12 @@ void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technic
         auto mxmlOrnam = symIdToOrnam(sid);
 
         if (mxmlOrnam != "") {
+            mxmlOrnam += color2xml(a);
+
             notations.tag(_xml, a);
             ornaments.tag(_xml);
             _xml.tagRaw(mxmlOrnam);
+            // accidental-mark is missing
         }
     }
 
@@ -3352,6 +3392,7 @@ void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technic
         if (mxmlTechn != "") {
             notations.tag(_xml, a);
             technical.tag(_xml);
+            mxmlTechn += color2xml(a);
             if (sid == SymId::stringsHarmonic) {
                 if (placement != "") {
                     attr += QString(" placement=\"%1\"").arg(placement);
@@ -3430,6 +3471,7 @@ static void arpeggiate(Arpeggio* arp, bool front, bool back, XmlWriter& xml, Not
     }
 
     if (tagName != "") {
+        tagName += color2xml(arp);
         tagName += ExportMusicXml::positioningAttributes(arp);
         xml.tagRaw(tagName);
     }
@@ -3698,6 +3740,7 @@ static void writeFingering(XmlWriter& xml, Notations& notations, Technical& tech
             if (!f->isStyled(Pid::FONT_STYLE)) {
                 attr += fontStyleToXML(static_cast<FontStyle>(f->getProperty(Pid::FONT_STYLE).toInt()), false);
             }
+            attr += color2xml(f);
 
             if (f->textStyleType() == TextStyleType::RH_GUITAR_FINGERING) {
                 xml.tagRaw("pluck" + attr, t);
@@ -4617,6 +4660,7 @@ static void wordsMetronome(XmlWriter& xml, const MStyle& s, TextBase const* cons
 
         xml.startElement("direction-type");
         QString tagName = QString("metronome parentheses=\"%1\"").arg(hasParen ? "yes" : "no");
+        tagName += color2xml(text);
         tagName += ExportMusicXml::positioningAttributes(text);
         xml.startElementRaw(tagName);
         int len1 = 0;
@@ -4650,6 +4694,7 @@ static void wordsMetronome(XmlWriter& xml, const MStyle& s, TextBase const* cons
                 attr = " enclosure=\"rectangle\"";
             }
         }
+        attr += color2xml(text);
         attr += ExportMusicXml::positioningAttributes(text);
         MScoreTextToMXML mttm("words", attr, defFmt, mtf);
         //LOGD("words('%s')", qPrintable(text->text()));
@@ -4782,10 +4827,14 @@ void ExportMusicXml::rehearsal(RehearsalMark const* const rmk, staff_idx_t staff
 
     directionTag(_xml, _attr, rmk);
     _xml.startElement("direction-type");
-    QString attr = positioningAttributes(rmk);
-    if (!rmk->hasFrame()) {
+    QString attr;
+    if (rmk->circle()) {
+        attr = " enclosure=\"circle\"";
+    } else if (!rmk->hasFrame()) {
         attr = " enclosure=\"none\"";
     }
+    attr += color2xml(rmk);
+    attr += positioningAttributes(rmk);
     // set the default words format
     const MStyle& style = _score->style();
     const QString mtf = style.styleSt(Sid::MusicalTextFont);
@@ -4890,6 +4939,7 @@ static void writeHairpinText(XmlWriter& xml, const TextLineBase* const tlb, bool
                 += QString(" font-family=\"%1\"").arg(tlb->getProperty(isStart ? Pid::BEGIN_FONT_FACE : Pid::END_FONT_FACE).value<String>());
             tag += QString(" font-size=\"%1\"").arg(tlb->getProperty(isStart ? Pid::BEGIN_FONT_SIZE : Pid::END_FONT_SIZE).toReal());
             tag += fontStyleToXML(static_cast<FontStyle>(tlb->getProperty(isStart ? Pid::BEGIN_FONT_STYLE : Pid::END_FONT_STYLE).toInt()));
+            tag += color2xml(tlb);
             tag += ExportMusicXml::positioningAttributes(tlb, isStart);
             xml.tagRaw(tag, dynamicPosition == -1 ? text : text.left(dynamicPosition));
             xml.endElement();
@@ -4904,6 +4954,7 @@ static void writeHairpinText(XmlWriter& xml, const TextLineBase* const tlb, bool
             // dynamic at front of text
             xml.startElement("direction-type");
             QString tag = "dynamics";
+            tag += color2xml(tlb);
             tag += ExportMusicXml::positioningAttributes(tlb, isStart);
             xml.startElementRaw(tag);
             xml.tagRaw(dynamicsType);
@@ -4955,17 +5006,20 @@ void ExportMusicXml::hairpin(Hairpin const* const hp, staff_idx_t staff, const F
         writeHairpinText(_xml, hp, hp->tick() == tick);
     }
     if (isLineType) {
-        if (hp->tick() == tick) {
-            _xml.startElement("direction-type");
-            QString tag = "dashes type=\"start\"";
-            tag += QString(" number=\"%1\"").arg(n + 1);
-            tag += positioningAttributes(hp, hp->tick() == tick);
-            _xml.tagRaw(tag);
-            _xml.endElement();
-        } else {
-            _xml.startElement("direction-type");
-            _xml.tagRaw(QString("dashes type=\"stop\" number=\"%1\"").arg(n + 1));
-            _xml.endElement();
+        if (hp->lineVisible()) {
+            if (hp->tick() == tick) {
+                _xml.startElement("direction-type");
+                QString tag = "dashes type=\"start\"";
+                tag += QString(" number=\"%1\"").arg(n + 1);
+                tag += color2xml(hp);
+                tag += positioningAttributes(hp, hp->tick() == tick);
+                _xml.tagRaw(tag);
+                _xml.endElement();
+            } else {
+                _xml.startElement("direction-type");
+                _xml.tagRaw(QString("dashes type=\"stop\" number=\"%1\"").arg(n + 1));
+                _xml.endElement();
+            }
         }
     } else {
         _xml.startElement("direction-type");
@@ -4979,6 +5033,7 @@ void ExportMusicXml::hairpin(Hairpin const* const hp, staff_idx_t staff, const F
             } else {
                 tag += "\"diminuendo\"";
             }
+            tag += color2xml(hp);
         } else {
             tag += "\"stop\"";
             if (hp->hairpinCircledTip() && hp->hairpinType() == HairpinType::DECRESC_HAIRPIN) {
@@ -5073,6 +5128,7 @@ void ExportMusicXml::ottava(Ottava const* const ot, staff_idx_t staff, const Fra
     if (octaveShiftXml != "") {
         directionTag(_xml, _attr, ot);
         _xml.startElement("direction-type");
+        octaveShiftXml += color2xml(ot);
         octaveShiftXml += positioningAttributes(ot, ot->tick() == tick);
         _xml.tagRaw(octaveShiftXml);
         _xml.endElement();
@@ -5122,6 +5178,7 @@ void ExportMusicXml::pedal(Pedal const* const pd, staff_idx_t staff, const Fract
     pedalXml = QString("pedal type=\"%1\"").arg(pedalType);
     pedalXml += lineText;
     pedalXml += signText;
+    pedalXml += color2xml(pd);
     pedalXml += positioningAttributes(pd, pd->tick() == tick);
     _xml.tagRaw(pedalXml);
     _xml.endElement();
@@ -5240,6 +5297,7 @@ void ExportMusicXml::textLine(TextLineBase const* const tl, staff_idx_t staff, c
         LOGD("HookType %d not supported", int(hookType));
     }
 
+    rest += color2xml(tl);
     rest += positioningAttributes(tl, tl->tick() == tick);
 
     directionTag(_xml, _attr, tl);
@@ -5295,6 +5353,7 @@ void ExportMusicXml::dynamic(Dynamic const* const dyn, staff_idx_t staff)
     _xml.startElement("direction-type");
 
     QString tagName = "dynamics";
+    tagName += color2xml(dyn);
     tagName += positioningAttributes(dyn);
     _xml.startElementRaw(tagName);
     const QString dynTypeName = TConv::toXml(dyn->dynamicType()).ascii();
@@ -5397,6 +5456,7 @@ void ExportMusicXml::symbol(Symbol const* const sym, staff_idx_t staff)
         mxmlName = QString("other-direction smufl=\"%1\"").arg(name.ascii());
     }
     directionTag(_xml, _attr, sym);
+    mxmlName += color2xml(sym);
     mxmlName += positioningAttributes(sym);
     _xml.startElement("direction-type");
     _xml.tagRaw(mxmlName);
@@ -6094,6 +6154,13 @@ static void writeMusicXML(const FiguredBass* item, XmlWriter& xml, bool isOrigin
     XmlWriter::Attributes attrs;
     if (item->hasParentheses()) {
         attrs = { { "parentheses", "yes" } };
+    }
+    if (item->placeAbove()) {
+        attrs.emplace_back(std::make_pair("placement", "above"));
+    }
+    addColorAttr(item, attrs);
+    if (!item->visible()) {
+        attrs.emplace_back(std::make_pair("print-object", "no"));
     }
     xml.startElement("figured-bass", attrs);
     for (FiguredBassItem* fbItem : item->items()) {

--- a/src/importexport/musicxml/internal/musicxml/importmxmlnotepitch.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlnotepitch.cpp
@@ -45,9 +45,11 @@ namespace mu::engraving {
 
 static Accidental* accidental(QXmlStreamReader& e, Score* score)
 {
-    bool cautionary = e.attributes().value("cautionary") == "yes";
-    bool editorial = e.attributes().value("editorial") == "yes";
-    bool parentheses = e.attributes().value("parentheses") == "yes";
+    const bool cautionary = e.attributes().value("cautionary") == "yes";
+    const bool editorial = e.attributes().value("editorial") == "yes";
+    const bool parentheses = e.attributes().value("parentheses") == "yes";
+    const bool brackets = e.attributes().value("bracket") == "yes";
+    const QColor accColor { e.attributes().value("color").toString() };
     QString smufl = e.attributes().value("smufl").toString();
 
     const auto s = e.readElementText();
@@ -56,9 +58,15 @@ static Accidental* accidental(QXmlStreamReader& e, Score* score)
     if (type != AccidentalType::NONE) {
         auto a = Factory::createAccidental(score->dummy());
         a->setAccidentalType(type);
-        if (editorial || cautionary || parentheses) {
-            a->setBracket(AccidentalBracket(cautionary || parentheses));
+        if (cautionary || parentheses) {
+            a->setBracket(AccidentalBracket(AccidentalBracket::PARENTHESIS));
             a->setRole(AccidentalRole::USER);
+        } else if (editorial || brackets) {
+            a->setBracket(AccidentalBracket(AccidentalBracket::BRACKET));
+            a->setRole(AccidentalRole::USER);
+        }
+        if (accColor.isValid()) {
+            a->setColor(accColor);
         }
         return a;
     }

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
@@ -75,7 +75,7 @@ enum class MusicXmlSlash : char {
 struct MusicXmlTupletDesc {
     MusicXmlTupletDesc();
     MxmlStartStop type;
-    PlacementV placement;
+    DirectionV direction;
     TupletBracketType bracket;
     TupletNumberType shownumber;
 };
@@ -307,8 +307,8 @@ private:
     void backup(Fraction& dura);
     void timeModification(Fraction& timeMod, TDuration& normalType);
     void stem(DirectionV& sd, bool& nost);
-    void doEnding(const QString& partId, Measure* measure, const QString& number, const QString& type, const QString& text,
-                  const bool print);
+    void doEnding(const QString& partId, Measure* measure, const QString& number, const QString& type, const QColor color,
+                  const QString& text, const bool print);
     void staffDetails(const QString& partId, Measure* measure = nullptr);
     void staffTuning(StringData* t);
     void skipLogCurrElem();

--- a/src/importexport/musicxml/tests/data/testArpGliss3.xml
+++ b/src/importexport/musicxml/tests/data/testArpGliss3.xml
@@ -99,7 +99,7 @@
         <type>half</type>
         <stem>down</stem>
         <notations>
-          <glissando line-type="wavy" number="1" type="stop" color="#005500"/>
+          <glissando line-type="wavy" number="1" type="stop"/>
           </notations>
         </note>
       </measure>
@@ -155,7 +155,7 @@
         <type>half</type>
         <stem>down</stem>
         <notations>
-          <slide line-type="solid" number="1" type="stop" color="#AA0000"/>
+          <slide line-type="solid" number="1" type="stop"/>
           </notations>
         </note>
       <barline location="right">

--- a/src/importexport/musicxml/tests/data/testBarStyles4.xml
+++ b/src/importexport/musicxml/tests/data/testBarStyles4.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>All bar styles with color</work-title>
+    </work>
+  <identification>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Flöte</part-name>
+      <part-abbreviation>Fl.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Flöte</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>74</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style color="#FF0000">dashed</bar-style>
+        </barline>
+      </measure>
+    <measure number="2">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style color="#0FF000">dotted</bar-style>
+        </barline>
+      </measure>
+    <measure number="3">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style color="#00FF00">heavy</bar-style>
+        </barline>
+      </measure>
+    <measure number="4">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style color="#000FF0">heavy-heavy</bar-style>
+        </barline>
+      </measure>
+    <measure number="5">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style color="#0000FF">heavy-light</bar-style>
+        </barline>
+      </measure>
+    <measure number="6">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style color="#F0000F">light-heavy</bar-style>
+        </barline>
+      </measure>
+    <measure number="7">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style color="#0F00F0">light-light</bar-style>
+        </barline>
+      </measure>
+    <measure number="8">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style color="#F0F0F0">none</bar-style>
+        </barline>
+      </measure>
+    <measure number="9">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style color="#0F0F0F">regular</bar-style>
+        </barline>
+      </measure>
+    <measure number="10">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style color="#FFF000">short</bar-style>
+        </barline>
+      </measure>
+    <measure number="11">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style color="#000FFF">tick</bar-style>
+        </barline>
+      </measure>
+    <measure number="12">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/data/testColorExport.mscx
+++ b/src/importexport/musicxml/tests/data/testColorExport.mscx
@@ -1,0 +1,570 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.10">
+  <programVersion>4.2.0</programVersion>
+  <programRevision>cd7763a</programRevision>
+  <Score>
+    <Division>480</Division>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2023-09-11</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="originalFormat">musicxml</metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="sourceRevisionId"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument id="piano">
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <controller ctrl="10" value="63"/>
+          <synti>Fluid</synti>
+          </Channel>
+        <Channel name="harmony">
+          <program value="0"/>
+          <controller ctrl="10" value="63"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            <color r="255" g="85" b="255" a="255"/>
+            </Clef>
+          <KeySig>
+            <color r="255" g="0" b="127" a="255"/>
+            <accidental>2</accidental>
+            </KeySig>
+          <TimeSig>
+            <color r="255" g="170" b="127" a="255"/>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Harmony>
+            <root>14</root>
+            <name>7</name>
+            <color r="148" g="82" b="0" a="255"/>
+            </Harmony>
+          <Tempo>
+            <tempo>1.333333</tempo>
+            <followText>1</followText>
+            <color r="148" g="33" b="147" a="255"/>
+            <text><sym>metNoteQuarterUp</sym> = 80</text>
+            </Tempo>
+          <Spanner type="TextLine">
+            <TextLine>
+              <endHookType>1</endHookType>
+              <color r="255" g="64" b="255" a="255"/>
+              <color r="255" g="64" b="255" a="255"/>
+              </TextLine>
+            <next>
+              <location>
+                <measures>1</measures>
+                </location>
+              </next>
+            </Spanner>
+          <Spanner type="HairPin">
+            <HairPin>
+              <subtype>0</subtype>
+              <color r="85" g="170" b="255" a="255"/>
+              <color r="85" g="170" b="255" a="255"/>
+              </HairPin>
+            <next>
+              <location>
+                <measures>1</measures>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Spanner type="Slur">
+              <Slur>
+                <color r="122" g="129" b="255" a="255"/>
+                <SlurSegment no="0">
+                  <color r="122" g="129" b="255" a="255"/>
+                  </SlurSegment>
+                </Slur>
+              <next>
+                <location>
+                  <fractions>1/2</fractions>
+                  </location>
+                </next>
+              </Spanner>
+            <StemDirection>up</StemDirection>
+            <Note>
+              <color r="255" g="85" b="0" a="255"/>
+              <pitch>69</pitch>
+              <tpc>17</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <color r="0" g="85" b="255" a="255"/>
+              <Accidental>
+                <subtype>accidentalNatural</subtype>
+                <color r="0" g="143" b="0" a="255"/>
+                </Accidental>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Spanner type="Slur">
+              <prev>
+                <location>
+                  <fractions>-1/2</fractions>
+                  </location>
+                </prev>
+              </Spanner>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <Spanner type="Tie">
+                <Tie>
+                  <color r="255" g="0" b="255" a="255"/>
+                  </Tie>
+                <next>
+                  <location>
+                    <fractions>1/4</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              <pitch>74</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          <Fermata>
+            <subtype>fermataAbove</subtype>
+            <color r="85" g="255" b="0" a="255"/>
+            </Fermata>
+          <Chord>
+            <durationType>quarter</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <fractions>-1/4</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
+              <pitch>74</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Dynamic>
+            <subtype>pp</subtype>
+            <velocity>33</velocity>
+            <color r="79" g="143" b="0" a="255"/>
+            </Dynamic>
+          <Spanner type="TextLine">
+            <prev>
+              <location>
+                <measures>-1</measures>
+                </location>
+              </prev>
+            </Spanner>
+          <Spanner type="HairPin">
+            <prev>
+              <location>
+                <measures>-1</measures>
+                </location>
+              </prev>
+            </Spanner>
+          <Spanner type="Volta">
+            <Volta>
+              <endHookType>1</endHookType>
+              <beginText>1.</beginText>
+              <color r="255" g="0" b="0" a="255"/>
+              <color r="255" g="0" b="0" a="255"/>
+              <endings>1</endings>
+              </Volta>
+            <next>
+              <location>
+                <measures>1</measures>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <durationType>quarter</durationType>
+            <StemDirection>up</StemDirection>
+            <Note>
+              <pitch>69</pitch>
+              <tpc>17</tpc>
+              <Spanner type="Glissando">
+                <Glissando>
+                  <color r="170" g="170" b="255" a="255"/>
+                  <diagonal>1</diagonal>
+                  <color r="170" g="170" b="255" a="255"/>
+                  <anchor>3</anchor>
+                  </Glissando>
+                <next>
+                  <location>
+                    <fractions>1/4</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <pitch>79</pitch>
+              <tpc>15</tpc>
+              <Spanner type="Glissando">
+                <prev>
+                  <location>
+                    <fractions>-1/4</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <StemDirection>up</StemDirection>
+            <Note>
+              <pitch>69</pitch>
+              <tpc>17</tpc>
+              <Spanner type="Glissando">
+                <Glissando>
+                  <text>gliss.</text>
+                  <subtype>1</subtype>
+                  <color r="255" g="170" b="0" a="255"/>
+                  <diagonal>1</diagonal>
+                  <color r="255" g="170" b="0" a="255"/>
+                  <anchor>3</anchor>
+                  </Glissando>
+                <next>
+                  <location>
+                    <fractions>1/4</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Lyrics>
+              <color r="255" g="85" b="255" a="255"/>
+              <text>LYRICS</text>
+              </Lyrics>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <pitch>79</pitch>
+              <tpc>15</tpc>
+              <Spanner type="Glissando">
+                <prev>
+                  <location>
+                    <fractions>-1/4</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <RehearsalMark>
+            <color r="0" g="145" b="147" a="255"/>
+            <text>B</text>
+            </RehearsalMark>
+          <Spanner type="Volta">
+            <prev>
+              <location>
+                <measures>-1</measures>
+                </location>
+              </prev>
+            </Spanner>
+          <Rest>
+            <color r="255" g="85" b="0" a="255"/>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Spanner type="Pedal">
+            <Pedal>
+              <endHookType>1</endHookType>
+              <beginText>&lt;sym&gt;keyboardPedalPed&lt;/sym&gt;</beginText>
+              <continueText>(&lt;sym&gt;keyboardPedalPed&lt;/sym&gt;)</continueText>
+              <color r="255" g="133" b="255" a="255"/>
+              <color r="255" g="133" b="255" a="255"/>
+              </Pedal>
+            <next>
+              <location>
+                <measures>1</measures>
+                <fractions>-1/4</fractions>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Articulation>
+              <subtype>articMarcatoTenutoAbove</subtype>
+              <anchor>0</anchor>
+              <color r="255" g="85" b="0" a="255"/>
+              </Articulation>
+            <StemDirection>up</StemDirection>
+            <Note>
+              <Accidental>
+                <subtype>accidentalFlat</subtype>
+                <color r="146" g="144" b="0" a="255"/>
+                </Accidental>
+              <pitch>68</pitch>
+              <tpc>10</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>half</durationType>
+            <Articulation>
+              <subtype>ornamentTurn</subtype>
+              <color r="0" g="249" b="0" a="255"/>
+              </Articulation>
+            <StemDirection>up</StemDirection>
+            <Note>
+              <pitch>68</pitch>
+              <tpc>10</tpc>
+              </Note>
+            </Chord>
+          <BarLine>
+            <subtype>double</subtype>
+            <color r="0" g="145" b="147" a="255"/>
+            </BarLine>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <StaffText>
+            <placement>below</placement>
+            <italic>1</italic>
+            <color r="148" g="82" b="0" a="255"/>
+            <text><i>Ausdruck</i></text>
+            </StaffText>
+          <Spanner type="Pedal">
+            <prev>
+              <location>
+                <measures>-1</measures>
+                <fractions>1/4</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          <Spanner type="Ottava">
+            <Ottava>
+              <subtype>8vb</subtype>
+              <color r="115" g="252" b="214" a="255"/>
+              <color r="115" g="252" b="214" a="255"/>
+              </Ottava>
+            <next>
+              <location>
+                <measures>1</measures>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <durationType>quarter</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            <Note>
+              <pitch>69</pitch>
+              <tpc>17</tpc>
+              </Note>
+            <Note>
+              <pitch>73</pitch>
+              <tpc>21</tpc>
+              </Note>
+            <Note>
+              <pitch>76</pitch>
+              <tpc>18</tpc>
+              </Note>
+            <Arpeggio>
+              <color r="115" g="253" b="255" a="255"/>
+              <subtype>1</subtype>
+              </Arpeggio>
+            </Chord>
+          <Rest>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Chord>
+            <durationType>quarter</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <pitch>73</pitch>
+              <tpc>21</tpc>
+              </Note>
+            <Tremolo>
+              <subtype>r32</subtype>
+              <color r="255" g="212" b="121" a="255"/>
+              </Tremolo>
+            </Chord>
+          <Rest>
+            <durationType>quarter</durationType>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Spanner type="Ottava">
+            <prev>
+              <location>
+                <measures>-1</measures>
+                </location>
+              </prev>
+            </Spanner>
+          <Spanner type="HairPin">
+            <HairPin>
+              <subtype>3</subtype>
+              <lineVisible>0</lineVisible>
+              <color r="145" g="145" b="145" a="255"/>
+              <color r="145" g="145" b="145" a="255"/>
+              </HairPin>
+            <next>
+              <location>
+                <measures>1</measures>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <durationType>whole</durationType>
+            <Ornament>
+              <subtype>ornamentTrill</subtype>
+              <color r="255" g="38" b="0" a="255"/>
+              </Ornament>
+            <Note>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Spanner type="HairPin">
+            <prev>
+              <location>
+                <measures>-1</measures>
+                </location>
+              </prev>
+            </Spanner>
+          <Spanner type="Pedal">
+            <Pedal>
+              <endHookType>1</endHookType>
+              <beginHookType>1</beginHookType>
+              <color r="4" g="51" b="255" a="255"/>
+              <color r="4" g="51" b="255" a="255"/>
+              </Pedal>
+            <next>
+              <location>
+                <fractions>1/1</fractions>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <Accidental>
+                <subtype>accidentalNatural</subtype>
+                </Accidental>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>half</durationType>
+            <StemDirection>up</StemDirection>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Spanner type="Pedal">
+            <prev>
+              <location>
+                <fractions>-1/1</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/importexport/musicxml/tests/data/testColorExport_ref.xml
+++ b/src/importexport/musicxml/tests/data/testColorExport_ref.xml
@@ -1,0 +1,432 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <identification>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key color="#FF007F">
+          <fifths>2</fifths>
+          </key>
+        <time color="#FFAA7F">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef color="#FF55FF">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <harmony print-frame="no" color="#945200">
+        <root>
+          <root-step>C</root-step>
+          </root>
+        <kind text="7">dominant</kind>
+        </harmony>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" color="#942193">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>80</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="80"/>
+        </direction>
+      <direction placement="above">
+        <direction-type>
+          <bracket type="start" number="1" line-end="none" line-type="solid" color="#FF40FF"/>
+          </direction-type>
+        </direction>
+      <direction placement="below">
+        <direction-type>
+          <wedge type="crescendo" color="#55AAFF" number="1"/>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notehead color="#FF5500">normal</notehead>
+        <notations>
+          <slur type="start" color="#7A81FF" number="1"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <accidental color="#008F00">natural</accidental>
+        <stem>down</stem>
+        <notehead color="#0055FF">normal</notehead>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <tie type="start"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <tied type="start" color="#FF00FF"/>
+          <slur type="stop" number="1"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <tie type="stop"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <tied type="stop"/>
+          <fermata type="upright" color="#55FF00"/>
+          </notations>
+        </note>
+      <direction placement="above">
+        <direction-type>
+          <bracket type="stop" number="1" line-end="down" end-length="15" color="#FF40FF"/>
+          </direction-type>
+        </direction>
+      <direction placement="below">
+        <direction-type>
+          <wedge type="stop" number="1"/>
+          </direction-type>
+        </direction>
+      </measure>
+    <measure number="2">
+      <barline location="left">
+        <ending number="1" type="start" color="#FF0000">1.</ending>
+        </barline>
+      <direction placement="below">
+        <direction-type>
+          <dynamics color="#4F8F00">
+            <pp/>
+            </dynamics>
+          </direction-type>
+        <sound dynamics="36.67"/>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <slide line-type="solid" number="1" type="start" color="#AAAAFF"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <slide line-type="solid" number="1" type="stop"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <glissando line-type="wavy" number="1" type="start" color="#FFAA00">gliss.</glissando>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <glissando line-type="wavy" number="1" type="stop"/>
+          </notations>
+        <lyric number="1" color="#FF55FF">
+          <syllabic>single</syllabic>
+          <text>LYRICS</text>
+          </lyric>
+        </note>
+      <barline location="right">
+        <ending number="1" type="stop"/>
+        </barline>
+      </measure>
+    <measure number="3">
+      <direction placement="above">
+        <direction-type>
+          <rehearsal color="#009193" font-weight="bold" font-size="14">B</rehearsal>
+          </direction-type>
+        </direction>
+      <note color="#FF5500">
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <pedal type="resume" line="yes" sign="yes" color="#FF85FF"/>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <accidental color="#929000">flat</accidental>
+        <stem>up</stem>
+        <notations>
+          <articulations>
+            <strong-accent type="up" color="#FF5500"/>
+            <tenuto placement="above" color="#FF5500"/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <notations>
+          <ornaments>
+            <turn color="#00F900"/>
+            </ornaments>
+          </notations>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <pedal type="stop" line="yes" sign="no" color="#FF85FF"/>
+          </direction-type>
+        </direction>
+      <barline location="right">
+        <bar-style color="#009193">light-light</bar-style>
+        </barline>
+      </measure>
+    <measure number="4">
+      <direction placement="below">
+        <direction-type>
+          <words color="#945200" font-style="italic">Ausdruck</words>
+          </direction-type>
+        </direction>
+      <direction placement="below">
+        <direction-type>
+          <octave-shift type="up" size="8" number="1" color="#73FCD6"/>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <arpeggiate direction="up" color="#73FDFF"/>
+          </notations>
+        </note>
+      <note>
+        <chord/>
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <arpeggiate direction="up" color="#73FDFF"/>
+          </notations>
+        </note>
+      <note>
+        <chord/>
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <arpeggiate direction="up" color="#73FDFF"/>
+          </notations>
+        </note>
+      <note>
+        <chord/>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <arpeggiate direction="up" color="#73FDFF"/>
+          </notations>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <ornaments>
+            <tremolo type="single" color="#FFD479">3</tremolo>
+            </ornaments>
+          </notations>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <octave-shift type="stop" size="8" number="1" color="#73FCD6"/>
+          </direction-type>
+        </direction>
+      </measure>
+    <measure number="5">
+      <direction placement="below">
+        <direction-type>
+          <words font-family="Edwin" font-size="10" font-style="italic" color="#919191">dim.</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <ornaments>
+            <trill-mark color="#FF2600"/>
+            </ornaments>
+          </notations>
+        </note>
+      <direction placement="below">
+        </direction>
+      </measure>
+    <measure number="6">
+      <direction placement="below">
+        <direction-type>
+          <pedal type="start" line="yes" sign="no" color="#0433FF"/>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <accidental>natural</accidental>
+        <stem>down</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <pedal type="stop" line="yes" sign="no" color="#0433FF"/>
+          </direction-type>
+        </direction>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/data/testColors.xml
+++ b/src/importexport/musicxml/tests/data/testColors.xml
@@ -2,11 +2,10 @@
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="4.0">
   <work>
-    <work-number>MuseScore testfile</work-number>
-    <work-title>Non-unique things</work-title>
+    <work-title>Color test</work-title>
     </work>
   <identification>
-    <creator type="composer">Leon Vinken</creator>
+    <creator type="composer">Klaus Retttinghaus</creator>
     <encoding>
       <software>MuseScore 0.7.0</software>
       <encoding-date>2007-09-10</encoding-date>
@@ -19,15 +18,15 @@
     </identification>
   <part-list>
     <score-part id="P1">
-      <part-name>Piccolo</part-name>
-      <part-abbreviation>Picc.</part-abbreviation>
+      <part-name>Violine</part-name>
+      <part-abbreviation>Vl.</part-abbreviation>
       <score-instrument id="P1-I1">
-        <instrument-name>Piccolo</instrument-name>
+        <instrument-name>Violine</instrument-name>
         </score-instrument>
       <midi-device id="P1-I1" port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
-        <midi-program>73</midi-program>
+        <midi-program>41</midi-program>
         <volume>78.7402</volume>
         <pan>0</pan>
         </midi-instrument>
@@ -37,116 +36,153 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
-          <fifths>0</fifths>
+        <key color="#00FDFF">
+          <fifths>-1</fifths>
           </key>
-        <time>
+        <time color="#4F8F00">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>
-        <clef>
+        <clef color="#FEFB03">
           <sign>G</sign>
           <line>2</line>
-          <clef-octave-change>1</clef-octave-change>
           </clef>
         </attributes>
       <note>
         <pitch>
-          <step>G</step>
-          <octave>5</octave>
+          <step>D</step>
+          <octave>4</octave>
           </pitch>
         <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <stem>up</stem>
+        <stem>down</stem>
         <notations>
-          <slur type="start" number="1"/>
+          <slide line-type="solid" number="1" type="start" color="#A873BE"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <articulations>
+            <accent color="#FF2600"/>
+            <staccato color="#FF2600"/>
+            </articulations>
+          <slide line-type="solid" number="1" type="stop"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <glissando line-type="wavy" number="1" type="start" color="#82A365">gliss.</glissando>
           </notations>
         </note>
       <note>
         <pitch>
           <step>A</step>
-          <octave>5</octave>
+          <octave>4</octave>
           </pitch>
         <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <stem>up</stem>
-        </note>
-      <note>
-        <pitch>
-          <step>B</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>quarter</type>
-        <stem>up</stem>
+        <stem>down</stem>
         <notations>
-          <slur type="stop" number="1"/>
+          <articulations>
+            <strong-accent type="up" color="#C3D610"/>
+            </articulations>
+          <glissando line-type="wavy" number="1" type="stop"/>
           </notations>
         </note>
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>6</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>quarter</type>
-        <stem>up</stem>
-        </note>
+      <barline location="right">
+        <bar-style color="#D783FF">regular</bar-style>
+        </barline>
       </measure>
     <measure number="2">
       <note>
         <pitch>
           <step>G</step>
-          <octave>5</octave>
+          <octave>4</octave>
           </pitch>
         <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <stem>up</stem>
-        </note>
-      <note>
-        <pitch>
-          <step>A</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>quarter</type>
-        <stem>up</stem>
+        <stem>down</stem>
         <notations>
-          <slur type="start" number="1"/>
+          <slur type="start" color="#EFCDAB" number="1"/>
           </notations>
         </note>
       <note>
         <pitch>
-          <step>B</step>
-          <octave>5</octave>
+          <step>A</step>
+          <octave>4</octave>
           </pitch>
         <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <stem>up</stem>
+        <stem>down</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <accidental color="#0F12A7">natural</accidental>
+        <stem>down</stem>
         <notations>
-          <slur type="stop" number="1"/>
+          <ornaments>
+            <mordent color="#047110"/>
+            </ornaments>
           </notations>
         </note>
       <note>
         <pitch>
           <step>C</step>
-          <octave>6</octave>
+          <alter>1</alter>
+          <octave>5</octave>
           </pitch>
         <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <stem>up</stem>
+        <accidental color="#A632F0">sharp</accidental>
+        <stem>down</stem>
+        <notations>
+          <ornaments>
+            <turn color="#007007"/>
+            </ornaments>
+          </notations>
         </note>
-      <barline location="right">
-        <bar-style>light-heavy</bar-style>
-        </barline>
+      </measure>
+    <measure number="3">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notehead color="#9437FF">normal</notehead>
+        <notations>
+          <slur type="stop" number="1"/>
+          </notations>
+        </note>
       </measure>
     </part>
   </score-partwise>

--- a/src/importexport/musicxml/tests/data/testCueNotes2_ref.xml
+++ b/src/importexport/musicxml/tests/data/testCueNotes2_ref.xml
@@ -59,7 +59,7 @@
         <type>eighth</type>
         <stem>up</stem>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>
@@ -89,7 +89,7 @@
         <type size="grace-cue">eighth</type>
         <stem>up</stem>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>

--- a/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_invisible_ref.xml
+++ b/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_invisible_ref.xml
@@ -422,7 +422,7 @@
         <type>quarter</type>
         <stem>up</stem>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>
@@ -480,7 +480,7 @@
         <type>quarter</type>
         <stem>up</stem>
         <notations print-object="no">
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>

--- a/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_noinvisible_ref.xml
+++ b/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_noinvisible_ref.xml
@@ -374,7 +374,7 @@
         <type>quarter</type>
         <stem>up</stem>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>

--- a/src/importexport/musicxml/tests/data/testGraceAfter2.xml
+++ b/src/importexport/musicxml/tests/data/testGraceAfter2.xml
@@ -59,7 +59,7 @@
         <type>half</type>
         <stem>up</stem>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>

--- a/src/importexport/musicxml/tests/data/testGraceAfter3.xml
+++ b/src/importexport/musicxml/tests/data/testGraceAfter3.xml
@@ -59,7 +59,7 @@
         <type>half</type>
         <stem>up</stem>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>

--- a/src/importexport/musicxml/tests/data/testLyricExtensions.xml
+++ b/src/importexport/musicxml/tests/data/testLyricExtensions.xml
@@ -161,7 +161,7 @@
         <type>quarter</type>
         <stem>up</stem>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" orientation="under" placement="below" number="1"/>
           </notations>
         <lyric number="1">
           <syllabic>single</syllabic>
@@ -194,7 +194,7 @@
         <type>quarter</type>
         <stem>up</stem>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" orientation="under" placement="below" number="1"/>
           </notations>
         <lyric number="1">
           <syllabic>begin</syllabic>

--- a/src/importexport/musicxml/tests/data/testMaxNumberLevel_ref.xml
+++ b/src/importexport/musicxml/tests/data/testMaxNumberLevel_ref.xml
@@ -133,7 +133,7 @@
         <type>whole</type>
         <staff>1</staff>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <backup>
@@ -155,7 +155,7 @@
         <type>whole</type>
         <staff>2</staff>
         <notations>
-          <slur type="start" placement="below" number="2"/>
+          <slur type="start" number="2"/>
           </notations>
         </note>
       <backup>
@@ -177,7 +177,7 @@
         <type>whole</type>
         <staff>3</staff>
         <notations>
-          <slur type="start" placement="below" number="3"/>
+          <slur type="start" number="3"/>
           </notations>
         </note>
       <backup>
@@ -199,7 +199,7 @@
         <type>whole</type>
         <staff>4</staff>
         <notations>
-          <slur type="start" placement="below" number="4"/>
+          <slur type="start" number="4"/>
           </notations>
         </note>
       <backup>
@@ -221,7 +221,7 @@
         <type>whole</type>
         <staff>5</staff>
         <notations>
-          <slur type="start" placement="below" number="5"/>
+          <slur type="start" number="5"/>
           </notations>
         </note>
       <backup>
@@ -243,7 +243,7 @@
         <type>whole</type>
         <staff>6</staff>
         <notations>
-          <slur type="start" placement="below" number="6"/>
+          <slur type="start" number="6"/>
           </notations>
         </note>
       <backup>
@@ -265,7 +265,7 @@
         <type>whole</type>
         <staff>7</staff>
         <notations>
-          <slur type="start" placement="below" number="7"/>
+          <slur type="start" number="7"/>
           </notations>
         </note>
       <backup>
@@ -287,7 +287,7 @@
         <type>whole</type>
         <staff>8</staff>
         <notations>
-          <slur type="start" placement="below" number="8"/>
+          <slur type="start" number="8"/>
           </notations>
         </note>
       <backup>
@@ -309,7 +309,7 @@
         <type>whole</type>
         <staff>9</staff>
         <notations>
-          <slur type="start" placement="below" number="9"/>
+          <slur type="start" number="9"/>
           </notations>
         </note>
       <backup>
@@ -331,7 +331,7 @@
         <type>whole</type>
         <staff>10</staff>
         <notations>
-          <slur type="start" placement="below" number="10"/>
+          <slur type="start" number="10"/>
           </notations>
         </note>
       <backup>
@@ -353,7 +353,7 @@
         <type>whole</type>
         <staff>11</staff>
         <notations>
-          <slur type="start" placement="below" number="11"/>
+          <slur type="start" number="11"/>
           </notations>
         </note>
       <backup>
@@ -375,7 +375,7 @@
         <type>whole</type>
         <staff>12</staff>
         <notations>
-          <slur type="start" placement="below" number="12"/>
+          <slur type="start" number="12"/>
           </notations>
         </note>
       <backup>
@@ -397,7 +397,7 @@
         <type>whole</type>
         <staff>13</staff>
         <notations>
-          <slur type="start" placement="below" number="13"/>
+          <slur type="start" number="13"/>
           </notations>
         </note>
       <backup>
@@ -419,7 +419,7 @@
         <type>whole</type>
         <staff>14</staff>
         <notations>
-          <slur type="start" placement="below" number="14"/>
+          <slur type="start" number="14"/>
           </notations>
         </note>
       <backup>
@@ -441,7 +441,7 @@
         <type>whole</type>
         <staff>15</staff>
         <notations>
-          <slur type="start" placement="below" number="15"/>
+          <slur type="start" number="15"/>
           </notations>
         </note>
       <backup>
@@ -463,7 +463,7 @@
         <type>whole</type>
         <staff>16</staff>
         <notations>
-          <slur type="start" placement="below" number="16"/>
+          <slur type="start" number="16"/>
           </notations>
         </note>
       </measure>

--- a/src/importexport/musicxml/tests/data/testMeasureRepeats1_ref.xml
+++ b/src/importexport/musicxml/tests/data/testMeasureRepeats1_ref.xml
@@ -247,7 +247,7 @@
         <type>half</type>
         <stem>down</stem>
         <notations>
-          <tied type="start"/>
+          <tied type="start" orientation="over" placement="above"/>
           </notations>
         </note>
       </measure>
@@ -278,7 +278,7 @@
         <type>quarter</type>
         <stem>down</stem>
         <notations>
-          <tied type="start"/>
+          <tied type="start" orientation="over" placement="above"/>
           </notations>
         </note>
       </measure>
@@ -327,7 +327,7 @@
         <type>half</type>
         <stem>down</stem>
         <notations>
-          <tied type="start"/>
+          <tied type="start" orientation="over" placement="above"/>
           </notations>
         </note>
       </measure>
@@ -357,7 +357,7 @@
         <type>quarter</type>
         <stem>down</stem>
         <notations>
-          <tied type="start"/>
+          <tied type="start" orientation="over" placement="above"/>
           </notations>
         </note>
       </measure>
@@ -401,7 +401,7 @@
         <type>half</type>
         <stem>down</stem>
         <notations>
-          <tied type="start"/>
+          <tied type="start" orientation="over" placement="above"/>
           </notations>
         </note>
       </measure>
@@ -431,7 +431,7 @@
         <type>quarter</type>
         <stem>down</stem>
         <notations>
-          <tied type="start"/>
+          <tied type="start" orientation="over" placement="above"/>
           </notations>
         </note>
       </measure>

--- a/src/importexport/musicxml/tests/data/testMultipleNotations_ref.xml
+++ b/src/importexport/musicxml/tests/data/testMultipleNotations_ref.xml
@@ -58,7 +58,7 @@
         <type>quarter</type>
         <stem>up</stem>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>
@@ -87,7 +87,7 @@
         <type>quarter</type>
         <stem>up</stem>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>

--- a/src/importexport/musicxml/tests/data/testNoteAttributes1.xml
+++ b/src/importexport/musicxml/tests/data/testNoteAttributes1.xml
@@ -251,7 +251,7 @@
         <type>quarter</type>
         <stem>up</stem>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           <articulations>
             <staccato/>
             </articulations>
@@ -267,7 +267,7 @@
         <type>quarter</type>
         <stem>up</stem>
         <notations>
-          <slur type="start" placement="below" number="2"/>
+          <slur type="start" number="2"/>
           <articulations>
             <staccato/>
             </articulations>

--- a/src/importexport/musicxml/tests/data/testSlurTieDirection.xml
+++ b/src/importexport/musicxml/tests/data/testSlurTieDirection.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="4.0">
-  <work>
-    <work-number>MuseScore testfile</work-number>
-    <work-title>Slurs</work-title>
-    </work>
   <identification>
-    <creator type="composer">Leon Vinken</creator>
     <encoding>
       <software>MuseScore 0.7.0</software>
       <encoding-date>2007-09-10</encoding-date>
@@ -19,14 +14,14 @@
     </identification>
   <part-list>
     <score-part id="P1">
-      <part-name>Staff 1</part-name>
+      <part-name></part-name>
       <score-instrument id="P1-I1">
-        <instrument-name>Staff 1</instrument-name>
+        <instrument-name></instrument-name>
         </score-instrument>
       <midi-device id="P1-I1" port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
-        <midi-program>1</midi-program>
+        <midi-program>74</midi-program>
         <volume>78.7402</volume>
         <pan>0</pan>
         </midi-instrument>
@@ -40,7 +35,7 @@
           <fifths>0</fifths>
           </key>
         <time>
-          <beats>2</beats>
+          <beats>4</beats>
           <beat-type>4</beat-type>
           </time>
         <clef>
@@ -56,46 +51,51 @@
         <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <stem>up</stem>
+        <stem>down</stem>
         <notations>
-          <slur type="start" number="1"/>
+          <slur type="start" orientation="under" placement="below" number="1"/>
           </notations>
         </note>
       <note>
         <pitch>
-          <step>D</step>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <tie type="start"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <tied type="start" orientation="under" placement="below"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <tie type="stop"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <tied type="stop"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
           <octave>5</octave>
           </pitch>
         <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <stem>up</stem>
+        <stem>down</stem>
         <notations>
           <slur type="stop" number="1"/>
           </notations>
-        </note>
-      <backup>
-        <duration>2</duration>
-        </backup>
-      <note>
-        <pitch>
-          <step>G</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>2</voice>
-        <type>quarter</type>
-        <stem>down</stem>
-        </note>
-      <note>
-        <pitch>
-          <step>A</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>2</voice>
-        <type>quarter</type>
-        <stem>down</stem>
         </note>
       </measure>
     <measure number="2">
@@ -107,41 +107,46 @@
         <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <stem>up</stem>
-        </note>
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>quarter</type>
-        <stem>up</stem>
-        </note>
-      <backup>
-        <duration>2</duration>
-        </backup>
-      <note>
-        <pitch>
-          <step>G</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>2</voice>
-        <type>quarter</type>
         <stem>down</stem>
         <notations>
-          <slur type="start" number="1"/>
+          <slur type="start" orientation="over" placement="above" number="1"/>
           </notations>
         </note>
       <note>
         <pitch>
-          <step>A</step>
-          <octave>4</octave>
+          <step>C</step>
+          <octave>5</octave>
           </pitch>
         <duration>1</duration>
-        <voice>2</voice>
+        <tie type="start"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <tied type="start" orientation="over" placement="above"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <tie type="stop"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <tied type="stop"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
         <notations>
@@ -158,95 +163,37 @@
         <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <stem>up</stem>
+        <stem>down</stem>
         <notations>
           <slur type="start" number="1"/>
           </notations>
         </note>
       <note>
         <pitch>
-          <step>D</step>
+          <step>C</step>
           <octave>5</octave>
           </pitch>
         <duration>1</duration>
+        <tie type="start"/>
         <voice>1</voice>
-        <type>quarter</type>
-        <stem>up</stem>
-        <notations>
-          <slur type="stop" number="1"/>
-          </notations>
-        </note>
-      <backup>
-        <duration>2</duration>
-        </backup>
-      <note>
-        <pitch>
-          <step>G</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
         <notations>
-          <slur type="start" number="1"/>
+          <tied type="start"/>
           </notations>
         </note>
       <note>
         <pitch>
-          <step>A</step>
-          <octave>4</octave>
+          <step>C</step>
+          <octave>5</octave>
           </pitch>
         <duration>1</duration>
-        <voice>2</voice>
+        <tie type="stop"/>
+        <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
         <notations>
-          <slur type="stop" number="1"/>
-          </notations>
-        </note>
-      </measure>
-    <measure number="4">
-      <attributes>
-        <time>
-          <beats>4</beats>
-          <beat-type>4</beat-type>
-          </time>
-        </attributes>
-      <note>
-        <grace/>
-        <pitch>
-          <step>G</step>
-          <octave>4</octave>
-          </pitch>
-        <voice>1</voice>
-        <type>16th</type>
-        <stem>up</stem>
-        </note>
-      <note>
-        <pitch>
-          <step>G</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>quarter</type>
-        <stem>up</stem>
-        <notations>
-          <slur type="start" number="1"/>
-          </notations>
-        </note>
-      <note>
-        <pitch>
-          <step>A</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>quarter</type>
-        <stem>up</stem>
-        <notations>
-          <slur type="stop" number="1"/>
+          <tied type="stop"/>
           </notations>
         </note>
       <note>
@@ -257,30 +204,7 @@
         <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <stem>up</stem>
-        <notations>
-          <slur type="start" number="1"/>
-          </notations>
-        </note>
-      <note>
-        <grace/>
-        <pitch>
-          <step>D</step>
-          <octave>5</octave>
-          </pitch>
-        <voice>1</voice>
-        <type>16th</type>
-        <stem>up</stem>
-        </note>
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>1</duration>
-        <voice>1</voice>
-        <type>quarter</type>
-        <stem>up</stem>
+        <stem>down</stem>
         <notations>
           <slur type="stop" number="1"/>
           </notations>

--- a/src/importexport/musicxml/tests/data/testSlurTieLineStyle.xml
+++ b/src/importexport/musicxml/tests/data/testSlurTieLineStyle.xml
@@ -53,7 +53,7 @@
         <type>quarter</type>
         <stem>down</stem>
         <notations>
-          <slur type="start" placement="above" number="1"/>
+          <slur type="start" orientation="over" placement="above" number="1"/>
           </notations>
         </note>
       <note>
@@ -109,7 +109,7 @@
         <type>quarter</type>
         <stem>down</stem>
         <notations>
-          <slur line-type="dotted" type="start" placement="above" number="1"/>
+          <slur type="start" line-type="dotted" orientation="over" placement="above" number="1"/>
           </notations>
         </note>
       <note>
@@ -165,7 +165,7 @@
         <type>quarter</type>
         <stem>down</stem>
         <notations>
-          <slur line-type="dashed" type="start" placement="above" number="1"/>
+          <slur type="start" line-type="dashed" orientation="over" placement="above" number="1"/>
           </notations>
         </note>
       <note>

--- a/src/importexport/musicxml/tests/data/testSlurs2.xml
+++ b/src/importexport/musicxml/tests/data/testSlurs2.xml
@@ -58,7 +58,7 @@
         <type>eighth</type>
         <stem>up</stem>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>
@@ -85,7 +85,7 @@
         <type>eighth</type>
         <stem>up</stem>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>
@@ -121,7 +121,7 @@
         <voice>1</voice>
         <type>whole</type>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>
@@ -149,7 +149,7 @@
         <type>quarter</type>
         <stem>up</stem>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>
@@ -162,7 +162,7 @@
         <type>whole</type>
         <notations>
           <slur type="stop" number="1"/>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>
@@ -191,7 +191,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>
@@ -250,7 +250,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>
@@ -291,7 +291,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>
@@ -328,7 +328,7 @@
         <voice>1</voice>
         <type>whole</type>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>

--- a/src/importexport/musicxml/tests/data/testTrackHandling.xml
+++ b/src/importexport/musicxml/tests/data/testTrackHandling.xml
@@ -630,7 +630,7 @@
         <type>quarter</type>
         <stem>up</stem>
         <notations>
-          <slur type="start" placement="above" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>
@@ -699,7 +699,7 @@
         <type>quarter</type>
         <stem>down</stem>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>
@@ -1809,7 +1809,7 @@
         <stem>up</stem>
         <staff>1</staff>
         <notations>
-          <slur type="start" placement="above" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>
@@ -1884,7 +1884,7 @@
         <stem>down</stem>
         <staff>1</staff>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>
@@ -1932,7 +1932,7 @@
         <stem>up</stem>
         <staff>2</staff>
         <notations>
-          <slur type="start" placement="above" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>
@@ -2007,7 +2007,7 @@
         <stem>down</stem>
         <staff>2</staff>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>
@@ -2555,7 +2555,7 @@
         <type>quarter</type>
         <stem>up</stem>
         <notations>
-          <slur type="start" placement="above" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>
@@ -2624,7 +2624,7 @@
         <type>quarter</type>
         <stem>down</stem>
         <notations>
-          <slur type="start" placement="below" number="1"/>
+          <slur type="start" number="1"/>
           </notations>
         </note>
       <note>

--- a/src/importexport/musicxml/tests/data/testTuplets8_ref.xml
+++ b/src/importexport/musicxml/tests/data/testTuplets8_ref.xml
@@ -63,7 +63,7 @@
           </time-modification>
         <stem>down</stem>
         <notations>
-          <tuplet type="start" number="1" bracket="yes"/>
+          <tuplet type="start" number="1" bracket="yes" placement="above"/>
           </notations>
         </note>
       <note>
@@ -192,7 +192,7 @@
           </time-modification>
         <stem>down</stem>
         <notations>
-          <tuplet type="start" number="1" bracket="yes"/>
+          <tuplet type="start" number="1" bracket="yes" placement="above"/>
           </notations>
         </note>
       <note>
@@ -325,7 +325,7 @@
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
         <notations>
-          <tuplet type="start" number="1" bracket="yes">
+          <tuplet type="start" number="1" bracket="yes" placement="above">
             <tuplet-actual>
               <tuplet-number>3</tuplet-number>
               <tuplet-type>quarter</tuplet-type>

--- a/src/importexport/musicxml/tests/data/testTuplets9.xml
+++ b/src/importexport/musicxml/tests/data/testTuplets9.xml
@@ -3,10 +3,10 @@
 <score-partwise version="4.0">
   <work>
     <work-number>MuseScore testfile</work-number>
-    <work-title>Title</work-title>
+    <work-title>Tuplets 9</work-title>
     </work>
   <identification>
-    <creator type="composer">Composer</creator>
+    <creator type="composer">Klaus Rettinghaus</creator>
     <encoding>
       <software>MuseScore 0.7.0</software>
       <encoding-date>2007-09-10</encoding-date>
@@ -19,15 +19,15 @@
     </identification>
   <part-list>
     <score-part id="P1">
-      <part-name>Piano</part-name>
-      <part-abbreviation>Pno.</part-abbreviation>
+      <part-name>Oboe</part-name>
+      <part-abbreviation>Ob.</part-abbreviation>
       <score-instrument id="P1-I1">
-        <instrument-name>Piano</instrument-name>
+        <instrument-name>Oboe</instrument-name>
         </score-instrument>
       <midi-device id="P1-I1" port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
-        <midi-program>1</midi-program>
+        <midi-program>69</midi-program>
         <volume>78.7402</volume>
         <pan>0</pan>
         </midi-instrument>
@@ -36,12 +36,12 @@
   <part id="P1">
     <measure number="1">
       <attributes>
-        <divisions>480</divisions>
+        <divisions>3</divisions>
         <key>
           <fifths>0</fifths>
           </key>
         <time>
-          <beats>4</beats>
+          <beats>1</beats>
           <beat-type>4</beat-type>
           </time>
         <clef>
@@ -51,405 +51,151 @@
         </attributes>
       <note>
         <pitch>
-          <step>C</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>53</duration>
-        <voice>1</voice>
-        <type>32nd</type>
-        <time-modification>
-          <actual-notes>9</actual-notes>
-          <normal-notes>8</normal-notes>
-          </time-modification>
-        <stem>down</stem>
-        <beam number="1">begin</beam>
-        <beam number="2">begin</beam>
-        <beam number="3">begin</beam>
-        <notations>
-          <tuplet type="start" bracket="no"/>
-          </notations>
-        </note>
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>53</duration>
-        <voice>1</voice>
-        <type>32nd</type>
-        <time-modification>
-          <actual-notes>9</actual-notes>
-          <normal-notes>8</normal-notes>
-          </time-modification>
-        <stem>down</stem>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        <beam number="3">continue</beam>
-        </note>
-      <note>
-        <pitch>
-          <step>E</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>53</duration>
-        <voice>1</voice>
-        <type>32nd</type>
-        <time-modification>
-          <actual-notes>9</actual-notes>
-          <normal-notes>8</normal-notes>
-          </time-modification>
-        <stem>down</stem>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        <beam number="3">continue</beam>
-        </note>
-      <note>
-        <pitch>
-          <step>F</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>53</duration>
-        <voice>1</voice>
-        <type>32nd</type>
-        <time-modification>
-          <actual-notes>9</actual-notes>
-          <normal-notes>8</normal-notes>
-          </time-modification>
-        <stem>down</stem>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        <beam number="3">continue</beam>
-        </note>
-      <note>
-        <pitch>
           <step>G</step>
-          <octave>5</octave>
+          <octave>4</octave>
           </pitch>
-        <duration>53</duration>
+        <duration>1</duration>
         <voice>1</voice>
-        <type>32nd</type>
+        <type>eighth</type>
         <time-modification>
-          <actual-notes>9</actual-notes>
-          <normal-notes>8</normal-notes>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
           </time-modification>
-        <stem>down</stem>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        <beam number="3">continue</beam>
+        <stem>up</stem>
+        <notations>
+          <tuplet type="start" bracket="yes"/>
+          </notations>
         </note>
       <note>
         <pitch>
           <step>A</step>
-          <octave>5</octave>
+          <octave>4</octave>
           </pitch>
-        <duration>53</duration>
+        <duration>1</duration>
         <voice>1</voice>
-        <type>32nd</type>
+        <type>eighth</type>
         <time-modification>
-          <actual-notes>9</actual-notes>
-          <normal-notes>8</normal-notes>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
           </time-modification>
-        <stem>down</stem>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        <beam number="3">continue</beam>
+        <stem>up</stem>
         </note>
       <note>
         <pitch>
           <step>B</step>
-          <octave>5</octave>
+          <octave>4</octave>
           </pitch>
-        <duration>53</duration>
+        <duration>1</duration>
         <voice>1</voice>
-        <type>32nd</type>
+        <type>eighth</type>
         <time-modification>
-          <actual-notes>9</actual-notes>
-          <normal-notes>8</normal-notes>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
           </time-modification>
-        <stem>down</stem>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        <beam number="3">continue</beam>
-        </note>
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>6</octave>
-          </pitch>
-        <duration>53</duration>
-        <voice>1</voice>
-        <type>32nd</type>
-        <time-modification>
-          <actual-notes>9</actual-notes>
-          <normal-notes>8</normal-notes>
-          </time-modification>
-        <stem>down</stem>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        <beam number="3">continue</beam>
-        </note>
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>6</octave>
-          </pitch>
-        <duration>53</duration>
-        <voice>1</voice>
-        <type>32nd</type>
-        <time-modification>
-          <actual-notes>9</actual-notes>
-          <normal-notes>8</normal-notes>
-          </time-modification>
-        <stem>down</stem>
-        <beam number="1">end</beam>
-        <beam number="2">end</beam>
-        <beam number="3">end</beam>
+        <stem>up</stem>
         <notations>
           <tuplet type="stop"/>
           </notations>
         </note>
+      </measure>
+    <measure number="2">
       <note>
         <pitch>
-          <step>C</step>
-          <octave>6</octave>
+          <step>G</step>
+          <octave>4</octave>
           </pitch>
-        <duration>133</duration>
+        <duration>1</duration>
         <voice>1</voice>
-        <type>16th</type>
-        <dot/>
-        <dot/>
-        <dot/>
-        <dot/>
+        <type>eighth</type>
         <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>4</normal-notes>
-          <normal-type>16th</normal-type>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
           </time-modification>
-        <stem>down</stem>
-        <beam number="1">begin</beam>
-        <beam number="2">begin</beam>
+        <stem>up</stem>
         <notations>
-          <tuplet type="start" bracket="no"/>
+          <tuplet type="start" bracket="yes" placement="below"/>
           </notations>
-        </note>
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>6</octave>
-          </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>256th</type>
-        <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>4</normal-notes>
-          <normal-type>16th</normal-type>
-          </time-modification>
-        <stem>down</stem>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        <beam number="3">begin</beam>
-        <beam number="4">begin</beam>
-        <beam number="5">begin</beam>
-        <beam number="6">begin</beam>
-        </note>
-      <note>
-        <pitch>
-          <step>B</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>256th</type>
-        <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>4</normal-notes>
-          <normal-type>16th</normal-type>
-          </time-modification>
-        <stem>down</stem>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        <beam number="3">continue</beam>
-        <beam number="4">continue</beam>
-        <beam number="5">continue</beam>
-        <beam number="6">continue</beam>
         </note>
       <note>
         <pitch>
           <step>A</step>
-          <octave>5</octave>
+          <octave>4</octave>
           </pitch>
-        <duration>4</duration>
+        <duration>1</duration>
         <voice>1</voice>
-        <type>256th</type>
+        <type>eighth</type>
         <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>4</normal-notes>
-          <normal-type>16th</normal-type>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
           </time-modification>
-        <stem>down</stem>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        <beam number="3">continue</beam>
-        <beam number="4">continue</beam>
-        <beam number="5">continue</beam>
-        <beam number="6">continue</beam>
+        <stem>up</stem>
         </note>
       <note>
         <pitch>
-          <step>G</step>
-          <octave>5</octave>
+          <step>B</step>
+          <octave>4</octave>
           </pitch>
-        <duration>4</duration>
+        <duration>1</duration>
         <voice>1</voice>
-        <type>256th</type>
+        <type>eighth</type>
         <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>4</normal-notes>
-          <normal-type>16th</normal-type>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
           </time-modification>
-        <stem>down</stem>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        <beam number="3">continue</beam>
-        <beam number="4">continue</beam>
-        <beam number="5">continue</beam>
-        <beam number="6">continue</beam>
-        </note>
-      <note>
-        <pitch>
-          <step>F</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>256th</type>
-        <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>4</normal-notes>
-          <normal-type>16th</normal-type>
-          </time-modification>
-        <stem>down</stem>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        <beam number="3">continue</beam>
-        <beam number="4">continue</beam>
-        <beam number="5">end</beam>
-        <beam number="6">end</beam>
-        </note>
-      <note>
-        <pitch>
-          <step>E</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>17</duration>
-        <voice>1</voice>
-        <type>64th</type>
-        <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>4</normal-notes>
-          <normal-type>16th</normal-type>
-          </time-modification>
-        <stem>down</stem>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        <beam number="3">continue</beam>
-        <beam number="4">end</beam>
-        </note>
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>34</duration>
-        <voice>1</voice>
-        <type>32nd</type>
-        <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>4</normal-notes>
-          <normal-type>16th</normal-type>
-          </time-modification>
-        <stem>down</stem>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        <beam number="3">end</beam>
-        </note>
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>69</duration>
-        <voice>1</voice>
-        <type>16th</type>
-        <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>4</normal-notes>
-          <normal-type>16th</normal-type>
-          </time-modification>
-        <stem>down</stem>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        </note>
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>69</duration>
-        <voice>1</voice>
-        <type>16th</type>
-        <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>4</normal-notes>
-          <normal-type>16th</normal-type>
-          </time-modification>
-        <stem>down</stem>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        </note>
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>69</duration>
-        <voice>1</voice>
-        <type>16th</type>
-        <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>4</normal-notes>
-          <normal-type>16th</normal-type>
-          </time-modification>
-        <stem>down</stem>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        </note>
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>69</duration>
-        <voice>1</voice>
-        <type>16th</type>
-        <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>4</normal-notes>
-          <normal-type>16th</normal-type>
-          </time-modification>
-        <stem>down</stem>
-        <beam number="1">end</beam>
-        <beam number="2">end</beam>
+        <stem>up</stem>
         <notations>
           <tuplet type="stop"/>
           </notations>
         </note>
+      </measure>
+    <measure number="3">
       <note>
-        <rest/>
-        <duration>960</duration>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
         <voice>1</voice>
-        <type>half</type>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <notations>
+          <tuplet type="start" bracket="yes" placement="above"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <notations>
+          <tuplet type="stop"/>
+          </notations>
         </note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -47,7 +47,7 @@ extern engraving::Err importCompressedMusicXml(MasterScore*, const QString&);
 
 static const String XML_IO_DATA_DIR("data/");
 
-static const std::string MODULE_NAME("importexport");
+static const std::string MODULE_NAME("iex_musicxml");
 
 static const std::string PREF_EXPORT_MUSICXML_EXPORTBREAKS("export/musicXML/exportBreaks");
 static const std::string PREF_IMPORT_MUSICXML_IMPORTBREAKS("import/musicXML/importBreaks");
@@ -395,6 +395,9 @@ TEST_F(Musicxml_Tests, barStyles2) {
 TEST_F(Musicxml_Tests, barStyles3) {
     mxmlIoTest("testBarStyles3");
 }
+TEST_F(Musicxml_Tests, barStyles4) {
+    mxmlIoTest("testBarStyles4");
+}
 TEST_F(Musicxml_Tests, bracketTypes) {
     mxmlImportTestRef("testBracketTypes");
 }
@@ -451,6 +454,12 @@ TEST_F(Musicxml_Tests, clefs1) {
 }
 TEST_F(Musicxml_Tests, clefs2) {
     mxmlIoTest("testClefs2");
+}
+TEST_F(Musicxml_Tests, colorExport) {
+    mxmlMscxExportTestRef("testColorExport");
+}
+TEST_F(Musicxml_Tests, colors) {
+    mxmlIoTest("testColors");
 }
 TEST_F(Musicxml_Tests, completeMeasureRests) {
     mxmlIoTest("testCompleteMeasureRests");
@@ -833,6 +842,9 @@ TEST_F(Musicxml_Tests, restsTypeWhole) {
 TEST_F(Musicxml_Tests, secondVoiceMelismata) {
     mxmlImportTestRef("testSecondVoiceMelismata");
 }
+TEST_F(Musicxml_Tests, slurTieDirection) {
+    mxmlIoTest("testSlurTieDirection");
+}
 TEST_F(Musicxml_Tests, slurTieLineStyle) {
     mxmlIoTest("testSlurTieLineStyle");
 }
@@ -994,6 +1006,9 @@ TEST_F(Musicxml_Tests, tuplets7) {
 }
 TEST_F(Musicxml_Tests, tuplets8) {
     mxmlMscxExportTestRef("testTuplets8");
+}
+TEST_F(Musicxml_Tests, tuplets9) {
+    mxmlIoTest("testTuplets9");
 }
 TEST_F(Musicxml_Tests, twoNoteTremoloTuplet) {
     mxmlIoTest("testTwoNoteTremoloTuplet");


### PR DESCRIPTION
This PR brings a major update to MusicXML support. Focusing on color, it brings some other addition and fixes.

Color support in detail:

  * color import/export for accidentals
  * color import/export for articulations
  * color import/export for barlines
  * color import/export for clefs
  * color import/export for fermatas
  * color import/export for figured bass
  * color import/export for hairpins
  * color import/export for keys
  * color import/export for ornaments
  * color import/export for pedal lines
  * color import/export for slurs and ties
  * color import/export for time signatures
  * color import/export for voltas
  * color export for arpeggios
  * color export for breath marks and caesuras
  * color export for chord symbols
  * color export for dynamics
  * color export for fingerings
  * color export for metronome
  * color export for rehearsal marks
  * color export for text lines
  * color export for tremolo
  * color export for jumps and markers

Further improvements:
  * import/export of curlew fermata
  * import/export of tuplet placement
  * improve import/export of barlines
  * improve import/export of accidental brackets
  * improve pedal style
  * improve figured bass
  * unify tie and slur handling
  * export WideDashed line style
  * export circled rehearsal marks
  * fix color for glissandos and slides
  * fix export of tempo change lines
  * fix export of dynamics extenders
  * new tests added

Fixes #17841

Also addresses most of #18159 (except for special text).
Also addresses `cresc.`/`dim.` line issue from #18158.
