### PR TITLE
Fix crash when building with VST3 SDK v3.7.9

### DIFF
--- a/src/framework/vst/internal/vstplugin.cpp
+++ b/src/framework/vst/internal/vstplugin.cpp
@@ -119,6 +119,11 @@ void VstPlugin::load()
             return;
         }
 
+        if (!m_pluginProvider->init()) {
+            LOGE() << "Unable to initialize vst plugin provider";
+            return;
+        }
+
         auto controller = m_pluginProvider->controller();
 
         if (!controller) {

--- a/src/framework/vst/internal/vstpluginprovider.cpp
+++ b/src/framework/vst/internal/vstpluginprovider.cpp
@@ -22,6 +22,8 @@
 
 #include "vstpluginprovider.h"
 
+#include "log.h"
+
 using namespace mu::vst;
 
 class VstPluginProvider::Impl : public Steinberg::Vst::PlugProvider
@@ -32,7 +34,21 @@ public:
     Impl(const PluginFactory& factory, const ClassInfo& info)
         : Steinberg::Vst::PlugProvider(factory, info)
     {
+    }
+
+    bool init()
+    {
+        if (!initialize()) {
+            return false;
+        }
+
+        IF_ASSERT_FAILED(controller) {
+            return false;
+        }
+
         controller->queryInterface(Steinberg::Vst::IMidiMapping_iid, (void**)&midiMapping);
+
+        return true;
     }
 
     PluginMidiMappingPtr midiMapping;
@@ -45,6 +61,11 @@ VstPluginProvider::VstPluginProvider(const PluginFactory& factory, const ClassIn
 
 VstPluginProvider::~VstPluginProvider()
 {
+}
+
+bool VstPluginProvider::init()
+{
+    return m_impl->init();
 }
 
 PluginComponentPtr VstPluginProvider::component() const

--- a/src/framework/vst/internal/vstpluginprovider.h
+++ b/src/framework/vst/internal/vstpluginprovider.h
@@ -32,6 +32,8 @@ public:
     VstPluginProvider(const PluginFactory& factory, const ClassInfo& info);
     ~VstPluginProvider();
 
+    bool init();
+
     PluginComponentPtr component() const;
     PluginControllerPtr controller() const;
     PluginMidiMappingPtr midiMapping() const;


### PR DESCRIPTION
I got this crash when opening this score: https://github.com/musescore/MuseScore/files/13753150/Test.mscz.zip (from https://github.com/orgs/musescore/discussions/20631) in a local build, created with version 3.7.9 of the VST3 SDK.