### PR TITLE
Only set line to below if explicit in XML

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -1373,8 +1373,10 @@ static void addTextToNote(int l, int c, String txt, String placement, String fon
 
 static void setSLinePlacement(SLine* sli, const String& placement)
 {
-    sli->setPlacement(placement == u"above" ? PlacementV::ABOVE : PlacementV::BELOW);
-    sli->setPropertyFlags(Pid::PLACEMENT, PropertyFlags::UNSTYLED);
+    if (placement == u"above" || placement == u"below") {
+        sli->setPlacement(placement == u"above" ? PlacementV::ABOVE : PlacementV::BELOW);
+        sli->setPropertyFlags(Pid::PLACEMENT, PropertyFlags::UNSTYLED);
+    }
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: see image
<img width="431" alt="Screenshot 2024-02-06 at 14 43 39" src="https://github.com/musescore/MuseScore/assets/26510874/118aa49e-d735-4d14-8f72-7c2f769425ff">
Ottavas without a `placement` value in their musicXML would have their placement calculated correctly, then overwritten incorrectly.