### PR TITLE
Added AccessibleWindowInterface for the MuseScore main window

### DIFF
--- a/src/framework/accessibility/CMakeLists.txt
+++ b/src/framework/accessibility/CMakeLists.txt
@@ -36,6 +36,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/accessiblestub.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/accessibleiteminterface.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/accessibleiteminterface.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/accessiblewindowinterface.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/accessiblewindowinterface.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/accessibilityconfiguration.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/accessibilityconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/qaccessibleinterfaceregister.cpp

--- a/src/framework/accessibility/accessibilitymodule.cpp
+++ b/src/framework/accessibility/accessibilitymodule.cpp
@@ -51,9 +51,7 @@ void AccessibilityModule::resolveImports()
 {
     auto accr = ioc()->resolve<IQAccessibleInterfaceRegister>(moduleName());
     if (accr) {
-#ifdef Q_OS_MAC
         accr->registerInterfaceGetter("QQuickWindow", AccessibilityController::accessibleInterface);
-#endif
         accr->registerInterfaceGetter("mu::accessibility::AccessibleObject", AccessibleObject::accessibleInterface);
     }
 }

--- a/src/framework/accessibility/internal/accessibilitycontroller.cpp
+++ b/src/framework/accessibility/internal/accessibilitycontroller.cpp
@@ -33,7 +33,7 @@
 
 #include "accessibleobject.h"
 #include "accessiblestub.h"
-#include "accessibleiteminterface.h"
+#include "accessiblewindowinterface.h"
 
 #include "log.h"
 
@@ -57,9 +57,9 @@ AccessibilityController::~AccessibilityController()
     unreg(this);
 }
 
-QAccessibleInterface* AccessibilityController::accessibleInterface(QObject*)
+QAccessibleInterface* AccessibilityController::accessibleInterface(QObject* window)
 {
-    return static_cast<QAccessibleInterface*>(new AccessibleItemInterface(s_rootObject));
+    return static_cast<QAccessibleInterface*>(new AccessibleWindowInterface(window, s_rootObject));
 }
 
 static QAccessibleInterface* muAccessibleFactory(const QString& classname, QObject* object)

--- a/src/framework/accessibility/internal/accessiblewindowinterface.cpp
+++ b/src/framework/accessibility/internal/accessiblewindowinterface.cpp
@@ -1,0 +1,139 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "accessiblewindowinterface.h"
+
+#include <QWindow>
+
+#include "accessibilitycontroller.h"
+
+#include "translation.h"
+#include "log.h"
+
+//#define MUE_ENABLE_ACCESSIBILITY_TRACE
+
+#undef MYLOG
+#ifdef MUE_ENABLE_ACCESSIBILITY_TRACE
+#define MYLOG() LOGI()
+#else
+#define MYLOG() LOGN()
+#endif
+
+using namespace mu::accessibility;
+
+AccessibleWindowInterface::AccessibleWindowInterface(QObject* window, AccessibleObject* children)
+    : m_children(children)
+{
+    m_window = qobject_cast<QWindow*>(window);
+}
+
+bool AccessibleWindowInterface::isValid() const
+{
+    return m_window != nullptr;
+}
+
+QObject* AccessibleWindowInterface::object() const
+{
+    return m_window;
+}
+
+QWindow* AccessibleWindowInterface::window() const
+{
+    return m_window;
+}
+
+QRect AccessibleWindowInterface::rect() const
+{
+    if (!m_window) {
+        return {};
+    }
+    return QRect(m_window->x(), m_window->y(), m_window->width(), m_window->height());
+}
+
+QAccessibleInterface* AccessibleWindowInterface::parent() const
+{
+    return nullptr;
+}
+
+int AccessibleWindowInterface::childCount() const
+{
+    int count = m_children->controller().lock()->childCount(m_children->item());
+    MYLOG() << "item: " << m_children->item()->accessibleName() << ", childCount: " << count;
+    return count;
+}
+
+QAccessibleInterface* AccessibleWindowInterface::child(int index) const
+{
+    QAccessibleInterface* iface = m_children->controller().lock()->child(m_children->item(), index);
+    MYLOG() << "item: " << m_children->item()->accessibleName() << ", child: " << index << " " << iface->text(QAccessible::Name);
+    return iface;
+}
+
+int AccessibleWindowInterface::indexOfChild(const QAccessibleInterface* iface) const
+{
+    int idx = m_children->controller().lock()->indexOfChild(m_children->item(), iface);
+    MYLOG() << "item: " << m_children->item()->accessibleName() << ", indexOfChild: " << iface->text(QAccessible::Name) << " = " << idx;
+    return idx;
+}
+
+QAccessibleInterface* AccessibleWindowInterface::childAt(int, int) const
+{
+    NOT_IMPLEMENTED;
+    return nullptr;
+}
+
+QAccessibleInterface* AccessibleWindowInterface::focusChild() const
+{
+    QAccessibleInterface* child = m_children->controller().lock()->focusedChild(m_children->item());
+    MYLOG() << "item: " << m_children->item()->accessibleName() << ", focused child: " << (child ? child->text(QAccessible::Name) : "null");
+    return child;
+}
+
+QAccessible::State AccessibleWindowInterface::state() const
+{
+    QAccessible::State st;
+    st.active = true;
+    return st;
+}
+
+QAccessible::Role AccessibleWindowInterface::role() const
+{
+    return QAccessible::Window;
+}
+
+QString AccessibleWindowInterface::text(QAccessible::Text) const
+{
+    if (!m_window) {
+        return {};
+    }
+    return m_window->title();
+}
+
+void AccessibleWindowInterface::setText(QAccessible::Text, const QString&)
+{
+    NOT_IMPLEMENTED;
+}
+
+void* AccessibleWindowInterface::interface_cast(QAccessible::InterfaceType)
+{
+    //! NOTE Not implemented
+    return nullptr;
+}

--- a/src/framework/accessibility/internal/accessiblewindowinterface.h
+++ b/src/framework/accessibility/internal/accessiblewindowinterface.h
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_ACCESSIBILITY_ACCESSIBLEWINDOWINTERFACE_H
+#define MU_ACCESSIBILITY_ACCESSIBLEWINDOWINTERFACE_H
+
+#include <QAccessibleInterface>
+
+#include "accessibleobject.h"
+
+#include "modularity/ioc.h"
+#include "ui/iinteractiveprovider.h"
+
+namespace mu::accessibility {
+class AccessibleWindowInterface : public QAccessibleInterface
+{
+public:
+    AccessibleWindowInterface(QObject* window, AccessibleObject* children);
+
+    bool isValid() const override;
+    QObject* object() const override;
+    QWindow* window() const override;
+    QRect rect() const override;
+
+    QAccessibleInterface* focusChild() const override;
+    QAccessibleInterface* childAt(int x, int y) const override;
+
+    QAccessibleInterface* parent() const override;
+    QAccessibleInterface* child(int index) const override;
+    int childCount() const override;
+    int indexOfChild(const QAccessibleInterface* iface) const override;
+
+    QAccessible::State state() const override;
+    QAccessible::Role role() const override;
+    QString text(QAccessible::Text) const override;
+    void setText(QAccessible::Text, const QString& text) override;
+protected:
+    void* interface_cast(QAccessible::InterfaceType t) override;
+
+private:
+    QWindow* m_window = nullptr;
+    AccessibleObject* m_children = nullptr;
+};
+}
+
+#endif // MU_ACCESSIBILITY_ACCESSIBLEWINDOWINTERFACE_H


### PR DESCRIPTION
Previously, on all platforms but Mac, the default QTQuick window
interface was used for the main window, but that interface had no
knowledge of the MuseScore accessibility tree. This meant that it was
not possible to get to accessible children from the main window's
accessible interface, nor was it possible to ask the main window for
the item with focus. Both of those problems are resolved by
explicitily implementing this interface and connecting the main window
with the rest of the accessibility tree.

Previously on Mac, MuseScore
didn't present a main window but instead exposed a forest of top level
items. That broke windows accessibility clients, so it was Mac
specific. With the introduction of this top-level window interface,
MuseScore presents a proper tree of items on all platforms.

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [ ] I signed the [CLA](https://musescore.org/en/cla)
- [ ] The title of the PR describes the problem it addresses
- [ ] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [ ] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ ] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
