### PR TITLE
Fix empty midi input device list on linux

### DIFF
--- a/src/framework/midi/internal/platform/lin/alsamidiinport.cpp
+++ b/src/framework/midi/internal/platform/lin/alsamidiinport.cpp
@@ -75,7 +75,7 @@ MidiDeviceList AlsaMidiInPort::availableDevices() const
     std::lock_guard lock(m_devicesMutex);
 
     int streams = SND_SEQ_OPEN_INPUT;
-    unsigned int cap = SND_SEQ_PORT_CAP_SUBS_WRITE | SND_SEQ_PORT_CAP_WRITE;
+    unsigned int cap = SND_SEQ_PORT_CAP_SUBS_READ | SND_SEQ_PORT_CAP_READ;
     unsigned int type = SND_SEQ_PORT_TYPE_PORT | SND_SEQ_PORT_TYPE_HARDWARE;
 
     MidiDeviceList ret;

--- a/src/framework/midi/internal/platform/lin/alsamidioutport.cpp
+++ b/src/framework/midi/internal/platform/lin/alsamidioutport.cpp
@@ -74,7 +74,7 @@ std::vector<MidiDevice> AlsaMidiOutPort::availableDevices() const
     std::lock_guard lock(m_devicesMutex);
 
     int streams = SND_SEQ_OPEN_OUTPUT;
-    unsigned int cap = SND_SEQ_PORT_CAP_SUBS_READ | SND_SEQ_PORT_CAP_READ;
+    unsigned int cap = SND_SEQ_PORT_CAP_SUBS_WRITE | SND_SEQ_PORT_CAP_WRITE;
     unsigned int type = SND_SEQ_PORT_TYPE_PORT | SND_SEQ_PORT_TYPE_HARDWARE;
 
     std::vector<MidiDevice> ret;


### PR DESCRIPTION
Resolves: #337844 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Fix empty midi input device list on linux

Fix midi port capabilities for input ports (read instead of write)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- NA I created a unit test or vtest to verify the changes I made (if applicable)
