### PR TITLE
Fix #19381: increase text line hook height limits

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/HooksSection.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/HooksSection.qml
@@ -100,8 +100,8 @@ Column {
             propertyItem: root.startHookHeight
 
             step: 0.5
-            maxValue: 10.0
-            minValue: -10.0
+            maxValue: 1000.0
+            minValue: -1000.0
             decimals: 2
 
             navigationName: "StartHookHeight"
@@ -119,8 +119,8 @@ Column {
             propertyItem: root.endHookHeight
 
             step: 0.5
-            maxValue: 10.0
-            minValue: -10.0
+            maxValue: 1000.0
+            minValue: -1000.0
             decimals: 2
 
             navigationName: "EndHookHeight"


### PR DESCRIPTION
Resolves: #19381 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
The height limits are increased from ±10 to ±1000. Not only ±100 because that would not be enough for A4 paper and default staff size if you want to have huge hooks.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
