### PR TITLE
Find tremolo chords on paste

### DIFF
--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -341,18 +341,22 @@ Chord::Chord(const Chord& c, bool link)
         }
         add(t);
     } else if (c.m_tremoloTwoChord) {
-        TremoloTwoChord* t = Factory::copyTremoloTwoChord(*(c.m_tremoloTwoChord));
-        if (link) {
-            score()->undo(new Link(t, const_cast<TremoloTwoChord*>(c.m_tremoloTwoChord)));
-        }
-
         if (c.m_tremoloTwoChord->chord1() == &c) {
-            t->setChords(this, nullptr);
-        } else {
-            t->setChords(nullptr, this);
-        }
+            TremoloTwoChord* t = Factory::copyTremoloTwoChord(*(c.m_tremoloTwoChord));
+            if (link) {
+                score()->undo(new Link(t, const_cast<TremoloTwoChord*>(c.m_tremoloTwoChord)));
+            }
 
-        add(t);
+            if (c.m_tremoloTwoChord->chord1() == &c) {
+                t->setChords(this, nullptr);
+                m_tremoloTwoChord = t;
+            } else {
+                t->setChords(nullptr, this);
+            }
+            add(t);
+        } else {
+            setTremoloTwoChord(nullptr);
+        }
     }
 
     for (EngravingItem* e : c.el()) {

--- a/src/engraving/rw/read400/read400.cpp
+++ b/src/engraving/rw/read400/read400.cpp
@@ -290,6 +290,7 @@ bool Read400::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fract
 
     std::vector<Harmony*> pastedHarmony;
     std::vector<Chord*> graceNotes;
+    std::vector<TremoloTwoChord*> twoNoteTrems;
     Beam* startingBeam = nullptr;
     Tuplet* tuplet = nullptr;
     Fraction dstTick = dst->tick();
@@ -472,16 +473,21 @@ bool Read400::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fract
                             // but these will be removed later
                             TremoloTwoChord* t = chord->tremoloTwoChord();
                             if (t) {
-                                if (doScale) {
-                                    Fraction d = t->durationType().ticks();
-                                    t->setDurationType(d * scale);
-                                }
-                                Measure* m = score->tick2measure(tick);
-                                Fraction ticks = cr->actualTicks();
-                                Fraction rticks = m->endTick() - tick;
-                                if (rticks < ticks || (rticks != ticks && rticks < ticks * 2)) {
-                                    MScore::setError(MsError::DEST_TREMOLO);
-                                    return false;
+                                if (t->chord1() == chord) {
+                                    twoNoteTrems.push_back(t);
+                                    if (doScale) {
+                                        Fraction d = t->durationType().ticks();
+                                        t->setDurationType(d * scale);
+                                    }
+                                    Measure* m = score->tick2measure(tick);
+                                    Fraction ticks = cr->actualTicks();
+                                    Fraction rticks = m->endTick() - tick;
+                                    if (rticks < ticks || (rticks != ticks && rticks < ticks * 2)) {
+                                        MScore::setError(MsError::DEST_TREMOLO);
+                                        return false;
+                                    }
+                                } else {
+                                    chord->setTremoloTwoChord(nullptr);
                                 }
                             }
                             for (size_t i = 0; i < graceNotes.size(); ++i) {
@@ -662,6 +668,34 @@ bool Read400::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fract
                 }
             }
         }
+        // Set tremolo chords
+        for (TremoloTwoChord* trem : twoNoteTrems) {
+            Chord* c1 = toChord(trem->explicitParent());
+            Segment* c2Seg = c1->segment()->next(SegmentType::ChordRest);
+            EngravingItem* item = nullptr;
+            while (c2Seg) {
+                item = c2Seg->element(c1->track());
+                if (item && item->isChord()) {
+                    break;
+                }
+                c2Seg = c2Seg->next(SegmentType::ChordRest);
+            }
+            if (c2Seg == nullptr || !item) {
+                LOGD("no segment or item for second note of tremolo found");
+                delete trem;
+                continue;
+            }
+            Chord* c2 = toChord(item);
+            if (c2->ticks() != c1->ticks()) {
+                LOGD("no matching chord for second note of tremolo found");
+                delete trem;
+                continue;
+            }
+
+            trem->setChords(c1, c2);
+            c2->setTremoloTwoChord(trem);
+        }
+
         // fix up spanners
         if (doScale && spannerFound) {
             // build list of original spanners

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -2603,6 +2603,7 @@ bool TRead::readProperties(Chord* ch, XmlReader& e, ReadContext& ctx)
         TRead::read(trem, e, ctx);
         trem->setParent(ch);
         trem->setDurationType(ch->durationType());
+        trem->setChord1(ch);
         ch->setTremoloTwoChord(trem, false);
     } else if (tag == "tickOffset") {      // obsolete
     } else if (tag == "ChordLine") {


### PR DESCRIPTION
Resolves: #20936 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->
Resolves: crash on opening parts seen below
Resolves: crashes when closing a score after creating parts or adding a linked stave containing a 2 note tremolo.

Connect tremolo's chords immediately on paste to remove any chance they might not be set at the correct time during layout.

This PR also removes some redundant tremolo copying code from `Excerpt::cloneMeasure` and `Excerpt::cloneStaff` as the tremolo is already cloned when the chord is cloned.  A tremolo is only cloned by a chord if it is the first chord in a tremolo.  Before these changes the tremolo was being cloned 3 times, ending up with inconsistent pointers between the tremolos and chords which caused crashes on closing the score.