### PR TITLE
Fix: Horizontal Distance from Notes -> Horizontal distance from notes

### DIFF
--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -6666,7 +6666,7 @@ By default, they will be placed such as that their right end are at the same lev
                <item row="2" column="0" colspan="2">
                 <widget class="QGroupBox" name="groupBox_tuplets_horizontalDist">
                  <property name="title">
-                  <string>Horizontal Distance from Notes</string>
+                  <string>Horizontal distance from notes</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_17">
                   <item row="1" column="1">


### PR DESCRIPTION
Fix: Horizontal Distance from Notes -> Horizontal distance from notes - like 'Vertical distance from notes' in the same file (see https://github.com/musescore/MuseScore/pull/19155).

Greetings,
Gootector

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
