### PR TITLE
new logic for section break on frame

### DIFF
--- a/src/engraving/dom/box.cpp
+++ b/src/engraving/dom/box.cpp
@@ -463,7 +463,7 @@ void Box::manageExclusionFromParts(bool exclude)
         }
     } else {
         for (Score* score : masterScore()->scoreList()) {
-            if (score == this->score() || (!this->score()->isMaster() && !score->isMaster())) {
+            if (score == this->score() || (titleFrame && !this->score()->isMaster() && !score->isMaster())) {
                 continue;
             }
 

--- a/src/engraving/dom/box.cpp
+++ b/src/engraving/dom/box.cpp
@@ -33,6 +33,7 @@
 #include "stafftext.h"
 #include "system.h"
 #include "text.h"
+#include "undo.h"
 
 #include "log.h"
 
@@ -422,6 +423,12 @@ EngravingItem* Box::drop(EditData& data)
 
 void Box::manageExclusionFromParts(bool exclude)
 {
+    // manage Layout Breaks - remove old ones first
+    LayoutBreak* sectionBreak = sectionBreakElement();
+    if (sectionBreak) {
+        toEngravingItem(sectionBreak)->manageExclusionFromParts(true);
+    }
+
     bool titleFrame = this == score()->first() && type() == ElementType::VBOX;
     if (exclude) {
         const std::list<EngravingObject*> links = linkList();
@@ -437,8 +444,24 @@ void Box::manageExclusionFromParts(bool exclude)
             linkedItem->score()->undoRemoveElement(linkedItem, false);
             linkedItem->undoUnlink();
         }
+
+        // manage Layout Breaks - there are no linked boxes, so add linked Line Breaks to previous measure
+        if (sectionBreak && !titleFrame) {
+            if (MeasureBase* prevMeasure = this->prevMeasure()) {
+                for (Score* score : masterScore()->scoreList()) {
+                    if (score == this->score()) {
+                        continue;
+                    }
+                    if (MeasureBase* localPrevMeasure = score->tick2measure(prevMeasure->tick())) {
+                        EngravingItem* newSectionBreak = sectionBreak->linkedClone();
+                        newSectionBreak->setScore(score);
+                        newSectionBreak->setParent(localPrevMeasure);
+                        score->undo(new AddElement(newSectionBreak));
+                    }
+                }
+            }
+        }
     } else {
-        std::vector<MeasureBase*> newFrames;
         for (Score* score : masterScore()->scoreList()) {
             if (score == this->score() || (!this->score()->isMaster() && !score->isMaster())) {
                 continue;
@@ -453,6 +476,7 @@ void Box::manageExclusionFromParts(bool exclude)
                 if (item->isText() && toText(item)->textStyleType() == TextStyleType::INSTRUMENT_EXCERPT) {
                     continue;
                 }
+                // add frame items (Layout Break, Title, ...)
                 newFrame->add(item->linkedClone());
             }
 
@@ -468,9 +492,6 @@ void Box::manageExclusionFromParts(bool exclude)
                 }
             }
 
-            newFrames.push_back(newFrame);
-        }
-        for (MeasureBase* newFrame : newFrames) {
             newFrame->linkTo(this);
         }
     }

--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -1032,6 +1032,15 @@ void Excerpt::cloneStaves(Score* sourceScore, Score* dstScore, const std::vector
 
     for (MeasureBase* mb = sourceScore->measures()->first(); mb; mb = mb->next()) {
         if (mb->excludeFromOtherParts()) {
+            // if excluded measure contains section break, add it to precedent measure in part
+            if (LayoutBreak* sectionBreak = mb->sectionBreakElement()) {
+                if (MeasureBase* prevMB = measures->last()) {
+                    EngravingItem* newSectionBreak = sectionBreak->linkedClone();
+                    newSectionBreak->setScore(dstScore);
+                    newSectionBreak->setParent(prevMB);
+                    dstScore->undo(new AddElement(newSectionBreak));
+                }
+            }
             continue;
         }
         MeasureBase* newMeasure = cloneMeasure(mb, dstScore, sourceScore, sourceStavesIndexes, trackList, tieMap);


### PR DESCRIPTION
Resolves: no. 13 of #19527 
Resolves: #20049 
<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
New logic for section break on the frame:
if frame is unlinked from parts, add section break to the previous measure in the part

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
