### PR TITLE
[4.2.1] Prevent crash on deleting 1st measure with slur

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -4896,6 +4896,8 @@ void Score::undoChangeElement(EngravingItem* oldElement, EngravingItem* newEleme
 {
     if (!oldElement) {
         undoAddElement(newElement);
+    } else if (oldElement->isSpanner()) {
+        undo(new ChangeElement(oldElement, newElement));
     } else {
         const std::list<EngravingObject*> links = oldElement->linkList();
         for (EngravingObject* obj : links) {


### PR DESCRIPTION
Resolves: #21065 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

The original crash happened when deleting the first bar of a score which contained the start of a slur extending beyond the bar.

This is a **very** temporary solution - `Score::undoChangeElement` needs some attention in master!