### PR TITLE
Allow reading of 4.2+ scores in 4.1.1

### DIFF
--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1400,7 +1400,7 @@ bool ProjectActionsController::checkCanIgnoreError(const Ret& ret, const io::pat
         return askIfUserAgreesToOpenProjectWithIncompatibleVersion(ret.text());
     case engraving::Err::FileTooNew:
         warnFileTooNew(filepath);
-        return false;
+        return askIfUserAgreesToOpenProjectWithIncompatibleVersion(ret.text());
     case engraving::Err::FileCorrupted:
         return askIfUserAgreesToOpenCorruptedProject(io::filename(filepath).toString(), ret.text());
     case engraving::Err::FileCriticallyCorrupted:


### PR DESCRIPTION
I'm not expecting this to ever get merged, but the artifacts might be useful

Although a similar PR for master (and 4.2.1) to prevent that mess on futur file format changes might pass muster?