### PR TITLE
fix invalid availability

### DIFF
--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -208,8 +208,7 @@ bool MeiExporter::writeHeader()
 
         if (!m_score->metaTag(u"copyright").isEmpty()) {
             pugi::xml_node availability = pubStmt.append_child("availability");
-            pugi::xml_node distributor = availability.append_child("distributor");
-            distributor.text().set(m_score->metaTag(u"copyright").toStdString().c_str());
+            availability.text().set(m_score->metaTag(u"copyright").toStdString().c_str());
         }
     }
 

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -874,7 +874,7 @@ bool MeiImporter::readMeiHead(pugi::xml_node root)
         }
     }
 
-    pugi::xml_node copyrightNode = root.select_node("//meiHead/fileDesc/pubStmt/availability/distributor").node();
+    pugi::xml_node copyrightNode = root.select_node("//meiHead/fileDesc/pubStmt/availability").node();
     if (copyrightNode) {
         m_score->setMetaTag(u"copyright", String(copyrightNode.text().as_string()));
     }

--- a/src/importexport/mei/tests/data/metadata-01.mei
+++ b/src/importexport/mei/tests/data/metadata-01.mei
@@ -15,9 +15,7 @@
          </titleStmt>
          <pubStmt>
             <date isodate="2023-08-11T14:53:16" />
-            <availability>
-               <distributor>Public domain</distributor>
-            </availability>
+            <availability>Public domain</availability>
          </pubStmt>
       </fileDesc>
    </meiHead>

--- a/src/importexport/mei/tests/data/metadata-01.mscx
+++ b/src/importexport/mei/tests/data/metadata-01.mscx
@@ -13,7 +13,7 @@
     <metaTag name="composer">Composer of the piece</metaTag>
     <metaTag name="copyright">Public domain</metaTag>
     <metaTag name="lyricist">Metastasio</metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Metadata test (title)&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;arranger&quot;&gt;Arranger of the piece&lt;/persName&gt;&lt;persName role=&quot;composer&quot;&gt;Composer of the piece&lt;/persName&gt;&lt;persName role=&quot;lyricist&quot;&gt;Metastasio&lt;/persName&gt;&lt;persName role=&quot;translator&quot;&gt;Deepl&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:53:16&quot;/&gt;&lt;availability&gt;&lt;distributor&gt;Public domain&lt;/distributor&gt;&lt;/availability&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Metadata test (title)&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;arranger&quot;&gt;Arranger of the piece&lt;/persName&gt;&lt;persName role=&quot;composer&quot;&gt;Composer of the piece&lt;/persName&gt;&lt;persName role=&quot;lyricist&quot;&gt;Metastasio&lt;/persName&gt;&lt;persName role=&quot;translator&quot;&gt;Deepl&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:53:16&quot;/&gt;&lt;availability&gt;Public domain&lt;/availability&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="poet"></metaTag>


### PR DESCRIPTION
This PR fixes a small problem with invalid output to MEI: the element `distributor` is not available in MEI Basic.