### PR TITLE
fix #19373 move all hairpins, when inserting measure into part

### DIFF
--- a/src/engraving/dom/box.cpp
+++ b/src/engraving/dom/box.cpp
@@ -430,22 +430,7 @@ void Box::manageExclusionFromParts(bool exclude)
             if (score == this->score()) {
                 continue;
             }
-            MeasureBase* newMB = nullptr;
-            if (!next()->isMeasure() && !next()->excludeFromOtherParts()) {
-                for (auto e : next()->linkList()) {
-                    if (e->score() == score) {
-                        newMB = toMeasureBase(e);
-                        break;
-                    }
-                }
-            }
-            // no linked frame found in score; use measure as insert point
-            if (!newMB) {
-                newMB = score->tick2measure(next()->tick());
-            }
-            if (!newMB) {
-                LOGD("measure base not found in score");
-            }
+            MeasureBase* newMB = next()->getInScore(score, true);
             MeasureBase* newFrame = score->insertMeasure(type(), newMB);
             newFrame->setExcludeFromOtherParts(false);
             newFrames.push_back(newFrame);

--- a/src/engraving/dom/box.cpp
+++ b/src/engraving/dom/box.cpp
@@ -430,7 +430,23 @@ void Box::manageExclusionFromParts(bool exclude)
             if (score == this->score()) {
                 continue;
             }
-            MeasureBase* newFrame = score->insertMeasure(type(), next());
+            MeasureBase* newMB = nullptr;
+            if (!next()->isMeasure() && !next()->excludeFromOtherParts()) {
+                for (auto e : next()->linkList()) {
+                    if (e->score() == score) {
+                        newMB = toMeasureBase(e);
+                        break;
+                    }
+                }
+            }
+            // no linked frame found in score; use measure as insert point
+            if (!newMB) {
+                newMB = score->tick2measure(next()->tick());
+            }
+            if (!newMB) {
+                LOGD("measure base not found in score");
+            }
+            MeasureBase* newFrame = score->insertMeasure(type(), newMB);
             newFrame->setExcludeFromOtherParts(false);
             newFrames.push_back(newFrame);
         }

--- a/src/engraving/dom/box.cpp
+++ b/src/engraving/dom/box.cpp
@@ -389,16 +389,16 @@ EngravingItem* Box::drop(EditData& data)
     case ElementType::ACTION_ICON:
         switch (toActionIcon(e)->actionType()) {
         case ActionIconType::VFRAME:
-            score()->insertMeasure(ElementType::VBOX, this);
+            score()->insertBox(ElementType::VBOX, this);
             break;
         case ActionIconType::TFRAME:
-            score()->insertMeasure(ElementType::TBOX, this);
+            score()->insertBox(ElementType::TBOX, this);
             break;
         case ActionIconType::FFRAME:
-            score()->insertMeasure(ElementType::FBOX, this);
+            score()->insertBox(ElementType::FBOX, this);
             break;
         case ActionIconType::HFRAME:
-            score()->insertMeasure(ElementType::HBOX, this);
+            score()->insertBox(ElementType::HBOX, this);
             break;
         case ActionIconType::MEASURE:
             score()->insertMeasure(ElementType::MEASURE, this);
@@ -431,7 +431,7 @@ void Box::manageExclusionFromParts(bool exclude)
                 continue;
             }
             MeasureBase* newMB = next()->getInScore(score, true);
-            MeasureBase* newFrame = score->insertMeasure(type(), newMB);
+            MeasureBase* newFrame = score->insertBox(type(), newMB);
             newFrame->setExcludeFromOtherParts(false);
             newFrames.push_back(newFrame);
         }

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -684,7 +684,7 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
             for (Score* score : scoreList()) {
                 MeasureBase* titleFrame = score->first();
                 if (!titleFrame || !titleFrame->isVBox()) {
-                    titleFrame = score->insertMeasure(ElementType::VBOX, titleFrame);
+                    titleFrame = score->insertBox(ElementType::VBOX, titleFrame);
                 }
                 if (!linkedFrame) {
                     linkedFrame = titleFrame;

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -29,7 +29,6 @@
 #include "articulation.h"
 #include "barline.h"
 #include "beam.h"
-#include "box.h"
 #include "bracket.h"
 #include "breath.h"
 #include "chord.h"
@@ -666,7 +665,7 @@ Slur* Score::addSlur(ChordRest* firstChordRest, ChordRest* secondChordRest, cons
     return slur;
 }
 
-TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement, bool addToAllScores)
+TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
 {
     TextBase* textBox = nullptr;
 
@@ -681,13 +680,20 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement, 
         if (destinationElement && destinationElement->isVBox()) {
             frame = toMeasureBase(destinationElement);
         } else {
-            frame = first();
-
-            if (!frame || !frame->isVBox()) {
-                InsertMeasureOptions options;
-                options.addToAllScores = addToAllScores;
-
-                frame = insertMeasure(ElementType::VBOX, frame, options);
+            MeasureBase* linkedFrame = nullptr;
+            for (Score* score : scoreList()) {
+                MeasureBase* titleFrame = score->first();
+                if (!titleFrame || !titleFrame->isVBox()) {
+                    titleFrame = score->insertMeasure(ElementType::VBOX, titleFrame);
+                }
+                if (!linkedFrame) {
+                    linkedFrame = titleFrame;
+                } else {
+                    score->undo(new Link(titleFrame, linkedFrame));
+                }
+                if (score == this->score()) {
+                    frame = titleFrame;
+                }
             }
         }
 
@@ -3977,315 +3983,78 @@ void Score::nextInputPos(ChordRest* cr, bool doSelect)
 
 //---------------------------------------------------------
 //   insertMeasure
-//    Create a new MeasureBase of type type and insert
-//    before measure.
-//    If measure is zero, append new MeasureBase.
+//    if inserting Measure, act on master score
+//    (and add to all linked scores)
+//    if inserting Box, add to local score only
 //---------------------------------------------------------
 
 MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, const InsertMeasureOptions& options)
 {
+    MeasureBase* localInsertMeasureBase = nullptr;
+    if (type == ElementType::MEASURE) {
+        if (MeasureBase* masterInsertMeasure = masterScore()->insertMeasure(beforeMeasure, options)) {
+            localInsertMeasureBase = tick2measureBase(masterInsertMeasure->tick());
+        }
+    } else {
+        localInsertMeasureBase = insertBox(type, beforeMeasure, options);
+    }
+
+    return localInsertMeasureBase;
+}
+
+//---------------------------------------------------------
+//   insertBox
+//---------------------------------------------------------
+
+MeasureBase* Score::insertBox(ElementType type, MeasureBase* beforeMeasure, const InsertMeasureOptions& options)
+{
+    const bool isFrame = type == ElementType::FBOX || type == ElementType::HBOX || type == ElementType::TBOX || type == ElementType::VBOX;
+
+    if (!isFrame) {
+        return nullptr;
+    }
+
     Fraction tick;
     if (beforeMeasure) {
         if (beforeMeasure->isMeasure()) {
-            if (toMeasure(beforeMeasure)->isMMRest()) {
-                beforeMeasure = toMeasure(beforeMeasure)->prev();
-                beforeMeasure = beforeMeasure ? beforeMeasure->next() : firstMeasure();
+            Measure* m = toMeasure(beforeMeasure);
+            if (m->isMMRest()) {
+                beforeMeasure = m->mmRestFirst();
                 deselectAll();
             }
             for (size_t staffIdx = 0; staffIdx < nstaves(); ++staffIdx) {
-                if (toMeasure(beforeMeasure)->isMeasureRepeatGroupWithPrevM(staffIdx)) {
+                if (m->isMeasureRepeatGroupWithPrevM(staffIdx)) {
                     MScore::setError(MsError::CANNOT_SPLIT_MEASURE_REPEAT);
                     return nullptr;
                 }
             }
+        } else {
+            beforeMeasure = beforeMeasure->top(); // don't try to insert in front of nested frame
         }
         tick = beforeMeasure->tick();
     } else {
         tick = last() ? last()->endTick() : Fraction(0, 1);
     }
 
-    const Fraction currentTimeSig = sigmap()->timesig(tick.ticks()).nominal();   // use nominal time signature of current measure
-    Measure* localMeasure = nullptr; // measure base in "this" score
-    MeasureBase* linkedMasterMeasure = nullptr; // measure base in root score (for linking)
-    Fraction ticks   = { 0, 1 };
-
-    MeasureBase* result = nullptr;
     const bool isBeginning = tick.isZero();
 
-    const bool isFrame = type == ElementType::FBOX || type == ElementType::HBOX || type == ElementType::TBOX || type == ElementType::VBOX;
     const bool isTitleFrame = (type == ElementType::VBOX || type == ElementType::TBOX) && isBeginning;
     const bool dontCloneFrameToParts = isFrame && !isTitleFrame;
 
-    std::list<Score*> scores;
-    if (options.addToAllScores && !dontCloneFrameToParts) {
-        scores = scoreList();
-    } else {
-        scores.push_back(this);
-    }
+    MeasureBase* newMeasureBase = toMeasureBase(Factory::createItem(type, dummy()));
+    newMeasureBase->setTick(tick);
+    newMeasureBase->setExcludeFromOtherParts(dontCloneFrameToParts);
 
-    for (Score* score : scores) {
-        MeasureBase* actualBeforeMeasure = nullptr;
+    newMeasureBase->setNext(beforeMeasure);
+    newMeasureBase->setPrev(beforeMeasure ? beforeMeasure->prev() : last());
 
-        if (beforeMeasure) {
-            if (beforeMeasure->score() == score) {
-                actualBeforeMeasure = beforeMeasure;
-            } else if (beforeMeasure->isMeasure()) {
-                actualBeforeMeasure = score->tick2measure(tick);
-            } else if (beforeMeasure->links()) {
-                for (EngravingObject* m : *beforeMeasure->links()) {
-                    if (m && m->isMeasureBase() && m->score() == score) {
-                        actualBeforeMeasure = toMeasureBase(m);
-                        break;
-                    }
-                }
-            }
-
-            if (!actualBeforeMeasure) {
-                LOGD("measure not found");
-            }
-        }
-
-        MeasureBase* newMeasureBase = toMeasureBase(Factory::createItem(type, score->dummy()));
-        newMeasureBase->setTick(tick);
-        newMeasureBase->setExcludeFromOtherParts(dontCloneFrameToParts);
-
-        if (score == this) {
-            result = newMeasureBase;
-        }
-
-        if (actualBeforeMeasure) {
-            actualBeforeMeasure = actualBeforeMeasure->top(); // don't try to insert in front of nested frame
-        }
-        newMeasureBase->setNext(actualBeforeMeasure);
-        newMeasureBase->setPrev(actualBeforeMeasure ? actualBeforeMeasure->prev() : score->last());
-        if (newMeasureBase->isMeasure()) {
-            Measure* m = toMeasure(newMeasureBase);
-            m->setTimesig(currentTimeSig);
-            m->setTicks(currentTimeSig);
-        }
-        undo(new InsertMeasures(newMeasureBase, newMeasureBase));
-
-        if (type == ElementType::MEASURE) {
-            Measure* newMeasure  = toMeasure(newMeasureBase); // new measure
-            ticks = newMeasure->ticks();
-            Measure* measureInsert = nullptr; // insert before
-            if (actualBeforeMeasure) {
-                if (actualBeforeMeasure->isMeasure()) {
-                    measureInsert = toMeasure(actualBeforeMeasure);
-                } else {
-                    measureInsert = score->tick2measure(actualBeforeMeasure->tick());
-                }
-            }
-
-            if (score->isMaster()) {
-                localMeasure = newMeasure;
-            }
-
-            std::vector<TimeSig*> timeSigList;
-            std::vector<KeySig*> keySigList;
-            std::vector<Clef*> clefList;
-            std::vector<Clef*> previousClefList;
-            std::list<Clef*> specialCaseClefs;
-            std::vector<BarLine*> previousBarLinesList;
-
-            Measure* pm = newMeasure->prevMeasure();
-
-            //
-            // remove clef, barlines, time and key signatures
-            //
-            if (measureInsert) {
-                // if inserting before first measure, always preserve clefs and signatures
-                // at the begining of the score (move them back)
-                if (pm && !options.moveSignaturesClef && !isBeginning) {
-                    Segment* ps = pm->findSegment(SegmentType::Clef, tick);
-                    if (ps && ps->enabled()) {
-                        for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
-                            EngravingItem* pc = ps->element(staffIdx * VOICES);
-                            if (pc) {
-                                previousClefList.push_back(toClef(pc));
-                                undo(new RemoveElement(pc));
-                                if (ps->empty()) {
-                                    undoRemoveElement(ps);
-                                }
-                            }
-                        }
-                    }
-                }
-
-                if (options.moveSignaturesClef || isBeginning) {
-                    for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
-                        for (Segment* s = measureInsert->first(); s && s->rtick().isZero(); s = s->next()) {
-                            if (!s->enabled()) {
-                                continue;
-                            }
-                            EngravingItem* e = s->element(staffIdx * VOICES);
-                            // if it's a clef, we only add if it's a header clef
-                            bool moveClef = s->isHeaderClefType() && e && e->isClef() && !toClef(e)->forInstrumentChange();
-                            // otherwise, we only add if e exists and is generated
-                            bool moveOther = e && !e->isClef() && (!e->generated() || tick.isZero());
-                            bool specialCase = false;
-                            if (e && e->isClef() && !moveClef && isBeginning
-                                && toClef(e)->clefToBarlinePosition() != ClefToBarlinePosition::AFTER) {
-                                // special case:
-                                // there is a non-header clef at global tick 0, and we are inserting at the beginning of the score.
-                                // this clef will be moved with the measure it accompanies, but it will be moved before the barline.
-                                specialCase = true;
-                                moveClef = true;
-                            }
-                            if (!moveClef && !moveOther) {
-                                continue; // this item will remain with the old measure
-                            }
-                            // otherwise, this item is moved back to the new measure
-                            EngravingItem* ee = 0;
-                            if (e->isKeySig()) {
-                                KeySig* ks = toKeySig(e);
-                                if (ks->forInstrumentChange()) {
-                                    continue;
-                                }
-                                keySigList.push_back(ks);
-                                // if instrument change on that place, set correct key signature for instrument change
-                                bool ic = s->next(SegmentType::ChordRest)->findAnnotation(ElementType::INSTRUMENT_CHANGE,
-                                                                                          e->part()->startTrack(),
-                                                                                          e->part()->endTrack() - 1);
-                                if (ic) {
-                                    KeySigEvent ke = ks->keySigEvent();
-                                    ke.setForInstrumentChange(true);
-                                    undoChangeKeySig(ks->staff(), e->tick(), ke);
-                                } else {
-                                    ee = e;
-                                }
-                            } else if (e->isTimeSig()) {
-                                TimeSig* ts = toTimeSig(e);
-                                timeSigList.push_back(ts);
-                                ee = e;
-                            }
-                            if (specialCase) {
-                                specialCaseClefs.push_back(toClef(e));
-                                ee = e;
-                            } else if (tick.isZero() && e->isClef()) {
-                                Clef* clef = toClef(e);
-                                clefList.push_back(clef);
-                                ee = e;
-                            }
-                            if (ee) {
-                                undo(new RemoveElement(ee));
-                                if (s->empty()) {
-                                    undoRemoveElement(s);
-                                }
-                            }
-                        }
-                    }
-
-                    if (localMeasure && measureInsert->repeatStart()) {
-                        localMeasure->undoChangeProperty(Pid::REPEAT_START, true);
-                        measureInsert->undoChangeProperty(Pid::REPEAT_START, false);
-                    }
-                }
-            } else if (!measureInsert && tick == Fraction(0, 1)) {
-                // If inserting measure into an empty score, restore default C key signature
-                // and 4/4 time signature
-                score->restoreInitialKeySigAndTimeSig();
-            }
-
-            if (pm && !options.moveSignaturesClef) {
-                Segment* pbs = pm->findSegment(SegmentType::EndBarLine, tick);
-                if (pbs && pbs->enabled()) {
-                    for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
-                        EngravingItem* pb = pbs->element(staffIdx * VOICES);
-                        if (pb && !pb->generated()) {
-                            previousBarLinesList.push_back(toBarLine(pb));
-                            undo(new RemoveElement(pb));
-                            if (pbs->empty()) {
-                                pbs->setEnabled(false);
-                            }
-                        }
-                    }
-                }
-                if (localMeasure && pm->repeatEnd()) {
-                    localMeasure->undoChangeProperty(Pid::REPEAT_END, true);
-                    pm->undoChangeProperty(Pid::REPEAT_END, false);
-                }
-            }
-
-            //
-            // move clef, barline, time, key signatures
-            //
-            for (TimeSig* ts : timeSigList) {
-                TimeSig* nts = Factory::copyTimeSig(*ts);
-                Segment* s   = newMeasure->undoGetSegmentR(SegmentType::TimeSig, Fraction(0, 1));
-                nts->setParent(s);
-                undoAddElement(nts);
-            }
-            for (KeySig* ks : keySigList) {
-                KeySig* nks = Factory::copyKeySig(*ks);
-                Segment* s  = newMeasure->undoGetSegmentR(SegmentType::KeySig, Fraction(0, 1));
-                nks->setParent(s);
-                if (!nks->isAtonal()) {
-                    nks->setKey(nks->concertKey());  // to set correct (transposing) key
-                }
-                undoAddElement(nks);
-            }
-            for (Clef* clef : clefList) {
-                Clef* nClef = Factory::copyClef(*clef);
-                Segment* s  = newMeasure->undoGetSegmentR(SegmentType::HeaderClef, Fraction(0, 1));
-                nClef->setParent(s);
-                undoAddElement(nClef);
-            }
-            for (Clef* clef : previousClefList) {
-                Clef* nClef = Factory::copyClef(*clef);
-                Segment* s  = newMeasure->undoGetSegmentR(SegmentType::Clef, newMeasure->ticks());
-                nClef->setParent(s);
-                undoAddElement(nClef);
-            }
-            for (Clef* clef : specialCaseClefs) {
-                Clef* nClef = Factory::copyClef(*clef);
-                Segment* s  = newMeasure->undoGetSegmentR(SegmentType::Clef, newMeasure->ticks());
-                nClef->setParent(s);
-                undoAddElement(nClef);
-            }
-            for (BarLine* barLine : previousBarLinesList) {
-                BarLine* nBarLine = Factory::copyBarLine(*barLine);
-                Segment* s = newMeasure->undoGetSegmentR(SegmentType::EndBarLine, newMeasure->ticks());
-                nBarLine->setParent(s);
-                undoAddElement(nBarLine);
-            }
-        } else {
-            // a frame, not a measure
-            if (score->isMaster()) {
-                linkedMasterMeasure = newMeasureBase;
-            } else if (linkedMasterMeasure && newMeasureBase != linkedMasterMeasure) {
-                newMeasureBase->linkTo(linkedMasterMeasure);
-                if (linkedMasterMeasure->isTBox()) {
-                    toTBox(newMeasureBase)->text()->linkTo(toTBox(linkedMasterMeasure)->text());
-                }
-            }
-        }
-    }
-
-    undoInsertTime(tick, ticks);
-
-    if (localMeasure && !options.createEmptyMeasures) {
-        //
-        // fill measure with rest
-        //
-        Score* score = localMeasure->score();
-
-        // add rest to all staves and to all the staves linked to it
-        for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
-            size_t track = staffIdx * VOICES;
-            Rest* rest = Factory::createRest(score->dummy()->segment(), TDuration(DurationType::V_MEASURE));
-            Fraction timeStretch(score->staff(staffIdx)->timeStretch(localMeasure->tick()));
-            rest->setTicks(localMeasure->ticks() * timeStretch);
-            rest->setTrack(track);
-            score->undoAddCR(rest, localMeasure, tick);
-        }
-    }
+    undo(new InsertMeasures(newMeasureBase, newMeasureBase));
 
     if (options.needDeselectAll) {
         deselectAll();
     }
 
-    return result;
+    return newMeasureBase;
 }
 
 void Score::restoreInitialKeySigAndTimeSig()

--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -348,7 +348,7 @@ void Excerpt::createExcerpt(Excerpt* excerpt)
     MeasureBase* scoreMeasure = score->first();
 
     if ((!scoreMeasure || !scoreMeasure->isVBox()) && !masterMeasure->excludeFromOtherParts()) {
-        score->insertMeasure(ElementType::VBOX, scoreMeasure);
+        score->insertBox(ElementType::VBOX, scoreMeasure);
         scoreMeasure = score->first();
     }
 

--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -348,10 +348,7 @@ void Excerpt::createExcerpt(Excerpt* excerpt)
     MeasureBase* scoreMeasure = score->first();
 
     if ((!scoreMeasure || !scoreMeasure->isVBox()) && !masterMeasure->excludeFromOtherParts()) {
-        Score::InsertMeasureOptions options;
-        options.addToAllScores = false;
-
-        score->insertMeasure(ElementType::VBOX, scoreMeasure, options);
+        score->insertMeasure(ElementType::VBOX, scoreMeasure);
         scoreMeasure = score->first();
     }
 

--- a/src/engraving/dom/joinMeasure.cpp
+++ b/src/engraving/dom/joinMeasure.cpp
@@ -102,7 +102,7 @@ void MasterScore::joinMeasure(const Fraction& tick1, const Fraction& tick2)
     InsertMeasureOptions options;
     options.createEmptyMeasures = true;
     options.moveSignaturesClef = false;
-    insertMeasure(ElementType::MEASURE, next, options);
+    insertMeasure(next, options);
 
     for (Score* s : scoreList()) {
         Measure* sM1 = s->tick2measure(startTick);

--- a/src/engraving/dom/masterscore.cpp
+++ b/src/engraving/dom/masterscore.cpp
@@ -532,10 +532,6 @@ MeasureBase* MasterScore::insertMeasure(MeasureBase* beforeMeasure, const Insert
         MeasureBase* newMeasureBase = toMeasureBase(Factory::createMeasure(score->dummy()->system()));
         newMeasureBase->setTick(tick);
 
-        if (score == this) {
-            result = newMeasureBase;
-        }
-
         if (actualBeforeMeasure) {
             actualBeforeMeasure = actualBeforeMeasure->top(); // don't try to insert in front of nested frame
         }
@@ -560,6 +556,7 @@ MeasureBase* MasterScore::insertMeasure(MeasureBase* beforeMeasure, const Insert
         }
 
         if (score->isMaster()) {
+            result = newMeasureBase;
             masterMeasure = newMeasure;
         }
 

--- a/src/engraving/dom/masterscore.h
+++ b/src/engraving/dom/masterscore.h
@@ -224,6 +224,8 @@ public:
     void splitMeasure(const Fraction&);
     void joinMeasure(const Fraction&, const Fraction&);
 
+    MeasureBase* insertMeasure(MeasureBase* beforeMeasure = nullptr, const InsertMeasureOptions& options = InsertMeasureOptions());
+
     IFileInfoProviderPtr fileInfo() const;
     void setFileInfoProvider(IFileInfoProviderPtr fileInfoProvider);
 

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -1654,16 +1654,16 @@ EngravingItem* Measure::drop(EditData& data)
     case ElementType::ACTION_ICON:
         switch (toActionIcon(e)->actionType()) {
         case ActionIconType::VFRAME:
-            score()->insertMeasure(ElementType::VBOX, this);
+            score()->insertBox(ElementType::VBOX, this);
             break;
         case ActionIconType::HFRAME:
-            score()->insertMeasure(ElementType::HBOX, this);
+            score()->insertBox(ElementType::HBOX, this);
             break;
         case ActionIconType::TFRAME:
-            score()->insertMeasure(ElementType::TBOX, this);
+            score()->insertBox(ElementType::TBOX, this);
             break;
         case ActionIconType::FFRAME:
-            score()->insertMeasure(ElementType::FBOX, this);
+            score()->insertBox(ElementType::FBOX, this);
             break;
         case ActionIconType::MEASURE:
             score()->insertMeasure(ElementType::MEASURE, this);

--- a/src/engraving/dom/measurebase.cpp
+++ b/src/engraving/dom/measurebase.cpp
@@ -299,6 +299,30 @@ MeasureBase* MeasureBase::top() const
 }
 
 //---------------------------------------------------------
+//   getInScore
+//---------------------------------------------------------
+
+MeasureBase* MeasureBase::getInScore(Score* score, bool useNextMeasureFallback) const
+{
+    MeasureBase* newMB = nullptr;
+    if (!isMeasure() && !excludeFromOtherParts()) {
+        for (auto e : linkList()) {
+            if (e->score() == score) {
+                newMB = toMeasureBase(e);
+                break;
+            }
+        }
+    }
+    if (isMeasure() || (!newMB && useNextMeasureFallback)) {
+        newMB = score->tick2measure(tick());
+    }
+    if (!newMB) {
+        LOGD("measure base not found in score");
+    }
+    return newMB;
+}
+
+//---------------------------------------------------------
 //   tick
 //---------------------------------------------------------
 

--- a/src/engraving/dom/measurebase.h
+++ b/src/engraving/dom/measurebase.h
@@ -96,6 +96,8 @@ public:
     void setPrev(MeasureBase* e) { m_prev = e; }
     MeasureBase* top() const;
 
+    MeasureBase* getInScore(Score* score, bool useNextMeasureFallback = false) const;
+
     Measure* nextMeasure() const;
     Measure* prevMeasure() const;
     Measure* nextMeasureMM() const;

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -462,7 +462,7 @@ public:
     NoteVal noteValForPosition(Position pos, AccidentalType at, bool& error);
 
     Slur* addSlur(ChordRest* firstChordRest, ChordRest* secondChordRest, const Slur* slurTemplate);
-    TextBase* addText(TextStyleType type, EngravingItem* destinationElement = nullptr, bool addToAllScores = true);
+    TextBase* addText(TextStyleType type, EngravingItem* destinationElement = nullptr);
 
     void deleteItem(EngravingItem*);
     void deleteMeasures(MeasureBase* firstMeasure, MeasureBase* lastMeasure, bool preserveTies = false);
@@ -826,11 +826,12 @@ public:
         bool createEmptyMeasures = false;
         bool moveSignaturesClef = true;
         bool needDeselectAll = true;
-        bool addToAllScores = true;
     };
 
     MeasureBase* insertMeasure(ElementType type, MeasureBase* beforeMeasure = nullptr,
                                const InsertMeasureOptions& options = InsertMeasureOptions());
+    MeasureBase* insertBox(ElementType type, MeasureBase* beforeMeasure = nullptr,
+                           const InsertMeasureOptions& options = InsertMeasureOptions());
 
     Audio* audio() const { return m_audio; }
     void setAudio(Audio* a) { m_audio = a; }

--- a/src/engraving/dom/splitMeasure.cpp
+++ b/src/engraving/dom/splitMeasure.cpp
@@ -115,9 +115,9 @@ void MasterScore::splitMeasure(const Fraction& tick)
     options.createEmptyMeasures = true;
     options.moveSignaturesClef = false;
 
-    insertMeasure(ElementType::MEASURE, nm, options);
+    insertMeasure(nm, options);
     Measure* m2 = toMeasure(nm ? nm->prev() : lastMeasure());
-    insertMeasure(ElementType::MEASURE, m2, options);
+    insertMeasure(m2, options);
     Measure* m1 = toMeasure(m2->prev());
 
     for (Score* s : scoreList()) {

--- a/src/engraving/tests/links_tests.cpp
+++ b/src/engraving/tests/links_tests.cpp
@@ -51,7 +51,7 @@ static void addTitleText(Score* score, const String& title)
 {
     MeasureBase* measure = score->first();
     if (!measure->isVBox()) {
-        score->insertMeasure(ElementType::VBOX, measure);
+        score->insertBox(ElementType::VBOX, measure);
         measure = score->first();
     }
 

--- a/src/engraving/tests/measure_tests.cpp
+++ b/src/engraving/tests/measure_tests.cpp
@@ -49,7 +49,7 @@ TEST_F(Engraving_MeasureTests, DISABLED_insertMeasureMiddle) //TODO: verify prog
 
     score->startCmd();
     Measure* m = score->firstMeasure()->nextMeasure();
-    score->insertMeasure(ElementType::MEASURE, m);
+    score->insertMeasure(m);
     score->endCmd();
 
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measure-1.mscx", MEASURE_DATA_DIR + u"measure-1-ref.mscx"));
@@ -63,7 +63,7 @@ TEST_F(Engraving_MeasureTests, DISABLED_insertMeasureBegin) // TODO: verify prog
 
     score->startCmd();
     Measure* m = score->firstMeasure();
-    score->insertMeasure(ElementType::MEASURE, m);
+    score->insertMeasure(m);
     score->endCmd();
 
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measure-2.mscx", MEASURE_DATA_DIR + u"measure-2-ref.mscx"));
@@ -76,7 +76,7 @@ TEST_F(Engraving_MeasureTests, DISABLED_insertMeasureEnd) // TODO: verify progra
     EXPECT_TRUE(score);
 
     score->startCmd();
-    score->insertMeasure(ElementType::MEASURE, 0);
+    score->insertMeasure(0);
     score->endCmd();
 
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measure-3.mscx", MEASURE_DATA_DIR + u"measure-3-ref.mscx"));
@@ -89,7 +89,7 @@ TEST_F(Engraving_MeasureTests, insertAtBeginning)
     EXPECT_TRUE(score);
     Measure* m = score->firstMeasure();
     score->startCmd();
-    score->insertMeasure(ElementType::MEASURE, m);
+    score->insertMeasure(m);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measure-insert_beginning.mscx",
                                             MEASURE_DATA_DIR + u"measure-insert_beginning-ref.mscx"));
@@ -105,7 +105,7 @@ TEST_F(Engraving_MeasureTests, insertBfClefChange)
     Measure* m = score->firstMeasure()->nextMeasure();
     m = m->nextMeasure()->nextMeasure();
     score->startCmd();
-    score->insertMeasure(ElementType::MEASURE, m);
+    score->insertMeasure(m);
     score->endCmd();
 
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measure-insert_bf_clef.mscx", MEASURE_DATA_DIR + u"measure-insert_bf_clef-ref.mscx"));
@@ -116,7 +116,7 @@ TEST_F(Engraving_MeasureTests, insertBfClefChange)
 
     m = score->firstMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure();
     score->startCmd();
-    score->insertMeasure(ElementType::MEASURE, m);
+    score->insertMeasure(m);
     score->endCmd();
 
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measure-insert_bf_clef-2.mscx",
@@ -137,7 +137,7 @@ TEST_F(Engraving_MeasureTests, insertBfKeyChange)
     Measure* m = score->firstMeasure()->nextMeasure();
     m = m->nextMeasure()->nextMeasure();
     score->startCmd();
-    score->insertMeasure(ElementType::MEASURE, m);
+    score->insertMeasure(m);
     score->endCmd();
 
     EXPECT_TRUE(score->checkKeys());
@@ -151,7 +151,7 @@ TEST_F(Engraving_MeasureTests, insertBfKeyChange)
 
     m = score->firstMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure();
     score->startCmd();
-    score->insertMeasure(ElementType::MEASURE, m);
+    score->insertMeasure(m);
     score->endCmd();
     EXPECT_TRUE(score->checkKeys());
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measure-insert_bf_key-2.mscx",
@@ -180,7 +180,7 @@ TEST_F(Engraving_MeasureTests, spanner_a)
 
     Measure* m = score->firstMeasure()->nextMeasure();
     score->startCmd();
-    score->insertMeasure(ElementType::MEASURE, m);
+    score->insertMeasure(m);
     score->endCmd();
 
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measure-4.mscx", MEASURE_DATA_DIR + u"measure-4-ref.mscx"));
@@ -202,7 +202,7 @@ TEST_F(Engraving_MeasureTests, spanner_b)
 
     Measure* m = score->firstMeasure();
     score->startCmd();
-    score->insertMeasure(ElementType::MEASURE, m);
+    score->insertMeasure(m);
     score->endCmd();
 
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measure-5.mscx", MEASURE_DATA_DIR + u"measure-5-ref.mscx"));

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -239,7 +239,7 @@ TEST_F(Engraving_PartsTests, appendMeasure)
     createParts(score);
 
     score->startCmd();
-    score->insertMeasure(ElementType::MEASURE, 0);
+    score->insertMeasure(0);
     score->endCmd();
 
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"part-all-appendmeasures.mscx", PARTS_DATA_DIR + u"part-all-appendmeasures.mscx"));
@@ -263,7 +263,7 @@ TEST_F(Engraving_PartsTests, insertMeasure)
 
     score->startCmd();
     Measure* m = score->firstMeasure();
-    score->insertMeasure(ElementType::MEASURE, m);
+    score->insertMeasure(m);
     score->endCmd();
 
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"part-all-insertmeasures.mscx", PARTS_DATA_DIR + u"part-all-insertmeasures.mscx"));

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2144,16 +2144,16 @@ bool NotationInteraction::dropCanvas(EngravingItem* e)
     if (e->isActionIcon()) {
         switch (mu::engraving::toActionIcon(e)->actionType()) {
         case mu::engraving::ActionIconType::VFRAME:
-            score()->insertMeasure(ElementType::VBOX);
+            score()->insertBox(ElementType::VBOX);
             break;
         case mu::engraving::ActionIconType::HFRAME:
-            score()->insertMeasure(ElementType::HBOX);
+            score()->insertBox(ElementType::HBOX);
             break;
         case mu::engraving::ActionIconType::TFRAME:
-            score()->insertMeasure(ElementType::TBOX);
+            score()->insertBox(ElementType::TBOX);
             break;
         case mu::engraving::ActionIconType::FFRAME:
-            score()->insertMeasure(ElementType::FBOX);
+            score()->insertBox(ElementType::FBOX);
             break;
         case mu::engraving::ActionIconType::MEASURE:
             score()->insertMeasure(ElementType::MEASURE);

--- a/src/plugins/api/score.cpp
+++ b/src/plugins/api/score.cpp
@@ -59,7 +59,7 @@ void Score::addText(const QString& type, const QString& txt)
 {
     MeasureBase* measure = score()->first();
     if (!measure || !measure->isVBox()) {
-        score()->insertMeasure(ElementType::VBOX, measure);
+        score()->insertBox(ElementType::VBOX, measure);
         measure = score()->first();
     }
     mu::engraving::TextStyleType tid = mu::engraving::TextStyleType::DEFAULT;


### PR DESCRIPTION
Resolves: #19373
Resolves: #19587
Resolves partialy (second issue) of #19476

<!-- Add a short description of and motivation for the changes here -->
~~undoInsertTime "acts on the linked scores as well", but only in score, there are all elements to be linked~~
inserting Measures always acts in `masterScore` and adds measures to all scores
inserting Frames acts in local score


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
