### PR TITLE
Fix bends glitch

### DIFF
--- a/src/engraving/rendering/dev/systemlayout.cpp
+++ b/src/engraving/rendering/dev/systemlayout.cpp
@@ -514,7 +514,8 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
         ctx.mutState().setStartWithLongNames(ctx.state().firstSystem() && layoutBreak->startWithLongNames());
     }
 
-    if (oldSystem && oldSystem->tick() >= system->endTick() && !(oldSystem->page() && oldSystem->page() != ctx.state().page())) {
+    if (oldSystem && !oldSystem->measures().empty() && oldSystem->measures().front()->tick() >= system->endTick()
+        && !(oldSystem->page() && oldSystem->page() != ctx.state().page())) {
         // We may have previously processed the ties of the next system (in LayoutChords::updateLineAttachPoints()).
         // We need to restore them to the correct state.
         SystemLayout::restoreTiesAndBends(oldSystem, ctx);


### PR DESCRIPTION
Resolves: (see video from @bkunda).

https://github.com/musescore/MuseScore/assets/93707756/4e59dda8-56b9-4478-ad7c-24cd1cc8dec9

Was caused by #20486 because it turns out that `oldSystem->tick()` is unreliable at this stage, so we need to use the tick() of the first measure instead. Let's be sure that now both issues are fixed. 