### PR TITLE
Professional pitch range for accordion updated to C1 - C#8

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -3450,7 +3450,7 @@
                   <barlineSpan>2</barlineSpan>
                   <clef staff="2">F</clef>
                   <aPitchRange>36-93</aPitchRange>
-                  <pPitchRange>12-97</pPitchRange>
+                  <pPitchRange>28-97</pPitchRange>
                   <Channel>
                         <!--MIDI: Bank 0, Prog 21; MS General: Accordion-->
                         <program value="21"/> <!--Accordion-->

--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -3450,7 +3450,7 @@
                   <barlineSpan>2</barlineSpan>
                   <clef staff="2">F</clef>
                   <aPitchRange>36-93</aPitchRange>
-                  <pPitchRange>36-93</pPitchRange>
+                  <pPitchRange>12-97</pPitchRange>
                   <Channel>
                         <!--MIDI: Bank 0, Prog 21; MS General: Accordion-->
                         <program value="21"/> <!--Accordion-->


### PR DESCRIPTION
Musescore seemed to be telling me the notes I was using were out of range for my instrument, to my surprise! I hope this will correct that inaccuracy 

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
