### PR TITLE
Fix #19340: Increase maxValues for fretboards

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/notation/fretdiagrams/internal/FretAdvancedSettingsTab.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/fretdiagrams/internal/FretAdvancedSettingsTab.qml
@@ -105,7 +105,7 @@ FocusableItem {
 
                 step: 1
                 decimals: 0
-                maxValue: 6
+                maxValue: 24
                 minValue: 1
 
                 navigationName: "VisibleFrets"
@@ -124,7 +124,7 @@ FocusableItem {
 
                 step: 1
                 decimals: 0
-                maxValue: 12
+                maxValue: 24
                 minValue: 1
 
                 navigationName: "FretNumber"


### PR DESCRIPTION
Resolves: #19340 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

Increased the maxValue for FretNumber to 24 and increased the maxValue for VisibleFrets to 24. Issue discussion recommended reintruducing this MS3 if the engraving engine handles it "somewhat gracefully."

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
