### PR TITLE
Check a note is on a visible stave before checking cross staff validity

### DIFF
--- a/src/engraving/dom/chordrest.cpp
+++ b/src/engraving/dom/chordrest.cpp
@@ -1267,7 +1267,7 @@ void ChordRest::undoAddAnnotation(EngravingItem* a)
 
 void ChordRest::checkStaffMoveValidity()
 {
-    if (!staff()) {
+    if (!staff() || !staff()->visible()) {
         return;
     }
     staff_idx_t idx = m_staffMove ? vStaffIdx() : staffIdx() + m_storedStaffMove;


### PR DESCRIPTION
Resolves: #19765 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

This was causing issues in parts where an instrument with cross staff notes had been added and then hidden again.  This caused the note to fail the `checkStaffMoveValidity` check, when the staff wasn't visible and shouldn't have been checked.
<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
