### PR TITLE
Fix a lot of typos in MEI import/export

### DIFF
--- a/src/engraving/rendering/stable/systemlayout.cpp
+++ b/src/engraving/rendering/stable/systemlayout.cpp
@@ -873,7 +873,7 @@ void SystemLayout::layoutSystemElements(System* system, LayoutContext& ctx)
                             }
                         }
 
-                        // add beams to skline
+                        // add beams to skyline
                         if (e->isChordRest()) {
                             ChordRest* cr = toChordRest(e);
                             if (BeamLayout::isTopBeam(cr)) {

--- a/src/importexport/mei/internal/meiconverter.cpp
+++ b/src/importexport/mei/internal/meiconverter.cpp
@@ -107,20 +107,20 @@ bool Convert::isDirWithExt(const libmei::Dir& meiDir)
 bool Convert::isMordent(const engraving::Ornament* ornament)
 {
     switch (ornament->symId()) {
-    case engraving::SymId::ornamentMordent:
-    case engraving::SymId::ornamentShortTrill:
-    case engraving::SymId::ornamentTremblement:
-    case engraving::SymId::ornamentPrallMordent:
-    case engraving::SymId::ornamentUpPrall:
-    case engraving::SymId::ornamentPrecompMordentUpperPrefix:
-    case engraving::SymId::ornamentUpMordent:
-    case engraving::SymId::ornamentDownMordent:
-    case engraving::SymId::ornamentPrallDown:
-    case engraving::SymId::ornamentPrallUp:
-    case engraving::SymId::ornamentLinePrall:
-    case engraving::SymId::ornamentPrecompSlide:
-    case engraving::SymId::ornamentTremblementCouperin:
-    case engraving::SymId::ornamentPinceCouperin:
+    case (engraving::SymId::ornamentMordent):
+    case (engraving::SymId::ornamentShortTrill):
+    case (engraving::SymId::ornamentTremblement):
+    case (engraving::SymId::ornamentPrallMordent):
+    case (engraving::SymId::ornamentUpPrall):
+    case (engraving::SymId::ornamentPrecompMordentUpperPrefix):
+    case (engraving::SymId::ornamentUpMordent):
+    case (engraving::SymId::ornamentDownMordent):
+    case (engraving::SymId::ornamentPrallDown):
+    case (engraving::SymId::ornamentPrallUp):
+    case (engraving::SymId::ornamentLinePrall):
+    case (engraving::SymId::ornamentPrecompSlide):
+    case (engraving::SymId::ornamentTremblementCouperin):
+    case (engraving::SymId::ornamentPinceCouperin):
         return true;
     default:
         return false;
@@ -130,9 +130,9 @@ bool Convert::isMordent(const engraving::Ornament* ornament)
 bool Convert::isTrill(const engraving::Ornament* ornament)
 {
     switch (ornament->symId()) {
-    case engraving::SymId::ornamentTrill:
-    case engraving::SymId::ornamentShake3:
-    case engraving::SymId::ornamentShakeMuffat1:
+    case (engraving::SymId::ornamentTrill):
+    case (engraving::SymId::ornamentShake3):
+    case (engraving::SymId::ornamentShakeMuffat1):
         return true;
     default:
         return false;
@@ -142,9 +142,9 @@ bool Convert::isTrill(const engraving::Ornament* ornament)
 bool Convert::isTurn(const engraving::Ornament* ornament)
 {
     switch (ornament->symId()) {
-    case engraving::SymId::ornamentTurnInverted:
-    case engraving::SymId::ornamentTurnSlash:
-    case engraving::SymId::ornamentTurn:
+    case (engraving::SymId::ornamentTurnInverted):
+    case (engraving::SymId::ornamentTurnSlash):
+    case (engraving::SymId::ornamentTurn):
         return true;
     default:
         return false;
@@ -2024,18 +2024,18 @@ libmei::Mordent Convert::mordentToMEI(const engraving::Ornament* ornament)
     // @form
     switch (ornament->symId()) {
     case (engraving::SymId::ornamentMordent):
-    case engraving::SymId::ornamentPrallMordent:
-    case engraving::SymId::ornamentUpMordent:
-    case engraving::SymId::ornamentDownMordent:
+    case (engraving::SymId::ornamentPrallMordent):
+    case (engraving::SymId::ornamentUpMordent):
+    case (engraving::SymId::ornamentDownMordent):
         meiMordent.SetForm(libmei::mordentLog_FORM_lower);
         break;
-    case engraving::SymId::ornamentShortTrill:
-    case engraving::SymId::ornamentTremblement:
-    case engraving::SymId::ornamentUpPrall:
-    case engraving::SymId::ornamentPrecompMordentUpperPrefix:
-    case engraving::SymId::ornamentPrallDown:
-    case engraving::SymId::ornamentPrallUp:
-    case engraving::SymId::ornamentLinePrall:
+    case (engraving::SymId::ornamentShortTrill):
+    case (engraving::SymId::ornamentTremblement):
+    case (engraving::SymId::ornamentUpPrall):
+    case (engraving::SymId::ornamentPrecompMordentUpperPrefix):
+    case (engraving::SymId::ornamentPrallDown):
+    case (engraving::SymId::ornamentPrallUp):
+    case (engraving::SymId::ornamentLinePrall):
         meiMordent.SetForm(libmei::mordentLog_FORM_upper);
         break;
     default:
@@ -2044,15 +2044,15 @@ libmei::Mordent Convert::mordentToMEI(const engraving::Ornament* ornament)
 
     // @long
     switch (ornament->symId()) {
-    case engraving::SymId::ornamentTremblement:
-    case engraving::SymId::ornamentPrallMordent:
-    case engraving::SymId::ornamentUpPrall:
-    case engraving::SymId::ornamentPrecompMordentUpperPrefix:
-    case engraving::SymId::ornamentUpMordent:
-    case engraving::SymId::ornamentDownMordent:
-    case engraving::SymId::ornamentPrallDown:
-    case engraving::SymId::ornamentPrallUp:
-    case engraving::SymId::ornamentLinePrall:
+    case (engraving::SymId::ornamentTremblement):
+    case (engraving::SymId::ornamentPrallMordent):
+    case (engraving::SymId::ornamentUpPrall):
+    case (engraving::SymId::ornamentPrecompMordentUpperPrefix):
+    case (engraving::SymId::ornamentUpMordent):
+    case (engraving::SymId::ornamentDownMordent):
+    case (engraving::SymId::ornamentPrallDown):
+    case (engraving::SymId::ornamentPrallUp):
+    case (engraving::SymId::ornamentLinePrall):
         meiMordent.SetLong(libmei::BOOLEAN_true);
         break;
     default:
@@ -2063,9 +2063,9 @@ libmei::Mordent Convert::mordentToMEI(const engraving::Ornament* ornament)
     bool smufl = true;
     switch (ornament->symId()) {
     case (engraving::SymId::ornamentMordent):
-    case engraving::SymId::ornamentShortTrill:
-    case engraving::SymId::ornamentTremblement:
-    case engraving::SymId::ornamentPrallMordent:
+    case (engraving::SymId::ornamentShortTrill):
+    case (engraving::SymId::ornamentTremblement):
+    case (engraving::SymId::ornamentPrallMordent):
         smufl = false;
         break;
     default:
@@ -2650,11 +2650,11 @@ std::pair<libmei::data_STEMDIRECTION, double> Convert::stemToMEI(const engraving
 engraving::TremoloType Convert::stemModFromMEI(const libmei::data_STEMMODIFIER meiStemMod)
 {
     switch (meiStemMod) {
-    case libmei::STEMMODIFIER_1slash:  return engraving::TremoloType::R8;
-    case libmei::STEMMODIFIER_2slash: return engraving::TremoloType::R16;
-    case libmei::STEMMODIFIER_3slash: return engraving::TremoloType::R32;
-    case libmei::STEMMODIFIER_4slash: return engraving::TremoloType::R64;
-    case libmei::STEMMODIFIER_z: return engraving::TremoloType::BUZZ_ROLL;
+    case (libmei::STEMMODIFIER_1slash):  return engraving::TremoloType::R8;
+    case (libmei::STEMMODIFIER_2slash): return engraving::TremoloType::R16;
+    case (libmei::STEMMODIFIER_3slash): return engraving::TremoloType::R32;
+    case (libmei::STEMMODIFIER_4slash): return engraving::TremoloType::R64;
+    case (libmei::STEMMODIFIER_z): return engraving::TremoloType::BUZZ_ROLL;
     default:
         return engraving::TremoloType::INVALID_TREMOLO;
     }
@@ -2663,11 +2663,11 @@ engraving::TremoloType Convert::stemModFromMEI(const libmei::data_STEMMODIFIER m
 libmei::data_STEMMODIFIER Convert::stemModToMEI(const engraving::TremoloSingleChord* tremolo)
 {
     switch (tremolo->tremoloType()) {
-    case engraving::TremoloType::R8:  return libmei::STEMMODIFIER_1slash;
-    case engraving::TremoloType::R16: return libmei::STEMMODIFIER_2slash;
-    case engraving::TremoloType::R32: return libmei::STEMMODIFIER_3slash;
-    case engraving::TremoloType::R64: return libmei::STEMMODIFIER_4slash;
-    case engraving::TremoloType::BUZZ_ROLL: return libmei::STEMMODIFIER_z;
+    case (engraving::TremoloType::R8):  return libmei::STEMMODIFIER_1slash;
+    case (engraving::TremoloType::R16): return libmei::STEMMODIFIER_2slash;
+    case (engraving::TremoloType::R32): return libmei::STEMMODIFIER_3slash;
+    case (engraving::TremoloType::R64): return libmei::STEMMODIFIER_4slash;
+    case (engraving::TremoloType::BUZZ_ROLL): return libmei::STEMMODIFIER_z;
     default:
         return libmei::STEMMODIFIER_NONE;
     }

--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -1329,7 +1329,7 @@ bool MeiExporter::writeRest(const Rest* rest, const Staff* staff)
 
 /**
  * Write a syl with the corresponding text syllable and the elision type.
- * The elision type is passed to the Convert methods that deals with the adjustment of @con and @worpos.
+ * The elision type is passed to the Convert methods that deals with the adjustment of @con and @wordpos.
  */
 
 bool MeiExporter::writeSyl(const Lyrics* lyrics, const String& text, ElisionType elision)

--- a/src/importexport/mei/internal/meiexporter.h
+++ b/src/importexport/mei/internal/meiexporter.h
@@ -200,7 +200,7 @@ private:
     const engraving::Segment* m_keySig;
     /** Same for the timeSig segment */
     const engraving::Segment* m_timeSig;
-    /** A flag indicating that we have mulitple sections in the file */
+    /** A flag indicating that we have multiple sections in the file */
     bool m_hasSections;
 
     /** A list of items (first) for which we know the @startid (second)  */

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -1587,7 +1587,7 @@ bool MeiImporter::readArtic(pugi::xml_node articNode, Chord* chord)
 
     Articulation* articulation = static_cast<Articulation*>(this->addToChordRest(meiArtic, nullptr, chord));
     if (!articulation) {
-        // Warning message given in MeiExpoter::addSpanner
+        // Warning message given in MeiImporter::addSpanner
         return true;
     }
 
@@ -2186,7 +2186,7 @@ bool MeiImporter::readBreath(pugi::xml_node breathNode, Measure* measure)
 
     Breath* breath = static_cast<Breath*>(this->addAnnotation(meiBreath, measure));
     if (!breath) {
-        // Warning message given in MeiExpoter::addAnnotation
+        // Warning message given in MeiImporter::addAnnotation
         return true;
     }
 
@@ -2211,7 +2211,7 @@ bool MeiImporter::readCaesura(pugi::xml_node caesuraNode, Measure* measure)
 
     Breath* breath = static_cast<Breath*>(this->addAnnotation(meiCaesura, measure));
     if (!breath) {
-        // Warning message given in MeiExpoter::addAnnotation
+        // Warning message given in MeiImporter::addAnnotation
         return true;
     }
 
@@ -2241,14 +2241,14 @@ bool MeiImporter::readDir(pugi::xml_node dirNode, Measure* measure)
     if (Convert::isDirWithExt(meiDir)) {
         TextLineBase* textLineBase = static_cast<TextLineBase*>(this->addSpanner(meiDir, measure, dirNode));
         if (!textLineBase) {
-            // Warning message given in MeiExpoter::addSpanner
+            // Warning message given in MeiImporter::addSpanner
             return true;
         }
         Convert::dirFromMEI(textLineBase, meiLines, meiDir, warning);
     } else {
         TextBase* textBase = static_cast<TextBase*>(this->addAnnotation(meiDir, measure));
         if (!textBase) {
-            // Warning message given in MeiExpoter::addAnnotation
+            // Warning message given in MeiImporter::addAnnotation
             return true;
         }
         Convert::dirFromMEI(textBase, meiLines, meiDir, warning);
@@ -2273,7 +2273,7 @@ bool MeiImporter::readDynam(pugi::xml_node dynamNode, Measure* measure)
 
     Dynamic* dynamic = static_cast<Dynamic*>(this->addAnnotation(meiDynam, measure));
     if (!dynamic) {
-        // Warning message given in MeiExpoter::addAnnotation
+        // Warning message given in MeiImporter::addAnnotation
         return true;
     }
 
@@ -2340,7 +2340,7 @@ bool MeiImporter::readFb(pugi::xml_node harmNode, Measure* measure)
 
     FiguredBass* figuredBass = static_cast<FiguredBass*>(this->addAnnotation(meiHarm, measure));
     if (!figuredBass) {
-        // Warning message given in MeiExpoter::addAnnotation
+        // Warning message given in MeiImporter::addAnnotation
         return true;
     }
     // Needs to be registered by hand because we pass meiHarm to MeiImporter::addAnnotation
@@ -2391,7 +2391,7 @@ bool MeiImporter::readFermata(pugi::xml_node fermataNode, Measure* measure)
     }
 
     if (!fermata) {
-        // Warning message given in MeiExpoter::addAnnotation
+        // Warning message given in MeiImporter::addAnnotation
         return true;
     }
 
@@ -2416,7 +2416,7 @@ bool MeiImporter::readHairpin(pugi::xml_node hairpinNode, Measure* measure)
 
     Hairpin* hairpin = static_cast<Hairpin*>(this->addSpanner(meiHairpin, measure, hairpinNode));
     if (!hairpin) {
-        // Warning message given in MeiExpoter::addSpanner
+        // Warning message given in MeiImporter::addSpanner
         return true;
     }
 
@@ -2442,7 +2442,7 @@ bool MeiImporter::readHarm(pugi::xml_node harmNode, Measure* measure)
 
     Harmony* harmony = static_cast<Harmony*>(this->addAnnotation(meiHarm, measure));
     if (!harmony) {
-        // Warning message given in MeiExpoter::addAnnotation
+        // Warning message given in MeiImporter::addAnnotation
         return true;
     }
 
@@ -2497,7 +2497,7 @@ bool MeiImporter::readOctave(pugi::xml_node octaveNode, Measure* measure)
 
     Ottava* ottava = static_cast<Ottava*>(this->addSpanner(meiOctave, measure, octaveNode));
     if (!ottava) {
-        // Warning message given in MeiExpoter::addSpanner
+        // Warning message given in MeiImporter::addSpanner
         return true;
     }
 
@@ -2548,7 +2548,7 @@ bool MeiImporter::readPedal(pugi::xml_node pedalNode, Measure* measure)
 
     Pedal* pedal = static_cast<Pedal*>(this->addSpanner(meiPedal, measure, pedalNode));
     if (!pedal) {
-        // Warning message given in MeiExpoter::addSpanner
+        // Warning message given in MeiImporter::addSpanner
         return true;
     }
 
@@ -2604,7 +2604,7 @@ bool MeiImporter::readSlur(pugi::xml_node slurNode, Measure* measure)
 
     Slur* slur = static_cast<Slur*>(this->addSpanner(meiSlur, measure, slurNode));
     if (!slur) {
-        // Warning message given in MeiExpoter::addSpanner
+        // Warning message given in MeiImporter::addSpanner
         return true;
     }
 
@@ -2629,7 +2629,7 @@ bool MeiImporter::readTempo(pugi::xml_node tempoNode, Measure* measure)
 
     TempoText* tempoText = static_cast<TempoText*>(this->addAnnotation(meiTempo, measure));
     if (!tempoText) {
-        // Warning message given in MeiExpoter::addAnnotation
+        // Warning message given in MeiImporter::addAnnotation
         return true;
     }
 

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -336,7 +336,7 @@ ChordRest* MeiImporter::addChordRest(pugi::xml_node node, Measure* measure, int 
 }
 
 /**
- * Add grace notes to a ChordRest When a grace group was previously read and added to MeiImpoter::m_graceNotes
+ * Add grace notes to a ChordRest When a grace group was previously read and added to MeiImporter::m_graceNotes
  * Ignore (delete) the grace notes if the ChordRest is a Rest.
  * Look at m_graceNoteType for setting the acciaccatura note type (when grace notes precede only)
  */
@@ -935,7 +935,7 @@ bool MeiImporter::readScore(pugi::xml_node root)
 
 /**
  * Read a scoreDef (initial or intermediate).
- * For the intial scoreDef, also tries to build the part structure from the scoreDef relying on staffGrp@label and staffDef@label.
+ * For the initial scoreDef, also tries to build the part structure from the scoreDef relying on staffGrp@label and staffDef@label.
  * Sets the time signature and key signature to the global m_timeSigs and m_keySigs maps.
  * Uses the SCOREDEF_IDX index position for global (scoreDef) time signature and key signatures.
  * Since the map are ordered, these will have priority over the ones read in MeiImporter::readStaffDef.
@@ -2156,7 +2156,7 @@ bool MeiImporter::readArpeg(pugi::xml_node arpegNode, Measure* measure)
 
     Arpeggio* arpeggio = static_cast<Arpeggio*>(this->addToChordRest(meiArpeg, measure));
     if (!arpeggio) {
-        // Warning message given in MeiExpoter::addToChordRest
+        // Warning message given in MeiImporter::addToChordRest
         return true;
     }
 
@@ -2471,7 +2471,7 @@ bool MeiImporter::readMordent(pugi::xml_node mordentNode, Measure* measure)
 
     Ornament* ornament = static_cast<Ornament*>(this->addToChordRest(meiMordent, measure));
     if (!ornament) {
-        // Warning message given in MeiExpoter::addToChordRest
+        // Warning message given in MeiImporter::addToChordRest
         return true;
     }
 
@@ -2522,7 +2522,7 @@ bool MeiImporter::readOrnam(pugi::xml_node ornamNode, Measure* measure)
 
     Ornament* ornament = static_cast<Ornament*>(this->addToChordRest(meiOrnam, measure));
     if (!ornament) {
-        // Warning message given in MeiExpoter::addToChordRest
+        // Warning message given in MeiImporter::addToChordRest
         return true;
     }
 
@@ -2658,7 +2658,7 @@ bool MeiImporter::readTie(pugi::xml_node tieNode, Measure* measure)
     // We do not use addSpanner here because Tie object are added directly to the start and end Note objects
     Note* startNote = this->findStartNote(meiTie);
     if (!startNote) {
-        // Here we could detect if a if its a tied chord (for files not exported from MuseScore)
+        // Here we could detect if it's a tied chord (for files not exported from MuseScore)
         // We would need a dedicated list and tie each note once the second chord has been found.
         return true;
     }
@@ -2693,7 +2693,7 @@ bool MeiImporter::readTrill(pugi::xml_node trillNode, Measure* measure)
 
     Ornament* ornament = static_cast<Ornament*>(this->addToChordRest(meiTrill, measure));
     if (!ornament) {
-        // Warning message given in MeiExpoter::addToChordRest
+        // Warning message given in MeiImporter::addToChordRest
         return true;
     }
 
@@ -2719,7 +2719,7 @@ bool MeiImporter::readTurn(pugi::xml_node turnNode, Measure* measure)
 
     Ornament* ornament = static_cast<Ornament*>(this->addToChordRest(meiTurn, measure));
     if (!ornament) {
-        // Warning message given in MeiExpoter::addToChordRest
+        // Warning message given in MeiImporter::addToChordRest
         return true;
     }
 
@@ -2828,7 +2828,7 @@ bool MeiImporter::buildIdMap(pugi::xml_node scoreNode)
 
 /**
  * Create a mapping for <staff> `@n` and <layer> `@n`.
- * Usefull only when reading MEI files where the sequence of `@n` is not starting from 1 or not sequential.
+ * Useful only when reading MEI files where the sequence of `@n` is not starting from 1 or not sequential.
  * Not really useful when reading MEI files generated from MuseScore since these will have sequential numbers starting with 1.
  */
 

--- a/src/importexport/mei/internal/meiimporter.h
+++ b/src/importexport/mei/internal/meiimporter.h
@@ -104,7 +104,7 @@ private:
     bool readArtics(pugi::xml_node parentNode, engraving::Chord* chord);
     bool readArtic(pugi::xml_node articNode, engraving::Chord* chord);
     bool readBeam(pugi::xml_node beamNode, engraving::Measure* measure, int track, int& ticks);
-    bool readBTrem(pugi::xml_node beamNode, engraving::Measure* measure, int track, int& ticks);
+    bool readBTrem(pugi::xml_node bTremNode, engraving::Measure* measure, int track, int& ticks);
     bool readClef(pugi::xml_node clefNode, engraving::Measure* measure, int track, int& ticks);
     bool readChord(pugi::xml_node chordNode, engraving::Measure* measure, int track, int& ticks);
     bool readGraceGrp(pugi::xml_node graceGrpNode, engraving::Measure* measure, int track, int& ticks);


### PR DESCRIPTION
This PR brings another round of fixing typos. Also it does some minor code style unification in the `meiconverter`. 
No changes in behavior expected.