### PR TITLE
Fix hidden staff conditions with spanners

### DIFF
--- a/src/engraving/rendering/dev/systemlayout.cpp
+++ b/src/engraving/rendering/dev/systemlayout.cpp
@@ -596,7 +596,7 @@ void SystemLayout::hideEmptyStaves(System* system, LayoutContext& ctx, bool isFi
 
     Fraction stick = system->measures().front()->tick();
     Fraction etick = system->measures().back()->endTick();
-    auto spanners = ctx.dom().spannerMap().findOverlapping(stick.ticks(), etick.ticks() - 1);
+    auto& spanners = ctx.dom().spannerMap().findOverlapping(stick.ticks(), etick.ticks() - 1);
 
     for (const Staff* staff : ctx.dom().staves()) {
         SysStaff* ss  = system->staff(staffIdx);
@@ -609,10 +609,10 @@ void SystemLayout::hideEmptyStaves(System* system, LayoutContext& ctx, bool isFi
                 && !(isFirstSystem && ctx.conf().styleB(Sid::dontHideStavesInFirstSystem))
                 && hideMode != Staff::HideMode::NEVER)) {
             bool hideStaff = true;
-            for (auto spanner : spanners) {
+            for (auto& spanner : spanners) {
                 if (spanner.value->staff() == staff
                     && !spanner.value->systemFlag()
-                    && !spanner.value->isHairpin()) {
+                    && !(spanner.stop == stick.ticks() && !spanner.value->isSlur())) {
                     hideStaff = false;
                     break;
                 }


### PR DESCRIPTION
Resolves: #20782 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

Spanners should only make the following bar visible if the spanner is a slur.