### PR TITLE
File format: store excerpts by a unique and safe name

### DIFF
--- a/src/engraving/compat/writescorehook.cpp
+++ b/src/engraving/compat/writescorehook.cpp
@@ -60,18 +60,12 @@ void WriteScoreHook::onWriteExcerpts302(Score* score, XmlWriter& xml, WriteConte
         isWriteExcerpts = true;
     }
 
-    if (isWriteExcerpts) {
-        if (score->isMaster()) {
-            if (!selectionOnly) {
-                MasterScore* mScore = static_cast<MasterScore*>(score);
-                for (const Excerpt* excerpt : mScore->excerpts()) {
-                    if (excerpt->excerptScore() != score) {
-                        write::Writer::write(excerpt->excerptScore(), xml, ctx, selectionOnly, *this); // recursion write
-                    }
-                }
+    if (isWriteExcerpts && score->isMaster() && !selectionOnly) {
+        MasterScore* mScore = static_cast<MasterScore*>(score);
+        for (const Excerpt* excerpt : mScore->excerpts()) {
+            if (excerpt->excerptScore() != score) {
+                write::Writer::write(excerpt->excerptScore(), xml, ctx, selectionOnly, *this);         // recursion write
             }
-        } else {
-            xml.tag("name", score->excerpt()->name());
         }
     }
 }

--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -127,15 +127,18 @@ const String& Excerpt::name() const
     return m_name;
 }
 
-void Excerpt::setName(const String& name)
+void Excerpt::setName(const String& name, bool saveAndNotify)
 {
     if (m_name == name) {
         return;
     }
 
     m_name = name;
-    writeNameToMetaTags();
-    m_nameChanged.notify();
+
+    if (saveAndNotify) {
+        writeNameToMetaTags();
+        m_nameChanged.notify();
+    }
 }
 
 void Excerpt::writeNameToMetaTags()

--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -156,6 +156,45 @@ async::Notification Excerpt::nameChanged() const
     return m_nameChanged;
 }
 
+static inline bool isValidExcerptFileNameCharacter(char16_t c)
+{
+    return (u'a' <= c && c <= u'z')
+           || (u'A' <= c && c <= 'Z')
+           || (u'0' <= c && c <= '9')
+           || c == u'_' || c == u'-' || c == u' ';
+}
+
+static inline String escapeExcerptFileName(const String& name)
+{
+    String result;
+    result.reserve(name.size());
+
+    for (const char16_t& c : name.toStdU16String()) {
+        if (isValidExcerptFileNameCharacter(c)) {
+            result.append(c);
+        } else {
+            result.append(u'_');
+        }
+    }
+
+    return result;
+}
+
+String Excerpt::makeFileName(size_t index) const
+{
+    if (index == mu::nidx && m_masterScore) {
+        index = mu::indexOf(m_masterScore->excerpts(), this);
+    }
+
+    const String escapedName = escapeExcerptFileName(m_name);
+
+    if (index == mu::nidx) {
+        return escapedName;
+    }
+
+    return String(u"%1_%2").arg(String::number(index), escapedName);
+}
+
 bool Excerpt::containsPart(const Part* part) const
 {
     for (Part* _part : m_parts) {

--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -156,6 +156,20 @@ async::Notification Excerpt::nameChanged() const
     return m_nameChanged;
 }
 
+const String& Excerpt::fileName() const
+{
+    IF_ASSERT_FAILED(!m_fileName.empty()) {
+        const_cast<Excerpt*>(this)->updateFileName();
+    }
+
+    return m_fileName;
+}
+
+void Excerpt::setFileName(const String& fileName)
+{
+    m_fileName = fileName;
+}
+
 static inline bool isValidExcerptFileNameCharacter(char16_t c)
 {
     return (u'a' <= c && c <= u'z')
@@ -180,7 +194,7 @@ static inline String escapeExcerptFileName(const String& name)
     return result;
 }
 
-String Excerpt::makeFileName(size_t index) const
+void Excerpt::updateFileName(size_t index)
 {
     if (index == mu::nidx && m_masterScore) {
         index = mu::indexOf(m_masterScore->excerpts(), this);
@@ -189,10 +203,10 @@ String Excerpt::makeFileName(size_t index) const
     const String escapedName = escapeExcerptFileName(m_name);
 
     if (index == mu::nidx) {
-        return escapedName;
+        m_fileName = escapedName;
+    } else {
+        m_fileName = String(u"%1_%2").arg(String::number(index), escapedName);
     }
-
-    return String(u"%1_%2").arg(String::number(index), escapedName);
 }
 
 bool Excerpt::containsPart(const Part* part) const

--- a/src/engraving/dom/excerpt.h
+++ b/src/engraving/dom/excerpt.h
@@ -23,8 +23,6 @@
 #ifndef MU_ENGRAVING_EXCERPT_H
 #define MU_ENGRAVING_EXCERPT_H
 
-#include <map>
-
 #include "types/fraction.h"
 #include "types/types.h"
 #include "types/string.h"
@@ -61,7 +59,13 @@ public:
     const String& name() const;
     void setName(const String& name, bool saveAndNotify = true);
     async::Notification nameChanged() const;
-    String makeFileName(size_t index = mu::nidx) const;
+
+    // The name used to store this excerpt in the msc file/folder.
+    // When reading/writing, the engraving module sets this value, so that other
+    // modules can also read/write data about this excerpt using the correct name.
+    const String& fileName() const;
+    void setFileName(const String& fileName);
+    void updateFileName(size_t index = mu::nidx);
 
     std::vector<Part*>& parts() { return m_parts; }
     const std::vector<Part*>& parts() const { return m_parts; }
@@ -100,6 +104,7 @@ private:
     MasterScore* m_masterScore = nullptr;
     Score* m_excerptScore = nullptr;
     String m_name;
+    String m_fileName;
     async::Notification m_nameChanged;
     std::vector<Part*> m_parts;
     TracksMap m_tracksMapping;

--- a/src/engraving/dom/excerpt.h
+++ b/src/engraving/dom/excerpt.h
@@ -59,7 +59,7 @@ public:
     void setExcerptScore(Score* s);
 
     const String& name() const;
-    void setName(const String& name);
+    void setName(const String& name, bool saveAndNotify = true);
     async::Notification nameChanged() const;
 
     std::vector<Part*>& parts() { return m_parts; }

--- a/src/engraving/dom/excerpt.h
+++ b/src/engraving/dom/excerpt.h
@@ -61,6 +61,7 @@ public:
     const String& name() const;
     void setName(const String& name, bool saveAndNotify = true);
     async::Notification nameChanged() const;
+    String makeFileName(size_t index = mu::nidx) const;
 
     std::vector<Part*>& parts() { return m_parts; }
     const std::vector<Part*>& parts() const { return m_parts; }

--- a/src/engraving/infrastructure/mscreader.cpp
+++ b/src/engraving/infrastructure/mscreader.cpp
@@ -163,7 +163,7 @@ ByteArray MscReader::readScoreFile() const
     return fileData(mscxFileName);
 }
 
-std::vector<String> MscReader::excerptNames() const
+std::vector<String> MscReader::excerptFileNames() const
 {
     if (!reader()->isContainer()) {
         NOT_SUPPORTED << " not container";
@@ -180,16 +180,16 @@ std::vector<String> MscReader::excerptNames() const
     return names;
 }
 
-ByteArray MscReader::readExcerptStyleFile(const String& name) const
+ByteArray MscReader::readExcerptStyleFile(const String& excerptFileName) const
 {
-    String fileName = name + u".mss";
-    return fileData(u"Excerpts/" + name + u"/" + fileName);
+    String fileName = excerptFileName + u".mss";
+    return fileData(u"Excerpts/" + excerptFileName + u"/" + fileName);
 }
 
-ByteArray MscReader::readExcerptFile(const String& name) const
+ByteArray MscReader::readExcerptFile(const String& excerptFileName) const
 {
-    String fileName = name + u".mscx";
-    return fileData(u"Excerpts/" + name + u"/" + fileName);
+    String fileName = excerptFileName + u".mscx";
+    return fileData(u"Excerpts/" + excerptFileName + u"/" + fileName);
 }
 
 ByteArray MscReader::readChordListFile() const

--- a/src/engraving/infrastructure/mscreader.h
+++ b/src/engraving/infrastructure/mscreader.h
@@ -59,9 +59,9 @@ public:
     ByteArray readStyleFile() const;
     ByteArray readScoreFile() const;
 
-    std::vector<String> excerptNames() const;
-    ByteArray readExcerptStyleFile(const String& name) const;
-    ByteArray readExcerptFile(const String& name) const;
+    std::vector<String> excerptFileNames() const;
+    ByteArray readExcerptStyleFile(const String& excerptFileName) const;
+    ByteArray readExcerptFile(const String& excerptFileName) const;
 
     ByteArray readChordListFile() const;
     ByteArray readThumbnailFile() const;

--- a/src/engraving/infrastructure/mscwriter.cpp
+++ b/src/engraving/infrastructure/mscwriter.cpp
@@ -160,16 +160,16 @@ void MscWriter::writeScoreFile(const ByteArray& data)
     addFileData(mainFileName(), data);
 }
 
-void MscWriter::addExcerptStyleFile(const String& name, const ByteArray& data)
+void MscWriter::addExcerptStyleFile(const String& excerptFileName, const ByteArray& data)
 {
-    String fileName = name + u".mss";
-    addFileData(u"Excerpts/" + name + u"/" + fileName, data);
+    String fileName = excerptFileName + u".mss";
+    addFileData(u"Excerpts/" + excerptFileName + u"/" + fileName, data);
 }
 
-void MscWriter::addExcerptFile(const String& name, const ByteArray& data)
+void MscWriter::addExcerptFile(const String& excerptFileName, const ByteArray& data)
 {
-    String fileName = name + u".mscx";
-    addFileData(u"Excerpts/" + name + u"/" + fileName, data);
+    String fileName = excerptFileName + u".mscx";
+    addFileData(u"Excerpts/" + excerptFileName + u"/" + fileName, data);
 }
 
 void MscWriter::writeChordListFile(const ByteArray& data)

--- a/src/engraving/infrastructure/mscwriter.h
+++ b/src/engraving/infrastructure/mscwriter.h
@@ -60,8 +60,8 @@ public:
 
     void writeStyleFile(const ByteArray& data);
     void writeScoreFile(const ByteArray& data);
-    void addExcerptStyleFile(const String& name, const ByteArray& data);
-    void addExcerptFile(const String& name, const ByteArray& data);
+    void addExcerptStyleFile(const String& excerptFileName, const ByteArray& data);
+    void addExcerptFile(const String& excerptFileName, const ByteArray& data);
     void writeChordListFile(const ByteArray& data);
     void writeThumbnailFile(const ByteArray& data);
     void addImageFile(const String& fileName, const ByteArray& data);

--- a/src/engraving/rw/mscloader.cpp
+++ b/src/engraving/rw/mscloader.cpp
@@ -141,6 +141,7 @@ mu::Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader
 
             Excerpt* ex = new Excerpt(masterScore);
             ex->setExcerptScore(partScore);
+            ex->setFileName(excerptFileName);
 
             ByteArray excerptStyleData = mscReader.readExcerptStyleFile(excerptFileName);
             Buffer excerptStyleBuf(&excerptStyleData);

--- a/src/engraving/rw/mscloader.cpp
+++ b/src/engraving/rw/mscloader.cpp
@@ -133,8 +133,8 @@ mu::Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader
 
     // Read excerpts
     if (ret && masterScore->mscVersion() >= 400) {
-        std::vector<String> excerptNames = mscReader.excerptNames();
-        for (const String& excerptName : excerptNames) {
+        std::vector<String> excerptFileNames = mscReader.excerptFileNames();
+        for (const String& excerptFileName : excerptFileNames) {
             Score* partScore = masterScore->createScore();
 
             compat::ReadStyleHook::setupDefaultStyle(partScore);
@@ -142,15 +142,15 @@ mu::Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader
             Excerpt* ex = new Excerpt(masterScore);
             ex->setExcerptScore(partScore);
 
-            ByteArray excerptStyleData = mscReader.readExcerptStyleFile(excerptName);
+            ByteArray excerptStyleData = mscReader.readExcerptStyleFile(excerptFileName);
             Buffer excerptStyleBuf(&excerptStyleData);
             excerptStyleBuf.open(IODevice::ReadOnly);
             partScore->style().read(&excerptStyleBuf);
 
-            ByteArray excerptData = mscReader.readExcerptFile(excerptName);
+            ByteArray excerptData = mscReader.readExcerptFile(excerptFileName);
 
             XmlReader xml(excerptData);
-            xml.setDocName(excerptName);
+            xml.setDocName(excerptFileName);
 
             ReadInOutData partReadInData;
             partReadInData.links = masterReadOutData.links;
@@ -169,7 +169,17 @@ mu::Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader
 
             partScore->linkMeasures(masterScore);
 
-            ex->setName(excerptName);
+            if (ex->name().empty()) {
+                // If no excerpt name tag was found while reading, try the "partName" meta tag
+                const String nameFromMeta = partScore->metaTag(u"partName");
+
+                if (nameFromMeta.empty()) {
+                    // If that's also empty, fall back to the filename
+                    ex->setName(excerptFileName, /*saveAndNotify=*/ false);
+                } else {
+                    ex->setName(nameFromMeta, /*saveAndNotify=*/ false);
+                }
+            }
 
             masterScore->addExcerpt(ex);
         }

--- a/src/engraving/rw/mscsaver.cpp
+++ b/src/engraving/rw/mscsaver.cpp
@@ -76,14 +76,14 @@ bool MscSaver::writeMscz(MasterScore* score, MscWriter& mscWriter, bool onlySele
             const std::vector<Excerpt*>& excerpts = score->excerpts();
 
             for (size_t excerptIndex = 0; excerptIndex < excerpts.size(); ++excerptIndex) {
-                const Excerpt* excerpt = excerpts.at(excerptIndex);
+                Excerpt* excerpt = excerpts.at(excerptIndex);
 
                 Score* partScore = excerpt->excerptScore();
                 IF_ASSERT_FAILED(partScore && partScore != score) {
                     continue;
                 }
 
-                String excerptFileName = excerpt->makeFileName(excerptIndex);
+                excerpt->updateFileName(excerptIndex);
 
                 // Write excerpt style
                 {
@@ -92,7 +92,7 @@ bool MscSaver::writeMscz(MasterScore* score, MscWriter& mscWriter, bool onlySele
                     styleStyleBuf.open(IODevice::WriteOnly);
                     partScore->style().write(&styleStyleBuf);
 
-                    mscWriter.addExcerptStyleFile(excerptFileName, excerptStyleData);
+                    mscWriter.addExcerptStyleFile(excerpt->fileName(), excerptStyleData);
                 }
 
                 // Write excerpt
@@ -103,7 +103,7 @@ bool MscSaver::writeMscz(MasterScore* score, MscWriter& mscWriter, bool onlySele
 
                     RWRegister::writer()->writeScore(excerpt->excerptScore(), &excerptBuf, onlySelection, &masterWriteOutData);
 
-                    mscWriter.addExcerptFile(excerptFileName, excerptData);
+                    mscWriter.addExcerptFile(excerpt->fileName(), excerptData);
                 }
             }
         }

--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -3359,7 +3359,7 @@ bool Read206::readScore206(Score* score, XmlReader& e, ReadContext& ctx)
         } else if (tag == "name") {
             String n = e.readText();
             if (!score->isMaster()) {                 //ignore the name if it's not a child score
-                score->excerpt()->setName(n);
+                score->excerpt()->setName(n, /*saveAndNotify=*/ false);
             }
         } else if (tag == "layoutMode") {
             String s = e.readText();

--- a/src/engraving/rw/read302/read302.cpp
+++ b/src/engraving/rw/read302/read302.cpp
@@ -187,7 +187,7 @@ bool Read302::readScore302(Score* score, XmlReader& e, ReadContext& ctx)
         } else if (tag == "name") {
             String n = e.readText();
             if (!score->isMaster()) {     //ignore the name if it's not a child score
-                score->excerpt()->setName(n);
+                score->excerpt()->setName(n, /*saveAndNotify=*/ false);
             }
         } else if (tag == "layoutMode") {
             String s = e.readText();

--- a/src/engraving/rw/read400/read400.cpp
+++ b/src/engraving/rw/read400/read400.cpp
@@ -224,7 +224,7 @@ bool Read400::readScore400(Score* score, XmlReader& e, ReadContext& ctx)
         } else if (tag == "name") {
             String n = e.readText();
             if (!score->isMaster()) {     //ignore the name if it's not a child score
-                score->excerpt()->setName(n);
+                score->excerpt()->setName(n, /*saveAndNotify=*/ false);
             }
         } else if (tag == "layoutMode") {
             String s = e.readText();

--- a/src/engraving/rw/read410/read410.cpp
+++ b/src/engraving/rw/read410/read410.cpp
@@ -231,7 +231,7 @@ bool Read410::readScore410(Score* score, XmlReader& e, ReadContext& ctx)
         } else if (tag == "name") {
             String n = e.readText();
             if (!score->isMaster()) {     //ignore the name if it's not a child score
-                score->excerpt()->setName(n);
+                score->excerpt()->setName(n, /*saveAndNotify=*/ false);
             }
         } else if (tag == "layoutMode") {
             String s = e.readText();

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -1398,7 +1398,7 @@ void TRead::read(Excerpt* item, XmlReader& e, ReadContext&)
     while (e.readNextStartElement()) {
         const AsciiStringView tag = e.name();
         if (tag == "name" || tag == "title") {
-            item->setName(e.readText().trimmed());
+            item->setName(e.readText().trimmed(), /*saveAndNotify=*/ false);
         } else if (tag == "part") {
             size_t partIdx = static_cast<size_t>(e.readInt());
             if (partIdx >= pl.size()) {

--- a/src/engraving/rw/write/writer.cpp
+++ b/src/engraving/rw/write/writer.cpp
@@ -108,8 +108,11 @@ void Writer::write(Score* score, XmlWriter& xml, WriteContext& ctx, bool selecti
 
     xml.startElement(score);
 
-    if (score->excerpt()) {
-        Excerpt* e = score->excerpt();
+    if (Excerpt* e = score->excerpt()) {
+        if (!e->name().empty()) {
+            xml.tag("name", e->name());
+        }
+
         const TracksMap& tracks = e->tracksMapping();
         if (!(tracks.size() == e->nstaves() * VOICES) && !tracks.empty()) {
             for (auto it = tracks.begin(); it != tracks.end(); ++it) {

--- a/src/engraving/tests/chordsymbol_data/add-part-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/add-part-ref.mscx
@@ -101,6 +101,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Classical Guitar</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -208,7 +209,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Classical Guitar</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/chordsymbol_data/no-system-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/no-system-ref.mscx
@@ -196,6 +196,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Flute</name>
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
@@ -302,9 +303,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Flute</name>
       </Score>
     <Score>
+      <name>Alto Saxophone</name>
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
@@ -429,7 +430,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto Saxophone</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/chordsymbol_data/transpose-part-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/transpose-part-ref.mscx
@@ -122,6 +122,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Flute</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -132,7 +133,6 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
-      <metaTag name="partName">Flute</metaTag>
       <Part id="1">
         <Staff id="1">
           <linkedTo>1</linkedTo>
@@ -248,7 +248,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Flute</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/compat206_data/articulations-double-ref.mscx
+++ b/src/engraving/tests/compat206_data/articulations-double-ref.mscx
@@ -1808,6 +1808,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Piano</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -3932,7 +3933,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Piano</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/compat206_data/hairpin-ref.mscx
+++ b/src/engraving/tests/compat206_data/hairpin-ref.mscx
@@ -594,6 +594,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Piano</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1277,7 +1278,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Piano</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/compat206_data/lidemptytext-ref.mscx
+++ b/src/engraving/tests/compat206_data/lidemptytext-ref.mscx
@@ -227,6 +227,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Bass</name>
       <Division>480</Division>
       <Style>
         <pedalPosBelow x="0" y="0"/>
@@ -345,7 +346,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Bass</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/compat206_data/userstylesparts-ref.mscx
+++ b/src/engraving/tests/compat206_data/userstylesparts-ref.mscx
@@ -379,6 +379,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Piano</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -611,9 +612,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Piano</name>
       </Score>
     <Score>
+      <name>Flute 1</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -869,9 +870,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Flute 1</name>
       </Score>
     <Score>
+      <name>Flute 2</name>
       <initialPartId>3</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1127,7 +1128,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Flute 2</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/exchangevoices_data/undoChangeVoice01-ref.mscx
+++ b/src/engraving/tests/exchangevoices_data/undoChangeVoice01-ref.mscx
@@ -554,6 +554,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Piano</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1192,7 +1193,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Piano</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/exchangevoices_data/undoChangeVoice02-ref.mscx
+++ b/src/engraving/tests/exchangevoices_data/undoChangeVoice02-ref.mscx
@@ -535,6 +535,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Piano</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1151,7 +1152,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Piano</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-54346-parts.mscx
+++ b/src/engraving/tests/parts_data/part-54346-parts.mscx
@@ -269,6 +269,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>B♭ Trumpet</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -428,9 +429,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>B♭ Trumpet</name>
       </Score>
     <Score>
+      <name>C Trumpet</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -572,7 +573,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>C Trumpet</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-all-appendmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-appendmeasures.mscx
@@ -1075,6 +1075,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1771,9 +1772,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -2286,7 +2287,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-all-insertmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-insertmeasures.mscx
@@ -1071,6 +1071,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1766,9 +1767,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -2274,7 +2275,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-all-parts.mscx
+++ b/src/engraving/tests/parts_data/part-all-parts.mscx
@@ -1057,6 +1057,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1743,9 +1744,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -2248,7 +2249,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-all-uappendmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-uappendmeasures.mscx
@@ -1057,6 +1057,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1743,9 +1744,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -2248,7 +2249,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-all-uinsertmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-uinsertmeasures.mscx
@@ -1057,6 +1057,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1743,9 +1744,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -2248,7 +2249,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-breath-add.mscx
+++ b/src/engraving/tests/parts_data/part-breath-add.mscx
@@ -769,6 +769,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1195,9 +1196,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1631,7 +1632,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-breath-del.mscx
+++ b/src/engraving/tests/parts_data/part-breath-del.mscx
@@ -765,6 +765,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1186,9 +1187,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1622,7 +1623,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-breath-parts.mscx
+++ b/src/engraving/tests/parts_data/part-breath-parts.mscx
@@ -777,6 +777,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1202,9 +1203,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1642,7 +1643,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-breath-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-breath-uadd.mscx
@@ -765,6 +765,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1186,9 +1187,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1622,7 +1623,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-breath-udel.mscx
+++ b/src/engraving/tests/parts_data/part-breath-udel.mscx
@@ -769,6 +769,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1195,9 +1196,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1631,7 +1632,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-breath-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-breath-uradd.mscx
@@ -769,6 +769,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1195,9 +1196,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1631,7 +1632,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-breath-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-breath-urdel.mscx
@@ -765,6 +765,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1186,9 +1187,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1622,7 +1623,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-chordline-add.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-add.mscx
@@ -769,6 +769,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1195,9 +1196,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1631,7 +1632,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-chordline-del.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-del.mscx
@@ -760,6 +760,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1175,9 +1176,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1599,7 +1600,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-chordline-parts.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-parts.mscx
@@ -764,6 +764,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1183,9 +1184,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1606,7 +1607,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-chordline-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-uadd.mscx
@@ -765,6 +765,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1186,9 +1187,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1622,7 +1623,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-chordline-udel.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-udel.mscx
@@ -764,6 +764,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1184,9 +1185,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1608,7 +1609,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-chordline-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-uradd.mscx
@@ -769,6 +769,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1195,9 +1196,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1631,7 +1632,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-chordline-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-urdel.mscx
@@ -760,6 +760,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1175,9 +1176,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1599,7 +1600,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-empty-parts.mscx
+++ b/src/engraving/tests/parts_data/part-empty-parts.mscx
@@ -765,6 +765,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1185,9 +1186,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1620,7 +1621,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-fingering-add.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-add.mscx
@@ -769,6 +769,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1195,9 +1196,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1631,7 +1632,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-fingering-del.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-del.mscx
@@ -769,6 +769,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1190,9 +1191,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1626,7 +1627,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-fingering-parts.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-parts.mscx
@@ -774,6 +774,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1200,9 +1201,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1635,7 +1636,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-fingering-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-uadd.mscx
@@ -765,6 +765,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1186,9 +1187,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1622,7 +1623,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-fingering-udel.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-udel.mscx
@@ -774,6 +774,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1201,9 +1202,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1637,7 +1638,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-fingering-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-uradd.mscx
@@ -769,6 +769,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1195,9 +1196,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1631,7 +1632,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-fingering-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-urdel.mscx
@@ -769,6 +769,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1190,9 +1191,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1626,7 +1627,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-image-add.mscx
+++ b/src/engraving/tests/parts_data/part-image-add.mscx
@@ -770,6 +770,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1197,9 +1198,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1633,7 +1634,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-image-del.mscx
+++ b/src/engraving/tests/parts_data/part-image-del.mscx
@@ -765,6 +765,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1180,9 +1181,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1604,7 +1605,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-image-parts.mscx
+++ b/src/engraving/tests/parts_data/part-image-parts.mscx
@@ -776,6 +776,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1202,9 +1203,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1625,7 +1626,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-image-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-image-uadd.mscx
@@ -765,6 +765,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1186,9 +1187,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1622,7 +1623,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-image-udel.mscx
+++ b/src/engraving/tests/parts_data/part-image-udel.mscx
@@ -776,6 +776,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1203,9 +1204,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1627,7 +1628,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-image-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-image-uradd.mscx
@@ -770,6 +770,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1197,9 +1198,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1633,7 +1634,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-image-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-image-urdel.mscx
@@ -765,6 +765,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1180,9 +1181,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1604,7 +1605,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-measure-repeat-add.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-add.mscx
@@ -779,6 +779,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1205,9 +1206,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1641,7 +1642,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-measure-repeat-del.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-del.mscx
@@ -796,6 +796,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1233,9 +1234,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1700,7 +1701,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-measure-repeat-parts.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-parts.mscx
@@ -813,6 +813,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1291,9 +1292,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1786,7 +1787,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-measure-repeat-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-uadd.mscx
@@ -765,6 +765,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1186,9 +1187,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1622,7 +1623,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-measure-repeat-udel.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-udel.mscx
@@ -801,6 +801,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1232,9 +1233,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1699,7 +1700,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-measure-repeat-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-uradd.mscx
@@ -779,6 +779,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1205,9 +1206,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1641,7 +1642,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-measure-repeat-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-urdel.mscx
@@ -796,6 +796,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1233,9 +1234,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1700,7 +1701,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-stemless-parts.mscx
+++ b/src/engraving/tests/parts_data/part-stemless-parts.mscx
@@ -476,6 +476,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Flute</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -743,9 +744,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Flute</name>
       </Score>
     <Score>
+      <name>Oboe</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1005,7 +1006,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Oboe</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-symbol-add.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-add.mscx
@@ -769,6 +769,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1195,9 +1196,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1631,7 +1632,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-symbol-del.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-del.mscx
@@ -765,6 +765,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1186,9 +1187,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1622,7 +1623,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-symbol-parts.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-parts.mscx
@@ -769,6 +769,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1194,9 +1195,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1629,7 +1630,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-symbol-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-uadd.mscx
@@ -765,6 +765,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1186,9 +1187,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1622,7 +1623,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-symbol-udel.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-udel.mscx
@@ -769,6 +769,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1195,9 +1196,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1631,7 +1632,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-symbol-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-uradd.mscx
@@ -769,6 +769,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1195,9 +1196,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1631,7 +1632,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/part-symbol-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-urdel.mscx
@@ -765,6 +765,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1186,9 +1187,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Alto</name>
       </Score>
     <Score>
+      <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -1622,7 +1623,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Tenor</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/partExclusion-part-0.mscx
+++ b/src/engraving/tests/parts_data/partExclusion-part-0.mscx
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="4.20">
   <Score>
+    <name>Flute</name>
     <Division>480</Division>
     <Style>
       <Spatium>1.74978</Spatium>
@@ -250,6 +251,5 @@
           </voice>
         </Measure>
       </Staff>
-    <name>Flute</name>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/partExclusion-part-1.mscx
+++ b/src/engraving/tests/parts_data/partExclusion-part-1.mscx
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="4.20">
   <Score>
+    <name>Flute</name>
     <Division>480</Division>
     <Style>
       <Spatium>1.74978</Spatium>
@@ -218,6 +219,5 @@
           </voice>
         </Measure>
       </Staff>
-    <name>Flute</name>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/partPropertyLinking-part-0.mscx
+++ b/src/engraving/tests/parts_data/partPropertyLinking-part-0.mscx
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="4.20">
   <Score>
+    <name>Flute</name>
     <Division>480</Division>
     <Style>
       <Spatium>1.74978</Spatium>
@@ -78,6 +79,5 @@
           </voice>
         </Measure>
       </Staff>
-    <name>Flute</name>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/partPropertyLinking-part-1.mscx
+++ b/src/engraving/tests/parts_data/partPropertyLinking-part-1.mscx
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="4.20">
   <Score>
+    <name>Flute</name>
     <Division>480</Division>
     <Style>
       <Spatium>1.74978</Spatium>
@@ -84,6 +85,5 @@
           </voice>
         </Measure>
       </Staff>
-    <name>Flute</name>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/partStyle-score-ref.mscx
+++ b/src/engraving/tests/parts_data/partStyle-score-ref.mscx
@@ -308,6 +308,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Flute</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -503,9 +504,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Flute</name>
       </Score>
     <Score>
+      <name>Oboe</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -668,7 +669,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Oboe</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/partStyle-score-reload-ref.mscx
+++ b/src/engraving/tests/parts_data/partStyle-score-reload-ref.mscx
@@ -303,6 +303,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Flute</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -495,9 +496,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Flute</name>
       </Score>
     <Score>
+      <name>Oboe</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
@@ -664,7 +665,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Oboe</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/parts_data/voices-ref.mscx
+++ b/src/engraving/tests/parts_data/voices-ref.mscx
@@ -1063,6 +1063,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Piano</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -1804,9 +1805,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Piano</name>
       </Score>
     <Score>
+      <name>Trombone</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -2303,9 +2304,9 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Trombone</name>
       </Score>
     <Score>
+      <name>Trombone</name>
       <Division>480</Division>
       <Style>
         <Spatium>1.74978</Spatium>
@@ -2802,7 +2803,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Trombone</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/spanners_data/glissando-cloning04-ref.mscx
+++ b/src/engraving/tests/spanners_data/glissando-cloning04-ref.mscx
@@ -132,6 +132,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Flute</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -268,7 +269,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Flute</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/tools_data/undoResequencePart01-ref.mscx
+++ b/src/engraving/tests/tools_data/undoResequencePart01-ref.mscx
@@ -301,6 +301,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Flute</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -313,7 +314,6 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
-      <metaTag name="partName">Flute</metaTag>
       <Part id="1">
         <Staff id="1">
           <linkedTo>1</linkedTo>
@@ -644,7 +644,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Flute</name>
       </Score>
     </Score>
   </museScore>

--- a/src/engraving/tests/tools_data/undoResequencePart02-ref.mscx
+++ b/src/engraving/tests/tools_data/undoResequencePart02-ref.mscx
@@ -301,6 +301,7 @@
         </Measure>
       </Staff>
     <Score>
+      <name>Flute</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
@@ -313,7 +314,6 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
-      <metaTag name="partName">Flute</metaTag>
       <Part id="1">
         <Staff id="1">
           <linkedTo>1</linkedTo>
@@ -644,7 +644,6 @@
             </voice>
           </Measure>
         </Staff>
-      <name>Flute</name>
       </Score>
     </Score>
   </museScore>

--- a/src/notation/iexcerptnotation.h
+++ b/src/notation/iexcerptnotation.h
@@ -41,6 +41,7 @@ public:
     virtual QString name() const = 0;
     virtual void setName(const QString& name) = 0;
     virtual async::Notification nameChanged() const = 0;
+    virtual String makeFileName() const = 0;
 
     virtual INotationPtr notation() = 0;
     virtual IExcerptNotationPtr clone() const = 0;

--- a/src/notation/iexcerptnotation.h
+++ b/src/notation/iexcerptnotation.h
@@ -41,7 +41,8 @@ public:
     virtual QString name() const = 0;
     virtual void setName(const QString& name) = 0;
     virtual async::Notification nameChanged() const = 0;
-    virtual String makeFileName() const = 0;
+
+    virtual const String& fileName() const = 0;
 
     virtual INotationPtr notation() = 0;
     virtual IExcerptNotationPtr clone() const = 0;

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -134,9 +134,9 @@ mu::async::Notification ExcerptNotation::nameChanged() const
     return m_excerpt->nameChanged();
 }
 
-mu::String ExcerptNotation::makeFileName() const
+const mu::String& ExcerptNotation::fileName() const
 {
-    return m_excerpt->makeFileName();
+    return m_excerpt->fileName();
 }
 
 INotationPtr ExcerptNotation::notation()

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -134,6 +134,11 @@ mu::async::Notification ExcerptNotation::nameChanged() const
     return m_excerpt->nameChanged();
 }
 
+mu::String ExcerptNotation::makeFileName() const
+{
+    return m_excerpt->makeFileName();
+}
+
 INotationPtr ExcerptNotation::notation()
 {
     return shared_from_this();

--- a/src/notation/internal/excerptnotation.h
+++ b/src/notation/internal/excerptnotation.h
@@ -46,6 +46,7 @@ public:
     QString name() const override;
     void setName(const QString& name) override;
     async::Notification nameChanged() const override;
+    String makeFileName() const override;
 
     INotationPtr notation() override;
     IExcerptNotationPtr clone() const override;

--- a/src/notation/internal/excerptnotation.h
+++ b/src/notation/internal/excerptnotation.h
@@ -46,7 +46,8 @@ public:
     QString name() const override;
     void setName(const QString& name) override;
     async::Notification nameChanged() const override;
-    String makeFileName() const override;
+
+    const String& fileName() const override;
 
     INotationPtr notation() override;
     IExcerptNotationPtr clone() const override;

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -226,7 +226,7 @@ mu::Ret NotationProject::doLoad(const io::path_t& path, const io::path_t& styleP
     // Load view settings (needs to be done after notations are created)
     m_masterNotation->notation()->viewState()->read(reader);
     for (IExcerptNotationPtr excerpt : m_masterNotation->excerpts()) {
-        excerpt->notation()->viewState()->read(reader, u"Excerpts/" + excerpt->makeFileName() + u"/");
+        excerpt->notation()->viewState()->read(reader, u"Excerpts/" + excerpt->fileName() + u"/");
     }
 
     return make_ret(Ret::Code::Ok);
@@ -712,7 +712,7 @@ mu::Ret NotationProject::writeProject(MscWriter& msczWriter, bool onlySelection,
     // Write view settings
     m_masterNotation->notation()->viewState()->write(msczWriter);
     for (IExcerptNotationPtr excerpt : m_masterNotation->excerpts()) {
-        excerpt->notation()->viewState()->write(msczWriter, u"Excerpts/" + excerpt->makeFileName() + u"/");
+        excerpt->notation()->viewState()->write(msczWriter, u"Excerpts/" + excerpt->fileName() + u"/");
     }
 
     return make_ret(Ret::Code::Ok);

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -226,7 +226,7 @@ mu::Ret NotationProject::doLoad(const io::path_t& path, const io::path_t& styleP
     // Load view settings (needs to be done after notations are created)
     m_masterNotation->notation()->viewState()->read(reader);
     for (IExcerptNotationPtr excerpt : m_masterNotation->excerpts()) {
-        excerpt->notation()->viewState()->read(reader, u"Excerpts/" + excerpt->name() + u"/");
+        excerpt->notation()->viewState()->read(reader, u"Excerpts/" + excerpt->makeFileName() + u"/");
     }
 
     return make_ret(Ret::Code::Ok);
@@ -712,7 +712,7 @@ mu::Ret NotationProject::writeProject(MscWriter& msczWriter, bool onlySelection,
     // Write view settings
     m_masterNotation->notation()->viewState()->write(msczWriter);
     for (IExcerptNotationPtr excerpt : m_masterNotation->excerpts()) {
-        excerpt->notation()->viewState()->write(msczWriter, u"Excerpts/" + excerpt->name() + u"/");
+        excerpt->notation()->viewState()->write(msczWriter, u"Excerpts/" + excerpt->makeFileName() + u"/");
     }
 
     return make_ret(Ret::Code::Ok);


### PR DESCRIPTION
The uniqueness of the names is guaranteed because each name is prefixed with the index of the excerpt. This has the additional advantage that we can eventually use those numbers to preserve the _order_ of the excerpts across launches.

This PR can still read files that have already been created in older 4.2 builds.
~However, for all older files, the viewstate.json file of existing excerpts won't be read, until you re-save the file in the build from this PR.
I think I know a way around that, which I'm still planning to implement, so therefore I'm marking this as draft for now. Feedback is already welcome though.~

Resolves: #14477
Resolves: #19054
Resolves: #19301