### PR TITLE
fix #19575 allow removing key signature in mmrest mode

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -2365,7 +2365,7 @@ void Score::deleteItem(EngravingItem* el)
         return;
     }
     // cannot remove generated elements
-    if (el->generated() && !(el->isBracket() || el->isBarLine() || el->isClef() || el->isMeasureNumber())) {
+    if (el->generated() && !(el->isBracket() || el->isBarLine() || el->isClef() || el->isMeasureNumber() || el->isKeySig())) {
         return;
     }
 //      LOGD("%s", el->typeName());
@@ -2399,6 +2399,16 @@ void Score::deleteItem(EngravingItem* el)
     case ElementType::KEYSIG:
     {
         KeySig* k = toKeySig(el);
+        Measure* m = k->measure();
+        if (m->isMMRest()) {
+            m = m->mmRestFirst();
+            if (Segment* s = m->findSegment(SegmentType::KeySig, k->tick())) {
+                k = toKeySig(s->element(k->track()));
+            }
+            if (!k || k->generated()) {
+                return;
+            }
+        }
         bool ic = k->segment()->next(SegmentType::ChordRest)->findAnnotation(ElementType::INSTRUMENT_CHANGE,
                                                                              el->part()->startTrack(), el->part()->endTrack() - 1);
         undoRemoveElement(k);


### PR DESCRIPTION
Resolves: #19575 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
KeySig, yoummee!
 
<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
