### PR TITLE
Use numeric limits instead of random big number in shape edge methods

### DIFF
--- a/src/engraving/infrastructure/shape.cpp
+++ b/src/engraving/infrastructure/shape.cpp
@@ -302,7 +302,7 @@ double Shape::bottom() const
 
 double Shape::rightMostEdgeAtHeight(double yAbove, double yBelow) const
 {
-    double edge = -100000.0;
+    double edge = -std::numeric_limits<double>::max();
     for (const ShapeElement& sh : m_elements) {
         if (sh.bottom() > yAbove && sh.top() < yBelow) {
             edge = std::max(edge, sh.right());
@@ -314,7 +314,7 @@ double Shape::rightMostEdgeAtHeight(double yAbove, double yBelow) const
 
 double Shape::leftMostEdgeAtHeight(double yAbove, double yBelow) const
 {
-    double edge = 100000.0;
+    double edge = std::numeric_limits<double>::max();
     for (const ShapeElement& sh : m_elements) {
         if (sh.bottom() > yAbove && sh.top() < yBelow) {
             edge = std::min(edge, sh.left());


### PR DESCRIPTION
Resolves: #20551 

The bug happens because in continuous view the score can have in principle "infinite" width. For big scores, the width ended up being larger than the big number I had used.