### PR TITLE
Fix default settings for MusicXML import

### DIFF
--- a/src/importexport/musicxml/internal/musicxmlconfiguration.cpp
+++ b/src/importexport/musicxml/internal/musicxmlconfiguration.cpp
@@ -43,6 +43,7 @@ void MusicXmlConfiguration::init()
     settings()->setDefaultValue(MUSICXML_EXPORT_LAYOUT_KEY, Val(true));
     settings()->setDefaultValue(MUSICXML_EXPORT_BREAKS_TYPE_KEY, Val(MusicxmlExportBreaksType::All));
     settings()->setDefaultValue(MUSICXML_EXPORT_INVISIBLE_ELEMENTS_KEY, Val(false));
+    settings()->setDefaultValue(MIGRATION_APPLY_EDWIN_FOR_XML, Val(false));
     settings()->setDefaultValue(MIGRATION_NOT_ASK_AGAIN_KEY, Val(false));
 }
 

--- a/src/importexport/musicxml/musicxmlmodule.cpp
+++ b/src/importexport/musicxml/musicxmlmodule.cpp
@@ -61,11 +61,6 @@ void MusicXmlModule::registerExports()
 
 void MusicXmlModule::resolveImports()
 {
-    //! TODO For some reason, the configuration init should be here,
-    //! we need to find out if this is not correct... for the correct one,
-    //! it should be in the onInit module
-    m_configuration->init();
-
     auto readers = modularity::ioc()->resolve<INotationReadersRegister>(moduleName());
     if (readers) {
         readers->reg({ "xml", "musicxml", "mxl" }, std::make_shared<MusicXmlReader>());
@@ -76,4 +71,9 @@ void MusicXmlModule::resolveImports()
         writers->reg({ "musicxml", "xml" }, std::make_shared<MusicXmlWriter>());
         writers->reg({ "mxl" }, std::make_shared<MxlWriter>());
     }
+}
+
+void MusicXmlModule::onInit(const framework::IApplication::RunMode&)
+{
+    m_configuration->init();
 }

--- a/src/importexport/musicxml/musicxmlmodule.h
+++ b/src/importexport/musicxml/musicxmlmodule.h
@@ -36,6 +36,7 @@ public:
     void registerResources() override;
     void registerExports() override;
     void resolveImports() override;
+    void onInit(const framework::IApplication::RunMode&) override;
 
 private:
     std::shared_ptr<MusicXmlConfiguration> m_configuration;

--- a/src/importexport/musicxml/tests/data/testMeasureStyleSlash_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testMeasureStyleSlash_ref.mscx
@@ -3,6 +3,15 @@
   <Score>
     <Division>480</Division>
     <Style>
+      <pageWidth>8.27001</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.0889</pagePrintableWidth>
+      <pageEvenLeftMargin>0.590551</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.590551</pageOddLeftMargin>
+      <pageEvenTopMargin>0.590551</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
+      <pageOddTopMargin>0.590551</pageOddTopMargin>
+      <pageOddBottomMargin>0.590551</pageOddBottomMargin>
       <lyricsOddFontSize>11</lyricsOddFontSize>
       <lyricsEvenFontSize>11</lyricsEvenFontSize>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
@@ -24,7 +33,7 @@
       <bendFontSize>10</bendFontSize>
       <headerFontSize>10</headerFontSize>
       <footerFontSize>10</footerFontSize>
-      <Spatium>1.74978</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -109,7 +118,7 @@
         <height>3.5</height>
         <Text>
           <style>title</style>
-          <offset x="0" y="-0.0559929"/>
+          <offset x="0" y="-0.0564445"/>
           <text><font size="24"/>Test measure-style/slash</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testVoltaHiding_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testVoltaHiding_ref.mscx
@@ -3,6 +3,15 @@
   <Score>
     <Division>480</Division>
     <Style>
+      <pageWidth>8.49999</pageWidth>
+      <pageHeight>11</pageHeight>
+      <pagePrintableWidth>7.31889</pagePrintableWidth>
+      <pageEvenLeftMargin>0.590551</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.590551</pageOddLeftMargin>
+      <pageEvenTopMargin>0.590551</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
+      <pageOddTopMargin>0.590551</pageOddTopMargin>
+      <pageOddBottomMargin>0.590551</pageOddBottomMargin>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>


### PR DESCRIPTION
Resolves: #17828

Regarding that mysterious misplaced `m_configuration->init()` call:
- in 025baf68ba4739a8b7d3aad8a24283dcef446285, where it was created, it was in the correct place
- in b2ff7d629ea09a89639683634920f2e677a8f384, it was accidentally moved to `resolveImports`, along with some things that _do_ belong in `resolveImports`