### PR TITLE
fix #19323 move or remove TimeSigs of joined measures

### DIFF
--- a/src/engraving/dom/joinMeasure.cpp
+++ b/src/engraving/dom/joinMeasure.cpp
@@ -20,11 +20,13 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include "factory.h"
 #include "masterscore.h"
 #include "measure.h"
 #include "range.h"
 #include "score.h"
 #include "spanner.h"
+#include "timesig.h"
 #include "undo.h"
 
 using namespace mu;
@@ -135,5 +137,43 @@ void MasterScore::joinMeasure(const Fraction& tick1, const Fraction& tick2)
     inserted->adjustToLen(newLen, /* appendRests... */ false);
 
     range.write(this, m1->tick());
+
+    // if there are some Time Signatures in joined measures, move last one to the next measure (if there is not one already)
+    Segment* ts = inserted->last()->prev(SegmentType::TimeSig);
+    if (ts && ts->rtick().isNotZero()) {
+        for (Segment* insMSeg = inserted->last()->prev(SegmentType::TimeSig); insMSeg && insMSeg->rtick().isNotZero(); insMSeg = insMSeg->prev(SegmentType::TimeSig)) {
+            for (staff_idx_t staffIdx = 0; staffIdx < nstaves(); ++staffIdx) {
+                if (TimeSig* insTimeSig = toTimeSig(insMSeg->element(staffIdx * VOICES))) {
+                    TimeSig* lts = nullptr;
+                    for (EngravingObject* l : insTimeSig->linkList()) {
+                        Score* score = l->score();
+                        TimeSig* timeSig = toTimeSig(l);
+                        Segment* tSeg = timeSig->segment();
+                        track_idx_t track = timeSig->track();
+                        Measure* sNext = next ? score->tick2measure(next->tick()) : nullptr;
+                        Segment* nextTSeg = sNext ? sNext->undoGetSegmentR(SegmentType::TimeSig, Fraction(0, 1)) : nullptr;
+                        if (sNext && !nextTSeg->element(track)){
+                            TimeSig* nsig = Factory::copyTimeSig(*timeSig);
+                            nsig->setScore(score);
+                            nsig->setTrack(track);
+                            nsig->setParent(nextTSeg);
+
+                            score->undo(new AddElement(nsig));
+
+                            if (!lts) {
+                                lts = nsig;
+                            } else {
+                                score->undo(new Link(lts, nsig));
+                            }
+                        }
+                        score->undo(new RemoveElement(timeSig));
+                        if (tSeg->empty()) {
+                            score->undo(new RemoveElement(tSeg));
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 }

--- a/src/engraving/dom/joinMeasure.cpp
+++ b/src/engraving/dom/joinMeasure.cpp
@@ -141,7 +141,8 @@ void MasterScore::joinMeasure(const Fraction& tick1, const Fraction& tick2)
     // if there are some Time Signatures in joined measures, move last one to the next measure (if there is not one already)
     Segment* ts = inserted->last()->prev(SegmentType::TimeSig);
     if (ts && ts->rtick().isNotZero()) {
-        for (Segment* insMSeg = inserted->last()->prev(SegmentType::TimeSig); insMSeg && insMSeg->rtick().isNotZero(); insMSeg = insMSeg->prev(SegmentType::TimeSig)) {
+        for (Segment* insMSeg = inserted->last()->prev(SegmentType::TimeSig); insMSeg && insMSeg->rtick().isNotZero();
+             insMSeg = insMSeg->prev(SegmentType::TimeSig)) {
             for (staff_idx_t staffIdx = 0; staffIdx < nstaves(); ++staffIdx) {
                 if (TimeSig* insTimeSig = toTimeSig(insMSeg->element(staffIdx * VOICES))) {
                     TimeSig* lts = nullptr;
@@ -152,7 +153,7 @@ void MasterScore::joinMeasure(const Fraction& tick1, const Fraction& tick2)
                         track_idx_t track = timeSig->track();
                         Measure* sNext = next ? score->tick2measure(next->tick()) : nullptr;
                         Segment* nextTSeg = sNext ? sNext->undoGetSegmentR(SegmentType::TimeSig, Fraction(0, 1)) : nullptr;
-                        if (sNext && !nextTSeg->element(track)){
+                        if (sNext && !nextTSeg->element(track)) {
                             TimeSig* nsig = Factory::copyTimeSig(*timeSig);
                             nsig->setScore(score);
                             nsig->setTrack(track);


### PR DESCRIPTION
Resolves: #19323 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->
move or remove TimeSigs of joined measures

<!-- Add a short description of and motivation for the changes here -->
If joining measures containing time signatures, resulting measure should have nominal time signature of preceding measure and following measure should have time signature which was the last one in joined measures (unless it has time signature already)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)


https://github.com/musescore/MuseScore/assets/1646034/4ac6177e-7735-40bf-96a8-13de179f1f89

