### PR TITLE
Arpeggio crash fixes

### DIFF
--- a/src/engraving/dom/arpeggio.cpp
+++ b/src/engraving/dom/arpeggio.cpp
@@ -62,7 +62,7 @@ Arpeggio::~Arpeggio()
 {
     // Remove reference to this arpeggio in any chords it may have spanned
     Chord* _chord = chord();
-    if (!_chord) {
+    if (!_chord || !_chord->segment()) {
         return;
     }
     for (track_idx_t _track = track(); _track <= track() + m_span; _track++) {

--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -779,9 +779,9 @@ void Chord::remove(EngravingItem* e)
 
     case ElementType::ARPEGGIO:
         if (m_spanArpeggio == m_arpeggio) {
-            m_spanArpeggio = 0;
+            m_spanArpeggio = nullptr;
         }
-        m_arpeggio = 0;
+        m_arpeggio = nullptr;
         break;
     case ElementType::TREMOLO:
         setTremolo(nullptr);

--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -778,6 +778,9 @@ void Chord::remove(EngravingItem* e)
     break;
 
     case ElementType::ARPEGGIO:
+        if (m_spanArpeggio == m_arpeggio) {
+            m_spanArpeggio = 0;
+        }
         m_arpeggio = 0;
         break;
     case ElementType::TREMOLO:


### PR DESCRIPTION
Resolves: #20246 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->
Prevent crash on arpeggio copy -> undo -> delete any element

Resolves another crash caused by the steps below:
1. Create a chord
2. Add an arpeggio
3. Delete the arpeggio
4. Delete the chord