### PR TITLE
not layouting ties for harmonic notes on tab staff

### DIFF
--- a/src/engraving/rendering/dev/slurtielayout.cpp
+++ b/src/engraving/rendering/dev/slurtielayout.cpp
@@ -1033,6 +1033,17 @@ TieSegment* SlurTieLayout::layoutTieWithNoEndNote(Tie* item)
     return segment;
 }
 
+static bool tieSegmentShouldBeSkipped(Tie* item)
+{
+    Note* startNote = item->startNote();
+    StaffType* st = item->staff()->staffType(startNote ? startNote->tick() : Fraction(0, 1));
+    if (!st || !st->isTabStaff()) {
+        return false;
+    }
+
+    return !st->showBackTied() || (startNote && startNote->harmonic());
+}
+
 TieSegment* SlurTieLayout::tieLayoutFor(Tie* item, System* system)
 {
     item->setPos(0, 0);
@@ -1047,11 +1058,11 @@ TieSegment* SlurTieLayout::tieLayoutFor(Tie* item, System* system)
     }
 
     // do not layout ties in tablature if not showing back-tied fret marks
-    StaffType* st = item->staff()->staffType(item->startNote() ? item->startNote()->tick() : Fraction(0, 1));
-    if (st && st->isTabStaff() && !st->showBackTied()) {
+    if (tieSegmentShouldBeSkipped(item)) {
         if (!item->segmentsEmpty()) {
             item->eraseSpannerSegments();
         }
+
         return nullptr;
     }
 
@@ -1107,11 +1118,11 @@ TieSegment* SlurTieLayout::tieLayoutFor(Tie* item, System* system)
 TieSegment* SlurTieLayout::tieLayoutBack(Tie* item, System* system)
 {
     // do not layout ties in tablature if not showing back-tied fret marks
-    StaffType* st = item->staff()->staffType(item->startNote() ? item->startNote()->tick() : Fraction(0, 1));
-    if (st->isTabStaff() && !st->showBackTied()) {
+    if (tieSegmentShouldBeSkipped(item)) {
         if (!item->segmentsEmpty()) {
             item->eraseSpannerSegments();
         }
+
         return nullptr;
     }
 


### PR DESCRIPTION
Solves this double ties rendering
<img width="217" alt="Screenshot 2023-10-31 at 16 04 55" src="https://github.com/musescore/MuseScore/assets/24373905/409aab66-fba8-4cc1-b83e-019dcde94da9">
