### PR TITLE
fix #19092 - correct full measure rest in parts

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -5279,49 +5279,6 @@ void Score::undoChangeClef(Staff* ostaff, EngravingItem* e, ClefType ct, bool fo
 }
 
 //---------------------------------------------------------
-//   findLinkedVoiceElement
-//---------------------------------------------------------
-
-static EngravingItem* findLinkedVoiceElement(EngravingItem* e, Staff* nstaff)
-{
-    Excerpt* se = e->score()->excerpt();
-    Excerpt* de = nstaff->score()->excerpt();
-    track_idx_t strack = e->track();
-    track_idx_t dtrack = nstaff->idx() * VOICES + e->voice();
-
-    if (se) {
-        strack = mu::key(se->tracksMapping(), strack);
-    }
-
-    if (de) {
-        std::vector<track_idx_t> l = mu::values(de->tracksMapping(), strack);
-        if (l.empty()) {
-            // simply return the first linked element whose staff is equal to nstaff
-            for (EngravingObject* ee : e->linkList()) {
-                EngravingItem* el = toEngravingItem(ee);
-                if (el->staff() == nstaff) {
-                    return el;
-                }
-            }
-            return 0;
-        }
-        for (track_idx_t i : l) {
-            if (nstaff->idx() * VOICES <= i && (nstaff->idx() + 1) * VOICES > i) {
-                dtrack = i;
-                break;
-            }
-        }
-    }
-
-    Score* score     = nstaff->score();
-    Segment* segment = toSegment(e->explicitParent());
-    Measure* measure = segment->measure();
-    Measure* m       = score->tick2measure(measure->tick());
-    Segment* s       = m->findSegment(segment->segmentType(), segment->tick());
-    return s ? s->element(dtrack) : nullptr;
-}
-
-//---------------------------------------------------------
 //   findLinkedChord
 //---------------------------------------------------------
 

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -5389,20 +5389,8 @@ static Chord* findLinkedChord(Chord* c, Staff* nstaff)
 
 void Score::undoChangeChordRestLen(ChordRest* cr, const TDuration& d)
 {
-    auto sl = cr->staff()->staffList();
-    for (Staff* staff : sl) {
-        ChordRest* ncr;
-        if (cr->isGrace()) {
-            ncr = findLinkedChord(toChord(cr), staff);
-        } else {
-            ncr = toChordRest(findLinkedVoiceElement(cr, staff));
-        }
-        if (!ncr) {
-            continue;
-        }
-        ncr->undoChangeProperty(Pid::DURATION_TYPE_WITH_DOTS, d.typeWithDots());
-        ncr->undoChangeProperty(Pid::DURATION, d.fraction());
-    }
+    cr->undoChangeProperty(Pid::DURATION_TYPE_WITH_DOTS, d.typeWithDots());
+    cr->undoChangeProperty(Pid::DURATION, d.fraction());
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -1743,8 +1743,10 @@ void Measure::adjustToLen(Fraction nf, bool appendRestsIfNecessary)
         if (rests == 1 && chords == 0) {
             // if measure value didn't change, stick to whole measure rest
             if (m_timesig == nf) {
-                rest->undoChangeProperty(Pid::DURATION, nf * stretch);
-                rest->undoChangeProperty(Pid::DURATION_TYPE_WITH_DOTS, DurationTypeWithDots(DurationType::V_MEASURE));
+                for (EngravingObject* e : rest->linkList()) {
+                    e->undoChangeProperty(Pid::DURATION, nf * stretch);
+                    e->undoChangeProperty(Pid::DURATION_TYPE_WITH_DOTS, DurationTypeWithDots(DurationType::V_MEASURE));
+                }
             } else {          // if measure value did change, represent with rests actual measure value
                 // convert the measure duration in a list of values (no dots for rests)
                 std::vector<TDuration> durList = toDurationList(nf * stretch, false, 0);

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -1743,19 +1743,15 @@ void Measure::adjustToLen(Fraction nf, bool appendRestsIfNecessary)
         if (rests == 1 && chords == 0) {
             // if measure value didn't change, stick to whole measure rest
             if (m_timesig == nf) {
-                for (EngravingObject* e : rest->linkList()) {
-                    e->undoChangeProperty(Pid::DURATION, nf * stretch);
-                    e->undoChangeProperty(Pid::DURATION_TYPE_WITH_DOTS, DurationTypeWithDots(DurationType::V_MEASURE));
-                }
+                rest->undoChangeProperty(Pid::DURATION, nf * stretch);
+                rest->undoChangeProperty(Pid::DURATION_TYPE_WITH_DOTS, DurationTypeWithDots(DurationType::V_MEASURE));
             } else {          // if measure value did change, represent with rests actual measure value
                 // convert the measure duration in a list of values (no dots for rests)
                 std::vector<TDuration> durList = toDurationList(nf * stretch, false, 0);
 
                 // set the existing rest to the first value of the duration list
-                for (EngravingObject* e : rest->linkList()) {
-                    e->undoChangeProperty(Pid::DURATION, durList[0].fraction());
-                    e->undoChangeProperty(Pid::DURATION_TYPE_WITH_DOTS, durList[0].typeWithDots());
-                }
+                rest->undoChangeProperty(Pid::DURATION, durList[0].fraction());
+                rest->undoChangeProperty(Pid::DURATION_TYPE_WITH_DOTS, durList[0].typeWithDots());
 
                 // add rests for any other duration list value
                 Fraction tickOffset = tick() + rest->actualTicks();

--- a/src/engraving/dom/property.cpp
+++ b/src/engraving/dom/property.cpp
@@ -246,8 +246,8 @@ static constexpr PropertyMetaData propertyList[] = {
     { Pid::LINE_VISIBLE,            true,  "lineVisible",           P_TYPE::BOOL,               PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "visible line") },
     { Pid::MAG,                     false, "mag",                   P_TYPE::REAL,               PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "mag") },
     { Pid::USE_DRUMSET,             false, "useDrumset",            P_TYPE::BOOL,               PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "using drumset") },
-    { Pid::DURATION,                false, 0,                       P_TYPE::FRACTION,           PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "duration") },
-    { Pid::DURATION_TYPE_WITH_DOTS, false, 0,                       P_TYPE::DURATION_TYPE_WITH_DOTS, PropertyGroup::APPEARANCE, DUMMY_QT_TR_NOOP("propertyName", "duration type") },
+    { Pid::DURATION,                true,  0,                       P_TYPE::FRACTION,           PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "duration") },
+    { Pid::DURATION_TYPE_WITH_DOTS, true,  0,                       P_TYPE::DURATION_TYPE_WITH_DOTS, PropertyGroup::APPEARANCE, DUMMY_QT_TR_NOOP("propertyName", "duration type") },
     { Pid::ACCIDENTAL_ROLE,         false, "role",                  P_TYPE::ACCIDENTAL_ROLE,    PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "role") },
     { Pid::TRACK,                   false, 0,                       P_TYPE::SIZE_T,             PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "track") },
 


### PR DESCRIPTION
Resolves: #19092 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->
correct ~~multimeasure~~ fullmeasure rest in parts after changing measure in score

<!-- Add a short description of and motivation for the changes here -->
changes to rests needs to be aplied to linked rests (in parts) as well

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
