### PR TITLE
Typos/cleanup plugins.md

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -9,22 +9,21 @@ Here are some points concerning MuseScore plugin development:
 #### Plugins are QML components.
 MuseScore plugins are coded in
 [QML](https://doc.qt.io/qt-5/qmlapplications.html#what-is-qml).
-Each plugin is a QML component using which implements some logic inside its
-instance of \ref Ms::PluginAPI::PluginAPI "MuseScore" class and are capable to
-interact both with MuseScore API and with Qt itself (so MuseScore plugins can
-create their own windows, dialogs). Most of the plugins are contained within a
-single `.qml` file though they may contain more items like resources and
+Each plugin is a QML component which implements some logic inside its
+instance of \ref Ms::PluginAPI::PluginAPI "MuseScore" class, and is capable of
+interacting both with MuseScore API and with Qt itself (so MuseScore plugins can
+create their own windows and/or dialogs). Most of the plugins are contained within a
+single `.qml` file, but they may contain other items such as resources and
 translation files.
 
 #### Debugging plugins
-MuseScore provides a simple plugin code editor which allows developing and
-instantly testing the developed plugin. This editor can be launched with Plugins →
-Plugin Creator menu item or by pressing
-<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>.
+MuseScore provides a simple plugin code editor which allows for developing and
+instantly testing the developed plugin. This editor can be launched via Plugins →
+Plugin Creator or by pressing <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>.
 
-Clicking on a New button will create a sample plugin, you can also run your
+Clicking on a New button will create a sample plugin. You can also run your
 plugin with the Run button and see some debugging output in the console window below
-the editing area. In order to print some debugging messages to that console use
+the editing area. In order to print some debugging messages to the console use
 `console.log()`:
 ```
 var e = newElement(Element.STAFF_TEXT);
@@ -32,7 +31,7 @@ console.log("the created element:", e, e.name);
 ```
 
 Alternatively, you can edit your plugin's code with your favourite text editor
-and test it by launching it from MuseScore as long as the plugin is properly
+and test it by launching it from MuseScore, as long as the plugin is properly
 installed. See [this Handbook
 page](https://musescore.org/en/handbook/plugins#installation)
 for the reference on plugins installation.
@@ -55,7 +54,7 @@ MuseScore {
 }
 ```
 
-Here is what happens here.
+An explanation of the above code:
 
 - `import MuseScore 3.0` is necessary to use MuseScore API in QML code.
 - The `MuseScore { ... }` statement declares an object of `MuseScore` type (\ref
@@ -72,31 +71,31 @@ menu entry or via a shortcut). This is the entry point of your plugin.
 requests termination of the plugin's execution.
 
 ## Documentation from Earlier Versions
-Although it is not up to date, documentation for creating plugins for earlier versions is available and may be useful.
+Although it is not up to date, documentation for creating plugins for earlier versions is available and may be useful:
 https://musescore.org/en/handbook/developers-handbook/plugin-development
 
 
-## Plugins Installed By Default
+## Plugins Installed by Default
 MuseScore is shipped with a set of simple plugins which can also be used as
-a reference while developing your own plugins.
+a reference while developing your own plugins:
 
 ### ABC Import
-This plugin imports ABC text from a file or the clipboard. Internet connection is required, because it uses an external web-service for the conversion, which uses abc2xml and gets send the ABC data, returns MusicXML and imports that into MuseScore.
+This plugin imports ABC text from a file or the clipboard. An internet connection is required, because it uses an external web-service for the conversion, which uses abc2xml for the ABC data, returns MusicXML and imports that into MuseScore.
 
 ### Color Notes
-This demo plugin colors notes in the selected range (or the entire score), depending on their pitch. It colors the note head of all notes in all staves and voices according to the Boomwhackers convention. Each pitch has a different color. C and C♯ have different color. C♯ and D♭ have the same color.
-To color all the notes in black, just run that plugin again (on the same selection). You could also use the 'Remove Notes Color' plugin for this.
+This demo plugin colors notes in the selected range (or the entire score), depending on their pitch. It colors the note head of all notes in all staves and voices according to the Boomwhackers convention. Each pitch has a different color, e.g. C and C♯ have a different color; C♯ and D♭ have the same color.
+To color all notes in black, run the plugin again (on the same selection). You could also use the 'Remove Notes Color' plugin.
 
 ### Create Score
-This demo plugin creates a new score. It creates a new piano score with 4 quarters C D E F. It's a good start to learn how to make a new score and add notes from a plugin.
+This demo plugin creates a new score. It creates a new piano score with 4 quarters C D E F. It's a good start in learning how to make a new score and add notes from a plugin.
 
 ### helloQml
 This demo plugin shows some basic tasks.
 
 ### Note Names
-This plugin names notes in the selected range or the entire score. It displays the names of the notes (as a staff text) as per MuseScore's language settings, for voices 1 and 3 above the staff, for voices 2 and 4 below the staff, and for chords in a comma-separated list, starting with the top note.
+This plugin names notes in the selected range (or the entire score). It displays the names of the notes in staff text, as per MuseScore's language settings, above the staff for voices 1 and 3 and below the staff for voices 2 and 4. For chords the names appear in a comma-separated list, starting with the top note.
 
-### Note Names -Interactive
+### Note Names - Interactive
 This plugin names notes as per your language setting.
 
 ### Panel
@@ -109,24 +108,23 @@ Creates a random score.
 Creates a random score too.
 
 ### run
-This demo plugin runs an external command. Probably this will only work on Linux.
+This demo plugin runs an external command. This will probably only work on Linux.
 
 ### scorelist
 This test plugin iterates through the score list.
 
 ### View
-Demo plugin to demonstrate the use of a ScoreView
+This is a plugin to demonstrate the use of a ScoreView.
 
 ### Walk
-This test plugin walks through all elements in a score
-
+This test plugin walks through all elements in a score.
 
 ## Porting MuseScore 2 plugins
 This documentation corresponds to the plugins API for MuseScore 3.X version.
-To see the information on its difference from MuseScore 2 plugins API as well
+To see the information on its difference from MuseScore 2 plugins API, as well
 as some instructions on adapting MuseScore 2 plugins code to work with
 MuseScore 3, please refer to the \ref plugin2to3 page.
 
 ## Internationalization
-For the questions related to making a plugin translatable to different languages
+For questions related to making a plugin available in different languages,
 please refer to https://github.com/musescore/MuseScore/blob/master/doc/i18n.md.


### PR DESCRIPTION
Corrected some typos in plugins.md, also made various edits for clarity

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [ ] I signed the [CLA](https://musescore.org/en/cla)
- [ ] The title of the PR describes the problem it addresses
- [ ] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [ ] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ ] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
