### PR TITLE
Fix #9584: select time signature after changing it

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -1318,6 +1318,11 @@ void Score::cmdAddTimeSig(Measure* fm, staff_idx_t staffIdx, TimeSig* ts, bool l
         //  ignore if there is already a timesig
         //  with same values
         //
+        if (local) {
+            select(ots, SelectType::SINGLE, staffIdx);
+        } else {
+            selectElementsWithSameTypeOnSegment(ElementType::TIMESIG, seg);
+        }
         delete ts;
         return;
     }
@@ -1373,6 +1378,12 @@ void Score::cmdAddTimeSig(Measure* fm, staff_idx_t staffIdx, TimeSig* ts, bool l
                 nsig->undoChangeProperty(Pid::GROUP_NODES, ts->groups().nodes());
                 nsig->setSelected(false);
                 nsig->setDropTarget(false);
+            }
+
+            if (local) {
+                select(ots, SelectType::SINGLE, staffIdx);
+            } else {
+                selectElementsWithSameTypeOnSegment(ElementType::TIMESIG, seg);
             }
         }
     } else {
@@ -1455,6 +1466,12 @@ void Score::cmdAddTimeSig(Measure* fm, staff_idx_t staffIdx, TimeSig* ts, bool l
                 if (score->isMaster()) {
                     masterTimeSigs[nsig->track()] = nsig;
                 }
+            }
+
+            if (local) {
+                select(ots, SelectType::SINGLE, staffIdx);
+            } else {
+                selectElementsWithSameTypeOnSegment(ElementType::TIMESIG, seg);
             }
         }
     }

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -1919,6 +1919,32 @@ void Score::setSelection(const Selection& s)
 }
 
 //---------------------------------------------------------
+//   selectElementsWithSameTypeOnSegment
+//---------------------------------------------------------
+
+void Score::selectElementsWithSameTypeOnSegment(ElementType elementType, Segment* segment)
+{
+    TRACEFUNC;
+
+    IF_ASSERT_FAILED(segment) {
+        return;
+    }
+
+    deselectAll();
+
+    std::vector<EngravingItem*> elementsToSelect;
+
+    for (size_t staffIdx = 0; staffIdx < nstaves(); ++staffIdx) {
+        EngravingItem* element = segment->element(staffIdx * VOICES);
+        if (element && element->type() == elementType) {
+            elementsToSelect.push_back(element);
+        }
+    }
+
+    select(elementsToSelect, SelectType::ADD);
+}
+
+//---------------------------------------------------------
 //   getText
 //---------------------------------------------------------
 

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -554,6 +554,7 @@ public:
     Selection& selection() { return m_selection; }
     SelectionFilter& selectionFilter() { return m_selectionFilter; }
     void setSelection(const Selection& s);
+    void selectElementsWithSameTypeOnSegment(ElementType elementType, Segment* segment);
 
     Fraction pos();
     Measure* tick2measure(const Fraction& tick) const;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -761,34 +761,12 @@ void NotationInteraction::doSelect(const std::vector<EngravingItem*>& elements, 
         }
 
         if (segment) {
-            selectElementsWithSameTypeOnSegment(element->type(), segment);
+            score()->selectElementsWithSameTypeOnSegment(element->type(), segment);
             return;
         }
     }
 
     score()->select(elements, type, staffIndex);
-}
-
-void NotationInteraction::selectElementsWithSameTypeOnSegment(mu::engraving::ElementType elementType, mu::engraving::Segment* segment)
-{
-    TRACEFUNC;
-
-    IF_ASSERT_FAILED(segment) {
-        return;
-    }
-
-    score()->deselectAll();
-
-    std::vector<EngravingItem*> elementsToSelect;
-
-    for (size_t staffIdx = 0; staffIdx < score()->nstaves(); ++staffIdx) {
-        EngravingItem* element = segment->element(staffIdx * mu::engraving::VOICES);
-        if (element && element->type() == elementType) {
-            elementsToSelect.push_back(element);
-        }
-    }
-
-    score()->select(elementsToSelect, SelectType::ADD);
 }
 
 void NotationInteraction::selectAll()

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -300,7 +300,6 @@ private:
     void onElementDestroyed(EngravingItem* element);
 
     void doSelect(const std::vector<EngravingItem*>& elements, SelectType type, engraving::staff_idx_t staffIndex = 0);
-    void selectElementsWithSameTypeOnSegment(mu::engraving::ElementType elementType, mu::engraving::Segment* segment);
 
     void notifyAboutDragChanged();
     void notifyAboutDropChanged();


### PR DESCRIPTION
This makes it possible to change the time signature multiple times consecutively from palette without the need of selecting it every time.

Resolves: #9584

I copied the changes from the abandoned PR #15363 and added the changes suggested there. However, the method `NotationInteraction::selectElementsWithSameTypeOnSegment` is moved to the `Score` class instead of `utils.cpp` because that class already has some selection methods.

In the method I moved there is a `TRACEFUNC;`. I don’t know what that does so I didn’t touch it. Also I don’t know whether it’s possible to create a test for this (and if so how it’s done).

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
