### PR TITLE
Fix wrong offset value displayed in inspector when "Follow staff size" is disabled

### DIFF
--- a/src/inspector/models/abstractinspectormodel.cpp
+++ b/src/inspector/models/abstractinspectormodel.cpp
@@ -466,7 +466,7 @@ QVariant AbstractInspectorModel::valueFromElementUnits(const mu::engraving::Pid&
 
     switch (value.type()) {
     case P_TYPE::POINT: {
-        if (element->sizeIsSpatiumDependent() || (pid == Pid::OFFSET && element->offsetIsSpatiumDependent())) {
+        if (pid == Pid::OFFSET ? element->offsetIsSpatiumDependent() : element->sizeIsSpatiumDependent()) {
             return value.value<PointF>().toQPointF() / element->spatium();
         } else {
             return value.value<PointF>().toQPointF() / mu::engraving::DPMM;

--- a/src/inspector/models/abstractinspectormodel.cpp
+++ b/src/inspector/models/abstractinspectormodel.cpp
@@ -466,7 +466,7 @@ QVariant AbstractInspectorModel::valueFromElementUnits(const mu::engraving::Pid&
 
     switch (value.type()) {
     case P_TYPE::POINT: {
-        if (element->sizeIsSpatiumDependent()) {
+        if (element->sizeIsSpatiumDependent() || (pid == Pid::OFFSET && element->offsetIsSpatiumDependent())) {
             return value.value<PointF>().toQPointF() / element->spatium();
         } else {
             return value.value<PointF>().toQPointF() / mu::engraving::DPMM;


### PR DESCRIPTION
Resolves (see video):

When the size of the item is not spatium-dependent, we show its offset value in absolute units in the UI. But that's not correct, because the _offset_ of the item is often still spatium-dependent, even though the _size_ of it isn't.



https://github.com/musescore/MuseScore/assets/93707756/08fe1952-217e-4c42-9b2f-8515de78e573



