### PR TITLE
Add thumbnail when Ctrl+Shift+Dragging an element 

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1153,39 +1153,27 @@ void NotationInteraction::startDragCopy(const EngravingItem* element, QObject* d
         m_drag = nullptr;
     });
 
-    const qreal spatium = paletteConf()->paletteSpatium();
-    const qreal sizeRatio = spatium / gpaletteScore->style().spatium();
-    const qreal adjustedRatio = sizeRatio * 1.5;
+    const qreal adjustedRatio = 0.4;
+    const qreal width = element->ldata()->bbox().width();
+    const qreal height = element->ldata()->bbox().height();
 
-    engravingRenderer()->layoutItem(const_cast<EngravingItem*>(element));
-
-    qreal width = element->ldata()->bbox().width();
-    qreal height = element->ldata()->bbox().height();
-    // qreal width = 100;
-    // qreal height = 100;
     QSize pixmapSize = QSize(width * adjustedRatio, height * adjustedRatio);
-    // QSize pixmapSize = QSize(width, height);
-
-    static QPixmap pixmap(pixmapSize); // null or 1x1 crashes on Linux under ChromeOS?!
+    QPixmap pixmap(pixmapSize); // null or 1x1 crashes on Linux under ChromeOS?!
     pixmap.fill(Qt::white);
     QBitmap mask = pixmap.createMaskFromColor(Qt::white); // Transparent background
     pixmap.setMask(mask);
 
     QPainter painter(&pixmap);
     QPainter* qp = &painter;
-    qreal dpi = qp->device()->logicalDpiX();
+    const qreal dpi = qp->device()->logicalDpiX();
 
     Painter p(qp, "startDragCopy");
-    p.save();
     p.setAntialiasing(true);
-    p.setPen(paletteConf()->elementsColor());
 
     mu::engraving::MScore::pixelRatio = mu::engraving::DPI / dpi;
     p.translate(qAbs(element->ldata()->bbox().x() * adjustedRatio), qAbs(element->ldata()->bbox().y() * adjustedRatio));
     p.scale(adjustedRatio, adjustedRatio);
     engravingRenderer()->drawItem(element, &p);
-
-    p.restore();
 
     m_drag->setPixmap(pixmap);
     m_drag->exec(Qt::CopyAction);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1159,12 +1159,11 @@ void NotationInteraction::startDragCopy(const EngravingItem* element, QObject* d
 
     engravingRender()->layoutItem(const_cast<EngravingItem*>(element));
 
-    static QPixmap pixmap(2, 2); // null or 1x1 crashes on Linux under ChromeOS?!
-
     qreal width = element->ldata()->bbox().width();
     qreal height = element->ldata()->bbox().height();
     QSize pixmapSize = QSize(width * adjustedRatio, height * adjustedRatio);
-    pixmap = QPixmap(pixmapSize);
+
+    static QPixmap pixmap(pixmapSize); // null or 1x1 crashes on Linux under ChromeOS?!
     pixmap.fill(Qt::white);
     QBitmap mask = pixmap.createMaskFromColor(Qt::white); // Transparent background
     pixmap.setMask(mask);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -33,15 +33,14 @@
 #include <QDrag>
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>
-#include <QBitmap>
 
 #include "defer.h"
 #include "ptrutils.h"
 #include "containers.h"
 
-#include "draw/types/pen.h"
 #include "draw/painter.h"
 #include "draw/types/painterpath.h"
+#include "draw/types/pen.h"
 #include "engraving/internal/qmimedataadapter.h"
 
 #include "engraving/dom/actionicon.h"
@@ -1154,24 +1153,22 @@ void NotationInteraction::startDragCopy(const EngravingItem* element, QObject* d
     });
 
     const qreal adjustedRatio = 0.4;
-    const qreal width = element->ldata()->bbox().width();
-    const qreal height = element->ldata()->bbox().height();
+    const RectF bbox = element->ldata()->bbox();
+    const qreal width = bbox.width();
+    const qreal height = bbox.height();
 
     QSize pixmapSize = QSize(width * adjustedRatio, height * adjustedRatio);
-    QPixmap pixmap(pixmapSize); // null or 1x1 crashes on Linux under ChromeOS?!
-    pixmap.fill(Qt::white);
-    QBitmap mask = pixmap.createMaskFromColor(Qt::white); // Transparent background
-    pixmap.setMask(mask);
+    QPixmap pixmap(pixmapSize);
+    pixmap.fill(Qt::transparent);
 
-    QPainter painter(&pixmap);
-    QPainter* qp = &painter;
-    const qreal dpi = qp->device()->logicalDpiX();
+    QPainter qp(&pixmap);
+    const qreal dpi = qp.device()->logicalDpiX();
 
-    Painter p(qp, "startDragCopy");
+    Painter p(&qp, "startDragCopy");
     p.setAntialiasing(true);
 
     mu::engraving::MScore::pixelRatio = mu::engraving::DPI / dpi;
-    p.translate(qAbs(element->ldata()->bbox().x() * adjustedRatio), qAbs(element->ldata()->bbox().y() * adjustedRatio));
+    p.translate(qAbs(bbox.x() * adjustedRatio), qAbs(bbox.y() * adjustedRatio));
     p.scale(adjustedRatio, adjustedRatio);
     engravingRenderer()->drawItem(element, &p);
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1157,11 +1157,14 @@ void NotationInteraction::startDragCopy(const EngravingItem* element, QObject* d
     const qreal sizeRatio = spatium / gpaletteScore->style().spatium();
     const qreal adjustedRatio = sizeRatio * 1.5;
 
-    engravingRender()->layoutItem(const_cast<EngravingItem*>(element));
+    engravingRenderer()->layoutItem(const_cast<EngravingItem*>(element));
 
     qreal width = element->ldata()->bbox().width();
     qreal height = element->ldata()->bbox().height();
+    // qreal width = 100;
+    // qreal height = 100;
     QSize pixmapSize = QSize(width * adjustedRatio, height * adjustedRatio);
+    // QSize pixmapSize = QSize(width, height);
 
     static QPixmap pixmap(pixmapSize); // null or 1x1 crashes on Linux under ChromeOS?!
     pixmap.fill(Qt::white);

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -37,7 +37,10 @@
 
 #include "engraving/dom/engravingitem.h"
 #include "engraving/dom/elementgroup.h"
+#include "palette/ipaletteconfiguration.h"
 #include "scorecallbacks.h"
+
+#include "palette/internal/palettecell.h"
 
 namespace mu::engraving {
 class Lasso;
@@ -54,6 +57,8 @@ class NotationInteraction : public INotationInteraction, public async::Asyncable
     INJECT(ISelectInstrumentsScenario, selectInstrumentScenario)
     INJECT(framework::IInteractive, interactive)
     INJECT(engraving::rendering::ISingleRenderer, engravingRenderer)
+    INJECT_STATIC(mu::palette::IPaletteConfiguration, paletteConf)
+    INJECT_STATIC(engraving::rendering::ISingleRenderer, engravingRender)
 
 public:
     NotationInteraction(Notation* notation, INotationUndoStackPtr undoStack);

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -37,10 +37,7 @@
 
 #include "engraving/dom/engravingitem.h"
 #include "engraving/dom/elementgroup.h"
-#include "palette/ipaletteconfiguration.h"
 #include "scorecallbacks.h"
-
-#include "palette/internal/palettecell.h"
 
 namespace mu::engraving {
 class Lasso;
@@ -57,7 +54,6 @@ class NotationInteraction : public INotationInteraction, public async::Asyncable
     INJECT(ISelectInstrumentsScenario, selectInstrumentScenario)
     INJECT(framework::IInteractive, interactive)
     INJECT(engraving::rendering::ISingleRenderer, engravingRenderer)
-    INJECT_STATIC(mu::palette::IPaletteConfiguration, paletteConf)
 
 public:
     NotationInteraction(Notation* notation, INotationUndoStackPtr undoStack);

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -58,7 +58,6 @@ class NotationInteraction : public INotationInteraction, public async::Asyncable
     INJECT(framework::IInteractive, interactive)
     INJECT(engraving::rendering::ISingleRenderer, engravingRenderer)
     INJECT_STATIC(mu::palette::IPaletteConfiguration, paletteConf)
-    INJECT_STATIC(engraving::rendering::ISingleRenderer, engravingRender)
 
 public:
     NotationInteraction(Notation* notation, INotationUndoStackPtr undoStack);


### PR DESCRIPTION
Resolves: #18294


https://github.com/musescore/MuseScore/assets/105774228/54eb063c-8482-4174-aa87-b3a19f31888a


- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
