### PR TITLE
fixed #19776: Crash after changing barline, toggling on/off multi measure rest, Undo all and Redo all

### DIFF
--- a/src/engraving/rendering/dev/measurelayout.cpp
+++ b/src/engraving/rendering/dev/measurelayout.cpp
@@ -1171,7 +1171,7 @@ void MeasureLayout::layoutMeasure(MeasureBase* currentMB, LayoutContext& ctx)
             }
         }
     } else if (seg) {
-        ctx.mutDom().undoRemoveElement(seg);
+        ctx.mutDom().removeElement(seg);
     }
 
     for (Segment& s : measure->segments()) {


### PR DESCRIPTION
Resolves: #19776

The segment of the start repeat barline is created above in measure->getSegmentR and the creation occurs without the undo command. The crash occurred when trying to delete the segment by undo.

The logic is this: if an object in the layout system was created without the undo command, then it must be deleted without the undo command.

I looked at the history of [changes](https://github.com/musescore/MuseScore/commit/f7d965#diff-442333b869a4101b96d1e604d1e8507a3da7acdfdeeabc0d5ba7f52c7f44471aR2675) to this piece of code and see that earlier creation was with the undo command, but later it was changed to simply creating a segment.