### PR TITLE
CI: bump all appimage deployment dependencies to latest for ARM

### DIFF
--- a/build/ci/linux/package.sh
+++ b/build/ci/linux/package.sh
@@ -90,7 +90,7 @@ if [ "$PACKTYPE" == "appimage" ]; then
     *) unset UPDATE_INFORMATION;; # disable updates for other build modes
     esac
 
-    bash ./build/ci/linux/tools/make_appimage.sh "${INSTALL_DIR}" "${ARTIFACT_NAME}.AppImage"
+    bash ./build/ci/linux/tools/make_appimage.sh "${INSTALL_DIR}" "${ARTIFACT_NAME}.AppImage" "${PACKARCH}"
     mv "${INSTALL_DIR}/../${ARTIFACT_NAME}.AppImage" "${ARTIFACTS_DIR}/"
     bash ./build/ci/tools/make_artifact_name_env.sh $ARTIFACT_NAME.AppImage
 

--- a/build/ci/linux/setup-arm.sh
+++ b/build/ci/linux/setup-arm.sh
@@ -91,6 +91,7 @@ apt_packages=(
   sed
   desktop-file-utils # installs `desktop-file-validate` for appimagetool
   zsync # installs `zsyncmake` for appimagetool
+  libgpgme-dev # install for appimagetool
   libglib2.0-dev
   librsvg2-dev
   argagg-dev
@@ -225,7 +226,7 @@ cd /
 
 git clone https://github.com/linuxdeploy/linuxdeploy
 cd /linuxdeploy/
-git checkout --recurse-submodules 49f4f237762395c6a37
+git checkout --recurse-submodules 1-alpha-20231206-1
 git submodule update --init --recursive
 
 # patch src/core/generate-excludelist.sh to use curl instead of wget which fails on armhf
@@ -246,7 +247,7 @@ cd /
 
 git clone https://github.com/linuxdeploy/linuxdeploy-plugin-qt
 cd /linuxdeploy-plugin-qt/
-git checkout --recurse-submodules 59b6c1f90e21ba14
+git checkout --recurse-submodules 9a388d32b1e95d8b69e201356f050137eb6c0aa3
 git submodule update --init --recursive
 
 # patch src/core/generate-excludelist.sh to use curl instead of wget which fails on armhf
@@ -256,6 +257,7 @@ mkdir -p build
 cd build
 cmake -DBUILD_TESTING=OFF -DUSE_SYSTEM_BOOST=ON ..
 cmake --build . -j $(nproc)
+mkdir -p $BUILD_TOOLS/linuxdeploy
 mv /linuxdeploy-plugin-qt/build/bin/linuxdeploy-plugin-qt $BUILD_TOOLS/linuxdeploy/linuxdeploy-plugin-qt
 $BUILD_TOOLS/linuxdeploy/linuxdeploy --list-plugins
 cd /
@@ -266,7 +268,7 @@ cd /
 
 git clone https://github.com/linuxdeploy/linuxdeploy-plugin-appimage
 cd /linuxdeploy-plugin-appimage/
-git checkout --recurse-submodules 779bd58443e8cc
+git checkout --recurse-submodules 1-alpha-20230713-1
 git submodule update --init --recursive
 mkdir -p build
 cd build
@@ -299,49 +301,10 @@ appimagetool --version
 
 git clone https://github.com/AppImageCommunity/AppImageUpdate.git
 cd AppImageUpdate
-git checkout --recurse-submodules 2.0.0-alpha-1-20220512
+git checkout --recurse-submodules 2.0.0-alpha-1-20230526
 git submodule update --init --recursive
 mkdir -p build
 cd build
-
-if [ "$PACKARCH" == "armv7l" ]; then
-  cp ../ci/libgcrypt.pc /usr/lib/arm-linux-gnueabihf/pkgconfig/libgcrypt.pc
-  sed -i 's|x86_64-linux-gnu|arm-linux-gnueabihf|g' /usr/lib/arm-linux-gnueabihf/pkgconfig/libgcrypt.pc
-  sed -i 's|x86_64-pc-linux-gnu|arm-pc-linux-gnueabihf|g' /usr/lib/arm-linux-gnueabihf/pkgconfig/libgcrypt.pc
-  echo 'prefix=/usr
-exec_prefix=${prefix}
-includedir=${prefix}/include
-libdir=${prefix}/lib/arm-linux-gnueabihf
-host=arm-unknown-linux-gnueabihf
-mtcflags=
-mtlibs=
-
-Name: gpg-error
-Description: GPG Runtime
-Version: 1.27
-Cflags:
-Libs: -L${libdir} -lgpg-error
-Libs.private:
-URL: https://www.gnupg.org/software/libgpg-error/index.html' > /usr/lib/arm-linux-gnueabihf/pkgconfig/gpg-error.pc
-else
-  cp ../ci/libgcrypt.pc /usr/lib/aarch64-linux-gnu/pkgconfig/libgcrypt.pc
-  sed -i 's|x86_64|aarch64|g' /usr/lib/aarch64-linux-gnu/pkgconfig/libgcrypt.pc
-  echo 'prefix=/usr
-exec_prefix=${prefix}
-includedir=${prefix}/include
-libdir=${prefix}/lib/aarch64-linux-gnu
-host=aarch64-unknown-linux-gnu
-mtcflags=
-mtlibs=
-
-Name: gpg-error
-Description: GPG Runtime
-Version: 1.27
-Cflags:
-Libs: -L${libdir} -lgpg-error
-Libs.private:
-URL: https://www.gnupg.org/software/libgpg-error/index.html' > /usr/lib/aarch64-linux-gnu/pkgconfig/gpg-error.pc
-fi
 
 cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=Linux ..
 make -j"$(nproc)"
@@ -353,7 +316,6 @@ cp -v ../resources/*.xpm $BUILD_TOOLS/appimageupdatetool/appimageupdatetool-${PA
 $BUILD_TOOLS/linuxdeploy/linuxdeploy -v0 --appdir $BUILD_TOOLS/appimageupdatetool/appimageupdatetool-${PACKARCH}.AppDir  --output appimage -d ../resources/appimageupdatetool.desktop -i ../resources/appimage.png
 cd $BUILD_TOOLS/appimageupdatetool
 ln -s "appimageupdatetool-${PACKARCH}.AppDir/AppRun" appimageupdatetool # symlink for convenience
-rm -rf /usr/lib/arm-linux-gnueabihf/pkgconfig/libgcrypt.pc /usr/lib/aarch64-linux-gnu/pkgconfig/libgcrypt.pc
 cd /
 $BUILD_TOOLS/appimageupdatetool/appimageupdatetool --version
 

--- a/build/ci/linux/setup-arm.sh
+++ b/build/ci/linux/setup-arm.sh
@@ -306,7 +306,11 @@ git submodule update --init --recursive
 mkdir -p build
 cd build
 
-cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=Linux ..
+if [ "$PACKARCH" == "armv7l" ]; then
+  cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_CXX_FLAGS=-D_FILE_OFFSET_BITS=64 -DCMAKE_C_FLAGS=-D_FILE_OFFSET_BITS=64 .. 
+else
+  cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=Linux ..
+fi
 make -j"$(nproc)"
 # create the extracted appimage directory
 mkdir -p $BUILD_TOOLS/appimageupdatetool

--- a/build/ci/linux/setup-arm.sh
+++ b/build/ci/linux/setup-arm.sh
@@ -301,16 +301,12 @@ appimagetool --version
 
 git clone https://github.com/AppImageCommunity/AppImageUpdate.git
 cd AppImageUpdate
-git checkout --recurse-submodules 2.0.0-alpha-1-20230526
+git checkout --recurse-submodules 2.0.0-alpha-1-20220512
 git submodule update --init --recursive
 mkdir -p build
 cd build
 
-if [ "$PACKARCH" == "armv7l" ]; then
-  cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_CXX_FLAGS=-D_FILE_OFFSET_BITS=64 -DCMAKE_C_FLAGS=-D_FILE_OFFSET_BITS=64 .. 
-else
-  cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=Linux ..
-fi
+cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=Linux ..
 make -j"$(nproc)"
 # create the extracted appimage directory
 mkdir -p $BUILD_TOOLS/appimageupdatetool


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/pull/20356#issuecomment-1845478178
@cbjeukendrup

linuxdeploy-plugin-qt was too old on the arm setup script to use the EXTRA_PLATFORM_PLUGINS and so wayland qt plugins were not being added in arm builds.

the make_appimage.sh script was also updated to respect the passed architecture to the input but currently we still build the appimages for armhf/arm64 due to docker limitations with running appimages (specifically symptom number 2 here https://github.com/AppImage/AppImageKit/issues/1027#issuecomment-641601097). Not much time is saved by downloading vs building anyway for the newly available appimages (10 minutes less on the total 3hr build time).

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
