### PR TITLE
Fix #16930 - Page Background Wallpaper is reset when restarting

### DIFF
--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -262,7 +262,7 @@ const QPixmap& NotationConfiguration::backgroundWallpaper() const
     io::path_t path = backgroundWallpaperPath();
 
     static QPixmap wallpaper;
-    static io::path_t lastPath = path;
+    static io::path_t lastPath;
 
     if (path.empty()) {
         wallpaper = QPixmap();
@@ -331,7 +331,7 @@ const QPixmap& NotationConfiguration::foregroundWallpaper() const
     io::path_t path = foregroundWallpaperPath();
 
     static QPixmap wallpaper;
-    static io::path_t lastPath = path;
+    static io::path_t lastPath;
 
     if (path.empty()) {
         wallpaper = QPixmap();


### PR DESCRIPTION
Resolves: #16930

So far so good here, but testing would be appreciated. The problem, AFAIS, was that the static wallpaper variable was not getting loaded on initialization because of the != last path check, yet that needs to be kept as it is or else there would be inefficient updating of the QPixMap when notation redraws. 

Result: wallpaper is actual at initialization for both background and foreground.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
