### PR TITLE
Get grace note fret & string from main note

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -823,6 +823,8 @@ Note* Score::setGraceNote(Chord* ch, int pitch, NoteType type, int len)
         if (n->pitch() == pitch) {
             note->setTpc1(n->tpc1());
             note->setTpc2(n->tpc2());
+            note->setString(n->string());
+            note->setFret(n->fret());
             break;
         }
     }

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -2819,8 +2819,7 @@ bool Note::setProperty(Pid propertyId, const PropertyValue& v)
         break;
     case Pid::DOT_POSITION:
         setUserDotPosition(v.value<DirectionV>());
-        triggerLayout();
-        return true;
+        break;
     case Pid::HEAD_SCHEME:
         setHeadScheme(v.value<NoteHeadScheme>());
         break;


### PR DESCRIPTION
Resolves: #20770

Like for tpc, the string and fret of a grace note matches the parent chord when possible. Adding grace notes on a tab staff will now draw the grace notes on the string of the main note, instead of always the top string.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
