### PR TITLE
Add missing headers

### DIFF
--- a/src/framework/ui/uimodule.h
+++ b/src/framework/ui/uimodule.h
@@ -24,6 +24,7 @@
 #define MU_UI_UIMODULE_H
 
 #include "modularity/imodulesetup.h"
+#include <QtGlobal>
 
 namespace mu::ui {
 class UiConfiguration;

--- a/src/framework/ui/view/interactiveprovider.h
+++ b/src/framework/ui/view/interactiveprovider.h
@@ -26,6 +26,7 @@
 #include <QVariant>
 #include <QMap>
 #include <QStack>
+#include <QEventLoop>
 
 #include "modularity/ioc.h"
 #include "../iinteractiveprovider.h"

--- a/src/importexport/musicxml/internal/musicxml/musicxmlsupport.cpp
+++ b/src/importexport/musicxml/internal/musicxml/musicxmlsupport.cpp
@@ -34,6 +34,8 @@
 
 #include "log.h"
 
+#include <QXmlStreamReader>
+
 using AccidentalType = mu::engraving::AccidentalType;
 using SymId = mu::engraving::SymId;
 const static std::map<mu::String, AccidentalType> smuflAccidentalTypes {

--- a/src/importexport/videoexport/internal/videowriter.cpp
+++ b/src/importexport/videoexport/internal/videowriter.cpp
@@ -32,6 +32,8 @@
 
 #include "log.h"
 
+#include <QPainter>
+
 using namespace mu::iex::videoexport;
 using namespace mu::project;
 using namespace mu::notation;

--- a/src/learn/view/learnpagemodel.h
+++ b/src/learn/view/learnpagemodel.h
@@ -23,6 +23,7 @@
 #define MU_LEARN_LEARNPAGEMODEL_H
 
 #include <QObject>
+#include <QVariant>
 
 #include "async/asyncable.h"
 

--- a/src/project/internal/exporttype.h
+++ b/src/project/internal/exporttype.h
@@ -23,6 +23,8 @@
 #define MU_PROJECT_EXPORTTYPE_H
 
 #include <unordered_set>
+#include <QList>
+#include <QVariant>
 
 #include "containers.h"
 


### PR DESCRIPTION
On the Gentoo ebuild, the absence of these headers causes various errors, so we have to ship with this patch. Seems like it'd be a good idea to upstream it.