### PR TITLE
fix #19528 wrong keysig on next system after undo

### DIFF
--- a/src/engraving/rendering/dev/measurelayout.cpp
+++ b/src/engraving/rendering/dev/measurelayout.cpp
@@ -1654,7 +1654,6 @@ void MeasureLayout::addSystemHeader(Measure* m, bool isFirstSystem, LayoutContex
             }
         }
 
-        needKeysig = needKeysig && (keyIdx.key() != Key::C || keyIdx.concertKey() != Key::C || keyIdx.custom() || keyIdx.isAtonal());
         bool isPitchedStaff = staff->isPitchedStaff(m->tick());
 
         if (needKeysig && isPitchedStaff) {

--- a/src/engraving/tests/transpose_data/undoTranspose02-ref.mscx
+++ b/src/engraving/tests/transpose_data/undoTranspose02-ref.mscx
@@ -63,6 +63,9 @@
             <transposingClefType>G</transposingClefType>
             <isHeader>1</isHeader>
             </Clef>
+          <KeySig>
+            <concertKey>0</concertKey>
+            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>
@@ -330,6 +333,9 @@
             <transposingClefType>F</transposingClefType>
             <isHeader>1</isHeader>
             </Clef>
+          <KeySig>
+            <concertKey>0</concertKey>
+            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>


### PR DESCRIPTION
Resolves: #19528 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

add also Cmajor key sig to system header

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
