### PR TITLE
fix #20873: export hidden chord symbols

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -8297,7 +8297,7 @@ void ExportMusicXml::harmony(Harmony const* const h, FretDiagram const* const fd
             }
         } else {
             if (h->extensionName().empty()) {
-                m_xml.tag("kind", "");
+                m_xml.tag("kind", "none");
             } else {
                 m_xml.tag("kind", { { "text", h->extensionName() } }, "");
             }

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -6085,7 +6085,11 @@ static const FretDiagram* findFretDiagram(track_idx_t strack, track_idx_t etrack
 
 static bool commonAnnotations(ExportMusicXml* exp, const EngravingItem* e, staff_idx_t sstaff)
 {
-    bool instrChangeHandled  = false;
+    if (!exp->canWrite(e)) {
+        return false;
+    }
+
+    bool instrChangeHandled = false;
 
     // note: write the changed instrument details (transposition) here,
     // optionally writing the associated staff text is done below
@@ -6133,10 +6137,6 @@ static void annotations(ExportMusicXml* exp, track_idx_t strack, track_idx_t etr
         // if (fd) LOGD("annotations seg %p found fretboard diagram %p", seg, fd);
 
         for (const EngravingItem* e : seg->annotations()) {
-            if (!exp->canWrite(e)) {
-                continue;
-            }
-
             track_idx_t wtrack = mu::nidx;       // track to write annotation
 
             if (strack <= e->track() && e->track() < etrack) {
@@ -8210,12 +8210,17 @@ void ExportMusicXml::harmony(Harmony const* const h, FretDiagram const* const fd
     //      relative = String(" relative-x=\"%1\"").arg(String::number(rx, 2));
     //      }
     int rootTpc = h->rootTpc();
+    XmlWriter::Attributes harmonyAttrs;
+    if (!h->isStyled(Pid::PLACEMENT)) {
+        harmonyAttrs.push_back({ "placement", (h->placement() == PlacementV::BELOW) ? "below" : "above" });
+    }
+    harmonyAttrs.push_back({ "print-frame", h->hasFrame() ? "yes" : "no" });     // .append(relative));
+    if (!h->visible()) {
+        harmonyAttrs.push_back({ "print-object", "no" });
+    }
+    addColorAttr(h, harmonyAttrs);
+    m_xml.startElement("harmony", harmonyAttrs);
     if (rootTpc != Tpc::TPC_INVALID) {
-        XmlWriter::Attributes harmonyAttrs;
-        bool frame = h->hasFrame();
-        harmonyAttrs.push_back({ "print-frame", frame ? "yes" : "no" });     // .append(relative));
-        addColorAttr(h, harmonyAttrs);
-        m_xml.startElement("harmony", harmonyAttrs);
         m_xml.startElement("root");
         m_xml.tag("root-step", tpc2stepName(rootTpc));
         int alter = int(tpc2alter(rootTpc));
@@ -8315,15 +8320,11 @@ void ExportMusicXml::harmony(Harmony const* const h, FretDiagram const* const fd
         if (fd) {
             writeMusicXML(fd, m_xml);
         }
-
-        m_xml.endElement();
     } else {
         //
         // export an unrecognized Chord
         // which may contain arbitrary text
         //
-        m_xml.startElement("harmony", { { "print-frame", h->hasFrame() ? "yes" : "no" } });
-
         const String textName = h->hTextName();
         switch (h->harmonyType()) {
         case HarmonyType::NASHVILLE: {
@@ -8346,8 +8347,8 @@ void ExportMusicXml::harmony(Harmony const* const h, FretDiagram const* const fd
         }
         break;
         }
-        m_xml.endElement();           // harmony
     }
+    m_xml.endElement();
 }
 
 //---------------------------------------------------------

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -5854,6 +5854,7 @@ void MusicXMLParserPass2::harmony(const String& partId, Measure* measure, const 
                 ha->setRootTpc(step2tpc(step, AccidentalVal(alter)));
             }
         } else if (m_e.name() == "function") {
+            // deprecated in MusicXML 4.0
             // attributes: print-style
             ha->setRootTpc(Tpc::TPC_INVALID);
             ha->setBaseTpc(Tpc::TPC_INVALID);

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -5812,7 +5812,9 @@ void MusicXMLParserPass2::harmony(const String& partId, Measure* measure, const 
 {
     track_idx_t track = m_pass1.trackForPart(partId);
 
-    bool printObject = m_e.asciiAttribute("print-object") != "no";
+    const Color color = Color::fromString(m_e.asciiAttribute("color").ascii());
+    const String placement = m_e.asciiAttribute("placement").toString();
+    const bool printObject = m_e.asciiAttribute("print-object") != "no";
 
     String kind, kindText, functionText, symbols, parens;
     std::list<HDegree> degreeList;
@@ -5820,6 +5822,10 @@ void MusicXMLParserPass2::harmony(const String& partId, Measure* measure, const 
     FretDiagram* fd = 0;
     Harmony* ha = Factory::createHarmony(m_score->dummy()->segment());
     Fraction offset;
+    if (!placement.isEmpty()) {
+        ha->setPlacement(placement == "below" ? PlacementV::BELOW : PlacementV::ABOVE);
+        ha->setPropertyFlags(Pid::PLACEMENT, PropertyFlags::UNSTYLED);
+    }
     while (m_e.readNextStartElement()) {
         if (m_e.name() == "root") {
             String step;
@@ -5956,6 +5962,9 @@ void MusicXMLParserPass2::harmony(const String& partId, Measure* measure, const 
     ha->render();
 
     ha->setVisible(printObject);
+    if (color.isValid()) {
+        ha->setColor(color);
+    }
 
     // TODO-LV: do this only if ha points to a valid harmony
     // harmony = ha;
@@ -6068,7 +6077,7 @@ void MusicXMLParserLyric::parse()
         if (m_e.name() == "elision") {
             // TODO verify elision handling
             /*
-             String text = _e.readText();
+             String text = m_e.readText();
              if (text.empty())
              formattedText += " ";
              else

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -5813,7 +5813,7 @@ void MusicXMLParserPass2::harmony(const String& partId, Measure* measure, const 
     track_idx_t track = m_pass1.trackForPart(partId);
 
     const Color color = Color::fromString(m_e.asciiAttribute("color").ascii());
-    const String placement = m_e.asciiAttribute("placement").toString();
+    const String placement = m_e.attribute("placement");
     const bool printObject = m_e.asciiAttribute("print-object") != "no";
 
     String kind, kindText, functionText, symbols, parens;

--- a/src/importexport/musicxml/tests/data/testHarmony8.xml
+++ b/src/importexport/musicxml/tests/data/testHarmony8.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-number>MuseScore testfile</work-number>
+    <work-title>Harmony 8</work-title>
+    </work>
+  <identification>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Music</part-name>
+      <score-instrument id="P1-I1">
+        <instrument-name>Music</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <harmony print-frame="no">
+        <root>
+          <root-step>C</root-step>
+          </root>
+        <kind>major</kind>
+        </harmony>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="2">
+      <harmony print-frame="no" color="#FF8000">
+        <root>
+          <root-step>C</root-step>
+          </root>
+        <kind>major</kind>
+        </harmony>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="3">
+      <harmony placement="below" print-frame="no">
+        <root>
+          <root-step>C</root-step>
+          </root>
+        <kind>major</kind>
+        </harmony>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="4">
+      <harmony print-frame="no" print-object="no" color="#0000FF">
+        <root>
+          <root-step>C</root-step>
+          </root>
+        <kind>major</kind>
+        </harmony>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -628,6 +628,9 @@ TEST_F(Musicxml_Tests, harmony5) {
 TEST_F(Musicxml_Tests, harmony6) {
     mxmlMscxExportTestRef("testHarmony6");
 }
+TEST_F(Musicxml_Tests, harmony8) {
+    mxmlIoTest("testHarmony8");
+}
 TEST_F(Musicxml_Tests, hello) {
     mxmlIoTest("testHello");
 }


### PR DESCRIPTION
Resolves: #20873

<!-- Add a short description of and motivation for the changes here -->
This PR improves the MusicXML import/export of chord symbols: 

* export/import of invisible chord symbols
* export/import of chord symbol colors
* export/import of chord symbol positions (above/below staff)

IMHO a better solution than presented in #20877.