### PR TITLE
Plugin API: fix QProcess.start() for commands with multiple arguments

### DIFF
--- a/src/plugins/api/util.cpp
+++ b/src/plugins/api/util.cpp
@@ -138,6 +138,20 @@ int FileIO::modifiedTime()
     return fileInfo.lastModified().toSecsSinceEpoch();
 }
 
+void MsProcess::start(const QString& command)
+{
+    QT_WARNING_PUSH;
+    QT_WARNING_DISABLE_DEPRECATED;
+    DEPRECATED_USE("startWithArgs(program, [arg1, arg2, ...])");
+    QProcess::start(command);
+    QT_WARNING_POP;
+}
+
+void MsProcess::startWithArgs(const QString& program, const QStringList& args)
+{
+    QProcess::start(program, args, ReadWrite);
+}
+
 //---------------------------------------------------------
 //   setScore
 //---------------------------------------------------------

--- a/src/plugins/api/util.h
+++ b/src/plugins/api/util.h
@@ -136,8 +136,19 @@ public:
         : QProcess(parent) {}
 
 public slots:
-    //@ --
-    Q_INVOKABLE void start(const QString& program) { QProcess::start(program, {}, ReadWrite); }
+    /**
+     * Execute an external command.
+     * \param command A command line to execute.
+     * \warning This function is deprecated. Use \ref startWithArgs instead.
+     */
+    Q_INVOKABLE void start(const QString& command);
+    /**
+     * Execute an external command.
+     * \param program A program to execute.
+     * \param args An array of arguments passed to the program.
+     * \since MuseScore 4.3
+     */
+    Q_INVOKABLE void startWithArgs(const QString& program, const QStringList& args);
     //@ --
     Q_INVOKABLE bool waitForFinished(int msecs = 30000) { return QProcess::waitForFinished(msecs); }
     //@ --


### PR DESCRIPTION
Resolves: #20920

This pull request fixes `QProcess.start()` for commands with multiple arguments by providing two functions in the `QProcess` object exposed to the plugin's API (see the description of #20920 for the discussion of these two flavors of `QProcess::start()`):
1. `start(command)`: implements the old behavior using the deprecated `QProcess:start()` overload;
2. `startWithArgs(program, args)`: exposes the new overload of `QProcess::start()` available in the Qt's `QProcess` object.

Although this PR provides both old and new behavior of `QProcess::start()`, any option of the described in #20920 would be acceptable, and either the old or the new implementation can be removed from this PR if needed.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)