### PR TITLE
Avoid adding generated items to the undo stack

### DIFF
--- a/src/engraving/dom/box.cpp
+++ b/src/engraving/dom/box.cpp
@@ -453,7 +453,7 @@ void Box::manageExclusionFromParts(bool exclude)
                         EngravingItem* newSectionBreak = sectionBreak->linkedClone();
                         newSectionBreak->setScore(score);
                         newSectionBreak->setParent(localPrevMeasure);
-                        score->undo(new AddElement(newSectionBreak));
+                        score->doUndoAddElement(newSectionBreak);
                     }
                 }
             }

--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -1514,7 +1514,7 @@ void Chord::createStem()
     stem->setParent(this);
     stem->setGenerated(true);
     //! score()->undoAddElement calls add(), which assigns this created stem to _stem
-    score()->undoAddElement(stem);
+    score()->doUndoAddElement(stem);
 }
 
 void Chord::removeStem()
@@ -1535,7 +1535,7 @@ void Chord::createHook()
     Hook* hook = new Hook(this);
     hook->setParent(this);
     hook->setGenerated(true);
-    score()->undoAddElement(hook);
+    score()->doUndoAddElement(hook);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -1988,7 +1988,7 @@ void Score::upDown(bool up, UpDownMode mode)
                 for (EngravingObject* e : l) {
                     Note* ln = toNote(e);
                     if (ln->accidental()) {
-                        undo(new RemoveElement(ln->accidental()));
+                        doUndoRemoveElement(ln->accidental());
                     }
                 }
             }

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -1057,7 +1057,7 @@ bool Score::rewriteMeasures(Measure* fm, Measure* lm, const Fraction& ns, staff_
         auto spanners = s->spannerMap().findOverlapping(tick1.ticks(), tick2.ticks());
         for (auto i : spanners) {
             if (i.value->tick() >= tick1 && i.value->tick() < tick2) {
-                undo(new RemoveElement(i.value));
+                doUndoRemoveElement(i.value);
             }
         }
         s->undoRemoveMeasures(m1, m2, true);
@@ -3913,7 +3913,7 @@ void Score::removeChordRest(ChordRest* cr, bool clearSegment)
 {
     std::set<Segment*> segments;
     for (EngravingObject* e : cr->linkList()) {
-        undo(new RemoveElement(static_cast<EngravingItem*>(e)));
+        doUndoRemoveElement(static_cast<EngravingItem*>(e));
         if (clearSegment) {
             Segment* s = cr->segment();
             if (segments.find(s) == segments.end()) {
@@ -3923,7 +3923,7 @@ void Score::removeChordRest(ChordRest* cr, bool clearSegment)
     }
     for (Segment* s : segments) {
         if (s->empty()) {
-            undo(new RemoveElement(s));
+            doUndoRemoveElement(s);
         }
     }
     if (cr->beam()) {
@@ -3938,7 +3938,7 @@ void Score::removeChordRest(ChordRest* cr, bool clearSegment)
     if (cr->isChord()) {
         for (Spanner* spanner : toChord(cr)->startingSpanners()) {
             if (spanner->isTrill()) {
-                undo(new RemoveElement(spanner));
+                doUndoRemoveElement(spanner);
             }
         }
     }
@@ -4158,7 +4158,7 @@ void Score::checkSpanner(const Fraction& startTick, const Fraction& endTick, boo
     }
     if (removeOrphans) {
         for (auto s : sl) {       // actually remove scheduled spanners
-            undo(new RemoveElement(s));
+            doUndoRemoveElement(s);
         }
     }
     for (auto s : sl2) {      // shorten spanners that extended past end of score
@@ -5433,7 +5433,7 @@ void Score::undoRemoveStaff(Staff* staff)
 
     for (Spanner* spanner : spannersToRemove) {
         spanner->undoUnlink();
-        undo(new RemoveElement(spanner));
+        doUndoRemoveElement(spanner);
     }
 
     //
@@ -6416,7 +6416,7 @@ void Score::undoRemoveElement(EngravingItem* element, bool removeLinked)
     for (EngravingObject* ee : element->linkList()) {
         EngravingItem* e = static_cast<EngravingItem*>(ee);
         if (e == element || removeLinked) {
-            undo(new RemoveElement(e));
+            doUndoRemoveElement(e);
 
             if (e->explicitParent() && (e->explicitParent()->isSegment())) {
                 Segment* s = toSegment(e->explicitParent());
@@ -6446,7 +6446,7 @@ void Score::undoRemoveElement(EngravingItem* element, bool removeLinked)
             if (s->header() || s->trailer()) {        // probably more segment types (system header)
                 s->setEnabled(false);
             } else {
-                undo(new RemoveElement(s));
+                doUndoRemoveElement(s);
             }
         }
     }

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -4737,7 +4737,7 @@ void Score::cloneVoice(track_idx_t strack, track_idx_t dtrack, Segment* sf, cons
                             }
                         }
                     }
-                    undo(new AddElement(ns));
+                    doUndoAddElement(ns);
                 }
             }
         }
@@ -4991,7 +4991,7 @@ void Score::undoChangeKeySig(Staff* ostaff, const Fraction& tick, KeySigEvent ke
             nks->setParent(s);
             nks->setTrack(track);
             nks->setKeySigEvent(nkey);
-            undo(new AddElement(nks));
+            doUndoAddElement(nks);
             if (lks) {
                 undo(new Link(lks, nks));
             } else {
@@ -5168,7 +5168,7 @@ void Score::undoChangeClef(Staff* ostaff, EngravingItem* e, ClefType ct, bool fo
             clef->setClefType(ct);
             clef->setParent(destSeg);
             clef->setIsHeader(st == SegmentType::HeaderClef);
-            score->undo(new AddElement(clef));
+            score->doUndoAddElement(clef);
 
             renderer()->layoutItem(clef);
         }
@@ -5696,13 +5696,13 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
                 nsp->setTrack2(nsp->track() + diff);
                 nsp->computeStartElement();
                 nsp->computeEndElement();
-                undo(new AddElement(nsp));
+                doUndoAddElement(nsp);
             } else if (et == ElementType::MARKER || et == ElementType::JUMP) {
                 Measure* om = toMeasure(element->explicitParent());
                 Measure* m  = score->tick2measure(om->tick());
                 ne->setTrack(ntrack);
                 ne->setParent(m);
-                undo(new AddElement(ne));
+                doUndoAddElement(ne);
             } else if (et == ElementType::MEASURE_NUMBER) {
                 toMeasure(element->explicitParent())->undoChangeProperty(Pid::MEASURE_NUMBER_MODE,
                                                                          static_cast<int>(MeasureNumberMode::SHOW));
@@ -5713,7 +5713,7 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
                 Segment* seg      = m->undoGetSegment(SegmentType::ChordRest, tick);
                 ne->setTrack(ntrack);
                 ne->setParent(seg);
-                undo(new AddElement(ne));
+                doUndoAddElement(ne);
             }
         }
 
@@ -5741,7 +5741,7 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
             }
         }
         if (links == 0 || !addToLinkedStaves) {
-            undo(new AddElement(element));
+            doUndoAddElement(element);
             return;
         }
         for (EngravingObject* ee : *links) {
@@ -5774,7 +5774,7 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
             ne->setScore(e->score());
             ne->setSelected(false);
             ne->setParent(e);
-            undo(new AddElement(ne));
+            doUndoAddElement(ne);
         }
         return;
     }
@@ -5782,7 +5782,7 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
     if (et == ElementType::LAYOUT_BREAK) {
         LayoutBreak* lb = toLayoutBreak(element);
         if (lb->layoutBreakType() == LayoutBreakType::SECTION) {
-            undo(new AddElement(lb));
+            doUndoAddElement(lb);
             MeasureBase* m = lb->measure();
             if (m->isBox()) {
                 // for frames, use linked frames
@@ -5796,7 +5796,7 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
                                 EngravingItem* e = lb->linkedClone();
                                 e->setScore(score);
                                 e->setParent(box);
-                                undo(new AddElement(e));
+                                doUndoAddElement(e);
                             }
                         }
                     }
@@ -5814,7 +5814,7 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
                     e->setScore(s);
                     Measure* nm = s->tick2measure(m->tick());
                     e->setParent(nm);
-                    undo(new AddElement(e));
+                    doUndoAddElement(e);
                 }
             }
             return;
@@ -5857,7 +5857,7 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
             && et != ElementType::HARP_DIAGRAM
             && et != ElementType::FIGURED_BASS)
         ) {
-        undo(new AddElement(element));
+        doUndoAddElement(element);
         return;
     }
 
@@ -6019,7 +6019,7 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
                     BarLine* bl = toBarLine(seg->element(ntrack));
                     na->setParent(bl);
                 }
-                undo(new AddElement(na));
+                doUndoAddElement(na);
             } else if (element->isChordLine() || element->isLyrics()) {
                 ChordRest* cr    = toChordRest(element->explicitParent());
                 Segment* segment = cr->segment();
@@ -6040,7 +6040,7 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
                     Note* newNote = toChord(ncr)->findNote(oldChordLine->note()->pitch());
                     newChordLine->setNote(newNote);
                 }
-                undo(new AddElement(ne));
+                doUndoAddElement(ne);
             }
             //
             // elements with Segment as parent
@@ -6097,7 +6097,7 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
                     }
                 }
 
-                undo(new AddElement(ne));
+                doUndoAddElement(ne);
                 // transpose harmony if necessary
                 if (element->isHarmony() && ne != element) {
                     Harmony* h = toHarmony(ne);
@@ -6157,9 +6157,9 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
                         }
                     }
                 }
-                undo(new AddElement(nsp));
+                doUndoAddElement(nsp);
             } else if (et == ElementType::GLISSANDO || et == ElementType::GUITAR_BEND) {
-                undo(new AddElement(toSpanner(ne)));
+                doUndoAddElement(toSpanner(ne));
             } else if (element->isTremolo() && toTremolo(element)->twoNotes()) {
                 Tremolo* tremolo = toTremolo(element);
                 ChordRest* cr1 = toChordRest(tremolo->chord1());
@@ -6177,12 +6177,12 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
                 Tremolo* ntremolo = toTremolo(ne);
                 ntremolo->setChords(c1, c2);
                 ntremolo->setParent(c1);
-                undo(new AddElement(ntremolo));
+                doUndoAddElement(ntremolo);
             } else if (element->isTremolo() && !toTremolo(element)->twoNotes()) {
                 Chord* cr = toChord(element->explicitParent());
                 Chord* c1 = findLinkedChord(cr, score->staff(staffIdx));
                 ne->setParent(c1);
-                undo(new AddElement(ne));
+                doUndoAddElement(ne);
             } else if (element->isArpeggio()) {
                 ChordRest* cr = toChordRest(element->explicitParent());
                 Segment* s    = cr->segment();
@@ -6191,7 +6191,7 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
                 Segment* ns   = nm->findSegment(s->segmentType(), s->tick());
                 Chord* c1     = toChord(ns->element(staffIdx * VOICES + cr->voice()));
                 ne->setParent(c1);
-                undo(new AddElement(ne));
+                doUndoAddElement(ne);
             } else if (element->isTie()) {
                 Tie* tie       = toTie(element);
                 Note* n1       = tie->startNote();
@@ -6216,7 +6216,7 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
                 ntie->setTrack(c1->track());
                 ntie->setStartNote(nn1);
                 ntie->setEndNote(nn2);
-                undo(new AddElement(ntie));
+                doUndoAddElement(ntie);
             } else if (element->isInstrumentChange()) {
                 InstrumentChange* is = toInstrumentChange(element);
                 Segment* s1    = is->segment();
@@ -6234,7 +6234,7 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
                 } else if (nis != is) {
                     nis->setInstrument(*is->instrument());
                 }
-                undo(new AddElement(nis));
+                doUndoAddElement(nis);
                 // transpose root score; parts will follow
                 if (score->isMaster() && nis->staff()->transpose(tickStart) != oldV) {
                     auto i = part->instruments().upper_bound(tickStart.ticks());
@@ -6254,7 +6254,7 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
                 nbreath->setScore(score);
                 nbreath->setTrack(ntrack);
                 nbreath->setParent(seg);
-                undo(new AddElement(nbreath));
+                doUndoAddElement(nbreath);
             } else {
                 LOGW("undoAddElement: unhandled: <%s>", element->typeName());
             }
@@ -6398,7 +6398,7 @@ void Score::undoAddCR(ChordRest* cr, Measure* measure, const Fraction& tick)
                 toRest(newcr)->setGap(false);
             }
 
-            undo(new AddElement(newcr));
+            doUndoAddElement(newcr);
         }
     }
 }

--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -662,7 +662,7 @@ void Excerpt::cloneSpanner(Spanner* s, Score* score, track_idx_t dstTrack, track
         return;
     }
 
-    score->undo(new AddElement(ns));
+    score->doUndoAddElement(ns);
     ns->styleChanged();
 }
 
@@ -1039,7 +1039,7 @@ void Excerpt::cloneStaves(Score* sourceScore, Score* dstScore, const std::vector
                     EngravingItem* newSectionBreak = sectionBreak->linkedClone();
                     newSectionBreak->setScore(dstScore);
                     newSectionBreak->setParent(prevMB);
-                    dstScore->undo(new AddElement(newSectionBreak));
+                    dstScore->doUndoAddElement(newSectionBreak);
                 }
             }
             continue;
@@ -1234,7 +1234,7 @@ void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff, bool cloneSpanners)
                             ne1->setTrack(dstTrack);
                             ne1->setParent(seg);
                             ne1->setScore(score);
-                            score->undo(new AddElement(ne1));
+                            score->doUndoAddElement(ne1);
                             continue;
                         }
                         default:

--- a/src/engraving/dom/figuredbass.cpp
+++ b/src/engraving/dom/figuredbass.cpp
@@ -922,7 +922,7 @@ void FiguredBass::addItemToLinked(FiguredBassItem* item)
             item->setTrack(track());
             item->setParent(this);
             m_items.push_back(item);
-            score()->undo(new AddElement(item));
+            score()->doUndoAddElement(item);
         } else {
             bool isThisTextLinked = getProperty(Pid::TEXT_LINKED_TO_MASTER).toBool();
             bool isOtherTextLinked = linkedObject->getProperty(Pid::TEXT_LINKED_TO_MASTER).toBool();
@@ -938,7 +938,7 @@ void FiguredBass::addItemToLinked(FiguredBassItem* item)
             itemClone->setParent(linkedFb);
             itemClone->setScore(linkedFb->score());
             linkedFb->appendItem(itemClone);
-            linkedScore->undo(new AddElement(itemClone));
+            linkedScore->doUndoAddElement(itemClone);
         }
     }
 }

--- a/src/engraving/dom/joinMeasure.cpp
+++ b/src/engraving/dom/joinMeasure.cpp
@@ -159,7 +159,7 @@ void MasterScore::joinMeasure(const Fraction& tick1, const Fraction& tick2)
                             nsig->setTrack(track);
                             nsig->setParent(nextTSeg);
 
-                            score->undo(new AddElement(nsig));
+                            score->doUndoAddElement(nsig);
 
                             if (!lts) {
                                 lts = nsig;

--- a/src/engraving/dom/joinMeasure.cpp
+++ b/src/engraving/dom/joinMeasure.cpp
@@ -85,7 +85,7 @@ void MasterScore::joinMeasure(const Fraction& tick1, const Fraction& tick2)
 
     auto spanners = spannerMap().findContained(startTick.ticks(), endTick.ticks());
     for (auto i : spanners) {
-        undo(new RemoveElement(i.value));
+        doUndoRemoveElement(i.value);
     }
 
     for (auto i : spanner()) {
@@ -167,9 +167,9 @@ void MasterScore::joinMeasure(const Fraction& tick1, const Fraction& tick2)
                                 score->undo(new Link(lts, nsig));
                             }
                         }
-                        score->undo(new RemoveElement(timeSig));
+                        score->doUndoRemoveElement(timeSig);
                         if (tSeg->empty()) {
-                            score->undo(new RemoveElement(tSeg));
+                            score->doUndoRemoveElement(tSeg);
                         }
                     }
                 }

--- a/src/engraving/dom/masterscore.cpp
+++ b/src/engraving/dom/masterscore.cpp
@@ -582,7 +582,7 @@ MeasureBase* MasterScore::insertMeasure(MeasureBase* beforeMeasure, const Insert
                         EngravingItem* pc = ps->element(staffIdx * VOICES);
                         if (pc) {
                             previousClefList.push_back(toClef(pc));
-                            undo(new RemoveElement(pc));
+                            doUndoRemoveElement(pc);
                             if (ps->empty()) {
                                 undoRemoveElement(ps);
                             }
@@ -647,7 +647,7 @@ MeasureBase* MasterScore::insertMeasure(MeasureBase* beforeMeasure, const Insert
                             ee = e;
                         }
                         if (ee) {
-                            undo(new RemoveElement(ee));
+                            doUndoRemoveElement(ee);
                             if (s->empty()) {
                                 undoRemoveElement(s);
                             }
@@ -673,7 +673,7 @@ MeasureBase* MasterScore::insertMeasure(MeasureBase* beforeMeasure, const Insert
                     EngravingItem* pb = pbs->element(staffIdx * VOICES);
                     if (pb && !pb->generated()) {
                         previousBarLinesList.push_back(toBarLine(pb));
-                        undo(new RemoveElement(pb));
+                        doUndoRemoveElement(pb);
                         if (pbs->empty()) {
                             pbs->setEnabled(false);
                         }

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -1082,7 +1082,7 @@ void Measure::cmdRemoveStaves(staff_idx_t sStaff, staff_idx_t eStaff)
             EngravingItem* el = s->element(track);
             if (el) {
                 el->undoUnlink();
-                score()->undo(new RemoveElement(el));
+                score()->doUndoRemoveElement(el);
             }
         }
 
@@ -1091,7 +1091,7 @@ void Measure::cmdRemoveStaves(staff_idx_t sStaff, staff_idx_t eStaff)
         for (EngravingItem* e : annotations) {
             if (allowRemoveWhenRemovingStaves(e, sStaff, eStaff)) {
                 e->undoUnlink();
-                score()->undo(new RemoveElement(e));
+                score()->doUndoRemoveElement(e);
             }
         }
     }
@@ -1103,7 +1103,7 @@ void Measure::cmdRemoveStaves(staff_idx_t sStaff, staff_idx_t eStaff)
 
         if (allowRemoveWhenRemovingStaves(e, sStaff, eStaff)) {
             e->undoUnlink();
-            score()->undo(new RemoveElement(e));
+            score()->doUndoRemoveElement(e);
         }
     }
 

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -1527,6 +1527,15 @@ void Score::addElement(EngravingItem* element)
     element->triggerLayout();
 }
 
+void Score::doUndoAddElement(EngravingItem* element)
+{
+    if (element->generated()) {
+        addElement(element);
+    } else {
+        undo(new AddElement(element));
+    }
+}
+
 //---------------------------------------------------------
 //   removeElement
 ///   Remove \a element from its parent.

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -2690,9 +2690,10 @@ void Score::adjustKeySigs(track_idx_t sidx, track_idx_t eidx, KeyList km)
 
             Segment* s = measure->getSegment(SegmentType::KeySig, tick);
             KeySig* keysig = Factory::createKeySig(s);
+            keysig->setParent(s);
             keysig->setTrack(staffIdx * VOICES);
             keysig->setKeySigEvent(key);
-            s->add(keysig);
+            doUndoAddElement(keysig);
         }
     }
 }

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -1709,6 +1709,16 @@ void Score::removeElement(EngravingItem* element)
     }
 }
 
+void Score::doUndoRemoveElement(EngravingItem* element)
+{
+    if (element->generated()) {
+        removeElement(element);
+        element->deleteLater();
+    } else {
+        undo(new RemoveElement(element));
+    }
+}
+
 bool Score::containsElement(const EngravingItem* element) const
 {
     if (!element) {

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -451,6 +451,7 @@ public:
 
     void addElement(EngravingItem*);
     void removeElement(EngravingItem*);
+    void doUndoRemoveElement(EngravingItem*);
     bool containsElement(const EngravingItem*) const;
 
     Note* addPitch(NoteVal&, bool addFlag, InputState* externalInputState = nullptr);

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -450,6 +450,7 @@ public:
     void changeAccidental(Note* oNote, AccidentalType);
 
     void addElement(EngravingItem*);
+    void doUndoAddElement(EngravingItem*);
     void removeElement(EngravingItem*);
     void doUndoRemoveElement(EngravingItem*);
     bool containsElement(const EngravingItem*) const;

--- a/src/engraving/dom/undo.cpp
+++ b/src/engraving/dom/undo.cpp
@@ -947,16 +947,16 @@ static void removeNote(const Note* note)
 {
     Score* score = note->score();
     if (note->tieFor() && note->tieFor()->endNote()) {
-        score->undo(new RemoveElement(note->tieFor()));
+        score->doUndoRemoveElement(note->tieFor());
     }
     if (note->tieBack()) {
-        score->undo(new RemoveElement(note->tieBack()));
+        score->doUndoRemoveElement(note->tieBack());
     }
     for (Spanner* s : note->spannerBack()) {
-        score->undo(new RemoveElement(s));
+        score->doUndoRemoveElement(s);
     }
     for (Spanner* s : note->spannerFor()) {
-        score->undo(new RemoveElement(s));
+        score->doUndoRemoveElement(s);
     }
 }
 
@@ -972,7 +972,7 @@ RemoveElement::RemoveElement(EngravingItem* e)
     if (element->isChordRest()) {
         ChordRest* cr = toChordRest(element);
         if (cr->tuplet() && cr->tuplet()->elements().size() <= 1) {
-            score->undo(new RemoveElement(cr->tuplet()));
+            score->doUndoRemoveElement(cr->tuplet());
         }
         if (e->isChord()) {
             Chord* chord = toChord(e);
@@ -980,7 +980,7 @@ RemoveElement::RemoveElement(EngravingItem* e)
             if (chord->tremolo()) {
                 Tremolo* tremolo = chord->tremolo();
                 if (tremolo->twoNotes()) {
-                    score->undo(new RemoveElement(tremolo));
+                    score->doUndoRemoveElement(tremolo);
                 }
             }
             // Move arpeggio down to next available note

--- a/src/engraving/dom/undo.cpp
+++ b/src/engraving/dom/undo.cpp
@@ -795,6 +795,7 @@ void CloneVoice::redo(EditData*)
 
 AddElement::AddElement(EngravingItem* e)
 {
+    DO_ASSERT_X(!e->generated(), String(u"Generated item %1 passed to AddElement").arg(String::fromAscii(e->typeName())));
     element = e;
 }
 
@@ -966,6 +967,7 @@ static void removeNote(const Note* note)
 
 RemoveElement::RemoveElement(EngravingItem* e)
 {
+    DO_ASSERT_X(!e->generated(), String(u"Generated item %1 passed to RemoveElement").arg(String::fromAscii(e->typeName())));
     element = e;
 
     Score* score = element->score();

--- a/src/engraving/rendering/dev/chordlayout.cpp
+++ b/src/engraving/rendering/dev/chordlayout.cpp
@@ -460,7 +460,7 @@ void ChordLayout::layoutTablature(Chord* item, LayoutContext& ctx)
             Stem* stem = Factory::createStem(item);
             stem->setParent(item);
             stem->setGenerated(true);
-            ctx.mutDom().undo(new AddElement(stem));
+            ctx.mutDom().addElement(stem);
         }
         item->stem()->setPos(tab->chordStemPos(item) * _spatium);
         if (item->hook()) {
@@ -476,15 +476,15 @@ void ChordLayout::layoutTablature(Chord* item, LayoutContext& ctx)
         }
     } else {
         if (item->stem()) {
-            ctx.mutDom().undo(new RemoveElement(item->stem()));
+            ctx.mutDom().doUndoRemoveElement(item->stem());
             item->remove(item->stem());
         }
         if (item->hook()) {
-            ctx.mutDom().undo(new RemoveElement(item->hook()));
+            ctx.mutDom().doUndoRemoveElement(item->hook());
             item->remove(item->hook());
         }
         if (item->beam()) {
-            ctx.mutDom().undo(new RemoveElement(item->beam()));
+            ctx.mutDom().doUndoRemoveElement(item->beam());
             item->remove(item->beam());
         }
     }

--- a/src/engraving/rendering/dev/layoutcontext.cpp
+++ b/src/engraving/rendering/dev/layoutcontext.cpp
@@ -21,6 +21,7 @@
  */
 #include "layoutcontext.h"
 
+#include "dom/undo.h"
 #include "style/defaultstyle.h"
 
 #include "dom/mscoreview.h"
@@ -322,6 +323,16 @@ void DomAccessor::undoAddElement(EngravingItem* item, bool addToLinkedStaves, bo
         return;
     }
     score()->undoAddElement(item, addToLinkedStaves, ctrlModifier);
+}
+
+void DomAccessor::doUndoRemoveElement(EngravingItem* item)
+{
+    if (item->generated()) {
+        removeElement(item);
+        item->deleteLater();
+    } else {
+        undo(new RemoveElement(item));
+    }
 }
 
 void DomAccessor::undoRemoveElement(EngravingItem* item)

--- a/src/engraving/rendering/dev/layoutcontext.cpp
+++ b/src/engraving/rendering/dev/layoutcontext.cpp
@@ -317,6 +317,15 @@ compat::DummyElement* DomAccessor::dummyParent() const
     return score()->dummy();
 }
 
+void DomAccessor::doUndoAddElement(EngravingItem* item)
+{
+    if (item->generated()) {
+        addElement(item);
+    } else {
+        undo(new AddElement(item));
+    }
+}
+
 void DomAccessor::undoAddElement(EngravingItem* item, bool addToLinkedStaves, bool ctrlModifier)
 {
     IF_ASSERT_FAILED(score()) {

--- a/src/engraving/rendering/dev/layoutcontext.h
+++ b/src/engraving/rendering/dev/layoutcontext.h
@@ -168,6 +168,7 @@ public:
     // Create/Remove
     RootItem* rootItem() const;
     compat::DummyElement* dummyParent() const;
+    void doUndoAddElement(EngravingItem*);
     void undoAddElement(EngravingItem* item, bool addToLinkedStaves = true, bool ctrlModifier = false);
     void doUndoRemoveElement(EngravingItem* item);
     void undoRemoveElement(EngravingItem* item);

--- a/src/engraving/rendering/dev/layoutcontext.h
+++ b/src/engraving/rendering/dev/layoutcontext.h
@@ -169,6 +169,7 @@ public:
     RootItem* rootItem() const;
     compat::DummyElement* dummyParent() const;
     void undoAddElement(EngravingItem* item, bool addToLinkedStaves = true, bool ctrlModifier = false);
+    void doUndoRemoveElement(EngravingItem* item);
     void undoRemoveElement(EngravingItem* item);
     void undo(UndoCommand* cmd, EditData* ed = nullptr) const;
     void addElement(EngravingItem* item);

--- a/src/engraving/rendering/dev/measurelayout.cpp
+++ b/src/engraving/rendering/dev/measurelayout.cpp
@@ -344,7 +344,7 @@ void MeasureLayout::createMMRest(LayoutContext& ctx, Measure* firstMeasure, Meas
         }
     } else if (mmrSeg) {
         // TODO: remove elements from mmrSeg?
-        ctx.mutDom().undo(new RemoveElement(mmrSeg));
+        ctx.mutDom().doUndoRemoveElement(mmrSeg);
     }
 
     //
@@ -378,7 +378,7 @@ void MeasureLayout::createMMRest(LayoutContext& ctx, Measure* firstMeasure, Meas
         }
     } else if (mmrSeg) {
         // TODO: remove elements from mmrSeg?
-        ctx.mutDom().undo(new RemoveElement(mmrSeg));
+        ctx.mutDom().doUndoRemoveElement(mmrSeg);
     }
 
     //
@@ -407,7 +407,7 @@ void MeasureLayout::createMMRest(LayoutContext& ctx, Measure* firstMeasure, Meas
         }
     } else if (mmrSeg) {
         // TODO: remove elements from mmrSeg?
-        ctx.mutDom().undo(new RemoveElement(mmrSeg));
+        ctx.mutDom().doUndoRemoveElement(mmrSeg);
     }
 
     //
@@ -446,7 +446,7 @@ void MeasureLayout::createMMRest(LayoutContext& ctx, Measure* firstMeasure, Meas
         // TODO: remove elements from mmrSeg, then delete mmrSeg
         // previously we removed the segment if not empty,
         // but this resulted in "stale" keysig in mmrest after removed from underlying measure
-        //undo(new RemoveElement(mmrSeg));
+        //doUndoRemoveElement(mmrSeg);
     }
 
     mmrMeasure->checkHeader();
@@ -496,7 +496,7 @@ void MeasureLayout::createMMRest(LayoutContext& ctx, Measure* firstMeasure, Meas
             }
             // remove from mmr if no match found
             if (!found) {
-                ctx.mutDom().undo(new RemoveElement(e));
+                ctx.mutDom().doUndoRemoveElement(e);
             }
         }
     }
@@ -1372,11 +1372,7 @@ void MeasureLayout::layoutMeasureNumber(Measure* m, LayoutContext& ctx)
             TLayout::layoutMeasureNumber(t, t->mutldata());
         } else {
             if (t) {
-                if (t->generated()) {
-                    ctx.mutDom().removeElement(t);
-                } else {
-                    ctx.mutDom().undo(new RemoveElement(t));
-                }
+                ctx.mutDom().doUndoRemoveElement(t);
             }
         }
     }
@@ -1390,11 +1386,7 @@ void MeasureLayout::layoutMMRestRange(Measure* m, LayoutContext& ctx)
             const MStaff* ms = m->mstaves().at(staffIdx);
             MMRestRange* rr = ms->mmRangeText();
             if (rr) {
-                if (rr->generated()) {
-                    ctx.mutDom().removeElement(rr);
-                } else {
-                    ctx.mutDom().undo(new RemoveElement(rr));
-                }
+                ctx.mutDom().doUndoRemoveElement(rr);
             }
         }
 

--- a/src/engraving/rendering/dev/measurelayout.cpp
+++ b/src/engraving/rendering/dev/measurelayout.cpp
@@ -1925,6 +1925,7 @@ void MeasureLayout::addSystemHeader(Measure* m, bool isFirstSystem, LayoutContex
                 //
                 keysig = Factory::createKeySig(kSegment);
                 keysig->setTrack(track);
+                keysig->setGenerated(true);
                 keysig->setParent(kSegment);
                 kSegment->add(keysig);
             }

--- a/src/engraving/rendering/dev/measurelayout.cpp
+++ b/src/engraving/rendering/dev/measurelayout.cpp
@@ -228,7 +228,7 @@ void MeasureLayout::createMMRest(LayoutContext& ctx, Measure* firstMeasure, Meas
                     EngravingItem* eClone = generated ? e->clone() : e->linkedClone();
                     eClone->setGenerated(generated);
                     eClone->setParent(mmrEndBarlineSeg);
-                    ctx.mutDom().undoAddElement(eClone);
+                    ctx.mutDom().undoAddElement(eClone);// ???
                 } else {
                     BarLine* mmrEndBarline = toBarLine(mmrEndBarlineSeg->element(staffIdx * VOICES));
                     BarLine* lastMeasureEndBarline = toBarLine(e);
@@ -316,7 +316,7 @@ void MeasureLayout::createMMRest(LayoutContext& ctx, Measure* firstMeasure, Meas
             mmr->setTicks(mmrMeasure->ticks());
             mmr->setTrack(track);
             mmr->setParent(s);
-            ctx.mutDom().undo(new AddElement(mmr));
+            ctx.mutDom().doUndoAddElement(mmr);
         }
     }
 
@@ -367,7 +367,7 @@ void MeasureLayout::createMMRest(LayoutContext& ctx, Measure* firstMeasure, Meas
                     mmrTimeSig = underlyingTimeSig->generated() ? underlyingTimeSig->clone() : toTimeSig(
                         underlyingTimeSig->linkedClone());
                     mmrTimeSig->setParent(mmrSeg);
-                    ctx.mutDom().undo(new AddElement(mmrTimeSig));
+                    ctx.mutDom().doUndoAddElement(mmrTimeSig);
                 } else {
                     mmrTimeSig->setSig(underlyingTimeSig->sig(), underlyingTimeSig->timeSigType());
                     mmrTimeSig->setNumeratorString(underlyingTimeSig->numeratorString());
@@ -398,7 +398,7 @@ void MeasureLayout::createMMRest(LayoutContext& ctx, Measure* firstMeasure, Meas
                 if (!mmrAmbitus) {
                     mmrAmbitus = underlyingAmbitus->clone();
                     mmrAmbitus->setParent(mmrSeg);
-                    ctx.mutDom().undo(new AddElement(mmrAmbitus));
+                    ctx.mutDom().doUndoAddElement(mmrAmbitus);
                 } else {
                     mmrAmbitus->initFrom(underlyingAmbitus);
                     TLayout::layoutAmbitus(mmrAmbitus, mmrAmbitus->mutldata(), ctx);
@@ -431,7 +431,7 @@ void MeasureLayout::createMMRest(LayoutContext& ctx, Measure* firstMeasure, Meas
                         underlyingKeySig->linkedClone());
                     mmrKeySig->setParent(mmrSeg);
                     mmrKeySig->setGenerated(true);
-                    ctx.mutDom().undo(new AddElement(mmrKeySig));
+                    ctx.mutDom().doUndoAddElement(mmrKeySig);
                 } else {
                     if (!(mmrKeySig->keySigEvent() == underlyingKeySig->keySigEvent())) {
                         bool addKey = underlyingKeySig->isChange();
@@ -475,7 +475,7 @@ void MeasureLayout::createMMRest(LayoutContext& ctx, Measure* firstMeasure, Meas
             if (!found) {
                 EngravingItem* eClone = e->linkedClone();
                 eClone->setParent(s);
-                ctx.mutDom().undo(new AddElement(eClone));
+                ctx.mutDom().doUndoAddElement(eClone);
             }
         }
 
@@ -1925,7 +1925,6 @@ void MeasureLayout::addSystemHeader(Measure* m, bool isFirstSystem, LayoutContex
                 //
                 keysig = Factory::createKeySig(kSegment);
                 keysig->setTrack(track);
-                keysig->setGenerated(true);
                 keysig->setParent(kSegment);
                 kSegment->add(keysig);
             }


### PR DESCRIPTION
Resolves: #17494 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->
Resolves: #18499
There's some refactoring done to adding/removing elements here.  `doUndoAdd/RemoveElement` prevents adding generated items to the undo stack.  This will hopefully reduce the number of crashes we get where an item is removed from the score by an undo command when it wasn't added by one.