### PR TITLE
[4.2.1] Update BeamSettingsModel element list in `onNotationChanged`

### DIFF
--- a/src/inspector/models/notation/notes/beams/beamsettingsmodel.cpp
+++ b/src/inspector/models/notation/notes/beams/beamsettingsmodel.cpp
@@ -96,9 +96,11 @@ void BeamSettingsModel::loadProperties()
     loadProperties(propertyIdSet);
 }
 
-void BeamSettingsModel::onNotationChanged(const PropertyIdSet& changedPropertyIdSet, const StyleIdSet&)
+void BeamSettingsModel::onNotationChanged(const PropertyIdSet&, const StyleIdSet&)
 {
-    loadProperties(changedPropertyIdSet);
+    // The list of elements may have become invalid; beams might have been deleted and replaced during layout.
+    // Request the actual list to prevent crashes. TODO: Not ideal for performance though.
+    updateProperties();
 }
 
 void BeamSettingsModel::loadProperties(const mu::engraving::PropertyIdSet& propertyIdSet)


### PR DESCRIPTION
Prevents a crash that was the result of old beams (that were deleted and replaced during layout) still being stored in `m_elementList` at the moment that `onNotationChanged` is called in the case of undo.

Resolves: #21069

The problem is that `onNotationChanged` is called too early, before the `ElementRepositoryService` signals about `elementsUpdated` and `AbstractInspectorModel::updateProperties` is called. Perhaps we should refactor things somehow to ensure that `updateProperties` is called first, while avoiding doing unnecessary work.
For now, for 4.2.1, I've chosen this simpler solution. The disadvantage though is that in some cases unnecessary work may be done, which is not nice for performance. 

This would still need to be ported to master. 