### PR TITLE
Expose 'System Text Properties' in Properties Panel

### DIFF
--- a/src/inspector/models/text/textsettingsmodel.cpp
+++ b/src/inspector/models/text/textsettingsmodel.cpp
@@ -152,6 +152,7 @@ void TextSettingsModel::loadProperties()
 
     updateFramePropertiesAvailability();
     updateStaffPropertiesAvailability();
+    updateSystemPropertiesAvailability();
     updateIsDynamicSpecificSettings();
     updateIsHorizontalAlignmentAvailable();
 }
@@ -214,6 +215,11 @@ void TextSettingsModel::insertSpecialCharacters()
 void TextSettingsModel::showStaffTextProperties()
 {
     dispatcher()->dispatch("staff-text-properties");
+}
+
+void TextSettingsModel::showSystemTextProperties()
+{
+    dispatcher()->dispatch("system-text-properties");
 }
 
 PropertyItem* TextSettingsModel::fontFamily() const
@@ -323,6 +329,11 @@ bool TextSettingsModel::areStaffTextPropertiesAvailable() const
     return m_areStaffTextPropertiesAvailable;
 }
 
+bool TextSettingsModel::areSystemTextPropertiesAvailable() const
+{
+    return m_areSystemTextPropertiesAvailable;
+}
+
 bool TextSettingsModel::isSpecialCharactersInsertionAvailable() const
 {
     return m_isSpecialCharactersInsertionAvailable;
@@ -346,6 +357,16 @@ void TextSettingsModel::setAreStaffTextPropertiesAvailable(bool areStaffTextProp
 
     m_areStaffTextPropertiesAvailable = areStaffTextPropertiesAvailable;
     emit areStaffTextPropertiesAvailableChanged(m_areStaffTextPropertiesAvailable);
+}
+
+void TextSettingsModel::setAreSystemTextPropertiesAvailable(bool areSystemTextPropertiesAvailable)
+{
+    if (m_areSystemTextPropertiesAvailable == areSystemTextPropertiesAvailable) {
+        return;
+    }
+
+    m_areSystemTextPropertiesAvailable = areSystemTextPropertiesAvailable;
+    emit areSystemTextPropertiesAvailableChanged(m_areSystemTextPropertiesAvailable);
 }
 
 void TextSettingsModel::setIsSpecialCharactersInsertionAvailable(bool isSpecialCharactersInsertionAvailable)
@@ -397,6 +418,14 @@ void TextSettingsModel::updateStaffPropertiesAvailability()
                        == TextTypes::TextType::TEXT_TYPE_STAFF;
 
     setAreStaffTextPropertiesAvailable(isAvailable && !m_textType->isUndefined());
+}
+
+void TextSettingsModel::updateSystemPropertiesAvailability()
+{
+    bool isAvailable = static_cast<TextTypes::TextType>(m_textType->value().toInt())
+                       == TextTypes::TextType::TEXT_TYPE_SYSTEM;
+
+    setAreSystemTextPropertiesAvailable(isAvailable && !m_textType->isUndefined());
 }
 
 void TextSettingsModel::updateIsDynamicSpecificSettings()

--- a/src/inspector/models/text/textsettingsmodel.h
+++ b/src/inspector/models/text/textsettingsmodel.h
@@ -57,6 +57,7 @@ class TextSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(QVariantList textStyles READ textStyles NOTIFY textStylesChanged)
 
     Q_PROPERTY(bool areStaffTextPropertiesAvailable READ areStaffTextPropertiesAvailable NOTIFY areStaffTextPropertiesAvailableChanged)
+    Q_PROPERTY(bool areSystemTextPropertiesAvailable READ areSystemTextPropertiesAvailable NOTIFY areSystemTextPropertiesAvailableChanged)
     Q_PROPERTY(
         bool isSpecialCharactersInsertionAvailable READ isSpecialCharactersInsertionAvailable NOTIFY isSpecialCharactersInsertionAvailableChanged)
     Q_PROPERTY(bool isDynamicSpecificSettings READ isDynamicSpecificSettings NOTIFY isDynamicSpecificSettingsChanged)
@@ -67,6 +68,7 @@ public:
 
     Q_INVOKABLE void insertSpecialCharacters();
     Q_INVOKABLE void showStaffTextProperties();
+    Q_INVOKABLE void showSystemTextProperties();
 
     void createProperties() override;
     void requestElements() override;
@@ -98,12 +100,14 @@ public:
     QVariantList textStyles();
 
     bool areStaffTextPropertiesAvailable() const;
+    bool areSystemTextPropertiesAvailable() const;
     bool isSpecialCharactersInsertionAvailable() const;
     bool isDynamicSpecificSettings() const;
     bool isHorizontalAlignmentAvailable() const;
 
 public slots:
     void setAreStaffTextPropertiesAvailable(bool areStaffTextPropertiesAvailable);
+    void setAreSystemTextPropertiesAvailable(bool areSystemTextPropertiesAvailable);
     void setIsSpecialCharactersInsertionAvailable(bool isSpecialCharactersInsertionAvailable);
     void setIsDynamicSpecificSettings(bool isOnlyDynamics);
     void setIsHorizontalAlignmentAvailable(bool isHorizontalAlignmentAvailable);
@@ -112,6 +116,7 @@ signals:
     void textStylesChanged();
 
     void areStaffTextPropertiesAvailableChanged(bool areStaffTextPropertiesAvailable);
+    void areSystemTextPropertiesAvailableChanged(bool areSystemTextPropertiesAvailable);
     void isSpecialCharactersInsertionAvailableChanged(bool isSpecialCharactersInsertionAvailable);
     void isDynamicSpecificSettingsChanged(bool isDynamicSpecificSettings);
     void isHorizontalAlignmentAvailableChanged(bool isHorizontalAlignmentAvailable);
@@ -122,6 +127,7 @@ private:
 
     void updateFramePropertiesAvailability();
     void updateStaffPropertiesAvailability();
+    void updateSystemPropertiesAvailability();
     void updateIsDynamicSpecificSettings();
     void updateIsHorizontalAlignmentAvailable();
 
@@ -147,6 +153,7 @@ private:
     QVariantList m_textStyles;
 
     bool m_areStaffTextPropertiesAvailable = false;
+    bool m_areSystemTextPropertiesAvailable = false;
     bool m_isSpecialCharactersInsertionAvailable = false;
     bool m_isDynamicSpecificSettings = false;
     bool m_isHorizontalAlignmentAvailable = true;

--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextSettings.qml
@@ -170,6 +170,7 @@ Column {
     }
 
     FlatButton {
+        id: staffTextPropertiesButton
         width: parent.width
 
         navigation.name: "Staff text properties"
@@ -182,6 +183,22 @@ Column {
 
         onClicked: {
             root.model.showStaffTextProperties()
+        }
+    }
+
+    FlatButton {
+        width: parent.width
+
+        navigation.name: "System text properties"
+        navigation.panel: root.navigationPanel
+        navigation.row: staffTextPropertiesButton.navigationRowEnd + 1
+
+        text: qsTrc("inspector", "System text properties")
+
+        visible: root.model ? root.model.areSystemTextPropertiesAvailable : false
+
+        onClicked: {
+            root.model.showSystemTextProperties()
         }
     }
 }


### PR DESCRIPTION
Resolves: #21224

'System Text Properties' is now available via the properties panel, just like 'Staff Text Properties'.
