### PR TITLE
[MU4 Suggestion] Change shape of mouse cursor on tabs/title bar of detachable panels to make clear that they can be detached #16011

### DIFF
--- a/src/appshell/qml/dockwindow/DockFrame.qml
+++ b/src/appshell/qml/dockwindow/DockFrame.qml
@@ -108,6 +108,8 @@ Rectangle {
         hoverEnabled: false
         propagateComposedEvents: true
         enabled: tabsPanel.visible
+        acceptedButtons: Qt.NoButton
+        cursorShape: Qt.SizeAllCursor
     }
 
     Rectangle {

--- a/src/appshell/qml/dockwindow/DockFrame.qml
+++ b/src/appshell/qml/dockwindow/DockFrame.qml
@@ -108,8 +108,6 @@ Rectangle {
         hoverEnabled: false
         propagateComposedEvents: true
         enabled: tabsPanel.visible
-        acceptedButtons: Qt.NoButton
-        cursorShape: Qt.SizeAllCursor
     }
 
     Rectangle {

--- a/src/appshell/qml/dockwindow/DockTitleBar.qml
+++ b/src/appshell/qml/dockwindow/DockTitleBar.qml
@@ -56,6 +56,13 @@ Item {
 
         visible: parent.visible
 
+        MouseArea {
+            id: hoverArea
+            anchors.fill: parent
+            acceptedButtons: Qt.NoButton
+            cursorShape: Qt.SizeAllCursor
+        }
+
         Column {
             id: titleBarContent
 

--- a/src/appshell/qml/dockwindow/DockTitleBar.qml
+++ b/src/appshell/qml/dockwindow/DockTitleBar.qml
@@ -46,6 +46,13 @@ Item {
 
     visible: Boolean(titleBarCpp)
 
+    MouseArea {
+        id: mouseArea
+        anchors.fill: parent
+        acceptedButtons: Qt.NoButton
+        cursorShape: Qt.SizeAllCursor
+    }
+
     KDDW.TitleBarBase {
         id: titleBar
 

--- a/src/appshell/qml/dockwindow/DockTitleBar.qml
+++ b/src/appshell/qml/dockwindow/DockTitleBar.qml
@@ -56,13 +56,6 @@ Item {
 
         visible: parent.visible
 
-        MouseArea {
-            id: hoverArea
-            anchors.fill: parent
-            acceptedButtons: Qt.NoButton
-            cursorShape: Qt.SizeAllCursor
-        }
-
         Column {
             id: titleBarContent
 

--- a/src/appshell/qml/dockwindow/DockToolBar.qml
+++ b/src/appshell/qml/dockwindow/DockToolBar.qml
@@ -85,7 +85,6 @@ DockToolBarView {
             visible: root.floatable
 
             mouseArea.objectName: root.objectName + "_gripButton"
-            mouseArea.cursorShape: Qt.SizeAllCursor
 
             transparent: true
             contentItem: StyledIconLabel {

--- a/src/appshell/qml/dockwindow/DockToolBar.qml
+++ b/src/appshell/qml/dockwindow/DockToolBar.qml
@@ -85,6 +85,7 @@ DockToolBarView {
             visible: root.floatable
 
             mouseArea.objectName: root.objectName + "_gripButton"
+            mouseArea.cursorShape: Qt.SizeAllCursor
 
             transparent: true
             contentItem: StyledIconLabel {


### PR DESCRIPTION
Pull request for issue #16011 
Yesterday I checked the mouse cursor shape, and it worked. The mouse cursor for all three areas had been modified. (Today I deleted my older versions, and unfortunately, now my computer shows no effect, which is the previous problem)
@cbjeukendrup mentor, please help me to re-set my Qt creator, so that I can see my modification effect again (This time things are quite different)