### PR TITLE
Make changing excerpt name undoable

### DIFF
--- a/src/notation/iexcerptnotation.h
+++ b/src/notation/iexcerptnotation.h
@@ -39,7 +39,8 @@ public:
     virtual bool isEmpty() const = 0;
 
     virtual QString name() const = 0;
-    virtual void setName(const QString& name) = 0;
+    virtual void setName(const QString& name) = 0; // not undoable
+    virtual void undoSetName(const QString& name) = 0; // undoable
     virtual async::Notification nameChanged() const = 0;
 
     virtual const String& fileName() const = 0;

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -24,6 +24,7 @@
 
 #include "engraving/dom/excerpt.h"
 #include "engraving/dom/text.h"
+#include "engraving/dom/undo.h"
 
 #include "log.h"
 
@@ -127,6 +128,25 @@ void ExcerptNotation::setName(const QString& name)
     if (changed) {
         notifyAboutNotationChanged();
     }
+}
+
+void ExcerptNotation::undoSetName(const QString& name)
+{
+    if (name == this->name()) {
+        return;
+    }
+
+    if (!score()) {
+        setName(name);
+        return;
+    }
+
+    undoStack()->prepareChanges();
+
+    score()->undo(new engraving::ChangeExcerptTitle(m_excerpt, name));
+
+    undoStack()->commitChanges();
+    notifyAboutNotationChanged();
 }
 
 mu::async::Notification ExcerptNotation::nameChanged() const

--- a/src/notation/internal/excerptnotation.h
+++ b/src/notation/internal/excerptnotation.h
@@ -45,6 +45,7 @@ public:
 
     QString name() const override;
     void setName(const QString& name) override;
+    void undoSetName(const QString& name) override;
     async::Notification nameChanged() const override;
 
     const String& fileName() const override;

--- a/src/notation/view/partlistmodel.cpp
+++ b/src/notation/view/partlistmodel.cpp
@@ -261,7 +261,7 @@ void PartListModel::setPartTitle(int partIndex, const QString& title)
         return;
     }
 
-    excerpt->setName(title);
+    excerpt->undoSetName(title);
     notifyAboutNotationChanged(partIndex);
 }
 


### PR DESCRIPTION
Also ensures that score gets marked as needing to be saved.

Resolves: #20698