### PR TITLE
MusicXML: Correctly export all trill types

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -2849,8 +2849,7 @@ static void wavyLineStart(const Trill* tr, const int number, Notations& notation
 {
     notations.tag(xml, tr);
     ornaments.tag(xml);
-    switch (tr->trillType())
-    {
+    switch (tr->trillType()) {
     case TrillType::TRILL_LINE:
         xml.tagRaw(u"trill-mark" + color2xml(tr));
         break;

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -2849,19 +2849,27 @@ static void wavyLineStart(const Trill* tr, const int number, Notations& notation
 {
     notations.tag(xml, tr);
     ornaments.tag(xml);
-    if (tr->trillType() == TrillType::TRILL_LINE) {
+    switch (tr->trillType())
+    {
+    case TrillType::TRILL_LINE:
         xml.tagRaw(u"trill-mark" + color2xml(tr));
-    } else if (tr->trillType() == TrillType::UPPRALL_LINE) {
+        break;
+    case TrillType::UPPRALL_LINE:
         xml.tagRaw(u"other-ornament smufl=\"ornamentBottomLeftConcaveStroke\"" + color2xml(tr));
-    } else if (tr->trillType() == TrillType::DOWNPRALL_LINE) {
+        break;
+    case TrillType::DOWNPRALL_LINE:
         xml.tagRaw(u"other-ornament smufl=\"ornamentLeftVerticalStroke\"" + color2xml(tr));
+        break;
+    case TrillType::PRALLPRALL_LINE:
+    default:
+        break;
     }
-    writeAccidental(xml, u"accidental-mark", tr->accidental());
     String tagName = u"wavy-line type=\"start\"";
     tagName += String(u" number=\"%1\"").arg(number + 1);
     tagName += color2xml(tr);
     tagName += ExportMusicXml::positioningAttributes(tr, true);
     xml.tagRaw(tagName);
+    writeAccidental(xml, u"accidental-mark", tr->accidental());
 }
 
 //---------------------------------------------------------

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -2847,10 +2847,15 @@ static void writeAccidental(XmlWriter& xml, const String& tagName, const Acciden
 
 static void wavyLineStart(const Trill* tr, const int number, Notations& notations, Ornaments& ornaments, XmlWriter& xml)
 {
-    // mscore only supports wavy-line with trill-mark
     notations.tag(xml, tr);
     ornaments.tag(xml);
-    xml.tagRaw(u"trill-mark" + color2xml(tr));
+    if (tr->trillType() == TrillType::TRILL_LINE) {
+        xml.tagRaw(u"trill-mark" + color2xml(tr));
+    } else if (tr->trillType() == TrillType::UPPRALL_LINE) {
+        xml.tagRaw(u"other-ornament smufl=\"ornamentBottomLeftConcaveStroke\"" + color2xml(tr));
+    } else if (tr->trillType() == TrillType::DOWNPRALL_LINE) {
+        xml.tagRaw(u"other-ornament smufl=\"ornamentLeftVerticalStroke\"" + color2xml(tr));
+    }
     writeAccidental(xml, u"accidental-mark", tr->accidental());
     String tagName = u"wavy-line type=\"start\"";
     tagName += String(u" number=\"%1\"").arg(number + 1);
@@ -3038,6 +3043,8 @@ static std::vector<String> symIdToArtic(const SymId sid)
 
     case SymId::articStaccatissimoAbove:
     case SymId::articStaccatissimoBelow:
+    case SymId::articStaccatissimoWedgeAbove:
+    case SymId::articStaccatissimoWedgeBelow:
         return { u"staccatissimo" };
         break;
 
@@ -3104,6 +3111,11 @@ static std::vector<String> symIdToArtic(const SymId sid)
     case SymId::articTenutoAccentAbove:
     case SymId::articTenutoAccentBelow:
         return { u"tenuto", u"accent" };
+        break;
+
+    case SymId::articStaccatissimoStrokeAbove:
+    case SymId::articStaccatissimoStrokeBelow:
+        return { u"spiccato" };
         break;
 
     default:

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -1215,7 +1215,7 @@ static bool convertArticulationToSymId(const String& mxmlName, SymId& id)
         map[u"up-bow"]           = SymId::stringsUpBow;
         map[u"down-bow"]         = SymId::stringsDownBow;
         map[u"detached-legato"]  = SymId::articTenutoStaccatoAbove;
-        map[u"spiccato"]         = SymId::articStaccatissimoAbove;
+        map[u"spiccato"]         = SymId::articStaccatissimoStrokeAbove;
         map[u"snap-pizzicato"]   = SymId::pluckedSnapPizzicatoAbove;
         map[u"schleifer"]        = SymId::ornamentPrecompSlide;
         map[u"open"]             = SymId::brassMuteOpen;

--- a/src/importexport/musicxml/tests/data/testNoteAttributes2.xml
+++ b/src/importexport/musicxml/tests/data/testNoteAttributes2.xml
@@ -17,11 +17,6 @@
       <supports element="print" attribute="new-system" type="no"/>
       <supports element="stem" type="yes"/>
       </encoding>
-    <miscellaneous>
-      <miscellaneous-field name="description">
-        Note: both staccatissimo and spiccato are imported as staccatissimo.
-        </miscellaneous-field>
-      </miscellaneous>
     </identification>
   <part-list>
     <score-part id="P1">

--- a/src/importexport/musicxml/tests/data/testNoteAttributes2_ref.xml
+++ b/src/importexport/musicxml/tests/data/testNoteAttributes2_ref.xml
@@ -466,7 +466,7 @@
         <stem>up</stem>
         <notations>
           <articulations>
-            <staccatissimo/>
+            <spiccato/>
             </articulations>
           </notations>
         </note>

--- a/src/importexport/musicxml/tests/data/testTrills.mscx
+++ b/src/importexport/musicxml/tests/data/testTrills.mscx
@@ -1,0 +1,387 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.20">
+  <Score>
+    <Division>480</Division>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="audioComUrl"></metaTag>
+    <metaTag name="composer">Klaus Rettinghaus</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="subtitle"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Trills</metaTag>
+    <Order id="orchestral">
+      <name>Orchestral</name>
+      <instrument id="flute">
+        <family id="flutes">Flutes</family>
+        </instrument>
+      <section id="woodwind" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>flutes</family>
+        <family>oboes</family>
+        <family>clarinets</family>
+        <family>saxophones</family>
+        <family>bassoons</family>
+        <unsorted group="woodwinds"/>
+        </section>
+      <section id="brass" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>horns</family>
+        <family>trumpets</family>
+        <family>cornets</family>
+        <family>flugelhorns</family>
+        <family>trombones</family>
+        <family>tubas</family>
+        </section>
+      <section id="timpani" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>timpani</family>
+        </section>
+      <section id="percussion" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>keyboard-percussion</family>
+        <family>drums</family>
+        <family>unpitched-metal-percussion</family>
+        <family>unpitched-wooden-percussion</family>
+        <family>other-percussion</family>
+        </section>
+      <family>keyboards</family>
+      <family>harps</family>
+      <family>organs</family>
+      <family>synths</family>
+      <soloists/>
+      <section id="voices" brackets="true" barLineSpan="false" thinBrackets="true">
+        <family>voices</family>
+        <family>voice-groups</family>
+        </section>
+      <section id="strings" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>orchestral-strings</family>
+        </section>
+      <unsorted/>
+      </Order>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Flute</trackName>
+      <Instrument id="flute">
+        <longName>Flute</longName>
+        <shortName>Fl.</shortName>
+        <trackName>Flute</trackName>
+        <minPitchP>59</minPitchP>
+        <maxPitchP>98</maxPitchP>
+        <minPitchA>60</minPitchA>
+        <maxPitchA>93</maxPitchA>
+        <instrumentId>wind.flutes.flute</instrumentId>
+        <Channel>
+          <program value="73"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <KeySig>
+            <eid>38654705687</eid>
+            <concertKey>0</concertKey>
+            </KeySig>
+          <TimeSig>
+            <eid>47244640281</eid>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Spanner type="Trill">
+            <Trill>
+              <subtype>trill</subtype>
+              <eid>197568495714</eid>
+              <Ornament>
+                <subtype>ornamentTrill</subtype>
+                <eid>201863462945</eid>
+                </Ornament>
+              </Trill>
+            <next>
+              <location>
+                <fractions>1/4</fractions>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <eid>206158430324</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>219043332117</eid>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Spanner type="Trill">
+            <prev>
+              <location>
+                <fractions>-1/4</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          <Spanner type="Trill">
+            <Trill>
+              <subtype>upprall</subtype>
+              <eid>227633266786</eid>
+              <Ornament>
+                <subtype>ornamentUpPrall</subtype>
+                <eid>231928234017</eid>
+                </Ornament>
+              </Trill>
+            <next>
+              <location>
+                <fractions>1/4</fractions>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <eid>236223201396</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>249108103189</eid>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Spanner type="Trill">
+            <prev>
+              <location>
+                <fractions>-1/4</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          <Spanner type="Trill">
+            <Trill>
+              <subtype>downprall</subtype>
+              <eid>257698037858</eid>
+              <Ornament>
+                <subtype>ornamentDownMordent</subtype>
+                <eid>261993005089</eid>
+                </Ornament>
+              </Trill>
+            <next>
+              <location>
+                <fractions>1/4</fractions>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <eid>266287972468</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>279172874261</eid>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Spanner type="Trill">
+            <prev>
+              <location>
+                <fractions>-1/4</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          <Spanner type="Trill">
+            <Trill>
+              <subtype>prallprall</subtype>
+              <eid>296352743522</eid>
+              <Ornament>
+                <subtype>ornamentTrill</subtype>
+                <eid>300647710753</eid>
+                </Ornament>
+              </Trill>
+            <next>
+              <location>
+                <measures>1</measures>
+                <fractions>-3/4</fractions>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <eid>304942678132</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>317827579925</eid>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Spanner type="Trill">
+            <prev>
+              <location>
+                <measures>-1</measures>
+                <fractions>3/4</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          <Spanner type="Trill">
+            <Trill>
+              <subtype>trill</subtype>
+              <eid>197568495714</eid>
+              <Ornament>
+                <Accidental>
+                  <subtype>accidentalFlat</subtype>
+                  <eid>3577707757585</eid>
+                  <placement>above</placement>
+                  </Accidental>
+                <intervalAbove>second,minor</intervalAbove>
+                <subtype>ornamentTrill</subtype>
+                <eid>201863462945</eid>
+                </Ornament>
+              </Trill>
+            <next>
+              <location>
+                <fractions>1/4</fractions>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <eid>206158430324</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>219043332117</eid>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Spanner type="Trill">
+            <prev>
+              <location>
+                <fractions>-1/4</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          <Spanner type="Trill">
+            <Trill>
+              <subtype>upprall</subtype>
+              <eid>227633266786</eid>
+              <Ornament>
+                <Accidental>
+                  <subtype>accidentalFlat</subtype>
+                  <eid>3586297692177</eid>
+                  <placement>above</placement>
+                  </Accidental>
+                <intervalAbove>second,minor</intervalAbove>
+                <subtype>ornamentUpPrall</subtype>
+                <eid>231928234017</eid>
+                </Ornament>
+              </Trill>
+            <next>
+              <location>
+                <fractions>1/4</fractions>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <eid>236223201396</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>249108103189</eid>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Spanner type="Trill">
+            <prev>
+              <location>
+                <fractions>-1/4</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          <Spanner type="Trill">
+            <Trill>
+              <subtype>downprall</subtype>
+              <eid>257698037858</eid>
+              <Ornament>
+                <Accidental>
+                  <subtype>accidentalFlat</subtype>
+                  <eid>3612067495953</eid>
+                  </Accidental>
+                <intervalBelow>second,major</intervalBelow>
+                <subtype>ornamentDownMordent</subtype>
+                <eid>261993005089</eid>
+                </Ornament>
+              </Trill>
+            <next>
+              <location>
+                <fractions>1/4</fractions>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <eid>266287972468</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>279172874261</eid>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Spanner type="Trill">
+            <prev>
+              <location>
+                <fractions>-1/4</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          <Spanner type="Trill">
+            <Trill>
+              <subtype>prallprall</subtype>
+              <eid>296352743522</eid>
+              <Ornament>
+                <Accidental>
+                  <subtype>accidentalFlat</subtype>
+                  <eid>3594887626769</eid>
+                  <placement>above</placement>
+                  </Accidental>
+                <intervalAbove>second,minor</intervalAbove>
+                <subtype>ornamentTrill</subtype>
+                <eid>300647710753</eid>
+                </Ornament>
+              </Trill>
+            <next>
+              <location>
+                <fractions>1/4</fractions>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <eid>304942678132</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>317827579925</eid>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <BarLine>
+            <eid>3655017168908</eid>
+            </BarLine>
+          <Spanner type="Trill">
+            <prev>
+              <location>
+                <fractions>-1/4</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/importexport/musicxml/tests/data/testTrills_ref.xml
+++ b/src/importexport/musicxml/tests/data/testTrills_ref.xml
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Trills</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Klaus Rettinghaus</creator>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Flute</part-name>
+      <part-abbreviation>Fl.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Flute</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>74</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <ornaments>
+            <trill-mark/>
+            <wavy-line type="start" number="1"/>
+            <wavy-line type="stop" number="1"/>
+            </ornaments>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <ornaments>
+            <other-ornament smufl="ornamentBottomLeftConcaveStroke"/>
+            <wavy-line type="start" number="1"/>
+            <wavy-line type="stop" number="1"/>
+            </ornaments>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <ornaments>
+            <other-ornament smufl="ornamentLeftVerticalStroke"/>
+            <wavy-line type="start" number="1"/>
+            <wavy-line type="stop" number="1"/>
+            </ornaments>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <ornaments>
+            <wavy-line type="start" number="1"/>
+            <wavy-line type="stop" number="1"/>
+            </ornaments>
+          </notations>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <ornaments>
+            <trill-mark/>
+            <wavy-line type="start" number="1"/>
+            <accidental-mark placement="above">flat</accidental-mark>
+            <wavy-line type="stop" number="1"/>
+            </ornaments>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <ornaments>
+            <other-ornament smufl="ornamentBottomLeftConcaveStroke"/>
+            <wavy-line type="start" number="1"/>
+            <accidental-mark placement="above">flat</accidental-mark>
+            <wavy-line type="stop" number="1"/>
+            </ornaments>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <ornaments>
+            <other-ornament smufl="ornamentLeftVerticalStroke"/>
+            <wavy-line type="start" number="1"/>
+            <accidental-mark placement="below">flat</accidental-mark>
+            <wavy-line type="stop" number="1"/>
+            </ornaments>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <ornaments>
+            <wavy-line type="start" number="1"/>
+            <accidental-mark placement="above">flat</accidental-mark>
+            <wavy-line type="stop" number="1"/>
+            </ornaments>
+          </notations>
+        </note>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -1007,6 +1007,9 @@ TEST_F(Musicxml_Tests, trackHandling) {
 TEST_F(Musicxml_Tests, tremolo) {
     mxmlIoTest("testTremolo");
 }
+TEST_F(Musicxml_Tests, trills) {
+    mxmlMscxExportTestRef("testTrills");
+}
 TEST_F(Musicxml_Tests, tuplets1) {
     mxmlIoTestRef("testTuplets1");
 }


### PR DESCRIPTION
This PR addresses some more of the problems reported in #17553:

- the `stroke` and `wedge` articulations are now exported as `spiccato` and `staccatissimo` respectively
- the `upprall`, `downprall`, and `prallprall` lines are now exported as `wavy-line` elements with the correct start glyph as `other-ornament` with a smufl attribute