### PR TITLE
Allow entering a melisma in voice 2 while a longer note sustains in voice 1

### DIFF
--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -734,14 +734,19 @@ void Spanner::computeStartElement()
             if (!seg || seg->empty()) {
                 seg = score()->tick2segment(tick(), false, SegmentType::ChordRest);
             }
-            track_idx_t strack = (track() / VOICES) * VOICES;
-            track_idx_t etrack = strack + VOICES;
-            m_startElement = 0;
+            m_startElement = nullptr;
             if (seg) {
-                for (track_idx_t t = strack; t < etrack; ++t) {
-                    if (seg->element(t)) {
-                        m_startElement = seg->element(t);
-                        break;
+                EngravingItem* e = seg->element(track());
+                if (e) {
+                    m_startElement = e;
+                } else {
+                    track_idx_t strack = (track() / VOICES) * VOICES;
+                    track_idx_t etrack = strack + VOICES;
+                    for (track_idx_t t = strack; t < etrack; ++t) {
+                        if (seg->element(t)) {
+                            m_startElement = seg->element(t);
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Resolves: #19962 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

Melismas returned the chord in the first voice found in the segment as their `startCR` when we really want the chord in the same voice as the melisma.
See below for an example of what couldn't be inputted before.
<img width="555" alt="Screenshot 2023-11-28 at 16 54 15" src="https://github.com/musescore/MuseScore/assets/26510874/74696a9e-2d17-4266-8969-ad9731bbd22a">

I opted to add an exception to `Spanner::startCR()` rather than overriding as I thought that was most appropriate for this single case.
