### PR TITLE
Fix #19987 Menu Navigation not working with Left/Right arrows

### DIFF
--- a/src/appshell/qml/platform/AppMenuBar.qml
+++ b/src/appshell/qml/platform/AppMenuBar.qml
@@ -205,9 +205,18 @@ ListView {
         id: menuLoader
 
         property string menuId: ""
+        property bool hasSiblingMenus: true
 
         onHandleMenuItem: function(itemId) {
             Qt.callLater(appMenuModel.handleMenuItem, itemId)
+        }
+
+        onOpenPrevMenu: {
+            appMenuModel.openPrevMenu()
+        }
+
+        onOpenNextMenu: {
+            appMenuModel.openNextMenu()
         }
 
         onOpened: {

--- a/src/appshell/view/navigableappmenumodel.cpp
+++ b/src/appshell/view/navigableappmenumodel.cpp
@@ -97,6 +97,18 @@ void NavigableAppMenuModel::handleMenuItem(const QString& itemId)
     AppMenuModel::handleMenuItem(itemId);
 }
 
+void NavigableAppMenuModel::openPrevMenu()
+{
+    navigate(Qt::Key_Left);
+    activateHighlightedMenu();
+}
+
+void NavigableAppMenuModel::openNextMenu()
+{
+    navigate(Qt::Key_Right);
+    activateHighlightedMenu();
+}
+
 void NavigableAppMenuModel::openMenu(const QString& menuId, bool byHover)
 {
     bool navigationStarted = isNavigationStarted();
@@ -343,7 +355,6 @@ bool NavigableAppMenuModel::processEventForAppMenu(QEvent* event)
     default:
         break;
     }
-
     return false;
 }
 

--- a/src/appshell/view/navigableappmenumodel.h
+++ b/src/appshell/view/navigableappmenumodel.h
@@ -48,6 +48,8 @@ public:
     Q_INVOKABLE void load() override;
     Q_INVOKABLE void handleMenuItem(const QString& itemId) override;
     Q_INVOKABLE void openMenu(const QString& menuId, bool byHover);
+    Q_INVOKABLE void openPrevMenu();
+    Q_INVOKABLE void openNextMenu();
 
     bool isNavigationStarted() const;
     bool isMenuOpened() const;

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledMenuLoader.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledMenuLoader.qml
@@ -29,11 +29,14 @@ Loader {
     id: loader
 
     signal handleMenuItem(string itemId)
+    signal openPrevMenu()
+    signal openNextMenu()
     signal opened()
     signal closed(bool force)
 
     property alias menu: loader.item
     property var menuAnchorItem: null
+    property bool hasSiblingMenus: false
 
     property alias isMenuOpened: loader.active
 
@@ -60,6 +63,14 @@ Loader {
         onHandleMenuItem: function(itemId) {
             itemMenu.close()
             Qt.callLater(loader.handleMenuItem, itemId)
+        }
+
+        onOpenPrevMenu: {
+           Qt.callLater(loader.openPrevMenu)
+        }  
+
+        onOpenNextMenu: {
+            Qt.callLater(loader.openNextMenu)
         }
 
         onClosed: function(force) {

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
@@ -33,8 +33,11 @@ MenuView {
     property alias model: view.model
 
     property int preferredAlign: Qt.AlignRight // Left, HCenter, Right
+    property bool hasSiblingMenus: loader.hasSiblingMenus
 
     signal handleMenuItem(string itemId)
+    signal openPrevMenu()
+    signal openNextMenu()
 
     property alias width: content.width
     property alias height: content.height
@@ -138,6 +141,10 @@ MenuView {
                 case NavigationEvent.Right:
                     var selectedItem = prv.selectedItem()
                     if (!Boolean(selectedItem) || !selectedItem.hasSubMenu) {
+                       if (root.hasSiblingMenus)  {
+                            root.close(true)
+                            root.openNextMenu()
+                       }
                         return
                     }
 
@@ -160,6 +167,10 @@ MenuView {
                     }
 
                     root.close()
+
+                    if(root.hasSiblingMenus) {
+                        root.openPrevMenu()
+                    }
                     break
                 case NavigationEvent.Up:
                 case NavigationEvent.Down:
@@ -180,6 +191,7 @@ MenuView {
             var menuLoaderComponent = Qt.createComponent("../StyledMenuLoader.qml");
             root.subMenuLoader = menuLoaderComponent.createObject(root)
             root.subMenuLoader.menuAnchorItem = root.anchorItem
+            root.subMenuLoader.hasSiblingMenus = root.hasSiblingMenus
 
             root.subMenuLoader.handleMenuItem.connect(function(itemId) {
                 Qt.callLater(root.handleMenuItem, itemId)
@@ -195,6 +207,7 @@ MenuView {
 
                 if (force) {
                     root.close(true)
+                    root.openNextMenu()
                 }
             })
         }


### PR DESCRIPTION
Resolves: #19987

Add a force close upon using Right Arrow on a non-submenu item
Use signals when appropriate to invoke openPrevMenu/openNextMenu 
Add hasSiblingMenus property to allow context menus using the StyledMenu class to be closed using left/right arrow key

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
