### PR TITLE
Fix #20163: Opening styles from bends context menu resolves to correct page (4.2.0)

### DIFF
--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1421,6 +1421,11 @@ QString EditStyle::pageCodeForElement(const EngravingItem* element)
         return "vibrato";
 
     case ElementType::BEND:
+    case ElementType::GUITAR_BEND:
+    case ElementType::GUITAR_BEND_SEGMENT:
+    case ElementType::GUITAR_BEND_HOLD:
+    case ElementType::GUITAR_BEND_HOLD_SEGMENT:
+    case ElementType::GUITAR_BEND_TEXT:
         return "bend";
 
     case ElementType::TEXTLINE:


### PR DESCRIPTION
Resolves: #20163