### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/engraving/dom/arpeggio.cpp
+++ b/src/engraving/dom/arpeggio.cpp
@@ -94,7 +94,7 @@ void Arpeggio::findAndAttachToChords()
     }
 
     if (lastTrack != etrack) {
-        int newSpan = lastTrack - track() + 1;
+        track_idx_t newSpan = lastTrack - track() + 1;
         undoChangeProperty(Pid::ARPEGGIO_SPAN, newSpan);
     }
 }


### PR DESCRIPTION
reg.: 'initializing': conversion from 'size_t' to 'int', possible loss of data (C4267)