### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/engraving/rendering/dev/slurtielayout.cpp
+++ b/src/engraving/rendering/dev/slurtielayout.cpp
@@ -1524,8 +1524,6 @@ void SlurTieLayout::adjustY(TieSegment* tieSegment)
 
     int closestLineToArc = round(yMidApogee / staffLineDist);
     bool isArcInsideStaff =  closestLineToArc >= 0 && closestLineToArc < staff->lines(tick);
-    Tie* tie = tieSegment->tie();
-    Note* note = tie->startNote();
     if (!isArcInsideStaff) {
         return;
     }


### PR DESCRIPTION
reg.: local variable is initialized but not referenced (C4189)