### PR TITLE
Correct cross beam position for MU1&2 scores

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -2764,6 +2764,17 @@ void Score::cmdResetNoteAndRestGroupings()
     }
 }
 
+static void resetBeamOffSet(void*, EngravingItem* e)
+{
+    // Reset completely cross staff beams from MU1&2
+    if (e->isBeam() && toBeam(e)->fullCross()) {
+        e->reset();
+    }
+}
+
+//---------------------------------------------------------
+//   cmdResetAllPositions
+//---------------------------------------------------------
 void Score::cmdResetAllPositions(bool undoable)
 {
     TRACEFUNC;
@@ -2782,6 +2793,13 @@ void Score::resetAutoplace()
     TRACEFUNC;
 
     scanElements(nullptr, resetElementPosition);
+}
+
+void Score::resetCrossBeams()
+{
+    TRACEFUNC;
+
+    scanElements(nullptr, resetBeamOffSet);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -5682,6 +5682,11 @@ void Score::doLayoutRange(const Fraction& st, const Fraction& et)
         m_resetAutoplace = false;
         resetAutoplace();
     }
+
+    if (m_resetCrossBeams) {
+        m_resetCrossBeams = false;
+        resetCrossBeams();
+    }
 }
 
 void Score::createPaddingTable()

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -290,12 +290,14 @@ public:
     void addMeasure(MeasureBase*, MeasureBase*);
     void linkMeasures(Score* score);
     void setResetAutoplace() { m_resetAutoplace = true; }
+    void setResetCrossBeams() { m_resetCrossBeams = true; }
 
     Excerpt* excerpt() { return m_excerpt; }
     void setExcerpt(Excerpt* e) { m_excerpt = e; }
 
     // methods for resetting elements for pre-4.0 score migration
     void resetAutoplace();
+    void resetCrossBeams();
 
     void cmdAddBracket();
     void cmdAddParentheses();
@@ -1077,6 +1079,7 @@ private:
 
     ScoreOrder m_scoreOrder;                 // used for score ordering
     bool m_resetAutoplace = false;
+    bool m_resetCrossBeams = false;
     int m_mscVersion = Constants::MSC_VERSION;     // version of current loading *.msc file
 
     bool m_isOpen = false;

--- a/src/project/internal/projectmigrator.cpp
+++ b/src/project/internal/projectmigrator.cpp
@@ -134,6 +134,12 @@ void ProjectMigrator::resetStyleSettings(mu::engraving::MasterScore* score)
     score->resetStyleValue(mu::engraving::Sid::measureSpacing);
 }
 
+bool ProjectMigrator::resetCrossBeams(engraving::MasterScore* score)
+{
+    score->setResetCrossBeams();
+    return true;
+}
+
 Ret ProjectMigrator::migrateProject(engraving::EngravingProjectPtr project, const MigrationOptions& opt)
 {
     TRACEFUNC;
@@ -158,6 +164,10 @@ Ret ProjectMigrator::migrateProject(engraving::EngravingProjectPtr project, cons
 
     if (ok && score->mscVersion() < 300) {
         ok = resetAllElementsPositions(score);
+    }
+
+    if (ok && score->mscVersion() <= 206) {
+        ok = resetCrossBeams(score);
     }
 
     if (ok && score->mscVersion() != mu::engraving::Constants::MSC_VERSION) {

--- a/src/project/internal/projectmigrator.h
+++ b/src/project/internal/projectmigrator.h
@@ -47,6 +47,7 @@ private:
     bool applyLelandStyle(mu::engraving::MasterScore* score);
     bool applyEdwinStyle(mu::engraving::MasterScore* score);
     bool resetAllElementsPositions(mu::engraving::MasterScore* score);
+    bool resetCrossBeams(mu::engraving::MasterScore* score);
     void resetStyleSettings(mu::engraving::MasterScore* score);
 
     bool m_resetStyleSettings{ false };


### PR DESCRIPTION
Resolves: #19979 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

This scales the beam's offset correctly and preserves the user's custom values.  This needs to be done post first layout as that's when we find out if a beam's chords are all moved to a different stave.