### PR TITLE
Select previous note upon deleting in note input mode

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3584,8 +3584,7 @@ void Score::cmdDeleteSelection()
             select(noteSelectedAfterDeletion, SelectType::SINGLE);
             m_is.moveToNextInputPos();
             return;
-        }
-        else if (!crSelectedAfterDeletion) {
+        } else if (!crSelectedAfterDeletion) {
             crSelectedAfterDeletion = m_is.cr();
         }
     }

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3440,7 +3440,8 @@ ChordRest* Score::deleteRange(Segment* s1, Segment* s2, track_idx_t track1, trac
 
 void Score::cmdDeleteSelection()
 {
-    ChordRest* crSelectedAfterDeletion = 0;              // select something after deleting notes
+    Note* noteSelectedAfterDeletion = 0;                 // select previous note if in note input mode
+    ChordRest* crSelectedAfterDeletion = 0;              // otherwise, select something after deleting notes
 
     if (selection().isRange()) {
         Segment* s1 = selection().startSegment();
@@ -3565,6 +3566,9 @@ void Score::cmdDeleteSelection()
             if (needFindCR) {
                 crSelectedAfterDeletion = findCR(tick, track);
             }
+            if (!noteSelectedAfterDeletion && e->isNote()) {
+                noteSelectedAfterDeletion = prevChordNote(toNote(e));
+            }
 
             // add these linked elements to list of already-deleted elements
             for (EngravingObject* se : links) {
@@ -3576,9 +3580,12 @@ void Score::cmdDeleteSelection()
     deselectAll();
     // make new selection if appropriate
     if (noteEntryMode()) {
-        if (crSelectedAfterDeletion) {
-            m_is.setSegment(crSelectedAfterDeletion->segment());
-        } else {
+        if (noteSelectedAfterDeletion) {
+            select(noteSelectedAfterDeletion, SelectType::SINGLE);
+            m_is.moveToNextInputPos();
+            return;
+        }
+        else if (!crSelectedAfterDeletion) {
             crSelectedAfterDeletion = m_is.cr();
         }
     }

--- a/src/engraving/tests/noteinputdelete_tests.cpp
+++ b/src/engraving/tests/noteinputdelete_tests.cpp
@@ -71,7 +71,7 @@ TEST_F(Engraving_NoteInputDeleteTests, note)
 
     // Check all notes were deleted
     for (size_t i = 0; i < NUM_NOTES; ++i) {
-        Fraction tick = { (int)(i+1) , 4 };
+        Fraction tick = { (int)(i + 1), 4 };
         ChordRest* cr = score->findCR(tick, track);
         EXPECT_FALSE(cr);  //nullptr
     }

--- a/src/engraving/tests/noteinputdelete_tests.cpp
+++ b/src/engraving/tests/noteinputdelete_tests.cpp
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "dom/chord.h"
+#include "dom/chordrest.h"
+#include "dom/factory.h"
+#include "dom/masterscore.h"
+#include "dom/measure.h"
+#include "dom/mscore.h"
+#include "dom/note.h"
+#include "dom/segment.h"
+
+#include "engraving/compat/scoreaccess.h"
+
+using namespace mu;
+using namespace mu::engraving;
+
+static const String NOTE_DATA_DIR("note_data/");
+
+class Engraving_NoteInputDeleteTests : public ::testing::Test
+{
+};
+
+//---------------------------------------------------------
+///   note
+///   read/write test of note
+//---------------------------------------------------------
+
+TEST_F(Engraving_NoteInputDeleteTests, note)
+{
+    MasterScore* score = compat::ScoreAccess::createMasterScore();
+    score->setNoteEntryMode(true);
+
+    const size_t NUM_NOTES = 4;
+    track_idx_t track;
+
+    // Insert notes in note input mode
+    for (size_t i = 0; i < NUM_NOTES; ++i) {
+        Chord* c = Factory::createChord(score->dummy()->segment());
+        track = c->track();
+        Note* note = Factory::createNote(c);
+        c->add(note);
+        note->setPitch(72 + i);
+    }
+
+    // Consecutively delete all notes
+    for (size_t i = 0; i < NUM_NOTES; ++i) {
+        score->cmdDeleteSelection();
+    }
+
+    // Check all notes were deleted
+    for (size_t i = 0; i < NUM_NOTES; ++i) {
+        Fraction tick = { (int)(i+1) , 4 };
+        ChordRest* cr = score->findCR(tick, track);
+        EXPECT_FALSE(cr);  //nullptr
+    }
+
+    delete score;
+}


### PR DESCRIPTION
Resolves: #17557

In note-input mode, select previous note upon deleting. This allows consecutively deleting notes in note-input mode. Also select the segment following the previous note, which will allow the same behavior (as if the deleted note was never written) of tweaking the previous note's pitch or continuing to write notes via note-input mode.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
