### PR TITLE
Enable ALSA virtual MIDI devices

### DIFF
--- a/src/framework/midi/internal/platform/lin/alsamidiinport.cpp
+++ b/src/framework/midi/internal/platform/lin/alsamidiinport.cpp
@@ -75,8 +75,9 @@ MidiDeviceList AlsaMidiInPort::availableDevices() const
     std::lock_guard lock(m_devicesMutex);
 
     int streams = SND_SEQ_OPEN_INPUT;
-    unsigned int cap = SND_SEQ_PORT_CAP_SUBS_READ | SND_SEQ_PORT_CAP_READ;
-    unsigned int type = SND_SEQ_PORT_TYPE_PORT | SND_SEQ_PORT_TYPE_HARDWARE;
+    const unsigned int cap = SND_SEQ_PORT_CAP_SUBS_READ | SND_SEQ_PORT_CAP_READ;
+    const unsigned int type_hw = SND_SEQ_PORT_TYPE_PORT | SND_SEQ_PORT_TYPE_HARDWARE;
+    const unsigned int type_sw = SND_SEQ_PORT_TYPE_PORT | SND_SEQ_PORT_TYPE_SOFTWARE;
 
     MidiDeviceList ret;
 
@@ -112,7 +113,7 @@ MidiDeviceList AlsaMidiInPort::availableDevices() const
             uint32_t types = snd_seq_port_info_get_type(pinfo);
             uint32_t caps = snd_seq_port_info_get_capability(pinfo);
 
-            bool canConnect = ((caps & cap) == cap) && ((types & type) == type);
+            bool canConnect = ((caps & cap) == cap) && (((types & type_hw) == type_hw) || ((types & type_sw) == type_sw));
 
             if (canConnect) {
                 MidiDevice dev;

--- a/src/framework/midi/internal/platform/lin/alsamidioutport.cpp
+++ b/src/framework/midi/internal/platform/lin/alsamidioutport.cpp
@@ -74,8 +74,9 @@ std::vector<MidiDevice> AlsaMidiOutPort::availableDevices() const
     std::lock_guard lock(m_devicesMutex);
 
     int streams = SND_SEQ_OPEN_OUTPUT;
-    unsigned int cap = SND_SEQ_PORT_CAP_SUBS_WRITE | SND_SEQ_PORT_CAP_WRITE;
-    unsigned int type = SND_SEQ_PORT_TYPE_PORT | SND_SEQ_PORT_TYPE_HARDWARE;
+    const unsigned int cap = SND_SEQ_PORT_CAP_SUBS_WRITE | SND_SEQ_PORT_CAP_WRITE;
+    const unsigned int type_hw = SND_SEQ_PORT_TYPE_PORT | SND_SEQ_PORT_TYPE_HARDWARE;
+    const unsigned int type_sw = SND_SEQ_PORT_TYPE_PORT | SND_SEQ_PORT_TYPE_SOFTWARE;
 
     std::vector<MidiDevice> ret;
 
@@ -111,7 +112,7 @@ std::vector<MidiDevice> AlsaMidiOutPort::availableDevices() const
             uint32_t types = snd_seq_port_info_get_type(pinfo);
             uint32_t caps = snd_seq_port_info_get_capability(pinfo);
 
-            bool canConnect = ((caps & cap) == cap) && ((types & type) == type);
+            bool canConnect = ((caps & cap) == cap) && (((types & type_hw) == type_hw) || ((types & type_sw) == type_sw));
 
             if (canConnect) {
                 MidiDevice dev;


### PR DESCRIPTION
On Linux platform, only hardware MIDI devices are listed and thus can be picked. This commit enables also virtual MIDI devices (e.g. snd_virmidi, snd_seq_dummy) which can be arbitrary routed to other hard- and software MIDI devices.

The patch is tested Debian 12 with a M-AUDIO Oxygen Pro Mini MIDI device (see screenshots)
![Screenshot_2023-12-14_19-57-52](https://github.com/musescore/MuseScore/assets/5285079/389e4e47-070d-410d-9752-0142160b5e69)
![linux_virt_midi_device](https://github.com/musescore/MuseScore/assets/5285079/05011169-9809-4fd9-b33f-cff5a4f23621)

