### PR TITLE
MEI export: fix lyrics on rests

### DIFF
--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -1275,7 +1275,7 @@ bool MeiExporter::writeRest(const Rest* rest, const Staff* staff)
         Convert::colorToMEI(rest, meiRest);
         this->writeBeamTypeAtt(rest, meiRest);
         this->writeStaffIdenAtt(rest, staff, meiRest);
-        this->writeVerses(rest);
+        // this->writeVerses(rest);
         const char prefix = (rest->visible()) ? 'r' : 's';
         std::string xmlId = this->getXmlIdFor(rest, prefix);
         meiRest.Write(restNode, xmlId);


### PR DESCRIPTION
When exporting a rest with lyrics to MEI an invalid MEI file is created. This small PR fixes it by commenting out the line that is responsible for that behavior. 