### PR TITLE
Fix missing flags

### DIFF
--- a/src/engraving/dom/chordrest.cpp
+++ b/src/engraving/dom/chordrest.cpp
@@ -36,6 +36,7 @@
 #include "figuredbass.h"
 #include "harmony.h"
 #include "harppedaldiagram.h"
+#include "hook.h"
 #include "instrchange.h"
 #include "keysig.h"
 #include "lyrics.h"
@@ -595,13 +596,21 @@ void ChordRest::removeDeleteBeam(bool beamed)
         Beam* b = m_beam;
         m_beam->remove(this);
         if (b->empty()) {
-            score()->undoRemoveElement(b);
+            score()->doUndoRemoveElement(b);
         } else {
             renderer()->layoutBeam1(b);
         }
     }
     if (!beamed && isChord()) {
-        renderer()->layoutStem(toChord(this));
+        Chord* c = toChord(this);
+        if (c->shouldHaveHook()) {
+            if (!c->hook()) {
+                c->createHook();
+            }
+        } else if (c->hook()) {
+            score()->doUndoRemoveElement(c->hook());
+        }
+        renderer()->layoutStem(c);
     }
 }
 

--- a/src/engraving/rendering/dev/beamlayout.cpp
+++ b/src/engraving/rendering/dev/beamlayout.cpp
@@ -684,6 +684,11 @@ void BeamLayout::createBeams(LayoutContext& ctx, Measure* measure)
                             && ctx.state().prevMeasure()
                             && !(prevCR->isChord() && prevCR->durationType().type() <= DurationType::V_QUARTER)) {
                             beam = prevBeam;
+                            if (prevCR->isChord()) {
+                                if (Hook* hook = toChord(prevCR)->hook()) {
+                                    ctx.mutDom().doUndoRemoveElement(hook);
+                                }
+                            }
                             //a1 = beam ? beam->elements().front() : prevCR;
                             a1 = beam ? nullptr : prevCR;               // when beam is found, a1 is no longer required.
                         } else if (prevBeam && prevBeam == cr->beam() && prevBeam->elements().front() == prevCR) {

--- a/src/engraving/rendering/dev/modifydom.cpp
+++ b/src/engraving/rendering/dev/modifydom.cpp
@@ -115,15 +115,7 @@ void ModifyDom::createStems(const Measure* measure, LayoutContext& ctx)
                     continue;
                 }
 
-                auto createStems = [](Chord* chord, LayoutContext& ctx) {
-                    if (chord->shouldHaveHook()) {
-                        if (!chord->hook()) {
-                            chord->createHook();
-                        }
-                    } else {
-                        ctx.mutDom().undoRemoveElement(chord->hook());
-                    }
-
+                auto createStems = [](Chord* chord) {
                     if (!chord->shouldHaveStem()) {
                         chord->removeStem();
                         return;
@@ -138,10 +130,10 @@ void ModifyDom::createStems(const Measure* measure, LayoutContext& ctx)
                     Chord* chord = toChord(cr);
 
                     for (Chord* c : chord->graceNotes()) {
-                        createStems(c, ctx);
+                        createStems(c);
                     }
 
-                    createStems(chord, ctx);     // create stems needed to calculate spacing
+                    createStems(chord);     // create stems needed to calculate spacing
                     // stem direction can change later during beam processing
                 }
             }


### PR DESCRIPTION
Resolves: #20358 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->
Resolves: https://github.com/musescore/MuseScore/issues/20923

Creating hooks depend on there being no beam for a chord, however the hook creating code had been moved to before beams were deleted.