### PR TITLE
Hide Expr. items from soundfont context menu (temporary fix) (4.3.0)

### DIFF
--- a/src/playback/view/internal/inputresourceitem.cpp
+++ b/src/playback/view/internal/inputresourceitem.cpp
@@ -345,6 +345,12 @@ QVariantMap InputResourceItem::buildMsBasicMenuItem(const AudioResourceMetaList&
                 continue;
             }
 
+            // Temporary fix, see: https://github.com/musescore/MuseScore/issues/20142
+            String title = menuItem.value("title").toString();
+            if (title.contains(String("Expr."))) {
+                continue;
+            }
+
             subItems << menuItem;
 
             if (isSubItemCurrent) {


### PR DESCRIPTION
Temporary fix for: #20142