### PR TITLE
minimal header clef / time to note distance 1,5 sp in UI

### DIFF
--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -4767,6 +4767,9 @@ By default, they will be placed such as that their right end are at the same lev
                     <property name="suffix">
                      <string extracomment="spatium unit">sp</string>
                     </property>
+                    <property name="minimum">
+                     <double>1.500000000000000</double>
+                    </property>
                     <property name="singleStep">
                      <double>0.100000000000000</double>
                     </property>
@@ -4779,6 +4782,9 @@ By default, they will be placed such as that their right end are at the same lev
                     </property>
                     <property name="suffix">
                      <string extracomment="spatium unit">sp</string>
+                    </property>
+                    <property name="minimum">
+                     <double>1.500000000000000</double>
                     </property>
                     <property name="singleStep">
                      <double>0.100000000000000</double>


### PR DESCRIPTION
<!-- Add a short description of and motivation for the changes here -->
Style - Measure - System Header
- Clef/key to first note
- Time to first note

have real minimal values 1,5 sp

now UI reflect it
<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
