### PR TITLE
Fix #19338: Tooltip added to mixer to view full mixer track names

### DIFF
--- a/src/playback/qml/MuseScore/Playback/internal/MixerTitleSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerTitleSection.qml
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
 import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
@@ -62,6 +63,21 @@ MixerPanelSection {
         color: Utils.colorWithAlpha(labelColor, resolveLabelColorOpacity())
         border.color: labelColor
         border.width: 1
+
+        MouseArea{
+            id: mouseArea
+            anchors.fill: parent
+
+            hoverEnabled: true
+
+            onContainsMouseChanged: {
+                if (mouseArea.containsMouse) {
+                    ui.tooltip.show(root, channelItem.title, "", "")
+                } else {
+                    ui.tooltip.hide(root)
+                }
+            }
+        }
 
         StyledTextLabel {
             anchors.centerIn: parent

--- a/src/playback/qml/MuseScore/Playback/internal/MixerTitleSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerTitleSection.qml
@@ -20,7 +20,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import QtQuick 2.15
-import QtQuick.Layouts 1.15
 
 import MuseScore.Ui 1.0
 import MuseScore.UiComponents 1.0
@@ -64,20 +63,6 @@ MixerPanelSection {
         border.color: labelColor
         border.width: 1
 
-        MouseArea{
-            id: mouseArea
-            anchors.fill: parent
-
-            hoverEnabled: true
-
-            onContainsMouseChanged: {
-                if (mouseArea.containsMouse) {
-                    ui.tooltip.show(root, channelItem.title, "", "")
-                } else {
-                    ui.tooltip.hide(root)
-                }
-            }
-        }
 
         StyledTextLabel {
             anchors.centerIn: parent
@@ -88,6 +73,21 @@ MixerPanelSection {
             width: margin + parent.width + margin
 
             text: channelItem.title
+        }
+
+        MouseArea {
+            id: mouseArea
+            anchors.fill: parent
+
+            hoverEnabled: true
+
+            onContainsMouseChanged: {
+                if (mouseArea.containsMouse) {
+                    ui.tooltip.show(root, channelItem.title)
+                } else {
+                    ui.tooltip.hide(root)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves: #19338 

This change creates a tooltip that displays the full track name when the user hovers over the mixer title section. This allows users to view the full names of truncated tracks.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
