### PR TITLE
[engraving] fixed crash on measure undo delete. 4.2.1

### DIFF
--- a/src/engraving/compat/dummyelement.cpp
+++ b/src/engraving/compat/dummyelement.cpp
@@ -30,6 +30,7 @@
 #include "dom/chord.h"
 #include "dom/note.h"
 #include "dom/bracketItem.h"
+#include "dom/ledgerline.h"
 
 #ifndef ENGRAVING_NO_ACCESSIBILITY
 #include "accessibility/accessibleitem.h"
@@ -45,6 +46,11 @@ DummyElement::DummyElement(EngravingObject* parent)
 
 DummyElement::~DummyElement()
 {
+    for (LedgerLine* l : m_ledgerLinePool) {
+        delete l;
+    }
+    m_ledgerLinePool.clear();
+
     delete m_bracketItem;
     delete m_note;
     delete m_chord;
@@ -90,6 +96,11 @@ void DummyElement::init()
     m_bracketItem->setParent(m_system);
 }
 
+EngravingItem* DummyElement::clone() const
+{
+    return nullptr;
+}
+
 RootItem* DummyElement::rootItem()
 {
     return m_root;
@@ -130,9 +141,27 @@ BracketItem* DummyElement::bracketItem()
     return m_bracketItem;
 }
 
-EngravingItem* DummyElement::clone() const
+LedgerLine* DummyElement::createLedgerLine(EngravingItem* parent)
 {
-    return nullptr;
+    LedgerLine* v = nullptr;
+    if (!m_ledgerLinePool.empty()) {
+        v = *m_ledgerLinePool.begin();
+        m_ledgerLinePool.erase(m_ledgerLinePool.begin());
+        v->setParent(parent);
+        v->setLen(0.0);
+        v->setVertical(false);
+        v->setNext(nullptr);
+    } else {
+        v = new LedgerLine(parent);
+    }
+    return v;
+}
+
+void DummyElement::destroyLedgerLine(LedgerLine* l)
+{
+    l->setParent(this);
+    l->m_next = nullptr;
+    m_ledgerLinePool.insert(l);
 }
 
 #ifndef ENGRAVING_NO_ACCESSIBILITY

--- a/src/engraving/compat/dummyelement.h
+++ b/src/engraving/compat/dummyelement.h
@@ -42,6 +42,8 @@ public:
 
     void init();
 
+    EngravingItem* clone() const override;
+
     RootItem* rootItem();
     Page* page();
     System* system();
@@ -51,7 +53,8 @@ public:
     Note* note();
     BracketItem* bracketItem();
 
-    EngravingItem* clone() const override;
+    LedgerLine* createLedgerLine(EngravingItem* parent);
+    void destroyLedgerLine(LedgerLine* l);
 
     PropertyValue getProperty(Pid) const override { return PropertyValue(); }
     bool setProperty(Pid, const PropertyValue&) override { return false; }
@@ -69,6 +72,7 @@ private:
     Chord* m_chord = nullptr;
     Note* m_note = nullptr;
     BracketItem* m_bracketItem = nullptr;
+    std::set<LedgerLine*> m_ledgerLinePool;
 };
 }
 

--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -433,7 +433,7 @@ Chord::~Chord()
     delete m_hook;
     for (LedgerLine* ll = m_ledgerLines; ll;) {
         LedgerLine* llNext = ll->next();
-        delete ll;
+        LedgerLine::destroy(ll);
         ll = llNext;
     }
     DeleteAll(m_graceNotes);
@@ -1009,7 +1009,7 @@ void Chord::addLedgerLines()
             double _spatium = spatium();
             double stepDistance = lineDistance * 0.5;
             for (auto lld : vecLines) {
-                LedgerLine* h = new LedgerLine(score()->dummy());
+                LedgerLine* h = LedgerLine::create(score()->dummy());
                 h->setParent(this);
                 h->setTrack(track);
                 h->setVisible(lld.visible && staffVisible);

--- a/src/engraving/dom/ledgerline.cpp
+++ b/src/engraving/dom/ledgerline.cpp
@@ -25,12 +25,23 @@
 #include "chord.h"
 #include "measure.h"
 #include "system.h"
+#include "score.h"
 
 #include "log.h"
 
 using namespace mu;
 
 namespace mu::engraving {
+LedgerLine* LedgerLine::create(EngravingItem* parent)
+{
+    return parent->score()->dummy()->createLedgerLine(parent);
+}
+
+void LedgerLine::destroy(LedgerLine* l)
+{
+    l->score()->dummy()->destroyLedgerLine(l);
+}
+
 //---------------------------------------------------------
 //   LedgerLine
 //---------------------------------------------------------

--- a/src/engraving/dom/ledgerline.h
+++ b/src/engraving/dom/ledgerline.h
@@ -25,6 +25,10 @@
 
 #include "engravingitem.h"
 
+namespace mu::engraving::compat {
+class DummyElement;
+}
+
 namespace mu::engraving {
 class Chord;
 
@@ -39,12 +43,14 @@ class Chord;
 
 class LedgerLine final : public EngravingItem
 {
-    OBJECT_ALLOCATOR(engraving, LedgerLine)
+    //OBJECT_ALLOCATOR(engraving, LedgerLine)
     DECLARE_CLASSOF(ElementType::LEDGER_LINE)
 
 public:
-    LedgerLine(EngravingItem*);
-    ~LedgerLine();
+
+    static LedgerLine* create(EngravingItem* parent);
+    static void destroy(LedgerLine* l);
+
     LedgerLine& operator=(const LedgerLine&) = delete;
 
     LedgerLine* clone() const override { return new LedgerLine(*this); }
@@ -70,6 +76,11 @@ public:
     DECLARE_LAYOUTDATA_METHODS(LedgerLine);
 
 private:
+
+    friend class compat::DummyElement;
+
+    LedgerLine(EngravingItem*);
+    ~LedgerLine();
 
     double m_len = 0.0;
     LedgerLine* m_next = nullptr;

--- a/src/engraving/rendering/dev/chordlayout.cpp
+++ b/src/engraving/rendering/dev/chordlayout.cpp
@@ -102,7 +102,7 @@ void ChordLayout::layoutPitched(Chord* item, LayoutContext& ctx)
 
     while (item->ledgerLines()) {
         LedgerLine* l = item->ledgerLines()->next();
-        delete item->ledgerLines();
+        LedgerLine::destroy(item->ledgerLines());
         item->setLedgerLine(l);
     }
 
@@ -335,7 +335,7 @@ void ChordLayout::layoutTablature(Chord* item, LayoutContext& ctx)
 
     while (item->ledgerLines()) {
         LedgerLine* l = item->ledgerLines()->next();
-        delete item->ledgerLines();
+        LedgerLine::destroy(item->ledgerLines());
         item->setLedgerLine(l);
     }
 
@@ -429,7 +429,7 @@ void ChordLayout::layoutTablature(Chord* item, LayoutContext& ctx)
         double extraLen    = 0;
         double llX         = stemX - (headWidth + extraLen) * 0.5;
         for (int i = 0; i < ledgerLines; i++) {
-            LedgerLine* ldgLin = new LedgerLine(ctx.mutDom().dummyParent());
+            LedgerLine* ldgLin = LedgerLine::create(ctx.mutDom().dummyParent());
             ldgLin->setParent(item);
             ldgLin->setTrack(item->track());
             ldgLin->setVisible(item->visible());

--- a/src/engraving/rendering/dev/measurelayout.cpp
+++ b/src/engraving/rendering/dev/measurelayout.cpp
@@ -2122,6 +2122,7 @@ void MeasureLayout::computeWidth(Measure* m, LayoutContext& ctx, Fraction minTic
         m->setWidth(0.0);
         return;
     }
+
     double x = 0.0;
     bool first = m->isFirstInSystem();
 

--- a/src/engraving/rendering/stable/chordlayout.cpp
+++ b/src/engraving/rendering/stable/chordlayout.cpp
@@ -102,7 +102,7 @@ void ChordLayout::layoutPitched(Chord* item, LayoutContext& ctx)
 
     while (item->ledgerLines()) {
         LedgerLine* l = item->ledgerLines()->next();
-        delete item->ledgerLines();
+        LedgerLine::destroy(item->ledgerLines());
         item->setLedgerLine(l);
     }
 
@@ -276,7 +276,7 @@ void ChordLayout::layoutTablature(Chord* item, LayoutContext& ctx)
 
     while (item->ledgerLines()) {
         LedgerLine* l = item->ledgerLines()->next();
-        delete item->ledgerLines();
+        LedgerLine::destroy(item->ledgerLines());
         item->setLedgerLine(l);
     }
 
@@ -370,7 +370,7 @@ void ChordLayout::layoutTablature(Chord* item, LayoutContext& ctx)
         double extraLen    = 0;
         double llX         = stemX - (headWidth + extraLen) * 0.5;
         for (int i = 0; i < ledgerLines; i++) {
-            LedgerLine* ldgLin = new LedgerLine(ctx.mutDom().dummyParent());
+            LedgerLine* ldgLin = LedgerLine::create(ctx.mutDom().dummyParent());
             ldgLin->setParent(item);
             ldgLin->setTrack(item->track());
             ldgLin->setVisible(item->visible());


### PR DESCRIPTION
Resolves: #20947

Crash in HorizontalSpacing::computePadding
because it refers to a deleted object (LedgerLine)
The segment contains rotten data in shapes

I haven't found the real reason or a good fix. I added a hotfix, it will slightly affect performance, but it fixes the problem and will not crash.
I'll explore the master in more detail, if I find a better solution, I'll port it to 4.2.1

