### PR TITLE
fixed #21159: Musescore4 crashes when "limit scroll to page borders" is activated

### DIFF
--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -32,13 +32,15 @@ NotationPaintView::NotationPaintView(QQuickItem* parent)
 
 void NotationPaintView::onLoadNotation(INotationPtr notation)
 {
-    m_isLoadingNotation = true;
+    m_isLocalMatrixUpdate = true;
     setMatrix(notation->viewState()->matrix());
-    m_isLoadingNotation = false;
+    m_isLocalMatrixUpdate = false;
 
     notation->viewState()->matrixChanged().onReceive(this, [this](const Transform& matrix, NotationPaintView* sender) {
         if (sender != this) {
+            m_isLocalMatrixUpdate = true;
             setMatrix(matrix);
+            m_isLocalMatrixUpdate = false;
         }
     });
 
@@ -56,7 +58,7 @@ void NotationPaintView::onMatrixChanged(const Transform& oldMatrix, const Transf
 {
     AbstractNotationPaintView::onMatrixChanged(oldMatrix, newMatrix, overrideZoomType);
 
-    if (!m_isLoadingNotation && notation()) {
+    if (!m_isLocalMatrixUpdate && notation()) {
         notation()->viewState()->setMatrix(newMatrix, this);
 
         if (overrideZoomType) {

--- a/src/notation/view/notationpaintview.h
+++ b/src/notation/view/notationpaintview.h
@@ -36,7 +36,7 @@ private:
 
     void onMatrixChanged(const draw::Transform& oldMatrix, const draw::Transform& newMatrix, bool overrideZoomType = true) override;
 
-    bool m_isLoadingNotation = false;
+    bool m_isLocalMatrixUpdate = false;
 };
 }
 


### PR DESCRIPTION
Resolves: #21159

Fixed infinity updating of matrix