### PR TITLE
Refine engraving of StringTuning elements

### DIFF
--- a/src/engraving/dom/stringtunings.cpp
+++ b/src/engraving/dom/stringtunings.cpp
@@ -268,7 +268,7 @@ String StringTunings::generateText() const
                 }
             }
 
-            visibleStringList.emplace_back(String(guitarStringSymbol(i + 1) + u" \u2012 "
+            visibleStringList.emplace_back(String(guitarStringSymbol(i + 1) + u" \u2013 "
                                                   + String(pitchStr[0]).toUpper() + accidental) + u"  ");
         }
     }

--- a/src/engraving/dom/stringtunings.h
+++ b/src/engraving/dom/stringtunings.h
@@ -33,7 +33,7 @@ class StringTunings final : public StaffTextBase
     DECLARE_CLASSOF(ElementType::STRING_TUNINGS)
 
 public:
-    explicit StringTunings(Segment* parent, TextStyleType textStyleType = TextStyleType::STAFF);
+    explicit StringTunings(Segment* parent, TextStyleType textStyleType = TextStyleType::STRING_TUNINGS);
     StringTunings(const StringTunings& s);
 
     StringTunings* clone() const override;

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -820,6 +820,8 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::stringNumberOffset,            "stringNumberOffset",            PointF(0.0, 0.0) },
     { Sid::preferSameStringForTranspose,  "preferSameStringForTranspose",  false },
 
+    { Sid::stringTuningsFontSize,         "stringTuningsFontSize",         9.0 },
+
     { Sid::harpPedalDiagramFontFace,          "harpPedalDiagramFontFace",          "Edwin" },
     { Sid::harpPedalDiagramFontSize,          "harpPedalDiagramFontSize",          10.0 },
     { Sid::harpPedalDiagramLineSpacing,       "harpPedalDiagramLineSpacing",       1.0 },

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -832,6 +832,8 @@ enum class Sid {
     stringNumberOffset,
     preferSameStringForTranspose,
 
+    stringTuningsFontSize,
+
     harpPedalDiagramFontFace,
     harpPedalDiagramFontSize,
     harpPedalDiagramLineSpacing,

--- a/src/engraving/style/textstyle.cpp
+++ b/src/engraving/style/textstyle.cpp
@@ -214,6 +214,23 @@ const TextStyle stringNumberTextStyle { {
     { TextStylePropertyType::FrameFillColor,       Sid::stringNumberFrameBgColor,               Pid::FRAME_BG_COLOR },
 } };
 
+const TextStyle stringTuningsStyle { { // identical to staffText except for fontSize
+    { TextStylePropertyType::FontFace,             Sid::staffTextFontFace,                      Pid::FONT_FACE },
+    { TextStylePropertyType::FontSize,             Sid::stringTuningsFontSize,                  Pid::FONT_SIZE },
+    { TextStylePropertyType::LineSpacing,          Sid::staffTextLineSpacing,                   Pid::TEXT_LINE_SPACING },
+    { TextStylePropertyType::SizeSpatiumDependent, Sid::staffTextFontSpatiumDependent,          Pid::SIZE_SPATIUM_DEPENDENT },
+    { TextStylePropertyType::FontStyle,            Sid::staffTextFontStyle,                     Pid::FONT_STYLE },
+    { TextStylePropertyType::Color,                Sid::staffTextColor,                         Pid::COLOR },
+    { TextStylePropertyType::TextAlign,            Sid::staffTextAlign,                         Pid::ALIGN },
+    { TextStylePropertyType::Offset,               Sid::staffTextPosAbove,                      Pid::OFFSET },
+    { TextStylePropertyType::FrameType,            Sid::staffTextFrameType,                     Pid::FRAME_TYPE },
+    { TextStylePropertyType::FramePadding,         Sid::staffTextFramePadding,                  Pid::FRAME_PADDING },
+    { TextStylePropertyType::FrameWidth,           Sid::staffTextFrameWidth,                    Pid::FRAME_WIDTH },
+    { TextStylePropertyType::FrameRound,           Sid::staffTextFrameRound,                    Pid::FRAME_ROUND },
+    { TextStylePropertyType::FrameBorderColor,     Sid::staffTextFrameFgColor,                  Pid::FRAME_FG_COLOR },
+    { TextStylePropertyType::FrameFillColor,       Sid::staffTextFrameBgColor,                  Pid::FRAME_BG_COLOR },
+} };
+
 const TextStyle harpPedalDiagramTextStyle { {
     { TextStylePropertyType::FontFace,             Sid::harpPedalDiagramFontFace,               Pid::FONT_FACE },
     { TextStylePropertyType::FontSize,             Sid::harpPedalDiagramFontSize,               Pid::FONT_SIZE },
@@ -1093,7 +1110,7 @@ const TextStyle* textStyle(TextStyleType idx)
     case TextStyleType::LH_GUITAR_FINGERING: return &lhGuitarFingeringTextStyle;
     case TextStyleType::RH_GUITAR_FINGERING: return &rhGuitarFingeringTextStyle;
     case TextStyleType::STRING_NUMBER: return &stringNumberTextStyle;
-    case TextStyleType::STRING_TUNINGS: return &stringNumberTextStyle; // todo
+    case TextStyleType::STRING_TUNINGS: return &stringTuningsStyle; // todo
     case TextStyleType::HARP_PEDAL_DIAGRAM: return &harpPedalDiagramTextStyle;
     case TextStyleType::HARP_PEDAL_TEXT_DIAGRAM: return &harpPedalTextDiagramTextStyle;
 

--- a/src/importexport/musicxml/tests/data/testBeamModes_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBeamModes_ref.mscx
@@ -17,6 +17,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testBracketTypes_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBracketTypes_ref.mscx
@@ -17,6 +17,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testCueGraceNotes_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testCueGraceNotes_ref.mscx
@@ -17,6 +17,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testCueNotes3_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testCueNotes3_ref.mscx
@@ -18,6 +18,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testDSalCodaMisplaced_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDSalCodaMisplaced_ref.mscx
@@ -17,6 +17,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testDSalCoda_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDSalCoda_ref.mscx
@@ -17,6 +17,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testExcessHiddenStaves_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testExcessHiddenStaves_ref.mscx
@@ -19,6 +19,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testInferredSubtitle_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredSubtitle_ref.mscx
@@ -17,6 +17,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testLyricBracket_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testLyricBracket_ref.mscx
@@ -17,6 +17,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testMeasureStyleSlash_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testMeasureStyleSlash_ref.mscx
@@ -20,6 +20,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testNegativeOffset_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testNegativeOffset_ref.mscx
@@ -17,6 +17,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testPartNames_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPartNames_ref.mscx
@@ -18,6 +18,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testPedalChangesBroken_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPedalChangesBroken_ref.mscx
@@ -17,6 +17,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
@@ -17,6 +17,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testSecondVoiceMelismata_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSecondVoiceMelismata_ref.mscx
@@ -17,6 +17,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testStaffEmptiness_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testStaffEmptiness_ref.mscx
@@ -17,6 +17,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testTempoTextSpace1_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTempoTextSpace1_ref.mscx
@@ -17,6 +17,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testTempoTextSpace2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTempoTextSpace2_ref.mscx
@@ -17,6 +17,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testTextOrder_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTextOrder_ref.mscx
@@ -17,6 +17,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testTextQuirkInference_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTextQuirkInference_ref.mscx
@@ -17,6 +17,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testVoltaHiding_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testVoltaHiding_ref.mscx
@@ -18,6 +18,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/importexport/musicxml/tests/data/testWedgeOffset_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testWedgeOffset_ref.mscx
@@ -17,6 +17,7 @@
       <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
       <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
       <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
       <tempoFontSize>10</tempoFontSize>
       <tempoChangeFontSize>10</tempoChangeFontSize>

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -1856,7 +1856,7 @@ PalettePtr PaletteCreator::newGuitarPalette(bool defaultPalette)
 
     auto stringTunings = makeElement<StringTunings>(gpaletteScore);
     stringTunings->setXmlText(u"<sym>guitarString6</sym> - D");
-    stringTunings->initTextStyleType(TextStyleType::STAFF);
+    stringTunings->initTextStyleType(TextStyleType::STRING_TUNINGS);
     sp->appendElement(stringTunings, QT_TRANSLATE_NOOP("palette", "String tunings"))->setElementTranslated(true);
 
     sp->appendActionIcon(ActionIconType::STANDARD_BEND, "standard-bend", 1.25);


### PR DESCRIPTION
Swap figure-dash with n-dash character. Set default size to 9pt.

Note that string tuning elements created before this changed have been saved with the old text style so they will load at 10pt. New items will have the new default. Also, if coming from a previous 4.2 build, reset the Guitar palette so that the item updates with the new size.