### PR TITLE
Fix crash when opening score where arpeggio spans to a Rest

### DIFF
--- a/src/engraving/rendering/dev/arpeggiolayout.cpp
+++ b/src/engraving/rendering/dev/arpeggiolayout.cpp
@@ -123,10 +123,9 @@ void ArpeggioLayout::clearAccidentals(Arpeggio* item, LayoutContext& ctx)
     }
 
     const Segment* seg = item->chord()->segment();
-    const Chord* endChord = toChord(seg->elementAt(item->endTrack()));
-    if (!endChord) {
-        endChord = item->chord();
-    }
+    const EngravingItem* endEl = seg->elementAt(item->endTrack());
+    const Chord* endChord = endEl && endEl->isChord() ? toChord(endEl) : item->chord();
+
     const Part* part = item->part();
     const track_idx_t partStartTrack = part->startTrack();
     const track_idx_t partEndTrack = part->endTrack();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/20203

In the score in this issue, there is an Arpeggio with a staff span of 2, which in 4.2 gets converted to a track span of 5. That's fine, but on the staff below the Arpeggio, there is a Rest, so the Arpeggio would end on that Rest. That leads to a crash because of a missing `isChord` check.

@miiizen Do you think we should additionally try to correct the Arpeggio's endTrack, to prevent the situation that the Arpeggio would end on nothing or on a Rest? Either while reading, or while layouting; it seems that you added things to the Arpeggio interaction code to prevent this situation from arising in new scores, but apparently it can exist in existing scores.