### PR TITLE
Guitar bend widget stabilization

### DIFF
--- a/src/inspector/models/notation/bends/bendsettingsmodel.cpp
+++ b/src/inspector/models/notation/bends/bendsettingsmodel.cpp
@@ -52,10 +52,8 @@ BendSettingsModel::BendSettingsModel(QObject* parent, IElementRepositoryService*
 
 void BendSettingsModel::createProperties()
 {
-    m_lineThickness = buildPropertyItem(Pid::LINE_WIDTH);
-
-    m_bendDirection = buildPropertyItem(Pid::DIRECTION);
-    m_showHoldLine = buildPropertyItem(Pid::BEND_SHOW_HOLD_LINE);
+    m_bendDirection = buildPropertyItem(mu::engraving::Pid::DIRECTION);
+    m_showHoldLine = buildPropertyItem(mu::engraving::Pid::BEND_SHOW_HOLD_LINE);
 
     loadBendCurve();
 }
@@ -73,7 +71,6 @@ void BendSettingsModel::requestElements()
 
 void BendSettingsModel::loadProperties()
 {
-    loadPropertyItem(m_lineThickness, formatDoubleFunc);
     loadPropertyItem(m_bendDirection);
     loadPropertyItem(m_showHoldLine);
 
@@ -84,14 +81,8 @@ void BendSettingsModel::loadProperties()
 
 void BendSettingsModel::resetProperties()
 {
-    m_lineThickness->resetToDefault();
     m_bendDirection->resetToDefault();
     m_showHoldLine->resetToDefault();
-}
-
-PropertyItem* BendSettingsModel::lineThickness() const
-{
-    return m_lineThickness;
 }
 
 bool BendSettingsModel::areSettingsAvailable() const

--- a/src/inspector/models/notation/bends/bendsettingsmodel.cpp
+++ b/src/inspector/models/notation/bends/bendsettingsmodel.cpp
@@ -67,6 +67,7 @@ void BendSettingsModel::requestElements()
     }
 
     emit areSettingsAvailableChanged(areSettingsAvailable());
+    emit isBendCurveEnabledChanged();
 }
 
 void BendSettingsModel::loadProperties()
@@ -263,4 +264,9 @@ void BendSettingsModel::setBendCurve(const QVariantList& newBendCurve)
 
     m_bendCurve = points;
     emit bendCurveChanged();
+}
+
+bool BendSettingsModel::isBendCurveEnabled() const
+{
+    return item() != nullptr;
 }

--- a/src/inspector/models/notation/bends/bendsettingsmodel.h
+++ b/src/inspector/models/notation/bends/bendsettingsmodel.h
@@ -35,6 +35,7 @@ class BendSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(PropertyItem * showHoldLine READ showHoldLine CONSTANT)
     Q_PROPERTY(bool isShowHoldLineAvailable READ isShowHoldLineAvailable NOTIFY isShowHoldLineAvailableChanged)
 
+    Q_PROPERTY(bool isBendCurveEnabled READ isBendCurveEnabled NOTIFY isBendCurveEnabledChanged)
     Q_PROPERTY(QVariantList bendCurve READ bendCurve WRITE setBendCurve NOTIFY bendCurveChanged)
 
     Q_PROPERTY(bool areSettingsAvailable READ areSettingsAvailable NOTIFY areSettingsAvailableChanged)
@@ -57,10 +58,13 @@ public:
 
     void setBendCurve(const QVariantList& newBendCurve);
 
+    bool isBendCurveEnabled() const;
+
 signals:
     void areSettingsAvailableChanged(bool areSettingsAvailable);
     void isShowHoldLineAvailableChanged(bool isAvailable);
 
+    void isBendCurveEnabledChanged();
     void bendCurveChanged();
 
 private:

--- a/src/inspector/models/notation/bends/bendsettingsmodel.h
+++ b/src/inspector/models/notation/bends/bendsettingsmodel.h
@@ -36,7 +36,6 @@ class BendSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(bool isShowHoldLineAvailable READ isShowHoldLineAvailable NOTIFY isShowHoldLineAvailableChanged)
 
     Q_PROPERTY(QVariantList bendCurve READ bendCurve WRITE setBendCurve NOTIFY bendCurveChanged)
-    Q_PROPERTY(PropertyItem * lineThickness READ lineThickness CONSTANT)
 
     Q_PROPERTY(bool areSettingsAvailable READ areSettingsAvailable NOTIFY areSettingsAvailableChanged)
 
@@ -53,7 +52,6 @@ public:
     bool isShowHoldLineAvailable() const;
 
     QVariantList bendCurve() const;
-    PropertyItem* lineThickness() const;
 
     bool areSettingsAvailable() const;
 
@@ -80,8 +78,6 @@ private:
     bool m_isShowHoldLineAvailable = false;
 
     CurvePoints m_bendCurve;
-
-    PropertyItem* m_lineThickness = nullptr;
 };
 }
 

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/bends/BendSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/bends/BendSettings.qml
@@ -70,7 +70,7 @@ Column {
 
     InspectorPropertyView {
         id: bendCurve
-        titleText: qsTrc("inspector", "Click to add or remove points")
+        titleText: qsTrc("inspector", "Customize bend")
 
         enabled: true
         visible: true

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/bends/BendSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/bends/BendSettings.qml
@@ -72,7 +72,7 @@ Column {
         id: bendCurve
         titleText: qsTrc("inspector", "Customize bend")
 
-        enabled: true
+        enabled: root.model ? root.model.isBendCurveEnabled : false
         visible: true
 
         navigationPanel: root.navigationPanel
@@ -81,6 +81,8 @@ Column {
         BendGridCanvas {
             height: 200
             width: parent.width
+
+            enabled: bendCurve.enabled
 
             pointList: root.model ? root.model.bendCurve : null
 

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/bends/BendSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/bends/BendSettings.qml
@@ -86,6 +86,8 @@ Column {
         navigationPanel: root.navigationPanel
         navigationRowStart: showHoldSection.navigation.row + 1
 
+        spacing: 0
+
         BendGridCanvas {
             height: 200
             width: parent.width

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/bends/BendSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/bends/BendSettings.qml
@@ -96,17 +96,4 @@ Column {
             }
         }
     }
-
-    SpinBoxPropertyView {
-        titleText: qsTrc("inspector", "Line thickness")
-        propertyItem: root.model ? root.model.lineThickness : null
-
-        maxValue: 10
-        minValue: 0.1
-        step: 0.1
-        decimals: 2
-
-        navigationPanel: root.navigationPanel
-        navigationRowStart: bendCurve.navigationRowEnd + 1
-    }
 }

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/bends/BendSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/bends/BendSettings.qml
@@ -43,10 +43,18 @@ Column {
         bendTypeSection.focusOnFirst()
     }
 
-    DirectionSection {
-        id: directionSection
+    PlacementSection {
+        id: placmentSection
 
         propertyItem: root.model ? root.model.bendDirection : null
+
+        //! NOTE: Bend uses the direction property,
+        // but for convenience we will display it in the placement section
+        model: [
+            { text: qsTrc("inspector", "Auto"), value: DirectionTypes.VERTICAL_AUTO },
+            { text: qsTrc("inspector", "Above"), value: DirectionTypes.VERTICAL_UP },
+            { text: qsTrc("inspector", "Below"), value: DirectionTypes.VERTICAL_DOWN }
+        ]
 
         navigationPanel: root.navigationPanel
         navigationRowStart: root.navigationRowStart + 1
@@ -59,7 +67,7 @@ Column {
 
         navigationName: "HoldLine"
         navigationPanel: root.navigationPanel
-        navigationRowStart: directionSection.navigationRowEnd + 1
+        navigationRowStart: placementSection.navigationRowEnd + 1
 
         model: [
             { text: qsTrc("inspector", "Auto"), value: BendTypes.SHOW_HOLD_AUTO},

--- a/src/inspector/view/widgets/bendgridcanvas.cpp
+++ b/src/inspector/view/widgets/bendgridcanvas.cpp
@@ -74,6 +74,10 @@ BendGridCanvas::BendGridCanvas(QQuickItem* parent)
     uiConfig()->fontChanged().onNotify(this, [this]() {
         update();
     });
+
+    connect(this, &BendGridCanvas::enabledChanged, [this](){
+        update();
+    });
 }
 
 QVariant BendGridCanvas::pointList() const
@@ -181,7 +185,10 @@ void BendGridCanvas::paint(QPainter* painter)
     QRectF frameRect = this->frameRect();
 
     drawBackground(painter, frameRect);
-    drawCurve(painter, frameRect);
+
+    if (isEnabled()) {
+        drawCurve(painter, frameRect);
+    }
 }
 
 void BendGridCanvas::mousePressEvent(QMouseEvent* event)
@@ -378,7 +385,7 @@ void BendGridCanvas::drawBackground(QPainter* painter, const QRectF& frameRect)
     const qreal columnWidth = this->columnWidth(frameRect);
 
     const ThemeInfo& currentTheme = uiConfig()->currentTheme();
-    QColor primaryLinesColor(currentTheme.codeKey == DARK_THEME_CODE ? Qt::white : Qt::black);
+    QColor primaryLinesColor(isEnabled() ? (currentTheme.codeKey == DARK_THEME_CODE ? Qt::white : Qt::black) : Qt::gray);
     QColor secondaryLinesColor(Qt::gray);
 
     painter->setRenderHint(QPainter::Antialiasing, true);

--- a/src/inspector/view/widgets/bendgridcanvas.cpp
+++ b/src/inspector/view/widgets/bendgridcanvas.cpp
@@ -205,6 +205,8 @@ void BendGridCanvas::mousePressEvent(QMouseEvent* event)
 
     m_currentPointIndex = this->pointIndex(point);
     m_canvasWasChanged = false;
+
+    update();
 }
 
 void BendGridCanvas::mouseMoveEvent(QMouseEvent* event)
@@ -549,7 +551,7 @@ void BendGridCanvas::drawCurve(QPainter* painter, const QRectF& frameRect)
     QBrush activeBrush(color, Qt::SolidPattern);
 
     QColor hoverColor(color);
-    hoverColor.setAlpha(200);
+    hoverColor.setAlpha(150);
     QBrush hoverBrush(hoverColor, Qt::SolidPattern);
 
     painter->setPen(Qt::NoPen);
@@ -571,7 +573,7 @@ void BendGridCanvas::drawCurve(QPainter* painter, const QRectF& frameRect)
 
             painter->setBrush(backgroundBrush);
             painter->drawEllipse(pos, GRIP_CENTER_RADIUS, GRIP_CENTER_RADIUS);
-        } else if (m_hoverPointIndex.has_value() && m_currentPointIndex.has_value()) { // focused
+        } else if (m_focusedPointIndex.has_value() && m_focusedPointIndex.value() == i) { // focused
             QColor fontPrimaryColor(currentTheme.values[FONT_PRIMARY_COLOR].toString());
             QBrush fontPrimaryBrush(fontPrimaryColor, Qt::SolidPattern);
             painter->setBrush(fontPrimaryBrush);
@@ -582,18 +584,21 @@ void BendGridCanvas::drawCurve(QPainter* painter, const QRectF& frameRect)
 
             painter->setBrush(activeBrush);
             painter->drawEllipse(pos, GRIP_RADIUS, GRIP_RADIUS);
-        } else if (m_hoverPointIndex.has_value() && m_hoverPointIndex.value() == i) { // hover
-            painter->setBrush(activeBrush);
-            painter->drawEllipse(pos, GRIP_RADIUS, GRIP_RADIUS);
-
-            painter->setBrush(hoverBrush);
-            painter->drawEllipse(pos, GRIP_CENTER_RADIUS, GRIP_CENTER_RADIUS);
         } else if (m_currentPointIndex.has_value() && m_currentPointIndex.value() == i) { // selected
             painter->setBrush(backgroundBrush);
             painter->drawEllipse(pos, GRIP_SELECTED_RADIUS, GRIP_SELECTED_RADIUS);
 
             painter->setBrush(activeBrush);
             painter->drawEllipse(pos, GRIP_RADIUS, GRIP_RADIUS);
+        } else if (m_hoverPointIndex.has_value() && m_hoverPointIndex.value() == i) { // hover
+            painter->setBrush(activeBrush);
+            painter->drawEllipse(pos, GRIP_RADIUS, GRIP_RADIUS);
+
+            painter->setBrush(backgroundBrush);
+            painter->drawEllipse(pos, GRIP_CENTER_RADIUS, GRIP_CENTER_RADIUS);
+
+            painter->setBrush(hoverBrush);
+            painter->drawEllipse(pos, GRIP_CENTER_RADIUS, GRIP_CENTER_RADIUS);
         }
     }
 }

--- a/src/inspector/view/widgets/bendgridcanvas.h
+++ b/src/inspector/view/widgets/bendgridcanvas.h
@@ -123,8 +123,9 @@ private:
     /// Show negative pitch values. Happens in tremoloBarCanvas.
     bool m_showNegativeRows = false;
 
-    std::optional<int> m_hoverPointIndex;
     std::optional<int> m_currentPointIndex;
+    std::optional<int> m_focusedPointIndex;
+    std::optional<int> m_hoverPointIndex;
 
     bool m_canvasWasChanged = false;
 };


### PR DESCRIPTION
Fixed these points from #19898
- Remove “line thickness” setting
- States. Hover state missing. Focus state should only be used for keyboard focus (accessibility)
- Widget label
- Lines should not be able to extend past the grid border
- Widget should be disabled when pre-4.2 bend is selected: