### PR TITLE
fix #20768 - relayout whole score, when exclude / include measure from count

### DIFF
--- a/src/engraving/dom/measurebase.cpp
+++ b/src/engraving/dom/measurebase.cpp
@@ -448,7 +448,11 @@ bool MeasureBase::setProperty(Pid id, const PropertyValue& value)
         }
         break;
     }
-    triggerLayout();
+    if (id == Pid::IRREGULAR || id == Pid::NO_OFFSET) {
+        triggerLayoutAll();
+    } else {
+        triggerLayout();
+    }
     score()->setPlaylistDirty();
     return true;
 }


### PR DESCRIPTION
relayout whole score, when exclude / include measure from count, or if measure numbers offset is set

Resolves: #20768 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
