### PR TITLE
OSXAudioDriver: specify property size for name property

### DIFF
--- a/src/framework/audio/internal/platform/osx/osxaudiodriver.mm
+++ b/src/framework/audio/internal/platform/osx/osxaudiodriver.mm
@@ -273,6 +273,7 @@ void OSXAudioDriver::updateDeviceMap()
 
     for (auto&& deviceId : audioObjects) {
         CFStringRef nameRef;
+        propertySize = sizeof(nameRef);
 
         result = AudioObjectGetPropertyData(deviceId, &namePropertyAddress, 0, NULL, &propertySize, &nameRef);
         if (result != noErr) {


### PR DESCRIPTION
To prevent write out of bounds

Should resolve very sporadic crashes in Address Sanitizer builds; probably this wouldn't ever cause a crash in a release build. Also brings our code in line with other examples of similar code found on the internet. 