### PR TITLE
Adjust the way MEI IDs are preserved or generated

### DIFF
--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -119,6 +119,12 @@ bool MeiExporter::write(std::string& meiData)
         m_mei = meiDoc.append_child("mei");
         m_mei.append_attribute("xmlns") = "http://www.music-encoding.org/ns/mei";
 
+        // Save xml:id metaTag's as mei@xml:id
+        String xmlId = m_score->metaTag(u"xml:id");
+        if (!xmlId.isEmpty()) {
+            m_mei.append_attribute("xml:id") = xmlId.toStdString().c_str();
+        }
+
         libmei::AttConverter converter;
         libmei::meiVersion_MEIVERSION meiVersion = libmei::meiVersion_MEIVERSION_5_0plusbasic;
         m_mei.append_attribute("meiversion") = (converter.MeiVersionMeiversionToStr(meiVersion)).c_str();
@@ -2089,7 +2095,13 @@ std::string MeiExporter::getXmlIdFor(const EngravingItem* item, const char c)
     if (m_xmlIDCounter == 0) {
         std::random_device rd;
         std::mt19937 randomGenerator(rd());
-        m_xmlIDCounter = randomGenerator();
+        // Use xml:id metaTag's hash to initialize IDs
+        String xmlId = m_score->metaTag(u"xml:id");
+        if (!xmlId.isEmpty()) {
+            m_xmlIDCounter = static_cast<int>(xmlId.hash());
+        } else {
+            m_xmlIDCounter = randomGenerator();
+        }
     }
 
     return c + this->generateHashID();

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -116,16 +116,18 @@ bool MeiImporter::read(const io::path_t& path)
         Convert::logs.push_back(String("The MEI file does not seem to be a MEI basic version '%1' file").arg(String(MEI_BASIC_VERSION)));
     }
 
-    pugi::xml_attribute xmlId = root.attribute("xml:id");
-    if (xmlId && !String(xmlId.value()).empty()) {
-        m_score->setMetaTag(u"xml:id", String(xmlId.value()));
-    }
-
     bool success = true;
 
     success = success && this->readMeiHead(root);
 
     success = success && this->readScore(root);
+
+    pugi::xml_attribute xmlId = root.attribute("xml:id");
+    if (xmlId && !String(xmlId.value()).empty()) {
+        m_score->setMetaTag(u"xml:id", String(xmlId.value()));
+        // Do not keep a xml:id map when having a xml:id seed.
+        m_uids.clear();
+    }
 
     return success;
 }

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -116,6 +116,11 @@ bool MeiImporter::read(const io::path_t& path)
         Convert::logs.push_back(String("The MEI file does not seem to be a MEI basic version '%1' file").arg(String(MEI_BASIC_VERSION)));
     }
 
+    pugi::xml_attribute xmlId = root.attribute("xml:id");
+    if (xmlId && !String(xmlId.value()).empty()) {
+        m_score->setMetaTag(u"xml:id", String(xmlId.value()));
+    }
+
     bool success = true;
 
     success = success && this->readMeiHead(root);

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -126,7 +126,7 @@ bool MeiImporter::read(const io::path_t& path)
     if (xmlId && !String(xmlId.value()).empty()) {
         m_score->setMetaTag(u"xml:id", String(xmlId.value()));
         // Do not keep a xml:id map when having a xml:id seed.
-        m_uids.clear();
+        m_uids->clear();
     }
 
     return success;


### PR DESCRIPTION
The PR adds a way to seed the random generator with value to be given in a MuseScore `xml:id` metatag. The value is written into  / read from the `mei@xml:id`.