### PR TITLE
fixed #20578: ARM appimages removed after release

### DIFF
--- a/build/ci/release/correct_release_info.py
+++ b/build/ci/release/correct_release_info.py
@@ -48,6 +48,28 @@ release_body_html = release_body_html.replace("\n</ul>\n", "</ul>")
 release_info_json["body"] = "'" + release_body_html + "'"
 release_info_json["bodyMarkdown"] = release_body_markdown
 
+print("=== Split release assets ===")
+
+# For backward compatibility, we must adhere to the rule:
+#   for each platform, there should be one file with the corresponding extension.
+# Let's place the new files into a new field with separate handling in MuseScore.
+
+release_assets = release_info_json["assets"]
+release_new_assets = []
+
+i = 0
+while i < len(release_assets):
+    asset = release_assets[i]
+    name = asset.get("name")
+    if ".AppImage" in name and ("aarch64" in name or "armv7l" in name):
+        release_new_assets.append(asset)
+        del release_assets[i]
+    else:
+        i += 1
+
+release_info_json["assets"] = release_assets
+release_info_json["assetsNew"] = release_new_assets
+
 release_info_json_updated = json.dumps(release_info_json)
 
 print("=== Write json ===")

--- a/src/framework/global/CMakeLists.txt
+++ b/src/framework/global/CMakeLists.txt
@@ -65,6 +65,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/allocator.h
     ${CMAKE_CURRENT_LIST_DIR}/dlib.h
     ${CMAKE_CURRENT_LIST_DIR}/iprocess.h
+    ${CMAKE_CURRENT_LIST_DIR}/isysteminfo.h
 
     ${CMAKE_CURRENT_LIST_DIR}/types/bytearray.cpp
     ${CMAKE_CURRENT_LIST_DIR}/types/bytearray.h
@@ -151,6 +152,8 @@ else()
         ${CMAKE_CURRENT_LIST_DIR}/internal/invoker.h
         ${CMAKE_CURRENT_LIST_DIR}/internal/process.cpp
         ${CMAKE_CURRENT_LIST_DIR}/internal/process.h
+        ${CMAKE_CURRENT_LIST_DIR}/internal/systeminfo.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/internal/systeminfo.h
 
         ${CMAKE_CURRENT_LIST_DIR}/io/internal/filesystem.cpp
         ${CMAKE_CURRENT_LIST_DIR}/io/internal/filesystem.h

--- a/src/framework/global/globalmodule.cpp
+++ b/src/framework/global/globalmodule.cpp
@@ -63,14 +63,15 @@ void GlobalModule::registerExports()
 {
     m_configuration = std::make_shared<GlobalConfiguration>();
     s_asyncInvoker = std::make_shared<Invoker>();
+    m_systemInfo = std::make_shared<SystemInfo>();
 
     ioc()->registerExport<IApplication>(moduleName(), new Application());
     ioc()->registerExport<IGlobalConfiguration>(moduleName(), m_configuration);
+    ioc()->registerExport<ISystemInfo>(moduleName(), m_systemInfo);
     ioc()->registerExport<IInteractive>(moduleName(), new Interactive());
     ioc()->registerExport<IFileSystem>(moduleName(), new FileSystem());
     ioc()->registerExport<ICryptographicHash>(moduleName(), new CryptographicHash());
     ioc()->registerExport<IProcess>(moduleName(), new Process());
-    ioc()->registerExport<ISystemInfo>(moduleName(), new SystemInfo());
 }
 
 void GlobalModule::onPreInit(const IApplication::RunMode& mode)
@@ -179,6 +180,7 @@ void GlobalModule::onPreInit(const IApplication::RunMode& mode)
 void GlobalModule::onInit(const IApplication::RunMode&)
 {
     m_configuration->init();
+    m_systemInfo->init();
 }
 
 void GlobalModule::onDeinit()

--- a/src/framework/global/globalmodule.cpp
+++ b/src/framework/global/globalmodule.cpp
@@ -35,6 +35,7 @@
 #include "internal/invoker.h"
 #include "internal/cryptographichash.h"
 #include "internal/process.h"
+#include "internal/systeminfo.h"
 
 #include "runtime.h"
 #include "async/processevents.h"
@@ -69,6 +70,7 @@ void GlobalModule::registerExports()
     ioc()->registerExport<IFileSystem>(moduleName(), new FileSystem());
     ioc()->registerExport<ICryptographicHash>(moduleName(), new CryptographicHash());
     ioc()->registerExport<IProcess>(moduleName(), new Process());
+    ioc()->registerExport<ISystemInfo>(moduleName(), new SystemInfo());
 }
 
 void GlobalModule::onPreInit(const IApplication::RunMode& mode)

--- a/src/framework/global/globalmodule.h
+++ b/src/framework/global/globalmodule.h
@@ -31,6 +31,10 @@
 #include "modularity/ioc.h"
 #include "io/ifilesystem.h"
 
+namespace mu {
+class SystemInfo;
+}
+
 namespace mu::framework {
 class Invoker;
 class GlobalConfiguration;
@@ -51,6 +55,7 @@ public:
 
 private:
     std::shared_ptr<GlobalConfiguration> m_configuration;
+    std::shared_ptr<SystemInfo> m_systemInfo;
 
     std::optional<mu::logger::Level> m_loggerLevel;
 

--- a/src/framework/global/internal/systeminfo.cpp
+++ b/src/framework/global/internal/systeminfo.cpp
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "systeminfo.h"
+
+#include <QSysInfo>
+
+using namespace mu;
+
+static const std::string CPU_ARCHITECTURE_KEY = "cpuArchitecture";
+static const std::string PRODUCT_TYPE_KEY = "productType";
+
+void SystemInfo::init()
+{
+    CpuArchitecture cpuArchitecture = CpuArchitecture::Unknown;
+    QString arch = QSysInfo::buildCpuArchitecture();
+
+    if (arch == "x86_64") {
+        cpuArchitecture = CpuArchitecture::x86_64;
+    } else if (arch == "arm") {
+        cpuArchitecture = CpuArchitecture::Arm;
+    } else if (arch == "arm64") {
+        cpuArchitecture = CpuArchitecture::Arm64;
+    }
+
+    m_params[CPU_ARCHITECTURE_KEY] = Val(int(cpuArchitecture));
+
+    ProductType productType = ProductType::Unknown;
+#if defined(Q_OS_WIN)
+    productType = ProductType::Windows;
+#elif defined(Q_OS_MACOS)
+    productType = ProductType::MacOS;
+#elif defined(Q_OS_LINUX)
+    productType = ProductType::Linux;
+#endif
+
+    m_params[PRODUCT_TYPE_KEY] = Val(int(productType));
+}
+
+SystemInfo::CpuArchitecture SystemInfo::cpuArchitecture() const
+{
+    return static_cast<CpuArchitecture>(m_params.at(CPU_ARCHITECTURE_KEY).toInt());
+}
+
+SystemInfo::ProductType SystemInfo::productType() const
+{
+    return static_cast<ProductType>(m_params.at(PRODUCT_TYPE_KEY).toInt());
+}

--- a/src/framework/global/internal/systeminfo.h
+++ b/src/framework/global/internal/systeminfo.h
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_SYSTEMINFO_H
+#define MU_SYSTEMINFO_H
+
+#include <map>
+
+#include "types/val.h"
+
+#include "../isysteminfo.h"
+
+namespace mu {
+class SystemInfo : public ISystemInfo
+{
+public:
+    void init();
+
+    CpuArchitecture cpuArchitecture() const override;
+    ProductType productType() const override;
+
+private:
+    std::unordered_map<std::string, Val> m_params;
+};
+}
+
+#endif // MU_SYSTEMINFO_H

--- a/src/framework/global/isysteminfo.h
+++ b/src/framework/global/isysteminfo.h
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_ISYSTEMINFO_H
+#define MU_ISYSTEMINFO_H
+
+#include "modularity/imoduleinterface.h"
+
+namespace mu {
+class ISystemInfo : MODULE_EXPORT_INTERFACE
+{
+    INTERFACE_ID(ISystemInfo)
+public:
+    virtual ~ISystemInfo() = default;
+
+    enum class CpuArchitecture {
+        Unknown,
+        Arm,
+        Arm64,
+        x86_64
+    };
+
+    enum class ProductType {
+        Unknown,
+        Windows,
+        MacOS,
+        Linux
+    };
+
+    virtual CpuArchitecture cpuArchitecture() const = 0;
+    virtual ProductType productType() const = 0;
+};
+}
+
+#endif // MU_ISYSTEMINFO_H

--- a/src/framework/global/tests/CMakeLists.txt
+++ b/src/framework/global/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/mocks/processmock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/globalconfigurationmock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/interactivemock.h
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/systeminfomock.h
 
     ${CMAKE_CURRENT_LIST_DIR}/uri_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/val_tests.cpp

--- a/src/framework/global/tests/mocks/systeminfomock.h
+++ b/src/framework/global/tests/mocks/systeminfomock.h
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef SYSTEMINFOMOCK_H
+#define SYSTEMINFOMOCK_H
+
+#include <gmock/gmock.h>
+
+#include "global/isysteminfo.h"
+
+namespace mu {
+class SystemInfoMock : public ISystemInfo
+{
+public:
+    MOCK_METHOD(CpuArchitecture, cpuArchitecture, (), (const, override));
+    MOCK_METHOD(ProductType, productType, (), (const, override));
+};
+}
+
+#endif // SYSTEMINFOMOCK_H

--- a/src/framework/network/CMakeLists.txt
+++ b/src/framework/network/CMakeLists.txt
@@ -33,4 +33,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/networkmanagercreator.h
     )
 
+if (MUE_BUILD_UNIT_TESTS)
+    add_subdirectory(tests)
+endif()
+
 include(${PROJECT_SOURCE_DIR}/build/module.cmake)

--- a/src/framework/network/networktypes.h
+++ b/src/framework/network/networktypes.h
@@ -26,6 +26,7 @@
 #include <QNetworkRequest>
 
 class QHttpMultiPart;
+class QIODevice;
 
 namespace mu::network {
 struct RequestHeaders

--- a/src/framework/network/tests/CMakeLists.txt
+++ b/src/framework/network/tests/CMakeLists.txt
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-CLA-applies
+#
+# MuseScore
+# Music Composition & Notation
+#
+# Copyright (C) 2024 MuseScore BVBA and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+set(MODULE_TEST network_test)
+
+set(MODULE_TEST_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/networkmanagercreatormock.h
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/networkmanagermock.h
+)
+
+set(MODULE_TEST_LINK
+    network
+)
+
+set(MODULE_TEST_DATA_ROOT ${CMAKE_CURRENT_LIST_DIR})
+
+include(${PROJECT_SOURCE_DIR}/src/framework/testing/gtest.cmake)
+

--- a/src/framework/network/tests/mocks/networkmanagercreatormock.h
+++ b/src/framework/network/tests/mocks/networkmanagercreatormock.h
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_NETWORK_NETWORKMANAGERCREATORMOCK_H
+#define MU_NETWORK_NETWORKMANAGERCREATORMOCK_H
+
+#include <gmock/gmock.h>
+
+#include "network/inetworkmanagercreator.h"
+
+namespace mu::network {
+class NetworkManagerCreatorMock : public INetworkManagerCreator
+{
+public:
+    MOCK_METHOD(INetworkManagerPtr, makeNetworkManager, (), (const, override));
+};
+}
+
+#endif // MU_NETWORK_NETWORKMANAGERCREATORMOCK_H

--- a/src/framework/network/tests/mocks/networkmanagermock.h
+++ b/src/framework/network/tests/mocks/networkmanagermock.h
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_NETWORK_NETWORKMANAGERMOCK_H
+#define MU_NETWORK_NETWORKMANAGERMOCK_H
+
+#include <gmock/gmock.h>
+
+#include "network/inetworkmanager.h"
+
+namespace mu::network {
+class NetworkManagerMock : public INetworkManager
+{
+public:
+    MOCK_METHOD(Ret, get, (const QUrl&, IncomingDevice*, const RequestHeaders&), (override));
+    MOCK_METHOD(Ret, head, (const QUrl&, const RequestHeaders&), (override));
+    MOCK_METHOD(Ret, post, (const QUrl&, OutgoingDevice*, IncomingDevice*, const RequestHeaders&), (override));
+    MOCK_METHOD(Ret, put, (const QUrl&, OutgoingDevice*, IncomingDevice*, const RequestHeaders&), (override));
+    MOCK_METHOD(Ret, patch, (const QUrl&, OutgoingDevice*, IncomingDevice*, const RequestHeaders&), (override));
+    MOCK_METHOD(Ret, del, (const QUrl&, IncomingDevice*, const RequestHeaders&), (override));
+
+    MOCK_METHOD(framework::Progress, progress, (), (const, override));
+
+    MOCK_METHOD(void, abort, (), (override));
+};
+}
+
+#endif // MU_NETWORK_NETWORKMANAGERMOCK_H

--- a/src/update/CMakeLists.txt
+++ b/src/update/CMakeLists.txt
@@ -47,5 +47,9 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/updatemodel.h
     )
 
+if (MUE_BUILD_UNIT_TESTS)
+    add_subdirectory(tests)
+endif()
+
 include(${PROJECT_SOURCE_DIR}/build/module.cmake)
 

--- a/src/update/internal/updateservice.h
+++ b/src/update/internal/updateservice.h
@@ -28,8 +28,9 @@
 #include "iinteractive.h"
 #include "network/inetworkmanagercreator.h"
 #include "io/ifilesystem.h"
-#include "../iupdateconfiguration.h"
+#include "global/isysteminfo.h"
 
+#include "../iupdateconfiguration.h"
 #include "../iupdateservice.h"
 
 namespace mu::update {
@@ -39,6 +40,7 @@ class UpdateService : public IUpdateService, public async::Asyncable
     INJECT(network::INetworkManagerCreator, networkManagerCreator)
     INJECT(IUpdateConfiguration, configuration)
     INJECT(io::IFileSystem, fileSystem)
+    INJECT(ISystemInfo, systemInfo)
 
 public:
     RetVal<ReleaseInfo> checkForUpdate() override;
@@ -48,7 +50,11 @@ public:
     framework::Progress updateProgress() override;
 
 private:
+    std::string platformFileSuffix() const;
+    ISystemInfo::CpuArchitecture assetArch(const QString& asset) const;
+
     RetVal<ReleaseInfo> parseRelease(const QByteArray& json) const;
+    QJsonObject resolveReleaseAsset(const QJsonObject& release) const;
 
     void clear();
 

--- a/src/update/tests/CMakeLists.txt
+++ b/src/update/tests/CMakeLists.txt
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-CLA-applies
+#
+# MuseScore
+# Music Composition & Notation
+#
+# Copyright (C) 2024 MuseScore BVBA and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+set(MODULE_TEST update_test)
+
+set(MODULE_TEST_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/updateconfigurationmock.h
+    ${CMAKE_CURRENT_LIST_DIR}/updateservice_tests.cpp
+)
+
+set(MODULE_TEST_LINK
+    update
+)
+
+set(MODULE_TEST_DATA_ROOT ${CMAKE_CURRENT_LIST_DIR})
+
+include(${PROJECT_SOURCE_DIR}/src/framework/testing/gtest.cmake)
+

--- a/src/update/tests/mocks/updateconfigurationmock.h
+++ b/src/update/tests/mocks/updateconfigurationmock.h
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_UPDATE_UPDATECONFIGURATIONMOCK_H
+#define MU_UPDATE_UPDATECONFIGURATIONMOCK_H
+
+#include <gmock/gmock.h>
+
+#include "update/iupdateconfiguration.h"
+
+namespace mu::update {
+class UpdateConfigurationMock : public IUpdateConfiguration
+{
+public:
+    MOCK_METHOD(bool, isAppUpdatable, (), (const, override));
+
+    MOCK_METHOD(bool, allowUpdateOnPreRelease, (), (const, override));
+    MOCK_METHOD(void, setAllowUpdateOnPreRelease, (bool), (override));
+
+    MOCK_METHOD(bool, needCheckForUpdate, (), (const, override));
+    MOCK_METHOD(void, setNeedCheckForUpdate, (bool), (override));
+
+    MOCK_METHOD(std::string, skippedReleaseVersion, (), (const, override));
+    MOCK_METHOD(void, setSkippedReleaseVersion, (const std::string&), (const, override));
+
+    MOCK_METHOD(std::string, checkForUpdateUrl, (), (const, override));
+    MOCK_METHOD(network::RequestHeaders, checkForUpdateHeaders, (), (const, override));
+
+    MOCK_METHOD(std::string, museScoreUrl, (), (const, override));
+    MOCK_METHOD(std::string, museScorePrivacyPolicyUrl, (), (const, override));
+
+    MOCK_METHOD(io::path_t, updateDataPath, (), (const, override));
+};
+}
+
+#endif // MU_UPDATE_UPDATECONFIGURATIONMOCK_H

--- a/src/update/tests/updateservice_tests.cpp
+++ b/src/update/tests/updateservice_tests.cpp
@@ -1,0 +1,219 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+using ::testing::_;
+using ::testing::Return;
+
+#include "framework/network/networktypes.h"
+
+#include "mocks/updateconfigurationmock.h"
+#include "network/tests/mocks/networkmanagercreatormock.h"
+#include "network/tests/mocks/networkmanagermock.h"
+#include "global/tests/mocks/systeminfomock.h"
+
+#include "update/internal/updateservice.h"
+
+using namespace mu;
+using namespace mu::update;
+
+class UpdateServiceTests : public ::testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_service = new UpdateService();
+
+        m_configuration = std::make_shared<UpdateConfigurationMock>();
+        m_service->setconfiguration(m_configuration);
+
+        m_networkManagerCreator = std::make_shared<network::NetworkManagerCreatorMock>();
+        m_service->setnetworkManagerCreator(m_networkManagerCreator);
+
+        m_networkManager = std::make_shared<network::NetworkManagerMock>();
+        ON_CALL(*m_networkManagerCreator, makeNetworkManager())
+        .WillByDefault(Return(m_networkManager));
+
+        m_systemInfoMock = std::make_shared<SystemInfoMock>();
+        m_service->setsystemInfo(m_systemInfoMock);
+    }
+
+    void TearDown() override
+    {
+        delete m_service;
+    }
+
+    void makeReleaseInfo() const
+    {
+        QString releaseInfo = "{"
+                              "\"tag_name\": \"v5.0\","
+                              "\"assets\": ["
+                              "{ \"name\": \"MuseScore.dmg\", \"browser_download_url\": \"blabla\" },"
+                              "{ \"name\": \"MuseScore.msi\", \"browser_download_url\": \"blabla\" },"
+                              "{ \"name\": \"MuseScore.AppImage\", \"browser_download_url\": \"blabla\" }"
+                              "],"
+                              "\"assetsNew\": ["
+                              "{ \"name\": \"MuseScore-arm.AppImage\", \"browser_download_url\": \"blabla\" },"
+                              "{ \"name\": \"MuseScore-aarch64.AppImage\", \"browser_download_url\": \"blabla\" }"
+                              "]"
+                              "}";
+
+        EXPECT_CALL(*m_networkManager, get(_, _, _))
+        .WillOnce(testing::Invoke(
+                      [releaseInfo](const QUrl&, network::IncomingDevice* buf, const network::RequestHeaders&) {
+            buf->open(network::IncomingDevice::WriteOnly);
+            buf->write(releaseInfo.toUtf8());
+            buf->close();
+
+            return make_ok();
+        }));
+    }
+
+    UpdateService* m_service = nullptr;
+    std::shared_ptr<UpdateConfigurationMock> m_configuration;
+
+    std::shared_ptr<network::NetworkManagerCreatorMock> m_networkManagerCreator;
+    std::shared_ptr<network::NetworkManagerMock> m_networkManager;
+    std::shared_ptr<SystemInfoMock> m_systemInfoMock;
+};
+
+TEST_F(UpdateServiceTests, ParseRelease_Linux_x86_64)
+{
+    //! [GIVEN] Release info
+    makeReleaseInfo();
+
+    //! [GIVEN] System is Linux x86_64
+    ON_CALL(*m_systemInfoMock, productType())
+    .WillByDefault(Return(ISystemInfo::ProductType::Linux));
+
+    ON_CALL(*m_systemInfoMock, cpuArchitecture())
+    .WillByDefault(Return(ISystemInfo::CpuArchitecture::x86_64));
+
+    //! [WHEN] Check for update
+    mu::RetVal<ReleaseInfo> retVal = m_service->checkForUpdate();
+
+    //! [THEN] Should return correct release file
+    EXPECT_TRUE(retVal.ret);
+    EXPECT_EQ(retVal.val.fileName, "MuseScore.AppImage");
+}
+
+TEST_F(UpdateServiceTests, ParseRelease_Linux_arm)
+{
+    //! [GIVEN] Release info
+    makeReleaseInfo();
+
+    //! [GIVEN] System is Linux arm
+    ON_CALL(*m_systemInfoMock, productType())
+    .WillByDefault(Return(ISystemInfo::ProductType::Linux));
+
+    ON_CALL(*m_systemInfoMock, cpuArchitecture())
+    .WillByDefault(Return(ISystemInfo::CpuArchitecture::Arm));
+
+    //! [WHEN] Check for update
+    mu::RetVal<ReleaseInfo> retVal = m_service->checkForUpdate();
+
+    //! [THEN] Should return correct release file
+    EXPECT_TRUE(retVal.ret);
+    EXPECT_EQ(retVal.val.fileName, "MuseScore-arm.AppImage");
+}
+
+TEST_F(UpdateServiceTests, ParseRelease_Linux_aarch64)
+{
+    //! [GIVEN] Release info
+    makeReleaseInfo();
+
+    //! [GIVEN] System is Linux arm64
+    ON_CALL(*m_systemInfoMock, productType())
+    .WillByDefault(Return(ISystemInfo::ProductType::Linux));
+
+    ON_CALL(*m_systemInfoMock, cpuArchitecture())
+    .WillByDefault(Return(ISystemInfo::CpuArchitecture::Arm64));
+
+    //! [WHEN] Check for update
+    mu::RetVal<ReleaseInfo> retVal = m_service->checkForUpdate();
+
+    //! [THEN] Should return correct release file
+    EXPECT_TRUE(retVal.ret);
+    EXPECT_EQ(retVal.val.fileName, "MuseScore-aarch64.AppImage");
+}
+
+TEST_F(UpdateServiceTests, ParseRelease_Linux_Unknown)
+{
+    //! [GIVEN] Release info
+    makeReleaseInfo();
+
+    //! [GIVEN] System is Linux Unknown
+    ON_CALL(*m_systemInfoMock, productType())
+    .WillByDefault(Return(ISystemInfo::ProductType::Linux));
+
+    ON_CALL(*m_systemInfoMock, cpuArchitecture())
+    .WillByDefault(Return(ISystemInfo::CpuArchitecture::Unknown));
+
+    //! [WHEN] Check for update
+    mu::RetVal<ReleaseInfo> retVal = m_service->checkForUpdate();
+
+    //! [THEN] Should return correct release file
+    EXPECT_TRUE(retVal.ret);
+    EXPECT_EQ(retVal.val.fileName, "MuseScore.AppImage");
+}
+
+TEST_F(UpdateServiceTests, ParseRelease_Windows)
+{
+    //! [GIVEN] Release info
+    makeReleaseInfo();
+
+    //! [GIVEN] System is Windows, cpuArchitecture isn't important
+    ON_CALL(*m_systemInfoMock, productType())
+    .WillByDefault(Return(ISystemInfo::ProductType::Windows));
+
+    EXPECT_CALL(*m_systemInfoMock, cpuArchitecture())
+    .Times(1);
+
+    //! [WHEN] Check for update
+    mu::RetVal<ReleaseInfo> retVal = m_service->checkForUpdate();
+
+    //! [THEN] Should return correct release file
+    EXPECT_TRUE(retVal.ret);
+    EXPECT_EQ(retVal.val.fileName, "MuseScore.msi");
+}
+
+TEST_F(UpdateServiceTests, ParseRelease_MacOS)
+{
+    //! [GIVEN] Release info
+    makeReleaseInfo();
+
+    //! [GIVEN] System is MacOS, cpuArchitecture isn't important
+    ON_CALL(*m_systemInfoMock, productType())
+    .WillByDefault(Return(ISystemInfo::ProductType::MacOS));
+
+    EXPECT_CALL(*m_systemInfoMock, cpuArchitecture())
+    .Times(1);
+
+    //! [WHEN] Check for update
+    mu::RetVal<ReleaseInfo> retVal = m_service->checkForUpdate();
+
+    //! [THEN] Should return correct release file
+    EXPECT_TRUE(retVal.ret);
+    EXPECT_EQ(retVal.val.fileName, "MuseScore.dmg");
+}


### PR DESCRIPTION
Resolves: #20578

The idea is to add a new field to the resulting JSON and handle this new field in the newer versions of MuseScore. The older versions will only work with the old field and process the list with a single MuseScore version per platform.

I've created a release with arm and aarch builds(from the latest release) for testing. To access it, you'll need to enable 'allowUpdateOnPreRelease' in the settings in DevTools -> Settings.