### PR TITLE
gp-import: fixed potential crash when tuplet is imported for empty measure

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -406,12 +406,20 @@ void GPConverter::fixEmptyMeasures()
                 continue;
             }
             for (size_t i = 1; i < segItemPairs.size(); ++i) {
-                segItemPairs.at(i).first->remove(segItemPairs.at(i).second);
+                Rest* rest = toRest(segItemPairs.at(i).second);
+                if (Tuplet* tuplet = rest->tuplet()) {
+                    tuplet->remove(rest);
+                }
+
+                segItemPairs.at(i).first->remove(rest);
             }
 
             Rest* rest = toRest(segItemPairs.at(0).second);
             rest->setTicks(lastMeasure->ticks());
             rest->setDurationType(DurationType::V_MEASURE);
+            if (Tuplet* tuplet = rest->tuplet()) {
+                tuplet->remove(rest);
+            }
         }
     }
 }


### PR DESCRIPTION
also removed tuplet from remaining rest on empty measure:
![Screenshot 2024-01-18 at 17 06 13](https://github.com/musescore/MuseScore/assets/24373905/a3d6d401-ff53-4993-99aa-7961d1809f75)
[tuplet.gp.zip](https://github.com/musescore/MuseScore/files/13979777/tuplet.gp.zip)
