### PR TITLE
Fix #20062: Select section not working

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -4213,6 +4213,8 @@ void Score::cmdSelectSection()
     }
 
     m_selection.setRange(toMeasure(sm)->first(), toMeasure(em)->last(), 0, nstaves());
+    setUpdateAll();
+    update();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/select.cpp
+++ b/src/engraving/dom/select.cpp
@@ -687,7 +687,12 @@ void Selection::setRange(Segment* startSegment, Segment* endSegment, staff_idx_t
     m_activeSegment = endSegment;
     m_staffStart    = staffStart;
     m_staffEnd      = staffEnd;
-    setState(SelState::RANGE);
+
+    if (m_state == SelState::RANGE) {
+        m_score->setSelectionChanged(true);
+    } else {
+        setState(SelState::RANGE);
+    }
 }
 
 //---------------------------------------------------------
@@ -702,13 +707,17 @@ void Selection::setRangeTicks(const Fraction& tick1, const Fraction& tick2, staf
 {
     assert(staffEnd > staffStart && staffEnd <= m_score->nstaves());
 
-    deselectAll();
     m_plannedTick1 = tick1;
     m_plannedTick2 = tick2;
     m_startSegment = m_endSegment = m_activeSegment = nullptr;
     m_staffStart    = staffStart;
     m_staffEnd      = staffEnd;
-    setState(SelState::RANGE);
+
+    if (m_state == SelState::RANGE) {
+        m_score->setSelectionChanged(true);
+    } else {
+        setState(SelState::RANGE);
+    }
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: #20062

Selecting a range beforehand is required for select section to update the range. **This was how it worked in MuseScore 3**.

setState contains an if statement that prevents duplicate states which also prevents select section from working. This was introduced in https://github.com/musescore/MuseScore/pull/12977 which caused the regression.


https://github.com/musescore/MuseScore/blob/53d463f69391fb108175a285a52b9fb995d922c5/src/engraving/dom/select.cpp#L773-L775

This commit fixes the issue by deselecting the selection before setting the state, just like in the Selection::setRangeTicks() just below it.

Also, I do not fully understand why Selection::deselectAll() clears the selection, then does another function call to update the state right after.

https://github.com/musescore/MuseScore/blob/53d463f69391fb108175a285a52b9fb995d922c5/src/engraving/dom/select.cpp#L401-L408

This commit would still fix the issue if it just used Selection::clear(), so I am wondering if it is necessary to use Selection::deselectAll().

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
