### PR TITLE
split / join measures in parts

### DIFF
--- a/src/engraving/dom/chordrest.cpp
+++ b/src/engraving/dom/chordrest.cpp
@@ -168,7 +168,7 @@ EngravingItem* ChordRest::drop(EditData& data)
 
     case ElementType::BAR_LINE:
         if (data.control()) {
-            score()->splitMeasure(segment());
+            score()->cmdSplitMeasure(this);
         } else {
             BarLine* bl = toBarLine(e);
             bl->setPos(PointF());

--- a/src/engraving/dom/joinMeasure.cpp
+++ b/src/engraving/dom/joinMeasure.cpp
@@ -40,6 +40,23 @@ void Score::cmdJoinMeasure(Measure* m1, Measure* m2)
     if (!m1 || !m2) {
         return;
     }
+    masterScore()->joinMeasure(m1->tick(), m2->tick());
+}
+
+//---------------------------------------------------------
+//   joinMeasure
+//    join measures from tick1 upto (including) tick2
+//    always acts in masterScore
+//---------------------------------------------------------
+
+void MasterScore::joinMeasure(const Fraction& tick1, const Fraction& tick2)
+{
+    Measure* m1 = tick2measure(tick1);
+    Measure* m2 = tick2measure(tick2);
+
+    if (!m1 || !m2) {
+        return;
+    }
 
     for (size_t staffIdx = 0; staffIdx < nstaves(); ++staffIdx) {
         if (m1->isMeasureRepeatGroupWithPrevM(static_cast<int>(staffIdx))
@@ -55,34 +72,42 @@ void Score::cmdJoinMeasure(Measure* m1, Measure* m2)
     if (m2->isMMRest()) {
         m2 = m2->mmRestLast();
     }
-    startCmd();
 
     deselectAll();
 
     ScoreRange range;
     range.read(m1->first(), m2->last());
 
-    Fraction tick1 = m1->tick();
-    Fraction tick2 = m2->endTick();
+    Fraction startTick = m1->tick();
+    Fraction endTick = m2->endTick();
 
-    auto spanners = m_spanner.findContained(tick1.ticks(), tick2.ticks());
+    auto spanners = spannerMap().findContained(startTick.ticks(), endTick.ticks());
     for (auto i : spanners) {
         undo(new RemoveElement(i.value));
     }
 
     for (auto i : spanner()) {
         Spanner* s = i.second;
-        if (s->tick() >= tick1 && s->tick() < tick2) {
+        if (s->tick() >= startTick && s->tick() < endTick) {
             s->setStartElement(0);
         }
-        if (s->tick2() >= tick1 && s->tick2() < tick2) {
+        if (s->tick2() >= startTick && s->tick2() < endTick) {
             s->setEndElement(0);
         }
     }
 
-    deleteMeasures(m1, m2, true);
-
     MeasureBase* next = m2->next();
+    InsertMeasureOptions options;
+    options.createEmptyMeasures = true;
+    options.moveSignaturesClef = false;
+    insertMeasure(ElementType::MEASURE, next, options);
+
+    for (Score* s : scoreList()) {
+        Measure* sM1 = s->tick2measure(startTick);
+        Measure* sM2 = s->tick2measure(m2->tick());
+        s->undoRemoveMeasures(sM1, sM2, true);
+    }
+
     const Fraction newTimesig = m1->timesig();
     Fraction newLen;
     for (Measure* mm = m1; mm; mm = mm->nextMeasure()) {
@@ -92,13 +117,10 @@ void Score::cmdJoinMeasure(Measure* m1, Measure* m2)
         }
     }
 
-    InsertMeasureOptions options;
-    options.createEmptyMeasures = true;
-
-    insertMeasure(ElementType::MEASURE, next, options);
     // The loop since measures are not currently linked in MuseScore
-    for (Score* s : masterScore()->scoreList()) {
-        Measure* ins = s->tick2measure(tick1);
+    // change nominal time sig, as inserted measure took it from next measure
+    for (Score* s : scoreList()) {
+        Measure* ins = s->tick2measure(startTick);
         ins->undoChangeProperty(Pid::TIMESIG_NOMINAL, newTimesig);
 //             TODO: there was a commented chunk of code regarding setting bar
 //             line types. Should we handle them here too?
@@ -109,7 +131,5 @@ void Score::cmdJoinMeasure(Measure* m1, Measure* m2)
     inserted->adjustToLen(newLen, /* appendRests... */ false);
 
     range.write(this, m1->tick());
-
-    endCmd();
 }
 }

--- a/src/engraving/dom/joinMeasure.cpp
+++ b/src/engraving/dom/joinMeasure.cpp
@@ -122,10 +122,14 @@ void MasterScore::joinMeasure(const Fraction& tick1, const Fraction& tick2)
     for (Score* s : scoreList()) {
         Measure* ins = s->tick2measure(startTick);
         ins->undoChangeProperty(Pid::TIMESIG_NOMINAL, newTimesig);
-//             TODO: there was a commented chunk of code regarding setting bar
-//             line types. Should we handle them here too?
-//             m->setEndBarLineType(m2->endBarLineType(), m2->endBarLineGenerated(),
-//             m2->endBarLineVisible(), m2->endBarLineColor());
+        // set correct barline types if needed
+        // TODO: handle other end barline types; they may differ per staff
+        if (m2->endBarLineType() == BarLineType::END_REPEAT) {
+            ins->undoChangeProperty(Pid::REPEAT_END, true);
+        }
+        if (m1->getProperty(Pid::REPEAT_START).toBool()) {
+            ins->undoChangeProperty(Pid::REPEAT_START, true);
+        }
     }
     Measure* inserted = (next ? next->prevMeasure() : lastMeasure());
     inserted->adjustToLen(newLen, /* appendRests... */ false);

--- a/src/engraving/dom/masterscore.h
+++ b/src/engraving/dom/masterscore.h
@@ -216,6 +216,7 @@ public:
     MasterScore* unrollRepeats();
 
     void splitMeasure(const Fraction&);
+    void joinMeasure(const Fraction&, const Fraction&);
 
     IFileInfoProviderPtr fileInfo() const;
     void setFileInfoProvider(IFileInfoProviderPtr fileInfoProvider);

--- a/src/engraving/dom/masterscore.h
+++ b/src/engraving/dom/masterscore.h
@@ -215,6 +215,8 @@ public:
 
     MasterScore* unrollRepeats();
 
+    void splitMeasure(const Fraction&);
+
     IFileInfoProviderPtr fileInfo() const;
     void setFileInfoProvider(IFileInfoProviderPtr fileInfoProvider);
 

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -785,7 +785,6 @@ public:
     void setMetaTag(const String& tag, const String& val);
 
     void cmdSplitMeasure(ChordRest*);
-    void splitMeasure(Segment*);
     void cmdJoinMeasure(Measure*, Measure*);
 
     int pageNumberOffset() const { return m_pageNumberOffset; }

--- a/src/engraving/tests/join_data/join01-ref.mscx
+++ b/src/engraving/tests/join_data/join01-ref.mscx
@@ -74,9 +74,6 @@
             <transposingClefType>G</transposingClefType>
             <isHeader>1</isHeader>
             </Clef>
-          <KeySig>
-            <concertKey>0</concertKey>
-            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>

--- a/src/engraving/tests/join_data/join02-ref.mscx
+++ b/src/engraving/tests/join_data/join02-ref.mscx
@@ -74,9 +74,6 @@
             <transposingClefType>G</transposingClefType>
             <isHeader>1</isHeader>
             </Clef>
-          <KeySig>
-            <concertKey>0</concertKey>
-            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>

--- a/src/engraving/tests/join_data/join03-ref.mscx
+++ b/src/engraving/tests/join_data/join03-ref.mscx
@@ -74,9 +74,6 @@
             <transposingClefType>G</transposingClefType>
             <isHeader>1</isHeader>
             </Clef>
-          <KeySig>
-            <concertKey>0</concertKey>
-            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>

--- a/src/engraving/tests/join_data/join04-ref.mscx
+++ b/src/engraving/tests/join_data/join04-ref.mscx
@@ -74,9 +74,6 @@
             <transposingClefType>G</transposingClefType>
             <isHeader>1</isHeader>
             </Clef>
-          <KeySig>
-            <concertKey>0</concertKey>
-            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>

--- a/src/engraving/tests/join_data/join05-ref.mscx
+++ b/src/engraving/tests/join_data/join05-ref.mscx
@@ -74,9 +74,6 @@
             <transposingClefType>G</transposingClefType>
             <isHeader>1</isHeader>
             </Clef>
-          <KeySig>
-            <concertKey>0</concertKey>
-            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>

--- a/src/engraving/tests/join_data/join07-ref.mscx
+++ b/src/engraving/tests/join_data/join07-ref.mscx
@@ -74,9 +74,6 @@
             <transposingClefType>G</transposingClefType>
             <isHeader>1</isHeader>
             </Clef>
-          <KeySig>
-            <concertKey>0</concertKey>
-            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>

--- a/src/engraving/tests/join_tests.cpp
+++ b/src/engraving/tests/join_tests.cpp
@@ -61,7 +61,9 @@ void Engraving_JoinTests::join(const char* p1, const char* p2, int index)
 
     EXPECT_NE(m1, m2);
 
+    score->startCmd();
     score->cmdJoinMeasure(m1, m2);
+    score->endCmd();
 
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, String::fromUtf8(p1), JOIN_DATA_DIR + String::fromUtf8(p2)));
     delete score;

--- a/src/engraving/tests/split_tests.cpp
+++ b/src/engraving/tests/split_tests.cpp
@@ -52,7 +52,9 @@ void Engraving_SplitTests::split(const char* f1, const char* ref, int index)
     }
     ChordRest* cr = toChordRest(s->element(0));
 
+    score->startCmd();
     score->cmdSplitMeasure(cr);
+    score->endCmd();
 
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, String::fromUtf8(f1), SPLIT_DATA_DIR + String::fromUtf8(ref)));
     delete score;


### PR DESCRIPTION
Resolves: #17115 
Resolves: #19283

<!-- Add a short description of and motivation for the changes here -->
split and join measures now always acts in masterScore (under the hood)

In joinMeasure it was deleteMeasures used before, to handle parts. 
But it has side effect, that it also creates "lastDeletedKeySignature" in next measure.
This was fixed by InsertMeasureOption "moveSignaturesClef" (by omitting  moveSignaturesClef = false).
But it has side effect, that if "next measure" already contains key signature, it is moved too (#19283).

Now undoRemoveMeasures function is used instead of deleteMeasures.

(Thats why utests failed - in undoRemoveMeasure, there is no check of missing initial key signature, so joining first two measures in score with no initial key sig doesn't create new one.)

Also correct repeat barlines are preserved now.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
