### PR TITLE
Make sure "reset" command for Beam is fully undoable

### DIFF
--- a/src/engraving/dom/beam.cpp
+++ b/src/engraving/dom/beam.cpp
@@ -444,8 +444,8 @@ void Beam::reset()
         undoChangeProperty(Pid::USER_MODIFIED, false);
     }
     undoChangeProperty(Pid::STEM_DIRECTION, DirectionV::AUTO);
-    resetProperty(Pid::BEAM_NO_SLOPE);
-    setGenerated(true);
+    undoResetProperty(Pid::BEAM_NO_SLOPE);
+    undoChangeProperty(Pid::GENERATED, true);
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/19398

(I had made this change on some local branch already a while ago, and now incidentally found that there is an issue for it, so therefore I'm creating a PR now)