### PR TITLE
Properly invalidate layout data when editing first accidental of the measure

### DIFF
--- a/src/engraving/rendering/dev/passresetlayoutdata.cpp
+++ b/src/engraving/rendering/dev/passresetlayoutdata.cpp
@@ -45,7 +45,7 @@ void PassResetLayoutData::doRun(Score* score, LayoutContext& ctx)
         resetLayoutData(score->rootItem());
     } else {
         MeasureBase* m = ctx.mutState().nextMeasure();
-        while (m && m->tick() < ctx.state().endTick()) {
+        while (m && m->tick() <= ctx.state().endTick()) {
             resetLayoutData(m);
             m = m->next();
         }


### PR DESCRIPTION
like adding parentheses to it

Resolves: https://github.com/musescore/MuseScore/issues/19574

When editing the first accidental of the measure, the layout range start tick is Fraction(0,1) and the end tick too. This means that the measure will be excluded from "reset layout data" pass. 

A proper solution would be to get rid of the "reset layout data" pass and add proper invalidation to specific elements whenever a property of those elements is edited, but I assumed it would be better to do that later. 