### PR TITLE
"Auto" option for tie placement on chords

### DIFF
--- a/src/engraving/dom/tie.cpp
+++ b/src/engraving/dom/tie.cpp
@@ -378,7 +378,12 @@ void Tie::calculateIsInside()
     if (startIsSingleNote && endIsSingleNote) {
         setIsInside(style().styleV(Sid::tiePlacementSingleNote).value<TiePlacement>() == TiePlacement::INSIDE);
     } else {
-        setIsInside(style().styleV(Sid::tiePlacementChord).value<TiePlacement>() == TiePlacement::INSIDE);
+        if (style().styleV(Sid::tiePlacementChord).value<TiePlacement>() == TiePlacement::AUTO) {
+            setIsInside(!(up() ? (startN == startChord->upNote() && endN == endChord->upNote())
+                          : (startN == startChord->downNote() && endN == endChord->downNote())));
+        } else {
+            setIsInside(style().styleV(Sid::tiePlacementChord).value<TiePlacement>() == TiePlacement::INSIDE);
+        }
     }
 }
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/TiePlacementSelector.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/TiePlacementSelector.qml
@@ -51,7 +51,7 @@ Rectangle {
             ]
 
             delegate: FlatRadioButton {
-                width: 106
+                width: 107
                 height: 30
 
                 checked: modelData.value === tiePlacementSelector.placementSingleNotes.value
@@ -70,12 +70,13 @@ Rectangle {
 
         RadioButtonGroup {
             model: [
-                { iconCode: IconCode.TIE_CHORD_INSIDE, value: 1, title: qsTrc("inspector", "Inside") },
-                { iconCode: IconCode.TIE_CHORD_OUTSIDE, value: 2, title: qsTrc("inspector", "Outside") }
+                { iconCode: IconCode.TIE_CHORD_INSIDE,  value: 1, title: qsTrc("inspector", "Inside") },
+                { iconCode: IconCode.TIE_CHORD_OUTSIDE, value: 2, title: qsTrc("inspector", "Outside") },
+                { iconCode: IconCode.AUTO_TEXT,         value: 0, title: qsTrc("inspector", "Auto") }
             ]
 
             delegate: FlatRadioButton {
-                width: 106
+                width: 70
                 height: 30
 
                 checked: modelData.value === tiePlacementSelector.placementChords.value


### PR DESCRIPTION
Resolves: #20539 

This PR introduces an 'Auto' option for tie placement on chords, combining inside and outside placement to achieve visually appealing results.
The factors for placement are calculated based on a tie's current direction, which enables nicer results when flipping said direction. I originally wrote a version that determines placement without regard for direction, so if that is preferred it shouldn't be much extra work.
The icon in the style dialog is a placeholder.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
