### PR TITLE
Fix #19059: MIDI import dropdown widened

### DIFF
--- a/src/appshell/qml/Preferences/internal/MidiSection.qml
+++ b/src/appshell/qml/Preferences/internal/MidiSection.qml
@@ -43,7 +43,6 @@ BaseSection {
 
         control.textRole: "title"
         control.valueRole: "value"
-        control.width: 132
 
         navigation.name: "ShortestNoteBox"
         navigation.panel: root.navigation


### PR DESCRIPTION
Resolves: #19059

Hard coded value for width of preferences->import->MIDI dropdown was too small. Removed this binding, ensures consistency with above dropdown (charset import).