### PR TITLE
fix #18149 - insert measure after selection (don't move keysig, timesig and clef)

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -4082,7 +4082,9 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
             // remove clef, barlines, time and key signatures
             //
             if (measureInsert) {
-                if (pm && !options.moveSignaturesClef) {
+                // if inserting before first measure, always preserve clefs and signatures
+                // at the begining of the score (move them back)
+                if (pm && !options.moveSignaturesClef && !isBeginning) {
                     Segment* ps = pm->findSegment(SegmentType::Clef, tick);
                     if (ps && ps->enabled()) {
                         for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
@@ -4098,7 +4100,7 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
                     }
                 }
 
-                if (options.moveSignaturesClef) {
+                if (options.moveSignaturesClef || isBeginning) {
                     for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
                         for (Segment* s = measureInsert->first(); s && s->rtick().isZero(); s = s->next()) {
                             if (!s->enabled()) {

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -4080,11 +4080,11 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
             // remove clef, barlines, time and key signatures
             //
             if (measureInsert) {
-                for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
-                    Measure* pm = newMeasure->prevMeasure();
-                    if (pm && !options.moveSignaturesClef) {
-                        Segment* ps = pm->findSegment(SegmentType::Clef, tick);
-                        if (ps && ps->enabled()) {
+                Measure* pm = newMeasure->prevMeasure();
+                if (pm && !options.moveSignaturesClef) {
+                    Segment* ps = pm->findSegment(SegmentType::Clef, tick);
+                    if (ps && ps->enabled()) {
+                        for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
                             EngravingItem* pc = ps->element(staffIdx * VOICES);
                             if (pc) {
                                 previousClefList.push_back(toClef(pc));
@@ -4094,8 +4094,10 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
                                 }
                             }
                         }
-                        Segment* pbs = pm->findSegment(SegmentType::EndBarLine, tick);
-                        if (pbs && pbs->enabled()) {
+                    }
+                    Segment* pbs = pm->findSegment(SegmentType::EndBarLine, tick);
+                    if (pbs && pbs->enabled()) {
+                        for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
                             EngravingItem* pb = pbs->element(staffIdx * VOICES);
                             if (pb && !pb->generated()) {
                                 previousBarLinesList.push_back(toBarLine(pb));
@@ -4106,7 +4108,9 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
                             }
                         }
                     }
-                    if (options.moveSignaturesClef) {
+                }
+                if (options.moveSignaturesClef) {
+                    for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
                         for (Segment* s = measureInsert->first(); s && s->rtick().isZero(); s = s->next()) {
                             if (!s->enabled()) {
                                 continue;
@@ -4167,15 +4171,15 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
                                 }
                             }
                         }
-                        if (measureInsert->repeatStart()) {
-                            localMeasure->undoChangeProperty(Pid::REPEAT_START, true);
-                            measureInsert->undoChangeProperty(Pid::REPEAT_START, false);
-                        }
-                    } else {
-                        if (pm->repeatEnd()) {
-                            localMeasure->undoChangeProperty(Pid::REPEAT_END, true);
-                            pm->undoChangeProperty(Pid::REPEAT_END, false);
-                        }
+                    }
+                    if (measureInsert->repeatStart()) {
+                        localMeasure->undoChangeProperty(Pid::REPEAT_START, true);
+                        measureInsert->undoChangeProperty(Pid::REPEAT_START, false);
+                    }
+                } else {
+                    if (pm && pm->repeatEnd()) {
+                        localMeasure->undoChangeProperty(Pid::REPEAT_END, true);
+                        pm->undoChangeProperty(Pid::REPEAT_END, false);
                     }
                 }
             } else if (!measureInsert && tick == Fraction(0, 1)) {

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -4167,6 +4167,15 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
                                 }
                             }
                         }
+                        if (measureInsert->repeatStart()) {
+                            localMeasure->undoChangeProperty(Pid::REPEAT_START, true);
+                            measureInsert->undoChangeProperty(Pid::REPEAT_START, false);
+                        }
+                    } else {
+                        if (pm->repeatEnd()) {
+                            localMeasure->undoChangeProperty(Pid::REPEAT_END, true);
+                            pm->undoChangeProperty(Pid::REPEAT_END, false);
+                        }
                     }
                 }
             } else if (!measureInsert && tick == Fraction(0, 1)) {

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -4109,7 +4109,7 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
                         }
                     }
 
-                    if (pm->repeatEnd()) {
+                    if (localMeasure && pm->repeatEnd()) {
                         localMeasure->undoChangeProperty(Pid::REPEAT_END, true);
                         pm->undoChangeProperty(Pid::REPEAT_END, false);
                     }
@@ -4179,7 +4179,7 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
                         }
                     }
 
-                    if (measureInsert->repeatStart()) {
+                    if (localMeasure && measureInsert->repeatStart()) {
                         localMeasure->undoChangeProperty(Pid::REPEAT_START, true);
                         measureInsert->undoChangeProperty(Pid::REPEAT_START, false);
                     }

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -4082,11 +4082,11 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
             if (measureInsert) {
                 for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
                     Measure* pm = newMeasure->prevMeasure();
-                    if (pm) {
+                    if (pm && !options.moveSignaturesClef) {
                         Segment* ps = pm->findSegment(SegmentType::Clef, tick);
                         if (ps && ps->enabled()) {
                             EngravingItem* pc = ps->element(staffIdx * VOICES);
-                            if (pc && !options.moveSignaturesClef) {
+                            if (pc) {
                                 previousClefList.push_back(toClef(pc));
                                 undo(new RemoveElement(pc));
                                 if (ps->empty()) {
@@ -4097,7 +4097,7 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
                         Segment* pbs = pm->findSegment(SegmentType::EndBarLine, tick);
                         if (pbs && pbs->enabled()) {
                             EngravingItem* pb = pbs->element(staffIdx * VOICES);
-                            if (pb && !pb->generated() && !options.moveSignaturesClef) {
+                            if (pb && !pb->generated()) {
                                 previousBarLinesList.push_back(toBarLine(pb));
                                 undo(new RemoveElement(pb));
                                 if (pbs->empty()) {
@@ -4208,10 +4208,9 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
                 nClef->setParent(s);
                 undoAddElement(nClef);
             }
-            Measure* pm = newMeasure;
             for (Clef* clef : previousClefList) {
                 Clef* nClef = Factory::copyClef(*clef);
-                Segment* s  = pm->undoGetSegmentR(SegmentType::Clef, pm->ticks());
+                Segment* s  = newMeasure->undoGetSegmentR(SegmentType::Clef, newMeasure->ticks());
                 nClef->setParent(s);
                 undoAddElement(nClef);
             }
@@ -4223,7 +4222,7 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
             }
             for (BarLine* barLine : previousBarLinesList) {
                 BarLine* nBarLine = Factory::copyBarLine(*barLine);
-                Segment* s = pm->undoGetSegmentR(SegmentType::EndBarLine, pm->ticks());
+                Segment* s = newMeasure->undoGetSegmentR(SegmentType::EndBarLine, newMeasure->ticks());
                 nBarLine->setParent(s);
                 undoAddElement(nBarLine);
             }

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -4108,7 +4108,13 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
                             }
                         }
                     }
+
+                    if (pm->repeatEnd()) {
+                        localMeasure->undoChangeProperty(Pid::REPEAT_END, true);
+                        pm->undoChangeProperty(Pid::REPEAT_END, false);
+                    }
                 }
+
                 if (options.moveSignaturesClef) {
                     for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
                         for (Segment* s = measureInsert->first(); s && s->rtick().isZero(); s = s->next()) {
@@ -4172,14 +4178,10 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
                             }
                         }
                     }
+
                     if (measureInsert->repeatStart()) {
                         localMeasure->undoChangeProperty(Pid::REPEAT_START, true);
                         measureInsert->undoChangeProperty(Pid::REPEAT_START, false);
-                    }
-                } else {
-                    if (pm && pm->repeatEnd()) {
-                        localMeasure->undoChangeProperty(Pid::REPEAT_END, true);
-                        pm->undoChangeProperty(Pid::REPEAT_END, false);
                     }
                 }
             } else if (!measureInsert && tick == Fraction(0, 1)) {

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -4126,7 +4126,8 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
                                 keySigList.push_back(ks);
                                 // if instrument change on that place, set correct key signature for instrument change
                                 bool ic = s->next(SegmentType::ChordRest)->findAnnotation(ElementType::INSTRUMENT_CHANGE,
-                                                                                          e->part()->startTrack(), e->part()->endTrack() - 1);
+                                                                                          e->part()->startTrack(),
+                                                                                          e->part()->endTrack() - 1);
                                 if (ic) {
                                     KeySigEvent ke = ks->keySigEvent();
                                     ke.setForInstrumentChange(true);

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -4078,14 +4078,14 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
             //
             // remove clef, time and key signatures
             //
-            if (options.moveSignaturesClef && measureInsert) {
+            if (measureInsert) {
                 for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
-                    Measure* pm = measureInsert->prevMeasure();
+                    Measure* pm = newMeasure->prevMeasure();
                     if (pm) {
                         Segment* ps = pm->findSegment(SegmentType::Clef, tick);
                         if (ps && ps->enabled()) {
                             EngravingItem* pc = ps->element(staffIdx * VOICES);
-                            if (pc) {
+                            if (pc && !options.moveSignaturesClef) {
                                 previousClefList.push_back(toClef(pc));
                                 undo(new RemoveElement(pc));
                                 if (ps->empty()) {
@@ -4094,62 +4094,64 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
                             }
                         }
                     }
-                    for (Segment* s = measureInsert->first(); s && s->rtick().isZero(); s = s->next()) {
-                        if (!s->enabled()) {
-                            continue;
-                        }
-                        EngravingItem* e = s->element(staffIdx * VOICES);
-                        // if it's a clef, we only add if it's a header clef
-                        bool moveClef = s->isHeaderClefType() && e && e->isClef();
-                        // otherwise, we only add if e exists and is generated
-                        bool moveOther = e && !e->isClef() && (!e->generated() || tick.isZero());
-                        bool specialCase = false;
-                        if (e && e->isClef() && !moveClef && isBeginning
-                            && toClef(e)->clefToBarlinePosition() != ClefToBarlinePosition::AFTER) {
-                            // special case:
-                            // there is a non-header clef at global tick 0, and we are inserting at the beginning of the score.
-                            // this clef will be moved with the measure it accompanies, but it will be moved before the barline.
-                            specialCase = true;
-                            moveClef = true;
-                        }
-                        if (!moveClef && !moveOther) {
-                            continue; // this item will remain with the old measure
-                        }
-                        // otherwise, this item is moved back to the new measure
-                        EngravingItem* ee = 0;
-                        if (e->isKeySig()) {
-                            KeySig* ks = toKeySig(e);
-                            if (ks->forInstrumentChange()) {
+                    if (options.moveSignaturesClef) {
+                        for (Segment* s = measureInsert->first(); s && s->rtick().isZero(); s = s->next()) {
+                            if (!s->enabled()) {
                                 continue;
                             }
-                            keySigList.push_back(ks);
-                            // if instrument change on that place, set correct key signature for instrument change
-                            bool ic = s->next(SegmentType::ChordRest)->findAnnotation(ElementType::INSTRUMENT_CHANGE,
-                                                                                      e->part()->startTrack(), e->part()->endTrack() - 1);
-                            if (ic) {
-                                KeySigEvent ke = ks->keySigEvent();
-                                ke.setForInstrumentChange(true);
-                                undoChangeKeySig(ks->staff(), e->tick(), ke);
-                            } else {
+                            EngravingItem* e = s->element(staffIdx * VOICES);
+                            // if it's a clef, we only add if it's a header clef
+                            bool moveClef = s->isHeaderClefType() && e && e->isClef() && !toClef(e)->forInstrumentChange();
+                            // otherwise, we only add if e exists and is generated
+                            bool moveOther = e && !e->isClef() && (!e->generated() || tick.isZero());
+                            bool specialCase = false;
+                            if (e && e->isClef() && !moveClef && isBeginning
+                                && toClef(e)->clefToBarlinePosition() != ClefToBarlinePosition::AFTER) {
+                                // special case:
+                                // there is a non-header clef at global tick 0, and we are inserting at the beginning of the score.
+                                // this clef will be moved with the measure it accompanies, but it will be moved before the barline.
+                                specialCase = true;
+                                moveClef = true;
+                            }
+                            if (!moveClef && !moveOther) {
+                                continue; // this item will remain with the old measure
+                            }
+                            // otherwise, this item is moved back to the new measure
+                            EngravingItem* ee = 0;
+                            if (e->isKeySig()) {
+                                KeySig* ks = toKeySig(e);
+                                if (ks->forInstrumentChange()) {
+                                    continue;
+                                }
+                                keySigList.push_back(ks);
+                                // if instrument change on that place, set correct key signature for instrument change
+                                bool ic = s->next(SegmentType::ChordRest)->findAnnotation(ElementType::INSTRUMENT_CHANGE,
+                                                                                          e->part()->startTrack(), e->part()->endTrack() - 1);
+                                if (ic) {
+                                    KeySigEvent ke = ks->keySigEvent();
+                                    ke.setForInstrumentChange(true);
+                                    undoChangeKeySig(ks->staff(), e->tick(), ke);
+                                } else {
+                                    ee = e;
+                                }
+                            } else if (e->isTimeSig()) {
+                                TimeSig* ts = toTimeSig(e);
+                                timeSigList.push_back(ts);
                                 ee = e;
                             }
-                        } else if (e->isTimeSig()) {
-                            TimeSig* ts = toTimeSig(e);
-                            timeSigList.push_back(ts);
-                            ee = e;
-                        }
-                        if (specialCase) {
-                            specialCaseClefs.push_back(toClef(e));
-                            ee = e;
-                        } else if (tick.isZero() && e->isClef()) {
-                            Clef* clef = toClef(e);
-                            clefList.push_back(clef);
-                            ee = e;
-                        }
-                        if (ee) {
-                            undo(new RemoveElement(ee));
-                            if (s->empty()) {
-                                undoRemoveElement(s);
+                            if (specialCase) {
+                                specialCaseClefs.push_back(toClef(e));
+                                ee = e;
+                            } else if (tick.isZero() && e->isClef()) {
+                                Clef* clef = toClef(e);
+                                clefList.push_back(clef);
+                                ee = e;
+                            }
+                            if (ee) {
+                                undo(new RemoveElement(ee));
+                                if (s->empty()) {
+                                    undoRemoveElement(s);
+                                }
                             }
                         }
                     }
@@ -4184,10 +4186,10 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
                 nClef->setParent(s);
                 undoAddElement(nClef);
             }
-            Measure* pm = newMeasure->prevMeasure();
+            Measure* pm = newMeasure;
             for (Clef* clef : previousClefList) {
                 Clef* nClef = Factory::copyClef(*clef);
-                Segment* s  = pm->undoGetSegment(SegmentType::Clef, tick);
+                Segment* s  = pm->undoGetSegmentR(SegmentType::Clef, pm->ticks());
                 nClef->setParent(s);
                 undoAddElement(nClef);
             }

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -160,7 +160,7 @@ public:
 
     virtual Ret canAddBoxes() const = 0;
     virtual void addBoxes(BoxType boxType, int count, AddBoxesTarget target) = 0;
-    virtual void addBoxes(BoxType boxType, int count, int beforeBoxIndex) = 0;
+    virtual void addBoxes(BoxType boxType, int count, int beforeBoxIndex, bool insertAfter) = 0;
 
     virtual void copySelection() = 0;
     virtual mu::Ret repeatSelection() = 0;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3398,10 +3398,10 @@ void NotationInteraction::addBoxes(BoxType boxType, int count, AddBoxesTarget ta
         break;
     }
 
-    addBoxes(boxType, count, beforeBoxIndex);
+    addBoxes(boxType, count, beforeBoxIndex, target == AddBoxesTarget::AfterSelection);
 }
 
-void NotationInteraction::addBoxes(BoxType boxType, int count, int beforeBoxIndex)
+void NotationInteraction::addBoxes(BoxType boxType, int count, int beforeBoxIndex, bool insertAfter)
 {
     if (count < 1) {
         return;
@@ -3430,7 +3430,7 @@ void NotationInteraction::addBoxes(BoxType boxType, int count, int beforeBoxInde
 
     mu::engraving::Score::InsertMeasureOptions options;
     options.createEmptyMeasures = false;
-    options.moveSignaturesClef = true;
+    options.moveSignaturesClef = !insertAfter;
     options.needDeselectAll = false;
 
     for (int i = 0; i < count; ++i) {

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3398,10 +3398,10 @@ void NotationInteraction::addBoxes(BoxType boxType, int count, AddBoxesTarget ta
         break;
     }
 
-    addBoxes(boxType, count, beforeBoxIndex, target == AddBoxesTarget::AfterSelection);
+    addBoxes(boxType, count, beforeBoxIndex, target != AddBoxesTarget::AfterSelection);
 }
 
-void NotationInteraction::addBoxes(BoxType boxType, int count, int beforeBoxIndex, bool insertAfter)
+void NotationInteraction::addBoxes(BoxType boxType, int count, int beforeBoxIndex, bool moveSignaturesClef)
 {
     if (count < 1) {
         return;
@@ -3430,7 +3430,7 @@ void NotationInteraction::addBoxes(BoxType boxType, int count, int beforeBoxInde
 
     mu::engraving::Score::InsertMeasureOptions options;
     options.createEmptyMeasures = false;
-    options.moveSignaturesClef = !insertAfter;
+    options.moveSignaturesClef = moveSignaturesClef;
     options.needDeselectAll = false;
 
     for (int i = 0; i < count; ++i) {

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -168,7 +168,7 @@ public:
 
     Ret canAddBoxes() const override;
     void addBoxes(BoxType boxType, int count, AddBoxesTarget target) override;
-    void addBoxes(BoxType boxType, int count, int beforeBoxIndex) override;
+    void addBoxes(BoxType boxType, int count, int beforeBoxIndex, bool insertAfter = false) override;
 
     void copySelection() override;
     void copyLyrics() override;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -168,7 +168,7 @@ public:
 
     Ret canAddBoxes() const override;
     void addBoxes(BoxType boxType, int count, AddBoxesTarget target) override;
-    void addBoxes(BoxType boxType, int count, int beforeBoxIndex, bool insertAfter = false) override;
+    void addBoxes(BoxType boxType, int count, int beforeBoxIndex, bool moveSignaturesClef = true) override;
 
     void copySelection() override;
     void copyLyrics() override;


### PR DESCRIPTION
Resolves: #18149 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Insert after selection now behaves differently, comparing to insert before
It doesn't move clefs, key and time signatures

`InsertMeasureOptions` already have `moveSignaturesClef` property, but code for Clefs were broken, it is fixed now.

(~~It doesn't handle barlines, as they are inconsitent also in "insert measure before selection" - "standard" barlines behave differently, than repeat barlines.~~)

Also barlines are correctly moved now.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)


https://github.com/musescore/MuseScore/assets/1646034/786b297c-4570-4c37-b914-75e923abdff6


