### PR TITLE
Remove Audio.com hyperlink from AlsoShareAudioComDialog

### DIFF
--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -974,10 +974,7 @@ void ProjectActionsController::alsoShareAudioCom(const AudioFile& audio)
         return;
     }
 
-    QUrl audioComUrl = audioComService()->authorization()->cloudInfo().url;
-
     UriQuery query("musescore://project/alsoshareaudiocom");
-    query.addParam("audioComUrl", Val(audioComUrl.toString()));
     query.addParam("rememberChoice", Val(!configuration()->hasAskedAlsoShareAudioCom()));
     RetVal<Val> rv = interactive()->open(query);
 

--- a/src/project/qml/MuseScore/Project/AlsoShareAudioComDialog.qml
+++ b/src/project/qml/MuseScore/Project/AlsoShareAudioComDialog.qml
@@ -28,7 +28,6 @@ import MuseScore.UiComponents 1.0
 StyledDialogView {
     id: root
 
-    property string audioComUrl
     property bool rememberChoice
 
     contentHeight: 355
@@ -115,8 +114,7 @@ StyledDialogView {
 
                 Layout.fillWidth: true
 
-                //: The text between `<a href=\"%1\">` and `</a>` will be a clickable link to Audio.com
-                text: qsTrc("project/cloud", "Would you also like to share your music on <a href=\"%1\">Audio.com</a>?").arg(root.audioComUrl)
+                text: qsTrc("project/cloud", "Would you also like to share your music on Audio.com?")
                 font: ui.theme.largeBodyBoldFont
             }
 


### PR DESCRIPTION
As per @jessjwilliamson's request - hyperlink has been removed from new "also share" dialog.