### PR TITLE
fixed #20234: Entering notes past page in focus in medium and large scores causes crashing

### DIFF
--- a/src/engraving/dom/beam.cpp
+++ b/src/engraving/dom/beam.cpp
@@ -103,10 +103,13 @@ Beam::~Beam()
     // delete all references from chords
     //
     for (ChordRest* cr : m_elements) {
-        cr->setBeam(0);
+        cr->setBeam(nullptr);
     }
-    DeleteAll(m_beamSegments);
+
+    clearBeamSegments();
+
     DeleteAll(m_fragments);
+    m_fragments.clear();
 }
 
 //---------------------------------------------------------
@@ -845,6 +848,25 @@ bool Beam::hasAllRests()
         }
     }
     return true;
+}
+
+void Beam::clearBeamSegments()
+{
+    for (ChordRest* chordRest : m_elements) {
+        BeamSegment* chordRestBeamlet = chordRest->beamlet();
+        if (!chordRestBeamlet) {
+            continue;
+        }
+
+        for (BeamSegment* segment : m_beamSegments) {
+            if (segment == chordRestBeamlet) {
+                chordRest->setBeamlet(nullptr);
+            }
+        }
+    }
+
+    DeleteAll(m_beamSegments);
+    m_beamSegments.clear();
 }
 
 //-------------------------------------------------------

--- a/src/engraving/dom/beam.h
+++ b/src/engraving/dom/beam.h
@@ -67,7 +67,7 @@ public:
     bool isBefore = false;
 
     Shape shape() const;
-    EngravingItem* parentElement;
+    EngravingItem* parentElement = nullptr;
 
     BeamSegment(EngravingItem* b)
         : parentElement(b) {}
@@ -221,6 +221,7 @@ public:
 
     const std::vector<BeamSegment*>& beamSegments() const { return m_beamSegments; }
     std::vector<BeamSegment*>& beamSegments() { return m_beamSegments; }
+    void clearBeamSegments();
 
     const StaffType* tab() const { return m_tab; }
     void setTab(const StaffType* t) { m_tab = t; }

--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -416,18 +416,18 @@ void Chord::undoUnlink()
 Chord::~Chord()
 {
     DeleteAll(m_articulations);
-    delete m_arpeggio;
+
     if (m_tremolo) {
         if (m_tremolo->chord1() == this) {
-            Tremolo* tremoloPointer = m_tremolo;       // setTremolo(0) loses reference to the current pointer
-            if (m_tremolo->chord2()) {
-                m_tremolo->chord2()->setTremolo(0);
-            }
-            delete tremoloPointer;
-        } else if (!(m_tremolo->chord1())) { // delete orphaned tremolo
-            delete m_tremolo;
+            m_tremolo->setChord1(nullptr);
+        } else if (m_tremolo->chord2() == this) {
+            m_tremolo->setChord2(nullptr);
         }
+
+        m_tremolo = nullptr;
     }
+
+    delete m_arpeggio;
     delete m_stemSlash;
     delete m_stem;
     delete m_hook;

--- a/src/engraving/dom/chordrest.cpp
+++ b/src/engraving/dom/chordrest.cpp
@@ -124,8 +124,14 @@ ChordRest::~ChordRest()
     DeleteAll(m_lyrics);
     DeleteAll(m_el);
     delete m_tabDur;
-    if (m_beam && m_beam->contains(this)) {
-        delete m_beam;     // Beam destructor removes references to the deleted object
+
+    if (m_beam) {
+        mu::remove(m_beam->elements(), this);
+        m_beam = nullptr;
+    }
+
+    if (m_beamlet) {
+        m_beamlet = nullptr;
     }
 }
 

--- a/src/engraving/dom/tremolo.cpp
+++ b/src/engraving/dom/tremolo.cpp
@@ -73,6 +73,21 @@ Tremolo::Tremolo(const Tremolo& t)
     m_durationType = t.m_durationType;
 }
 
+Tremolo::~Tremolo()
+{
+    //
+    // delete all references from chords
+    //
+    if (m_chord1) {
+        m_chord1->setTremolo(nullptr);
+    }
+    if (m_chord2) {
+        m_chord2->setTremolo(nullptr);
+    }
+
+    clearBeamSegments();
+}
+
 void Tremolo::setParent(Chord* ch)
 {
     EngravingItem::setParent(ch);
@@ -661,5 +676,24 @@ void Tremolo::scanElements(void* data, void (* func)(void*, EngravingItem*), boo
         return;
     }
     EngravingItem::scanElements(data, func, all);
+}
+
+void Tremolo::clearBeamSegments()
+{
+    BeamSegment* chord1Segment = m_chord1 ? m_chord1->beamlet() : nullptr;
+    BeamSegment* chord2Segment = m_chord2 ? m_chord2->beamlet() : nullptr;
+
+    if (chord1Segment || chord2Segment) {
+        for (BeamSegment* segment : m_beamSegments) {
+            if (chord1Segment && chord1Segment == segment) {
+                m_chord1->setBeamlet(nullptr);
+            } else if (chord2Segment && chord2Segment == segment) {
+                m_chord2->setBeamlet(nullptr);
+            }
+        }
+    }
+
+    DeleteAll(m_beamSegments);
+    m_beamSegments.clear();
 }
 }

--- a/src/engraving/dom/tremolo.h
+++ b/src/engraving/dom/tremolo.h
@@ -54,6 +54,7 @@ public:
 
     Tremolo& operator=(const Tremolo&) = delete;
     Tremolo* clone() const override { return new Tremolo(*this); }
+    ~Tremolo() override;
 
     Chord* chord() const { return toChord(explicitParent()); }
     void setParent(Chord* ch);
@@ -158,6 +159,7 @@ public:
 
     const std::vector<BeamSegment*>& beamSegments() const { return m_beamSegments; }
     std::vector<BeamSegment*>& beamSegments() { return m_beamSegments; }
+    void clearBeamSegments();
 
     void computeShape();
 

--- a/src/engraving/rendering/dev/beamlayout.cpp
+++ b/src/engraving/rendering/dev/beamlayout.cpp
@@ -926,8 +926,7 @@ void BeamLayout::verticalAdjustBeamedRests(Rest* rest, Beam* beam, LayoutContext
 
 void BeamLayout::createBeamSegments(Beam* item, LayoutContext& ctx, const std::vector<ChordRest*>& chordRests)
 {
-    DeleteAll(item->beamSegments());
-    item->beamSegments().clear();
+    item->clearBeamSegments();
 
     bool levelHasBeam = false;
     int level = 0;

--- a/src/engraving/rendering/dev/tremololayout.cpp
+++ b/src/engraving/rendering/dev/tremololayout.cpp
@@ -298,11 +298,12 @@ void TremoloLayout::createBeamSegments(Tremolo* item, LayoutContext& ctx)
         return;
     }
 
-    DeleteAll(item->beamSegments());
-    item->beamSegments().clear();
+    item->clearBeamSegments();
+
     if (!item->twoNotes()) {
         return;
     }
+
     bool _isGrace = item->chord1()->isGrace();
     const PointF pagePos = item->pagePos();
     PointF startAnchor = item->layoutInfo->startAnchor() - PointF(0.0, pagePos.y());

--- a/src/engraving/rendering/stable/beamlayout.cpp
+++ b/src/engraving/rendering/stable/beamlayout.cpp
@@ -920,8 +920,7 @@ void BeamLayout::verticalAdjustBeamedRests(Rest* rest, Beam* beam, LayoutContext
 
 void BeamLayout::createBeamSegments(Beam* item, LayoutContext& ctx, const std::vector<ChordRest*>& chordRests)
 {
-    DeleteAll(item->beamSegments());
-    item->beamSegments().clear();
+    item->clearBeamSegments();
 
     bool levelHasBeam = false;
     int level = 0;

--- a/src/engraving/rendering/stable/tremololayout.cpp
+++ b/src/engraving/rendering/stable/tremololayout.cpp
@@ -298,11 +298,12 @@ void TremoloLayout::createBeamSegments(Tremolo* item, LayoutContext& ctx)
         return;
     }
 
-    DeleteAll(item->beamSegments());
-    item->beamSegments().clear();
+    item->clearBeamSegments();
+
     if (!item->twoNotes()) {
         return;
     }
+
     bool _isGrace = item->chord1()->isGrace();
     const PointF pagePos = item->pagePos();
     PointF startAnchor = item->layoutInfo->startAnchor() - PointF(0.0, pagePos.y());

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3625,6 +3625,8 @@ mu::Ret NotationInteraction::repeatSelection()
             ChordRest* cr = toChordRest(e);
             score()->pasteStaff(xml, cr->segment(), cr->staffIdx());
             apply();
+
+            showItem(cr);
         }
     }
 


### PR DESCRIPTION
Resolves: #20234

The issue is that when removing beam segments, the pointer to these segments is stored in the chord. In fact, we shouldn't retain a pointer to the segment in another object as it's risky and leads to such behavior - crashes. This fix only resolves the crash.