### PR TITLE
Fix DebugPaint related crashes

### DIFF
--- a/src/engraving/rendering/dev/debugpaint.cpp
+++ b/src/engraving/rendering/dev/debugpaint.cpp
@@ -106,7 +106,7 @@ void DebugPaint::paintElementDebug(mu::draw::Painter& painter, const EngravingIt
     painter.translate(-pos);
 }
 
-void DebugPaint::paintPageDebug(Painter& painter, const Page* page)
+void DebugPaint::paintPageDebug(Painter& painter, const Page* page, const std::vector<EngravingItem*>& items)
 {
     IF_ASSERT_FAILED(page) {
         return;
@@ -122,7 +122,6 @@ void DebugPaint::paintPageDebug(Painter& painter, const Page* page)
 
     painter.save();
 
-    EngravingItemList items = page->childrenItems(true);
     for (const EngravingItem* item : items) {
         paintElementDebug(painter, item);
     }

--- a/src/engraving/rendering/dev/debugpaint.h
+++ b/src/engraving/rendering/dev/debugpaint.h
@@ -42,7 +42,7 @@ class DebugPaint
 
 public:
     static void paintElementDebug(mu::draw::Painter& painter, const EngravingItem* item);
-    static void paintPageDebug(mu::draw::Painter& painter, const Page* page);
+    static void paintPageDebug(mu::draw::Painter& painter, const Page* page, const std::vector<EngravingItem*>& items);
 };
 }
 

--- a/src/engraving/rendering/dev/paint.cpp
+++ b/src/engraving/rendering/dev/paint.cpp
@@ -145,7 +145,7 @@ void Paint::paintScore(draw::Painter* painter, Score* score, const IScoreRendere
 
 #ifdef MUE_ENABLE_ENGRAVING_PAINT_DEBUGGER
             if (!opt.isPrinting) {
-                DebugPaint::paintPageDebug(*painter, page);
+                DebugPaint::paintPageDebug(*painter, page, elements);
             }
 #endif
 


### PR DESCRIPTION
DebugPaint::paintPageDebug was trying to paint _all_ children and grandchildren etc of the given page. But that `children` property isn't really meaningful; it contains all items that have this item as their parent, but not all those items are actually part of the score. So we get relatively many crashes from that currently. For example, when hiding a staff, the items from that staff stay children of their former parents (so that they can be added back on undo), but are no longer part of the score, so requesting their pagePos often causes a crash. Instead, we should only paint the items that are currently part of the score; let's use the same items in DebugPaint as we use for "real" painting, since DebugPainting an item that has not been painted itself is useless anyway.