### PR TITLE
Fix #19169: Smooth panning now limited to Continuous view (horizontal).

### DIFF
--- a/src/notation/view/abstractnotationpaintview.cpp
+++ b/src/notation/view/abstractnotationpaintview.cpp
@@ -1289,7 +1289,8 @@ void AbstractNotationPaintView::movePlaybackCursor(midi::tick_t tick)
     }
 
     if (configuration()->isAutomaticallyPanEnabled()) {
-        if (configuration()->isSmoothPanning() && adjustCanvasPositionSmoothPan(newCursorRect)) {
+        if ((notation()->viewMode() == engraving::LayoutMode::LINE) && configuration()->isSmoothPanning()
+            && adjustCanvasPositionSmoothPan(newCursorRect)) {
             return;
         }
 


### PR DESCRIPTION
Resolves: #19169