### PR TITLE
Issue form: add accessibility issue type

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -12,6 +12,7 @@ body:
         - Engraving bug (incorrect score rendering)
         - UX/Interaction bug (incorrect behaviour)
         - UI bug (incorrect info or interface appearance)
+        - Accessibility issue (e.g. for keyboard-only or screen reader users)
         - VST bug
         - Muse Sounds bug
         - General playback bug

--- a/.github/issue_add_label_config.yml
+++ b/.github/issue_add_label_config.yml
@@ -6,6 +6,8 @@ engraving:
     - "UX/Interaction bug \\(incorrect behaviour\\)"
 UI:
     - "UI bug \\(incorrect info or interface appearance\\)"
+accessibility:
+    - "Accessibility issue \\(e\\.g\\. for keyboard-only or screen reader users\\)"
 VST:
     - "VST bug"
 "Muse Sounds":

--- a/.github/issue_assign_by_label_config.yml
+++ b/.github/issue_assign_by_label_config.yml
@@ -13,6 +13,8 @@ playback:
 - DmitryArefiev
 UI:
 - Eism
+accessibility:
+- Eism
 cloud:
 - shoogle
 - cbjeukendrup


### PR DESCRIPTION
When reporting an accessibility issue, contributors currently have to choose either the UI or UX issue type, both of which aren't fully accurate. We then need to add the "accessibility" label later manually.

Now that we're increasingly frequently receiving issues about accessibility, I thought it would be efficient to add the accessibility option directly to the dropdown.

@Eism Please check especially if you agree with the second commit ;)