### PR TITLE
Move input cursor past tied chords

### DIFF
--- a/src/engraving/dom/input.cpp
+++ b/src/engraving/dom/input.cpp
@@ -35,6 +35,7 @@
 #include "select.h"
 #include "staff.h"
 #include "stem.h"
+#include "tie.h"
 
 using namespace mu;
 
@@ -310,14 +311,30 @@ void InputState::setSegment(Segment* s)
 //   nextInputPos
 //---------------------------------------------------------
 
-Segment* InputState::nextInputPos() const
+Segment* InputState::nextInputPos(Segment* seg = nullptr) const
 {
-    Measure* m = m_segment->measure();
-    Segment* s = m_segment->next1(SegmentType::ChordRest);
+    if (!seg) {
+        seg = m_segment;
+    }
+    Measure* m = seg->measure();
+    Segment* s = seg->next1(SegmentType::ChordRest);
     for (; s; s = s->next1(SegmentType::ChordRest)) {
         if (s->element(m_track)) {
             if (s->element(m_track)->isRest() && toRest(s->element(m_track))->isGap()) {
                 m = s->measure();
+            } else if (seg->element(m_track)->isChord()) {
+                Chord* chord = toChord(seg->element(m_track));
+                bool allTied = true;
+                for (Note* n : chord->notes()) {
+                    if (!n->tieFor()) {
+                        allTied = false;
+                        break;
+                    }
+                }
+                if (allTied && !chord->notes().empty()) {
+                    return nextInputPos(chord->notes()[chord->notes().size() - 1]->tieFor()->endNote()->chord()->segment());
+                }
+                return s;
             } else {
                 return s;
             }
@@ -330,7 +347,6 @@ Segment* InputState::nextInputPos() const
 
 //---------------------------------------------------------
 //   moveToNextInputPos
-//   TODO: special case: note is first note of tie: goto to last note of tie
 //---------------------------------------------------------
 
 void InputState::moveToNextInputPos()

--- a/src/engraving/dom/input.h
+++ b/src/engraving/dom/input.h
@@ -127,7 +127,7 @@ public:
 
 private:
 
-    Segment* nextInputPos() const;
+    Segment* nextInputPos(Segment* seg) const;
 
     track_idx_t m_track = 0;
     track_idx_t m_prevTrack = 0; // used for navigation


### PR DESCRIPTION
Currently, the input cursor does not take into account tied notes when calculating the new position:
![image](https://github.com/musescore/MuseScore/assets/116587995/fd6bfdfc-e5c4-48b2-b727-a330f5768162)

Now, the cursor places itself at the end of a tied chord:
![image](https://github.com/musescore/MuseScore/assets/116587995/8db8b00a-1044-4fee-9002-461b76d808fc)

Worth mentioning that not all input methods calculate the new cursor position via the method changed in this PR, perhaps it's worth standardising this behavior?

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
