### PR TITLE
Fix undo editing chord symbol text

### DIFF
--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -3422,7 +3422,14 @@ void TextBase::undoChangeProperty(Pid id, const PropertyValue& v, PropertyFlags 
         }
     }
 
-    if (propertyGroup(id) != PropertyGroup::TEXT) {
+    static const PropertyIdSet CHARACTER_SPECIFIC_PROPERTIES {
+        Pid::FONT_STYLE,
+        Pid::FONT_FACE,
+        Pid::FONT_SIZE,
+        Pid::TEXT_SCRIPT_ALIGN
+    };
+
+    if (!mu::contains(CHARACTER_SPECIFIC_PROPERTIES, id)) {
         EngravingItem::undoChangeProperty(id, v, ps);
         return;
     }


### PR DESCRIPTION
Basically reverts a particular change from c35963f27dc6338b9cd49117145ccb6274c2b227 (which was suggested by me, I'm afraid), but in a slightly different way, to make clearer why the old way was correct.

Resolves: https://github.com/musescore/MuseScore/issues/20165

(Note: this fix, and the linked issue, are _not_ about playback, only about the visual aspect.)