### PR TITLE
Revert "fix #15707 use saved parts of older score as generic parts, even if name doesn't match"

### DIFF
--- a/src/engraving/rw/compat/compatutils.cpp
+++ b/src/engraving/rw/compat/compatutils.cpp
@@ -195,7 +195,7 @@ void CompatUtils::assignInitialPartToExcerpts(const std::vector<Excerpt*>& excer
         excerpt->setInitialPartId(initialPartId);
         assignedPartIdSet.insert(initialPartId);
     };
-    // Excerpt name is same as Part name (Violin - Violin)
+
     for (Excerpt* excerpt : excerpts) {
         for (const Part* part : excerpt->excerptScore()->parts()) {
             if (excerpt->name() == part->partName()) {
@@ -204,7 +204,7 @@ void CompatUtils::assignInitialPartToExcerpts(const std::vector<Excerpt*>& excer
             }
         }
     }
-    // Excerpt name contains Part name (Violin1 - Violin)
+
     for (Excerpt* excerpt : excerpts) {
         if (excerpt->initialPartId().isValid()) {
             continue;
@@ -219,38 +219,6 @@ void CompatUtils::assignInitialPartToExcerpts(const std::vector<Excerpt*>& excer
                 assignInitialPartId(excerpt, part->id());
                 break;
             }
-        }
-    }
-    // Excerpt contains only single instrument
-    for (Excerpt* excerpt : excerpts) {
-        if (excerpt->initialPartId().isValid()) {
-            continue;
-        }
-
-        for (Part* part : excerpt->excerptScore()->parts()) {
-            if (mu::contains(assignedPartIdSet, part->id())) {
-                continue;
-            }
-
-            if (excerpt->excerptScore()->parts().size() == 1) {
-                assignInitialPartId(excerpt, part->id());
-                break;
-            }
-        }
-    }
-    // Excerpt contains instrument
-    for (Excerpt* excerpt : excerpts) {
-        if (excerpt->initialPartId().isValid()) {
-            continue;
-        }
-
-        for (Part* part : excerpt->excerptScore()->parts()) {
-            if (mu::contains(assignedPartIdSet, part->id())) {
-                continue;
-            }
-
-            assignInitialPartId(excerpt, part->id());
-            break;
         }
     }
 }

--- a/src/engraving/tests/compat206_data/lidemptytext-ref.mscx
+++ b/src/engraving/tests/compat206_data/lidemptytext-ref.mscx
@@ -229,7 +229,6 @@
         </Measure>
       </Staff>
     <Score>
-      <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
         <pedalPosBelow x="0" y="0"/>


### PR DESCRIPTION
Reverts musescore/MuseScore#15708

Might resolve #19637 to some extent