### PR TITLE
Fix #20657: Navigation for key dropdown and soloist button

### DIFF
--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsOnScoreView.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsOnScoreView.qml
@@ -165,6 +165,8 @@ Item {
                 font: ui.theme.bodyBoldFont
             }
 
+            property var itemModel: model
+
             FlatButton {
                 anchors.right: parent.right
                 anchors.leftMargin: 4
@@ -180,6 +182,24 @@ Item {
                 navigation.panel: instrumentsView.navigation
                 navigation.row: 1 + model.index
                 navigation.column: 1
+
+                // Navigate to the next/previous item in the list instead of the next item in the column
+                navigation.onNavigationEvent: function(event) {
+                    var nextItem
+                    switch (event.type) {
+                    case NavigationEvent.Up:
+                        nextItem = instrumentsView.itemAtIndex(itemModel.index - 1)
+                        break
+                    case NavigationEvent.Down:
+                    case NavigationEvent.Right:
+                        nextItem = instrumentsView.itemAtIndex(itemModel.index + 1)
+                        break
+                    }
+                    if (nextItem) {
+                        nextItem.navigation.requestActive()
+                        event.accepted = true
+                    }
+                }
 
                 onClicked: {
                     model.isSoloist = !model.isSoloist

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsView.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsView.qml
@@ -134,7 +134,25 @@ Item {
                 navigation.row: item.navigation.row
                 navigation.column: 1
                 navigation.accessible.name: itemTitleLabel.text + " " + qsTrc("instruments", "traits")
-                navigation.accessible.row: model.index
+                navigation.accessible.row: itemModel.index
+
+                // Navigate to the next/previous item in the list instead of the next item in the column
+                navigation.onNavigationEvent: function(event) {
+                    var nextItem
+                    switch (event.type) {
+                    case NavigationEvent.Up:
+                        nextItem = instrumentsView.itemAtIndex(itemModel.index - 1)
+                        break
+                    case NavigationEvent.Down:
+                    case NavigationEvent.Right:
+                        nextItem = instrumentsView.itemAtIndex(itemModel.index + 1)
+                        break
+                    }
+                    if (nextItem) {
+                        nextItem.navigation.requestActive()
+                        event.accepted = true
+                    }
+                }
 
                 anchors.right: parent.right
                 anchors.rightMargin: 4


### PR DESCRIPTION
Resolves: #20657

Also fixes a mistake I made [here](https://github.com/musescore/MuseScore/pull/20591) in `InstrumentsView.qml` resulting in some QML warnings. Fixed by replacing `model.index` with `itemModel.index`.