### PR TITLE
Only reopen parts if they were open before undo/redo operation

### DIFF
--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -653,8 +653,6 @@ void MasterNotation::updateExcerpts()
             updatedExcerpts.push_back(excerptNotation);
             continue;
         }
-
-        impl->setIsOpen(false);
     }
 
     // create notations for new excerpts
@@ -664,8 +662,10 @@ void MasterNotation::updateExcerpts()
         }
 
         IExcerptNotationPtr excerptNotation = createAndInitExcerptNotation(excerpt);
-        excerptNotation->notation()->setIsOpen(true);
-        excerptNotation->notation()->elements()->msScore()->doLayout();
+        bool open = excerpt->excerptScore()->isOpen();
+        if (open) {
+            excerptNotation->notation()->elements()->msScore()->doLayout();
+        }
 
         updatedExcerpts.push_back(excerptNotation);
     }


### PR DESCRIPTION
Resolves: #18748 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

Deleting a part which was closed by removing the instrument from the instruments panel, then undoing, redoing and undoing again was causing crashes.  If a part was closed and removed this way, it would be opened again on undo.  This PR saves whether a part was open or not before being removed, and restores that state when re-added after undo which resolves the crash.