### PR TITLE
CI: use ARM appimages where possible

### DIFF
--- a/.github/workflows/ci_linux_arm_mu4.yml
+++ b/.github/workflows/ci_linux_arm_mu4.yml
@@ -39,7 +39,9 @@ jobs:
       with:
         ref: ${{ env.CURRENT_RELEASE_BRANCH }}
     - name: setup QEMU
-      uses: docker/setup-qemu-action@v2
+      run: |
+        sudo apt update
+        sudo apt install qemu-user-static -y
     - name: "Configure workflow"
       env:
         pull_request_title: ${{ github.event.pull_request.title }}
@@ -128,7 +130,7 @@ jobs:
       run: |
         YT_API_KEY=${{ secrets.YOUTUBE_API_KEY }}; if [ -z "$YT_API_KEY" ]; then YT_API_KEY="''"; fi
         C_URL=${SENTRY_URL}; if [ -z "$C_URL" ]; then C_URL="''"; fi
-        sudo docker run -i -v "${PWD}:/MuseScore" "arm32v7/ubuntu:focal" /bin/bash -c "cd /MuseScore && \
+        sudo docker run -i -v "${PWD}:/MuseScore" -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static "arm32v7/ubuntu:focal" /bin/bash -c "cd /MuseScore && \
         bash /MuseScore/build/ci/linux/setup-arm.sh --arch armv7l && \
         bash /MuseScore/build/ci/linux/build.sh -n ${{ env.BUILD_NUMBER }} --youtube_api_key $YT_API_KEY --crash_log_url $C_URL --arch armv7l && \
         bash ./build/ci/linux/dumpsyms.sh && \
@@ -165,7 +167,9 @@ jobs:
       with:
         ref: ${{ env.CURRENT_RELEASE_BRANCH }}
     - name: setup QEMU
-      uses: docker/setup-qemu-action@v2
+      run: |
+        sudo apt update
+        sudo apt install qemu-user-static -y
     - name: "Configure workflow"
       env:
         pull_request_title: ${{ github.event.pull_request.title }}
@@ -247,7 +251,7 @@ jobs:
       run: |
         YT_API_KEY=${{ secrets.YOUTUBE_API_KEY }}; if [ -z "$YT_API_KEY" ]; then YT_API_KEY="''"; fi
         C_URL=${SENTRY_URL}; if [ -z "$C_URL" ]; then C_URL="''"; fi
-        sudo docker run -i -v "${PWD}:/MuseScore" "arm64v8/ubuntu:focal" /bin/bash -c "cd /MuseScore && \
+        sudo docker run -i -v "${PWD}:/MuseScore" -v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static "arm64v8/ubuntu:focal" /bin/bash -c "cd /MuseScore && \
         bash /MuseScore/build/ci/linux/setup-arm.sh --arch aarch64 && \
         bash /MuseScore/build/ci/linux/build.sh -n ${{ env.BUILD_NUMBER }} --youtube_api_key $YT_API_KEY --crash_log_url $C_URL --arch aarch64 && \
         bash ./build/ci/linux/dumpsyms.sh && \

--- a/build/ci/linux/setup-arm.sh
+++ b/build/ci/linux/setup-arm.sh
@@ -220,26 +220,26 @@ cmake --build . -j $(nproc)
 cmake --build . --target install
 cd /
 
-##########################################################################
-# Compile and install linuxdeploy
-##########################################################################
+# ##########################################################################
+# # Compile and install linuxdeploy
+# ##########################################################################
 
-git clone https://github.com/linuxdeploy/linuxdeploy
-cd /linuxdeploy/
-git checkout --recurse-submodules 1-alpha-20231206-1
-git submodule update --init --recursive
+# git clone https://github.com/linuxdeploy/linuxdeploy
+# cd /linuxdeploy/
+# git checkout --recurse-submodules 1-alpha-20231206-1
+# git submodule update --init --recursive
 
-# patch src/core/generate-excludelist.sh to use curl instead of wget which fails on armhf
-sed -i 's/wget --quiet "$url" -O -/curl "$url"/g' src/core/generate-excludelist.sh
+# # patch src/core/generate-excludelist.sh to use curl instead of wget which fails on armhf
+# sed -i 's/wget --quiet "$url" -O -/curl "$url"/g' src/core/generate-excludelist.sh
 
-mkdir -p build
-cd build
-cmake -DBUILD_TESTING=OFF -DUSE_SYSTEM_BOOST=ON ..
-cmake --build . -j $(nproc)
-mkdir -p $BUILD_TOOLS/linuxdeploy
-mv /linuxdeploy/build/bin/* $BUILD_TOOLS/linuxdeploy/
-$BUILD_TOOLS/linuxdeploy/linuxdeploy --version
-cd /
+# mkdir -p build
+# cd build
+# cmake -DBUILD_TESTING=OFF -DUSE_SYSTEM_BOOST=ON ..
+# cmake --build . -j $(nproc)
+# mkdir -p $BUILD_TOOLS/linuxdeploy
+# mv /linuxdeploy/build/bin/* $BUILD_TOOLS/linuxdeploy/
+# $BUILD_TOOLS/linuxdeploy/linuxdeploy --version
+# cd /
 
 ##########################################################################
 # Compile and install linuxdeploy-plugin-qt
@@ -259,65 +259,65 @@ cmake -DBUILD_TESTING=OFF -DUSE_SYSTEM_BOOST=ON ..
 cmake --build . -j $(nproc)
 mkdir -p $BUILD_TOOLS/linuxdeploy
 mv /linuxdeploy-plugin-qt/build/bin/linuxdeploy-plugin-qt $BUILD_TOOLS/linuxdeploy/linuxdeploy-plugin-qt
-$BUILD_TOOLS/linuxdeploy/linuxdeploy --list-plugins
+# $BUILD_TOOLS/linuxdeploy/linuxdeploy --list-plugins
 cd /
 
-##########################################################################
-# Compile and install linuxdeploy-plugin-appimage
-##########################################################################
+# ##########################################################################
+# # Compile and install linuxdeploy-plugin-appimage
+# ##########################################################################
 
-git clone https://github.com/linuxdeploy/linuxdeploy-plugin-appimage
-cd /linuxdeploy-plugin-appimage/
-git checkout --recurse-submodules 1-alpha-20230713-1
-git submodule update --init --recursive
-mkdir -p build
-cd build
-cmake -DBUILD_TESTING=OFF ..
-cmake --build . -j $(nproc)
-mv /linuxdeploy-plugin-appimage/build/src/linuxdeploy-plugin-appimage $BUILD_TOOLS/linuxdeploy/linuxdeploy-plugin-appimage
-cd /
-$BUILD_TOOLS/linuxdeploy/linuxdeploy --list-plugins
+# git clone https://github.com/linuxdeploy/linuxdeploy-plugin-appimage
+# cd /linuxdeploy-plugin-appimage/
+# git checkout --recurse-submodules 1-alpha-20230713-1
+# git submodule update --init --recursive
+# mkdir -p build
+# cd build
+# cmake -DBUILD_TESTING=OFF ..
+# cmake --build . -j $(nproc)
+# mv /linuxdeploy-plugin-appimage/build/src/linuxdeploy-plugin-appimage $BUILD_TOOLS/linuxdeploy/linuxdeploy-plugin-appimage
+# cd /
+# $BUILD_TOOLS/linuxdeploy/linuxdeploy --list-plugins
 
-##########################################################################
-# Compile and install AppImageKit
-##########################################################################
+# ##########################################################################
+# # Compile and install AppImageKit
+# ##########################################################################
 
-git clone https://github.com/AppImage/AppImageKit
-cd /AppImageKit/
-git checkout --recurse-submodules 13
-git submodule update --init --recursive
-mkdir -p build
-cd build
-cmake -DBUILD_TESTING=OFF ..
-cmake --build . -j $(nproc)
-cmake --build . --target install
-mkdir -p $BUILD_TOOLS/appimagetool
-cd /
-appimagetool --version
+# git clone https://github.com/AppImage/AppImageKit
+# cd /AppImageKit/
+# git checkout --recurse-submodules 13
+# git submodule update --init --recursive
+# mkdir -p build
+# cd build
+# cmake -DBUILD_TESTING=OFF ..
+# cmake --build . -j $(nproc)
+# cmake --build . --target install
+# mkdir -p $BUILD_TOOLS/appimagetool
+# cd /
+# appimagetool --version
 
-##########################################################################
-# Compile and install appimageupdatetool
-##########################################################################
+# ##########################################################################
+# # Compile and install appimageupdatetool
+# ##########################################################################
 
-git clone https://github.com/AppImageCommunity/AppImageUpdate.git
-cd AppImageUpdate
-git checkout --recurse-submodules 2.0.0-alpha-1-20220512
-git submodule update --init --recursive
-mkdir -p build
-cd build
+# git clone https://github.com/AppImageCommunity/AppImageUpdate.git
+# cd AppImageUpdate
+# git checkout --recurse-submodules 2.0.0-alpha-1-20220512
+# git submodule update --init --recursive
+# mkdir -p build
+# cd build
 
-cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=Linux ..
-make -j"$(nproc)"
-# create the extracted appimage directory
-mkdir -p $BUILD_TOOLS/appimageupdatetool
-make install DESTDIR=$BUILD_TOOLS/appimageupdatetool/appimageupdatetool-${PACKARCH}.AppDir
-mkdir -p $BUILD_TOOLS/appimageupdatetool/appimageupdatetool-${PACKARCH}.AppDir/resources
-cp -v ../resources/*.xpm $BUILD_TOOLS/appimageupdatetool/appimageupdatetool-${PACKARCH}.AppDir/resources/
-$BUILD_TOOLS/linuxdeploy/linuxdeploy -v0 --appdir $BUILD_TOOLS/appimageupdatetool/appimageupdatetool-${PACKARCH}.AppDir  --output appimage -d ../resources/appimageupdatetool.desktop -i ../resources/appimage.png
-cd $BUILD_TOOLS/appimageupdatetool
-ln -s "appimageupdatetool-${PACKARCH}.AppDir/AppRun" appimageupdatetool # symlink for convenience
-cd /
-$BUILD_TOOLS/appimageupdatetool/appimageupdatetool --version
+# cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=Linux ..
+# make -j"$(nproc)"
+# # create the extracted appimage directory
+# mkdir -p $BUILD_TOOLS/appimageupdatetool
+# make install DESTDIR=$BUILD_TOOLS/appimageupdatetool/appimageupdatetool-${PACKARCH}.AppDir
+# mkdir -p $BUILD_TOOLS/appimageupdatetool/appimageupdatetool-${PACKARCH}.AppDir/resources
+# cp -v ../resources/*.xpm $BUILD_TOOLS/appimageupdatetool/appimageupdatetool-${PACKARCH}.AppDir/resources/
+# $BUILD_TOOLS/linuxdeploy/linuxdeploy -v0 --appdir $BUILD_TOOLS/appimageupdatetool/appimageupdatetool-${PACKARCH}.AppDir  --output appimage -d ../resources/appimageupdatetool.desktop -i ../resources/appimage.png
+# cd $BUILD_TOOLS/appimageupdatetool
+# ln -s "appimageupdatetool-${PACKARCH}.AppDir/AppRun" appimageupdatetool # symlink for convenience
+# cd /
+# $BUILD_TOOLS/appimageupdatetool/appimageupdatetool --version
 
 cd ${CURRDIR}
 

--- a/build/ci/linux/tools/make_appimage.sh
+++ b/build/ci/linux/tools/make_appimage.sh
@@ -40,7 +40,14 @@ function extract_appimage()
   # Extract AppImage so we can run it without having to install FUSE
   local -r appimage="$1" binary_name="$2"
   local -r appdir="${appimage%.AppImage}.AppDir"
-  "./${appimage}" --appimage-extract >/dev/null # dest folder "squashfs-root"
+  # run appimage in docker container with QEMU emulation directly since binfmt fails
+  if [[ "$PACKARCH" == aarch64 ]]; then
+    /usr/bin/qemu-aarch64-static "./${appimage}" --appimage-extract >/dev/null # dest folder "squashfs-root"
+  elif [[ "$PACKARCH" == armhf ]]; then
+    /usr/bin/qemu-arm-static "./${appimage}" --appimage-extract >/dev/null # dest folder "squashfs-root"
+  else
+    "./${appimage}" --appimage-extract >/dev/null # dest folder "squashfs-root"
+  fi
   mv squashfs-root "${appdir}" # rename folder to avoid collisions
   ln -s "${appdir}/AppRun" "${binary_name}" # symlink for convenience
   rm -f "${appimage}"
@@ -64,17 +71,6 @@ fi
 export PATH="$BUILD_TOOLS/appimagetool:$PATH"
 appimagetool --version
 
-if [[ ! -d $BUILD_TOOLS/appimageupdatetool ]]; then
-  mkdir $BUILD_TOOLS/appimageupdatetool
-  cd $BUILD_TOOLS/appimageupdatetool
-  download_appimage_release AppImage/AppImageUpdate appimageupdatetool continuous
-  cd $ORIGIN_DIR
-fi
-if [[ "${UPDATE_INFORMATION}" ]]; then
-  export PATH="$BUILD_TOOLS/appimageupdatetool:$PATH"
-  appimageupdatetool --version
-fi
-
 function download_linuxdeploy_component()
 {
   download_appimage_release "linuxdeploy/$1" "$1" continuous
@@ -94,6 +90,42 @@ if [[ ! -f $BUILD_TOOLS/linuxdeploy/linuxdeploy-plugin-qt ]]; then
 fi
 export PATH="$BUILD_TOOLS/linuxdeploy:$PATH"
 linuxdeploy --list-plugins
+
+if [[ ! -d $BUILD_TOOLS/appimageupdatetool ]]; then
+  if [[ "$PACKARCH" == aarch64 ]] || [[ "$PACKARCH" == armhf ]]; then
+    ##########################################################################
+    # Compile and install appimageupdatetool
+    ##########################################################################
+
+    git clone https://github.com/AppImageCommunity/AppImageUpdate.git
+    cd AppImageUpdate
+    git checkout --recurse-submodules 2.0.0-alpha-1-20220512
+    git submodule update --init --recursive
+    mkdir -p build
+    cd build
+
+    cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=Linux ..
+    make -j"$(nproc)"
+    # create the extracted appimage directory
+    mkdir -p $BUILD_TOOLS/appimageupdatetool
+    make install DESTDIR=$BUILD_TOOLS/appimageupdatetool/appimageupdatetool-${PACKARCH}.AppDir
+    mkdir -p $BUILD_TOOLS/appimageupdatetool/appimageupdatetool-${PACKARCH}.AppDir/resources
+    cp -v ../resources/*.xpm $BUILD_TOOLS/appimageupdatetool/appimageupdatetool-${PACKARCH}.AppDir/resources/
+    $BUILD_TOOLS/linuxdeploy/linuxdeploy -v0 --appdir $BUILD_TOOLS/appimageupdatetool/appimageupdatetool-${PACKARCH}.AppDir  --output appimage -d ../resources/appimageupdatetool.desktop -i ../resources/appimage.png
+    cd $BUILD_TOOLS/appimageupdatetool
+    ln -s "appimageupdatetool-${PACKARCH}.AppDir/AppRun" appimageupdatetool # symlink for convenience
+    cd $ORIGIN_DIR
+  else
+    mkdir $BUILD_TOOLS/appimageupdatetool
+    cd $BUILD_TOOLS/appimageupdatetool
+    download_appimage_release AppImage/AppImageUpdate appimageupdatetool continuous
+    cd $ORIGIN_DIR
+  fi
+fi
+if [[ "${UPDATE_INFORMATION}" ]]; then
+  export PATH="$BUILD_TOOLS/appimageupdatetool:$PATH"
+  appimageupdatetool --version
+fi
 
 ##########################################################################
 # BUNDLE DEPENDENCIES INTO APPDIR


### PR DESCRIPTION
add workaround for appimage format being incompatible with QEMU https://github.com/AppImage/AppImageKit/issues/965

This is a minor optimization PR that lowers maintenance burden as we no longer have to build many of the appimage dependencies for armhf/arm64. The time saved on running the action as a result of this PR is ~20 mintues. See the test action https://github.com/theofficialgman/MuseScore/actions/runs/7177390601

This is not necessary to pick to 4.2.0 unless desired.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
