### PR TITLE
fix #17350 - check trailing measures in master score

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -4030,9 +4030,10 @@ void Score::addRemoveBreaks(int interval, bool lock)
 
 void Score::cmdRemoveEmptyTrailingMeasures()
 {
-    auto beginMeasure = firstTrailingMeasure();
+    Score* mScore = masterScore();
+    auto beginMeasure = mScore->firstTrailingMeasure();
     if (beginMeasure) {
-        deleteMeasures(beginMeasure, lastMeasure());
+        mScore->deleteMeasures(beginMeasure, mScore->lastMeasure());
     }
 }
 


### PR DESCRIPTION
Resolves: #17350 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
trailing measures may differ per part, so it is important, to check them in score

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
