### PR TITLE
Fix #20583: Property defaults for HBox, VBox, and TBox

### DIFF
--- a/src/engraving/dom/box.cpp
+++ b/src/engraving/dom/box.cpp
@@ -288,7 +288,7 @@ HBox::HBox(System* parent)
     : Box(ElementType::HBOX, parent)
 {
     initElementStyle(&hBoxStyle);
-    setBoxWidth(Spatium(5.0));
+    resetProperty(Pid::BOX_WIDTH);
 }
 
 //---------------------------------------------------------
@@ -574,6 +574,8 @@ PropertyValue HBox::propertyDefault(Pid id) const
     switch (id) {
     case Pid::CREATE_SYSTEM_HEADER:
         return true;
+    case Pid::BOX_WIDTH:
+        return Spatium(5.0);
     default:
         return Box::propertyDefault(id);
     }
@@ -587,7 +589,7 @@ VBox::VBox(const ElementType& type, System* parent)
     : Box(type, parent)
 {
     initElementStyle(&boxStyle);
-    setBoxHeight(Spatium(10.0));
+    resetProperty(Pid::BOX_HEIGHT);
     setLineBreak(true);
 }
 
@@ -613,6 +615,20 @@ PropertyValue VBox::getProperty(Pid propertyId) const
         return isAutoSizeEnabled();
     default:
         return Box::getProperty(propertyId);
+    }
+}
+
+//---------------------------------------------------------
+//   propertyDefault
+//---------------------------------------------------------
+
+PropertyValue VBox::propertyDefault(Pid id) const
+{
+    switch (id) {
+    case Pid::BOX_HEIGHT:
+        return Spatium(10.0);
+    default:
+        return Box::propertyDefault(id);
     }
 }
 
@@ -655,7 +671,7 @@ void FBox::add(EngravingItem* e)
 TBox::TBox(System* parent)
     : VBox(ElementType::TBOX, parent)
 {
-    setBoxHeight(Spatium(1));
+    resetProperty(Pid::BOX_HEIGHT);
     m_text  = Factory::createText(this, TextStyleType::FRAME);
     m_text->setLayoutToParentWidth(true);
     m_text->setParent(this);
@@ -733,6 +749,20 @@ void TBox::remove(EngravingItem* el)
         el->removed();
     } else {
         VBox::remove(el);
+    }
+}
+
+//---------------------------------------------------------
+//   propertyDefault
+//---------------------------------------------------------
+
+PropertyValue TBox::propertyDefault(Pid id) const
+{
+    switch (id) {
+    case Pid::BOX_HEIGHT:
+        return Spatium(1);
+    default:
+        return VBox::propertyDefault(id);
     }
 }
 

--- a/src/engraving/dom/box.h
+++ b/src/engraving/dom/box.h
@@ -156,6 +156,7 @@ public:
     double maxHeight() const;
 
     PropertyValue getProperty(Pid propertyId) const override;
+    PropertyValue propertyDefault(Pid) const override;
 
     void startEditDrag(EditData&) override;
 
@@ -210,6 +211,8 @@ public:
     EngravingItem* drop(EditData&) override;
     void add(EngravingItem* e) override;
     void remove(EngravingItem* el) override;
+
+    PropertyValue propertyDefault(Pid) const override;
 
     String accessibleExtraInfo() const override;
 

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -359,7 +359,7 @@ void TWrite::writeItems(const ElementList& items, XmlWriter& xml, WriteContext& 
     }
 }
 
-void TWrite::writeProperty(const EngravingItem* item, XmlWriter& xml, Pid pid)
+void TWrite::writeProperty(const EngravingItem* item, XmlWriter& xml, Pid pid, bool force)
 {
     if (item->isStyled(pid)) {
         return;
@@ -370,7 +370,7 @@ void TWrite::writeProperty(const EngravingItem* item, XmlWriter& xml, Pid pid)
         return;
     }
     PropertyFlags f = item->propertyFlags(pid);
-    PropertyValue d = (f != PropertyFlags::STYLED) ? item->propertyDefault(pid) : PropertyValue();
+    PropertyValue d = !force && (f != PropertyFlags::STYLED) ? item->propertyDefault(pid) : PropertyValue();
 
     if (pid == Pid::FONT_STYLE) {
         FontStyle ds = FontStyle(d.isValid() ? d.toInt() : 0);
@@ -742,7 +742,8 @@ void TWrite::writeProperties(const Box* item, XmlWriter& xml, WriteContext& ctx)
         Pid::BOX_HEIGHT, Pid::BOX_WIDTH, Pid::TOP_GAP, Pid::BOTTOM_GAP,
         Pid::LEFT_MARGIN, Pid::RIGHT_MARGIN, Pid::TOP_MARGIN, Pid::BOTTOM_MARGIN, Pid::BOX_AUTOSIZE
     }) {
-        writeProperty(item, xml, id);
+        bool force = (item->isVBox() && id == Pid::BOX_HEIGHT) || (item->isHBox() && id == Pid::BOX_WIDTH);
+        writeProperty(item, xml, id, force);
     }
     writeItemProperties(item, xml, ctx);
     for (const EngravingItem* e : item->el()) {

--- a/src/engraving/rw/write/twrite.h
+++ b/src/engraving/rw/write/twrite.h
@@ -305,7 +305,7 @@ public:
 
     static void writeSegments(XmlWriter& xml, WriteContext& ctx, track_idx_t st, track_idx_t et, Segment* sseg, Segment* eseg, bool, bool);
 
-    static void writeProperty(const EngravingItem* item, XmlWriter& xml, Pid pid);
+    static void writeProperty(const EngravingItem* item, XmlWriter& xml, Pid pid, bool force = false);
 
 private:
 


### PR DESCRIPTION
Resolves: #20583

Horizontal frames exhibited the same broken behaviour, now fixed. Text frames were _technically_ broken too so I applied the same logic there for good measure.

Note this doesn't address #20584, some design is needed before we can do that.