### PR TITLE
Introduce advanced glyph shapes using smufl cutouts and apply it to accidentals

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -1638,6 +1638,16 @@ RectF EngravingItem::symBbox(const SymIdList& symbols) const
     return score()->engravingFont()->bbox(symbols, magS());
 }
 
+Shape EngravingItem::symShapeWithCutouts(SymId id) const
+{
+    Shape shape = score()->engravingFont()->shapeWithCutouts(id, magS());
+    for (ShapeElement& element : shape.elements()) {
+        element.setItem(this);
+    }
+
+    return shape;
+}
+
 //---------------------------------------------------------
 //   symSmuflAnchor
 //---------------------------------------------------------
@@ -2535,9 +2545,6 @@ Shape EngravingItem::LayoutData::shape(LD_ACCESS mode) const
             //! We can remove it the moment we figure out the layout order of the elements
             TLayout::fillTupletShape(toTuplet(m_item), static_cast<Tuplet::LayoutData*>(const_cast<LayoutData*>(this)));
             return m_shape.value(LD_ACCESS::CHECK);
-        } break;
-        case ElementType::ACCIDENTAL: {
-            return Shape(sh.bbox(), m_item);
         } break;
         default:
             break;

--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -456,6 +456,7 @@ public:
     double symWidth(const SymIdList&) const;
     RectF symBbox(SymId id) const;
     RectF symBbox(const SymIdList&) const;
+    Shape symShapeWithCutouts(SymId id) const;
 
     PointF symSmuflAnchor(SymId symId, SmuflAnchorId anchorId) const;
 

--- a/src/engraving/iengravingfont.h
+++ b/src/engraving/iengravingfont.h
@@ -15,6 +15,7 @@ class Painter;
 
 namespace mu::engraving {
 class Shape;
+class EngravingItem;
 
 class IEngravingFont
 {
@@ -45,6 +46,8 @@ public:
     virtual RectF bbox(const SymIdList& s, const mu::SizeF& mag) const = 0;
     virtual Shape shape(const SymIdList& s, double mag) const = 0;
     virtual Shape shape(const SymIdList& s, const mu::SizeF& mag) const = 0;
+    virtual Shape shapeWithCutouts(SymId id, double mag) = 0;
+    virtual Shape shapeWithCutouts(SymId id, const mu::SizeF& mag) = 0;
 
     virtual PointF smuflAnchor(SymId symId, SmuflAnchorId anchorId, double mag) const = 0;
 

--- a/src/engraving/infrastructure/shape.cpp
+++ b/src/engraving/infrastructure/shape.cpp
@@ -33,6 +33,15 @@ using namespace mu;
 using namespace mu::draw;
 using namespace mu::engraving;
 
+Shape::Shape(const std::vector<RectF>& rects, const EngravingItem* p)
+{
+    m_type = Type::Composite;
+    m_elements.reserve(rects.size());
+    for (const RectF& rect : rects) {
+        m_elements.emplace_back(ShapeElement(rect, p));
+    }
+}
+
 //---------------------------------------------------------
 //   addHorizontalSpacing
 //    This methods creates "walls". They are represented by
@@ -92,6 +101,25 @@ Shape Shape::translated(const PointF& pt) const
     s.m_elements.reserve(m_elements.size());
     for (const ShapeElement& r : m_elements) {
         s.add(r.translated(pt), r.item());
+    }
+    return s;
+}
+
+Shape& Shape::scale(const SizeF& mag)
+{
+    for (RectF& r : m_elements) {
+        r.scale(mag);
+    }
+    invalidateBBox();
+    return *this;
+}
+
+Shape Shape::scaled(const SizeF& mag) const
+{
+    Shape s;
+    s.m_elements.reserve(m_elements.size());
+    for (const ShapeElement& r : m_elements) {
+        s.add(r.scaled(mag), r.item());
     }
     return s;
 }

--- a/src/engraving/infrastructure/shape.h
+++ b/src/engraving/infrastructure/shape.h
@@ -52,6 +52,7 @@ public:
         : mu::RectF(f) {}
 
     const EngravingItem* item() const { return m_item; }
+    void setItem(const EngravingItem* item) { m_item = item; }
     bool ignoreForLayout() const { return m_ignoreForLayout; }
 
 private:
@@ -78,6 +79,7 @@ public:
         : m_type(t) {}
     Shape(const mu::RectF& r, const EngravingItem* p = nullptr, Type t = Type::Fixed)
         : m_type(t) { setBBox(r, p); }
+    Shape(const std::vector<mu::RectF>& rects, const EngravingItem* p = nullptr);
 
     Type type() const { return m_type; }
     bool isComposite() const { return m_type == Type::Composite; }
@@ -140,6 +142,8 @@ public:
     void translateX(double);
     void translateY(double);
     Shape translated(const mu::PointF&) const;
+    Shape& scale(const mu::SizeF&);
+    Shape scaled(const mu::SizeF&) const;
 
     const mu::RectF& bbox() const;
     double minVerticalDistance(const Shape&) const;

--- a/src/engraving/internal/engravingfont.h
+++ b/src/engraving/internal/engravingfont.h
@@ -75,6 +75,8 @@ public:
     RectF bbox(const SymIdList& s, const mu::SizeF& mag) const override;
     Shape shape(const SymIdList& s, double mag) const override;
     Shape shape(const SymIdList& s, const mu::SizeF& mag) const override;
+    Shape shapeWithCutouts(SymId id, double mag) override;
+    Shape shapeWithCutouts(SymId id, const mu::SizeF& mag) override;
 
     double width(SymId id, double mag) const override;
     double width(const SymIdList&, double mag) const override;
@@ -99,6 +101,7 @@ private:
     struct Sym {
         char32_t code;
         RectF bbox;
+        Shape shapeWithCutouts;
         double advance = 0.0;
 
         std::map<SmuflAnchorId, mu::PointF> smuflAnchors;
@@ -120,6 +123,8 @@ private:
     void loadStylisticAlternates(const JsonObject& glyphsWithAlternatesObject);
     void loadEngravingDefaults(const JsonObject& engravingDefaultsObject);
     void computeMetrics(Sym& sym, const Smufl::Code& code);
+
+    void constructShapeWithCutouts(Shape& shape, SymId id);
 
     Sym& sym(SymId id);
     const Sym& sym(SymId id) const;

--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -499,13 +499,15 @@ void TLayout::layoutAccidental(const Accidental* item, Accidental::LayoutData* l
         return { SymId::noSym, SymId::noSym };
     };
 
+    Shape shape;
+
     // Single?
     SymId singleSym = accidentalSingleSym(item);
     if (singleSym != SymId::noSym && conf.engravingFont()->isValid(singleSym)) {
         Accidental::LayoutData::Sym s(singleSym, 0.0, 0.0);
         ldata->syms.push_back(s);
 
-        ldata->addBbox(item->symBbox(singleSym));
+        shape.add(item->symShapeWithCutouts(singleSym));
     }
     // Multi
     else {
@@ -523,7 +525,7 @@ void TLayout::layoutAccidental(const Accidental* item, Accidental::LayoutData* l
             Accidental::LayoutData::Sym ls(bracketSyms.first, 0.0,
                                            item->bracket() == AccidentalBracket::BRACE ? item->spatium() * 0.4 : 0.0);
             ldata->syms.push_back(ls);
-            ldata->addBbox(item->symBbox(bracketSyms.first));
+            shape.add(item->symBbox(bracketSyms.first), item);
 
             x += item->symAdvance(bracketSyms.first) + margin;
         }
@@ -532,7 +534,7 @@ void TLayout::layoutAccidental(const Accidental* item, Accidental::LayoutData* l
         SymId mainSym = item->symId();
         Accidental::LayoutData::Sym ms(mainSym, x, 0.0);
         ldata->syms.push_back(ms);
-        ldata->addBbox(item->symBbox(mainSym).translated(x, 0.0));
+        shape.add(item->symShapeWithCutouts(mainSym).translated(PointF(x, 0.0)));
 
         // Right
         if (bracketSyms.second != SymId::noSym) {
@@ -541,9 +543,11 @@ void TLayout::layoutAccidental(const Accidental* item, Accidental::LayoutData* l
             Accidental::LayoutData::Sym rs(bracketSyms.second, x,
                                            item->bracket() == AccidentalBracket::BRACE ? item->spatium() * 0.4 : 0.0);
             ldata->syms.push_back(rs);
-            ldata->addBbox(item->symBbox(bracketSyms.second).translated(x, 0.0));
+            shape.add(item->symBbox(bracketSyms.second).translated(x, 0.0), item);
         }
     }
+
+    ldata->setShape(shape);
 }
 
 void TLayout::layoutActionIcon(const ActionIcon* item, ActionIcon::LayoutData* ldata)
@@ -4372,7 +4376,7 @@ void TLayout::fillNoteShape(const Note* item, Note::LayoutData* ldata)
 
     Accidental* acc = item->accidental();
     if (acc && acc->addToSkyline()) {
-        shape.add(acc->ldata()->bbox().translated(acc->pos()), acc);
+        shape.add(acc->ldata()->shape().translated(acc->pos()));
     }
     for (auto e : item->el()) {
         if (e->addToSkyline()) {

--- a/src/framework/draw/types/geometry.h
+++ b/src/framework/draw/types/geometry.h
@@ -356,6 +356,20 @@ public:
     inline void adjust(double xp1, double yp1, double xp2, double yp2) { m_x += xp1; m_y += yp1; m_w += xp2 - xp1; m_h += yp2 - yp1; }
     inline RectX<T> adjusted(T xp1, T yp1, T xp2, T yp2) const { return RectX<T>(m_x + xp1, m_y + yp1, m_w + xp2 - xp1, m_h + yp2 - yp1); }
 
+    inline RectX<T>& scale(const SizeX<T>& mag)
+    {
+        m_x *= mag.width();
+        m_y *= mag.height();
+        m_w *= mag.width();
+        m_h *= mag.height();
+        return *this;
+    }
+
+    inline RectX<T> scaled(const SizeX<T>& mag) const
+    {
+        return RectX<T>(m_x * mag.width(), m_y * mag.height(), m_w * mag.width(), m_h * mag.height());
+    }
+
     bool contains(const PointX<T>& p) const;
     bool contains(const RectX<T>& r) const;
 

--- a/src/importexport/guitarpro/tests/data/volta.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/volta.gp5-ref.mscx
@@ -224,7 +224,7 @@
             </Tuplet>
           <Beam>
             <l1>-28</l1>
-            <l2>-22</l2>
+            <l2>-24</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/src/importexport/musicxml/tests/data/testLayout.xml
+++ b/src/importexport/musicxml/tests/data/testLayout.xml
@@ -78,12 +78,12 @@
       </score-part>
     </part-list>
   <part id="P1">
-    <measure number="1" width="236.76">
+    <measure number="1" width="235.41">
       <print>
         <system-layout>
           <system-margins>
             <left-margin>50.00</left-margin>
-            <right-margin>742.27</right-margin>
+            <right-margin>743.62</right-margin>
             </system-margins>
           <top-system-distance>170.00</top-system-distance>
           </system-layout>
@@ -110,7 +110,7 @@
           <line>4</line>
           </clef>
         </attributes>
-      <note default-x="135.62" default-y="-10.00">
+      <note default-x="134.94" default-y="-10.00">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
@@ -142,7 +142,7 @@
           </direction-type>
         <staff>2</staff>
         </direction>
-      <note default-x="108.43" default-y="-115.00">
+      <note default-x="107.08" default-y="-115.00">
         <grace slash="yes"/>
         <pitch>
           <step>F</step>
@@ -155,7 +155,7 @@
         <stem>up</stem>
         <staff>2</staff>
         </note>
-      <note default-x="129.87" default-y="-110.00">
+      <note default-x="128.52" default-y="-110.00">
         <pitch>
           <step>G</step>
           <octave>4</octave>
@@ -166,7 +166,7 @@
         <stem>down</stem>
         <staff>2</staff>
         </note>
-      <note default-x="160.27" default-y="-135.00">
+      <note default-x="158.92" default-y="-135.00">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -183,7 +183,7 @@
           </direction-type>
         <staff>2</staff>
         </direction>
-      <note default-x="190.66" default-y="-125.00">
+      <note default-x="189.31" default-y="-125.00">
         <pitch>
           <step>D</step>
           <octave>3</octave>


### PR DESCRIPTION
Currently, our layout system (meaning all the collision checks) looks at accidentals like this:
![image](https://github.com/musescore/MuseScore/assets/93707756/ed3a54d0-dd54-499b-9dbd-94a9b17815b6)

With this PR, we look at accidentals like this:
![image](https://github.com/musescore/MuseScore/assets/93707756/50a9338d-d3ce-4741-8a2c-907762d9d93c)

In score very heavy of accidentals, this may have a small performance cost, because every accidental now is made of more than a single rectangle. However, that cost is basically offset by the gain made with [this optimization](https://github.com/musescore/MuseScore/pull/20963). Besides, it is exactly in the situation with many accidentals that using cutouts like this can dramatically improve the layout.

This allows smufl cutouts to be used also by any other item that needs them in future.

