### PR TITLE
Adjust incorrect arpeggio span on paste

### DIFF
--- a/src/engraving/dom/arpeggio.cpp
+++ b/src/engraving/dom/arpeggio.cpp
@@ -80,11 +80,17 @@ const TranslatableString& Arpeggio::arpeggioTypeName() const
 
 void Arpeggio::findAndAttachToChords()
 {
-    Chord* _chord = chord();
-    track_idx_t strack = track();
-    track_idx_t etrack = track() + (m_span - 1);
-    track_idx_t lastTrack = strack;
+    const track_idx_t strack = track();
+    const Chord* _chord = chord();
+    const Part* part = _chord->part();
+    const track_idx_t btrack = part->endTrack();
 
+    if (strack + m_span > btrack) {
+        rebaseEndAnchor(AnchorRebaseDirection::UP);
+    }
+
+    const track_idx_t etrack = strack + (m_span - 1);
+    track_idx_t lastTrack = strack;
     for (track_idx_t track = strack; track <= etrack; track++) {
         EngravingItem* e = _chord->segment()->element(track);
         if (e && e->isChord()) {
@@ -94,7 +100,7 @@ void Arpeggio::findAndAttachToChords()
     }
 
     if (lastTrack != etrack) {
-        track_idx_t newSpan = lastTrack - track() + 1;
+        track_idx_t newSpan = lastTrack - strack + 1;
         undoChangeProperty(Pid::ARPEGGIO_SPAN, newSpan);
     }
 }

--- a/src/engraving/rendering/dev/chordlayout.cpp
+++ b/src/engraving/rendering/dev/chordlayout.cpp
@@ -557,6 +557,7 @@ void ChordLayout::layoutTablature(Chord* item, LayoutContext& ctx)
     }                                     // end of if(duration_symbols)
 
     if (item->arpeggio()) {
+        item->arpeggio()->findAndAttachToChords();
         double y = upnote->pos().y() - upnote->headHeight() * .5;
         TLayout::layoutArpeggio(item->arpeggio(), item->arpeggio()->mutldata(), ctx.conf());
         lll += item->arpeggio()->width() + _spatium * .5;


### PR DESCRIPTION
Resolves: #20765 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

Fix arpeggio spanning outside of its part on paste and crash on TAB staves
