### PR TITLE
Show version-dependent release notes in app updater

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -25,8 +25,11 @@ jobs:
       - name: Update info about the release in musescore-updates
         run: |
           S3_URL="s3://musescore-updates/feed/latest.xml"
+          S3_ALL_URL="s3://musescore-updates/feed/all.xml"
+          
           if [ ${{ github.event.inputs.mode }} == "testing" ]; then
             S3_URL="s3://musescore-updates/feed/latest.test.xml"
+            S3_ALL_URL="s3://musescore-updates/feed/all.test.xml"
           fi
 
           sudo bash ./build/ci/release/make_release_info_file.sh \
@@ -40,3 +43,18 @@ jobs:
             --s3_url ${S3_URL} \
             --s3_bucket ${{ secrets.S3_BUCKET_UPDATE }} \
             --file_name "release_info.json"
+
+          sudo bash ./build/ci/release/make_previous_releases_notes.sh \
+            --s3_key ${{ secrets.S3_KEY_UPDATE }} \
+            --s3_secret ${{ secrets.S3_SECRET_UPDATE }} \
+            --s3_url ${S3_ALL_URL} \
+            --s3_bucket ${{ secrets.S3_BUCKET_UPDATE }} \
+            --current_file_name "release_info.json" \
+            --previous_file_name "previous_releases_notes.json"
+          
+          sudo bash ./build/ci/release/push_file_to_s3.sh \
+            --s3_key ${{ secrets.S3_KEY_UPDATE }} \
+            --s3_secret ${{ secrets.S3_SECRET_UPDATE }} \
+            --s3_url ${S3_ALL_URL} \
+            --s3_bucket ${{ secrets.S3_BUCKET_UPDATE }} \
+            --file_name "previous_releases_notes.json"

--- a/build/ci/release/append_release_to_previous_releases.py
+++ b/build/ci/release/append_release_to_previous_releases.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-CLA-applies
+#
+# MuseScore
+# Music Composition & Notation
+#
+# Copyright (C) 2024 MuseScore BVBA and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import sys
+import json
+
+CURRENT_RELEASE_INFO_FILE = sys.argv[1]
+PREVIOUS_RELEASE_INFO_FILE = sys.argv[2]
+
+print("=== Load jsons ===")
+
+json_file = open(CURRENT_RELEASE_INFO_FILE, "r+")
+current_release_info_json = json.load(json_file)
+json_file.close()
+
+json_file = open(PREVIOUS_RELEASE_INFO_FILE, "r+")
+previous_release_info_json = json.load(json_file)
+json_file.close()
+
+print("=== Append current release notes to previous releases notes ===")
+
+tag_name = current_release_info_json["tag_name"]
+version = tag_name[1:]
+new_release = {"version": version, "notes": current_release_info_json["bodyMarkdown"]}
+
+if "releases" not in previous_release_info_json:
+    previous_release_info_json["releases"] = []
+
+is_release_already_in_previous_releases = False
+for release in previous_release_info_json["releases"]:
+    if release["version"] in version:
+        release["notes"] = new_release["notes"]
+        is_release_already_in_previous_releases = True
+
+if not is_release_already_in_previous_releases:
+    previous_release_info_json["releases"].append(new_release)
+
+previous_release_info_json_updated = json.dumps(previous_release_info_json)
+
+print("=== Write json ===")
+
+json_file = open(PREVIOUS_RELEASE_INFO_FILE, "w")
+json_file.write(previous_release_info_json_updated)
+json_file.close()

--- a/build/ci/release/get_file_from_s3.sh
+++ b/build/ci/release/get_file_from_s3.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-CLA-applies
+#
+# MuseScore
+# Music Composition & Notation
+#
+# Copyright (C) 2024 MuseScore BVBA and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+ARTIFACTS_DIR=build.artifacts
+
+S3_KEY=""
+S3_SECRET=""
+S3_URL=""
+S3_BUCKET=""
+
+LOCAL_FILE_NAME=""
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --s3_key) S3_KEY="$2"; shift ;;
+        --s3_secret) S3_SECRET="$2"; shift ;;
+        --s3_url) S3_URL="$2"; shift ;;
+        --s3_bucket) S3_BUCKET="$2"; shift ;;
+        --local_file_name) LOCAL_FILE_NAME="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+command -v s3cmd >/dev/null 2>&1
+if [[ $? -ne 0 ]]; then
+    echo "=== Install tools ==="
+
+    apt install python3-setuptools
+
+    echo "Install s3cmd"
+    pip3 install s3cmd
+fi
+
+cat >~/.s3cfg <<EOL
+[default]
+access_key = ${S3_KEY}
+secret_key = ${S3_SECRET}
+host_base = ${S3_BUCKET}
+host_bucket = ${S3_BUCKET}
+website_endpoint = https://${S3_BUCKET}
+EOL
+
+echo "=== Get file from S3 ==="
+
+s3cmd get "$S3_URL" "$ARTIFACTS_DIR/$LOCAL_FILE_NAME"

--- a/build/ci/release/make_previous_releases_notes.sh
+++ b/build/ci/release/make_previous_releases_notes.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-CLA-applies
+#
+# MuseScore
+# Music Composition & Notation
+#
+# Copyright (C) 2024 MuseScore BVBA and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+ARTIFACTS_DIR=build.artifacts
+
+S3_KEY=""
+S3_SECRET=""
+S3_URL=""
+S3_BUCKET=""
+
+CURRENT_FILE_NAME=""
+PREVIOUS_FILE_NAME=""
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --s3_key) S3_KEY="$2"; shift ;;
+        --s3_secret) S3_SECRET="$2"; shift ;;
+        --s3_url) S3_URL="$2"; shift ;;
+        --s3_bucket) S3_BUCKET="$2"; shift ;;
+        --current_file_name) CURRENT_FILE_NAME="$2"; shift ;;
+        --previous_file_name) PREVIOUS_FILE_NAME="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+echo "=== Get release info ==="
+
+sudo bash ./build/ci/release/get_file_from_s3.sh \
+            --s3_key "${S3_KEY}" \
+            --s3_secret "${S3_SECRET}" \
+            --s3_url "${S3_URL}" \
+            --s3_bucket "${S3_BUCKET}" \
+            --local_file_name "${PREVIOUS_FILE_NAME}"
+
+echo "=== Append release info to previous releases ==="
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+python3 "$HERE"/append_release_to_previous_releases.py ${ARTIFACTS_DIR}/"${CURRENT_FILE_NAME}" ${ARTIFACTS_DIR}/"${PREVIOUS_FILE_NAME}"

--- a/src/framework/global/types/version.cpp
+++ b/src/framework/global/types/version.cpp
@@ -98,6 +98,11 @@ Version::Version(const mu::String& versionStr)
     setSuffix(versionStr.right(versionStr.size() - versionStr.indexOf(SUFFIX_DELIMITER) - 1));
 }
 
+Version::Version(const std::string& versionStr)
+    : Version(mu::String::fromStdString(versionStr))
+{
+}
+
 int Version::majorVersion() const
 {
     return m_major;

--- a/src/framework/global/types/version.h
+++ b/src/framework/global/types/version.h
@@ -30,6 +30,7 @@ class Version
 public:
     Version(int major, int minor = 0, int patch = 0, const String& suffix = String(), int suffixVersion = 0);
     Version(const String& versionStr);
+    Version(const std::string& versionStr);
 
     int majorVersion() const;
     int minorVersion() const;

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/ExpandableBlank.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/ExpandableBlank.qml
@@ -32,6 +32,7 @@ FocusScope {
     property alias menuItemComponent: expandableSection.menuItemComponent
 
     property alias title: expandableSection.title
+    property alias titleFont: expandableSection.titleFont
 
     property alias isExpanded: expandableSection.isExpanded
 

--- a/src/framework/uicomponents/qml/MuseScore/UiComponents/ExpandableBlankSection.qml
+++ b/src/framework/uicomponents/qml/MuseScore/UiComponents/ExpandableBlankSection.qml
@@ -28,6 +28,7 @@ FocusScope {
     id: root
 
     property alias title: titleLabel.text
+    property alias titleFont: titleLabel.font
 
     property alias menuItemComponent: menuLoader.sourceComponent
 

--- a/src/stubs/update/updateconfigurationstub.cpp
+++ b/src/stubs/update/updateconfigurationstub.cpp
@@ -55,12 +55,17 @@ void UpdateConfigurationStub::setSkippedReleaseVersion(const std::string&) const
 {
 }
 
+std::string UpdateConfigurationStub::previousReleasesNotesUrl() const
+{
+    return "";
+}
+
 std::string UpdateConfigurationStub::checkForUpdateUrl() const
 {
     return "";
 }
 
-mu::network::RequestHeaders UpdateConfigurationStub::checkForUpdateHeaders() const
+mu::network::RequestHeaders UpdateConfigurationStub::updateHeaders() const
 {
     return network::RequestHeaders();
 }

--- a/src/stubs/update/updateconfigurationstub.h
+++ b/src/stubs/update/updateconfigurationstub.h
@@ -40,7 +40,9 @@ public:
     void setSkippedReleaseVersion(const std::string& version) const override;
 
     std::string checkForUpdateUrl() const override;
-    network::RequestHeaders checkForUpdateHeaders() const override;
+    std::string previousReleasesNotesUrl() const override;
+
+    network::RequestHeaders updateHeaders() const override;
 
     std::string museScoreUrl() const override;
     std::string museScorePrivacyPolicyUrl() const override;

--- a/src/update/internal/updateconfiguration.cpp
+++ b/src/update/internal/updateconfiguration.cpp
@@ -106,7 +106,13 @@ std::string UpdateConfiguration::checkForUpdateUrl() const
            : "https://updates.musescore.org/feed/latest.test.xml";
 }
 
-mu::network::RequestHeaders UpdateConfiguration::checkForUpdateHeaders() const
+std::string UpdateConfiguration::previousReleasesNotesUrl() const
+{
+    return !allowUpdateOnPreRelease() ? "https://updates.musescore.org/feed/all.xml"
+           : "https://updates.musescore.org/feed/all.test.xml";
+}
+
+mu::network::RequestHeaders UpdateConfiguration::updateHeaders() const
 {
     network::RequestHeaders headers;
     headers.knownHeaders[QNetworkRequest::UserAgentHeader] = userAgent();

--- a/src/update/internal/updateconfiguration.h
+++ b/src/update/internal/updateconfiguration.h
@@ -49,7 +49,9 @@ public:
     void setSkippedReleaseVersion(const std::string& version) const override;
 
     std::string checkForUpdateUrl() const override;
-    network::RequestHeaders checkForUpdateHeaders() const override;
+    std::string previousReleasesNotesUrl() const override;
+
+    network::RequestHeaders updateHeaders() const override;
 
     std::string museScoreUrl() const override;
     std::string museScorePrivacyPolicyUrl() const override;

--- a/src/update/internal/updateservice.h
+++ b/src/update/internal/updateservice.h
@@ -24,6 +24,8 @@
 
 #include "async/asyncable.h"
 
+#include "global/types/version.h"
+
 #include "modularity/ioc.h"
 #include "iinteractive.h"
 #include "network/inetworkmanagercreator.h"
@@ -50,11 +52,14 @@ public:
     mu::Progress updateProgress() override;
 
 private:
+    RetVal<ReleaseInfo> parseRelease(const QByteArray& json) const;
+
     std::string platformFileSuffix() const;
     ISystemInfo::CpuArchitecture assetArch(const QString& asset) const;
-
-    RetVal<ReleaseInfo> parseRelease(const QByteArray& json) const;
     QJsonObject resolveReleaseAsset(const QJsonObject& release) const;
+
+    PrevReleasesNotesList previousReleasesNotes(const Version& updateVersion) const;
+    PrevReleasesNotesList parsePreviousReleasesNotes(const QByteArray& json) const;
 
     void clear();
 

--- a/src/update/iupdateconfiguration.h
+++ b/src/update/iupdateconfiguration.h
@@ -47,7 +47,9 @@ public:
     virtual void setSkippedReleaseVersion(const std::string& version) const = 0;
 
     virtual std::string checkForUpdateUrl() const = 0;
-    virtual network::RequestHeaders checkForUpdateHeaders() const = 0;
+    virtual std::string previousReleasesNotesUrl() const = 0;
+
+    virtual network::RequestHeaders updateHeaders() const = 0;
 
     virtual std::string museScoreUrl() const = 0;
     virtual std::string museScorePrivacyPolicyUrl() const = 0;

--- a/src/update/qml/MuseScore/Update/ReleaseInfoDialog.qml
+++ b/src/update/qml/MuseScore/Update/ReleaseInfoDialog.qml
@@ -32,6 +32,7 @@ StyledDialogView {
     id: root
 
     property alias notes: view.notes
+    property alias previousReleasesNotes: view.previousReleasesNotes
 
     contentWidth: 644
     contentHeight: 474

--- a/src/update/qml/MuseScore/Update/internal/ReleaseNotesView.qml
+++ b/src/update/qml/MuseScore/Update/internal/ReleaseNotesView.qml
@@ -30,6 +30,7 @@ Item {
     id: root
 
     property alias notes: notesLabel.text
+    property alias previousReleasesNotes: previousReleasesNotesRepeater.model
 
     QtObject {
         id: prv
@@ -42,7 +43,9 @@ Item {
 
         anchors.fill: parent
 
-        contentHeight: notesLabel.implicitHeight
+        property int notesSpacing: 12
+
+        contentHeight: notesLabel.implicitHeight + notesSpacing + previousReleasesNotesColumn.childrenRect.height
 
         StyledTextLabel {
             id: notesLabel
@@ -57,6 +60,48 @@ Item {
             lineHeight: 1.2
         }
 
+        Column {
+            id: previousReleasesNotesColumn
+
+            anchors.top: notesLabel.bottom
+            anchors.topMargin: flickable.notesSpacing
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+
+            spacing: flickable.notesSpacing
+
+            Repeater {
+                id: previousReleasesNotesRepeater
+
+                ExpandableBlank {
+                    width: parent.width
+
+                    title: qsTrc("update", "Read the %1 release notes").arg(modelData["version"])
+                    titleFont: ui.theme.largeBodyBoldFont
+
+                    isExpanded: false
+
+                    contentItemComponent: Column {
+                        height: implicitHeight
+                        width: parent.width
+
+                        StyledTextLabel {
+                            width: parent.width
+
+                            horizontalAlignment: Text.AlignLeft
+                            font: ui.theme.largeBodyFont
+                            wrapMode: Text.WordWrap
+                            textFormat: Text.MarkdownText
+                            lineHeight: 1.2
+
+                            text: modelData["notes"]
+                        }
+                    }
+                }
+            }
+        }
+
         ScrollBar.vertical: scrollBar
     }
 
@@ -66,5 +111,7 @@ Item {
         anchors.right: flickable.right
         anchors.rightMargin: -prv.sideMargin
         anchors.bottom: flickable.bottom
+
+        policy: ScrollBar.AlwaysOn
     }
 }

--- a/src/update/tests/mocks/updateconfigurationmock.h
+++ b/src/update/tests/mocks/updateconfigurationmock.h
@@ -42,7 +42,9 @@ public:
     MOCK_METHOD(void, setSkippedReleaseVersion, (const std::string&), (const, override));
 
     MOCK_METHOD(std::string, checkForUpdateUrl, (), (const, override));
-    MOCK_METHOD(network::RequestHeaders, checkForUpdateHeaders, (), (const, override));
+    MOCK_METHOD(std::string, previousReleasesNotesUrl, (), (const, override));
+
+    MOCK_METHOD(network::RequestHeaders, updateHeaders, (), (const, override));
 
     MOCK_METHOD(std::string, museScoreUrl, (), (const, override));
     MOCK_METHOD(std::string, museScorePrivacyPolicyUrl, (), (const, override));

--- a/src/update/tests/updateservice_tests.cpp
+++ b/src/update/tests/updateservice_tests.cpp
@@ -36,6 +36,7 @@ using ::testing::Return;
 #include "global/tests/mocks/systeminfomock.h"
 
 #include "update/internal/updateservice.h"
+#include "muversion.h"
 
 using namespace mu;
 using namespace mu::update;
@@ -59,6 +60,9 @@ public:
 
         m_systemInfoMock = std::make_shared<SystemInfoMock>();
         m_service->setsystemInfo(m_systemInfoMock);
+
+        ON_CALL(*m_systemInfoMock, productType())
+        .WillByDefault(Return(ISystemInfo::ProductType::Linux));
     }
 
     void TearDown() override
@@ -68,24 +72,55 @@ public:
 
     void makeReleaseInfo() const
     {
-        QString releaseInfo = "{"
-                              "\"tag_name\": \"v5.0\","
-                              "\"assets\": ["
-                              "{ \"name\": \"MuseScore.dmg\", \"browser_download_url\": \"blabla\" },"
-                              "{ \"name\": \"MuseScore.msi\", \"browser_download_url\": \"blabla\" },"
-                              "{ \"name\": \"MuseScore.AppImage\", \"browser_download_url\": \"blabla\" }"
-                              "],"
-                              "\"assetsNew\": ["
-                              "{ \"name\": \"MuseScore-arm.AppImage\", \"browser_download_url\": \"blabla\" },"
-                              "{ \"name\": \"MuseScore-aarch64.AppImage\", \"browser_download_url\": \"blabla\" }"
-                              "]"
-                              "}";
+        std::string checkForUpdateUrl = "checkForUpdateUrl";
+        EXPECT_CALL(*m_configuration, checkForUpdateUrl())
+        .WillOnce(Return(checkForUpdateUrl));
 
-        EXPECT_CALL(*m_networkManager, get(_, _, _))
+        QString releasesNotes = "{"
+                                "\"tag_name\": \"v5.0\","
+                                "\"assets\": ["
+                                "{ \"name\": \"MuseScore.dmg\", \"browser_download_url\": \"blabla\" },"
+                                "{ \"name\": \"MuseScore.msi\", \"browser_download_url\": \"blabla\" },"
+                                "{ \"name\": \"MuseScore.AppImage\", \"browser_download_url\": \"blabla\" }"
+                                "],"
+                                "\"assetsNew\": ["
+                                "{ \"name\": \"MuseScore-arm.AppImage\", \"browser_download_url\": \"blabla\" },"
+                                "{ \"name\": \"MuseScore-aarch64.AppImage\", \"browser_download_url\": \"blabla\" }"
+                                "]"
+                                "}";
+
+        EXPECT_CALL(*m_networkManager, get(QUrl(QString::fromStdString(checkForUpdateUrl)), _, _))
         .WillOnce(testing::Invoke(
-                      [releaseInfo](const QUrl&, network::IncomingDevice* buf, const network::RequestHeaders&) {
+                      [releasesNotes](const QUrl&, network::IncomingDevice* buf, const network::RequestHeaders&) {
             buf->open(network::IncomingDevice::WriteOnly);
-            buf->write(releaseInfo.toUtf8());
+            buf->write(releasesNotes.toUtf8());
+            buf->close();
+
+            return make_ok();
+        }));
+    }
+
+    void makePreviousReleasesNotes() const
+    {
+        std::string previousReleasesNotesUrl = "previousReleasesNotesUrl";
+        EXPECT_CALL(*m_configuration, previousReleasesNotesUrl())
+        .WillOnce(Return(previousReleasesNotesUrl));
+
+        //! [GIVEN] Previous releases notes. Contains chaotic order of versions
+        QString releasesNotes = QString("{"
+                                        "\"releases\": ["
+                                        "{ \"version\": \"40000.3\", \"notes\": \"blabla3\" },"
+                                        "{ \"version\": \"40000.4\", \"notes\": \"blabla4\" },"
+                                        "{ \"version\": \"%1\", \"notes\": \"blabla2\" },"
+                                        "{ \"version\": \"0.4.1\", \"notes\": \"blabla1\" }"
+                                        "]"
+                                        "}").arg(MUVersion::fullVersion());
+
+        EXPECT_CALL(*m_networkManager, get(QUrl(QString::fromStdString(previousReleasesNotesUrl)), _, _))
+        .WillOnce(testing::Invoke(
+                      [releasesNotes](const QUrl&, network::IncomingDevice* buf, const network::RequestHeaders&) {
+            buf->open(network::IncomingDevice::WriteOnly);
+            buf->write(releasesNotes.toUtf8());
             buf->close();
 
             return make_ok();
@@ -104,6 +139,7 @@ TEST_F(UpdateServiceTests, ParseRelease_Linux_x86_64)
 {
     //! [GIVEN] Release info
     makeReleaseInfo();
+    makePreviousReleasesNotes();
 
     //! [GIVEN] System is Linux x86_64
     ON_CALL(*m_systemInfoMock, productType())
@@ -124,6 +160,7 @@ TEST_F(UpdateServiceTests, ParseRelease_Linux_arm)
 {
     //! [GIVEN] Release info
     makeReleaseInfo();
+    makePreviousReleasesNotes();
 
     //! [GIVEN] System is Linux arm
     ON_CALL(*m_systemInfoMock, productType())
@@ -144,6 +181,7 @@ TEST_F(UpdateServiceTests, ParseRelease_Linux_aarch64)
 {
     //! [GIVEN] Release info
     makeReleaseInfo();
+    makePreviousReleasesNotes();
 
     //! [GIVEN] System is Linux arm64
     ON_CALL(*m_systemInfoMock, productType())
@@ -164,6 +202,7 @@ TEST_F(UpdateServiceTests, ParseRelease_Linux_Unknown)
 {
     //! [GIVEN] Release info
     makeReleaseInfo();
+    makePreviousReleasesNotes();
 
     //! [GIVEN] System is Linux Unknown
     ON_CALL(*m_systemInfoMock, productType())
@@ -184,6 +223,7 @@ TEST_F(UpdateServiceTests, ParseRelease_Windows)
 {
     //! [GIVEN] Release info
     makeReleaseInfo();
+    makePreviousReleasesNotes();
 
     //! [GIVEN] System is Windows, cpuArchitecture isn't important
     ON_CALL(*m_systemInfoMock, productType())
@@ -204,6 +244,7 @@ TEST_F(UpdateServiceTests, ParseRelease_MacOS)
 {
     //! [GIVEN] Release info
     makeReleaseInfo();
+    makePreviousReleasesNotes();
 
     //! [GIVEN] System is MacOS, cpuArchitecture isn't important
     ON_CALL(*m_systemInfoMock, productType())
@@ -218,4 +259,24 @@ TEST_F(UpdateServiceTests, ParseRelease_MacOS)
     //! [THEN] Should return correct release file
     EXPECT_TRUE(retVal.ret);
     EXPECT_EQ(retVal.val.fileName, "MuseScore.dmg");
+}
+
+TEST_F(UpdateServiceTests, CheckForUpdate_ReleasesNotes)
+{
+    //! [GIVEN] Release info
+    makeReleaseInfo();
+    makePreviousReleasesNotes();
+
+    //! [THEN] Versions should be in correct order and don't contain current version
+    PrevReleasesNotesList expectedReleasesNotes = {
+        { "40000.3", "blabla3" },
+        { "40000.4", "blabla4" },
+    };
+
+    //! [WHEN] Check for update
+    mu::RetVal<ReleaseInfo> retVal = m_service->checkForUpdate();
+
+    //! [THEN] Should return correct release file
+    EXPECT_TRUE(retVal.ret);
+    EXPECT_EQ(retVal.val.previousReleasesNotes, expectedReleasesNotes);
 }

--- a/src/update/updatetypes.h
+++ b/src/update/updatetypes.h
@@ -25,11 +25,28 @@
 #include <string>
 
 namespace mu::update {
-struct ReleaseInfo {
+struct PrevReleaseNotes {
+    std::string version;
     std::string notes;
+
+    PrevReleaseNotes() = default;
+    PrevReleaseNotes(const std::string& version, const std::string& notes)
+        : version(version), notes(notes) {}
+
+    bool operator ==(const PrevReleaseNotes& other) const
+    {
+        return version == other.version && notes == other.notes;
+    }
+};
+using PrevReleasesNotesList = std::vector<PrevReleaseNotes>;
+
+struct ReleaseInfo {
+    std::string version;
     std::string fileName;
     std::string fileUrl;
-    std::string version;
+
+    std::string notes;
+    PrevReleasesNotesList previousReleasesNotes;
 
     bool isValid() const
     {


### PR DESCRIPTION
Resolves: #21194

The idea is to save the release notes of each update into a separate file when updating release information on CI. 
During the update check, users will receive all release notes from previous updates, filtered based on the current version of the program.
