### PR TITLE
Lower macOS deployment target to 10.13

### DIFF
--- a/.github/workflows/ci_macos_mu4.yml
+++ b/.github/workflows/ci_macos_mu4.yml
@@ -25,7 +25,7 @@ on:
 
 env:
   CURRENT_RELEASE_BRANCH: 4.2.1
-  DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_15.1.app/Contents/Developer
 
 jobs:
   build_mu4:    

--- a/build/MacOSXBundleInfo.plist.in
+++ b/build/MacOSXBundleInfo.plist.in
@@ -466,7 +466,7 @@
 	<key>LSRequiresCarbon</key>
 	<true/>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.14.0</string>
+	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
 	<key>LSApplicationCategoryType</key>

--- a/build/ci/macos/setup.sh
+++ b/build/ci/macos/setup.sh
@@ -23,7 +23,7 @@ echo "Setup MacOS build environment"
 trap 'echo Setup failed; exit 1' ERR
 SKIP_ERR_FLAG=true
 
-export MACOSX_DEPLOYMENT_TARGET=10.14
+export MACOSX_DEPLOYMENT_TARGET=10.13
 
 # install dependencies
 wget -c --no-check-certificate -nv -O bottles.zip https://musescore.org/sites/musescore.org/files/2020-02/bottles-MuseScore-3.0-yosemite.zip

--- a/build/cmake/SetupBuildEnvironment.cmake
+++ b/build/cmake/SetupBuildEnvironment.cmake
@@ -137,7 +137,7 @@ if (OS_IS_MAC)
         message(STATUS "Building for default architecture(s)")
     endif()
 
-    set(MACOSX_DEPLOYMENT_TARGET 10.14)
-    set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14)
+    set(MACOSX_DEPLOYMENT_TARGET 10.13)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13)
 endif(OS_IS_MAC)
 

--- a/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
+++ b/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
@@ -35,35 +35,46 @@ id<NSObject> darkModeObserverToken = nil;
 
 void MacOSPlatformTheme::startListening()
 {
-    if (!darkModeObserverToken) {
-        darkModeObserverToken = [[NSDistributedNotificationCenter defaultCenter]
-                                 addObserverForName:@"AppleInterfaceThemeChangedNotification"
-                                 object:nil
-                                 queue:nil
-                                 usingBlock:^(NSNotification*) {
-                                     m_platformThemeChanged.notify();
-                                 }];
+    if (__builtin_available(macOS 10.14, *)) {
+        if (!darkModeObserverToken) {
+            darkModeObserverToken = [[NSDistributedNotificationCenter defaultCenter]
+                                     addObserverForName:@"AppleInterfaceThemeChangedNotification"
+                                     object:nil
+                                     queue:nil
+                                     usingBlock:^(NSNotification*) {
+                                         m_platformThemeChanged.notify();
+                                     }];
+        }
     }
 }
 
 void MacOSPlatformTheme::stopListening()
 {
-    if (darkModeObserverToken) {
-        [[NSDistributedNotificationCenter defaultCenter] removeObserver:darkModeObserverToken];
-        darkModeObserverToken = nil;
+    if (__builtin_available(macOS 10.14, *)) {
+        if (darkModeObserverToken) {
+            [[NSDistributedNotificationCenter defaultCenter] removeObserver:darkModeObserverToken];
+            darkModeObserverToken = nil;
+        }
     }
 }
 
 bool MacOSPlatformTheme::isFollowSystemThemeAvailable() const
 {
-    // Supported from macOS 10.14, which is our minimum supported version
-    return true;
+    if (__builtin_available(macOS 10.14, *)) {
+        return true;
+    }
+
+    return false;
 }
 
 bool MacOSPlatformTheme::isSystemThemeDark() const
 {
-    NSString* systemMode = [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
-    return [systemMode isEqualToString:@"Dark"];
+    if (__builtin_available(macOS 10.14, *)) {
+        NSString* systemMode = [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
+        return [systemMode isEqualToString:@"Dark"];
+    }
+
+    return false;
 }
 
 bool MacOSPlatformTheme::isGlobalMenuAvailable() const
@@ -78,12 +89,14 @@ Notification MacOSPlatformTheme::platformThemeChanged() const
 
 void MacOSPlatformTheme::applyPlatformStyleOnAppForTheme(const ThemeCode& themeCode)
 {
-    // The system will turn these appearance names into their high contrast
-    // counterparts automatically if system high contrast is enabled
-    if (isDarkTheme(themeCode)) {
-        [NSApp setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameDarkAqua]];
-    } else {
-        [NSApp setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameAqua]];
+    if (__builtin_available(macOS 10.14, *)) {
+        // The system will turn these appearance names into their high contrast
+        // counterparts automatically if system high contrast is enabled
+        if (isDarkTheme(themeCode)) {
+            [NSApp setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameDarkAqua]];
+        } else {
+            [NSApp setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameAqua]];
+        }
     }
 }
 


### PR DESCRIPTION
Back in the days, we chose 10.14, because:
- We still believed that we would switch to Qt 6 with MuseScore 4.1
- Qt 6 required 10.14
- We wanted to do a OS requirement bump from MuseScore 3.6 to 4.0, not from 4.0 to 4.1

But things turned out differently:
- Switching to Qt 6 is not going to happen anytime soon (there are too many things that are just not working or still missing; and why would we even switch, since the open source world is _still_ receiving LTS updates for Qt 5.15, albeit with one year delay with respect to commercial users)
- Nowadays, Qt 6 requires even 10.15 or even 11.0 (different documentation pages say different things)

So there is no point anymore in artificially limiting MuseScore to macOS 10.14+. This PR lifts that restriction, so that MuseScore 4.2 will run on macOS 10.13 (which _is_ really required, by Qt 5.15).