### PR TITLE
Correct arpeggio span on layout

### DIFF
--- a/src/engraving/dom/arpeggio.cpp
+++ b/src/engraving/dom/arpeggio.cpp
@@ -83,12 +83,19 @@ void Arpeggio::findAndAttachToChords()
     Chord* _chord = chord();
     track_idx_t strack = track();
     track_idx_t etrack = track() + (m_span - 1);
+    track_idx_t lastTrack = strack;
 
     for (track_idx_t track = strack; track <= etrack; track++) {
         EngravingItem* e = _chord->segment()->element(track);
         if (e && e->isChord()) {
             toChord(e)->undoChangeSpanArpeggio(this);
+            lastTrack = track;
         }
+    }
+
+    if (lastTrack != etrack) {
+        int newSpan = lastTrack - track() + 1;
+        undoChangeProperty(Pid::ARPEGGIO_SPAN, newSpan);
     }
 }
 

--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -2055,7 +2055,7 @@ void MeiExporter::fillControlEventMap(const std::string& xmlId, const ChordRest*
             // The arpeggio is spanning to a lower staff
             if (arpeggio->span() > 1) {
                 // We need to retrieve the chord it is spanning to
-                track_idx_t bottomTrack = arpeggio->track() + (arpeggio->span() - 1) * VOICES;
+                track_idx_t bottomTrack = arpeggio->track() + (arpeggio->span() - 1);
                 const EngravingItem* element = chord->segment()->element(bottomTrack);
                 // We do not know the xml:id of the chord yet, keep it in a map
                 if (element && element->isChord()) {

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -3112,7 +3112,7 @@ void MeiImporter::addSpannerEnds()
         // Go through the list of chord rest and check if they are on a staff below
         for (auto chordRest : plistChordRests) {
             Arpeggio* arpeggio = arpegMapEntry.first;
-            int span = static_cast<int>(chordRest->staffIdx() - arpeggio->staffIdx()) + 1;
+            int span = static_cast<int>(chordRest->track() - arpeggio->track()) + 1;
             // Adjust the span if it is currently smaller
             if (arpeggio->span() < span) {
                 arpeggio->setSpan(span);

--- a/src/importexport/mei/tests/data/arpeg-01.mscx
+++ b/src/importexport/mei/tests/data/arpeg-01.mscx
@@ -126,7 +126,7 @@
               </Note>
             <Arpeggio>
               <subtype>0</subtype>
-              <span>2</span>
+              <span>5</span>
               </Arpeggio>
             </Chord>
           <Chord>
@@ -145,7 +145,7 @@
               </Note>
             <Arpeggio>
               <subtype>1</subtype>
-              <span>2</span>
+              <span>5</span>
               </Arpeggio>
             </Chord>
           <Chord>
@@ -164,7 +164,7 @@
               </Note>
             <Arpeggio>
               <subtype>3</subtype>
-              <span>2</span>
+              <span>5</span>
               </Arpeggio>
             </Chord>
           <Chord>


### PR DESCRIPTION
If no chord is found at the end of an arpeggio span, fall back to the last chord found and reset the span.  
