### PR TITLE
More MusicXML fixes and improvements (master)

### DIFF
--- a/src/importexport/musicxml/imusicxmlconfiguration.h
+++ b/src/importexport/musicxml/imusicxmlconfiguration.h
@@ -42,6 +42,9 @@ public:
     virtual bool musicxmlExportLayout() const = 0;
     virtual void setMusicxmlExportLayout(bool value) = 0;
 
+    virtual bool musicxmlExportMu3Compat() const = 0;
+    virtual void setMusicxmlExportMu3Compat(bool value) = 0;
+
     enum class MusicxmlExportBreaksType {
         All, Manual, No
     };

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -5870,12 +5870,13 @@ static void directionJump(XmlWriter& xml, const Jump* const jp)
     if (sound != "") {
         xml.startElement("direction", { { "placement", (jp->placement() == PlacementV::BELOW) ? "below" : "above" } });
         xml.startElement("direction-type");
-        String positioning = ExportMusicXml::positioningAttributes(jp);
+        String attrs = color2xml(jp);
+        attrs += ExportMusicXml::positioningAttributes(jp);
         if (type != "") {
-            xml.tagRaw(type + positioning);
+            xml.tagRaw(type + attrs);
         }
         if (words != "") {
-            xml.tagRaw(u"words" + positioning, words);
+            xml.tagRaw(u"words" + attrs, words);
         }
         xml.endElement();
         if (sound != "") {
@@ -5999,12 +6000,13 @@ static void directionMarker(XmlWriter& xml, const Marker* const m, const std::ve
     if (!sound.empty()) {
         xml.startElement("direction", { { "placement", (m->placement() == PlacementV::BELOW) ? "below" : "above" } });
         xml.startElement("direction-type");
-        String positioning = ExportMusicXml::positioningAttributes(m);
+        String attrs = color2xml(m);
+        attrs += ExportMusicXml::positioningAttributes(m);
         if (!type.empty()) {
-            xml.tagRaw(type + positioning);
+            xml.tagRaw(type + attrs);
         }
         if (!words.empty()) {
-            xml.tagRaw(u"words" + positioning, words);
+            xml.tagRaw(u"words" + attrs, words);
         }
         xml.endElement();
         if (!sound.empty()) {

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -3459,6 +3459,14 @@ void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technic
         auto mxmlOrnam = symIdToOrnam(sid);
 
         if (mxmlOrnam != "") {
+            String placement;
+
+            if (!a->isStyled(Pid::ARTICULATION_ANCHOR) && a->anchor() != ArticulationAnchor::AUTO) {
+                placement = (a->anchor() == ArticulationAnchor::BOTTOM ? u"below" : u"above");
+            }
+            if (!placement.empty()) {
+                mxmlOrnam += String(u" placement=\"%1\"").arg(placement);
+            }
             mxmlOrnam += color2xml(a);
 
             notations.tag(m_xml, a);

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -5263,17 +5263,18 @@ void ExportMusicXml::hairpin(Hairpin const* const hp, staff_idx_t staff, const F
     }
 
     directionTag(m_xml, m_attr, hp);
-    if (hp->tick() == tick) {
-        writeHairpinText(m_xml, hp, hp->tick() == tick);
+    const bool hpTick = hp->tick() == tick;
+    if (hpTick) {
+        writeHairpinText(m_xml, hp, hpTick);
     }
     if (isLineType) {
         if (hp->lineVisible()) {
-            if (hp->tick() == tick) {
+            if (hpTick) {
                 m_xml.startElement("direction-type");
                 String tag = u"dashes type=\"start\"";
                 tag += String(u" number=\"%1\"").arg(n + 1);
                 tag += color2xml(hp);
-                tag += positioningAttributes(hp, hp->tick() == tick);
+                tag += positioningAttributes(hp, hpTick);
                 m_xml.tagRaw(tag);
                 m_xml.endElement();
             } else {
@@ -5285,7 +5286,7 @@ void ExportMusicXml::hairpin(Hairpin const* const hp, staff_idx_t staff, const F
     } else {
         m_xml.startElement("direction-type");
         String tag = u"wedge type=";
-        if (hp->tick() == tick) {
+        if (hpTick) {
             if (hp->hairpinType() == HairpinType::CRESC_HAIRPIN) {
                 tag += u"\"crescendo\"";
                 if (hp->hairpinCircledTip()) {
@@ -5295,6 +5296,7 @@ void ExportMusicXml::hairpin(Hairpin const* const hp, staff_idx_t staff, const F
                 tag += u"\"diminuendo\"";
             }
             tag += color2xml(hp);
+            tag += positioningAttributes(hp, hpTick);
         } else {
             tag += u"\"stop\"";
             if (hp->hairpinCircledTip() && hp->hairpinType() == HairpinType::DECRESC_HAIRPIN) {
@@ -5302,12 +5304,11 @@ void ExportMusicXml::hairpin(Hairpin const* const hp, staff_idx_t staff, const F
             }
         }
         tag += String(u" number=\"%1\"").arg(n + 1);
-        tag += positioningAttributes(hp, hp->tick() == tick);
         m_xml.tagRaw(tag);
         m_xml.endElement();
     }
-    if (hp->tick() != tick) {
-        writeHairpinText(m_xml, hp, hp->tick() == tick);
+    if (!hpTick) {
+        writeHairpinText(m_xml, hp, hpTick);
     }
     directionETag(m_xml, staff);
 }

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -6940,8 +6940,18 @@ void MusicXMLParserNotations::articulations()
                 m_breath = SymId::breathMarkComma;
             }
         } else if (m_e.name() == "caesura") {
-            m_breath = SymId::caesura;
-            m_e.skipCurrentElement();  // skip but don't log
+            auto value = m_e.readText();
+            if (value == "curved") {
+                m_breath = SymId::caesuraCurved;
+            } else if (value == "short") {
+                m_breath = SymId::caesuraShort;
+            } else if (value == "thick") {
+                m_breath = SymId::caesuraThick;
+            } else if (value == "single") {
+                m_breath = SymId::caesuraSingleStroke;
+            } else { // Use as the default symbol
+                m_breath = SymId::caesura;
+            }
         } else if (m_e.name() == "doit"
                    || m_e.name() == "falloff"
                    || m_e.name() == "plop"

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -1148,8 +1148,16 @@ static void addMordentToChord(const Notation& notation, ChordRest* cr)
     }
     if (articSym != SymId::noSym) {
         const Color color = Color::fromString(notation.attribute(u"color"));
+        const String place = notation.attribute(u"placement");
         Articulation* na = Factory::createArticulation(cr);
         na->setSymId(articSym);
+        if (place == u"above") {
+            na->setAnchor(ArticulationAnchor::TOP);
+        } else if (place == u"below") {
+            na->setAnchor(ArticulationAnchor::BOTTOM);
+        } else {
+            na->setAnchor(ArticulationAnchor::AUTO);
+        }
         if (color.isValid()) {
             na->setColor(color);
         }

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -6528,6 +6528,7 @@ void MusicXMLParserPass2::harmony(const String& partId, Measure* measure, const 
     ha->setVisible(printObject);
     if (color.isValid()) {
         ha->setColor(color);
+        ha->setPropertyFlags(Pid::COLOR, PropertyFlags::UNSTYLED);
     }
 
     // TODO-LV: do this only if ha points to a valid harmony

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -3019,6 +3019,10 @@ void MusicXMLParserDirection::direction(const String& partId,
                 t->setFrameRound(0);
             }
 
+            if (m_color.isValid()) {
+                t->setColor(m_color);
+            }
+
             String wordsPlacement = m_placement;
             // Case-based defaults
             if (wordsPlacement.empty()) {
@@ -3331,6 +3335,7 @@ void MusicXMLParserDirection::directionType(std::vector<MusicXmlSpannerDesc>& st
             }
         }
         String type = m_e.attribute("type");
+        m_color = Color::fromString(m_e.asciiAttribute("color").ascii());
         if (m_e.name() == "metronome") {
             m_metroText = metronome(m_tpoMetro);
         } else if (m_e.name() == "words") {

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -6526,6 +6526,9 @@ void MusicXMLParserPass2::harmony(const String& partId, Measure* measure, const 
     ha->render();
 
     ha->setVisible(printObject);
+    if (placement == u"below") {
+        ha->setPlacement(PlacementV::BELOW);
+    }
     if (color.isValid()) {
         ha->setColor(color);
         ha->setPropertyFlags(Pid::COLOR, PropertyFlags::UNSTYLED);

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
@@ -450,6 +450,7 @@ private:
     MusicXMLParserPass2& m_pass2;                // the pass2 results
     MxmlLogger* m_logger = nullptr;                        // Error logger
 
+    Color m_color;
     Hairpin* m_inferredHairpinStart = nullptr;
     StringList m_dynamicsList;
     String m_enclosure;

--- a/src/importexport/musicxml/internal/musicxmlconfiguration.cpp
+++ b/src/importexport/musicxml/internal/musicxmlconfiguration.cpp
@@ -22,6 +22,7 @@
 #include "musicxmlconfiguration.h"
 
 #include "settings.h"
+#include "translation.h"
 
 using namespace mu;
 using namespace muse;
@@ -32,6 +33,7 @@ static const std::string module_name("iex_musicxml");
 static const Settings::Key MUSICXML_IMPORT_BREAKS_KEY(module_name, "import/musicXML/importBreaks");
 static const Settings::Key MUSICXML_IMPORT_LAYOUT_KEY(module_name, "import/musicXML/importLayout");
 static const Settings::Key MUSICXML_EXPORT_LAYOUT_KEY(module_name, "export/musicXML/exportLayout");
+static const Settings::Key MUSICXML_EXPORT_MU3_COMPAT_KEY(module_name, "export/musicXML/exportMu3Compat");
 static const Settings::Key MUSICXML_EXPORT_BREAKS_TYPE_KEY(module_name, "export/musicXML/exportBreaks");
 static const Settings::Key MUSICXML_EXPORT_INVISIBLE_ELEMENTS_KEY(module_name, "export/musicXML/exportInvisibleElements");
 static const Settings::Key MIGRATION_APPLY_EDWIN_FOR_XML(module_name, "import/compatibility/apply_edwin_for_xml");
@@ -43,6 +45,10 @@ void MusicXmlConfiguration::init()
     settings()->setDefaultValue(MUSICXML_IMPORT_BREAKS_KEY, Val(true));
     settings()->setDefaultValue(MUSICXML_IMPORT_LAYOUT_KEY, Val(true));
     settings()->setDefaultValue(MUSICXML_EXPORT_LAYOUT_KEY, Val(true));
+    settings()->setDefaultValue(MUSICXML_EXPORT_MU3_COMPAT_KEY, Val(false));
+    settings()->setDescription(MUSICXML_EXPORT_MU3_COMPAT_KEY, muse::qtrc("project/export",
+                                                                          "Export to MusicXML compatible with older MuseScore versions").toStdString());
+    settings()->setCanBeManuallyEdited(MUSICXML_EXPORT_MU3_COMPAT_KEY, true);
     settings()->setDefaultValue(MUSICXML_EXPORT_BREAKS_TYPE_KEY, Val(MusicxmlExportBreaksType::All));
     settings()->setDefaultValue(MUSICXML_EXPORT_INVISIBLE_ELEMENTS_KEY, Val(false));
     settings()->setDefaultValue(MIGRATION_APPLY_EDWIN_FOR_XML, Val(false));
@@ -78,6 +84,16 @@ bool MusicXmlConfiguration::musicxmlExportLayout() const
 void MusicXmlConfiguration::setMusicxmlExportLayout(bool value)
 {
     settings()->setSharedValue(MUSICXML_EXPORT_LAYOUT_KEY, Val(value));
+}
+
+bool MusicXmlConfiguration::musicxmlExportMu3Compat() const
+{
+    return settings()->value(MUSICXML_EXPORT_MU3_COMPAT_KEY).toBool();
+}
+
+void MusicXmlConfiguration::setMusicxmlExportMu3Compat(bool value)
+{
+    settings()->setSharedValue(MUSICXML_EXPORT_MU3_COMPAT_KEY, Val(value));
 }
 
 MusicXmlConfiguration::MusicxmlExportBreaksType MusicXmlConfiguration::musicxmlExportBreaksType() const

--- a/src/importexport/musicxml/internal/musicxmlconfiguration.h
+++ b/src/importexport/musicxml/internal/musicxmlconfiguration.h
@@ -39,6 +39,9 @@ public:
     bool musicxmlExportLayout() const override;
     void setMusicxmlExportLayout(bool value) override;
 
+    bool musicxmlExportMu3Compat() const override;
+    void setMusicxmlExportMu3Compat(bool value) override;
+
     MusicxmlExportBreaksType musicxmlExportBreaksType() const override;
     void setMusicxmlExportBreaksType(MusicxmlExportBreaksType breaksType) override;
 


### PR DESCRIPTION
* Import color for chord symbols, apparently export works already
* Import chord symbols placement, apparently export works already
* Im- and export more caesuras and breath marks
    incl. exporting their color and placement, color gets ignored on import though and placement needs to get forced to above explicitly, for them to not end up below (this actually fixes a real bug).
* Export color for Jumps and Markers, ignored on import though
* Im- and export ornament placement
* Move hairpin positioning next to coloring (similar to how (de-)crescendo lines are handled)
* Import color for fingerings, apparently export works already
* Import color for dynamics, rehearsal marks, tempo-, staff- and expression text, apparently export works already