### PR TITLE
fixed #20454: Selection become offset after hibernation

### DIFF
--- a/src/appshell/internal/platform/win/winframelesswindowcontroller.cpp
+++ b/src/appshell/internal/platform/win/winframelesswindowcontroller.cpp
@@ -118,6 +118,7 @@ bool WinFramelessWindowController::nativeEventFilter(const QByteArray& eventType
         return false;
     }
 
+    LOGD() << "=================== msg " << msg->message;
     switch (msg->message) {
     case WM_NCCALCSIZE: {
         return removeWindowFrame(msg, result);

--- a/src/appshell/internal/platform/win/winframelesswindowcontroller.cpp
+++ b/src/appshell/internal/platform/win/winframelesswindowcontroller.cpp
@@ -43,6 +43,12 @@ static void updateWindowPosition()
     SetWindowPos(s_hwnd, nullptr, 0, 0, 0, 0, SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE);
 }
 
+static void redrawWindowContent()
+{
+    //! Redrawing a window by updating a position
+    updateWindowPosition();
+}
+
 WinFramelessWindowController::WinFramelessWindowController()
     : FramelessWindowController()
 {
@@ -90,8 +96,8 @@ bool WinFramelessWindowController::eventFilter(QObject* watched, QEvent* event)
 
     if (m_screen != window->screen()) {
         m_screen = window->screen();
-        //! Redrawing a window by updating a position
-        updateWindowPosition();
+
+        redrawWindowContent();
     }
 
     return false;
@@ -124,6 +130,12 @@ bool WinFramelessWindowController::nativeEventFilter(const QByteArray& eventType
     }
     case WM_NCRBUTTONDOWN: {
         return processMouseRightClick(msg);
+    }
+    case WM_SHOWWINDOW: {
+        if (msg->wParam) { // the window is being shown
+            redrawWindowContent();
+        }
+        return false;
     }
     default:
         break;


### PR DESCRIPTION
Resolves: #20454

Since we are removing the window frames, we have to update the window content(recalculate offsets) before showing it.