### PR TITLE
Add figured bass to parts & score

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -5873,7 +5873,8 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
             && et != ElementType::FRET_DIAGRAM
             && et != ElementType::FERMATA
             && et != ElementType::HARMONY
-            && et != ElementType::HARP_DIAGRAM)
+            && et != ElementType::HARP_DIAGRAM
+            && et != ElementType::FIGURED_BASS)
         ) {
         undo(new AddElement(element));
         return;
@@ -6076,7 +6077,8 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
                      || element->isFretDiagram()
                      || element->isFermata()
                      || element->isHarmony()
-                     || element->isHarpPedalDiagram()) {
+                     || element->isHarpPedalDiagram()
+                     || element->isFiguredBass()) {
                 Segment* segment
                     = element->explicitParent()->isFretDiagram() ? toSegment(element->explicitParent()->explicitParent()) : toSegment(
                           element->explicitParent());

--- a/src/engraving/dom/engravingobject.h
+++ b/src/engraving/dom/engravingobject.h
@@ -78,6 +78,7 @@ class FBox;
 class FSymbol;
 class Fermata;
 class FiguredBass;
+class FiguredBassItem;
 class Fingering;
 class FretDiagram;
 class Glissando;
@@ -424,6 +425,7 @@ public:
     CONVERT(LyricsLine,    LYRICSLINE)
     CONVERT(LyricsLineSegment, LYRICSLINE_SEGMENT)
     CONVERT(FiguredBass,   FIGURED_BASS)
+    CONVERT(FiguredBassItem, FIGURED_BASS_ITEM)
     CONVERT(StaffState,    STAFF_STATE)
     CONVERT(Arpeggio,      ARPEGGIO)
     CONVERT(Image,         IMAGE)
@@ -799,6 +801,7 @@ CONVERT(NoteHead)
 CONVERT(LyricsLine)
 CONVERT(LyricsLineSegment)
 CONVERT(FiguredBass)
+CONVERT(FiguredBassItem)
 CONVERT(StaffState)
 CONVERT(Arpeggio)
 CONVERT(Image)

--- a/src/engraving/dom/figuredbass.h
+++ b/src/engraving/dom/figuredbass.h
@@ -91,6 +91,7 @@ class FiguredBass;
 class FiguredBassItem final : public EngravingItem
 {
     OBJECT_ALLOCATOR(engraving, FiguredBassItem)
+    DECLARE_CLASSOF(ElementType::FIGURED_BASS_ITEM)
 
 public:
     enum class Modifier : char {
@@ -292,6 +293,9 @@ public:
     size_t itemsCount() const { return m_items.size(); }
     void appendItem(FiguredBassItem* item) { m_items.push_back(item); }
     const std::vector<FiguredBassItem*>& items() const { return m_items; }
+    void clearItems();
+    void addItemToLinked(FiguredBassItem* item);
+    virtual void remove(EngravingItem* item) override;
 
     // the array of configured fonts
     static const std::vector<FiguredBassFont>& FBFonts();

--- a/src/engraving/dom/figuredbass.h
+++ b/src/engraving/dom/figuredbass.h
@@ -276,6 +276,7 @@ public:
     void startEdit(EditData&) override;
     bool isEditAllowed(EditData&) const override;
     void endEdit(EditData&) override;
+    void regenerateText();
 
     bool onNote() const { return m_onNote; }
     void setOnNote(bool val) { m_onNote = val; }
@@ -295,7 +296,6 @@ public:
     const std::vector<FiguredBassItem*>& items() const { return m_items; }
     void clearItems();
     void addItemToLinked(FiguredBassItem* item);
-    virtual void remove(EngravingItem* item) override;
 
     // the array of configured fonts
     static const std::vector<FiguredBassFont>& FBFonts();

--- a/src/engraving/tests/parts_data/part-image-parts.mscx
+++ b/src/engraving/tests/parts_data/part-image-parts.mscx
@@ -126,7 +126,7 @@
               <linkedMain/>
               <Image>
                 <Image>
-                  <z>8499</z>
+                  <z>8599</z>
                   <path>71b2e9f575296b78c22ba721cd71f6e5.png</path>
                   <linkPath>schnee.png</linkPath>
                   </Image>
@@ -848,7 +848,7 @@
                   </linked>
                 <Image>
                   <Image>
-                    <z>8499</z>
+                    <z>8599</z>
                     <path>71b2e9f575296b78c22ba721cd71f6e5.png</path>
                     <linkPath>schnee.png</linkPath>
                     </Image>

--- a/src/engraving/tests/parts_data/part-image-udel.mscx
+++ b/src/engraving/tests/parts_data/part-image-udel.mscx
@@ -126,7 +126,7 @@
               <linkedMain/>
               <Image>
                 <Image>
-                  <z>8499</z>
+                  <z>8599</z>
                   <path>71b2e9f575296b78c22ba721cd71f6e5.png</path>
                   <linkPath>schnee.png</linkPath>
                   </Image>
@@ -849,7 +849,7 @@
                   </linked>
                 <Image>
                   <Image>
-                    <z>8499</z>
+                    <z>8599</z>
                     <path>71b2e9f575296b78c22ba721cd71f6e5.png</path>
                     <linkPath>schnee.png</linkPath>
                     </Image>

--- a/src/engraving/tests/parts_data/part-image.mscx
+++ b/src/engraving/tests/parts_data/part-image.mscx
@@ -122,7 +122,7 @@
             <Note>
               <Image>
                 <Image>
-                  <z>8499</z>
+                  <z>8599</z>
                   <path>71b2e9f575296b78c22ba721cd71f6e5.png</path>
                   <linkPath>schnee.png</linkPath>
                   </Image>

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -107,6 +107,7 @@ enum class ElementType {
     HOOK,
     LYRICS,
     FIGURED_BASS,
+    FIGURED_BASS_ITEM,
     MARKER,
     JUMP,
     FINGERING,

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -202,6 +202,7 @@ static const std::vector<Item<ElementType> > ELEMENT_TYPES = {
     { ElementType::HOOK,                 "Hook",                 TranslatableString("engraving", "Flag") }, // internally called "Hook", but "Flag" in SMuFL, so here externally too
     { ElementType::LYRICS,               "Lyrics",               TranslatableString("engraving", "Lyrics") },
     { ElementType::FIGURED_BASS,         "FiguredBass",          TranslatableString("engraving", "Figured bass") },
+    { ElementType::FIGURED_BASS_ITEM,    "FiguredBassItem",      TranslatableString("engraving", "Figured bass item") },
     { ElementType::MARKER,               "Marker",               TranslatableString("engraving", "Marker") },
     { ElementType::JUMP,                 "Jump",                 TranslatableString("engraving", "Jump") },
     { ElementType::FINGERING,            "Fingering",            TranslatableString("engraving", "Fingering") },


### PR DESCRIPTION
Resolves: #17625 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

Figured bass is now linked between parts and score.
Undo still doesn't update the text of the figured bass item.