### PR TITLE
Enable ALSA virtual software MIDI devices

### DIFF
--- a/src/framework/midi/internal/platform/lin/alsamidiinport.cpp
+++ b/src/framework/midi/internal/platform/lin/alsamidiinport.cpp
@@ -76,7 +76,7 @@ MidiDeviceList AlsaMidiInPort::availableDevices() const
 
     int streams = SND_SEQ_OPEN_INPUT;
     unsigned int cap = SND_SEQ_PORT_CAP_SUBS_READ | SND_SEQ_PORT_CAP_READ;
-    unsigned int type = SND_SEQ_PORT_TYPE_PORT | SND_SEQ_PORT_TYPE_HARDWARE;
+    unsigned int type = SND_SEQ_PORT_TYPE_PORT | SND_SEQ_PORT_TYPE_HARDWARE | SND_SEQ_PORT_TYPE_SOFTWARE;
 
     MidiDeviceList ret;
 

--- a/src/framework/midi/internal/platform/lin/alsamidioutport.cpp
+++ b/src/framework/midi/internal/platform/lin/alsamidioutport.cpp
@@ -75,7 +75,7 @@ std::vector<MidiDevice> AlsaMidiOutPort::availableDevices() const
 
     int streams = SND_SEQ_OPEN_OUTPUT;
     unsigned int cap = SND_SEQ_PORT_CAP_SUBS_WRITE | SND_SEQ_PORT_CAP_WRITE;
-    unsigned int type = SND_SEQ_PORT_TYPE_PORT | SND_SEQ_PORT_TYPE_HARDWARE;
+    unsigned int type = SND_SEQ_PORT_TYPE_PORT | SND_SEQ_PORT_TYPE_HARDWARE | SND_SEQ_PORT_TYPE_SOFTWARE;
 
     std::vector<MidiDevice> ret;
 


### PR DESCRIPTION
On Linux platform, only hardware MIDI
devices are listed and can be picked. This commit enables also virtual software MIDI devices (e.g. snd_virmidi) which can be arbitrary routed to other hard- and software MIDI devices.

On MacOS e.g. virtual software MIDI devices are also listed (see screenshot).
![Bildschirmfoto 2023-12-09 um 09 03 50](https://github.com/musescore/MuseScore/assets/5285079/b2457e38-87d5-49ec-abf7-30f8a2b10236)
