### PR TITLE
"first measure" in barnumbers is "first in score", not "measure numbered 1"

### DIFF
--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -533,8 +533,10 @@ bool Measure::showsMeasureNumberInAutoMode()
         return false;
     }
 
+    Measure* prevMeasure = this->prevMeasure();
+
     // Measure numbers should not show on first measure unless specified with Sid::showMeasureNumberOne
-    if (!no()) {
+    if (!prevMeasure || prevMeasure->sectionBreak() || (prevMeasure->irregular() && prevMeasure->isFirstInSection())) {
         return style().styleB(Sid::showMeasureNumberOne);
     }
 
@@ -543,7 +545,7 @@ bool Measure::showsMeasureNumberInAutoMode()
         //   1) This is the first measure of the system OR
         //   2) The previous measure in the system is the first, and is irregular.
         return isFirstInSystem()
-               || (prevMeasure() && prevMeasure()->irregular() && prevMeasure()->isFirstInSystem());
+               || (prevMeasure && prevMeasure->irregular() && prevMeasure->isFirstInSystem());
     } else {
         // In the case of an interval, we should show the measure number either if:
         //   1) We should show them every measure
@@ -1928,6 +1930,16 @@ bool Measure::isFirstInSystem() const
         return false;
     }
     return system()->firstMeasure() == this;
+}
+
+//---------------------------------------------------------
+//   isFirstInSection
+//---------------------------------------------------------
+
+bool Measure::isFirstInSection() const
+{
+    Measure* prevMeasure = this->prevMeasure();
+    return !prevMeasure || prevMeasure->sectionBreak();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -533,10 +533,13 @@ bool Measure::showsMeasureNumberInAutoMode()
         return false;
     }
 
+    int interval = style().styleI(Sid::measureNumberInterval);
     Measure* prevMeasure = this->prevMeasure();
 
     // Measure numbers should not show on first measure unless specified with Sid::showMeasureNumberOne
-    if (!prevMeasure || prevMeasure->sectionBreak() || (prevMeasure->irregular() && prevMeasure->isFirstInSection())) {
+    // except, when showing numbers on each measure, and first measure is after anacrusis - then show always
+    if (!prevMeasure || prevMeasure->sectionBreak()
+        || (prevMeasure->irregular() && prevMeasure->isFirstInSection() && interval != 1)) {
         return style().styleB(Sid::showMeasureNumberOne);
     }
 
@@ -549,7 +552,6 @@ bool Measure::showsMeasureNumberInAutoMode()
     } else {
         // In the case of an interval, we should show the measure number either if:
         //   1) We should show them every measure
-        int interval = style().styleI(Sid::measureNumberInterval);
         if (interval == 1) {
             return true;
         }
@@ -557,7 +559,7 @@ bool Measure::showsMeasureNumberInAutoMode()
         //   2) (measureNumber + 1) % interval == 0 (or 1 if measure number one is numbered.)
         // If measure number 1 is numbered, and the interval is let's say 5, then we should number #1, 6, 11, 16, etc.
         // If measure number 1 is not numbered, with the same interval (5), then we should number #5, 10, 15, 20, etc.
-        return ((no() + 1) % style().styleI(Sid::measureNumberInterval)) == (style().styleB(Sid::showMeasureNumberOne) ? 1 : 0);
+        return ((no() + 1) % interval) == (style().styleB(Sid::showMeasureNumberOne) ? 1 : 0);
     }
 }
 

--- a/src/engraving/dom/measure.h
+++ b/src/engraving/dom/measure.h
@@ -284,6 +284,7 @@ public:
     bool isFinalMeasureOfSection() const;
     bool isAnacrusis() const;
     bool isFirstInSystem() const;
+    bool isFirstInSection() const;
 
     bool breakMultiMeasureRest() const { return m_breakMultiMeasureRest; }
     void setBreakMultiMeasureRest(bool val) { m_breakMultiMeasureRest = val; }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/20016

<!-- Add a short description of and motivation for the changes here -->

Measure::isFirstInSection() is true, if is first in score, or first after section break

- "Show first" measure numbers depends now on this, and not on "measure numbered one" (first commit)
- when showing all measures numbers and score has anacrusis, "Show first" setting is ignored, and number is showed also on first measure (after anacrusis) (second commit)