### PR TITLE
don't remove title frames in parts

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -2898,6 +2898,25 @@ void Score::deleteItem(EngravingItem* el)
     }
     break;
 
+    case ElementType::VBOX:
+    {
+        // don't remove title frames in parts, because they contain part name
+        // remove title, subtitle, ... instead, and unlink frame siblinks
+        if (el == score()->first() && score()->isMaster()) {
+            ElementList els = toMeasureBase(el)->el();
+            for (EngravingItem* e : els) {
+                deleteItem(e);
+            }
+            undoRemoveElement(el, false);
+            for (EngravingObject* linkedFrame : el->linkList()) {
+                linkedFrame->undoUnlink();
+            }
+        } else {
+            undoRemoveElement(el);
+        }
+    }
+    break;
+
     default:
         undoRemoveElement(el);
         break;


### PR DESCRIPTION
don't remove title frames in parts, because they contain instrument name

- remove only title, subtitle, composer, lyricist texts in frames

Resolves: first issue of #19476 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
