### PR TITLE
Don't run assertion-based EXPECT_DEATH tests in Release builds

### DIFF
--- a/src/framework/global/tests/iodevice_tests.cpp
+++ b/src/framework/global/tests/iodevice_tests.cpp
@@ -25,6 +25,10 @@
 
 #include "io/buffer.h"
 
+#ifdef NDEBUG
+#include "log.h"
+#endif
+
 using namespace mu;
 using namespace mu::io;
 
@@ -49,6 +53,7 @@ TEST_F(Global_IO_IODeviceTests, Open_ReadOnly)
     //! CHECK
     EXPECT_EQ(rba, ba);
 
+#ifndef NDEBUG
     //! DO Try Write data
     std::string data = " World!";
     ByteArray wrba(reinterpret_cast<const uint8_t*>(data.c_str()), data.size());
@@ -58,6 +63,9 @@ TEST_F(Global_IO_IODeviceTests, Open_ReadOnly)
         size_t size = buf.write(wrba);
         EXPECT_EQ(size, 0);
     }, ".*isOpenModeWriteable\\(\\).*");
+#else
+    LOGW() << "Cannot check for assertion failure in Release mode; please build in Debug mode instead";
+#endif
 }
 
 TEST_F(Global_IO_IODeviceTests, Open_WriteOnly)
@@ -78,6 +86,7 @@ TEST_F(Global_IO_IODeviceTests, Open_WriteOnly)
     //! CHECK
     EXPECT_EQ(size, wrba.size());
 
+#ifndef NDEBUG
     //! DO Try Read
     EXPECT_DEATH({
         ByteArray rba = buf.readAll();
@@ -94,6 +103,9 @@ TEST_F(Global_IO_IODeviceTests, Open_WriteOnly)
         size_t s = buf.read(&d, 1);
         EXPECT_EQ(s, 0);
     }, ".*isOpenModeReadable\\(\\).*");
+#else
+    LOGW() << "Cannot check for assertion failure in Release mode; please build in Debug mode instead";
+#endif
 }
 
 TEST_F(Global_IO_IODeviceTests, Open_ReadWrite)


### PR DESCRIPTION
A few contributors have encountered that these tests were failing; turned out they were using a Release build with assertions disabled, while these tests expect certain methods to crash because of assertion failures.

Even though building in Release mode may not be the most useful thing to do for development builds, I think the tests should not fail because of that; so in release builds I disabled the EXPECT_DEATH tests and added a warning instead, saying that these tests should actually be built in debug mode.