### PR TITLE
Fix #13440: Text etc no longer clickable during playback

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -579,7 +579,17 @@ void NotationViewInputController::mousePressEvent(QMouseEvent* event)
 
     if (playbackController()->isPlaying()) {
         if (hitElement) {
-            playbackController()->seekElement(hitElement);
+            switch (hitElement->type()) {
+            case ElementType::NOTE:
+            case ElementType::REST:
+            case ElementType::MMREST:
+            case ElementType::MEASURE:
+            case ElementType::BAR_LINE: {
+                playbackController()->seekElement(hitElement);
+                break;
+            }
+            default: break;
+            }
         }
         return;
     }


### PR DESCRIPTION
Resolves: #13440

Notes, rests, measures, and barlines are now the only elements that will cause the playhead to jump during playback.