### PR TITLE
Switch to Node.js 20 actions

### DIFF
--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.11.0
+      uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
     - name: Clone repository
@@ -82,7 +82,7 @@ jobs:
 
     - name: Upload artifacts on GitHub
       if: ${{ always() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.GITHUB_ARTIFACT_NAME }}
         path: ./build.artifacts/

--- a/.github/workflows/ci_linux_arm_mu4.yml
+++ b/.github/workflows/ci_linux_arm_mu4.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.11.0
+      uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
     - name: Clone repository (default)
@@ -146,7 +146,7 @@ jobs:
         sudo bash ./build/ci/tools/osuosl/publish.sh -s ${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }} --os linux --arch armv7l -v 4
     - name: Upload artifacts on GitHub
       if: env.DO_BUILD == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.UPLOAD_ARTIFACT_NAME }}
         path: ./build.artifacts/
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.11.0
+      uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
     - name: Clone repository (default)
@@ -267,7 +267,7 @@ jobs:
         sudo bash ./build/ci/tools/osuosl/publish.sh -s ${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }} --os linux --arch aarch64 -v 4
     - name: Upload artifacts on GitHub
       if: env.DO_BUILD == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.UPLOAD_ARTIFACT_NAME }}
         path: ./build.artifacts/

--- a/.github/workflows/ci_linux_mu3.yml
+++ b/.github/workflows/ci_linux_mu3.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.11.0
+      uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
     - name: Clone repository (default)
@@ -37,7 +37,7 @@ jobs:
         NOW=$(date -u +"%F-%T")
         echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
     - name: Ccache cache files
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.ccache
         key: ${{github.workflow}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
@@ -107,7 +107,7 @@ jobs:
         sudo bash ./build/ci/tools/osuosl/publish.sh -s ${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }} --os linux -v $VER
     - name: Upload artifacts on GitHub
       if: env.DO_BUILD == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: MuseScore_${{ github.run_id }}
         path: ./build.artifacts/

--- a/.github/workflows/ci_linux_mu4.yml
+++ b/.github/workflows/ci_linux_mu4.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.11.0
+      uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
     - name: Clone repository (default)
@@ -43,7 +43,7 @@ jobs:
       with:
         ref: ${{ env.CURRENT_RELEASE_BRANCH }}
     - name: Ccache cache files
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.ccache
         key: ${{github.workflow}}-ccache-$(date -u +"%F-%T")
@@ -191,7 +191,7 @@ jobs:
         sudo bash ./build/ci/tools/osuosl/publish.sh -s ${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }} --os linux -v 4
     - name: Upload artifacts on GitHub
       if: env.DO_BUILD == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.UPLOAD_ARTIFACT_NAME }}
         path: ./build.artifacts/      

--- a/.github/workflows/ci_lupdate.yml
+++ b/.github/workflows/ci_lupdate.yml
@@ -86,7 +86,7 @@ jobs:
         labels: strings
         reviewers: cbjeukendrup
     - name: Upload artifacts on GitHub
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: MuseScore_tsfiles_${{ env.BUILD_NUMBER }}
         path: ./share/locale

--- a/.github/workflows/ci_macos_mu3.yml
+++ b/.github/workflows/ci_macos_mu3.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: macos-10.15
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.11.0
+      uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
     - name: Clone repository (default)
@@ -117,7 +117,7 @@ jobs:
         bash ./build/ci/tools/sparkle_appcast_gen.sh -p macos
     - name: Upload artifacts on GitHub
       if: env.DO_BUILD == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: MuseScore_${{ github.run_id }}
         path: ./build.artifacts/

--- a/.github/workflows/ci_macos_mu4.yml
+++ b/.github/workflows/ci_macos_mu4.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: macos-13
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.11.0
+      uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
     - name: Clone repository (default)
@@ -44,7 +44,7 @@ jobs:
       with:
         ref: ${{ env.CURRENT_RELEASE_BRANCH }}
     - name: Ccache cache files
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.ccache
         key: ${{github.workflow}}-ccache-$(date -u +"%F-%T")
@@ -220,7 +220,7 @@ jobs:
         bash ./build/ci/tools/sparkle_appcast_gen.sh -p macos   
     - name: Upload artifacts on GitHub
       if: env.DO_BUILD == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.UPLOAD_ARTIFACT_NAME }}
         path: ./build.artifacts/

--- a/.github/workflows/ci_tx2s3.yml
+++ b/.github/workflows/ci_tx2s3.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Upload artifacts on GitHub
       if: env.DO_RUN == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: MuseScore_locale_${{ env.BUILD_NUMBER }}
         path: ./share/locale

--- a/.github/workflows/ci_utests.yml
+++ b/.github/workflows/ci_utests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.11.0
+      uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
     - name: Clone repository
@@ -24,7 +24,7 @@ jobs:
         echo "BUILD_NUMBER=$BUILD_NUMBER" >> $GITHUB_ENV
         echo "BUILD_NUMBER: $BUILD_NUMBER"
     - name: Ccache cache files
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.ccache
         key: ${{github.workflow}}-ccache-$(date -u +"%F-%T")

--- a/.github/workflows/ci_vtests.yml
+++ b/.github/workflows/ci_vtests.yml
@@ -15,7 +15,7 @@ jobs:
       artifact_name: ${{ steps.output_data.outputs.artifact_name }}
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.11.0
+      uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
     - name: Clone repository
@@ -67,7 +67,7 @@ jobs:
     - name: Clone repository
       uses: actions/checkout@v4
     - name: Ccache cache files
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.ccache
         key: ${{github.workflow}}-ccache-$(date -u +"%F-%T")
@@ -82,7 +82,7 @@ jobs:
       run: |
         bash ./build/ci/vtests/build_and_pack.sh
     - name: Upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: current_build
         path: ./build.artifacts/
@@ -98,7 +98,7 @@ jobs:
       with:
         ref: ${{ needs.setup.outputs.reference_sha }}
     - name: Ccache cache files
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.ccache
         key: ${{github.workflow}}-ccache-$(date -u +"%F-%T")
@@ -113,7 +113,7 @@ jobs:
       run: |
         bash ./build/ci/vtests/build_and_pack.sh
     - name: Upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: reference_build
         path: ./build.artifacts/
@@ -127,12 +127,12 @@ jobs:
     - name: Clone repository
       uses: actions/checkout@v4
     - name: Download current
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: current_build
         path: ./musescore_current
     - name: Download reference
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: reference_build
         path: ./musescore_reference
@@ -147,7 +147,7 @@ jobs:
         ./vtest/vtest-compare-pngs.sh --ci 1
     - name: Upload comparison
       if: env.VTEST_DIFF_FOUND == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ needs.setup.outputs.artifact_name }}
         path: ./comparison

--- a/.github/workflows/ci_windows_mu3.yml
+++ b/.github/workflows/ci_windows_mu3.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: windows-2019
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.11.0
+      uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
     - name: Clone repository (default)
@@ -114,7 +114,7 @@ jobs:
         bash ./build/ci/tools/sparkle_appcast_gen.sh -p windows
     - name: Upload artifacts on GitHub
       if: ${{ always() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: MuseScore_x64_${{ github.run_id }}
         path: build.artifacts\ 

--- a/.github/workflows/ci_windows_mu4.yml
+++ b/.github/workflows/ci_windows_mu4.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: windows-2022
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.11.0
+      uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
     - name: Clone repository (default)
@@ -210,7 +210,7 @@ jobs:
         bash ./build/ci/tools/sparkle_appcast_gen.sh -p windows 
     - name: Upload artifacts on GitHub
       if: ${{ always() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.UPLOAD_ARTIFACT_NAME }}
         path: build.artifacts\ 
@@ -220,7 +220,7 @@ jobs:
     runs-on: windows-2022
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.11.0
+      uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
     - name: Clone repository (default)
@@ -338,7 +338,7 @@ jobs:
         bash ./build/ci/tools/osuosl/publish.sh -s ${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }} --os windows -v 4 --arch x86_64-portable
     - name: Upload artifacts on GitHub
       if: env.DO_BUILD == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.UPLOAD_ARTIFACT_NAME }}
         path: build.artifacts\

--- a/.github/workflows/ci_withoutqt.yml
+++ b/.github/workflows/ci_withoutqt.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.11.0
+      uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
     - name: Clone repository


### PR DESCRIPTION
To avoid messages like this:

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: xxxx
For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.