### PR TITLE
Use MiterJoin for drawing tuplet brackets

### DIFF
--- a/src/engraving/rendering/dev/tdraw.cpp
+++ b/src/engraving/rendering/dev/tdraw.cpp
@@ -3042,7 +3042,10 @@ void TDraw::draw(const Tuplet* item, Painter* painter)
         painter->translate(-pos);
     }
     if (item->hasBracket()) {
-        painter->setPen(Pen(color, item->bracketWidth().val() * item->mag()));
+        Pen pen(color, item->bracketWidth().val() * item->mag());
+        pen.setJoinStyle(PenJoinStyle::MiterJoin);
+        pen.setCapStyle(PenCapStyle::FlatCap);
+        painter->setPen(pen);
         if (!item->number()) {
             painter->drawPolyline(item->bracketL, 4);
         } else {


### PR DESCRIPTION
Just a quick little fix.

Before:
<img width="842" alt="image" src="https://github.com/musescore/MuseScore/assets/93707756/a9614d00-9a73-4ce3-8628-d51dcf2743a5">

After:
<img width="844" alt="image" src="https://github.com/musescore/MuseScore/assets/93707756/b23a81cd-2595-4e2b-8c51-f000083482ad">
