### PR TITLE
MusicXML: system dividers and line thickness import/export

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -1322,15 +1322,63 @@ static void defaults(XmlWriter& xml, const MStyle& s, double& millimeters, const
 
     writePageFormat(s, xml, INCH / millimeters * tenths);
 
-    // TODO: also write default system layout here
     // when exporting only manual or no breaks, system-distance is not written at all
+    if (s.styleB(Sid::dividerLeft) || s.styleB(Sid::dividerRight)) {
+        xml.startElement("system-layout");
+        xml.startElement("system-dividers");
+        if (s.styleB(Sid::dividerLeft)) {
+            xml.tag("left-divider", { { "print-object", "yes" },
+                        { "relative-x", s.styleD(Sid::dividerLeftX) * 10 },
+                        { "relative-y", s.styleD(Sid::dividerLeftY) * 10 } });
+        } else {
+            xml.tag("left-divider", { { "print-object", "no" } });
+        }
+        if (s.styleB(Sid::dividerRight)) {
+            xml.tag("right-divider", { { "print-object", "yes" },
+                        { "relative-x", s.styleD(Sid::dividerRightX) * 10 },
+                        { "relative-y", s.styleD(Sid::dividerRightY) * 10 } });
+        } else {
+            xml.tag("right-divider", { { "print-object", "no" } });
+        }
+        xml.endElement();
+        xml.endElement();
+    }
+
+    {
+        xml.startElement("appearance");
+        // line width values in tenth
+        xml.tag("line-width", { { "type", "light barline" } }, s.styleS(Sid::barWidth).val() * 10);
+        xml.tag("line-width", { { "type", "heavy barline" } }, s.styleS(Sid::endBarWidth).val() * 10);
+        xml.tag("line-width", { { "type", "beam" } }, s.styleS(Sid::beamWidth).val() * 10);
+        xml.tag("line-width", { { "type", "bracket" } }, s.styleS(Sid::bracketWidth).val() * 10);
+        xml.tag("line-width", { { "type", "dashes" } }, s.styleS(Sid::lyricsDashLineThickness).val() * 10);
+        xml.tag("line-width", { { "type", "enclosure" } }, s.styleD(Sid::staffTextFrameWidth) * 10);
+        xml.tag("line-width", { { "type", "ending" } }, s.styleS(Sid::voltaLineWidth).val() * 10);
+        xml.tag("line-width", { { "type", "extend" } }, s.styleS(Sid::lyricsLineThickness).val() * 10);
+        xml.tag("line-width", { { "type", "leger" } }, s.styleS(Sid::ledgerLineWidth).val() * 10);
+        xml.tag("line-width", { { "type", "pedal" } }, s.styleS(Sid::pedalLineWidth).val() * 10);
+        xml.tag("line-width", { { "type", "octave shift" } }, s.styleS(Sid::ottavaLineWidth).val() * 10);
+        xml.tag("line-width", { { "type", "slur middle" } }, s.styleS(Sid::SlurMidWidth).val() * 10);
+        xml.tag("line-width", { { "type", "slur tip" } }, s.styleS(Sid::SlurEndWidth).val() * 10);
+        xml.tag("line-width", { { "type", "staff" } }, s.styleS(Sid::staffLineWidth).val() * 10);
+        xml.tag("line-width", { { "type", "stem" } }, s.styleS(Sid::stemWidth).val() * 10);
+        xml.tag("line-width", { { "type", "tie middle" } }, s.styleS(Sid::SlurMidWidth).val() * 10);
+        xml.tag("line-width", { { "type", "tie tip" } }, s.styleS(Sid::SlurEndWidth).val() * 10);
+        xml.tag("line-width", { { "type", "tuplet bracket" } }, s.styleS(Sid::tupletBracketWidth).val() * 10);
+        xml.tag("line-width", { { "type", "wedge" } }, s.styleS(Sid::hairpinLineWidth).val() * 10);
+        // note size values in percent
+        xml.tag("note-size", { { "type", "cue" } }, s.styleD(Sid::smallNoteMag) * 100);
+        xml.tag("note-size", { { "type", "grace" } }, s.styleD(Sid::graceNoteMag) * 100);
+        xml.tag("note-size", { { "type", "grace-cue" } }, s.styleD(Sid::graceNoteMag) * s.styleD(Sid::smallNoteMag) * 100);
+        xml.endElement();
+    }
 
     // font defaults
     // as MuseScore supports dozens of different styles, while MusicXML only has defaults
-    // for music (TODO), words and lyrics, use Tid STAFF (typically used for words)
+    // for music, words and lyrics, use Tid STAFF (typically used for words)
     // and LYRIC1 to get MusicXML defaults
 
-    // TODO xml.tagE("music-font font-family=\"TBD\" font-size=\"TBD\"");
+    xml.tag("music-font", { { "font-family", s.styleSt(Sid::MusicalSymbolFont) } });
     xml.tag("word-font", { { "font-family", s.styleSt(Sid::staffTextFontFace) }, { "font-size", s.styleD(Sid::staffTextFontSize) } });
     xml.tag("lyric-font",
             { { "font-family", s.styleSt(Sid::lyricsOddFontFace) }, { "font-size", s.styleD(Sid::lyricsOddFontSize) } });

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -1535,9 +1535,7 @@ void MusicXMLParserPass1::defaults()
     bool isImportLayout = musicxmlImportLayout();
 
     while (_e.readNextStartElement()) {
-        if (_e.name() == "appearance") {
-            _e.skipCurrentElement();        // skip but don't log
-        } else if (_e.name() == "scaling") {
+        if (_e.name() == "scaling") {
             while (_e.readNextStartElement()) {
                 if (_e.name() == "millimeters") {
                     millimeter = _e.readElementText().toDouble();
@@ -1559,18 +1557,36 @@ void MusicXMLParserPass1::defaults()
             }
         } else if (_e.name() == "system-layout") {
             while (_e.readNextStartElement()) {
-                if (_e.name() == "system-dividers") {
-                    _e.skipCurrentElement();            // skip but don't log
-                } else if (_e.name() == "system-margins") {
+                if (_e.name() == "system-margins") {
                     _e.skipCurrentElement();            // skip but don't log
                 } else if (_e.name() == "system-distance") {
-                    Spatium val(_e.readElementText().toDouble() / 10.0);
+                    const Spatium val(_e.readElementText().toDouble() / 10.0);
                     if (isImportLayout) {
                         _score->style().set(Sid::minSystemDistance, val);
                         //LOGD("system distance %f", val.val());
                     }
                 } else if (_e.name() == "top-system-distance") {
                     _e.skipCurrentElement();            // skip but don't log
+                } else if (_e.name() == "system-dividers") {
+                    while (_e.readNextStartElement()) {
+                        if (_e.name() == "left-divider") {
+                            _score->style().set(Sid::dividerLeft, !(_e.attributes().value("print-object") == "no"));
+                            if (isImportLayout) {
+                                _score->style().set(Sid::dividerLeftX, _e.attributes().value("relative-x").toDouble() / 10.0);
+                                _score->style().set(Sid::dividerLeftY, _e.attributes().value("relative-y").toDouble() / 10.0);
+                            }
+                            _e.skipCurrentElement();
+                        } else if (_e.name() == "right-divider") {
+                            _score->style().set(Sid::dividerRight, !(_e.attributes().value("print-object") == "no"));
+                            if (isImportLayout) {
+                                _score->style().set(Sid::dividerRightX, _e.attributes().value("relative-x").toDouble() / 10.0);
+                                _score->style().set(Sid::dividerRightY, _e.attributes().value("relative-y").toDouble() / 10.0);
+                            }
+                            _e.skipCurrentElement();
+                        } else {
+                            skipLogCurrElem();
+                        }
+                    }
                 } else {
                     skipLogCurrElem();
                 }
@@ -1586,6 +1602,8 @@ void MusicXMLParserPass1::defaults()
                     skipLogCurrElem();
                 }
             }
+        } else if (_e.name() == "appearance") {
+            _e.skipCurrentElement();        // skip but don't log
         } else if (_e.name() == "music-font") {
             _e.skipCurrentElement();        // skip but don't log
         } else if (_e.name() == "word-font") {

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.h
@@ -134,6 +134,7 @@ public:
     void partGroup(const int scoreParts, MusicXmlPartGroupList& partGroupList, MusicXmlPartGroupMap& partGroups);
     void scorePart();
     void scoreInstrument(const QString& partId);
+    void setStyle(const QString& type, const double val);
     void midiInstrument(const QString& partId);
     void part();
     void measure(const QString& partId, const Fraction cTime, Fraction& mdur, VoiceOverlapDetector& vod, const int measureNr);

--- a/src/importexport/musicxml/tests/data/testLayout.xml
+++ b/src/importexport/musicxml/tests/data/testLayout.xml
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <identification>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1696.93</page-height>
+      <page-width>1200.48</page-width>
+      <page-margins type="even">
+        <left-margin>85.725</left-margin>
+        <right-margin>85.725</right-margin>
+        <top-margin>85.725</top-margin>
+        <bottom-margin>85.725</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>85.725</left-margin>
+        <right-margin>85.725</right-margin>
+        <top-margin>85.725</top-margin>
+        <bottom-margin>85.725</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <appearance>
+      <line-width type="light barline">2</line-width>
+      <line-width type="heavy barline">10</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="bracket">6.5</line-width>
+      <line-width type="dashes">1</line-width>
+      <line-width type="enclosure">1</line-width>
+      <line-width type="ending">1.3</line-width>
+      <line-width type="extend">1</line-width>
+      <line-width type="leger">2.2</line-width>
+      <line-width type="pedal">1.5</line-width>
+      <line-width type="octave shift">1.8</line-width>
+      <line-width type="slur middle">2.5</line-width>
+      <line-width type="slur tip">0.5</line-width>
+      <line-width type="staff">2</line-width>
+      <line-width type="stem">1.8</line-width>
+      <line-width type="tie middle">2.5</line-width>
+      <line-width type="tie tip">0.5</line-width>
+      <line-width type="tuplet bracket">1</line-width>
+      <line-width type="wedge">1.5</line-width>
+      <note-size type="cue">75</note-size>
+      <note-size type="grace">75</note-size>
+      <note-size type="grace-cue">56.25</note-size>
+      </appearance>
+    <music-font font-family="Leland"/>
+    <word-font font-family="Edwin" font-size="10"/>
+    <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Klav.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="236.76">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50.00</left-margin>
+            <right-margin>742.27</right-margin>
+            </system-margins>
+          <top-system-distance>170.00</top-system-distance>
+          </system-layout>
+        <staff-layout number="2">
+          <staff-distance>65.00</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note default-x="135.62" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <direction placement="above">
+        <direction-type>
+          <octave-shift type="down" size="8" number="1" default-y="24.13"/>
+          </direction-type>
+        <staff>2</staff>
+        </direction>
+      <note default-x="83.18" default-y="-130.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <pedal type="start" line="yes" default-y="-65.00"/>
+          </direction-type>
+        <staff>2</staff>
+        </direction>
+      <note default-x="108.43" default-y="-115.00">
+        <grace slash="yes"/>
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>4</octave>
+          </pitch>
+        <voice>5</voice>
+        <type>eighth</type>
+        <accidental>sharp</accidental>
+        <stem>up</stem>
+        <staff>2</staff>
+        </note>
+      <note default-x="129.87" default-y="-110.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        </note>
+      <note default-x="160.27" default-y="-135.00">
+        <pitch>
+          <step>B</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        </note>
+      <direction placement="above">
+        <direction-type>
+          <octave-shift type="stop" size="8" number="1"/>
+          </direction-type>
+        <staff>2</staff>
+        </direction>
+      <note default-x="190.66" default-y="-125.00">
+        <pitch>
+          <step>D</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <pedal type="stop" line="yes"/>
+          </direction-type>
+        <staff>2</staff>
+        </direction>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/data/testSystemDistance_ref.xml
+++ b/src/importexport/musicxml/tests/data/testSystemDistance_ref.xml
@@ -61,8 +61,8 @@
       <note-size type="grace">70</note-size>
       <note-size type="grace-cue">49</note-size>
       </appearance>
-      <music-font font-family="Leland"/>
-            <word-font font-family="Edwin" font-size="10"/>
+    <music-font font-family="Leland"/>
+    <word-font font-family="Edwin" font-size="10"/>
     <lyric-font font-family="Edwin" font-size="10"/>
     </defaults>
   <credit page="1">

--- a/src/importexport/musicxml/tests/data/testSystemDistance_ref.xml
+++ b/src/importexport/musicxml/tests/data/testSystemDistance_ref.xml
@@ -37,7 +37,32 @@
         <bottom-margin>85.725</bottom-margin>
         </page-margins>
       </page-layout>
-    <word-font font-family="Edwin" font-size="10"/>
+    <appearance>
+      <line-width type="light barline">1.8</line-width>
+      <line-width type="heavy barline">5.5</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="bracket">4.4</line-width>
+      <line-width type="dashes">1.5</line-width>
+      <line-width type="enclosure">1</line-width>
+      <line-width type="ending">1.1</line-width>
+      <line-width type="extend">1</line-width>
+      <line-width type="leger">1.6</line-width>
+      <line-width type="pedal">1.1</line-width>
+      <line-width type="octave shift">1.1</line-width>
+      <line-width type="slur middle">2.1</line-width>
+      <line-width type="slur tip">0.7</line-width>
+      <line-width type="staff">1.1</line-width>
+      <line-width type="stem">1.1</line-width>
+      <line-width type="tie middle">2.1</line-width>
+      <line-width type="tie tip">0.7</line-width>
+      <line-width type="tuplet bracket">1</line-width>
+      <line-width type="wedge">1.2</line-width>
+      <note-size type="cue">70</note-size>
+      <note-size type="grace">70</note-size>
+      <note-size type="grace-cue">49</note-size>
+      </appearance>
+      <music-font font-family="Leland"/>
+            <word-font font-family="Edwin" font-size="10"/>
     <lyric-font font-family="Edwin" font-size="10"/>
     </defaults>
   <credit page="1">

--- a/src/importexport/musicxml/tests/data/testSystemDividers.xml
+++ b/src/importexport/musicxml/tests/data/testSystemDividers.xml
@@ -1,0 +1,1180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <identification>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>6.99911</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1696.94</page-height>
+      <page-width>1200.48</page-width>
+      <page-margins type="even">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <system-layout>
+      <system-dividers>
+        <left-divider print-object="yes" relative-x="0" relative-y="-15"/>
+        <right-divider print-object="yes" relative-x="-50" relative-y="20"/>
+        </system-dividers>
+      </system-layout>
+    <appearance>
+      <line-width type="light barline">1</line-width>
+      <line-width type="heavy barline">5</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="bracket">5</line-width>
+      <line-width type="dashes">1</line-width>
+      <line-width type="enclosure">1</line-width>
+      <line-width type="ending">1.3</line-width>
+      <line-width type="extend">1</line-width>
+      <line-width type="leger">1.1</line-width>
+      <line-width type="pedal">1</line-width>
+      <line-width type="octave shift">1</line-width>
+      <line-width type="slur middle">2.5</line-width>
+      <line-width type="slur tip">0.5</line-width>
+      <line-width type="staff">0.91</line-width>
+      <line-width type="stem">0.91</line-width>
+      <line-width type="tie middle">2.5</line-width>
+      <line-width type="tie tip">0.5</line-width>
+      <line-width type="tuplet bracket">1</line-width>
+      <line-width type="wedge">1</line-width>
+      <note-size type="cue">70</note-size>
+      <note-size type="grace">70</note-size>
+      <note-size type="grace-cue">49</note-size>
+      </appearance>
+    <music-font font-family="Leland"/>
+    <word-font font-family="Edwin" font-size="10"/>
+    <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+  <part-list>
+    <part-group type="start" number="1">
+      <group-symbol>bracket</group-symbol>
+      </part-group>
+    <part-group type="start" number="2">
+      <group-symbol>square</group-symbol>
+      </part-group>
+    <score-part id="P1">
+      <part-name>Violine 1</part-name>
+      <part-abbreviation>Vl. 1</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Violine</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>41</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P2">
+      <part-name>Violine 2</part-name>
+      <part-abbreviation>Vl. 2</part-abbreviation>
+      <score-instrument id="P2-I1">
+        <instrument-name>Violine</instrument-name>
+        </score-instrument>
+      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-instrument id="P2-I1">
+        <midi-channel>4</midi-channel>
+        <midi-program>41</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="2"/>
+    <score-part id="P3">
+      <part-name>Bratsche</part-name>
+      <part-abbreviation>Bra.</part-abbreviation>
+      <score-instrument id="P3-I1">
+        <instrument-name>Bratsche</instrument-name>
+        </score-instrument>
+      <midi-device id="P3-I1" port="1"></midi-device>
+      <midi-instrument id="P3-I1">
+        <midi-channel>7</midi-channel>
+        <midi-program>42</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P4">
+      <part-name>Violoncello</part-name>
+      <part-abbreviation>Vc.</part-abbreviation>
+      <score-instrument id="P4-I1">
+        <instrument-name>Violoncello</instrument-name>
+        </score-instrument>
+      <midi-device id="P4-I1" port="1"></midi-device>
+      <midi-instrument id="P4-I1">
+        <midi-channel>11</midi-channel>
+        <midi-program>43</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="1"/>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="152.47">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>126.97</left-margin>
+            <right-margin>0.00</right-margin>
+            </system-margins>
+          <top-system-distance>170.00</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="100.32" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2" width="83.29">
+      <note default-x="34.65" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="3" width="83.29">
+      <note default-x="34.65" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="4" width="83.29">
+      <note default-x="34.65" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="5" width="83.29">
+      <note default-x="34.65" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="6" width="83.29">
+      <note default-x="34.65" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="7" width="83.29">
+      <note default-x="34.65" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="8" width="83.29">
+      <note default-x="34.65" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="9" width="83.29">
+      <note default-x="34.65" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="10" width="83.29">
+      <note default-x="34.65" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="11" width="130.14">
+      <print new-system="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>68.10</left-margin>
+            <right-margin>0.00</right-margin>
+            </system-margins>
+          <system-distance>143.84</system-distance>
+          </system-layout>
+        </print>
+      <note default-x="75.60" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="12" width="83.08">
+      <note default-x="34.54" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="13" width="83.08">
+      <note default-x="34.54" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="14" width="83.08">
+      <note default-x="34.54" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="15" width="83.08">
+      <note default-x="34.54" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="16" width="83.08">
+      <note default-x="34.54" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="17" width="83.08">
+      <note default-x="34.54" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="18" width="83.08">
+      <note default-x="34.54" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="19" width="83.08">
+      <note default-x="34.54" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="20" width="83.08">
+      <note default-x="34.54" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="21" width="83.08">
+      <note default-x="34.54" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="22" width="129.35">
+      <print new-system="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>68.10</left-margin>
+            <right-margin>0.00</right-margin>
+            </system-margins>
+          <system-distance>143.84</system-distance>
+          </system-layout>
+        </print>
+      <note default-x="75.21" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="23" width="82.29">
+      <note default-x="34.15" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="24" width="82.29">
+      <note default-x="34.15" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="25" width="82.29">
+      <note default-x="34.15" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="26" width="82.29">
+      <note default-x="34.15" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="27" width="82.29">
+      <note default-x="34.15" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="28" width="82.29">
+      <note default-x="34.15" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="29" width="82.29">
+      <note default-x="34.15" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="30" width="82.29">
+      <note default-x="34.15" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="31" width="82.29">
+      <note default-x="34.15" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="32" width="90.99">
+      <note default-x="34.15" default-y="-10.00">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P2">
+    <measure number="1" width="152.47">
+      <print>
+        <staff-layout number="1">
+          <staff-distance>57.53</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="100.32" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2" width="83.29">
+      <note default-x="34.65" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="3" width="83.29">
+      <note default-x="34.65" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="4" width="83.29">
+      <note default-x="34.65" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="5" width="83.29">
+      <note default-x="34.65" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="6" width="83.29">
+      <note default-x="34.65" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="7" width="83.29">
+      <note default-x="34.65" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="8" width="83.29">
+      <note default-x="34.65" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="9" width="83.29">
+      <note default-x="34.65" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="10" width="83.29">
+      <note default-x="34.65" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="11" width="130.14">
+      <print new-system="yes">
+        <staff-layout number="1">
+          <staff-distance>57.53</staff-distance>
+          </staff-layout>
+        </print>
+      <note default-x="75.60" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="12" width="83.08">
+      <note default-x="34.54" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="13" width="83.08">
+      <note default-x="34.54" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="14" width="83.08">
+      <note default-x="34.54" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="15" width="83.08">
+      <note default-x="34.54" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="16" width="83.08">
+      <note default-x="34.54" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="17" width="83.08">
+      <note default-x="34.54" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="18" width="83.08">
+      <note default-x="34.54" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="19" width="83.08">
+      <note default-x="34.54" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="20" width="83.08">
+      <note default-x="34.54" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="21" width="83.08">
+      <note default-x="34.54" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="22" width="129.35">
+      <print new-system="yes">
+        <staff-layout number="1">
+          <staff-distance>57.53</staff-distance>
+          </staff-layout>
+        </print>
+      <note default-x="75.21" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="23" width="82.29">
+      <note default-x="34.15" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="24" width="82.29">
+      <note default-x="34.15" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="25" width="82.29">
+      <note default-x="34.15" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="26" width="82.29">
+      <note default-x="34.15" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="27" width="82.29">
+      <note default-x="34.15" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="28" width="82.29">
+      <note default-x="34.15" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="29" width="82.29">
+      <note default-x="34.15" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="30" width="82.29">
+      <note default-x="34.15" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="31" width="82.29">
+      <note default-x="34.15" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="32" width="90.99">
+      <note default-x="34.15" default-y="-107.53">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P3">
+    <measure number="1" width="152.47">
+      <print>
+        <staff-layout number="1">
+          <staff-distance>57.53</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>C</sign>
+          <line>3</line>
+          </clef>
+        </attributes>
+      <note default-x="100.32" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2" width="83.29">
+      <note default-x="34.65" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="3" width="83.29">
+      <note default-x="34.65" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="4" width="83.29">
+      <note default-x="34.65" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="5" width="83.29">
+      <note default-x="34.65" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="6" width="83.29">
+      <note default-x="34.65" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="7" width="83.29">
+      <note default-x="34.65" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="8" width="83.29">
+      <note default-x="34.65" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="9" width="83.29">
+      <note default-x="34.65" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="10" width="83.29">
+      <note default-x="34.65" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="11" width="130.14">
+      <print new-system="yes">
+        <staff-layout number="1">
+          <staff-distance>57.53</staff-distance>
+          </staff-layout>
+        </print>
+      <note default-x="75.60" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="12" width="83.08">
+      <note default-x="34.54" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="13" width="83.08">
+      <note default-x="34.54" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="14" width="83.08">
+      <note default-x="34.54" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="15" width="83.08">
+      <note default-x="34.54" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="16" width="83.08">
+      <note default-x="34.54" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="17" width="83.08">
+      <note default-x="34.54" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="18" width="83.08">
+      <note default-x="34.54" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="19" width="83.08">
+      <note default-x="34.54" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="20" width="83.08">
+      <note default-x="34.54" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="21" width="83.08">
+      <note default-x="34.54" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="22" width="129.35">
+      <print new-system="yes">
+        <staff-layout number="1">
+          <staff-distance>57.53</staff-distance>
+          </staff-layout>
+        </print>
+      <note default-x="75.21" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="23" width="82.29">
+      <note default-x="34.15" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="24" width="82.29">
+      <note default-x="34.15" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="25" width="82.29">
+      <note default-x="34.15" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="26" width="82.29">
+      <note default-x="34.15" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="27" width="82.29">
+      <note default-x="34.15" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="28" width="82.29">
+      <note default-x="34.15" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="29" width="82.29">
+      <note default-x="34.15" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="30" width="82.29">
+      <note default-x="34.15" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="31" width="82.29">
+      <note default-x="34.15" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="32" width="90.99">
+      <note default-x="34.15" default-y="-205.07">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P4">
+    <measure number="1" width="152.47">
+      <print>
+        <staff-layout number="1">
+          <staff-distance>57.53</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note default-x="100.32" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2" width="83.29">
+      <note default-x="34.65" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="3" width="83.29">
+      <note default-x="34.65" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="4" width="83.29">
+      <note default-x="34.65" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="5" width="83.29">
+      <note default-x="34.65" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="6" width="83.29">
+      <note default-x="34.65" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="7" width="83.29">
+      <note default-x="34.65" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="8" width="83.29">
+      <note default-x="34.65" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="9" width="83.29">
+      <note default-x="34.65" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="10" width="83.29">
+      <note default-x="34.65" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="11" width="130.14">
+      <print new-system="yes">
+        <staff-layout number="1">
+          <staff-distance>57.53</staff-distance>
+          </staff-layout>
+        </print>
+      <note default-x="75.60" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="12" width="83.08">
+      <note default-x="34.54" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="13" width="83.08">
+      <note default-x="34.54" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="14" width="83.08">
+      <note default-x="34.54" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="15" width="83.08">
+      <note default-x="34.54" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="16" width="83.08">
+      <note default-x="34.54" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="17" width="83.08">
+      <note default-x="34.54" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="18" width="83.08">
+      <note default-x="34.54" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="19" width="83.08">
+      <note default-x="34.54" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="20" width="83.08">
+      <note default-x="34.54" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="21" width="83.08">
+      <note default-x="34.54" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="22" width="129.35">
+      <print new-system="yes">
+        <staff-layout number="1">
+          <staff-distance>57.53</staff-distance>
+          </staff-layout>
+        </print>
+      <note default-x="75.21" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="23" width="82.29">
+      <note default-x="34.15" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="24" width="82.29">
+      <note default-x="34.15" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="25" width="82.29">
+      <note default-x="34.15" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="26" width="82.29">
+      <note default-x="34.15" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="27" width="82.29">
+      <note default-x="34.15" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="28" width="82.29">
+      <note default-x="34.15" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="29" width="82.29">
+      <note default-x="34.15" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="30" width="82.29">
+      <note default-x="34.15" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="31" width="82.29">
+      <note default-x="34.15" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="32" width="90.99">
+      <note default-x="34.15" default-y="-302.60">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -61,7 +61,7 @@ static const std::string PREF_EXPORT_MUSICXML_EXPORTINVISIBLE("export/musicXML/e
 class Musicxml_Tests : public ::testing::Test
 {
 public:
-    void mxmlIoTest(const char* file);
+    void mxmlIoTest(const char* file, bool exportLayout = false);
     void mxmlIoTestRef(const char* file);
     void mxmlIoTestRefBreaks(const char* file);
     void mxmlMscxExportTestRef(const char* file, bool exportLayout = false);
@@ -127,13 +127,13 @@ bool Musicxml_Tests::saveCompareMusicXmlScore(MasterScore* score, const String& 
 //   read a MusicXML file, write to a new file and verify both files are identical
 //---------------------------------------------------------
 
-void Musicxml_Tests::mxmlIoTest(const char* file)
+void Musicxml_Tests::mxmlIoTest(const char* file, bool exportLayout)
 {
     MScore::debugMode = true;
 
     setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual));
     setValue(PREF_IMPORT_MUSICXML_IMPORTBREAKS, Val(true));
-    setValue(PREF_EXPORT_MUSICXML_EXPORTLAYOUT, Val(false));
+    setValue(PREF_EXPORT_MUSICXML_EXPORTLAYOUT, Val(exportLayout));
     setValue(PREF_EXPORT_MUSICXML_EXPORTINVISIBLE, Val(true));
 
     String fileName = String::fromUtf8(file);
@@ -155,6 +155,7 @@ void Musicxml_Tests::mxmlIoTestRef(const char* file)
     MScore::debugMode = true;
 
     setValue(PREF_EXPORT_MUSICXML_EXPORTBREAKS, Val(IMusicXmlConfiguration::MusicxmlExportBreaksType::Manual));
+    setValue(PREF_EXPORT_MUSICXML_EXPORTLAYOUT, Val(false));
     setValue(PREF_IMPORT_MUSICXML_IMPORTBREAKS, Val(true));
     setValue(PREF_EXPORT_MUSICXML_EXPORTINVISIBLE, Val(true));
 
@@ -628,6 +629,9 @@ TEST_F(Musicxml_Tests, keysig1) {
 TEST_F(Musicxml_Tests, keysig2) {
     mxmlIoTest("testKeysig2");
 }
+TEST_F(Musicxml_Tests, layout) {
+    mxmlIoTest("testLayout", true);
+}
 TEST_F(Musicxml_Tests, lessWhiteSpace) {
     mxmlIoTestRef("testLessWhiteSpace");
 }
@@ -816,6 +820,9 @@ TEST_F(Musicxml_Tests, systemBrackets5) {
 }
 TEST_F(Musicxml_Tests, systemDistance) {
     mxmlMscxExportTestRef("testSystemDistance", true);
+}
+TEST_F(Musicxml_Tests, systemDividers) {
+    mxmlIoTest("testSystemDividers", true);
 }
 TEST_F(Musicxml_Tests, tablature1) {
     mxmlIoTest("testTablature1");


### PR DESCRIPTION
This add support for the MusicXML element `appearance` to export/import thickness of lines and relative sizes for small notes and adds full support for `system-dividers`.