### PR TITLE
Fix format warnings '%lld int64_t {aka long int}'

### DIFF
--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -2631,7 +2631,7 @@ bool TextBase::validateText(String& s)
         s = d;
         return true;
     }
-    LOGD("xml error at line %lld column %lld: %s", xml.lineNumber(), xml.columnNumber(), muPrintable(xml.errorString()));
+    LOGD() << "xml error at line " << xml.lineNumber() << " column " << xml.columnNumber() << ": " << xml.errorString();
     LOGD("text: |%s|", muPrintable(ss));
     return false;
 }

--- a/src/engraving/rw/read114/read114.cpp
+++ b/src/engraving/rw/read114/read114.cpp
@@ -2990,7 +2990,7 @@ Err Read114::readScore(Score* score, XmlReader& e, ReadInOutData* out)
     }
 
     if (e.error() != XmlStreamReader::NoError) {
-        LOGD("%lld %lld: %s ", e.lineNumber(), e.columnNumber(), muPrintable(e.errorString()));
+        LOGD() << e.lineNumber() << " " << e.columnNumber() << ": " << e.errorString();
         return Err::FileBadFormat;
     }
 

--- a/src/engraving/rw/xmlreader.cpp
+++ b/src/engraving/rw/xmlreader.cpp
@@ -143,10 +143,10 @@ void XmlReader::unknown()
         LOGD("%s ", muPrintable(errorString()));
     }
     if (!m_docName.isEmpty()) {
-        LOGD("tag in <%s> line %lld col %lld: %s", muPrintable(m_docName), lineNumber() + m_offsetLines,
-             columnNumber(), name().ascii());
+        LOGD() << "tag in <" << m_docName << "> line " << lineNumber() + m_offsetLines << " col " << columnNumber() << ": " <<
+            name().ascii();
     } else {
-        LOGD("line %lld col %lld: %s", lineNumber() + m_offsetLines, columnNumber(), name().ascii());
+        LOGD() << "line " << lineNumber() + m_offsetLines << " col " << columnNumber() << ": " << name().ascii();
     }
     skipCurrentElement();
 }


### PR DESCRIPTION
Trivial patch for fixing the following warnings by modifying '%lld' to '%ld' for int64_t:

```
read114.cpp:2993:23: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 4 has type ‘int64_t’ {aka ‘long int’} [-Wformat=]
 2993 |         LOGD("%lld %lld: %s ", e.lineNumber(), e.columnNumber(), muPrintable(e.errorString()));
      |                    ~~~^                        ~~~~~~~~~~~~~~~~
      |                       |                                      |
      |                       long long int                          int64_t {aka long int}
      |                    %ld

xmlreader.cpp:149:32: warning: format ‘%lld’ expects argument of type ‘long long int’, but argumen t 4 has type ‘int64_t’ {aka ‘long int’} [-Wformat=]
  149 |         LOGD("line %lld col %lld: %s", lineNumber() + m_offsetLines, columnNumber(), name().ascii());
      |                             ~~~^                                     ~~~~~~~~~~~~~~
      |                                |                                                 |
      |                                long long int                                     int64_t {aka long int}
      |                             %ld

xmlreader.cpp:146:44: warning: format ‘%lld’ expects argument of type ‘long long int’, but argumen t 5 has type ‘int64_t’ {aka ‘long int’} [-Wformat=]
  146 |         LOGD("tag in <%s> line %lld col %lld: %s", muPrintable(m_docName), lineNumber() + m_offsetLines,
      |                                         ~~~^
      |                                            |
      |                                            long long int
      |                                         %ld
  147 |              columnNumber(), name().ascii());
      |              ~~~~~~~~~~~~~~
      |                          |
      |                          int64_t {aka long int}

textbase.cpp:2634:44: warning: format ‘%lld’ expects argument of type ‘long long int’, but argume nt 4 has type ‘int64_t’ {aka ‘long int’} [-Wformat=]
 2634 |     LOGD("xml error at line %lld column %lld: %s", xml.lineNumber(), xml.columnNumber(), muPrintable(xml.errorString()));
      |                                         ~~~^                         ~~~~~~~~~~~~~~~~~~
      |                                            |                                         |
      |                                            long long int                             int64_t {aka long int}
      |                                         %ld

```
