### PR TITLE
Fix crash on alt+arrow navigation from grace note to preceding rest

### DIFF
--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -2777,7 +2777,10 @@ EngravingItem* Chord::prevElement()
         if (isGrace()) {
             ChordRest* next = prevChordRest(this);
             if (next) {
-                return toChord(next)->notes().back();
+                if (next->isChord()) {
+                    return toChord(next)->notes().back();
+                }
+                return toRest(next);
             }
         }
 

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -1740,6 +1740,10 @@ Spanner* Segment::firstSpanner(staff_idx_t activeStaff)
     if (range.first != range.second) {  // range not empty
         for (auto i = range.first; i != range.second; ++i) {
             Spanner* s = i->second;
+            if (s->segmentsEmpty()) {
+                continue;
+            }
+
             EngravingItem* e = s->startElement();
             if (!e) {
                 continue;
@@ -1765,6 +1769,10 @@ Spanner* Segment::lastSpanner(staff_idx_t activeStaff)
     if (range.first != range.second) {  // range not empty
         for (auto i = --range.second;; --i) {
             Spanner* s = i->second;
+            if (s->segmentsEmpty()) {
+                continue;
+            }
+
             EngravingItem* e = s->startElement();
             if (!e) {
                 continue;


### PR DESCRIPTION
To reproduce the crash:
- Enter a rest
- Enter a chord after the rest
- Enter a grace note on that chord
- Select the grace note
- Do alt+leftArrow (should navigate backwards and select the rest) -> crash
