### PR TITLE
Fixed an (apparent) issue with how dialogs alwaysOnTop implementation

### DIFF
--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -211,20 +211,7 @@ void PopupView::open()
         }
 
         qWindow->setTitle(m_title);
-
-        if (m_alwaysOnTop) {
-#ifdef Q_OS_MAC
-            auto updateStayOnTopHint = [this]() {
-                bool stay = qApp->applicationState() == Qt::ApplicationActive;
-                m_window->qWindow()->setFlag(Qt::WindowStaysOnTopHint, stay);
-            };
-            updateStayOnTopHint();
-            connect(qApp, &QApplication::applicationStateChanged, this, updateStayOnTopHint);
-#endif
-        } else {
-            qWindow->setModality(m_modal ? Qt::ApplicationModal : Qt::NonModal);
-        }
-
+        setupAlwaysOnTop();
         qWindow->setFlag(Qt::FramelessWindowHint, m_frameless);
 #ifdef MUE_DISABLE_UI_MODALITY
         qWindow->setModality(Qt::NonModal);
@@ -547,6 +534,13 @@ bool PopupView::alwaysOnTop() const
     return m_alwaysOnTop;
 }
 
+void PopupView::setupAlwaysOnTop()
+{
+    if (isDialog()) {
+        m_window->setAlwaysOnTop(m_alwaysOnTop);
+    }
+}
+
 void PopupView::setAlwaysOnTop(bool alwaysOnTop)
 {
     if (m_alwaysOnTop == alwaysOnTop) {
@@ -554,6 +548,7 @@ void PopupView::setAlwaysOnTop(bool alwaysOnTop)
     }
 
     m_alwaysOnTop = alwaysOnTop;
+    setupAlwaysOnTop();
     emit alwaysOnTopChanged();
 }
 

--- a/src/framework/uicomponents/view/popupview.h
+++ b/src/framework/uicomponents/view/popupview.h
@@ -242,6 +242,8 @@ protected:
 
     QQmlEngine* engine() const;
 
+    void setupAlwaysOnTop();
+
     IPopupWindow* m_window = nullptr;
 
     QQmlComponent* m_component = nullptr;

--- a/src/framework/uicomponents/view/popupwindow/ipopupwindow.h
+++ b/src/framework/uicomponents/view/popupwindow/ipopupwindow.h
@@ -65,6 +65,7 @@ public:
 
     virtual void setOnHidden(const std::function<void()>& callback) = 0;
 
+    virtual void setAlwaysOnTop(const bool& alwaysOnTop) = 0;
 signals:
     void aboutToClose(QQuickCloseEvent* event);
 };

--- a/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
+++ b/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
@@ -277,3 +277,21 @@ void PopupWindow_QQuickView::updateSize(const QSize& newSize)
         m_view->resize(newSize);
     }
 }
+
+void PopupWindow_QQuickView::setAlwaysOnTop(const bool& alwaysOnTop)
+{
+    if (!m_view) {
+        return;
+    }
+
+    Qt::WindowFlags flags = m_view->flags();
+    if (alwaysOnTop) {
+        // From Qt5 documentation: Note that on some window managers on X11 you
+        // also have to pass Qt::X11BypassWindowManagerHint for this flag to work
+        // correctly.
+        flags |= Qt::WindowStaysOnTopHint;
+    } else {
+        flags &= (~Qt::WindowStaysOnTopHint);
+    }
+    m_view->setFlags(flags);
+}

--- a/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.h
+++ b/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.h
@@ -72,6 +72,7 @@ public:
 
     void setOnHidden(const std::function<void()>& callback) override;
 
+    void setAlwaysOnTop(const bool& alwaysOnTop) override;
 private:
     bool eventFilter(QObject* watched, QEvent* event) override;
 


### PR DESCRIPTION
The original implementation did not refresh the state of the actual dialog alwaysOnTop state, and instead updated the property only. Additionally, the original implementation relied on a mechanism for setting the window "staysOnTopHint" that no longer appears needed.

I've updated the PopupView class to correctly handle both issues.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
