### PR TITLE
fix #19480 last tied note accidentals

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -2033,9 +2033,11 @@ static void changeAccidental2(Note* n, int pitch, int tpc)
             }
         } else {
             Note* nn = n;
-            while (nn->tieFor()) {
+            while (nn && nn->tieFor()) {
                 nn = nn->tieFor()->endNote();
-                score->undo(new ChangePitch(nn, pitch, tpc1, tpc2));
+                if (nn) {
+                    score->undo(new ChangePitch(nn, pitch, tpc1, tpc2));
+                }
             }
         }
     }

--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -2032,7 +2032,9 @@ static void changeAccidental2(Note* n, int pitch, int tpc)
                 }
             }
         } else {
-            for (Note* nn = n; nn && nn->tieFor(); nn = nn->tieFor()->endNote()) {
+            Note* nn = n;
+            while (nn->tieFor()) {
+                nn = nn->tieFor()->endNote();
                 score->undo(new ChangePitch(nn, pitch, tpc1, tpc2));
             }
         }


### PR DESCRIPTION
Resolves: #19480 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Caused by [43df579](https://github.com/musescore/MuseScore/pull/18780/commits/43df579064264092db0265dcf7e63b9781605409) 

Last tied note was excluded by for loop condition

I reverted that change and added other safety check(s)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
