### PR TITLE
Optimization: avoid unnecessary copy of Shape object when translating

### DIFF
--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -3214,11 +3214,11 @@ void GraceNotesGroup::addToShape()
         staff_idx_t staffIdx = grace->staffIdx();
         staff_idx_t vStaffIdx = grace->vStaffIdx();
         Shape& s = _appendedSegment->staffShape(staffIdx);
-        s.add(grace->shape(LD_ACCESS::PASS).translated(grace->pos()));
+        s.add(grace->shape(LD_ACCESS::PASS).translate(grace->pos()));
         if (vStaffIdx != staffIdx) {
             // Cross-staff grace notes add their shape to both the origin and the destination staff
             Shape& s2 = _appendedSegment->staffShape(vStaffIdx);
-            s2.add(grace->shape().translated(grace->pos()));
+            s2.add(grace->shape().translate(grace->pos()));
         }
     }
 }

--- a/src/engraving/dom/rest.cpp
+++ b/src/engraving/dom/rest.cpp
@@ -514,7 +514,7 @@ int Rest::computeWholeRestOffset(int voiceOffset, int lines) const
                 continue;
             }
             Chord* chord = toChord(item);
-            Shape chordShape = chord->shape().translated(chord->pos());
+            Shape chordShape = chord->shape().translate(chord->pos());
             chordShape.removeInvisibles();
             if (chordShape.empty()) {
                 continue;

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -2403,7 +2403,7 @@ void Segment::addPreAppendedToShape()
             toGraceNotesGroup(item)->addToShape();
         } else {
             Shape& shape = m_shapes[item->vStaffIdx()];
-            shape.add(item->shape().translated(item->pos()));
+            shape.add(item->shape().translate(item->pos()));
         }
     }
 }

--- a/src/engraving/infrastructure/shape.cpp
+++ b/src/engraving/infrastructure/shape.cpp
@@ -89,6 +89,7 @@ void Shape::translateY(double yo)
 Shape Shape::translated(const PointF& pt) const
 {
     Shape s;
+    s.m_elements.reserve(m_elements.size());
     for (const ShapeElement& r : m_elements) {
         s.add(r.translated(pt), r.item());
     }

--- a/src/engraving/rendering/dev/autoplace.cpp
+++ b/src/engraving/rendering/dev/autoplace.cpp
@@ -193,7 +193,7 @@ void Autoplace::autoplaceSpannerSegment(const SpannerSegment* item, EngravingIte
         bool above = item->spanner()->placeAbove();
         SkylineLine sl(!above);
         Shape sh = item->shape();
-        sl.add(sh.translated(item->pos()));
+        sl.add(sh.translate(item->pos()));
         double yd = 0.0;
         staff_idx_t stfIdx = item->systemFlag() ? item->staffIdxOrNextVisible() : item->staffIdx();
         if (stfIdx == mu::nidx) {

--- a/src/engraving/rendering/dev/beamlayout.cpp
+++ b/src/engraving/rendering/dev/beamlayout.cpp
@@ -887,12 +887,12 @@ void BeamLayout::verticalAdjustBeamedRests(Rest* rest, Beam* beam, LayoutContext
         restToBeamPadding = 0.35 * spatium;
     }
 
-    Shape beamShape = beam->shape().translated(beam->pagePos());
+    Shape beamShape = beam->shape().translate(beam->pagePos());
     beamShape.remove_if([&](ShapeElement& el) {
         return el.item() && el.item()->isBeamSegment() && toBeamSegment(el.item())->isBeamlet;
     });
 
-    Shape restShape = rest->shape().translated(rest->pagePos() - rest->offset());
+    Shape restShape = rest->shape().translate(rest->pagePos() - rest->offset());
     double minBeamToRestXDist = up && firstRest ? 0.1 * spatium : 0.0;
 
     double restToBeamClearance = up

--- a/src/engraving/rendering/dev/chordlayout.cpp
+++ b/src/engraving/rendering/dev/chordlayout.cpp
@@ -1148,7 +1148,7 @@ void ChordLayout::layoutArticulations3(Chord* item, Slur* slur, LayoutContext& c
                 Articulation* aa = *iter2;
                 aa->mutldata()->moveY(minDist);
                 if (sstaff && aa->addToSkyline()) {
-                    sstaff->skyline().add(aa->shape().translated(aa->pos() + item->pos() + s->pos() + m->pos()));
+                    sstaff->skyline().add(aa->shape().translate(aa->pos() + item->pos() + s->pos() + m->pos()));
                     for (ShapeElement& sh : s->staffShape(item->staffIdx()).elements()) {
                         if (sh.item() == aa) {
                             sh.translate(0.0, minDist);
@@ -3140,14 +3140,14 @@ void ChordLayout::resolveRestVSChord(std::vector<Rest*>& rests, std::vector<Chor
             bool ignoreYOffset = (restAbove && restYOffset > 0) || (!restAbove && restYOffset < 0);
             PointF offset = ignoreYOffset ? PointF(0, restYOffset) : PointF(0, 0);
 
-            Shape chordShape = chord->shape().translated(chord->pos());
+            Shape chordShape = chord->shape().translate(chord->pos());
             chordShape.removeInvisibles();
             if (chordShape.empty()) {
                 continue;
             }
 
             double clearance = 0.0;
-            Shape restShape = rest->shape().translated(rest->pos() - offset);
+            Shape restShape = rest->shape().translate(rest->pos() - offset);
             if (chord->segment() == rest->segment()) {
                 clearance = restAbove
                             ? restShape.verticalClearance(chordShape)
@@ -3218,7 +3218,7 @@ void ChordLayout::resolveRestVSRest(std::vector<Rest*>& rests, const Staff* staf
         }
 
         RestVerticalClearance& rest1Clearance = rest1->verticalClearance();
-        Shape shape1 = rest1->shape().translated(rest1->pos() - rest1->offset());
+        Shape shape1 = rest1->shape().translate(rest1->pos() - rest1->offset());
 
         Rest* rest2 = rests[i + 1];
         if (!rest2->visible() || !rest2->autoplace()) {
@@ -3229,7 +3229,7 @@ void ChordLayout::resolveRestVSRest(std::vector<Rest*>& rests, const Staff* staf
             continue;
         }
 
-        Shape shape2 = rest2->shape().translated(rest2->pos() - rest2->offset());
+        Shape shape2 = rest2->shape().translate(rest2->pos() - rest2->offset());
         RestVerticalClearance& rest2Clearance = rest2->verticalClearance();
 
         double clearance;
@@ -3275,8 +3275,8 @@ void ChordLayout::resolveRestVSRest(std::vector<Rest*>& rests, const Staff* staf
         Beam* beam1 = rest1->beam();
         Beam* beam2 = rest2->beam();
         if (beam1 && beam2 && considerBeams) {
-            shape1 = rest1->shape().translated(rest1->pos() - rest1->offset());
-            shape2 = rest2->shape().translated(rest2->pos() - rest2->offset());
+            shape1 = rest1->shape().translate(rest1->pos() - rest1->offset());
+            shape2 = rest2->shape().translate(rest2->pos() - rest2->offset());
 
             ChordRest* beam1Start = beam1->elements().front();
             ChordRest* beam1End = beam1->elements().back();
@@ -3765,7 +3765,7 @@ void ChordLayout::fillShape(const Chord* item, ChordRest::LayoutData* ldata, con
         } else if (!beamlet->isBefore && item->up()) {
             xPos += stem->width();
         }
-        shape.add(beamlet->shape().translated(PointF(-xPos, 0.0)));
+        shape.add(beamlet->shape().translate(PointF(-xPos, 0.0)));
     }
 
     ldata->setShape(shape);

--- a/src/engraving/rendering/dev/slurtielayout.cpp
+++ b/src/engraving/rendering/dev/slurtielayout.cpp
@@ -1797,7 +1797,7 @@ void SlurTieLayout::adjustXforLedgerLines(TieSegment* tieSegment, bool start, Ch
         return;
     }
 
-    Shape noteShape = note->shape().translated(note->pos() + chordSystemPos);
+    Shape noteShape = note->shape().translate(note->pos() + chordSystemPos);
     double xNoteEdge = (start ? noteShape.right() : -noteShape.left()) + padding;
 
     resultingX = start ? std::max(resultingX, xNoteEdge) : std::min(resultingX, xNoteEdge);

--- a/src/engraving/rendering/dev/systemlayout.cpp
+++ b/src/engraving/rendering/dev/systemlayout.cpp
@@ -833,7 +833,7 @@ void SystemLayout::layoutSystemElements(System* system, LayoutContext& ctx)
 
                         // add element to skyline
                         if (e->addToSkyline()) {
-                            skyline.add(e->shape().translated(e->pos() + p));
+                            skyline.add(e->shape().translate(e->pos() + p));
                             // add grace notes to skyline
                             if (e->isChord()) {
                                 GraceNotesGroup& graceBefore = toChord(e)->graceNotesBefore();
@@ -841,10 +841,10 @@ void SystemLayout::layoutSystemElements(System* system, LayoutContext& ctx)
                                 TLayout::layoutGraceNotesGroup2(&graceBefore, graceBefore.mutldata());
                                 TLayout::layoutGraceNotesGroup2(&graceAfter, graceAfter.mutldata());
                                 if (!graceBefore.empty()) {
-                                    skyline.add(graceBefore.shape().translated(graceBefore.pos() + p));
+                                    skyline.add(graceBefore.shape().translate(graceBefore.pos() + p));
                                 }
                                 if (!graceAfter.empty()) {
-                                    skyline.add(graceAfter.shape().translated(graceAfter.pos() + p));
+                                    skyline.add(graceAfter.shape().translate(graceAfter.pos() + p));
                                 }
                             }
                             // If present, add ornament cue note to skyline

--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -2853,7 +2853,7 @@ void TLayout::layoutGraceNotesGroup(GraceNotesGroup* item, LayoutContext& ctx)
                 }
             }
         }
-        _shape.add(graceShape.translated(mu::PointF(offset, 0.0)));
+        _shape.add(graceShape.translate(mu::PointF(offset, 0.0)));
         double xpos = offset - item->parent()->rxoffset() - item->parent()->ldata()->pos().x();
         grace->setPos(xpos, 0.0);
     }
@@ -2968,7 +2968,7 @@ void TLayout::layoutGuitarBendSegment(GuitarBendSegment* item, LayoutContext& ct
     SysStaff* staff = item->system()->staff(item->staffIdx());
     Skyline& skyline = staff->skyline();
     SkylineLine& skylineLine = tabStaff ? skyline.north() : (item->guitarBend()->ldata()->up() ? skyline.north() : skyline.south());
-    skylineLine.add(item->shape().translated(item->pos()));
+    skylineLine.add(item->shape().translate(item->pos()));
 
     fillGuitarBendSegmentShape(item, ldata);
 }
@@ -2979,7 +2979,7 @@ void TLayout::fillGuitarBendSegmentShape(const GuitarBendSegment* item, GuitarBe
     Shape shape;
     shape.add(ldata->bbox(), item);
     if (!item->bendText()->empty()) {
-        shape.add(item->bendText()->shape().translated(item->bendText()->pos()));
+        shape.add(item->bendText()->shape().translate(item->bendText()->pos()));
     }
     ldata->setShape(shape);
 }
@@ -3211,7 +3211,7 @@ void TLayout::layoutHairpinSegment(HairpinSegment* item, LayoutContext& ctx)
         bool above = item->spanner()->placeAbove();
         SkylineLine sl(!above);
         Shape sh = item->shape();
-        sl.add(sh.translated(item->pos()));
+        sl.add(sh.translate(item->pos()));
         if (above) {
             d  = item->system()->topDistance(item->staffIdx(), sl);
             if (d > -md) {
@@ -4393,7 +4393,7 @@ void TLayout::fillNoteShape(const Note* item, Note::LayoutData* ldata)
             // isn't fully known yet, so we use an approximation
             double sp = item->spatium();
             PointF approxRelPos(noteBBox.width() + 0.25 * sp, -0.25 * sp);
-            shape.add(bendSeg->shape().translated(approxRelPos));
+            shape.add(bendSeg->shape().translate(approxRelPos));
         }
     }
 


### PR DESCRIPTION
Every time we need to use the `shape` of an item, we do a call like this:

`Shape sh = item->shape().translated(item->pos());`

In this call, `item->shape()` returns a copy of the shape, and the `translated()` returns a translated copy of the copy. This means that every time we make this call we are making one unnecessary copy. There are two possible ways to improve this:
1. Instead of `Shape EngravingItem::shape()`, write the method as `const Shape& EngravingItem::shape()`. That way, we return a const reference, instead of a copy.
2. Let `EngravingItem::shape()` return a copy, but use the `translate()` method (which translates the actual shape without making a copy of it) instead of `translated()`.  

To my surprise, option 1 makes the code _slower_, not faster. Probably, that is because the time needed to access the const ref memory location (which may be distant) is more that the time saved from avoiding the copy.

Therefore, this PR implements option 2, by replacing `translated()` with `translate()` wherever possible. I have tested it on a few big files and on average `Score::doLayoutRange` (which contains the whole layout) is about 2% faster. Not much, but still worth it.

@oktophonie FYI. Also @miiizen FYI, this is something you may want to keep in mind for the future.