### PR TITLE
Fix the percussion crash

### DIFF
--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -4256,7 +4256,9 @@ void TLayout::fillNoteShape(const Note* item, Note::LayoutData* ldata)
         }
     }
 
-    if (item->part()->instrument()->hasStrings() && !item->staffType()->isTabStaff()) {
+    // This method is also called from SingleLayout, where `part` may be nullptr
+    Part* part = item->part();
+    if (part && part->instrument()->hasStrings() && !item->staffType()->isTabStaff()) {
         GuitarBend* bend = item->bendFor();
         if (bend && bend->type() == GuitarBendType::SLIGHT_BEND && !bend->segmentsEmpty()) {
             GuitarBendSegment* bendSeg = toGuitarBendSegment(bend->frontSegment());

--- a/src/engraving/rendering/single/singlelayout.cpp
+++ b/src/engraving/rendering/single/singlelayout.cpp
@@ -762,6 +762,7 @@ void SingleLayout::layout(Chord* item, const Context& ctx)
 {
     LayoutContext tctx(ctx.dontUseScore());
     ChordLayout::layout(item, tctx);
+    ChordLayout::layoutStem(item, tctx);
 }
 
 void SingleLayout::layout(ChordLine* item, const Context& ctx)


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/19516 (again)
Resolves: https://github.com/musescore/MuseScore/issues/19811 (this time also the position of stems in the Percussion palette)