### PR TITLE
added styles for tied notes for guitar pro import

### DIFF
--- a/src/engraving/data/styles/gp-style.mss
+++ b/src/engraving/data/styles/gp-style.mss
@@ -29,5 +29,8 @@
     <wahShowTabCommon>1</wahShowTabCommon>
     <golpeShowTabSimple>0</golpeShowTabSimple>
     <golpeShowTabCommon>1</golpeShowTabCommon>
+    <tabShowTiedFret>1</tabShowTiedFret>
+    <tabParenthesizeTiedFret>1</tabParenthesizeTiedFret>
+    <parenthesizeTiedFretIfArticulation>1</parenthesizeTiedFretIfArticulation>
   </Style>
 </museScore>


### PR DESCRIPTION
This should be default for GP import:


<img width="367" alt="abariska 2024-01-18 at 12 56 54" src="https://github.com/musescore/MuseScore/assets/101250347/6d5f64b4-ad03-45e9-a859-b2c4e65e7e3d">

