### PR TITLE
Fix #15551: View->Fullscreen is now toggle on Mac

### DIFF
--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -185,9 +185,7 @@ MenuItem* AppMenuModel::makeEditMenu()
 MenuItem* AppMenuModel::makeViewMenu()
 {
     MenuItemList viewItems {
-#ifndef Q_OS_MAC
         makeMenuItem("fullscreen"),
-#endif
         makeMenuItem("toggle-palettes"),
         makeMenuItem("masterpalette"),
         makeMenuItem("toggle-instruments"),

--- a/src/appshell/view/internal/platform/macos/macosappmenumodelhook.mm
+++ b/src/appshell/view/internal/platform/macos/macosappmenumodelhook.mm
@@ -30,4 +30,5 @@ void MacOSAppMenuModelHook::onAppMenuInited()
 {
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"NSDisabledDictationMenuItem"];
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"NSDisabledCharacterPaletteMenuItem"];
+    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"NSFullScreenMenuItemEverywhere"];
 }

--- a/src/framework/shortcuts/internal/shortcutsconfiguration.cpp
+++ b/src/framework/shortcuts/internal/shortcutsconfiguration.cpp
@@ -29,7 +29,12 @@
 using namespace mu::shortcuts;
 using namespace mu::framework;
 
+#ifndef Q_OS_MAC
 static const mu::io::path_t SHORTCUTS_FILE_NAME("/shortcuts.xml");
+#else
+static const mu::io::path_t SHORTCUTS_FILE_NAME("/shortcuts-Mac.xml");
+#endif
+
 static const mu::io::path_t SHORTCUTS_DEFAULT_FILE_PATH(":/data" + SHORTCUTS_FILE_NAME);
 
 static const std::string MIDIMAPPINGS_FILE_NAME("/midi_mappings.xml");


### PR DESCRIPTION
Resolves: #15551

Disables the OS-generated fullscreen menu item, uses the application's menu item.
