### PR TITLE
Call localtime_r instead of localtime

### DIFF
--- a/src/framework/global/serialization/internal/zipcontainer.cpp
+++ b/src/framework/global/serialization/internal/zipcontainer.cpp
@@ -585,8 +585,13 @@ void ZipContainer::Impl::addEntry(EntryType type, const std::string& fileName, c
     writeUInt(header.h.uncompressed_size, (uint)contents.size());
 
     std::time_t t = std::time(0);   // get time now
-    std::tm* now = std::localtime(&t);
-    writeMSDosDate(header.h.last_mod_file, *now);
+    std::tm now;
+#ifdef WIN32
+    localtime_s(&now, &t);
+#else
+    localtime_r(&t, &now);
+#endif
+    writeMSDosDate(header.h.last_mod_file, now);
     ByteArray data = contents;
     if (compression == ZipContainer::AlwaysCompress) {
         writeUShort(header.h.compression_method, CompressionMethodDeflated);

--- a/src/framework/global/thirdparty/kors_logger/src/logger.cpp
+++ b/src/framework/global/thirdparty/kors_logger/src/logger.cpp
@@ -81,19 +81,24 @@ DateTime DateTime::now()
     milliseconds ms_d = duration_cast< milliseconds >(system_clock::now().time_since_epoch());
 
     std::time_t sec = static_cast<std::time_t>(ms_d.count() / 1000);
-    std::tm* tm = std::localtime(&sec);
-    assert(tm);
-    if (!tm) {
+    std::tm tm;
+#ifdef WIN32
+    bool err = localtime_s(&tm, &sec) != 0;
+#else
+    bool err = localtime_r(&sec, &tm) == nullptr;
+#endif
+    assert(!err);
+    if (err) {
         return DateTime();
     }
 
     DateTime dt;
-    dt.date.year = tm->tm_year + 1900;
-    dt.date.mon = tm->tm_mon + 1;
-    dt.date.day = tm->tm_mday;
-    dt.time.hour = tm->tm_hour;
-    dt.time.min = tm->tm_min;
-    dt.time.sec = tm->tm_sec;
+    dt.date.year = tm.tm_year + 1900;
+    dt.date.mon = tm.tm_mon + 1;
+    dt.date.day = tm.tm_mday;
+    dt.time.hour = tm.tm_hour;
+    dt.time.min = tm.tm_min;
+    dt.time.sec = tm.tm_sec;
     dt.time.msec = ms_d.count() - (sec * 1000);
 
     return dt;

--- a/src/framework/global/types/datetime.cpp
+++ b/src/framework/global/types/datetime.cpp
@@ -152,12 +152,17 @@ Date Date::currentDate()
     milliseconds ms_d = duration_cast< milliseconds >(system_clock::now().time_since_epoch());
 
     std::time_t sec = static_cast<std::time_t>(ms_d.count() / 1000);
-    std::tm* tm = std::localtime(&sec);
-    assert(tm);
-    if (!tm) {
+    std::tm tm;
+#ifdef WIN32
+    bool err = localtime_s(&tm, &sec) != 0;
+#else
+    bool err = localtime_r(&sec, &tm) == nullptr;
+#endif
+    assert(!err);
+    if (err) {
         return Date();
     }
-    return dateFromTM(*tm);
+    return dateFromTM(tm);
 }
 
 String Date::toString(DateFormat format) const
@@ -207,12 +212,17 @@ Time Time::currentTime()
     milliseconds ms_d = duration_cast< milliseconds >(system_clock::now().time_since_epoch());
 
     std::time_t sec = static_cast<std::time_t>(ms_d.count() / 1000);
-    std::tm* tm = std::localtime(&sec);
-    assert(tm);
-    if (!tm) {
+    std::tm tm;
+#ifdef WIN32
+    bool err = localtime_s(&tm, &sec) != 0;
+#else
+    bool err = localtime_r(&sec, &tm) == nullptr;
+#endif
+    assert(!err);
+    if (err) {
         return Time();
     }
-    return timeFromTM(*tm);
+    return timeFromTM(tm);
 }
 
 String Time::toString(DateFormat format) const
@@ -256,13 +266,18 @@ DateTime DateTime::currentDateTime()
     milliseconds ms_d = duration_cast< milliseconds >(system_clock::now().time_since_epoch());
 
     std::time_t sec = static_cast<std::time_t>(ms_d.count() / 1000);
-    std::tm* tm = std::localtime(&sec);
-    assert(tm);
-    if (!tm) {
+    std::tm tm;
+#ifdef WIN32
+    bool err = localtime_s(&tm, &sec) != 0;
+#else
+    bool err = localtime_r(&sec, &tm) == nullptr;
+#endif
+    assert(!err);
+    if (err) {
         return DateTime();
     }
 
-    return datetimeFromTM(*tm);
+    return datetimeFromTM(tm);
 }
 
 String DateTime::toString(DateFormat format) const


### PR DESCRIPTION
<!-- Add a short description of and motivation for the changes here -->
I did a build with the Thread Sanitizer to look (unsuccessfully) for the cause of https://github.com/musescore/MuseScore/issues/20878.  There are many complaints about unsynchronized calls to `localtime` in different threads.  The `localtime` function is not thread safe.  Call `localtime_r` instead.

The `kors_logger` part has been submitted upstream: https://github.com/igorkorsukov/kors_logger/pull/2

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
