### PR TITLE
Hide extra dots when toggling rhythmic slashes

### DIFF
--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -2247,6 +2247,9 @@ void Chord::setSlash(bool flag, bool stemless)
             n->undoChangeProperty(Pid::FIXED_LINE, 0);
             n->undoChangeProperty(Pid::PLAY, true);
             n->undoChangeProperty(Pid::VISIBLE, true);
+            for (NoteDot* dot : n->dots()) {
+                dot->undoChangeProperty(Pid::VISIBLE, true);
+            }
             if (staff()->isDrumStaff(tick())) {
                 const Drumset* ds = part()->instrument(tick())->drumset();
                 int pitch = n->pitch();
@@ -2308,6 +2311,9 @@ void Chord::setSlash(bool flag, bool stemless)
         // hide all but first notehead
         if (i) {
             n->undoChangeProperty(Pid::VISIBLE, false);
+            for (NoteDot* dot : n->dots()) {
+                dot->undoChangeProperty(Pid::VISIBLE, false);
+            }
         }
     }
 }

--- a/src/engraving/rendering/dev/chordlayout.cpp
+++ b/src/engraving/rendering/dev/chordlayout.cpp
@@ -3418,6 +3418,9 @@ void ChordLayout::layoutNote2(Note* item, LayoutContext& ctx)
     }
     int dots = item->chord()->dots();
     if (dots && !item->dots().empty()) {
+        if (item->chord()->slash() && !item->visible()) {
+            item->setDotsHidden(true);
+        }
         // if chords have notes with different mag, dots must still  align
         double correctMag = item->chord()->notes().size() > 1 ? item->chord()->mag() : item->mag();
         double d  = ctx.conf().point(ctx.conf().styleS(Sid::dotNoteDistance)) * correctMag;


### PR DESCRIPTION
Resolves: #19610 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->
Dot's lines aren't adjusted when rhythmic slashes are on.  All but one dot is made invisible as we do with the noteheads.