### PR TITLE
Fix #21175: Include fret diagram harmony symbols, bend holds, and bend text in range selections

### DIFF
--- a/src/engraving/dom/select.h
+++ b/src/engraving/dom/select.h
@@ -39,6 +39,7 @@ class Note;
 class Measure;
 class Chord;
 class Tuplet;
+class GuitarBend;
 
 //---------------------------------------------------------
 //   ElementPattern
@@ -226,6 +227,7 @@ private:
     void appendFiltered(EngravingItem* e);
     void appendChord(Chord* chord);
     void appendTupletHierarchy(Tuplet* innermostTuplet);
+    void appendGuitarBend(GuitarBend* guitarBend);
 
     Score* m_score = nullptr;
     SelState m_state = SelState::NONE;


### PR DESCRIPTION
Resolves: #21175