### PR TITLE
Initialise MuseSampler and VST modules in command line mode too

### DIFF
--- a/src/framework/musesampler/musesamplermodule.cpp
+++ b/src/framework/musesampler/musesamplermodule.cpp
@@ -68,7 +68,7 @@ void MuseSamplerModule::resolveImports()
 
 void MuseSamplerModule::onInit(const framework::IApplication::RunMode& mode)
 {
-    if (framework::IApplication::RunMode::GuiApp != mode) {
+    if (framework::IApplication::RunMode::AudioPluginRegistration == mode) {
         return;
     }
 

--- a/src/framework/vst/vstmodule.cpp
+++ b/src/framework/vst/vstmodule.cpp
@@ -115,12 +115,8 @@ void VSTModule::registerUiTypes()
     ioc()->resolve<ui::IUiEngine>(moduleName())->addSourceImportPath(vst_QML_IMPORT);
 }
 
-void VSTModule::onInit(const framework::IApplication::RunMode& mode)
+void VSTModule::onInit(const framework::IApplication::RunMode&)
 {
-    if (mode == framework::IApplication::RunMode::ConsoleApp) {
-        return;
-    }
-
     s_configuration->init();
     s_pluginModulesRepo->init();
 }


### PR DESCRIPTION
For audio export

Resolves: #19160 (I'm quite sure that there's also a duplicate of that issue somewhere, but I really can't find it apparently)