### PR TITLE
Restrict spanner's end segment type to ChordRest or BarLineType

### DIFF
--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -578,7 +578,7 @@ public:
     Segment* tick2segmentMM(const Fraction& tick, bool first, SegmentType st) const;
     Segment* tick2segmentMM(const Fraction& tick) const;
     Segment* tick2segmentMM(const Fraction& tick, bool first) const;
-    Segment* tick2leftSegment(const Fraction& tick, bool useMMrest = false, bool anySegmentType = false) const;
+    Segment* tick2leftSegment(const Fraction& tick, bool useMMrest = false, SegmentType st = SegmentType::ChordRest) const;
     Segment* tick2rightSegment(const Fraction& tick, bool useMMrest = false) const;
     Segment* tick2leftSegmentMM(const Fraction& tick) { return tick2leftSegment(tick, /* useMMRest */ true); }
 

--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -33,6 +33,7 @@
 #include "segment.h"
 #include "staff.h"
 #include "system.h"
+#include "types/typesconv.h"
 
 #include "log.h"
 
@@ -1095,7 +1096,11 @@ Segment* Spanner::startSegment() const
 
 Segment* Spanner::endSegment() const
 {
-    return score()->tick2leftSegment(tick2(), style().styleB(Sid::createMultiMeasureRests), systemFlag());
+    bool mmRest = style().styleB(Sid::createMultiMeasureRests);
+    Measure* m = mmRest ? score()->tick2measureMM(tick()) : score()->tick2measure(tick());
+
+    SegmentType st = (systemFlag() && tick2() == score()->endTick()) || m->isMMRest() ? SPANNER_ANCHOR_SEG_TYPE : SegmentType::ChordRest;
+    return score()->tick2leftSegment(tick2(), mmRest, st);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/types.h
+++ b/src/engraving/dom/types.h
@@ -410,8 +410,8 @@ enum class SegmentType {
     TimeSigAnnounce    = 0x1000,
     All                = -1,   ///< Includes all barline types
     /// Alias for `BeginBarLine | StartRepeatBarLine | BarLine | EndBarLine`
-    BarLineType        = BeginBarLine | StartRepeatBarLine | BarLine | EndBarLine
-                         ///\}
+    BarLineType        = BeginBarLine | StartRepeatBarLine | BarLine | EndBarLine,
+    ///\}
 };
 
 constexpr SegmentType operator|(const SegmentType t1, const SegmentType t2)
@@ -423,6 +423,9 @@ constexpr bool operator&(const SegmentType t1, const SegmentType t2)
 {
     return static_cast<int>(t1) & static_cast<int>(t2);
 }
+
+constexpr SegmentType SPANNER_ANCHOR_SEG_TYPE = SegmentType::ChordRest | SegmentType::BeginBarLine | SegmentType::BarLine
+                                                | SegmentType::EndBarLine;
 
 //---------------------------------------------------------
 //   FontStyle

--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -206,7 +206,7 @@ Segment* Score::tick2segment(const Fraction& tick, bool first) const
 /// the first segment *before* this tick position
 //---------------------------------------------------------
 
-Segment* Score::tick2leftSegment(const Fraction& tick, bool useMMrest, bool anySegmentType) const
+Segment* Score::tick2leftSegment(const Fraction& tick, bool useMMrest, SegmentType segmentType) const
 {
     Measure* m = useMMrest ? tick2measureMM(tick) : tick2measure(tick);
     if (m == 0) {
@@ -215,7 +215,6 @@ Segment* Score::tick2leftSegment(const Fraction& tick, bool useMMrest, bool anyS
     }
 
     // loop over all segments
-    SegmentType segmentType = anySegmentType ? SegmentType::All : SegmentType::ChordRest;
     Segment* ps = 0;
     for (Segment* s = m->first(segmentType); s; s = s->next(segmentType)) {
         if (tick < s->tick()) {


### PR DESCRIPTION
Resolves: #21259  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

The issue here was indeed `HeaderClef` segments.  System lines couldn't be extended in the same way past key signatures, time signatures, breaths, ambitus and start repeat barlines.  This PR restricts spanners anchored to segments to `ChordRest`, `BeginBarLine`, `BarLine` and `EndBarLine` segments to avoid the crash fixed here #18904.