### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/framework/global/thirdparty/kors_logger/src/log_base.h
+++ b/src/framework/global/thirdparty/kors_logger/src/log_base.h
@@ -89,6 +89,7 @@ SOFTWARE.
 #define NOT_SUPPORTED_USE(use) LOGW() << "Not supported!! Use:" << use
 
 #if __has_cpp_attribute(fallthrough)
+#undef FALLTHROUGH
 #define FALLTHROUGH [[fallthrough]]
 #else
 #define FALLTHROUGH (void)0

--- a/src/framework/global/thirdparty/kors_logger/src/logger.h
+++ b/src/framework/global/thirdparty/kors_logger/src/logger.h
@@ -119,8 +119,8 @@ public:
         PatternData() = default;
         std::string_view pattern;
         std::string beforeStr;
-        int index = -1;
-        int count = 0;
+        size_t index = static_cast<size_t>(-1);
+        size_t count = 0;
         size_t minWidth = 0;
     };
 


### PR DESCRIPTION
* reg. 'FALLTHROUGH': macro redefinition (C4005)
* reg: '=': conversion from 'size_t' to 'int', possible loss of data (C4267)