### PR TITLE
In continuous view, ties must be laid out on the whole system

### DIFF
--- a/src/engraving/rendering/dev/systemlayout.h
+++ b/src/engraving/rendering/dev/systemlayout.h
@@ -64,6 +64,7 @@ private:
     static void processLines(System* system, LayoutContext& ctx, std::vector<Spanner*> lines, bool align);
     static void layoutTies(Chord* ch, System* system, const Fraction& stick);
     static void doLayoutTies(System* system, std::vector<Segment*> sl, const Fraction& stick, const Fraction& etick);
+    static void doLayoutTiesLinear(System* system);
     static void layoutGuitarBends(const std::vector<Segment*>& sl, LayoutContext& ctx);
     static void justifySystem(System* system, double curSysWidth, double targetSystemWidth);
     static void updateCrossBeams(System* system, LayoutContext& ctx);


### PR DESCRIPTION
Resolves: #20382 

This was being done before via a workaround, but that was removed in b596466c98d045ecb20502f40343b53a3b5e0025
Now it is done explicitly.