### PR TITLE
Fixed console output

### DIFF
--- a/src/framework/global/thirdparty/kors_logger/src/logdefdest.cpp
+++ b/src/framework/global/thirdparty/kors_logger/src/logdefdest.cpp
@@ -110,12 +110,24 @@ void ConsoleLogDest::write(const LogMsg& logMsg)
     std::string msg;
     msg.reserve(100);
     msg.append(colorCode(logMsg.color));
-    msg.append(m_layout.output(logMsg));
+    std::string log = m_layout.output(logMsg);
+    msg.append(log);
     msg.append("\033[0m");
 #ifdef _WIN32
-    std::wstring temp = std::wstring(msg.begin(), msg.end());
-    OutputDebugString(temp.c_str());
+    std::wstring str = std::wstring(msg.begin(), msg.end());
+    size_t preview = 0;
+    for (size_t i = 0; i < str.size(); ++i) {
+        if (str.at(i) == L'\n') {
+            str[i] = L'\0';
+            OutputDebugString(&str[preview]);
+            OutputDebugString(L"\n");
+            preview = i + 1;
+        }
+    }
+
+    OutputDebugString(&str[preview]);
     OutputDebugString(L"\n");
+
 #else
     std::cout << msg << std::endl;
 #endif


### PR DESCRIPTION
Sometime we need output big messages, but on Windows this messages don't outputs to console. So, as solution, we can output messages line by line. 