### PR TITLE
Fix gcc compiler warnings

### DIFF
--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -5006,7 +5006,7 @@ void TLayout::layoutSymbol(const Symbol* item, Symbol::LayoutData* ldata, const 
         case ElementType::IMAGE: {
             Image* im = item_cast<Image*>(e);
             layoutImage(im, im->mutldata());
-        }
+        } break;
         default:
             UNREACHABLE;
             break;

--- a/src/framework/global/internal/interactive.cpp
+++ b/src/framework/global/internal/interactive.cpp
@@ -113,6 +113,11 @@ IInteractive::ButtonData Interactive::buttonData(Button b) const
     case IInteractive::Button::Apply:       return ButtonData(int(b), trc("global", "Apply"));
     case IInteractive::Button::Reset:       return ButtonData(int(b), trc("global", "Reset"));
     case IInteractive::Button::Continue:    return ButtonData(int(b), trc("global", "Continue"));
+    case IInteractive::Button::Next:
+    case IInteractive::Button::Back:
+    case IInteractive::Button::Select:
+    case IInteractive::Button::Clear:
+    case IInteractive::Button::Done:
     case IInteractive::Button::CustomButton: break;
     }
 

--- a/src/framework/uicomponents/view/buttonboxmodel.cpp
+++ b/src/framework/uicomponents/view/buttonboxmodel.cpp
@@ -115,7 +115,7 @@ const std::vector <ButtonBoxModel::ButtonRole>& ButtonBoxModel::chooseButtonLayo
 #endif
     }
 
-    IF_ASSERT_FAILED(index >= 0 && index < buttonRoleLayouts.size()) {
+    IF_ASSERT_FAILED(index != ButtonLayout::UnknownLayout && index < buttonRoleLayouts.size()) {
         index = 0;
     }
 


### PR DESCRIPTION
* reg. enumeration value not handled in switch [-Wswitch]
* reg. comparison of unsigned expression in ‘>= 0’ is always true [-Wtype-limits]
* reg. this statement may fall through [-Wimplicit-fallthrough=]