### PR TITLE
Fix #19279 Add/Remove Measure windows lose focus

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/SelectMeasuresCountDialog.qml
+++ b/src/notation/qml/MuseScore/NotationScene/SelectMeasuresCountDialog.qml
@@ -48,7 +48,7 @@ StyledDialogView {
             NavigationPanel {
                 id: measuresCountNavigationPanel
                 name: "MeasuresCountNavigationPanel"
-                enabled: parent && parent.enabled && parent.visible
+                enabled: content && content.enabled && content.visible
                 section: root.navigationSection
                 order: 1
                 direction: NavigationPanel.Horizontal


### PR DESCRIPTION
Resolves: #19279

~~The enable property was always false, its not needed as its already inherited from the parent~~
The enable property was always false using parent as no signal is sent when it changes, switch to using the visible content element

Regression from https://github.com/musescore/MuseScore/commit/7784f25e3176283b6e8f88ef68944acbaced2454

The weird thing was that `enabled: parent.enabled && parent.visible` worked fine but `enabled: parent && parent.enabled && parent.visible` does not, even though parent is always null (as least when I tried to debug it).

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
