### PR TITLE
Remove unecessary two note tremolo clones

### DIFF
--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -340,19 +340,6 @@ Chord::Chord(const Chord& c, bool link)
             score()->undo(new Link(t, const_cast<TremoloSingleChord*>(c.m_tremoloSingleChord)));
         }
         add(t);
-    } else if (c.m_tremoloTwoChord) {
-        TremoloTwoChord* t = Factory::copyTremoloTwoChord(*(c.m_tremoloTwoChord));
-        if (link) {
-            score()->undo(new Link(t, const_cast<TremoloTwoChord*>(c.m_tremoloTwoChord)));
-        }
-
-        if (c.m_tremoloTwoChord->chord1() == &c) {
-            t->setChords(this, nullptr);
-        } else {
-            t->setChords(nullptr, this);
-        }
-
-        add(t);
     }
 
     for (EngravingItem* e : c.el()) {


### PR DESCRIPTION
Resolves the following crash:
1. Create a score with a 2 note tremolo
2. Create a part containing the tremolo
3. Close the score

