### PR TITLE
Make adding `Part` to `Excerpt` properly undoable

### DIFF
--- a/src/engraving/dom/types.h
+++ b/src/engraving/dom/types.h
@@ -38,6 +38,7 @@ enum class CommandType {
     // Parts
     InsertPart,
     RemovePart,
+    AddPartToExcerpt,
     SetSoloist,
     ChangePart,
 

--- a/src/engraving/dom/undo.cpp
+++ b/src/engraving/dom/undo.cpp
@@ -1159,6 +1159,48 @@ void RemovePart::cleanup(bool undo)
 }
 
 //---------------------------------------------------------
+//   AddPartToExcerpt
+//---------------------------------------------------------
+
+AddPartToExcerpt::AddPartToExcerpt(Excerpt* e, Part* p, size_t targetPartIdx)
+    : m_excerpt(e), m_part(p), m_targetPartIdx(targetPartIdx)
+{
+    assert(m_excerpt);
+    assert(m_part);
+}
+
+void AddPartToExcerpt::undo(EditData*)
+{
+    mu::remove(m_excerpt->parts(), m_part);
+
+    if (Score* score = m_excerpt->excerptScore()) {
+        score->removePart(m_part);
+    }
+}
+
+void AddPartToExcerpt::redo(EditData*)
+{
+    std::vector<Part*>& excerptParts = m_excerpt->parts();
+    if (m_targetPartIdx < excerptParts.size()) {
+        excerptParts.insert(excerptParts.begin() + m_targetPartIdx, m_part);
+    } else {
+        excerptParts.push_back(m_part);
+    }
+
+    if (Score* score = m_excerpt->excerptScore()) {
+        score->insertPart(m_part, m_targetPartIdx);
+    }
+}
+
+void AddPartToExcerpt::cleanup(bool undo)
+{
+    if (!undo) {
+        delete m_part;
+        m_part = nullptr;
+    }
+}
+
+//---------------------------------------------------------
 //   SetSoloist
 //---------------------------------------------------------
 

--- a/src/engraving/dom/undo.h
+++ b/src/engraving/dom/undo.h
@@ -270,6 +270,25 @@ public:
     UNDO_CHANGED_OBJECTS({ m_part })
 };
 
+class AddPartToExcerpt : public UndoCommand
+{
+    OBJECT_ALLOCATOR(engraving, AddPartToExcerpt)
+
+    Excerpt* m_excerpt = nullptr;
+    Part* m_part = nullptr;
+    size_t m_targetPartIdx = 0;
+
+public:
+    AddPartToExcerpt(Excerpt* e, Part* p, size_t targetPartIdx);
+    void undo(EditData*) override;
+    void redo(EditData*) override;
+    void cleanup(bool undo) override;
+
+    UNDO_TYPE(CommandType::AddPartToExcerpt)
+    UNDO_NAME("AddPartToExcerpt")
+    UNDO_CHANGED_OBJECTS({ m_part })
+};
+
 class SetSoloist : public UndoCommand
 {
     OBJECT_ALLOCATOR(engraving, SetSoloist)

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -758,10 +758,10 @@ void NotationParts::doInsertPart(Part* part, size_t index)
     mu::engraving::InstrumentList instrumentsCopy = part->instruments();
     part->setInstruments({});
 
-    score()->insertPart(part, index);
-
-    if (score()->excerpt()) {
-        score()->excerpt()->parts().insert(score()->excerpt()->parts().begin() + index, part);
+    if (Excerpt* excerpt = score()->excerpt()) {
+        score()->undo(new AddPartToExcerpt(excerpt, part, index));
+    } else {
+        score()->undoInsertPart(part, index);
     }
 
     for (auto it = instrumentsCopy.cbegin(); it != instrumentsCopy.cend(); ++it) {
@@ -788,7 +788,6 @@ void NotationParts::doInsertPart(Part* part, size_t index)
         mu::engraving::Excerpt::cloneStaff2(staff, staffCopy, startTick, endTick);
     }
 
-    part->setScore(score());
     score()->remapBracketsAndBarlines();
 }
 
@@ -1047,7 +1046,11 @@ void NotationParts::insertNewParts(const PartInstrumentList& parts, const mu::en
         part->setLongName(formattedLongName);
         part->setShortName(formattedShortName);
 
-        score()->undo(new mu::engraving::InsertPart(part, partIdx));
+        if (Excerpt* excerpt = score()->excerpt()) {
+            score()->undo(new AddPartToExcerpt(excerpt, part, partIdx));
+        } else {
+            score()->undoInsertPart(part, partIdx);
+        }
         appendStaves(part, pi.instrumentTemplate, keyList);
         ++partIdx;
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/17333
Resolves the most probable cause of: https://github.com/musescore/MuseScore/issues/19698
Resolves the most probable cause of: https://github.com/musescore/MuseScore/issues/17720
Perhaps, the problem that this is resolving was also the actual cause of: https://github.com/musescore/MuseScore/issues/18021