### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/framework/vst/internal/vstplugin.cpp
+++ b/src/framework/vst/internal/vstplugin.cpp
@@ -170,10 +170,8 @@ void VstPlugin::stateBufferFromString(VstMemoryStream& buffer, char* strData, co
         return;
     }
 
-    static Steinberg::int32 numBytesRead = 0;
-
-    buffer.write(strData, strSize, &numBytesRead);
-    buffer.seek(0, static_cast<size_t>(Steinberg::IBStream::kIBSeekSet), nullptr);
+    buffer.write(strData, static_cast<Steinberg::int32>(strSize), nullptr);
+    buffer.seek(0, Steinberg::IBStream::kIBSeekSet, nullptr);
 }
 
 PluginViewPtr VstPlugin::createView() const


### PR DESCRIPTION
reg. 'argument': conversion from 'size_t' to 'Steinberg::int32', possible loss of data (C4267)