### PR TITLE
Fix #9975: Place rosette stars appropriately

### DIFF
--- a/src/engraving/dom/pedal.cpp
+++ b/src/engraving/dom/pedal.cpp
@@ -201,8 +201,8 @@ PointF Pedal::linePos(Grip grip, System** sys) const
     } else {
         EngravingItem* e = endElement();
         ChordRest* c = toChordRest(endElement());
-        if (!e || e == startElement() || (endHookType() == HookType::HOOK_90)) {
-            // pedal marking on single note or ends with non-angled hook:
+        if (!e || e == startElement() || (endHookType() == HookType::HOOK_90) || !lineVisible()) {
+            // pedal marking on single note or ends with non-angled hook or line not visible (rosette star):
             // extend to next note or end of measure
             Segment* seg = nullptr;
             if (!e) {

--- a/src/engraving/dom/pedal.cpp
+++ b/src/engraving/dom/pedal.cpp
@@ -201,7 +201,7 @@ PointF Pedal::linePos(Grip grip, System** sys) const
     } else {
         EngravingItem* e = endElement();
         ChordRest* c = toChordRest(endElement());
-        if (!e || e == startElement() || (endHookType() == HookType::HOOK_90) || !lineVisible()) {
+        if (!e || e == startElement() || (endHookType() != HookType::HOOK_45)) {
             // pedal marking on single note or ends with non-angled hook or line not visible (rosette star):
             // extend to next note or end of measure
             Segment* seg = nullptr;

--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -5922,6 +5922,10 @@ void TLayout::layoutTextLineBaseSegment(TextLineBaseSegment* item, LayoutContext
     // set end text position and extend bbox
     if (!item->endText()->empty()) {
         item->endText()->mutldata()->moveX(ldata->bbox().right());
+        //center end text for pedals (rosette star), prevents collision of rosette and "Ped" on following note
+        if (item->isPedalSegment() && !toPedalSegment(item)->pedal()->lineVisible()) {
+            item->endText()->mutldata()->moveX(-item->endText()->width() / 2);
+        }
         ldata->addBbox(item->endText()->ldata()->bbox().translated(item->endText()->pos()));
     }
 


### PR DESCRIPTION
Resolves: #9975 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Rosette stars (Ped * style notation) are now placed where the duration of the final note under the pedal ends, rather than at the start. This change centers pedal segment end text only when the line is invisible. 
<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
