### PR TITLE
Added default value to _stretch to avoid divsion by zero

### DIFF
--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -3239,7 +3239,7 @@ void Measure::stretchToTargetWidth(double targetWidth)
             double springConst = 1 / s.stretch();
             double width = s.width(LD_ACCESS::BAD) - s.widthOffset();
             double preTension = width * springConst;
-            springs.push_back(Spring(springConst, width, preTension, &s));
+            springs.emplace_back(springConst, width, preTension, &s);
         }
     }
     Segment::stretchSegmentsToWidth(springs, targetWidth - width());

--- a/src/engraving/dom/segment.h
+++ b/src/engraving/dom/segment.h
@@ -90,7 +90,7 @@ class Segment final : public EngravingItem
     Fraction _tick;    // { Fraction(0, 1) };
     Fraction _ticks;   // { Fraction(0, 1) };
     Spatium _extraLeadingSpace;
-    double _stretch;
+    double _stretch = 1.;
     double _widthOffset = 0.0; // part of the segment width that will not be stretched during system justification
 
     Segment* _next = nullptr;                       // linked list of segments inside a measure


### PR DESCRIPTION
Segment double _stretch wasn't initialised which cases division by zero here 
```cpp
    for (Segment& s : m_segments) {
        if (s.isChordRestType() && s.visible() && s.enabled() && !s.allElementsInvisible()) {
            double springConst = 1 / s.stretch();
            double width = s.width(LD_ACCESS::BAD) - s.widthOffset();
            double preTension = width * springConst;
            springs.emplace_back(springConst, width, preTension, &s);
        }
    }
```