### PR TITLE
Two improvements to the logger

### DIFF
--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -882,7 +882,7 @@ SegmentType Segment::segmentType(ElementType type)
     case ElementType::BREATH:
         return SegmentType::Breath;
     default:
-        LOGD("Segment:segmentType():  bad type: <%s>", TConv::toXml(type));
+        LOGD("Segment:segmentType():  bad type: <%s>", TConv::toXml(type).ascii());
         return SegmentType::Invalid;
     }
 }

--- a/src/engraving/rw/xmlreader.cpp
+++ b/src/engraving/rw/xmlreader.cpp
@@ -143,10 +143,10 @@ void XmlReader::unknown()
         LOGD("%s ", muPrintable(errorString()));
     }
     if (!m_docName.isEmpty()) {
-        LOGD("tag in <%s> line %ld col %lld: %s", muPrintable(m_docName), lineNumber() + m_offsetLines,
+        LOGD("tag in <%s> line %lld col %lld: %s", muPrintable(m_docName), lineNumber() + m_offsetLines,
              columnNumber(), name().ascii());
     } else {
-        LOGD("line %lld col %ld: %s", lineNumber() + m_offsetLines, columnNumber(), name().ascii());
+        LOGD("line %lld col %lld: %s", lineNumber() + m_offsetLines, columnNumber(), name().ascii());
     }
     skipCurrentElement();
 }

--- a/src/framework/global/thirdparty/kors_logger/src/logger.h
+++ b/src/framework/global/thirdparty/kors_logger/src/logger.h
@@ -32,6 +32,20 @@ SOFTWARE.
 
 #include "logstream.h"
 
+// Based on: https://stackoverflow.com/a/45642888
+#ifdef __GNUC__
+#define KORS_ATTRIBUTE_PRINTF(format_index, vargs_index) __attribute__((__format__(__printf__, format_index, vargs_index)))
+#else
+#define KORS_ATTRIBUTE_PRINTF(format_index, vargs_index)
+#endif
+
+#if defined(_MSC_VER)
+#include <sal.h>
+#define KORS_ANNOTATION_PRINTF _In_z_ _Printf_format_string_
+#else
+#define KORS_ANNOTATION_PRINTF
+#endif
+
 #undef ERROR
 #undef WARN
 #undef INFO
@@ -222,7 +236,7 @@ public:
     }
 
     inline Stream& stream() { return m_stream; }
-    Stream& stream(const char* msg, ...);
+    Stream& stream(KORS_ANNOTATION_PRINTF const char* msg, ...) KORS_ATTRIBUTE_PRINTF(2, 3);
 
 private:
     LogMsg m_msg;

--- a/src/framework/global/thirdparty/kors_logger/src/logstream.h
+++ b/src/framework/global/thirdparty/kors_logger/src/logstream.h
@@ -88,7 +88,7 @@ public:
     {
         m_ss << '[';
         for (size_t i = 0; i < t.size(); ++i) {
-            m_ss << t.at(i);
+            *this << t.at(i);
             if (i < t.size() - 1) {
                 m_ss << ',';
             }

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -1207,7 +1207,7 @@ void GuitarPro::createMeasures()
 {
     Fraction tick = Fraction(0, 1);
     Fraction ts;
-    LOGD("measures %d bars.size %d", measures, bars.size());
+    LOGD("measures %zu bars.size %zu", measures, bars.size());
 
     //      for (int i = 0; i < measures; ++i) {
     for (size_t i = 0; i < bars.size(); ++i) {     // ?? (ws)


### PR DESCRIPTION
The second commit enables the following:

https://github.com/musescore/MuseScore/assets/48658420/5c795441-ff6b-4b8b-9c0b-80066859d1a2

