### PR TITLE
Element seeking fixes (#19309 & #19259)

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -648,6 +648,8 @@ bool NotationViewInputController::needSelect(const ClickContext& ctx) const
         return !selection->range()->containsPoint(ctx.logicClickPos);
     } else if (!ctx.hitElement->selected()) {
         return true;
+    } else if (ctx.hitElement->selected() && selection->isRange()) {
+        return true;
     }
 
     return false;

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -169,12 +169,12 @@ bool PlaybackController::isLoaded() const
     return m_loadingTrackCount == 0;
 }
 
-bool PlaybackController::isLoopVisible() const
+bool PlaybackController::isLoopEnabled() const
 {
     return notationPlayback() ? notationPlayback()->loopBoundaries().visible : false;
 }
 
-bool PlaybackController::isPlaybackLooped() const
+bool PlaybackController::loopBoundariesSet() const
 {
     return notationPlayback() ? !notationPlayback()->loopBoundaries().isNull() : false;
 }
@@ -411,7 +411,7 @@ void PlaybackController::onSelectionChanged()
             updateMuteStates();
         }
 
-        if (!isPlaybackLooped()) {
+        if (!loopBoundariesSet()) {
             seekListSelection();
         }
 
@@ -455,7 +455,7 @@ void PlaybackController::play()
         return;
     }
 
-    if (isPlaybackLooped()) {
+    if (loopBoundariesSet() && isLoopEnabled()) {
         msecs_t startMsecs = playbackStartMsecs();
         seek(startMsecs);
     }
@@ -612,12 +612,12 @@ void PlaybackController::toggleCountIn()
 
 void PlaybackController::toggleLoopPlayback()
 {
-    if (isLoopVisible()) {
+    if (isLoopEnabled()) {
         hideLoop();
         return;
     }
 
-    if (isPlaybackLooped() && !selection()->isRange()) {
+    if (loopBoundariesSet() && !selection()->isRange()) {
         showLoop();
         return;
     }
@@ -1240,7 +1240,7 @@ void PlaybackController::updateAuxMuteStates()
 bool PlaybackController::actionChecked(const ActionCode& actionCode) const
 {
     QMap<std::string, bool> isChecked {
-        { LOOP_CODE, isLoopVisible() },
+        { LOOP_CODE, isLoopEnabled() },
         { MIDI_ON_CODE, notationConfiguration()->isMidiInputEnabled() },
         { REPEAT_CODE, notationConfiguration()->isPlayRepeatsEnabled() },
         { PLAY_CHORD_SYMBOLS_CODE, notationConfiguration()->isPlayChordSymbolsEnabled() },

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -128,8 +128,8 @@ private:
     bool isPaused() const;
     bool isLoaded() const;
 
-    bool isLoopVisible() const;
-    bool isPlaybackLooped() const;
+    bool isLoopEnabled() const;
+    bool loopBoundariesSet() const;
 
     void onNotationChanged();
 


### PR DESCRIPTION
Resolves: #19309
Resolves: #19259

Renamed `PlaybackController::isPlaybackLooped` to `loopBoundariesSet`. Part of the issue was an assumption that playback should always be looped whenever loop boundaries are non-null, but non-null loop boundaries can also occur if a loop was set and subsequently disabled (made invisible).

The renaming should make this more explicit.