### PR TITLE
Fix #17074: Show placement inspector control for text-lines

### DIFF
--- a/src/engraving/dom/textline.cpp
+++ b/src/engraving/dom/textline.cpp
@@ -251,9 +251,9 @@ engraving::PropertyValue TextLine::propertyDefault(Pid propertyId) const
     switch (propertyId) {
     case Pid::PLACEMENT:
         if (systemFlag()) {
-            return style().styleV(Sid::textLinePlacement);
-        } else {
             return style().styleV(Sid::systemTextLinePlacement);
+        } else {
+            return style().styleV(Sid::textLinePlacement);
         }
     case Pid::BEGIN_TEXT:
     case Pid::CONTINUE_TEXT:

--- a/src/inspector/models/notation/lines/textlinesettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/textlinesettingsmodel.cpp
@@ -89,7 +89,6 @@ void TextLineSettingsModel::createProperties()
     m_dashGapLength = buildPropertyItem(Pid::DASH_GAP_LEN);
 
     m_placement = buildPropertyItem(Pid::PLACEMENT);
-    m_placement->setIsVisible(false);
 
     m_beginningText = buildPropertyItem(Pid::BEGIN_TEXT);
     m_beginningTextOffset = buildPointFPropertyItem(Pid::BEGIN_TEXT_OFFSET);


### PR DESCRIPTION
Resolves: #17074
Edit: Placement property defaults were being read incorrectly for system vs. text lines, corrected by this PR

<img width="685" alt="placement" src="https://github.com/musescore/MuseScore/assets/47119327/d5dc3aec-029f-42c2-95d2-c0b417e57389">