### PR TITLE
fixed #19126: Ctr+Shift+Note letter shortcut doesn't work after assigning

### DIFF
--- a/src/framework/shortcuts/qml/MuseScore/Shortcuts/internal/ShortcutsList.qml
+++ b/src/framework/shortcuts/qml/MuseScore/Shortcuts/internal/ShortcutsList.qml
@@ -50,6 +50,11 @@ ValueList {
                 roleName: "searchKey"
                 roleValue: root.searchText
                 compareType: CompareType.Contains
+            },
+            FilterValue {
+                roleName: "title"
+                roleValue: ""
+                compareType: CompareType.NotEqual
             }
         ]
     }

--- a/src/framework/shortcuts/view/shortcutsmodel.cpp
+++ b/src/framework/shortcuts/view/shortcutsmodel.cpp
@@ -103,12 +103,8 @@ void ShortcutsModel::load()
     m_shortcuts.clear();
 
     for (const UiAction& action : uiactionsRegister()->getActions()) {
-        if (action.title.isEmpty() || action.description.isEmpty()) {
-            continue;
-        }
-
         Shortcut shortcut = shortcutsRegister()->shortcut(action.code);
-        if (shortcut.action != action.code) {
+        if (!shortcut.isValid()) {
             shortcut.action = action.code;
             shortcut.context = action.scCtx;
         }


### PR DESCRIPTION
Resolves: #19126

We pass m_shortcuts to the EditShortcutDialog, as a result, the dialog does not work with the full list of shortcuts.  Also, a lot of shortcuts are ignored because of this condition. For example, 'insert <note>', 'image', 'chord-tie'
Fixed my comment in https://github.com/musescore/MuseScore/pull/12414/files#r956457632