### PR TITLE
Fix #19165: missing line end on tempo changes

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -6192,6 +6192,9 @@ static void spannerStop(ExportMusicXml* exp, track_idx_t strack, track_idx_t etr
             case ElementType::LET_RING:
                 exp->textLine(toLetRing(e), sstaff, Fraction(-1, 1));
                 break;
+            case ElementType::GRADUAL_TEMPO_CHANGE:
+                exp->textLine(toGradualTempoChange(e), sstaff, Fraction(-1, 1));
+                break;
             case ElementType::PALM_MUTE:
                 exp->textLine(toPalmMute(e), sstaff, Fraction(-1, 1));
                 break;


### PR DESCRIPTION
This fixes the missing line end on gradual tempo changes in MusicXML export.

Closes #19165 