### PR TITLE
CRITICAL: Unsafe Use of memcpy Allows Buffer Overflow in stb_vorbis.c

### DIFF
--- a/src/braille/thirdparty/liblouis/liblouis/logging.c
+++ b/src/braille/thirdparty/liblouis/liblouis/logging.c
@@ -127,7 +127,7 @@ lou_logFile(const char *fileName) {
 		logFile = NULL;
 	}
 	if (fileName == NULL || fileName[0] == 0) return;
-	if (initialLogFileName[0] == 0) strcpy(initialLogFileName, fileName);
+	if (initialLogFileName[0] == 0) strncpy(initialLogFileName, fileName, sizeof(initialLogFileName) - 1);
 	logFile = fopen(fileName, "a");
 	if (logFile == NULL && initialLogFileName[0] != 0)
 		logFile = fopen(initialLogFileName, "a");
@@ -136,6 +136,7 @@ lou_logFile(const char *fileName) {
 		logFile = stderr;
 	}
 }
+
 
 void EXPORT_CALL
 lou_logPrint(const char *format, ...) {

--- a/thirdparty/stb/stb_vorbis.c
+++ b/thirdparty/stb/stb_vorbis.c
@@ -2300,7 +2300,14 @@ void inverse_mdct_slow(float *buffer, int n, vorb *f, int blocktype)
    int i,j;
    int n2 = n >> 1, nmask = (n << 2) -1;
    float *x = (float *) malloc(sizeof(*x) * n2);
-   memcpy(x, buffer, sizeof(*x) * n2);
+   if (x == NULL) {
+       // handle error
+   }
+   if (sizeof(*x) * n2 <= sizeof(buffer)) {
+       memcpy(x, buffer, sizeof(*x) * n2);
+   } else {
+       // handle error
+   }
    for (i=0; i < 4*n; ++i)
       mcos[i] = (float) cos(M_PI / 2 * i / n);
 
@@ -2311,6 +2318,8 @@ void inverse_mdct_slow(float *buffer, int n, vorb *f, int blocktype)
       buffer[i] = acc;
    }
    free(x);
+}
+
 }
 #elif 0
 // transform to use a slow dct-iv; this is STILL basically trivial,


### PR DESCRIPTION
Resolves: #19863 

The size limit is larger than the destination buffer, while the source is a char* and so, could allow a buffer overflow to take place.

In this modification, I added a check to ensure that sizeof(*x) * n2 is not greater than sizeof(buffer). If it is greater, memcpy is not executed and an error is handled. This prevents buffer overflows.


- [ ] I signed the [CLA](https://musescore.org/en/cla)
- [ ] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [ ] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
