### PR TITLE
fix #19096: brought back snd render for midi-export

### DIFF
--- a/src/engraving/compat/midi/compatmidirender.cpp
+++ b/src/engraving/compat/midi/compatmidirender.cpp
@@ -8,6 +8,21 @@ void CompatMidiRender::renderScore(Score* score, EventsHolder& events, const Com
     internal.renderScore(events, ctx, expandRepeats);
 }
 
+int CompatMidiRender::getControllerForSnd(Score* score, int globalSndController)
+{
+    const int DEFAULT_CC = CTRL_BREATH;
+
+    SynthesizerState s = score->synthesizerState();
+    int method = s.method();
+    int controller = s.ccToUse();
+
+    if (method == -1) {
+        controller = (globalSndController == -1) ? DEFAULT_CC : globalSndController;
+    }
+
+    return controller;
+}
+
 void CompatMidiRender::createPlayEvents(const Score* score, Measure const* start, Measure const* const end)
 {
     if (!start) {

--- a/src/engraving/compat/midi/compatmidirender.h
+++ b/src/engraving/compat/midi/compatmidirender.h
@@ -76,6 +76,7 @@ class CompatMidiRender
 {
 public:
     static void renderScore(Score* score, EventsHolder& events, const CompatMidiRendererInternal::Context& ctx, bool expandRepeats);
+    static int getControllerForSnd(Score* score, int globalSndController);
     static void createPlayEvents(const Score* score, Measure const* start = nullptr, Measure const* end = nullptr);
     static void createPlayEvents(const Score* score, Chord* chord, Chord* prevChord = nullptr, Chord* nextChord = nullptr);
 private:

--- a/src/engraving/compat/midi/compatmidirenderinternal.h
+++ b/src/engraving/compat/midi/compatmidirenderinternal.h
@@ -141,7 +141,7 @@ public:
 
     struct Context
     {
-        SynthesizerState synthState;
+        int sndController = CTRL_BREATH;
         bool metronome = true;
         std::shared_ptr<ChannelLookup> channels = std::make_shared<ChannelLookup>();
 

--- a/src/engraving/tests/midirenderer_data/breath_controller.mscx
+++ b/src/engraving/tests/midirenderer_data/breath_controller.mscx
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.20">
+  <programVersion>4.2.0</programVersion>
+  <programRevision></programRevision>
+  <Score>
+    <Division>480</Division>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Composer / arranger</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2023-10-10</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Microsoft Windows</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="sourceRevisionId"></metaTag>
+    <metaTag name="subtitle">Subtitle</metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Untitled score</metaTag>
+    <Order id="orchestral">
+      <name>Orchestral</name>
+      <instrument id="flute">
+        <family id="flutes">Flutes</family>
+        </instrument>
+      <section id="woodwind" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>flutes</family>
+        <family>oboes</family>
+        <family>clarinets</family>
+        <family>saxophones</family>
+        <family>bassoons</family>
+        <unsorted group="woodwinds"/>
+        </section>
+      <section id="brass" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>horns</family>
+        <family>trumpets</family>
+        <family>cornets</family>
+        <family>flugelhorns</family>
+        <family>trombones</family>
+        <family>tubas</family>
+        </section>
+      <section id="timpani" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>timpani</family>
+        </section>
+      <section id="percussion" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>keyboard-percussion</family>
+        <family>drums</family>
+        <family>unpitched-metal-percussion</family>
+        <family>unpitched-wooden-percussion</family>
+        <family>other-percussion</family>
+        </section>
+      <family>keyboards</family>
+      <family>harps</family>
+      <family>organs</family>
+      <family>synths</family>
+      <soloists/>
+      <section id="voices" brackets="true" barLineSpan="false" thinBrackets="true">
+        <family>voices</family>
+        <family>voice-groups</family>
+        </section>
+      <section id="strings" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>orchestral-strings</family>
+        </section>
+      <unsorted/>
+      </Order>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Flute</trackName>
+      <Instrument id="flute">
+        <longName>Flute</longName>
+        <shortName>Fl.</shortName>
+        <trackName>Flute</trackName>
+        <minPitchP>59</minPitchP>
+        <maxPitchP>98</maxPitchP>
+        <minPitchA>60</minPitchA>
+        <maxPitchA>93</maxPitchA>
+        <instrumentId>wind.flutes.flute</instrumentId>
+        <Channel>
+          <program value="73"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <excludeFromParts>0</excludeFromParts>
+        <Text>
+          <style>title</style>
+          <text>Untitled score</text>
+          </Text>
+        <Text>
+          <style>subtitle</style>
+          <text>Subtitle</text>
+          </Text>
+        <Text>
+          <style>composer</style>
+          <text>Composer / arranger</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Dynamic>
+            <subtype>ppp</subtype>
+            <velocity>16</velocity>
+            </Dynamic>
+          <Spanner type="HairPin">
+            <HairPin>
+              <subtype>0</subtype>
+              </HairPin>
+            <next>
+              <location>
+                <measures>1</measures>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Dynamic>
+            <subtype>fff</subtype>
+            <velocity>126</velocity>
+            <offset x="-0.384535" y="2.73072"/>
+            </Dynamic>
+          <Spanner type="HairPin">
+            <prev>
+              <location>
+                <measures>-1</measures>
+                </location>
+              </prev>
+            </Spanner>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/importexport/midi/internal/midiexport/exportmidi.cpp
+++ b/src/importexport/midi/internal/midiexport/exportmidi.cpp
@@ -234,7 +234,8 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
     ctx.eachStringHasChannel = false;
     ctx.instrumentsHaveEffects = false;
     ctx.metronome = false;
-    ctx.synthState = synthState;
+    ctx.sndController = CompatMidiRender::getControllerForSnd(m_score, synthState.ccToUse());
+
     CompatMidiRender::renderScore(m_score, events, ctx, midiExpandRepeats);
 
     m_pauseMap.calculate(m_score);


### PR DESCRIPTION
brought back snd rendering, which was removed in https://github.com/musescore/MuseScore/pull/16232
the code of rendering is left unchanged (moved to renderSnd method),
but storing synthesizer state in a midi renderer context is replaced to storing Control Change - normally it is Breath Controller). The dynamics rendering method was also removed in 16232, it seems legacy, so in this PR I've left the controller choice method as it was previously, but without choosing the "dynamic render method".
Also added test not to loose CC2 data again