### PR TITLE
Check for invalid style number

### DIFF
--- a/src/engraving/style/style.cpp
+++ b/src/engraving/style/style.cpp
@@ -43,7 +43,7 @@ using namespace mu::engraving;
 
 const PropertyValue& MStyle::value(Sid idx) const
 {
-    if (idx == Sid::NOSTYLE) {
+    if (idx == Sid::NOSTYLE || size_t(idx) >= m_values.size()) {
         static PropertyValue dummy;
         return dummy;
     }


### PR DESCRIPTION
This prevents spurious segfaults at startup. It's probably the wrong fix, but posting it here anyway.

Resolves: #20878