### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/dom/arpeggio.cpp
+++ b/src/engraving/dom/arpeggio.cpp
@@ -94,7 +94,7 @@ void Arpeggio::findAndAttachToChords()
     }
 
     if (lastTrack != etrack) {
-        int newSpan = lastTrack - track() + 1;
+        track_idx_t newSpan = lastTrack - track() + 1;
         undoChangeProperty(Pid::ARPEGGIO_SPAN, newSpan);
     }
 }

--- a/src/engraving/rendering/dev/slurtielayout.cpp
+++ b/src/engraving/rendering/dev/slurtielayout.cpp
@@ -1530,8 +1530,6 @@ void SlurTieLayout::adjustY(TieSegment* tieSegment)
 
     int closestLineToArc = round(yMidApogee / staffLineDist);
     bool isArcInsideStaff =  closestLineToArc >= 0 && closestLineToArc < staff->lines(tick);
-    Tie* tie = tieSegment->tie();
-    Note* note = tie->startNote();
     if (!isArcInsideStaff) {
         return;
     }


### PR DESCRIPTION
* reg.: local variable is initialized but not referenced (C4189), see #20247
* reg.: 'initializing': conversion from 'size_t' to 'int', possible loss of data (C4267), see #20264