### PR TITLE
Fix #18941: Styled barlines before signatures

### DIFF
--- a/src/engraving/dom/mscore.h
+++ b/src/engraving/dom/mscore.h
@@ -122,6 +122,16 @@ enum class KeySigNatural : char {
 };
 
 //---------------------------------------------------------
+//    CourtesyBarlineMode (for key sig. and time sig. changes)
+//---------------------------------------------------------
+
+enum class CourtesyBarlineMode : char {
+    ALWAYS_SINGLE = 0,
+    ALWAYS_DOUBLE = 1,
+    DOUBLE_BEFORE_COURTESY = 2,
+};
+
+//---------------------------------------------------------
 //   UpDownMode
 //---------------------------------------------------------
 

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -417,6 +417,8 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::genCourtesyTimesig,      "genCourtesyTimesig",      true },
     { Sid::genCourtesyKeysig,       "genCourtesyKeysig",       true },
     { Sid::genCourtesyClef,         "genCourtesyClef",         true },
+    { Sid::keySigCourtesyBarlineMode, "keySigCourtesyBarlineMode", PropertyValue(int(CourtesyBarlineMode::DOUBLE_BEFORE_COURTESY)) },
+    { Sid::timeSigCourtesyBarlineMode, "timeSigCourtesyBarlineMode", PropertyValue(int(CourtesyBarlineMode::ALWAYS_SINGLE)) },
     { Sid::swingRatio,              "swingRatio",              PropertyValue(60) },
     { Sid::swingUnit,               "swingUnit",               PropertyValue(String(u"")) },
     { Sid::useStandardNoteNames,    "useStandardNoteNames",    true },

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -432,6 +432,9 @@ enum class Sid {
     genCourtesyKeysig,
     genCourtesyClef,
 
+    keySigCourtesyBarlineMode,
+    timeSigCourtesyBarlineMode,
+
     swingRatio,
     swingUnit,
 

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -237,6 +237,16 @@ EditStyle::EditStyle(QWidget* parent)
     ksng->addButton(radioKeySigNatBefore, int(KeySigNatural::BEFORE));
     ksng->addButton(radioKeySigNatAfter, int(KeySigNatural::AFTER));
 
+    QButtonGroup* ksbl = new QButtonGroup(this);
+    ksbl->addButton(radioKeySigCourtesyBarlineAlwaysSingle, int(CourtesyBarlineMode::ALWAYS_SINGLE));
+    ksbl->addButton(radioKeySigCourtesyBarlineAlwaysDouble, int(CourtesyBarlineMode::ALWAYS_DOUBLE));
+    ksbl->addButton(radioKeySigCourtesyBarlineDoubleBeforeNewSystem, int(CourtesyBarlineMode::DOUBLE_BEFORE_COURTESY));
+
+    QButtonGroup* tsbl = new QButtonGroup(this);
+    tsbl->addButton(radioTimeSigCourtesyBarlineAlwaysSingle, int(CourtesyBarlineMode::ALWAYS_SINGLE));
+    tsbl->addButton(radioTimeSigCourtesyBarlineAlwaysDouble, int(CourtesyBarlineMode::ALWAYS_DOUBLE));
+    tsbl->addButton(radioTimeSigCourtesyBarlineDoubleBeforeNewSystem, int(CourtesyBarlineMode::DOUBLE_BEFORE_COURTESY));
+
     QButtonGroup* ctg = new QButtonGroup(this);
     ctg->addButton(clefTab1, int(ClefType::TAB));
     ctg->addButton(clefTab2, int(ClefType::TAB_SERIF));
@@ -539,6 +549,8 @@ EditStyle::EditStyle(QWidget* parent)
         { StyleId::genCourtesyTimesig,       false, genCourtesyTimesig,           0 },
         { StyleId::genCourtesyKeysig,        false, genCourtesyKeysig,            0 },
         { StyleId::genCourtesyClef,          false, genCourtesyClef,              0 },
+        { StyleId::keySigCourtesyBarlineMode, false, ksbl,                        0 },
+        { StyleId::timeSigCourtesyBarlineMode, false, tsbl,                       0 },
         { StyleId::swingRatio,               false, swingBox,                     0 },
         { StyleId::chordsXmlFile,            false, chordsXmlFile,                0 },
         { StyleId::dotMag,                   true,  dotMag,                       0 },

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -4933,9 +4933,6 @@ By default, they will be placed such as that their right end are at the same lev
       </widget>
       <widget class="QWidget" name="PageBarlines">
        <layout class="QVBoxLayout" name="verticalLayout_17">
-        <property name="spacing">
-         <number>0</number>
-        </property>
         <item>
          <widget class="QGroupBox" name="groupBox_barlines">
           <property name="title">
@@ -5251,6 +5248,66 @@ By default, they will be placed such as that their right end are at the same lev
             <widget class="QCheckBox" name="showStartBarlineSingle">
              <property name="text">
               <string>Barline at start of single staff</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="keySigCourtesyBarlineGroup">
+          <property name="title">
+           <string>Use double barlines before key signatures</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_61">
+           <item>
+            <widget class="QRadioButton" name="radioKeySigCourtesyBarlineAlwaysDouble">
+             <property name="text">
+              <string>Always</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="radioKeySigCourtesyBarlineAlwaysSingle">
+             <property name="text">
+              <string>Never</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="radioKeySigCourtesyBarlineDoubleBeforeNewSystem">
+             <property name="text">
+              <string>Only before courtesy key signatures</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="timeSigCourtesyBarlineGroup">
+          <property name="title">
+           <string>Use double barlines before time signatures</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_62">
+           <item>
+            <widget class="QRadioButton" name="radioTimeSigCourtesyBarlineAlwaysDouble">
+             <property name="text">
+              <string>Always</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="radioTimeSigCourtesyBarlineAlwaysSingle">
+             <property name="text">
+              <string>Never</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="radioTimeSigCourtesyBarlineDoubleBeforeNewSystem">
+             <property name="text">
+              <string>Only before courtesy time signatures</string>
              </property>
             </widget>
            </item>
@@ -14604,6 +14661,12 @@ articulation markings are present</string>
   <tabstop>resetDoubleBarDistance</tabstop>
   <tabstop>repeatBarlineDotSeparation</tabstop>
   <tabstop>resetRepeatBarlineDotSeparation</tabstop>
+  <tabstop>radioKeySigCourtesyBarlineAlwaysDouble</tabstop>
+  <tabstop>radioKeySigCourtesyBarlineAlwaysSingle</tabstop>
+  <tabstop>radioKeySigCourtesyBarlineDoubleBeforeNewSystem</tabstop>
+  <tabstop>radioTimeSigCourtesyBarlineAlwaysDouble</tabstop>
+  <tabstop>radioTimeSigCourtesyBarlineAlwaysSingle</tabstop>
+  <tabstop>radioTimeSigCourtesyBarlineDoubleBeforeNewSystem</tabstop>
   <tabstop>shortenStem</tabstop>
   <tabstop>shortestStem</tabstop>
   <tabstop>accidentalNoteDistance</tabstop>


### PR DESCRIPTION
Resolves: #18941

This PR introduces style settings for drawing barlines in front of key signatures and time signatures: Either to always use single barlines, always use double barlines, or to use double barlines in front of a system change. The default settings haven't been changed so the behavior is the same.

![image](https://github.com/musescore/MuseScore/assets/116587995/953db790-5061-41dd-bdee-b925804273ea)