### PR TITLE
fixed #19812: Crash after switching from pitched staff to unpitched percussion staff and click Edit drumset

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -540,6 +540,21 @@ void NotationViewInputController::mousePressEvent(QMouseEvent* event)
         return;
     }
 
+    EngravingItem* hitElement = nullptr;
+    staff_idx_t hitStaffIndex = mu::nidx;
+
+    if (!m_readonly) {
+        m_prevHitElement = hitElementContext().element;
+
+        INotationInteraction::HitElementContext context;
+        context.element = viewInteraction()->hitElement(logicPos, hitWidth());
+        context.staff = viewInteraction()->hitStaff(logicPos);
+        viewInteraction()->setHitElementContext(context);
+
+        hitElement = context.element;
+        hitStaffIndex = context.staff ? context.staff->idx() : mu::nidx;
+    }
+
     // note enter mode
     if (m_view->isNoteEnterMode()) {
         if (button == Qt::RightButton) {
@@ -561,21 +576,6 @@ void NotationViewInputController::mousePressEvent(QMouseEvent* event)
     }
 
     m_beginPoint = logicPos;
-
-    EngravingItem* hitElement = nullptr;
-    staff_idx_t hitStaffIndex = mu::nidx;
-
-    if (!m_readonly) {
-        m_prevHitElement = hitElementContext().element;
-
-        INotationInteraction::HitElementContext context;
-        context.element = viewInteraction()->hitElement(logicPos, hitWidth());
-        context.staff = viewInteraction()->hitStaff(logicPos);
-        viewInteraction()->setHitElementContext(context);
-
-        hitElement = context.element;
-        hitStaffIndex = context.staff ? context.staff->idx() : mu::nidx;
-    }
 
     if (playbackController()->isPlaying()) {
         if (hitElement) {


### PR DESCRIPTION
Resolves: #19812

If you select an element on a non-drumset staff and start entering notes and click on the drumset staff, the context will not be updated and the drumset editing dialog will open with a non-drumset instrument. 