### PR TITLE
Fix #19446 All MS Basic documentation still references MuseScore_General

### DIFF
--- a/share/sound/MS Basic_License.md
+++ b/share/sound/MS Basic_License.md
@@ -1,21 +1,21 @@
-# MuseScore_General.sf2
+ # MS Basic.sf2
 ---
 
 Current version: 0.2  13th May 2020
 
-This is a scaled-down version of **MuseScore_General-HQ.sf2** that replaces some of the larger instruments to save memory and CPU on older PCs. This SoundFont is currently a work-in-progress. Detailed information on presets and sample sources used can be found in "MuseScore_General_Sample_Sources.csv". All instruments without attribution are still using samples from FluidR3Mono.
+This is a scaled-down version of **MS Basic-HQ.sf2** that replaces some of the larger instruments to save memory and CPU on older PCs. This SoundFont is currently a work-in-progress. Detailed information on presets and sample sources used can be found in "MS Basic_Sample_Sources.csv". All instruments without attribution are still using samples from FluidR3Mono.
 
 FluidR3 (original version) by Frank Wen Copyright (c) 2000-02
 
 Mono conversion (FluidR3Mono) by Michael Cowgill Copyright (c) 2014-17
 
-Adaptation for MuseScore_General.sf2 by S. Christian Collins Copyright (c) 2018-19
+Adaptation for MS Basic.sf2 by S. Christian Collins Copyright (c) 2018-19
 
 Temple Blocks instrument provided by Ethan Winer Copyright (c) 2002
 
 Drumline Cymbals provided by Michael Schorsch Copyright (c) 2016
 
-MuseScore_General.sf2 is shared under the MIT license as described in COPYING, as was FluidR3Mono and FluidR3 before it.
+MS Basic.sf2 is shared under the MIT license as described in COPYING, as was FluidR3Mono and FluidR3 before it.
 
 The COPYING and README files from the original FluidR3GM file are now displayed here for reference.
 

--- a/share/sound/MS Basic_Readme.md
+++ b/share/sound/MS Basic_Readme.md
@@ -1,20 +1,20 @@
-# MuseScore_General.sf2
+# MS Basic.sf2
 
 **Version 0.2**
 
 ---
 
-Please see **MuseScore_General_License.md** for authorship and license information.
+Please see **MS Basic_License.md** for authorship and license information.
 
-The purpose of this README is to provide useful information on instruments contained within MuseScore_General. It is currently a work-in-progress.
+The purpose of this README is to provide useful information on instruments contained within MS Basic. It is currently a work-in-progress.
 
 ## About
 
-This is a scaled-down version of **MuseScore_General-HQ.sf2** that replaces some of the larger instruments to save memory and CPU on older PCs. This SoundFont is currently a work-in-progress. Detailed information on presets and sample sources used can be found in "MuseScore_General_Sample_Sources.csv". All instruments without attribution are still using samples from FluidR3Mono.
+This is a scaled-down version of **MS Basic-HQ.sf2** that replaces some of the larger instruments to save memory and CPU on older PCs. This SoundFont is currently a work-in-progress. Detailed information on presets and sample sources used can be found in "MS Basic_Sample_Sources.csv". All instruments without attribution are still using samples from FluidR3Mono.
 
 ## SoundFont Compatibility
 
-**MuseScore_General** makes full use of SoundFont 2.01 specification modulators (particularly in the newer instruments) and requires a player/sampler with robust support for the standard. To my knowledge, the only SoundFont players that can accurately play this SoundFont are:
+**MS Basic** makes full use of SoundFont 2.01 specification modulators (particularly in the newer instruments) and requires a player/sampler with robust support for the standard. To my knowledge, the only SoundFont players that can accurately play this SoundFont are:
 
 * [MuseScore](https://musescore.org)
 * [FluidSynth](http://www.fluidsynth.org/)
@@ -30,7 +30,7 @@ The only SoundFont editors that can play this SoundFont correctly are:
 
 ### General MIDI Presets
 
-**MuseScore_General** is compatible with the [General MIDI standard](https://en.wikipedia.org/wiki/General_MIDI) with some additional presets from the [Roland GS standard](https://en.wikipedia.org/wiki/Roland_GS) as well.
+**MS Basic** is compatible with the [General MIDI standard](https://en.wikipedia.org/wiki/General_MIDI) with some additional presets from the [Roland GS standard](https://en.wikipedia.org/wiki/Roland_GS) as well.
 
 ### Fluid r3 Additional Drum Kits
 
@@ -54,9 +54,9 @@ These presets are used for marching percussion support in MuseScore and do not c
 
 ### Expressive Presets
 
-As of version 0.1.5, **MuseScore_General** features expressive variants of all sustained presets, indicated by "Expr." at the end of the preset name. The dynamics of these presets are controlled using MIDI Control Change #2 (CC2), allowing fluid crescendos and diminuendos while a note is being held. This makes for much more realistic expression of strings, brass, woodwinds, etc. Note velocity no longer controls dynamics in these presets, but in some instruments, velocity will have some effect on the speed of the note attack. In MuseScore, the default (and ideal) behavior is for expressive instruments to have their dynamics controlled by sending identical values to both CC2 and note velocity (the latter only during note-on, naturally).
+As of version 0.1.5, **MS Basic** features expressive variants of all sustained presets, indicated by "Expr." at the end of the preset name. The dynamics of these presets are controlled using MIDI Control Change #2 (CC2), allowing fluid crescendos and diminuendos while a note is being held. This makes for much more realistic expression of strings, brass, woodwinds, etc. Note velocity no longer controls dynamics in these presets, but in some instruments, velocity will have some effect on the speed of the note attack. In MuseScore, the default (and ideal) behavior is for expressive instruments to have their dynamics controlled by sending identical values to both CC2 and note velocity (the latter only during note-on, naturally).
 
-The expressive presets exist on higher bank numbers but use the same preset number as their non-expressive defaults. You can see what bank numbers the expressive presets use in column #2 ("Expr. Bank #") of the included **MuseScore_General_Sample_Sources.csv** file. The general rule is as follows:
+The expressive presets exist on higher bank numbers but use the same preset number as their non-expressive defaults. You can see what bank numbers the expressive presets use in column #2 ("Expr. Bank #") of the included **MS Basic_Sample_Sources.csv** file. The general rule is as follows:
 
 * Bank 0 expressive presets are on Bank 17
 * Bank 8 expressive presets are on Bank 18
@@ -64,7 +64,7 @@ The expressive presets exist on higher bank numbers but use the same preset numb
 
 ### Dummy Presets
 
-To maintain preset compatibility with the "HQ" version, **MuseScore_General** version contains dummy presets that are simply duplicates of the similar instruments found on bank 0. For example, the full SoundFont has the following instruments assigned to preset #48, all on different banks (presets listed in bank#:preset# format):
+To maintain preset compatibility with the "HQ" version, **MS Basic** version contains dummy presets that are simply duplicates of the similar instruments found on bank 0. For example, the full SoundFont has the following instruments assigned to preset #48, all on different banks (presets listed in bank#:preset# format):
 
 - 000:048 - Strings Fast
 - 020:048 - Violins Fast
@@ -73,6 +73,6 @@ To maintain preset compatibility with the "HQ" version, **MuseScore_General** ve
 - 040:048 - Celli Fast
 - 050:048 - Basses Fast
 
-In the HQ version of the SoundFont, each of these sounds different since they feature unique samples for each section, but in this **MuseScore_General**, these presets on banks 20 and higher are mere duplicates of **000:048 - Strings Fast**, and only exist to avoid issues transitioning between the HQ and lighter versions of the SoundFont.
+In the HQ version of the SoundFont, each of these sounds different since they feature unique samples for each section, but in this **MS Basic**, these presets on banks 20 and higher are mere duplicates of **000:048 - Strings Fast**, and only exist to avoid issues transitioning between the HQ and lighter versions of the SoundFont.
 
-All dummy presets are indicated as such in the included **MuseScore_General_Sample_Sources.csv** file.
+All dummy presets are indicated as such in the included **MS Basic_Sample_Sources.csv** file.

--- a/share/sound/MS_Basic_Changelog.md
+++ b/share/sound/MS_Basic_Changelog.md
@@ -1,4 +1,4 @@
-# MuseScore_General.sf2
+# MS Basic.sf2
 
 **Changelog**
 
@@ -47,7 +47,7 @@
 
 ## 0.1.6
 
-* The SoundFont was renamed from "MuseScore_General_Lite.sf2" to "MuseScore_General.sf2" and will be the version that ships with MuseScore by default. The SoundFont formerly named "MuseScore_General.sf2" has been renamed to "MuseScore_General_HQ.sf2" and will be downloadable through the MuseScore resource manager. Currently, the only difference between the two versions is that the HQ version includes the new ensemble strings based on VSCO 2 samples. Over time, more instruments will be upgraded in the HQ version, and the difference between the two versions will grow.
+* The SoundFont was renamed from "MS Basic_Lite.sf2" to "MS Basic.sf2" and will be the version that ships with MuseScore by default. The SoundFont formerly named "MS Basic.sf2" has been renamed to "MS Basic_HQ.sf2" and will be downloadable through the MuseScore resource manager. Currently, the only difference between the two versions is that the HQ version includes the new ensemble strings based on VSCO 2 samples. Over time, more instruments will be upgraded in the HQ version, and the difference between the two versions will grow.
 * Added the new pianos from the full version of the SoundFont, updating the following presets:
   - **"000:000 Grand Piano"**
   - **"008:000 Mellow Grand Piano"**
@@ -56,7 +56,7 @@
 
 ## 0.1.5
 
-* MuseScore_General now includes additional presets labeled "Expr." that can be dynamically controlled via MIDI Control Change #2 (CC2). To accommodate this new functionality, many instruments were reprogrammed to use modulators for velocity-based filtering rather than separate instrument layers within the preset. Please refer to the included "MuseScore_General_Readme.md" file for more information on these new presets.
+* MS Basic now includes additional presets labeled "Expr." that can be dynamically controlled via MIDI Control Change #2 (CC2). To accommodate this new functionality, many instruments were reprogrammed to use modulators for velocity-based filtering rather than separate instrument layers within the preset. Please refer to the included "MS Basic_Readme.md" file for more information on these new presets.
 * Reprogrammed the velocity-based effects for the following instruments:
   - **"000:056 Trumpet"**
   - **"000:057 Trombone"**
@@ -73,11 +73,11 @@
 ## 0.1.3
 
 * There are now two versions of the SoundFont:
-  - **MuseScore_General**: This is the version that will include all of the new instrument sounds as they are developed. To reach a higher sound quality, new instrument presets will often require more RAM and CPU than the older versions.
-  - **MuseScore_General_Lite**: This version is intended for more limited computers and uses less RAM and CPU by retaining the older, smaller instrument sounds where it is advantageous to do so. Currently, the only difference between the two versions is the acoustic pianos and ensemble strings (plus some synth-style presets that also use the strings samples: "Warm Pad", "Orchestra Pad", "Synth Strings 3"), but this difference will grow much greater over time.
-* Added "dummy" presets to **MuseScore_General_Lite** for preset compatibility with the new ensemble strings in the full version of **MuseScore_General**. These strings presets can be found on banks 20-32, but are merely duplicates of the ensemble strings presets present on bank 0 (Tremolo, Pizzicato, Fast and Slow strings).
+  - **MS Basic**: This is the version that will include all of the new instrument sounds as they are developed. To reach a higher sound quality, new instrument presets will often require more RAM and CPU than the older versions.
+  - **MS Basic_Lite**: This version is intended for more limited computers and uses less RAM and CPU by retaining the older, smaller instrument sounds where it is advantageous to do so. Currently, the only difference between the two versions is the acoustic pianos and ensemble strings (plus some synth-style presets that also use the strings samples: "Warm Pad", "Orchestra Pad", "Synth Strings 3"), but this difference will grow much greater over time.
+* Added "dummy" presets to **MS Basic_Lite** for preset compatibility with the new ensemble strings in the full version of **MS Basic**. These strings presets can be found on banks 20-32, but are merely duplicates of the ensemble strings presets present on bank 0 (Tremolo, Pizzicato, Fast and Slow strings).
 * Removed the superfluous **"001:048 Dry Strings"** preset.
-* Returned to the original FluidR3Mono pianos for lower memory consumption in **MuseScore_General_Lite**.
+* Returned to the original FluidR3Mono pianos for lower memory consumption in **MS Basic_Lite**.
 * Optimized the use of generators in all instruments, freeing thousands of generators for future instrument use (the limit is 65,535 instrument-level generators).
 
 ## 0.1.2


### PR DESCRIPTION
Changed all text with "MuseScore_General" to "MS Basic"

Resolves: #19446

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [ ] I signed the [CLA](https://musescore.org/en/cla)
- [ ] The title of the PR describes the problem it addresses
- [ ] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [ ] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ ] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
