### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/rendering/dev/layoutcontext.h
+++ b/src/engraving/rendering/dev/layoutcontext.h
@@ -48,7 +48,7 @@
 #define LAYOUT_CALL_CLEAR()
 #define LAYOUT_CALL_BEGIN(name, info)
 #define LAYOUT_CALL_END()
-#define LAYOUT_CALL(info) if (0) mu::logger::Stream()
+#define LAYOUT_CALL() if (0) mu::logger::Stream()
 #define LAYOUT_ITEM_INFO(item) ""
 #define LAYOUT_CALL_PRINT()
 #endif


### PR DESCRIPTION
reg.: not enough arguments for function-like macro invocation 'LAYOUT_CALL' (C4003)