### PR TITLE
OPTIMIZATION: Remove unnecessary calls to triggerLayoutAll

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -1893,9 +1893,13 @@ void EngravingItem::triggerLayout() const
     }
 }
 
-//---------------------------------------------------------
+//----------------------------------------------------------------------
 //   triggerLayoutAll
-//---------------------------------------------------------
+//
+//   *************************** CAUTION *******************************
+//   This causes a layout of the entire score: extremely expensive and
+//   likely unnecessary! Consider overriding triggerLayout() instead.
+//----------------------------------------------------------------------
 
 void EngravingItem::triggerLayoutAll() const
 {

--- a/src/engraving/dom/figuredbass.cpp
+++ b/src/engraving/dom/figuredbass.cpp
@@ -526,7 +526,7 @@ bool FiguredBassItem::setProperty(Pid propertyId, const PropertyValue& v)
     default:
         return EngravingItem::setProperty(propertyId, v);
     }
-    triggerLayoutAll();
+    triggerLayout();
     return true;
 }
 

--- a/src/engraving/dom/glissando.cpp
+++ b/src/engraving/dom/glissando.cpp
@@ -533,7 +533,7 @@ bool Glissando::setProperty(Pid propertyId, const PropertyValue& v)
         }
         break;
     }
-    triggerLayoutAll();
+    triggerLayout();
     return true;
 }
 

--- a/src/engraving/dom/guitarbend.cpp
+++ b/src/engraving/dom/guitarbend.cpp
@@ -296,7 +296,7 @@ bool GuitarBend::setProperty(Pid propertyId, const PropertyValue& v)
     default:
         return SLine::setProperty(propertyId, v);
     }
-    triggerLayoutAll();
+    triggerLayout();
     return true;
 }
 
@@ -564,7 +564,7 @@ bool GuitarBendSegment::setProperty(Pid propertyId, const PropertyValue& v)
     default:
         return LineSegment::setProperty(propertyId, v);
     }
-    triggerLayoutAll();
+    triggerLayout();
     return true;
 }
 

--- a/src/engraving/dom/layoutbreak.cpp
+++ b/src/engraving/dom/layoutbreak.cpp
@@ -241,7 +241,10 @@ bool LayoutBreak::setProperty(Pid propertyId, const PropertyValue& v)
         }
         break;
     }
-    triggerLayoutAll();
+    triggerLayout();
+    if (explicitParent() && measure()->next()) {
+        measure()->next()->triggerLayout();
+    }
     setGenerated(false);
     return true;
 }

--- a/src/engraving/dom/lyrics.cpp
+++ b/src/engraving/dom/lyrics.cpp
@@ -345,7 +345,10 @@ void Lyrics::endEdit(EditData& ed)
 {
     TextBase::endEdit(ed);
 
-    triggerLayoutAll();
+    triggerLayout();
+    if (m_separator) {
+        m_separator->triggerLayout();
+    }
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/lyricsline.cpp
+++ b/src/engraving/dom/lyricsline.cpp
@@ -112,7 +112,7 @@ bool LyricsLine::setProperty(Pid propertyId, const engraving::PropertyValue& v)
         }
         break;
     }
-    triggerLayoutAll();
+    triggerLayout();
     return true;
 }
 

--- a/src/engraving/dom/marker.cpp
+++ b/src/engraving/dom/marker.cpp
@@ -208,7 +208,7 @@ bool Marker::setProperty(Pid propertyId, const PropertyValue& v)
         }
         break;
     }
-    triggerLayoutAll();
+    triggerLayout();
     return true;
 }
 

--- a/src/engraving/dom/measurebase.cpp
+++ b/src/engraving/dom/measurebase.cpp
@@ -130,8 +130,6 @@ void MeasureBase::add(EngravingItem* e)
             setLineBreak(false);
             setSectionBreak(true);
             setNoBreak(false);
-            //does not work with repeats: score()->tempomap()->setPause(endTick(), b->pause());
-            triggerLayoutAll();
             break;
         case LayoutBreakType:: NOBREAK:
             setPageBreak(false);
@@ -169,17 +167,22 @@ void MeasureBase::remove(EngravingItem* el)
         case LayoutBreakType::SECTION:
             setSectionBreak(false);
             score()->setPause(endTick(), 0);
-            triggerLayoutAll();
             break;
         case LayoutBreakType::NOBREAK:
             setNoBreak(false);
             break;
         }
     }
+
     if (!m_el.remove(el)) {
         LOGD("MeasureBase(%p)::remove(%s,%p) not found", this, el->typeName(), el);
     } else {
         el->removed();
+    }
+
+    triggerLayout();
+    if (next()) {
+        next()->triggerLayout();
     }
 }
 
@@ -445,7 +448,7 @@ bool MeasureBase::setProperty(Pid id, const PropertyValue& value)
         }
         break;
     }
-    triggerLayoutAll();
+    triggerLayout();
     score()->setPlaylistDirty();
     return true;
 }

--- a/src/engraving/dom/slurtie.cpp
+++ b/src/engraving/dom/slurtie.cpp
@@ -273,7 +273,7 @@ bool SlurTieSegment::setProperty(Pid propertyId, const PropertyValue& v)
     default:
         return SpannerSegment::setProperty(propertyId, v);
     }
-    triggerLayoutAll();
+    triggerLayout();
     return true;
 }
 
@@ -428,7 +428,7 @@ bool SlurTie::setProperty(Pid propertyId, const PropertyValue& v)
     default:
         return Spanner::setProperty(propertyId, v);
     }
-    triggerLayoutAll();
+    triggerLayout();
     return true;
 }
 

--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -175,7 +175,7 @@ bool SpannerSegment::setProperty(Pid pid, const PropertyValue& v)
     switch (pid) {
     case Pid::OFFSET2:
         m_offset2 = v.value<PointF>();
-        triggerLayoutAll();
+        triggerLayout();
         break;
     default:
         return EngravingItem::setProperty(pid, v);
@@ -1341,17 +1341,6 @@ void Spanner::triggerLayout() const
     // Spanners do not have parent even when added to a score, so can't check parent here
     const track_idx_t tr2 = effectiveTrack2();
     score()->setLayout(m_tick, m_tick + m_ticks, staffIdx(), track2staff(tr2), this);
-}
-
-void Spanner::triggerLayoutAll() const
-{
-    // Spanners do not have parent even when added to a score, so can't check parent here
-    score()->setLayoutAll(staffIdx(), this);
-
-    const track_idx_t tr2 = track2();
-    if (tr2 != mu::nidx && tr2 != track()) {
-        score()->setLayoutAll(track2staff(tr2), this);
-    }
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/spanner.h
+++ b/src/engraving/dom/spanner.h
@@ -193,7 +193,6 @@ public:
     bool eitherEndVisible() const;
 
     virtual void triggerLayout() const override;
-    virtual void triggerLayoutAll() const override;
     virtual void add(EngravingItem*) override;
     virtual void remove(EngravingItem*) override;
     virtual void scanElements(void* data, void (* func)(void*, EngravingItem*), bool all=true) override;

--- a/src/engraving/dom/tie.cpp
+++ b/src/engraving/dom/tie.cpp
@@ -128,7 +128,7 @@ void TieSegment::changeAnchor(EditData& ed, EngravingItem* element)
         score()->endCmd();
         score()->startCmd();
         ed.view()->changeEditElement(newSegment);
-        triggerLayoutAll();
+        triggerLayout();
     }
 }
 

--- a/src/engraving/dom/trill.cpp
+++ b/src/engraving/dom/trill.cpp
@@ -319,7 +319,7 @@ bool Trill::setProperty(Pid propertyId, const PropertyValue& val)
         }
         break;
     }
-    triggerLayoutAll();
+    triggerLayout();
     return true;
 }
 

--- a/src/engraving/dom/vibrato.cpp
+++ b/src/engraving/dom/vibrato.cpp
@@ -210,7 +210,7 @@ bool Vibrato::setProperty(Pid propertyId, const PropertyValue& val)
         }
         break;
     }
-    triggerLayoutAll();
+    triggerLayout();
     return true;
 }
 


### PR DESCRIPTION
Resolves: #20003

The job of `triggerLayout` is to let the Score know that something has changed at this `tick`. That is done by calling `Score::setLayout`, which collects the changes into a range defined by a `startTick` and `endTick`. That is the region of the score for which the layout will be recomputed at the next round.

`triggerLayoutAll` signals that the whole score has changed, and therefore will cause the entire score to be recomputed. I suspect it mostly exist as a legacy hack, because in almost NO case does it make sense to layout the entire score after editing something. There _can_ be situations where editing an item should cause the re-computation of something before and/or after it (for instance, putting a layout break on a measure should also trigger the layout of the following one), but those situations should be handled by simply overriding `triggerLayout` wherever necessary.

I have left `triggerLayoutAll` only in a few selected places now:

- Change of system brackets (which do affect the whole score)
- Change of instrument
- Change of clef, time signature, key signature (and even in these cases, we can consider in future reducing the layout range to range affected by it, which isn't necessarily the whole score).

This needs to be carefully tested. A lot of editing operations should feel quicker on big scores now. The important thing to look out for is that the score always updates correctly after all editing operations @oktophonie @DmitryArefiev.