### PR TITLE
Fix crash in Measure & Staff/Part properties dialogs via keyboard

### DIFF
--- a/src/notation/view/widgets/editstaff.cpp
+++ b/src/notation/view/widgets/editstaff.cpp
@@ -460,7 +460,16 @@ void EditStaff::initStaff()
     const EngravingItem* element = context.element;
     Staff* staff = context.staff;
 
-    if (!element) {
+    if (interaction && !element) {
+        INotationSelectionPtr selection = interaction->selection();
+        if (selection->isRange()) {
+            INotationSelectionRangePtr range = selection->range();
+            element = range->measureRange().endMeasure;
+            staff = element->score()->staff(range->endStaffIndex() - 1);
+        }
+    }
+
+    IF_ASSERT_FAILED(element) {
         return;
     }
 
@@ -479,6 +488,10 @@ void EditStaff::initStaff()
         if (measure) {
             tick = measure->tick();
         }
+    }
+
+    IF_ASSERT_FAILED(staff) {
+        return;
     }
 
     setStaff(staff, tick);

--- a/src/notation/view/widgets/measureproperties.cpp
+++ b/src/notation/view/widgets/measureproperties.cpp
@@ -94,6 +94,13 @@ void MeasurePropertiesDialog::initMeasure()
     mu::engraving::Measure* measure = mu::engraving::toMeasure(context.element);
 
     if (!measure) {
+        INotationSelectionPtr selection = m_notation->interaction()->selection();
+        if (selection->isRange()) {
+            measure = selection->range()->measureRange().endMeasure;
+        }
+    }
+
+    IF_ASSERT_FAILED(measure) {
         return;
     }
 


### PR DESCRIPTION
Crash occurs when dialogs are opened via the keyboard.

Resolves #20580.