### PR TITLE
Update to the latest Xcode version and use single source of truth for macOS deployment target

### DIFF
--- a/.github/workflows/ci_macos_mu4.yml
+++ b/.github/workflows/ci_macos_mu4.yml
@@ -25,7 +25,7 @@ on:
 
 env:
   CURRENT_RELEASE_BRANCH: 4.2.1
-  DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
 
 jobs:
   build_mu4:    

--- a/build/MacOSXBundleInfo.plist.in
+++ b/build/MacOSXBundleInfo.plist.in
@@ -466,7 +466,7 @@
 	<key>LSRequiresCarbon</key>
 	<true/>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.14.0</string>
+	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
"Cherry-picking" the parts from #19570 that are useful/necessary anyway