### PR TITLE
[musicxml] fixed read files from Sibelius

### DIFF
--- a/src/framework/global/serialization/xmlstreamreader.cpp
+++ b/src/framework/global/serialization/xmlstreamreader.cpp
@@ -23,6 +23,8 @@
 
 #include <cstring>
 
+#include "global/types/string.h"
+
 #include "thirdparty/tinyxml/tinyxml2.h"
 
 #include "log.h"
@@ -71,8 +73,66 @@ XmlStreamReader::~XmlStreamReader()
     delete m_xml;
 }
 
-void XmlStreamReader::setData(const ByteArray& data)
+XmlStreamReader::Encoding XmlStreamReader::encoding(const ByteArray& data) const
 {
+    constexpr unsigned char u8Bom[] = { 239, 187, 191 };
+    constexpr unsigned char u16BEBom[] = { 254, 255 };
+    constexpr unsigned char u16LEBom[] = { 255, 254 };
+
+    // check Bom
+    if (std::memcmp(data.constChar(), u8Bom, 3) == 0) {
+        return Encoding::UTF_8;
+    }
+
+    if (std::memcmp(data.constChar(), u16LEBom, 2) == 0) {
+        return Encoding::UTF_16LE;
+    }
+
+    if (std::memcmp(data.constChar(), u16BEBom, 2) == 0) {
+        return Encoding::UTF_16BE;
+    }
+
+    // check content
+    const uint8_t* d = data.constData();
+    if (d[0] != 0 && d[1] != 0) {
+        return Encoding::UTF_8;
+    }
+
+    if (d[0] != 0 && d[1] == 0) {
+        return Encoding::UTF_16LE;
+    }
+
+    if (d[0] == 0 && d[1] != 0) {
+        return Encoding::UTF_16BE;
+    }
+
+    return Encoding::Unknown;
+}
+
+void XmlStreamReader::setData(const ByteArray& data_)
+{
+    if (data_.size() < 4) {
+        LOGE() << "empty data";
+        return;
+    }
+
+    Encoding enc = encoding(data_);
+    if (enc == Encoding::Unknown) {
+        LOGE() << "unknown encoding";
+        return;
+    }
+
+    if (enc == Encoding::UTF_16BE) {
+        LOGE() << "unsupported encoding UTF-16BE";
+        return;
+    }
+
+    ByteArray data = data_; // no copy, implicit sharing
+    if (enc == Encoding::UTF_16LE) {
+        String u16 = String::fromUtf16(data_);
+        data = u16.toUtf8();
+    }
+
     m_xml->doc.Clear();
     m_xml->err = m_xml->doc.Parse(reinterpret_cast<const char*>(data.constData()), data.size());
     m_token = m_xml->err == XML_SUCCESS ? TokenType::NoToken : TokenType::Invalid;

--- a/src/framework/global/serialization/xmlstreamreader.h
+++ b/src/framework/global/serialization/xmlstreamreader.h
@@ -123,6 +123,15 @@ public:
 private:
     struct Xml;
 
+    enum class Encoding {
+        Unknown,
+        UTF_8,
+        UTF_16LE,
+        UTF_16BE,
+    };
+
+    Encoding encoding(const ByteArray& data) const;
+
     void tryParseEntity(Xml* xml);
     String nodeValue(Xml* xml) const;
 

--- a/src/framework/global/types/string.cpp
+++ b/src/framework/global/types/string.cpp
@@ -310,6 +310,7 @@ struct String::Mutator {
     void reserve(size_t n) { s.reserve(n); }
     void resize(size_t n) { s.resize(n); }
     void clear() { s.clear(); }
+    void push_back(char16_t c) { s.push_back(c); }
     void insert(size_t p, const std::u16string& v) { s.insert(p, v); }
     void erase(size_t p, size_t n) { s.erase(p, n); }
 
@@ -428,6 +429,29 @@ String& String::prepend(const String& s)
 {
     mutStr() = s.constStr() + constStr();
     return *this;
+}
+
+String String::fromUtf16(const ByteArray& data)
+{
+    //make sure len is divisible by 2
+    size_t len = data.size();
+    if (len % 2) {
+        len--;
+    }
+
+    String u16;
+    u16.reserve(len / 2);
+    String::Mutator mut = u16.mutStr();
+
+    const uint8_t* d = data.constData();
+    for (size_t i = 0; i < len;) {
+        //little-endian
+        int lo = d[i++] & 0xFF;
+        int hi = d[i++] & 0xFF;
+        mut.push_back(hi << 8 | lo);
+    }
+
+    return u16;
 }
 
 String String::fromUtf8(const char* str)

--- a/src/framework/global/types/string.h
+++ b/src/framework/global/types/string.h
@@ -245,6 +245,8 @@ public:
     String& prepend(Char ch);
     String& prepend(const String& s);
 
+    static String fromUtf16(const ByteArray& data);
+
     static String fromUtf8(const char* str);
     ByteArray toUtf8() const;
 

--- a/src/importexport/musicxml/internal/musicxml/importmxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxml.cpp
@@ -97,9 +97,6 @@ static void updateNamesForAccidentals(Instrument* inst)
 
 Err importMusicXMLfromBuffer(Score* score, const String& /*name*/, const ByteArray& data)
 {
-    //LOGD("importMusicXMLfromBuffer(score %p, name '%s', dev %p)",
-    //       score, qPrintable(name), dev);
-
     MxmlLogger logger;
     logger.setLoggingLevel(MxmlLogger::Level::MXML_ERROR);   // errors only
     //logger.setLoggingLevel(MxmlLogger::Level::MXML_INFO);


### PR DESCRIPTION
I was told that after my changes in MusicXML, files from Sibelius do not open...
). I started to figure out what was going on, and what I see is that in this XML file there is a 0 after each character, but this indicates the end of the string, and accordingly the parser does not parse 

QXmlStreamReader can read such a file 
But some online validators also say a bad file...

![image](https://github.com/musescore/MuseScore/assets/3818029/ee60e616-8c1b-40a6-980b-32df7f12db9d)

![image](https://github.com/musescore/MuseScore/assets/3818029/eb95d6bf-0844-40d8-8a3b-147bfb41267c)

![image](https://github.com/musescore/MuseScore/assets/3818029/5ad153d8-3d6c-45fb-8d16-5aee0a4a7f27)

![image](https://github.com/musescore/MuseScore/assets/3818029/98daec26-e450-4320-a052-41fe5ae1d31f)

The first one I could read 
![image](https://github.com/musescore/MuseScore/assets/3818029/48b0ad0d-97c8-4b1c-b009-414378eb2074)

Bad file:
[grace-lyric.zip](https://github.com/musescore/MuseScore/files/14214572/grace-lyric.zip)
