### PR TITLE
Write location before spanner end on score end

### DIFF
--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -834,6 +834,27 @@ void TWrite::writeSpannerStart(Spanner* s, XmlWriter& xml, WriteContext& ctx, co
 void TWrite::writeSpannerEnd(Spanner* s, XmlWriter& xml, WriteContext& ctx, const EngravingItem* current, track_idx_t track, Fraction tick)
 {
     Fraction frac = fraction(ctx.clipboardmode(), current, tick);
+    if (frac == s->score()->endTick()) {
+        // Write a location tag if the spanner ends on the last tick of the score
+        Location spannerEndLoc = Location::absolute();
+        spannerEndLoc.setFrac(frac);
+        spannerEndLoc.setMeasure(0);
+        spannerEndLoc.setTrack(track);
+        spannerEndLoc.setVoice(track2voice(track));
+        spannerEndLoc.setStaff(s->staffIdx());
+
+        Location prevLoc = Location::absolute();
+        prevLoc.setFrac(ctx.curTick());
+        prevLoc.setMeasure(0);
+        prevLoc.setTrack(track);
+        prevLoc.setVoice(track2voice(track));
+        prevLoc.setStaff(s->staffIdx());
+
+        spannerEndLoc.toRelative(prevLoc);
+        if (spannerEndLoc.frac() != Fraction(0, 1)) {
+            write(&spannerEndLoc, xml, ctx);
+        }
+    }
     SpannerWriter w(xml, &ctx, current, s, static_cast<int>(track), frac, false);
     w.write();
 }


### PR DESCRIPTION
Resolves: #19082 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

This PR writes a location tag before any spanner which ends at the end of the score.  Ususally, these spanners would be written to the beginning of the following bar.  Instead they are written to the end of the bar, but when reading the file the location is ambiguous.  The location tag ensures the location is updated to the end tick of the file when reading the spanner end.