### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/rendering/stable/beamlayout.cpp
+++ b/src/engraving/rendering/stable/beamlayout.cpp
@@ -1232,7 +1232,7 @@ void BeamLayout::createBeamSegment(Beam* item, ChordRest* startCr, ChordRest* en
         if (level > 0) {
             double grow = item->growLeft();
             if (!RealIsEqual(item->growLeft(), item->growRight())) {
-                double anchorX;// = dev::BeamTremoloLayout::chordBeamAnchorX(item->m_layoutInfo.get(), chord, ChordBeamAnchorType::Middle);
+                double anchorX = 0.0;// = dev::BeamTremoloLayout::chordBeamAnchorX(item->m_layoutInfo.get(), chord, ChordBeamAnchorType::Middle);
                 double proportionAlongX = (anchorX - item->startAnchor().x()) / (item->endAnchor().x() - item->startAnchor().x());
                 grow = proportionAlongX * (item->growRight() - item->growLeft()) + item->growLeft();
             }
@@ -1451,7 +1451,7 @@ bool BeamLayout::layout2Cross(Beam* item, LayoutContext& ctx, const std::vector<
                 yLast = topFirst->stemPos().y();
             }
             int desiredSlant = round((yFirst - yLast) / item->spatium());
-            int slant;// = std::min(std::abs(desiredSlant), dev::BeamTremoloLayout::getMaxSlope(item->m_layoutInfo.get()));
+            int slant = 0;// = std::min(std::abs(desiredSlant), dev::BeamTremoloLayout::getMaxSlope(item->m_layoutInfo.get()));
             slant *= (desiredSlant < 0) ? -quarterSpace : quarterSpace;
             item->startAnchor().ry() += (slant / 2);
             item->endAnchor().ry() -= (slant / 2);

--- a/src/engraving/rendering/stable/beamlayout.cpp
+++ b/src/engraving/rendering/stable/beamlayout.cpp
@@ -117,6 +117,8 @@ void BeamLayout::layout(Beam* item, LayoutContext& ctx)
 
 void BeamLayout::layoutIfNeed(Beam* item, LayoutContext& ctx)
 {
+    UNUSED(item);
+    UNUSED(ctx);
 //    if (!(item->m_layoutInfo && item->m_layoutInfo->isValid())) {
 //        BeamLayout::layout(item, ctx);
 //    }
@@ -1533,11 +1535,16 @@ bool BeamLayout::layout2Cross(Beam* item, LayoutContext& ctx, const std::vector<
 
 PointF BeamLayout::chordBeamAnchor(const Beam* item, const ChordRest* chord, ChordBeamAnchorType anchorType)
 {
+    UNUSED(item);
+    UNUSED(chord);
+    UNUSED(anchorType);
     return PointF();//dev::BeamTremoloLayout::chordBeamAnchor(item->m_layoutInfo.get(), chord, anchorType);
 }
 
 double BeamLayout::chordBeamAnchorY(const Beam* item, const ChordRest* chord)
 {
+    UNUSED(item);
+    UNUSED(chord);
     return 0.0;//dev::BeamTremoloLayout::chordBeamAnchorY(item->m_layoutInfo.get(), chord);
 }
 

--- a/src/engraving/rendering/stable/beamlayout.cpp
+++ b/src/engraving/rendering/stable/beamlayout.cpp
@@ -1312,8 +1312,8 @@ void BeamLayout::createBeamletSegment(Beam* item, LayoutContext& ctx, ChordRest*
 bool BeamLayout::layout2Cross(Beam* item, LayoutContext& ctx, const std::vector<ChordRest*>& chordRests, int frag)
 {
     int fragmentIndex = (item->beamDirection() == DirectionV::AUTO || item->beamDirection() == DirectionV::DOWN) ? 0 : 1;
-    ChordRest* startCr = item->elements().front();
-    ChordRest* endCr = item->elements().back();
+    //ChordRest* startCr = item->elements().front();
+    //ChordRest* endCr = item->elements().back();
 
     const double quarterSpace = item->spatium() / 4;
     // imagine a line of beamed notes all in a row on the same staff. the first and last of those

--- a/src/engraving/rendering/stable/tremololayout.cpp
+++ b/src/engraving/rendering/stable/tremololayout.cpp
@@ -371,7 +371,7 @@ void TremoloLayout::createBeamSegments(TremoloDispatcher* item, LayoutContext& c
         // by the beam layout
         int beamSpacing = ctx.conf().styleB(Sid::useWideBeams) ? 4 : 3;
         for (ChordRest* cr : { item->chord1(), item->chord2() }) {
-            Chord* chord = toChord(cr);
+            //Chord* chord = toChord(cr);
             double addition = 0.0;
             if (cr->up() != item->up() && item->lines() > 1) {
                 // need to adjust further for beams on the opposite side

--- a/src/framework/global/types/number.h
+++ b/src/framework/global/types/number.h
@@ -154,6 +154,10 @@ inline T divide(const T& dividend, const T& divisor)
     return dividend / divisor;
 }
 
+#if (defined (_MSCVER) || defined (_MSC_VER))
+#pragma warning(push)
+#pragma warning(disable: 4723) // potential divide by 0
+#endif
 template<typename T>
 inline T divide(const T& dividend, const T& divisor, const T& def)
 {
@@ -162,6 +166,10 @@ inline T divide(const T& dividend, const T& divisor, const T& def)
     }
     return dividend / divisor;
 }
+
+#if (defined (_MSCVER) || defined (_MSC_VER))
+#pragma warning(pop)
+#endif
 
 template<typename T>
 inline number_t<T> divide(const number_t<T>& dividend, const number_t<T>& divisor, const number_t<T>& def)


### PR DESCRIPTION
* reg.: unreferenced formal parameter (C4100)
* reg.: local variable is initialized but not referenced (C4189)
* reg.: uninitialized local variable used (C4700)
* reg.: potential divide by 0 (C4723)