### PR TITLE
Spanner draw optimization (at least for Palettes)

### DIFF
--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -551,10 +551,15 @@ void Spanner::insertTimeUnmanaged(const Fraction& fromTick, const Fraction& len)
 
 void Spanner::scanElements(void* data, void (* func)(void*, EngravingItem*), bool all)
 {
+    if (score()->isPaletteScore()) {
+        EngravingObject::scanElements(data, func, all);
+        return;
+    }
+
     for (EngravingObject* child : scanChildren()) {
-        if (scanParent() && child->isSpannerSegment()) {
-            continue; // spanner segments are scanned by the system
-                      // except in the palette (in which case scanParent() == nullptr)
+        if (child->isSpannerSegment()) {
+            // spanner segments are scanned by the system
+            continue;
         }
         child->scanElements(data, func, all);
     }


### PR DESCRIPTION
`scanParent()` seems a somewhat expensive call, and prints some warning log messages about not-found segments. (However, unfortunately I couldn't see a huge speed-up in practice though.)