### PR TITLE
Added log tag to fluidsynth log output

### DIFF
--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
@@ -78,6 +78,9 @@ bool FluidSynth::isValid() const
 Ret FluidSynth::init()
 {
     auto fluid_log_out = [](int level, const char* message, void*) {
+#undef LOG_TAG
+#define LOG_TAG "FluidSynth"
+
         switch (level) {
         case FLUID_PANIC:
         case FLUID_ERR:  {
@@ -93,6 +96,9 @@ Ret FluidSynth::init()
             LOGD() << message;
         } break;
         }
+
+#undef LOG_TAG
+#define LOG_TAG CLASSFUNC
 
         if (level < FLUID_DBG) {
             bool debugme = true;


### PR DESCRIPTION
before:

```
...
18:18:40.099 | DEBUG | 6060            | <lambda_9ea47483211dd59abf6c2f56713e949f>::operator  | Unloading sample 'Tambourine'
18:18:40.099 | DEBUG | 6060            | <lambda_9ea47483211dd59abf6c2f56713e949f>::operator  | Unloading sample 'Scratch Push'
18:18:40.099 | DEBUG | 6060            | <lambda_9ea47483211dd59abf6c2f56713e949f>::operator  | Unloading sample 'Scratch Pull'
18:18:40.099 | DEBUG | 6060            | <lambda_9ea47483211dd59abf6c2f56713e949f>::operator  | Unloading sample 'Cow Bell'
18:18:40.099 | DEBUG | 6060            | <lambda_9ea47483211dd59abf6c2f56713e949f>::operator  | Unloading sample 'Rim Tap'
18:18:40.099 | DEBUG | 6060            | <lambda_9ea47483211dd59abf6c2f56713e949f>::operator  | Unloading sample 'Sticks(R)'
18:18:40.099 | DEBUG | 6060            | <lambda_9ea47483211dd59abf6c2f56713e949f>::operator  | Unloading sample 'Vibra Slap'
18:18:40.099 | DEBUG | 6060            | <lambda_9ea47483211dd59abf6c2f56713e949f>::operator  | Unloading sample 'Clap'
18:18:40.100 | DEBUG | 6060            | <lambda_9ea47483211dd59abf6c2f56713e949f>::operator  | Unloading sample 'Metronome Bell(L)'
18:18:40.100 | DEBUG | 6060            | <lambda_9ea47483211dd59abf6c2f56713e949f>::operator  | Unloading sample 'Metronome Click'
18:18:40.100 | DEBUG | 6060            | <lambda_9ea47483211dd59abf6c2f56713e949f>::operator  | Unloading sample 'Square Click'
18:18:40.100 | DEBUG | 6060            | <lambda_9ea47483211dd59abf6c2f56713e949f>::operator  | Unloading sample 'Sticks(L)'
18:18:40.100 | DEBUG | 6060            | <lambda_9ea47483211dd59abf6c2f56713e949f>::operator  | Unloading sample 'Slap'
18:18:40.100 | DEBUG | 6060            | <lambda_9ea47483211dd59abf6c2f56713e949f>::operator  | Unloading sample 'High Q'
```

after:
```
...
18:31:40.548 | DEBUG | 16580           | FluidSynth      | Unloading sample 'High Agogo'
18:31:40.548 | DEBUG | 16580           | FluidSynth      | Unloading sample 'Std Snr 2'
18:31:40.553 | DEBUG | 16580           | FluidSynth      | Unloading sample 'Std Snr 1'
18:31:40.554 | DEBUG | 16580           | FluidSynth      | Unloading sample 'Tambourine'
18:31:40.554 | DEBUG | 16580           | FluidSynth      | Unloading sample 'Scratch Push'
18:31:40.554 | DEBUG | 16580           | FluidSynth      | Unloading sample 'Scratch Pull'
18:31:40.554 | DEBUG | 16580           | FluidSynth      | Unloading sample 'Cow Bell'
18:31:40.554 | DEBUG | 16580           | FluidSynth      | Unloading sample 'Rim Tap'
18:31:40.554 | DEBUG | 16580           | FluidSynth      | Unloading sample 'Sticks(R)'
18:31:40.554 | DEBUG | 16580           | FluidSynth      | Unloading sample 'Vibra Slap'
18:31:40.554 | DEBUG | 16580           | FluidSynth      | Unloading sample 'Clap'
18:31:40.554 | DEBUG | 16580           | FluidSynth      | Unloading sample 'Metronome Bell(L)'
18:31:40.554 | DEBUG | 16580           | FluidSynth      | Unloading sample 'Metronome Click'
18:31:40.554 | DEBUG | 16580           | FluidSynth      | Unloading sample 'Square Click'
18:31:40.554 | DEBUG | 16580           | FluidSynth      | Unloading sample 'Sticks(L)'
18:31:40.555 | DEBUG | 16580           | FluidSynth      | Unloading sample 'Slap'
18:31:40.555 | DEBUG | 16580           | FluidSynth      | Unloading sample 'High Q'
```