### PR TITLE
Make sure "MuseScore version" text is not cut off in project properties

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/Properties/ProjectPropertiesFileInfoPanel.qml
+++ b/src/project/qml/MuseScore/Project/internal/Properties/ProjectPropertiesFileInfoPanel.qml
@@ -78,7 +78,6 @@ ColumnLayout {
         spacing: 8
 
         PropertyItem {
-            propertyNameWidth: root.propertyNameWidth
             index: 2
             propertyName: qsTrc("project/properties", "MuseScore version:")
             propertyValue: projectPropertiesModel.version


### PR DESCRIPTION
Resolves: #15411 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
By removing the `propertyNameWidth` line, the text "MuseScore version" is no longer cut off in the project properties.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
