### PR TITLE
Update default pedal styles

### DIFF
--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -3642,7 +3642,7 @@ void TRead::read(Pedal* p, XmlReader& e, ReadContext& ctx)
         }
     }
 
-    if (p->score()->mscVersion() < 420) {
+    if (p->score()->mscVersion() < 420 && !ctx.pasteMode()) {
         // Set to the pre-420 defaults if no value was specified;
         // or follow the new style setting if the specified value matches it
         if (!beginTextTag) {

--- a/src/engraving/style/style.cpp
+++ b/src/engraving/style/style.cpp
@@ -30,6 +30,7 @@
 #include "types/typesconv.h"
 
 #include "dom/mscore.h"
+#include "dom/pedal.h"
 #include "dom/types.h"
 
 #include "defaultstyle.h"
@@ -358,6 +359,18 @@ void MStyle::read(XmlReader& e, compat::ReadChordListHook* readChordListHook)
         } else if (tag == "chordlineThickness" && m_version < 410) {
             // Ignoring pre-4.1 value as it was wrong (it wasn't user-editable anyway)
             e.skipCurrentElement();
+        } else if (tag == "pedalText" && m_version < 420) {
+            // Ignore old default
+            String pedText = e.readText();
+            if (pedText != "") {
+                set(Sid::pedalText, pedText);
+            }
+        } else if (tag == "pedalContinueText" && m_version < 420 && e.readAsciiText() == "") {
+            // Ignore old default
+            String pedContText = e.readText();
+            if (pedContText != "") {
+                set(Sid::pedalText, pedContText);
+            }
         } else if (!readProperties(e)) {
             e.unknown();
         }


### PR DESCRIPTION
Resolves: #20646 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->
Problem occurs when opening 4.1 scores in 4.2.
This updates a score's pedal text defaults, and fixes missing text when adding from the palette.