### PR TITLE
Fix #20620: remove "ghost" spanners

### DIFF
--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -161,6 +161,11 @@ static void clearMeasures(mu::engraving::MasterScore* masterScore)
             measure->deleteLater();
         }
 
+        auto spanners = score->spanner();
+        for (auto spanner = spanners.begin(); spanner != spanners.end(); spanner = ++spanner) {
+            score->removeSpanner(spanner->second);
+        }
+
         measures->clear();
     }
 


### PR DESCRIPTION
Resolves: #20620 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
All spanners (slurs in the reported case) are now deleted when measures are cleared. Previously, they would stay under the score, holding reference to deleted objects and causing a delayed crash.

PR copied for master branch as requested by @RomanPudashkin 
<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
