### PR TITLE
Same Beat and Measure (Select All Similar Filter)

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -3603,6 +3603,7 @@ void Score::selectRange(EngravingItem* e, staff_idx_t staffIdx)
 void Score::collectMatch(void* data, EngravingItem* e)
 {
     ElementPattern* p = static_cast<ElementPattern*>(data);
+    auto eMeasure = e->findMeasure();
 
     if (p->type != int(ElementType::INVALID) && p->type != int(e->type())) {
         return;
@@ -3649,8 +3650,21 @@ void Score::collectMatch(void* data, EngravingItem* e)
         }
     }
 
-    if (p->measure && (p->measure != e->findMeasure())) {
-        return;
+    if (p->measure) {
+        if (!eMeasure && e->isSpannerSegment()) {
+            if (auto ss = toSpannerSegment(e)) {
+                if (auto s = ss->spanner()) {
+                    if (auto se = s->startElement()) {
+                        if (auto mse = se->findMeasure()) {
+                            eMeasure = mse;
+                        }
+                    }
+                }
+            }
+        }
+        if (p->measure != eMeasure) {
+            return;
+        }
     }
 
     if ((p->beat.isValid()) && (p->beat != e->beat())) {

--- a/src/notation/internal/notationelements.cpp
+++ b/src/notation/internal/notationelements.cpp
@@ -206,6 +206,8 @@ ElementPattern* NotationElements::constructElementPattern(const FilterElementsOp
     pattern->voice   = elementOptions->voice;
     pattern->system  = elementOptions->system;
     pattern->durationTicks = elementOptions->durationTicks;
+    pattern->beat = elementOptions->beat;
+    pattern->measure = elementOptions->measure;
 
     return pattern;
 }
@@ -224,6 +226,8 @@ mu::engraving::NotePattern* NotationElements::constructNotePattern(const FilterN
     pattern->staffEnd = notesOptions->staffEnd;
     pattern->voice = notesOptions->voice;
     pattern->system = notesOptions->system;
+    pattern->beat = notesOptions->beat;
+    pattern->measure = notesOptions->measure;
 
     return pattern;
 }

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -442,6 +442,8 @@ struct FilterElementsOptions
     int voice = -1;
     const mu::engraving::System* system = nullptr;
     Fraction durationTicks{ -1, 1 };
+    Fraction beat{ -1, 1 };
+    const Measure* measure = nullptr;
 
     bool bySubtype = false;
     int subtype = -1;

--- a/src/notation/view/widgets/selectdialog.cpp
+++ b/src/notation/view/widgets/selectdialog.cpp
@@ -121,7 +121,21 @@ FilterElementsOptions SelectDialog::elementOptions() const
     }
 
     if (sameMeasure->isChecked()) {
-        options.measure = m_element->findMeasure();
+        auto m = m_element->findMeasure();
+        if (!m && m_element->isSpannerSegment()) {
+            if (auto ss = toSpannerSegment(m_element)) {
+                if (auto s = ss->spanner()) {
+                    if (auto se = s->startElement()) {
+                        if (auto mse = se->findMeasure()) {
+                            m = mse;
+                        }
+                    }
+                }
+            }
+        }
+        if (m) {
+            options.measure = m;
+        }
     } else {
         options.measure = nullptr;
     }

--- a/src/notation/view/widgets/selectdialog.cpp
+++ b/src/notation/view/widgets/selectdialog.cpp
@@ -114,6 +114,18 @@ FilterElementsOptions SelectDialog::elementOptions() const
         options.durationTicks = Fraction(-1, 1);
     }
 
+    if (sameBeat->isChecked()) {
+        options.beat = m_element->beat();
+    } else {
+        options.beat = Fraction(0, 0);
+    }
+
+    if (sameMeasure->isChecked()) {
+        options.measure = m_element->findMeasure();
+    } else {
+        options.measure = nullptr;
+    }
+
     options.voice = sameVoice->isChecked() ? static_cast<int>(m_element->voice()) : -1;
     options.bySubtype = sameSubtype->isChecked();
 

--- a/src/notation/view/widgets/selectdialog.ui
+++ b/src/notation/view/widgets/selectdialog.ui
@@ -29,18 +29,22 @@
       <number>9</number>
      </property>
      <item>
-      <widget class="QGroupBox" name="groupBox_2">
+      <widget class="QGroupBox" name="select">
        <property name="title">
         <string>Select</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_2">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label">
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="sameSubtype">
           <property name="text">
-           <string>Element type:</string>
+           <string>Same subtype:</string>
           </property>
-          <property name="buddy">
-           <cstring>type</cstring>
+         </widget>
+        </item>
+        <item row="0" column="1" colspan="2">
+         <widget class="QLineEdit" name="type">
+          <property name="readOnly">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -65,20 +69,6 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QCheckBox" name="sameSubtype">
-          <property name="text">
-           <string>Same subtype:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1" colspan="2">
-         <widget class="QLineEdit" name="type">
-          <property name="readOnly">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
         <item row="1" column="1" colspan="2">
          <widget class="QLineEdit" name="subtype">
           <property name="readOnly">
@@ -86,14 +76,38 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="1" colspan="2">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Element type:</string>
+          </property>
+          <property name="buddy">
+           <cstring>type</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QCheckBox" name="sameBeat">
+          <property name="text">
+           <string>Same beat</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QCheckBox" name="sameMeasure">
+          <property name="text">
+           <string>Same measure</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
          <widget class="QCheckBox" name="sameSystem">
           <property name="text">
            <string>Same system</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item row="3" column="1">
          <widget class="QCheckBox" name="inSelection">
           <property name="text">
            <string>In selection</string>
@@ -104,7 +118,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QGroupBox" name="groupBox">
+      <widget class="QGroupBox" name="action">
        <property name="title">
         <string>Action</string>
        </property>
@@ -171,13 +185,14 @@
   <tabstop>sameSubtype</tabstop>
   <tabstop>subtype</tabstop>
   <tabstop>sameStaff</tabstop>
-  <tabstop>inSelection</tabstop>
   <tabstop>sameVoice</tabstop>
-  <tabstop>sameSystem</tabstop>
+  <tabstop>inSelection</tabstop>
   <tabstop>sameDuration</tabstop>
+  <tabstop>sameSystem</tabstop>
+  <tabstop>sameBeat</tabstop>
+  <tabstop>sameMeasure</tabstop>
   <tabstop>replace</tabstop>
   <tabstop>add</tabstop>
-  <tabstop>fromSelection</tabstop>
   <tabstop>subtract</tabstop>
  </tabstops>
  <resources/>

--- a/src/notation/view/widgets/selectnotedialog.cpp
+++ b/src/notation/view/widgets/selectnotedialog.cpp
@@ -139,6 +139,18 @@ FilterNotesOptions SelectNoteDialog::noteOptions() const
         options.durationTicks = mu::engraving::Fraction(-1, 1);
     }
 
+    if (sameBeat->isChecked()) {
+        options.beat = m_note->beat();
+    } else {
+        options.beat = Fraction(0, 0);
+    }
+
+    if (sameMeasure->isChecked()) {
+        options.measure = m_note->findMeasure();
+    } else {
+        options.measure = nullptr;
+    }
+
     if (sameStaff->isChecked()) {
         options.staffStart = static_cast<int>(m_note->staffIdx());
         options.staffEnd = static_cast<int>(m_note->staffIdx() + 1);

--- a/src/notation/view/widgets/selectnotedialog.ui
+++ b/src/notation/view/widgets/selectnotedialog.ui
@@ -29,29 +29,22 @@
       <number>9</number>
      </property>
      <item>
-      <widget class="QGroupBox" name="groupBox_2">
+      <widget class="QGroupBox" name="select">
        <property name="title">
         <string>Select</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_2">
-        <item row="0" column="1">
-         <widget class="QLabel" name="notehead">
+        <item row="3" column="0">
+         <widget class="QCheckBox" name="sameType">
+          <property name="text">
+           <string>Same type:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QLabel" name="durationTicks">
           <property name="text">
            <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QCheckBox" name="sameNotehead">
-          <property name="text">
-           <string>Same notehead:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="1" colspan="2">
-         <widget class="QCheckBox" name="sameSystem">
-          <property name="text">
-           <string>Same system</string>
           </property>
          </widget>
         </item>
@@ -62,6 +55,13 @@
           </property>
          </widget>
         </item>
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="samePitch">
+          <property name="text">
+           <string>Same pitch:</string>
+          </property>
+         </widget>
+        </item>
         <item row="4" column="1">
          <widget class="QLabel" name="durationType">
           <property name="text">
@@ -69,15 +69,29 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
-         <widget class="QCheckBox" name="sameDurationType">
+        <item row="7" column="0">
+         <widget class="QCheckBox" name="sameStaff">
           <property name="text">
-           <string>Same note type:</string>
+           <string>Same staff</string>
           </property>
          </widget>
         </item>
-        <item row="5" column="1">
-         <widget class="QLabel" name="durationTicks">
+        <item row="6" column="0">
+         <widget class="QCheckBox" name="sameName">
+          <property name="text">
+           <string>Same note name:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QLabel" name="type">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <widget class="QLabel" name="name">
           <property name="text">
            <string/>
           </property>
@@ -90,10 +104,10 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QCheckBox" name="samePitch">
+        <item row="0" column="0">
+         <widget class="QCheckBox" name="sameNotehead">
           <property name="text">
-           <string>Same pitch:</string>
+           <string>Same notehead:</string>
           </property>
          </widget>
         </item>
@@ -111,38 +125,17 @@
           </property>
          </widget>
         </item>
-        <item row="7" column="0">
-         <widget class="QCheckBox" name="sameStaff">
-          <property name="text">
-           <string>Same staff</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QCheckBox" name="sameType">
-          <property name="text">
-           <string>Same type:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QLabel" name="type">
+        <item row="0" column="1">
+         <widget class="QLabel" name="notehead">
           <property name="text">
            <string/>
           </property>
          </widget>
         </item>
-        <item row="6" column="0">
-         <widget class="QCheckBox" name="sameName">
+        <item row="8" column="1" colspan="2">
+         <widget class="QCheckBox" name="sameSystem">
           <property name="text">
-           <string>Same note name:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="QLabel" name="name">
-          <property name="text">
-           <string/>
+           <string>Same system</string>
           </property>
          </widget>
         </item>
@@ -153,6 +146,13 @@
           </property>
          </widget>
         </item>
+        <item row="4" column="0">
+         <widget class="QCheckBox" name="sameDurationType">
+          <property name="text">
+           <string>Same note type:</string>
+          </property>
+         </widget>
+        </item>
         <item row="2" column="1">
          <widget class="QLabel" name="string">
           <property name="text">
@@ -160,11 +160,25 @@
           </property>
          </widget>
         </item>
+        <item row="9" column="0">
+         <widget class="QCheckBox" name="sameBeat">
+          <property name="text">
+           <string>Same beat</string>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="1">
+         <widget class="QCheckBox" name="sameMeasure">
+          <property name="text">
+           <string>Same measure</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </item>
      <item>
-      <widget class="QGroupBox" name="groupBox">
+      <widget class="QGroupBox" name="action">
        <property name="title">
         <string>Action</string>
        </property>
@@ -238,9 +252,10 @@
   <tabstop>inSelection</tabstop>
   <tabstop>sameVoice</tabstop>
   <tabstop>sameSystem</tabstop>
+  <tabstop>sameBeat</tabstop>
+  <tabstop>sameMeasure</tabstop>
   <tabstop>replace</tabstop>
   <tabstop>add</tabstop>
-  <tabstop>fromSelection</tabstop>
   <tabstop>subtract</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
Continuing on #7421, resp. porting (the rest of) #5637

Resolves: https://musescore.org/en/node/295235

Images of the dialog, the English items are the additions:
![image](https://github.com/musescore/MuseScore/assets/1786669/b2d119c6-955f-4fef-9917-6947f922c29a)
![image](https://github.com/musescore/MuseScore/assets/1786669/154e5ffc-2ad7-4c8a-9c31-798fd6eed1ba)

The 1st commit brings Mu4 on par with Mu3
The 2nd commit fixes a bug with text lines that exists in Mu3 too

