### PR TITLE
Fix assertion failure when dragging image over score view

### DIFF
--- a/src/engraving/rendering/single/singlelayout.cpp
+++ b/src/engraving/rendering/single/singlelayout.cpp
@@ -152,6 +152,8 @@ void SingleLayout::layoutItem(EngravingItem* item)
         break;
     case ElementType::HARP_DIAGRAM: layout(toHarpPedalDiagram(item), ctx);
         break;
+    case ElementType::IMAGE:        layout(toImage(item), ctx);
+        break;
     case ElementType::INSTRUMENT_CHANGE: layout(toInstrumentChange(item), ctx);
         break;
     case ElementType::JUMP:         layout(toJump(item), ctx);
@@ -1100,6 +1102,17 @@ void SingleLayout::layout(HarpPedalDiagram* item, const Context& ctx)
 {
     item->updateDiagramText();
     layoutTextBase(item, ctx, item->mutldata());
+}
+
+void SingleLayout::layout(Image* item, const Context&)
+{
+    item->init();
+
+    SizeF imageSize = item->size();
+
+    Image::LayoutData* ldata = item->mutldata();
+    ldata->setPos(PointF());
+    ldata->setBbox(RectF(PointF(), item->size2pixel(imageSize)));
 }
 
 void SingleLayout::layout(InstrumentChange* item, const Context& ctx)

--- a/src/engraving/rendering/single/singlelayout.h
+++ b/src/engraving/rendering/single/singlelayout.h
@@ -67,6 +67,7 @@ class Hairpin;
 class HairpinSegment;
 class HarpPedalDiagram;
 
+class Image;
 class InstrumentChange;
 
 class Jump;
@@ -182,6 +183,7 @@ public:
     static void layout(Hairpin* item, const Context& ctx);
     static void layout(HarpPedalDiagram* item, const Context& ctx);
 
+    static void layout(Image* item, const Context& ctx);
     static void layout(InstrumentChange* item, const Context& ctx);
 
     static void layout(Jump* item, const Context& ctx);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1207,7 +1207,7 @@ bool NotationInteraction::startDrop(const QUrl& url)
     m_dropData.ed.dragOffset = QPointF();
     m_dropData.ed.dropElement->setParent(nullptr);
 
-    mu::engraving::EngravingItem::renderer()->layoutItem(m_dropData.ed.dropElement);
+    engravingRenderer()->layoutItem(m_dropData.ed.dropElement);
 
     return true;
 }


### PR DESCRIPTION
Use `ISingleRenderer` instead of `IScoreRenderer`

(I don't think this will have any consequences for release builds, so I'm not planning to port this to 4.2.0)