### PR TITLE
Added default value to _stretch to avoid divsion by zero

### DIFF
--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -3239,7 +3239,7 @@ void Measure::stretchToTargetWidth(double targetWidth)
             double springConst = 1 / s.stretch();
             double width = s.width(LD_ACCESS::BAD) - s.widthOffset();
             double preTension = width * springConst;
-            springs.push_back(Spring(springConst, width, preTension, &s));
+            springs.emplace_back(springConst, width, preTension, &s);
         }
     }
     Segment::stretchSegmentsToWidth(springs, targetWidth - width());

--- a/src/engraving/dom/segment.h
+++ b/src/engraving/dom/segment.h
@@ -90,7 +90,7 @@ class Segment final : public EngravingItem
     Fraction _tick;    // { Fraction(0, 1) };
     Fraction _ticks;   // { Fraction(0, 1) };
     Spatium _extraLeadingSpace;
-    double _stretch;
+    double _stretch = 1.;
     double _widthOffset = 0.0; // part of the segment width that will not be stretched during system justification
 
     Segment* _next = nullptr;                       // linked list of segments inside a measure

--- a/src/engraving/dom/stafftype.cpp
+++ b/src/engraving/dom/stafftype.cpp
@@ -1191,7 +1191,7 @@ void StaffType::initStaffTypes()
         StaffType(StaffGroup::STANDARD,   u"stdNormal", mtrc("engraving", "Standard"),        5, 0,     1,   true,  true, false, true, true, true, false,  engravingConfiguration()->defaultColor()),
         StaffType(StaffGroup::PERCUSSION, u"perc1Line", mtrc("engraving", "Perc. 1 line"),    1, 0,     1,   true,  true, false, true, false, true, false,  engravingConfiguration()->defaultColor()),
         StaffType(StaffGroup::PERCUSSION, u"perc2Line", mtrc("engraving", "Perc. 2 lines"),   2, 0,     1,   true,  true, false, true, false, true, false,  engravingConfiguration()->defaultColor()),
-        StaffType(StaffGroup::PERCUSSION, u"perc3Line", mtrc("engraving", "Perc. 3 lines"),   3, 0,     2,   true,  true, false, true, false, true, false,  engravingConfiguration()->defaultColor()),
+        StaffType(StaffGroup::PERCUSSION, u"perc3Line", mtrc("engraving", "Perc. 3 lines"),   3, 0,     1,   true,  true, false, true, false, true, false,  engravingConfiguration()->defaultColor()),
         StaffType(StaffGroup::PERCUSSION, u"perc5Line", mtrc("engraving", "Perc. 5 lines"),   5, 0,     1,   true,  true, false, true, false, true, false,  engravingConfiguration()->defaultColor()),
 
 //                 group            xml-name,     human-readable-name                  lin stpOff dist clef   bars stemless time   invis     color   duration font     size off genDur     fret font          size off  duration symbol repeat      thru       minim style              onLin  rests  stmDn  stmThr upsDn  sTFing nums  bkTied

--- a/src/engraving/dom/stafftype.cpp
+++ b/src/engraving/dom/stafftype.cpp
@@ -1191,7 +1191,7 @@ void StaffType::initStaffTypes()
         StaffType(StaffGroup::STANDARD,   u"stdNormal", mtrc("engraving", "Standard"),        5, 0,     1,   true,  true, false, true, true, true, false,  engravingConfiguration()->defaultColor()),
         StaffType(StaffGroup::PERCUSSION, u"perc1Line", mtrc("engraving", "Perc. 1 line"),    1, 0,     1,   true,  true, false, true, false, true, false,  engravingConfiguration()->defaultColor()),
         StaffType(StaffGroup::PERCUSSION, u"perc2Line", mtrc("engraving", "Perc. 2 lines"),   2, 0,     1,   true,  true, false, true, false, true, false,  engravingConfiguration()->defaultColor()),
-        StaffType(StaffGroup::PERCUSSION, u"perc3Line", mtrc("engraving", "Perc. 3 lines"),   3, 0,     1,   true,  true, false, true, false, true, false,  engravingConfiguration()->defaultColor()),
+        StaffType(StaffGroup::PERCUSSION, u"perc3Line", mtrc("engraving", "Perc. 3 lines"),   3, 0,     2,   true,  true, false, true, false, true, false,  engravingConfiguration()->defaultColor()),
         StaffType(StaffGroup::PERCUSSION, u"perc5Line", mtrc("engraving", "Perc. 5 lines"),   5, 0,     1,   true,  true, false, true, false, true, false,  engravingConfiguration()->defaultColor()),
 
 //                 group            xml-name,     human-readable-name                  lin stpOff dist clef   bars stemless time   invis     color   duration font     size off genDur     fret font          size off  duration symbol repeat      thru       minim style              onLin  rests  stmDn  stmThr upsDn  sTFing nums  bkTied


### PR DESCRIPTION
Segment double _stretch wasn't initialised which cases division by zero here 
```cpp
    for (Segment& s : m_segments) {
        if (s.isChordRestType() && s.visible() && s.enabled() && !s.allElementsInvisible()) {
            double springConst = 1 / s.stretch();
            double width = s.width(LD_ACCESS::BAD) - s.widthOffset();
            double preTension = width * springConst;
            springs.emplace_back(springConst, width, preTension, &s);
        }
    }
```