### PR TITLE
Fix a translatable string not being detected by lupdate

### DIFF
--- a/share/locale/musescore_en.ts
+++ b/share/locale/musescore_en.ts
@@ -11549,7 +11549,7 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Annotations:</translation>
     </message>
     <message>
-        <location filename="../../src/engraving/dom/barline.cpp" line="1218"/>
+        <location filename="../../src/engraving/dom/barline.cpp" line="1217"/>
         <location filename="../../src/engraving/dom/chordrest.cpp" line="1074"/>
         <location filename="../../src/engraving/dom/chordrest.cpp" line="1085"/>
         <location filename="../../src/engraving/dom/note.cpp" line="3109"/>
@@ -11559,7 +11559,7 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Start of %1</translation>
     </message>
     <message>
-        <location filename="../../src/engraving/dom/barline.cpp" line="1221"/>
+        <location filename="../../src/engraving/dom/barline.cpp" line="1220"/>
         <location filename="../../src/engraving/dom/chordrest.cpp" line="1077"/>
         <location filename="../../src/engraving/dom/chordrest.cpp" line="1087"/>
         <location filename="../../src/engraving/dom/note.cpp" line="3113"/>
@@ -22150,6 +22150,14 @@ In addition, Mastering MuseScore features a supportive community of musicians, w
         <location filename="../../src/notation/view/internal/stringtuningssettingsmodel.cpp" line="35"/>
         <source>Custom</source>
         <translation type="unfinished">Custom</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/notation/view/internal/stringtuningssettingsmodel.cpp" line="276"/>
+        <source>%n string(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n string(s)</numerusform>
+            <numerusform>%n string(s)</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../../src/notation/qml/MuseScore/NotationScene/internal/EditStyle/TiePlacementSelector.qml" line="41"/>

--- a/src/notation/view/internal/stringtuningssettingsmodel.cpp
+++ b/src/notation/view/internal/stringtuningssettingsmodel.cpp
@@ -269,9 +269,12 @@ QVariantList StringTuningsSettingsModel::numbersOfStrings() const
     }
 
     for (const StringTuningsInfo& stringTuning : stringTunings.at(m_itemId)) {
+        // `lupdate` does not detect the translatable string when the static_cast is in the same line as `qtrc`
+        int number = static_cast<int>(stringTuning.number);
+
         QVariantMap stringNumberMap;
-        stringNumberMap.insert("text", qtrc("notation", "%n string(s)", nullptr, static_cast<int>(stringTuning.number)));
-        stringNumberMap.insert("value", static_cast<int>(stringTuning.number));
+        stringNumberMap.insert("text", qtrc("notation", "%n string(s)", nullptr, number));
+        stringNumberMap.insert("value", number);
         numbersList << stringNumberMap;
     }
 


### PR DESCRIPTION
Resolves: #20673 (the part about "%n string(s)"; not the part about the preset names)