### PR TITLE
Use correct track for melisma length on XML import

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -172,11 +172,11 @@ void MusicXmlLyricsExtend::addLyric(Lyrics* const lyric)
 
 // find the duration of the chord starting at or after s and ending at tick
 
-static Fraction lastChordTicks(const Segment* s, const Fraction& tick)
+static Fraction lastChordTicks(const Segment* s, const Fraction& tick, const track_idx_t track)
 {
     while (s && s->tick() < tick) {
         for (EngravingItem* el : s->elist()) {
-            if (el && el->isChordRest()) {
+            if (el && el->isChordRest() && el->track() == track) {
                 ChordRest* cr = static_cast<ChordRest*>(el);
                 if (cr->tick() + cr->actualTicks() == tick) {
                     return cr->actualTicks();
@@ -205,7 +205,7 @@ void MusicXmlLyricsExtend::setExtend(const int no, const track_idx_t track, cons
             const ChordRest* par = static_cast<const ChordRest*>(el);
             if ((no == -1 && par->track() == track)
                 || (l->no() == no && track2staff(par->track()) == track2staff(track))) {
-                Fraction lct = lastChordTicks(l->segment(), tick);
+                Fraction lct = lastChordTicks(l->segment(), tick, track);
                 if (lct > Fraction(0, 1)) {
                     // set lyric tick to the total length from the lyric note
                     // plus all notes covered by the melisma minus the last note length


### PR DESCRIPTION
Resolves: see image.  There should be a melisma in voice 2 on "Ooh,".

<img width="644" alt="Screenshot 2024-02-07 at 10 48 33" src="https://github.com/musescore/MuseScore/assets/26510874/298cd7d8-380f-479c-9344-a5b066c9dced">
