### PR TITLE
For URLs specified on command line, assume local files by default

### DIFF
--- a/src/app/commandlineparser.cpp
+++ b/src/app/commandlineparser.cpp
@@ -21,6 +21,8 @@
  */
 #include "commandlineparser.h"
 
+#include <QDir>
+
 #include "global/io/dir.h"
 #include "global/muversion.h"
 
@@ -471,7 +473,7 @@ void CommandLineParser::parse(int argc, char** argv)
     // Startup
     if (m_runMode == IApplication::RunMode::GuiApp) {
         if (!scorefiles.isEmpty()) {
-            m_options.startup.scoreUrl = QUrl::fromUserInput(scorefiles[0]);
+            m_options.startup.scoreUrl = QUrl::fromUserInput(scorefiles[0], QDir::currentPath(), QUrl::AssumeLocalFile);
         }
 
         if (m_parser.isSet("score-display-name-override")) {


### PR DESCRIPTION
Otherwise, myscore.mscz would be interpreted as `https://myscore.mscz/`.

Resolves: #20190 (4.1.1 -> 4.2 regression)