### PR TITLE
More improvements of GuitarBend user interactions

### DIFF
--- a/src/appshell/qml/Preferences/NoteInputPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/NoteInputPreferencesPage.qml
@@ -41,6 +41,7 @@ PreferencesPage {
         NoteInputSection {
             advanceToNextNote: noteInputModel.advanceToNextNoteOnKeyRelease
             colorNotes: noteInputModel.colorNotesOutsideOfUsablePitchRange
+            warnGuitarBends: noteInputModel.warnGuitarBends
             delayBetweenNotes: noteInputModel.delayBetweenNotesInRealTimeModeMilliseconds
 
             navigation.section: root.navigationSection
@@ -52,6 +53,10 @@ PreferencesPage {
 
             onColorNotesChangeRequested: function(color) {
                 noteInputModel.colorNotesOutsideOfUsablePitchRange = color
+            }
+
+            onWarnGuitarBendsChangeRequested: function(warn) {
+                noteInputModel.warnGuitarBends = warn
             }
 
             onDelayBetweenNotesChangeRequested: function(delay) {

--- a/src/appshell/qml/Preferences/internal/NoteInputSection.qml
+++ b/src/appshell/qml/Preferences/internal/NoteInputSection.qml
@@ -32,10 +32,12 @@ BaseSection {
 
     property alias advanceToNextNote: advanceToNextNoteBox.checked
     property alias colorNotes: colorNotesBox.checked
+    property alias warnGuitarBends: warnBendsBox.checked
     property alias delayBetweenNotes: delayBetweenNotesControl.currentValue
 
     signal advanceToNextNoteChangeRequested(bool advance)
     signal colorNotesChangeRequested(bool color)
+    signal warnGuitarBendsChangeRequested(bool warn)
     signal delayBetweenNotesChangeRequested(int delay)
 
     CheckBox {
@@ -68,6 +70,21 @@ BaseSection {
         }
     }
 
+    CheckBox {
+        id: warnBendsBox
+        width: parent.width
+
+        text: qsTrc("appshell/preferences", "Color guitar bends outside of playble range")
+
+        navigation.name: "WarnBendBox"
+        navigation.panel: root.navigation
+        navigation.row: 2
+
+        onClicked: {
+            root.warnGuitarBendsChangeRequested(!checked)
+        }
+    }
+
     IncrementalPropertyControlWithTitle {
         id: delayBetweenNotesControl
 
@@ -80,7 +97,7 @@ BaseSection {
 
         navigation.name: "DelayBetweenNotesControl"
         navigation.panel: root.navigation
-        navigation.row: 2
+        navigation.row: 3
 
         onValueEdited: function(newValue) {
             root.delayBetweenNotesChangeRequested(newValue)

--- a/src/appshell/view/preferences/noteinputpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/noteinputpreferencesmodel.cpp
@@ -41,6 +41,11 @@ bool NoteInputPreferencesModel::colorNotesOutsideOfUsablePitchRange() const
     return notationConfiguration()->colorNotesOutsideOfUsablePitchRange();
 }
 
+bool NoteInputPreferencesModel::warnGuitarBends() const
+{
+    return notationConfiguration()->warnGuitarBends();
+}
+
 int NoteInputPreferencesModel::delayBetweenNotesInRealTimeModeMilliseconds() const
 {
     return notationConfiguration()->delayBetweenNotesInRealTimeModeMilliseconds();
@@ -84,6 +89,16 @@ void NoteInputPreferencesModel::setColorNotesOutsideOfUsablePitchRange(bool valu
 
     notationConfiguration()->setColorNotesOutsideOfUsablePitchRange(value);
     emit colorNotesOutsideOfUsablePitchRangeChanged(value);
+}
+
+void NoteInputPreferencesModel::setWarnGuitarBends(bool value)
+{
+    if (value == warnGuitarBends()) {
+        return;
+    }
+
+    notationConfiguration()->setWarnGuitarBends(value);
+    emit warnGuitarBendsChanged(value);
 }
 
 void NoteInputPreferencesModel::setDelayBetweenNotesInRealTimeModeMilliseconds(int delay)

--- a/src/appshell/view/preferences/noteinputpreferencesmodel.h
+++ b/src/appshell/view/preferences/noteinputpreferencesmodel.h
@@ -43,6 +43,8 @@ class NoteInputPreferencesModel : public QObject
     Q_PROPERTY(
         bool colorNotesOutsideOfUsablePitchRange READ colorNotesOutsideOfUsablePitchRange WRITE setColorNotesOutsideOfUsablePitchRange NOTIFY colorNotesOutsideOfUsablePitchRangeChanged)
     Q_PROPERTY(
+        bool warnGuitarBends READ warnGuitarBends WRITE setWarnGuitarBends NOTIFY warnGuitarBendsChanged)
+    Q_PROPERTY(
         int delayBetweenNotesInRealTimeModeMilliseconds READ delayBetweenNotesInRealTimeModeMilliseconds WRITE setDelayBetweenNotesInRealTimeModeMilliseconds NOTIFY delayBetweenNotesInRealTimeModeMillisecondsChanged)
 
     Q_PROPERTY(bool playNotesWhenEditing READ playNotesWhenEditing WRITE setPlayNotesWhenEditing NOTIFY playNotesWhenEditingChanged)
@@ -57,6 +59,7 @@ public:
 
     bool advanceToNextNoteOnKeyRelease() const;
     bool colorNotesOutsideOfUsablePitchRange() const;
+    bool warnGuitarBends() const;
     int delayBetweenNotesInRealTimeModeMilliseconds() const;
 
     bool playNotesWhenEditing() const;
@@ -67,6 +70,7 @@ public:
 public slots:
     void setAdvanceToNextNoteOnKeyRelease(bool value);
     void setColorNotesOutsideOfUsablePitchRange(bool value);
+    void setWarnGuitarBends(bool value);
     void setDelayBetweenNotesInRealTimeModeMilliseconds(int delay);
     void setPlayNotesWhenEditing(bool value);
     void setNotePlayDurationMilliseconds(int duration);
@@ -76,6 +80,7 @@ public slots:
 signals:
     void advanceToNextNoteOnKeyReleaseChanged(bool value);
     void colorNotesOutsideOfUsablePitchRangeChanged(bool value);
+    void warnGuitarBendsChanged(bool value);
     void delayBetweenNotesInRealTimeModeMillisecondsChanged(int delay);
     void playNotesWhenEditingChanged(bool value);
     void notePlayDurationMillisecondsChanged(int duration);

--- a/src/engraving/dom/guitarbend.cpp
+++ b/src/engraving/dom/guitarbend.cpp
@@ -93,7 +93,7 @@ Note* GuitarBend::endNote() const
     return toNote(endEl);
 }
 
-void GuitarBend::setEndNotePitch(int pitch, int quarterOff)
+void GuitarBend::setEndNotePitch(int pitch, QuarterOffset quarterOff)
 {
     Note* note = endNote();
     IF_ASSERT_FAILED(note) {
@@ -113,7 +113,7 @@ void GuitarBend::setEndNotePitch(int pitch, int quarterOff)
     score()->undoChangePitch(note, pitch, targetTpc1, targetTpc2);
 
     AccidentalType accidentalType = Accidental::value2subtype(tpc2alter(targetTpc1));
-    if (quarterOff == 1) {
+    if (quarterOff == QuarterOffset::QUARTER_SHARP) {
         switch (accidentalType) {
         case AccidentalType::NONE:
         case AccidentalType::NATURAL:
@@ -128,7 +128,7 @@ void GuitarBend::setEndNotePitch(int pitch, int quarterOff)
         default:
             break;
         }
-    } else if (quarterOff == -1) {
+    } else if (quarterOff == QuarterOffset::QUARTER_FLAT) {
         switch (accidentalType) {
         case AccidentalType::NONE:
         case AccidentalType::NATURAL:

--- a/src/engraving/dom/guitarbend.h
+++ b/src/engraving/dom/guitarbend.h
@@ -30,6 +30,12 @@
 #include "types.h"
 
 namespace mu::engraving {
+enum class QuarterOffset {
+    QUARTER_FLAT,
+    NONE,
+    QUARTER_SHARP
+};
+
 class GuitarBend final : public SLine
 {
     OBJECT_ALLOCATOR(engraving, GuitarBend)
@@ -57,7 +63,7 @@ public:
     Note* startNoteOfChain() const;
 
     Note* endNote() const;
-    void setEndNotePitch(int pitch, int quarterOff = 0);
+    void setEndNotePitch(int pitch, QuarterOffset quarterOff = QuarterOffset::NONE);
 
     bool isReleaseBend() const;
     bool isFullRelease() const;

--- a/src/engraving/dom/guitarbend.h
+++ b/src/engraving/dom/guitarbend.h
@@ -57,7 +57,7 @@ public:
     Note* startNoteOfChain() const;
 
     Note* endNote() const;
-    void setEndNotePitch(int pitch);
+    void setEndNotePitch(int pitch, int quarterOff = 0);
 
     bool isReleaseBend() const;
     bool isFullRelease() const;
@@ -74,6 +74,9 @@ public:
     void computeBendAmount();
     int totBendAmountIncludingPrecedingBends() const;
     void computeBendText();
+    void computeIsInvalidOrNeedsWarning();
+    bool isInvalid() const { return m_isInvalid; }
+    bool isBorderlineUnplayable() const { return m_isBorderlineUnplayable; }
 
     GuitarBend* findPrecedingBend() const;
 
@@ -82,6 +85,8 @@ public:
     GuitarBendHold* holdLine() const { return m_holdLine; }
 
     double lineWidth() const;
+
+    mu::draw::Color uiColor() const;
 
     struct LayoutData : public SLine::LayoutData
     {
@@ -104,6 +109,8 @@ public:
 
 private:
     GuitarBendHold* m_holdLine = nullptr;
+    bool m_isInvalid = false;
+    bool m_isBorderlineUnplayable = false;
 };
 
 class GuitarBendText; // forward decl
@@ -142,6 +149,8 @@ public:
     void setBendText(GuitarBendText* t) { m_text = t; }
 
     bool isUserModified() const override;
+
+    mu::draw::Color uiColor() const { return guitarBend()->uiColor(); }
 
     struct LayoutData : public LineSegment::LayoutData
     {

--- a/src/engraving/dom/mscore.cpp
+++ b/src/engraving/dom/mscore.cpp
@@ -56,6 +56,7 @@ double MScore::horizontalPageGapEven = 1.0;
 double MScore::horizontalPageGapOdd = 50.0;
 
 bool MScore::warnPitchRange;
+bool MScore::warnGuitarBends;
 int MScore::pedalEventsMinTicks;
 
 double MScore::nudgeStep;
@@ -90,6 +91,7 @@ void MScore::init()
 
     defaultPlayDuration = 300;        // ms
     warnPitchRange      = true;
+    warnGuitarBends     = true;
     pedalEventsMinTicks = 1;
 
     //

--- a/src/engraving/dom/mscore.h
+++ b/src/engraving/dom/mscore.h
@@ -200,6 +200,7 @@ public:
     static void setVerticalOrientation(bool val) { _verticalOrientation = val; }
 
     static bool warnPitchRange;
+    static bool warnGuitarBends;
     static int pedalEventsMinTicks;
 
     static double nudgeStep;

--- a/src/engraving/rendering/dev/tdraw.cpp
+++ b/src/engraving/rendering/dev/tdraw.cpp
@@ -1489,6 +1489,7 @@ void TDraw::draw(const GuitarBendSegment* item, Painter* painter)
     pen.setWidthF(item->lineWidth());
     pen.setCapStyle(PenCapStyle::FlatCap);
     pen.setJoinStyle(PenJoinStyle::MiterJoin);
+    pen.setColor(item->uiColor());
     painter->setPen(pen);
 
     Brush brush;
@@ -1499,7 +1500,7 @@ void TDraw::draw(const GuitarBendSegment* item, Painter* painter)
 
     if (item->staff()->isTabStaff(item->tick())) {
         brush.setStyle(BrushStyle::SolidPattern);
-        brush.setColor(item->curColor());
+        brush.setColor(item->uiColor());
         painter->setBrush(brush);
         painter->setNoPen();
         painter->drawPolygon(item->ldata()->arrow());

--- a/src/inspector/models/notation/bends/bendsettingsmodel.cpp
+++ b/src/inspector/models/notation/bends/bendsettingsmodel.cpp
@@ -270,12 +270,13 @@ void BendSettingsModel::setBendCurve(const QVariantList& newBendCurve)
 
     const CurvePoint& endTimePoint = points.at(END_POINT_INDEX);
 
-    int bendAmount = curvePitchToBendAmount(points[END_POINT_INDEX].pitch);
+    int bendAmount = curvePitchToBendAmount(endTimePoint.pitch);
     int pitch = bendAmount / 2 + bend->startNoteOfChain()->pitch();
-    int quarterOff = bendAmount % 2;
-    if (pitch == bend->startNote()->pitch() && quarterOff == 1) {
+    QuarterOffset quarterOff = bendAmount % 2 ? QuarterOffset::QUARTER_SHARP : QuarterOffset::NONE;
+    if (pitch == bend->startNote()->pitch() && quarterOff == QuarterOffset::QUARTER_SHARP) {
+        // Because a flat second is more readable than a sharp unison
         pitch += 1;
-        quarterOff = -1;
+        quarterOff = QuarterOffset::QUARTER_FLAT;
     }
 
     float starTimeFactor = static_cast<float>(points.at(START_POINT_INDEX).time) / CurvePoint::MAX_TIME;

--- a/src/inspector/models/notation/bends/bendsettingsmodel.h
+++ b/src/inspector/models/notation/bends/bendsettingsmodel.h
@@ -82,6 +82,7 @@ private:
     bool m_isShowHoldLineAvailable = false;
 
     CurvePoints m_bendCurve;
+    bool m_releaseBend = false;
 };
 }
 

--- a/src/inspector/types/bendtypes.h
+++ b/src/inspector/types/bendtypes.h
@@ -57,13 +57,17 @@ struct CurvePoint
     int pitch = 0;
 
     QList<MoveDirection> moveDirection;
+    bool limitMoveVerticallyByNearestPoints = true;
+
     bool endDashed = false;
 
     bool generated = false;
 
     CurvePoint() = default;
-    CurvePoint(int time, int pitch, const QList<MoveDirection>& moveDirection = {}, bool endDashed = false, bool generated = false)
-        : time(time), pitch(pitch), moveDirection(moveDirection), endDashed(endDashed), generated(generated) {}
+    CurvePoint(int time, int pitch, const QList<MoveDirection>& moveDirection = {}, bool endDashed = false, bool generated = false,
+               bool limitMoveVerticallyByNearestPoints = true)
+        : time(time), pitch(pitch), moveDirection(moveDirection), limitMoveVerticallyByNearestPoints(limitMoveVerticallyByNearestPoints),
+        endDashed(endDashed), generated(generated) {}
     CurvePoint(int time, int pitch, bool generated)
         : time(time), pitch(pitch), generated(generated) {}
 
@@ -97,6 +101,7 @@ struct CurvePoint
             directions << static_cast<int>(direction);
         }
         map["moveDirection"] = directions;
+        map["limitMoveVerticallyByNearestPoints"] = limitMoveVerticallyByNearestPoints;
 
         map["endDashed"] = endDashed;
         map["generated"] = generated;
@@ -117,6 +122,7 @@ struct CurvePoint
             directions << static_cast<MoveDirection>(var.toInt());
         }
         point.moveDirection = directions;
+        point.limitMoveVerticallyByNearestPoints = map["limitMoveVerticallyByNearestPoints"].toBool();
 
         point.endDashed = map["endDashed"].toBool();
         point.generated = map["generated"].toBool();

--- a/src/inspector/view/widgets/bendgridcanvas.cpp
+++ b/src/inspector/view/widgets/bendgridcanvas.cpp
@@ -823,17 +823,21 @@ bool BendGridCanvas::movePoint(int pointIndex, const CurvePoint& toPoint)
 
     if (canMoveVertically) {
         bool canMove = true;
-        bool moveToTop = currentPoint.pitch < toPoint.pitch;
 
-        if (pointIndex - 1 >= 0) {
-            const CurvePoint& leftPoint = m_points.at(pointIndex - 1);
-            bool isLeftValid = moveToTop ? leftPoint.pitch >= currentPoint.pitch : leftPoint.pitch <= currentPoint.pitch;
-            if (isLeftValid) {
-                canMove = leftPoint.generated || (moveToTop ? leftPoint.pitch > toPoint.pitch : leftPoint.pitch < toPoint.pitch);
+        if (currentPoint.limitMoveVerticallyByNearestPoints) {
+            bool moveToTop = currentPoint.pitch < toPoint.pitch;
+            if (pointIndex - 1 >= 0) {
+                const CurvePoint& leftPoint = m_points.at(pointIndex - 1);
+                bool isLeftValid = moveToTop ? leftPoint.pitch >= currentPoint.pitch : leftPoint.pitch <= currentPoint.pitch;
+                if (isLeftValid) {
+                    canMove = leftPoint.generated || (moveToTop ? leftPoint.pitch > toPoint.pitch : leftPoint.pitch < toPoint.pitch);
+                }
             }
-        }
 
-        if (canMove) {
+            if (!canMove) {
+                return moved;
+            }
+
             if (pointIndex + 1 < m_points.size()) {
                 const CurvePoint& rightPoint = m_points.at(pointIndex + 1);
                 bool isRightValid = moveToTop ? rightPoint.pitch >= currentPoint.pitch : rightPoint.pitch <= currentPoint.pitch;
@@ -841,28 +845,29 @@ bool BendGridCanvas::movePoint(int pointIndex, const CurvePoint& toPoint)
                     canMove = rightPoint.generated || (moveToTop ? rightPoint.pitch > toPoint.pitch : rightPoint.pitch < toPoint.pitch);
                 }
             }
+        }
 
-            if (canMove) {
-                currentPoint.pitch = toPoint.pitch;
+        if (canMove) {
+            currentPoint.pitch = toPoint.pitch;
 
-                bool isDashed = currentPoint.endDashed;
-                bool isNextDashed = (pointIndex + 1 < m_points.size()) && m_points.at(pointIndex + 1).endDashed;
+            bool isDashed = currentPoint.endDashed;
+            bool isNextDashed = (pointIndex + 1 < m_points.size()) && m_points.at(pointIndex + 1).endDashed;
 
-                if (isDashed) {
-                    m_points[pointIndex - 1].pitch = toPoint.pitch;
-                }
-
-                if (isNextDashed) {
-                    m_points[pointIndex + 1].pitch = toPoint.pitch;
-                }
-
-                moved = true;
+            if (isDashed) {
+                m_points[pointIndex - 1].pitch = toPoint.pitch;
             }
+
+            if (isNextDashed) {
+                m_points[pointIndex + 1].pitch = toPoint.pitch;
+            }
+
+            moved = true;
         }
     }
 
     if (canMoveHorizontally) {
         bool canMove = true;
+
         bool moveToLeft = currentPoint.time > toPoint.time;
         if (moveToLeft) {
             if (pointIndex - 1 >= 0) {

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -149,6 +149,9 @@ public:
     virtual bool colorNotesOutsideOfUsablePitchRange() const = 0;
     virtual void setColorNotesOutsideOfUsablePitchRange(bool value) = 0;
 
+    virtual bool warnGuitarBends() const = 0;
+    virtual void setWarnGuitarBends(bool value) = 0;
+
     virtual int delayBetweenNotesInRealTimeModeMilliseconds() const = 0;
     virtual void setDelayBetweenNotesInRealTimeModeMilliseconds(int delayMs) = 0;
 

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -71,6 +71,7 @@ static const Settings::Key IS_CANVAS_ORIENTATION_VERTICAL_KEY(module_name, "ui/c
 static const Settings::Key IS_LIMIT_CANVAS_SCROLL_AREA_KEY(module_name, "ui/canvas/scroll/limitScrollArea");
 
 static const Settings::Key COLOR_NOTES_OUTSIDE_OF_USABLE_PITCH_RANGE(module_name, "score/note/warnPitchRange");
+static const Settings::Key WARN_GUITAR_BENDS(module_name, "score/note/warnGuitarBends");
 static const Settings::Key REALTIME_DELAY(module_name, "io/midi/realtimeDelay");
 static const Settings::Key NOTE_DEFAULT_PLAY_DURATION(module_name, "score/note/defaultPlayDuration");
 
@@ -185,6 +186,7 @@ void NotationConfiguration::init()
     });
 
     settings()->setDefaultValue(COLOR_NOTES_OUTSIDE_OF_USABLE_PITCH_RANGE, Val(true));
+    settings()->setDefaultValue(WARN_GUITAR_BENDS, Val(true));
     settings()->setDefaultValue(REALTIME_DELAY, Val(750));
     settings()->setDefaultValue(NOTE_DEFAULT_PLAY_DURATION, Val(500));
 
@@ -217,6 +219,7 @@ void NotationConfiguration::init()
     });
 
     mu::engraving::MScore::warnPitchRange = colorNotesOutsideOfUsablePitchRange();
+    mu::engraving::MScore::warnGuitarBends = warnGuitarBends();
     mu::engraving::MScore::defaultPlayDuration = notePlayDurationMilliseconds();
 
     mu::engraving::MScore::setHRaster(DEFAULT_GRID_SIZE_SPATIUM);
@@ -660,6 +663,17 @@ void NotationConfiguration::setColorNotesOutsideOfUsablePitchRange(bool value)
 {
     mu::engraving::MScore::warnPitchRange = value;
     settings()->setSharedValue(COLOR_NOTES_OUTSIDE_OF_USABLE_PITCH_RANGE, Val(value));
+}
+
+bool NotationConfiguration::warnGuitarBends() const
+{
+    return settings()->value(WARN_GUITAR_BENDS).toBool();
+}
+
+void NotationConfiguration::setWarnGuitarBends(bool value)
+{
+    mu::engraving::MScore::warnGuitarBends = value;
+    settings()->setSharedValue(WARN_GUITAR_BENDS, Val(value));
 }
 
 int NotationConfiguration::delayBetweenNotesInRealTimeModeMilliseconds() const

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -152,6 +152,9 @@ public:
     bool colorNotesOutsideOfUsablePitchRange() const override;
     void setColorNotesOutsideOfUsablePitchRange(bool value) override;
 
+    bool warnGuitarBends() const override;
+    void setWarnGuitarBends(bool value) override;
+
     int delayBetweenNotesInRealTimeModeMilliseconds() const override;
     void setDelayBetweenNotesInRealTimeModeMilliseconds(int delayMs) override;
 


### PR DESCRIPTION
Resolves: #20013 

- Introducing warning colors for bends that are difficult to play (yellow) or that are simply unplayble/incorrect (red).
- Introduging appropriate microtonal accidentals when editing the bend from the property widget onto quarter-values.
