### PR TITLE
Fix disappearing ties when removing line break

### DIFF
--- a/src/engraving/rendering/dev/systemlayout.cpp
+++ b/src/engraving/rendering/dev/systemlayout.cpp
@@ -512,7 +512,7 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
         ctx.mutState().setStartWithLongNames(ctx.state().firstSystem() && layoutBreak->startWithLongNames());
     }
 
-    if (oldSystem && !(oldSystem->page() && oldSystem->page() != ctx.state().page())) {
+    if (oldSystem && oldSystem->tick() >= system->endTick() && !(oldSystem->page() && oldSystem->page() != ctx.state().page())) {
         // We may have previously processed the ties of the next system (in LayoutChords::updateLineAttachPoints()).
         // We need to restore them to the correct state.
         SystemLayout::restoreTiesAndBends(oldSystem, ctx);


### PR DESCRIPTION
Resolves: #20485 

This bug is just another version of #20382 (though the cause is different). The bug has always been there but was covered by other stuff that was happening which I've removed [here](https://github.com/musescore/MuseScore/pull/19127).