### PR TITLE
Ensure notes remain selected when tabbing to Braille panel

### DIFF
--- a/src/braille/internal/notationbraille.cpp
+++ b/src/braille/internal/notationbraille.cpp
@@ -908,6 +908,9 @@ void NotationBraille::setCurrentEngravingItem(EngravingItem* e, bool select)
             if (play) {
                 playbackController()->playElements({ e });
             }
+            if (e->isChord()) {
+                e = toChord(e)->upNote(); // select a note rather than the chord
+            }
             interaction()->select({ e });
         }
     }


### PR DESCRIPTION
Fix #19511.

Caveat: if the user has entered a chord, the selection will change to the top note in the chord regardless of which note was actually selected. Sadly there's no way to solve that without touching lots of code in the Braille module, but it's better than losing the selection entirely.

If the user is trying to add an element from the palettes then it often doesn't matter which note in the chord is selected, as long as one of them is selected. There are only a few palette elements that need to be attached to a specific note in the chord (e.g. fingerings, accidentals).