### PR TITLE
Recursively import MEI text nodes 

### DIFF
--- a/src/importexport/mei/internal/meiimporter.h
+++ b/src/importexport/mei/internal/meiimporter.h
@@ -82,7 +82,7 @@ private:
     bool readScore(pugi::xml_node root);
     bool readScoreDef(pugi::xml_node scoreDefNode, bool isInitial);
     bool readPgHead(pugi::xml_node pgHeadNode);
-    bool readLines(pugi::xml_node parentNode, StringList& lines);
+    bool readLines(pugi::xml_node parentNode, StringList& lines, size_t& line);
     bool readLinesWithSmufl(pugi::xml_node parentNode, StringList& lines);
     bool readStaffDefs(pugi::xml_node parentNode);
     bool readStaffGrps(pugi::xml_node parentNode, int& staffSpan, int column, size_t& idx);


### PR DESCRIPTION
This PR makes the MEI importer more flexible by recursively importing text content. Additional formatting encoded with MEI `<rend>` within text would cause for the descendant text to be ignored. This fixes it by ignoring the formatting but still importing the text.

Since this is only relevant for MEI files not written by MuseScore, this PR has not corresponding test case.
