### PR TITLE
Fix #10508: Open last session on startup

### DIFF
--- a/src/appshell/appshelltypes.h
+++ b/src/appshell/appshelltypes.h
@@ -55,7 +55,8 @@ enum class StartupModeType
     StartEmpty,
     ContinueLastSession,
     StartWithNewScore,
-    StartWithScore
+    StartWithScore,
+    Recovery
 };
 }
 

--- a/src/appshell/internal/startupscenario.cpp
+++ b/src/appshell/internal/startupscenario.cpp
@@ -169,9 +169,8 @@ mu::Uri StartupScenario::startupPageUri(StartupModeType modeType) const
     case StartupModeType::StartWithNewScore:
         return HOME_URI;
     case StartupModeType::StartWithScore:
-        return NOTATION_URI;
     case StartupModeType::ContinueLastSession:
-        return HOME_URI;
+        return NOTATION_URI;
     }
 
     return HOME_URI;

--- a/src/appshell/internal/startupscenario.cpp
+++ b/src/appshell/internal/startupscenario.cpp
@@ -94,7 +94,7 @@ void StartupScenario::run()
     StartupModeType modeType = resolveStartupModeType();
     bool isMainInstance = multiInstancesProvider()->isMainInstance();
     if (isMainInstance && sessionsManager()->hasProjectsForRestore()) {
-        modeType = StartupModeType::ContinueLastSession;
+        modeType = StartupModeType::Recovery;
     }
 
     Uri startupUri = startupPageUri(modeType);
@@ -148,6 +148,9 @@ void StartupScenario::onStartupPageOpened(StartupModeType modeType)
         dispatcher()->dispatch("file-new");
         break;
     case StartupModeType::ContinueLastSession:
+        dispatcher()->dispatch("continue-last-session");
+        break;
+    case StartupModeType::Recovery:
         restoreLastSession();
         break;
     case StartupModeType::StartWithScore: {
@@ -167,6 +170,7 @@ mu::Uri StartupScenario::startupPageUri(StartupModeType modeType) const
     switch (modeType) {
     case StartupModeType::StartEmpty:
     case StartupModeType::StartWithNewScore:
+    case StartupModeType::Recovery:
         return HOME_URI;
     case StartupModeType::StartWithScore:
     case StartupModeType::ContinueLastSession:
@@ -183,11 +187,6 @@ void StartupScenario::openScore(const project::ProjectFile& file)
 
 void StartupScenario::restoreLastSession()
 {
-    if (!sessionsManager()->hasProjectsForRestore()) {
-        dispatcher()->dispatch("continue-last-session");
-        return;
-    }
-
     IInteractive::Result result = interactive()->question(trc("appshell", "The previous session quit unexpectedly."),
                                                           trc("appshell", "Do you want to restore the session?"),
                                                           { IInteractive::Button::No, IInteractive::Button::Yes });

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1511,6 +1511,10 @@ void ProjectActionsController::continueLastSession()
     const ProjectFilesList& recentScorePaths = recentFilesController()->recentFilesList();
 
     if (recentScorePaths.empty()) {
+        Ret ret = openPageIfNeed(HOME_PAGE_URI);
+        if (!ret) {
+            LOGE() << ret.toString();
+        }
         return;
     }
 


### PR DESCRIPTION
Resolves: #10508

Also added a bit of logic to go to home screen if there are no recent projects (instead of showing an empty notation page).