### PR TITLE
Fix GH#19306: String data "Always open" field cut off

### DIFF
--- a/src/notation/view/widgets/editstringdata.cpp
+++ b/src/notation/view/widgets/editstringdata.cpp
@@ -49,6 +49,9 @@ EditStringData::EditStringData(QWidget* parent, std::vector<mu::engraving::instr
     _strings = strings;
     stringList->setHorizontalHeaderLabels({ qtrc("notation/editstringdata", "Always open"),
                                             qtrc("notation/editstringdata", "Pitch") });
+    QString toolTip = qtrc("notation/editstringdata",
+                           "<b>Always open</b><br>On tablature staves, fret positions other than ‘0’ cannot be entered on strings marked ‘always open’. Useful for instruments with strings that are not on the fretboard, such as the theorbo.");
+    stringList->horizontalHeaderItem(0)->setToolTip(toolTip);
     int numOfStrings = static_cast<int>(_strings->size());
     stringList->setRowCount(numOfStrings);
     // if any string, insert into string list control and select the first one
@@ -64,7 +67,8 @@ EditStringData::EditStringData(QWidget* parent, std::vector<mu::engraving::instr
             newCheck->setFlags(Qt::ItemFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled));
             newCheck->setCheckState(strg.open ? Qt::Checked : Qt::Unchecked);
 
-            newCheck->setData(OPEN_ACCESSIBLE_TITLE_ROLE, qtrc("notation/editstringdata", "Always open"));
+            newCheck->setData(OPEN_ACCESSIBLE_TITLE_ROLE, stringList->horizontalHeaderItem(0)->text());
+            newCheck->setToolTip(toolTip);
             newCheck->setData(Qt::AccessibleTextRole, openColumnAccessibleText(newCheck));
 
             stringList->setItem(i, 0, newCheck);

--- a/src/notation/view/widgets/editstringdata.ui
+++ b/src/notation/view/widgets/editstringdata.ui
@@ -2,20 +2,12 @@
 <ui version="4.0">
  <class>EditStringDataBase</class>
  <widget class="QDialog" name="EditStringDataBase">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>278</width>
-    <height>304</height>
-   </rect>
-  </property>
   <property name="windowTitle">
    <string>String data</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0">
+    <layout class="QVBoxLayout" name="verticalLayout">
      <item>
       <widget class="QLabel" name="label">
        <property name="text">
@@ -24,23 +16,26 @@
       </widget>
      </item>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0">
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
        <item>
         <widget class="QTableWidget" name="stringList">
-         <attribute name="horizontalHeaderDefaultSectionSize">
-          <number>50</number>
-         </attribute>
          <attribute name="horizontalHeaderStretchLastSection">
           <bool>true</bool>
          </attribute>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <column>
           <property name="text">
-           <string>Always open</string>
+           <string notr="true">Always open</string>
           </property>
          </column>
          <column>
           <property name="text">
-           <string>Pitch</string>
+           <string notr="true">Pitch</string>
           </property>
          </column>
         </widget>
@@ -48,17 +43,7 @@
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_3">
          <item>
-          <spacer name="verticalSpacer">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
+          <spacer name="verticalSpacer"/>
          </item>
          <item>
           <widget class="QPushButton" name="newString">
@@ -82,17 +67,7 @@
           </widget>
          </item>
          <item>
-          <spacer name="verticalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
+          <spacer name="verticalSpacer_2"/>
          </item>
         </layout>
        </item>
@@ -127,12 +102,6 @@
         <spacer name="horizontalSpacer">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
          </property>
         </spacer>
        </item>


### PR DESCRIPTION
Resolves: #19306 
at least after a revert to factory settings, else it might still use the previous too narrow dialog width
or after sizing the dialog manually
