### PR TITLE
fixed #19820 checkbox match staff size -> follow staff size in properties tab matching with the one in styles dialog

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
@@ -54,11 +54,11 @@ Column {
             anchors.rightMargin: 8
             anchors.verticalCenter: subscriptOptionsButtonList.verticalCenter
 
-            navigation.name: "Match staff size"
+            navigation.name: "Follow staff size"
             navigation.panel: root.navigationPanel
             navigation.row: root.navigationRowStart + 1
 
-            text: qsTrc("inspector", "Match staff size")
+            text: qsTrc("inspector", "Follow staff size")
             propertyItem: root.model ? root.model.isSizeSpatiumDependent : null
         }
 


### PR DESCRIPTION
Resolves: #19820 

Fixed the UI bug issue where the match staff size is present in the properties tab instead of follow staff size like the one present in styles dialog

![follow staff size_changes](https://github.com/musescore/MuseScore/assets/84094715/21b2b26c-c7ee-4eb3-a5d3-137e426aa99f)


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
