### PR TITLE
Fix compiler warning

### DIFF
--- a/src/framework/uicomponents/view/buttonboxmodel.cpp
+++ b/src/framework/uicomponents/view/buttonboxmodel.cpp
@@ -115,7 +115,7 @@ const std::vector <ButtonBoxModel::ButtonRole>& ButtonBoxModel::chooseButtonLayo
 #endif
     }
 
-    IF_ASSERT_FAILED(index != ButtonLayout::UnknownLayout && index < buttonRoleLayouts.size()) {
+    IF_ASSERT_FAILED(index < buttonRoleLayouts.size()) {
         index = 0;
     }
 


### PR DESCRIPTION
Clang complains about comparison of integers of different sign

That check is (more or less) tautological anyway; see a few lines higher