### PR TITLE
Prevent crash when select note, select title, click voice 2

### DIFF
--- a/src/engraving/dom/input.cpp
+++ b/src/engraving/dom/input.cpp
@@ -47,10 +47,16 @@ class DrumSet;
 
 const Drumset* InputState::drumset() const
 {
-    if (m_segment == 0 || m_track == mu::nidx) {
-        return 0;
+    if (!m_segment || m_track == mu::nidx) {
+        return nullptr;
     }
-    return m_segment->score()->staff(m_track / VOICES)->part()->instrument(m_segment->tick())->drumset();
+
+    const Staff* staff = m_segment->score()->staff(m_track / VOICES);
+    if (!staff) {
+        return nullptr;
+    }
+
+    return staff->part()->instrument(m_segment->tick())->drumset();
 }
 
 //---------------------------------------------------------
@@ -59,12 +65,16 @@ const Drumset* InputState::drumset() const
 
 StaffGroup InputState::staffGroup() const
 {
-    if (m_segment == 0 || m_track == mu::nidx) {
+    if (!m_segment || m_track == mu::nidx) {
         return StaffGroup::STANDARD;
     }
 
     Fraction tick = m_segment->tick();
     const Staff* staff = m_segment->score()->staff(m_track / VOICES);
+    if (!staff) {
+        return StaffGroup::STANDARD;
+    }
+
     StaffGroup staffGroup = staff->staffType(tick)->group();
     const Instrument* instrument = staff->part()->instrument(tick);
 
@@ -105,6 +115,15 @@ void InputState::setDots(int n)
         m_duration = DurationType::V_QUARTER;
     }
     m_duration.setDots(n);
+}
+
+void InputState::setVoice(voice_idx_t v)
+{
+    if (v >= VOICES || m_track == mu::nidx) {
+        return;
+    }
+
+    setTrack((m_track / VOICES) * VOICES + v);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/input.h
+++ b/src/engraving/dom/input.h
@@ -81,7 +81,7 @@ public:
     void setDrumNote(int v) { m_drumNote = v; }
 
     voice_idx_t voice() const { return m_track == mu::nidx ? 0 : (m_track % VOICES); }
-    void setVoice(voice_idx_t v) { setTrack((m_track / VOICES) * VOICES + v); }
+    void setVoice(voice_idx_t v);
     track_idx_t track() const { return m_track; }
     void setTrack(track_idx_t v) { m_prevTrack = m_track; m_track = v; }
     track_idx_t prevTrack() const { return m_prevTrack; }

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -648,7 +648,6 @@ public:
     const InputState& inputState() const { return m_is; }
     InputState& inputState() { return m_is; }
     void setInputState(const InputState& st) { m_is = st; }
-    void setInputTrack(int t) { inputState().setTrack(t); }
 
     void spatiumChanged(double oldValue, double newValue);
     void styleChanged() override;


### PR DESCRIPTION
Resolves: #20872

Adds some "just to be safe" checks too; but the core of the fix was to disallow setting the voice (i.e. modifying part of `m_track`) if the `m_track` currently equals `mu::nidx`. 

The result is that simply nothing will happen, which seems expected to me. 