### PR TITLE
Fix MSCV warning C4125 triggered by number in curly quotes in .ui file

### DIFF
--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -778,6 +778,14 @@ EditStyle::EditStyle(QWidget* parent)
     groupBox_rests->layout()->addWidget(restOffsetSelector);
 
     // ====================================================
+    // Measure repeats
+    // ====================================================
+
+    // Define string here instead of in the .ui file to avoid MSVC compiler warning C4125, which would
+    // be triggered by the decimal digit immediately following a non-ASCII character (curly quote).
+    oneMeasureRepeatShow1->setText(qtrc("EditStyleBase", "Show ‘1’ on 1-measure repeats"));
+
+    // ====================================================
     // BEAMS (QML)
     // ====================================================
 

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -6043,7 +6043,7 @@ By default, they will be placed such as that their right end are at the same lev
            <item row="2" column="0" colspan="2">
             <widget class="QCheckBox" name="oneMeasureRepeatShow1">
              <property name="text">
-              <string>Show ‘1’ on 1-measure repeats</string>
+              <string notr="true">Show ‘\1’ on 1-measure repeats [set in edidstyle.cpp]</string>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
### New description by @shoogle:

Fix [MSVC compiler warning C4125](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4125): decimal digit terminates octal escape sequence.

The warning is triggered because Qt's UI file compiler `uic` uses octal escape sequences for non-ASCII characters.

This in `editstyle.ui`:

```XML
<string>Show ‘1’ on 1-measure repeats</string>
```

Becomes this in `ui_editstyle.h` that gets generated in the build directory:
```CPP
"Show \342\200\2301\342\200\231 on 1-measure repeats"
```

The '1' appears immediately after an octal escape code, hence the warning is triggered.

---

If Qt's `uic` tool didn't do the escaping then the warning wouldn't be triggered.

Alternatively, if `uic` started a new string literal for the number, like this:

```CPP
"Show \342\200\230""1\342\200\231 on 1-measure repeats"
```

Or even placed each escape code in its own string literal, like this:

```CPP
"Show ""\342""\200""\230""1""\342""\200""\231"" on 1-measure repeats"
```

That would also avoid the warning. Code is [here](https://github.com/qt/qtbase/blob/78272c667f008f6afcf5f84e0add525b56c3a558/src/tools/uic/shared/language.cpp#L266).