### PR TITLE
Avoid assertion failure in ALSA cleanup

### DIFF
--- a/src/framework/audio/internal/platform/lin/linuxaudiodriver.cpp
+++ b/src/framework/audio/internal/platform/lin/linuxaudiodriver.cpp
@@ -92,8 +92,10 @@ static void alsaCleanup()
     if (s_alsaData->threadHandle) {
         pthread_join(s_alsaData->threadHandle, nullptr);
     }
-    snd_pcm_drain(s_alsaData->alsaDeviceHandle);
-    snd_pcm_close(s_alsaData->alsaDeviceHandle);
+    if (nullptr != s_alsaData->alsaDeviceHandle) {
+        snd_pcm_drain(s_alsaData->alsaDeviceHandle);
+        snd_pcm_close(s_alsaData->alsaDeviceHandle);
+    }
 
     if (nullptr != s_alsaData->buffer) {
         delete[] s_alsaData->buffer;


### PR DESCRIPTION
On an x86_64 Fedora 39 machine, switching from a build with jack enabled to one without, playback didn't work.  The cursor didn't move after pressing play.  I figured there must be a reference to jack in my configuration, so I opened Preferences and clicked the "Reset preferences" button.  At that point, an assertion failure was hit in alsa-lib, leading to an abort:
```
mscore: pcm.c:1361: snd_pcm_drain: Assertion `pcm' failed.
```
Repeating under GDB showed that `s_alsaData->alsaDeviceHandle` is null.  Adding this patch allowed me to press the "Reset preferences" button successfully, and playback worked afterwards.

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
