### PR TITLE
CI: add patchelf ppa for ARM to fix running on non-4K pagesizes

### DIFF
--- a/build/ci/linux/setup-arm.sh
+++ b/build/ci/linux/setup-arm.sh
@@ -135,11 +135,14 @@ DEBIAN_FRONTEND="noninteractive" TZ="Europe/London" apt-get install -y --no-inst
   "${apt_packages_runtime[@]}" \
   "${apt_packages_ffmpeg[@]}"
 
-# Add additional ppas (Qt 5.15.2 and Cmake)
+# Add additional ppas (Qt 5.15.2, Cmake, and patchelf)
 # Poor naming of the cmake ppa, this ppa has bionic/focal/jammy dists
 add-apt-repository --yes ppa:theofficialgman/cmake-bionic
 add-apt-repository --yes ppa:theofficialgman/opt-qt-5.15.2-focal-arm
+# minimum patchelf 0.12 needed for proper elf load memory alignment
+add-apt-repository --yes ppa:theofficialgman/patchelf
 apt-get update
+apt-get upgrade -y
 
 # add an exception for the "detected dubious ownership in repository" (only seen inside a Docker image)
 git config --global --add safe.directory /MuseScore


### PR DESCRIPTION
Resolves: #20342
@cbjeukendrup

<!-- Add a short description of and motivation for the changes here -->
Use patchelf from ppa (backported from jammy) created for fix running on non 4K pagesizes (https://github.com/NixOS/patchelf/commit/0470d6921b5a3fe8e92e356c8e11d120dbbb06c0).
https://launchpad.net/~theofficialgman/+archive/ubuntu/patchelf

test run here: https://github.com/theofficialgman/MuseScore/actions/runs/7123620314

Verified the isssue is fixed on an ARM64 system with 16K pagesize (Pi5 with 16K pagesize kernel).

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
