### PR TITLE
Fix GH#19629: An unset visible property on ornaments gets lost on Mu3 import

### DIFF
--- a/src/engraving/rw/compat/compatutils.cpp
+++ b/src/engraving/rw/compat/compatutils.cpp
@@ -269,6 +269,7 @@ void CompatUtils::replaceOldWithNewOrnaments(MasterScore* score)
         newOrnament->setDirection(oldOrnament->direction());
         newOrnament->setAutoplace(oldOrnament->autoplace());
         newOrnament->setPlayArticulation(oldOrnament->playArticulation());
+        newOrnament->setVisible(oldOrnament->visible());
 
         LinkedObjects* links = oldOrnament->links();
         newOrnament->setLinks(links);


### PR DESCRIPTION
Resolves: #19629