### PR TITLE
Fixed potential crash when destroying the score

### DIFF
--- a/src/engraving/dom/engravingobject.cpp
+++ b/src/engraving/dom/engravingobject.cpp
@@ -132,7 +132,11 @@ EngravingObject::~EngravingObject()
         EngravingObjectList children = m_children;
         for (EngravingObject* c : children) {
             c->m_parent = nullptr;
-            c->moveToDummy();
+            if (score()->dummy()) {
+                c->moveToDummy();
+            } else {
+                delete c;
+            }
         }
     } else {
         bool isPaletteScore = score()->isPaletteScore();

--- a/src/engraving/dom/rootitem.cpp
+++ b/src/engraving/dom/rootitem.cpp
@@ -37,7 +37,9 @@ RootItem::RootItem(Score* score)
 
 RootItem::~RootItem()
 {
-    delete m_dummy;
+    compat::DummyElement* d = m_dummy;
+    m_dummy = nullptr;
+    delete d;
 }
 
 compat::DummyElement* RootItem::dummy() const


### PR DESCRIPTION
During the destruction of DummyElement, it might happen that we attempt to delete an object with an undeleted child. In this case, we move such an object as a child to DummyElement, but we're already at the stage of destroying DummyElement — it's a problem

<details>
<summary> Stacktrace </summary>
MuseScore4
0x000140715bcd
mu::engraving::EngravingObject::~EngravingObject() engravingobject.cpp:113
MuseScore4
0x000140a756c3
mu::engraving::compat::DummyElement::~DummyElement() dummyelement.cpp:51
MuseScore4
0x000140a75814
<unknown>
MuseScore4
0x00014094598a
mu::engraving::RootItem::~RootItem() rootitem.cpp:40
MuseScore4
0x000140945a84
<unknown>
MuseScore4
0x00014084f545
mu::engraving::Score::~Score() score.cpp:420
MuseScore4
0x0001408bb814
<unknown>
MuseScore4
0x00014070f58b
mu::engraving::EngravingModule::onDestroy() engravingmodule.cpp:212
MuseScore4
0x00014053730e
mu::app::App::run(int,char * *) app.cpp:367
</details/