### PR TITLE
TAB ghost and dead notes refinements

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -2993,8 +2993,7 @@ void Score::cmdMirrorNoteHead()
         if (e->isNote()) {
             Note* note = toNote(e);
             if (note->staff() && note->staff()->isTabStaff(note->chord()->tick())) {
-                // Set to DEAD NOTE
-                e->undoChangeProperty(Pid::GHOST, !note->ghost());
+                e->undoChangeProperty(Pid::DEAD, !note->deadNote());
             } else {
                 DirectionH d = note->userMirror();
                 if (d == DirectionH::AUTO) {

--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -2993,6 +2993,7 @@ void Score::cmdMirrorNoteHead()
         if (e->isNote()) {
             Note* note = toNote(e);
             if (note->staff() && note->staff()->isTabStaff(note->chord()->tick())) {
+                // Set to DEAD NOTE
                 e->undoChangeProperty(Pid::GHOST, !note->ghost());
             } else {
                 DirectionH d = note->userMirror();
@@ -3098,21 +3099,26 @@ void Score::cmdAddBracket()
 void Score::cmdAddParentheses()
 {
     for (EngravingItem* el : selection().elements()) {
-        if (el->type() == ElementType::NOTE) {
-            Note* n = toNote(el);
-            n->setHeadHasParentheses(true);
-        } else if (el->type() == ElementType::ACCIDENTAL) {
-            Accidental* acc = toAccidental(el);
-            acc->undoChangeProperty(Pid::ACCIDENTAL_BRACKET, int(AccidentalBracket::PARENTHESIS));
-        } else if (el->type() == ElementType::HARMONY) {
-            Harmony* h = toHarmony(el);
-            h->setLeftParen(true);
-            h->setRightParen(true);
-            h->render();
-        } else if (el->type() == ElementType::TIMESIG) {
-            TimeSig* ts = toTimeSig(el);
-            ts->setLargeParentheses(true);
-        }
+        cmdAddParentheses(el);
+    }
+}
+
+void Score::cmdAddParentheses(EngravingItem* el)
+{
+    if (el->type() == ElementType::NOTE) {
+        Note* n = toNote(el);
+        n->undoChangeProperty(Pid::HEAD_HAS_PARENTHESES, !n->headHasParentheses());
+    } else if (el->type() == ElementType::ACCIDENTAL) {
+        Accidental* acc = toAccidental(el);
+        acc->undoChangeProperty(Pid::ACCIDENTAL_BRACKET, int(AccidentalBracket::PARENTHESIS));
+    } else if (el->type() == ElementType::HARMONY) {
+        Harmony* h = toHarmony(el);
+        h->setLeftParen(true);
+        h->setRightParen(true);
+        h->render();
+    } else if (el->type() == ElementType::TIMESIG) {
+        TimeSig* ts = toTimeSig(el);
+        ts->setLargeParentheses(true);
     }
 }
 

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -2948,6 +2948,11 @@ bool Note::setProperty(Pid propertyId, const PropertyValue& v)
         break;
     case Pid::DEAD:
         setDeadNote(v.toBool());
+        if (!staff()->isDrumStaff(tick())) {
+            NoteHeadGroup head
+                = (m_deadNote && m_headGroup != NoteHeadGroup::HEAD_CROSS) ? NoteHeadGroup::HEAD_CROSS : NoteHeadGroup::HEAD_NORMAL;
+            setHeadGroup(head);
+        }
         break;
     case Pid::HEAD_TYPE:
         setHeadType(v.value<NoteHeadType>());

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -1157,7 +1157,7 @@ double Note::headHeight() const
 double Note::tabHeadHeight(const StaffType* tab) const
 {
     if (tab && m_fret != INVALID_FRET_INDEX && m_string != INVALID_STRING_INDEX) {
-        return tab->fretBoxH() * magS();
+        return tab->fretBoxH(style()) * magS();
     }
     return headHeight();
 }

--- a/src/engraving/dom/note.h
+++ b/src/engraving/dom/note.h
@@ -385,7 +385,7 @@ public:
     void setScore(Score* s) override;
     void setDotRelativeLine(int);
 
-    void setHeadHasParentheses(bool hasParentheses, bool addToLinked = true);
+    void setHeadHasParentheses(bool hasParentheses, bool addToLinked = true, bool generated = false);
     bool headHasParentheses() const { return m_hasHeadParentheses; }
 
     static SymId noteHead(int direction, NoteHeadGroup, NoteHeadType, int tpc, Key key, NoteHeadScheme scheme);
@@ -449,6 +449,8 @@ public:
     void updateFrettingForTiesAndBends();
     bool shouldHideFret() const;
     bool shouldForceShowFret() const;
+
+    void setVisible(bool v) override;
 
     struct LayoutData : public EngravingItem::LayoutData {
         ld_field<bool> useTablature = { "[Note] useTablature", false };

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -299,6 +299,7 @@ public:
 
     void cmdAddBracket();
     void cmdAddParentheses();
+    void cmdAddParentheses(EngravingItem* el);
     void cmdAddBraces();
     void cmdAddFret(int fret);
     void cmdSetBeamMode(BeamMode);

--- a/src/engraving/dom/stafftype.h
+++ b/src/engraving/dom/stafftype.h
@@ -292,8 +292,12 @@ public:
     double durationFontUserY() const { return m_durationFontUserY; }
     double durationFontYOffset() const { setDurationMetrics(); return m_durationYOffset + m_durationFontUserY * SPATIUM20; }
     double durationGridYOffset() const { setDurationMetrics(); return m_durationGridYOffset; }
-    double fretBoxH() const { setFretMetrics(); return m_fretBoxH; }
-    double fretBoxY() const { setFretMetrics(); return m_fretBoxY + m_fretFontUserY * SPATIUM20; }
+    double fretBoxH(const MStyle& style) const { setFretMetrics(style); return m_fretBoxH; }
+    double fretBoxH() const { UNREACHABLE; return 0.0; }
+    double deadFretBoxH(const MStyle& style) const { setFretMetrics(style); return m_deadFretBoxH; }
+    double fretBoxY(const MStyle& style) const { setFretMetrics(style); return m_fretBoxY + m_fretFontUserY * SPATIUM20; }
+    double fretBoxY() const { UNREACHABLE; return 0.0; }
+    double deadFretBoxY(const MStyle& style) const { setFretMetrics(style); return m_deadFretBoxY + m_fretFontUserY * SPATIUM20; }
 
     // 2 methods to return the size of a box masking lines under a fret mark
     double fretMaskH() const { return m_lineDistance.val() * SPATIUM20; }
@@ -303,7 +307,8 @@ public:
     const String fretFontName() const { return m_fretFonts[m_fretFontIdx].displayName; }
     double fretFontSize() const { return m_fretFontSize; }
     double fretFontUserY() const { return m_fretFontUserY; }
-    double fretFontYOffset() const { setFretMetrics(); return m_fretYOffset + m_fretFontUserY * SPATIUM20; }
+    double fretFontYOffset(const MStyle& style) const { setFretMetrics(style); return m_fretYOffset + m_fretFontUserY * SPATIUM20; }
+    double fretFontYOffset() const { UNREACHABLE; return 0.0; }
     bool  genDurations() const { return m_genDurations; }
     bool  linesThrough() const { return m_linesThrough; }
     TablatureMinimStyle minimStyle() const { return m_minimStyle; }
@@ -363,7 +368,7 @@ private:
     friend class TabDurationSymbol;
 
     void  setDurationMetrics() const;
-    void  setFretMetrics() const;
+    void  setFretMetrics(const MStyle& style) const;
 
     static bool readConfigFile(const String& fileName);
 
@@ -429,11 +434,14 @@ private:
     mutable bool m_durationMetricsValid = false;     // whether duration font metrics are valid or not
     mutable double m_fretBoxH = 0.0;
     mutable double m_fretBoxY = 0.0;                // the height and the y rect.coord. (relative to staff line)
+    mutable double m_deadFretBoxH = 0.0;
+    mutable double m_deadFretBoxY = 0.0;
     // of a box bounding all fret characters (raster units) internally computed:
     // depends upon _onString, _useNumbers and the metrics of the fret font
     mu::draw::Font m_fretFont;                      // font used to draw fret marks; cached for efficiency
     size_t m_fretFontIdx = 0;                 // the index of current fret font in fret font array
     mutable double m_fretYOffset = 0.0;             // the vertical offset to draw fret marks with respect to the string lines;
+    mutable double m_deadFretYOffset = 0.0;
     // (raster units); internally computed: depends upon _onString, _useNumbers
     // and the metrics of the fret font
     mutable bool m_fretMetricsValid = false;       // whether fret font metrics are valid or not

--- a/src/engraving/rendering/dev/chordlayout.cpp
+++ b/src/engraving/rendering/dev/chordlayout.cpp
@@ -3492,7 +3492,8 @@ void ChordLayout::layoutNote2(Note* item, LayoutContext& ctx)
         double w = item->tabHeadWidth(staffType);
         double xOff = 0.5 * (w - widthWithoutParens);
         ldata->moveX(-xOff);
-        ldata->setBbox(0, staffType->fretBoxY() * item->magS(), w, staffType->fretBoxH() * item->magS());
+        ldata->setBbox(0, staffType->fretBoxY(ctx.conf().style()) * item->magS(), w,
+                       staffType->fretBoxH(ctx.conf().style()) * item->magS());
     } else if (isTabStaff && (!item->ghost() || item->shouldHideFret())) {
         item->setHeadHasParentheses(false, /*addToLinked=*/ false);
     }

--- a/src/engraving/rendering/dev/chordlayout.cpp
+++ b/src/engraving/rendering/dev/chordlayout.cpp
@@ -3488,13 +3488,13 @@ void ChordLayout::layoutNote2(Note* item, LayoutContext& ctx)
                      && (showTiedFret != ShowTiedFret::TIE_AND_FRET || item->isContinuationOfBend()) && !item->shouldHideFret();
     if (useParens) {
         double widthWithoutParens = item->tabHeadWidth(staffType);
-        if (!item->fretString().startsWith(u'(')) { // Hack: don't add parentheses if already added
-            item->setFretString(String(u"(%1)").arg(item->fretString()));
-        }
+        item->setHeadHasParentheses(true, /* addToLinked= */ false, /* generated= */ true);
         double w = item->tabHeadWidth(staffType);
         double xOff = 0.5 * (w - widthWithoutParens);
         ldata->moveX(-xOff);
         ldata->setBbox(0, staffType->fretBoxY() * item->magS(), w, staffType->fretBoxH() * item->magS());
+    } else if (isTabStaff && (!item->ghost() || item->shouldHideFret())) {
+        item->setHeadHasParentheses(false, /*addToLinked=*/ false);
     }
     int dots = item->chord()->dots();
     if (dots && !item->dots().empty()) {
@@ -3564,7 +3564,6 @@ void ChordLayout::layoutNote2(Note* item, LayoutContext& ctx)
                     const StaffType* tab = st->staffTypeForElement(item);
                     right = item->tabHeadWidth(tab);
                 }
-
                 if (Note::engravingConfiguration()->tablatureParenthesesZIndexWorkaround() && item->staff()->isTabStaff(e->tick())) {
                     e->mutldata()->moveX(right + item->symWidth(SymId::noteheadParenthesisRight));
                 } else {

--- a/src/engraving/rendering/dev/guitarbendlayout.cpp
+++ b/src/engraving/rendering/dev/guitarbendlayout.cpp
@@ -100,7 +100,7 @@ void GuitarBendLayout::layoutAngularBend(GuitarBendSegment* item, LayoutContext&
     }
 
     if (bend->type() == GuitarBendType::PRE_BEND && !startNote->headHasParentheses()) {
-        startNote->setHeadHasParentheses(true, /*addToLinked*/ false);
+        startNote->setHeadHasParentheses(true, /* addToLinked= */ false, /* generated= */ true);
         startNote->mutldata()->reset();
         TLayout::layoutChord(startNote->chord(), ctx);
     }

--- a/src/engraving/rendering/dev/tdraw.cpp
+++ b/src/engraving/rendering/dev/tdraw.cpp
@@ -2264,7 +2264,9 @@ void TDraw::draw(const Note* item, Painter* painter)
             startPosX += item->symWidth(SymId::noteheadParenthesisLeft);
         }
 
-        painter->drawText(PointF(startPosX, tab->fretFontYOffset() * item->magS()), item->fretString());
+        const MStyle& style = item->style();
+        double yOffset = tab->fretFontYOffset(style);
+        painter->drawText(PointF(startPosX, yOffset * item->magS()), item->fretString());
     }
     // NOT tablature
     else {

--- a/src/engraving/rendering/dev/tdraw.cpp
+++ b/src/engraving/rendering/dev/tdraw.cpp
@@ -2805,7 +2805,27 @@ void TDraw::draw(const StringTunings* item, draw::Painter* painter)
 void TDraw::draw(const Symbol* item, Painter* painter)
 {
     TRACE_DRAW_ITEM;
-    if (!item->isNoteDot() || !item->staff()->isTabStaff(item->tick())) {
+    bool tabStaff = item->staff() ? item->staff()->isTabStaff(item->tick()) : false;
+    if (tabStaff && (item->sym() == SymId::noteheadParenthesisLeft || item->sym() == SymId::noteheadParenthesisRight)) {
+        // Draw background for parentheses on TAB staves
+        auto config = item->engravingConfiguration();
+        const Symbol::LayoutData* ldata = item->ldata();
+        double d = item->spatium() * .1;
+        RectF bb = RectF(ldata->bbox().x() - d,
+                         ldata->bbox().y() - d,
+                         ldata->bbox().width() + 2 * d,
+                         ldata->bbox().height() + 2 * d
+                         );
+        if (!item->score()->getViewer().empty()) {
+            for (MuseScoreView* view : item->score()->getViewer()) {
+                view->drawBackground(painter, bb);
+            }
+        } else {
+            painter->fillRect(bb, config->noteBackgroundColor());
+        }
+    }
+
+    if (!item->isNoteDot() || !tabStaff) {
         painter->setPen(item->curColor());
         if (item->scoreFont()) {
             item->scoreFont()->draw(item->sym(), painter, item->magS(), PointF());

--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -4338,7 +4338,13 @@ void TLayout::layoutNote(const Note* item, Note::LayoutData* ldata)
 
         double w = item->tabHeadWidth(tab);     // !! use _fretString
         double mags = item->magS();
-        noteBBox = RectF(0, tab->fretBoxY() * mags, w, tab->fretBoxH() * mags);
+
+        const MStyle& style = item->style();
+
+        double y = item->deadNote() ? tab->deadFretBoxY(style) : tab->fretBoxY(style);
+        double height = item->deadNote() ? tab->deadFretBoxH(style) : tab->fretBoxH(style);
+
+        noteBBox = RectF(0, y * mags, w, height * mags);
 
         if (item->ghost() && Note::engravingConfiguration()->tablatureParenthesesZIndexWorkaround()) {
             noteBBox.setWidth(w + item->symWidth(SymId::noteheadParenthesisLeft) + item->symWidth(SymId::noteheadParenthesisRight));

--- a/src/engraving/rendering/single/singledraw.cpp
+++ b/src/engraving/rendering/single/singledraw.cpp
@@ -518,7 +518,7 @@ void SingleDraw::draw(const Note* item, Painter* painter)
             startPosX += item->symWidth(SymId::noteheadParenthesisLeft);
         }
 
-        painter->drawText(PointF(startPosX, tab->fretFontYOffset() * item->magS()), item->fretString());
+        painter->drawText(PointF(startPosX, tab->fretFontYOffset(item->style()) * item->magS()), item->fretString());
     }
     // NOT tablature
     else {

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -3136,7 +3136,11 @@ bool TRead::readProperties(Note* n, XmlReader& e, ReadContext& ctx)
     } else if (tag == "string") {
         n->setString(e.readInt());
     } else if (tag == "ghost") {
-        n->setGhost(e.readInt());
+        if (n->score()->mscVersion() < 400) {
+            n->setDeadNote(e.readInt());
+        } else {
+            n->setGhost(e.readInt());
+        }
     } else if (tag == "dead") {
         n->setDeadNote(e.readInt());
     } else if (tag == "headType") {

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -2303,6 +2303,10 @@ void TRead::read(Symbol* sym, XmlReader& e, ReadContext& ctx)
             }
         } else if (tag == "small" || tag == "subtype") {    // obsolete
             e.skipCurrentElement();
+        } else if (tag == "offset" && sym->score()->mscVersion() < 400 && sym->onTabStaff()
+                   && (symId == SymId::noteheadParenthesisLeft || symId == SymId::noteheadParenthesisRight)) {
+            // Reset mu3 TAB parentheses offset
+            e.skipCurrentElement();
         } else if (!TRead::readProperties(static_cast<BSymbol*>(sym), e, ctx)) {
             e.unknown();
         }

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -70,7 +70,6 @@ enum class ElementType {
     PART,
     STAFF,
     SCORE,
-    SYMBOL,
     TEXT,
     MEASURE_NUMBER,
     MMREST_RANGE,
@@ -84,10 +83,11 @@ enum class ElementType {
     ARPEGGIO,
     ACCIDENTAL,
     LEDGER_LINE,
-    STEM,  // list STEM before NOTE: notes in TAB might 'break' stems
-    HOOK,  // and this requires stems to be drawn before notes
-    NOTE,  // elements from CLEF to TIMESIG need to be in the order
-    CLEF,  // in which they appear in a measure
+    STEM,   // list STEM before NOTE: notes in TAB might 'break' stems
+    HOOK,   // and this requires stems to be drawn before notes
+    NOTE,   // elements from CLEF to TIMESIG need to be in the order
+    SYMBOL, // in which they appear in a measure
+    CLEF,
     KEYSIG,
     AMBITUS,
     TIMESIG,


### PR DESCRIPTION
Resolves: #21271
Resolves: #13736 
Resolves: #16500 
Resolves: #21331 

- Adding brackets to a note on a pitched stave also adds generated brackets to any linked TAB notes
- Adding brackets to a note on a TAB stave sets the note to a ghost note, and generated SMuFL brackets are added at layout time.  Bracket items (not generated) are also added to any linked pitched notes
- Brackets attached to notes on TAB staves have a white background
- Parentheses offset is reset on TAB staves on import from MU3
- Stacking order of symbols has been changed so they are drawn on top of the stave lines
- Shift + x now makes TAB notes dead notes and changes any linked notes on pitched staves to have cross noteheads
- Dead notes on TAB staves are drawn with an 'X' character which is centred properly
<img width="851" alt="Screenshot 2024-02-06 at 11 11 19" src="https://github.com/musescore/MuseScore/assets/26510874/f4788c2d-0c09-4176-9a5e-909818631878">


