### PR TITLE
Retain mode when importing key signature from a GP6 or GP7 file

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
@@ -850,9 +850,18 @@ GPTrack::RSE GP67DomBuilder::readTrackRSE(XmlDomNode* trackChildNode) const
 GPMasterBar::KeySig GP67DomBuilder::readKeySig(XmlDomNode* keyNode) const
 {
     const auto& accidentalCount = keyNode->firstChildElement("AccidentalCount");
-    int keyCount = accidentalCount.toElement().text().toInt();
+    const auto& modeNode = keyNode->firstChildElement("Mode");
 
-    return GPMasterBar::KeySig(keyCount);
+    String modeName = modeNode.toElement().text();
+
+    GPMasterBar::KeySig::Mode mode = GPMasterBar::KeySig::Mode::Major;
+    if (modeName == "Minor") {
+        mode = GPMasterBar::KeySig::Mode::Minor;
+    }
+
+    int keyCount = accidentalCount.toElement().text().toInt();
+    
+    return GPMasterBar::KeySig{ GPMasterBar::KeySig::Accidentals(keyCount), mode };
 }
 
 bool GP67DomBuilder::readUseFlats(XmlDomNode* keyNode) const

--- a/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gp67dombuilder.cpp
@@ -860,7 +860,7 @@ GPMasterBar::KeySig GP67DomBuilder::readKeySig(XmlDomNode* keyNode) const
     }
 
     int keyCount = accidentalCount.toElement().text().toInt();
-    
+
     return GPMasterBar::KeySig{ GPMasterBar::KeySig::Accidentals(keyCount), mode };
 }
 

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -933,8 +933,7 @@ void GPConverter::addKeySig(const GPMasterBar* mB, Measure* measure)
     auto convertMode = [](GPMasterBar::KeySig::Mode m) {
         if (m == GPMasterBar::KeySig::Mode::Major) {
             return KeyMode::MAJOR;
-        }
-        else {
+        } else {
             return KeyMode::MINOR;
         }
     };
@@ -967,7 +966,7 @@ void GPConverter::addKeySig(const GPMasterBar* mB, Measure* measure)
             continue;
         }
         int key = static_cast<int>(mB->keySig().accidentalCount);
-        
+
         bool useFlats = mB->useFlats() || key < 0;
         size_t numSharps = getNumSharps(key);
         IF_ASSERT_FAILED(numSharps != nidx) {

--- a/src/importexport/guitarpro/internal/gtp/gpmasterbar.h
+++ b/src/importexport/guitarpro/internal/gtp/gpmasterbar.h
@@ -14,10 +14,18 @@ public:
         Type type{ Type::None };
         int count{ 1 };
     };
-    enum class KeySig {
-        C_B = -7,
-        G_B, D_B, A_B, E_B, B_B, F,   C,
-        G,   D,   A,   E,   B,   F_S, C_S,
+    struct KeySig {
+        enum class Accidentals {
+            C_B = -7,
+            G_B, D_B, A_B, E_B, B_B, F, C,
+            G, D, A, E, B, F_S, C_S,
+        };
+        enum class Mode {
+            Major,
+            Minor
+        };
+        Accidentals accidentalCount{ Accidentals::C };
+        Mode mode{ Mode::Major };
     };
     enum class TripletFeelType {
         Triplet8th,

--- a/src/importexport/guitarpro/tests/data/UncompletedMeasure.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/UncompletedMeasure.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/accent.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/accent.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/accent.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/accent.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/all-percussion.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/all-percussion.gp-ref.mscx
@@ -537,6 +537,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/arpeggio.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/arpeggio.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/arpeggio.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/arpeggio.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/artificial-harmonic.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/artificial-harmonic.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/artificial-harmonic.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/artificial-harmonic.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/barline-last-measure.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/barline-last-measure.gp-ref.mscx
@@ -142,6 +142,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <StaffText>
             <text>Free time</text>
@@ -210,6 +211,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <StaffText>
             <text>Free time</text>

--- a/src/importexport/guitarpro/tests/data/barre.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/barre.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/barre.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/barre.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/basic-bend.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/basic-bend.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/basic-bend.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/basic-bend.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/beam-modes.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/beam-modes.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/beams-stems-ledger-lines.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/beams-stems-ledger-lines.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>12</sigN>

--- a/src/importexport/guitarpro/tests/data/beams-stems-ledger-lines.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/beams-stems-ledger-lines.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>12</sigN>

--- a/src/importexport/guitarpro/tests/data/bend.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/bend.gp-ref.mscx
@@ -81,6 +81,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/bend.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/bend.gpx-ref.mscx
@@ -81,6 +81,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/bend_and_harmonic.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/bend_and_harmonic.gp-ref.mscx
@@ -101,6 +101,7 @@ Cowboys From Hell</text>
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/brush.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/brush.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/brush.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/brush.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/chord_with_tied_harmonics.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/chord_with_tied_harmonics.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/chordnames_keyboard.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/chordnames_keyboard.gp-ref.mscx
@@ -88,6 +88,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -169,6 +170,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/chordnames_keyboard.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/chordnames_keyboard.gpx-ref.mscx
@@ -88,6 +88,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -166,6 +167,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/clefs.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/clefs.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/clefs.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/clefs.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/copyright.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/copyright.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/copyright.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/copyright.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/crescendo-diminuendo.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/crescendo-diminuendo.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/crescendo-diminuendo.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/crescendo-diminuendo.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/dead-note.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dead-note.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/dead-note.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dead-note.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/directions.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/directions.gp-ref.mscx
@@ -85,6 +85,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/directions.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/directions.gpx-ref.mscx
@@ -85,6 +85,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/dotted-gliss.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dotted-gliss.gp-ref.mscx
@@ -100,6 +100,7 @@ Innuendo</text>
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>12</sigN>

--- a/src/importexport/guitarpro/tests/data/dotted-gliss.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dotted-gliss.gpx-ref.mscx
@@ -102,6 +102,7 @@ Innuendo</text>
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>12</sigN>

--- a/src/importexport/guitarpro/tests/data/dotted-tuplets.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dotted-tuplets.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/dotted-tuplets.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dotted-tuplets.gpx-ref.mscx
@@ -82,6 +82,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/double-bar.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/double-bar.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/double-bar.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/double-bar.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/dynamic.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dynamic.gp-ref.mscx
@@ -142,6 +142,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -291,6 +292,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/dynamic.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/dynamic.gpx-ref.mscx
@@ -142,6 +142,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -291,6 +292,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/fade-in.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fade-in.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/fade-in.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fade-in.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/fermata.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fermata.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/fermata.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fermata.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/fingering.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fingering.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/fingering.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fingering.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/free-time.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/free-time.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <StaffText>
             <text>Free time</text>

--- a/src/importexport/guitarpro/tests/data/free-time.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/free-time.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <StaffText>
             <text>Free time</text>

--- a/src/importexport/guitarpro/tests/data/fret-diagram.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram.gp-ref.mscx
@@ -81,6 +81,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>12</sigN>

--- a/src/importexport/guitarpro/tests/data/fret-diagram.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram.gpx-ref.mscx
@@ -81,6 +81,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>12</sigN>

--- a/src/importexport/guitarpro/tests/data/fret-diagram_2instruments.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram_2instruments.gp-ref.mscx
@@ -142,6 +142,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -214,6 +215,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/fret-diagram_2instruments.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/fret-diagram_2instruments.gpx-ref.mscx
@@ -142,6 +142,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -206,6 +207,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/ghost-note.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ghost-note.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/ghost-note.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ghost-note.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/grace-before-beat.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/grace-before-beat.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/grace-before-beat.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/grace-before-beat.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/grace-durations.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/grace-durations.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/grace-on-beat.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/grace-on-beat.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/grace-on-beat.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/grace-on-beat.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/grace.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/grace.gp-ref.mscx
@@ -78,6 +78,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/grace.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/grace.gpx-ref.mscx
@@ -82,6 +82,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/heavy-accent.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/heavy-accent.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/heavy-accent.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/heavy-accent.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/hide-rests.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/hide-rests.gp-ref.mscx
@@ -142,6 +142,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -228,6 +229,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/instr-change-1-beat.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/instr-change-1-beat.gp-ref.mscx
@@ -101,6 +101,7 @@ The Wall</text>
         <voice>
           <KeySig>
             <concertKey>1</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/instr-change-1-beat.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/instr-change-1-beat.gpx-ref.mscx
@@ -101,6 +101,7 @@ The Wall</text>
         <voice>
           <KeySig>
             <concertKey>1</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/instr-change.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/instr-change.gp-ref.mscx
@@ -101,6 +101,7 @@ The Wall</text>
         <voice>
           <KeySig>
             <concertKey>1</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/instr-change.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/instr-change.gpx-ref.mscx
@@ -101,6 +101,7 @@ The Wall</text>
         <voice>
           <KeySig>
             <concertKey>1</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/keysig.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/keysig.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -137,6 +138,7 @@
         <voice>
           <KeySig>
             <concertKey>1</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -182,6 +184,7 @@
         <voice>
           <KeySig>
             <concertKey>2</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -230,6 +233,7 @@
         <voice>
           <KeySig>
             <concertKey>3</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -281,6 +285,7 @@
         <voice>
           <KeySig>
             <concertKey>4</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -335,6 +340,7 @@
         <voice>
           <KeySig>
             <concertKey>5</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -389,6 +395,7 @@
         <voice>
           <KeySig>
             <concertKey>6</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -443,6 +450,7 @@
         <voice>
           <KeySig>
             <concertKey>7</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -494,6 +502,7 @@
         <voice>
           <KeySig>
             <concertKey>-1</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -539,6 +548,7 @@
         <voice>
           <KeySig>
             <concertKey>-2</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -587,6 +597,7 @@
         <voice>
           <KeySig>
             <concertKey>-3</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -638,6 +649,7 @@
         <voice>
           <KeySig>
             <concertKey>-4</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -689,6 +701,7 @@
         <voice>
           <KeySig>
             <concertKey>-5</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -740,6 +753,7 @@
         <voice>
           <KeySig>
             <concertKey>-6</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -794,6 +808,7 @@
         <voice>
           <KeySig>
             <concertKey>-7</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -851,6 +866,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -896,6 +912,7 @@
         <voice>
           <KeySig>
             <concertKey>1</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -944,6 +961,7 @@
         <voice>
           <KeySig>
             <concertKey>2</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -992,6 +1010,7 @@
         <voice>
           <KeySig>
             <concertKey>3</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1043,6 +1062,7 @@
         <voice>
           <KeySig>
             <concertKey>4</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1097,6 +1117,7 @@
         <voice>
           <KeySig>
             <concertKey>5</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1151,6 +1172,7 @@
         <voice>
           <KeySig>
             <concertKey>6</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1205,6 +1227,7 @@
         <voice>
           <KeySig>
             <concertKey>7</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1259,6 +1282,7 @@
         <voice>
           <KeySig>
             <concertKey>-1</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1304,6 +1328,7 @@
         <voice>
           <KeySig>
             <concertKey>-2</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1352,6 +1377,7 @@
         <voice>
           <KeySig>
             <concertKey>-3</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1403,6 +1429,7 @@
         <voice>
           <KeySig>
             <concertKey>-4</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1454,6 +1481,7 @@
         <voice>
           <KeySig>
             <concertKey>-5</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1505,6 +1533,7 @@
         <voice>
           <KeySig>
             <concertKey>-6</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1559,6 +1588,7 @@
         <voice>
           <KeySig>
             <concertKey>-7</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1613,6 +1643,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/keysig.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/keysig.gpx-ref.mscx
@@ -79,6 +79,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -136,6 +137,7 @@
         <voice>
           <KeySig>
             <concertKey>1</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -181,6 +183,7 @@
         <voice>
           <KeySig>
             <concertKey>2</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -229,6 +232,7 @@
         <voice>
           <KeySig>
             <concertKey>3</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -283,6 +287,7 @@
         <voice>
           <KeySig>
             <concertKey>4</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -337,6 +342,7 @@
         <voice>
           <KeySig>
             <concertKey>5</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -391,6 +397,7 @@
         <voice>
           <KeySig>
             <concertKey>6</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -448,6 +455,7 @@
         <voice>
           <KeySig>
             <concertKey>7</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -499,6 +507,7 @@
         <voice>
           <KeySig>
             <concertKey>-1</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -544,6 +553,7 @@
         <voice>
           <KeySig>
             <concertKey>-2</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -592,6 +602,7 @@
         <voice>
           <KeySig>
             <concertKey>-3</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -643,6 +654,7 @@
         <voice>
           <KeySig>
             <concertKey>-4</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -694,6 +706,7 @@
         <voice>
           <KeySig>
             <concertKey>-5</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -748,6 +761,7 @@
         <voice>
           <KeySig>
             <concertKey>-6</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -802,6 +816,7 @@
         <voice>
           <KeySig>
             <concertKey>-7</concertKey>
+            <mode>major</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -859,6 +874,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -904,6 +920,7 @@
         <voice>
           <KeySig>
             <concertKey>1</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -952,6 +969,7 @@
         <voice>
           <KeySig>
             <concertKey>2</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1000,6 +1018,7 @@
         <voice>
           <KeySig>
             <concertKey>3</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1051,6 +1070,7 @@
         <voice>
           <KeySig>
             <concertKey>4</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1108,6 +1128,7 @@
         <voice>
           <KeySig>
             <concertKey>5</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1162,6 +1183,7 @@
         <voice>
           <KeySig>
             <concertKey>6</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1216,6 +1238,7 @@
         <voice>
           <KeySig>
             <concertKey>7</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1270,6 +1293,7 @@
         <voice>
           <KeySig>
             <concertKey>-1</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1315,6 +1339,7 @@
         <voice>
           <KeySig>
             <concertKey>-2</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1363,6 +1388,7 @@
         <voice>
           <KeySig>
             <concertKey>-3</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1414,6 +1440,7 @@
         <voice>
           <KeySig>
             <concertKey>-4</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1465,6 +1492,7 @@
         <voice>
           <KeySig>
             <concertKey>-5</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1516,6 +1544,7 @@
         <voice>
           <KeySig>
             <concertKey>-6</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1573,6 +1602,7 @@
         <voice>
           <KeySig>
             <concertKey>-7</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>
@@ -1627,6 +1657,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>minor</mode>
             </KeySig>
           <Chord>
             <durationType>quarter</durationType>

--- a/src/importexport/guitarpro/tests/data/legato-slide.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/legato-slide.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/legato-slide.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/legato-slide.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/let-ring.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/let-ring.gp-ref.mscx
@@ -79,6 +79,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/let-ring.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/let-ring.gpx-ref.mscx
@@ -79,6 +79,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/line_elements.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/line_elements.gp-ref.mscx
@@ -268,6 +268,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -506,6 +507,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -626,6 +628,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -863,6 +866,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -1090,6 +1094,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/mmrest.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/mmrest.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/mordents.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/mordents.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/mordents.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/mordents.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/multivoices.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/multivoices.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/multivoices.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/multivoices.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/ottava1.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava1.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/ottava1.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava1.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/ottava2.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava2.gp-ref.mscx
@@ -142,6 +142,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -319,6 +320,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/ottava2.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava2.gpx-ref.mscx
@@ -142,6 +142,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -319,6 +320,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/ottava3.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava3.gp-ref.mscx
@@ -142,6 +142,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -192,6 +193,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/ottava3.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava3.gpx-ref.mscx
@@ -142,6 +142,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -192,6 +193,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/ottava4.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava4.gp-ref.mscx
@@ -142,6 +142,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -319,6 +320,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/ottava4.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava4.gpx-ref.mscx
@@ -142,6 +142,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -319,6 +320,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/ottava5.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava5.gp-ref.mscx
@@ -142,6 +142,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -222,6 +223,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/ottava5.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/ottava5.gpx-ref.mscx
@@ -142,6 +142,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -222,6 +223,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/palm-mute.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/palm-mute.gp-ref.mscx
@@ -79,6 +79,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/palm-mute.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/palm-mute.gpx-ref.mscx
@@ -79,6 +79,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/percussion-beams.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/percussion-beams.gp-ref.mscx
@@ -537,6 +537,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/pick-up-down.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/pick-up-down.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/pick-up-down.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/pick-up-down.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/rasg.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/rasg.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/rasg.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/rasg.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/repeated-bars.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/repeated-bars.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/repeated-bars.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/repeated-bars.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/repeats.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/repeats.gp-ref.mscx
@@ -81,6 +81,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/repeats.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/repeats.gpx-ref.mscx
@@ -81,6 +81,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/rest-centered.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/rest-centered.gp-ref.mscx
@@ -79,6 +79,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/rest-centered.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/rest-centered.gpx-ref.mscx
@@ -79,6 +79,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/sforzato.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/sforzato.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/sforzato.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/sforzato.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/shift-slide.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/shift-slide.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/shift-slide.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/shift-slide.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slide-in-above.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-in-above.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slide-in-above.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-in-above.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slide-in-below.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-in-below.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slide-in-below.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-in-below.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slide-out-down.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-out-down.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slide-out-down.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-out-down.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slide-out-up.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-out-up.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slide-out-up.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slide-out-up.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur-notes-effect-mask.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slur.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slur.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slur_hammer_slur.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur_hammer_slur.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slur_hammer_slur.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur_hammer_slur.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slur_over_3_measures.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur_over_3_measures.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slur_over_3_measures.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur_over_3_measures.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slur_slur_hammer.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur_slur_hammer.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slur_slur_hammer.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur_slur_hammer.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slur_voices.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur_voices.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/slur_voices.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/slur_voices.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/spanner-in-uncomplete-measure.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/spanner-in-uncomplete-measure.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/tap-slap-pop.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tap-slap-pop.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/tap-slap-pop.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tap-slap-pop.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/tempo.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tempo.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/tempo.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tempo.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/text.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/text.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/text.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/text.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/timer.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/timer.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/timer.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/timer.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/tremolo-bar.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tremolo-bar.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/tremolo-bar.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tremolo-bar.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/tremolos.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tremolos.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/tremolos.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tremolos.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/trill.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/trill.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/trill.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/trill.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/tuplet-with-slur.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tuplet-with-slur.gp-ref.mscx
@@ -83,6 +83,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/tuplet-with-slur.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tuplet-with-slur.gpx-ref.mscx
@@ -83,6 +83,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/tuplets.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tuplets.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/tuplets2.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tuplets2.gpx-ref.mscx
@@ -96,6 +96,7 @@ solo concert</text>
         <voice>
           <KeySig>
             <concertKey>1</concertKey>
+            <mode>major</mode>
             </KeySig>
           <StaffText>
             <text>Free time</text>

--- a/src/importexport/guitarpro/tests/data/turn.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/turn.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/turn.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/turn.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/vibrato.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/vibrato.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/vibrato.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/vibrato.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/volta.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/volta.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/volta.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/volta.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/volume-swell.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/volume-swell.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/volume-swell.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/volume-swell.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>

--- a/src/importexport/guitarpro/tests/data/wah.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/wah.gp-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>

--- a/src/importexport/guitarpro/tests/data/wah.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/wah.gpx-ref.mscx
@@ -80,6 +80,7 @@
         <voice>
           <KeySig>
             <concertKey>0</concertKey>
+            <mode>major</mode>
             </KeySig>
           <TimeSig>
             <sigN>5</sigN>


### PR DESCRIPTION
Guitar Pro allows you to select a mode (major or minor) when picking a key signature. This is now imported into the MuseScore project, which is helpful when converting to MusicXML.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)