### PR TITLE
fix: vbox autosize bug

### DIFF
--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -1328,8 +1328,8 @@ void TLayout::layoutVBox(const VBox* item, VBox::LayoutData* ldata, const Layout
     for (EngravingItem* e : item->el()) {
         layoutItem(e, const_cast<LayoutContext&>(ctx));
     }
-
-    if (item->getProperty(Pid::BOX_AUTOSIZE).toBool()) {
+    bool boxAutoSize = item->getProperty(Pid::BOX_AUTOSIZE).toBool();
+    if (boxAutoSize) {
         double contentHeight = item->contentRect().height();
 
         if (contentHeight < item->minHeight()) {
@@ -1339,7 +1339,7 @@ void TLayout::layoutVBox(const VBox* item, VBox::LayoutData* ldata, const Layout
         ldata->setHeight(contentHeight);
     }
 
-    if (MScore::noImages) {
+    if (boxAutoSize && MScore::noImages) {
         // adjustLayoutWithoutImages
         double calculatedVBoxHeight = 0;
         const int padding = ctx.conf().spatium();


### PR DESCRIPTION
Imagine the situation when you have both **_autosize_** set to false and **_noimages_**.
Autosize property makes no sense in that case because **_noimages_** property will resize the box anyway.