### PR TITLE
Fix #19213: Certain text changes now only applied on enter/return

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/common/TextSection.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/common/TextSection.qml
@@ -45,7 +45,7 @@ InspectorPropertyView {
         navigation.row: root.navigationRowStart + 1
         navigation.accessible.name: root.titleText + " " + currentText
 
-        onTextEdited: function(newTextValue) {
+        onTextEditingFinished: function(newTextValue) {
             if (root.propertyItem) {
                 root.propertyItem.value = newTextValue
             }


### PR DESCRIPTION
Resolves: #19213 

The changed component is used in the property inspector of the following elements (and nowhere else):  

**Markers (e.g. Coda)**
- Properties -> Marker -> Label  

**Volta**
-  Properties -> Volta -> Repeat list  

**LineText (e.g. Accel.)**
-   Properties -> Tempo Change -> Text -> Beginning text
-    Properties -> Tempo Change -> Text -> “Continuing” text 
-    Properties -> Tempo Change -> Text -> “End text

**Glissando** 
-      Properties -> Glissando -> Text  

**Jumps (e.g. D.C. al Coda)**
-       Properties -> Jump -> Jump to 
-       Properties -> Jump -> Play until 
-       Properties -> Jump -> Continue at