### PR TITLE
Allow augmented seconds for non-trill ornaments

### DIFF
--- a/src/inspector/models/notation/ornaments/ornamentsettingsmodel.cpp
+++ b/src/inspector/models/notation/ornaments/ornamentsettingsmodel.cpp
@@ -65,6 +65,10 @@ void OrnamentSettingsModel::createProperties()
             newInterval.step = IntervalStep::SECOND;
             newInterval.type = IntervalType::MINOR;
             break;
+        case OrnamentTypes::BasicInterval::TYPE_AUGMENTED_SECOND:
+            newInterval.step = IntervalStep::SECOND;
+            newInterval.type = IntervalType::AUGMENTED;
+            break;
         default:
             break;
         }
@@ -109,6 +113,8 @@ void OrnamentSettingsModel::loadProperties()
             basicInterval = OrnamentTypes::BasicInterval::TYPE_MAJOR_SECOND;
         } else if (interval.step == IntervalStep::SECOND && interval.type == IntervalType::MINOR) {
             basicInterval = OrnamentTypes::BasicInterval::TYPE_MINOR_SECOND;
+        } else if (interval.step == IntervalStep::SECOND && interval.type == IntervalType::AUGMENTED) {
+            basicInterval = OrnamentTypes::BasicInterval::TYPE_AUGMENTED_SECOND;
         }
 
         return static_cast<int>(basicInterval);

--- a/src/inspector/types/ornamenttypes.h
+++ b/src/inspector/types/ornamenttypes.h
@@ -40,7 +40,8 @@ public:
         TYPE_INVALID,
         TYPE_AUTO_DIATONIC,
         TYPE_MAJOR_SECOND,
-        TYPE_MINOR_SECOND
+        TYPE_MINOR_SECOND,
+        TYPE_AUGMENTED_SECOND
     };
 
     // For ornaments that can define a custom interval (trills)

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/ornaments/OrnamentSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/ornaments/OrnamentSettings.qml
@@ -58,6 +58,7 @@ Column {
             { text: qsTrc("inspector", "Auto (diatonic)"), value: OrnamentTypes.TYPE_AUTO_DIATONIC},
             { text: qsTrc("inspector", "Minor second"), value: OrnamentTypes.TYPE_MINOR_SECOND},
             { text: qsTrc("inspector", "Major second"), value: OrnamentTypes.TYPE_MAJOR_SECOND},
+            { text: qsTrc("inspector", "Augmented second"), value: OrnamentTypes.TYPE_AUGMENTED_SECOND},
         ]
     }
 
@@ -75,6 +76,7 @@ Column {
             { text: qsTrc("inspector", "Auto (diatonic)"), value: OrnamentTypes.TYPE_AUTO_DIATONIC},
             { text: qsTrc("inspector", "Minor second"), value: OrnamentTypes.TYPE_MINOR_SECOND},
             { text: qsTrc("inspector", "Major second"), value: OrnamentTypes.TYPE_MAJOR_SECOND},
+            { text: qsTrc("inspector", "Augmented second"), value: OrnamentTypes.TYPE_AUGMENTED_SECOND},
         ]
     }
 


### PR DESCRIPTION
Resolves: #19715

Non-trill ornaments now have the option to display augmented seconds.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
