### PR TITLE
Fix #20306: Ensure interval fields are updated on property reset (4.3.0)

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/common/InspectorPropertyView.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/common/InspectorPropertyView.qml
@@ -129,7 +129,9 @@ Column {
 
                     enabled: root.isModified
 
-                    propertyItem: root.propertyItem
+                    onClicked: {
+                        root.requestResetToDefault()
+                    }
                 }
             }
 

--- a/src/inspector/view/qml/MuseScore/Inspector/common/PropertyResetButton.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/common/PropertyResetButton.qml
@@ -28,17 +28,10 @@ import MuseScore.Inspector 1.0
 FlatButton {
     id: root
 
-    required property PropertyItem propertyItem
-
     width: 20
     height: width
 
     icon: IconCode.UNDO
     toolTipTitle: qsTrc("inspector", "Reset")
     transparent: true
-    enabled: propertyItem.isModified
-
-    onClicked: {
-        propertyItem.resetToDefault()
-    }
 }

--- a/src/inspector/view/qml/MuseScore/Inspector/general/appearance/internal/ArrangeSection.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/general/appearance/internal/ArrangeSection.qml
@@ -71,7 +71,11 @@ Column {
                 navigation.row: root.resetButtonNavigationRow
                 navigation.accessible.name: qsTrc("inspector", "Reset stacking order to default")
 
-                propertyItem: root.arrangeOrderProperty
+                enabled: root.arrangeOrderProperty.isModified
+
+                onClicked: {
+                    root.arrangeOrderProperty.resetToDefault()
+                }
             }
         }
 


### PR DESCRIPTION
Resolves: #20306