### PR TITLE
fixed #20034: Crash when navigate slur with Orca enabled on Linux

### DIFF
--- a/src/engraving/accessibility/accessibleitem.cpp
+++ b/src/engraving/accessibility/accessibleitem.cpp
@@ -86,6 +86,10 @@ AccessibleRoot* AccessibleItem::accessibleRoot() const
         return nullptr;
     }
 
+    if (m_element->isType(ElementType::ROOT_ITEM)) {
+        return dynamic_cast<AccessibleRoot*>(m_element->accessible().get());
+    }
+
     Score* score = m_element->score();
     if (!score) {
         return nullptr;

--- a/src/engraving/compat/dummyelement.cpp
+++ b/src/engraving/compat/dummyelement.cpp
@@ -138,7 +138,7 @@ EngravingItem* DummyElement::clone() const
 #ifndef ENGRAVING_NO_ACCESSIBILITY
 AccessibleItemPtr DummyElement::createAccessible()
 {
-    return std::make_shared<AccessibleItem>(this, accessibility::IAccessible::Panel);
+    return std::make_shared<AccessibleItem>(this, accessibility::IAccessible::Group);
 }
 
 #endif

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -160,7 +160,6 @@ Score::Score()
     m_style = DefaultStyle::defaultStyle();
 
     m_rootItem = new RootItem(this);
-    m_rootItem->setParent(this);
     m_rootItem->init();
 
     //! NOTE Looks like a bug, `minimumPaddingUnit` is set using the default style's spatium value


### PR DESCRIPTION
Resolves: #20034

Also see https://github.com/musescore/MuseScore/pull/19457#issuecomment-1820555056