### PR TITLE
[bug-19963] Fixed layout of spacer. 4.2.0

### DIFF
--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -4863,7 +4863,7 @@ void TLayout::layoutSlur(Slur* item, LayoutContext& ctx)
 
 void TLayout::layoutSpacer(Spacer* item, LayoutContext&)
 {
-    UNUSED(item);
+    item->layout0();
 }
 
 void TLayout::layoutSpanner(Spanner* item, LayoutContext& ctx)


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/19963 