### PR TITLE
Remove segment directly, not via undo

### DIFF
--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -1550,7 +1550,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
         for (Segment& seg : nm->segments()) {
             seg.checkEmpty();
             if (seg.empty()) {
-                score->undoRemoveElement(&seg);
+                score->removeElement(&seg);
             }
         }
     }


### PR DESCRIPTION
Resolves: #19766 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

Segments weren't added with undo, so remove them without undo.
