### PR TITLE
Fix #13509: adds the possibility of keyboard shortcuts for super/subscript

### DIFF
--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -260,6 +260,8 @@ public:
     virtual void toggleItalic() = 0;
     virtual void toggleUnderline() = 0;
     virtual void toggleStrike() = 0;
+    virtual void toggleSubScript() = 0;
+    virtual void toggleSuperScript() = 0;
 
     virtual bool canInsertClef(mu::engraving::ClefType) const = 0;
     virtual void insertClef(mu::engraving::ClefType) = 0;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -395,6 +395,8 @@ void NotationActionController::init()
     registerAction("text-i", &Interaction::toggleItalic, &Controller::isEditingText);
     registerAction("text-u", &Interaction::toggleUnderline, &Controller::isEditingText);
     registerAction("text-s", &Interaction::toggleStrike, &Controller::isEditingText);
+    registerAction("text-sub", &Interaction::toggleSubScript, &Controller::isEditingText);
+    registerAction("text-sup", &Interaction::toggleSuperScript, &Controller::isEditingText);
 
     registerAction("select-next-measure", &Interaction::addToSelection, MoveDirection::Right, MoveSelectionType::Measure, PlayMode::NoPlay,
                    &Controller::isNotNoteInputMode);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5420,6 +5420,23 @@ void NotationInteraction::toggleFontStyle(mu::engraving::FontStyle style)
     notifyAboutTextEditingChanged();
 }
 
+void NotationInteraction::toggleVerticalAlignment(VerticalAlignment align)
+{
+    if (!m_editData.element || !m_editData.element->isTextBase()) {
+        LOGW("toggleVerticalAlignment called with invalid current element");
+        return;
+    }
+    mu::engraving::TextBase* text = toTextBase(m_editData.element);
+    int ialign = static_cast<int>(align);
+    int currentAlign = text->getProperty(mu::engraving::Pid::TEXT_SCRIPT_ALIGN).toInt();
+    score()->startCmd();
+    text->undoChangeProperty(mu::engraving::Pid::TEXT_SCRIPT_ALIGN, PropertyValue::fromValue(
+                                 (currentAlign == ialign) ? static_cast<int>(VerticalAlignment::AlignNormal) : ialign),
+                             mu::engraving::PropertyFlags::UNSTYLED);
+    score()->endCmd();
+    notifyAboutTextEditingChanged();
+}
+
 void NotationInteraction::toggleBold()
 {
     toggleFontStyle(mu::engraving::FontStyle::Bold);
@@ -5438,6 +5455,16 @@ void NotationInteraction::toggleUnderline()
 void NotationInteraction::toggleStrike()
 {
     toggleFontStyle(mu::engraving::FontStyle::Strike);
+}
+
+void NotationInteraction::toggleSubScript()
+{
+    toggleVerticalAlignment(VerticalAlignment::AlignSubScript);
+}
+
+void NotationInteraction::toggleSuperScript()
+{
+    toggleVerticalAlignment(VerticalAlignment::AlignSuperScript);
 }
 
 template<typename P>

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -266,6 +266,8 @@ public:
     void toggleItalic() override;
     void toggleUnderline() override;
     void toggleStrike() override;
+    void toggleSubScript() override;
+    void toggleSuperScript() override;
     void toggleArticulation(mu::engraving::SymId) override;
     void toggleAutoplace(bool) override;
 
@@ -313,6 +315,7 @@ private:
     void doDragLasso(const PointF& p);
     void endLasso();
     void toggleFontStyle(mu::engraving::FontStyle);
+    void toggleVerticalAlignment(mu::engraving::VerticalAlignment);
     void navigateToLyrics(bool, bool, bool);
 
     mu::engraving::Harmony* editedHarmony() const;

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1753,6 +1753,20 @@ const UiActionList NotationUiActions::m_actions = {
              TranslatableString("action", "Format text: strikethrough"),
              Checkable::Yes
              ),
+    UiAction("text-sub",
+             mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             TranslatableString("action", "Subscript"),
+             TranslatableString("action", "Format text: subscript"),
+             Checkable::Yes
+             ),
+    UiAction("text-sup",
+             mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             TranslatableString("action", "Superscript"),
+             TranslatableString("action", "Format text: superscript"),
+             Checkable::Yes
+             ),
     UiAction("pitch-up-diatonic",
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_ANY,


### PR DESCRIPTION
Resolves: #13509

You can now assign keyboard shortcuts to “Format text: superscript” and “Format text: subscript”.

Other than _italic_ and **bold** subscript and superscript cannot be combined so these cannot be simple toggles (so you could set subscript and superscript at the same time). It’s more like a “three-way toggle”; the following illustrates it (using SUB and SUP for keyboard shortcuts):
```
normal      –SUB→ subscript
normal      –SUP→ superscript
subscript   –SUB→ normal
subscript   –SUP→ superscript
superscript –SUB→ subscript
superscript –SUP→ normal
```
This is how it is done in LibreOffice.

This PR does NOT include default keyboard shortcuts (yet) because I would leave the decision on whether and which defaults should be chosen to some UI designer.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
