### PR TITLE
Fix gcc compiler errors

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -151,14 +151,14 @@ EngravingItem* EngravingItem::parentItem(bool explicitParent) const
     return nullptr;
 }
 
-static void сollectСhildrenItems(const EngravingObject* item, EngravingItemList& list, bool all)
+static void collectChildrenItems(const EngravingObject* item, EngravingItemList& list, bool all)
 {
     for (EngravingObject* ch : item->children()) {
         if (ch->isEngravingItem()) {
             list.push_back(static_cast<EngravingItem*>(ch));
 
             if (all) {
-                сollectСhildrenItems(ch, list, all);
+                collectChildrenItems(ch, list, all);
             }
         }
     }
@@ -167,7 +167,7 @@ static void сollectСhildrenItems(const EngravingObject* item, EngravingItemLis
 EngravingItemList EngravingItem::childrenItems(bool all) const
 {
     EngravingItemList list;
-    сollectСhildrenItems(this, list, all);
+    collectChildrenItems(this, list, all);
     return list;
 }
 


### PR DESCRIPTION
reg. stray (unicode characters?) '\321', '\201', '\320'  and ' \241`  in program
Shows when trying to build in QtCreator using MinGW (see also #19349)