### PR TITLE
Ensure notes remain selected when tabbing to Braille panel [4.2.0]

### DIFF
--- a/src/braille/internal/notationbraille.cpp
+++ b/src/braille/internal/notationbraille.cpp
@@ -908,6 +908,9 @@ void NotationBraille::setCurrentEngravingItem(EngravingItem* e, bool select)
             if (play) {
                 playbackController()->playElements({ e });
             }
+            if (e->isChord()) {
+                e = toChord(e)->upNote(); // select a note rather than the chord
+            }
             interaction()->select({ e });
         }
     }


### PR DESCRIPTION
Backport #20425 to the 4.2.0 branch.