### PR TITLE
Fix crash on undo delete measure

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -4304,12 +4304,14 @@ void Score::appendMeasures(int n)
 //   addSpanner
 //---------------------------------------------------------
 
-void Score::addSpanner(Spanner* s)
+void Score::addSpanner(Spanner* s, bool computeStartEnd)
 {
     m_spanner.addSpanner(s);
     s->added();
-    s->computeStartElement();
-    s->computeEndElement();
+    if (computeStartEnd) {
+        s->computeStartElement();
+        s->computeEndElement();
+    }
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -854,7 +854,7 @@ public:
     const SpannerMap& spannerMap() const { return m_spanner; }
     bool isSpannerStartEnd(const Fraction& tick, track_idx_t track) const;
     void removeSpanner(Spanner*);
-    void addSpanner(Spanner*);
+    void addSpanner(Spanner*, bool computeStartEnd = true);
     void cmdAddSpanner(Spanner* spanner, const mu::PointF& pos, bool systemStavesOnly = false);
     void cmdAddSpanner(Spanner* spanner, staff_idx_t staffIdx, Segment* startSegment, Segment* endSegment, bool ctrlModifier = false);
     void checkSpanner(const Fraction& startTick, const Fraction& lastTick, bool removeOrphans = true);


### PR DESCRIPTION
Resolves: #20947 

When undoing the measure delete, the tick of the spanners is updated before the tick of all the notes, so Spanner::computeStartElement computes garbage if we call it too soon. In this case, this causes the trill cue note to end up in the wrong place and cause chaos.

With this, we avoid recomputing start and end element in Spanner::setProperty, because they are recomputed anyway later. Additionally, we do some better management of Chord::startingSpanners and Chord::endingSpanners