### PR TITLE
Fix #13324: remove shortcut sequences

### DIFF
--- a/src/framework/shortcuts/data/shortcuts-Mac.xml
+++ b/src/framework/shortcuts/data/shortcuts-Mac.xml
@@ -520,14 +520,6 @@
     <seq>Shift+.</seq>
     </SC>
   <SC>
-    <key>add-8va</key>
-    <seq>Ctrl+Y,Ctrl+O,Ctrl+A</seq>
-    </SC>
-  <SC>
-    <key>add-8vb</key>
-    <seq>Ctrl+Y,Ctrl+O,Ctrl+B</seq>
-    </SC>
-  <SC>
     <key>notation-escape</key>
     <seq>Esc</seq>
     </SC>
@@ -755,14 +747,6 @@
     <seq>Ctrl+A</seq>
     </SC>
   <SC>
-    <key>clef-violin</key>
-    <seq>Ctrl+Y,Ctrl+1</seq>
-    </SC>
-  <SC>
-    <key>clef-bass</key>
-    <seq>Ctrl+Y,Ctrl+2</seq>
-    </SC>
-  <SC>
     <key>system-break</key>
     <seq>Return</seq>
     </SC>
@@ -782,22 +766,6 @@
   <SC>
     <key>show-keys</key>
     <seq>Shift+F2</seq>
-    </SC>
-  <SC>
-    <key>rest-1</key>
-    <seq>Shift+R, Shift+S</seq>
-    </SC>
-  <SC>
-    <key>rest-2</key>
-    <seq>Shift+R, Shift+M</seq>
-    </SC>
-  <SC>
-    <key>rest-4</key>
-    <seq>Shift+R, Shift+R</seq>
-    </SC>
-  <SC>
-    <key>rest-8</key>
-    <seq>Shift+R, Shift+Q</seq>
     </SC>
   <SC>
     <key>backspace</key>

--- a/src/framework/shortcuts/data/shortcuts.xml
+++ b/src/framework/shortcuts/data/shortcuts.xml
@@ -520,14 +520,6 @@
     <seq>Shift+.</seq>
     </SC>
   <SC>
-    <key>add-8va</key>
-    <seq>Ctrl+Y,Ctrl+O,Ctrl+A</seq>
-    </SC>
-  <SC>
-    <key>add-8vb</key>
-    <seq>Ctrl+Y,Ctrl+O,Ctrl+B</seq>
-    </SC>
-  <SC>
     <key>notation-escape</key>
     <seq>Esc</seq>
     </SC>
@@ -751,14 +743,6 @@
     <seq>Ctrl+A</seq>
     </SC>
   <SC>
-    <key>clef-violin</key>
-    <seq>Ctrl+Y,Ctrl+1</seq>
-    </SC>
-  <SC>
-    <key>clef-bass</key>
-    <seq>Ctrl+Y,Ctrl+2</seq>
-    </SC>
-  <SC>
     <key>system-break</key>
     <seq>Return</seq>
     </SC>
@@ -778,22 +762,6 @@
   <SC>
     <key>show-keys</key>
     <seq>Shift+F2</seq>
-    </SC>
-  <SC>
-    <key>rest-1</key>
-    <seq>Shift+R, Shift+S</seq>
-    </SC>
-  <SC>
-    <key>rest-2</key>
-    <seq>Shift+R, Shift+M</seq>
-    </SC>
-  <SC>
-    <key>rest-4</key>
-    <seq>Shift+R, Shift+R</seq>
-    </SC>
-  <SC>
-    <key>rest-8</key>
-    <seq>Shift+R, Shift+Q</seq>
     </SC>
   <SC>
     <key>backspace</key>

--- a/src/framework/shortcuts/data/shortcuts_AZERTY.xml
+++ b/src/framework/shortcuts/data/shortcuts_AZERTY.xml
@@ -529,14 +529,6 @@
     <seq>Shift+.</seq>
     </SC>
   <SC>
-    <key>add-8va</key>
-    <seq>Ctrl+Y,Ctrl+O,Ctrl+A</seq>
-    </SC>
-  <SC>
-    <key>add-8vb</key>
-    <seq>Ctrl+Y,Ctrl+O,Ctrl+B</seq>
-    </SC>
-  <SC>
     <key>notation-escape</key>
     <seq>Esc</seq>
     </SC>
@@ -777,14 +769,6 @@
     <seq>Ctrl+A</seq>
     </SC>
   <SC>
-    <key>clef-violin</key>
-    <seq>Ctrl+Y,Ctrl+1</seq>
-    </SC>
-  <SC>
-    <key>clef-bass</key>
-    <seq>Ctrl+Y,Ctrl+2</seq>
-    </SC>
-  <SC>
     <key>system-break</key>
     <seq>Return</seq>
     </SC>
@@ -804,22 +788,6 @@
   <SC>
     <key>show-keys</key>
     <seq>Shift+F2</seq>
-    </SC>
-  <SC>
-    <key>rest-1</key>
-    <seq>Shift+R, Shift+S</seq>
-    </SC>
-  <SC>
-    <key>rest-2</key>
-    <seq>Shift+R, Shift+M</seq>
-    </SC>
-  <SC>
-    <key>rest-4</key>
-    <seq>Shift+R, Shift+R</seq>
-    </SC>
-  <SC>
-    <key>rest-8</key>
-    <seq>Shift+R, Shift+Q</seq>
     </SC>
   <SC>
     <key>backspace</key>

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -158,10 +158,6 @@ void NotationActionController::init()
     registerAction("sharp2", [this]() { toggleAccidental(AccidentalType::SHARP2); });
 
     registerAction("rest", &Interaction::putRestToSelection);
-    registerAction("rest-1", &Interaction::putRest, Duration(DurationType::V_WHOLE));
-    registerAction("rest-2", &Interaction::putRest, Duration(DurationType::V_HALF));
-    registerAction("rest-4", &Interaction::putRest, Duration(DurationType::V_QUARTER));
-    registerAction("rest-8", &Interaction::putRest, Duration(DurationType::V_EIGHTH));
 
     registerAction("add-marcato", [this]() { addArticulation(SymbolId::articMarcatoAbove); });
     registerAction("add-sforzato", [this]() { addArticulation(SymbolId::articAccentAbove); });

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1067,30 +1067,6 @@ const UiActionList NotationUiActions::m_actions = {
              TranslatableString("action", "Rest"),
              TranslatableString("action", "Enter rest")
              ),
-    UiAction("rest-1",
-             mu::context::UiCtxNotationOpened,
-             mu::context::CTX_ANY,
-             TranslatableString("action", "Whole rest"),
-             TranslatableString("action", "Enter rest: whole")
-             ),
-    UiAction("rest-2",
-             mu::context::UiCtxNotationOpened,
-             mu::context::CTX_ANY,
-             TranslatableString("action", "Half rest"),
-             TranslatableString("action", "Enter rest: half")
-             ),
-    UiAction("rest-4",
-             mu::context::UiCtxNotationOpened,
-             mu::context::CTX_ANY,
-             TranslatableString("action", "Quarter rest"),
-             TranslatableString("action", "Enter rest: quarter")
-             ),
-    UiAction("rest-8",
-             mu::context::UiCtxNotationOpened,
-             mu::context::CTX_ANY,
-             TranslatableString("action", "Eighth rest"),
-             TranslatableString("action", "Enter rest: eighth")
-             ),
     UiAction("rest-TAB",
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_NOTATION_NOTE_INPUT_STAFF_TAB,


### PR DESCRIPTION
Resolves: #13324

All shortcut sequences are removed. Also, the possibility to set a shortcut for “enter whole rest” to “enter eighth rest” is removed because this can be done by selecting a duration and then enter a rest.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
