### PR TITLE
Resolve #10664 : Increase Input Cursor Size on TAB

### DIFF
--- a/src/notation/view/noteinputcursor.cpp
+++ b/src/notation/view/noteinputcursor.cpp
@@ -37,7 +37,9 @@ void NoteInputCursor::paint(mu::draw::Painter* painter)
     Color fillColor = configuration()->selectionColor(state.currentVoiceIndex);
     Color cursorRectColor = fillColor;
     cursorRectColor.setAlpha(configuration()->cursorOpacity());
-    painter->fillRect(cursorRect, cursorRectColor);
+    RectF cursorHightlightRect(cursorRect.topLeft().x() - cursorRect.width()/2, cursorRect.topLeft().y(), cursorRect.width()*2, cursorRect.height());
+    painter->fillRect(cursorHightlightRect, cursorRectColor);
+
 
     constexpr int leftLineWidth = 3;
     RectF leftLine(cursorRect.topLeft().x(), cursorRect.topLeft().y(), leftLineWidth, cursorRect.height());


### PR DESCRIPTION
Resolves: #10664 

created a separate Rect for the highlighted portion of the input cursor. Made this new Rect 2 times the size of the original and shifted left so it is centered.

- [X ] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
