### PR TITLE
gp-converter: not importing extra H/P text on chords

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1287,6 +1287,7 @@ void GPConverter::addContinuousSlideHammerOn()
     };
 
     std::unordered_map<Note*, Slur*> legatoSlides;
+    std::unordered_set<Chord*> hammerOnInChord;
     for (const auto& slide : _slideHammerOnMap) {
         Note* startNote = slide.first;
         Note* endNote = searchEndNote(startNote);
@@ -1339,7 +1340,12 @@ void GPConverter::addContinuousSlideHammerOn()
 
             // TODO-gp: implement for editing too. Now works just for import.
             if (slide.second == SlideHammerOn::HammerOn) {
-                Measure* measure = startNote->chord()->measure();
+                Chord* startChord = startNote->chord();
+                if (hammerOnInChord.find(startChord) != hammerOnInChord.end()) {
+                    continue;
+                }
+
+                Measure* measure = startChord->measure();
 
                 auto midTick = (startTick + endTick) / 2;
                 Segment* segment = measure->getSegment(SegmentType::ChordRest, midTick);
@@ -1349,6 +1355,7 @@ void GPConverter::addContinuousSlideHammerOn()
                 staffText->setPlainText(hammerText);
                 staffText->setTrack(track);
                 segment->add(staffText);
+                hammerOnInChord.insert(startChord);
             }
         }
     }


### PR DESCRIPTION
before:
![Screenshot 2023-10-05 at 13 16 05](https://github.com/musescore/MuseScore/assets/24373905/e071b519-4691-4f9f-9efb-9c4dcd17613a)

after:
![Screenshot 2023-10-05 at 13 15 12](https://github.com/musescore/MuseScore/assets/24373905/6893b6b7-a748-481b-9184-c1fc3e0a98f7)
[hammer-chord.gp.zip](https://github.com/musescore/MuseScore/files/12817155/hammer-chord.gp.zip)
