### PR TITLE
Properly support BPM and TIFF images for frames and canvas

### DIFF
--- a/src/appshell/view/preferences/appearancepreferencesmodel.cpp
+++ b/src/appshell/view/preferences/appearancepreferencesmodel.cpp
@@ -162,7 +162,7 @@ QStringList AppearancePreferencesModel::allFonts() const
 
 QStringList AppearancePreferencesModel::wallpaperPathFilter() const
 {
-    return { qtrc("appshell/preferences", "Images") + " (*.jpg *.jpeg *.png)",
+    return { qtrc("appshell/preferences", "Images") + " (*.jpg *.jpeg *.png *.bmp *.tif *.tiff)",
              qtrc("appshell/preferences", "All") + " (*)" };
 }
 

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -1243,10 +1243,13 @@ void NotationActionController::addImage()
         return;
     }
 
-    std::vector<std::string> filter = { trc("notation", "All Supported Files") + " (*.svg *.jpg *.jpeg *.png)",
+    std::vector<std::string> filter = { trc("notation", "All Supported Files") + " (*.svg *.jpg *.jpeg *.png *.bmp *.tif *.tiff)",
                                         trc("notation", "Scalable Vector Graphics") + " (*.svg)",
                                         trc("notation", "JPEG") + " (*.jpg *.jpeg)",
-                                        trc("notation", "PNG Bitmap Graphic") + " (*.png)" };
+                                        trc("notation", "PNG Bitmap Graphic") + " (*.png)",
+                                        trc("notation", "Bitmap") + " (*.bmp)",
+                                        trc("notation", "TIFF") + " (*.tif *.tiff)",
+                                        trc("notation", "All") + " (*)" };
 
     io::path_t path = interactive()->selectOpeningFile(qtrc("notation", "Insert Image"), "", filter);
     interaction->addImageToItem(path, item);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4219,6 +4219,9 @@ void NotationInteraction::addImageToItem(const io::path_t& imagePath, EngravingI
         { "jpg", ImageType::RASTER },
         { "jpeg", ImageType::RASTER },
         { "png", ImageType::RASTER },
+        { "bmp", ImageType::RASTER },
+        { "tif", ImageType::RASTER },
+        { "tiff", ImageType::RASTER },
     };
 
     io::path_t suffix = io::suffix(imagePath);

--- a/src/palette/view/widgets/palettewidget.cpp
+++ b/src/palette/view/widgets/palettewidget.cpp
@@ -821,6 +821,9 @@ void PaletteWidget::dragEnterEvent(QDragEnterEvent* event)
                 || suffix == "jpg"
                 || suffix == "jpeg"
                 || suffix == "png"
+                || suffix == "bmp"
+                || suffix == "tif"
+                || suffix == "tiff"
                 ) {
                 event->acceptProposedAction();
             }


### PR DESCRIPTION
via https://musescore.org/en/handbook/4/working-images I've just learned that BMP and TIF files are supported image formats (and supported since Mu3, see https://musescore.org/en/handbook/3/images), but then found that for the frames' "Add image" dialog and Edit > Preferences > Canvas these formats are not being offered.
While for the former "drag'n'drop" is a workaround, for the latter it is to change the filter to "all files".