### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/engraving/tests/playbackeventsrendering_tests.cpp
+++ b/src/engraving/tests/playbackeventsrendering_tests.cpp
@@ -1114,7 +1114,7 @@ TEST_F(Engraving_PlaybackEventsRendererTests, Glissando_on_tied_notes)
 
     expectedPitches.clear();
     for (size_t i = 0; i < expectedSubNotesCount; ++i) {
-        expectedPitches.push_back(nominalPitchLevel + i * PITCH_LEVEL_STEP);
+        expectedPitches.push_back(nominalPitchLevel + int(i) * PITCH_LEVEL_STEP);
     }
 
     // [WHEN] Request to render a chord with the A4 note on it


### PR DESCRIPTION
reg.: 'argument': conversion from 'size_t' to '_Ty', possible loss of data (C4267)
