### PR TITLE
Correctly explode grace notes and fix selection after exploding

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -3375,9 +3375,16 @@ void Score::cmdExplode()
     // reset selection to top staff only
     // force complete measures
     Segment* startSegment = selection().startSegment();
-    Segment* endSegment = selection().endSegment();
+    Segment* endSegment   = selection().endSegment();
     Measure* startMeasure = startSegment->measure();
-    Measure* endMeasure = endSegment ? endSegment->measure() : lastMeasure();
+    Measure* endMeasure   = nullptr;
+    if (!endSegment) {
+        endMeasure = lastMeasure();
+    } else if (endSegment->tick() == endSegment->measure()->tick()) {
+        endMeasure = endSegment->measure()->prevMeasure() ? endSegment->measure()->prevMeasure() : firstMeasure();
+    } else {
+        endMeasure = endSegment->measure();
+    }
 
     Fraction lTick = endMeasure->endTick();
     bool voice = false;
@@ -3404,6 +3411,9 @@ void Score::cmdExplode()
                 if (e && e->type() == ElementType::CHORD) {
                     Chord* c = toChord(e);
                     n = std::max(n, int(c->notes().size()));
+                    for (Chord* graceChord : c->graceNotes()) {
+                        n = std::max(n, int(graceChord->notes().size()));
+                    }
                 }
             }
             lastStaff = std::min(nstaves(), srcStaff + n);
@@ -3421,24 +3431,32 @@ void Score::cmdExplode()
             }
         }
 
+        auto doExplode = [this](Chord* c, size_t lastStaff, size_t srcStaff, size_t i) -> void
+        {
+            std::vector<Note*> notes = c->notes();
+            size_t nnotes = notes.size();
+            // keep note "i" from top, which is backwards from nnotes - 1
+            // reuse notes if there are more instruments than notes
+            size_t stavesPerNote = std::max((lastStaff - srcStaff) / nnotes, static_cast<size_t>(1));
+            size_t keepIndex = static_cast<size_t>(std::max(static_cast<int>(nnotes) - 1 - static_cast<int>(i / stavesPerNote), 0));
+            Note* keepNote = c->notes()[keepIndex];
+            for (Note* n : notes) {
+                if (n != keepNote) {
+                    undoRemoveElement(n);
+                }
+            }
+        };
+
         // loop through each staff removing all but one note from each chord
         for (size_t i = 0; srcStaff + i < lastStaff; ++i) {
             track_idx_t track = (srcStaff + i) * VOICES;
             for (Segment* s = startSegment; s && s != endSegment; s = s->next1()) {
                 EngravingItem* e = s->element(track);
                 if (e && e->type() == ElementType::CHORD) {
-                    Chord* c = toChord(e);
-                    std::vector<Note*> notes = c->notes();
-                    size_t nnotes = notes.size();
-                    // keep note "i" from top, which is backwards from nnotes - 1
-                    // reuse notes if there are more instruments than notes
-                    size_t stavesPerNote = std::max((lastStaff - srcStaff) / nnotes, static_cast<size_t>(1));
-                    size_t keepIndex = static_cast<size_t>(std::max(static_cast<int>(nnotes) - 1 - static_cast<int>(i / stavesPerNote), 0));
-                    Note* keepNote = c->notes()[keepIndex];
-                    for (Note* n : notes) {
-                        if (n != keepNote) {
-                            undoRemoveElement(n);
-                        }
+                    Chord* c = toChord(e); //chord, laststaff, srcstaff
+                    doExplode(c, lastStaff, srcStaff, i);
+                    for (Chord* graceChord : c->graceNotes()) {
+                        doExplode(graceChord, lastStaff, srcStaff, i);
                     }
                 }
             }


### PR DESCRIPTION
Resolves: #21291
Resolves: #21342

Grace notes are taken into account when exploding measures. When starting a selection on a measure's end segment, 'Explode' no longer selects and erases the following measure.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
