### PR TITLE
Fixed an issue with TopLevelDialogs closing on app switching.

### DIFF
--- a/src/framework/ui/CMakeLists.txt
+++ b/src/framework/ui/CMakeLists.txt
@@ -147,8 +147,9 @@ set(MODULE_UI
     )
 
 set(MODULE_LINK
-    accessibility
-    )
+  accessibility
+  uicomponents
+)
 
 if (OS_IS_MAC)
     find_library(AppKit NAMES AppKit)

--- a/src/framework/uicomponents/view/topleveldialog.h
+++ b/src/framework/uicomponents/view/topleveldialog.h
@@ -37,8 +37,18 @@ public:
     explicit TopLevelDialog(QWidget* parent = nullptr);
     TopLevelDialog(const TopLevelDialog& dialog);
 
+    // Owners of this dialog should call this method before performing any
+    // visibility operations like show, hide, etc. and inhibit those operations
+    // if this returns true.
+    bool shouldInhibitVisibilityEvents()
+    {
+        return m_shouldInhibitVisibilityEvents;
+    }
+
 protected:
     bool event(QEvent* e) override;
+private:
+    bool m_shouldInhibitVisibilityEvents = false;
 };
 }
 


### PR DESCRIPTION
Resolves: #19975 

Keeping a dialog on the top of the application windows stack was implemented using the Qt::WindowStaysOnTopHint window flag and connecting this to a signal from the main application so that when switching to another running app Qt::WindowStaysOnTopHint is turned off. This prevents the top level dialog from being on top of _all_ windows running on a computer.

Qt5 automatically hides any window that has no parent (i.e. dialogs) when window flags are set. In InteractiveProvider::openWidgetDialog a set of closures are setup to handle show/hide events. These closures do not take into account the case where Qt is hiding a window because window flags are being set.

This PR adds a specific boolean flag that is used by both the TopLevelDialog and the InteractiveProvider closures to orchestrate the window flag settings while avoiding deletions and re-insertions of the dialog.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
