### PR TITLE
Fix crashing of tuning plugins by Bill Hails

### DIFF
--- a/share/plugins/tuning/tuning.qml
+++ b/share/plugins/tuning/tuning.qml
@@ -31,7 +31,7 @@ MuseScore {
     thumbnailName: "modal_tuning.png"
 
     width: 790
-    height: 544
+    height: 574
 
     property var offsetTextWidth: 40;
     property var offsetLabelAlignment: 0x02 | 0x80;

--- a/share/plugins/tuning_modal/Modal_Tuning.qml
+++ b/share/plugins/tuning_modal/Modal_Tuning.qml
@@ -31,7 +31,7 @@ MuseScore {
     thumbnailName: "modal_tuning.png"
 
     width: 860
-    height: 722
+    height: 822
 
     property var offsetTextWidth: 40;
     property var offsetLabelAlignment: 0x02 | 0x40;

--- a/share/plugins/tuning_modal/Temperaments.qml
+++ b/share/plugins/tuning_modal/Temperaments.qml
@@ -31,7 +31,7 @@ MuseScore {
     thumbnailName: "modal_tuning.png"
 
     width: 900
-    height: 722
+    height: 822
 
     property var offsetTextWidth: 40;
     property var offsetLabelAlignment: 0x02 | 0x80;


### PR DESCRIPTION
Resolves: #19326 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
When developing my own tuning plugin for MS4 on MacOS, I noticed that since 4.1, Qt Text components would crash only on Mac (fine on windows 10+). I then noticed that the vanilla tuning plugins by Bill Hails also crashes for the same reason.

While I made the "simplest" changes to fix this crash (updating `Qt.Controls` version in the plugin implementations), one downside of this fix is the loss of theming that was inherited by earlier `Qt.Controls` packages (somehow). Consider the before and after:

![image](https://github.com/musescore/MuseScore/assets/24703878/ee36bda2-9b3d-4e93-98b1-65b36ea0b4b5)

This may raise accessibility concerns, in addition to the fact that these changes will be made to both Windows and Mac, despite the crash only occurring on Mac. My preferred patch (if I could budget the time) would be either (i) to deploy the patched version only for Mac, or (ii) to rewrite the plugin using `MuseScore.UIComponents` as mentioned [here](https://github.com/musescore/MuseScore/issues/19326#issuecomment-1738234996).

Nonetheless, I hope that this PR can at least inspire the changes that fixes these plugins for MacOS, as they have served me well for microtonal compositions.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [ ] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
