### PR TITLE
Remove unneeded include from videowriter.cpp causing compile error

### DIFF
--- a/src/importexport/videoexport/internal/videowriter.cpp
+++ b/src/importexport/videoexport/internal/videowriter.cpp
@@ -28,7 +28,6 @@
 #include "engraving/libmscore/repeatlist.h"
 #include "engraving/libmscore/masterscore.h"
 
-#include "engraving/infrastructure/paint.h"
 #include "notation/view/playbackcursor.h"
 
 #include "log.h"


### PR DESCRIPTION
Resolves: https://discord.com/channels/818804595450445834/939880479887327302/1141636401776050196

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
