### PR TITLE
'Show stem slash' property for all grace notes

### DIFF
--- a/src/engraving/dom/chord.h
+++ b/src/engraving/dom/chord.h
@@ -176,6 +176,10 @@ public:
     void setEndsGlissandoOrGuitarBend(bool val) { m_endsGlissando = val; }
     void updateEndsGlissandoOrGuitarBend();
     StemSlash* stemSlash() const { return m_stemSlash; }
+    bool showStemSlash() const { return m_showStemSlash; }
+    void setShowStemSlashInAdvance();
+    void requestShowStemSlash(bool show);
+    void setShowStemSlash(bool show) { m_showStemSlash = show; }
     bool slash();
     void setSlash(bool flag, bool stemless);
     void removeMarkings(bool keepTremolo = false) override;
@@ -211,7 +215,7 @@ public:
     void cmdUpdateNotes(AccidentalState*);
 
     NoteType noteType() const { return m_noteType; }
-    void setNoteType(NoteType t) { m_noteType = t; }
+    void setNoteType(NoteType t);
     bool isGrace() const { return m_noteType != NoteType::NORMAL; }
     void toGraceAfter();
 
@@ -346,7 +350,8 @@ private:
 
     Stem* m_stem = nullptr;
     Hook* m_hook = nullptr;
-    StemSlash* m_stemSlash = nullptr;     // for acciacatura
+    StemSlash* m_stemSlash = nullptr;     // for grace notes
+    bool m_showStemSlash = false;
 
     Arpeggio* m_arpeggio = nullptr;       // arpeggio which starts on the chord
     Arpeggio* m_spanArpeggio = nullptr;   // arpeggio which spans over this chord

--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -847,6 +847,7 @@ Note* Score::setGraceNote(Chord* ch, int pitch, NoteType type, int len)
     chord->setDurationType(d);
     chord->setTicks(d.fraction());
     chord->setNoteType(type);
+    chord->setShowStemSlashInAdvance();
     chord->mutldata()->setMag(ch->staff()->staffMag(chord->tick()) * style().styleD(Sid::graceNoteMag));
 
     undoAddElement(chord);

--- a/src/engraving/dom/property.cpp
+++ b/src/engraving/dom/property.cpp
@@ -143,6 +143,7 @@ static constexpr PropertyMetaData propertyList[] = {
     { Pid::BEAM_MODE,               true, "BeamMode",               P_TYPE::BEAM_MODE,          PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "beam mode") },
     { Pid::BEAM_NO_SLOPE,           true, "noSlope",                P_TYPE::BOOL,               PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "without slope") },
     { Pid::USER_LEN,                false, "userLen",               P_TYPE::MILLIMETRE,         PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "length") },
+    { Pid::SHOW_STEM_SLASH,         true,  "showStemSlash",         P_TYPE::BOOL,               PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "show stem slash") },
 
     { Pid::SPACE,                   false, "space",                 P_TYPE::MILLIMETRE,         PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "space") },
     { Pid::TEMPO,                   true,  "tempo",                 P_TYPE::TEMPO,              PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "tempo") },

--- a/src/engraving/dom/property.h
+++ b/src/engraving/dom/property.h
@@ -152,6 +152,7 @@ enum class Pid {
     BEAM_MODE,
     BEAM_NO_SLOPE,
     USER_LEN,         // used for stems
+    SHOW_STEM_SLASH,  // used for grace notes
 
     SPACE,            // used for spacer
     TEMPO,

--- a/src/engraving/rendering/dev/chordlayout.cpp
+++ b/src/engraving/rendering/dev/chordlayout.cpp
@@ -1210,7 +1210,7 @@ void ChordLayout::layoutStem(Chord* item, const LayoutContext& ctx)
     }
 
     // Add Stem slash
-    if ((item->noteType() == NoteType::ACCIACCATURA) && !(item->beam() && item->beam()->elements().front() != item)) {
+    if ((item->showStemSlash()) && !(item->beam() && item->beam()->elements().front() != item)) {
         if (!item->stemSlash()) {
             item->add(Factory::createStemSlash(item));
         }

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -2594,6 +2594,8 @@ bool TRead::readProperties(Chord* ch, XmlReader& e, ReadContext& ctx)
     } else if (TRead::readProperty(ch, tag, e, ctx, Pid::STEM_DIRECTION)) {
     } else if (tag == "noStem") {
         ch->setNoStem(e.readInt());
+    } else if (tag == "showStemSlash") {
+        ch->setShowStemSlash(e.readBool());
     } else if (tag == "Arpeggio") {
         Arpeggio* arpeggio = Factory::createArpeggio(ch);
         arpeggio->setTrack(ch->track());

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -878,6 +878,9 @@ void TWrite::write(const Chord* item, XmlWriter& xml, WriteContext& ctx)
     if (item->hook() && item->hook()->isUserModified()) {
         write(item->hook(), xml, ctx);
     }
+    if (item->showStemSlash() && item->isUserModified()) {
+        xml.tag("showStemSlash", item->showStemSlash());
+    }
     if (item->stemSlash() && item->stemSlash()->isUserModified()) {
         write(item->stemSlash(), xml, ctx);
     }

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -4099,7 +4099,7 @@ void ExportMusicXml::chord(Chord* chord, staff_idx_t staff, const std::vector<Ly
         m_xml.startElementRaw(noteTag);
 
         if (grace) {
-            if (note->noteType() == NoteType::ACCIACCATURA) {
+            if (note->chord()->showStemSlash()) {
                 m_xml.tag("grace", { { "slash", "yes" } });
             } else {
                 m_xml.tag("grace");

--- a/src/inspector/models/notation/notes/chords/chordsettingsmodel.h
+++ b/src/inspector/models/notation/notes/chords/chordsettingsmodel.h
@@ -30,11 +30,27 @@ class ChordSettingsModel : public AbstractInspectorModel
     Q_OBJECT
 
     Q_PROPERTY(PropertyItem * isStemless READ isStemless CONSTANT)
+    Q_PROPERTY(PropertyItem * showStemSlash READ showStemSlash CONSTANT)
+
+    Q_PROPERTY(bool showStemSlashVisible READ showStemSlashVisible NOTIFY showStemSlashVisibleChanged)
+    Q_PROPERTY(bool showStemSlashEnabled READ showStemSlashEnabled NOTIFY showStemSlashEnabledChanged)
 
 public:
     explicit ChordSettingsModel(QObject* parent, IElementRepositoryService* repository);
 
     PropertyItem* isStemless() const;
+    PropertyItem* showStemSlash() const;
+
+    bool showStemSlashVisible() const;  //  chord is grace
+    bool showStemSlashEnabled() const;  //  chord is not stemless
+
+public slots:
+    void setShowStemSlashVisible(bool showStemSlashVisible);
+    void setShowStemSlashEnabled(bool showStemSlashEnabled);
+
+signals:
+    void showStemSlashVisibleChanged(bool showStemSlashVisible);
+    void showStemSlashEnabledChanged(bool showStemSlashEnabled);
 
 private:
     void createProperties() override;
@@ -42,7 +58,14 @@ private:
     void loadProperties() override;
     void resetProperties() override;
 
+    void updateShowStemSlashVisible();
+    void updateShowStemSlashEnabled();
+
     PropertyItem* m_isStemless = nullptr;
+    PropertyItem* m_showStemSlash = nullptr;
+
+    bool m_showStemSlashVisible = false;
+    bool m_showStemSlashEnabled = false;
 };
 }
 

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/notes/StemSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/notes/StemSettings.qml
@@ -60,6 +60,17 @@ FocusableItem {
             navigation.row: root.navigationRowStart + 1
         }
 
+        PropertyCheckBox {
+            text: qsTrc("inspector", "Show stem slash")
+            propertyItem: root.chordModel ? root.chordModel.showStemSlash : null
+            visible: root.chordModel ? root.chordModel.showStemSlashVisible : false
+            enabled: root.chordModel ? root.chordModel.showStemSlashEnabled : false
+
+            navigation.name: "Show stem slash"
+            navigation.panel: root.navigationPanel
+            navigation.row: root.navigationRowStart + 2
+        }
+
         DirectionSection {
             id: stemDirectionGroup
 
@@ -67,7 +78,7 @@ FocusableItem {
             propertyItem: root.stemModel ? root.stemModel.stemDirection : null
 
             navigationPanel: root.navigationPanel
-            navigationRowStart: root.navigationRowStart + 2
+            navigationRowStart: root.navigationRowStart + 3
         }
 
         Column {


### PR DESCRIPTION
This PR introduces a property 'Show stem slash' for all grace notes. The slash is shown by default for acciaccaturas, and is toggleable for all grace notes on a per-beam basis.

![image](https://github.com/musescore/MuseScore/assets/116587995/ba0bbdea-454d-4d65-9a9f-d6859ad6859f)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
