### PR TITLE
Adds notation options to change text color to red

### DIFF
--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -260,6 +260,7 @@ public:
     virtual void toggleItalic() = 0;
     virtual void toggleUnderline() = 0;
     virtual void toggleStrike() = 0;
+    virtual void toggleRed() = 0;
 
     virtual bool canInsertClef(mu::engraving::ClefType) const = 0;
     virtual void insertClef(mu::engraving::ClefType) = 0;

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -260,7 +260,6 @@ public:
     virtual void toggleItalic() = 0;
     virtual void toggleUnderline() = 0;
     virtual void toggleStrike() = 0;
-    virtual void toggleRed() = 0;
 
     virtual bool canInsertClef(mu::engraving::ClefType) const = 0;
     virtual void insertClef(mu::engraving::ClefType) = 0;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -395,7 +395,7 @@ void NotationActionController::init()
     registerAction("text-i", &Interaction::toggleItalic, &Controller::isEditingText);
     registerAction("text-u", &Interaction::toggleUnderline, &Controller::isEditingText);
     registerAction("text-s", &Interaction::toggleStrike, &Controller::isEditingText);
-
+    registerAction("text-red", &Interaction::toggleRed, &Controller::isEditingText);
     registerAction("select-next-measure", &Interaction::addToSelection, MoveDirection::Right, MoveSelectionType::Measure, PlayMode::NoPlay,
                    &Controller::isNotNoteInputMode);
     registerAction("select-prev-measure", &Interaction::addToSelection, MoveDirection::Left, MoveSelectionType::Measure, PlayMode::NoPlay,

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -395,6 +395,7 @@ void NotationActionController::init()
     registerAction("text-i", &Interaction::toggleItalic, &Controller::isEditingText);
     registerAction("text-u", &Interaction::toggleUnderline, &Controller::isEditingText);
     registerAction("text-s", &Interaction::toggleStrike, &Controller::isEditingText);
+    registerAction("text-red", &Interaction::toggleRed, &Controller::isEditingText);
     registerAction("select-next-measure", &Interaction::addToSelection, MoveDirection::Right, MoveSelectionType::Measure, PlayMode::NoPlay,
                    &Controller::isNotNoteInputMode);
     registerAction("select-prev-measure", &Interaction::addToSelection, MoveDirection::Left, MoveSelectionType::Measure, PlayMode::NoPlay,

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -395,7 +395,6 @@ void NotationActionController::init()
     registerAction("text-i", &Interaction::toggleItalic, &Controller::isEditingText);
     registerAction("text-u", &Interaction::toggleUnderline, &Controller::isEditingText);
     registerAction("text-s", &Interaction::toggleStrike, &Controller::isEditingText);
-    registerAction("text-red", &Interaction::toggleRed, &Controller::isEditingText);
     registerAction("select-next-measure", &Interaction::addToSelection, MoveDirection::Right, MoveSelectionType::Measure, PlayMode::NoPlay,
                    &Controller::isNotNoteInputMode);
     registerAction("select-prev-measure", &Interaction::addToSelection, MoveDirection::Left, MoveSelectionType::Measure, PlayMode::NoPlay,

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5420,13 +5420,6 @@ void NotationInteraction::toggleFontStyle(mu::engraving::FontStyle style)
     notifyAboutTextEditingChanged();
 }
 
-void NotationInteraction::toggleRed()
-{
-//FIXME
-   /*mu::engraving::TextBase* text = toTextBase(m_editData.element);
-    int currentColor = text->getProperty(mu::engraving::Pid::COLOR).toInt();
-    text->textColor( ).RED;*/
-}
 
 void NotationInteraction::toggleBold()
 {

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5420,6 +5420,11 @@ void NotationInteraction::toggleFontStyle(mu::engraving::FontStyle style)
     notifyAboutTextEditingChanged();
 }
 
+void NotationInteraction::toggleRed()
+{
+    mu::engraving::TextBase* text = toTextBase(m_editData.element);
+    text->textColor().RED;
+}
 
 void NotationInteraction::toggleBold()
 {

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5420,6 +5420,14 @@ void NotationInteraction::toggleFontStyle(mu::engraving::FontStyle style)
     notifyAboutTextEditingChanged();
 }
 
+void NotationInteraction::toggleRed()
+{
+//FIXME
+   /*mu::engraving::TextBase* text = toTextBase(m_editData.element);
+    int currentColor = text->getProperty(mu::engraving::Pid::COLOR).toInt();
+    text->textColor( ).RED;*/
+}
+
 void NotationInteraction::toggleBold()
 {
     toggleFontStyle(mu::engraving::FontStyle::Bold);

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -266,6 +266,7 @@ public:
     void toggleItalic() override;
     void toggleUnderline() override;
     void toggleStrike() override;
+    void toggleRed() override;
     void toggleArticulation(mu::engraving::SymId) override;
     void toggleAutoplace(bool) override;
     bool canInsertClef(mu::engraving::ClefType) const override;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -268,7 +268,7 @@ public:
     void toggleStrike() override;
     void toggleArticulation(mu::engraving::SymId) override;
     void toggleAutoplace(bool) override;
-
+   void toggleRed() override;
     bool canInsertClef(mu::engraving::ClefType) const override;
     void insertClef(mu::engraving::ClefType) override;
 

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -268,7 +268,6 @@ public:
     void toggleStrike() override;
     void toggleArticulation(mu::engraving::SymId) override;
     void toggleAutoplace(bool) override;
-   void toggleRed() override;
     bool canInsertClef(mu::engraving::ClefType) const override;
     void insertClef(mu::engraving::ClefType) override;
 

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1753,6 +1753,13 @@ const UiActionList NotationUiActions::m_actions = {
              TranslatableString("action", "Format text: strikethrough"),
              Checkable::Yes
              ),
+    UiAction("text-red",
+            mu::context::UiCtxNotationOpened,
+            mu::context::CTX_NOTATION_OPENED,
+            TranslatableString("action", "Red"),
+            TranslatableString("action", "Format text: red"),
+            Checkable::Yes
+            ),
     UiAction("pitch-up-diatonic",
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_ANY,

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1753,13 +1753,6 @@ const UiActionList NotationUiActions::m_actions = {
              TranslatableString("action", "Format text: strikethrough"),
              Checkable::Yes
              ),
-    UiAction("text-red",
-            mu::context::UiCtxNotationOpened,
-            mu::context::CTX_NOTATION_OPENED,
-            TranslatableString("action","Red"),
-            TranslatableString("action", "Format text: red"),
-            Checkable::Yes
-            ),
     UiAction("pitch-up-diatonic",
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_ANY,

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1753,6 +1753,13 @@ const UiActionList NotationUiActions::m_actions = {
              TranslatableString("action", "Format text: strikethrough"),
              Checkable::Yes
              ),
+    UiAction("text-red",
+            mu::context::UiCtxNotationOpened,
+            mu::context::CTX_NOTATION_OPENED,
+            TranslatableString("action","Red"),
+            TranslatableString("action", "Format text: red"),
+            Checkable::Yes
+            ),
     UiAction("pitch-up-diatonic",
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_ANY,


### PR DESCRIPTION
This is my first time contributing to an OS project so I attempted to add a feature allowing users to change the text color to red quickly, as they might for making text italics or bold, for visibility and annotation purposes. Please let me know if this is acceptable. Thank you!

- [x ] I signed the [CLA](https://musescore.org/en/cla)
- [x ] The title of the PR describes the problem it addresses
- [x ] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x ] If changes are extensive, there is a sequence of easily reviewable commits
- [x ] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x ] There are no unnecessary changes
- [x ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
