### PR TITLE
Fix #19509: Measure properties not in context menu for keyboard users

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -1091,7 +1091,7 @@ ElementType NotationViewInputController::selectionType() const
     if (auto hitElement = hitElementContext().element) {
         return hitElement->type();
     } else if (selection->isRange()) {
-        return ElementType::STAFF;
+        return ElementType::MEASURE;
     } else if (auto selectedElement = selection->element()) {
         return selectedElement->type();
     }


### PR DESCRIPTION
Resolves: #19509 

Refer to this comment for more info https://github.com/musescore/MuseScore/issues/19509#issuecomment-1816903133

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
