### PR TITLE
Update arpeggio top handle position across parts

### DIFF
--- a/src/engraving/dom/arpeggio.cpp
+++ b/src/engraving/dom/arpeggio.cpp
@@ -121,7 +121,7 @@ void Arpeggio::rebaseStartAnchor(AnchorRebaseDirection direction)
                     track_idx_t newSpan = m_span + track() - curTrack;
                     if (newSpan != 0) {
                         undoChangeProperty(Pid::ARPEGGIO_SPAN, newSpan);
-                        score()->undo(new ChangeParent(this, e, e->staffIdx()));
+                        score()->undoChangeParent(this, e, e->staffIdx());
                         break;
                     }
                 }
@@ -136,7 +136,7 @@ void Arpeggio::rebaseStartAnchor(AnchorRebaseDirection direction)
                 if (newSpan != 0) {
                     chord()->undoChangeSpanArpeggio(nullptr);
                     undoChangeProperty(Pid::ARPEGGIO_SPAN, newSpan);
-                    score()->undo(new ChangeParent(this, e, e->staffIdx()));
+                    score()->undoChangeParent(this, e, e->staffIdx());
                     break;
                 }
             }
@@ -217,7 +217,7 @@ void Arpeggio::editDrag(EditData& ed)
                     detachFromChords(track(), c->track() - 1);
                 }
                 undoChangeProperty(Pid::ARPEGGIO_SPAN, newSpan);
-                score()->undo(new ChangeParent(this, c, c->staffIdx()));
+                score()->undoChangeParent(this, c, c->staffIdx());
                 m_userLen1 = 0.0;
             }
         }

--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -1817,7 +1817,7 @@ void Chord::undoChangeSpanArpeggio(Arpeggio* a)
         }
         Chord* chord = toChord(linkedObject);
         Score* score = chord->score();
-        EngravingItem* linkedArp = a->findLinkedInScore(score);
+        EngravingItem* linkedArp = chord->spanArpeggio();
         if (score && linkedArp) {
             score->undo(new ChangeSpanArpeggio(chord, toArpeggio(linkedArp)));
         }


### PR DESCRIPTION
Previously, changing which chord the top handle was attached to wouldn't update parts.  This fixes that.
Also fixes a crash when adjusting handles with parts open.