### PR TITLE
"Enter to confirm" in dialogs

### DIFF
--- a/src/framework/uicomponents/view/dialogview.cpp
+++ b/src/framework/uicomponents/view/dialogview.cpp
@@ -28,6 +28,7 @@
 #include <QApplication>
 
 #include "log.h"
+#include "async/async.h"
 
 using namespace muse::uicomponents;
 
@@ -43,6 +44,93 @@ DialogView::DialogView(QQuickItem* parent)
 bool DialogView::isDialog() const
 {
     return true;
+}
+
+bool DialogView::eventFilter(QObject* watched, QEvent* event)
+{
+    if (event->type() != QEvent::ShortcutOverride) {
+        return PopupView::eventFilter(watched, event);
+    }
+
+    QKeyEvent* keyEvent = dynamic_cast<QKeyEvent*>(event);
+    if (!keyEvent || !shortcutOverrideIsAllowed()) {
+        return PopupView::eventFilter(watched, event);
+    }
+
+    const auto triggerControl = [this, event](QObject* navigation) {
+        // Both spontaneous and synthetic events will be received
+        // We intercept both, but only need to invoke once
+        if (event->spontaneous()) {
+            async::Async::call(this, [navigation]() {
+                QMetaObject::invokeMethod(navigation, "triggered");
+            });
+        }
+    };
+
+    switch (keyEvent->key()) {
+    case Qt::Key_Enter:
+    case Qt::Key_Return: {
+        // Rule: Enter/return should always trigger the accent button unless the currently highlighted control
+        // is itself a button, in which case we should trigger that button...
+        QObject* accentButtonNavigation = nullptr;
+        for (const QObject* btn : findButtons()) {
+            const QVariant navigationVar = btn->property("navigation");
+            const QVariant visibleVar = btn->property("visible");
+            if (!navigationVar.isValid() || !visibleVar.isValid() || !visibleVar.toBool()) {
+                continue;
+            }
+
+            QObject* navigation = navigationVar.value<QObject*>();
+            if (!navigation) {
+                continue;
+            }
+
+            // Is this button highlighed? If so trigger it...
+            const QVariant navigationHighlightVar = navigation->property("highlight");
+            if (navigationHighlightVar.isValid() && navigationHighlightVar.toBool()) {
+                triggerControl(navigation);
+                event->accept();
+                return true;
+            }
+
+            const QVariant accentButtonVar = btn->property("accentButton");
+            if (!accentButtonVar.isValid() || !accentButtonVar.toBool()) {
+                continue;
+            }
+
+            // If accentButtonNavigation has been set before, then there are multiple visible accent buttons. This
+            // shouldn't be allowed per the above rule...
+            IF_ASSERT_FAILED(!accentButtonNavigation) {
+                continue;
+            }
+
+            accentButtonNavigation = navigation;
+        }
+
+        // Did we find an accent button? If so trigger it...
+        if (accentButtonNavigation) {
+            triggerControl(accentButtonNavigation);
+            event->accept();
+            return true;
+        }
+    }
+    default: break;
+    }
+
+    return PopupView::eventFilter(watched, event);
+}
+
+bool DialogView::shortcutOverrideIsAllowed() const
+{
+    //! NOTE: We should only override shortcuts if the current window is active.
+    //! There are objects that do not activate focus when opened, for example Dropdowns.
+    //! Therefore, we cannot simply use the current active window inside DialogView::eventFilter.
+    //! Instead, we should ask the navigation system which window has focus:
+    if (ui::INavigationSection* section = navigationController()->activeSection()) {
+        return section->window() == qWindow();
+    }
+
+    return false;
 }
 
 void DialogView::beforeOpen()
@@ -134,6 +222,18 @@ void DialogView::updateGeometry()
 QRect DialogView::viewGeometry() const
 {
     return QRect(m_globalPos.toPoint(), QSize(contentWidth(), contentHeight()));
+}
+
+QSet<const QObject*> DialogView::findButtons() const
+{
+    QSet<const QObject*> buttons;
+    for (const QObject* obj: findChildren<QObject*>()) {
+        const QString className = obj->metaObject()->className();
+        if (className.contains("FlatButton")) {
+            buttons.insert(obj);
+        }
+    }
+    return buttons;
 }
 
 void DialogView::exec()

--- a/src/framework/uicomponents/view/dialogview.h
+++ b/src/framework/uicomponents/view/dialogview.h
@@ -48,7 +48,12 @@ public:
     Q_INVOKABLE void accept();
     Q_INVOKABLE void reject(int code = -1);
 
+protected:
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
 private:
+    bool shortcutOverrideIsAllowed() const;
+
     bool isDialog() const override;
     void beforeOpen() override;
     void onHidden() override;
@@ -58,6 +63,8 @@ private:
     void updateGeometry() override;
 
     QRect viewGeometry() const override;
+
+    QSet<const QObject*> findButtons() const;
 
     QEventLoop m_loop;
 };


### PR DESCRIPTION
Going forward, we plan to implement the following in `StyledDialogView` components:

- Pressing enter/return no longer triggers the focused control (spacebar does this anyway).
- Instead, enter/return triggers the dialog's accent button
- Buttons are an exception to the rule, as outlined [here](https://github.com/musescore/MuseScore/issues/19739#issuecomment-2255680284).

Resolves: #19739
Resolves: #12222