### PR TITLE
Added channels handling to event map

### DIFF
--- a/src/engraving/compat/midi/event.cpp
+++ b/src/engraving/compat/midi/event.cpp
@@ -246,6 +246,7 @@ void EventsHolder::mergePitchWheelEvents(EventsHolder& pitchWheelEvents)
         _channels[i].merge(pitchWheelEvents[i]);
     }
 }
+
 //---------------------------------------------------------
 //   class EventsHolder::fixupMIDI
 //---------------------------------------------------------

--- a/src/engraving/compat/midi/event.cpp
+++ b/src/engraving/compat/midi/event.cpp
@@ -214,6 +214,11 @@ EventMap::events_multimap_t& EventMap::operator[](std::size_t idx)
     return _channels[idx];
 }
 
+const EventMap::events_multimap_t& EventMap::operator[](std::size_t idx) const
+{
+    assert(idx < size());
+    return _channels[idx];
+}
 //---------------------------------------------------------
 //   class EventMap::fixupMIDI
 //---------------------------------------------------------

--- a/src/engraving/compat/midi/event.cpp
+++ b/src/engraving/compat/midi/event.cpp
@@ -239,7 +239,7 @@ void EventsHolder::mergePitchWheelEvents(EventsHolder& pitchWheelEvents)
                     && pwEvent->second.type() == ME_PITCHBEND) {
                     PitchWheelSpecs specs;
                     NPlayEvent pwReset(ME_PITCHBEND, i, specs.mLimit % 128, specs.mLimit / 128);
-                    _channels[i].insert(std::pair<int, NPlayEvent>(tick - 1, pwReset));
+                    _channels[i].insert(std::pair<int, NPlayEvent>(((tick - pwEvent->first) / 2) + pwEvent->first, pwReset));
                 }
             }
         }

--- a/src/engraving/compat/midi/event.cpp
+++ b/src/engraving/compat/midi/event.cpp
@@ -239,6 +239,7 @@ void EventsHolder::mergePitchWheelEvents(EventsHolder& pitchWheelEvents)
                     && pwEvent->second.type() == ME_PITCHBEND) {
                     PitchWheelSpecs specs;
                     NPlayEvent pwReset(ME_PITCHBEND, i, specs.mLimit % 128, specs.mLimit / 128);
+                    pwReset.setOriginatingStaff(pwEvent->second.getOriginatingStaff());
                     _channels[i].insert(std::pair<int, NPlayEvent>(((tick - pwEvent->first) / 2) + pwEvent->first, pwReset));
                 }
             }

--- a/src/engraving/compat/midi/event.cpp
+++ b/src/engraving/compat/midi/event.cpp
@@ -200,7 +200,7 @@ void EventList::insert(const Event& e)
     push_back(e);
 }
 
-EventMap::events_multimap_t& EventMap::operator[](std::size_t idx)
+EventsHolder::events_multimap_t& EventsHolder::operator[](std::size_t idx)
 {
     if (size() == 0) {
         _channels.emplace_back();
@@ -214,13 +214,20 @@ EventMap::events_multimap_t& EventMap::operator[](std::size_t idx)
     return _channels[idx];
 }
 
-const EventMap::events_multimap_t& EventMap::operator[](std::size_t idx) const
+const EventsHolder::events_multimap_t& EventsHolder::operator[](std::size_t idx) const
 {
+    // Since EventsHolder acts more like a vector
+    // Using const subscript operator for a nonexistent element is UB
+    /*
+     * cppreference.com
+     * Unlike std::map::operator[], this operator never inserts a new element into the container.
+     * Accessing a nonexistent element through this operator is undefined behavior.
+     */
     assert(idx < size());
     return _channels[idx];
 }
 
-void EventMap::mergePitchWheelEvents(EventMap& pitchWheelEvents)
+void EventsHolder::mergePitchWheelEvents(EventsHolder& pitchWheelEvents)
 {
     for (size_t i = 0; i < size(); ++i) {
         for (const auto& eventPair : _channels[i]) {
@@ -240,10 +247,10 @@ void EventMap::mergePitchWheelEvents(EventMap& pitchWheelEvents)
     }
 }
 //---------------------------------------------------------
-//   class EventMap::fixupMIDI
+//   class EventsHolder::fixupMIDI
 //---------------------------------------------------------
 
-void EventMap::fixupMIDI()
+void EventsHolder::fixupMIDI()
 {
     /* track info for each of the 128 possible MIDI notes */
     struct channelInfo {

--- a/src/engraving/compat/midi/event.h
+++ b/src/engraving/compat/midi/event.h
@@ -189,6 +189,7 @@ class EventMap
 public:
     [[nodiscard]] size_t size() const { return _channels.size(); }
     events_multimap_t& operator[](std::size_t idx);
+    const events_multimap_t& operator[](std::size_t idx) const;
     void mergePitchWheelEvents(EventMap& pitchWheelEvents);
     void fixupMIDI();
 };

--- a/src/engraving/compat/midi/event.h
+++ b/src/engraving/compat/midi/event.h
@@ -169,7 +169,7 @@ public:
 
 //---------------------------------------------------------
 //   EventList
-//   EventMap
+//   EventsHolder
 //---------------------------------------------------------
 
 class EventList : public std::vector<Event>
@@ -180,9 +180,9 @@ public:
     void insertNote(int channel, Note*);
 };
 
-class EventMap
+class EventsHolder
 {
-    OBJECT_ALLOCATOR(engraving, EventMap)
+    OBJECT_ALLOCATOR(engraving, EventsHolder)
 
     using events_multimap_t = std::multimap<int, NPlayEvent>;
     std::vector<events_multimap_t> _channels;
@@ -190,7 +190,7 @@ public:
     [[nodiscard]] size_t size() const { return _channels.size(); }
     events_multimap_t& operator[](std::size_t idx);
     const events_multimap_t& operator[](std::size_t idx) const;
-    void mergePitchWheelEvents(EventMap& pitchWheelEvents);
+    void mergePitchWheelEvents(EventsHolder& pitchWheelEvents);
     void fixupMIDI();
 };
 

--- a/src/engraving/compat/midi/event.h
+++ b/src/engraving/compat/midi/event.h
@@ -180,19 +180,17 @@ public:
     void insertNote(int channel, Note*);
 };
 
-class EventMap : public std::multimap<int, NPlayEvent>
+class EventMap
 {
     OBJECT_ALLOCATOR(engraving, EventMap)
 
-    int _highestChannel = 15;
+    using events_multimap_t = std::multimap<int, NPlayEvent>;
+    std::vector<events_multimap_t> _channels;
 public:
+    [[nodiscard]] size_t size() const { return _channels.size(); }
+    events_multimap_t& operator[](std::size_t idx);
+    void mergePitchWheelEvents(EventMap& pitchWheelEvents);
     void fixupMIDI();
-    void registerChannel(int c)
-    {
-        if (c > _highestChannel) {
-            _highestChannel = c;
-        }
-    }
 };
 
 typedef EventList::iterator iEvent;

--- a/src/engraving/compat/midi/midirender.cpp
+++ b/src/engraving/compat/midi/midirender.cpp
@@ -215,12 +215,6 @@ static void playNote(EventsHolder& events, const Note* note, PlayNoteParams para
         return;
     }
     bool useDrumSet = note->part()->instrument(note->tick())->useDrumset();
-    // We need to set Pitch Value to initial in case previous note was with bendUp
-    if (!useDrumSet && params.onTime - params.offset - 1 > 0) {
-        PitchWheelSpecs specs;
-        NPlayEvent pwReset(ME_PITCHBEND, params.channel, specs.mLimit % 128, specs.mLimit / 128);
-        events[params.channel].insert(std::pair<int, NPlayEvent>(std::max(0, params.onTime - params.offset - 1), pwReset));
-    }
 
     events[params.channel].insert(std::pair<int, NPlayEvent>(std::max(0, params.onTime - params.offset), ev));
     // adds portamento for continuous glissando

--- a/src/engraving/compat/midi/midirender.cpp
+++ b/src/engraving/compat/midi/midirender.cpp
@@ -1189,6 +1189,7 @@ void MidiRenderer::renderScore(EventMap& events, const Context& ctx)
     renderSpanners(events, pitchWheelRender);
 
     EventMap pitchWheelEvents = pitchWheelRender.renderPitchWheel();
+    events.mergePitchWheelEvents(pitchWheelEvents);
 //    events->merge(pitchWheelEvents);
 
     if (ctx.metronome) {

--- a/src/engraving/compat/midi/midirender.cpp
+++ b/src/engraving/compat/midi/midirender.cpp
@@ -189,7 +189,7 @@ static Fraction getPlayTicksForBend(const Note* note)
 //---------------------------------------------------------
 //   playNote
 //---------------------------------------------------------
-static void playNote(EventMap& events, const Note* note, PlayNoteParams params, PitchWheelRenderer& pitchWheelRenderer)
+static void playNote(EventsHolder& events, const Note* note, PlayNoteParams params, PitchWheelRenderer& pitchWheelRenderer)
 {
     if (!note->play()) {
         return;
@@ -336,7 +336,7 @@ static void collectBend(const PitchValues& playData, staff_idx_t staffIdx,
 //   collectNote
 //---------------------------------------------------------
 
-static void collectNote(EventMap& events, const Note* note, const CollectNoteParams& noteParams, Staff* staff,
+static void collectNote(EventsHolder& events, const Note* note, const CollectNoteParams& noteParams, Staff* staff,
                         PitchWheelRenderer& pitchWheelRenderer, const MidiRenderer::Context& context)
 {
     if (!note->play() || note->hidden()) {      // do not play overlapping notes
@@ -469,7 +469,7 @@ static void collectNote(EventMap& events, const Note* note, const CollectNotePar
 //   aeolusSetStop
 //---------------------------------------------------------
 
-static void aeolusSetStop(int tick, int channel, int i, int k, bool val, EventMap& events)
+static void aeolusSetStop(int tick, int channel, int i, int k, bool val, EventsHolder& events)
 {
     NPlayEvent event;
     event.setType(ME_CONTROLLER);
@@ -493,7 +493,7 @@ static void aeolusSetStop(int tick, int channel, int i, int k, bool val, EventMa
 //   collectProgramChanges
 //---------------------------------------------------------
 
-static void collectProgramChanges(EventMap& events, Measure const* m, const Staff* staff, int tickOffset)
+static void collectProgramChanges(EventsHolder& events, Measure const* m, const Staff* staff, int tickOffset)
 {
     int firstStaffIdx = static_cast<int>(staff->idx());
     int nextStaffIdx  = firstStaffIdx + 1;
@@ -550,7 +550,7 @@ static void collectProgramChanges(EventMap& events, Measure const* m, const Staf
 //    renderHarmony
 ///    renders chord symbols
 //---------------------------------------------------------
-static void renderHarmony(EventMap& events, Measure const* m, Harmony* h, int tickOffset)
+static void renderHarmony(EventsHolder& events, Measure const* m, Harmony* h, int tickOffset)
 {
     if (!h->isRealizable()) {
         return;
@@ -591,8 +591,8 @@ static void renderHarmony(EventMap& events, Measure const* m, Harmony* h, int ti
     }
 }
 
-void MidiRenderer::collectGraceBeforeChordEvents(Chord* chord, EventMap& events, double veloMultiplier, Staff* st, int tickOffset,
-                                                 PitchWheelRenderer& pitchWheelRenderer,  MidiInstrumentEffect effect)
+void MidiRenderer::collectGraceBeforeChordEvents(Chord* chord, EventsHolder& events, double veloMultiplier, Staff* st, int tickOffset,
+                                                 PitchWheelRenderer& pitchWheelRenderer, MidiInstrumentEffect effect)
 {
     // calculate offset for grace notes here
     const auto& grChords = chord->graceNotesBefore();
@@ -661,7 +661,7 @@ MidiRenderer::ChordParams MidiRenderer::collectChordParams(const Chord* chord, i
 //   collectMeasureEventsDefault
 //---------------------------------------------------------
 
-void MidiRenderer::doCollectMeasureEvents(EventMap& events, Measure const* m, const Staff* staff, int tickOffset,
+void MidiRenderer::doCollectMeasureEvents(EventsHolder& events, Measure const* m, const Staff* staff, int tickOffset,
                                           PitchWheelRenderer& pitchWheelRenderer)
 {
     staff_idx_t firstStaffIdx = staff->idx();
@@ -778,7 +778,7 @@ MidiRenderer::MidiRenderer(Score* s)
 //    redirects to the correct function based on the passed method
 //---------------------------------------------------------
 
-void MidiRenderer::collectMeasureEvents(EventMap& events, Measure const* m, const Staff* staff, int tickOffset,
+void MidiRenderer::collectMeasureEvents(EventsHolder& events, Measure const* m, const Staff* staff, int tickOffset,
                                         PitchWheelRenderer& pitchWheelRenderer)
 {
     doCollectMeasureEvents(events, m, staff, tickOffset, pitchWheelRenderer);
@@ -790,7 +790,7 @@ void MidiRenderer::collectMeasureEvents(EventMap& events, Measure const* m, cons
 //   renderStaff
 //---------------------------------------------------------
 
-void MidiRenderer::renderStaff(EventMap& events, const Staff* staff, PitchWheelRenderer& pitchWheelRenderer)
+void MidiRenderer::renderStaff(EventsHolder& events, const Staff* staff, PitchWheelRenderer& pitchWheelRenderer)
 {
     Measure const* lastMeasure = nullptr;
 
@@ -832,7 +832,7 @@ void MidiRenderer::renderStaff(EventMap& events, const Staff* staff, PitchWheelR
 //   renderSpanners
 //---------------------------------------------------------
 
-void MidiRenderer::renderSpanners(EventMap& events, PitchWheelRenderer& pitchWheelRenderer)
+void MidiRenderer::renderSpanners(EventsHolder& events, PitchWheelRenderer& pitchWheelRenderer)
 {
     for (const auto& sp : score->spannerMap().map()) {
         Spanner* s = sp.second;
@@ -937,7 +937,7 @@ static VibratoParams getVibratoParams(VibratoType type)
     return params;
 }
 
-void MidiRenderer::doRenderSpanners(EventMap& events, Spanner* s, uint32_t channel, PitchWheelRenderer& pitchWheelRenderer,
+void MidiRenderer::doRenderSpanners(EventsHolder& events, Spanner* s, uint32_t channel, PitchWheelRenderer& pitchWheelRenderer,
                                     MidiInstrumentEffect effect)
 {
     std::vector<std::pair<int, std::pair<bool, int> > > pedalEventList;
@@ -1127,7 +1127,7 @@ static bool graceNotesMerged(Chord* chord)
 ///   add metronome tick events
 //---------------------------------------------------------
 
-void MidiRenderer::renderMetronome(EventMap& events)
+void MidiRenderer::renderMetronome(EventsHolder& events)
 {
     Measure const* const start = score->firstMeasure();
     Measure const* const end = score->lastMeasure();
@@ -1142,7 +1142,7 @@ void MidiRenderer::renderMetronome(EventMap& events)
 ///   add metronome tick events
 //---------------------------------------------------------
 
-void MidiRenderer::renderMetronome(EventMap& events, Measure const* m)
+void MidiRenderer::renderMetronome(EventsHolder& events, Measure const* m)
 {
     int msrTick         = m->tick().ticks();
     BeatsPerSecond tempo = score->tempomap()->tempo(msrTick);
@@ -1166,7 +1166,7 @@ void MidiRenderer::renderMetronome(EventMap& events, Measure const* m)
     }
 }
 
-void MidiRenderer::renderScore(EventMap& events, const Context& ctx)
+void MidiRenderer::renderScore(EventsHolder& events, const Context& ctx)
 {
     _context = ctx;
     PitchWheelRenderer pitchWheelRender(wheelSpec);
@@ -1188,7 +1188,7 @@ void MidiRenderer::renderScore(EventMap& events, const Context& ctx)
     // create sustain pedal events
     renderSpanners(events, pitchWheelRender);
 
-    EventMap pitchWheelEvents = pitchWheelRender.renderPitchWheel();
+    EventsHolder pitchWheelEvents = pitchWheelRender.renderPitchWheel();
     events.mergePitchWheelEvents(pitchWheelEvents);
 //    events->merge(pitchWheelEvents);
 

--- a/src/engraving/compat/midi/midirender.cpp
+++ b/src/engraving/compat/midi/midirender.cpp
@@ -214,7 +214,6 @@ static void playNote(EventsHolder& events, const Note* note, PlayNoteParams para
     if (params.offTime > 0 && params.offTime < params.onTime) {
         return;
     }
-    bool useDrumSet = note->part()->instrument(note->tick())->useDrumset();
 
     events[params.channel].insert(std::pair<int, NPlayEvent>(std::max(0, params.onTime - params.offset), ev));
     // adds portamento for continuous glissando

--- a/src/engraving/compat/midi/midirender.cpp
+++ b/src/engraving/compat/midi/midirender.cpp
@@ -189,7 +189,7 @@ static Fraction getPlayTicksForBend(const Note* note)
 //---------------------------------------------------------
 //   playNote
 //---------------------------------------------------------
-static void playNote(EventMap* events, const Note* note, PlayNoteParams params, PitchWheelRenderer& pitchWheelRenderer)
+static void playNote(EventMap& events, const Note* note, PlayNoteParams params, PitchWheelRenderer& pitchWheelRenderer)
 {
     if (!note->play()) {
         return;
@@ -202,7 +202,7 @@ static void playNote(EventMap* events, const Note* note, PlayNoteParams params, 
     if (params.callAllSoundOff && params.onTime != 0) {
         NPlayEvent ev1(ME_CONTROLLER, params.channel, CTRL_ALL_NOTES_OFF, 0);
         ev1.setEffect(params.effect);
-        events->insert(std::pair<int, NPlayEvent>(params.onTime - 1, ev1));
+        events[params.channel].insert(std::pair<int, NPlayEvent>(params.onTime - 1, ev1));
     }
 
     NPlayEvent ev(ME_NOTEON, params.channel, params.pitch, params.velo);
@@ -219,11 +219,10 @@ static void playNote(EventMap* events, const Note* note, PlayNoteParams params, 
     if (!useDrumSet && params.onTime - params.offset - 1 > 0) {
         PitchWheelSpecs specs;
         NPlayEvent pwReset(ME_PITCHBEND, params.channel, specs.mLimit % 128, specs.mLimit / 128);
-        events->insert(std::pair<int, NPlayEvent>(std::max(0, params.onTime - params.offset - 1), pwReset));
+        events[params.channel].insert(std::pair<int, NPlayEvent>(std::max(0, params.onTime - params.offset - 1), pwReset));
     }
 
-    events->insert(std::pair<int, NPlayEvent>(std::max(0, params.onTime - params.offset), ev));
-
+    events[params.channel].insert(std::pair<int, NPlayEvent>(std::max(0, params.onTime - params.offset), ev));
     // adds portamento for continuous glissando
     for (Spanner* spanner : note->spannerFor()) {
         if (spanner->type() == ElementType::GLISSANDO) {
@@ -241,8 +240,9 @@ static void playNote(EventMap* events, const Note* note, PlayNoteParams params, 
     }
 
     ev.setVelo(0);
-    if (!useDrumSet && params.offTime != -1) {
-        events->insert(std::pair<int, NPlayEvent>(std::max(0, params.offTime - params.offset), ev));
+    if (!note->part()->instrument(note->tick())->useDrumset()
+        && params.offTime != -1) {
+        events[params.channel].insert(std::pair<int, NPlayEvent>(std::max(0, params.offTime - params.offset), ev));
     }
 }
 
@@ -336,7 +336,7 @@ static void collectBend(const PitchValues& playData, staff_idx_t staffIdx,
 //   collectNote
 //---------------------------------------------------------
 
-static void collectNote(EventMap* events, const Note* note, const CollectNoteParams& noteParams, Staff* staff,
+static void collectNote(EventMap& events, const Note* note, const CollectNoteParams& noteParams, Staff* staff,
                         PitchWheelRenderer& pitchWheelRenderer, const MidiRenderer::Context& context)
 {
     if (!note->play() || note->hidden()) {      // do not play overlapping notes
@@ -348,7 +348,6 @@ static void collectNote(EventMap* events, const Note* note, const CollectNotePar
     MidiInstrumentEffect noteEffect = noteParams.effect;
 
     int noteChannel = getChannel(instr, note, noteEffect, context);
-    events->registerChannel(noteChannel);
 
     int tieLen = 0;
     if (chord->isGrace()) {
@@ -430,7 +429,6 @@ static void collectNote(EventMap* events, const Note* note, const CollectNotePar
                 eventEffect = MidiInstrumentEffect::SLIDE;
                 eventChannel = getChannel(instr, note, eventEffect, context);
                 playParams.slide = true;
-                events->registerChannel(eventChannel);
             }
 
             playParams.effect = eventEffect;
@@ -471,7 +469,7 @@ static void collectNote(EventMap* events, const Note* note, const CollectNotePar
 //   aeolusSetStop
 //---------------------------------------------------------
 
-static void aeolusSetStop(int tick, int channel, int i, int k, bool val, EventMap* events)
+static void aeolusSetStop(int tick, int channel, int i, int k, bool val, EventMap& events)
 {
     NPlayEvent event;
     event.setType(ME_CONTROLLER);
@@ -483,10 +481,10 @@ static void aeolusSetStop(int tick, int channel, int i, int k, bool val, EventMa
     }
 
     event.setChannel(static_cast<uint8_t>(channel));
-    events->insert(std::pair<int, NPlayEvent>(tick, event));
+    events[channel].insert(std::pair<int, NPlayEvent>(tick, event));
 
     event.setValue(k);
-    events->insert(std::pair<int, NPlayEvent>(tick, event));
+    events[channel].insert(std::pair<int, NPlayEvent>(tick, event));
 //      event.setValue(0x40 + i);
 //      events->insert(std::pair<int,NPlayEvent>(tick, event));
 }
@@ -495,7 +493,7 @@ static void aeolusSetStop(int tick, int channel, int i, int k, bool val, EventMa
 //   collectProgramChanges
 //---------------------------------------------------------
 
-static void collectProgramChanges(EventMap* events, Measure const* m, const Staff* staff, int tickOffset)
+static void collectProgramChanges(EventMap& events, Measure const* m, const Staff* staff, int tickOffset)
 {
     int firstStaffIdx = static_cast<int>(staff->idx());
     int nextStaffIdx  = firstStaffIdx + 1;
@@ -525,9 +523,9 @@ static void collectProgramChanges(EventMap* events, Measure const* m, const Staf
                         NPlayEvent e1(event);
                         e1.setOriginatingStaff(firstStaffIdx);
                         if (e1.dataA() == CTRL_PROGRAM) {
-                            events->insert(std::pair<int, NPlayEvent>(tick.ticks() - 1, e1));
+                            events[channel].insert(std::pair<int, NPlayEvent>(tick.ticks() - 1, e1));
                         } else {
-                            events->insert(std::pair<int, NPlayEvent>(tick.ticks(), e1));
+                            events[channel].insert(std::pair<int, NPlayEvent>(tick.ticks(), e1));
                         }
                     }
                 }
@@ -552,7 +550,7 @@ static void collectProgramChanges(EventMap* events, Measure const* m, const Staf
 //    renderHarmony
 ///    renders chord symbols
 //---------------------------------------------------------
-static void renderHarmony(EventMap* events, Measure const* m, Harmony* h, int tickOffset)
+static void renderHarmony(EventMap& events, Measure const* m, Harmony* h, int tickOffset)
 {
     if (!h->isRealizable()) {
         return;
@@ -563,7 +561,6 @@ static void renderHarmony(EventMap* events, Measure const* m, Harmony* h, int ti
         return;
     }
 
-    events->registerChannel(channel->channel());
     if (!staff->isPrimaryStaff()) {
         return;
     }
@@ -588,13 +585,13 @@ static void renderHarmony(EventMap* events, Measure const* m, Harmony* h, int ti
     for (int p : pitches) {
         ev.setPitch(p);
         ev.setVelo(velocity);
-        events->insert(std::pair<int, NPlayEvent>(onTime, ev));
+        events[channel->channel()].insert(std::pair<int, NPlayEvent>(onTime, ev));
         ev.setVelo(0);
-        events->insert(std::pair<int, NPlayEvent>(offTime, ev));
+        events[channel->channel()].insert(std::pair<int, NPlayEvent>(offTime, ev));
     }
 }
 
-void MidiRenderer::collectGraceBeforeChordEvents(Chord* chord, EventMap* events, double veloMultiplier, Staff* st, int tickOffset,
+void MidiRenderer::collectGraceBeforeChordEvents(Chord* chord, EventMap& events, double veloMultiplier, Staff* st, int tickOffset,
                                                  PitchWheelRenderer& pitchWheelRenderer,  MidiInstrumentEffect effect)
 {
     // calculate offset for grace notes here
@@ -664,7 +661,7 @@ MidiRenderer::ChordParams MidiRenderer::collectChordParams(const Chord* chord, i
 //   collectMeasureEventsDefault
 //---------------------------------------------------------
 
-void MidiRenderer::doCollectMeasureEvents(EventMap* events, Measure const* m, const Staff* staff, int tickOffset,
+void MidiRenderer::doCollectMeasureEvents(EventMap& events, Measure const* m, const Staff* staff, int tickOffset,
                                           PitchWheelRenderer& pitchWheelRenderer)
 {
     staff_idx_t firstStaffIdx = staff->idx();
@@ -781,7 +778,7 @@ MidiRenderer::MidiRenderer(Score* s)
 //    redirects to the correct function based on the passed method
 //---------------------------------------------------------
 
-void MidiRenderer::collectMeasureEvents(EventMap* events, Measure const* m, const Staff* staff, int tickOffset,
+void MidiRenderer::collectMeasureEvents(EventMap& events, Measure const* m, const Staff* staff, int tickOffset,
                                         PitchWheelRenderer& pitchWheelRenderer)
 {
     doCollectMeasureEvents(events, m, staff, tickOffset, pitchWheelRenderer);
@@ -793,7 +790,7 @@ void MidiRenderer::collectMeasureEvents(EventMap* events, Measure const* m, cons
 //   renderStaff
 //---------------------------------------------------------
 
-void MidiRenderer::renderStaff(EventMap* events, const Staff* staff, PitchWheelRenderer& pitchWheelRenderer)
+void MidiRenderer::renderStaff(EventMap& events, const Staff* staff, PitchWheelRenderer& pitchWheelRenderer)
 {
     Measure const* lastMeasure = nullptr;
 
@@ -835,7 +832,7 @@ void MidiRenderer::renderStaff(EventMap* events, const Staff* staff, PitchWheelR
 //   renderSpanners
 //---------------------------------------------------------
 
-void MidiRenderer::renderSpanners(EventMap* events, PitchWheelRenderer& pitchWheelRenderer)
+void MidiRenderer::renderSpanners(EventMap& events, PitchWheelRenderer& pitchWheelRenderer)
 {
     for (const auto& sp : score->spannerMap().map()) {
         Spanner* s = sp.second;
@@ -940,7 +937,7 @@ static VibratoParams getVibratoParams(VibratoType type)
     return params;
 }
 
-void MidiRenderer::doRenderSpanners(EventMap* events, Spanner* s, uint32_t channel, PitchWheelRenderer& pitchWheelRenderer,
+void MidiRenderer::doRenderSpanners(EventMap& events, Spanner* s, uint32_t channel, PitchWheelRenderer& pitchWheelRenderer,
                                     MidiInstrumentEffect effect)
 {
     std::vector<std::pair<int, std::pair<bool, int> > > pedalEventList;
@@ -998,7 +995,7 @@ void MidiRenderer::doRenderSpanners(EventMap* events, Spanner* s, uint32_t chann
         }
         event.setOriginatingStaff(pe.second.second);
         event.setEffect(effect);
-        events->insert(std::pair<int, NPlayEvent>(pe.first, event));
+        events[channel].insert(std::pair<int, NPlayEvent>(pe.first, event));
     }
 }
 
@@ -1130,7 +1127,7 @@ static bool graceNotesMerged(Chord* chord)
 ///   add metronome tick events
 //---------------------------------------------------------
 
-void MidiRenderer::renderMetronome(EventMap* events)
+void MidiRenderer::renderMetronome(EventMap& events)
 {
     Measure const* const start = score->firstMeasure();
     Measure const* const end = score->lastMeasure();
@@ -1145,7 +1142,7 @@ void MidiRenderer::renderMetronome(EventMap* events)
 ///   add metronome tick events
 //---------------------------------------------------------
 
-void MidiRenderer::renderMetronome(EventMap* events, Measure const* m)
+void MidiRenderer::renderMetronome(EventMap& events, Measure const* m)
 {
     int msrTick         = m->tick().ticks();
     BeatsPerSecond tempo = score->tempomap()->tempo(msrTick);
@@ -1165,11 +1162,11 @@ void MidiRenderer::renderMetronome(EventMap* events, Measure const* m)
     }
 
     for (int tick = msrTick; tick < endTick; tick += clickTicks, rtick += clickTicks) {
-        events->insert(std::pair<int, NPlayEvent>(tick, NPlayEvent(timeSig.rtick2beatType(rtick))));
+        events[0].insert(std::pair<int, NPlayEvent>(tick, NPlayEvent(timeSig.rtick2beatType(rtick))));
     }
 }
 
-void MidiRenderer::renderScore(EventMap* events, const Context& ctx)
+void MidiRenderer::renderScore(EventMap& events, const Context& ctx)
 {
     _context = ctx;
     PitchWheelRenderer pitchWheelRender(wheelSpec);
@@ -1186,13 +1183,13 @@ void MidiRenderer::renderScore(EventMap* events, const Context& ctx)
     for (const Staff* st : score->staves()) {
         renderStaff(events, st, pitchWheelRender);
     }
-    events->fixupMIDI();
+    events.fixupMIDI();
 
     // create sustain pedal events
     renderSpanners(events, pitchWheelRender);
 
     EventMap pitchWheelEvents = pitchWheelRender.renderPitchWheel();
-    events->merge(pitchWheelEvents);
+//    events->merge(pitchWheelEvents);
 
     if (ctx.metronome) {
         renderMetronome(events);

--- a/src/engraving/compat/midi/midirender.h
+++ b/src/engraving/compat/midi/midirender.h
@@ -31,7 +31,7 @@
 #include "pitchwheelrenderer.h"
 
 namespace mu::engraving {
-class EventMap;
+class EventsHolder;
 class MasterScore;
 class Staff;
 class SynthesizerState;
@@ -75,24 +75,24 @@ public:
 
     explicit MidiRenderer(Score* s);
 
-    void renderScore(EventMap& events, const Context& ctx);
+    void renderScore(EventsHolder& events, const Context& ctx);
 
     static const int ARTICULATION_CONV_FACTOR { 100000 };
 
 private:
 
-    void renderStaff(EventMap& events, const Staff* sctx, PitchWheelRenderer& pitchWheelRenderer);
+    void renderStaff(EventsHolder& events, const Staff* sctx, PitchWheelRenderer& pitchWheelRenderer);
 
-    void renderSpanners(EventMap& events, PitchWheelRenderer& pitchWheelRenderer);
-    void doRenderSpanners(EventMap& events, Spanner* s, uint32_t channel, PitchWheelRenderer& pitchWheelRenderer,
+    void renderSpanners(EventsHolder& events, PitchWheelRenderer& pitchWheelRenderer);
+    void doRenderSpanners(EventsHolder& events, Spanner* s, uint32_t channel, PitchWheelRenderer& pitchWheelRenderer,
                           MidiInstrumentEffect effect);
 
-    void renderMetronome(EventMap& events);
-    void renderMetronome(EventMap& events, Measure const* m);
+    void renderMetronome(EventsHolder& events);
+    void renderMetronome(EventsHolder& events, Measure const* m);
 
-    void collectMeasureEvents(EventMap& events, Measure const* m, const Staff* sctx, int tickOffset,
+    void collectMeasureEvents(EventsHolder& events, Measure const* m, const Staff* sctx, int tickOffset,
                               PitchWheelRenderer& pitchWheelRenderer);
-    void doCollectMeasureEvents(EventMap& events, Measure const* m, const Staff* sctx, int tickOffset,
+    void doCollectMeasureEvents(EventsHolder& events, Measure const* m, const Staff* sctx, int tickOffset,
                                 PitchWheelRenderer& pitchWheelRenderer);
 
     struct ChordParams {
@@ -102,8 +102,8 @@ private:
     };
 
     ChordParams collectChordParams(const Chord* chord, int tickOffset) const;
-    void collectGraceBeforeChordEvents(Chord* chord, EventMap& events, double veloMultiplier, Staff* st, int tickOffset,
-                                       PitchWheelRenderer& pitchWheelRenderer,  MidiInstrumentEffect effect);
+    void collectGraceBeforeChordEvents(Chord* chord, EventsHolder& events, double veloMultiplier, Staff* st, int tickOffset,
+                                       PitchWheelRenderer& pitchWheelRenderer, MidiInstrumentEffect effect);
 
     Score* score = nullptr;
 

--- a/src/engraving/compat/midi/midirender.h
+++ b/src/engraving/compat/midi/midirender.h
@@ -75,24 +75,24 @@ public:
 
     explicit MidiRenderer(Score* s);
 
-    void renderScore(EventMap* events, const Context& ctx);
+    void renderScore(EventMap& events, const Context& ctx);
 
     static const int ARTICULATION_CONV_FACTOR { 100000 };
 
 private:
 
-    void renderStaff(EventMap* events, const Staff* sctx, PitchWheelRenderer& pitchWheelRenderer);
+    void renderStaff(EventMap& events, const Staff* sctx, PitchWheelRenderer& pitchWheelRenderer);
 
-    void renderSpanners(EventMap* events, PitchWheelRenderer& pitchWheelRenderer);
-    void doRenderSpanners(EventMap* events, Spanner* s, uint32_t channel, PitchWheelRenderer& pitchWheelRenderer,
+    void renderSpanners(EventMap& events, PitchWheelRenderer& pitchWheelRenderer);
+    void doRenderSpanners(EventMap& events, Spanner* s, uint32_t channel, PitchWheelRenderer& pitchWheelRenderer,
                           MidiInstrumentEffect effect);
 
-    void renderMetronome(EventMap* events);
-    void renderMetronome(EventMap* events, Measure const* m);
+    void renderMetronome(EventMap& events);
+    void renderMetronome(EventMap& events, Measure const* m);
 
-    void collectMeasureEvents(EventMap* events, Measure const* m, const Staff* sctx, int tickOffset,
+    void collectMeasureEvents(EventMap& events, Measure const* m, const Staff* sctx, int tickOffset,
                               PitchWheelRenderer& pitchWheelRenderer);
-    void doCollectMeasureEvents(EventMap* events, Measure const* m, const Staff* sctx, int tickOffset,
+    void doCollectMeasureEvents(EventMap& events, Measure const* m, const Staff* sctx, int tickOffset,
                                 PitchWheelRenderer& pitchWheelRenderer);
 
     struct ChordParams {
@@ -102,7 +102,7 @@ private:
     };
 
     ChordParams collectChordParams(const Chord* chord, int tickOffset) const;
-    void collectGraceBeforeChordEvents(Chord* chord, EventMap* events, double veloMultiplier, Staff* st, int tickOffset,
+    void collectGraceBeforeChordEvents(Chord* chord, EventMap& events, double veloMultiplier, Staff* st, int tickOffset,
                                        PitchWheelRenderer& pitchWheelRenderer,  MidiInstrumentEffect effect);
 
     Score* score = nullptr;

--- a/src/engraving/compat/midi/pitchwheelrenderer.cpp
+++ b/src/engraving/compat/midi/pitchwheelrenderer.cpp
@@ -108,7 +108,7 @@ void PitchWheelRenderer::renderChannelPitchWheel(EventMap& pitchWheelEvents,
                 if (staffInfoValid) {
                     evb.setOriginatingStaff(staffIdx);
                 }
-                pitchWheelEvents.emplace_hint(pitchWheelEvents.end(), std::make_pair(tick, evb));
+                pitchWheelEvents[channel].emplace_hint(pitchWheelEvents[channel].end(), std::make_pair(tick, evb));
                 forceUpdate = false;
             }
 

--- a/src/engraving/compat/midi/pitchwheelrenderer.cpp
+++ b/src/engraving/compat/midi/pitchwheelrenderer.cpp
@@ -25,9 +25,9 @@ void PitchWheelRenderer::addPitchWheelFunction(const PitchWheelFunction& functio
     functions.functions.push_back(function);
 }
 
-EventMap PitchWheelRenderer::renderPitchWheel() const noexcept
+EventsHolder PitchWheelRenderer::renderPitchWheel() const noexcept
 {
-    EventMap pitchWheelEvents;
+    EventsHolder pitchWheelEvents;
 
     for (const auto& function : _functions) {
         renderChannelPitchWheel(pitchWheelEvents, function.second, function.first);
@@ -38,7 +38,7 @@ EventMap PitchWheelRenderer::renderPitchWheel() const noexcept
 
 //! MARK: PRIVATE METHODS
 
-void PitchWheelRenderer::renderChannelPitchWheel(EventMap& pitchWheelEvents,
+void PitchWheelRenderer::renderChannelPitchWheel(EventsHolder& pitchWheelEvents,
                                                  const PitchWheelFunctions& functions,
                                                  uint32_t channel) const noexcept
 {

--- a/src/engraving/compat/midi/pitchwheelrenderer.h
+++ b/src/engraving/compat/midi/pitchwheelrenderer.h
@@ -46,7 +46,7 @@ public:
 
     void addPitchWheelFunction(const PitchWheelFunction& function, uint32_t channel, staff_idx_t staffIdx, MidiInstrumentEffect effect);
 
-    EventMap renderPitchWheel() const noexcept;
+    EventsHolder renderPitchWheel() const noexcept;
 
     static void generateRanges(const std::list<PitchWheelFunction>& functions, std::map<int, int, std::greater<> >& ranges);
 
@@ -59,7 +59,7 @@ private:
         std::list<PitchWheelFunction> functions;
     };
 
-    void renderChannelPitchWheel(EventMap& pitchWheelEvents, const PitchWheelFunctions& functions, uint32_t channel) const noexcept;
+    void renderChannelPitchWheel(EventsHolder& pitchWheelEvents, const PitchWheelFunctions& functions, uint32_t channel) const noexcept;
 
     int32_t findNextStartTick(const std::list<PitchWheelFunction>& functions) const noexcept;
 

--- a/src/engraving/dom/rendermidi.cpp
+++ b/src/engraving/dom/rendermidi.cpp
@@ -1605,7 +1605,7 @@ void Score::createPlayEvents(Measure const* start, Measure const* const end)
     }
 }
 
-void Score::renderMidi(EventMap& events, const MidiRenderer::Context& ctx, bool expandRepeats)
+void Score::renderMidi(EventsHolder& events, const MidiRenderer::Context& ctx, bool expandRepeats)
 {
     masterScore()->setExpandRepeats(expandRepeats);
     MidiRenderer(this).renderScore(events, ctx);

--- a/src/engraving/dom/rendermidi.cpp
+++ b/src/engraving/dom/rendermidi.cpp
@@ -1605,7 +1605,7 @@ void Score::createPlayEvents(Measure const* start, Measure const* const end)
     }
 }
 
-void Score::renderMidi(EventMap* events, const MidiRenderer::Context& ctx, bool expandRepeats)
+void Score::renderMidi(EventMap& events, const MidiRenderer::Context& ctx, bool expandRepeats)
 {
     masterScore()->setExpandRepeats(expandRepeats);
     MidiRenderer(this).renderScore(events, ctx);

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -648,7 +648,7 @@ public:
     void cmdPaste(const IMimeData* ms, MuseScoreView* view, Fraction scale = Fraction(1, 1));
     bool pasteStaff(XmlReader&, Segment* dst, staff_idx_t staffIdx, Fraction scale = Fraction(1, 1));
     void pasteSymbols(XmlReader& e, ChordRest* dst);
-    void renderMidi(EventMap* events, const MidiRenderer::Context& ctx, bool expandRepeats);
+    void renderMidi(EventMap& events, const MidiRenderer::Context& ctx, bool expandRepeats);
 
     static void transposeChord(Chord* c, const Fraction& tick);
 

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -96,7 +96,7 @@ class Chord;
 class ChordRest;
 class Clef;
 class Element;
-class EventMap;
+class EventsHolder;
 class Excerpt;
 class FiguredBass;
 class Hairpin;
@@ -648,7 +648,7 @@ public:
     void cmdPaste(const IMimeData* ms, MuseScoreView* view, Fraction scale = Fraction(1, 1));
     bool pasteStaff(XmlReader&, Segment* dst, staff_idx_t staffIdx, Fraction scale = Fraction(1, 1));
     void pasteSymbols(XmlReader& e, ChordRest* dst);
-    void renderMidi(EventMap& events, const MidiRenderer::Context& ctx, bool expandRepeats);
+    void renderMidi(EventsHolder& events, const MidiRenderer::Context& ctx, bool expandRepeats);
 
     static void transposeChord(Chord* c, const Fraction& tick);
 

--- a/src/engraving/tests/midirenderer_tests.cpp
+++ b/src/engraving/tests/midirenderer_tests.cpp
@@ -43,7 +43,6 @@ static NPlayEvent noteEvent(int pitch, int volume, int channel)
     return NPlayEvent(EventType::ME_NOTEON, channel, pitch, volume);
 }
 
-
 static int getEventsCount(EventsHolder& events)
 {
     int eventsCount = 0;
@@ -109,7 +108,7 @@ static EventsHolder getNoteOnEvents(const EventsHolder& events)
             if (ev.second.type() != EventType::ME_NOTEON) {
                 continue;
             }
-            filteredEventMap[i].insert({ev.first, ev.second});
+            filteredEventMap[i].insert({ ev.first, ev.second });
         }
     }
 
@@ -201,7 +200,7 @@ TEST_F(MidiRenderer_Tests, graceBeforeBeat)
 
     EventsHolder events = renderMidiEvents(u"grace_before_beat.mscx");
 
-    EXPECT_EQ(events[DEFAULT_CHANNEL].size(), 8);
+    EXPECT_EQ(events[DEFAULT_CHANNEL].size(), 6);
 
     checkEventInterval(events, 0, 239, 59, defVol);
     checkEventInterval(events, 240, 479, 55, defVol);
@@ -214,7 +213,7 @@ TEST_F(MidiRenderer_Tests, graceOnBeat)
 
     EventsHolder events = renderMidiEvents(u"grace_on_beat.mscx");
 
-    EXPECT_EQ(events[DEFAULT_CHANNEL].size(), 8);
+    EXPECT_EQ(events[DEFAULT_CHANNEL].size(), 6);
 
     checkEventInterval(events, 0, 479, 59, defVol);
     checkEventInterval(events, 480, 719, 55, defVol);
@@ -228,7 +227,7 @@ TEST_F(MidiRenderer_Tests, ghostNote)
 
     EventsHolder events = renderMidiEvents(u"ghost_note.mscx");
 
-    EXPECT_EQ(events[DEFAULT_CHANNEL].size(), 5);
+    EXPECT_EQ(events[DEFAULT_CHANNEL].size(), 4);
 
     checkEventInterval(events, 0, 479, 59, defVol);
     checkEventInterval(events, 480, 959, 57, ghostVol);
@@ -240,7 +239,7 @@ TEST_F(MidiRenderer_Tests, simpleTremolo)
 
     EventsHolder events = renderMidiEvents(u"simple_tremolo.mscx");
 
-    EXPECT_EQ(events[DEFAULT_CHANNEL].size(), 11);
+    EXPECT_EQ(events[DEFAULT_CHANNEL].size(), 8);
 
     checkEventInterval(events, 0, 239, 59, defVol);
     checkEventInterval(events, 240, 479, 59, defVol);

--- a/src/engraving/tests/midirenderer_tests.cpp
+++ b/src/engraving/tests/midirenderer_tests.cpp
@@ -151,7 +151,7 @@ TEST_F(MidiRenderer_Tests, mergePitchWheelEvents)
     noteEvents[DEFAULT_CHANNEL].insert(std::make_pair(200, note2_ON));
     noteEvents[DEFAULT_CHANNEL].insert(std::make_pair(300, note2_OFF));
     noteEvents.mergePitchWheelEvents(pitchWheelEvents);
-    EXPECT_NE(noteEvents[DEFAULT_CHANNEL].find(199), noteEvents[DEFAULT_CHANNEL].end());
+    EXPECT_NE(noteEvents[DEFAULT_CHANNEL].find(145), noteEvents[DEFAULT_CHANNEL].end());
 }
 
 TEST_F(MidiRenderer_Tests, subscriptOperator)

--- a/src/engraving/tests/pitchwheelrender_tests.cpp
+++ b/src/engraving/tests/pitchwheelrender_tests.cpp
@@ -29,6 +29,7 @@
 
 using namespace mu;
 using namespace mu::engraving;
+static int DEFAULT_CHANNEL = 0;
 
 class PitchWheelRender_Tests : public ::testing::Test
 {
@@ -100,12 +101,12 @@ TEST_F(PitchWheelRender_Tests, simpleLinear)
 
     EventMap events = render.renderPitchWheel();
 
-    EXPECT_EQ(events.begin()->second.channel(), 0);
+    EXPECT_EQ(events[DEFAULT_CHANNEL].begin()->second.channel(), 0);
 
-    EXPECT_EQ(events.size(), 10);
+    EXPECT_EQ(events[DEFAULT_CHANNEL].size(), 10);
 
-    EXPECT_EQ(pitch(events.find(10)->second), 8202);
-    EXPECT_EQ(pitch(events.find(90)->second), 8282);
+    EXPECT_EQ(pitch(events[DEFAULT_CHANNEL].find(10)->second), 8202);
+    EXPECT_EQ(pitch(events[DEFAULT_CHANNEL].find(90)->second), 8282);
 //    EXPECT_EQ(pitch(events.find(100)->second), 8192);
 }
 
@@ -161,14 +162,10 @@ TEST_F(PitchWheelRender_Tests, channelTest)
     render.addPitchWheelFunction(func, 1, 0, MidiInstrumentEffect::NONE);
 
     EventMap events = render.renderPitchWheel();
-    std::set<int> channels;
-    for (const auto& ev : events) {
-        channels.insert(ev.second.channel());
-    }
 
-    EXPECT_EQ(channels.size(), 2);
-    EXPECT_EQ(channels.count(0), 1);
-    EXPECT_EQ(channels.count(1), 1);
+    EXPECT_EQ(events[0].size(), 3);
+    EXPECT_EQ(events[0].count(0), 1);
+    EXPECT_EQ(events[1].count(0), 1);
 }
 
 TEST_F(PitchWheelRender_Tests, twoConnectedFunctions)
@@ -212,9 +209,9 @@ TEST_F(PitchWheelRender_Tests, twoConnectedFunctions)
 
     EventMap events = render.renderPitchWheel();
 
-    EXPECT_EQ(events.size(), 6);
+    EXPECT_EQ(events[DEFAULT_CHANNEL].size(), 6);
     std::set<int> expectedValues = { 8192, 8202, 8212, 8222, 8232, 8242 };
-    for (const auto& ev : events) {
+    for (const auto& ev : events[DEFAULT_CHANNEL]) {
         EXPECT_TRUE(expectedValues.count(pitch(ev.second)) > 0);
     }
 }
@@ -260,9 +257,9 @@ TEST_F(PitchWheelRender_Tests, twoDevidedFunctions)
 
     EventMap events = render.renderPitchWheel();
 
-    EXPECT_EQ(events.size(), 5);
+    EXPECT_EQ(events[DEFAULT_CHANNEL].size(), 5);
     std::multimap<int, int> expectedValues = { { 0, 8192 }, { 10, 8202 }, { 20, 8212 }, { 40, 8222 }, { 50, 8232 } };
-    for (const auto& ev : events) {
+    for (const auto& ev : events[DEFAULT_CHANNEL]) {
         auto it = expectedValues.find(ev.first);
         EXPECT_TRUE(it != expectedValues.end());
         EXPECT_EQ(it->second, pitch(ev.second));
@@ -309,10 +306,10 @@ TEST_F(PitchWheelRender_Tests, twoOverlappedFunctions)
 
     EventMap events = render.renderPitchWheel();
 
-    EXPECT_EQ(events.size(), 4);
+    EXPECT_EQ(events[DEFAULT_CHANNEL].size(), 4);
     std::multimap<int, int> pitches;
     std::multimap<int, int> expectedValues = { { 0, 8192 }, { 10, 8202 }, { 20, 8222 }, { 30, 8212 } };
-    for (const auto& ev : events) {
+    for (const auto& ev : events[DEFAULT_CHANNEL]) {
         auto it = expectedValues.find(ev.first);
         EXPECT_TRUE(it != expectedValues.end());
         EXPECT_EQ(it->second, pitch(ev.second));
@@ -365,7 +362,7 @@ TEST_F(PitchWheelRender_Tests, threeDevidedFunctions)
 
     std::multimap<int, int> pitches;
     std::multimap<int, int> expectedValues = { { 10, 8202 }, { 20, 8192 }, { 30, 8212 }, { 40, 8192 }, { 60, 8222 } };
-    for (const auto& ev : events) {
+    for (const auto& ev : events[DEFAULT_CHANNEL]) {
         auto it = expectedValues.find(ev.first);
         EXPECT_TRUE(it != expectedValues.end());
         EXPECT_EQ(it->second, pitch(ev.second));
@@ -418,7 +415,7 @@ TEST_F(PitchWheelRender_Tests, threeOverLappedFunctions)
 
     std::multimap<int, int> pitches;
     std::multimap<int, int> expectedValues = { { 0, 8202 }, { 20, 8212 }, { 40, 8222 }, { 50, 8212 }, { 60, 8202 }, { 70, 8192 } };
-    for (const auto& ev : events) {
+    for (const auto& ev : events[DEFAULT_CHANNEL]) {
         auto it = expectedValues.find(ev.first);
         EXPECT_TRUE(it != expectedValues.end());
         EXPECT_EQ(it->second, pitch(ev.second));

--- a/src/engraving/tests/pitchwheelrender_tests.cpp
+++ b/src/engraving/tests/pitchwheelrender_tests.cpp
@@ -99,7 +99,7 @@ TEST_F(PitchWheelRender_Tests, simpleLinear)
     func.func = linearFunc;
     render.addPitchWheelFunction(func, 0, 0, MidiInstrumentEffect::NONE);
 
-    EventMap events = render.renderPitchWheel();
+    EventsHolder events = render.renderPitchWheel();
 
     EXPECT_EQ(events[DEFAULT_CHANNEL].begin()->second.channel(), 0);
 
@@ -136,7 +136,7 @@ TEST_F(PitchWheelRender_Tests, twoReverseFunctions)
     func.func = reverseLinearFunc;
     render.addPitchWheelFunction(func, 0, 0, MidiInstrumentEffect::NONE);
 
-    EventMap events = render.renderPitchWheel();
+    EventsHolder events = render.renderPitchWheel();
     EXPECT_EQ(events.size(), 1);
 }
 
@@ -161,7 +161,7 @@ TEST_F(PitchWheelRender_Tests, channelTest)
     render.addPitchWheelFunction(func, 0, 0, MidiInstrumentEffect::NONE);
     render.addPitchWheelFunction(func, 1, 0, MidiInstrumentEffect::NONE);
 
-    EventMap events = render.renderPitchWheel();
+    EventsHolder events = render.renderPitchWheel();
 
     EXPECT_EQ(events[0].size(), 3);
     EXPECT_EQ(events[0].count(0), 1);
@@ -207,7 +207,7 @@ TEST_F(PitchWheelRender_Tests, twoConnectedFunctions)
         render.addPitchWheelFunction(func, 0, 0, MidiInstrumentEffect::NONE);
     }
 
-    EventMap events = render.renderPitchWheel();
+    EventsHolder events = render.renderPitchWheel();
 
     EXPECT_EQ(events[DEFAULT_CHANNEL].size(), 6);
     std::set<int> expectedValues = { 8192, 8202, 8212, 8222, 8232, 8242 };
@@ -255,7 +255,7 @@ TEST_F(PitchWheelRender_Tests, twoDevidedFunctions)
         render.addPitchWheelFunction(func, 0, 0, MidiInstrumentEffect::NONE);
     }
 
-    EventMap events = render.renderPitchWheel();
+    EventsHolder events = render.renderPitchWheel();
 
     EXPECT_EQ(events[DEFAULT_CHANNEL].size(), 5);
     std::multimap<int, int> expectedValues = { { 0, 8192 }, { 10, 8202 }, { 20, 8212 }, { 40, 8222 }, { 50, 8232 } };
@@ -304,7 +304,7 @@ TEST_F(PitchWheelRender_Tests, twoOverlappedFunctions)
         render.addPitchWheelFunction(func, 0, 0, MidiInstrumentEffect::NONE);
     }
 
-    EventMap events = render.renderPitchWheel();
+    EventsHolder events = render.renderPitchWheel();
 
     EXPECT_EQ(events[DEFAULT_CHANNEL].size(), 4);
     std::multimap<int, int> pitches;
@@ -358,7 +358,7 @@ TEST_F(PitchWheelRender_Tests, threeDevidedFunctions)
         render.addPitchWheelFunction(func, 0, 0, MidiInstrumentEffect::NONE);
     }
 
-    EventMap events = render.renderPitchWheel();
+    EventsHolder events = render.renderPitchWheel();
 
     std::multimap<int, int> pitches;
     std::multimap<int, int> expectedValues = { { 10, 8202 }, { 20, 8192 }, { 30, 8212 }, { 40, 8192 }, { 60, 8222 } };
@@ -411,7 +411,7 @@ TEST_F(PitchWheelRender_Tests, threeOverLappedFunctions)
         render.addPitchWheelFunction(func, 0, 0, MidiInstrumentEffect::NONE);
     }
 
-    EventMap events = render.renderPitchWheel();
+    EventsHolder events = render.renderPitchWheel();
 
     std::multimap<int, int> pitches;
     std::multimap<int, int> expectedValues = { { 0, 8202 }, { 20, 8212 }, { 40, 8222 }, { 50, 8212 }, { 60, 8202 }, { 70, 8192 } };

--- a/src/importexport/midi/internal/midiexport/exportmidi.cpp
+++ b/src/importexport/midi/internal/midiexport/exportmidi.cpp
@@ -228,7 +228,7 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
         tracks.push_back(MidiTrack());
     }
 
-    EventMap events;
+    EventsHolder events;
     MidiRenderer::Context ctx;
     ctx.eachStringHasChannel = false;
     ctx.instrumentsHaveEffects = false;

--- a/src/importexport/midi/internal/midiexport/exportmidi.cpp
+++ b/src/importexport/midi/internal/midiexport/exportmidi.cpp
@@ -309,7 +309,7 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
                         if (event.discard() == staffIdx + 1 && event.velo() > 0) {
                             // turn note off so we can restrike it in another track
                             track.insert(m_pauseMap.addPauseTicks(item.first), MidiEvent(ME_NOTEON, channel,
-                                                                                          event.pitch(), 0));
+                                                                                         event.pitch(), 0));
                         }
 
                         staff_idx_t equivalentStaffIdx = staffIdx;
@@ -343,17 +343,17 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
                             // use the note values instead of the event values if portamento is suppressed
                             if (!exportRPNs && event.portamento()) {
                                 track.insert(m_pauseMap.addPauseTicks(item.first), MidiEvent(ME_NOTEON, channel,
-                                                                                              event.note()->pitch(), event.velo()));
+                                                                                             event.note()->pitch(), event.velo()));
                             } else {
                                 track.insert(m_pauseMap.addPauseTicks(item.first), MidiEvent(ME_NOTEON, channel,
-                                                                                              event.pitch(), event.velo()));
+                                                                                             event.pitch(), event.velo()));
                             }
                         } else if (event.type() == ME_CONTROLLER) {
                             track.insert(m_pauseMap.addPauseTicks(item.first), MidiEvent(ME_CONTROLLER, channel,
-                                                                                          event.controller(), event.value()));
+                                                                                         event.controller(), event.value()));
                         } else if (event.type() == ME_PITCHBEND) {
                             track.insert(m_pauseMap.addPauseTicks(item.first), MidiEvent(ME_PITCHBEND, channel,
-                                                                                          event.dataA(), event.dataB()));
+                                                                                         event.dataA(), event.dataB()));
                         } else {
                             LOGD("writeMidi: unknown midi event 0x%02x", event.type());
                         }


### PR DESCRIPTION
Related to https://github.com/musescore/MuseScore/pull/18180
After fixing midi export for pitch wheel events downside was unnecessary "pitch wheel reset" events before every note on.
This PR fixes this problem.