### PR TITLE
19535 undo redo undo crash

### DIFF
--- a/build_overrides.cmake.txt
+++ b/build_overrides.cmake.txt
@@ -1,0 +1,2 @@
+# build_overrides.cmake
+set(ENV{QTDIR} "$ENV{HOME}/Qt/5.15.2/gcc_64") # or wherever Qt is located

--- a/build_overrides.cmake.txt
+++ b/build_overrides.cmake.txt
@@ -1,2 +1,0 @@
-# build_overrides.cmake
-set(ENV{QTDIR} "$ENV{HOME}/Qt/5.15.2/gcc_64") # or wherever Qt is located

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -570,6 +570,7 @@ void Segment::checkElement(EngravingItem* el, track_idx_t track)
 void Segment::add(EngravingItem* el)
 {
 //      LOGD("%p segment %s add(%d, %d, %s)", this, subTypeName(), tick(), el->track(), el->typeName());
+
     if (el->explicitParent() != this) {
         el->setParent(this);
     }

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -548,7 +548,7 @@ void Segment::removeStaff(staff_idx_t staff)
 void Segment::checkElement(EngravingItem* el, track_idx_t track)
 {   
     // prevent segmentation fault on out of bounds index
-    if (track >= m_elist.size()) {
+    IF_ASSERT_FAILED(track < m_elist.size()) {
         return;
     }
     // generated elements can be overwritten

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -546,7 +546,11 @@ void Segment::removeStaff(staff_idx_t staff)
 //---------------------------------------------------------
 
 void Segment::checkElement(EngravingItem* el, track_idx_t track)
-{
+{   
+    // prevent segmentation fault on out of bounds index
+    if (track >= m_elist.size()) {
+        return;
+    }
     // generated elements can be overwritten
     if (m_elist[track] && !m_elist[track]->generated()) {
         LOGD("add(%s): there is already a %s at track %zu tick %d",
@@ -566,7 +570,7 @@ void Segment::checkElement(EngravingItem* el, track_idx_t track)
 void Segment::add(EngravingItem* el)
 {
 //      LOGD("%p segment %s add(%d, %d, %s)", this, subTypeName(), tick(), el->track(), el->typeName());
-
+    std::cout << "Segment::add\n";
     if (el->explicitParent() != this) {
         el->setParent(this);
     }
@@ -734,6 +738,7 @@ void Segment::add(EngravingItem* el)
 void Segment::remove(EngravingItem* el)
 {
 // LOGD("%p Segment::remove %s %p", this, el->typeName(), el);
+    std::cout << "Segment::add\n";
 
     track_idx_t track = el->track();
 

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -570,7 +570,6 @@ void Segment::checkElement(EngravingItem* el, track_idx_t track)
 void Segment::add(EngravingItem* el)
 {
 //      LOGD("%p segment %s add(%d, %d, %s)", this, subTypeName(), tick(), el->track(), el->typeName());
-    std::cout << "Segment::add\n";
     if (el->explicitParent() != this) {
         el->setParent(this);
     }
@@ -738,7 +737,6 @@ void Segment::add(EngravingItem* el)
 void Segment::remove(EngravingItem* el)
 {
 // LOGD("%p Segment::remove %s %p", this, el->typeName(), el);
-    std::cout << "Segment::add\n";
 
     track_idx_t track = el->track();
 


### PR DESCRIPTION
Resolves: #19535  

Using gdb, I found that there was a segmentation fault in Segment::checkElement during the crash, so I added a check to ensure that the code does not access m_elist out of bounds

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
