### PR TITLE
[13562-edit_line_style_text] edit inspector text to better describe line style

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/LineStyleSection.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/LineStyleSection.qml
@@ -70,7 +70,7 @@ Column {
 
     FlatRadioButtonGroupPropertyView {
         id: styleSection
-        titleText: qsTrc("inspector", "Line Style")
+        titleText: qsTrc("inspector", "Line style")
         propertyItem: root.lineStyle
 
         navigationPanel: root.navigationPanel

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/LineStyleSection.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/LineStyleSection.qml
@@ -70,7 +70,7 @@ Column {
 
     FlatRadioButtonGroupPropertyView {
         id: styleSection
-        titleText: qsTrc("inspector", "Style")
+        titleText: qsTrc("inspector", "Line Style")
         propertyItem: root.lineStyle
 
         navigationPanel: root.navigationPanel


### PR DESCRIPTION
Resolves: #13562 

In the inspector, the title for line styles was too vague, and was made more precise.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
