### PR TITLE
Fix incorrect choice of accidentals on notes with same midi pitches on capx file import.

### DIFF
--- a/src/importexport/capella/internal/capella.cpp
+++ b/src/importexport/capella/internal/capella.cpp
@@ -798,7 +798,6 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
                 chord->add(note);
                 note->setPitch(clampPitch(pitch));
                 note->setHeadGroup(NoteHeadGroup(n.headGroup));
-                // TODO: compute tpc from pitch & line
                 note->setTpcFromPitch();
                 if (o->rightTie) {
                     Tie* tie = Factory::createTie(score->dummy());
@@ -979,6 +978,7 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
         }
     }
     Fraction endTick = tick;
+    score->spell(); // Call respell-pitches to correct accidentals
 
     //
     // pass II

--- a/src/importexport/capella/internal/capella.cpp
+++ b/src/importexport/capella/internal/capella.cpp
@@ -1381,6 +1381,7 @@ void convertCapella(Score* score, Capella* cap, bool capxMode)
         }
         systemTick = mtick;
     }
+    score->spell(); // Call respell-pitches to correct accidentals
 
     //
     // fill empty measures with rests

--- a/src/importexport/capella/tests/data/test4.cap-ref.mscx
+++ b/src/importexport/capella/tests/data/test4.cap-ref.mscx
@@ -100,11 +100,11 @@
             <Note>
               <eid>R_R</eid>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalSharp</subtype>
                 <eid>S_S</eid>
                 </Accidental>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               </Note>
             </Chord>
           <Beam>
@@ -117,41 +117,37 @@
             <durationType>eighth</durationType>
             <Note>
               <eid>V_V</eid>
-              <Accidental>
-                <subtype>accidentalNatural</subtype>
-                <eid>W_W</eid>
-                </Accidental>
               <pitch>64</pitch>
               <tpc>18</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>X_X</eid>
+            <eid>W_W</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>Y_Y</eid>
+              <eid>X_X</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>Z_Z</eid>
+            <eid>Y_Y</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>a_a</eid>
+              <eid>Z_Z</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>b_b</eid>
+                <eid>a_a</eid>
                 </Accidental>
               <pitch>66</pitch>
               <tpc>20</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>c_c</eid>
+            <eid>b_b</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>d_d</eid>
+              <eid>c_c</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
@@ -159,70 +155,66 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>e_e</eid>
+        <eid>d_d</eid>
         <LayoutBreak>
-          <eid>f_f</eid>
+          <eid>e_e</eid>
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
           <Beam>
-            <eid>g_g</eid>
+            <eid>f_f</eid>
             <l1>-4</l1>
             <l2>-6</l2>
             </Beam>
           <Chord>
-            <eid>h_h</eid>
+            <eid>g_g</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>i_i</eid>
+              <eid>h_h</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>j_j</eid>
+                <eid>i_i</eid>
                 </Accidental>
               <pitch>68</pitch>
               <tpc>22</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>k_k</eid>
+            <eid>j_j</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>l_l</eid>
+              <eid>k_k</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>m_m</eid>
+            <eid>l_l</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>n_n</eid>
+              <eid>m_m</eid>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
-                <eid>o_o</eid>
+                <subtype>accidentalSharp</subtype>
+                <eid>n_n</eid>
                 </Accidental>
               <pitch>70</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>p_p</eid>
+            <eid>o_o</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>q_q</eid>
-              <Accidental>
-                <subtype>accidentalNatural</subtype>
-                <eid>r_r</eid>
-                </Accidental>
+              <eid>p_p</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>s_s</eid>
+            <eid>q_q</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>t_t</eid>
+              <eid>r_r</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               </Note>

--- a/src/importexport/capella/tests/data/test4.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/test4.capx-ref.mscx
@@ -100,11 +100,11 @@
             <Note>
               <eid>R_R</eid>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
+                <subtype>accidentalSharp</subtype>
                 <eid>S_S</eid>
                 </Accidental>
               <pitch>63</pitch>
-              <tpc>11</tpc>
+              <tpc>23</tpc>
               </Note>
             </Chord>
           <Beam>
@@ -117,41 +117,37 @@
             <durationType>eighth</durationType>
             <Note>
               <eid>V_V</eid>
-              <Accidental>
-                <subtype>accidentalNatural</subtype>
-                <eid>W_W</eid>
-                </Accidental>
               <pitch>64</pitch>
               <tpc>18</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>X_X</eid>
+            <eid>W_W</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>Y_Y</eid>
+              <eid>X_X</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>Z_Z</eid>
+            <eid>Y_Y</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>a_a</eid>
+              <eid>Z_Z</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>b_b</eid>
+                <eid>a_a</eid>
                 </Accidental>
               <pitch>66</pitch>
               <tpc>20</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>c_c</eid>
+            <eid>b_b</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>d_d</eid>
+              <eid>c_c</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
@@ -159,70 +155,66 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>e_e</eid>
+        <eid>d_d</eid>
         <LayoutBreak>
-          <eid>f_f</eid>
+          <eid>e_e</eid>
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
           <Beam>
-            <eid>g_g</eid>
+            <eid>f_f</eid>
             <l1>-4</l1>
             <l2>-6</l2>
             </Beam>
           <Chord>
-            <eid>h_h</eid>
+            <eid>g_g</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>i_i</eid>
+              <eid>h_h</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>j_j</eid>
+                <eid>i_i</eid>
                 </Accidental>
               <pitch>68</pitch>
               <tpc>22</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>k_k</eid>
+            <eid>j_j</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>l_l</eid>
+              <eid>k_k</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>m_m</eid>
+            <eid>l_l</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>n_n</eid>
+              <eid>m_m</eid>
               <Accidental>
-                <subtype>accidentalFlat</subtype>
-                <eid>o_o</eid>
+                <subtype>accidentalSharp</subtype>
+                <eid>n_n</eid>
                 </Accidental>
               <pitch>70</pitch>
-              <tpc>12</tpc>
+              <tpc>24</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>p_p</eid>
+            <eid>o_o</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>q_q</eid>
-              <Accidental>
-                <subtype>accidentalNatural</subtype>
-                <eid>r_r</eid>
-                </Accidental>
+              <eid>p_p</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>s_s</eid>
+            <eid>q_q</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>t_t</eid>
+              <eid>r_r</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               </Note>

--- a/src/importexport/capella/tests/data/test7.cap-ref.mscx
+++ b/src/importexport/capella/tests/data/test7.cap-ref.mscx
@@ -508,101 +508,105 @@
             <durationType>eighth</durationType>
             <Note>
               <eid>rB_rB</eid>
+              <Accidental>
+                <subtype>accidentalFlat</subtype>
+                <eid>sB_sB</eid>
+                </Accidental>
               <pitch>61</pitch>
-              <tpc>21</tpc>
+              <tpc>9</tpc>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
-        <eid>sB_sB</eid>
+        <eid>tB_tB</eid>
         <LayoutBreak>
-          <eid>tB_tB</eid>
+          <eid>uB_uB</eid>
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
           <KeySig>
-            <eid>uB_uB</eid>
+            <eid>vB_vB</eid>
             <concertKey>-2</concertKey>
             </KeySig>
           <Beam>
-            <eid>vB_vB</eid>
+            <eid>wB_wB</eid>
             <l1>10</l1>
             <l2>6</l2>
             </Beam>
           <Chord>
-            <eid>wB_wB</eid>
+            <eid>xB_xB</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>xB_xB</eid>
+              <eid>yB_yB</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>yB_yB</eid>
+            <eid>zB_zB</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>zB_zB</eid>
+              <eid>0B_0B</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>0B_0B</eid>
+            <eid>1B_1B</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>1B_1B</eid>
+              <eid>2B_2B</eid>
               <pitch>63</pitch>
               <tpc>11</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>2B_2B</eid>
+            <eid>3B_3B</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>3B_3B</eid>
+              <eid>4B_4B</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               </Note>
             </Chord>
           <Beam>
-            <eid>4B_4B</eid>
+            <eid>5B_5B</eid>
             <l1>-6</l1>
             <l2>-6</l2>
             </Beam>
           <Chord>
-            <eid>5B_5B</eid>
+            <eid>6B_6B</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>6B_6B</eid>
+              <eid>7B_7B</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>7B_7B</eid>
+            <eid>8B_8B</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>8B_8B</eid>
+              <eid>9B_9B</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>9B_9B</eid>
+            <eid>+B_+B</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>+B_+B</eid>
+              <eid>/B_/B</eid>
               <pitch>70</pitch>
               <tpc>12</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>/B_/B</eid>
+            <eid>AC_AC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>AC_AC</eid>
+              <eid>BC_BC</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               </Note>
@@ -610,90 +614,90 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>BC_BC</eid>
+        <eid>CC_CC</eid>
         <voice>
           <KeySig>
-            <eid>CC_CC</eid>
+            <eid>DC_DC</eid>
             <concertKey>-3</concertKey>
             </KeySig>
           <Beam>
-            <eid>DC_DC</eid>
+            <eid>EC_EC</eid>
             <l1>10</l1>
             <l2>6</l2>
             </Beam>
           <Chord>
-            <eid>EC_EC</eid>
+            <eid>FC_FC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>FC_FC</eid>
+              <eid>GC_GC</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>GC_GC</eid>
+            <eid>HC_HC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>HC_HC</eid>
+              <eid>IC_IC</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>IC_IC</eid>
+            <eid>JC_JC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>JC_JC</eid>
+              <eid>KC_KC</eid>
               <pitch>63</pitch>
               <tpc>11</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>KC_KC</eid>
+            <eid>LC_LC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>LC_LC</eid>
+              <eid>MC_MC</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               </Note>
             </Chord>
           <Beam>
-            <eid>MC_MC</eid>
+            <eid>NC_NC</eid>
             <l1>-6</l1>
             <l2>-6</l2>
             </Beam>
           <Chord>
-            <eid>NC_NC</eid>
+            <eid>OC_OC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>OC_OC</eid>
+              <eid>PC_PC</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>PC_PC</eid>
+            <eid>QC_QC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>QC_QC</eid>
+              <eid>RC_RC</eid>
               <pitch>68</pitch>
               <tpc>10</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>RC_RC</eid>
+            <eid>SC_SC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>SC_SC</eid>
+              <eid>TC_TC</eid>
               <pitch>70</pitch>
               <tpc>12</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>TC_TC</eid>
+            <eid>UC_UC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>UC_UC</eid>
+              <eid>VC_VC</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               </Note>
@@ -701,94 +705,94 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>VC_VC</eid>
+        <eid>WC_WC</eid>
         <LayoutBreak>
-          <eid>WC_WC</eid>
+          <eid>XC_XC</eid>
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
           <KeySig>
-            <eid>XC_XC</eid>
+            <eid>YC_YC</eid>
             <concertKey>-4</concertKey>
             </KeySig>
           <Beam>
-            <eid>YC_YC</eid>
+            <eid>ZC_ZC</eid>
             <l1>10</l1>
             <l2>6</l2>
             </Beam>
           <Chord>
-            <eid>ZC_ZC</eid>
+            <eid>aC_aC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>aC_aC</eid>
+              <eid>bC_bC</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>bC_bC</eid>
+            <eid>cC_cC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>cC_cC</eid>
+              <eid>dC_dC</eid>
               <pitch>61</pitch>
               <tpc>9</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>dC_dC</eid>
+            <eid>eC_eC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>eC_eC</eid>
+              <eid>fC_fC</eid>
               <pitch>63</pitch>
               <tpc>11</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>fC_fC</eid>
+            <eid>gC_gC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>gC_gC</eid>
+              <eid>hC_hC</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               </Note>
             </Chord>
           <Beam>
-            <eid>hC_hC</eid>
+            <eid>iC_iC</eid>
             <l1>-6</l1>
             <l2>-6</l2>
             </Beam>
           <Chord>
-            <eid>iC_iC</eid>
+            <eid>jC_jC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>jC_jC</eid>
+              <eid>kC_kC</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>kC_kC</eid>
+            <eid>lC_lC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>lC_lC</eid>
+              <eid>mC_mC</eid>
               <pitch>68</pitch>
               <tpc>10</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>mC_mC</eid>
+            <eid>nC_nC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>nC_nC</eid>
+              <eid>oC_oC</eid>
               <pitch>70</pitch>
               <tpc>12</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>oC_oC</eid>
+            <eid>pC_pC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>pC_pC</eid>
+              <eid>qC_qC</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               </Note>
@@ -796,90 +800,90 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>qC_qC</eid>
+        <eid>rC_rC</eid>
         <voice>
           <KeySig>
-            <eid>rC_rC</eid>
+            <eid>sC_sC</eid>
             <concertKey>-5</concertKey>
             </KeySig>
           <Beam>
-            <eid>sC_sC</eid>
+            <eid>tC_tC</eid>
             <l1>10</l1>
             <l2>6</l2>
             </Beam>
           <Chord>
-            <eid>tC_tC</eid>
+            <eid>uC_uC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>uC_uC</eid>
+              <eid>vC_vC</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>vC_vC</eid>
+            <eid>wC_wC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>wC_wC</eid>
+              <eid>xC_xC</eid>
               <pitch>61</pitch>
               <tpc>9</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>xC_xC</eid>
+            <eid>yC_yC</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>yC_yC</eid>
+              <eid>zC_zC</eid>
               <pitch>63</pitch>
               <tpc>11</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>zC_zC</eid>
+            <eid>0C_0C</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>0C_0C</eid>
+              <eid>1C_1C</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               </Note>
             </Chord>
           <Beam>
-            <eid>1C_1C</eid>
+            <eid>2C_2C</eid>
             <l1>-6</l1>
             <l2>-6</l2>
             </Beam>
           <Chord>
-            <eid>2C_2C</eid>
+            <eid>3C_3C</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>3C_3C</eid>
+              <eid>4C_4C</eid>
               <pitch>66</pitch>
               <tpc>8</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>4C_4C</eid>
+            <eid>5C_5C</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>5C_5C</eid>
+              <eid>6C_6C</eid>
               <pitch>68</pitch>
               <tpc>10</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>6C_6C</eid>
+            <eid>7C_7C</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>7C_7C</eid>
+              <eid>8C_8C</eid>
               <pitch>70</pitch>
               <tpc>12</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>8C_8C</eid>
+            <eid>9C_9C</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>9C_9C</eid>
+              <eid>+C_+C</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               </Note>
@@ -887,94 +891,94 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>+C_+C</eid>
+        <eid>/C_/C</eid>
         <LayoutBreak>
-          <eid>/C_/C</eid>
+          <eid>AD_AD</eid>
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
           <KeySig>
-            <eid>AD_AD</eid>
+            <eid>BD_BD</eid>
             <concertKey>-6</concertKey>
             </KeySig>
           <Beam>
-            <eid>BD_BD</eid>
+            <eid>CD_CD</eid>
             <l1>10</l1>
             <l2>6</l2>
             </Beam>
           <Chord>
-            <eid>CD_CD</eid>
+            <eid>DD_DD</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>DD_DD</eid>
+              <eid>ED_ED</eid>
               <pitch>59</pitch>
               <tpc>7</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>ED_ED</eid>
+            <eid>FD_FD</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>FD_FD</eid>
+              <eid>GD_GD</eid>
               <pitch>61</pitch>
               <tpc>9</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>GD_GD</eid>
+            <eid>HD_HD</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>HD_HD</eid>
+              <eid>ID_ID</eid>
               <pitch>63</pitch>
               <tpc>11</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>ID_ID</eid>
+            <eid>JD_JD</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>JD_JD</eid>
+              <eid>KD_KD</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               </Note>
             </Chord>
           <Beam>
-            <eid>KD_KD</eid>
+            <eid>LD_LD</eid>
             <l1>-6</l1>
             <l2>-6</l2>
             </Beam>
           <Chord>
-            <eid>LD_LD</eid>
+            <eid>MD_MD</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>MD_MD</eid>
+              <eid>ND_ND</eid>
               <pitch>66</pitch>
               <tpc>8</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>ND_ND</eid>
+            <eid>OD_OD</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>OD_OD</eid>
+              <eid>PD_PD</eid>
               <pitch>68</pitch>
               <tpc>10</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>PD_PD</eid>
+            <eid>QD_QD</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>QD_QD</eid>
+              <eid>RD_RD</eid>
               <pitch>70</pitch>
               <tpc>12</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>RD_RD</eid>
+            <eid>SD_SD</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>SD_SD</eid>
+              <eid>TD_TD</eid>
               <pitch>59</pitch>
               <tpc>7</tpc>
               </Note>
@@ -982,94 +986,94 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>TD_TD</eid>
+        <eid>UD_UD</eid>
         <LayoutBreak>
-          <eid>UD_UD</eid>
+          <eid>VD_VD</eid>
           <subtype>line</subtype>
           </LayoutBreak>
         <voice>
           <KeySig>
-            <eid>VD_VD</eid>
+            <eid>WD_WD</eid>
             <concertKey>-7</concertKey>
             </KeySig>
           <Beam>
-            <eid>WD_WD</eid>
+            <eid>XD_XD</eid>
             <l1>10</l1>
             <l2>6</l2>
             </Beam>
           <Chord>
-            <eid>XD_XD</eid>
+            <eid>YD_YD</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>YD_YD</eid>
+              <eid>ZD_ZD</eid>
               <pitch>59</pitch>
               <tpc>7</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>ZD_ZD</eid>
+            <eid>aD_aD</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>aD_aD</eid>
+              <eid>bD_bD</eid>
               <pitch>61</pitch>
               <tpc>9</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>bD_bD</eid>
+            <eid>cD_cD</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>cD_cD</eid>
+              <eid>dD_dD</eid>
               <pitch>63</pitch>
               <tpc>11</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>dD_dD</eid>
+            <eid>eD_eD</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>eD_eD</eid>
+              <eid>fD_fD</eid>
               <pitch>64</pitch>
               <tpc>6</tpc>
               </Note>
             </Chord>
           <Beam>
-            <eid>fD_fD</eid>
+            <eid>gD_gD</eid>
             <l1>-6</l1>
             <l2>-6</l2>
             </Beam>
           <Chord>
-            <eid>gD_gD</eid>
+            <eid>hD_hD</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>hD_hD</eid>
+              <eid>iD_iD</eid>
               <pitch>66</pitch>
               <tpc>8</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>iD_iD</eid>
+            <eid>jD_jD</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>jD_jD</eid>
+              <eid>kD_kD</eid>
               <pitch>68</pitch>
               <tpc>10</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>kD_kD</eid>
+            <eid>lD_lD</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>lD_lD</eid>
+              <eid>mD_mD</eid>
               <pitch>70</pitch>
               <tpc>12</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>mD_mD</eid>
+            <eid>nD_nD</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>nD_nD</eid>
+              <eid>oD_oD</eid>
               <pitch>59</pitch>
               <tpc>7</tpc>
               </Note>


### PR DESCRIPTION
Port of #6032, plus adjusting 2 unit tests (both for test 4), which actually prove the fix right.

Resolves: https://musescore.org/en/node/304625 issue b), issue a) seems fixed in MusicXML import since long, but still exists in Capella import