### PR TITLE
Fix #20716: Crash when appending frames in parts (4.2.1)

### DIFF
--- a/src/engraving/dom/box.cpp
+++ b/src/engraving/dom/box.cpp
@@ -464,7 +464,7 @@ void Box::manageExclusionFromParts(bool exclude)
                 continue;
             }
 
-            MeasureBase* newMB = next()->getInScore(score, true);
+            MeasureBase* newMB = next() ? next()->getInScore(score, true) : nullptr;
             Score::InsertMeasureOptions options;
             options.cloneBoxToAllParts = false;
             MeasureBase* newFrame = score->insertBox(type(), newMB, options);


### PR DESCRIPTION
Resolves: #20716
Master PR: #20817