### PR TITLE
fix #19684 barline mmrest crash

### DIFF
--- a/src/engraving/dom/barline.cpp
+++ b/src/engraving/dom/barline.cpp
@@ -69,10 +69,17 @@ static void undoChangeBarLineType(BarLine* bl, BarLineType barType, bool allStav
             m->undoChangeProperty(Pid::REPEAT_START, false);
         }
         m = m->prevMeasure();
-        if (!m || m->isFirstInSystem()) {
+        if (!m || (m->system() && m->isFirstInSystem())) {
             return;
         }
         bl = const_cast<BarLine*>(m->endBarLine());
+
+        if (!bl) {
+            // TODO investigate, why barline is missing,
+            // when standard measure changes to multimeasure-rest measure after inserting measure
+            // see GH #19684
+            return;
+        }
     }
 
     switch (barType) {
@@ -130,7 +137,7 @@ static void undoChangeBarLineType(BarLine* bl, BarLineType barType, bool allStav
                     }
 
                     lmeasure->undoChangeProperty(Pid::REPEAT_END, false);
-                    if (lmeasure->nextMeasure() && !lmeasure->nextMeasure()->isFirstInSystem()) {
+                    if (lmeasure->nextMeasure() && (!lmeasure->nextMeasure()->system() || !lmeasure->nextMeasure()->isFirstInSystem())) {
                         lmeasure->nextMeasure()->undoChangeProperty(Pid::REPEAT_START, false);
                     }
                     Segment* lsegment = lmeasure->undoGetSegmentR(SegmentType::EndBarLine, lmeasure->ticks());


### PR DESCRIPTION
Resolves: #19684 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
End barline is added to measure during layout. It means, in some situations, if we are in mmrest mode and measure was not in score before in standard mode, it has no end barline.

Other situation, with exactly same problem is:
1. create empty score
2. create part
3. add start repeat somewhere to score
4. switch to part
5. select start repeat barline and change it to some other one

So if we are in mmrest mode, we need use mmrest measures and their barlines (as standard barlines may be undefined).

In first commits, there are just nullchecks.
Second commit handles barlines and measures in mmrest mode correctly.

TODO: there are still weired places in code (and coresponding issues), so it needs some refactor, but may be, I can post them as separate issue.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
