### PR TITLE
Fix #19470: remove “show navigator” option from general preferences

### DIFF
--- a/src/appshell/qml/Preferences/GeneralPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/GeneralPreferencesPage.qml
@@ -70,7 +70,6 @@ PreferencesPage {
         ProgramStartSection {
             startupModes: preferencesModel.startupModes
             scorePathFilter: preferencesModel.scorePathFilter()
-            panels: preferencesModel.panels
 
             navigation.section: root.navigationSection
             navigation.order: root.navigationOrderStart + 2
@@ -81,10 +80,6 @@ PreferencesPage {
 
             onStartupScorePathChanged: function(path) {
                 preferencesModel.setStartupScorePath(path)
-            }
-
-            onPanelsVisibleChanged: function(panelIndex, visible) {
-                preferencesModel.setPanelVisible(panelIndex, visible)
             }
         }
 

--- a/src/appshell/qml/Preferences/internal/ProgramStartSection.qml
+++ b/src/appshell/qml/Preferences/internal/ProgramStartSection.qml
@@ -34,11 +34,8 @@ BaseSection {
     property alias startupModes: startupModesBox.model
     property var scorePathFilter: null
 
-    property alias panels: panelsView.model
-
     signal currentStartupModesChanged(int index)
     signal startupScorePathChanged(string path)
-    signal panelsVisibleChanged(int panelIndex, bool visible)
 
     rowSpacing: 16
 
@@ -92,32 +89,6 @@ BaseSection {
                 onPathEdited: function(newPath) {
                     root.startupScorePathChanged(newPath)
                 }
-            }
-        }
-    }
-
-    ListView {
-        id: panelsView
-
-        spacing: root.rowSpacing
-        interactive: false
-
-        width: parent.width
-        height: contentHeight
-
-        delegate: CheckBox {
-            width: parent.width
-
-            text: modelData.title
-            checked: modelData.visible
-
-            navigation.name: modelData.title
-            navigation.panel: root.navigation
-            navigation.row: startupModesBox.count + model.index
-            navigation.column: 0
-
-            onClicked: {
-                root.panelsVisibleChanged(model.index, !checked)
             }
         }
     }

--- a/src/appshell/view/preferences/generalpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/generalpreferencesmodel.cpp
@@ -214,34 +214,6 @@ GeneralPreferencesModel::StartModeList GeneralPreferencesModel::allStartupModes(
     return modes;
 }
 
-QVariantList GeneralPreferencesModel::panels() const
-{
-    QVariantList result;
-
-    for (const Panel& panel: allPanels()) {
-        QVariantMap obj;
-        obj["title"] = panel.title;
-        obj["visible"] = panel.visible;
-
-        result << obj;
-    }
-
-    return result;
-}
-
-GeneralPreferencesModel::PanelList GeneralPreferencesModel::allPanels() const
-{
-    PanelList panels {
-        /*
-         * TODO: https://github.com/musescore/MuseScore/issues/9807
-         * Panel { SplashScreen, qtrc("appshell/preferences", "Show splash screen"), configuration()->needShowSplashScreen() },
-         */
-        Panel { Navigator, qtrc("appshell/preferences", "Show navigator"), configuration()->isNotationNavigatorVisible() },
-    };
-
-    return panels;
-}
-
 QStringList GeneralPreferencesModel::scorePathFilter() const
 {
     return { qtrc("appshell/preferences", "MuseScore file") + " (*.mscz)",
@@ -274,28 +246,4 @@ void GeneralPreferencesModel::setStartupScorePath(const QString& scorePath)
     configuration()->setStartupScorePath(scorePath);
 
     emit startupModesChanged();
-}
-
-void GeneralPreferencesModel::setPanelVisible(int panelIndex, bool visible)
-{
-    PanelList panels = allPanels();
-
-    if (panelIndex < 0 || panelIndex >= panels.size()) {
-        return;
-    }
-
-    Panel panel = panels[panelIndex];
-
-    switch (panel.type) {
-    case SplashScreen:
-        configuration()->setNeedShowSplashScreen(visible);
-        break;
-    case Navigator:
-        configuration()->setIsNotationNavigatorVisible(visible);
-        break;
-    case Unknown:
-        return;
-    }
-
-    emit panelsChanged();
 }

--- a/src/appshell/view/preferences/generalpreferencesmodel.h
+++ b/src/appshell/view/preferences/generalpreferencesmodel.h
@@ -59,7 +59,6 @@ class GeneralPreferencesModel : public QObject, public async::Asyncable
     Q_PROPERTY(bool isNeedRestart READ isNeedRestart WRITE setIsNeedRestart NOTIFY isNeedRestartChanged)
 
     Q_PROPERTY(QVariantList startupModes READ startupModes NOTIFY startupModesChanged)
-    Q_PROPERTY(QVariantList panels READ panels NOTIFY panelsChanged)
 
 public:
     explicit GeneralPreferencesModel(QObject* parent = nullptr);
@@ -69,7 +68,6 @@ public:
 
     Q_INVOKABLE void setCurrentStartupMode(int modeIndex);
     Q_INVOKABLE void setStartupScorePath(const QString& scorePath);
-    Q_INVOKABLE void setPanelVisible(int panelIndex, bool visible);
 
     Q_INVOKABLE QStringList scorePathFilter() const;
 
@@ -80,7 +78,6 @@ public:
     QString currentKeyboardLayout() const;
 
     QVariantList startupModes() const;
-    QVariantList panels() const;
 
     bool isOSCRemoteControl() const;
     int oscPort() const;
@@ -104,27 +101,11 @@ signals:
     void isNeedRestartChanged();
 
     void startupModesChanged();
-    void panelsChanged();
 
 private:
     framework::Progress m_languageUpdateProgress;
 
     bool m_isNeedRestart = false;
-
-    enum PanelType {
-        Unknown,
-        SplashScreen,
-        Navigator
-    };
-
-    struct Panel
-    {
-        PanelType type = Unknown;
-        QString title;
-        bool visible = false;
-    };
-
-    using PanelList = QList<Panel>;
 
     struct StartMode
     {
@@ -137,7 +118,6 @@ private:
 
     using StartModeList = QList<StartMode>;
 
-    PanelList allPanels() const;
     StartModeList allStartupModes() const;
 };
 }


### PR DESCRIPTION
Some code that looks like it becomes unused now is removed too.

Resolves: #19470

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ ] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)

Concerning unnecessary changes: Is removing unused code necessary?
