### PR TITLE
disable deploying wayland platform plugins

### DIFF
--- a/build/ci/linux/tools/make_appimage.sh
+++ b/build/ci/linux/tools/make_appimage.sh
@@ -105,7 +105,7 @@ mv "${qt_sql_drivers_path}/libqsqlpsql.so" "${qt_sql_drivers_tmp}/libqsqlpsql.so
 
 # Semicolon-separated list of platforms to deploy in addition to `libqxcb.so`.
 # Used by linuxdeploy-plugin-qt.
-export EXTRA_PLATFORM_PLUGINS="libqoffscreen.so;libqwayland-egl.so;libqwayland-generic.so"
+export EXTRA_PLATFORM_PLUGINS="libqoffscreen.so"
 
 # Colon-separated list of root directories containing QML files.
 # Needed for linuxdeploy-plugin-qt to scan for QML imports.
@@ -183,11 +183,6 @@ unwanted_files=(
 # additions at https://github.com/linuxdeploy/linuxdeploy-plugin-qt/issues
 additional_qt_components=(
   plugins/printsupport/libcupsprintersupport.so
-
-  # Wayland support (run with QT_QPA_PLATFORM=wayland to use)
-  plugins/wayland-decoration-client
-  plugins/wayland-graphics-integration-client
-  plugins/wayland-shell-integration
 )
 
 # ADDITIONAL LIBRARIES


### PR DESCRIPTION
wayland platform plugins currently deployed in the CI are built on ubuntu focal and only compatible with wayland prior to 1.20. Attempting to run the appimage on modern wayland DEs results in a symbol lookup error https://github.com/musescore/MuseScore/issues/18598 so disable for now until a workaround is implemented in a future release

I see no reason to PR this to the master branch as one of the alternative solutions here should be looked into https://github.com/musescore/MuseScore/issues/18598#issuecomment-1846496244 for future releases. For 4.2.0, since the release is closer, I think we should just revert to being X11 only which is what this PR does.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
