### PR TITLE
Add lyrics on grace notes to their parent notes instead on XML import

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
@@ -123,6 +123,15 @@ private:
     std::set<Lyrics*> m_lyrics;
 };
 
+struct GraceNoteLyrics {
+    Lyrics* lyric = nullptr;
+    bool extend = false;
+    int no = 0;
+
+    GraceNoteLyrics(Lyrics* lyric, bool extend, int no)
+        : lyric(lyric), extend(extend), no(no) {}
+};
+
 //---------------------------------------------------------
 //   MusicXMLParserLyric
 //---------------------------------------------------------
@@ -351,6 +360,7 @@ private:
     int m_multiMeasureRestCount = 0;
     int m_measureNumber = 0;                       // Current measure number as written in the score
     MusicXmlLyricsExtend m_extendedLyrics;         // Lyrics with "extend" requiring fixup
+    std::vector<GraceNoteLyrics> m_graceNoteLyrics;   // Lyrics to be moved from grace note to main note
 
     MusicXmlSlash m_measureStyleSlash;             // Are we inside a measure to be displayed as slashes?
 

--- a/src/importexport/musicxml/tests/data/testLyrics1_ref.xml
+++ b/src/importexport/musicxml/tests/data/testLyrics1_ref.xml
@@ -110,6 +110,10 @@
         <type>whole</type>
         <lyric number="1">
           <syllabic>single</syllabic>
+          <text>lyr3</text>
+          </lyric>
+        <lyric number="1">
+          <syllabic>single</syllabic>
           <text>lyr4</text>
           </lyric>
         </note>
@@ -133,6 +137,10 @@
         <duration>4</duration>
         <voice>1</voice>
         <type>whole</type>
+        <lyric number="1">
+          <syllabic>single</syllabic>
+          <text>lyr5</text>
+          </lyric>
         </note>
       </measure>
     <measure number="5">


### PR DESCRIPTION
As we don't support lyrics on grace notes, we previously discarded any lyrics attached to grace notes on XML import.  Instead, this PR adds those notes to the main note.
![Screenshot 2024-02-08 at 14 09 13](https://github.com/musescore/MuseScore/assets/26510874/c5cce361-c821-4b88-b7a9-e0456fba0766)
