### PR TITLE
Relayout chord when direction changes

### DIFF
--- a/src/engraving/rendering/dev/measurelayout.cpp
+++ b/src/engraving/rendering/dev/measurelayout.cpp
@@ -1324,7 +1324,13 @@ void MeasureLayout::layoutCrossStaff(MeasureBase* mb, LayoutContext& ctx)
                 Tremolo* tremolo = c->tremolo();
                 if ((beam && (beam->cross() || beam->userModified()))
                     || (tremolo && tremolo->twoNotes() && tremolo->userModified())) {
+                    bool prevUp = c->up();
                     ChordLayout::computeUp(c, ctx); // for cross-staff beams
+                    if (c->up() != prevUp) {
+                        // Chord has changed direction, lay out again
+                        ChordLayout::layoutChords1(ctx, &s, c->vStaffIdx());
+                        s.createShape(c->vStaffIdx());
+                    }
                 }
                 if (!c->graceNotes().empty()) {
                     for (Chord* grace : c->graceNotes()) {


### PR DESCRIPTION
Resolves: (See image) <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->
![image_480](https://github.com/musescore/MuseScore/assets/26510874/f5b1dbfd-96d8-4d62-b0b3-a149e6a783d9)
When chord stem direction is recalculated, lay out the chord again to get correct note positioning within the chord.

<img width="306" alt="Screenshot 2023-10-17 at 15 40 50" src="https://github.com/musescore/MuseScore/assets/26510874/50d4d10a-4713-4871-bc01-c0618481cf28">

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
