### PR TITLE
Search score, not just staves for linked system elements

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -2238,6 +2238,16 @@ EngravingItem* EngravingItem::findLinkedInScore(const Score* score) const
         return nullptr;
     }
 
+    // If this is a system element it may not be on the same stave, so just check if linked elements are in the score
+    if (systemFlag() && track() == 0) {
+        for (EngravingObject* linked : *links()) {
+            if (linked != this && linked->score() == score) {
+                return toEngravingItem(linked);
+            }
+        }
+        return nullptr;
+    }
+
     Staff* linkedStaffInScore = staff()->findLinkedInScore(score);
 
     if (!linkedStaffInScore) {
@@ -2258,7 +2268,6 @@ EngravingItem* EngravingItem::findLinkedInStaff(const Staff* staff) const
             return toEngravingItem(linked);
         }
     }
-
     return nullptr;
 }
 

--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -1441,7 +1441,8 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                     }
                     bool systemObject = e->systemFlag() && e->track() == 0;
                     bool alreadyCloned = bool(e->findLinkedInScore(score));
-                    bool cloneAnnotation = e->track() == srcTrack || (systemObject && !alreadyCloned);
+                    bool cloneAnnotation = !alreadyCloned && (e->track() == srcTrack || systemObject);
+
                     if (!cloneAnnotation) {
                         continue;
                     }


### PR DESCRIPTION
Resolves: #19472 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

When checking if an element had already been added to a staff which was being cloned, we were only checking staves with the same id.  This was missing system elements, which frequently aren't on the same staff in parts as they are in the score.
<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
