### PR TITLE
Set general inspector properties when importing MU3 ornaments into MU4

### DIFF
--- a/src/engraving/rw/compat/compatutils.cpp
+++ b/src/engraving/rw/compat/compatutils.cpp
@@ -267,6 +267,8 @@ void CompatUtils::replaceOldWithNewOrnaments(MasterScore* score)
         newOrnament->setPos(oldOrnament->pos());
         newOrnament->setOrnamentStyle(oldOrnament->ornamentStyle());
         newOrnament->setDirection(oldOrnament->direction());
+        newOrnament->setAutoplace(oldOrnament->autoplace());
+        newOrnament->setPlayArticulation(oldOrnament->playArticulation());
 
         LinkedObjects* links = oldOrnament->links();
         newOrnament->setLinks(links);


### PR DESCRIPTION
Resolves: #19638

Addresses lost autoplace property discussed in #19627 **for ornaments only** - this issue is still present for other engraving items.