### PR TITLE
Notation unit tests fix. Big obj file generation fix

### DIFF
--- a/src/notation/tests/CMakeLists.txt
+++ b/src/notation/tests/CMakeLists.txt
@@ -42,5 +42,8 @@ set(MODULE_TEST_LINK
 
 set(MODULE_TEST_DATA_ROOT ${CMAKE_CURRENT_LIST_DIR})
 
-include(${PROJECT_SOURCE_DIR}/src/framework/testing/gtest.cmake)
+if (MSVC)
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
+endif (MSVC)
 
+include(${PROJECT_SOURCE_DIR}/src/framework/testing/gtest.cmake)


### PR DESCRIPTION
error: C1128: number of sections exceeded object file format limit: compile with /bigobj

There is nothing criminal in the code, but a big obj file is generated. Perhaps the code can be optimized to reduce the output file, or maybe this is due to the inclusion of big interfaces such as NotationInteraction

also see https://github.com/musescore/MuseScore/pull/20981