### PR TITLE
Fix MSVC linker warnings

### DIFF
--- a/src/engraving/rendering/stable/gettremolodispatcher.h
+++ b/src/engraving/rendering/stable/gettremolodispatcher.h
@@ -7,7 +7,7 @@
 #include "dom/tremolosinglechord.h"
 
 namespace mu::engraving::rendering::stable {
-TremoloDispatcher* tremoloDispatcher(Chord* c)
+inline TremoloDispatcher* tremoloDispatcher(Chord* c)
 {
     if (!c) {
         return nullptr;


### PR DESCRIPTION
reg.: "class mu::engraving::TremoloDispatcher * __cdecl mu::engraving::rendering::stable::tremoloDispatcher(class mu::engraving::Chord *)" (?tremoloDispatcher@stable@rendering@engraving@mu@@YAPEAVTremoloDispatcher@34@PEAVChord@34@@Z) already defined in slurtielayout.cpp.obj; second definition ignored (LNK4006)