### PR TITLE
Recommend unique filename for new/default score

### DIFF
--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -74,7 +74,7 @@ static void setupScoreMetaTags(mu::engraving::MasterScore* masterScore, const Pr
     }
 }
 
-static QString scoreDefaultTitle()
+QString NotationProject::scoreDefaultTitle()
 {
     return qtrc("project", "Untitled score");
 }

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -58,6 +58,8 @@ class NotationProject : public INotationProject, public async::Asyncable
 public:
     ~NotationProject() override;
 
+    static QString scoreDefaultTitle();
+
     Ret load(const io::path_t& path, const io::path_t& stylePath = io::path_t(), bool forceMode = false,
              const std::string& format = "") override;
     Ret createNew(const ProjectCreateOptions& projectInfo) override;

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -29,6 +29,7 @@
 #include "settings.h"
 
 #include "engraving/infrastructure/mscio.h"
+#include "project/internal/notationproject.h"
 
 #include "log.h"
 
@@ -288,6 +289,7 @@ io::path_t ProjectConfiguration::defaultSavingFilePath(INotationProjectPtr proje
     io::path_t folderPath;
     io::path_t filename;
     std::string theSuffix = suffix;
+    std::string theFilenameAddition = filenameAddition;
 
     io::path_t projectPath = project->path();
     bool isLocalProject = !project->isCloudProject();
@@ -334,9 +336,28 @@ io::path_t ProjectConfiguration::defaultSavingFilePath(INotationProjectPtr proje
         theSuffix = DEFAULT_FILE_SUFFIX;
     }
 
+    if (project->isNewlyCreated() && filename.toQString() == NotationProject::scoreDefaultTitle()) {
+        theFilenameAddition += uniqueFileNameAddition(filename + theFilenameAddition, folderPath, theSuffix);
+    }
+
     return folderPath
-           .appendingComponent(filename + filenameAddition)
+           .appendingComponent(filename + theFilenameAddition)
            .appendingSuffix(theSuffix);
+}
+
+std::string ProjectConfiguration::uniqueFileNameAddition(const io::path_t& filename, const io::path_t& folderPath, const std::string& suffix) const {
+    // Check to make sure there isn't already a default titled file existing
+    // Return a filename addition to make the "complete" filename unique
+    const std::string theSuffix = suffix.empty()? DEFAULT_FILE_SUFFIX : suffix;
+    std::string addition;
+    int id = 1;
+    while(fileSystem()->exists(folderPath
+                             .appendingComponent(filename + addition)
+                             .appendingSuffix(theSuffix))) {
+        addition = " (" + std::to_string(id) + ")";
+        id++;
+    }
+    return addition;
 }
 
 SaveLocationType ProjectConfiguration::lastUsedSaveLocationType() const

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -345,15 +345,16 @@ io::path_t ProjectConfiguration::defaultSavingFilePath(INotationProjectPtr proje
            .appendingSuffix(theSuffix);
 }
 
-std::string ProjectConfiguration::uniqueFileNameAddition(const io::path_t& filename, const io::path_t& folderPath, const std::string& suffix) const {
-    // Check to make sure there isn't already a default titled file existing
-    // Return a filename addition to make the "complete" filename unique
-    const std::string theSuffix = suffix.empty()? DEFAULT_FILE_SUFFIX : suffix;
+std::string ProjectConfiguration::uniqueFileNameAddition(const io::path_t& filename, const io::path_t& folderPath,
+                                                         const std::string& suffix) const
+{
+    // Return a filename addition which would make filename unique if it wasn't already
+    const std::string theSuffix = suffix.empty() ? DEFAULT_FILE_SUFFIX : suffix;
     std::string addition;
     int id = 1;
-    while(fileSystem()->exists(folderPath
-                             .appendingComponent(filename + addition)
-                             .appendingSuffix(theSuffix))) {
+    while (fileSystem()->exists(folderPath
+                                .appendingComponent(filename + addition)
+                                .appendingSuffix(theSuffix))) {
         addition = " (" + std::to_string(id) + ")";
         id++;
     }

--- a/src/project/internal/projectconfiguration.h
+++ b/src/project/internal/projectconfiguration.h
@@ -156,6 +156,7 @@ private:
     io::path_t appTemplatesPath() const;
     io::path_t legacyCloudProjectsPath() const;
     io::path_t cloudProjectsPath() const;
+    std::string uniqueFileNameAddition(const io::path_t& filename, const io::path_t& folderPath, const std::string& suffix) const;
 
     async::Channel<io::path_t> m_userTemplatesPathChanged;
     async::Channel<io::path_t> m_userScoresPathChanged;


### PR DESCRIPTION
Resolves: #20140 

In the special case of a newly created score that has a default title, and there already exists an "Untitled\ score.mscz" file in the chosen save directory, recommend a different file name when saving locally (ex. "Untitled\ score (1).mscz") to prevent accidental overwriting.

This issue was brought up by a user who accidentally saved over an existing file, even though there is usually an overwrite dialog warning raised by the OS in this scenario, but thought MuseScore would number the new file in an intelligent way. 

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)