### PR TITLE
Align harmony correctly on MusicXML import

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -5941,6 +5941,7 @@ void MusicXMLParserPass2::harmony(const String& partId, Measure* measure, const 
     if (fd) {
         fd->setTrack(track);
         Segment* s = measure->getSegment(SegmentType::ChordRest, sTime + offset);
+        ha->setProperty(Pid::ALIGN, Align(AlignH::HCENTER, AlignV::TOP));
         s->add(fd);
     }
 


### PR DESCRIPTION
Resolves: see image
<img width="142" alt="Screenshot 2024-02-07 at 08 53 06" src="https://github.com/musescore/MuseScore/assets/26510874/d59cc05b-0e32-4789-8db3-14b40297e205">

We set harmony element's alignment when adding to a fret diagram usually, this was neglected in musicXML import.
