### PR TITLE
Fix GH#20255: Right-click > "Select similar" broken

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -3603,7 +3603,6 @@ void Score::selectRange(EngravingItem* e, staff_idx_t staffIdx)
 void Score::collectMatch(void* data, EngravingItem* e)
 {
     ElementPattern* p = static_cast<ElementPattern*>(data);
-    auto eMeasure = e->findMeasure();
 
     if (p->type != int(ElementType::INVALID) && p->type != int(e->type())) {
         return;
@@ -3651,6 +3650,7 @@ void Score::collectMatch(void* data, EngravingItem* e)
     }
 
     if (p->measure) {
+        auto eMeasure = e->findMeasure();
         if (!eMeasure && e->isSpannerSegment()) {
             if (auto ss = toSpannerSegment(e)) {
                 if (auto s = ss->spanner()) {
@@ -3753,6 +3753,8 @@ void Score::selectSimilar(EngravingItem* e, bool sameStaff)
     pattern.voice   = mu::nidx;
     pattern.system  = 0;
     pattern.durationTicks = Fraction(-1, 1);
+    pattern.beat    = Fraction(0, 0);
+    pattern.measure = 0;
 
     score->scanElements(&pattern, collectMatch);
 
@@ -3789,6 +3791,8 @@ void Score::selectSimilarInRange(EngravingItem* e)
     pattern.voice   = mu::nidx;
     pattern.system  = 0;
     pattern.durationTicks = Fraction(-1, 1);
+    pattern.beat    = Fraction(0, 0);
+    pattern.measure = 0;
 
     score->scanElementsInRange(&pattern, collectMatch);
 

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -3751,10 +3751,7 @@ void Score::selectSimilar(EngravingItem* e, bool sameStaff)
     pattern.staffStart = sameStaff ? e->staffIdx() : mu::nidx;
     pattern.staffEnd = sameStaff ? e->staffIdx() + 1 : mu::nidx;
     pattern.voice   = mu::nidx;
-    pattern.system  = 0;
     pattern.durationTicks = Fraction(-1, 1);
-    pattern.beat    = Fraction(0, 0);
-    pattern.measure = 0;
 
     score->scanElements(&pattern, collectMatch);
 
@@ -3789,10 +3786,7 @@ void Score::selectSimilarInRange(EngravingItem* e)
     pattern.staffStart = selection().staffStart();
     pattern.staffEnd = selection().staffEnd();
     pattern.voice   = mu::nidx;
-    pattern.system  = 0;
     pattern.durationTicks = Fraction(-1, 1);
-    pattern.beat    = Fraction(0, 0);
-    pattern.measure = 0;
 
     score->scanElementsInRange(&pattern, collectMatch);
 

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -3750,8 +3750,7 @@ void Score::selectSimilar(EngravingItem* e, bool sameStaff)
     }
     pattern.staffStart = sameStaff ? e->staffIdx() : mu::nidx;
     pattern.staffEnd = sameStaff ? e->staffIdx() + 1 : mu::nidx;
-    pattern.voice   = mu::nidx;
-    pattern.durationTicks = Fraction(-1, 1);
+    pattern.voice = mu::nidx;
 
     score->scanElements(&pattern, collectMatch);
 
@@ -3785,8 +3784,7 @@ void Score::selectSimilarInRange(EngravingItem* e)
     }
     pattern.staffStart = selection().staffStart();
     pattern.staffEnd = selection().staffEnd();
-    pattern.voice   = mu::nidx;
-    pattern.durationTicks = Fraction(-1, 1);
+    pattern.voice = mu::nidx;
 
     score->scanElementsInRange(&pattern, collectMatch);
 

--- a/src/engraving/dom/select.h
+++ b/src/engraving/dom/select.h
@@ -51,7 +51,7 @@ struct ElementPattern {
     staff_idx_t staffEnd = 0;   // exclusive
     voice_idx_t voice = 0;
     bool subtypeValid = false;
-    Fraction durationTicks;
+    Fraction durationTicks { -1, 1 };
     Fraction beat { 0, 0 };
     const Measure* measure = nullptr;
     const System* system = nullptr;
@@ -61,21 +61,14 @@ struct ElementPattern {
 //   NotePattern
 //---------------------------------------------------------
 
-struct NotePattern {
+struct NotePattern : ElementPattern {
     std::list<Note*> el;
     int pitch = -1;
     int string = INVALID_STRING_INDEX;
     int tpc = Tpc::TPC_INVALID;
     NoteHeadGroup notehead = NoteHeadGroup::HEAD_INVALID;
     TDuration durationType = TDuration();
-    Fraction durationTicks;
     NoteType type = NoteType::INVALID;
-    staff_idx_t staffStart;
-    staff_idx_t staffEnd;   // exclusive
-    voice_idx_t voice;
-    Fraction beat { 0, 0 };
-    const Measure* measure = nullptr;
-    const System* system = nullptr;
 };
 
 //---------------------------------------------------------

--- a/src/engraving/dom/select.h
+++ b/src/engraving/dom/select.h
@@ -50,11 +50,11 @@ struct ElementPattern {
     staff_idx_t staffStart = 0;
     staff_idx_t staffEnd = 0;   // exclusive
     voice_idx_t voice = 0;
-    const System* system = nullptr;
     bool subtypeValid = false;
     Fraction durationTicks;
     Fraction beat { 0, 0 };
     const Measure* measure = nullptr;
+    const System* system = nullptr;
 };
 
 //---------------------------------------------------------

--- a/src/notation/internal/notationelements.cpp
+++ b/src/notation/internal/notationelements.cpp
@@ -197,7 +197,7 @@ mu::engraving::Score* NotationElements::score() const
 
 ElementPattern* NotationElements::constructElementPattern(const FilterElementsOptions* elementOptions) const
 {
-    ElementPattern* pattern = new ElementPattern;
+    mu::engraving::ElementPattern* pattern = new mu::engraving::ElementPattern();
     pattern->type = static_cast<int>(elementOptions->elementType);
     pattern->subtype = elementOptions->subtype;
     pattern->subtypeValid = elementOptions->bySubtype;

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -442,8 +442,8 @@ struct FilterElementsOptions
     int voice = -1;
     const mu::engraving::System* system = nullptr;
     Fraction durationTicks{ -1, 1 };
-    Fraction beat{ -1, 1 };
-    const Measure* measure = nullptr;
+    Fraction beat{ 0, 0 };
+    const mu::engraving::Measure* measure = nullptr;
 
     bool bySubtype = false;
     int subtype = -1;
@@ -461,7 +461,7 @@ struct FilterNotesOptions : FilterElementsOptions
     int pitch = -1;
     int string = mu::engraving::INVALID_STRING_INDEX;
     int tpc = mu::engraving::Tpc::TPC_INVALID;
-    engraving::NoteHeadGroup notehead = engraving::NoteHeadGroup::HEAD_INVALID;
+    mu::engraving::NoteHeadGroup notehead = mu::engraving::NoteHeadGroup::HEAD_INVALID;
     mu::engraving::TDuration durationType = mu::engraving::TDuration();
     mu::engraving::NoteType noteType = mu::engraving::NoteType::INVALID;
 };

--- a/src/notation/view/widgets/selectdialog.cpp
+++ b/src/notation/view/widgets/selectdialog.cpp
@@ -133,9 +133,7 @@ FilterElementsOptions SelectDialog::elementOptions() const
                 }
             }
         }
-        if (m) {
-            options.measure = m;
-        }
+        options.measure = m;
     } else {
         options.measure = nullptr;
     }

--- a/src/notation/view/widgets/selectnotedialog.cpp
+++ b/src/notation/view/widgets/selectnotedialog.cpp
@@ -142,7 +142,7 @@ FilterNotesOptions SelectNoteDialog::noteOptions() const
     if (sameBeat->isChecked()) {
         options.beat = m_note->beat();
     } else {
-        options.beat = Fraction(0, 0);
+        options.beat = mu::engraving::Fraction(0, 0);
     }
 
     if (sameMeasure->isChecked()) {


### PR DESCRIPTION
That `Fraction beat{ 0, 0 };` is the core of this fix, the rest is mostly cosmetic and for symmetry and consistency.

Resolves: #20255