### PR TITLE
Added default Prefer value to setTpcFromPitch. force gp5 import to use sharps

### DIFF
--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -761,14 +761,14 @@ int Note::tpc2default(int p) const
 //   setTpcFromPitch
 //---------------------------------------------------------
 
-void Note::setTpcFromPitch()
+void Note::setTpcFromPitch(Prefer prefer /* = Prefer::NEAREST */)
 {
     // works best if note is already added to score, otherwise we can't determine transposition or key
     Fraction tick = chord() ? chord()->tick() : Fraction(-1, 1);
     Interval v = staff() ? staff()->transpose(tick) : Interval();
     Key cKey = (staff() && chord()) ? staff()->concertKey(chord()->tick()) : Key::C;
     // set concert pitch tpc
-    m_tpc[0] = pitch2tpc(m_pitch, cKey, Prefer::NEAREST);
+    m_tpc[0] = pitch2tpc(m_pitch, cKey, prefer);
     // set transposed tpc
     if (v.isZero()) {
         m_tpc[1] = m_tpc[0];

--- a/src/engraving/dom/note.h
+++ b/src/engraving/dom/note.h
@@ -243,7 +243,7 @@ public:
     void setTpc(int v);
     void setTpc1(int v) { m_tpc[0] = v; }
     void setTpc2(int v) { m_tpc[1] = v; }
-    void setTpcFromPitch();
+    void setTpcFromPitch(Prefer prefer = Prefer::NEAREST);
     int tpc1default(int pitch) const;
     int tpc2default(int pitch) const;
     int transposeTpc(int tpc) const;

--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -46,6 +46,7 @@
 #include "engraving/dom/measurebase.h"
 #include "engraving/dom/note.h"
 #include "engraving/dom/notedot.h"
+#include "engraving/dom/pitchspelling.h"
 #include "engraving/dom/part.h"
 #include "engraving/dom/rehearsalmark.h"
 #include "engraving/dom/rest.h"
@@ -356,7 +357,7 @@ Fraction GuitarPro5::readBeat(const Fraction& tick, int voice, Measure* measure,
                 if (note->fret() == -20) {
                     delnote.push_back(note);
                 } else {
-                    note->setTpcFromPitch();
+                    note->setTpcFromPitch(Prefer::SHARPS);
                 }
             }
         }
@@ -1235,7 +1236,7 @@ GuitarPro::ReadNoteResult GuitarPro5::readNoteEffects(Note* note)
             int pitch = staff->part()->instrument()->stringData()->getPitch(note->string(), harmonicOvertone, staff);
 
             note->setPitch(std::clamp(pitch, 0, 127));
-            note->setTpcFromPitch();
+            note->setTpcFromPitch(Prefer::SHARPS);
         } else if (type >= HARMONIC_MARK_ARTIFICIAL && type <= HARMONIC_MARK_SEMI) {
             int fret = (type == HARMONIC_MARK_TAP ? (readChar() - note->fret()) : note->fret());
             float midi = note->pitch() + fret;
@@ -1295,7 +1296,7 @@ GuitarPro::ReadNoteResult GuitarPro5::readNoteEffects(Note* note)
             int pitch = staff->part()->instrument()->stringData()->getPitch(note->string(), overtoneFret + note->part()->capoFret(), staff);
 
             harmonicNote->setPitch(std::clamp(pitch, 0, 127));
-            harmonicNote->setTpcFromPitch();
+            harmonicNote->setTpcFromPitch(Prefer::SHARPS);
             note->chord()->add(harmonicNote);
 
             switch (type) {
@@ -1587,7 +1588,7 @@ GuitarPro::ReadNoteResult GuitarPro5::readNote(int string, Note* note)
                 note2->setString(true_note->string());
                 note2->setFret(true_note->fret());
                 note2->setPitch(true_note->pitch());
-                note2->setTpcFromPitch();
+                note2->setTpcFromPitch(Prefer::SHARPS);
                 chord1->setNoteType(true_note->noteType());
                 chord1->add(note2);
                 Tie* tie = Factory::createTie(note2);

--- a/src/importexport/guitarpro/tests/data/all-percussion.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/all-percussion.gp5-ref.mscx
@@ -561,7 +561,7 @@
             <durationType>eighth</durationType>
             <Note>
               <pitch>27</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>27</fret>
               <string>0</string>
               </Note>
@@ -634,7 +634,7 @@
             <durationType>half</durationType>
             <Note>
               <pitch>34</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>34</fret>
               <string>0</string>
               </Note>
@@ -692,7 +692,7 @@
             <durationType>half</durationType>
             <Note>
               <pitch>39</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>39</fret>
               <string>0</string>
               </Note>
@@ -769,7 +769,7 @@
             <durationType>half</durationType>
             <Note>
               <pitch>46</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <head>xcircle</head>
               <fret>46</fret>
               <string>0</string>
@@ -828,7 +828,7 @@
             <durationType>half</durationType>
             <Note>
               <pitch>51</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <head>cross</head>
               <fret>51</fret>
               <string>0</string>
@@ -909,7 +909,7 @@
             <durationType>half</durationType>
             <Note>
               <pitch>58</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>58</fret>
               <string>0</string>
               </Note>
@@ -968,7 +968,7 @@
             <durationType>half</durationType>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <head>cross</head>
               <fret>63</fret>
               <string>0</string>
@@ -1047,7 +1047,7 @@
             <durationType>half</durationType>
             <Note>
               <pitch>70</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>70</fret>
               <string>0</string>
               </Note>
@@ -1104,7 +1104,7 @@
             <durationType>half</durationType>
             <Note>
               <pitch>75</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>75</fret>
               <string>0</string>
               </Note>
@@ -1179,7 +1179,7 @@
             <durationType>half</durationType>
             <Note>
               <pitch>82</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>82</fret>
               <string>0</string>
               </Note>
@@ -1236,7 +1236,7 @@
             <durationType>half</durationType>
             <Note>
               <pitch>87</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>87</fret>
               <string>0</string>
               </Note>

--- a/src/importexport/guitarpro/tests/data/capo-fret.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/capo-fret.gp5-ref.mscx
@@ -139,10 +139,10 @@
               </Note>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>58</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>

--- a/src/importexport/guitarpro/tests/data/copyright.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/copyright.gp5-ref.mscx
@@ -92,10 +92,10 @@
             <durationType>half</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>58</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>3</fret>
               <string>2</string>
               </Note>

--- a/src/importexport/guitarpro/tests/data/fingering.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fingering.gp5-ref.mscx
@@ -160,13 +160,13 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <Fingering>
                 <text>T</text>
                 </Fingering>
               <pitch>51</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>1</fret>
               <string>3</string>
               </Note>
@@ -189,9 +189,6 @@
           <Chord>
             <durationType>half</durationType>
             <Note>
-              <Accidental>
-                <subtype>accidentalNatural</subtype>
-                </Accidental>
               <Fingering>
                 <text>M</text>
                 </Fingering>

--- a/src/importexport/guitarpro/tests/data/fret-diagram.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram.gp5-ref.mscx
@@ -144,10 +144,10 @@
               </Note>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
@@ -175,10 +175,10 @@
               </Note>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>51</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
@@ -193,13 +193,13 @@
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
@@ -220,7 +220,7 @@
               </Note>
             <Note>
               <pitch>51</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
@@ -232,13 +232,13 @@
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
@@ -259,7 +259,7 @@
               </Note>
             <Note>
               <pitch>51</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
@@ -271,13 +271,13 @@
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
@@ -306,7 +306,7 @@
               </Note>
             <Note>
               <pitch>51</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
@@ -318,13 +318,13 @@
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
@@ -349,7 +349,7 @@
               </Note>
             <Note>
               <pitch>51</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
@@ -361,13 +361,13 @@
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
@@ -388,7 +388,7 @@
               </Note>
             <Note>
               <pitch>51</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
@@ -400,13 +400,13 @@
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
@@ -427,7 +427,7 @@
               </Note>
             <Note>
               <pitch>51</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
@@ -439,13 +439,13 @@
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
@@ -464,23 +464,23 @@
             <velocity>96</velocity>
             </Dynamic>
           <Beam>
-            <l1>-36</l1>
-            <l2>-36</l2>
+            <l1>-32</l1>
+            <l2>-32</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>46</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
               <pitch>51</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
@@ -492,22 +492,22 @@
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>70</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>5</fret>
               <string>1</string>
               </Note>
@@ -520,13 +520,13 @@
             <durationType>16th</durationType>
             <Note>
               <pitch>46</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
               <pitch>51</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
@@ -538,19 +538,19 @@
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
               <pitch>70</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>5</fret>
               <string>1</string>
               </Note>
@@ -559,13 +559,13 @@
             <durationType>16th</durationType>
             <Note>
               <pitch>46</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
               <pitch>51</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
@@ -577,19 +577,19 @@
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
               <pitch>70</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>5</fret>
               <string>1</string>
               </Note>
@@ -598,13 +598,13 @@
             <durationType>eighth</durationType>
             <Note>
               <pitch>46</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
               <pitch>51</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
@@ -616,19 +616,19 @@
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
               <pitch>70</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>5</fret>
               <string>1</string>
               </Note>
@@ -638,20 +638,20 @@
             <velocity>96</velocity>
             </Dynamic>
           <Beam>
-            <l1>-36</l1>
-            <l2>-36</l2>
+            <l1>-32</l1>
+            <l2>-32</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
             <Note>
               <pitch>46</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
               <pitch>51</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
@@ -663,19 +663,19 @@
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
               <pitch>70</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>5</fret>
               <string>1</string>
               </Note>
@@ -688,13 +688,13 @@
             <durationType>16th</durationType>
             <Note>
               <pitch>46</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
               <pitch>51</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
@@ -706,19 +706,19 @@
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
               <pitch>70</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>5</fret>
               <string>1</string>
               </Note>
@@ -727,13 +727,13 @@
             <durationType>16th</durationType>
             <Note>
               <pitch>46</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
               <pitch>51</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
@@ -745,19 +745,19 @@
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
               <pitch>70</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>5</fret>
               <string>1</string>
               </Note>
@@ -766,13 +766,13 @@
             <durationType>eighth</durationType>
             <Note>
               <pitch>46</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
               <pitch>51</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
@@ -784,19 +784,19 @@
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
               <pitch>70</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>5</fret>
               <string>1</string>
               </Note>

--- a/src/importexport/guitarpro/tests/data/grace.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/grace.gp5-ref.mscx
@@ -235,10 +235,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>70</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <fret>6</fret>
               <string>0</string>
               </Note>

--- a/src/importexport/guitarpro/tests/data/keysig.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/keysig.gp5-ref.mscx
@@ -182,10 +182,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalNatural</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>60</pitch>
-              <tpc>14</tpc>
+              <tpc>26</tpc>
               <fret>15</fret>
               <string>4</string>
               </Note>
@@ -193,6 +193,9 @@
           <Chord>
             <durationType>quarter</durationType>
             <Note>
+              <Accidental>
+                <subtype>accidentalNatural</subtype>
+                </Accidental>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <fret>14</fret>
@@ -261,10 +264,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalNatural</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>48</pitch>
-              <tpc>14</tpc>
+              <tpc>26</tpc>
               <fret>3</fret>
               <string>4</string>
               </Note>
@@ -292,10 +295,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalNatural</subtype>
+                <subtype>accidentalDoubleSharp</subtype>
                 </Accidental>
               <pitch>50</pitch>
-              <tpc>16</tpc>
+              <tpc>28</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -344,10 +347,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalNatural</subtype>
+                <subtype>accidentalDoubleSharp</subtype>
                 </Accidental>
               <pitch>57</pitch>
-              <tpc>17</tpc>
+              <tpc>29</tpc>
               <fret>12</fret>
               <string>4</string>
               </Note>
@@ -408,10 +411,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalNatural</subtype>
+                <subtype>accidentalDoubleSharp</subtype>
                 </Accidental>
               <pitch>57</pitch>
-              <tpc>17</tpc>
+              <tpc>29</tpc>
               <fret>12</fret>
               <string>4</string>
               </Note>
@@ -448,10 +451,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalNatural</subtype>
+                <subtype>accidentalDoubleSharp</subtype>
                 </Accidental>
               <pitch>52</pitch>
-              <tpc>18</tpc>
+              <tpc>30</tpc>
               <fret>7</fret>
               <string>4</string>
               </Note>
@@ -696,10 +699,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalNatural</subtype>
                 </Accidental>
               <pitch>52</pitch>
-              <tpc>6</tpc>
+              <tpc>18</tpc>
               <fret>7</fret>
               <string>4</string>
               </Note>
@@ -707,9 +710,6 @@
           <Chord>
             <durationType>quarter</durationType>
             <Note>
-              <Accidental>
-                <subtype>accidentalNatural</subtype>
-                </Accidental>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <fret>8</fret>
@@ -739,10 +739,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalDoubleFlat</subtype>
+                <subtype>accidentalNatural</subtype>
                 </Accidental>
               <pitch>57</pitch>
-              <tpc>5</tpc>
+              <tpc>17</tpc>
               <fret>12</fret>
               <string>4</string>
               </Note>
@@ -803,10 +803,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalDoubleFlat</subtype>
+                <subtype>accidentalNatural</subtype>
                 </Accidental>
               <pitch>57</pitch>
-              <tpc>5</tpc>
+              <tpc>17</tpc>
               <fret>12</fret>
               <string>4</string>
               </Note>
@@ -904,10 +904,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalNatural</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>53</pitch>
-              <tpc>13</tpc>
+              <tpc>25</tpc>
               <fret>8</fret>
               <string>4</string>
               </Note>
@@ -950,10 +950,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalNatural</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>60</pitch>
-              <tpc>14</tpc>
+              <tpc>26</tpc>
               <fret>15</fret>
               <string>4</string>
               </Note>
@@ -969,10 +969,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalNatural</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>60</pitch>
-              <tpc>14</tpc>
+              <tpc>26</tpc>
               <fret>15</fret>
               <string>4</string>
               </Note>
@@ -980,6 +980,9 @@
           <Chord>
             <durationType>quarter</durationType>
             <Note>
+              <Accidental>
+                <subtype>accidentalNatural</subtype>
+                </Accidental>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <fret>14</fret>
@@ -999,10 +1002,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalNatural</subtype>
+                <subtype>accidentalDoubleSharp</subtype>
                 </Accidental>
               <pitch>55</pitch>
-              <tpc>15</tpc>
+              <tpc>27</tpc>
               <fret>10</fret>
               <string>4</string>
               </Note>
@@ -1042,10 +1045,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalNatural</subtype>
+                <subtype>accidentalDoubleSharp</subtype>
                 </Accidental>
               <pitch>50</pitch>
-              <tpc>16</tpc>
+              <tpc>28</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -1085,10 +1088,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalNatural</subtype>
+                <subtype>accidentalDoubleSharp</subtype>
                 </Accidental>
               <pitch>50</pitch>
-              <tpc>16</tpc>
+              <tpc>28</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
@@ -1137,10 +1140,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalNatural</subtype>
+                <subtype>accidentalDoubleSharp</subtype>
                 </Accidental>
               <pitch>57</pitch>
-              <tpc>17</tpc>
+              <tpc>29</tpc>
               <fret>12</fret>
               <string>4</string>
               </Note>
@@ -1186,10 +1189,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalNatural</subtype>
+                <subtype>accidentalDoubleSharp</subtype>
                 </Accidental>
               <pitch>59</pitch>
-              <tpc>19</tpc>
+              <tpc>31</tpc>
               <fret>14</fret>
               <string>4</string>
               </Note>
@@ -1376,10 +1379,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalNatural</subtype>
                 </Accidental>
               <pitch>59</pitch>
-              <tpc>7</tpc>
+              <tpc>19</tpc>
               <fret>14</fret>
               <string>4</string>
               </Note>
@@ -1425,10 +1428,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalNatural</subtype>
                 </Accidental>
               <pitch>52</pitch>
-              <tpc>6</tpc>
+              <tpc>18</tpc>
               <fret>7</fret>
               <string>4</string>
               </Note>
@@ -1489,10 +1492,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalNatural</subtype>
                 </Accidental>
               <pitch>52</pitch>
-              <tpc>6</tpc>
+              <tpc>18</tpc>
               <fret>7</fret>
               <string>4</string>
               </Note>
@@ -1500,9 +1503,6 @@
           <Chord>
             <durationType>quarter</durationType>
             <Note>
-              <Accidental>
-                <subtype>accidentalNatural</subtype>
-                </Accidental>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <fret>8</fret>
@@ -1532,10 +1532,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalDoubleFlat</subtype>
+                <subtype>accidentalNatural</subtype>
                 </Accidental>
               <pitch>57</pitch>
-              <tpc>5</tpc>
+              <tpc>17</tpc>
               <fret>12</fret>
               <string>4</string>
               </Note>

--- a/src/importexport/guitarpro/tests/data/line_elements.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/line_elements.gp5-ref.mscx
@@ -982,10 +982,10 @@
             <durationType>whole</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>58</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               <play>0</play>
               <fret>3</fret>
               <string>2</string>

--- a/src/importexport/guitarpro/tests/data/tempo.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tempo.gp5-ref.mscx
@@ -213,10 +213,10 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>51</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>1</fret>
               <string>3</string>
               </Note>

--- a/src/importexport/guitarpro/tests/data/volta.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/volta.gp5-ref.mscx
@@ -268,10 +268,10 @@
             <durationType>eighth</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>4</fret>
               <string>1</string>
               </Note>
@@ -312,7 +312,7 @@
             <durationType>eighth</durationType>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>4</fret>
               <string>1</string>
               </Note>
@@ -356,7 +356,7 @@
             <durationType>eighth</durationType>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>4</fret>
               <string>1</string>
               </Note>
@@ -833,10 +833,10 @@
             <durationType>eighth</durationType>
             <Note>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>4</fret>
               <string>1</string>
               </Note>
@@ -877,7 +877,7 @@
             <durationType>eighth</durationType>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>4</fret>
               <string>1</string>
               </Note>
@@ -921,7 +921,7 @@
             <durationType>eighth</durationType>
             <Note>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               <fret>4</fret>
               <string>1</string>
               </Note>


### PR DESCRIPTION
gp5 file contains no informations about accidental type to use on note. By default all notes in gp5 prefer sharps. So we have to force gp5 import to use sharps, but not rely on Prefer::Nearest.
