### PR TITLE
Add the existing "First system indentation'"property to system break inspector (master)

### DIFF
--- a/src/inspector/models/notation/sectionbreaks/sectionbreaksettingsmodel.cpp
+++ b/src/inspector/models/notation/sectionbreaks/sectionbreaksettingsmodel.cpp
@@ -40,6 +40,7 @@ void SectionBreakSettingsModel::createProperties()
     m_shouldStartWithLongInstrNames = buildPropertyItem(mu::engraving::Pid::START_WITH_LONG_NAMES);
     m_shouldResetBarNums = buildPropertyItem(mu::engraving::Pid::START_WITH_MEASURE_ONE);
     m_pauseDuration = buildPropertyItem(mu::engraving::Pid::PAUSE);
+    m_firstSystemIndent = buildPropertyItem(mu::engraving::Pid::FIRST_SYSTEM_INDENTATION);
 }
 
 void SectionBreakSettingsModel::requestElements()
@@ -52,6 +53,7 @@ void SectionBreakSettingsModel::loadProperties()
     loadPropertyItem(m_shouldStartWithLongInstrNames);
     loadPropertyItem(m_shouldResetBarNums);
     loadPropertyItem(m_pauseDuration, formatDoubleFunc);
+    loadPropertyItem(m_firstSystemIndent);
 }
 
 void SectionBreakSettingsModel::resetProperties()
@@ -59,6 +61,7 @@ void SectionBreakSettingsModel::resetProperties()
     m_shouldStartWithLongInstrNames->resetToDefault();
     m_shouldResetBarNums->resetToDefault();
     m_pauseDuration->resetToDefault();
+    m_firstSystemIndent->resetToDefault();
 }
 
 PropertyItem* SectionBreakSettingsModel::shouldStartWithLongInstrNames() const
@@ -74,4 +77,9 @@ PropertyItem* SectionBreakSettingsModel::shouldResetBarNums() const
 PropertyItem* SectionBreakSettingsModel::pauseDuration() const
 {
     return m_pauseDuration;
+}
+
+PropertyItem* SectionBreakSettingsModel::firstSystemIndent() const
+{
+    return m_firstSystemIndent;
 }

--- a/src/inspector/models/notation/sectionbreaks/sectionbreaksettingsmodel.h
+++ b/src/inspector/models/notation/sectionbreaks/sectionbreaksettingsmodel.h
@@ -32,6 +32,7 @@ class SectionBreakSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(PropertyItem * shouldStartWithLongInstrNames READ shouldStartWithLongInstrNames CONSTANT)
     Q_PROPERTY(PropertyItem * shouldResetBarNums READ shouldResetBarNums CONSTANT)
     Q_PROPERTY(PropertyItem * pauseDuration READ pauseDuration CONSTANT)
+    Q_PROPERTY(PropertyItem * firstSystemIndent READ firstSystemIndent CONSTANT)
 
 public:
     explicit SectionBreakSettingsModel(QObject* parent, IElementRepositoryService* repository);
@@ -44,11 +45,13 @@ public:
     PropertyItem* shouldStartWithLongInstrNames() const;
     PropertyItem* shouldResetBarNums() const;
     PropertyItem* pauseDuration() const;
+    PropertyItem* firstSystemIndent() const;
 
 private:
     PropertyItem* m_shouldStartWithLongInstrNames = nullptr;
     PropertyItem* m_shouldResetBarNums = nullptr;
     PropertyItem* m_pauseDuration = nullptr;
+    PropertyItem* m_firstSystemIndent = nullptr;
 };
 }
 

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/sectionbreaks/SectionBreakSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/sectionbreaks/SectionBreakSettings.qml
@@ -71,11 +71,22 @@ Column {
     }
 
     PropertyCheckBox {
+        id: shouldResetBarNums
         text: qsTrc("inspector", "Reset measure numbers for new section")
         propertyItem: root.model ? root.model.shouldResetBarNums : null
 
         navigation.name: "ResetBarNumbers"
         navigation.panel: root.navigationPanel
         navigation.row: startWithLongInstrNames.navigation.row + 1
+    }
+
+    PropertyCheckBox {
+        id: startWithfirstSystemIndented
+        text: qsTrc("inspector", "Indent first system of new section")
+        propertyItem: root.model ? root.model.firstSystemIndent : null
+
+        navigation.name: "FirstSystemIndent"
+        navigation.panel: root.navigationPanel
+        navigation.row: shouldResetBarNums.navigation.row + 1
     }
 }


### PR DESCRIPTION
to make it accessible. Leftover from #7445, which ported #6941 from 3.x to master, but left out the UI for setting/unsetting it.