### PR TITLE
center one-line staff

### DIFF
--- a/src/engraving/dom/stafftypechange.cpp
+++ b/src/engraving/dom/stafftypechange.cpp
@@ -137,13 +137,12 @@ bool StaffTypeChange::setProperty(Pid propertyId, const PropertyValue& v)
     {
         int linesOld = m_staffType->lines();
         int linesNew = v.toInt();
-        Spatium yOffset = m_staffType->yoffset();
 
-        // if change to one line staff, center by setting y offset 2
+        // if change to one line staff, center by setting y offset 2 Spatium * lineDistance
         if (linesNew == 1 && linesOld != 1) {
-            m_staffType->setYoffset(yOffset + Spatium(2));
+            m_staffType->setYoffset(Spatium(2 * m_staffType->lineDistance()));
         } else if (linesOld == 1 && linesNew != 1) {
-            m_staffType->setYoffset(yOffset - Spatium(2));
+            m_staffType->setYoffset(Spatium(0));
         }
 
         m_staffType->setLines(linesNew);

--- a/src/engraving/dom/stafftypechange.cpp
+++ b/src/engraving/dom/stafftypechange.cpp
@@ -133,7 +133,8 @@ bool StaffTypeChange::setProperty(Pid propertyId, const PropertyValue& v)
     case Pid::STEP_OFFSET:
         m_staffType->setStepOffset(v.toInt());
         break;
-    case Pid::STAFF_LINES: {
+    case Pid::STAFF_LINES:
+    {
         int linesOld = m_staffType->lines();
         int linesNew = v.toInt();
         Spatium yOffset = m_staffType->yoffset();
@@ -172,7 +173,8 @@ bool StaffTypeChange::setProperty(Pid propertyId, const PropertyValue& v)
     case Pid::STAFF_GEN_KEYSIG:
         m_staffType->setGenKeysig(v.toBool());
         break;
-    case Pid::MAG: {
+    case Pid::MAG:
+    {
         double _spatium = spatium();
         m_staffType->setUserMag(v.toDouble());
         Staff* _staff = staff();
@@ -181,7 +183,8 @@ bool StaffTypeChange::setProperty(Pid propertyId, const PropertyValue& v)
         }
     }
     break;
-    case Pid::SMALL: {
+    case Pid::SMALL:
+    {
         double _spatium = spatium();
         m_staffType->setSmall(v.toBool());
         Staff* _staff = staff();

--- a/src/engraving/dom/stafftypechange.cpp
+++ b/src/engraving/dom/stafftypechange.cpp
@@ -149,8 +149,14 @@ bool StaffTypeChange::setProperty(Pid propertyId, const PropertyValue& v)
     }
     break;
     case Pid::LINE_DISTANCE:
+    {
+        Spatium yOffset = m_staffType->yoffset() - 2 * m_staffType->lineDistance();
         m_staffType->setLineDistance(v.value<Spatium>());
-        break;
+        if (m_staffType->lines() == 1) {
+            m_staffType->setYoffset(yOffset + Spatium(2 * m_staffType->lineDistance()));
+        }
+    }
+    break;
     case Pid::STAFF_SHOW_BARLINES:
         m_staffType->setShowBarlines(v.toBool());
         break;

--- a/src/engraving/dom/stafftypechange.cpp
+++ b/src/engraving/dom/stafftypechange.cpp
@@ -133,9 +133,21 @@ bool StaffTypeChange::setProperty(Pid propertyId, const PropertyValue& v)
     case Pid::STEP_OFFSET:
         m_staffType->setStepOffset(v.toInt());
         break;
-    case Pid::STAFF_LINES:
-        m_staffType->setLines(v.toInt());
-        break;
+    case Pid::STAFF_LINES: {
+        int linesOld = m_staffType->lines();
+        int linesNew = v.toInt();
+        Spatium yOffset = m_staffType->yoffset();
+
+        // if change to one line staff, center by setting y offset 2
+        if (linesNew == 1 && linesOld != 1) {
+            m_staffType->setYoffset(yOffset + Spatium(2));
+        } else if (linesOld == 1 && linesNew != 1) {
+            m_staffType->setYoffset(yOffset - Spatium(2));
+        }
+
+        m_staffType->setLines(linesNew);
+    }
+    break;
     case Pid::LINE_DISTANCE:
         m_staffType->setLineDistance(v.value<Spatium>());
         break;


### PR DESCRIPTION
(For some context see comments to https://github.com/musescore/MuseScore/pull/19086)

 <!-- Add a short description of and motivation for the changes here -->
One line staff looks better, if it is centered. It can be done manually by setting y - offset. 
This PR just makes it happen automagically, whenever user changes number of lines to one, or move it back, if user increase number of lines.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
