### PR TITLE
6-key Braille input

### DIFF
--- a/src/appshell/appshell.qrc
+++ b/src/appshell/appshell.qrc
@@ -107,7 +107,7 @@
         <file>resources/LoadingScreen.svg</file>
         <file>qml/Preferences/BraillePreferencesPage.qml</file>
         <file>qml/Preferences/internal/BrailleSection.qml</file>
-        <file>qml/Preferences/internal/BrailleTableSection.qml</file>
+        <file>qml/Preferences/internal/BrailleAdvancedSection.qml</file>
         <file>qml/Preferences/internal/MeiSection.qml</file>
         <file>qml/Preferences/internal/PublishMuseScoreComSection.qml</file>
     </qresource>

--- a/src/appshell/qml/Preferences/BraillePreferencesPage.qml
+++ b/src/appshell/qml/Preferences/BraillePreferencesPage.qml
@@ -45,17 +45,18 @@ PreferencesPage {
             navigation.order: root.navigationOrderStart + 1
 
             onBraillePanelEnabledChangeRequested: function(val) {
-                preferencesModel.braillePanelEnabled = val
-                brailleTable.enabled = val;
+                preferencesModel.braillePanelEnabled = val;
             }
         }
 
         SeparatorLine { }
 
-        BrailleTableSection {
-            id: brailleTable
-            tables: preferencesModel.tables()
+        BrailleAdvancedSection {
+            id: brailleAdvanced
+            tables: preferencesModel.brailleTables()
+            directions: preferencesModel.intervalDirections()
             brailleTable: preferencesModel.brailleTable
+            intervalDirection: preferencesModel.intervalDirection
 
             navigation.section: root.navigationSection
             navigation.order: root.navigationOrderStart + 2
@@ -63,12 +64,16 @@ PreferencesPage {
             enabled: preferencesModel.braillePanelEnabled
 
             onBrailleTableChangeRequested: function(table) {
-                preferencesModel.brailleTable = table
+                preferencesModel.brailleTable = table;
+            }
+
+            onIntervalDirectionChangeRequested: function(direction) {
+                preferencesModel.intervalDirection = direction;
             }
 
             onFocusChanged: {
                 if (activeFocus) {
-                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height));
                 }
             }
         }

--- a/src/appshell/qml/Preferences/internal/BrailleAdvancedSection.qml
+++ b/src/appshell/qml/Preferences/internal/BrailleAdvancedSection.qml
@@ -31,7 +31,11 @@ BaseSection {
     property var tables: null
     property string brailleTable: ""
 
+    property var directions: null
+    property string intervalDirection: ""
+
     signal brailleTableChangeRequested(string table)
+    signal intervalDirectionChangeRequested(string direction)
 
     ComboBoxWithTitle {
         title: qsTrc("appshell/preferences", "Braille table for lyrics:")
@@ -45,7 +49,23 @@ BaseSection {
         navigation.row: 1
 
         onValueEdited: function(newIndex, newValue) {
-            root.brailleTableChangeRequested(newValue)
+            root.brailleTableChangeRequested(newValue);
+        }
+    }
+
+    ComboBoxWithTitle {
+        title: qsTrc("appshell/preferences", "Interval direction:")
+        columnWidth: root.columnWidth
+
+        currentIndex: control.indexOfValue(root.intervalDirection)
+        model: root.directions
+
+        navigation.name: "IntervalDirectionBox"
+        navigation.panel: root.navigation
+        navigation.row: 2
+
+        onValueEdited: function(newIndex, newValue) {
+            root.intervalDirectionChangeRequested(newValue);
         }
     }
 }

--- a/src/appshell/qml/Preferences/internal/BrailleAdvancedSection.qml
+++ b/src/appshell/qml/Preferences/internal/BrailleAdvancedSection.qml
@@ -32,10 +32,10 @@ BaseSection {
     property string brailleTable: ""
 
     property var directions: null
-    property string intervalDirection: ""
+    property int intervalDirection: -1
 
     signal brailleTableChangeRequested(string table)
-    signal intervalDirectionChangeRequested(string direction)
+    signal intervalDirectionChangeRequested(int direction)
 
     ComboBoxWithTitle {
         title: qsTrc("appshell/preferences", "Braille table for lyrics:")

--- a/src/appshell/qml/Preferences/internal/BrailleSection.qml
+++ b/src/appshell/qml/Preferences/internal/BrailleSection.qml
@@ -44,7 +44,7 @@ BaseSection {
         navigation.row: 0
 
         onClicked: {
-            root.braillePanelEnabledChangeRequested(!checked)
+            root.braillePanelEnabledChangeRequested(!checked);
         }
     }
 }

--- a/src/appshell/view/preferences/braillepreferencesmodel.cpp
+++ b/src/appshell/view/preferences/braillepreferencesmodel.cpp
@@ -22,8 +22,6 @@
 
 #include "braillepreferencesmodel.h"
 
-#include "log.h"
-
 using namespace mu::appshell;
 
 BraillePreferencesModel::BraillePreferencesModel(QObject* parent)
@@ -36,6 +34,26 @@ bool BraillePreferencesModel::braillePanelEnabled() const
     return brailleConfiguration()->braillePanelEnabled();
 }
 
+QString BraillePreferencesModel::brailleTable() const
+{
+    return brailleConfiguration()->brailleTable();
+}
+
+QString BraillePreferencesModel::intervalDirection() const
+{
+    return brailleConfiguration()->intervalDirection();
+}
+
+QStringList BraillePreferencesModel::brailleTables() const
+{
+    return brailleConfiguration()->brailleTableList();
+}
+
+QStringList BraillePreferencesModel::intervalDirections() const
+{
+    return brailleConfiguration()->intervalDirectionsList();
+}
+
 void BraillePreferencesModel::setBraillePanelEnabled(bool value)
 {
     if (value == braillePanelEnabled()) {
@@ -44,11 +62,6 @@ void BraillePreferencesModel::setBraillePanelEnabled(bool value)
 
     brailleConfiguration()->setBraillePanelEnabled(value);
     emit braillePanelEnabledChanged(value);
-}
-
-QString BraillePreferencesModel::brailleTable() const
-{
-    return brailleConfiguration()->brailleTable();
 }
 
 void BraillePreferencesModel::setBrailleTable(QString table)
@@ -61,7 +74,12 @@ void BraillePreferencesModel::setBrailleTable(QString table)
     emit brailleTableChanged(table);
 }
 
-QStringList BraillePreferencesModel::tables() const
+void BraillePreferencesModel::setIntervalDirection(QString direction)
 {
-    return brailleConfiguration()->brailleTableList();
+    if (direction == intervalDirection()) {
+        return;
+    }
+
+    brailleConfiguration()->setIntervalDirection(direction);
+    emit intervalDirectionChanged(direction);
 }

--- a/src/appshell/view/preferences/braillepreferencesmodel.cpp
+++ b/src/appshell/view/preferences/braillepreferencesmodel.cpp
@@ -22,7 +22,10 @@
 
 #include "braillepreferencesmodel.h"
 
+#include "translation.h"
+
 using namespace mu::appshell;
+using namespace mu::braille;
 
 BraillePreferencesModel::BraillePreferencesModel(QObject* parent)
     : QObject(parent)
@@ -39,9 +42,9 @@ QString BraillePreferencesModel::brailleTable() const
     return brailleConfiguration()->brailleTable();
 }
 
-QString BraillePreferencesModel::intervalDirection() const
+int BraillePreferencesModel::intervalDirection() const
 {
-    return brailleConfiguration()->intervalDirection();
+    return static_cast<int>(brailleConfiguration()->intervalDirection());
 }
 
 QStringList BraillePreferencesModel::brailleTables() const
@@ -49,9 +52,25 @@ QStringList BraillePreferencesModel::brailleTables() const
     return brailleConfiguration()->brailleTableList();
 }
 
-QStringList BraillePreferencesModel::intervalDirections() const
+QVariantList BraillePreferencesModel::intervalDirections() const
 {
-    return brailleConfiguration()->intervalDirectionsList();
+    return QVariantList {
+        QVariantMap {
+            //: Braille chord interval direction: automatic (based on clef)
+            { "text", qtrc("appshell/preferences", "Auto") },
+            { "value", static_cast<int>(BrailleIntervalDirection::Auto) },
+        },
+        QVariantMap {
+            //: Braille chord interval direction: up (ascending)
+            { "text", qtrc("appshell/preferences", "Up") },
+            { "value", static_cast<int>(BrailleIntervalDirection::Up) },
+        },
+        QVariantMap {
+            //: Braille chord interval direction: down (descending)
+            { "text", qtrc("appshell/preferences", "Down") },
+            { "value", static_cast<int>(BrailleIntervalDirection::Down) },
+        },
+    };
 }
 
 void BraillePreferencesModel::setBraillePanelEnabled(bool value)
@@ -74,12 +93,12 @@ void BraillePreferencesModel::setBrailleTable(QString table)
     emit brailleTableChanged(table);
 }
 
-void BraillePreferencesModel::setIntervalDirection(QString direction)
+void BraillePreferencesModel::setIntervalDirection(int direction)
 {
     if (direction == intervalDirection()) {
         return;
     }
 
-    brailleConfiguration()->setIntervalDirection(direction);
+    brailleConfiguration()->setIntervalDirection(static_cast<BrailleIntervalDirection>(direction));
     emit intervalDirectionChanged(direction);
 }

--- a/src/appshell/view/preferences/braillepreferencesmodel.h
+++ b/src/appshell/view/preferences/braillepreferencesmodel.h
@@ -32,28 +32,32 @@ namespace mu::appshell {
 class BraillePreferencesModel : public QObject
 {
     Q_OBJECT
+
     INJECT(braille::IBrailleConfiguration, brailleConfiguration)
 
-    Q_PROPERTY(
-        bool braillePanelEnabled READ braillePanelEnabled WRITE setBraillePanelEnabled NOTIFY braillePanelEnabledChanged)
-    Q_PROPERTY(
-        QString brailleTable READ brailleTable WRITE setBrailleTable NOTIFY brailleTableChanged)
+    Q_PROPERTY(bool braillePanelEnabled READ braillePanelEnabled WRITE setBraillePanelEnabled NOTIFY braillePanelEnabledChanged)
+    Q_PROPERTY(QString brailleTable READ brailleTable WRITE setBrailleTable NOTIFY brailleTableChanged)
+    Q_PROPERTY(QString intervalDirection READ intervalDirection WRITE setIntervalDirection NOTIFY intervalDirectionChanged)
 
 public:
     explicit BraillePreferencesModel(QObject* parent = nullptr);
 
-    Q_INVOKABLE QStringList tables() const;
-
     bool braillePanelEnabled() const;
     QString brailleTable() const;
+    QString intervalDirection() const;
+
+    Q_INVOKABLE QStringList brailleTables() const;
+    Q_INVOKABLE QStringList intervalDirections() const;
 
 public slots:
     void setBraillePanelEnabled(bool value);
     void setBrailleTable(QString table);
+    void setIntervalDirection(QString direction);
 
 signals:
     void braillePanelEnabledChanged(bool value);
     void brailleTableChanged(QString value);
+    void intervalDirectionChanged(QString value);
 };
 }
 

--- a/src/appshell/view/preferences/braillepreferencesmodel.h
+++ b/src/appshell/view/preferences/braillepreferencesmodel.h
@@ -37,27 +37,27 @@ class BraillePreferencesModel : public QObject
 
     Q_PROPERTY(bool braillePanelEnabled READ braillePanelEnabled WRITE setBraillePanelEnabled NOTIFY braillePanelEnabledChanged)
     Q_PROPERTY(QString brailleTable READ brailleTable WRITE setBrailleTable NOTIFY brailleTableChanged)
-    Q_PROPERTY(QString intervalDirection READ intervalDirection WRITE setIntervalDirection NOTIFY intervalDirectionChanged)
+    Q_PROPERTY(int intervalDirection READ intervalDirection WRITE setIntervalDirection NOTIFY intervalDirectionChanged)
 
 public:
     explicit BraillePreferencesModel(QObject* parent = nullptr);
 
     bool braillePanelEnabled() const;
     QString brailleTable() const;
-    QString intervalDirection() const;
+    int intervalDirection() const;
 
     Q_INVOKABLE QStringList brailleTables() const;
-    Q_INVOKABLE QStringList intervalDirections() const;
+    Q_INVOKABLE QVariantList intervalDirections() const;
 
 public slots:
     void setBraillePanelEnabled(bool value);
     void setBrailleTable(QString table);
-    void setIntervalDirection(QString direction);
+    void setIntervalDirection(int direction);
 
 signals:
     void braillePanelEnabledChanged(bool value);
     void brailleTableChanged(QString value);
-    void intervalDirectionChanged(QString value);
+    void intervalDirectionChanged(int value);
 };
 }
 

--- a/src/braille/CMakeLists.txt
+++ b/src/braille/CMakeLists.txt
@@ -17,10 +17,16 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/ibrailleconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/ibrailleconverter.h
     ${CMAKE_CURRENT_LIST_DIR}/inotationbraille.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/braillecode.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/braillecode.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/brailleconfiguration.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/brailleconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/brailleconverter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/brailleconverter.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/brailleinput.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/brailleinput.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/brailleinputparser.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/brailleinputparser.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/braillewriter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/braillewriter.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/braille.cpp

--- a/src/braille/brailletypes.h
+++ b/src/braille/brailletypes.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2023 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_BRAILLE_BRAILLETYPES_H
+#define MU_BRAILLE_BRAILLETYPES_H
+
+namespace mu::braille {
+enum class BrailleMode
+{
+    Undefined = 0,
+    Navigation,
+    BrailleInput,
+};
+
+enum class BrailleIntervalDirection
+{
+    Auto = 0,
+    Up,
+    Down,
+};
+}
+
+#endif // MU_BRAILLE_BRAILLETYPES_H

--- a/src/braille/ibrailleconfiguration.h
+++ b/src/braille/ibrailleconfiguration.h
@@ -37,11 +37,15 @@ public:
     virtual bool braillePanelEnabled() const = 0;
     virtual void setBraillePanelEnabled(const bool enabled) = 0;
 
+    virtual async::Notification intervalDirectionChanged() const = 0;
+    virtual QString intervalDirection() const = 0;
+    virtual void setIntervalDirection(const QString direction) = 0;
+    virtual QStringList intervalDirectionsList() const = 0;
+
     virtual async::Notification brailleTableChanged() const = 0;
     virtual QString brailleTable() const = 0;
     virtual void setBrailleTable(const QString table) = 0;
-
-    virtual QStringList brailleTableList() = 0;
+    virtual QStringList brailleTableList() const = 0;
 };
 }
 

--- a/src/braille/ibrailleconfiguration.h
+++ b/src/braille/ibrailleconfiguration.h
@@ -25,6 +25,8 @@
 #include "modularity/imoduleinterface.h"
 #include "async/notification.h"
 
+#include "brailletypes.h"
+
 namespace mu::braille {
 class IBrailleConfiguration : MODULE_EXPORT_INTERFACE
 {
@@ -38,9 +40,8 @@ public:
     virtual void setBraillePanelEnabled(const bool enabled) = 0;
 
     virtual async::Notification intervalDirectionChanged() const = 0;
-    virtual QString intervalDirection() const = 0;
-    virtual void setIntervalDirection(const QString direction) = 0;
-    virtual QStringList intervalDirectionsList() const = 0;
+    virtual BrailleIntervalDirection intervalDirection() const = 0;
+    virtual void setIntervalDirection(const BrailleIntervalDirection direction) = 0;
 
     virtual async::Notification brailleTableChanged() const = 0;
     virtual QString brailleTable() const = 0;

--- a/src/braille/inotationbraille.h
+++ b/src/braille/inotationbraille.h
@@ -28,6 +28,13 @@
 #include "modularity/imoduleinterface.h"
 
 namespace mu::braille {
+enum class BrailleMode
+{
+    Undefined = 0,
+    Navigation,
+    BrailleInput,
+};
+
 class INotationBraille : MODULE_EXPORT_INTERFACE
 {
     INTERFACE_ID(INotationBraille)
@@ -39,14 +46,25 @@ public:
     virtual ValCh<int> cursorPosition() const = 0;
     virtual ValCh<int> currentItemPositionStart() const = 0;
     virtual ValCh<int> currentItemPositionEnd() const = 0;
-    virtual ValCh<std::string> shortcut() const = 0;
+    virtual ValCh<std::string> keys() const = 0;
     virtual ValCh<bool> enabled() const = 0;
+    virtual ValCh<QString> intervalDirection() const = 0;
+    virtual ValCh<int> mode() const = 0;
+    virtual ValCh<std::string> cursorColor() const = 0;
 
-    virtual void setEnabled(bool enabled) = 0;
+    virtual void setEnabled(const bool enabled) = 0;
+    virtual void setIntervalDirection(const QString direction) = 0;
 
     virtual void setCursorPosition(const int pos) = 0;
     virtual void setCurrentItemPosition(const int, const int) = 0;
-    virtual void setShortcut(const QString&) = 0;
+    virtual void setKeys(const QString&) = 0;
+
+    virtual void setMode(const BrailleMode) = 0;
+    virtual void toggleMode() = 0;
+    virtual bool isNavigationMode() = 0;
+    virtual bool isBrailleInputMode() = 0;
+
+    virtual void setCursorColor(const QString) = 0;
 };
 }
 

--- a/src/braille/inotationbraille.h
+++ b/src/braille/inotationbraille.h
@@ -23,18 +23,12 @@
 #ifndef MU_BRAILLE_INOTATIONBRAILLE_H
 #define MU_BRAILLE_INOTATIONBRAILLE_H
 
+#include "modularity/imoduleinterface.h"
 #include "types/retval.h"
 
-#include "modularity/imoduleinterface.h"
+#include "brailletypes.h"
 
 namespace mu::braille {
-enum class BrailleMode
-{
-    Undefined = 0,
-    Navigation,
-    BrailleInput,
-};
-
 class INotationBraille : MODULE_EXPORT_INTERFACE
 {
     INTERFACE_ID(INotationBraille)
@@ -48,12 +42,12 @@ public:
     virtual ValCh<int> currentItemPositionEnd() const = 0;
     virtual ValCh<std::string> keys() const = 0;
     virtual ValCh<bool> enabled() const = 0;
-    virtual ValCh<QString> intervalDirection() const = 0;
+    virtual ValCh<BrailleIntervalDirection> intervalDirection() const = 0;
     virtual ValCh<int> mode() const = 0;
     virtual ValCh<std::string> cursorColor() const = 0;
 
     virtual void setEnabled(const bool enabled) = 0;
-    virtual void setIntervalDirection(const QString direction) = 0;
+    virtual void setIntervalDirection(const BrailleIntervalDirection direction) = 0;
 
     virtual void setCursorPosition(const int pos) = 0;
     virtual void setCurrentItemPosition(const int, const int) = 0;

--- a/src/braille/internal/braille.cpp
+++ b/src/braille/internal/braille.cpp
@@ -904,24 +904,21 @@ bool Braille::write(QIODevice& device)
 
 bool Braille::convertMeasure(Measure* measure, BrailleEngravingItemList* beis)
 {
-    size_t nrStaves = m_score->staves().size();
-
-    std::vector<BrailleEngravingItemList> measureBraille(nrStaves);
-    std::vector<BrailleEngravingItemList> lyrics(nrStaves + 1);
+    int nrStaves = static_cast<int>(m_score->staves().size());
 
     if (measure->hasMMRest() && m_score->style().styleB(Sid::createMultiMeasureRests)) {
         measure = measure->mmRest();
     }
 
-    for (size_t i = 0; i < nrStaves; ++i) {
+    for (int i = 0; i < nrStaves; ++i) {
         BrailleEngravingItemList measureBraille;
         BrailleEngravingItemList measureLyrics;
 
-        brailleMeasureItems(&measureBraille, measure, static_cast<int>(i));
+        brailleMeasureItems(&measureBraille, measure, i);
         //measureBraille.log();
         beis->join(&measureBraille, true, false);
 
-        brailleMeasureLyrics(&measureLyrics, measure, static_cast<int>(i));
+        brailleMeasureLyrics(&measureLyrics, measure, i);
         if (!measureLyrics.isEmpty()) {
             beis->join(&measureLyrics, true, false);
         }
@@ -1165,8 +1162,9 @@ bool Braille::hasTies(ChordRest* chordRest)
 bool Braille::ascendingChords(ClefType clefType)
 {
     // 9.2. Direction of Intervals (in Chords). Page 75. Music Braille Code 2015
-    // In Treble, Soprano, Alto clefs: Write the upper most note, then rest of notes as intervals downward
-    // In Tenor, Baritone, Bass clefs: Write the lower most note, then rest of notes as intervals upward
+    // In Treble, Soprano, Alto clefs: Write the highest note, then give remaining notes as intervals downward.
+    // In Tenor, Baritone, Bass clefs: Write the lowest note, then give remaining notes as intervals upward.
+    // All intervals are relative to the original (highest or lowest) note.
     switch (clefType) {
     case ClefType::G:              //Treble clef
     case ClefType::G15_MB:         //Treble clef 15ma bassa
@@ -1776,8 +1774,9 @@ QString Braille::brailleChord(Chord* chord)
     QString hairpinBrailleBefore = brailleHairpinBefore(chord, chordHairpins);
 
     // 9.2. Direction of Intervals (in Chords). Page 75. Music Braille Code 2015
-    // In Treble, Soprano, Alto clefs: Write the upper most note, then rest of notes as intervals downward
-    // In Tenor, Baritone, Bass clefs: Write the lower most note, then rest of notes as intervals upward
+    // In Treble, Soprano, Alto clefs: Write the highest note, then give remaining notes as intervals downward.
+    // In Tenor, Baritone, Bass clefs: Write the lowest note, then give remaining notes as intervals upward.
+    // All intervals are relative to the original (highest or lowest) note.
     std::vector<Note*> notes;
     if (ascendingChords(m_context.currentClefType[chord->staffIdx()])) {
         for (auto it = chord->notes().begin(); it != chord->notes().end(); ++it) {

--- a/src/braille/internal/braille.cpp
+++ b/src/braille/internal/braille.cpp
@@ -24,6 +24,8 @@
 
 #include <QRegularExpression>
 
+#include "containers.h"
+
 #include "engraving/dom/accidental.h"
 #include "engraving/dom/arpeggio.h"
 #include "engraving/dom/articulation.h"
@@ -65,10 +67,8 @@
 #include "engraving/dom/utils.h"
 #include "engraving/dom/volta.h"
 
-#include "containers.h"
-
 #include "louis.h"
-#include "braille.h"
+#include "braillecode.h"
 
 namespace mu::engraving {
 // Max lyrics num
@@ -316,158 +316,112 @@ namespace mu::engraving {
 #define BRAILLE_UP_BOW                  QString("<'")
 #define BRAILLE_LEFT_HAND_PIZZICATO     QString("_>")
 
-std::string Braille_UpperNumbers[] = { "245", "1", "12", "14", "145",
-                                       "15", "124", "1245", "125", "24" };
-
-std::string Braille_LowerNumbers[] = { "356", "2", "23", "25", "256",
-                                       "26", "235", "2356", "236", "35" };
-
-std::string Braille_LyricLineIndicator = "56-23";
-
-std::string Braille_NumIndicator = "3456";
-
-std::string getBraillePattern(std::string dots)
+BrailleEngravingItem::BrailleEngravingItem(BEIType type,
+                                           EngravingItem* el,
+                                           QString braille)
 {
-    const char* dotc = dots.c_str();
-    int d = atoi(dotc);
-    switch (d) {
-    case 0: return " ";
-    case 1: return "⠁";
-    case 2: return "⠂";
-    case 12: return "⠃";
-    case 3: return "⠄";
-    case 13: return "⠅";
-    case 23: return "⠆";
-    case 123: return "⠇";
-    case 4: return "⠈";
-    case 14: return "⠉";
-    case 24: return "⠊";
-    case 124: return "⠋";
-    case 34: return "⠌";
-    case 134: return "⠍";
-    case 234: return "⠎";
-    case 1234: return "⠏";
-
-    case 5: return "⠐";
-    case 15: return "⠑";
-    case 25: return "⠒";
-    case 125: return "⠓";
-    case 35: return "⠔";
-    case 135: return "⠕";
-    case 235: return "⠖";
-    case 1235: return "⠗";
-    case 45: return "⠘";
-    case 145: return "⠙";
-    case 245: return "⠚";
-    case 1245: return "⠛";
-    case 345: return "⠜";
-    case 1345: return "⠝";
-    case 2345: return "⠞";
-    case 12345: return "⠟";
-
-    case 6: return "⠠";
-    case 16: return "⠡";
-    case 26: return "⠢";
-    case 126: return "⠣";
-    case 36: return "⠤";
-    case 136: return "⠥";
-    case 236: return "⠦";
-    case 1236: return "⠧";
-    case 46: return "⠨";
-    case 146: return "⠩";
-    case 246: return "⠪";
-    case 1246: return "⠫";
-    case 346: return "⠬";
-    case 1346: return "⠭";
-    case 2346: return "⠮";
-    case 12346: return "⠯";
-
-    case 56: return "⠰";
-    case 156: return "⠱";
-    case 256: return "⠲";
-    case 1256: return "⠳";
-    case 356: return "⠴";
-    case 1356: return "⠵";
-    case 2356: return "⠶";
-    case 12356: return "⠷";
-    case 456: return "⠸";
-    case 1456: return "⠹";
-    case 2456: return "⠺";
-    case 12456: return "⠻";
-    case 3456: return "⠼";
-    case 13456: return "⠽";
-    case 23456: return "⠾";
-    case 123456: return "⠿";
+    m_type = type;
+    m_el = el;
+    m_braille = braille;
+    if (type == BEIType::EndOfLine) {
+        m_start = -1;
+        m_end = -1;
+    } else {
+        m_start = 0;
+        m_end = braille.length();
     }
-    return " ";
 }
 
-std::string translate2Braille(std::string codes)
+BrailleEngravingItem::BrailleEngravingItem(BEIType type,
+                                           EngravingItem* e, QString b,
+                                           QString extra_info, int extra_val)
+    : BrailleEngravingItem(type, e, b)
 {
-    std::stringstream test(codes);
-    std::string segment;
-    std::vector<std::string> seglist;
-
-    std::string txt = "";
-    while (std::getline(test, segment, '-')) {
-        txt.append(getBraillePattern(segment));
-    }
-    return txt;
+    m_extra_info = extra_info;
+    m_extra_val = extra_val;
 }
 
-std::string intToBrailleUpperNumbers(std::string txt, bool indicator)
+BrailleEngravingItem::~BrailleEngravingItem()
 {
-    std::string braille = "";
-    if (indicator) {
-        braille.append(translate2Braille(Braille_NumIndicator));
-    }
-
-    for (size_t i=0; i < txt.length(); i++) {
-        char c = txt.at(i);
-        if (c - '0' <= 9) {
-            braille.append(translate2Braille(Braille_UpperNumbers[c - '0']));
-        }
-    }
-    return braille;
+    m_braille = QString();
+    m_extra_info = QString();
 }
 
-std::string intToBrailleLowerNumbers(std::string txt, bool indicator)
+BEIType BrailleEngravingItem::type()
 {
-    std::string braille = "";
-    if (indicator) {
-        braille.append(Braille_NumIndicator);
-    }
-
-    for (size_t i=0; i < txt.length(); i++) {
-        char c = txt.at(i);
-        if (c - '0' <= 9) {
-            braille.append(Braille_LowerNumbers[c - '0']);
-        }
-    }
-    return braille;
+    return m_type;
 }
 
-BrailleEngravingItems::BrailleEngravingItems()
+EngravingItem* BrailleEngravingItem::el()
+{
+    return m_el;
+}
+
+QString BrailleEngravingItem::braille()
+{
+    return m_braille;
+}
+
+int BrailleEngravingItem::start()
+{
+    return m_start;
+}
+
+int BrailleEngravingItem::end()
+{
+    return m_end;
+}
+
+QString BrailleEngravingItem::extra_info()
+{
+    return m_extra_info;
+}
+
+int BrailleEngravingItem::extra_val()
+{
+    return m_extra_val;
+}
+
+void BrailleEngravingItem::setBraille(QString b)
+{
+    m_braille = b;
+}
+
+void BrailleEngravingItem::setPos(int start, int end)
+{
+    m_start = start;
+    m_end = end;
+}
+
+void BrailleEngravingItem::setExtra(QString info, int val)
+{
+    m_extra_info = info;
+    m_extra_val = val;
+}
+
+BrailleEngravingItemList::BrailleEngravingItemList()
 {
     m_braille_str = QString();
 }
 
-BrailleEngravingItems::~BrailleEngravingItems()
+BrailleEngravingItemList::~BrailleEngravingItemList()
 {
     clear();
 }
 
-void BrailleEngravingItems::clear()
+void BrailleEngravingItemList::clear()
 {
     m_braille_str = QString();
     m_items.clear();
 }
 
-void BrailleEngravingItems::join(BrailleEngravingItems* another, bool newline, bool del)
+void BrailleEngravingItemList::join(BrailleEngravingItemList* another, bool newline, bool del)
 {
     int len = m_braille_str.length();
 
     if (newline && !m_braille_str.isEmpty()) {
+        BrailleEngravingItem item = BrailleEngravingItem(BEIType::EndOfLine, NULL, "\n");
+        m_items.push_back(item);
         m_braille_str.append("\n");
         len++;
     }
@@ -475,50 +429,108 @@ void BrailleEngravingItems::join(BrailleEngravingItems* another, bool newline, b
     m_braille_str.append(another->brailleStr());
 
     for (auto item: *another->items()) {
-        item.second.first += len;
-        item.second.second += len;
+        int start = item.start() + len;
+        int end = item.end() + len;
+        item.setPos(start, end);
         m_items.push_back(item);
     }
+
     if (del) {
         delete another;
     }
 }
 
-void BrailleEngravingItems::join(const std::vector<BrailleEngravingItems*>& lst, bool newline, bool del)
+void BrailleEngravingItemList::join(std::vector<BrailleEngravingItemList*> lst, bool newline, bool del)
 {
     for (auto item: lst) {
         join(item, newline, del);
     }
 }
 
-QString BrailleEngravingItems::brailleStr()
+QString BrailleEngravingItemList::brailleStr()
 {
     return m_braille_str;
 }
 
-std::vector<std::pair<EngravingItem*, std::pair<int, int> > >* BrailleEngravingItems::items()
+std::vector<BrailleEngravingItem>* BrailleEngravingItemList::items()
 {
     return &m_items;
 }
 
-void BrailleEngravingItems::setBrailleStr(const QString& str)
+void BrailleEngravingItemList::setBrailleStr(QString str)
 {
     m_braille_str = str;
     m_items.clear();
 }
 
-void BrailleEngravingItems::addPrefixStr(const QString& str)
+void BrailleEngravingItemList::insert(int pos, BrailleEngravingItem bei)
 {
-    int len = str.length();
-    m_braille_str = str + m_braille_str;
+    if (bei.braille().isEmpty()) {
+        return;
+    }
 
-    for (size_t i=0; i < m_items.size(); i++) {
-        m_items[i].second.first += len;
-        m_items[i].second.second += len;
+    if (pos == 0) { // insert front
+        QString buff = bei.braille();
+        int len = bei.braille().length();
+
+        for (size_t i=0; i < m_items.size(); i++) {
+            int start = m_items[i].start() + len;
+            int end = m_items[i].end() + len;
+            m_items[i].setPos(start, end);
+        }
+
+        bei.setPos(0, len);
+        m_items.insert(m_items.begin(), bei);
+        m_braille_str = buff.append(m_braille_str);
+    } else if (pos >= m_braille_str.length()) { // insert back
+        int len = bei.braille().length();
+
+        int start = m_braille_str.length();
+        int end = start + len - 1;
+        bei.setPos(start, end);
+        m_items.push_back(bei);
+
+        m_braille_str.append(bei.braille());
+    } else { // insert middle
+        std::vector<BrailleEngravingItem> lst;
+        QString buff = "";
+
+        std::vector<BrailleEngravingItem>::iterator ptr;
+        int inc = 0;
+        for (ptr = m_items.begin(); ptr < m_items.end(); ptr++) {
+            if (ptr->start() >= pos) {
+                if (inc == 0) {
+                    if (bei.type() != BEIType::EndOfLine) {
+                        inc = bei.braille().length();
+                        int start = buff.length();
+                        int end = start + inc - 1;
+                        bei.setPos(start, end);
+                    }
+                    lst.push_back(bei);
+                }
+                if (ptr->type() != BEIType::EndOfLine) {
+                    int start = ptr->start() + inc;
+                    int end = ptr->end() + inc;
+                    ptr->setPos(start, end);
+                }
+                lst.push_back(*ptr);
+            } else {
+                lst.push_back(*ptr);
+            }
+            buff.append(bei.braille());
+        }
+
+        m_braille_str = buff;
+        m_items = lst;
     }
 }
 
-void BrailleEngravingItems::addEngravingItem(EngravingItem* el, const QString& braille)
+bool BrailleEngravingItemList::isEmpty()
+{
+    return m_braille_str.isEmpty();
+}
+
+void BrailleEngravingItemList::addEngravingItem(EngravingItem* el, const QString& braille)
 {
     //braille = braille.replace(QRegularExpression ("/\\/"), "\\\\");
     //Manual doubling slashes '\' because Regex doesn't work. Don't know why.
@@ -531,14 +543,12 @@ void BrailleEngravingItems::addEngravingItem(EngravingItem* el, const QString& b
     }
     QString unitxt = QString::fromStdString(braille_long_translate(table_ascii_to_unicode.c_str(), txt.toStdString()));
 
-    int start = m_braille_str.length();
-    int end = start + unitxt.length();
-    m_items.push_back({ el, { start, end } });
-
-    m_braille_str.append(unitxt);
+    BrailleEngravingItem bei = BrailleEngravingItem(BEIType::EngravingItem, el, unitxt);
+    bei.setExtra(el->typeName(), -1);
+    insert(MAX_LIVE_BRAILLE_LENGTH, bei);
 }
 
-void BrailleEngravingItems::addLyricsItem(Lyrics* l)
+void BrailleEngravingItemList::addLyricsItem(Lyrics* l)
 {
     std::string txt = l->plainText().toStdString();
     QString unitxt = QString::fromStdString(braille_long_translate(table_for_literature.c_str(), txt));
@@ -546,58 +556,56 @@ void BrailleEngravingItems::addLyricsItem(Lyrics* l)
     switch (l->syllabic()) {
     case LyricsSyllabic::SINGLE:
     case LyricsSyllabic::BEGIN:
+    {
         if (!m_braille_str.isEmpty()) {
             m_braille_str.append(" ");
         }
+    }
     // fallthrough
     case LyricsSyllabic::END:
     case LyricsSyllabic::MIDDLE:
-        int start = m_braille_str.length();
-        int end = start + unitxt.length();
-        m_items.push_back({ l, { start, end } });
-        m_braille_str.append(unitxt);
+    {
+        BrailleEngravingItem bei = BrailleEngravingItem(BEIType::LyricItem, l, unitxt, QString::fromStdString(txt), -1);
+        insert(MAX_LIVE_BRAILLE_LENGTH, bei);
         break;
+    }
     }
 }
 
-mu::engraving::EngravingItem* BrailleEngravingItems::getEngravingItem(int pos)
+BrailleEngravingItem* BrailleEngravingItemList::getItem(int pos)
 {
     for (size_t i=0; i < m_items.size(); i++) {
-        if (m_items[i].second.first <= pos && m_items[i].second.second >= pos) {
-            return m_items[i].first;
+        if (m_items[i].start() <= pos && m_items[i].end() >= pos) {
+            return &m_items[i];
         }
     }
     return nullptr;
 }
 
-std::pair<int, int> BrailleEngravingItems::getBraillePos(EngravingItem* e)
+BrailleEngravingItem* BrailleEngravingItemList::getItem(engraving::EngravingItem* e)
 {
-    //LOGD() << "getBraillePos " << e << " " << e->accessibleInfo();
     for (size_t i=0; i < m_items.size(); i++) {
-        if (!m_items[i].first) {
+        if (!m_items[i].el()) {
             continue;
         }
-        //LOGD() << " -" << _items[i].first << " " << _items[i].first->accessibleInfo() << " {" << _items[i].second.first << "," << _items[i].second.second << "}";
-        if (m_items[i].first == e) {
-            return m_items[i].second;
+        if (m_items[i].el() == e) {
+            return &m_items[i];
         }
-        if (m_items[i].first->elementBase() == e->elementBase()) {
-            return m_items[i].second;
+        if (m_items[i].el()->elementBase() == e->elementBase()) {
+            return &m_items[i];
         }
     }
-    //LOGD() << "getBraillePos " << e->accessibleInfo() << " NOT FOUND";
-    return { -1, -1 };
+    return nullptr;
 }
 
-void BrailleEngravingItems::log()
+void BrailleEngravingItemList::log()
 {
     LOGD() << brailleStr();
     for (size_t i=0; i < m_items.size(); i++) {
-        if (!m_items[i].first) {
-            LOGD() << " - null {" << m_items[i].second.first << "," << m_items[i].second.second << "}";
+        if (!m_items[i].el()) {
+            LOGD() << " - null {" << m_items[i].start() << "," << m_items[i].end() << "}";
         } else {
-            LOGD() << " -" << m_items[i].first->accessibleInfo() << " {" << m_items[i].second.first << "," << m_items[i].second.second <<
-                "}";
+            LOGD() << " -" << m_items[i].el()->accessibleInfo() << " {" << m_items[i].start() << "," << m_items[i].end() << "}";
         }
     }
 }
@@ -894,64 +902,37 @@ bool Braille::write(QIODevice& device)
     return true;
 }
 
-bool Braille::convertMeasure(Measure* measure, BrailleEngravingItems* beiz)
+bool Braille::convertMeasure(Measure* measure, BrailleEngravingItemList* beis)
 {
     size_t nrStaves = m_score->staves().size();
 
-    std::vector<BrailleEngravingItems> measureBraille(nrStaves);
-    std::vector<BrailleEngravingItems> lyrics(nrStaves + 1);
+    std::vector<BrailleEngravingItemList> measureBraille(nrStaves);
+    std::vector<BrailleEngravingItemList> lyrics(nrStaves + 1);
 
-    /*
-    for (MeasureBase* mb = m_score->measures()->first(); mb != nullptr; mb = mb->next()) {
-        if (!mb->isMeasure() || mb != measure ) {
-            continue;
-        }
-
-        Measure* m = toMeasure(mb);
-
-        if (m->hasMMRest() && m_score->styleB(Sid::createMultiMeasureRests)) {
-            mb = m = m->mmRest();
-        }
-
-        for (size_t i = 0; i < nrStaves; ++i) {
-            BrailleEngravingItems measureBraille;
-            BrailleEngravingItems measureLyrics;
-
-            brailleMeasureItems(&measureBraille, m, static_cast<int>(i));
-            measureBraille.log();
-            beiz->join(&measureBraille, true, false);
-
-            brailleMeasureLyrics(&measureLyrics, m, static_cast<int>(i));
-            if(!measureLyrics.isEmpty()) {
-                beiz->join(&measureLyrics, true, false);
-            }
-        }
-    }
-    */
     if (measure->hasMMRest() && m_score->style().styleB(Sid::createMultiMeasureRests)) {
         measure = measure->mmRest();
     }
 
     for (size_t i = 0; i < nrStaves; ++i) {
-        BrailleEngravingItems measureBraille2;
-        BrailleEngravingItems measureLyrics;
+        BrailleEngravingItemList measureBraille;
+        BrailleEngravingItemList measureLyrics;
 
-        brailleMeasureItems(&measureBraille2, measure, static_cast<int>(i));
-        measureBraille2.log();
-        beiz->join(&measureBraille2, true, false);
+        brailleMeasureItems(&measureBraille, measure, static_cast<int>(i));
+        //measureBraille.log();
+        beis->join(&measureBraille, true, false);
 
         brailleMeasureLyrics(&measureLyrics, measure, static_cast<int>(i));
         if (!measureLyrics.isEmpty()) {
-            beiz->join(&measureLyrics, true, false);
+            beis->join(&measureLyrics, true, false);
         }
     }
 
     return true;
 }
 
-bool Braille::convertItem(EngravingItem* el, BrailleEngravingItems* bei)
+bool Braille::convertItem(EngravingItem* el, BrailleEngravingItemList* beis)
 {
-    return brailleSingleItem(bei, el);
+    return brailleSingleItem(beis, el);
 }
 
 void Braille::resetOctave(size_t stave)
@@ -1257,7 +1238,7 @@ BarLine* Braille::lastBarline(Measure* measure, track_idx_t track)
     return nullptr;
 }
 
-bool Braille::brailleSingleItem(BrailleEngravingItems* beiz, EngravingItem* el)
+bool Braille::brailleSingleItem(BrailleEngravingItemList* beiz, EngravingItem* el)
 {
     resetOctaves();
 
@@ -1311,7 +1292,7 @@ bool Braille::brailleSingleItem(BrailleEngravingItems* beiz, EngravingItem* el)
     return false;
 }
 
-void Braille::brailleMeasureItems(BrailleEngravingItems* beiz, Measure* measure, int staffCount)
+void Braille::brailleMeasureItems(BrailleEngravingItemList* beiz, Measure* measure, int staffCount)
 {
     //QTextStream out(&rez);
     //LOGD("Braille::brailleMeasure %d", staffCount);
@@ -1398,7 +1379,11 @@ void Braille::brailleMeasureItems(BrailleEngravingItems* beiz, Measure* measure,
             m_score->endCmd();
 */
             resetOctave(staffCount);
-            beiz->addEngravingItem(nullptr, BRAILLE_FULL_MEASURE_IN_ACORD);
+
+            QString in_accord = QString::fromStdString(translate2Braille(Braille_FullMeasureAccord.code));
+            BrailleEngravingItem bei = BrailleEngravingItem(BEIType::VoiceInAccord, NULL, in_accord);
+            beiz->insert(MAX_LIVE_BRAILLE_LENGTH, bei);
+
             for (auto seg = measure->first(); seg; seg = seg->next()) {
                 EngravingItem* el = seg->element(staffCount * VOICES + i);
                 if (!el) {
@@ -1445,9 +1430,9 @@ void Braille::brailleMeasureItems(BrailleEngravingItems* beiz, Measure* measure,
     }
 }
 
-void Braille::brailleMeasureLyrics(BrailleEngravingItems* beiz, Measure* measure, int staffCount)
+void Braille::brailleMeasureLyrics(BrailleEngravingItemList* beiz, Measure* measure, int staffCount)
 {
-    BrailleEngravingItems lyrics[MAX_LYRICS_NUM];
+    BrailleEngravingItemList lyrics[MAX_LYRICS_NUM];
 
     for (auto seg = measure->first(); seg; seg = seg->next()) {
         if (!seg->isChordRestType()) {
@@ -1470,7 +1455,9 @@ void Braille::brailleMeasureLyrics(BrailleEngravingItems* beiz, Measure* measure
         if (lyrics[i].isEmpty()) {
             lyrics[i].clear();
         } else {
-            lyrics[i].addPrefixStr(QString::fromStdString(translate2Braille(Braille_LyricLineIndicator)));
+            QString braille = QString::fromStdString(translate2Braille(Braille_LyricLineIndicator.code));
+            BrailleEngravingItem bei = BrailleEngravingItem(BEIType::LineIndicator, NULL, braille);
+            lyrics[i].insert(0, bei);
             beiz->join(&lyrics[i], true, false);
         }
     }

--- a/src/braille/internal/braillecode.cpp
+++ b/src/braille/internal/braillecode.cpp
@@ -34,7 +34,7 @@ braille_code::braille_code(std::string t, std::string c)
     tag = t;
     code = c;
     braille = translate2Braille(code);
-    cells_num = braille.length();
+    num_cells = static_cast<int>(braille.length());
     master_braille_code_list.push_back(this);
 }
 
@@ -47,7 +47,7 @@ braille_code::~braille_code()
 
 void braille_code::print()
 {
-    LOGD() << " Braille code " << tag << " " << code << " " << braille << " " << cells_num;
+    LOGD() << " Braille code " << tag << " " << code << " " << braille << " " << num_cells;
 }
 
 braille_code Braille_CapIndicator = braille_code("CapIndicator", "6");
@@ -880,75 +880,87 @@ std::string getBraillePattern(std::string dots)
 {
     const char* dotc = dots.c_str();
     int d = atoi(dotc);
+
     switch (d) {
+    // No dots
     case 0: return " ";
+
+    // One dot
     case 1: return "⠁";
     case 2: return "⠂";
-    case 12: return "⠃";
     case 3: return "⠄";
-    case 13: return "⠅";
-    case 23: return "⠆";
-    case 123: return "⠇";
     case 4: return "⠈";
-    case 14: return "⠉";
-    case 24: return "⠊";
-    case 124: return "⠋";
-    case 34: return "⠌";
-    case 134: return "⠍";
-    case 234: return "⠎";
-    case 1234: return "⠏";
-
     case 5: return "⠐";
-    case 15: return "⠑";
-    case 25: return "⠒";
-    case 125: return "⠓";
-    case 35: return "⠔";
-    case 135: return "⠕";
-    case 235: return "⠖";
-    case 1235: return "⠗";
-    case 45: return "⠘";
-    case 145: return "⠙";
-    case 245: return "⠚";
-    case 1245: return "⠛";
-    case 345: return "⠜";
-    case 1345: return "⠝";
-    case 2345: return "⠞";
-    case 12345: return "⠟";
-
     case 6: return "⠠";
-    case 16: return "⠡";
-    case 26: return "⠢";
-    case 126: return "⠣";
-    case 36: return "⠤";
-    case 136: return "⠥";
-    case 236: return "⠦";
-    case 1236: return "⠧";
-    case 46: return "⠨";
-    case 146: return "⠩";
-    case 246: return "⠪";
-    case 1246: return "⠫";
-    case 346: return "⠬";
-    case 1346: return "⠭";
-    case 2346: return "⠮";
-    case 12346: return "⠯";
 
+    // Two dots
+    case 12: return "⠃";
+    case 13: return "⠅";
+    case 14: return "⠉";
+    case 15: return "⠑";
+    case 16: return "⠡";
+    case 23: return "⠆";
+    case 24: return "⠊";
+    case 25: return "⠒";
+    case 26: return "⠢";
+    case 34: return "⠌";
+    case 35: return "⠔";
+    case 36: return "⠤";
+    case 45: return "⠘";
+    case 46: return "⠨";
     case 56: return "⠰";
+
+    // Three dots
+    case 123: return "⠇";
+    case 124: return "⠋";
+    case 125: return "⠓";
+    case 126: return "⠣";
+    case 134: return "⠍";
+    case 135: return "⠕";
+    case 136: return "⠥";
+    case 145: return "⠙";
+    case 146: return "⠩";
     case 156: return "⠱";
+    case 234: return "⠎";
+    case 235: return "⠖";
+    case 236: return "⠦";
+    case 245: return "⠚";
+    case 246: return "⠪";
     case 256: return "⠲";
-    case 1256: return "⠳";
+    case 345: return "⠜";
+    case 346: return "⠬";
     case 356: return "⠴";
-    case 1356: return "⠵";
-    case 2356: return "⠶";
-    case 12356: return "⠷";
     case 456: return "⠸";
+
+    // Four dots
+    case 1234: return "⠏";
+    case 1235: return "⠗";
+    case 1236: return "⠧";
+    case 1245: return "⠛";
+    case 1246: return "⠫";
+    case 1256: return "⠳";
+    case 1345: return "⠝";
+    case 1346: return "⠭";
+    case 1356: return "⠵";
     case 1456: return "⠹";
+    case 2345: return "⠞";
+    case 2346: return "⠮";
+    case 2356: return "⠶";
     case 2456: return "⠺";
-    case 12456: return "⠻";
     case 3456: return "⠼";
+
+    // Five dots
+    case 12345: return "⠟";
+    case 12346: return "⠯";
+    case 12356: return "⠷";
+    case 12456: return "⠻";
     case 13456: return "⠽";
     case 23456: return "⠾";
+
+    // Six dots
     case 123456: return "⠿";
     }
+
     return " ";
 }
 

--- a/src/braille/internal/braillecode.cpp
+++ b/src/braille/internal/braillecode.cpp
@@ -1,0 +1,1137 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2023 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+#include "braillecode.h"
+
+namespace mu::engraving {
+std::vector<braille_code*> master_braille_code_list;
+
+braille_code::braille_code(std::string t, std::string c)
+{
+    tag = t;
+    code = c;
+    braille = translate2Braille(code);
+    cells_num = braille.length();
+    master_braille_code_list.push_back(this);
+}
+
+braille_code::~braille_code()
+{
+    tag.clear();
+    code.clear();
+    braille.clear();
+}
+
+void braille_code::print()
+{
+    LOGD() << " Braille code " << tag << " " << code << " " << braille << " " << cells_num;
+}
+
+braille_code Braille_CapIndicator = braille_code("CapIndicator", "6");
+braille_code Braille_NumIndicator = braille_code("NumIndicator", "3456");
+braille_code Braille_TxtIndicator = braille_code("TextIndicator", "345");
+
+//[Letter]
+braille_code Braille_a = braille_code("a", "1");
+braille_code Braille_b = braille_code("b", "12");
+braille_code Braille_c = braille_code("c", "14");
+braille_code Braille_d = braille_code("d", "145");
+braille_code Braille_e = braille_code("e", "15");
+braille_code Braille_f = braille_code("f", "124");
+braille_code Braille_g = braille_code("g", "1245");
+braille_code Braille_h = braille_code("h", "125");
+braille_code Braille_i = braille_code("i", "24");
+braille_code Braille_j = braille_code("j", "245");
+braille_code Braille_k = braille_code("k", "13");
+braille_code Braille_l = braille_code("l", "123");
+braille_code Braille_m = braille_code("m", "134");
+braille_code Braille_n = braille_code("n", "1345");
+braille_code Braille_o = braille_code("o", "135");
+braille_code Braille_p = braille_code("p", "1234");
+braille_code Braille_q = braille_code("q", "12345");
+braille_code Braille_r = braille_code("r", "1235");
+braille_code Braille_s = braille_code("s", "234");
+braille_code Braille_t = braille_code("t", "2345");
+braille_code Braille_u = braille_code("u", "136");
+braille_code Braille_v = braille_code("v", "1236");
+braille_code Braille_w = braille_code("w", "2456");
+braille_code Braille_x = braille_code("x", "1346");
+braille_code Braille_y = braille_code("y", "13456");
+braille_code Braille_z = braille_code("z", "1356");
+
+braille_code* Braille_Letters[] = {
+    &Braille_a, &Braille_b, &Braille_c, &Braille_d, &Braille_e,
+    &Braille_f, &Braille_g, &Braille_h, &Braille_i, &Braille_j,
+    &Braille_k, &Braille_l, &Braille_m, &Braille_n, &Braille_o,
+    &Braille_p, &Braille_q, &Braille_r, &Braille_s, &Braille_t,
+    &Braille_u, &Braille_v, &Braille_w, &Braille_x, &Braille_y,
+    &Braille_z };
+
+//upper and lower numbers
+braille_code Braille_Upper0 = braille_code("Upper0", "245");
+braille_code Braille_Upper1 = braille_code("Upper1", "1");
+braille_code Braille_Upper2 = braille_code("Upper2", "12");
+braille_code Braille_Upper3 = braille_code("Upper3", "14");
+braille_code Braille_Upper4 = braille_code("Upper4", "145");
+braille_code Braille_Upper5 = braille_code("Upper5", "15");
+braille_code Braille_Upper6 = braille_code("Upper6", "124");
+braille_code Braille_Upper7 = braille_code("Upper7", "1245");
+braille_code Braille_Upper8 = braille_code("Upper8", "125");
+braille_code Braille_Upper9 = braille_code("Upper9", "24");
+
+braille_code* Braille_UpperNumbers[] = {
+    &Braille_Upper0, &Braille_Upper1, &Braille_Upper2, &Braille_Upper3,
+    &Braille_Upper4, &Braille_Upper5, &Braille_Upper6, &Braille_Upper7,
+    &Braille_Upper8, &Braille_Upper9, };
+
+//#lower numbers
+braille_code Braille_Lower0 = braille_code("Lower0", "356");
+braille_code Braille_Lower1 = braille_code("Lower1", "2");
+braille_code Braille_Lower2 = braille_code("Lower2", "23");
+braille_code Braille_Lower3 = braille_code("Lower3", "25");
+braille_code Braille_Lower4 = braille_code("Lower4", "256");
+braille_code Braille_Lower5 = braille_code("Lower5", "26");
+braille_code Braille_Lower6 = braille_code("Lower6", "235");
+braille_code Braille_Lower7 = braille_code("Lower7", "2356");
+braille_code Braille_Lower8 = braille_code("Lower8", "236");
+braille_code Braille_Lower9 = braille_code("Lower9", "35");
+
+braille_code* Braille_LowerNumbers[] ={
+    &Braille_Lower0, &Braille_Lower1, &Braille_Lower2, &Braille_Lower3,
+    &Braille_Lower4, &Braille_Lower5, &Braille_Lower6, &Braille_Lower7,
+    &Braille_Lower8, &Braille_Lower9 };
+
+//[NoteShape]
+//#Notes: Braille note shapes are same such as whole=16th=256, half=32nd=512 etc.
+//#to deal with complicate back-translation and reading issues, each note should be defined, even it could easily handle by coding.
+braille_code Braille_aWhole = braille_code("aWhole", "2346");
+braille_code Braille_aHalf = braille_code("aHalf", "234");
+braille_code Braille_aQuarter = braille_code("aQuarter", "246");
+braille_code Braille_a8th = braille_code("a8th", "24");
+braille_code Braille_bWhole = braille_code("bWhole", "23456");
+braille_code Braille_bHalf = braille_code("bHalf", "2345");
+braille_code Braille_bQuarter = braille_code("bQuarter", "2456");
+braille_code Braille_b8th = braille_code("b8th", "245");
+braille_code Braille_cWhole = braille_code("cWhole", "13456");
+braille_code Braille_cHalf = braille_code("cHalf", "1345");
+braille_code Braille_cQuarter = braille_code("cQuarter", "1456");
+braille_code Braille_c8th = braille_code("c8th", "145");
+braille_code Braille_dWhole = braille_code("dWhole", "1356");
+braille_code Braille_dHalf = braille_code("dHalf", "135");
+braille_code Braille_dQuarter = braille_code("dQuarter", "156");
+braille_code Braille_d8th = braille_code("d8th", "15");
+braille_code Braille_eWhole = braille_code("eWhole", "12346");
+braille_code Braille_eHalf = braille_code("eHalf", "1234");
+braille_code Braille_eQuarter = braille_code("eQuarter", "1246");
+braille_code Braille_e8th = braille_code("e8th", "124");
+braille_code Braille_fWhole = braille_code("fWhole", "123456");
+braille_code Braille_fHalf = braille_code("fHalf", "12345");
+braille_code Braille_fQuarter = braille_code("fQuarter", "12456");
+braille_code Braille_f8th = braille_code("f8th", "1245");
+braille_code Braille_gWhole = braille_code("gWhole", "12356");
+braille_code Braille_gHalf = braille_code("gHalf", "1235");
+braille_code Braille_gQuarter = braille_code("gQuarter", "1256");
+braille_code Braille_g8th = braille_code("g8th", "125");
+//#16th to 128th notes
+braille_code Braille_a16th = braille_code("a16th", "2346");
+braille_code Braille_a32nd = braille_code("a32nd", "234");
+braille_code Braille_a64th = braille_code("a64th", "246");
+braille_code Braille_a128th = braille_code("a128th", "24");
+braille_code Braille_b16th = braille_code("b16th", "23456");
+braille_code Braille_b32nd = braille_code("b32nd", "2345");
+braille_code Braille_b64th = braille_code("b64th", "2456");
+braille_code Braille_b128th = braille_code("b128th", "245");
+braille_code Braille_c16th = braille_code("c16th", "13456");
+braille_code Braille_c32nd = braille_code("c32nd", "1345");
+braille_code Braille_c64th = braille_code("c64th", "1456");
+braille_code Braille_c128th = braille_code("c128th", "145");
+braille_code Braille_d16th = braille_code("d16th", "1356");
+braille_code Braille_d32nd = braille_code("d32nd", "135");
+braille_code Braille_d64th = braille_code("d64th", "156");
+braille_code Braille_d128th = braille_code("d128th", "15");
+braille_code Braille_e16th = braille_code("e16th", "12346");
+braille_code Braille_e32nd = braille_code("e32nd", "1234");
+braille_code Braille_e64th = braille_code("e64th", "1246");
+braille_code Braille_e128th = braille_code("e128th", "124");
+braille_code Braille_f16th = braille_code("f16th", "123456");
+braille_code Braille_f32nd = braille_code("f32nd", "12345");
+braille_code Braille_f64th = braille_code("f64th", "12456");
+braille_code Braille_f128th = braille_code("f128th", "1245");
+braille_code Braille_g16th = braille_code("g16th", "12356");
+braille_code Braille_g32nd = braille_code("g32nd", "1235");
+braille_code Braille_g64th = braille_code("g64th", "1256");
+braille_code Braille_g128th = braille_code("g128th", "125");
+//#256th to 2048th notes
+braille_code Braille_a256th = braille_code("a256th", "2346");
+braille_code Braille_a512th = braille_code("a512th", "234");
+braille_code Braille_a1024th = braille_code("a1024th", "246");
+braille_code Braille_a2048th = braille_code("a2048th", "24");
+braille_code Braille_b256th = braille_code("b256th", "23456");
+braille_code Braille_b512th = braille_code("b512th", "2345");
+braille_code Braille_b1024th = braille_code("b1024th", "2456");
+braille_code Braille_b2048th = braille_code("b2048th", "245");
+braille_code Braille_c256th = braille_code("c256th", "13456");
+braille_code Braille_c512th = braille_code("c512th", "1345");
+braille_code Braille_c1024th = braille_code("c1024th", "1456");
+braille_code Braille_c2048th = braille_code("c2048th", "145");
+braille_code Braille_d256th = braille_code("d256th", "1356");
+braille_code Braille_d512th = braille_code("d512th", "135");
+braille_code Braille_d1024th = braille_code("d1024th", "156");
+braille_code Braille_d2048th = braille_code("d2048th", "15");
+braille_code Braille_e256th = braille_code("e256th", "12346");
+braille_code Braille_e512th = braille_code("e512th", "1234");
+braille_code Braille_e1024th = braille_code("e1024th", "1246");
+braille_code Braille_e2048th = braille_code("e2048th", "124");
+braille_code Braille_f256th = braille_code("f256th", "123456");
+braille_code Braille_f512th = braille_code("f512th", "12345");
+braille_code Braille_f1024th = braille_code("f1024th", "12456");
+braille_code Braille_f2048th = braille_code("f2048th", "1245");
+braille_code Braille_g256th = braille_code("g256th", "12356");
+braille_code Braille_g512th = braille_code("g512th", "1235");
+braille_code Braille_g1024th = braille_code("g1024th", "1256");
+braille_code Braille_g2048th = braille_code("g2048th", "125");
+//#special notes: breve (double whole notes)
+//#Advised to use the definitions of Haipeng as first option for breve notes right below this section.
+braille_code Braille_aBreve = braille_code("aBreve", "2346-13");
+braille_code Braille_bBreve = braille_code("bBreve", "23456-13");
+braille_code Braille_cBreve = braille_code("cBreve", "13456-13");
+braille_code Braille_dBreve = braille_code("dBreve", "1356-13");
+braille_code Braille_eBreve = braille_code("eBreve", "12346-13");
+braille_code Braille_fBreve = braille_code("fBreve", "123456-13");
+braille_code Braille_gBreve = braille_code("gBreve", "12356-13");
+//##########Added by Haipeng
+//#Another kind of breve, mainly used other than the above one which should be used mainly in plain chant
+braille_code Braille_aBreveAlt = braille_code("aBreveAlt", "2346-45-14-2346");
+braille_code Braille_bBreveAlt = braille_code("bBreveAlt", "23456-45-14-23456");
+braille_code Braille_cBreveAlt = braille_code("cBreveAlt", "13456-45-14-13456");
+braille_code Braille_dBreveAlt = braille_code("dBreveAlt", "1356-45-14-1356");
+braille_code Braille_eBreveAlt = braille_code("eBreveAlt", "12346-45-14-12346");
+braille_code Braille_fBreveAlt = braille_code("fBreveAlt", "123456-45-14-123456");
+braille_code Braille_gBreveAlt = braille_code("gBreveAlt", "12356-45-14-12356");
+//##Other longer notes in ancient music, including Longa and Maxima (quadruple whole note)
+braille_code Braille_aLonga = braille_code("aLonga", "2346-45-14-45-14-2346");
+braille_code Braille_bLonga = braille_code("bLonga", "23456-45-14-45-14-23456");
+braille_code Braille_cLonga = braille_code("cLonga", "13456-45-14-45-14-13456");
+braille_code Braille_dLonga = braille_code("dLonga", "1356-45-14-45-14-1356");
+braille_code Braille_eLonga = braille_code("eLonga", "12346-45-14-45-14-12346");
+braille_code Braille_fLonga = braille_code("fLonga", "123456-45-14-45-14-123456");
+braille_code Braille_gLonga = braille_code("gLonga", "12356-45-14-45-14-12356");
+braille_code Braille_aMaxima = braille_code("aMaxima", "2346-45-14-45-14-45-14-2346");
+braille_code Braille_bMaxima = braille_code("bMaxima", "23456-45-14-45-14-45-14-23456");
+braille_code Braille_cMaxima = braille_code("cMaxima", "13456-45-14-45-14-45-14-13456");
+braille_code Braille_dMaxima = braille_code("dMaxima", "1356-45-14-45-14-45-14-1356");
+braille_code Braille_eMaxima = braille_code("eMaxima", "12346-45-14-45-14-45-14-12346");
+braille_code Braille_fMaxima = braille_code("fMaxima", "123456-45-14-45-14-45-14-123456");
+braille_code Braille_gMaxima = braille_code("gMaxima", "12356-45-14-45-14-45-14-12356");
+
+braille_code* Braille_aNotes[] = {
+    &Braille_aMaxima, &Braille_aLonga, &Braille_aBreve,
+    &Braille_aWhole, &Braille_aHalf, &Braille_aQuarter,
+    &Braille_a8th, &Braille_a16th, &Braille_a32nd,
+    &Braille_a64th, &Braille_a128th, &Braille_a256th,
+    &Braille_a512th, &Braille_a128th, &Braille_a2048th,
+    &Braille_aBreveAlt };
+braille_code* Braille_bNotes[] = {
+    &Braille_bMaxima, &Braille_bLonga, &Braille_bBreve,
+    &Braille_bWhole, &Braille_bHalf, &Braille_bQuarter,
+    &Braille_b8th, &Braille_b16th, &Braille_b32nd,
+    &Braille_b64th, &Braille_b128th, &Braille_b256th,
+    &Braille_b512th, &Braille_b128th, &Braille_b2048th,
+    &Braille_bBreveAlt };
+braille_code* Braille_cNotes[] = {
+    &Braille_cMaxima, &Braille_cLonga, &Braille_cBreve,
+    &Braille_cWhole, &Braille_cHalf, &Braille_cQuarter,
+    &Braille_c8th, &Braille_c16th, &Braille_c32nd,
+    &Braille_c64th, &Braille_c128th, &Braille_c256th,
+    &Braille_c512th, &Braille_c128th, &Braille_c2048th,
+    &Braille_cBreveAlt };
+braille_code* Braille_dNotes[] = {
+    &Braille_dMaxima, &Braille_dLonga, &Braille_dBreve,
+    &Braille_dWhole, &Braille_dHalf, &Braille_dQuarter,
+    &Braille_d8th, &Braille_d16th, &Braille_d32nd,
+    &Braille_d64th, &Braille_d128th, &Braille_d256th,
+    &Braille_d512th, &Braille_d128th, &Braille_d2048th,
+    &Braille_dBreveAlt };
+braille_code* Braille_eNotes[] = {
+    &Braille_eMaxima, &Braille_eLonga, &Braille_eBreve,
+    &Braille_eWhole, &Braille_eHalf, &Braille_eQuarter,
+    &Braille_e8th, &Braille_e16th, &Braille_e32nd,
+    &Braille_e64th, &Braille_e128th, &Braille_e256th,
+    &Braille_e512th, &Braille_e128th, &Braille_e2048th,
+    &Braille_eBreveAlt };
+braille_code* Braille_fNotes[] = {
+    &Braille_fMaxima, &Braille_fLonga, &Braille_fBreve,
+    &Braille_fWhole, &Braille_fHalf, &Braille_fQuarter,
+    &Braille_f8th, &Braille_f16th, &Braille_f32nd,
+    &Braille_f64th, &Braille_f128th, &Braille_f256th,
+    &Braille_f512th, &Braille_f128th, &Braille_f2048th,
+    &Braille_fBreveAlt };
+braille_code* Braille_gNotes[] = {
+    &Braille_gMaxima, &Braille_gLonga, &Braille_gBreve,
+    &Braille_gWhole, &Braille_gHalf, &Braille_gQuarter,
+    &Braille_g8th, &Braille_g16th, &Braille_g32nd,
+    &Braille_g64th, &Braille_g128th, &Braille_g256th,
+    &Braille_g512th, &Braille_g128th, &Braille_g2048th,
+    &Braille_gBreveAlt };
+
+braille_code* Braille_wholeNotes[] = {
+    &Braille_aWhole, &Braille_bWhole, &Braille_cWhole,
+    &Braille_dWhole, &Braille_eWhole, &Braille_fWhole, &Braille_gWhole
+};
+braille_code* Braille_halfNotes[] = {
+    &Braille_aHalf, &Braille_bHalf, &Braille_cHalf,
+    &Braille_dHalf, &Braille_eHalf, &Braille_fHalf, &Braille_gHalf
+};
+braille_code* Braille_quarterNotes[] = {
+    &Braille_aQuarter, &Braille_bQuarter, &Braille_cQuarter,
+    &Braille_dQuarter, &Braille_eQuarter, &Braille_fQuarter, &Braille_gQuarter
+};
+braille_code* Braille_8thNotes[] = {
+    &Braille_a8th, &Braille_b8th, &Braille_c8th,
+    &Braille_d8th, &Braille_e8th, &Braille_f8th, &Braille_g8th
+};
+braille_code* Braille_16thNotes[] = {
+    &Braille_a16th, &Braille_b16th, &Braille_c16th,
+    &Braille_d16th, &Braille_e16th, &Braille_f16th, &Braille_g16th
+};
+braille_code* Braille_32ndNotes[] = {
+    &Braille_a32nd, &Braille_b32nd, &Braille_c32nd,
+    &Braille_d32nd, &Braille_e32nd, &Braille_f32nd, &Braille_g32nd
+};
+braille_code* Braille_64thNotes[] = {
+    &Braille_a64th, &Braille_b64th, &Braille_c64th,
+    &Braille_d64th, &Braille_e64th, &Braille_f64th, &Braille_g64th
+};
+braille_code* Braille_128thNotes[] = {
+    &Braille_a128th, &Braille_b128th, &Braille_c128th,
+    &Braille_d128th, &Braille_e128th, &Braille_f128th, &Braille_g128th
+};
+braille_code* Braille_256thNotes[] = {
+    &Braille_a256th, &Braille_b256th, &Braille_c256th,
+    &Braille_d256th, &Braille_e256th, &Braille_f256th, &Braille_g256th
+};
+braille_code* Braille_512thNotes[] = {
+    &Braille_a512th, &Braille_b512th, &Braille_c512th,
+    &Braille_d512th, &Braille_e512th, &Braille_f512th, &Braille_g512th
+};
+braille_code* Braille_1024thNotes[] = {
+    &Braille_a1024th, &Braille_b1024th, &Braille_c1024th,
+    &Braille_d1024th, &Braille_e1024th, &Braille_f1024th, &Braille_g1024th
+};
+braille_code* Braille_2048thNotes[] = {
+    &Braille_a2048th, &Braille_b2048th, &Braille_c2048th,
+    &Braille_d2048th, &Braille_e2048th, &Braille_f2048th, &Braille_g2048th
+};
+
+//####################
+
+//#Braille rests' shapes are same as notes above, whole rest=16th rest=256th etc.
+braille_code Braille_RestWhole = braille_code("RestWhole", "134");
+braille_code Braille_RestHalf = braille_code("RestHalf", "136");
+braille_code Braille_RestQuarter = braille_code("RestQuarter", "1236");
+braille_code Braille_Rest8th = braille_code("Rest8th", "1346");
+//#16th to 128th rests
+braille_code Braille_Rest16th = braille_code("Rest16th", "134");
+braille_code Braille_Rest32nd = braille_code("Rest32nd", "136");
+braille_code Braille_Rest64th = braille_code("Rest64th", "1236");
+braille_code Braille_Rest128th = braille_code("Rest128th", "1346");
+//#256th to 2048th rests
+braille_code Braille_Rest256th = braille_code("Rest256th", "134");
+braille_code Braille_Rest512th = braille_code("Rest512th", "136");
+braille_code Braille_Rest1024th = braille_code("Rest1024th", "1236");
+braille_code Braille_Rest2048th = braille_code("Rest2048th", "1346");
+//#breve rest, use Haipeng's breve rest definition below as first option.
+braille_code Braille_RestBreve = braille_code("RestBreve", "134-13");
+//##########Added by Haipeng##########
+//#More widely used Breve rest, swap the above with Alt
+braille_code Braille_RestBreveAlt = braille_code("RestBreveAlt", "134-45-14-134");
+//#Other longer rests in ancient music
+braille_code Braille_RestLonga = braille_code("RestLonga", "134-45-14-45-14-134");
+braille_code Braille_RestMaxima = braille_code("RestMaxima", "134-45-14-45-14-45-14-134");
+
+braille_code* Braille_Rests[] = {
+    &Braille_RestMaxima, &Braille_RestLonga, &Braille_RestBreve,
+    &Braille_RestWhole, &Braille_RestHalf, &Braille_RestQuarter,
+    &Braille_Rest8th, &Braille_Rest16th, &Braille_Rest32nd,
+    &Braille_Rest64th, &Braille_Rest128th, &Braille_Rest256th,
+    &Braille_Rest512th, &Braille_Rest128th, &Braille_Rest2048th,
+    &Braille_RestBreveAlt };
+//####################
+
+//[MusicPunctuation]
+braille_code Braille_PlusSign = braille_code("PlusSign", "346");
+braille_code Braille_MinusSign = braille_code("MinusSign", "36");
+braille_code Braille_SlashSign = braille_code("SlashSign", "34");
+//#note dot sign, to add value for the associated note and some other situations
+braille_code Braille_Dot = braille_code("Dot", "3");
+braille_code Braille_Parentheses = braille_code("Parentheses", "6-3");
+braille_code Braille_OpenParentheses = braille_code("OpenParentheses", "6-3");
+braille_code Braille_CloseParentheses = braille_code("CloseParentheses", "6-3");
+braille_code Braille_SpecialParentheses = braille_code("SpecialParentheses", "2356");
+braille_code Braille_PageIndicator = braille_code("PageIndicator", "5-25");
+braille_code Braille_LineIndicator = braille_code("LineIndicator", "6-123");
+braille_code Braille_Hyphen = braille_code("Hyphen", "5");
+braille_code Braille_MusicComma = braille_code("MusicComma", "126-2");
+braille_code Braille_MusicCommaEnd = braille_code("MusicCommaEnd", "126-2-3");
+//##########Added by Haipeng##########
+//#Prefix for cautionary accidentals and hidden rests
+braille_code Braille_Cautionary = braille_code("Cautionary", "5");
+//#Prefix for editorial elements such as dashed slurs, ties and hairpins
+braille_code Braille_Editorial = braille_code("Editorial", "5-123");
+//####################
+braille_code Braille_EqualSign = braille_code("EqualSign", "2356");
+braille_code Braille_UpperOpenBracket = braille_code("UpperOpenBracket", "56-2");
+braille_code Braille_UpperCloseBracket = braille_code("UpperCloseBracket", "5-23");
+braille_code Braille_UpperBrokenOpenBracket = braille_code("UpperBrokenOpenBracket", "56-2-2");
+braille_code Braille_UpperBrokenCloseBracket = braille_code("UpperBrokenCloseBracket", "5-5-23");
+braille_code Braille_UpperOpenEndedBracket = braille_code("UpperOpenEndedBracket", "56-2");
+braille_code Braille_UpperCloseEndedBracket = braille_code("UpperCloseEndedBracket", "5-3");
+braille_code Braille_LowerOpenBracket = braille_code("LowerOpenBracket", "56-3");
+braille_code Braille_LowerCloseBracket = braille_code("LowerCloseBracket", "6-23");
+braille_code Braille_LowerBrokenOpenBracket = braille_code("LowerBrokenOpenBracket", "56-3-3");
+braille_code Braille_LowerBrokenCloseBracket = braille_code("LowerBrokenCloseBracket", "6-6-23");
+braille_code Braille_LowerOpenEndedBracket = braille_code("LowerOpenEndedBracket", "56-3");
+braille_code Braille_LowerCloseEndedBracket = braille_code("LowerCloseEndedBracket", "6-2");
+braille_code Braille_OpenMusicCodeIndicator = braille_code("OpenMusicCodeIndicator", "6-3");
+braille_code Braille_CloseMusicCodeIndicator = braille_code("CloseMusicCodeIndicator", "56-23");
+braille_code Braille_AsteriskSign = braille_code("AsteriskSign", "345-26-35");
+braille_code Braille_FootnoteSeparator = braille_code("FootnoteSeparator", "36-36-36-36-36");
+//[Harmony]
+braille_code Braille_Diminished = braille_code("Diminished", "256");
+braille_code Braille_HalfDiminished = braille_code("", "256-3");
+braille_code Braille_Triangle = braille_code("HalfDiminished", "356");
+braille_code Braille_HalfTriangle = braille_code("HalfTriangle", "356-3");
+//#No chord
+braille_code Braille_NoHarmony = braille_code("NoHarmony", "6-6-1345-14");
+
+//##########Newly added by Haipeng
+//#A figure is prefixed by a number sign, so here only give the signs not available elsewhere
+braille_code Braille_IsolatedSharp = braille_code("IsolatedSharp", "146-13");
+braille_code Braille_IsolatedDoubleSharp = braille_code("IsolatedDoubleSharp", "146-146-13");
+braille_code Braille_IsolatedFlat = braille_code("IsolatedFlat", "126-13");
+braille_code Braille_IsolatedDoubleFlat = braille_code("IsolatedDoubleFlat", "126-126-13");
+braille_code Braille_IsolatedNatural = braille_code("IsolatedNatural", "16-13");
+braille_code Braille_Cross = braille_code("Cross", "56");
+
+braille_code Braille_FiguredBassIndicator = braille_code("FiguredBassIndicator", "56-345");
+braille_code Braille_FiguredBassSeparator = braille_code("FiguredBassSeparator", "36");
+braille_code Braille_PlusAccidental = braille_code("PlusAccidental", "346");
+braille_code Braille_AccidentalIsolator = braille_code("AccidentalIsolator", "13");
+braille_code Braille_BackslashFigure = braille_code("BackslashFigure", "56");
+braille_code Braille_SlashFigure = braille_code("SlashFigure", "34");
+braille_code Braille_FigureExtension = braille_code("FigureExtension", "1");
+//####################
+//#note value indicators: to add before a note having same Braille shape but with different value like between  half and 32nd notes.
+//#whole-8th notes range
+braille_code Braille_FirstValueRange = braille_code("FirstValueRange", "45-126-2");
+//#16th-128th notes range
+braille_code Braille_SecondValueRange = braille_code("SecondValueRange", "6-126-2");
+//#256th notes and and further range
+braille_code Braille_ThirdValueRange = braille_code("ThirdValueRange", "56-126-2");
+
+braille_code* Braille_ValueRanges[] = { &Braille_FirstValueRange, &Braille_SecondValueRange, &Braille_ThirdValueRange };
+//#octave signs
+//#based on Piano keyboard, octave 0 and 8 for lowest and highest notes out of the full octave
+//#there are 7 full octaves from 1 to 7
+braille_code Braille_Octave0 = braille_code("Octave0", "4-4");
+braille_code Braille_Octave1 = braille_code("Octave1", "4");
+braille_code Braille_Octave2 = braille_code("Octave2", "45");
+braille_code Braille_Octave3 = braille_code("Octave3", "456");
+braille_code Braille_Octave4 = braille_code("Octave4", "5");
+braille_code Braille_Octave5 = braille_code("Octave5", "46");
+braille_code Braille_Octave6 = braille_code("Octave6", "56");
+braille_code Braille_Octave7 = braille_code("Octave7", "6");
+braille_code Braille_Octave8 = braille_code("Octave8", "6-6");
+
+braille_code* Braille_Octaves[] = {
+    &Braille_Octave0, &Braille_Octave1, &Braille_Octave2,
+    &Braille_Octave3, &Braille_Octave4, &Braille_Octave5,
+    &Braille_Octave6, &Braille_Octave7, &Braille_Octave8 };
+//#clef signs
+braille_code Braille_ClefG = braille_code("ClefG", "345-34-123");
+braille_code Braille_ClefF = braille_code("ClefF", "345-3456-123");
+braille_code Braille_ClefC = braille_code("ClefC", "345-346-123");
+//#Treble and bass clefs used in different hands
+braille_code Braille_ClefGLeft = braille_code("ClefGLeft", "345-34-13");
+braille_code Braille_ClefFRight = braille_code("ClefFRight", "345-3456-13");
+//#special clefs
+//#G/F/C clef on first line (French violin), second/third/fourth/fifth line etc
+braille_code Braille_ClefGFirstLine = braille_code("ClefGFirstLine", "345-34-4-123");
+braille_code Braille_ClefGThirdLine = braille_code("ClefGThirdLine", "345-34-456-123");
+braille_code Braille_ClefGFourthLine = braille_code("ClefGFourthLine", "345-34-5-123");
+braille_code Braille_ClefGFifthLine = braille_code("ClefGFifthLine", "345-34-46-123");
+braille_code Braille_ClefFFirstLine = braille_code("ClefFFirstLine", "345-3456-4-123");
+braille_code Braille_ClefFSecondLine = braille_code("ClefFSecondLine", "345-3456-45-123");
+braille_code Braille_ClefFThirdLine = braille_code("ClefFThirdLine", "345-3456-456-123");
+//braille_code Braille_ClefFFourthLine = braille_code("ClefFFourthLine", "345-3456-5-123");
+braille_code Braille_ClefFFifthLine = braille_code("ClefFFifthLine", "345-3456-46-123");
+braille_code Braille_ClefCFirstLine = braille_code("ClefCFirstLine", "345-346-4-123");
+braille_code Braille_ClefCSecondLine = braille_code("ClefCSecondLine", "345-346-45-123");
+//braille_code Braille_ClefCThirdLine = braille_code("ClefCThirdLine", "345-346-456-123");
+braille_code Braille_ClefCFourthLine = braille_code("ClefCFourthLine", "345-346-5-123");
+braille_code Braille_ClefCFifthLine = braille_code("ClefCFifthLine", "345-346-46-123");
+//#hands
+braille_code Braille_RightHand = braille_code("RightHand", "46-345");
+braille_code Braille_LeftHand = braille_code("LeftHand", "456-345");
+//##########Added by Haipeng##########
+//#Right and left hands with reversed interval directions in hand-changing passage. Not used for general interval direction changes such as piano left hand reading downwards in orchestral scores where all intervals are down.
+braille_code Braille_RightHandUp = braille_code("RightHandUp", "46-345-345");
+braille_code Braille_LeftHandDown = braille_code("LeftHandDown", "456-345-345");
+//####################
+braille_code Braille_OrganPedal = braille_code("OrganPedal", "45-345");
+//##########Added by Haipeng##########
+//#Chord and figured bass prefix
+braille_code Braille_ChordPrefix = braille_code("ChordPrefix", "25-345");
+//#Accordion prefix, detected by instrument definition
+//AccordionBass 6-345
+//#Outline prefix, when producing piano accompaniment with melody outline
+braille_code Braille_Outline = braille_code("Outline", "5-345");
+//####################
+//#accidental signs: natural, sharp and flat.
+braille_code Braille_NaturalAccidental = braille_code("NaturalAccidental", "16");
+//#sharps
+braille_code Braille_SharpAccidental = braille_code("SharpAccidental", "146");
+//#1/4 sharp
+braille_code Braille_QuarterSharp = braille_code("QuarterSharp", "4-146");
+//#3/4 sharp
+braille_code Braille_ThreeQuarterSharp = braille_code("ThreeQuarterSharp", "456-146");
+//#flats
+braille_code Braille_FlatAccidental = braille_code("FlatAccidental", "126");
+braille_code Braille_QuarterFlat = braille_code("QuarterFlat", "4-126");
+braille_code Braille_ThreeQuarterFlat = braille_code("ThreeQuarterFlat", "456-126");
+
+braille_code* Braille_Accidentals[] = {
+    &Braille_NaturalAccidental,
+    &Braille_SharpAccidental, &Braille_QuarterSharp, &Braille_ThreeQuarterSharp,
+    &Braille_FlatAccidental, &Braille_QuarterFlat, &Braille_ThreeQuarterFlat
+};
+//#Time signatures
+braille_code Braille_CommonTime = braille_code("CommonTime", "46-14");
+braille_code Braille_CutTime = braille_code("CutTime", "456-14");
+//# time signature by seconds
+braille_code Braille_TimeInSecondSign = braille_code("TimeInSecondSign", "45");
+braille_code Braille_TimeExtensionSign = braille_code("TimeExtensionSign", "36-36");
+//#ties
+braille_code Braille_NoteTie = braille_code("NoteTie", "4-14");
+braille_code Braille_ChordTie = braille_code("ChordTie", "46-14");
+braille_code Braille_ChordTieDoubling = braille_code("ChordTieDoubling", "46-14-14");
+braille_code Braille_Arpeggio = braille_code("Arpeggio", "45-14");
+braille_code Braille_TieLetRing = braille_code("TieLetRing", "56-14");
+braille_code Braille_TieNoStart = braille_code("TieNoStart", "46-56-14");
+//##########Added by Haipeng##########
+braille_code Braille_TieCrossVoice = braille_code("TieCrossVoice", "456-4-14");
+braille_code Braille_TieCrossVoiceFrom = braille_code("TieCrossVoiceFrom", "46-456-4-14");
+braille_code Braille_TieCrossStaff = braille_code("TieCrossStaff", "5-4-14");
+braille_code Braille_TieCrossStaffFrom = braille_code("TieCrossStaffFrom", "46-5-4-14");
+braille_code Braille_ChordTieCrossVoice = braille_code("ChordTieCrossVoice", "456-46-14");
+braille_code Braille_ChordTieCrossVoiceFrom = braille_code("ChordTieCrossVoiceFrom", "46-456-46-14");
+braille_code Braille_ChordTieCrossStaff = braille_code("ChordTieCrossStaff", "5-46-14");
+braille_code Braille_ChordTieCrossStaffFrom = braille_code("ChordTieCrossStaffFrom", "46-5-46-14");
+//####################
+//#slurs
+braille_code Braille_NoteSlur = braille_code("NoteSlur", "14");
+braille_code Braille_LongSlurOpenBracket = braille_code("LongSlurOpenBracket", "56-12");
+braille_code Braille_LongSlurCloseBracket = braille_code("LongSlurCloseBracket", "45-23");
+braille_code Braille_ConvergentSlur = braille_code("ConvergentSlur", "6-14");
+braille_code Braille_SameNoteSlur = braille_code("SameNoteSlur", "56-14");
+
+braille_code Braille_GraceSlur = braille_code("GraceSlur", "56-14");
+braille_code Braille_GraceSlurDoubling = braille_code("GraceSlurDoubling", "56-14-14");
+//##########Added by Haipeng##########
+braille_code Braille_SlurCrossVoice = braille_code("SlurCrossVoice", "456-14");
+braille_code Braille_SlurCrossVoiceFrom = braille_code("SlurCrossVoiceFrom", "46-456-14");
+braille_code Braille_SlurCrossStaff = braille_code("slurCrossStaff", "5-14");
+braille_code Braille_SlurCrossStaffFrom = braille_code("SlurCrossStaffFrom", "46-5-14");
+//####################
+//#Intervals, Braille signs to write for chords
+//#Braille sign for second interval has same dots for 9, 16, 23 (+7)
+braille_code Braille_Interval2 = braille_code("Interval2", "34");
+braille_code Braille_Interval3 = braille_code("Interval3", "346");
+braille_code Braille_Interval4 = braille_code("Interval4", "3456");
+braille_code Braille_Interval5 = braille_code("Interval5", "35");
+braille_code Braille_Interval6 = braille_code("Interval6", "356");
+braille_code Braille_Interval7 = braille_code("Interval7", "25");
+braille_code Braille_Interval8 = braille_code("Interval8", "36");
+
+braille_code* Braille_Intervals[] = {
+    &Braille_Interval2, &Braille_Interval3, &Braille_Interval4,
+    &Braille_Interval5, &Braille_Interval6, &Braille_Interval7,
+    &Braille_Interval8 };
+//#tuplet: note grouping 2/3/5/6/XXX-notes grouping
+braille_code Braille_Tuplet3 = braille_code("Tuplet3", "23");
+braille_code Braille_TupletPrefix = braille_code("TupletPrefix", "456");
+//#repeats' signs in print score
+braille_code Braille_RepetitionForward = braille_code("RepetitionForward", "126-2356");
+braille_code Braille_RepetitionBackward = braille_code("RepetitionBackward", "126-23");
+braille_code Braille_Coda = braille_code("Coda", "346-123");
+braille_code Braille_Segno = braille_code("Segno", "346");
+// Fermata
+braille_code Braille_InvertedType = braille_code("InvertedType", "5");
+braille_code Braille_FermataDefault = braille_code("FermataDefault", "126-123");
+braille_code Braille_FermataSquare = braille_code("FermataSquare", "56-126-123");
+braille_code Braille_FermataAngled = braille_code("FermataAngled", "45-126-123");
+braille_code Braille_FermataDoubleSquare = braille_code("FermataDoubleSquare", "56-56-126-123");
+braille_code Braille_FermataDoubleAngled = braille_code("FermataDoubleAngled", "45-45-126-123");
+braille_code Braille_FermataHalfCurve = braille_code("FermataHalfCurve", "45-126-123");
+braille_code Braille_FermataDoubleDot = braille_code("FermataDoubleDot", "56-126-123");
+//##Newly added by Haipeng##
+braille_code Braille_FermataBarline = braille_code("FermataBarline", "456-126-123");
+braille_code Braille_FermataNormalBarline = braille_code("FermataNormalBarline", "456");
+//#Braille measure or partial repetition sign
+braille_code Braille_NotesRepeat = braille_code("NotesRepeat", "2356");
+//#Newly added by Haipeng##
+//#This repeat should be used according to beamings in unmeasured passage. It should be used between beams, within a long beam, but can't cross beams in different places, thus break the musical meaning implied by the beaming.
+braille_code Braille_StartingBeamRepeat = braille_code("StartingBeamRepeat", "16-2356");
+//#barlines
+braille_code Braille_SingleBarline = braille_code("SingleBarline", "0");
+braille_code Braille_DashedBarline = braille_code("DashedBarline", "13");
+braille_code Braille_SpecialBarline = braille_code("SpecialBarline", "123");
+braille_code Braille_SectionalDouble = braille_code("SectionalDouble", "126-13-3");
+braille_code Braille_FinalDouble = braille_code("FinalDouble", "126-13");
+//#fingering
+braille_code Braille_Finger0 = braille_code("Finger0", "13"); //#thumb
+braille_code Braille_Finger1 = braille_code("Finger1", "1");     //#index
+braille_code Braille_Finger2 = braille_code("Finger2", "12");    //#middle
+braille_code Braille_Finger3 = braille_code("Finger3", "123");   //#ring
+braille_code Braille_Finger4 = braille_code("Finger4", "2");     //#little
+braille_code Braille_Finger5 = braille_code("Finger5", "13");    //#open string
+
+braille_code Braille_FingerSlur = braille_code("FingerSlur", "14");    //Finger slur
+
+braille_code* Braille_Fingers[] = { &Braille_Finger0, &Braille_Finger1, &Braille_Finger2,
+                                    &Braille_Finger3, &Braille_Finger4, &Braille_Finger5 };
+//##Comment by Haipeng: The names above are not strict, but I believe they can be correctly mapped to Musicxml.##
+//#plucks, for string instruments
+braille_code Braille_PluckP = braille_code("PluckP", "1234"); //#thumb
+braille_code Braille_PluckI = braille_code("PluckI", "24");   //#index
+braille_code Braille_PluckM = braille_code("PluckM", "134");  //#middle
+braille_code Braille_PluckA = braille_code("PluckA", "1");    //#ring
+braille_code Braille_PluckC = braille_code("PluckC", "1346");   //#little
+
+braille_code* Braille_Plucks[] = { &Braille_PluckP, &Braille_PluckI, &Braille_PluckM,
+                                   &Braille_PluckA, &Braille_PluckC };
+
+braille_code Braille_Dot6PluckP = braille_code("Dot6PluckP", "6-1");
+braille_code Braille_Dot6PluckI = braille_code("Dot6PluckI", "6-12");
+braille_code Braille_Dot6PluckM = braille_code("Dot6PluckM", "6-123");
+braille_code Braille_Dot6PluckA = braille_code("Dot6PluckA", "6-2");
+braille_code Braille_Dot6PluckC = braille_code("Dot6PluckC", "6-13");
+//#string
+braille_code Braille_String1 = braille_code("String1", "146-1");
+braille_code Braille_String2 = braille_code("String2", "146-12");
+braille_code Braille_String3 = braille_code("String3", "146-123");
+braille_code Braille_String4 = braille_code("String4", "146-2");
+braille_code Braille_String5 = braille_code("String5", "146-13");
+braille_code Braille_String6 = braille_code("String6", "146-23");
+braille_code Braille_String7 = braille_code("String7", "146-3");
+
+braille_code* Braille_Strings[] = {
+    &Braille_String1, &Braille_String2, &Braille_String3,
+    &Braille_String4, &Braille_String5, &Braille_String6,
+    &Braille_String7 };
+
+braille_code Braille_String1_Doubling = braille_code("String1Doubling", "146-1-1");
+braille_code Braille_String2_Doubling = braille_code("String2Doubling", "146-12-12");
+braille_code Braille_String3_Doubling = braille_code("String3Doubling", "146-123-123");
+braille_code Braille_String4_Doubling = braille_code("String4Doubling", "146-2-2");
+braille_code Braille_String5_Doubling = braille_code("String5Doubling", "146-13-13");
+braille_code Braille_String6_Doubling = braille_code("String6Doubling", "146-23-23");
+braille_code Braille_String7_Doubling = braille_code("String7Doubling", "146-3-3");
+
+braille_code* Braille_Strings_Doubling[] = {
+    &Braille_String1_Doubling, &Braille_String2_Doubling, &Braille_String3_Doubling,
+    &Braille_String4_Doubling, &Braille_String5_Doubling, &Braille_String6_Doubling,
+    &Braille_String7_Doubling };
+//[Fret]
+//#frets
+braille_code Braille_Fret1 = braille_code("Fret1", "345-345");
+braille_code Braille_Fret2 = braille_code("Fret2", "345-34");
+braille_code Braille_Fret3 = braille_code("Fret3", "345-346");
+braille_code Braille_Fret4 = braille_code("Fret4", "345-3456");
+braille_code Braille_Fret5 = braille_code("Fret5", "345-35");
+braille_code Braille_Fret6 = braille_code("Fret6", "345-356");
+braille_code Braille_Fret7 = braille_code("Fret7", "6-345-25");
+braille_code Braille_Fret8 = braille_code("Fret8", "345-36");
+braille_code Braille_Fret9 = braille_code("Fret9", "345-36-34");
+braille_code Braille_Fret10 = braille_code("Fret10", "345-36-346");
+braille_code Braille_Fret11 = braille_code("Fret11", "345-36-3456");
+braille_code Braille_Fret12 = braille_code("Fret12", "345-36-35");
+braille_code Braille_Fret13 = braille_code("Fret13", "345-36-356");
+
+braille_code* Braille_Frets[] = {
+    &Braille_Fret1, &Braille_Fret2, &Braille_Fret3,
+    &Braille_Fret4, &Braille_Fret5, &Braille_Fret6,
+    &Braille_Fret7, &Braille_Fret8, &Braille_Fret9,
+    &Braille_Fret10, &Braille_Fret11, &Braille_Fret12,
+    &Braille_Fret13 };
+//[VoiceAccord]
+//#accord
+braille_code Braille_FullMeasureAccord = braille_code("FullMeasureAccord", "126-345");
+braille_code Braille_PartialMeasureAccord = braille_code("PartialMeasureAccord", "5-2");
+braille_code Braille_MeasureSeparator = braille_code("MeasureSeparator", "46-13");
+//[Pedal]
+//#pedal signs
+braille_code Braille_PedalDown = braille_code("PedalDown", "126-14");
+braille_code Braille_PedalUp = braille_code("PedalUp", "16-14");
+braille_code Braille_NotePedalUpDownAtNote = braille_code("NotePedalUpDownAtNote", "16-126-14");
+braille_code Braille_HalfPedal = braille_code("HalfPedal", "5-126-14");
+braille_code Braille_AfterNotePedalDown = braille_code("AfterNotePedalDown", "6-126-14");
+braille_code Braille_AfterNotePedalUp = braille_code("AfterNotePedalUp", "5-16-14");
+braille_code Braille_NoPedal = braille_code("NoPedal", "16-14");
+//[Ornament]
+//#articulations, ornaments
+braille_code Braille_Spiccato = braille_code("Spiccato", "236");
+braille_code Braille_Staccato = braille_code("Staccato", "236");
+braille_code Braille_Staccatissimo = braille_code("Staccatissimo", "6-236");
+braille_code Braille_DetachedLegato = braille_code("DetachedLegato", "5-236");
+braille_code Braille_Tenuto = braille_code("Tenuto", "456-236");
+braille_code Braille_Accent = braille_code("Accent", "46-236");
+braille_code Braille_Stress = braille_code("Stress", "45-236");
+braille_code Braille_Unstress = braille_code("Unstress", "4-236");
+braille_code Braille_StrongAccent = braille_code("StrongAccent", "56-236");
+//##########Added by Haipeng##########
+braille_code Braille_SoftAccent = braille_code("SoftAccent", "16-3");
+braille_code Braille_Scoop = braille_code("Scoop", "126-3-14");
+braille_code Braille_Plop = braille_code("Plop", "126-12-14");
+braille_code Braille_Doit = braille_code("Doit", "14-126-3");
+braille_code Braille_Falloff = braille_code("Falloff", "14-126-12");
+braille_code Braille_UpBow = braille_code("UpBow", "126-3");
+braille_code Braille_DownBow = braille_code("DownBow", "126-12");
+braille_code Braille_HarmonicNatural = braille_code("HarmonicNatural", "13");
+braille_code Braille_HarmonicArtificial = braille_code("HarmonicArtificial", "16-123");
+braille_code Braille_OpenString = braille_code("OpenString", "13");
+braille_code Braille_Stopped = braille_code("Stopped", "126-12");
+braille_code Braille_SnapPizzicato = braille_code("SnapPizzicato", "16-13");
+braille_code Braille_HammerOn = braille_code("HammerOn", "126-3");
+braille_code Braille_PullOff = braille_code("PullOff", "126-12");
+//####################
+braille_code Braille_ArpeggiateUp = braille_code("ArpeggiateUp", "345-13");
+braille_code Braille_ArpeggiateDown = braille_code("ArpeggiateDown", "345-13-13");
+braille_code Braille_Cue = braille_code("Cue", "6-26");
+braille_code Braille_GraceShort = braille_code("GraceShort", "26");
+braille_code Braille_GraceLong = braille_code("GraceLong", "5-26");
+braille_code Braille_TrillMark = braille_code("TrillMark", "235");
+braille_code Braille_Turn = braille_code("Turn", "6-256");
+braille_code Braille_InvertedTurn = braille_code("InvertedTurn", "6-256-123");
+braille_code Braille_DelayedTurn = braille_code("DelayedTurn", "256");
+braille_code Braille_DelayedInvertedTurn = braille_code("DelayedInvertedTurn", "256-123");
+braille_code Braille_MordentShort = braille_code("MordentShort", "5-235-123");
+braille_code Braille_MordentLong = braille_code("MordentLong", "56-235-123");
+braille_code Braille_InvertedMordentShort = braille_code("InvertedMordentShort", "5-235");
+braille_code Braille_InvertedMordentLong = braille_code("InvertedMordentLong", "56-235");
+//##Added by Haipeng##
+braille_code Braille_Schleifer = braille_code("Schleifer", "4-26");
+braille_code Braille_Shake = braille_code("Shake", "5-235-123");
+braille_code Braille_BreathMark = braille_code("BreathMark", "345-2");
+braille_code Braille_Caesura = braille_code("Caesura", "6-34");
+
+braille_code Braille_TremoloSingle1 = braille_code("TremoloSingle1", "45-12");
+braille_code Braille_TremoloSingle2 = braille_code("TremoloSingle2", "45-123");
+braille_code Braille_TremoloSingle3 = braille_code("TremoloSingle3", "45-2");
+braille_code Braille_TremoloSingle4 = braille_code("TremoloSingle4", "45-13");
+braille_code Braille_TremoloSingle5 = braille_code("TremoloSingle5", "45-3");
+
+braille_code* Braille_TremoloSingles[] = {
+    &Braille_TremoloSingle1, &Braille_TremoloSingle2, &Braille_TremoloSingle3,
+    &Braille_TremoloSingle4, &Braille_TremoloSingle5 };
+
+braille_code Braille_TremoloDouble1 = braille_code("TremoloDouble1", "46-12");
+braille_code Braille_TremoloDouble2 = braille_code("TremoloDouble2", "46-123");
+braille_code Braille_TremoloDouble3 = braille_code("TremoloDouble3", "46-2");
+braille_code Braille_TremoloDouble4 = braille_code("TremoloDouble4", "46-1");
+braille_code Braille_TremoloDouble5 = braille_code("TremoloDouble5", "46-3");
+
+braille_code* Braille_TremoloDoubles[] = {
+    &Braille_TremoloDouble1, &Braille_TremoloDouble2, &Braille_TremoloDouble3,
+    &Braille_TremoloDouble4, &Braille_TremoloDouble5 };
+
+braille_code Braille_Glissando = braille_code("Glissando", "4-1");
+braille_code Braille_LongGlissandoStart = braille_code("LongGlissandoStart", "4-1-3");
+braille_code Braille_LongGlissandoStop = braille_code("LongGlissandoStop", "6-4-1");
+braille_code Braille_Slide = braille_code("Slide", "4-1");
+braille_code Braille_LongSlideStart = braille_code("LongSlideStart", "4-1-3");
+braille_code Braille_LongSlideStop = braille_code("LongSlideStop", "6-4-1");
+//##########Added by Haipeng##########
+//[Noteheads]
+braille_code Braille_blackHead = braille_code("blackHead", "26-1");
+braille_code Braille_XShape = braille_code("XShape", "26-12");
+braille_code Braille_Diamond = braille_code("Diamond", "26-123");
+braille_code Braille_DiamondHarmonic = braille_code("DiamondHarmonic", "16-123");
+braille_code Braille_Slashed = braille_code("Slashed", "26-13");
+//#Comment: If the diamond is in a chord, then use DiamondHarmonic, since it's an artificial harmonic.
+braille_code Braille_StemOnly = braille_code("StemOnly", "26-13");
+braille_code Braille_Circled = braille_code("Circled", "26-2");
+//[Stems]
+braille_code Braille_StemPrefix = braille_code("StemPrefix", "456");
+braille_code Braille_StemWhole = braille_code("StemWhole", "3");
+braille_code Braille_StemHalf = braille_code("StemHalf", "13");
+braille_code Braille_StemQuarter = braille_code("StemQuarter", "1");
+braille_code Braille_Stem8th = braille_code("Stem8th", "12");
+braille_code Braille_Stem16th = braille_code("Stem16th", "123");
+braille_code Braille_Stem32nd = braille_code("Stem32nd", "2");
+//[HarpPedalDiagram]
+braille_code Braille_HarpPedalBegin = braille_code("HarpPedalBegin", "345-36");
+braille_code Braille_HarpPedalEnd = braille_code("HarpPedalEnd", "3-345");
+braille_code Braille_HarpPedalRaised = braille_code("HarpPedalRaised", "12");
+braille_code Braille_HarpPedalCentered = braille_code("HarpPedalCentered", "2");
+braille_code Braille_HarpPedalLowered = braille_code("HarpPedalLowered", "23");
+braille_code Braille_HarpPedalDivider = braille_code("HarpPedalDivider", "123");
+//[FetherBeams]
+braille_code Braille_FanBeamAccelerando = braille_code("FanBeamAccelerando", "45-126-2-6-126-2");
+braille_code Braille_FanBeamRitardando = braille_code("FanBeamRitardando", "6-126-2-45-126-2");
+braille_code Braille_FanBeamSteady = braille_code("FanBeamSteady", "6-126-2-6-126-2");
+braille_code Braille_FanBeamEnd = braille_code("FanBeamEnd", "56-13");
+// Placement
+braille_code Braille_PlacementBelow = braille_code("PlacementBelow", "6");
+// Hand interval up/down
+braille_code Braille_LeftHandIntervalDown = braille_code("LeftHandIntervalDown", "456-345-345");
+braille_code Braille_RightHandIntervalUp = braille_code("RightHandIntervalUp", "46-345-345");
+// Additional braille codes
+braille_code Braille_NewLine = braille_code("NewLine", "\n");
+// Slurs
+braille_code Braille_SlurCrossVoiceDubling = braille_code("SlurCrossVoiceDubling", "456-14-14");
+braille_code Braille_SlurCrossStaffDubling = braille_code("SlurCrossStaffDubling", "5-14-14");
+// Wavy
+braille_code Braille_OrnamentWavyStart = braille_code("OrnamentWavyStart", "3-3");
+braille_code Braille_OrnamentWavyStop = braille_code("OrnamentWavyStop", "345-3");
+braille_code Braille_WavyRepetitionLine = braille_code("WavyRepetitionLine", "26-2356");
+// Dubling
+braille_code Braille_CueDubling = braille_code("CueDubling", "6-26-26");
+braille_code Braille_GraceLongDubling = braille_code("GraceLongDubling", "5-26-26");
+// Noteheads dubling
+braille_code Braille_blackHeadDubling = braille_code("blackHeadDubling", "26-1-1");
+braille_code Braille_XShapeDubling = braille_code("XShapeDubling", "26-12-12");
+braille_code Braille_DiamondDubling = braille_code("DiamondDubling", "26-123-123");
+braille_code Braille_DiamondHarmonicDubling = braille_code("DiamondHarmonicDubling", "16-123-16-123");
+braille_code Braille_SlashedDubling = braille_code("SlashedDubling", "26-13-13");
+braille_code Braille_StemOnlyDubling = braille_code("StemOnlyDubling", "26-13-13");
+braille_code Braille_CircledDubling = braille_code("CircledDubling", "26-2-2");
+// Tremolo dubling
+braille_code Braille_TremoloSingle1Dubling = braille_code("TremoloSingle1Dubling", "45-12-12");
+braille_code Braille_TremoloSingle2Dubling = braille_code("TremoloSingle2Dubling", "45-123-123");
+braille_code Braille_TremoloSingle3Dubling = braille_code("TremoloSingle3Dubling", "45-2-2");
+braille_code Braille_TremoloSingle4Dubling = braille_code("TremoloSingle4Dubling", "45-13-13");
+braille_code Braille_TremoloSingle5Dubling = braille_code("TremoloSingle5Dubling", "45-3-3");
+braille_code Braille_TremoloDouble1Dubling = braille_code("TremoloDouble1Dubling", "46-12-12");
+braille_code Braille_TremoloDouble2Dubling = braille_code("TremoloDouble2Dubling", "46-123-123");
+braille_code Braille_TremoloDouble3Dubling = braille_code("TremoloDouble3Dubling", "46-2-2");
+braille_code Braille_TremoloDouble4Dubling = braille_code("TremoloDouble4Dubling", "46-1-1");
+braille_code Braille_TremoloDouble5Dubling = braille_code("TremoloDouble5Dubling", "46-3-3");
+// Dash sign
+braille_code Braille_DashSign = braille_code("DashSign", "36");
+// Dashline
+braille_code Braille_DashLineStart = braille_code("DashLineStart", "3-3");
+braille_code Braille_DashLineStop = braille_code("DashLineStop", "345-3");
+braille_code Braille_DashNestedLineStart = braille_code("DashNestedLineStart", "36-36");
+braille_code Braille_DashNestedLineStop = braille_code("DashNestedLineStop", "345-36");
+// Elision
+braille_code Braille_Elision2 = braille_code("Elision2", "12");
+braille_code Braille_Elision3 = braille_code("Elision3", "123");
+// Empty
+braille_code Braille_Empty = braille_code("Empty", "");
+// line over line format
+braille_code Braille_HarmonyLineIndicator = braille_code("HarmonyLineIndicator", "25-345");
+braille_code Braille_LyricLineIndicator = braille_code("LyricLineIndicator", "56-23");
+braille_code Braille_MusicLineIndicator = braille_code("MusicLineIndicator", "6-3");
+braille_code Braille_PluckLineIndicator = braille_code("PluckLineIndicator", "0-0");
+braille_code Braille_SoloMelodyLineIndicator = braille_code("SoloMelodyLineIndicator", "5-345");
+// wedge stop
+braille_code Braille_WedgeCStop = braille_code("WedgeCStop", "345-25");
+braille_code Braille_WedgeDStop = braille_code("WedgeDStop", "345-256");
+// Repeats
+braille_code Braille_PartialRepeat = braille_code("PartialRepeat", "2356");
+braille_code Braille_MeasureRepeat = braille_code("MeasureRepeat", "2356"); // ??? 2356?
+// Check dot
+braille_code Braille_CheckDot = braille_code("CheckDot", "");
+// Check figure Bass Separator
+braille_code Braille_CheckFiguredBassSeparator = braille_code("CheckFiguredBassSeparator", "");
+// Thumb
+braille_code Braille_ThumbPosition = braille_code("ThumbPosition", "16-13");
+// Accordion
+braille_code Braille_AccordionMiddle2 = braille_code("AccordionMiddle2", "34");
+braille_code Braille_AccordionMiddle3 = braille_code("AccordionMiddle3", "346");
+// String intrument
+braille_code Braille_LeftHandPizzicato = braille_code("LeftHandPizzicato", "456-345");
+
+std::string getBraillePattern(std::string dots)
+{
+    const char* dotc = dots.c_str();
+    int d = atoi(dotc);
+    switch (d) {
+    case 0: return " ";
+    case 1: return "⠁";
+    case 2: return "⠂";
+    case 12: return "⠃";
+    case 3: return "⠄";
+    case 13: return "⠅";
+    case 23: return "⠆";
+    case 123: return "⠇";
+    case 4: return "⠈";
+    case 14: return "⠉";
+    case 24: return "⠊";
+    case 124: return "⠋";
+    case 34: return "⠌";
+    case 134: return "⠍";
+    case 234: return "⠎";
+    case 1234: return "⠏";
+
+    case 5: return "⠐";
+    case 15: return "⠑";
+    case 25: return "⠒";
+    case 125: return "⠓";
+    case 35: return "⠔";
+    case 135: return "⠕";
+    case 235: return "⠖";
+    case 1235: return "⠗";
+    case 45: return "⠘";
+    case 145: return "⠙";
+    case 245: return "⠚";
+    case 1245: return "⠛";
+    case 345: return "⠜";
+    case 1345: return "⠝";
+    case 2345: return "⠞";
+    case 12345: return "⠟";
+
+    case 6: return "⠠";
+    case 16: return "⠡";
+    case 26: return "⠢";
+    case 126: return "⠣";
+    case 36: return "⠤";
+    case 136: return "⠥";
+    case 236: return "⠦";
+    case 1236: return "⠧";
+    case 46: return "⠨";
+    case 146: return "⠩";
+    case 246: return "⠪";
+    case 1246: return "⠫";
+    case 346: return "⠬";
+    case 1346: return "⠭";
+    case 2346: return "⠮";
+    case 12346: return "⠯";
+
+    case 56: return "⠰";
+    case 156: return "⠱";
+    case 256: return "⠲";
+    case 1256: return "⠳";
+    case 356: return "⠴";
+    case 1356: return "⠵";
+    case 2356: return "⠶";
+    case 12356: return "⠷";
+    case 456: return "⠸";
+    case 1456: return "⠹";
+    case 2456: return "⠺";
+    case 12456: return "⠻";
+    case 3456: return "⠼";
+    case 13456: return "⠽";
+    case 23456: return "⠾";
+    case 123456: return "⠿";
+    }
+    return " ";
+}
+
+std::string translate2Braille(std::string codes)
+{
+    std::stringstream test(codes);
+    std::string segment;
+    std::vector<std::string> seglist;
+
+    std::string txt = "";
+    while (std::getline(test, segment, '-')) {
+        txt.append(getBraillePattern(segment));
+    }
+    return txt;
+}
+
+std::string intToBrailleUpperNumbers(std::string txt, bool indicator)
+{
+    std::string braille = "";
+    if (indicator) {
+        braille.append(translate2Braille(Braille_NumIndicator.code));
+    }
+
+    for (size_t i=0; i < txt.length(); i++) {
+        char c = txt.at(i);
+        if (c - '0' <= 9) {
+            braille.append(translate2Braille(Braille_UpperNumbers[c - '0']->code));
+        }
+    }
+    return braille;
+}
+
+std::string intToBrailleLowerNumbers(std::string txt, bool indicator)
+{
+    std::string braille = "";
+    if (indicator) {
+        braille.append(Braille_NumIndicator.code);
+    }
+
+    for (size_t i=0; i < txt.length(); i++) {
+        char c = txt.at(i);
+        if (c - '0' <= 9) {
+            braille.append(Braille_LowerNumbers[c - '0']->code);
+        }
+    }
+    return braille;
+}
+
+std::vector<std::string> splitCodes(std::string code)
+{
+    std::stringstream test(code);
+    std::string segment;
+    std::vector<std::string> seglist;
+
+    std::vector<std::string> lst;
+    while (std::getline(test, segment, '-')) {
+        lst.push_back(segment);
+    }
+    return lst;
+}
+
+braille_code* findBrailleCode(std::vector<braille_code*> code_lst, std::string code, bool partial_match)
+{
+    if (partial_match) {
+        std::vector<std::string> codes = splitCodes(code);
+
+        for (braille_code* br : code_lst) {
+            std::vector<std::string> lst = splitCodes(br->code);
+
+            if (codes.size() > lst.size()) {
+                return nullptr;
+            }
+
+            for (size_t i=0; i < codes.size(); i++) {
+                if (codes[i] != lst[i]) {
+                    return nullptr;
+                }
+            }
+            return br;
+        }
+    } else {
+        for (braille_code* br : code_lst) {
+            if (br->code == code) {
+                return br;
+            }
+        }
+    }
+    return nullptr;
+}
+
+braille_code* findRest(const std::string braille)
+{
+    for (int i=3; i <= 6; i++) {
+        if (braille == Braille_Rests[i]->code) {
+            return Braille_Rests[i];
+        }
+    }
+    return NULL;
+}
+
+braille_code* findNote(const std::string braille)
+{
+    for (int i=3; i <= 6; i++) {
+        if (braille == Braille_aNotes[i]->code) {
+            return Braille_aNotes[i];
+        }
+    }
+
+    for (int i=3; i <= 6; i++) {
+        if (braille == Braille_bNotes[i]->code) {
+            return Braille_bNotes[i];
+        }
+    }
+
+    for (int i=3; i <= 6; i++) {
+        if (braille == Braille_cNotes[i]->code) {
+            return Braille_cNotes[i];
+        }
+    }
+
+    for (int i=3; i <= 6; i++) {
+        if (braille == Braille_dNotes[i]->code) {
+            return Braille_dNotes[i];
+        }
+    }
+
+    for (int i=3; i <= 6; i++) {
+        if (braille == Braille_eNotes[i]->code) {
+            return Braille_eNotes[i];
+        }
+    }
+
+    for (int i=3; i <= 6; i++) {
+        if (braille == Braille_fNotes[i]->code) {
+            return Braille_fNotes[i];
+        }
+    }
+
+    for (int i=3; i <= 6; i++) {
+        if (braille == Braille_gNotes[i]->code) {
+            return Braille_gNotes[i];
+        }
+    }
+    return NULL;
+}
+
+braille_code* findOctave(const std::string braille)
+{
+    for (int i=0; i <= 8; i++) {
+        if (braille == Braille_Octaves[i]->code) {
+            return Braille_Octaves[i];
+        }
+    }
+    return NULL;
+}
+
+braille_code* findAccidental(const std::string braille)
+{
+    for (int i=0; i <= 6; i++) {
+        if (braille == Braille_Accidentals[i]->code) {
+            return Braille_Accidentals[i];
+        }
+    }
+    return NULL;
+}
+
+braille_code* findFinger(const std::string braille)
+{
+    for (int i=0; i < 6; i++) {
+        if (braille == Braille_Fingers[i]->code) {
+            return Braille_Fingers[i];
+        }
+    }
+    return NULL;
+}
+
+braille_code* findInterval(const std::string braille)
+{
+    for (int i=0; i <= 6; i++) {
+        if (braille == Braille_Intervals[i]->code) {
+            return Braille_Intervals[i];
+        }
+    }
+    return NULL;
+}
+}

--- a/src/braille/internal/braillecode.h
+++ b/src/braille/internal/braillecode.h
@@ -1,0 +1,785 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2023 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_BRAILLE_BRAILLEDOTS_H
+#define MU_BRAILLE_BRAILLEDOTS_H
+
+#include <string>
+
+namespace mu::engraving {
+class braille_code
+{
+public:
+    braille_code(std::string t, std::string c);
+    ~braille_code();
+    void print();
+    std::string tag;
+    std::string code;
+    std::string braille;
+    int cells_num;
+};
+
+//In the table below, things added by Haipeng are indicated as this:
+//Short (one or two) list: "Added by Haipeng" is enclosed by two hash signs on both sides, then every entry is marked as a hash.
+//Longer list: "Added by Haipeng" is enclosed by 10 hash signs on both sides. Comments within this section begins with two hashes, and normal entries begin with one hash. The end of section is marked by a line of 20 hashes.
+
+//[BrailleIndicator]
+//Braille indicators
+extern braille_code Braille_CapIndicator;
+extern braille_code Braille_NumIndicator;
+extern braille_code Braille_TxtIndicator;
+
+//[Letter]
+extern braille_code Braille_a;
+extern braille_code Braille_b;
+extern braille_code Braille_c;
+extern braille_code Braille_d;
+extern braille_code Braille_e;
+extern braille_code Braille_f;
+extern braille_code Braille_g;
+extern braille_code Braille_h;
+extern braille_code Braille_i;
+extern braille_code Braille_j;
+extern braille_code Braille_k;
+extern braille_code Braille_l;
+extern braille_code Braille_m;
+extern braille_code Braille_n;
+extern braille_code Braille_o;
+extern braille_code Braille_p;
+extern braille_code Braille_q;
+extern braille_code Braille_r;
+extern braille_code Braille_s;
+extern braille_code Braille_t;
+extern braille_code Braille_u;
+extern braille_code Braille_v;
+extern braille_code Braille_w;
+extern braille_code Braille_x;
+extern braille_code Braille_y;
+extern braille_code Braille_z;
+
+extern braille_code* Braille_Letter[];
+//[Number]
+//upper and lower numbers
+extern braille_code Braille_Upper0;
+extern braille_code Braille_Upper1;
+extern braille_code Braille_Upper2;
+extern braille_code Braille_Upper3;
+extern braille_code Braille_Upper4;
+extern braille_code Braille_Upper5;
+extern braille_code Braille_Upper6;
+extern braille_code Braille_Upper7;
+extern braille_code Braille_Upper8;
+extern braille_code Braille_Upper9;
+
+extern braille_code* Braille_UpperNumbers[];
+
+//#lower numbers
+extern braille_code Braille_Lower0;
+extern braille_code Braille_Lower1;
+extern braille_code Braille_Lower2;
+extern braille_code Braille_Lower3;
+extern braille_code Braille_Lower4;
+extern braille_code Braille_Lower5;
+extern braille_code Braille_Lower6;
+extern braille_code Braille_Lower7;
+extern braille_code Braille_Lower8;
+extern braille_code Braille_Lower9;
+
+extern braille_code* Braille_LowerNumbers[];
+
+//[NoteShape]
+//#Notes: Braille note shapes are same such as whole=16th=256, half=32nd=512 etc.
+//#to deal with complicate back-translation and reading issues, each note should be defined, even it could easily handle by coding.
+extern braille_code Braille_aWhole;
+extern braille_code Braille_aHalf;
+extern braille_code Braille_aQuarter;
+extern braille_code Braille_a8th;
+extern braille_code Braille_bWhole;
+extern braille_code Braille_bHalf;
+extern braille_code Braille_bQuarter;
+extern braille_code Braille_b8th;
+extern braille_code Braille_cWhole;
+extern braille_code Braille_cHalf;
+extern braille_code Braille_cQuarter;
+extern braille_code Braille_c8th;
+extern braille_code Braille_dWhole;
+extern braille_code Braille_dHalf;
+extern braille_code Braille_dQuarter;
+extern braille_code Braille_d8th;
+extern braille_code Braille_eWhole;
+extern braille_code Braille_eHalf;
+extern braille_code Braille_eQuarter;
+extern braille_code Braille_e8th;
+extern braille_code Braille_fWhole;
+extern braille_code Braille_fHalf;
+extern braille_code Braille_fQuarter;
+extern braille_code Braille_f8th;
+extern braille_code Braille_gWhole;
+extern braille_code Braille_gHalf;
+extern braille_code Braille_gQuarter;
+extern braille_code Braille_g8th;
+//#16th to 128th notes
+extern braille_code Braille_a16th;
+extern braille_code Braille_a32nd;
+extern braille_code Braille_a64th;
+extern braille_code Braille_a128th;
+extern braille_code Braille_b16th;
+extern braille_code Braille_b32nd;
+extern braille_code Braille_b64th;
+extern braille_code Braille_b128th;
+extern braille_code Braille_c16th;
+extern braille_code Braille_c32nd;
+extern braille_code Braille_c64th;
+extern braille_code Braille_c128th;
+extern braille_code Braille_d16th;
+extern braille_code Braille_d32nd;
+extern braille_code Braille_d64th;
+extern braille_code Braille_d128th;
+extern braille_code Braille_e16th;
+extern braille_code Braille_e32nd;
+extern braille_code Braille_e64th;
+extern braille_code Braille_e128th;
+extern braille_code Braille_f16th;
+extern braille_code Braille_f32nd;
+extern braille_code Braille_f64th;
+extern braille_code Braille_f128th;
+extern braille_code Braille_g16th;
+extern braille_code Braille_g32nd;
+extern braille_code Braille_g64th;
+extern braille_code Braille_g128th;
+//#256th to 2048th notes
+extern braille_code Braille_a256th;
+extern braille_code Braille_a512th;
+extern braille_code Braille_a1024th;
+extern braille_code Braille_a2048th;
+extern braille_code Braille_b256th;
+extern braille_code Braille_b512th;
+extern braille_code Braille_b1024th;
+extern braille_code Braille_b2048th;
+extern braille_code Braille_c256th;
+extern braille_code Braille_c512th;
+extern braille_code Braille_c1024th;
+extern braille_code Braille_c2048th;
+extern braille_code Braille_d256th;
+extern braille_code Braille_d512th;
+extern braille_code Braille_d1024th;
+extern braille_code Braille_d2048th;
+extern braille_code Braille_e256th;
+extern braille_code Braille_e512th;
+extern braille_code Braille_e1024th;
+extern braille_code Braille_e2048th;
+extern braille_code Braille_f256th;
+extern braille_code Braille_f512th;
+extern braille_code Braille_f1024th;
+extern braille_code Braille_f2048th;
+extern braille_code Braille_g256th;
+extern braille_code Braille_g512th;
+extern braille_code Braille_g1024th;
+extern braille_code Braille_g2048th;
+//#special notes: breve (double whole notes)
+//#Advised to use the definitions of Haipeng as first option for breve notes right below this section.
+extern braille_code Braille_aBreve;
+extern braille_code Braille_bBreve;
+extern braille_code Braille_cBreve;
+extern braille_code Braille_dBreve;
+extern braille_code Braille_eBreve;
+extern braille_code Braille_fBreve;
+extern braille_code Braille_gBreve;
+//##########Added by Haipeng
+//#Another kind of breve, mainly used other than the above one which should be used mainly in plain chant
+extern braille_code Braille_aBreveAlt;
+extern braille_code Braille_bBreveAlt;
+extern braille_code Braille_cBreveAlt;
+extern braille_code Braille_dBreveAlt;
+extern braille_code Braille_eBreveAlt;
+extern braille_code Braille_fBreveAlt;
+extern braille_code Braille_gBreveAlt;
+//##Other longer notes in ancient music, including Longa and Maxima (quadruple whole note)
+extern braille_code Braille_aLonga;
+extern braille_code Braille_bLonga;
+extern braille_code Braille_cLonga;
+extern braille_code Braille_dLonga;
+extern braille_code Braille_eLonga;
+extern braille_code Braille_fLonga;
+extern braille_code Braille_gLonga;
+extern braille_code Braille_aMaxima;
+extern braille_code Braille_bMaxima;
+extern braille_code Braille_cMaxima;
+extern braille_code Braille_dMaxima;
+extern braille_code Braille_eMaxima;
+extern braille_code Braille_fMaxima;
+extern braille_code Braille_gMaxima;
+
+extern braille_code* Braille_aNotes[];
+extern braille_code* Braille_bNotes[];
+extern braille_code* Braille_cNotes[];
+extern braille_code* Braille_dNotes[];
+extern braille_code* Braille_eNotes[];
+extern braille_code* Braille_fNotes[];
+extern braille_code* Braille_gNotes[];
+
+extern braille_code* Braille_wholeNotes[];
+extern braille_code* Braille_halfNotes[];
+extern braille_code* Braille_quarterNotes[];
+extern braille_code* Braille_8thNotes[];
+extern braille_code* Braille_16thNotes[];
+extern braille_code* Braille_32ndNotes[];
+extern braille_code* Braille_64thNotes[];
+extern braille_code* Braille_128thNotes[];
+extern braille_code* Braille_256thNotes[];
+extern braille_code* Braille_512thNotes[];
+extern braille_code* Braille_1024thNotes[];
+extern braille_code* Braille_2048thNotes[];
+//####################
+
+//#Braille rests' shapes are same as notes above, whole rest=16th rest=256th etc.
+extern braille_code Braille_RestWhole;
+extern braille_code Braille_RestHalf;
+extern braille_code Braille_RestQuarter;
+extern braille_code Braille_Rest8th;
+//#16th to 128th rests
+extern braille_code Braille_Rest16th;
+extern braille_code Braille_Rest32nd;
+extern braille_code Braille_Rest64th;
+extern braille_code Braille_Rest128th;
+//#256th to 2048th rests
+extern braille_code Braille_Rest256th;
+extern braille_code Braille_Rest512th;
+extern braille_code Braille_Rest1024th;
+extern braille_code Braille_Rest2048th;
+//#breve rest, use Haipeng's breve rest definition below as first option.
+extern braille_code Braille_RestBreve;
+//##########Added by Haipeng##########
+//#More widely used Breve rest, swap the above with Alt
+extern braille_code Braille_RestBreveAlt;
+//#Other longer rests in ancient music
+extern braille_code Braille_RestLonga;
+extern braille_code Braille_RestMaxima;
+
+extern braille_code* Braille_Rests[];
+//####################
+
+//[MusicPunctuation]
+extern braille_code Braille_PlusSign;
+extern braille_code Braille_MinusSign;
+extern braille_code Braille_SlashSign;
+//#note dot sign, to add value for the associated note and some other situations
+extern braille_code Braille_Dot;
+extern braille_code Braille_Parentheses;
+extern braille_code Braille_OpenParentheses;
+extern braille_code Braille_CloseParentheses;
+extern braille_code Braille_SpecialParentheses;
+extern braille_code Braille_PageIndicator;
+extern braille_code Braille_LineIndicator;
+extern braille_code Braille_Hyphen;
+extern braille_code Braille_MusicComma;
+extern braille_code Braille_MusicCommaEnd;
+//##########Added by Haipeng##########
+//#Prefix for cautionary accidentals and hidden rests
+extern braille_code Braille_Cautionary;
+//#Prefix for editorial elements such as dashed slurs, ties and hairpins
+extern braille_code Braille_Editorial;
+//####################
+extern braille_code Braille_EqualSign;
+extern braille_code Braille_UpperOpenBracket;
+extern braille_code Braille_UpperCloseBracket;
+extern braille_code Braille_UpperBrokenOpenBracket;
+extern braille_code Braille_UpperBrokenCloseBracket;
+extern braille_code Braille_UpperOpenEndedBracket;
+extern braille_code Braille_UpperCloseEndedBracket;
+extern braille_code Braille_LowerOpenBracket;
+extern braille_code Braille_LowerCloseBracket;
+extern braille_code Braille_LowerBrokenOpenBracket;
+extern braille_code Braille_LowerBrokenCloseBracket;
+extern braille_code Braille_LowerOpenEndedBracket;
+extern braille_code Braille_LowerCloseEndedBracket;
+extern braille_code Braille_OpenMusicCodeIndicator;
+extern braille_code Braille_CloseMusicCodeIndicator;
+extern braille_code Braille_AsteriskSign;
+extern braille_code Braille_FootnoteSeparator;
+
+//[Harmony]
+extern braille_code Braille_Diminished;
+extern braille_code Braille_HalfDiminished;
+extern braille_code Braille_Triangle;
+extern braille_code Braille_HalfTriangle;
+//#No chord
+extern braille_code Braille_NoHarmony;
+
+//##########Newly added by Haipeng
+//[FiguredBass]
+//#A figure is prefixed by a number sign, so here only give the signs not available elsewhere
+extern braille_code Braille_IsolatedSharp;
+extern braille_code Braille_IsolatedDoubleSharp;
+extern braille_code Braille_IsolatedFlat;
+extern braille_code Braille_IsolatedDoubleFlat;
+extern braille_code Braille_IsolatedNatural;
+extern braille_code Braille_Cross;
+
+extern braille_code Braille_FiguredBassIndicator;
+extern braille_code Braille_FiguredBassSeparator;
+extern braille_code Braille_PlusAccidental;
+extern braille_code Braille_AccidentalIsolator;
+extern braille_code Braille_BackslashFigure;
+extern braille_code Braille_SlashFigure;
+extern braille_code Braille_FigureExtension;
+//####################
+
+//[ValueIndicator]
+//#note value indicators: to add before a note having same Braille shape but with different value like between  half and 32nd notes.
+//#whole-8th notes range
+extern braille_code Braille_FirstValueRange;
+//#16th-128th notes range
+extern braille_code Braille_SecondValueRange;
+//#256th notes and and further range
+extern braille_code Braille_ThirdValueRange;
+
+extern braille_code* Braille_ValueRanges[];
+
+//[Octave]
+//#octave signs
+//#based on Piano keyboard, octave 0 and 8 for lowest and highest notes out of the full octave
+//#there are 7 full octaves from 1 to 7
+extern braille_code Braille_Octave0;
+extern braille_code Braille_Octave1;
+extern braille_code Braille_Octave2;
+extern braille_code Braille_Octave3;
+extern braille_code Braille_Octave4;
+extern braille_code Braille_Octave5;
+extern braille_code Braille_Octave6;
+extern braille_code Braille_Octave7;
+extern braille_code Braille_Octave8;
+
+extern braille_code* Braille_Octaves[];
+
+//[Clef]
+//#clef signs
+extern braille_code Braille_ClefG;
+extern braille_code Braille_ClefF;
+extern braille_code Braille_ClefC;
+//#Treble and bass clefs used in different hands
+extern braille_code Braille_ClefGLeft;
+extern braille_code Braille_ClefFRight;
+//#special clefs
+//#G/F/C clef on first line (French violin), second/third/fourth/fifth line etc
+extern braille_code Braille_ClefGFirstLine;
+extern braille_code Braille_ClefGThirdLine;
+extern braille_code Braille_ClefGFourthLine;
+extern braille_code Braille_ClefGFifthLine;
+extern braille_code Braille_ClefFFirstLine;
+extern braille_code Braille_ClefFSecondLine;
+extern braille_code Braille_ClefFThirdLine;
+//extern braille_code Braille_ClefFFourthLine = {"ClefFFourthLine", "345-3456-5-123", false, false};
+extern braille_code Braille_ClefFFifthLine;
+extern braille_code Braille_ClefCFirstLine;
+extern braille_code Braille_ClefCSecondLine;
+//extern braille_code Braille_ClefCThirdLine = {"ClefCThirdLine", "345-346-456-123", false, false};
+extern braille_code Braille_ClefCFourthLine;
+extern braille_code Braille_ClefCFifthLine;
+
+//[HandSign]
+//#hands
+extern braille_code Braille_RightHand;
+extern braille_code Braille_LeftHand;
+//##########Added by Haipeng##########
+//#Right and left hands with reversed interval directions in hand-changing passage. Not used for general interval direction changes such as piano left hand reading downwards in orchestral scores where all intervals are down.
+extern braille_code Braille_RightHandUp;
+extern braille_code Braille_LeftHandDown;
+//####################
+extern braille_code Braille_OrganPedal;
+//##########Added by Haipeng##########
+//#Chord and figured bass prefix
+extern braille_code Braille_ChordPrefix;
+//#Accordion prefix, detected by instrument definition
+//AccordionBass 6-345
+//#Outline prefix, when producing piano accompaniment with melody outline
+extern braille_code Braille_Outline;
+//####################
+
+//[Accidental]
+//#accidental signs: natural, sharp and flat.
+extern braille_code Braille_NaturalAccidental;
+//#sharps
+extern braille_code Braille_SharpAccidental;
+//#1/4 sharp
+extern braille_code Braille_QuarterSharp;
+//#3/4 sharp
+extern braille_code Braille_ThreeQuarterSharp;
+//#flats
+extern braille_code Braille_FlatAccidental;
+extern braille_code Braille_QuarterFlat;
+extern braille_code Braille_ThreeQuarterFlat;
+
+extern braille_code* Braille_Accidentals[];
+//[TimeSignature]
+//#Time signatures
+extern braille_code Braille_CommonTime;
+extern braille_code Braille_CutTime;
+//# time signature by seconds
+extern braille_code Braille_TimeInSecondSign;
+extern braille_code Braille_TimeExtensionSign;
+//[Tie]
+//#ties
+extern braille_code Braille_NoteTie;
+extern braille_code Braille_ChordTie;
+extern braille_code Braille_ChordTieDoubling;
+extern braille_code Braille_Arpeggio;
+extern braille_code Braille_TieLetRing;
+extern braille_code Braille_TieNoStart;
+//##########Added by Haipeng##########
+extern braille_code Braille_TieCrossVoice;
+extern braille_code Braille_TieCrossVoiceFrom;
+extern braille_code Braille_TieCrossStaff;
+extern braille_code Braille_TieCrossStaffFrom;
+extern braille_code Braille_ChordTieCrossVoice;
+extern braille_code Braille_ChordTieCrossVoiceFrom;
+extern braille_code Braille_ChordTieCrossStaff;
+extern braille_code Braille_ChordTieCrossStaffFrom;
+//####################
+//[Slur]
+//#slurs
+extern braille_code Braille_NoteSlur;
+extern braille_code Braille_LongSlurOpenBracket;
+extern braille_code Braille_LongSlurCloseBracket;
+extern braille_code Braille_ConvergentSlur;
+extern braille_code Braille_SameNoteSlur;
+
+extern braille_code Braille_GraceSlur;
+extern braille_code Braille_GraceSlurDoubling;
+//##########Added by Haipeng##########
+extern braille_code Braille_SlurCrossVoice;
+extern braille_code Braille_SlurCrossVoiceFrom;
+extern braille_code Braille_SlurCrossStaff;
+extern braille_code Braille_SlurCrossStaffFrom;
+//####################
+//[Interval]
+//#Intervals, Braille signs to write for chords
+//#Braille sign for second interval has same dots for 9, 16, 23 (+7)
+extern braille_code Braille_Interval2;
+extern braille_code Braille_Interval3;
+extern braille_code Braille_Interval4;
+extern braille_code Braille_Interval5;
+extern braille_code Braille_Interval6;
+extern braille_code Braille_Interval7;
+extern braille_code Braille_Interval8;
+
+extern braille_code* Braille_Intervals[];
+//[Tuplet]
+//#tuplet: note grouping 2/3/5/6/XXX-notes grouping
+extern braille_code Braille_Tuplet3;
+extern braille_code Braille_TupletPrefix;
+extern braille_code Braille_TupletSuffix;
+//[Repetition]
+//#repeats' signs in print score
+extern braille_code Braille_RepetitionForward;
+extern braille_code Braille_RepetitionBackward;
+extern braille_code Braille_Coda;
+extern braille_code Braille_Segno;
+// Fermata
+extern braille_code Braille_InvertedType;
+extern braille_code Braille_FermataDefault;
+extern braille_code Braille_FermataSquare;
+extern braille_code Braille_FermataAngled;
+extern braille_code Braille_FermataDoubleSquare;
+extern braille_code Braille_FermataDoubleAngled;
+extern braille_code Braille_FermataHalfCurve;
+extern braille_code Braille_FermataDoubleDot;
+//##Newly added by Haipeng##
+extern braille_code Braille_FermataBarline;
+extern braille_code Braille_FermataNormalBarline;
+//#Braille measure or partial repetition sign
+extern braille_code Braille_NotesRepeat;
+//#Newly added by Haipeng##
+//#This repeat should be used according to beamings in unmeasured passage. It should be used between beams, within a long beam, but can't cross beams in different places, thus break the musical meaning implied by the beaming.
+extern braille_code Braille_StartingBeamRepeat;
+//[Barline]
+//#barlines
+extern braille_code Braille_SingleBarline;
+extern braille_code Braille_DashedBarline;
+extern braille_code Braille_SpecialBarline;
+extern braille_code Braille_SectionalDouble;
+extern braille_code Braille_FinalDouble;
+//[Finger]
+//#fingering
+extern braille_code Braille_Finger0;
+extern braille_code Braille_Finger1;
+extern braille_code Braille_Finger2;
+extern braille_code Braille_Finger3;
+extern braille_code Braille_Finger4;
+extern braille_code Braille_Finger5;
+
+extern braille_code Braille_FingerSlur;
+
+extern braille_code* Braille_Fingers[];
+//##Comment by Haipeng: The names above are not strict, but I believe they can be correctly mapped to Musicxml.##
+//[Pluck]
+//#plucks, for string instruments
+extern braille_code Braille_PluckP;
+extern braille_code Braille_PluckI;
+extern braille_code Braille_PluckM;
+extern braille_code Braille_PluckA;
+extern braille_code Braille_PluckC;
+
+extern braille_code* Braille_Plucks[];
+
+extern braille_code Braille_Dot6PluckP;
+extern braille_code Braille_Dot6PluckI;
+extern braille_code Braille_Dot6PluckM;
+extern braille_code Braille_Dot6PluckA;
+extern braille_code Braille_Dot6PluckC;
+//[String]
+//#string
+extern braille_code Braille_String1;
+extern braille_code Braille_String2;
+extern braille_code Braille_String3;
+extern braille_code Braille_String4;
+extern braille_code Braille_String5;
+extern braille_code Braille_String6;
+extern braille_code Braille_String7;
+
+extern braille_code* Braille_Strings[];
+
+extern braille_code Braille_String1_Doubling;
+extern braille_code Braille_String2_Doubling;
+extern braille_code Braille_String3_Doubling;
+extern braille_code Braille_String4_Doubling;
+extern braille_code Braille_String5_Doubling;
+extern braille_code Braille_String6_Doubling;
+extern braille_code Braille_String7_Doubling;
+
+extern braille_code* Braille_Strings_Doubling[];
+//[Fret]
+//#frets
+extern braille_code Braille_Fret1;
+extern braille_code Braille_Fret2;
+extern braille_code Braille_Fret3;
+extern braille_code Braille_Fret4;
+extern braille_code Braille_Fret5;
+extern braille_code Braille_Fret6;
+extern braille_code Braille_Fret7;
+extern braille_code Braille_Fret8;
+extern braille_code Braille_Fret9;
+extern braille_code Braille_Fret10;
+extern braille_code Braille_Fret11;
+extern braille_code Braille_Fret12;
+extern braille_code Braille_Fret13;
+
+extern braille_code* Braille_Frets[];
+//[VoiceAccord]
+//#accord
+extern braille_code Braille_FullMeasureAccord;
+extern braille_code Braille_PartialMeasureAccord;
+extern braille_code Braille_MeasureSeparator;
+//[Pedal]
+//#pedal signs
+extern braille_code Braille_PedalDown;
+extern braille_code Braille_PedalUp;
+extern braille_code Braille_NotePedalUpDownAtNote;
+extern braille_code Braille_HalfPedal;
+extern braille_code Braille_AfterNotePedalDown;
+extern braille_code Braille_AfterNotePedalUp;
+extern braille_code Braille_NoPedal;
+//[Ornament]
+//#articulations, ornaments
+extern braille_code Braille_Spiccato;
+extern braille_code Braille_Staccato;
+extern braille_code Braille_Staccatissimo;
+extern braille_code Braille_DetachedLegato;
+extern braille_code Braille_Tenuto;
+extern braille_code Braille_Accent;
+extern braille_code Braille_Stress;
+extern braille_code Braille_Unstress;
+extern braille_code Braille_StrongAccent;
+//##########Added by Haipeng##########
+extern braille_code Braille_SoftAccent;
+extern braille_code Braille_Scoop;
+extern braille_code Braille_Plop;
+extern braille_code Braille_Doit;
+extern braille_code Braille_Falloff;
+extern braille_code Braille_UpBow;
+extern braille_code Braille_DownBow;
+extern braille_code Braille_HarmonicNatural;
+extern braille_code Braille_HarmonicArtificial;
+extern braille_code Braille_OpenString;
+extern braille_code Braille_Stopped;
+extern braille_code Braille_SnapPizzicato;
+extern braille_code Braille_HammerOn;
+extern braille_code Braille_PullOff;
+//####################
+extern braille_code Braille_ArpeggiateUp;
+extern braille_code Braille_ArpeggiateDown;
+extern braille_code Braille_Cue;
+extern braille_code Braille_GraceShort;
+extern braille_code Braille_GraceLong;
+extern braille_code Braille_TrillMark;
+extern braille_code Braille_Turn;
+extern braille_code Braille_InvertedTurn;
+extern braille_code Braille_DelayedTurn;
+extern braille_code Braille_DelayedInvertedTurn;
+extern braille_code Braille_MordentShort;
+extern braille_code Braille_MordentLong;
+extern braille_code Braille_InvertedMordentShort;
+extern braille_code Braille_InvertedMordentLong;
+//##Added by Haipeng##
+extern braille_code Braille_Schleifer;
+extern braille_code Braille_Shake;
+extern braille_code Braille_BreathMark;
+extern braille_code Braille_Caesura;
+
+extern braille_code Braille_TremoloSingle1;
+extern braille_code Braille_TremoloSingle2;
+extern braille_code Braille_TremoloSingle3;
+extern braille_code Braille_TremoloSingle4;
+extern braille_code Braille_TremoloSingle5;
+
+extern braille_code* Braille_TremoloSingles[];
+
+extern braille_code Braille_TremoloDouble1;
+extern braille_code Braille_TremoloDouble2;
+extern braille_code Braille_TremoloDouble3;
+extern braille_code Braille_TremoloDouble4;
+extern braille_code Braille_TremoloDouble5;
+
+extern braille_code* Braille_TremoloDoubles[];
+
+extern braille_code Braille_Glissando;
+extern braille_code Braille_LongGlissandoStart;
+extern braille_code Braille_LongGlissandoStop;
+extern braille_code Braille_Slide;
+extern braille_code Braille_LongSlideStart;
+extern braille_code Braille_LongSlideStop;
+//##########Added by Haipeng##########
+//[Noteheads]
+extern braille_code Braille_blackHead;
+extern braille_code Braille_XShape;
+extern braille_code Braille_Diamond;
+extern braille_code Braille_DiamondHarmonic;
+extern braille_code Braille_Slashed;
+//#Comment: If the diamond is in a chord, then use DiamondHarmonic, since it's an artificial harmonic.
+extern braille_code Braille_StemOnly;
+extern braille_code Braille_Circled;
+//[Stems]
+extern braille_code Braille_StemPrefix;
+extern braille_code Braille_StemWhole;
+extern braille_code Braille_StemHalf;
+extern braille_code Braille_StemQuarter;
+extern braille_code Braille_Stem8th;
+extern braille_code Braille_Stem16th;
+extern braille_code Braille_Stem32nd;
+//[HarpPedalDiagram]
+extern braille_code Braille_HarpPedalBegin;
+extern braille_code Braille_HarpPedalEnd;
+extern braille_code Braille_HarpPedalRaised;
+extern braille_code Braille_HarpPedalCentered;
+extern braille_code Braille_HarpPedalLowered;
+extern braille_code Braille_HarpPedalDivider;
+//[FetherBeams]
+extern braille_code Braille_FanBeamAccelerando;
+extern braille_code Braille_FanBeamRitardando;
+extern braille_code Braille_FanBeamSteady;
+extern braille_code Braille_FanBeamEnd;
+// Placement
+extern braille_code Braille_PlacementBelow;
+// Hand interval up/down
+extern braille_code Braille_LeftHandIntervalDown;
+extern braille_code Braille_RightHandIntervalUp;
+// Additional braille codes
+extern braille_code Braille_NewLine;
+// Slurs
+extern braille_code Braille_SlurCrossVoiceDubling;
+extern braille_code Braille_SlurCrossStaffDubling;
+// Wavy
+extern braille_code Braille_OrnamentWavyStart;
+extern braille_code Braille_OrnamentWavyStop;
+extern braille_code Braille_WavyRepetitionLine;
+// Dubling
+extern braille_code Braille_CueDubling;
+extern braille_code Braille_GraceLongDubling;
+// Noteheads dubling
+extern braille_code Braille_blackHeadDubling;
+extern braille_code Braille_XShapeDubling;
+extern braille_code Braille_DiamondDubling;
+extern braille_code Braille_DiamondHarmonicDubling;
+extern braille_code Braille_SlashedDubling;
+extern braille_code Braille_StemOnlyDubling;
+extern braille_code Braille_CircledDubling;
+// Tremolo dubling
+extern braille_code Braille_TremoloSingle1Dubling;
+extern braille_code Braille_TremoloSingle2Dubling;
+extern braille_code Braille_TremoloSingle3Dubling;
+extern braille_code Braille_TremoloSingle4Dubling;
+extern braille_code Braille_TremoloSingle5Dubling;
+extern braille_code Braille_TremoloDouble1Dubling;
+extern braille_code Braille_TremoloDouble2Dubling;
+extern braille_code Braille_TremoloDouble3Dubling;
+extern braille_code Braille_TremoloDouble4Dubling;
+extern braille_code Braille_TremoloDouble5Dubling;
+// Dash sign
+extern braille_code Braille_DashSign;
+// Dashline
+extern braille_code Braille_DashLineStart;
+extern braille_code Braille_DashLineStop;
+extern braille_code Braille_DashNestedLineStart;
+extern braille_code Braille_DashNestedLineStop;
+// Elision
+extern braille_code Braille_Elision2;
+extern braille_code Braille_Elision3;
+// Empty
+extern braille_code Braille_Empty;
+// line over line format
+extern braille_code Braille_HarmonyLineIndicator;
+extern braille_code Braille_LyricLineIndicator;
+extern braille_code Braille_MusicLineIndicator;
+extern braille_code Braille_PluckLineIndicator;
+extern braille_code Braille_SoloMelodyLineIndicator;
+// wedge stop
+extern braille_code Braille_WedgeCStop;
+extern braille_code Braille_WedgeDStop;
+// Repeats
+extern braille_code Braille_PartialRepeat;
+extern braille_code Braille_MeasureRepeat;
+// Check dot
+extern braille_code Braille_CheckDot;
+// Check figure Bass Separator
+extern braille_code Braille_CheckFiguredBassSeparator;
+//
+extern braille_code Braille_ThumbPosition;
+// Accordion
+extern braille_code Braille_AccordionMiddle2;
+extern braille_code Braille_AccordionMiddle3;
+// String intrument
+extern braille_code Braille_LeftHandPizzicato;
+
+std::string getBraillePattern(std::string dots);
+std::string translate2Braille(std::string codes);
+std::string intToBrailleUpperNumbers(std::string txt, bool indicator);
+std::string intToBrailleLowerNumbers(std::string txt, bool indicator);
+
+braille_code* findBrailleCode(std::string code, bool partial_match = false);
+braille_code* findNote(const std::string braille);
+braille_code* findRest(const std::string braille);
+braille_code* findOctave(const std::string braille);
+braille_code* findAccidental(const std::string braille);
+braille_code* findFinger(const std::string braille);
+braille_code* findInterval(const std::string braille);
+}
+#endif // MU_BRAILLE_BRAILLEDOTS_H

--- a/src/braille/internal/braillecode.h
+++ b/src/braille/internal/braillecode.h
@@ -35,7 +35,7 @@ public:
     std::string tag;
     std::string code;
     std::string braille;
-    int cells_num;
+    int num_cells;
 };
 
 //In the table below, things added by Haipeng are indicated as this:

--- a/src/braille/internal/brailleconfiguration.cpp
+++ b/src/braille/internal/brailleconfiguration.cpp
@@ -24,6 +24,7 @@
 
 #include "settings.h"
 
+using namespace mu::braille;
 using namespace mu::framework;
 
 namespace mu::engraving {
@@ -43,7 +44,7 @@ void BrailleConfiguration::init()
     settings()->valueChanged(BRAILLE_TABLE).onReceive(this, [this](const Val&) {
         m_brailleTableChanged.notify();
     });
-    settings()->setDefaultValue(BRAILLE_INTERVAL_DIRECTION, Val("Auto"));
+    settings()->setDefaultValue(BRAILLE_INTERVAL_DIRECTION, Val(BrailleIntervalDirection::Auto));
     settings()->valueChanged(BRAILLE_INTERVAL_DIRECTION).onReceive(this, [this](const Val&) {
         m_intervalDirectionChanged.notify();
     });
@@ -69,23 +70,14 @@ async::Notification BrailleConfiguration::intervalDirectionChanged() const
     return m_intervalDirectionChanged;
 }
 
-QString BrailleConfiguration::intervalDirection() const
+BrailleIntervalDirection BrailleConfiguration::intervalDirection() const
 {
-    return settings()->value(BRAILLE_INTERVAL_DIRECTION).toQString();
+    return settings()->value(BRAILLE_INTERVAL_DIRECTION).toEnum<BrailleIntervalDirection>();
 }
 
-void BrailleConfiguration::setIntervalDirection(const QString direction)
+void BrailleConfiguration::setIntervalDirection(const BrailleIntervalDirection direction)
 {
     settings()->setSharedValue(BRAILLE_INTERVAL_DIRECTION, Val(direction));
-}
-
-QStringList BrailleConfiguration::intervalDirectionsList() const
-{
-    return {
-        "Auto",
-        "Up",
-        "Down",
-    };
 }
 
 async::Notification BrailleConfiguration::brailleTableChanged() const

--- a/src/braille/internal/brailleconfiguration.cpp
+++ b/src/braille/internal/brailleconfiguration.cpp
@@ -19,19 +19,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include "brailleconfiguration.h"
 
 #include "settings.h"
 
-using namespace mu;
 using namespace mu::framework;
-using namespace mu::async;
 
 namespace mu::engraving {
 static const std::string module_name("braille");
 
 static const Settings::Key BRAILLE_STATUS(module_name, "score/braille/status");
 static const Settings::Key BRAILLE_TABLE(module_name, "score/braille/table");
+static const Settings::Key BRAILLE_INTERVAL_DIRECTION(module_name, "score/braille/intervalDirection");
 
 void BrailleConfiguration::init()
 {
@@ -39,9 +39,13 @@ void BrailleConfiguration::init()
     settings()->valueChanged(BRAILLE_STATUS).onReceive(this, [this](const Val&) {
         m_braillePanelEnabledChanged.notify();
     });
-    settings()->setDefaultValue(BRAILLE_TABLE, Val("default"));
+    settings()->setDefaultValue(BRAILLE_TABLE, Val("Unified English uncontracted braille [en-ueb-g1.ctb]"));
     settings()->valueChanged(BRAILLE_TABLE).onReceive(this, [this](const Val&) {
         m_brailleTableChanged.notify();
+    });
+    settings()->setDefaultValue(BRAILLE_INTERVAL_DIRECTION, Val("Auto"));
+    settings()->valueChanged(BRAILLE_INTERVAL_DIRECTION).onReceive(this, [this](const Val&) {
+        m_intervalDirectionChanged.notify();
     });
 }
 
@@ -60,6 +64,30 @@ void BrailleConfiguration::setBraillePanelEnabled(const bool enabled)
     settings()->setSharedValue(BRAILLE_STATUS, Val(enabled));
 }
 
+async::Notification BrailleConfiguration::intervalDirectionChanged() const
+{
+    return m_intervalDirectionChanged;
+}
+
+QString BrailleConfiguration::intervalDirection() const
+{
+    return settings()->value(BRAILLE_INTERVAL_DIRECTION).toQString();
+}
+
+void BrailleConfiguration::setIntervalDirection(const QString direction)
+{
+    settings()->setSharedValue(BRAILLE_INTERVAL_DIRECTION, Val(direction));
+}
+
+QStringList BrailleConfiguration::intervalDirectionsList() const
+{
+    return {
+        "Auto",
+        "Up",
+        "Down",
+    };
+}
+
 async::Notification BrailleConfiguration::brailleTableChanged() const
 {
     return m_brailleTableChanged;
@@ -70,12 +98,12 @@ QString BrailleConfiguration::brailleTable() const
     return settings()->value(BRAILLE_TABLE).toQString();
 }
 
-void BrailleConfiguration::setBrailleTable(const QString tabl)
+void BrailleConfiguration::setBrailleTable(const QString table)
 {
-    settings()->setSharedValue(BRAILLE_TABLE, Val(tabl));
+    settings()->setSharedValue(BRAILLE_TABLE, Val(table));
 }
 
-QStringList BrailleConfiguration::brailleTableList()
+QStringList BrailleConfiguration::brailleTableList() const
 {
     return {
         "Afrikaans uncontracted braille [afr-za-g1.ctb]",

--- a/src/braille/internal/brailleconfiguration.h
+++ b/src/braille/internal/brailleconfiguration.h
@@ -19,6 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #ifndef MU_BRAILLE_BRAILLECONFIGURATION_H
 #define MU_BRAILLE_BRAILLECONFIGURATION_H
 
@@ -36,15 +37,20 @@ public:
     bool braillePanelEnabled() const override;
     void setBraillePanelEnabled(const bool enabled) override;
 
+    async::Notification intervalDirectionChanged() const override;
+    QString intervalDirection() const override;
+    void setIntervalDirection(const QString) override;
+    QStringList intervalDirectionsList() const override;
+
     async::Notification brailleTableChanged() const override;
     QString brailleTable() const override;
     void setBrailleTable(const QString table) override;
-
-    QStringList brailleTableList() override;
+    QStringList brailleTableList() const override;
 
 private:
     async::Notification m_braillePanelEnabledChanged;
     async::Notification m_brailleTableChanged;
+    async::Notification m_intervalDirectionChanged;
 };
 }
 

--- a/src/braille/internal/brailleconfiguration.h
+++ b/src/braille/internal/brailleconfiguration.h
@@ -38,9 +38,8 @@ public:
     void setBraillePanelEnabled(const bool enabled) override;
 
     async::Notification intervalDirectionChanged() const override;
-    QString intervalDirection() const override;
-    void setIntervalDirection(const QString) override;
-    QStringList intervalDirectionsList() const override;
+    braille::BrailleIntervalDirection intervalDirection() const override;
+    void setIntervalDirection(const braille::BrailleIntervalDirection) override;
 
     async::Notification brailleTableChanged() const override;
     QString brailleTable() const override;

--- a/src/braille/internal/brailleconverter.h
+++ b/src/braille/internal/brailleconverter.h
@@ -22,7 +22,7 @@
 #ifndef MU_BRAILLE_BRAILLECONVERTER_H
 #define MU_BRAILLE_BRAILLECONVERTER_H
 
-#include "../ibrailleconverter.h"
+#include "ibrailleconverter.h"
 
 namespace mu::engraving {
 class BrailleConverter : public mu::braille::IBrailleConverter

--- a/src/braille/internal/brailleinput.cpp
+++ b/src/braille/internal/brailleinput.cpp
@@ -1,0 +1,870 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2023 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "brailleinput.h"
+
+using namespace mu::notation;
+
+namespace mu::engraving {
+BrailleInputState brailleInputState;
+
+QString parseBrailleKeyInput(QString keys)
+{
+    static std::map<std::string, std::string > braille_input_keys = {
+        { "S", "3" }, { "D", "2" }, { "F", "1" },
+        { "J", "4" }, { "K", "5" }, { "L", "6" }
+    };
+
+    QStringList lst = keys.split(QString::fromStdString("+"));
+
+    std::vector<std::string> nlst;
+    for (int i = 0; i < lst.size(); i++) {
+        std::string key = lst.at(i).toStdString();
+
+        if (braille_input_keys.find(key) != braille_input_keys.end()) {
+            nlst.push_back(braille_input_keys[key]);
+        }
+    }
+    std::sort(nlst.begin(), nlst.end());
+
+    QString buff = QString();
+    for (auto n : nlst) {
+        buff.append(QString::fromStdString(n));
+    }
+
+    return buff;
+}
+
+NoteName getNoteName(const braille_code* code)
+{
+    char c = code->tag[0];
+    switch (c) {
+    case 'A': case 'a':
+        return NoteName::A;
+    case 'B': case 'b':
+        return NoteName::B;
+    case 'C': case 'c':
+        return NoteName::C;
+    case 'D': case 'd':
+        return NoteName::D;
+    case 'E': case 'e':
+        return NoteName::E;
+    case 'F': case 'f':
+        return NoteName::F;
+    case 'G': case 'g':
+        return NoteName::G;
+    }
+    return NoteName::C;
+}
+
+std::vector<DurationType> getNoteDurations(const braille_code* code)
+{
+    for (int i=0; i < 7; i++) {
+        if (code->code == Braille_wholeNotes[i]->code) {
+            //return {DurationType::V_WHOLE, DurationType::V_16TH, DurationType::V_256TH};
+            return { DurationType::V_WHOLE, DurationType::V_16TH };
+        }
+    }
+
+    for (int i=0; i < 7; i++) {
+        if (code->code == Braille_halfNotes[i]->code) {
+            //return {DurationType::V_HALF, DurationType::V_32ND, DurationType::V_512TH};
+            return { DurationType::V_HALF, DurationType::V_32ND };
+        }
+    }
+
+    for (int i=0; i < 7; i++) {
+        if (code->code == Braille_quarterNotes[i]->code) {
+            //return {DurationType::V_QUARTER, DurationType::V_64TH, DurationType::V_1024TH};
+            return { DurationType::V_QUARTER, DurationType::V_64TH };
+        }
+    }
+
+    for (int i=0; i < 7; i++) {
+        if (code->code == Braille_8thNotes[i]->code) {
+            return { DurationType::V_EIGHTH, DurationType::V_128TH };
+        }
+    }
+
+    return {};
+}
+
+std::vector<DurationType> getRestDurations(const braille_code* code)
+{
+    if (code->code == Braille_RestWhole.code) {
+        return { DurationType::V_WHOLE, DurationType::V_16TH };
+    }
+
+    if (code->code == Braille_RestHalf.code) {
+        return { DurationType::V_HALF, DurationType::V_32ND };
+    }
+
+    if (code->code == Braille_RestQuarter.code) {
+        return { DurationType::V_QUARTER, DurationType::V_64TH };
+    }
+
+    if (code->code == Braille_Rest8th.code) {
+        return { DurationType::V_EIGHTH, DurationType::V_128TH };
+    }
+
+    return {};
+}
+
+int getInterval(const braille_code* code)
+{
+    char c = code->tag.back();
+    if (c < '2' || c > '8') {
+        return -1;
+    } else {
+        return c - '0';
+    }
+}
+
+bool isNoteName(const braille_code* code)
+{
+    static std::vector<std::string> note_names = {
+        "aMaxima", "aLonga", "aBreve", "aWhole", "aHalf",
+        "aQuarter", "a8th", "a16th", "a32nd", "a64th", "a128th",
+        "a256th", "a512th", "a128th", "a2048th", "aBreveAlt",
+
+        "bMaxima", "bLonga", "bBreve", "bWhole", "bHalf",
+        "bQuarter", "b8th", "b16th", "b32nd", "b64th", "b128th",
+        "b256th", "b512th", "b128th", "b2048th", "bBreveAlt",
+
+        "cMaxima", "cLonga", "cBreve", "cWhole", "cHalf",
+        "cQuarter", "c8th", "c16th", "c32nd", "c64th", "c128th",
+        "c256th", "c512th", "c128th", "c2048th", "cBreveAlt",
+
+        "dMaxima", "dLonga", "dBreve", "dWhole", "dHalf",
+        "dQuarter", "d8th", "d16th", "d32nd", "d64th", "d128th",
+        "d256th", "d512th", "d128th", "d2048th", "dBreveAlt",
+
+        "eMaxima", "eLonga", "eBreve", "eWhole", "eHalf",
+        "eQuarter", "e8th", "e16th", "e32nd", "e64th", "e128th",
+        "e256th", "e512th", "e128th", "e2048th", "eBreveAlt",
+
+        "fMaxima", "fLonga", "fBreve", "fWhole", "fHalf",
+        "fQuarter", "f8th", "f16th", "f32nd", "f64th", "f128th",
+        "f256th", "f512th", "f128th", "f2048th", "fBreveAlt",
+
+        "gMaxima", "gLonga", "gBreve", "gWhole", "gHalf",
+        "gQuarter", "g8th", "g16th", "g32nd", "g64th", "g128th",
+        "g256th", "g512th", "g128th", "g2048th", "gBreveAlt",
+    };
+
+    return std::find(note_names.begin(), note_names.end(), code->tag) != note_names.end();
+}
+
+QString fromNoteName(NoteName notename)
+{
+    switch (notename) {
+    case NoteName::A:
+        return "A";
+    case NoteName::B:
+        return "B";
+    case NoteName::C:
+        return "C";
+    case NoteName::D:
+        return "D";
+    case NoteName::E:
+        return "E";
+    case NoteName::F:
+        return "F";
+    case NoteName::G:
+        return "G";
+    default:
+        return "";
+    }
+}
+
+AccidentalType getAccidentalType(const braille_code* code)
+{
+    if (code->tag == "NaturalAccidental") {
+        return AccidentalType::NATURAL;
+    }
+
+    if (code->tag == "SharpAccidental") {
+        return AccidentalType::SHARP;
+    }
+
+    if (code->tag == "FlatAccidental") {
+        return AccidentalType::FLAT;
+    }
+
+    return AccidentalType::NONE;
+}
+
+SymbolId getArticulation(const braille_code* code)
+{
+    static std::map<std::string, SymbolId> articulations = {
+        { "Finger0", SymbolId::fingering0 },
+        { "Finger1", SymbolId::fingering1 },
+        { "Finger2", SymbolId::fingering2 },
+        { "Finger3", SymbolId::fingering3 },
+        { "Finger4", SymbolId::fingering4 },
+        { "Finger5", SymbolId::fingering5 },
+    };
+
+    if (articulations.find(code->tag) != articulations.end()) {
+        return articulations[code->tag];
+    }
+
+    return SymbolId::noSym;
+}
+
+int getOctave(const braille_code* code)
+{
+    static std::map<std::string, int> octaves = {
+        { "Octave1", 1 }, { "Octave2", 2 }, { "Octave3", 3 }, { "Octave4", 4 },
+        { "Octave5", 5 }, { "Octave6", 6 }, { "Octave7", 7 },
+    };
+
+    if (octaves.find(code->tag) != octaves.end()) {
+        return octaves[code->tag];
+    }
+    return -1;
+}
+
+int getOctaveDiff(NoteName source, NoteName dest)
+// 0: same octave, -1: prev octave, 1: next octave
+{
+    if (dest > source) {
+        int diff = (int)dest - (int)source + 1;
+        return diff >= 6 ? -1 : 0;
+    } else if (dest < source) {
+        int diff = (int)source - (int)dest + 1;
+        return diff >= 6 ? +1 : 0;
+    } else {
+        return 0;
+    }
+}
+
+int getOctaveDiff(IntervalDirection direction, NoteName source, int interval)
+{
+    int diff;
+    switch (direction) {
+    case IntervalDirection::Up:
+        diff = (interval + (int)source - 1) / 7;
+        break;
+    case IntervalDirection::Down:
+        int src = (int)source + 1;
+        diff = 0;
+        while (src < interval) {
+            src += 7;
+            diff--;
+        }
+        break;
+    }
+    LOGD() << "Direction DOWN " << fromNoteName(source) << " " << (int)source << " " << interval << " diff " << diff;
+    return diff;
+}
+
+NoteName getNoteNameForInterval(IntervalDirection direction, NoteName source, int interval)
+{
+    NoteName note;
+    switch (direction) {
+    case IntervalDirection::Up:
+        note = (NoteName)(((int)source + interval - 1) % 7);
+        break;
+    case IntervalDirection::Down:
+        int src = (int)source;
+        while (src < interval) {
+            src += 7;
+        }
+        note = (NoteName)((src - interval) % 7 + 1);
+        break;
+    }
+    return note;
+}
+
+BrailleInputState::BrailleInputState()
+{
+    initialize();
+}
+
+BrailleInputState::~BrailleInputState()
+{
+    _input_buffer.clear();
+}
+
+void BrailleInputState::initialize()
+{
+    _accidental = AccidentalType::NONE;
+    _note_name = NoteName::C;
+    _articulation = SymbolId::noSym;
+    _octave = 4;
+    _voice = 0;
+    _dots = 0;
+    _input_buffer.clear();
+    _code_num = 0;
+    _note_slur = _long_slur_start = _long_slur_stop = _tie = false;
+    _note_group = NoteGroup::Group1;
+    _intervals.clear();
+    _accord = false;
+    _tuplet_number = -1;
+}
+
+void BrailleInputState::reset()
+{
+    _input_buffer = QString();
+    _accidental = AccidentalType::NONE;
+    _articulation = SymbolId::noSym;
+    _dots = 0;
+    _code_num = 0;
+    _note_slur = _long_slur_start = _long_slur_stop = _tie = false;
+    _added_octave = -1;
+    _accord = false;
+    _tuplet_indicator = false;
+}
+
+void BrailleInputState::resetBuffer()
+{
+    _input_buffer = QString();
+    _code_num = 0;
+}
+
+void BrailleInputState::insertToBuffer(const QString code)
+{
+    if (_input_buffer.isEmpty()) {
+        _input_buffer = code;
+        _code_num = 0;
+    } else {
+        _input_buffer.append("-").append(code);
+        _code_num++;
+    }
+}
+
+BieSequencePatternType BrailleInputState::parseBraille(IntervalDirection direction)
+{
+    std::string braille = translate2Braille(_input_buffer.toStdString());
+    BieSequencePattern* pattern = BieRecognize(braille, tupletIndicator());
+
+    if (pattern == NULL) {
+        return BieSequencePatternType::Undefined;
+    }
+
+    switch (pattern->type()) {
+    case BieSequencePatternType::Note: {
+        clearIntervals();
+
+        braille_code* code = pattern->res("note");
+
+        NoteName note_name = getNoteName(code);
+        int octave_diff = getOctaveDiff(chordBaseNoteName(), note_name);
+
+        setNoteName(note_name);
+        setNoteDurations(getNoteDurations(code));
+
+        code = pattern->res("octave");
+        if (code != NULL) {
+            setAddedOctave(getOctave(code));
+        } else {
+            setAddedOctave(chordBaseNoteOctave() + octave_diff);
+        }
+
+        code = pattern->res("accidental");
+        if (code != NULL) {
+            setAccidental(getAccidentalType(code));
+        }
+
+        code = pattern->res("long-slur-start");
+        if (code != NULL) {
+            setLongSlurStart(true);
+        }
+
+        code = pattern->res("accord");
+        if (code != NULL) {
+            setAccord(true);
+        }
+        break;
+    }
+    case BieSequencePatternType::Rest: {
+        braille_code* code = pattern->res("rest");
+        setNoteDurations(getRestDurations(code));
+
+        code = pattern->res("accord");
+        if (code != NULL) {
+            setAccord(true);
+        }
+        break;
+    }
+    case BieSequencePatternType::Interval: {
+        braille_code* code = pattern->res("interval");
+        int interval = getInterval(code);
+        interval = addInterval(interval);
+        int octave_diff = getOctaveDiff(direction, chordBaseNoteName(), interval);
+
+        NoteName note_name = getNoteNameForInterval(direction, chordBaseNoteName(), interval);
+        setNoteName(note_name, false);
+
+        code = pattern->res("octave");
+        if (code != NULL) {
+            setAddedOctave(getOctave(code));
+        } else {
+            setAddedOctave(chordBaseNoteOctave() + octave_diff);
+        }
+
+        code = pattern->res("accidental");
+        if (code != NULL) {
+            setAccidental(getAccidentalType(code));
+        }
+
+        break;
+    }
+    case BieSequencePatternType::Tuplet3: {
+        setTupletNumber(3);
+        setTupletDuration(Duration(DurationType::V_EIGHTH));
+        break;
+    }
+    case BieSequencePatternType::Tuplet: {
+        braille_code* code = pattern->res("tuplet-number");
+        setTupletNumber(code->tag.back() - '0');
+
+        code = pattern->res("c-note");
+
+        std::string stateTuplet;
+        stateTuplet = "Tuplet " + std::to_string(tupletNumber()) + " " + code->tag;
+        LOGD() << stateTuplet;
+        if (code->tag == "cWhole") {
+            setTupletDuration(Duration(DurationType::V_WHOLE));
+        } else if (code->tag == "cHalf") {
+            setTupletDuration(Duration(DurationType::V_HALF));
+        } else if (code->tag == "cQuarter") {
+            setTupletDuration(Duration(DurationType::V_QUARTER));
+        } else if (code->tag == "c8th") {
+            setTupletDuration(Duration(DurationType::V_EIGHTH));
+        } else {
+            setTupletDuration(Duration(DurationType::V_INVALID));
+        }
+        break;
+    }
+    case BieSequencePatternType::Tie: {
+        braille_code* code = pattern->res("tie");
+        if (code != NULL) {
+            setTie(true);
+        }
+        break;
+    }
+    case BieSequencePatternType::NoteSlur: {
+        braille_code* code = pattern->res("note-slur");
+        if (code != NULL) {
+            setNoteSlur(true);
+        }
+        break;
+    }
+    case BieSequencePatternType::LongSlurStop: {
+        braille_code* code = pattern->res("long-slur-stop");
+        if (code != NULL) {
+            setLongSlurStop(true);
+        }
+        break;
+    }
+    case BieSequencePatternType::Dot: {
+        braille_code* code = pattern->res("dot");
+        if (code != NULL) {
+            setDots(1);
+        }
+        break;
+    }
+    default: {
+        break;
+    }
+    }
+
+    return pattern->type();
+}
+
+QString BrailleInputState::buffer()
+{
+    return _input_buffer;
+}
+
+AccidentalType BrailleInputState::accidental()
+{
+    return _accidental;
+}
+
+NoteName BrailleInputState::noteName()
+{
+    return _note_name;
+}
+
+NoteName BrailleInputState::chordBaseNoteName()
+{
+    return _chordbase_note_name;
+}
+
+NoteGroup BrailleInputState::noteGroup()
+{
+    return _note_group;
+}
+
+DurationType BrailleInputState::currentDuration()
+{
+    return _current_duration;
+}
+
+std::vector<DurationType> BrailleInputState::noteDurations()
+{
+    return _note_durations;
+}
+
+bool BrailleInputState::isDurationMatch()
+{
+    return std::find(_note_durations.begin(), _note_durations.end(), _current_duration) != _note_durations.end();
+}
+
+DurationType BrailleInputState::getCloseDuration()
+{
+    switch (_note_group) {
+    case NoteGroup::Group1: {
+        return _note_durations[0];
+        break;
+    }
+    case NoteGroup::Group2: {
+        return _note_durations[1];
+        break;
+    }
+    case NoteGroup::Group3: {
+        return _note_durations[2];
+        break;
+    }
+    default: {
+        if (isDurationMatch()) {
+            return _current_duration;
+        } else {
+            for (auto d : _note_durations) {
+                if (d > _current_duration) {
+                    return d;
+                }
+            }
+        }
+    }
+    }
+    return _note_durations.back();
+}
+
+SymbolId BrailleInputState::articulation()
+{
+    return _articulation;
+}
+
+int BrailleInputState::octave()
+{
+    return _octave;
+}
+
+int BrailleInputState::dots()
+{
+    return _dots;
+}
+
+int BrailleInputState::addedOctave()
+{
+    return _added_octave;
+}
+
+int BrailleInputState::chordBaseNoteOctave()
+{
+    return _chordbase_note_octave;
+}
+
+voice_idx_t BrailleInputState::voice()
+{
+    return _voice;
+}
+
+void BrailleInputState::setAccidental(const AccidentalType accidental)
+{
+    _accidental = accidental;
+}
+
+void BrailleInputState::setNoteName(const NoteName notename, const bool chord_base)
+{
+    _note_name = notename;
+    if (chord_base) {
+        _chordbase_note_name = notename;
+    }
+}
+
+void BrailleInputState::setNoteGroup(const NoteGroup notegroup)
+{
+    LOGD() << (int)notegroup;
+    _note_group = notegroup;
+}
+
+void BrailleInputState::setCurrentDuration(const DurationType duration)
+{
+    _current_duration = duration;
+}
+
+void BrailleInputState::setNoteDurations(const std::vector<DurationType> durations)
+{
+    _note_durations = durations;
+}
+
+void BrailleInputState::setArticulation(const SymbolId articulation)
+{
+    _articulation = articulation;
+}
+
+void BrailleInputState::setOctave(const int octave, const bool chord_base)
+{
+    _octave = octave;
+
+    if (chord_base) {
+        _chordbase_note_octave = octave;
+    }
+}
+
+void BrailleInputState::setDots(const int dots)
+{
+    _dots = dots;
+}
+
+void BrailleInputState::setAddedOctave(const int octave)
+{
+    LOGD() << octave;
+    _added_octave = octave;
+}
+
+void BrailleInputState::setVoice(const voice_idx_t voice)
+{
+    _voice = voice;
+}
+
+std::vector<int> BrailleInputState::intervals()
+{
+    return _intervals;
+}
+
+void BrailleInputState::removeLastInterval()
+{
+    if (!_intervals.empty()) {
+        _intervals.pop_back();
+    }
+}
+
+void BrailleInputState::clearIntervals()
+{
+    _intervals.clear();
+}
+
+int BrailleInputState::addInterval(int interval)
+{
+    if (!intervals().empty()) {
+        int last = _intervals.back();
+        while (interval < last) {
+            interval += 7;
+        }
+    }
+
+    _intervals.push_back(interval);
+    return interval;
+}
+
+bool BrailleInputState::tie()
+{
+    return _tie;
+}
+
+void BrailleInputState::setTie(const bool s)
+{
+    _tie = s;
+}
+
+Note* BrailleInputState::tieStartNote()
+{
+    return _tie_start_note;
+}
+
+void BrailleInputState::setTieStartNote(Note* note)
+{
+    _tie_start_note = note;
+}
+
+void BrailleInputState::clearTie()
+{
+    _tie_start_note = NULL;
+}
+
+void BrailleInputState::setNoteSlur(const bool s)
+{
+    _note_slur = s;
+}
+
+void BrailleInputState::setLongSlurStart(const bool s)
+{
+    _long_slur_start = s;
+}
+
+void BrailleInputState::setLongSlurStop(const bool s)
+{
+    _long_slur_stop = s;
+}
+
+bool BrailleInputState::noteSlur()
+{
+    return _note_slur;
+}
+
+bool BrailleInputState::longSlurStart()
+{
+    return _long_slur_start;
+}
+
+bool BrailleInputState::longSlurStop()
+{
+    return _long_slur_stop;
+}
+
+Note* BrailleInputState::slurStartNote()
+{
+    return _slur_start_note;
+}
+
+Note* BrailleInputState::longSlurStartNote()
+{
+    return _long_slur_start_note;
+}
+
+void BrailleInputState::setSlurStartNote(Note* note)
+{
+    _slur_start_note = note;
+}
+
+void BrailleInputState::setLongSlurStartNote(Note* note)
+{
+    _long_slur_start_note = note;
+}
+
+void BrailleInputState::clearSlur()
+{
+    _slur_start_note = NULL;
+}
+
+void BrailleInputState::clearLongSlur()
+{
+    _long_slur_start_note = NULL;
+}
+
+bool BrailleInputState::accord()
+{
+    return _accord;
+}
+
+void BrailleInputState::setAccord(const bool val)
+{
+    _accord = val;
+}
+
+int BrailleInputState::tupletNumber()
+{
+    return _tuplet_number;
+}
+
+void BrailleInputState::setTupletNumber(const int num)
+{
+    _tuplet_number = num;
+}
+
+Duration BrailleInputState::tupletDuration()
+{
+    return _tuplet_duration;
+}
+
+void BrailleInputState::setTupletDuration(const Duration d)
+{
+    switch (noteGroup()) {
+    case NoteGroup::Group2: {
+        switch (d.type()) {
+        case DurationType::V_WHOLE: {
+            _tuplet_duration = Duration(DurationType::V_16TH);
+            break;
+        }
+        case DurationType::V_HALF: {
+            _tuplet_duration = Duration(DurationType::V_32ND);
+            break;
+        }
+        case DurationType::V_QUARTER: {
+            _tuplet_duration = Duration(DurationType::V_64TH);
+            break;
+        }
+        case DurationType::V_EIGHTH: {
+            _tuplet_duration = Duration(DurationType::V_128TH);
+            break;
+        }
+        default: {
+            _tuplet_duration = Duration(DurationType::V_INVALID);
+            break;
+        }
+        }
+        break;
+    }
+    case NoteGroup::Group3: {
+        switch (d.type()) {
+        case DurationType::V_WHOLE: {
+            _tuplet_duration = Duration(DurationType::V_256TH);
+            break;
+        }
+        case DurationType::V_HALF: {
+            _tuplet_duration = Duration(DurationType::V_512TH);
+            break;
+        }
+        case DurationType::V_QUARTER: {
+            _tuplet_duration = Duration(DurationType::V_1024TH);
+            break;
+        }
+        case DurationType::V_EIGHTH: {
+            _tuplet_duration = Duration(DurationType::V_INVALID);
+            break;
+        }
+        default: {
+            _tuplet_duration = Duration(DurationType::V_INVALID);
+            break;
+        }
+        }
+        break;
+    }
+    default: {
+        _tuplet_duration = d;
+        break;
+    }
+    }
+}
+
+void BrailleInputState::clearTuplet()
+{
+    _tuplet_number = -1;
+    _tuplet_duration = Duration(DurationType::V_INVALID);
+}
+
+bool BrailleInputState::tupletIndicator()
+{
+    return _tuplet_indicator;
+}
+
+void BrailleInputState::setTupletIndicator(bool val)
+{
+    _tuplet_indicator = val;
+}
+}

--- a/src/braille/internal/brailleinput.h
+++ b/src/braille/internal/brailleinput.h
@@ -1,0 +1,170 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2023 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_BRAILLE_BRAILLEINPUT_H
+#define MU_BRAILLE_BRAILLEINPUT_H
+
+#include "notation/notationtypes.h"
+
+#include "braillecode.h"
+#include "brailleinputparser.h"
+
+namespace mu::engraving {
+enum class NoteGroup
+{
+    Undefined = 0,
+    Group1, // whole, half, quarter, 8th
+    Group2, // 16th, 32nd, 64th, 128th
+    Group3  // 256th, 512th, 1024th, 2048th
+};
+
+enum class IntervalDirection
+{
+    Up,
+    Down
+};
+
+class BrailleInputState
+{
+public:
+    BrailleInputState();
+    ~BrailleInputState();
+
+    void initialize();
+    void reset();
+    void resetBuffer();
+    void insertToBuffer(const QString);
+    QString buffer();
+
+    BieSequencePatternType parseBraille(IntervalDirection direction);
+
+    AccidentalType accidental();
+    notation::NoteName noteName();
+    notation::NoteName chordBaseNoteName();
+    NoteGroup noteGroup();
+
+    DurationType currentDuration();
+    std::vector<DurationType> noteDurations();
+    bool isDurationMatch();
+    DurationType getCloseDuration();
+
+    notation::SymbolId articulation();
+    int octave();
+    int dots();
+    int addedOctave();
+    int chordBaseNoteOctave();
+    voice_idx_t voice();
+    bool noteSlur();
+    bool longSlurStart();
+    bool longSlurStop();
+    bool tie();
+
+    void setAccidental(const AccidentalType accidental);
+    void setNoteName(const notation::NoteName notename, const bool chord_base = true);
+    void setCurrentDuration(const DurationType duration);
+    void setNoteDurations(const std::vector<DurationType> durations);
+    void setArticulation(const notation::SymbolId articulation);
+    void setOctave(const int octave, const bool chord_base = false);
+    void setDots(const int dots);
+    void setAddedOctave(const int octave);
+    void setVoice(const voice_idx_t voice);
+
+    void setNoteGroup(const NoteGroup g);
+
+    std::vector<int> intervals();
+    void clearIntervals();
+    void removeLastInterval();
+    int addInterval(int interval);
+
+    void setTie(const bool s);
+    Note* tieStartNote();
+    void setTieStartNote(Note*);
+    void clearTie();
+
+    void setNoteSlur(const bool s);
+    void setLongSlurStart(const bool s);
+    void setLongSlurStop(const bool s);
+    Note* slurStartNote();
+    Note* longSlurStartNote();
+    void setSlurStartNote(Note*);
+    void setLongSlurStartNote(Note*);
+    void clearSlur();
+    void clearLongSlur();
+
+    bool accord();
+    void setAccord(const bool val);
+
+    int tupletNumber();
+    void setTupletNumber(const int num);
+    notation::Duration tupletDuration();
+    void setTupletDuration(const notation::Duration d);
+    void clearTuplet();
+    bool tupletIndicator();
+    void setTupletIndicator(bool val);
+private:
+    AccidentalType _accidental = AccidentalType::NONE;
+    notation::NoteName _note_name = notation::NoteName::C;
+    notation::NoteName _chordbase_note_name = notation::NoteName::C;
+    notation::SymbolId _articulation = notation::SymbolId::noSym;
+    int _octave = 4;
+    int _chordbase_note_octave = 4;
+    int _added_octave = -1;
+    int _dots = 0;
+    voice_idx_t _voice = 0;
+    QString _input_buffer = QString();
+    int _code_num = 0;
+
+    DurationType _current_duration;
+    std::vector<DurationType> _note_durations;
+    NoteGroup _note_group = NoteGroup::Undefined;
+
+    std::vector<int> _intervals;
+
+    bool _tie;
+    Note* _tie_start_note =  NULL;
+
+    bool _note_slur, _long_slur_start, _long_slur_stop;
+    Note* _slur_start_note =  NULL;
+    Note* _long_slur_start_note =  NULL;
+
+    bool _accord;
+    int _tuplet_number = -1;
+    notation::Duration _tuplet_duration;
+    bool _tuplet_indicator = false;
+};
+
+QString parseBrailleKeyInput(QString keys);
+
+notation::NoteName getNoteName(const braille_code* code);
+std::vector<DurationType> getNoteDurations(const braille_code* code);
+std::vector<DurationType> getRestDurations(const braille_code* code);
+int getInterval(const braille_code* code);
+bool isNoteName(const braille_code* code);
+QString fromNoteName(notation::NoteName);
+AccidentalType getAccidentalType(const braille_code* code);
+notation::SymbolId getArticulation(const braille_code* code);
+int getOctave(const braille_code* code);
+int getOctaveDiff(notation::NoteName source, notation::NoteName dest);
+int getOctaveDiff(IntervalDirection direction, notation::NoteName source, int interval);
+notation::NoteName getNoteNameForInterval(IntervalDirection direction, notation::NoteName source, int interval);
+}
+#endif // MU_BRAILLE_BRAILLEINPUT_H

--- a/src/braille/internal/brailleinput.h
+++ b/src/braille/internal/brailleinput.h
@@ -27,6 +27,7 @@
 
 #include "braillecode.h"
 #include "brailleinputparser.h"
+#include "brailletypes.h"
 
 namespace mu::engraving {
 enum class NoteGroup
@@ -39,8 +40,8 @@ enum class NoteGroup
 
 enum class IntervalDirection
 {
-    Up,
-    Down
+    Up      = static_cast<char>(braille::BrailleIntervalDirection::Up),
+    Down    = static_cast<char>(braille::BrailleIntervalDirection::Down),
 };
 
 class BrailleInputState
@@ -163,8 +164,7 @@ QString fromNoteName(notation::NoteName);
 AccidentalType getAccidentalType(const braille_code* code);
 notation::SymbolId getArticulation(const braille_code* code);
 int getOctave(const braille_code* code);
-int getOctaveDiff(notation::NoteName source, notation::NoteName dest);
-int getOctaveDiff(IntervalDirection direction, notation::NoteName source, int interval);
-notation::NoteName getNoteNameForInterval(IntervalDirection direction, notation::NoteName source, int interval);
+int getOctaveDiff(notation::NoteName source, notation::NoteName note);
+std::pair<notation::NoteName, int> applyInterval(notation::NoteName source, int interval, IntervalDirection direction);
 }
 #endif // MU_BRAILLE_BRAILLEINPUT_H

--- a/src/braille/internal/brailleinputparser.cpp
+++ b/src/braille/internal/brailleinputparser.cpp
@@ -1,0 +1,344 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2023 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "brailleinputparser.h"
+
+#include "braillecode.h"
+
+namespace mu::engraving {
+static BiePattern pattern_accord = { "accord", { &Braille_FullMeasureAccord } };
+
+static BiePattern pattern_accidentals = { "accidental",
+                                          { &Braille_NaturalAccidental, &Braille_SharpAccidental, &Braille_FlatAccidental } };
+
+static BiePattern pattern_octaves = { "octave",
+                                      { &Braille_Octave0, &Braille_Octave1, &Braille_Octave2,
+                                        &Braille_Octave3, &Braille_Octave4, &Braille_Octave5,
+                                        &Braille_Octave6, &Braille_Octave7, &Braille_Octave8 } };
+
+static BiePattern pattern_notes ={ "note",
+                                   { &Braille_aWhole, &Braille_aHalf, &Braille_aQuarter, &Braille_a8th,
+                                     &Braille_bWhole, &Braille_bHalf, &Braille_bQuarter, &Braille_b8th,
+                                     &Braille_cWhole, &Braille_cHalf, &Braille_cQuarter, &Braille_c8th,
+                                     &Braille_dWhole, &Braille_dHalf, &Braille_dQuarter, &Braille_d8th,
+                                     &Braille_eWhole, &Braille_eHalf, &Braille_eQuarter, &Braille_f8th,
+                                     &Braille_fWhole, &Braille_fHalf, &Braille_fQuarter, &Braille_e8th,
+                                     &Braille_gWhole, &Braille_gHalf, &Braille_gQuarter, &Braille_g8th } };
+
+static BiePattern pattern_c_notes ={ "c-note",
+                                     { &Braille_cWhole, &Braille_cHalf, &Braille_cQuarter, &Braille_c8th } };
+
+static BiePattern pattern_dot = { "dot", { &Braille_Dot } };
+static BiePattern pattern_dot_2 = { "dot-2", { &Braille_Dot } };
+static BiePattern pattern_dot_3 = { "dot-3", { &Braille_Dot } };
+static BiePattern pattern_tie = { "tie", { &Braille_NoteTie } };
+static BiePattern pattern_note_slur = { "note-slur", { &Braille_NoteSlur } };
+static BiePattern pattern_slur_start = { "long-slur-start", { &Braille_LongSlurOpenBracket } };
+static BiePattern pattern_slur_stop = { "long-slur-stop", { &Braille_LongSlurCloseBracket } };
+
+static BiePattern pattern_rests ={ "rest",
+                                   { &Braille_RestWhole, &Braille_RestHalf, &Braille_RestQuarter, &Braille_Rest8th } };
+
+static BiePattern pattern_intervals ={ "interval",
+                                       { &Braille_Interval2, &Braille_Interval3, &Braille_Interval4, &Braille_Interval5,
+                                         &Braille_Interval6, &Braille_Interval7, &Braille_Interval8 } };
+
+static BiePattern pattern_fingerings ={ "fingering",
+                                        { &Braille_Finger0, &Braille_Finger1, &Braille_Finger2,
+                                          &Braille_Finger3, &Braille_Finger4, &Braille_Finger5 } };
+
+static BiePattern pattern_tuplet_indicator ={ "tuplet-indicator", { &Braille_Tuplet3 } };
+static BiePattern pattern_tuplet3 ={ "tuplet3", { &Braille_Tuplet3 } };
+static BiePattern pattern_tuplet_prefix ={ "tuplet-prefix", { &Braille_TupletPrefix } };
+static BiePattern pattern_tuplet_suffix ={ "tuplet-suffix", { &Braille_Dot } };
+
+static BiePattern pattern_tuplet_numbers ={ "tuplet-number",
+                                            { &Braille_Lower2, &Braille_Lower3, &Braille_Lower5, &Braille_Lower6,
+                                              &Braille_Lower7, &Braille_Lower8, &Braille_Lower9 } };
+
+static int maxPatternLength(BiePattern* pattern)
+{
+    int max = 0;
+    for (auto code : pattern->codes) {
+        if (code->cells_num > max) {
+            max = code->cells_num;
+        }
+    }
+    return max;
+}
+
+BieSequencePattern::BieSequencePattern(BieSequencePatternType t, std::string sequence)
+{
+    _type = t;
+    patterns.clear();
+    max_cell_length = 0;
+
+    int len = sequence.length();
+    QString key = QString();
+    bool mandatory = false;
+    char openning = ' ';
+    int i = 0;
+    while (i < len) {
+        char c = sequence.at(i);
+        //LOGD() << i << " c=" << c << " open=" << openning;
+        switch (c) {
+        case '(': {
+            if (openning != ' ') {
+                _valid = false;
+                return;
+            }
+            mandatory = true;
+            openning = '(';
+            break;
+        }
+        case ')': {
+            if (openning != '(') {
+                _valid = false;
+                return;
+            }
+            openning = ' ';
+            break;
+        }
+        case '[': {
+            if (openning != ' ') {
+                _valid = false;
+                return;
+            }
+            mandatory = false;
+            openning = '[';
+            break;
+        }
+        case ']': {
+            if (openning != '[') {
+                _valid = false;
+                return;
+            }
+            openning = ' ';
+            break;
+        }
+        case '{': {
+            // ignore
+            break;
+        }
+        case '}': {
+            // ignore
+            break;
+        }
+        default: {
+            key.push_back(sequence.at(i));
+            break;
+        }
+        }
+
+        if (openning == ' ' && !key.isEmpty()) {
+            //LOGD() << key << " " << mandatory;
+            BiePattern* pattern = NULL;
+            if (key == "accord") {
+                pattern = &pattern_accord;
+            } else if (key == "accord") {
+                pattern = &pattern_accord;
+            } else if (key == "accidental") {
+                pattern = &pattern_accidentals;
+            } else if (key == "octave") {
+                pattern = &pattern_octaves;
+            } else if (key == "note") {
+                pattern = &pattern_notes;
+            } else if (key == "dot") {
+                pattern = &pattern_dot;
+            } else if (key == "dot-2") {
+                pattern = &pattern_dot_2;
+            } else if (key == "dot-3") {
+                pattern = &pattern_dot_3;
+            } else if (key == "tie") {
+                pattern = &pattern_tie;
+            } else if (key == "note-slur") {
+                pattern = &pattern_note_slur;
+            } else if (key == "long-slur-start") {
+                pattern = &pattern_slur_start;
+            } else if (key == "long-slur-stop") {
+                pattern = &pattern_slur_stop;
+            } else if (key == "rest") {
+                pattern = &pattern_rests;
+            } else if (key == "interval") {
+                pattern = &pattern_intervals;
+            } else if (key == "fingering") {
+                pattern = &pattern_fingerings;
+            } else if (key == "tuplet-indicator") {
+                pattern = &pattern_tuplet_indicator;
+            } else if (key == "tuplet3") {
+                pattern = &pattern_tuplet3;
+            } else if (key == "tuplet-prefix") {
+                pattern = &pattern_tuplet_prefix;
+            } else if (key == "tuplet-number") {
+                pattern = &pattern_tuplet_numbers;
+            } else if (key == "tuplet-suffix") {
+                pattern = &pattern_tuplet_suffix;
+            } else if (key == "c-note") {
+                pattern = &pattern_c_notes;
+            }
+            if (pattern != NULL) {
+                patterns.push_back({ pattern->name, pattern->codes, mandatory });
+                int n = maxPatternLength(pattern);
+                if (max_cell_length < n) {
+                    max_cell_length = n;
+                }
+                if (mandatory) {
+                    _mandatories++;
+                }
+            }
+            mandatory = false;
+            key = QString();
+        }
+        i++;
+    }
+    _valid = true;
+}
+
+BieSequencePattern::~BieSequencePattern()
+{
+    // TODO
+}
+
+BieSequencePatternType BieSequencePattern::type()
+{
+    return _type;
+}
+
+bool BieSequencePattern::recognize(std::string braille)
+{
+    _res.clear();
+
+    size_t pos = 0;
+    size_t cursor = 0;
+
+    int mandatory_matches = 0;
+    while (cursor < braille.length() && pos < patterns.size()) {
+        //LOGD() << "cursor: " << cursor;
+        bool match = false;
+        for (auto code : patterns[pos].codes) {
+            int len = code->cells_num;
+            if (cursor + len <= braille.length()) {
+                std::string bxt = braille.substr(cursor, len);
+                if (bxt == code->braille) {
+                    //code->print();
+                    match = true;
+                    _res[patterns[pos].name] = code;
+                    if (patterns[pos].mandatory) {
+                        mandatory_matches++;
+                    }
+                    pos++;
+                    cursor += len;
+                    break;
+                }
+            }
+        }
+        if (!match) {
+            if (patterns[pos].mandatory) {
+                return false;
+            } else {
+                pos++;
+            }
+        }
+    }
+    //for(std::map<std::string, braille_code *>::iterator it = _res.begin(); it != _res.end(); ++it) {
+    //    LOGD() << "Key: " << it->first << " value: " << it->second->tag;
+    //}
+    return mandatory_matches == _mandatories && cursor >= braille.length();
+}
+
+std::map<std::string, braille_code*> BieSequencePattern::res()
+{
+    return _res;
+}
+
+braille_code* BieSequencePattern::res(std::string key)
+{
+    return _res[key];
+}
+
+bool BieSequencePattern::valid()
+{
+    return _valid;
+}
+
+BieSequencePattern* BieRecognize(std::string braille, bool tuplet_indicator)
+{
+    //static std::string note_input_seq = "{[accord][long-slur-start][accidental][octave](note)[dot][dot-2][dot-3][fingering][note-slur][long-slur-stop][tie]}";
+    static std::string note_input_seq = "{[accord][long-slur-start][accidental][octave](note)}";
+    static BieSequencePattern bie_note_input(BieSequencePatternType::Note, note_input_seq);
+
+    //static std::string rest_input_seq = "{[accord](rest)[dot][dot-2][dot-3][slur]}";
+    static std::string rest_input_seq = "{[accord](rest)}";
+    static BieSequencePattern bie_rest_input(BieSequencePatternType::Rest, rest_input_seq);
+
+    static std::string interval_input_seq = "{[accidental][octave](interval)}";
+    static BieSequencePattern bie_interval_input(BieSequencePatternType::Interval, interval_input_seq);
+
+    static std::string tuplet3_seq = "{(tuplet3)}";
+    static BieSequencePattern bie_tuplet3(BieSequencePatternType::Tuplet3, tuplet3_seq);
+
+    static std::string tuplet_seq = "{(tuplet-prefix)(tuplet-number)(c-note)(tuplet-suffix)}";
+    static BieSequencePattern bie_tuplet(BieSequencePatternType::Tuplet, tuplet_seq);
+
+    static std::string dot_seq = "{(dot)}";
+    static BieSequencePattern bie_dot(BieSequencePatternType::Dot, dot_seq);
+
+    static std::string tie_seq = "{(tie)}";
+    static BieSequencePattern bie_tie(BieSequencePatternType::Tie, tie_seq);
+
+    static std::string noteslur_seq = "{(note-slur)}";
+    static BieSequencePattern bie_noteslur(BieSequencePatternType::NoteSlur, noteslur_seq);
+
+    static std::string longslur_seq = "{(long-slur-stop)}";
+    static BieSequencePattern bie_longslur(BieSequencePatternType::LongSlurStop, longslur_seq);
+
+    BieSequencePattern* res = NULL;
+
+    if (!tuplet_indicator) { // check note input before tuplet
+        if (bie_note_input.valid() && bie_note_input.recognize(braille)) {
+            res = &bie_note_input;
+        } else if (bie_rest_input.valid() && bie_rest_input.recognize(braille)) {
+            res = &bie_rest_input;
+        } else if (bie_interval_input.valid() && bie_interval_input.recognize(braille)) {
+            res = &bie_interval_input;
+        } else if (bie_tuplet3.valid() && bie_tuplet3.recognize(braille)) {
+            res = &bie_tuplet3;
+            //} else if(bie_tuplet.valid() && bie_tuplet.recognize(braille)) {
+            //    res = &bie_tuplet;
+        } else if (bie_tie.valid() && bie_tie.recognize(braille)) {
+            res = &bie_tie;
+        } else if (bie_noteslur.valid() && bie_noteslur.recognize(braille)) {
+            res = &bie_noteslur;
+        } else if (bie_longslur.valid() && bie_longslur.recognize(braille)) {
+            res = &bie_longslur;
+        } else if (bie_dot.valid() && bie_dot.recognize(braille)) {
+            res = &bie_dot;
+        }
+    } else { // check tuplet input
+        if (bie_tuplet.valid() && bie_tuplet.recognize(braille)) {
+            res = &bie_tuplet;
+        }
+    }
+
+    return res;
+}
+}

--- a/src/braille/internal/brailleinputparser.cpp
+++ b/src/braille/internal/brailleinputparser.cpp
@@ -79,8 +79,8 @@ static int maxPatternLength(BiePattern* pattern)
 {
     int max = 0;
     for (auto code : pattern->codes) {
-        if (code->cells_num > max) {
-            max = code->cells_num;
+        if (code->num_cells > max) {
+            max = code->num_cells;
         }
     }
     return max;
@@ -92,12 +92,11 @@ BieSequencePattern::BieSequencePattern(BieSequencePatternType t, std::string seq
     patterns.clear();
     max_cell_length = 0;
 
-    int len = sequence.length();
+    size_t len = sequence.length();
     QString key = QString();
     bool mandatory = false;
     char openning = ' ';
-    int i = 0;
-    while (i < len) {
+    for (size_t i = 0; i < len; ++i) {
         char c = sequence.at(i);
         //LOGD() << i << " c=" << c << " open=" << openning;
         switch (c) {
@@ -208,7 +207,6 @@ BieSequencePattern::BieSequencePattern(BieSequencePatternType t, std::string seq
             mandatory = false;
             key = QString();
         }
-        i++;
     }
     _valid = true;
 }
@@ -235,7 +233,7 @@ bool BieSequencePattern::recognize(std::string braille)
         //LOGD() << "cursor: " << cursor;
         bool match = false;
         for (auto code : patterns[pos].codes) {
-            int len = code->cells_num;
+            int len = code->num_cells;
             if (cursor + len <= braille.length()) {
                 std::string bxt = braille.substr(cursor, len);
                 if (bxt == code->braille) {

--- a/src/braille/internal/brailleinputparser.h
+++ b/src/braille/internal/brailleinputparser.h
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2023 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_BRAILLE_BRAILLEINPUTPARSER_H
+#define MU_BRAILLE_BRAILLEINPUTPARSER_H
+
+#include <string>
+
+namespace mu::engraving {
+class braille_code;
+
+struct BiePattern {
+    std::string name;
+    std::vector<braille_code*> codes;
+    bool mandatory = false;
+};
+
+enum class BieSequencePatternType {
+    Undefined,
+    Note,
+    Interval,
+    Rest,
+    Tuplet3,
+    Tuplet,
+    Dot,
+    Tie,
+    NoteSlur,
+    LongSlurStop
+};
+
+class BieSequencePattern
+{
+public:
+    BieSequencePattern(BieSequencePatternType t, std::string sequence);
+    ~BieSequencePattern();
+
+    BieSequencePatternType type();
+    bool recognize(std::string braille);
+    std::map<std::string, braille_code*> res();
+    braille_code* res(std::string key);
+    bool valid();
+private:
+    BieSequencePatternType _type;
+    std::vector<BiePattern> patterns;
+    bool _valid;
+    std::map<std::string, braille_code*> _res;
+    int max_cell_length;
+    int _mandatories = 0;
+};
+
+BieSequencePattern* BieRecognize(std::string braille, bool tuplet_indicator);
+}
+
+#endif // MU_BRAILLE_BRAILLEINPUTPARSER_H

--- a/src/braille/internal/braillewriter.cpp
+++ b/src/braille/internal/braillewriter.cpp
@@ -24,8 +24,6 @@
 
 #include "braille.h"
 
-#include "log.h"
-
 using namespace mu::project;
 
 namespace mu::engraving {

--- a/src/braille/internal/louis.cpp
+++ b/src/braille/internal/louis.cpp
@@ -19,12 +19,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include <string.h>
-#include <stdlib.h>
-#include <stdint.h>
+
 #include <iostream>
 #include <sstream>
+#include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <vector>
 
 #include "braille/thirdparty/liblouis/liblouis/internal.h"

--- a/src/braille/internal/notationbraille.cpp
+++ b/src/braille/internal/notationbraille.cpp
@@ -20,42 +20,41 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "io/iodevice.h"
-#include "io/buffer.h"
-
 #include "notationbraille.h"
 
 #include "translation.h"
 
-#include "engraving/dom/masterscore.h"
-#include "engraving/dom/spanner.h"
+#include "engraving/dom/factory.h"
+#include "engraving/dom/measure.h"
 #include "engraving/dom/segment.h"
 #include "engraving/dom/slur.h"
+#include "engraving/dom/spanner.h"
 #include "engraving/dom/staff.h"
-#include "engraving/dom/part.h"
-#include "engraving/dom/sig.h"
-#include "engraving/dom/measure.h"
+#include "engraving/dom/tie.h"
 
-#include "braille/internal/braille.h"
-#include "braille/internal/louis.h"
+#include "braille.h"
+#include "braillecode.h"
+#include "brailleinput.h"
+#include "brailleinputparser.h"
+#include "louis.h"
 
-#include "log.h"
-
-using namespace mu::notation;
-using namespace mu::async;
-using namespace mu::engraving;
+using namespace mu::braille;
 using namespace mu::io;
+using namespace mu::notation;
 
+namespace mu::engraving {
 void NotationBraille::init()
 {
     setEnabled(brailleConfiguration()->braillePanelEnabled());
     setCurrentItemPosition(-1, -1);
 
+    setMode(BrailleMode::Navigation);
+
     path_t tablesdir = tablesDefaultDirPath();
     setTablesDir(tablesdir.toStdString().c_str());
     initTables(tablesdir.toStdString());
 
-    std::string welcome = braille_translate(table_for_literature.c_str(), "Welcome to MuseScore 4.0!");
+    std::string welcome = braille_translate(table_for_literature.c_str(), "Welcome to MuseScore 4!");
     setBrailleInfo(QString(welcome.c_str()));
 
     brailleConfiguration()->braillePanelEnabledChanged().onNotify(this, [this]() {
@@ -68,14 +67,41 @@ void NotationBraille::init()
         updateTableForLyricsFromPreferences();
     });
 
+    setIntervalDirection(brailleConfiguration()->intervalDirection());
+    brailleConfiguration()->intervalDirectionChanged().onNotify(this, [this]() {
+        QString direction = brailleConfiguration()->intervalDirection();
+        setIntervalDirection(direction);
+    });
+
     globalContext()->currentNotationChanged().onNotify(this, [this]() {
         if (notation()) {
+            notation()->interaction()->selectionChanged().onNotify(this, [this]() {
+                doBraille();
+            });
+
             notation()->notationChanged().onNotify(this, [this]() {
+                setCurrentItemPosition(0, 0);
                 doBraille(true);
             });
 
-            notation()->interaction()->selectionChanged().onNotify(this, [this]() {
-                doBraille();
+            notation()->interaction()->noteInput()->stateChanged().onNotify(this, [this]() {
+                if (interaction()->noteInput()->isNoteInputMode()) {
+                    if (isNavigationMode()) {
+                        setMode(BrailleMode::BrailleInput);
+                    }
+                } else {
+                    if (isBrailleInputMode()) {
+                        setMode(BrailleMode::Navigation);
+                    }
+                }
+            });
+
+            notation()->interaction()->noteInput()->noteAdded().onNotify(this, [this]() {
+                if (currentEngravingItem() != nullptr && currentEngravingItem()->isNote()) {
+                    LOGD() << "Note added: " << currentEngravingItem()->accessibleInfo();
+                    Note* note = toNote(currentEngravingItem());
+                    brailleInput()->setOctave(note->octave());
+                }
             });
         }
     });
@@ -105,6 +131,7 @@ void NotationBraille::doBraille(bool force)
 
         if (selection()->isSingle()) {
             e = selection()->element();
+            LOGD() << " selected " << e->accessibleInfo();
             m = e->findMeasure();
         } else if (selection()->isRange()) {
             for (auto el: selection()->elements()) {
@@ -124,30 +151,32 @@ void NotationBraille::doBraille(bool force)
             m = e->findMeasure();
         }
         if (e) {
+            setCurrentEngravingItem(e, false);
+
             if (!m) {
-                brailleEngravingItems()->clear();
+                brailleEngravingItemList()->clear();
                 Braille lb(score());
-                bool res = lb.convertItem(e, brailleEngravingItems());
+                bool res = lb.convertItem(e, brailleEngravingItemList());
                 if (!res) {
                     QString txt = e->accessibleInfo();
                     std::string braille = braille_long_translate(table_for_literature.c_str(), txt.toStdString());
-                    brailleEngravingItems()->setBrailleStr(QString::fromStdString(braille));
+                    brailleEngravingItemList()->setBrailleStr(QString::fromStdString(braille));
                     setBrailleInfo(QString::fromStdString(braille));
                 } else {
-                    setBrailleInfo(brailleEngravingItems()->brailleStr());
+                    setBrailleInfo(brailleEngravingItemList()->brailleStr());
                 }
                 current_measure = nullptr;
             } else {
                 if (m != current_measure || force) {
-                    brailleEngravingItems()->clear();
+                    brailleEngravingItemList()->clear();
                     Braille lb(score());
-                    lb.convertMeasure(m, brailleEngravingItems());
-                    setBrailleInfo(brailleEngravingItems()->brailleStr());
+                    lb.convertMeasure(m, brailleEngravingItemList());
+                    setBrailleInfo(brailleEngravingItemList()->brailleStr());
                     current_measure = m;
                 }
-                std::pair<int, int> pos = brailleEngravingItems()->getBraillePos(e);
-                if (pos.first != -1) {
-                    setCurrentItemPosition(pos.first, pos.second);
+                current_bei = brailleEngravingItemList()->getItem(e);
+                if (current_bei != nullptr) {
+                    setCurrentItemPosition(current_bei->start(), current_bei->end());
                 }
             }
         }
@@ -184,14 +213,29 @@ mu::ValCh<int> NotationBraille::currentItemPositionEnd() const
     return m_currentItemPositionEnd;
 }
 
-mu::ValCh<std::string> NotationBraille::shortcut() const
+mu::ValCh<std::string> NotationBraille::keys() const
 {
-    return m_shortcut;
+    return m_keys;
 }
 
 mu::ValCh<bool> NotationBraille::enabled() const
 {
     return m_enabled;
+}
+
+mu::ValCh<QString> NotationBraille::intervalDirection() const
+{
+    return m_intervalDirection;
+}
+
+mu::ValCh<int> NotationBraille::mode() const
+{
+    return m_mode;
+}
+
+mu::ValCh<std::string> NotationBraille::cursorColor() const
+{
+    return m_cursorColor;
 }
 
 void NotationBraille::setEnabled(bool enabled)
@@ -202,14 +246,27 @@ void NotationBraille::setEnabled(bool enabled)
     m_enabled.set(enabled);
 }
 
-mu::engraving::BrailleEngravingItems* NotationBraille::brailleEngravingItems()
+void NotationBraille::setIntervalDirection(const QString direction)
 {
-    return &m_bei;
+    if (direction == m_enabled.val) {
+        return;
+    }
+    m_intervalDirection.set(direction);
+}
+
+BrailleEngravingItemList* NotationBraille::brailleEngravingItemList()
+{
+    return &m_beil;
 }
 
 QString NotationBraille::getBrailleStr()
 {
-    return m_bei.brailleStr();
+    return m_beil.brailleStr();
+}
+
+BrailleInputState* NotationBraille::brailleInput()
+{
+    return &m_braille_input;
 }
 
 void NotationBraille::setBrailleInfo(const QString& info)
@@ -225,15 +282,21 @@ void NotationBraille::setBrailleInfo(const QString& info)
 
 void NotationBraille::setCursorPosition(const int pos)
 {
-    if (m_cursorPosition.val == pos) {
+    if (!isNavigationMode()) {
+        return;
+    }
+
+    if (m_cursorPosition.val == pos || pos == 0) {
         return;
     }
 
     m_cursorPosition.set(pos);
 
-    notation::EngravingItem* el = brailleEngravingItems()->getEngravingItem(pos);
-    if (el != nullptr) {
-        interaction()->select({ el });
+    current_bei = brailleEngravingItemList()->getItem(pos);
+    if (current_bei != NULL && current_bei->el() != NULL
+        && (current_bei->type() == BEIType::EngravingItem
+            || current_bei->type() == BEIType::LyricItem)) {
+        setCurrentEngravingItem(current_bei->el(), true);
     }
 }
 
@@ -258,32 +321,599 @@ INotationInteractionPtr NotationBraille::interaction()
     return notation() ? notation()->interaction() : nullptr;
 }
 
-void NotationBraille::setShortcut(const QString& sequence)
+DurationType getDuration(const QString key)
+{
+    static const DurationType types[] = {
+        DurationType::V_64TH, DurationType::V_32ND, DurationType::V_16TH,
+        DurationType::V_EIGHTH, DurationType::V_QUARTER, DurationType::V_HALF,
+        DurationType::V_WHOLE, DurationType::V_BREVE, DurationType::V_LONG
+    };
+    bool is_ok = false;
+    int val = key.toInt(&is_ok);
+
+    if (!is_ok || val < 1 || val > 9) {
+        return DurationType::V_INVALID;
+    } else {
+        return types[val - 1];
+    }
+}
+
+void NotationBraille::setInputNoteDuration(Duration d)
+{
+    InputState& inputState = score()->inputState();
+    inputState.setDuration(d);
+    score()->setInputState(inputState);
+    brailleInput()->setCurrentDuration(d.type());
+}
+
+void NotationBraille::setTupletDuration(int tuplet, Duration d)
+{
+    LOGD() << tuplet << " " << (int)d.type();
+    brailleInput()->setCurrentDuration(d.type());
+
+    switch (tuplet) {
+    case 2:
+        d = d.shiftRetainDots(-1, false);
+        d = d.shiftRetainDots(-1, true);
+        break;
+    case 3:
+        d = d.shiftRetainDots(-1, false);
+        break;
+    case 5: case 6: case 7:
+        d = d.shiftRetainDots(-2, false);
+        break;
+    case 8:
+        d = d.shiftRetainDots(-2, false);
+        d = d.shiftRetainDots(-1, true);
+        break;
+    case 9:
+        d = d.shiftRetainDots(-3, false);
+        break;
+    }
+    InputState& inputState = score()->inputState();
+    inputState.setDuration(d);
+    score()->setInputState(inputState);
+}
+
+static TupletOptions makeTupletOption(int num)
+{
+    TupletOptions option;
+    switch (num) {
+    case 2:
+        option.ratio = { 2, 3 };
+        break;
+    case 3:
+        option.ratio = { 3, 2 };
+        break;
+    case 5:
+        option.ratio = { 5, 4 };
+        break;
+    case 6:
+        option.ratio = { 6, 4 };
+        break;
+    case 7:
+        option.ratio = { 7, 4 };
+        break;
+    case 8:
+        option.ratio = { 8, 6 };
+        break;
+    case 9:
+        option.ratio = { 9, 8 };
+        break;
+    default:
+        break;
+    }
+    return option;
+}
+
+bool matchPattern(const std::string sequence, const std::string pattern)
+{
+    QStringList seqs = QString::fromStdString(sequence).split("+");
+    QStringList pats = QString::fromStdString(pattern).split("+");
+
+    if (seqs.length() != pats.length()) {
+        return false;
+    }
+    seqs.sort();
+    pats.sort();
+
+    for (int i = 0; i < seqs.length(); i++) {
+        if (seqs.at(i) != pats.at(i)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void NotationBraille::setKeys(const QString& sequence)
 {
     LOGD() << sequence;
     std::string seq = sequence.toStdString();
-    m_shortcut.set(seq);
+    m_keys.set(seq);
 
     if (seq == "Left") {
         interaction()->moveSelection(MoveDirection::Left, MoveSelectionType::Chord);
     } else if (seq == "Right") {
         interaction()->moveSelection(MoveDirection::Right, MoveSelectionType::Chord);
-    } else if (seq == "Ctrl+Left") {
+    } else if (matchPattern(seq, "Ctrl+Left")) {
         interaction()->moveSelection(MoveDirection::Left, MoveSelectionType::Measure);
-    } else if (seq == "Ctrl+Right") {
+    } else if (matchPattern(seq, "Ctrl+Right")) {
         interaction()->moveSelection(MoveDirection::Right, MoveSelectionType::Measure);
-    } else if (seq == "Alt+Left") {
+    } else if (matchPattern(seq, "Alt+Left")) {
         interaction()->moveSelection(MoveDirection::Left, MoveSelectionType::EngravingItem);
-    } else if (seq == "Alt+Right") {
+    } else if (matchPattern(seq, "Alt+Right")) {
         interaction()->moveSelection(MoveDirection::Right, MoveSelectionType::EngravingItem);
-    } else if (seq == "Ctrl+End") {
+    } else if (matchPattern(seq, "Ctrl+End")) {
         interaction()->selectLastElement();
-    } else if (seq == "Ctrl+Home") {
+    } else if (matchPattern(seq, "Ctrl+Home")) {
         interaction()->selectFirstElement();
+    } else if (seq == "Delete") {
+        if (currentEngravingItem()) {
+            interaction()->deleteSelection();
+            if (!brailleInput()->intervals().empty()) {
+                brailleInput()->removeLastInterval();
+            }
+        }
+    } else if (seq == "N") {
+        toggleMode();
+        brailleInput()->initialize();
+    } else if (seq == "Plus") {
+        if (isBrailleInputMode()) {
+            interaction()->noteInput()->doubleNoteInputDuration();
+        }
+    } else if (seq == "Minus") {
+        if (isBrailleInputMode()) {
+            interaction()->noteInput()->halveNoteInputDuration();
+        }
+    } else if (matchPattern(seq, "Space+F") && isBrailleInputMode()) {
+        brailleInput()->setNoteGroup(NoteGroup::Group1);
+        brailleInput()->resetBuffer();
+    } else if (matchPattern(seq, "Space+D") && isBrailleInputMode()) {
+        brailleInput()->setNoteGroup(NoteGroup::Group2);
+        brailleInput()->resetBuffer();
+    } else if (matchPattern(seq, "Space+S") && isBrailleInputMode()) {
+        brailleInput()->setNoteGroup(NoteGroup::Group3);
+        brailleInput()->resetBuffer();
+    } else if (matchPattern(seq, "Space+S+D+J+K") && isBrailleInputMode()) {
+        LOGD() << "tuplet input";
+        brailleInput()->setTupletIndicator(true);
+        brailleInput()->resetBuffer();
+    } else if (seq == "Space") {
+        brailleInput()->reset();
+    } else if (isBrailleInputMode() && !sequence.isEmpty()) {
+        QString pattern = parseBrailleKeyInput(sequence);
+        if (!pattern.isEmpty()) {
+            brailleInput()->insertToBuffer(pattern);
+        } else {
+            brailleInput()->insertToBuffer(sequence);
+        }
+        LOGD() << brailleInput()->buffer();
+        std::string braille = translate2Braille(brailleInput()->buffer().toStdString());
+        BieRecognize(braille, brailleInput()->tupletIndicator());
+        BieSequencePatternType type = brailleInput()->parseBraille(getIntervalDirection());
+        switch (type) {
+        case BieSequencePatternType::Note: {
+            LOGD() << "note";
+            if (brailleInput()->accidental() != mu::notation::AccidentalType::NONE) {
+                interaction()->noteInput()->setAccidental(brailleInput()->accidental());
+            }
+
+            setVoice(brailleInput()->accord());
+
+            if (brailleInput()->tupletNumber() != -1
+                && brailleInput()->tupletDuration().type() != DurationType::V_INVALID) {
+                Duration duration = brailleInput()->tupletDuration();
+                int tuplet = brailleInput()->tupletNumber();
+                setTupletDuration(tuplet, duration);
+                TupletOptions option = makeTupletOption(brailleInput()->tupletNumber());
+                interaction()->noteInput()->addTuplet(option);
+                brailleInput()->clearTuplet();
+            }
+
+            DurationType d = brailleInput()->getCloseDuration();
+            Duration duration = Duration(d);
+            setInputNoteDuration(duration);
+
+            interaction()->noteInput()->addNote(brailleInput()->noteName(), NoteAddingMode::NextChord);
+
+            if (brailleInput()->addedOctave() != -1) {
+                if (brailleInput()->addedOctave() < brailleInput()->octave()) {
+                    for (int i = brailleInput()->addedOctave(); i < brailleInput()->octave(); i++) {
+                        interaction()->movePitch(MoveDirection::Down, PitchMode::OCTAVE);
+                    }
+                } else if (brailleInput()->addedOctave() > brailleInput()->octave()) {
+                    for (int i = brailleInput()->octave(); i < brailleInput()->addedOctave(); i++) {
+                        interaction()->movePitch(MoveDirection::Up, PitchMode::OCTAVE);
+                    }
+                }
+                brailleInput()->setOctave(brailleInput()->addedOctave(), true);
+            }
+
+            if (brailleInput()->longSlurStart()) {
+                if (brailleInput()->longSlurStartNote() == NULL) {
+                    if (currentEngravingItem() != NULL && currentEngravingItem()->isNote()) {
+                        Note* note = toNote(currentEngravingItem());
+                        brailleInput()->setLongSlurStartNote(note);
+                    }
+                }
+            }
+
+            if (brailleInput()->tieStartNote() != NULL) {
+                addTie();
+                brailleInput()->clearTie();
+            }
+
+            if (brailleInput()->slurStartNote() != NULL) {
+                addSlur();
+                brailleInput()->clearSlur();
+            }
+
+            playbackController()->playElements({ currentEngravingItem() });
+            brailleInput()->reset();
+            break;
+        }
+        case BieSequencePatternType::Rest: {
+            LOGD() << "rest";
+            DurationType d = brailleInput()->getCloseDuration();
+            Duration duration = Duration(d);
+            if (brailleInput()->dots() > 0) {
+                duration.setDots(brailleInput()->dots());
+            }
+            setInputNoteDuration(Duration(duration));
+            interaction()->putRest(duration);
+            brailleInput()->reset();
+            break;
+        }
+        case BieSequencePatternType::Interval: {
+            LOGD() << "interval";
+            if (brailleInput()->accidental() != mu::notation::AccidentalType::NONE) {
+                interaction()->noteInput()->setAccidental(brailleInput()->accidental());
+            }
+            interaction()->noteInput()->addNote(brailleInput()->noteName(), NoteAddingMode::CurrentChord);
+
+            if (brailleInput()->addedOctave() != -1) {
+                if (brailleInput()->addedOctave() < brailleInput()->octave()) {
+                    for (int i = brailleInput()->addedOctave(); i < brailleInput()->octave(); i++) {
+                        interaction()->movePitch(MoveDirection::Down, PitchMode::OCTAVE);
+                    }
+                } else if (brailleInput()->addedOctave() > brailleInput()->octave()) {
+                    for (int i = brailleInput()->octave(); i < brailleInput()->addedOctave(); i++) {
+                        interaction()->movePitch(MoveDirection::Up, PitchMode::OCTAVE);
+                    }
+                }
+                brailleInput()->setOctave(brailleInput()->addedOctave());
+            }
+            playbackController()->playElements({ currentEngravingItem() });
+            brailleInput()->reset();
+            break;
+        }
+        case BieSequencePatternType::Tuplet: case BieSequencePatternType::Tuplet3: {
+            LOGD() << "tuplet";
+            std::string stateTuplet;
+            stateTuplet = "Tuplet " + std::to_string(brailleInput()->tupletNumber());
+            auto notationAccessibility = notation()->accessibility();
+            if (!notationAccessibility) {
+                return;
+            }
+            notationAccessibility->setTriggeredCommand(stateTuplet);
+            break;
+        }
+        case BieSequencePatternType::Tie: {
+            LOGD() << "tie";
+            if (brailleInput()->tie()) {
+                if (currentEngravingItem() != NULL && currentEngravingItem()->isNote()) {
+                    Note* note = toNote(currentEngravingItem());
+                    brailleInput()->setTieStartNote(note);
+                }
+            }
+            brailleInput()->reset();
+            break;
+        }
+        case BieSequencePatternType::NoteSlur: {
+            LOGD() << "note slur";
+            if (brailleInput()->noteSlur()) {
+                if (brailleInput()->slurStartNote() == NULL) {
+                    if (currentEngravingItem() != NULL && currentEngravingItem()->isNote()) {
+                        Note* note = toNote(currentEngravingItem());
+                        brailleInput()->setSlurStartNote(note);
+                    }
+                }
+            }
+            brailleInput()->reset();
+            break;
+        }
+        case BieSequencePatternType::LongSlurStop: {
+            LOGD() << "long slur stop";
+            if (brailleInput()->longSlurStop()) {
+                if (brailleInput()->longSlurStartNote() != NULL) {
+                    addLongSlur();
+                    brailleInput()->clearLongSlur();
+                }
+            }
+            brailleInput()->reset();
+            break;
+        }
+        case BieSequencePatternType::Dot: {
+            LOGD() << "dot " << brailleInput()->dots();
+            if (brailleInput()->dots() > 0) {
+                interaction()->increaseDecreaseDuration(-brailleInput()->dots(), true);
+            }
+            brailleInput()->reset();
+            break;
+        }
+        default: {
+            // TODO
+        }
+        }
+    } else if (isBrailleInputMode() && !sequence.isEmpty()) {
+        QString pattern = parseBrailleKeyInput(sequence);
+        if (!pattern.isEmpty()) {
+            brailleInput()->insertToBuffer(pattern);
+        } else {
+            brailleInput()->insertToBuffer(sequence);
+        }
     }
+}
+
+bool NotationBraille::addTie()
+{
+    if (!brailleInput()->tieStartNote()) {
+        return false;
+    }
+
+    if (!currentEngravingItem() || !currentEngravingItem()->isNote()) {
+        return false;
+    }
+
+    score()->startCmd();
+    Note* note = toNote(currentEngravingItem());
+
+    Tie* tie = Factory::createTie(score()->dummy());
+    tie->setStartNote(brailleInput()->tieStartNote());
+    tie->setEndNote(note);
+    tie->setTrack(brailleInput()->tieStartNote()->track());
+    tie->setTick(brailleInput()->tieStartNote()->chord()->segment()->tick());
+    tie->setTicks(note->chord()->segment()->tick() - brailleInput()->tieStartNote()->chord()->segment()->tick());
+    score()->undoAddElement(tie);
+    score()->endCmd();
+    return true;
+}
+
+bool NotationBraille::addSlur()
+{
+    if (brailleInput()->slurStartNote() != NULL
+        && currentEngravingItem() != NULL && currentEngravingItem()->isNote()) {
+        Note* note1 = brailleInput()->slurStartNote();
+        Note* note2 = toNote(currentEngravingItem());
+
+        if (note1->parent()->isChordRest() && note2->parent()->isChordRest()) {
+            LOGD() << "add slur";
+            ChordRest* firstChordRest = toChordRest(note1->parent());
+            ChordRest* secondChordRest = toChordRest(note2->parent());
+
+            score()->startCmd();
+
+            Slur* slur = Factory::createSlur(firstChordRest->measure()->system());
+            slur->setScore(firstChordRest->score());
+            slur->setTick(firstChordRest->tick());
+            slur->setTick2(secondChordRest->tick());
+            slur->setTrack(firstChordRest->track());
+            if (secondChordRest->staff()->part() == firstChordRest->staff()->part()
+                && !secondChordRest->staff()->isLinked(firstChordRest->staff())) {
+                slur->setTrack2(secondChordRest->track());
+            } else {
+                slur->setTrack2(firstChordRest->track());
+            }
+            slur->setStartElement(firstChordRest);
+            slur->setEndElement(secondChordRest);
+
+            firstChordRest->score()->undoAddElement(slur);
+            SlurSegment* ss = new SlurSegment(firstChordRest->score()->dummy()->system());
+            ss->setSpannerSegmentType(SpannerSegmentType::SINGLE);
+            if (firstChordRest == secondChordRest) {
+                ss->setSlurOffset(Grip::END, PointF(3.0 * firstChordRest->spatium(), 0.0));
+            }
+            slur->add(ss);
+
+            score()->endCmd();
+            doBraille(true);
+            return true;
+        }
+        return false;
+    } else {
+        return false;
+    }
+}
+
+bool NotationBraille::addLongSlur()
+{
+    if (brailleInput()->longSlurStartNote() != NULL
+        && currentEngravingItem() != NULL && currentEngravingItem()->isNote()) {
+        Note* note1 = brailleInput()->longSlurStartNote();
+        Note* note2 = toNote(currentEngravingItem());
+
+        if (note1->parent()->isChordRest() && note2->parent()->isChordRest()) {
+            ChordRest* firstChordRest = toChordRest(note1->parent());
+            ChordRest* secondChordRest = toChordRest(note2->parent());
+
+            score()->startCmd();
+
+            Slur* slur = Factory::createSlur(firstChordRest->measure()->system());
+            slur->setScore(firstChordRest->score());
+            slur->setTick(firstChordRest->tick());
+            slur->setTick2(secondChordRest->tick());
+            slur->setTrack(firstChordRest->track());
+            if (secondChordRest->staff()->part() == firstChordRest->staff()->part()
+                && !secondChordRest->staff()->isLinked(firstChordRest->staff())) {
+                slur->setTrack2(secondChordRest->track());
+            } else {
+                slur->setTrack2(firstChordRest->track());
+            }
+            slur->setStartElement(firstChordRest);
+            slur->setEndElement(secondChordRest);
+
+            firstChordRest->score()->undoAddElement(slur);
+            SlurSegment* ss = new SlurSegment(firstChordRest->score()->dummy()->system());
+            ss->setSpannerSegmentType(SpannerSegmentType::SINGLE);
+            if (firstChordRest == secondChordRest) {
+                ss->setSlurOffset(Grip::END, PointF(3.0 * firstChordRest->spatium(), 0.0));
+            }
+            slur->add(ss);
+
+            score()->endCmd();
+            doBraille(true);
+            return true;
+        }
+        return false;
+    } else {
+        return false;
+    }
+}
+
+bool NotationBraille::setVoice(bool new_voice)
+{
+    if (currentEngravingItem() == NULL || currentMeasure() == NULL) {
+        return false;
+    }
+
+    staff_idx_t staff = currentEngravingItem()->staffIdx();
+
+    if (new_voice) {
+        int voices = 0;
+        for (size_t i = 1; i < VOICES; ++i) {
+            if (current_measure->hasVoice(staff * VOICES + i)) {
+                voices++;
+            }
+        }
+        if (voices >= 3) {
+            return false;
+        }
+
+        score()->inputState().moveInputPos(currentMeasure()->segments().firstCRSegment());
+        interaction()->noteInput()->setCurrentVoice(voices + 1);
+        return true;
+    } else {
+        Segment* segment = score()->inputState().segment();
+        Measure* measure = segment->measure();
+        if (!measure->hasVoice(staff + 1) && segment->tick() == measure->tick()) {
+            interaction()->noteInput()->setCurrentVoice(0);
+        }
+        return false;
+    }
+}
+
+void NotationBraille::setMode(const BrailleMode mode)
+{
+    switch (mode) {
+    case BrailleMode::Undefined:
+    case BrailleMode::Navigation:
+        setCursorColor("black");
+        break;
+    case BrailleMode::BrailleInput:
+        setCursorColor("green");
+        break;
+    }
+
+    m_mode.set((int)mode);
+}
+
+void NotationBraille::toggleMode()
+{
+    std::string stateTitle;
+
+    switch ((BrailleMode)mode().val) {
+    case BrailleMode::Undefined:
+    case BrailleMode::Navigation:
+        setMode(BrailleMode::BrailleInput);
+        interaction()->noteInput()->startNoteInput();
+        stateTitle = trc("notation", "Note input mode");
+        break;
+    case BrailleMode::BrailleInput:
+        setMode(BrailleMode::Navigation);
+        interaction()->noteInput()->endNoteInput();
+        stateTitle = trc("notation", "Normal mode");
+        break;
+    }
+
+    auto notationAccessibility = notation()->accessibility();
+    if (!notationAccessibility) {
+        return;
+    }
+    notationAccessibility->setTriggeredCommand(stateTitle);
+}
+
+bool NotationBraille::isNavigationMode()
+{
+    return mode().val == (int)BrailleMode::Navigation;
+}
+
+bool NotationBraille::isBrailleInputMode()
+{
+    return mode().val == (int)BrailleMode::BrailleInput;
+}
+
+void NotationBraille::setCursorColor(const QString color)
+{
+    m_cursorColor.set(color.toStdString());
 }
 
 path_t NotationBraille::tablesDefaultDirPath() const
 {
     return globalConfiguration()->appDataPath() + "tables";
+}
+
+void NotationBraille::setCurrentEngravingItem(EngravingItem* e, bool select)
+{
+    if (!e) {
+        return;
+    }
+
+    bool play = current_engraving_item != e;
+    current_engraving_item = e;
+    if (isNavigationMode()) {
+        if (select) {
+            if (play) {
+                playbackController()->playElements({ e });
+            }
+            interaction()->select({ e });
+        }
+    }
+}
+
+IntervalDirection NotationBraille::getIntervalDirection()
+{
+    if (m_intervalDirection.val == "Up") {
+        return IntervalDirection::Up;
+    } else if (m_intervalDirection.val == "Down") {
+        return IntervalDirection::Down;
+    } else if (m_intervalDirection.val == "Auto") {
+        if (currentEngravingItem() != NULL && currentEngravingItem()->isNote()) {
+            Note* note = toNote(currentEngravingItem());
+            Staff* staff = note->staff();
+            Fraction tick = note->tick();
+            if (staff) {
+                ClefType clef = staff->clef(tick);
+                if (clef >= ClefType::G && clef <= ClefType::C3) {
+                    return IntervalDirection::Down;
+                } else {
+                    return IntervalDirection::Up;
+                }
+            } else {
+                return IntervalDirection::Down;
+            }
+        }
+    }
+
+    return IntervalDirection::Down;
+}
+
+EngravingItem* NotationBraille::currentEngravingItem()
+{
+    return current_engraving_item;
+}
+
+Measure* NotationBraille::currentMeasure()
+{
+    return current_measure;
+}
 }

--- a/src/braille/internal/notationbraille.h
+++ b/src/braille/internal/notationbraille.h
@@ -73,12 +73,12 @@ public:
     ValCh<int> currentItemPositionEnd() const override;
     ValCh<std::string> keys() const override;
     ValCh<bool> enabled() const override;
-    ValCh<QString> intervalDirection() const override;
+    ValCh<braille::BrailleIntervalDirection> intervalDirection() const override;
     ValCh<int> mode() const override;
     ValCh<std::string> cursorColor() const override;
 
     void setEnabled(const bool enabled) override;
-    void setIntervalDirection(const QString direction) override;
+    void setIntervalDirection(const braille::BrailleIntervalDirection direction) override;
 
     void setCursorPosition(const int pos) override;
     void setCurrentItemPosition(const int, const int) override;
@@ -112,9 +112,8 @@ private:
     void updateTableForLyricsFromPreferences();
     io::path_t tablesDefaultDirPath() const;
 
-    IntervalDirection getIntervalDirection();
+    IntervalDirection currentIntervalDirection();
 
-    Notation* m_notation;
     Measure* current_measure = nullptr;
     EngravingItem* current_engraving_item = nullptr;
     BrailleEngravingItem* current_bei = nullptr;
@@ -128,7 +127,7 @@ private:
     ValCh<std::string> m_keys;
     ValCh<bool> m_enabled;
     ValCh<int> m_mode;
-    ValCh<QString> m_intervalDirection;
+    ValCh<braille::BrailleIntervalDirection> m_intervalDirection;
     ValCh<std::string> m_cursorColor;
 
     async::Notification m_selectionChanged;

--- a/src/braille/internal/notationbraille.h
+++ b/src/braille/internal/notationbraille.h
@@ -23,22 +23,19 @@
 #ifndef MU_BRAILLE_NOTATIONBRAILLE_H
 #define MU_BRAILLE_NOTATIONBRAILLE_H
 
-#include "modularity/ioc.h"
-#include "global/iglobalconfiguration.h"
-#include "io/ifilesystem.h"
-#include "ui/iuiconfiguration.h"
-#include "engraving/iengravingconfiguration.h"
-
-#include "inotationbraille.h"
-#include "notation/notationtypes.h"
-
 #include "async/asyncable.h"
 #include "async/notification.h"
-
-#include "braille/internal/braille.h"
 #include "context/iglobalcontext.h"
-#include "notation/inotationconfiguration.h"
+#include "global/iglobalconfiguration.h"
 #include "ibrailleconfiguration.h"
+#include "inotationbraille.h"
+#include "modularity/ioc.h"
+#include "notation/inotationconfiguration.h"
+#include "notation/notationtypes.h"
+#include "playback/iplaybackcontroller.h"
+
+#include "braille.h"
+#include "brailleinput.h"
 
 namespace mu::engraving {
 class Score;
@@ -50,50 +47,90 @@ class NotationBraille : public mu::braille::INotationBraille, public async::Asyn
     INJECT(context::IGlobalContext, globalContext)
     INJECT(notation::INotationConfiguration, notationConfiguration)
     INJECT(braille::IBrailleConfiguration, brailleConfiguration)
+    INJECT(playback::IPlaybackController, playbackController)
 
 public:
     void init();
     void doBraille(bool force = false);
 
+    bool addNote();
+    bool setVoice(bool new_voice = false);
+    bool addSlurStart();
+    bool addSlurEnd();
+    bool addTie();
+    bool addSlur();
+    bool addLongSlur();
+    bool addTuplet(const mu::notation::TupletOptions& options);
+    bool incDuration();
+    bool decDuration();
+    bool setArticulation();
+    void setInputNoteDuration(notation::Duration d);
+    void setTupletDuration(int tuplet, notation::Duration d);
+
     ValCh<std::string> brailleInfo() const override;
     ValCh<int> cursorPosition() const override;
     ValCh<int> currentItemPositionStart() const override;
     ValCh<int> currentItemPositionEnd() const override;
-    ValCh<std::string> shortcut() const override;
+    ValCh<std::string> keys() const override;
     ValCh<bool> enabled() const override;
+    ValCh<QString> intervalDirection() const override;
+    ValCh<int> mode() const override;
+    ValCh<std::string> cursorColor() const override;
 
-    void setEnabled(bool enabled) override;
+    void setEnabled(const bool enabled) override;
+    void setIntervalDirection(const QString direction) override;
 
     void setCursorPosition(const int pos) override;
     void setCurrentItemPosition(const int, const int) override;
-    void setShortcut(const QString&) override;
+    void setKeys(const QString&) override;
+
+    void setMode(const braille::BrailleMode) override;
+    void toggleMode() override;
+    bool isNavigationMode() override;
+    bool isBrailleInputMode() override;
+
+    void setCursorColor(const QString color) override;
+
+    EngravingItem* currentEngravingItem();
+    Measure* currentMeasure();
 
     notation::INotationPtr notation();
     notation::INotationInteractionPtr interaction();
 
-    BrailleEngravingItems* brailleEngravingItems();
+    BrailleEngravingItemList* brailleEngravingItemList();
     QString getBrailleStr();
+
+    BrailleInputState* brailleInput();
 
 private:
     Score* score();
     Selection* selection();
 
-    Measure* current_measure = nullptr;
-
     void setBrailleInfo(const QString& info);
-    void setCurrentShortcut(const QString& sequence);
+    void setCurrentEngravingItem(EngravingItem* el, bool select);
 
     void updateTableForLyricsFromPreferences();
     io::path_t tablesDefaultDirPath() const;
+
+    IntervalDirection getIntervalDirection();
+
+    Notation* m_notation;
+    Measure* current_measure = nullptr;
+    EngravingItem* current_engraving_item = nullptr;
+    BrailleEngravingItem* current_bei = nullptr;
+    BrailleEngravingItemList m_beil;
+    BrailleInputState m_braille_input;
 
     ValCh<std::string> m_brailleInfo;
     ValCh<int> m_cursorPosition;
     ValCh<int> m_currentItemPositionStart;
     ValCh<int> m_currentItemPositionEnd;
-    ValCh<std::string> m_shortcut;
+    ValCh<std::string> m_keys;
     ValCh<bool> m_enabled;
+    ValCh<int> m_mode;
+    ValCh<QString> m_intervalDirection;
+    ValCh<std::string> m_cursorColor;
 
-    BrailleEngravingItems m_bei;
     async::Notification m_selectionChanged;
 };
 }

--- a/src/braille/qml/MuseScore/Braille/BrailleView.qml
+++ b/src/braille/qml/MuseScore/Braille/BrailleView.qml
@@ -39,19 +39,36 @@ StyledFlickable {
 
     BrailleModel {
         id: brailleModel
+        property int keys_pressed: 0
+        property string keys_buffer: ""
 
         onCurrentItemChanged: {
             if(brailleModel.currentItemPositionStart.valueOf() != -1 &&
                     brailleModel.currentItemPositionEnd.valueOf() != -1) {
-                    //brailleInfo.select(brailleModel.currentItemPositionStart.valueOf(), brailleModel.currentItemPositionEnd.valueOf());
+                    //brailleTextArea.select(brailleModel.currentItemPositionStart.valueOf(), brailleModel.currentItemPositionEnd.valueOf());
                 if(brailleTextArea.focus) {
                     brailleTextArea.cursorPosition = brailleModel.currentItemPositionEnd.valueOf();
                 }
             }
         }
+
         onBraillePanelEnabledChanged: {
             root.visible = brailleModel.enabled
         }
+
+        onBrailleModeChanged: {
+            switch(brailleModel.mode) {
+                case 1: {
+                    fakeNavCtrl.accessible.setName("Braille: Normal mode");
+                    break;
+                }
+                case 2: {
+                    fakeNavCtrl.accessible.setName("Braille: Note input mode");
+                    break;
+                }
+            }
+        }
+
         Component.onCompleted: {
             root.visible = brailleModel.enabled
         }
@@ -61,6 +78,94 @@ StyledFlickable {
         id: brailleTextArea
         text: brailleModel.brailleInfo
         wrapMode: Text.AlignLeft
+
+        property var keyMap: new Map([
+            [Qt.Key_0, "0"],
+            [Qt.Key_1, "1"],
+            [Qt.Key_2, "2"],
+            [Qt.Key_3, "3"],
+            [Qt.Key_4, "4"],
+            [Qt.Key_5, "5"],
+            [Qt.Key_6, "6"],
+            [Qt.Key_7, "7"],
+            [Qt.Key_8, "8"],
+            [Qt.Key_9, "9"],
+            [Qt.Key_A, "A"],
+            [Qt.Key_B, "B"],
+            [Qt.Key_C, "C"],
+            [Qt.Key_D, "D"],
+            [Qt.Key_E, "E"],
+            [Qt.Key_F, "F"],
+            [Qt.Key_G, "G"],
+            [Qt.Key_H, "H"],
+            [Qt.Key_I, "I"],
+            [Qt.Key_J, "J"],
+            [Qt.Key_K, "K"],
+            [Qt.Key_L, "L"],
+            [Qt.Key_M, "M"],
+            [Qt.Key_N, "N"],
+            [Qt.Key_O, "O"],
+            [Qt.Key_P, "P"],
+            [Qt.Key_Q, "Q"],
+            [Qt.Key_R, "R"],
+            [Qt.Key_S, "S"],
+            [Qt.Key_T, "T"],
+            [Qt.Key_U, "U"],
+            [Qt.Key_V, "V"],
+            [Qt.Key_W, "W"],
+            [Qt.Key_X, "X"],
+            [Qt.Key_Y, "Y"],
+            [Qt.Key_Z, "Z"],
+            [Qt.Key_Space, "Space"],
+            [Qt.Key_Right, "Right"],
+            [Qt.Key_Left, "Left"],
+            [Qt.Key_Up, "Up"],
+            [Qt.Key_Down, "Down"],
+            [Qt.Key_PageUp, "PageUp"],
+            [Qt.Key_PageDown, "PageDown"],
+            [Qt.Key_Home, "Home"],
+            [Qt.Key_End, "End"],
+            [Qt.Key_Delete, "Delete"],
+            [Qt.Key_Escape, "Escape"],
+            [Qt.Key_Minus, "Minus"],
+            [Qt.Key_Plus, "Plus"],
+         ])
+
+        cursorDelegate: Rectangle {
+            id: brailleCursor
+            visible: brailleTextArea.cursorVisible
+            color: brailleModel.cursorColor
+            width: brailleTextArea.cursorRectangle.width
+
+            SequentialAnimation {
+                loops: Animation.Infinite
+                running: brailleTextArea.cursorVisible
+
+                PropertyAction {
+                    target: brailleCursor
+                    property: 'visible'
+                    value: true
+                }
+
+                PauseAnimation {
+                    duration: 600
+                }
+
+                PropertyAction {
+                    target: brailleCursor
+                    property: 'visible'
+                    value: false
+                }
+
+                PauseAnimation {
+                    duration: 600
+                }
+
+                onStopped: {
+                    brailleCursor.visible = false
+                }
+            }
+        }
 
         NavigationControl {
             id: fakeNavCtrl
@@ -114,51 +219,68 @@ StyledFlickable {
                 //! NOTE: We need to handle Tab key here because https://doc.qt.io/qt-5/qml-qtquick-controls2-textarea.html#tab-focus
                 //!       and we don't use qt navigation system
                 if (textInputFieldModel.handleShortcut(Qt.Key_Tab, Qt.NoModifier)) {
-                    brailleTextArea.focus = false
-                    event.accepted = true
-                    return
+                    brailleTextArea.focus = false;
+                    event.accepted = true;
+                    return;
                 }
             }
 
-            if (event.key !== Qt.Key_Shift && event.key !== Qt.Key_Alt &&
-                    event.key !== Qt.Key_Control) {
+            if (event.key !== Qt.Key_Shift
+                && event.key !== Qt.Key_Alt
+                && event.key !== Qt.Key_Control
+            ) {
 
-                var shortcut = "";
+                ++brailleModel.keys_pressed;
 
-                if(event.modifiers === Qt.ShiftModifier) {
-                    shortcut = shortcut === "" ? "Shift" : shortcut += "+Shift";
+                var keys = "";
+
+                if (event.modifiers === Qt.ShiftModifier) {
+                    keys = keys === "" ? "Shift" : keys += "+Shift";
                 }
 
-                if(event.modifiers === Qt.AltModifier) {
-                    shortcut = shortcut === "" ? "Alt" : shortcut += "+Alt";
+                if (event.modifiers === Qt.AltModifier) {
+                    keys = keys === "" ? "Alt" : keys += "+Alt";
                 }
-                if(event.modifiers === Qt.ControlModifier) {
-                    shortcut = shortcut === "" ? "Ctrl" : shortcut += "+Ctrl";
+                if (event.modifiers === Qt.ControlModifier) {
+                    keys = keys === "" ? "Ctrl" : keys += "+Ctrl";
                 }
 
-                if(shortcut !== "") shortcut += "+";
-
-                if(event.key === Qt.Key_Right) {
-                    shortcut += "Right"
-                } else if(event.key === Qt.Key_Left) {
-                    shortcut += "Left"
-                } else if(event.key === Qt.Key_Up) {
-                    shortcut += "Up"
-                } else if(event.key === Qt.Key_Down) {
-                    shortcut += "Down"
-                } else if(event.key === Qt.Key_PageUp) {
-                    shortcut += "PgUp"
-                } else if(event.key === Qt.Key_PageDown) {
-                    shortcut += "PgDown"
-                } else if(event.key === Qt.Key_Home) {
-                    shortcut += "Home"
-                } else if(event.key === Qt.Key_End) {
-                    shortcut += "End"
+                if (keys !== "") {
+                    keys += "+";
                 }
-                if(shortcut !== "Left" && shortcut !== "Right" &&
-                        shortcut !== "Up" && shortcut !== "Down") {
-                    brailleModel.shorcut = shortcut;
+
+                if (keyMap.get(event.key) !== "") {
+                    keys += keyMap.get(event.key);
+                }
+
+                if (keys !== "Left"
+                    && keys !== "Right"
+                    && keys !== "Up"
+                    && keys !== "Down"
+                ) {
+                    if (brailleModel.keys_buffer !== "") {
+                        brailleModel.keys_buffer += "+";
+                    }
+                    brailleModel.keys_buffer += keys;
                     event.accepted = true;
+                }
+            }
+        }
+
+        Keys.onReleased: {
+            if (event.key !== Qt.Key_Shift
+                && event.key !== Qt.Key_Alt
+                && event.key !== Qt.Key_Control
+            ) {
+                brailleModel.keys_pressed--;
+
+                if(brailleModel.keys_pressed <= 0) {
+                    brailleModel.keys = brailleModel.keys_buffer;
+                    brailleModel.keys_buffer = "";
+                    brailleModel.keys_pressed = 0;
+                    // set the focus back to braille
+                    root.navigationPanel.setActive(true);
+                    fakeNavCtrl.setActive(true);
                 }
             }
         }

--- a/src/braille/view/braillemodel.h
+++ b/src/braille/view/braillemodel.h
@@ -27,14 +27,14 @@
 
 #include "async/asyncable.h"
 #include "actions/actionable.h"
-
-#include "modularity/ioc.h"
-#include "inotationbraille.h"
-#include "ibrailleconfiguration.h"
-#include "notation/inotationconfiguration.h"
 #include "context/iglobalcontext.h"
+#include "modularity/ioc.h"
+#include "notation/inotationconfiguration.h"
 
-namespace mu::notation {
+#include "ibrailleconfiguration.h"
+#include "inotationbraille.h"
+
+namespace mu::engraving {
 class BrailleModel : public QObject, public async::Asyncable, public actions::Actionable
 {
     Q_OBJECT
@@ -48,8 +48,10 @@ class BrailleModel : public QObject, public async::Asyncable, public actions::Ac
     Q_PROPERTY(int cursorPosition READ cursorPosition WRITE setCursorPosition NOTIFY cursorPositionChanged)
     Q_PROPERTY(int currentItemPositionStart READ currentItemPositionStart NOTIFY currentItemChanged)
     Q_PROPERTY(int currentItemPositionEnd READ currentItemPositionEnd NOTIFY currentItemChanged)
-    Q_PROPERTY(QString shorcut READ shortcut WRITE setShortcut NOTIFY shortcutFired)
+    Q_PROPERTY(QString keys READ keys WRITE setKeys NOTIFY keysFired)
     Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY braillePanelEnabledChanged)
+    Q_PROPERTY(int mode READ mode WRITE setMode NOTIFY brailleModeChanged)
+    Q_PROPERTY(QString cursorColor READ cursorColor NOTIFY brailleModeChanged)
 
 public:
     explicit BrailleModel(QObject* parent = nullptr);
@@ -59,26 +61,35 @@ public:
     QString brailleInfo() const;
 
     int cursorPosition() const;
-    void setCursorPosition(int pos) const;
+    void setCursorPosition(int pos);
 
     int currentItemPositionStart() const;
     int currentItemPositionEnd() const;
 
-    QString shortcut() const;
-    void setShortcut(const QString& sequence) const;
+    QString keys() const;
+    void setKeys(const QString& sequence);
 
     bool enabled() const;
-    void setEnabled(bool e) const;
+    void setEnabled(bool e);
+
+    int mode() const;
+    void setMode(int mode);
+    bool isNavigationMode();
+    bool isBrailleInputMode();
+
+    QString cursorColor() const;
 
 signals:
-    void brailleInfoChanged() const;
-    void cursorPositionChanged() const;
-    void currentItemChanged() const;
-    void shortcutFired() const;
-    void braillePanelEnabledChanged() const;
+    void brailleInfoChanged();
+    void cursorPositionChanged();
+    void currentItemChanged();
+    void keysFired();
+    void braillePanelEnabledChanged();
+    void brailleModeChanged();
+    void cursorColorChanged();
 
 private:
-    INotationPtr notation() const;
+    notation::INotationPtr notation() const;
 
     void onCurrentNotationChanged();
 
@@ -86,8 +97,9 @@ private:
     void listenChangesInnotationBraille();
     void listenCursorPositionChanges();
     void listenCurrentItemChanges();
-    void listenShortcuts();
+    void listenKeys();
     void listenBraillePanelEnabledChanges();
+    void listenBrailleModeChanges();
 };
 }
 

--- a/src/notation/qml/MuseScore/NotationScene/NotationView.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NotationView.qml
@@ -214,6 +214,13 @@ FocusScope {
                 sourceComponent: BrailleView {
                     navigationPanel.section: navSec
                     navigationPanel.order: brailleViewLoader.navigationOrder
+
+                    navigationPanel.onActiveChanged: {
+                        if (active) {
+                            notationView.navigationPanel.setActive(false);
+                            fakeNavCtrl.setActive(false);
+                        }
+                    }
                 }
             }
 

--- a/src/stubs/braille/brailleconfigurationstub.cpp
+++ b/src/stubs/braille/brailleconfigurationstub.cpp
@@ -43,18 +43,13 @@ async::Notification BrailleConfigurationStub::intervalDirectionChanged() const
     return {};
 }
 
-QString BrailleConfigurationStub::intervalDirection() const
+BrailleIntervalDirection BrailleConfigurationStub::intervalDirection() const
 {
     return {};
 }
 
-void BrailleConfigurationStub::setIntervalDirection(const QString)
+void BrailleConfigurationStub::setIntervalDirection(const BrailleIntervalDirection)
 {
-}
-
-QStringList BrailleConfigurationStub::intervalDirectionsList() const
-{
-    return {};
 }
 
 async::Notification BrailleConfigurationStub::brailleTableChanged() const

--- a/src/stubs/braille/brailleconfigurationstub.cpp
+++ b/src/stubs/braille/brailleconfigurationstub.cpp
@@ -22,8 +22,8 @@
 #include "brailleconfigurationstub.h"
 
 using namespace mu;
-using namespace mu::braille;
 
+namespace mu::braille {
 async::Notification BrailleConfigurationStub::braillePanelEnabledChanged() const
 {
     return {};
@@ -36,6 +36,25 @@ bool BrailleConfigurationStub::braillePanelEnabled() const
 
 void BrailleConfigurationStub::setBraillePanelEnabled(const bool)
 {
+}
+
+async::Notification BrailleConfigurationStub::intervalDirectionChanged() const
+{
+    return {};
+}
+
+QString BrailleConfigurationStub::intervalDirection() const
+{
+    return {};
+}
+
+void BrailleConfigurationStub::setIntervalDirection(const QString)
+{
+}
+
+QStringList BrailleConfigurationStub::intervalDirectionsList() const
+{
+    return {};
 }
 
 async::Notification BrailleConfigurationStub::brailleTableChanged() const
@@ -52,7 +71,8 @@ void BrailleConfigurationStub::setBrailleTable(const QString)
 {
 }
 
-QStringList BrailleConfigurationStub::brailleTableList()
+QStringList BrailleConfigurationStub::brailleTableList() const
 {
     return {};
+}
 }

--- a/src/stubs/braille/brailleconfigurationstub.h
+++ b/src/stubs/braille/brailleconfigurationstub.h
@@ -33,9 +33,8 @@ public:
     void setBraillePanelEnabled(const bool enabled) override;
 
     async::Notification intervalDirectionChanged() const override;
-    QString intervalDirection() const override;
-    void setIntervalDirection(const QString direction) override;
-    virtual QStringList intervalDirectionsList() const override;
+    BrailleIntervalDirection intervalDirection() const override;
+    void setIntervalDirection(const BrailleIntervalDirection direction) override;
 
     async::Notification brailleTableChanged() const override;
     QString brailleTable() const override;

--- a/src/stubs/braille/brailleconfigurationstub.h
+++ b/src/stubs/braille/brailleconfigurationstub.h
@@ -32,11 +32,15 @@ public:
     bool braillePanelEnabled() const override;
     void setBraillePanelEnabled(const bool enabled) override;
 
+    async::Notification intervalDirectionChanged() const override;
+    QString intervalDirection() const override;
+    void setIntervalDirection(const QString direction) override;
+    virtual QStringList intervalDirectionsList() const override;
+
     async::Notification brailleTableChanged() const override;
     QString brailleTable() const override;
     void setBrailleTable(const QString table) override;
-
-    QStringList brailleTableList() override;
+    QStringList brailleTableList() const override;
 };
 }
 


### PR DESCRIPTION
Implement the ability to enter notes in the Braille panel and have them rendered in the score.

Demo: https://youtu.be/xnD5Py4YbfI?t=206

To test:

1. Enable the Braille panel in **Preferences > Braille**.
2. Create a blank score.
3. Navigate to a rest in an empty measure.
4. Tab to the Braille panel.
5. Press `N` to begin note input.
6. Press and release the `S`, `F` and `K` keys all at the same time.

Result:
- In the Braille panel, the ⠕ character (Braille dots 1, 3, 5) appears.
- In the score, a half-note D appears.