### PR TITLE
Fix #19407: Allow uninterrupted typing when selecting text styles

### DIFF
--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatRadioButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatRadioButton.qml
@@ -57,16 +57,8 @@ RadioDelegate {
                                  : ui.theme.defaultButtonSize
     hoverEnabled: true
 
-    function ensureActiveFocus() {
-        if (!root.activeFocus) {
-            root.forceActiveFocus()
-        }
-    }
-
     onClicked: {
         navigation.requestActiveByInteraction()
-
-        root.ensureActiveFocus()
     }
 
     onPressedChanged: {

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatToggleButton.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/FlatToggleButton.qml
@@ -48,12 +48,6 @@ FocusScope {
 
     opacity: root.enabled ? 1.0 : ui.theme.itemOpacityDisabled
 
-    function ensureActiveFocus() {
-        if (!root.activeFocus) {
-            root.forceActiveFocus()
-        }
-    }
-
     NavigationControl {
         id: navCtrl
         name: root.objectName != "" ? root.objectName : "FlatToggleButton"
@@ -91,8 +85,6 @@ FocusScope {
         hoverEnabled: true
         onClicked: {
             navigation.requestActiveByInteraction()
-
-            root.ensureActiveFocus()
             root.toggled()
         }
 


### PR DESCRIPTION
Resolves: #19407

Also prevents focus being pulled away from the text input when clicking horizontal/vertical alignment buttons in the properties panel.