### PR TITLE
Several Translation issues

### DIFF
--- a/src/appshell/view/internal/splashscreen/newinstanceloadingscreenview.cpp
+++ b/src/appshell/view/internal/splashscreen/newinstanceloadingscreenview.cpp
@@ -39,7 +39,7 @@ NewInstanceLoadingScreenView::NewInstanceLoadingScreenView(const QString& openin
         m_message = qtrc("appshell", "Loading new score…\u200e");
         m_dialogSize = QSize(288, 80);
     } else {
-        m_message = qtrc("appshell", "Loading \"%1\"…\u200e").arg(openingFileName);
+        m_message = qtrc("appshell", "Loading “%1”…\u200e").arg(openingFileName);
         m_dialogSize = QSize(360, 80);
     }
 

--- a/src/engraving/engravingerrors.h
+++ b/src/engraving/engravingerrors.h
@@ -61,7 +61,7 @@ inline Ret make_ret(Err err, const io::path_t& filePath = "")
         text = mtrc("engraving", "Unknown error");
         break;
     case Err::FileNotFound:
-        text = mtrc("engraving", "File \"%1\" not found").arg(filePath.toString());
+        text = mtrc("engraving", "File “%1” not found").arg(filePath.toString());
         break;
     case Err::FileOpenError:
         text = mtrc("engraving", "File open error");
@@ -87,10 +87,10 @@ inline Ret make_ret(Err err, const io::path_t& filePath = "")
         text = mtrc("engraving", "This file was last saved in a development version of 3.0.");
         break;
     case Err::FileCorrupted:
-        text = mtrc("engraving", "File \"%1\" is corrupted.").arg(filePath.toString());
+        text = mtrc("engraving", "File “%1” is corrupted.").arg(filePath.toString());
         break;
     case Err::FileCriticallyCorrupted:
-        text = mtrc("engraving", "File \"%1\" is critically corrupted and cannot be processed.").arg(filePath.toString());
+        text = mtrc("engraving", "File “%1” is critically corrupted and cannot be processed.").arg(filePath.toString());
         break;
     case Err::Undefined:
     case Err::UnknownError:

--- a/src/inspector/view/qml/MuseScore/Inspector/common/InspectorPropertyView.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/common/InspectorPropertyView.qml
@@ -124,7 +124,7 @@ Column {
                     navigation.name: root.navigationName + "Reset"
                     navigation.panel: root.navigationPanel
                     navigation.row: root.buttonNavigationRow
-                    navigation.accessible.name: root.titleText ? qsTrc("inspector", "Reset \"%1\" to default value").arg(root.titleText)
+                    navigation.accessible.name: root.titleText ? qsTrc("inspector", "Reset “%1” to default value").arg(root.titleText)
                                                                : qsTrc("inspector", "Reset property to default value")
 
                     enabled: root.isModified

--- a/src/inspector/view/qml/MuseScore/Inspector/general/appearance/internal/HorizontalSpacingSection.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/general/appearance/internal/HorizontalSpacingSection.qml
@@ -55,7 +55,7 @@ Item {
         navigationPanel: root.navigationPanel
         navigationRowStart: root.navigationRowStart + 1
 
-        titleText: qsTrc("inspector", "Leading")
+        titleText: qsTrc("inspector", "Leading space")
         propertyItem: root.leadingSpace
 
         icon: IconCode.HORIZONTAL

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/keysignatures/KeySignatureSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/keysignatures/KeySignatureSettings.qml
@@ -65,8 +65,10 @@ Column {
         model: [
             { text: qsTrc("inspector", "Unknown"), value: KeySignatureTypes.MODE_UNKNOWN },
             { text: qsTrc("inspector", "None"), value: KeySignatureTypes.MODE_NONE },
-            { text: qsTrc("inspector", "Major"), value: KeySignatureTypes.MODE_MAJOR },
-            { text: qsTrc("inspector", "Minor"), value: KeySignatureTypes.MODE_MINOR },
+            //: mode of a key signature, not an interval
+            { text: qsTrc("inspector", "Major", "key signature mode"), value: KeySignatureTypes.MODE_MAJOR },
+            //: mode of a key signature, not an interval
+            { text: qsTrc("inspector", "Minor", "key signature mode"), value: KeySignatureTypes.MODE_MINOR },
             { text: qsTrc("inspector", "Dorian"), value: KeySignatureTypes.MODE_DORIAN },
             { text: qsTrc("inspector", "Phrygian"), value: KeySignatureTypes.MODE_PHRYGIAN },
             { text: qsTrc("inspector", "Lydian"), value: KeySignatureTypes.MODE_LYDIAN },

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/notes/HeadSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/notes/HeadSettings.qml
@@ -144,7 +144,7 @@ FocusableItem {
                 DropdownPropertyView {
                     id: noteHeadSystemSection
 
-                    titleText: qsTrc("inspector", "Notehead system")
+                    titleText: qsTrc("inspector", "Notehead scheme")
                     propertyItem: root.model ? root.model.headSystem : null
 
                     model: root.model.possibleHeadSystemTypes()

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/ornaments/OrnamentSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/ornaments/OrnamentSettings.qml
@@ -124,8 +124,10 @@ Column {
                 ] : [
                     { text: qsTrc("inspector", "Auto (diatonic)"), value: OrnamentTypes.TYPE_AUTO},
                     { text: qsTrc("inspector", "Augmented"), value: OrnamentTypes.TYPE_AUGMENTED},
-                    { text: qsTrc("inspector", "Major"), value: OrnamentTypes.TYPE_MAJOR},
-                    { text: qsTrc("inspector", "Minor"), value: OrnamentTypes.TYPE_MINOR},
+                    //: Interval, not the mode of a key signature
+                    { text: qsTrc("inspector", "Major", "interval quality"), value: OrnamentTypes.TYPE_MAJOR},
+                    //: Interval, not the mode of a key signature
+                    { text: qsTrc("inspector", "Minor", "interval quality"), value: OrnamentTypes.TYPE_MINOR},
                     { text: qsTrc("inspector", "Diminished"), value: OrnamentTypes.TYPE_DIMINISHED},
                 ]
 

--- a/src/notation/view/pianokeyboard/pianokeyboardpanelcontextmenumodel.cpp
+++ b/src/notation/view/pianokeyboard/pianokeyboardpanelcontextmenumodel.cpp
@@ -97,11 +97,11 @@ MenuItem* PianoKeyboardPanelContextMenuModel::makeViewMenu()
     items << makeSeparator();
 
     std::vector<std::pair<TranslatableString, int> > possibleNumbersOfKeys {
-        { TranslatableString("notation", "128 notes (full)"), 128 },
-        { TranslatableString("notation", "88 notes (piano)"), 88 },
-        { TranslatableString("notation", "61 notes"), 61 },
-        { TranslatableString("notation", "49 notes"), 49 },
-        { TranslatableString("notation", "25 notes"), 25 },
+        { TranslatableString("notation", "128 keys (full)"), 128 },
+        { TranslatableString("notation", "88 keys (piano)"), 88 },
+        { TranslatableString("notation", "61 keys"), 61 },
+        { TranslatableString("notation", "49 keys"), 49 },
+        { TranslatableString("notation", "25 keys"), 25 },
     };
 
     for (auto [title, numberOfKeys] : possibleNumbersOfKeys) {

--- a/src/notation/view/selectionfiltermodel.cpp
+++ b/src/notation/view/selectionfiltermodel.cpp
@@ -196,7 +196,7 @@ QString SelectionFilterModel::titleForType(SelectionFilterType type) const
     case SelectionFilterType::ARPEGGIO:
         return qtrc("notation", "Arpeggios");
     case SelectionFilterType::GLISSANDO:
-        return qtrc("notation", "Glissandi");
+        return qtrc("notation", "Glissandos");
     case SelectionFilterType::FRET_DIAGRAM:
         return qtrc("notation", "Fretboard diagrams");
     case SelectionFilterType::BREATH:

--- a/src/notation/view/widgets/breaksdialog.ui
+++ b/src/notation/view/widgets/breaksdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Add/Remove System Breaks</string>
+   <string>Add/remove system breaks</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>

--- a/src/notation/view/widgets/editpitch.ui
+++ b/src/notation/view/widgets/editpitch.ui
@@ -11,13 +11,13 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Note Selection</string>
+   <string>Note selection</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Select Note:</string>
+      <string>Select note:</string>
      </property>
     </widget>
    </item>

--- a/src/notation/view/widgets/editstaff.ui
+++ b/src/notation/view/widgets/editstaff.ui
@@ -691,132 +691,132 @@
             </property>
             <item>
              <property name="text">
-              <string>0 - Perfect Unison</string>
+              <string>0 - Perfect unison</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>1 - Augmented Unison</string>
+              <string>1 - Augmented unison</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>0 - Diminished Second</string>
+              <string>0 - Diminished second</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>1 - Minor Second</string>
+              <string>1 - Minor second</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>2 - Major Second</string>
+              <string>2 - Major second</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>3 - Augmented Second</string>
+              <string>3 - Augmented second</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>2 - Diminished Third</string>
+              <string>2 - Diminished third</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>3 - Minor Third</string>
+              <string>3 - Minor third</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>4 - Major Third</string>
+              <string>4 - Major third</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>5 - Augmented Third</string>
+              <string>5 - Augmented third</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>4 - Diminished Fourth</string>
+              <string>4 - Diminished fourth</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>5 - Perfect Fourth</string>
+              <string>5 - Perfect fourth</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>6 - Augmented Fourth</string>
+              <string>6 - Augmented fourth</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>6 - Diminished Fifth</string>
+              <string>6 - Diminished fifth</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>7 - Perfect Fifth</string>
+              <string>7 - Perfect fifth</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>8 - Augmented Fifth</string>
+              <string>8 - Augmented fifth</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>7 - Diminished Sixth</string>
+              <string>7 - Diminished sixth</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>8 - Minor Sixth</string>
+              <string>8 - Minor sixth</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>9 - Major Sixth</string>
+              <string>9 - Major sixth</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>10 - Augmented Sixth</string>
+              <string>10 - Augmented sixth</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>9 - Diminished Seventh</string>
+              <string>9 - Diminished seventh</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>10 - Minor Seventh</string>
+              <string>10 - Minor seventh</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>11 - Major Seventh</string>
+              <string>11 - Major seventh</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>12 - Augmented Seventh</string>
+              <string>12 - Augmented seventh</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>11 - Diminished Octave</string>
+              <string>11 - Diminished octave</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>12 - Perfect Octave</string>
+              <string>12 - Perfect octave</string>
              </property>
             </item>
            </widget>
@@ -958,7 +958,7 @@
          <item>
           <widget class="QPushButton" name="editStringData">
            <property name="text">
-            <string>Edit String Data…</string>
+            <string>Edit string data…</string>
            </property>
           </widget>
          </item>

--- a/src/notation/view/widgets/editstafftype.ui
+++ b/src/notation/view/widgets/editstafftype.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Edit Staff Type</string>
+   <string>Edit staff type</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_4">
    <item>
@@ -435,7 +435,7 @@
               </property>
               <widget class="QWidget" name="tab">
                <attribute name="title">
-                <string>Fret Marks</string>
+                <string>Fret marks</string>
                </attribute>
                <layout class="QVBoxLayout" name="verticalLayout_2">
                 <item>
@@ -714,7 +714,7 @@
               </widget>
               <widget class="QWidget" name="tab_2">
                <attribute name="title">
-                <string>Note Values</string>
+                <string>Note values</string>
                </attribute>
                <layout class="QVBoxLayout" name="verticalLayout_11">
                 <property name="spacing">
@@ -1335,7 +1335,7 @@
        <item>
         <widget class="QPushButton" name="templateReset">
          <property name="text">
-          <string>&lt; Reset to Template</string>
+          <string>&lt; Reset to template</string>
          </property>
         </widget>
        </item>
@@ -1361,7 +1361,7 @@
           <string>Create a new staff type of current group.</string>
          </property>
          <property name="text">
-          <string>Add to Templates</string>
+          <string>Add to templates</string>
          </property>
         </widget>
        </item>

--- a/src/notation/view/widgets/editstringdata.ui
+++ b/src/notation/view/widgets/editstringdata.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>String Data</string>
+   <string>String data</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -4922,7 +4922,7 @@ By default, they will be placed such as that their right end are at the same lev
               <string>Reset to default</string>
              </property>
              <property name="accessibleName">
-              <string>Reset 'Show repeat barline tips (&quot;winged&quot; repeats)' value</string>
+              <string>Reset 'Show repeat barline tips (“winged” repeats)' value</string>
              </property>
              <property name="text">
               <string notr="true"/>
@@ -5030,7 +5030,7 @@ By default, they will be placed such as that their right end are at the same lev
            <item row="0" column="0" colspan="2">
             <widget class="QCheckBox" name="showRepeatBarTips">
              <property name="text">
-              <string>Show repeat barline tips (&quot;winged&quot; repeats)</string>
+              <string>Show repeat barline tips (“winged” repeats)</string>
              </property>
             </widget>
            </item>
@@ -6043,7 +6043,7 @@ By default, they will be placed such as that their right end are at the same lev
            <item row="2" column="0" colspan="2">
             <widget class="QCheckBox" name="oneMeasureRepeatShow1">
              <property name="text">
-              <string>Show &quot;1&quot; on 1-measure repeats</string>
+              <string>Show '1' on 1-measure repeats</string>
              </property>
             </widget>
            </item>

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -61,12 +61,12 @@
       </item>
       <item>
        <property name="text">
-        <string>Header, Footer</string>
+        <string>Header, footer</string>
        </property>
       </item>
       <item>
        <property name="text">
-        <string>Measure Numbers</string>
+        <string>Measure numbers</string>
        </property>
       </item>
       <item>
@@ -106,7 +106,7 @@
       </item>
       <item>
        <property name="text">
-        <string>Measure Repeats</string>
+        <string>Measure repeats</string>
        </property>
       </item>
       <item>
@@ -166,12 +166,12 @@
       </item>
       <item>
        <property name="text">
-        <string>Text Line</string>
+        <string>Text line</string>
        </property>
       </item>
       <item>
        <property name="text">
-        <string>System Text Line</string>
+        <string>System text line</string>
        </property>
       </item>
       <item>
@@ -186,12 +186,12 @@
       </item>
       <item>
        <property name="text">
-        <string>Staff Text</string>
+        <string>Staff text</string>
        </property>
       </item>
       <item>
        <property name="text">
-        <string>Tempo Text</string>
+        <string>Tempo text</string>
        </property>
       </item>
       <item>
@@ -211,32 +211,32 @@
       </item>
       <item>
        <property name="text">
-        <string>Rehearsal Marks</string>
+        <string>Rehearsal marks</string>
        </property>
       </item>
       <item>
        <property name="text">
-        <string>Figured Bass</string>
+        <string>Figured bass</string>
        </property>
       </item>
       <item>
        <property name="text">
-        <string>Chord Symbols</string>
+        <string>Chord symbols</string>
        </property>
       </item>
       <item>
        <property name="text">
-        <string>Fretboard Diagrams</string>
+        <string>Fretboard diagrams</string>
        </property>
       </item>
       <item>
        <property name="text">
-        <string>Tablature Styles</string>
+        <string>Tablature styles</string>
        </property>
       </item>
       <item>
        <property name="text">
-        <string>Text Styles</string>
+        <string>Text styles</string>
        </property>
       </item>
      </widget>
@@ -600,7 +600,7 @@
                <item>
                 <widget class="QGroupBox" name="swingSettings">
                  <property name="title">
-                  <string>Swing Settings</string>
+                  <string>Swing settings</string>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_39">
                   <item>
@@ -625,14 +625,14 @@
                     <item>
                      <widget class="QRadioButton" name="swingEighth">
                       <property name="text">
-                       <string>Eighth Note</string>
+                       <string>Eighth note</string>
                       </property>
                      </widget>
                     </item>
                     <item>
                      <widget class="QRadioButton" name="swingSixteenth">
                       <property name="text">
-                       <string>Sixteenth Note</string>
+                       <string>Sixteenth note</string>
                       </property>
                      </widget>
                     </item>
@@ -2261,7 +2261,7 @@
             <item>
              <widget class="QGroupBox" name="showHeader">
               <property name="title">
-               <string>Header Text</string>
+               <string>Header text</string>
               </property>
               <property name="checkable">
                <bool>true</bool>
@@ -2564,7 +2564,7 @@
             <item>
              <widget class="QGroupBox" name="showFooter">
               <property name="title">
-               <string>Footer Text</string>
+               <string>Footer text</string>
               </property>
               <property name="checkable">
                <bool>true</bool>
@@ -2888,7 +2888,7 @@
         <item>
          <widget class="QGroupBox" name="showMeasureNumber">
           <property name="title">
-           <string>Measure Numbers</string>
+           <string>Measure numbers</string>
           </property>
           <property name="checkable">
            <bool>true</bool>
@@ -3278,7 +3278,7 @@
         <item>
          <widget class="QGroupBox" name="groupBox_systemBrackets">
           <property name="title">
-           <string>System Brackets</string>
+           <string>System brackets</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_44">
            <item row="0" column="1">
@@ -3499,7 +3499,7 @@
         <item>
          <widget class="QGroupBox" name="groupBox_systemDividers">
           <property name="title">
-           <string>System Dividers</string>
+           <string>System dividers</string>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_41">
            <item>
@@ -3932,7 +3932,7 @@ By default, they will be placed such as that their right end are at the same lev
         <item>
          <widget class="QGroupBox" name="keySigNaturalsGroup">
           <property name="title">
-           <string>♮ in Key Signatures</string>
+           <string>♮ in key signatures</string>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_35">
            <item>
@@ -5554,7 +5554,7 @@ By default, they will be placed such as that their right end are at the same lev
         <item>
          <widget class="QGroupBox" name="multiMeasureRests">
           <property name="title">
-           <string>Multimeasure Rests</string>
+           <string>Multimeasure rests</string>
           </property>
           <property name="checkable">
            <bool>true</bool>
@@ -5825,7 +5825,7 @@ By default, they will be placed such as that their right end are at the same lev
            <item row="4" column="0" colspan="6">
             <widget class="QGroupBox" name="oldStyleMultiMeasureRests">
              <property name="title">
-              <string>Old-Style Multimeasure Rests</string>
+              <string>Old-style multimeasure rests</string>
              </property>
              <property name="checkable">
               <bool>true</bool>
@@ -6184,7 +6184,7 @@ By default, they will be placed such as that their right end are at the same lev
                <item row="1" column="0" colspan="2">
                 <widget class="QGroupBox" name="verticalDistance">
                  <property name="title">
-                  <string>Vertical Distance from Notes</string>
+                  <string>Vertical distance from notes</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_20">
                   <item row="0" column="2">
@@ -8379,7 +8379,7 @@ By default, they will be placed such as that their right end are at the same lev
         <item>
          <widget class="QGroupBox" name="groupBox_pedalLine">
           <property name="title">
-           <string>Pedal Line</string>
+           <string>Pedal line</string>
           </property>
           <layout class="QGridLayout" name="gridLayout11">
            <item row="0" column="1">
@@ -8703,7 +8703,7 @@ By default, they will be placed such as that their right end are at the same lev
         <item>
          <widget class="QGroupBox" name="groupBox_trillLine">
           <property name="title">
-           <string>Trill Line</string>
+           <string>Trill line</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_14">
            <item row="1" column="0">
@@ -8839,7 +8839,7 @@ By default, they will be placed such as that their right end are at the same lev
         <item>
          <widget class="QGroupBox" name="groupBox_vibratoLine">
           <property name="title">
-           <string>Vibrato Line</string>
+           <string>Vibrato line</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_141">
            <item row="1" column="0">
@@ -9104,7 +9104,7 @@ By default, they will be placed such as that their right end are at the same lev
         <item>
          <widget class="QGroupBox" name="groupBox_textLine">
           <property name="title">
-           <string>Text Line</string>
+           <string>Text line</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_18">
            <item row="2" column="0">
@@ -9252,7 +9252,7 @@ By default, they will be placed such as that their right end are at the same lev
         <item>
          <widget class="QGroupBox" name="groupBox_systemTextLine">
           <property name="title">
-           <string>System Text Line</string>
+           <string>System text line</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_461">
            <item row="2" column="0">
@@ -9403,7 +9403,7 @@ By default, they will be placed such as that their right end are at the same lev
         <item>
          <widget class="QGroupBox" name="groupBox_articulationsOrnaments">
           <property name="title">
-           <string>Articulations, Ornaments</string>
+           <string>Articulations, ornaments</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_9">
            <item row="3" column="2">
@@ -9824,7 +9824,7 @@ By default, they will be placed such as that their right end are at the same lev
         <item row="0" column="0">
          <widget class="QGroupBox" name="groupBox_staffText">
           <property name="title">
-           <string>Staff Text</string>
+           <string>Staff text</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_33">
            <item row="1" column="3">
@@ -10020,7 +10020,7 @@ By default, they will be placed such as that their right end are at the same lev
         <item>
          <widget class="QGroupBox" name="groupBox_tempoText">
           <property name="title">
-           <string>Tempo Text</string>
+           <string>Tempo text</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_26">
            <item row="3" column="0">
@@ -10259,7 +10259,7 @@ By default, they will be placed such as that their right end are at the same lev
             <item row="0" column="1">
              <widget class="QGroupBox" name="lyricsDashBox">
               <property name="title">
-               <string>Lyrics Dash</string>
+               <string>Lyrics dash</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_24">
                <item row="0" column="1">
@@ -10534,7 +10534,7 @@ By default, they will be placed such as that their right end are at the same lev
             <item row="0" column="0" rowspan="2">
              <widget class="QGroupBox" name="lyricsTextBox">
               <property name="title">
-               <string>Lyrics Text</string>
+               <string>Lyrics text</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_23">
                <item row="5" column="1">
@@ -10862,7 +10862,7 @@ By default, they will be placed such as that their right end are at the same lev
             <item row="1" column="1">
              <widget class="QGroupBox" name="lyricsMelismaBox">
               <property name="title">
-               <string>Lyrics Melisma</string>
+               <string>Lyrics eelisma</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_25">
                <item row="0" column="2">
@@ -11309,7 +11309,7 @@ By default, they will be placed such as that their right end are at the same lev
         <item>
          <widget class="QGroupBox" name="groupBox_rehearsalMarks">
           <property name="title">
-           <string>Rehearsal Marks</string>
+           <string>Rehearsal marks</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_28">
            <item row="3" column="0">
@@ -11493,7 +11493,7 @@ By default, they will be placed such as that their right end are at the same lev
         <item>
          <widget class="QGroupBox" name="groupBox_figuredBass">
           <property name="title">
-           <string>Figured Bass</string>
+           <string>Figured bass</string>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_32">
            <item>
@@ -11721,7 +11721,7 @@ By default, they will be placed such as that their right end are at the same lev
         <item>
          <widget class="QGroupBox" name="groupBox_chordSymbols">
           <property name="title">
-           <string>Chord Symbols</string>
+           <string>Chord symbols</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_13">
            <property name="leftMargin">
@@ -12336,7 +12336,7 @@ By default, they will be placed such as that their right end are at the same lev
            </size>
           </property>
           <property name="title">
-           <string>Fretboard Diagrams</string>
+           <string>Fretboard diagrams</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_471">
            <item row="9" column="0">
@@ -13244,7 +13244,7 @@ By default, they will be placed such as that their right end are at the same lev
            </sizepolicy>
           </property>
           <property name="title">
-           <string>Edit Text Style</string>
+           <string>Edit text style</string>
           </property>
           <layout class="QGridLayout" name="_12">
            <item row="12" column="0" colspan="3">
@@ -13703,7 +13703,7 @@ By default, they will be placed such as that their right end are at the same lev
            <item row="3" column="0">
             <widget class="QLabel" name="label_14711">
              <property name="text">
-              <string>Line Spacing:</string>
+              <string>Line spacing:</string>
              </property>
              <property name="buddy">
               <cstring>textStyleLineSpacing</cstring>
@@ -13783,7 +13783,7 @@ By default, they will be placed such as that their right end are at the same lev
      <item>
       <widget class="QPushButton" name="resetStylesButton">
        <property name="text">
-        <string>Reset All Styles to Default</string>
+        <string>Reset all styles to default</string>
        </property>
       </widget>
      </item>

--- a/src/notation/view/widgets/measureproperties.ui
+++ b/src/notation/view/widgets/measureproperties.ui
@@ -49,7 +49,7 @@
             </property>
             <row>
              <property name="text">
-              <string>New Row</string>
+              <string>New row</string>
              </property>
             </row>
             <column>
@@ -96,7 +96,7 @@
        <item>
         <widget class="QGroupBox" name="groupBox">
          <property name="title">
-          <string>Measure Duration</string>
+          <string>Measure duration</string>
          </property>
          <layout class="QGridLayout">
           <property name="verticalSpacing">
@@ -428,12 +428,12 @@
             </item>
             <item>
              <property name="text">
-              <string>Always Show</string>
+              <string>Always show</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>Always Hide</string>
+              <string>Always hide</string>
              </property>
             </item>
            </widget>

--- a/src/notation/view/widgets/pagesettings.ui
+++ b/src/notation/view/widgets/pagesettings.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Page Settings</string>
+   <string>Page settings</string>
   </property>
   <layout class="QGridLayout">
    <property name="leftMargin">
@@ -52,7 +52,7 @@
      <item>
       <widget class="QPushButton" name="resetPageStyleButton">
        <property name="text">
-        <string>Reset All Page Settings to Default</string>
+        <string>Reset all page settings to default</string>
        </property>
       </widget>
      </item>
@@ -72,7 +72,7 @@
      <item>
       <widget class="QPushButton" name="buttonApplyToAllParts">
        <property name="text">
-        <string>Apply to all Parts</string>
+        <string>Apply to all parts</string>
        </property>
       </widget>
      </item>
@@ -105,7 +105,7 @@
      <item>
       <widget class="QGroupBox" name="groupBox">
        <property name="title">
-        <string>Page Size</string>
+        <string>Page size</string>
        </property>
        <layout class="QGridLayout">
         <item row="3" column="0">
@@ -285,7 +285,7 @@
      <item>
       <widget class="QGroupBox" name="groupBox_3">
        <property name="title">
-        <string>Odd Page Margins</string>
+        <string>Odd page margins</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_3">
         <item row="1" column="0" colspan="2">
@@ -386,7 +386,7 @@
      <item>
       <widget class="QGroupBox" name="groupBox_4">
        <property name="title">
-        <string>Even Page Margins</string>
+        <string>Even page margins</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_2">
         <item row="1" column="3" colspan="2">

--- a/src/notation/view/widgets/realizeharmonydialog.ui
+++ b/src/notation/view/widgets/realizeharmonydialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Realize Chord Symbols</string>
+   <string>Realize chord symbols</string>
   </property>
   <property name="toolTip">
    <string>Convert chord symbols into notes</string>
@@ -92,7 +92,7 @@
          </sizepolicy>
         </property>
         <property name="title">
-         <string>Override With Custom Options</string>
+         <string>Override with custom options</string>
         </property>
         <property name="checkable">
          <bool>true</bool>

--- a/src/notation/view/widgets/selectnotedialog.ui
+++ b/src/notation/view/widgets/selectnotedialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Select Notes</string>
+   <string>Select notes</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>

--- a/src/notation/view/widgets/stafftextpropertiesdialog.ui
+++ b/src/notation/view/widgets/stafftextpropertiesdialog.ui
@@ -24,13 +24,13 @@
      </property>
      <widget class="QWidget" name="tabSwingSettings">
       <attribute name="title">
-       <string>Swing Settings</string>
+       <string>Swing settings</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
         <widget class="QGroupBox" name="setSwingBox">
          <property name="title">
-          <string>Swing Settings</string>
+          <string>Swing settings</string>
          </property>
          <property name="checkable">
           <bool>true</bool>

--- a/src/notation/view/widgets/transposedialog.ui
+++ b/src/notation/view/widgets/transposedialog.ui
@@ -20,7 +20,7 @@
       <item>
        <widget class="mu::uicomponents::RadioButtonGroupBox" name="chromaticBox">
         <property name="title">
-         <string>Transpose Chromatically</string>
+         <string>Transpose chromatically</string>
         </property>
         <property name="checkable">
          <bool>true</bool>
@@ -168,10 +168,10 @@
          <item>
           <widget class="mu::uicomponents::RadioButtonGroupBox" name="transposeByInterval">
            <property name="toolTip">
-            <string>Transpose by Interval</string>
+            <string>Transpose by interval</string>
            </property>
            <property name="title">
-            <string>By Interval</string>
+            <string>By interval</string>
            </property>
            <property name="checkable">
             <bool>true</bool>
@@ -209,132 +209,132 @@
               </property>
               <item>
                <property name="text">
-                <string>Perfect Unison</string>
+                <string>Perfect unison</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Augmented Unison</string>
+                <string>Augmented unison</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Diminished Second</string>
+                <string>Diminished second</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Minor Second</string>
+                <string>Minor second</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Major Second</string>
+                <string>Major second</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Augmented Second</string>
+                <string>Augmented second</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Diminished Third</string>
+                <string>Diminished third</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Minor Third</string>
+                <string>Minor third</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Major Third</string>
+                <string>Major third</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Augmented Third</string>
+                <string>Augmented third</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Diminished Fourth</string>
+                <string>Diminished fourth</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Perfect Fourth</string>
+                <string>Perfect fourth</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Augmented Fourth</string>
+                <string>Augmented fourth</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Diminished Fifth</string>
+                <string>Diminished fifth</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Perfect Fifth</string>
+                <string>Perfect fifth</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Augmented Fifth</string>
+                <string>Augmented fifth</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Diminished Sixth</string>
+                <string>Diminished sixth</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Minor Sixth</string>
+                <string>Minor sixth</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Major Sixth</string>
+                <string>Major sixth</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Augmented Sixth</string>
+                <string>Augmented sixth</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Diminished Seventh</string>
+                <string>Diminished seventh</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Minor Seventh</string>
+                <string>Minor seventh</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Major Seventh</string>
+                <string>Major seventh</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Augmented Seventh</string>
+                <string>Augmented seventh</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Diminished Octave</string>
+                <string>Diminished octave</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Perfect Octave</string>
+                <string>Perfect octave</string>
                </property>
               </item>
              </widget>
@@ -368,7 +368,7 @@
       <item>
        <widget class="mu::uicomponents::RadioButtonGroupBox" name="diatonicBox">
         <property name="title">
-         <string>Transpose Diatonically</string>
+         <string>Transpose diatonically</string>
         </property>
         <property name="checkable">
          <bool>true</bool>
@@ -491,12 +491,12 @@
            </property>
            <item>
             <property name="text">
-             <string>Single ♯ and ♭ Only</string>
+             <string>Single ♯ and ♭ only</string>
             </property>
            </item>
            <item>
             <property name="text">
-             <string>Use Double ♯ and ♭</string>
+             <string>Use double ♯ and ♭</string>
             </property>
            </item>
           </widget>

--- a/src/notation/view/widgets/tupletdialog.ui
+++ b/src/notation/view/widgets/tupletdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Create Tuplet</string>
+   <string>Create tuplet</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">

--- a/src/notation/view/widgets/voicing_select.ui
+++ b/src/notation/view/widgets/voicing_select.ui
@@ -85,7 +85,7 @@
      </item>
      <item>
       <property name="text">
-       <string>Root Only</string>
+       <string>Root only</string>
       </property>
      </item>
      <item>
@@ -95,22 +95,22 @@
      </item>
      <item>
       <property name="text">
-       <string extracomment="2nd note an octave down">Drop Two</string>
+       <string extracomment="2nd note an octave down">Drop two</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string extracomment="6 note chord">Six Note</string>
+       <string extracomment="6 note chord">Six note</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string extracomment="4 note chord">Four Note</string>
+       <string extracomment="4 note chord">Four note</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string extracomment="3 note chord">Three Note</string>
+       <string extracomment="3 note chord">Three note</string>
       </property>
      </item>
     </widget>
@@ -119,17 +119,17 @@
     <widget class="QComboBox" name="durationBox">
      <item>
       <property name="text">
-       <string>Until Next Chord Symbol</string>
+       <string>Until next chord symbol</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>Until Measure End</string>
+       <string>Until measure end</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>Chord/Rest Duration</string>
+       <string>Chord/rest duration</string>
       </property>
      </item>
     </widget>

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -578,7 +578,7 @@ PalettePtr PaletteCreator::newLayoutPalette()
 PalettePtr PaletteCreator::newFingeringPalette(bool defaultPalette)
 {
     PalettePtr sp = std::make_shared<Palette>(Palette::Type::Fingering);
-    sp->setName(QT_TRANSLATE_NOOP("palette", "Fingering"));
+    sp->setName(QT_TRANSLATE_NOOP("palette", "Fingerings"));
     sp->setMag(1.5);
     sp->setGridSize(28, 30);
     sp->setDrawGrid(true);

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -1007,7 +1007,7 @@ PalettePtr PaletteCreator::newBreathPalette(bool defaultPalette)
 PalettePtr PaletteCreator::newArpeggioPalette()
 {
     PalettePtr sp = std::make_shared<Palette>(Palette::Type::Arpeggio);
-    sp->setName(QT_TRANSLATE_NOOP("palette", "Arpeggios & glissandi"));
+    sp->setName(QT_TRANSLATE_NOOP("palette", "Arpeggios & glissandos"));
     sp->setGridSize(42, 44);
     sp->setDrawGrid(true);
     sp->setVisible(false);

--- a/src/palette/view/widgets/editdrumsetdialog.ui
+++ b/src/palette/view/widgets/editdrumsetdialog.ui
@@ -422,7 +422,7 @@
      <item>
       <widget class="QPushButton" name="saveButton">
        <property name="text">
-        <string>Save As…</string>
+        <string>Save as…</string>
        </property>
       </widget>
      </item>

--- a/src/palette/view/widgets/keyedit.ui
+++ b/src/palette/view/widgets/keyedit.ui
@@ -35,7 +35,7 @@
        </sizepolicy>
       </property>
       <property name="title">
-       <string>Create Key Signature</string>
+       <string>Create key signature</string>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
        <property name="leftMargin">

--- a/src/palette/view/widgets/masterpalette.ui
+++ b/src/palette/view/widgets/masterpalette.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Master Palette</string>
+   <string>Master palette</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/palette/view/widgets/palettewidget.cpp
+++ b/src/palette/view/widgets/palettewidget.cpp
@@ -1148,7 +1148,7 @@ void PaletteWidget::contextMenuEvent(QContextMenuEvent* event)
         if (cell) {
             std::string title = mu::trc("palette", "Delete palette cell");
             std::string question
-                = mu::qtrc("palette", "Are you sure you want to delete palette cell \"%1\"?").arg(cell->name).toStdString();
+                = mu::qtrc("palette", "Are you sure you want to delete palette cell “%1”?").arg(cell->name).toStdString();
 
             IInteractive::Result result = interactive()->question(title, question, {
                 IInteractive::Button::Yes,

--- a/src/palette/view/widgets/specialcharactersdialog.ui
+++ b/src/palette/view/widgets/specialcharactersdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Special Characters</string>
+   <string>Special characters</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>

--- a/src/plugins/internal/pluginsactioncontroller.cpp
+++ b/src/plugins/internal/pluginsactioncontroller.cpp
@@ -78,7 +78,7 @@ void PluginsActionController::onPluginTriggered(const CodeKey& codeKey)
     }
 
     IInteractive::Result result = interactive()->warning(
-        qtrc("plugins", "The plugin \"%1\" is currently disabled. Do you want to enable it now?").arg(pluginName).toStdString(),
+        qtrc("plugins", "The plugin “%1” is currently disabled. Do you want to enable it now?").arg(pluginName).toStdString(),
         trc("plugins", "Alternatively, you can enable it at any time from Home > Plugins."),
         { interactive()->buttonData(IInteractive::Button::No),
           interactive()->buttonData(IInteractive::Button::Yes) }, 0);

--- a/src/project/qml/MuseScore/Project/internal/NewScore/KeySignatureSettings.qml
+++ b/src/project/qml/MuseScore/Project/internal/NewScore/KeySignatureSettings.qml
@@ -97,7 +97,8 @@ FlatButton {
 
                 StyledTabButton {
                     id: majorTab
-                    text: qsTrc("project/newscore", "Major")
+                    //: mode of a key signature, not an interval
+                    text: qsTrc("project/newscore", "Major", "key signature mode")
 
                     navigation.name: "MajorTab"
                     navigation.panel: bar.navigationPanel
@@ -105,7 +106,8 @@ FlatButton {
                 }
 
                 StyledTabButton {
-                    text: qsTrc("project/newscore", "Minor")
+                    //: mode of a key signature, not an interval
+                    text: qsTrc("project/newscore", "Minor", "key signature mode")
 
                     navigation.name: "MinorTab"
                     navigation.panel: bar.navigationPanel


### PR DESCRIPTION
* Differentiating the meanings of "Minor" and "Major"
  Resolves: #19153
* "notes" to "keys", as this is about the piano keyboard
* Sentence case vs. Title Case in transpose dialog
* Sentence case vs. Title Case in breaks dialog
* Sentence case vs. Title Case in editpitch dialog
* Sentence case vs. Title Case in editstaff dialog
* Sentence case vs. Title Case in editstafftype dialog
* Sentence case vs. Title Case in editstringdata dialog
* Sentence case vs. Title Case in keyedit dialog
* Sentence case vs. Title Case in masterpalette dialog
* Sentence case vs. Title Case in measureproperties dialog
* Sentence case vs. Title Case in pagesettings dialog
* Sentence case vs. Title Case in realizeharmony dialog
* Sentence case vs. Title Case in selectnote dialog
* Sentence case vs. Title Case in specialcharacters dialog
* Sentence case vs. Title Case in stafftextproperties dialog
* Sentence case vs. Title Case in tuplet dialog
* Sentence case vs. Title Case in voicingselect dialog
* Sentence case vs. Title Case in voicingselect dialog
* Sentence case vs. Title Case in editstyle dialog
* Sentence case vs. Title Case in editdrumset dialog
* Plural for palettes
* English plurals rather than Italian ones
* Use winged double quotes (as per discussion in #17748)
   Not sure whether the single quotes should also get changed to winged ones, there are some 140 strings affected, the vast majority of them in the editstyle dialog, which is slated to get converted to QML
* Better naming, "Leading" to "Leading space"
* "Notehead scheme" in staff properties different from "Notehead system" in Properties panel
   Resolves #19166