### PR TITLE
A few fixes for ordering of instruments/parts on a score

### DIFF
--- a/share/instruments/orders.xml
+++ b/share/instruments/orders.xml
@@ -17,21 +17,25 @@
             <family>flugelhorns</family>
             <family>trombones</family>
             <family>tubas</family>
+            <unsorted group="brass"/>
         </section>
         <section id="timpani">
             <family>timpani</family>
         </section>
         <section id="percussion">
             <family>keyboard-percussion</family>
+            <unsorted group="pitched-percussion"/>
             <family>drums</family>
             <family>unpitched-metal-percussion</family>
             <family>unpitched-wooden-percussion</family>
             <family>other-percussion</family>
+            <unsorted group="unpitched-percussion"/>
         </section>
         <family>keyboards</family>
         <family>harps</family>
         <family>organs</family>
         <family>synths</family>
+        <unsorted/>
         <soloists/>
         <section id="voices" barLineSpan="false">
             <family>voices</family>
@@ -40,7 +44,6 @@
         <section id="strings">
             <family>orchestral-strings</family>
         </section>
-        <unsorted/>
     </Order>
     <Order id="choir">
         <name>Choir</name>
@@ -118,6 +121,7 @@
             <family>flutes</family>
             <family>clarinets</family>
             <family>saxophones</family>
+            <unsorted group="woodwinds"/>
         </section>
         <section id="trumpets" thinBrackets="false">
             <family>trumpets</family>
@@ -223,6 +227,7 @@
         <section id="percussion" thinBrackets="false">
             <family>timpani</family>
             <family>keyboard-percussion</family>
+            <unsorted group="pitched-percussion"/>
             <family>drums</family>
             <unsorted group="unpitched-percussion"/>
         </section>
@@ -250,9 +255,11 @@
         <section id="tubas" thinBrackets="false">
             <family>tubas</family>
         </section>
+        <unsorted group="brass"/>
         <section id="percussion" thinBrackets="false">
             <family>timpani</family>
             <family>keyboard-percussion</family>
+            <unsorted group="pitched-percussion"/>
             <family>drums</family>
             <unsorted group="unpitched-percussion"/>
         </section>

--- a/share/instruments/orders.xml
+++ b/share/instruments/orders.xml
@@ -241,7 +241,7 @@
         </section>
         <section id="horns" thinBrackets="false">
             <family>flugelhorns</family>
-            <family>horns</family>
+            <family>alto-horns</family>
         </section>
         <section id="baritones" thinBrackets="false">
             <family>baritone-horns</family>

--- a/src/engraving/dom/scoreorder.cpp
+++ b/src/engraving/dom/scoreorder.cpp
@@ -337,7 +337,8 @@ int ScoreOrder::instrumentSortingIndex(const String& instrumentId, bool isSolois
                    && (sg.unsorted == ii.instrTemplate->groupId)) {
             index = i;
             priority = Priority::UnsortedGroup;
-        } else if ((priority < Priority::Unsorted) && (sg.family == UnsortedGroup)) {
+        } else if ((priority < Priority::Unsorted) && (sg.family == UnsortedGroup)
+                   && (sg.unsorted == u"")) {
             index = i;
             priority = Priority::Unsorted;
         }

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -1102,8 +1102,7 @@ int NotationParts::resolveNewInstrumentNumber(const InstrumentTemplate& instrume
     for (const Part* part : score()->parts()) {
         const Instrument* partInstrument = part->instrument();
 
-        if (partInstrument->id() == instrument.id
-            && partInstrument->trait().name == instrument.trait.name) {
+        if (partInstrument->id() == instrument.id) {
             ++count;
         }
     }
@@ -1115,7 +1114,7 @@ int NotationParts::resolveNewInstrumentNumber(const InstrumentTemplate& instrume
     for (const PartInstrument& partInstrument: allNewInstruments) {
         const InstrumentTemplate& templ = partInstrument.instrumentTemplate;
 
-        if (templ.id == instrument.id && templ.trait.name == instrument.trait.name) {
+        if (templ.id == instrument.id) {
             ++count;
         }
     }


### PR DESCRIPTION
Resolves: #14328
- ScoreOrder now correctly differentiates `<unsorted/>` and `<unsorted group=.../>` tags
- Added `<unsorted/>` tags to orders.xml to put unsorted brass/woodwinds/percussion with their respective sections of the score, instead of lumping them up into one unsorted section at the bottom.

Resolves: #15791
- Replaced `horn` in brass band order with `alto-horn` since brass bands generally have alto horns, not french horns.

Also
- Fixed incorrect part numbering (Ex. Horns in F 1/2) when adding new instruments with `traits` to a score that has been saved before.

----
- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
