### PR TITLE
Prevent unusable duration on deleting a cross staff tuplet

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3346,7 +3346,7 @@ ChordRest* Score::deleteRange(Segment* s1, Segment* s2, track_idx_t track1, trac
                 }
 
                 if (currentTuplet != cr1->tuplet()) {
-                    if (f.isValid()) { // Set rests for the previous tuplet we were dealing with
+                    if (f.isValid() && !fullMeasure) { // Set rests for the previous tuplet we were dealing with
                         setRest(tick, track, f, false, currentTuplet);
                     }
                     Tuplet* t = cr1->tuplet();

--- a/src/engraving/dom/tuplet.cpp
+++ b/src/engraving/dom/tuplet.cpp
@@ -531,7 +531,15 @@ bool Tuplet::cross() const
 
 staff_idx_t Tuplet::vStaffIdx() const
 {
+    if (elements().empty()) {
+        return mu::nidx;
+    }
+
     const DurationElement* cr = elements().front();
+    if (!cr) {
+        return mu::nidx;
+    }
+
     while (cr->isTuplet()) {
         const Tuplet* t = toTuplet(cr);
         if (t->elements().empty()) {

--- a/src/engraving/dom/tuplet.cpp
+++ b/src/engraving/dom/tuplet.cpp
@@ -525,6 +525,24 @@ bool Tuplet::cross() const
 }
 
 //---------------------------------------------------------
+//   vStaffIdx
+///  Staff index for layout based on the first ChordRest
+//---------------------------------------------------------
+
+staff_idx_t Tuplet::vStaffIdx() const
+{
+    const DurationElement* cr = elements().front();
+    while (cr->isTuplet()) {
+        const Tuplet* t = toTuplet(cr);
+        if (t->elements().empty()) {
+            break;
+        }
+        cr = t->elements().front();
+    }
+    return cr->vStaffIdx();
+}
+
+//---------------------------------------------------------
 //   elementsDuration
 ///  Get the sum of the element fraction in the tuplet,
 ///  even if the tuplet is not complete yet

--- a/src/engraving/dom/tuplet.h
+++ b/src/engraving/dom/tuplet.h
@@ -124,6 +124,7 @@ public:
     Fraction elementsDuration();
     void sortElements();
     bool cross() const;
+    staff_idx_t vStaffIdx() const override;
 
     const mu::PointF& p1() const { return m_p1; }
     mu::PointF& p1() { return m_p1; }

--- a/src/engraving/rendering/dev/tupletlayout.cpp
+++ b/src/engraving/rendering/dev/tupletlayout.cpp
@@ -400,7 +400,8 @@ void TupletLayout::layout(Tuplet* item, LayoutContext& ctx)
     if (item->explicitParent()->isMeasure()) {
         System* s = toMeasure(item->explicitParent())->system();
         if (s) {
-            mp.ry() += s->staff(item->vStaffIdx())->y();
+            SysStaff* tupletStaff = s->staff(item->vStaffIdx());
+            mp.ry() += tupletStaff ? tupletStaff->y() : 0.0;
         }
     }
     item->p1() -= mp;

--- a/src/engraving/rendering/dev/tupletlayout.cpp
+++ b/src/engraving/rendering/dev/tupletlayout.cpp
@@ -161,15 +161,11 @@ void TupletLayout::layout(Tuplet* item, LayoutContext& ctx)
     double noteRight     = (style.styleMM(Sid::tupletNoteRightDistance) - style.styleMM(Sid::tupletBracketWidth) / 2) * cr2->mag();
 
     int move = 0;
-    item->setStaffIdx(cr1->vStaffIdx());
     if (outOfStaff && cr1->isChordRest() && cr2->isChordRest()) {
         // account for staff move when adjusting bracket to avoid staff
         // but don't attempt adjustment unless both endpoints are in same staff
         if (toChordRest(cr1)->staffMove() == toChordRest(cr2)->staffMove()) {
             move = toChordRest(cr1)->staffMove();
-            if (move == 1) {
-                item->setStaffIdx(cr1->vStaffIdx());
-            }
         } else {
             outOfStaff = false;
         }
@@ -404,7 +400,7 @@ void TupletLayout::layout(Tuplet* item, LayoutContext& ctx)
     if (item->explicitParent()->isMeasure()) {
         System* s = toMeasure(item->explicitParent())->system();
         if (s) {
-            mp.ry() += s->staff(item->staffIdx())->y();
+            mp.ry() += s->staff(item->vStaffIdx())->y();
         }
     }
     item->p1() -= mp;


### PR DESCRIPTION
Resolves: #17042 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
