### PR TITLE
Avoid redrawing navigator unless navigator viewport is changed

### DIFF
--- a/src/notation/view/notationnavigator.cpp
+++ b/src/notation/view/notationnavigator.cpp
@@ -209,10 +209,10 @@ void NotationNavigator::setCursorRect(const QRectF& rect)
     bool moved = moveCanvasToRect(newCursorRect);
     m_cursorRect = newCursorRect;
 
+    rescale();
     m_cursorRectView->setSize(this->size());
     m_cursorRectView->setRect(fromLogical(newCursorRect));
 
-    rescale();
     if (moved) {
         update();
     }

--- a/src/notation/view/notationnavigator.cpp
+++ b/src/notation/view/notationnavigator.cpp
@@ -37,7 +37,6 @@ using namespace mu::notation;
 NotationNavigatorViewRect::NotationNavigatorViewRect(QQuickItem* parent)
     : QQuickPaintedItem(parent)
 {
-    this->setSize(parent->size()); // FIXME: doesn't set the size
 }
 
 void NotationNavigatorViewRect::paint(QPainter* painter)
@@ -50,11 +49,6 @@ void NotationNavigatorViewRect::paint(QPainter* painter)
     painter->setBrush(QColor(color.red(), color.green(), color.blue(), configuration()->cursorOpacity()));
 
     painter->drawRect(m_cursorRect.toQRectF());
-}
-
-mu::RectF NotationNavigatorViewRect::getRect()
-{
-    return m_cursorRect;
 }
 
 void NotationNavigatorViewRect::setRect(RectF cursorRect)
@@ -139,15 +133,14 @@ void NotationNavigator::mousePressEvent(QMouseEvent* event)
 {
     TRACEFUNC;
 
-    RectF cursorRect = m_viewRect->getRect();
     PointF logicPos = toLogical(event->pos());
     m_startMove = logicPos;
-    if (cursorRect.contains(logicPos)) {
+    if (m_cursorRect.contains(logicPos)) {
         return;
     }
 
-    double dx = logicPos.x() - (cursorRect.x() + (cursorRect.width() / 2));
-    double dy = logicPos.y() - (cursorRect.y() + (cursorRect.height() / 2));
+    double dx = logicPos.x() - (m_cursorRect.x() + (m_cursorRect.width() / 2));
+    double dy = logicPos.y() - (m_cursorRect.y() + (m_cursorRect.height() / 2));
 
     moveNotationRequested(-dx, -dy);
 }
@@ -220,8 +213,10 @@ void NotationNavigator::setCursorRect(const QRectF& rect)
     RectF newCursorRect = notationContentRect().intersected(RectF::fromQRectF(rect));
 
     bool moved = moveCanvasToRect(newCursorRect);
+    m_cursorRect = newCursorRect;
 
-    m_viewRect->setRect(newCursorRect);
+    m_viewRect->setSize(this->size());
+    m_viewRect->setRect(fromLogical(newCursorRect));
 
     rescale();
     if (moved) {

--- a/src/notation/view/notationnavigator.cpp
+++ b/src/notation/view/notationnavigator.cpp
@@ -21,19 +21,18 @@
  */
 #include "notationnavigator.h"
 
-#include "draw/types/geometry.h"
 #include "engraving/dom/system.h"
 
 #include "log.h"
 
 using namespace mu::notation;
 
-NotationNavigatorViewRect::NotationNavigatorViewRect(QQuickItem* parent)
+NotationNavigatorCursorView::NotationNavigatorCursorView(QQuickItem* parent)
     : QQuickPaintedItem(parent)
 {
 }
 
-void NotationNavigatorViewRect::paint(QPainter* painter)
+void NotationNavigatorCursorView::paint(QPainter* painter)
 {
     TRACEFUNC;
 
@@ -45,13 +44,13 @@ void NotationNavigatorViewRect::paint(QPainter* painter)
     painter->drawRect(m_cursorRect.toQRectF());
 }
 
-void NotationNavigatorViewRect::setRect(const RectF& cursorRect)
+void NotationNavigatorCursorView::setRect(const RectF& cursorRect)
 {
     m_cursorRect = cursorRect;
 }
 
 NotationNavigator::NotationNavigator(QQuickItem* parent)
-    : AbstractNotationPaintView(parent), m_cursorRectView(new NotationNavigatorViewRect(this))
+    : AbstractNotationPaintView(parent), m_cursorRectView(new NotationNavigatorCursorView(this))
 {
     setReadonly(true);
 }

--- a/src/notation/view/notationnavigator.cpp
+++ b/src/notation/view/notationnavigator.cpp
@@ -25,12 +25,6 @@
 #include "engraving/dom/system.h"
 
 #include "log.h"
-#include <memory>
-#include <qevent.h>
-#include <qpainter.h>
-#include <qquickitem.h>
-#include <qquickpainteditem.h>
-#include <qwidget.h>
 
 using namespace mu::notation;
 
@@ -51,13 +45,13 @@ void NotationNavigatorViewRect::paint(QPainter* painter)
     painter->drawRect(m_cursorRect.toQRectF());
 }
 
-void NotationNavigatorViewRect::setRect(RectF cursorRect)
+void NotationNavigatorViewRect::setRect(const RectF& cursorRect)
 {
     m_cursorRect = cursorRect;
 }
 
 NotationNavigator::NotationNavigator(QQuickItem* parent)
-    : AbstractNotationPaintView(parent), m_viewRect(std::make_unique<NotationNavigatorViewRect>(this))
+    : AbstractNotationPaintView(parent), m_cursorRectView(new NotationNavigatorViewRect(this))
 {
     setReadonly(true);
 }
@@ -71,7 +65,7 @@ void NotationNavigator::load()
 
     uiConfiguration()->currentThemeChanged().onNotify(this, [this]() {
         update();
-        m_viewRect->update();
+        m_cursorRectView->update();
     });
 
     AbstractNotationPaintView::load();
@@ -215,14 +209,14 @@ void NotationNavigator::setCursorRect(const QRectF& rect)
     bool moved = moveCanvasToRect(newCursorRect);
     m_cursorRect = newCursorRect;
 
-    m_viewRect->setSize(this->size());
-    m_viewRect->setRect(fromLogical(newCursorRect));
+    m_cursorRectView->setSize(this->size());
+    m_cursorRectView->setRect(fromLogical(newCursorRect));
 
     rescale();
     if (moved) {
         update();
     }
-    m_viewRect->update();
+    m_cursorRectView->update();
 }
 
 int NotationNavigator::orientation() const

--- a/src/notation/view/notationnavigator.h
+++ b/src/notation/view/notationnavigator.h
@@ -37,14 +37,14 @@
 #include "abstractnotationpaintview.h"
 
 namespace mu::notation {
-class NotationNavigatorViewRect : public QQuickPaintedItem
+class NotationNavigatorCursorView : public QQuickPaintedItem
 {
     Q_OBJECT
 
     INJECT(INotationConfiguration, configuration)
 
 public:
-    NotationNavigatorViewRect(QQuickItem* parent = nullptr);
+    NotationNavigatorCursorView(QQuickItem* parent = nullptr);
 
     void setRect(const RectF& cursorRect);
 
@@ -103,7 +103,7 @@ private:
     PageList pages() const;
 
     RectF m_cursorRect;
-    NotationNavigatorViewRect* m_cursorRectView;
+    NotationNavigatorCursorView* m_cursorRectView = nullptr;
     PointF m_startMove;
 };
 }

--- a/src/notation/view/notationnavigator.h
+++ b/src/notation/view/notationnavigator.h
@@ -26,10 +26,6 @@
 #include <QMouseEvent>
 #include <QPainter>
 #include <QQuickPaintedItem>
-#include <memory>
-#include <qpainter.h>
-#include <qquickpainteditem.h>
-#include <qwidget.h>
 
 #include "draw/types/geometry.h"
 #include "modularity/ioc.h"
@@ -47,13 +43,15 @@ class NotationNavigatorViewRect : public QQuickPaintedItem
 
     INJECT(INotationConfiguration, configuration)
 
-    virtual void paint(QPainter* painter) override;
-    RectF m_cursorRect;
-
 public:
     NotationNavigatorViewRect(QQuickItem* parent = nullptr);
 
-    void setRect(RectF cursorRect);
+    void setRect(const RectF& cursorRect);
+
+private:
+    virtual void paint(QPainter* painter) override;
+
+    RectF m_cursorRect;
 };
 
 class NotationNavigator : public AbstractNotationPaintView
@@ -105,7 +103,7 @@ private:
     PageList pages() const;
 
     RectF m_cursorRect;
-    std::unique_ptr<NotationNavigatorViewRect> m_viewRect;
+    NotationNavigatorViewRect* m_cursorRectView;
     PointF m_startMove;
 };
 }

--- a/src/notation/view/notationnavigator.h
+++ b/src/notation/view/notationnavigator.h
@@ -53,7 +53,6 @@ class NotationNavigatorViewRect : public QQuickPaintedItem
 public:
     NotationNavigatorViewRect(QQuickItem* parent = nullptr);
 
-    RectF getRect();
     void setRect(RectF cursorRect);
 };
 
@@ -105,6 +104,7 @@ private:
 
     PageList pages() const;
 
+    RectF m_cursorRect;
     std::unique_ptr<NotationNavigatorViewRect> m_viewRect;
     PointF m_startMove;
 };

--- a/src/notation/view/notationnavigator.h
+++ b/src/notation/view/notationnavigator.h
@@ -26,7 +26,12 @@
 #include <QMouseEvent>
 #include <QPainter>
 #include <QQuickPaintedItem>
+#include <memory>
+#include <qpainter.h>
+#include <qquickpainteditem.h>
+#include <qwidget.h>
 
+#include "draw/types/geometry.h"
 #include "modularity/ioc.h"
 #include "async/asyncable.h"
 #include "inotationconfiguration.h"
@@ -36,6 +41,22 @@
 #include "abstractnotationpaintview.h"
 
 namespace mu::notation {
+class NotationNavigatorViewRect : public QQuickPaintedItem
+{
+    Q_OBJECT
+
+    INJECT(INotationConfiguration, configuration)
+
+    virtual void paint(QPainter* painter) override;
+    RectF m_cursorRect;
+
+public:
+    NotationNavigatorViewRect(QQuickItem* parent = nullptr);
+
+    RectF getRect();
+    void setRect(RectF cursorRect);
+};
+
 class NotationNavigator : public AbstractNotationPaintView
 {
     Q_OBJECT
@@ -76,16 +97,15 @@ private:
     void mousePressEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
 
-    void paintCursor(QPainter* painter);
     void paintPageNumbers(QPainter* painter);
 
-    void moveCanvasToRect(const RectF& viewRect);
+    bool moveCanvasToRect(const RectF& viewRect);
 
     bool isVerticalOrientation() const;
 
     PageList pages() const;
 
-    RectF m_cursorRect;
+    std::unique_ptr<NotationNavigatorViewRect> m_viewRect;
     PointF m_startMove;
 };
 }


### PR DESCRIPTION
Resolves: #10201 (partially) <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

This PR decouples the navigator’s cursor from the rest of the navigator as was done in MS3. This avoids having to redraw the whole navigator when only the cursor is moved, improving performance on large scores.

~~Currently, I haven’t figured out how to get the cursor drawn again. Any help with this would be welcome.~~ I fixed this, but my solution is probably hacky as I’m unfamiliar with Qt. Looking for advice on the implementation.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable) – n/a
