### PR TITLE
[4.2.1] Fix a translatable string not being detected by lupdate

### DIFF
--- a/share/locale/musescore_en.ts
+++ b/share/locale/musescore_en.ts
@@ -11555,7 +11555,7 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Annotations:</translation>
     </message>
     <message>
-        <location filename="../../src/engraving/dom/barline.cpp" line="1165"/>
+        <location filename="../../src/engraving/dom/barline.cpp" line="1164"/>
         <location filename="../../src/engraving/dom/chordrest.cpp" line="1078"/>
         <location filename="../../src/engraving/dom/chordrest.cpp" line="1089"/>
         <location filename="../../src/engraving/dom/note.cpp" line="3108"/>
@@ -11565,7 +11565,7 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Start of %1</translation>
     </message>
     <message>
-        <location filename="../../src/engraving/dom/barline.cpp" line="1168"/>
+        <location filename="../../src/engraving/dom/barline.cpp" line="1167"/>
         <location filename="../../src/engraving/dom/chordrest.cpp" line="1081"/>
         <location filename="../../src/engraving/dom/chordrest.cpp" line="1091"/>
         <location filename="../../src/engraving/dom/note.cpp" line="3112"/>
@@ -22148,6 +22148,14 @@ In addition, Mastering MuseScore features a supportive community of musicians, w
         <source>Custom</source>
         <translation type="unfinished">Custom</translation>
     </message>
+    <message numerus="yes">
+        <location filename="../../src/notation/view/internal/stringtuningssettingsmodel.cpp" line="276"/>
+        <source>%n string(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n string(s)</numerusform>
+            <numerusform>%n string(s)</numerusform>
+        </translation>
+    </message>
     <message>
         <location filename="../../src/notation/qml/MuseScore/NotationScene/internal/EditStyle/TiePlacementSelector.qml" line="41"/>
         <source>Placement on single notes:</source>
@@ -26081,7 +26089,7 @@ failed.</translation>
         <translation type="unfinished">Open</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectconfiguration.cpp" line="330"/>
+        <location filename="../../src/project/internal/projectconfiguration.cpp" line="333"/>
         <source>Untitled</source>
         <translation type="unfinished">Untitled</translation>
     </message>

--- a/src/notation/view/internal/stringtuningssettingsmodel.cpp
+++ b/src/notation/view/internal/stringtuningssettingsmodel.cpp
@@ -269,9 +269,12 @@ QVariantList StringTuningsSettingsModel::numbersOfStrings() const
     }
 
     for (const StringTuningsInfo& stringTuning : stringTunings.at(m_itemId)) {
+        // `lupdate` does not detect the translatable string when the static_cast is in the same line as `qtrc`
+        int number = static_cast<int>(stringTuning.number);
+
         QVariantMap stringNumberMap;
-        stringNumberMap.insert("text", qtrc("notation", "%n string(s)", nullptr, static_cast<int>(stringTuning.number)));
-        stringNumberMap.insert("value", static_cast<int>(stringTuning.number));
+        stringNumberMap.insert("text", qtrc("notation", "%n string(s)", nullptr, number));
+        stringNumberMap.insert("value", number);
         numbersList << stringNumberMap;
     }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/20673 (the part about "%n string(s)"; not the part about the preset names)
Ports: #20684