### PR TITLE
Fix: years without spaces

### DIFF
--- a/src/appshell/qml/AboutMusicXMLDialog.qml
+++ b/src/appshell/qml/AboutMusicXMLDialog.qml
@@ -68,7 +68,7 @@ StyledDialogView {
                 StyledTextLabel {
                     width: parent.width
 
-                    text: qsTrc("appshell/about", "Copyright 2004 - 2017 the Contributors to the MusicXML Specification, published by the W3C Music Notation Community Group under the W3C Community Final Specification Agreement:")
+                    text: qsTrc("appshell/about", "Copyright 2004-2017 the Contributors to the MusicXML Specification, published by the W3C Music Notation Community Group under the W3C Community Final Specification Agreement:")
                     wrapMode: Text.WordWrap
                     maximumLineCount: 3
                 }

--- a/src/appshell/qml/AboutMusicXMLDialog.qml
+++ b/src/appshell/qml/AboutMusicXMLDialog.qml
@@ -68,7 +68,7 @@ StyledDialogView {
                 StyledTextLabel {
                     width: parent.width
 
-                    text: qsTrc("appshell/about", "Copyright © 2004-2021 the Contributors to the MusicXML Specification, published by the W3C Music Notation Community Group under the W3C Community Final Specification Agreement (FSA):")
+                    text: qsTrc("appshell/about", "Copyright © 2004-2021 the Contributors to the MusicXML Specification, published by the Music Notation Community Group under the W3C Community Final Specification Agreement (FSA):")
                     wrapMode: Text.WordWrap
                     maximumLineCount: 3
                 }

--- a/src/appshell/qml/AboutMusicXMLDialog.qml
+++ b/src/appshell/qml/AboutMusicXMLDialog.qml
@@ -68,7 +68,7 @@ StyledDialogView {
                 StyledTextLabel {
                     width: parent.width
 
-                    text: qsTrc("appshell/about", "Copyright 2004-2021 the Contributors to the MusicXML Specification, published by the W3C Music Notation Community Group under the W3C Community Final Specification Agreement:")
+                    text: qsTrc("appshell/about", "Copyright © 2004-2021 the Contributors to the MusicXML Specification, published by the W3C Music Notation Community Group under the W3C Community Final Specification Agreement (FSA):")
                     wrapMode: Text.WordWrap
                     maximumLineCount: 3
                 }

--- a/src/appshell/qml/AboutMusicXMLDialog.qml
+++ b/src/appshell/qml/AboutMusicXMLDialog.qml
@@ -68,7 +68,7 @@ StyledDialogView {
                 StyledTextLabel {
                     width: parent.width
 
-                    text: qsTrc("appshell/about", "Copyright 2004-2017 the Contributors to the MusicXML Specification, published by the W3C Music Notation Community Group under the W3C Community Final Specification Agreement:")
+                    text: qsTrc("appshell/about", "Copyright 2004-2021 the Contributors to the MusicXML Specification, published by the W3C Music Notation Community Group under the W3C Community Final Specification Agreement:")
                     wrapMode: Text.WordWrap
                     maximumLineCount: 3
                 }


### PR DESCRIPTION
Years without spaces - like "Copyright © 1999-2023 MuseScore BVBA and others." in the AboutDialog.qml (/src/appshell/qml/AboutDialog.qml).

Greetings,
Gootector

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
