### PR TITLE
Notation-specific solo-mute states

### DIFF
--- a/src/engraving/infrastructure/mscreader.cpp
+++ b/src/engraving/infrastructure/mscreader.cpp
@@ -232,9 +232,9 @@ ByteArray MscReader::readAudioFile() const
     return fileData(u"audio.ogg");
 }
 
-ByteArray MscReader::readAudioSettingsJsonFile() const
+ByteArray MscReader::readAudioSettingsJsonFile(const io::path_t& pathPrefix) const
 {
-    return fileData(u"audiosettings.json");
+    return fileData(pathPrefix.toString() + u"audiosettings.json");
 }
 
 ByteArray MscReader::readViewSettingsJsonFile(const io::path_t& pathPrefix) const

--- a/src/engraving/infrastructure/mscreader.h
+++ b/src/engraving/infrastructure/mscreader.h
@@ -70,8 +70,8 @@ public:
     ByteArray readImageFile(const String& fileName) const;
 
     ByteArray readAudioFile() const;
-    ByteArray readAudioSettingsJsonFile() const;
-    ByteArray readViewSettingsJsonFile(const io::path_t& pathPrefix) const;
+    ByteArray readAudioSettingsJsonFile(const io::path_t& pathPrefix = "") const;
+    ByteArray readViewSettingsJsonFile(const io::path_t& pathPrefix = "") const;
 
 private:
 

--- a/src/engraving/infrastructure/mscwriter.cpp
+++ b/src/engraving/infrastructure/mscwriter.cpp
@@ -192,9 +192,9 @@ void MscWriter::writeAudioFile(const ByteArray& data)
     addFileData(u"audio.ogg", data);
 }
 
-void MscWriter::writeAudioSettingsJsonFile(const ByteArray& data)
+void MscWriter::writeAudioSettingsJsonFile(const ByteArray& data, const io::path_t& pathPrefix)
 {
-    addFileData(u"audiosettings.json", data);
+    addFileData(pathPrefix.toString() + u"audiosettings.json", data);
 }
 
 void MscWriter::writeViewSettingsJsonFile(const ByteArray& data, const io::path_t& pathPrefix)

--- a/src/engraving/infrastructure/mscwriter.h
+++ b/src/engraving/infrastructure/mscwriter.h
@@ -66,7 +66,7 @@ public:
     void writeThumbnailFile(const ByteArray& data);
     void addImageFile(const String& fileName, const ByteArray& data);
     void writeAudioFile(const ByteArray& data);
-    void writeAudioSettingsJsonFile(const ByteArray& data);
+    void writeAudioSettingsJsonFile(const ByteArray& data, const io::path_t& pathPrefix = "");
     void writeViewSettingsJsonFile(const ByteArray& data, const io::path_t& pathPrefix = "");
 
 private:

--- a/src/notation/CMakeLists.txt
+++ b/src/notation/CMakeLists.txt
@@ -36,6 +36,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/inotation.h
     ${CMAKE_CURRENT_LIST_DIR}/inotationpainting.h
     ${CMAKE_CURRENT_LIST_DIR}/inotationviewstate.h
+    ${CMAKE_CURRENT_LIST_DIR}/inotationsolomutestate.h
     ${CMAKE_CURRENT_LIST_DIR}/inotationnoteinput.h
     ${CMAKE_CURRENT_LIST_DIR}/inotationselection.h
     ${CMAKE_CURRENT_LIST_DIR}/inotationinteraction.h
@@ -66,6 +67,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/notationpainting.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/notationviewstate.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/notationviewstate.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/notationsolomutestate.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/notationsolomutestate.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/notationundostack.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/notationundostack.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/notationstyle.cpp

--- a/src/notation/inotation.h
+++ b/src/notation/inotation.h
@@ -29,6 +29,7 @@
 #include "notationtypes.h"
 #include "inotationpainting.h"
 #include "inotationviewstate.h"
+#include "inotationsolomutestate.h"
 #include "inotationstyle.h"
 #include "inotationplayback.h"
 #include "inotationelements.h"
@@ -75,6 +76,9 @@ public:
 
     virtual INotationPaintingPtr painting() const = 0;
     virtual INotationViewStatePtr viewState() const = 0;
+
+    // solo-mute state
+    virtual INotationSoloMuteStatePtr soloMuteState() const = 0;
 
     // input (mouse)
     virtual INotationInteractionPtr interaction() const = 0;

--- a/src/notation/inotationsolomutestate.h
+++ b/src/notation/inotationsolomutestate.h
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_NOTATION_INOTATIONSOLOMUTESTATE_H
+#define MU_NOTATION_INOTATIONSOLOMUTESTATE_H
+
+#include "engraving/infrastructure/mscreader.h"
+#include "io/iodevice.h"
+
+#include "notationtypes.h"
+
+namespace mu::notation {
+class INotationSoloMuteState
+{
+public:
+    struct SoloMuteState {
+        bool mute = false;
+        bool solo = false;
+
+        bool operator ==(const SoloMuteState& other) const
+        {
+            return mute == other.mute
+                   && solo == other.solo;
+        }
+    };
+
+    virtual ~INotationSoloMuteState() = default;
+
+    virtual Ret read(const engraving::MscReader& reader, const io::path_t& pathPrefix = "") = 0;
+    virtual Ret write(io::IODevice* out) = 0;
+
+    virtual bool trackSoloMuteStateExists(const engraving::InstrumentTrackId& trackId) const = 0;
+    virtual SoloMuteState trackSoloMuteState(const engraving::InstrumentTrackId& trackId) const = 0;
+    virtual void setTrackSoloMuteState(const engraving::InstrumentTrackId& trackId, const SoloMuteState& state) = 0;
+    virtual void removeTrackSoloMuteState(const engraving::InstrumentTrackId& trackId) = 0;
+    virtual async::Channel<engraving::InstrumentTrackId, SoloMuteState> trackSoloMuteStateChanged() const = 0;
+};
+
+using INotationSoloMuteStatePtr = std::shared_ptr<INotationSoloMuteState>;
+}
+
+#endif // MU_NOTATION_INOTATIONSOLOMUTESTATE_H

--- a/src/notation/internal/notation.cpp
+++ b/src/notation/internal/notation.cpp
@@ -28,6 +28,7 @@
 
 #include "notationpainting.h"
 #include "notationviewstate.h"
+#include "notationsolomutestate.h"
 #include "notationinteraction.h"
 #include "notationplayback.h"
 #include "notationundostack.h"
@@ -47,6 +48,7 @@ Notation::Notation(mu::engraving::Score* score)
 {
     m_painting = std::make_shared<NotationPainting>(this);
     m_viewState = std::make_shared<NotationViewState>(this);
+    m_soloMuteState = std::make_shared<NotationSoloMuteState>();
     m_undoStack = std::make_shared<NotationUndoStack>(this, m_notationChanged);
     m_interaction = std::make_shared<NotationInteraction>(this, m_undoStack);
     m_midiInput = std::make_shared<NotationMidiInput>(this, m_interaction, m_undoStack);
@@ -270,6 +272,11 @@ INotationPaintingPtr Notation::painting() const
 INotationViewStatePtr Notation::viewState() const
 {
     return m_viewState;
+}
+
+INotationSoloMuteStatePtr Notation::soloMuteState() const
+{
+    return m_soloMuteState;
 }
 
 INotationInteractionPtr Notation::interaction() const

--- a/src/notation/internal/notation.h
+++ b/src/notation/internal/notation.h
@@ -68,6 +68,7 @@ public:
 
     INotationPaintingPtr painting() const override;
     INotationViewStatePtr viewState() const override;
+    INotationSoloMuteStatePtr soloMuteState() const override;
     INotationInteractionPtr interaction() const override;
     INotationMidiInputPtr midiInput() const override;
     INotationUndoStackPtr undoStack() const override;
@@ -100,6 +101,7 @@ private:
 
     INotationPaintingPtr m_painting = nullptr;
     INotationViewStatePtr m_viewState = nullptr;
+    INotationSoloMuteStatePtr m_soloMuteState = nullptr;
     INotationInteractionPtr m_interaction = nullptr;
     INotationStylePtr m_style = nullptr;
     INotationMidiInputPtr m_midiInput = nullptr;

--- a/src/notation/internal/notationsolomutestate.cpp
+++ b/src/notation/internal/notationsolomutestate.cpp
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <QJsonArray>
+
+#include "notationsolomutestate.h"
+#include "notation.h"
+
+using namespace mu;
+using namespace mu::notation;
+
+Ret NotationSoloMuteState::read(const engraving::MscReader& reader, const io::path_t& pathPrefix)
+{
+    ByteArray json = reader.readAudioSettingsJsonFile(pathPrefix);
+
+    if (json.empty()) {
+        return make_ret(Ret::Code::UnknownError);
+    }
+
+    QJsonObject rootObj = QJsonDocument::fromJson(json.toQByteArrayNoCopy()).object();
+
+    QJsonArray tracksArray = rootObj.value("tracks").toArray();
+    for (const QJsonValue track : tracksArray) {
+        QJsonObject trackObject = track.toObject();
+
+        ID partId = trackObject.value("partId").toString();
+        std::string instrumentId = trackObject.value("instrumentId").toString().toStdString();
+        InstrumentTrackId id = { partId, instrumentId };
+
+        QJsonObject soloMuteObj = trackObject.value("soloMuteState").toObject();
+        SoloMuteState soloMuteState;
+        soloMuteState.mute = soloMuteObj.value("mute").toBool();
+        soloMuteState.solo = soloMuteObj.value("solo").toBool();
+
+        m_trackSoloMuteStatesMap.emplace(id, std::move(soloMuteState));
+    }
+
+    return make_ret(Ret::Code::Ok);
+}
+
+Ret NotationSoloMuteState::write(io::IODevice* out)
+{
+    QJsonObject rootObj;
+    QJsonArray tracksArray;
+
+    for (auto pair : m_trackSoloMuteStatesMap) {
+        QJsonObject currentTrack;
+        currentTrack["instrumentId"] = QString::fromStdString(pair.first.instrumentId);
+        currentTrack["partId"] = pair.first.partId.toQString();
+
+        QJsonObject soloMuteStateObject;
+        soloMuteStateObject["mute"] = pair.second.mute;
+        soloMuteStateObject["solo"] = pair.second.solo;
+
+        currentTrack["soloMuteState"] = soloMuteStateObject;
+        tracksArray.append(currentTrack);
+    }
+
+    rootObj["tracks"] = tracksArray;
+
+    out->write(QJsonDocument(rootObj).toJson());
+
+    return make_ret(Ret::Code::Ok);
+}
+
+bool NotationSoloMuteState::trackSoloMuteStateExists(const engraving::InstrumentTrackId& partId) const
+{
+    auto search = m_trackSoloMuteStatesMap.find(partId);
+    return search != m_trackSoloMuteStatesMap.end();
+}
+
+mu::notation::INotationSoloMuteState::SoloMuteState NotationSoloMuteState::trackSoloMuteState(const InstrumentTrackId& partId) const
+{
+    auto search = m_trackSoloMuteStatesMap.find(partId);
+
+    if (search == m_trackSoloMuteStatesMap.end()) {
+        return {};
+    }
+
+    return search->second;
+}
+
+void NotationSoloMuteState::setTrackSoloMuteState(const InstrumentTrackId& partId, const SoloMuteState& state)
+{
+    auto it = m_trackSoloMuteStatesMap.find(partId);
+    if (it != m_trackSoloMuteStatesMap.end() && it->second == state) {
+        return;
+    }
+
+    m_trackSoloMuteStatesMap.insert_or_assign(partId, state);
+    m_trackSoloMuteStateChanged.send(partId, state);
+}
+
+void NotationSoloMuteState::removeTrackSoloMuteState(const engraving::InstrumentTrackId& trackId)
+{
+    auto soloMuteSearch = m_trackSoloMuteStatesMap.find(trackId);
+    if (soloMuteSearch != m_trackSoloMuteStatesMap.end()) {
+        m_trackSoloMuteStatesMap.erase(soloMuteSearch);
+    }
+}
+
+mu::async::Channel<InstrumentTrackId, INotationSoloMuteState::SoloMuteState> NotationSoloMuteState::trackSoloMuteStateChanged() const
+{
+    return m_trackSoloMuteStateChanged;
+}

--- a/src/notation/internal/notationsolomutestate.h
+++ b/src/notation/internal/notationsolomutestate.h
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_NOTATION_NOTATIONSOLOMUTESTATE_H
+#define MU_NOTATION_NOTATIONSOLOMUTESTATE_H
+
+#include "../inotationsolomutestate.h"
+#include "async/asyncable.h"
+
+namespace mu::notation {
+class NotationSoloMuteState : public INotationSoloMuteState, public async::Asyncable
+{
+public:
+    Ret read(const engraving::MscReader& reader, const io::path_t& pathPrefix = "") override;
+    Ret write(io::IODevice* out) override;
+
+    bool trackSoloMuteStateExists(const engraving::InstrumentTrackId& trackId) const override;
+    SoloMuteState trackSoloMuteState(const engraving::InstrumentTrackId& trackId) const override;
+    void setTrackSoloMuteState(const engraving::InstrumentTrackId& trackId, const SoloMuteState& state) override;
+    void removeTrackSoloMuteState(const engraving::InstrumentTrackId& trackId) override;
+    async::Channel<engraving::InstrumentTrackId, SoloMuteState> trackSoloMuteStateChanged() const override;
+
+private:
+    std::unordered_map<engraving::InstrumentTrackId, SoloMuteState> m_trackSoloMuteStatesMap;
+    async::Channel<engraving::InstrumentTrackId, SoloMuteState> m_trackSoloMuteStateChanged;
+};
+}
+
+#endif // MU_NOTATION_NOTATIONSOLOMUTESTATE_H

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -88,6 +88,10 @@ public:
 
     async::Promise<audio::SoundPresetList> availableSoundPresets(engraving::InstrumentTrackId instrumentTrackId) const override;
 
+    notation::INotationSoloMuteState::SoloMuteState trackSoloMuteState(const engraving::InstrumentTrackId& trackId) const override;
+    void setTrackSoloMuteState(const engraving::InstrumentTrackId& trackId,
+                               const notation::INotationSoloMuteState::SoloMuteState& state) const override;
+
     void playElements(const std::vector<const notation::EngravingItem*>& elements) override;
     void playMetronome(int tick) override;
     void seekElement(const notation::EngravingItem* element) override;

--- a/src/playback/iplaybackcontroller.h
+++ b/src/playback/iplaybackcontroller.h
@@ -73,6 +73,10 @@ public:
 
     virtual async::Promise<audio::SoundPresetList> availableSoundPresets(engraving::InstrumentTrackId instrumentTrackId) const = 0;
 
+    virtual notation::INotationSoloMuteState::SoloMuteState trackSoloMuteState(const engraving::InstrumentTrackId& trackId) const = 0;
+    virtual void setTrackSoloMuteState(const engraving::InstrumentTrackId& trackId,
+                                       const notation::INotationSoloMuteState::SoloMuteState& state) const = 0;
+
     virtual void playElements(const std::vector<const notation::EngravingItem*>& elements) = 0;
     virtual void playMetronome(int tick) = 0;
     virtual void seekElement(const notation::EngravingItem* element) = 0;

--- a/src/playback/tests/mocks/playbackcontrollermock.h
+++ b/src/playback/tests/mocks/playbackcontrollermock.h
@@ -59,6 +59,11 @@ public:
 
     MOCK_METHOD(async::Promise<audio::SoundPresetList>, availableSoundPresets, (engraving::InstrumentTrackId), (const, override));
 
+    MOCK_METHOD(notation::INotationSoloMuteState::SoloMuteState, trackSoloMuteState, (const engraving::InstrumentTrackId&),
+                (const, override));
+    MOCK_METHOD(void, setTrackSoloMuteState, (const engraving::InstrumentTrackId&, const notation::INotationSoloMuteState::SoloMuteState&),
+                (const, override));
+
     MOCK_METHOD(void, playElements, ((const std::vector<const notation::EngravingItem*>&)), (override));
     MOCK_METHOD(void, playMetronome, (int), (override));
     MOCK_METHOD(void, seekElement, (const notation::EngravingItem*), (override));

--- a/src/playback/view/internal/mixerchannelitem.cpp
+++ b/src/playback/view/internal/mixerchannelitem.cpp
@@ -344,7 +344,7 @@ void MixerChannelItem::loadAuxSendItems(const AuxSendsParams& auxSends)
     }
 }
 
-void MixerChannelItem::loadSoloMuteState(project::IProjectAudioSettings::SoloMuteState&& newState)
+void MixerChannelItem::loadSoloMuteState(notation::INotationSoloMuteState::SoloMuteState&& newState)
 {
     if (m_soloMuteState.mute != newState.mute) {
         m_soloMuteState.mute = newState.mute;

--- a/src/playback/view/internal/mixerchannelitem.h
+++ b/src/playback/view/internal/mixerchannelitem.h
@@ -110,7 +110,7 @@ public:
 
     void loadInputParams(audio::AudioInputParams&& newParams);
     void loadOutputParams(audio::AudioOutputParams&& newParams);
-    void loadSoloMuteState(project::IProjectAudioSettings::SoloMuteState&& newState);
+    void loadSoloMuteState(notation::INotationSoloMuteState::SoloMuteState&& newState);
 
     void subscribeOnAudioSignalChanges(audio::AudioSignalChanges&& audioSignalChanges);
 
@@ -153,7 +153,7 @@ signals:
 
     void inputParamsChanged(const audio::AudioInputParams& params);
     void outputParamsChanged(const audio::AudioOutputParams& params);
-    void soloMuteStateChanged(const project::IProjectAudioSettings::SoloMuteState& state);
+    void soloMuteStateChanged(const notation::INotationSoloMuteState::SoloMuteState& state);
 
     void inputResourceItemChanged();
     void outputResourceItemListChanged();
@@ -187,7 +187,7 @@ protected:
 
     audio::AudioInputParams m_inputParams;
     audio::AudioOutputParams m_outParams;
-    project::IProjectAudioSettings::SoloMuteState m_soloMuteState;
+    notation::INotationSoloMuteState::SoloMuteState m_soloMuteState;
 
     InputResourceItem* m_inputResourceItem = nullptr;
     QMap<audio::AudioFxChainOrder, OutputResourceItem*> m_outputResourceItems;

--- a/src/playback/view/mixerpanelmodel.h
+++ b/src/playback/view/mixerpanelmodel.h
@@ -75,6 +75,7 @@ private:
     };
 
     void loadItems();
+    void onNotationChanged();
     void onTrackAdded(const audio::TrackId& trackId);
     void addItem(MixerChannelItem* item, int index);
     void removeItem(const audio::TrackId trackId);

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -195,17 +195,11 @@ mu::Ret NotationProject::doLoad(const io::path_t& path, const io::path_t& styleP
     masterScore->update();
 
     // Load audio settings
+    bool tryCompatAudio = false;
     ret = m_projectAudioSettings->read(reader);
     if (!ret) {
         m_projectAudioSettings->makeDefault();
-
-        // Apply compat audio settings
-        if (!settingsCompat.audioSettings.empty()) {
-            for (const auto& audioCompat : settingsCompat.audioSettings) {
-                IProjectAudioSettings::SoloMuteState state = { audioCompat.second.mute, audioCompat.second.solo };
-                m_projectAudioSettings->setTrackSoloMuteState(audioCompat.second.instrumentId, state);
-            }
-        }
+        tryCompatAudio = true;
     }
 
     // Load cloud info
@@ -223,10 +217,22 @@ mu::Ret NotationProject::doLoad(const io::path_t& path, const io::path_t& styleP
     // Set current if all success
     m_masterNotation->setMasterScore(masterScore);
 
-    // Load view settings (needs to be done after notations are created)
+    // Load view settings & solo-mute states (needs to be done after notations are created)
     m_masterNotation->notation()->viewState()->read(reader);
+    m_masterNotation->notation()->soloMuteState()->read(reader);
     for (IExcerptNotationPtr excerpt : m_masterNotation->excerpts()) {
-        excerpt->notation()->viewState()->read(reader, u"Excerpts/" + excerpt->fileName() + u"/");
+        io::path_t path = u"Excerpts/" + excerpt->fileName() + u"/";
+        excerpt->notation()->viewState()->read(reader, path);
+        excerpt->notation()->soloMuteState()->read(reader, path);
+    }
+
+    // Apply compat audio settings (needs to be done after notations are created)
+    if (tryCompatAudio && !settingsCompat.audioSettings.empty()) {
+        for (const auto& audioCompat : settingsCompat.audioSettings) {
+            notation::INotationSoloMuteState::SoloMuteState state = { audioCompat.second.mute, audioCompat.second.solo };
+            INotationSoloMuteStatePtr soloMuteStatePtr = m_masterNotation->notation()->soloMuteState();
+            soloMuteStatePtr->setTrackSoloMuteState(audioCompat.second.instrumentId, state);
+        }
     }
 
     return make_ret(Ret::Code::Ok);
@@ -702,17 +708,24 @@ mu::Ret NotationProject::writeProject(MscWriter& msczWriter, bool onlySelection,
         return make_ret(notation::Err::UnknownError);
     }
 
-    // Write audio settings
-    ret = m_projectAudioSettings->write(msczWriter);
+    // Write master audio settings
+    ret = m_projectAudioSettings->write(msczWriter, m_masterNotation->notation()->soloMuteState());
     if (!ret) {
         LOGE() << "failed write project audio settings, err: " << ret.toString();
         return ret;
     }
 
-    // Write view settings
+    // Write view settings and excerpt solo-mute states
     m_masterNotation->notation()->viewState()->write(msczWriter);
     for (IExcerptNotationPtr excerpt : m_masterNotation->excerpts()) {
-        excerpt->notation()->viewState()->write(msczWriter, u"Excerpts/" + excerpt->fileName() + u"/");
+        io::path_t path = u"Excerpts/" + excerpt->fileName() + u"/";
+        excerpt->notation()->viewState()->write(msczWriter, path);
+
+        ByteArray soloMuteData;
+        Buffer soloMuteBuf(&soloMuteData);
+        soloMuteBuf.open(IODevice::WriteOnly);
+        excerpt->notation()->soloMuteState()->write(&soloMuteBuf /*out*/);
+        msczWriter.writeAudioSettingsJsonFile(soloMuteData, path);
     }
 
     return make_ret(Ret::Code::Ok);

--- a/src/project/internal/projectaudiosettings.h
+++ b/src/project/internal/projectaudiosettings.h
@@ -52,10 +52,6 @@ public:
     audio::AudioOutputParams trackOutputParams(const engraving::InstrumentTrackId& partId) const override;
     void setTrackOutputParams(const engraving::InstrumentTrackId& partId, const audio::AudioOutputParams& params) override;
 
-    SoloMuteState trackSoloMuteState(const engraving::InstrumentTrackId& trackId) const override;
-    void setTrackSoloMuteState(const engraving::InstrumentTrackId& trackId, const SoloMuteState& state) override;
-    async::Channel<engraving::InstrumentTrackId, SoloMuteState> trackSoloMuteStateChanged() const override;
-
     SoloMuteState auxSoloMuteState(audio::aux_channel_idx_t index) const override;
     void setAuxSoloMuteState(audio::aux_channel_idx_t index, const SoloMuteState& state) override;
     async::Channel<audio::aux_channel_idx_t, SoloMuteState> auxSoloMuteStateChanged() const override;
@@ -68,7 +64,7 @@ public:
     async::Notification settingsChanged() const override;
 
     Ret read(const engraving::MscReader& reader);
-    Ret write(engraving::MscWriter& writer);
+    Ret write(engraving::MscWriter& writer, notation::INotationSoloMuteStatePtr masterSoloMuteStatePtr);
 
     //! NOTE Used for new or imported project (score)
     void makeDefault();
@@ -106,7 +102,7 @@ private:
     QString resourceTypeToString(const audio::AudioResourceType& type) const;
 
     QJsonObject buildAuxObject(audio::aux_channel_idx_t index, const audio::AudioOutputParams& params) const;
-    QJsonObject buildTrackObject(const engraving::InstrumentTrackId& id) const;
+    QJsonObject buildTrackObject(notation::INotationSoloMuteStatePtr masterSoloMuteStatePtr, const engraving::InstrumentTrackId& id) const;
 
     audio::AudioOutputParams m_masterOutputParams;
 
@@ -116,8 +112,6 @@ private:
 
     std::unordered_map<engraving::InstrumentTrackId, audio::AudioInputParams> m_trackInputParamsMap;
     std::unordered_map<engraving::InstrumentTrackId, audio::AudioOutputParams> m_trackOutputParamsMap;
-    std::unordered_map<engraving::InstrumentTrackId, SoloMuteState> m_trackSoloMuteStatesMap;
-    async::Channel<engraving::InstrumentTrackId, SoloMuteState> m_trackSoloMuteStateChanged;
 
     async::Notification m_settingsChanged;
 

--- a/src/project/iprojectaudiosettings.h
+++ b/src/project/iprojectaudiosettings.h
@@ -28,12 +28,15 @@
 #include "audio/audiotypes.h"
 #include "engraving/types/types.h"
 #include "playback/playbacktypes.h"
+#include "notation/inotationsolomutestate.h"
 #include "types/retval.h"
 
 namespace mu::project {
 class IProjectAudioSettings
 {
 public:
+    using SoloMuteState = notation::INotationSoloMuteState::SoloMuteState;
+
     virtual ~IProjectAudioSettings() = default;
 
     virtual audio::AudioOutputParams masterAudioOutputParams() const = 0;
@@ -49,21 +52,6 @@ public:
 
     virtual audio::AudioOutputParams trackOutputParams(const engraving::InstrumentTrackId& trackId) const = 0;
     virtual void setTrackOutputParams(const engraving::InstrumentTrackId& trackId, const audio::AudioOutputParams& params) = 0;
-
-    struct SoloMuteState {
-        bool mute = false;
-        bool solo = false;
-
-        bool operator ==(const SoloMuteState& other) const
-        {
-            return mute == other.mute
-                   && solo == other.solo;
-        }
-    };
-
-    virtual SoloMuteState trackSoloMuteState(const engraving::InstrumentTrackId& trackId) const = 0;
-    virtual void setTrackSoloMuteState(const engraving::InstrumentTrackId& trackId, const SoloMuteState& state) = 0;
-    virtual async::Channel<engraving::InstrumentTrackId, SoloMuteState> trackSoloMuteStateChanged() const = 0;
 
     virtual SoloMuteState auxSoloMuteState(audio::aux_channel_idx_t index) const = 0;
     virtual void setAuxSoloMuteState(audio::aux_channel_idx_t index, const SoloMuteState& state) = 0;

--- a/src/stubs/playback/playbackcontrollerstub.cpp
+++ b/src/stubs/playback/playbackcontrollerstub.cpp
@@ -119,6 +119,16 @@ mu::async::Promise<mu::audio::SoundPresetList> PlaybackControllerStub::available
     });
 }
 
+mu::notation::INotationSoloMuteState::SoloMuteState PlaybackControllerStub::trackSoloMuteState(const engraving::InstrumentTrackId&) const
+{
+    return notation::INotationSoloMuteState::SoloMuteState();
+}
+
+void PlaybackControllerStub::setTrackSoloMuteState(const engraving::InstrumentTrackId&,
+                                                   const notation::INotationSoloMuteState::SoloMuteState&) const
+{
+}
+
 void PlaybackControllerStub::playElements(const std::vector<const notation::EngravingItem*>&)
 {
 }

--- a/src/stubs/playback/playbackcontrollerstub.h
+++ b/src/stubs/playback/playbackcontrollerstub.h
@@ -56,6 +56,10 @@ public:
 
     async::Promise<audio::SoundPresetList> availableSoundPresets(engraving::InstrumentTrackId instrumentTrackId) const override;
 
+    notation::INotationSoloMuteState::SoloMuteState trackSoloMuteState(const engraving::InstrumentTrackId& trackId) const override;
+    void setTrackSoloMuteState(const engraving::InstrumentTrackId& trackId,
+                               const notation::INotationSoloMuteState::SoloMuteState& state) const override;
+
     void playElements(const std::vector<const notation::EngravingItem*>& elements) override;
     void playMetronome(int tick) override;
     void seekElement(const notation::EngravingItem* element) override;


### PR DESCRIPTION
PR will aim to address points brought up in #19433 (and #20564). Each "notation" (i.e. part score) has its own independent solo-mute state.