### PR TITLE
New tie-fret-tab-show-not-show thing

### DIFF
--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -1405,6 +1405,72 @@ void Note::updateFrettingForTiesAndBends()
     setFret(prevNote->fret());
 }
 
+bool Note::shouldHideFret() const
+{
+    if (!tieBack() || shouldForceShowFret()) {
+        return false;
+    }
+
+    if (isContinuationOfBend()) {
+        return true;
+    }
+
+    ShowTiedFret showTiedFret = style().value(Sid::tabShowTiedFret).value<ShowTiedFret>();
+    if (showTiedFret == ShowTiedFret::TIE_AND_FRET) {
+        return false;
+    }
+
+    ParenthesizeTiedFret parenthTiedFret = style().value(Sid::tabParenthesizeTiedFret).value<ParenthesizeTiedFret>();
+    if (parenthTiedFret == ParenthesizeTiedFret::NEVER || !rtick().isZero()) {
+        return true;
+    }
+
+    if (parenthTiedFret == ParenthesizeTiedFret::START_OF_MEASURE) {
+        return false;
+    }
+
+    const Measure* measure = findMeasure();
+    bool isStartOfSystem = measure && measure->system() && measure->isFirstInSystem();
+
+    return !isStartOfSystem;
+}
+
+bool Note::shouldForceShowFret() const
+{
+    if (!style().styleB(Sid::parenthesizeTiedFretIfArticulation)) {
+        return false;
+    }
+
+    Chord* ch = chord();
+    if (!ch) {
+        return false;
+    }
+
+    auto hasTremoloBar = [&] () {
+        for (EngravingItem* item : ch->segment()->annotations()) {
+            if (item && item->isTremoloBar() && item->track() == track()) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    auto hasVibratoLine = [&] () {
+        auto spanners = score()->spannerMap().findOverlapping(tick().ticks(), (tick() + ch->actualTicks()).ticks());
+        for (auto interval : spanners) {
+            Spanner* sp = interval.value;
+            if (sp->isVibrato() && sp->startElement() == ch) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    bool startsNonBendSpanner = !spannerFor().empty() && !bendFor();
+
+    return !ch->articulations().empty() || ch->chordLine() || startsNonBendSpanner || hasTremoloBar() || hasVibratoLine();
+}
+
 void Note::setupAfterRead(const Fraction& ctxTick, bool pasteMode)
 {
     // ensure sane values:
@@ -3612,6 +3678,25 @@ bool Note::isGraceBendStart() const
     GuitarBend* bend = bendFor();
 
     return bend && bend->type() == GuitarBendType::GRACE_NOTE_BEND;
+}
+
+bool Note::isContinuationOfBend() const
+{
+    if (bendBack()) {
+        return true;
+    }
+
+    Tie* tie = tieBack();
+    Note* note = nullptr;
+    while (tie && tie->startNote()) {
+        note = tie->startNote();
+        if (note->bendBack()) {
+            return true;
+        }
+        tie = note->tieBack();
+    }
+
+    return false;
 }
 
 bool Note::hasAnotherStraightAboveOrBelow(bool above) const

--- a/src/engraving/dom/note.h
+++ b/src/engraving/dom/note.h
@@ -430,6 +430,7 @@ public:
 
     bool isPreBendStart() const;
     bool isGraceBendStart() const;
+    bool isContinuationOfBend() const;
 
     bool hasAnotherStraightAboveOrBelow(bool above) const;
 
@@ -446,6 +447,8 @@ public:
     bool isNoteName() const;
 
     void updateFrettingForTiesAndBends();
+    bool shouldHideFret() const;
+    bool shouldForceShowFret() const;
 
     struct LayoutData : public EngravingItem::LayoutData {
         ld_field<bool> useTablature = { "[Note] useTablature", false };

--- a/src/engraving/dom/stafftype.h
+++ b/src/engraving/dom/stafftype.h
@@ -182,6 +182,18 @@ enum class StaffTypes : signed char {
     TAB_DEFAULT = StaffTypes::TAB_6COMMON,
 };
 
+enum class ShowTiedFret {
+    TIE_AND_FRET,
+    TIE,
+    NONE,
+};
+
+enum class ParenthesizeTiedFret {
+    START_OF_SYSTEM,
+    START_OF_MEASURE,
+    NEVER,
+};
+
 //---------------------------------------------------------
 //   StaffType
 //---------------------------------------------------------

--- a/src/engraving/rendering/dev/chordlayout.cpp
+++ b/src/engraving/rendering/dev/chordlayout.cpp
@@ -3072,7 +3072,7 @@ void ChordLayout::updateLineAttachPoints(Chord* chord, bool isFirstInMeasure, La
         for (Note* note : chord->notes()) {
             Tie* tieBack = note->tieBack();
             if (tieBack && tieBack->startNote()->findMeasure() != note->findMeasure()) {
-                SlurTieLayout::tieLayoutBack(tieBack, note->findMeasure()->system());
+                SlurTieLayout::tieLayoutBack(tieBack, note->findMeasure()->system(), ctx);
             }
         }
     }
@@ -3453,13 +3453,10 @@ void ChordLayout::layoutNote2(Note* item, LayoutContext& ctx)
     bool isTabStaff = staffType && staffType->isTabStaff();
     // First, for tab staves that have show back-tied fret marks option, we add parentheses to the tied note if
     // the tie spans a system boundary. This can't be done in layout as the system of each note is not decided yet
-    bool useParens = isTabStaff && !staffType->showBackTied() && !item->fixed();
-    if (useParens
-        && item->tieBack()
-        && (
-            item->chord()->measure()->system() != item->tieBack()->startNote()->chord()->measure()->system()
-            || !item->el().empty()
-            )) {
+    ShowTiedFret showTiedFret = item->style().value(Sid::tabShowTiedFret).value<ShowTiedFret>();
+    bool useParens = isTabStaff && !item->fixed() && item->tieBack()
+                     && showTiedFret != ShowTiedFret::TIE_AND_FRET && !item->shouldHideFret();
+    if (useParens) {
         if (!item->fretString().startsWith(u'(')) { // Hack: don't add parentheses if already added
             item->setFretString(String(u"(%1)").arg(item->fretString()));
         }

--- a/src/engraving/rendering/dev/measurelayout.cpp
+++ b/src/engraving/rendering/dev/measurelayout.cpp
@@ -125,7 +125,7 @@ void MeasureLayout::layout2(Measure* item, LayoutContext& ctx)
                     SlurTieLayout::tieLayoutFor(tieFor, item->system());
                 }
                 if (tieBack && tieBack->tick() < stick && tieBack->isCrossStaff()) {
-                    SlurTieLayout::tieLayoutBack(tieBack, item->system());
+                    SlurTieLayout::tieLayoutBack(tieBack, item->system(), ctx);
                 }
             }
         }

--- a/src/engraving/rendering/dev/slurtielayout.cpp
+++ b/src/engraving/rendering/dev/slurtielayout.cpp
@@ -27,6 +27,7 @@
 
 #include "dom/slur.h"
 #include "dom/chord.h"
+#include "dom/score.h"
 #include "dom/system.h"
 #include "dom/staff.h"
 #include "dom/stafftype.h"
@@ -1436,7 +1437,13 @@ static bool tieSegmentShouldBeSkipped(Tie* item)
         return false;
     }
 
-    return !st->showBackTied() || (startNote && startNote->harmonic());
+    if (startNote->isContinuationOfBend()) {
+        return true;
+    }
+
+    ShowTiedFret showTiedFret = item->style().value(Sid::tabShowTiedFret).value<ShowTiedFret>();
+
+    return showTiedFret == ShowTiedFret::NONE;
 }
 
 TieSegment* SlurTieLayout::tieLayoutFor(Tie* item, System* system)
@@ -1511,8 +1518,12 @@ TieSegment* SlurTieLayout::tieLayoutFor(Tie* item, System* system)
     return segment;
 }
 
-TieSegment* SlurTieLayout::tieLayoutBack(Tie* item, System* system)
+TieSegment* SlurTieLayout::tieLayoutBack(Tie* item, System* system, LayoutContext& ctx)
 {
+    if (item->staffType() && item->staffType()->isTabStaff()) {
+        // On TAB, the presence of this tie may require to add a parenthesis
+        ChordLayout::layout(item->endNote()->chord(), ctx);
+    }
     // do not layout ties in tablature if not showing back-tied fret marks
     if (tieSegmentShouldBeSkipped(item)) {
         if (!item->segmentsEmpty()) {

--- a/src/engraving/rendering/dev/slurtielayout.h
+++ b/src/engraving/rendering/dev/slurtielayout.h
@@ -51,7 +51,7 @@ public:
     static SpannerSegment* layoutSystem(Slur* item, System* system, LayoutContext& ctx);
 
     static TieSegment* tieLayoutFor(Tie* item, System* system);
-    static TieSegment* tieLayoutBack(Tie* item, System* system);
+    static TieSegment* tieLayoutBack(Tie* item, System* system, LayoutContext& ctx);
     static void resolveVerticalTieCollisions(const std::vector<TieSegment*>& stackedTies);
 
     static void computeUp(Slur* slur, LayoutContext& ctx);

--- a/src/engraving/rendering/dev/systemlayout.cpp
+++ b/src/engraving/rendering/dev/systemlayout.cpp
@@ -904,9 +904,9 @@ void SystemLayout::layoutSystemElements(System* system, LayoutContext& ctx)
 
     // ties
     if (ctx.conf().isLinearMode()) {
-        doLayoutTiesLinear(system);
+        doLayoutTiesLinear(system, ctx);
     } else {
-        doLayoutTies(system, sl, stick, etick);
+        doLayoutTies(system, sl, stick, etick, ctx);
     }
     // guitar bends
     layoutGuitarBends(sl, ctx);
@@ -1331,7 +1331,7 @@ void SystemLayout::layoutSystemElements(System* system, LayoutContext& ctx)
     }
 }
 
-void SystemLayout::doLayoutTies(System* system, std::vector<Segment*> sl, const Fraction& stick, const Fraction& etick)
+void SystemLayout::doLayoutTies(System* system, std::vector<Segment*> sl, const Fraction& stick, const Fraction& etick, LayoutContext& ctx)
 {
     UNUSED(etick);
 
@@ -1342,14 +1342,14 @@ void SystemLayout::doLayoutTies(System* system, std::vector<Segment*> sl, const 
             }
             Chord* c = toChord(e);
             for (Chord* ch : c->graceNotes()) {
-                layoutTies(ch, system, stick);
+                layoutTies(ch, system, stick, ctx);
             }
-            layoutTies(c, system, stick);
+            layoutTies(c, system, stick, ctx);
         }
     }
 }
 
-void SystemLayout::doLayoutTiesLinear(System* system)
+void SystemLayout::doLayoutTiesLinear(System* system, LayoutContext& ctx)
 {
     constexpr Fraction start = Fraction(0, 1);
     for (Measure* measure = system->firstMeasure(); measure; measure = measure->nextMeasure()) {
@@ -1363,9 +1363,9 @@ void SystemLayout::doLayoutTiesLinear(System* system)
                 }
                 Chord* c = toChord(e);
                 for (Chord* ch : c->graceNotes()) {
-                    layoutTies(ch, system, start);
+                    layoutTies(ch, system, start, ctx);
                 }
-                layoutTies(c, system, start);
+                layoutTies(c, system, start, ctx);
             }
         }
     }
@@ -1559,7 +1559,7 @@ void SystemLayout::processLines(System* system, LayoutContext& ctx, std::vector<
     }
 }
 
-void SystemLayout::layoutTies(Chord* ch, System* system, const Fraction& stick)
+void SystemLayout::layoutTies(Chord* ch, System* system, const Fraction& stick, LayoutContext& ctx)
 {
     SysStaff* staff = system->staff(ch->staffIdx());
     if (!staff->show()) {
@@ -1579,7 +1579,7 @@ void SystemLayout::layoutTies(Chord* ch, System* system, const Fraction& stick)
         t = note->tieBack();
         if (t) {
             if (t->startNote()->tick() < stick) {
-                TieSegment* ts = SlurTieLayout::tieLayoutBack(t, system);
+                TieSegment* ts = SlurTieLayout::tieLayoutBack(t, system, ctx);
                 if (ts && ts->addToSkyline()) {
                     staff->skyline().add(ts->shape().translate(ts->pos()));
                     stackedBackwardTies.push_back(ts);
@@ -1674,7 +1674,7 @@ void SystemLayout::restoreTiesAndBends(System* system, LayoutContext& ctx)
     }
     Fraction stick = system->measures().front()->tick();
     Fraction etick = system->measures().back()->endTick();
-    doLayoutTies(system, segList, stick, etick);
+    doLayoutTies(system, segList, stick, etick, ctx);
     layoutGuitarBends(segList, ctx);
 }
 

--- a/src/engraving/rendering/dev/systemlayout.h
+++ b/src/engraving/rendering/dev/systemlayout.h
@@ -62,9 +62,9 @@ public:
 private:
     static System* getNextSystem(LayoutContext& lc);
     static void processLines(System* system, LayoutContext& ctx, std::vector<Spanner*> lines, bool align);
-    static void layoutTies(Chord* ch, System* system, const Fraction& stick);
-    static void doLayoutTies(System* system, std::vector<Segment*> sl, const Fraction& stick, const Fraction& etick);
-    static void doLayoutTiesLinear(System* system);
+    static void layoutTies(Chord* ch, System* system, const Fraction& stick, LayoutContext& ctx);
+    static void doLayoutTies(System* system, std::vector<Segment*> sl, const Fraction& stick, const Fraction& etick, LayoutContext& ctx);
+    static void doLayoutTiesLinear(System* system, LayoutContext& ctx);
     static void layoutGuitarBends(const std::vector<Segment*>& sl, LayoutContext& ctx);
     static void justifySystem(System* system, double curSysWidth, double targetSystemWidth);
     static void updateCrossBeams(System* system, LayoutContext& ctx);

--- a/src/engraving/rendering/dev/tdraw.cpp
+++ b/src/engraving/rendering/dev/tdraw.cpp
@@ -2220,17 +2220,11 @@ void TDraw::draw(const Note* item, Painter* painter)
 
     // tablature
     if (tablature) {
-        if (item->displayFret() == Note::DisplayFretOption::Hide) {
+        if (item->displayFret() == Note::DisplayFretOption::Hide || item->shouldHideFret()) {
             return;
         }
         const Staff* st = item->staff();
         const StaffType* tab = st->staffTypeForElement(item);
-        if (item->tieBack() && !tab->showBackTied()) {
-            if (item->chord()->measure()->system() == item->tieBack()->startNote()->chord()->measure()->system() && item->el().empty()) {
-                // fret should be hidden, so return without drawing it
-                return;
-            }
-        }
         // draw background, if required (to hide a segment of string line or to show a fretting conflict)
         if (!tab->linesThrough() || item->fretConflict()) {
             double d  = item->spatium() * .1;

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -29,6 +29,7 @@
 #include "dom/articulation.h"
 #include "dom/mscore.h"
 #include "dom/realizedharmony.h"
+#include "dom/stafftype.h"
 #include "dom/textbase.h"
 #include "dom/tuplet.h"
 #include "dom/types.h"
@@ -1596,6 +1597,10 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::wahShowTabCommon, "wahShowTabCommon", true },
     { Sid::golpeShowTabSimple, "golpeShowTabSimple", true },
     { Sid::golpeShowTabCommon, "golpeShowTabCommon", true },
+
+    { Sid::tabShowTiedFret, "tabShowTiedFret", int(ShowTiedFret::TIE_AND_FRET) },
+    { Sid::tabParenthesizeTiedFret, "tabParenthesizeTiedFret", int(ParenthesizeTiedFret::START_OF_SYSTEM) },
+    { Sid::parenthesizeTiedFretIfArticulation, "parenthesizeTiedFretIfArticulation", true },
 
     { Sid::chordlineThickness, "chordlineThickness", Spatium(0.16) },
 

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -1606,6 +1606,10 @@ enum class Sid {
     golpeShowTabSimple,
     golpeShowTabCommon,
 
+    tabShowTiedFret,
+    tabParenthesizeTiedFret,
+    parenthesizeTiedFretIfArticulation,
+
     chordlineThickness,
 
     autoplaceEnabled,

--- a/src/framework/ui/view/uitheme.cpp
+++ b/src/framework/ui/view/uitheme.cpp
@@ -930,7 +930,9 @@ void UiTheme::drawRadioButtonIndicator(QPainter* painter, const QRect& rect, con
     QColor borderColor = fontPrimaryColor();
     QColor backgroundColor = textFieldColor();
 
-    if (styleState.pressed) {
+    if (!styleState.enabled) {
+        borderColor.setAlphaF(itemOpacityDisabled());
+    } else if (styleState.pressed) {
         borderColor.setAlphaF(buttonOpacityHit());
     } else if (styleState.hovered) {
         borderColor.setAlphaF(buttonOpacityHover());

--- a/src/notation/view/widgets/editstafftype.cpp
+++ b/src/notation/view/widgets/editstafftype.cpp
@@ -145,7 +145,6 @@ EditStaffType::EditStaffType(QWidget* parent)
     connect(showTabFingering,  &QCheckBox::toggled, this, &EditStaffType::updatePreview);
     connect(upsideDown,        &QCheckBox::toggled, this, &EditStaffType::updatePreview);
     connect(numbersRadio,      &QCheckBox::toggled, this, &EditStaffType::updatePreview);
-    connect(showBackTied,      &QCheckBox::toggled, this, &EditStaffType::updatePreview);
 
     connect(templateReset,  &QPushButton::clicked, this, &EditStaffType::resetToTemplateClicked);
     connect(addToTemplates, &QPushButton::clicked, this, &EditStaffType::addToTemplatesClicked);
@@ -283,7 +282,6 @@ void EditStaffType::setValues()
         aboveLinesRadio->setChecked(!staffType.onLines());
         linesThroughRadio->setChecked(staffType.linesThrough());
         linesBrokenRadio->setChecked(!staffType.linesThrough());
-        showBackTied->setChecked(staffType.showBackTied());
 
         idx = durFontName->findText(staffType.durationFontName(), Qt::MatchFixedString);
         if (idx == -1) {
@@ -450,7 +448,6 @@ void EditStaffType::setFromDlg()
     staffType.setFretFontSize(fretFontSize->value());
     staffType.setFretFontUserY(fretY->value());
     staffType.setLinesThrough(linesThroughRadio->isChecked());
-    staffType.setShowBackTied(showBackTied->isChecked());
     staffType.setMinimStyle(minimNoneRadio->isChecked() ? mu::engraving::TablatureMinimStyle::NONE
                             : (minimShortRadio->isChecked() ? mu::engraving::TablatureMinimStyle::SHORTER : mu::engraving::
                                TablatureMinimStyle::
@@ -512,7 +509,6 @@ void EditStaffType::blockSignals(bool block)
     aboveLinesRadio->blockSignals(block);
     linesThroughRadio->blockSignals(block);
     linesBrokenRadio->blockSignals(block);
-    showBackTied->blockSignals(block);
 
     durFontName->blockSignals(block);
     durFontSize->blockSignals(block);

--- a/src/notation/view/widgets/editstafftype.ui
+++ b/src/notation/view/widgets/editstafftype.ui
@@ -29,7 +29,6 @@
       <widget class="QLabel" name="groupName">
        <property name="font">
         <font>
-         <weight>75</weight>
          <bold>true</bold>
         </font>
        </property>
@@ -218,7 +217,7 @@
         <number>0</number>
        </property>
        <property name="currentIndex">
-        <number>0</number>
+        <number>2</number>
        </property>
        <widget class="QWidget" name="page">
         <layout class="QVBoxLayout" name="verticalLayout_7" stretch="0,0,0">
@@ -681,13 +680,6 @@
                 </item>
                 <item>
                  <layout class="QHBoxLayout" name="horizontalLayout_3">
-                  <item>
-                   <widget class="QCheckBox" name="showBackTied">
-                    <property name="text">
-                     <string>Show back-tied fret marks</string>
-                    </property>
-                   </widget>
-                  </item>
                   <item>
                    <widget class="QCheckBox" name="showTabFingering">
                     <property name="text">
@@ -1431,7 +1423,6 @@
   <tabstop>aboveLinesRadio</tabstop>
   <tabstop>linesThroughRadio</tabstop>
   <tabstop>linesBrokenRadio</tabstop>
-  <tabstop>showBackTied</tabstop>
   <tabstop>showTabFingering</tabstop>
   <tabstop>durFontName</tabstop>
   <tabstop>durFontSize</tabstop>

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -264,6 +264,12 @@ EditStyle::EditStyle(QWidget* parent)
     tabParenthFrets->addButton(tabParenthMeasure, int(ParenthesizeTiedFret::START_OF_MEASURE));
     tabParenthFrets->addButton(tabParenthNone, int(ParenthesizeTiedFret::NEVER));
 
+    void (QButtonGroup::* tabShowTiedFretsButtonClicked)(QAbstractButton*) = &QButtonGroup::buttonClicked;
+    connect(tabShowTiedFrets, tabShowTiedFretsButtonClicked, this, [this](QAbstractButton*){
+        updateParenthesisIndicatingTiesGroupState();
+    });
+    updateParenthesisIndicatingTiesGroupState();
+
     // ====================================================
     // Style widgets
     // ====================================================
@@ -2449,4 +2455,9 @@ void EditStyle::resetUserStyleName()
 {
     styleName->clear();
     endEditUserStyleName();
+}
+
+void EditStyle::updateParenthesisIndicatingTiesGroupState()
+{
+    groupBox_2->setEnabled(tabShowTies->isChecked());
 }

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -268,7 +268,6 @@ EditStyle::EditStyle(QWidget* parent)
     connect(tabShowTiedFrets, tabShowTiedFretsButtonClicked, this, [this](QAbstractButton*){
         updateParenthesisIndicatingTiesGroupState();
     });
-    updateParenthesisIndicatingTiesGroupState();
 
     // ====================================================
     // Style widgets
@@ -1971,6 +1970,8 @@ void EditStyle::setValues()
     for (const LineStyleSelect* lineStyleSelect : m_lineStyleSelects) {
         lineStyleSelect->update();
     }
+
+    updateParenthesisIndicatingTiesGroupState();
 }
 
 //---------------------------------------------------------
@@ -2459,5 +2460,5 @@ void EditStyle::resetUserStyleName()
 
 void EditStyle::updateParenthesisIndicatingTiesGroupState()
 {
-    groupBox_2->setEnabled(tabShowTies->isChecked());
+    groupBox_2->setEnabled(tabShowTies->isChecked() || tabShowNone->isChecked());
 }

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -38,6 +38,7 @@
 #include "engraving/dom/figuredbass.h"
 #include "engraving/dom/masterscore.h"
 #include "engraving/dom/realizedharmony.h"
+#include "engraving/dom/stafftype.h"
 #include "engraving/dom/text.h"
 #include "engraving/style/textstyle.h"
 #include "engraving/types/symnames.h"
@@ -252,6 +253,16 @@ EditStyle::EditStyle(QWidget* parent)
     QButtonGroup* articulationKeepTogether = new QButtonGroup(this);
     articulationKeepTogether->addButton(radioArticKeepTogether, 1);
     articulationKeepTogether->addButton(radioArticAllowSeparate, 0);
+
+    QButtonGroup* tabShowTiedFrets = new QButtonGroup(this);
+    tabShowTiedFrets->addButton(tabShowTiesAndFret, int(ShowTiedFret::TIE_AND_FRET));
+    tabShowTiedFrets->addButton(tabShowTies, int(ShowTiedFret::TIE));
+    tabShowTiedFrets->addButton(tabShowNone, int(ShowTiedFret::NONE));
+
+    QButtonGroup* tabParenthFrets = new QButtonGroup(this);
+    tabParenthFrets->addButton(tabParenthSystem, int(ParenthesizeTiedFret::START_OF_SYSTEM));
+    tabParenthFrets->addButton(tabParenthMeasure, int(ParenthesizeTiedFret::START_OF_MEASURE));
+    tabParenthFrets->addButton(tabParenthNone, int(ParenthesizeTiedFret::NEVER));
 
     // ====================================================
     // Style widgets
@@ -625,6 +636,10 @@ EditStyle::EditStyle(QWidget* parent)
         { StyleId::wahShowTabCommon, false, wahShowTabCommon, 0 },
         { StyleId::golpeShowTabSimple, false, golpeShowTabSimple, 0 },
         { StyleId::golpeShowTabCommon, false, golpeShowTabCommon, 0 },
+
+        { StyleId::tabShowTiedFret, false, tabShowTiedFrets, 0 },
+        { StyleId::tabParenthesizeTiedFret, false, tabParenthFrets, 0 },
+        { StyleId::parenthesizeTiedFretIfArticulation, false, tabParenthArticulation, 0 },
     };
 
     // ====================================================
@@ -1075,9 +1090,6 @@ EditStyle::EditStyle(QWidget* parent)
     connect(textStyleColor, &Awl::ColorLabel::colorChanged, [=]() {
         textStyleValueChanged(TextStylePropertyType::Color, textStyleColor->color());
     });
-
-    // TODO: bring back the tab styles button and make sure right styles are applied as default
-    resetTabStylesButton->setVisible(false);
 
     connect(textStyles, &QListWidget::currentRowChanged, this, &EditStyle::textStyleChanged);
     textStyles->setCurrentRow(s_lastSubPageRow);

--- a/src/notation/view/widgets/editstyle.h
+++ b/src/notation/view/widgets/editstyle.h
@@ -139,6 +139,7 @@ private slots:
     void editUserStyleName();
     void endEditUserStyleName();
     void resetUserStyleName();
+    void updateParenthesisIndicatingTiesGroupState();
 
 private:
     QString m_currentPageCode;

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -12916,8 +12916,8 @@ By default, they will be placed such as that their right end are at the same lev
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>354</width>
-                <height>385</height>
+                <width>583</width>
+                <height>584</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_40">
@@ -12938,15 +12938,15 @@ By default, they will be placed such as that their right end are at the same lev
                 </widget>
                </item>
                <item>
-                <layout class="QHBoxLayout" name="horizontalLayout" stretch="4,1">
+                <layout class="QGridLayout" name="gridLayout_36">
                  <property name="topMargin">
                   <number>0</number>
                  </property>
                  <property name="rightMargin">
                   <number>0</number>
                  </property>
-                 <item>
-                  <layout class="QVBoxLayout" name="verticalLayout_38" stretch="0,0,0">
+                 <item row="0" column="0">
+                  <layout class="QVBoxLayout" name="verticalLayout_38" stretch="0,0">
                    <property name="leftMargin">
                     <number>12</number>
                    </property>
@@ -12973,63 +12973,22 @@ By default, they will be placed such as that their right end are at the same lev
                      <property name="verticalSpacing">
                       <number>6</number>
                      </property>
-                     <item row="5" column="0">
-                      <widget class="QCheckBox" name="dynamicsShowTabCommon">
-                       <property name="text">
-                        <string/>
-                       </property>
-                       <property name="checked">
-                        <bool>false</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="8" column="2">
-                      <widget class="QLabel" name="label_183">
-                       <property name="text">
-                        <string>Staccato</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="6" column="0">
-                      <widget class="QCheckBox" name="hairpinShowTabCommon">
-                       <property name="text">
-                        <string/>
-                       </property>
-                       <property name="checked">
-                        <bool>false</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="12" column="1">
-                      <widget class="QCheckBox" name="rasgueadoShowTabSimple">
+                     <item row="14" column="2">
+                      <widget class="QCheckBox" name="mordentShowTabSimple">
                        <property name="text">
                         <string/>
                        </property>
                       </widget>
                      </item>
-                     <item row="7" column="2">
-                      <widget class="QLabel" name="label_182">
-                       <property name="text">
-                        <string>Accent and marcato marks</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="14" column="1">
-                      <widget class="QCheckBox" name="turnShowTabSimple">
+                     <item row="16" column="2">
+                      <widget class="QCheckBox" name="wahShowTabSimple">
                        <property name="text">
                         <string/>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="9" column="2">
-                      <widget class="QLabel" name="label_59">
-                       <property name="text">
-                        <string>Harmonic marks</string>
                        </property>
                       </widget>
                      </item>
                      <item row="4" column="0">
-                      <widget class="QCheckBox" name="fermataShowTabCommon">
+                      <widget class="QCheckBox" name="slurShowTabCommon">
                        <property name="text">
                         <string/>
                        </property>
@@ -13038,14 +12997,7 @@ By default, they will be placed such as that their right end are at the same lev
                        </property>
                       </widget>
                      </item>
-                     <item row="14" column="2">
-                      <widget class="QLabel" name="label_200">
-                       <property name="text">
-                        <string>Turns</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="15" column="0">
+                     <item row="16" column="0">
                       <widget class="QCheckBox" name="wahShowTabCommon">
                        <property name="text">
                         <string/>
@@ -13055,36 +13007,8 @@ By default, they will be placed such as that their right end are at the same lev
                        </property>
                       </widget>
                      </item>
-                     <item row="13" column="1">
-                      <widget class="QCheckBox" name="mordentShowTabSimple">
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="15" column="1">
-                      <widget class="QCheckBox" name="wahShowTabSimple">
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="11" column="2">
-                      <widget class="QLabel" name="label_192">
-                       <property name="text">
-                        <string>Palm mute (P.M.)</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="10" column="2">
-                      <widget class="QLabel" name="label_190">
-                       <property name="text">
-                        <string>Let ring</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="11" column="1">
-                      <widget class="QCheckBox" name="palmMuteShowTabSimple">
+                     <item row="6" column="0">
+                      <widget class="QCheckBox" name="dynamicsShowTabCommon">
                        <property name="text">
                         <string/>
                        </property>
@@ -13093,81 +13017,87 @@ By default, they will be placed such as that their right end are at the same lev
                        </property>
                       </widget>
                      </item>
-                     <item row="3" column="1">
-                      <widget class="QCheckBox" name="slurShowTabSimple">
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="5" column="2">
-                      <widget class="QLabel" name="label_175">
-                       <property name="text">
-                        <string>Dynamics</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="3" column="2">
-                      <widget class="QLabel" name="label_63">
-                       <property name="text">
-                        <string>Slurs</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="15" column="2">
-                      <widget class="QLabel" name="label_201">
-                       <property name="text">
-                        <string>Wah open/close</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="6" column="2">
-                      <widget class="QLabel" name="label_181">
-                       <property name="text">
-                        <string>Crescendo and diminuendo lines</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="16" column="0">
-                      <widget class="QCheckBox" name="golpeShowTabCommon">
-                       <property name="text">
-                        <string/>
-                       </property>
-                       <property name="checked">
-                        <bool>false</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="1">
-                      <widget class="QLabel" name="label_57">
-                       <property name="text">
-                        <string>Simple</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="13" column="0">
+                     <item row="14" column="0">
                       <widget class="QCheckBox" name="mordentShowTabCommon">
                        <property name="text">
                         <string/>
                        </property>
                       </widget>
                      </item>
-                     <item row="14" column="0">
-                      <widget class="QCheckBox" name="turnShowTabCommon">
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="8" column="1">
+                     <item row="9" column="2">
                       <widget class="QCheckBox" name="staccatoShowTabSimple">
                        <property name="text">
                         <string/>
                        </property>
                       </widget>
                      </item>
-                     <item row="9" column="0">
-                      <widget class="QCheckBox" name="harmonicMarkShowTabCommon">
+                     <item row="17" column="4">
+                      <widget class="QLabel" name="label_215">
+                       <property name="text">
+                        <string>Golpe</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="13" column="2">
+                      <widget class="QCheckBox" name="rasgueadoShowTabSimple">
+                       <property name="text">
+                        <string/>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="8" column="4">
+                      <widget class="QLabel" name="label_182">
+                       <property name="text">
+                        <string>Accent and marcato marks</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="1">
+                      <spacer name="horizontalSpacer_63">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeType">
+                        <enum>QSizePolicy::Minimum</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>80</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item row="17" column="2">
+                      <widget class="QCheckBox" name="golpeShowTabSimple">
+                       <property name="text">
+                        <string/>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="6" column="4">
+                      <widget class="QLabel" name="label_175">
+                       <property name="text">
+                        <string>Dynamics</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="10" column="4">
+                      <widget class="QLabel" name="label_59">
+                       <property name="text">
+                        <string>Harmonic marks</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="7" column="4">
+                      <widget class="QLabel" name="label_181">
+                       <property name="text">
+                        <string>Crescendo and diminuendo lines</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="13" column="0">
+                      <widget class="QCheckBox" name="rasgueadoShowTabCommon">
                        <property name="text">
                         <string/>
                        </property>
@@ -13176,21 +13106,55 @@ By default, they will be placed such as that their right end are at the same lev
                        </property>
                       </widget>
                      </item>
-                     <item row="6" column="1">
-                      <widget class="QCheckBox" name="hairpinShowTabSimple">
+                     <item row="10" column="2">
+                      <widget class="QCheckBox" name="harmonicMarkShowTabSimple">
+                       <property name="text">
+                        <string/>
+                       </property>
+                       <property name="checked">
+                        <bool>false</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="8" column="2">
+                      <widget class="QCheckBox" name="accentShowTabSimple">
                        <property name="text">
                         <string/>
                        </property>
                       </widget>
                      </item>
-                     <item row="16" column="1">
-                      <widget class="QCheckBox" name="golpeShowTabSimple">
+                     <item row="4" column="2">
+                      <widget class="QCheckBox" name="slurShowTabSimple">
                        <property name="text">
                         <string/>
                        </property>
                       </widget>
                      </item>
-                     <item row="0" column="0">
+                     <item row="12" column="0">
+                      <widget class="QCheckBox" name="palmMuteShowTabCommon">
+                       <property name="text">
+                        <string/>
+                       </property>
+                       <property name="checked">
+                        <bool>false</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="15" column="0">
+                      <widget class="QCheckBox" name="turnShowTabCommon">
+                       <property name="text">
+                        <string/>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="5" column="2">
+                      <widget class="QCheckBox" name="fermataShowTabSimple">
+                       <property name="text">
+                        <string/>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="0">
                       <widget class="QLabel" name="label_4">
                        <property name="text">
                         <string>Common</string>
@@ -13203,17 +13167,7 @@ By default, they will be placed such as that their right end are at the same lev
                        </property>
                       </widget>
                      </item>
-                     <item row="10" column="1">
-                      <widget class="QCheckBox" name="letRingShowTabSimple">
-                       <property name="text">
-                        <string/>
-                       </property>
-                       <property name="checked">
-                        <bool>false</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="7" column="0">
+                     <item row="8" column="0">
                       <widget class="QCheckBox" name="accentShowTabCommon">
                        <property name="text">
                         <string/>
@@ -13223,29 +13177,8 @@ By default, they will be placed such as that their right end are at the same lev
                        </property>
                       </widget>
                      </item>
-                     <item row="5" column="1">
-                      <widget class="QCheckBox" name="dynamicsShowTabSimple">
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="7" column="1">
-                      <widget class="QCheckBox" name="accentShowTabSimple">
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="4" column="2">
-                      <widget class="QLabel" name="label_174">
-                       <property name="text">
-                        <string>Fermatas</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="3" column="0">
-                      <widget class="QCheckBox" name="slurShowTabCommon">
+                     <item row="7" column="0">
+                      <widget class="QCheckBox" name="hairpinShowTabCommon">
                        <property name="text">
                         <string/>
                        </property>
@@ -13254,15 +13187,8 @@ By default, they will be placed such as that their right end are at the same lev
                        </property>
                       </widget>
                      </item>
-                     <item row="16" column="2">
-                      <widget class="QLabel" name="label_215">
-                       <property name="text">
-                        <string>Golpe</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="9" column="1">
-                      <widget class="QCheckBox" name="harmonicMarkShowTabSimple">
+                     <item row="5" column="0">
+                      <widget class="QCheckBox" name="fermataShowTabCommon">
                        <property name="text">
                         <string/>
                        </property>
@@ -13271,68 +13197,14 @@ By default, they will be placed such as that their right end are at the same lev
                        </property>
                       </widget>
                      </item>
-                     <item row="12" column="0">
-                      <widget class="QCheckBox" name="rasgueadoShowTabCommon">
+                     <item row="4" column="4">
+                      <widget class="QLabel" name="label_63">
                        <property name="text">
-                        <string/>
-                       </property>
-                       <property name="checked">
-                        <bool>false</bool>
+                        <string>Slurs</string>
                        </property>
                       </widget>
                      </item>
-                     <item row="4" column="1">
-                      <widget class="QCheckBox" name="fermataShowTabSimple">
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="10" column="0">
-                      <widget class="QCheckBox" name="letRingShowTabCommon">
-                       <property name="text">
-                        <string/>
-                       </property>
-                       <property name="checked">
-                        <bool>false</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="13" column="2">
-                      <widget class="QLabel" name="label_199">
-                       <property name="text">
-                        <string>Mordents</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="12" column="2">
-                      <widget class="QLabel" name="label_197">
-                       <property name="text">
-                        <string>Rasgueado</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="11" column="0">
-                      <widget class="QCheckBox" name="palmMuteShowTabCommon">
-                       <property name="text">
-                        <string/>
-                       </property>
-                       <property name="checked">
-                        <bool>false</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="8" column="0">
-                      <widget class="QCheckBox" name="staccatoShowTabCommon">
-                       <property name="text">
-                        <string/>
-                       </property>
-                       <property name="checked">
-                        <bool>false</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="1">
+                     <item row="2" column="2">
                       <spacer name="verticalSpacer_37">
                        <property name="orientation">
                         <enum>Qt::Vertical</enum>
@@ -13348,34 +13220,161 @@ By default, they will be placed such as that their right end are at the same lev
                        </property>
                       </spacer>
                      </item>
-                    </layout>
-                   </item>
-                   <item>
-                    <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="2,1">
-                     <property name="spacing">
-                      <number>6</number>
-                     </property>
-                     <property name="leftMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="topMargin">
-                      <number>16</number>
-                     </property>
-                     <item>
-                      <widget class="QPushButton" name="resetTabStylesButton">
+                     <item row="12" column="4">
+                      <widget class="QLabel" name="label_192">
                        <property name="text">
-                        <string>Reset tablature styles to default</string>
+                        <string>Palm mute (P.M.)</string>
                        </property>
                       </widget>
                      </item>
-                     <item>
-                      <spacer name="horizontalSpacer_63">
+                     <item row="14" column="4">
+                      <widget class="QLabel" name="label_199">
+                       <property name="text">
+                        <string>Mordents</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="6" column="2">
+                      <widget class="QCheckBox" name="dynamicsShowTabSimple">
+                       <property name="text">
+                        <string/>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="7" column="2">
+                      <widget class="QCheckBox" name="hairpinShowTabSimple">
+                       <property name="text">
+                        <string/>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="15" column="2">
+                      <widget class="QCheckBox" name="turnShowTabSimple">
+                       <property name="text">
+                        <string/>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="15" column="4">
+                      <widget class="QLabel" name="label_200">
+                       <property name="text">
+                        <string>Turns</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="11" column="0">
+                      <widget class="QCheckBox" name="letRingShowTabCommon">
+                       <property name="text">
+                        <string/>
+                       </property>
+                       <property name="checked">
+                        <bool>false</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="11" column="4">
+                      <widget class="QLabel" name="label_190">
+                       <property name="text">
+                        <string>Let ring</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="2">
+                      <widget class="QLabel" name="label_57">
+                       <property name="text">
+                        <string>Simple</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="17" column="0">
+                      <widget class="QCheckBox" name="golpeShowTabCommon">
+                       <property name="text">
+                        <string/>
+                       </property>
+                       <property name="checked">
+                        <bool>false</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="16" column="4">
+                      <widget class="QLabel" name="label_201">
+                       <property name="text">
+                        <string>Wah open/close</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="9" column="4">
+                      <widget class="QLabel" name="label_183">
+                       <property name="text">
+                        <string>Staccato</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="10" column="0">
+                      <widget class="QCheckBox" name="harmonicMarkShowTabCommon">
+                       <property name="text">
+                        <string/>
+                       </property>
+                       <property name="checked">
+                        <bool>false</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="13" column="4">
+                      <widget class="QLabel" name="label_197">
+                       <property name="text">
+                        <string>Rasgueado</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="9" column="0">
+                      <widget class="QCheckBox" name="staccatoShowTabCommon">
+                       <property name="text">
+                        <string/>
+                       </property>
+                       <property name="checked">
+                        <bool>false</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="12" column="2">
+                      <widget class="QCheckBox" name="palmMuteShowTabSimple">
+                       <property name="text">
+                        <string/>
+                       </property>
+                       <property name="checked">
+                        <bool>false</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="5" column="4">
+                      <widget class="QLabel" name="label_174">
+                       <property name="text">
+                        <string>Fermatas</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="11" column="2">
+                      <widget class="QCheckBox" name="letRingShowTabSimple">
+                       <property name="text">
+                        <string/>
+                       </property>
+                       <property name="checked">
+                        <bool>false</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="3">
+                      <spacer name="horizontalSpacer_66">
                        <property name="orientation">
                         <enum>Qt::Horizontal</enum>
                        </property>
+                       <property name="sizeType">
+                        <enum>QSizePolicy::Minimum</enum>
+                       </property>
                        <property name="sizeHint" stdset="0">
                         <size>
-                         <width>40</width>
+                         <width>80</width>
                          <height>20</height>
                         </size>
                        </property>
@@ -13398,7 +13397,7 @@ By default, they will be placed such as that their right end are at the same lev
                    </item>
                   </layout>
                  </item>
-                 <item>
+                 <item row="0" column="1">
                   <spacer name="horizontalSpacer_32">
                    <property name="orientation">
                     <enum>Qt::Horizontal</enum>
@@ -13412,6 +13411,74 @@ By default, they will be placed such as that their right end are at the same lev
                   </spacer>
                  </item>
                 </layout>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBox">
+                 <property name="title">
+                  <string>Tied fret marks</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_59">
+                  <item>
+                   <widget class="QRadioButton" name="tabShowTiesAndFret">
+                    <property name="text">
+                     <string>Show ties and repeat fret marks</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QRadioButton" name="tabShowTies">
+                    <property name="text">
+                     <string>Show ties only</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QRadioButton" name="tabShowNone">
+                    <property name="text">
+                     <string>Show initial fret mark only</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBox_2">
+                 <property name="title">
+                  <string>Parenthesis indicating ties</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_60">
+                  <item>
+                   <widget class="QRadioButton" name="tabParenthSystem">
+                    <property name="text">
+                     <string>Only show at the start of a system</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QRadioButton" name="tabParenthMeasure">
+                    <property name="text">
+                     <string>Always show at the start of a bar</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QRadioButton" name="tabParenthNone">
+                    <property name="text">
+                     <string>Never show</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="tabParenthArticulation">
+                    <property name="text">
+                     <string>Always show parenthesised fret marks when 
+articulation markings are present</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
                </item>
               </layout>
              </widget>
@@ -14581,7 +14648,6 @@ By default, they will be placed such as that their right end are at the same lev
   <tabstop>wahShowTabSimple</tabstop>
   <tabstop>golpeShowTabCommon</tabstop>
   <tabstop>golpeShowTabSimple</tabstop>
-  <tabstop>resetTabStylesButton</tabstop>
   <tabstop>textStyles</tabstop>
   <tabstop>styleName</tabstop>
   <tabstop>resetTextStyleName</tabstop>


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/20536

New options for showing/hiding ties and fret marks in TAB staves