### PR TITLE
Add missing "Set to style" to Pedal Inspector

### DIFF
--- a/src/engraving/dom/pedal.cpp
+++ b/src/engraving/dom/pedal.cpp
@@ -54,6 +54,7 @@ static const ElementStyle pedalStyle {
     { Sid::pedalDashLineLen,                   Pid::DASH_LINE_LEN },
     { Sid::pedalDashGapLen,                    Pid::DASH_GAP_LEN },
     { Sid::pedalPlacement,                     Pid::PLACEMENT },
+    { Sid::pedalLineStyle,                     Pid::LINE_STYLE },
     { Sid::pedalPosBelow,                      Pid::OFFSET },
     { Sid::pedalFontSpatiumDependent,          Pid::TEXT_SIZE_SPATIUM_DEPENDENT }
 };


### PR DESCRIPTION
Mu3 has the same issue, there's a Pedal line style setting in Format > Style, but no "set to style" in Inspector