### PR TITLE
Fix #17655: Style dialog allows negative values for ottava hook heigh…

### DIFF
--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -277,8 +277,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>692</width>
-                <height>595</height>
+                <width>592</width>
+                <height>441</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -873,8 +873,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>659</width>
-                <height>658</height>
+                <width>408</width>
+                <height>484</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_4">
@@ -2253,8 +2253,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>722</width>
-             <height>382</height>
+             <width>685</width>
+             <height>298</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -4019,8 +4019,8 @@ By default, they will be placed such as that their right end are at the same lev
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>379</width>
-                <height>798</height>
+                <width>239</width>
+                <height>593</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_56">
@@ -6176,8 +6176,8 @@ By default, they will be placed such as that their right end are at the same lev
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>559</width>
-                <height>515</height>
+                <width>364</width>
+                <height>386</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_54">
@@ -10238,8 +10238,8 @@ By default, they will be placed such as that their right end are at the same lev
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>594</width>
-             <height>440</height>
+             <width>380</width>
+             <height>324</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout_57">
@@ -11749,8 +11749,8 @@ By default, they will be placed such as that their right end are at the same lev
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>615</width>
-                <height>568</height>
+                <width>384</width>
+                <height>422</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_55">
@@ -12727,8 +12727,8 @@ By default, they will be placed such as that their right end are at the same lev
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>584</width>
-                <height>536</height>
+                <width>354</width>
+                <height>385</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_40">

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -277,8 +277,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>592</width>
-                <height>441</height>
+                <width>692</width>
+                <height>595</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -873,8 +873,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>408</width>
-                <height>484</height>
+                <width>659</width>
+                <height>658</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_4">
@@ -2253,8 +2253,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>685</width>
-             <height>298</height>
+             <width>722</width>
+             <height>382</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -4019,8 +4019,8 @@ By default, they will be placed such as that their right end are at the same lev
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>239</width>
-                <height>593</height>
+                <width>379</width>
+                <height>798</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_56">
@@ -6176,8 +6176,8 @@ By default, they will be placed such as that their right end are at the same lev
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>364</width>
-                <height>386</height>
+                <width>559</width>
+                <height>515</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_54">
@@ -8001,6 +8001,9 @@ By default, they will be placed such as that their right end are at the same lev
              <property name="suffix">
               <string extracomment="spatium unit">sp</string>
              </property>
+             <property name="minimum">
+              <double>-99.000000000000000</double>
+             </property>
             </widget>
            </item>
            <item row="7" column="0">
@@ -8105,6 +8108,9 @@ By default, they will be placed such as that their right end are at the same lev
              </property>
              <property name="suffix">
               <string extracomment="spatium unit">sp</string>
+             </property>
+             <property name="minimum">
+              <double>-99.000000000000000</double>
              </property>
             </widget>
            </item>
@@ -10232,8 +10238,8 @@ By default, they will be placed such as that their right end are at the same lev
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>380</width>
-             <height>324</height>
+             <width>594</width>
+             <height>440</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout_57">
@@ -11743,8 +11749,8 @@ By default, they will be placed such as that their right end are at the same lev
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>384</width>
-                <height>422</height>
+                <width>615</width>
+                <height>568</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_55">
@@ -12721,8 +12727,8 @@ By default, they will be placed such as that their right end are at the same lev
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>354</width>
-                <height>385</height>
+                <width>584</width>
+                <height>536</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_40">


### PR DESCRIPTION
…ts consistent with inspector

Resolves: #17655<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
