### PR TITLE
Fix MSCV compiler warnings

### DIFF
--- a/src/engraving/compat/midi/compatmidirender.h
+++ b/src/engraving/compat/midi/compatmidirender.h
@@ -71,7 +71,6 @@
 #include "log.h"
 
 namespace mu::engraving {
-using namespace mu::engraving;
 class CompatMidiRender
 {
 public:

--- a/src/engraving/compat/midi/compatmidirenderinternal.cpp
+++ b/src/engraving/compat/midi/compatmidirenderinternal.cpp
@@ -1172,6 +1172,7 @@ void CompatMidiRendererInternal::renderMetronome(EventsHolder& events, Measure c
 
 void CompatMidiRendererInternal::renderScore(EventsHolder& events, const Context& ctx, bool expandRepeats)
 {
+    UNUSED(expandRepeats);
     _context = ctx;
     PitchWheelRenderer pitchWheelRender(wheelSpec);
 

--- a/src/engraving/dom/stringtunings.cpp
+++ b/src/engraving/dom/stringtunings.cpp
@@ -275,8 +275,8 @@ String StringTunings::generateText() const
         return u"";
     }
 
-    int columnCount = 0;
-    int rowCount = 0;
+    size_t columnCount = 0;
+    size_t rowCount = 0;
 
     if (visibleStringList.size() < 4) {
         rowCount = visibleStringList.size();
@@ -287,8 +287,8 @@ String StringTunings::generateText() const
     }
 
     String result;
-    for (int i = 0; i < rowCount; ++i) {
-        for (int j = 0; j < columnCount; ++j) {
+    for (size_t i = 0; i < rowCount; ++i) {
+        for (size_t j = 0; j < columnCount; ++j) {
             size_t index = i + j * rowCount;
             if (index < visibleStringList.size()) {
                 result += visibleStringList[index];

--- a/src/notation/view/internal/stringtuningssettingsmodel.cpp
+++ b/src/notation/view/internal/stringtuningssettingsmodel.cpp
@@ -271,14 +271,14 @@ QVariantList StringTuningsSettingsModel::numbersOfStrings() const
     return numbersList;
 }
 
-size_t StringTuningsSettingsModel::currentNumberOfStrings() const
+int StringTuningsSettingsModel::currentNumberOfStrings() const
 {
     return m_item ? engraving::toStringTunings(m_item)->getProperty(engraving::Pid::STRINGTUNINGS_STRINGS_COUNT).toInt() : 0;
 }
 
 void StringTuningsSettingsModel::setCurrentNumberOfStrings(int number)
 {
-    int currentNumber = static_cast<int>(currentNumberOfStrings());
+    int currentNumber = currentNumberOfStrings();
     if (currentNumber == number) {
         return;
     }

--- a/src/notation/view/internal/stringtuningssettingsmodel.h
+++ b/src/notation/view/internal/stringtuningssettingsmodel.h
@@ -72,7 +72,7 @@ public:
 
     QVariantList numbersOfStrings() const;
 
-    size_t currentNumberOfStrings() const;
+    int currentNumberOfStrings() const;
     void setCurrentNumberOfStrings(int number);
 
     QList<StringTuningsItem*> strings() const;


### PR DESCRIPTION
* reg. 'engraving': namespace uses itself (C4515)
* reg. 'expandRepeats': unreferenced formal parameter (C4100)
* reg. '=' conversion from 'size_t' to 'int', possible loss of data (C4267)