### PR TITLE
Fix MSCV compiler warnings

### DIFF
--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -1187,9 +1187,9 @@ TEST_F(Engraving_PartsTests, partExclusion)
             if (item && item->isClef() && !item->generated()) {
                 itemsToExclude.push_back(item);
             }
-            for (EngravingItem* item : segment.annotations()) {
-                if (item->isTextBase()) {
-                    itemsToExclude.push_back(item);
+            for (EngravingItem* annotation : segment.annotations()) {
+                if (annotation->isTextBase()) {
+                    itemsToExclude.push_back(annotation);
                 }
             }
         }

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -5126,11 +5126,11 @@ void ExportMusicXml::textLine(TextLineBase const* const tl, staff_idx_t staff, c
     switch (hookType) {
     case HookType::HOOK_90T:
         lineEnd = "both";
-        rest += QString(" end-length=\"%1\"").arg(fabsf(hookHeight * 20));
+        rest += QString(" end-length=\"%1\"").arg(std::abs(hookHeight * 20));
         break;
     case HookType::HOOK_90:
         lineEnd = (hookHeight < 0.0) ? "up" : "down";
-        rest += QString(" end-length=\"%1\"").arg(fabsf(hookHeight * 10));
+        rest += QString(" end-length=\"%1\"").arg(std::abs(hookHeight * 10));
         break;
     case HookType::NONE:
         lineEnd = "none";

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -3989,7 +3989,7 @@ By default, they will be placed such as that their right end are at the same lev
          <enum>QLayout::SetMinimumSize</enum>
         </property>
         <item>
-         <widget class="QGroupBox" name="groupbox_measure">
+         <widget class="QGroupBox" name="groupBox_measure">
           <property name="title">
            <string>Measures</string>
           </property>
@@ -5922,7 +5922,7 @@ By default, they will be placed such as that their right end are at the same lev
       <widget class="QWidget" name="PageMeasureRepeats">
        <layout class="QGridLayout" name="gridLayout_58">
         <item row="0" column="0">
-         <widget class="QGroupBox" name="groupBox_2">
+         <widget class="QGroupBox" name="groupBox_measure_repeats">
           <property name="title">
            <string>Measure repeats</string>
           </property>
@@ -7279,7 +7279,7 @@ By default, they will be placed such as that their right end are at the same lev
          </widget>
         </item>
         <item>
-         <widget class="QGroupBox" name="groupBox">
+         <widget class="QGroupBox" name="groupBox_ties">
           <property name="title">
            <string>Ties</string>
           </property>
@@ -13312,7 +13312,7 @@ By default, they will be placed such as that their right end are at the same lev
           </property>
           <layout class="QGridLayout" name="_12">
            <item row="12" column="0" colspan="3">
-            <widget class="QGroupBox" name="groupBox_40">
+            <widget class="QGroupBox" name="groupBox_text_style">
              <property name="title">
               <string/>
              </property>


### PR DESCRIPTION
* reg. declaration of 'item' hides previous local declaration (C4456)
* reg. declaration of 'groupBox' hides class member (C4458)
   Plus some minor cleanup