### PR TITLE
Add "disable version checking" option to DevTools (#20899) (Master)

### DIFF
--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1568,7 +1568,7 @@ bool ProjectActionsController::checkCanIgnoreError(const Ret& ret, const io::pat
         return askIfUserAgreesToOpenProjectWithIncompatibleVersion(ret.text());
     case engraving::Err::FileTooNew:
         warnFileTooNew(filepath);
-        return false;
+        return configuration()->disableVersionChecking();
     case engraving::Err::FileCorrupted:
         return askIfUserAgreesToOpenCorruptedProject(io::filename(filepath).toString(), ret.text());
     case engraving::Err::FileCriticallyCorrupted:

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -62,6 +62,7 @@ static const Settings::Key HAS_ASKED_AUDIO_GENERATION_SETTINGS(module_name, "pro
 static const Settings::Key GENERATE_AUDIO_TIME_PERIOD_TYPE_KEY(module_name, "project/generateAudioTimePeriodType");
 static const Settings::Key NUMBER_OF_SAVES_TO_GENERATE_AUDIO_KEY(module_name, "project/numberOfSavesToGenerateAudio");
 static const Settings::Key SHOW_CLOUD_IS_NOT_AVAILABLE_WARNING(module_name, "project/showCloudIsNotAvailableWarning");
+static const Settings::Key DISABLE_VERSION_CHECKING(module_name, "project/disableVersionChecking");
 
 static const std::string DEFAULT_FILE_SUFFIX(".mscz");
 static const std::string DEFAULT_FILE_FILTER("*.mscz");
@@ -114,6 +115,8 @@ void ProjectConfiguration::init()
     settings()->setDefaultValue(GENERATE_AUDIO_TIME_PERIOD_TYPE_KEY, Val(static_cast<int>(GenerateAudioTimePeriodType::Never)));
     settings()->setDefaultValue(NUMBER_OF_SAVES_TO_GENERATE_AUDIO_KEY, Val(10));
     settings()->setDefaultValue(SHOW_CLOUD_IS_NOT_AVAILABLE_WARNING, Val(true));
+
+    settings()->setDefaultValue(DISABLE_VERSION_CHECKING, Val(false));
 
     if (!userTemplatesPath().empty()) {
         fileSystem()->makePath(userTemplatesPath());
@@ -664,4 +667,14 @@ bool ProjectConfiguration::showCloudIsNotAvailableWarning() const
 void ProjectConfiguration::setShowCloudIsNotAvailableWarning(bool show)
 {
     settings()->setSharedValue(SHOW_CLOUD_IS_NOT_AVAILABLE_WARNING, Val(show));
+}
+
+bool ProjectConfiguration::disableVersionChecking() const
+{
+    return settings()->value(DISABLE_VERSION_CHECKING).toBool();
+}
+
+void ProjectConfiguration::setDisableVersionChecking(bool disable)
+{
+    settings()->setSharedValue(DISABLE_VERSION_CHECKING, Val(disable));
 }

--- a/src/project/internal/projectconfiguration.h
+++ b/src/project/internal/projectconfiguration.h
@@ -152,6 +152,9 @@ public:
     bool showCloudIsNotAvailableWarning() const override;
     void setShowCloudIsNotAvailableWarning(bool show) override;
 
+    bool disableVersionChecking() const override;
+    void setDisableVersionChecking(bool disable) override;
+
 private:
     io::path_t appTemplatesPath() const;
     io::path_t legacyCloudProjectsPath() const;

--- a/src/project/iprojectconfiguration.h
+++ b/src/project/iprojectconfiguration.h
@@ -157,6 +157,9 @@ public:
 
     virtual bool showCloudIsNotAvailableWarning() const = 0;
     virtual void setShowCloudIsNotAvailableWarning(bool show) = 0;
+
+    virtual bool disableVersionChecking() const = 0;
+    virtual void setDisableVersionChecking(bool disable) = 0;
 };
 }
 

--- a/src/project/tests/mocks/projectconfigurationmock.h
+++ b/src/project/tests/mocks/projectconfigurationmock.h
@@ -134,6 +134,9 @@ public:
 
     MOCK_METHOD(bool, showCloudIsNotAvailableWarning, (), (const, override));
     MOCK_METHOD(void, setShowCloudIsNotAvailableWarning, (bool), (override));
+
+    MOCK_METHOD(bool, disableVersionChecking, (), (const, override));
+    MOCK_METHOD(void, setDisableVersionChecking, (bool), (override));
 };
 }
 

--- a/src/stubs/project/projectconfigurationstub.cpp
+++ b/src/stubs/project/projectconfigurationstub.cpp
@@ -323,3 +323,12 @@ bool ProjectConfigurationStub::showCloudIsNotAvailableWarning() const
 void ProjectConfigurationStub::setShowCloudIsNotAvailableWarning(bool)
 {
 }
+
+bool ProjectConfigurationStub::disableVersionChecking() const
+{
+    return false;
+}
+
+void ProjectConfigurationStub::setDisableVersionChecking(bool)
+{
+}

--- a/src/stubs/project/projectconfigurationstub.h
+++ b/src/stubs/project/projectconfigurationstub.h
@@ -125,6 +125,9 @@ public:
 
     bool showCloudIsNotAvailableWarning() const override;
     void setShowCloudIsNotAvailableWarning(bool show) override;
+
+    bool disableVersionChecking() const override;
+    void setDisableVersionChecking(bool disable) override;
 };
 }
 


### PR DESCRIPTION
Resolves: #20899

Option allows files created in newer versions of MuseScore to be opened in older version (warning will still display).