### PR TITLE
fixed #19501: Accidentals are disappearing from score

### DIFF
--- a/src/engraving/dom/accidental.h
+++ b/src/engraving/dom/accidental.h
@@ -124,7 +124,7 @@ public:
 
         std::vector<Sym> syms;
 
-        bool isValid() const { return !syms.empty(); }
+        bool isValid() const override { return EngravingItem::LayoutData::isValid() && !syms.empty(); }
     };
     DECLARE_LAYOUTDATA_METHODS(Accidental);
 

--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -504,7 +504,7 @@ public:
             //m_pos.reset();
         }
 
-        bool isValid() const { return m_bbox.has_value(); }
+        virtual bool isValid() const { return m_bbox.has_value(); }
 
         bool isSkipDraw() const { return m_isSkipDraw; }
         void setIsSkipDraw(bool val) { m_isSkipDraw = val; }

--- a/src/engraving/rendering/single/singlelayout.cpp
+++ b/src/engraving/rendering/single/singlelayout.cpp
@@ -267,7 +267,7 @@ compat::DummyElement* SingleLayout::Context::dummyParent() const
 
 void SingleLayout::layout(Accidental* item, const Context&)
 {
-    if (!item->layoutData()) {
+    if (!item->layoutData() || !item->layoutData()->isValid()) {
         Accidental::LayoutData* ldata = item->mutLayoutData();
         SymId symId = item->symId();
         Accidental::LayoutData::Sym s(symId, 0.0, 0.0);


### PR DESCRIPTION
Resolves: #19501
Resolves: #19374

The problem is that the isValid method of the Accidental::LayoutData structure overrides the isValid method of the EngravingItem::LayoutData structure

When replacing(in this [commit](https://github.com/musescore/MuseScore/commit/81269faed5281670a03b7df846d3e0eeed6445f3)) it seems that this behavior was not expected

Also see [this change](https://github.com/musescore/MuseScore/commit/53b8b7177c6213c52f5f21cf5197df28083c968e#diff-9ae28bce4509a36168b7379e7456c6e565d89154d3e6d4c00720c764e6572284L268) - I think it was a mistake