### PR TITLE
Konrad/preliminary vibrato

### DIFF
--- a/src/engraving/playback/metaparsers/internal/spannersmetaparser.cpp
+++ b/src/engraving/playback/metaparsers/internal/spannersmetaparser.cpp
@@ -44,6 +44,7 @@ bool SpannersMetaParser::isAbleToParse(const EngravingItem* spannerItem)
         ElementType::TRILL,
         ElementType::GLISSANDO,
         ElementType::GUITAR_BEND,
+        ElementType::VIBRATO,
     };
 
     return SUPPORTED_TYPES.find(spannerItem->type()) != SUPPORTED_TYPES.cend();
@@ -81,6 +82,10 @@ void SpannersMetaParser::doParse(const EngravingItem* item, const RenderingConte
     }
     case ElementType::GUITAR_BEND: {
         type = mpe::ArticulationType::Multibend;
+        break;
+    }
+    case ElementType::VIBRATO: {
+        type = mpe::ArticulationType::Vibrato;
         break;
     }
     case ElementType::TRILL: {

--- a/src/framework/musesampler/internal/apitypes.h
+++ b/src/framework/musesampler/internal/apitypes.h
@@ -282,8 +282,7 @@ typedef ms_Result (* ms_MuseSampler_add_track_event_range_end)(ms_MuseSampler, m
 
 // Added in 0.5
 typedef ms_Result (* ms_MuseSampler_add_pitch_bend)(ms_MuseSampler ms, ms_Track track, ms_PitchBendInfo info);
-typedef ms_Result (*ms_MuseSampler_add_vibrato)(ms_MuseSampler ms, ms_Track track, ms_VibratoInfo info);
-
+typedef ms_Result (* ms_MuseSampler_add_vibrato)(ms_MuseSampler ms, ms_Track track, ms_VibratoInfo info);
 
 typedef ms_Result (* ms_MuseSampler_start_audition_note)(ms_MuseSampler ms, ms_Track track, ms_AuditionStartNoteEvent evt);
 // Added in 0.3

--- a/src/framework/musesampler/internal/apitypes.h
+++ b/src/framework/musesampler/internal/apitypes.h
@@ -226,10 +226,10 @@ typedef struct ms_PitchBendInfo
 
 typedef struct ms_VibratoInfo
 {
-  int64_t event_id;
-  long long _start_us;
-  long long _duration_us;
-  int _depth_cents;
+    int64_t event_id;
+    long long _start_us;
+    long long _duration_us;
+    int _depth_cents;
 } ms_VibratoInfo;
 
 typedef ms_Result (* ms_init)();

--- a/src/framework/musesampler/internal/apitypes.h
+++ b/src/framework/musesampler/internal/apitypes.h
@@ -224,6 +224,14 @@ typedef struct ms_PitchBendInfo
     ms_PitchBendType _type;
 } ms_PitchBendInfo;
 
+typedef struct ms_VibratoInfo
+{
+  int64_t event_id;
+  long long _start_us;
+  long long _duration_us;
+  int _depth_cents;
+} ms_VibratoInfo;
+
 typedef ms_Result (* ms_init)();
 typedef ms_Result (* ms_disable_reverb)();
 typedef int (* ms_contains_instrument)(const char* mpe_id, const char* musicxml_id);
@@ -274,6 +282,8 @@ typedef ms_Result (* ms_MuseSampler_add_track_event_range_end)(ms_MuseSampler, m
 
 // Added in 0.5
 typedef ms_Result (* ms_MuseSampler_add_pitch_bend)(ms_MuseSampler ms, ms_Track track, ms_PitchBendInfo info);
+typedef ms_Result (*ms_MuseSampler_add_vibrato)(ms_MuseSampler ms, ms_Track track, ms_VibratoInfo info);
+
 
 typedef ms_Result (* ms_MuseSampler_start_audition_note)(ms_MuseSampler ms, ms_Track track, ms_AuditionStartNoteEvent evt);
 // Added in 0.3

--- a/src/framework/musesampler/internal/libhandler.h
+++ b/src/framework/musesampler/internal/libhandler.h
@@ -217,6 +217,7 @@ struct MuseSamplerLibHandler
     ms_MuseSampler_add_track_event_range_end addTrackEventRangeEnd = nullptr;
 
     ms_MuseSampler_add_pitch_bend addPitchBend = nullptr;
+    ms_MuseSampler_add_vibrato addVibrato = nullptr;
 
     std::function<bool(ms_MuseSampler ms, ms_Track track, ms_AuditionStartNoteEvent_2)> startAuditionNote = nullptr;
     ms_MuseSampler_stop_audition_note stopAuditionNote = nullptr;
@@ -377,6 +378,7 @@ public:
             }
 
             addPitchBend = (ms_MuseSampler_add_pitch_bend)getLibFunc(m_lib, "ms_MuseSampler_add_pitch_bend");
+            addVibrato = (ms_MuseSampler_add_vibrato)getLibFunc(m_lib, "ms_MuseSampler_add_vibrato");
         } else if (at_least_v_0_4) {
             if (addNoteEventInternal3 = (ms_MuseSampler_add_track_note_event_3)getLibFunc(m_lib, "ms_MuseSampler_add_track_note_event_3");
                 addNoteEventInternal3 != nullptr) {

--- a/src/framework/musesampler/internal/musesamplersequencer.cpp
+++ b/src/framework/musesampler/internal/musesamplersequencer.cpp
@@ -251,6 +251,9 @@ void MuseSamplerSequencer::addNoteEvent(const mpe::NoteEvent& noteEvent)
     if (noteEvent.expressionCtx().articulations.contains(mpe::ArticulationType::Multibend)) {
         addPitchBends(noteEvent, noteEventId);
     }
+    if (noteEvent.expressionCtx().articulations.contains(mpe::ArticulationType::Vibrato)) {
+        addVibrato(noteEvent, noteEventId);
+    }
 }
 
 void MuseSamplerSequencer::addPitchBends(const mpe::NoteEvent& noteEvent, long long noteEventId)
@@ -284,6 +287,24 @@ void MuseSamplerSequencer::addPitchBends(const mpe::NoteEvent& noteEvent, long l
 
         m_samplerLib->addPitchBend(m_sampler, m_track, pitchBend);
     }
+}
+
+void MuseSamplerSequencer::addVibrato(const mpe::NoteEvent& noteEvent, long long noteEventId)
+{
+    if (!m_samplerLib->addVibrato) {
+        return;
+    }
+    mpe::duration_t duration = noteEvent.arrangementCtx().actualDuration;
+    constexpr auto MAX_VIBRATO_DURATION_US = (int64_t)0.1*1000000;
+    constexpr int VIBRATO_DEPTH_CENTS = 13;
+
+    ms_VibratoInfo vibrato;
+    vibrato.event_id = noteEventId;
+    vibrato._start_us = std::min((int64_t)(duration * 0.1), MAX_VIBRATO_DURATION_US);
+    vibrato._duration_us = duration;
+    vibrato._depth_cents = VIBRATO_DEPTH_CENTS;
+
+    m_samplerLib->addVibrato(m_sampler, m_track, vibrato);
 }
 
 void MuseSamplerSequencer::pitchAndTuning(const mpe::pitch_level_t nominalPitch, int& pitch, int& centsOffset) const

--- a/src/framework/musesampler/internal/musesamplersequencer.cpp
+++ b/src/framework/musesampler/internal/musesamplersequencer.cpp
@@ -295,12 +295,14 @@ void MuseSamplerSequencer::addVibrato(const mpe::NoteEvent& noteEvent, long long
         return;
     }
     mpe::duration_t duration = noteEvent.arrangementCtx().actualDuration;
-    constexpr auto MAX_VIBRATO_DURATION_US = (int64_t)0.1*1000000;
+    // stand-in data before actual mpe support
+    constexpr auto MAX_VIBRATO_STARTOFFSET_US = (int64_t)0.1*1000000;
+    // stand-in data before actual mpe support
     constexpr int VIBRATO_DEPTH_CENTS = 13;
 
     ms_VibratoInfo vibrato;
     vibrato.event_id = noteEventId;
-    vibrato._start_us = std::min((int64_t)(duration * 0.1), MAX_VIBRATO_DURATION_US);
+    vibrato._start_us = std::min((int64_t)(duration * 0.1), MAX_VIBRATO_STARTOFFSET_US);
     vibrato._duration_us = duration;
     vibrato._depth_cents = VIBRATO_DEPTH_CENTS;
 

--- a/src/framework/musesampler/internal/musesamplersequencer.cpp
+++ b/src/framework/musesampler/internal/musesamplersequencer.cpp
@@ -296,7 +296,7 @@ void MuseSamplerSequencer::addVibrato(const mpe::NoteEvent& noteEvent, long long
     }
     mpe::duration_t duration = noteEvent.arrangementCtx().actualDuration;
     // stand-in data before actual mpe support
-    constexpr auto MAX_VIBRATO_STARTOFFSET_US = (int64_t)0.1*1000000;
+    constexpr auto MAX_VIBRATO_STARTOFFSET_US = (int64_t)0.1 * 1000000;
     // stand-in data before actual mpe support
     constexpr int VIBRATO_DEPTH_CENTS = 13;
 

--- a/src/framework/musesampler/internal/musesamplersequencer.h
+++ b/src/framework/musesampler/internal/musesamplersequencer.h
@@ -75,6 +75,7 @@ private:
 
     void addNoteEvent(const mpe::NoteEvent& noteEvent);
     void addPitchBends(const mpe::NoteEvent& noteEvent, long long noteEventId);
+    void addVibrato(const mpe::NoteEvent& noteEvent, long long noteEventId);
 
     void pitchAndTuning(const mpe::pitch_level_t nominalPitch, int& pitch, int& centsOffset) const;
     int pitchLevelToCents(const mpe::pitch_level_t pitchLevel) const;


### PR DESCRIPTION
MuseSampler provides an interface to adding vibrato to individual notes similar to guitar bends.
This PR calls that interface with a very simple preliminary vibrato articulation. It basically just translates the presence of a vibrato line on a note into a fixed vibrato depth. 

Note that this is just supposed to be a reasonable stand-in for the fleshed out mpe implementation.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
