### PR TITLE
Update drum staff when editing kit

### DIFF
--- a/src/engraving/dom/undo.cpp
+++ b/src/engraving/dom/undo.cpp
@@ -2821,6 +2821,10 @@ void ChangeDrumset::flip(EditData*)
     Drumset d = *instrument->drumset();
     instrument->setDrumset(&drumset);
     drumset = d;
+
+    if (part->staves().size() > 0) {
+        part->score()->setLayout(Fraction(0, 1), part->score()->endTick(), part->staves().front()->idx(), part->staves().back()->idx());
+    }
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/undo.h
+++ b/src/engraving/dom/undo.h
@@ -1425,12 +1425,13 @@ class ChangeDrumset : public UndoCommand
 
     Instrument* instrument = nullptr;
     Drumset drumset;
+    Part* part = nullptr;
 
     void flip(EditData*) override;
 
 public:
-    ChangeDrumset(Instrument* i, const Drumset* d)
-        : instrument(i), drumset(*d) {}
+    ChangeDrumset(Instrument* i, const Drumset* d, Part* p)
+        : instrument(i), drumset(*d), part(p) {}
 
     UNDO_TYPE(CommandType::ChangeDrumset)
     UNDO_NAME("ChangeDrumset")

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -624,7 +624,7 @@ void NotationParts::replaceDrumset(const InstrumentKey& instrumentKey, const Dru
 
     startEdit();
 
-    score()->undo(new mu::engraving::ChangeDrumset(instrument, &newDrumset));
+    score()->undo(new mu::engraving::ChangeDrumset(instrument, &newDrumset, part));
 
     apply();
 


### PR DESCRIPTION
Resolves: #18886 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Opted for `score()->setLayout()` over `score()->layoutAll()` to only re-layout percussion staves
<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
