### PR TITLE
Cycle through overlapping elements on Ctrl+Click

### DIFF
--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -53,6 +53,7 @@ public:
 
     // Hit
     virtual EngravingItem* hitElement(const muse::PointF& pos, float width) const = 0;
+    virtual std::vector<EngravingItem*> hitElements(const muse::PointF& pos, float width) const = 0;
     virtual Staff* hitStaff(const muse::PointF& pos) const = 0;
 
     struct HitElementContext
@@ -81,6 +82,9 @@ public:
     virtual void clearSelection() = 0;
     virtual muse::async::Notification selectionChanged() const = 0;
     virtual void selectTopOrBottomOfChord(MoveDirection d) = 0;
+
+    // Deselect
+    virtual void deselect(EngravingItem* element) = 0;
 
     // SelectionFilter
     virtual bool isSelectionTypeFiltered(SelectionFilterType type) const = 0;
@@ -294,8 +298,6 @@ public:
     virtual muse::async::Channel<ShowItemRequest> showItemRequested() const = 0;
 
     virtual void setGetViewRectFunc(const std::function<muse::RectF()>& func) = 0;
-
-    virtual void setLogicClickPos(const muse::PointF& logicPos) = 0;
 };
 
 using INotationInteractionPtr = std::shared_ptr<INotationInteraction>;

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -294,6 +294,8 @@ public:
     virtual muse::async::Channel<ShowItemRequest> showItemRequested() const = 0;
 
     virtual void setGetViewRectFunc(const std::function<muse::RectF()>& func) = 0;
+
+    virtual void setLogicClickPos(const muse::PointF& logicPos) = 0;
 };
 
 using INotationInteractionPtr = std::shared_ptr<INotationInteraction>;

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -83,9 +83,6 @@ public:
     virtual muse::async::Notification selectionChanged() const = 0;
     virtual void selectTopOrBottomOfChord(MoveDirection d) = 0;
 
-    // Deselect
-    virtual void deselect(EngravingItem* element) = 0;
-
     // SelectionFilter
     virtual bool isSelectionTypeFiltered(SelectionFilterType type) const = 0;
     virtual void setSelectionTypeFiltered(SelectionFilterType type, bool filtered) = 0;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -751,32 +751,37 @@ void NotationInteraction::selectTopOrBottomOfChord(MoveDirection d)
 
 static bool elementLower(const EngravingItem* e1, const EngravingItem* e2)
 {
-    if (!e1->selectable())
+    if (!e1->selectable()) {
         return false;
-    if (!e2->selectable())
+    }
+    if (!e2->selectable()) {
         return true;
-    if (e1->isNote() && e2->isStem())
+    }
+    if (e1->isNote() && e2->isStem()) {
         return true;
-    if (e2->isNote() && e1->isStem())
+    }
+    if (e2->isNote() && e1->isStem()) {
         return false;
+    }
     if (e1->z() == e2->z()) {
         // same stacking order, prefer non-hidden elements
         if (e1->type() == e2->type()) {
             if (e1->type() == ElementType::NOTEDOT) {
                 const NoteDot* n1 = static_cast<const NoteDot*>(e1);
                 const NoteDot* n2 = static_cast<const NoteDot*>(e2);
-                if (n1->note() && n1->note()->hidden())
+                if (n1->note() && n1->note()->hidden()) {
                     return false;
-                else if (n2->note() && n2->note()->hidden())
+                } else if (n2->note() && n2->note()->hidden()) {
                     return true;
-            }
-            else if (e1->type() == ElementType::NOTE) {
+                }
+            } else if (e1->type() == ElementType::NOTE) {
                 const Note* n1 = static_cast<const Note*>(e1);
                 const Note* n2 = static_cast<const Note*>(e2);
-                if (n1->hidden())
+                if (n1->hidden()) {
                     return false;
-                else if (n2->hidden())
+                } else if (n2->hidden()) {
                     return true;
+                }
             }
         }
         // different types, or same type but nothing hidden - use track
@@ -787,7 +792,7 @@ static bool elementLower(const EngravingItem* e1, const EngravingItem* e2)
     return e1->z() <= e2->z();
 }
 
-std::vector<EngravingItem *> NotationInteraction::elementsNear(const mu::PointF& pos) const
+std::vector<EngravingItem*> NotationInteraction::elementsNear(const mu::PointF& pos) const
 {
     std::vector<EngravingItem*> ll;
     Page* page = point2page(pos);
@@ -886,8 +891,7 @@ void NotationInteraction::doSelect(const std::vector<EngravingItem*>& elements, 
             if (elements.front()->selected()) {
                 score()->deselect(elements.front());
                 return;
-            }
-            else {
+            } else {
                 score()->select(elements.front(), type, staffIndex);
                 return;
             }
@@ -904,11 +908,10 @@ void NotationInteraction::doSelect(const std::vector<EngravingItem*>& elements, 
         for (size_t i = 0; i <= ll.size(); ++i) {
             if (found) {
                 e = ll[currTop];
-                if (!e->isMeasure()){
+                if (!e->isMeasure()) {
                     break;
                 }
-            }
-            else if (ll[currTop]->selected()) {
+            } else if (ll[currTop]->selected()) {
                 found = true;
                 score()->deselect(ll[currTop]);
                 e = nullptr;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -749,6 +749,102 @@ void NotationInteraction::selectTopOrBottomOfChord(MoveDirection d)
     showItem(target);
 }
 
+static bool elementLower(const EngravingItem* e1, const EngravingItem* e2)
+{
+    if (!e1->selectable())
+        return false;
+    if (!e2->selectable())
+        return true;
+    if (e1->isNote() && e2->isStem())
+        return true;
+    if (e2->isNote() && e1->isStem())
+        return false;
+    if (e1->z() == e2->z()) {
+        // same stacking order, prefer non-hidden elements
+        if (e1->type() == e2->type()) {
+            if (e1->type() == ElementType::NOTEDOT) {
+                const NoteDot* n1 = static_cast<const NoteDot*>(e1);
+                const NoteDot* n2 = static_cast<const NoteDot*>(e2);
+                if (n1->note() && n1->note()->hidden())
+                    return false;
+                else if (n2->note() && n2->note()->hidden())
+                    return true;
+            }
+            else if (e1->type() == ElementType::NOTE) {
+                const Note* n1 = static_cast<const Note*>(e1);
+                const Note* n2 = static_cast<const Note*>(e2);
+                if (n1->hidden())
+                    return false;
+                else if (n2->hidden())
+                    return true;
+            }
+        }
+        // different types, or same type but nothing hidden - use track
+        return e1->track() <= e2->track();
+    }
+
+    // default case, use stacking order
+    return e1->z() <= e2->z();
+}
+
+std::vector<EngravingItem *> NotationInteraction::elementsNear(const mu::PointF& pos) const
+{
+    std::vector<EngravingItem*> ll;
+    Page* page = point2page(pos);
+    if (!page) {
+        return ll;
+    }
+
+    mu::PointF p = pos - page->pos();
+    double w = configuration()->selectionProximity();
+    RectF r(p.x() - w, p.y() - w, 3.0 * w, 3.0 * w);
+
+    std::vector<EngravingItem*> el = page->items(r);
+    for (int i = 0; i < MAX_HEADERS; i++) {
+        if (score()->headerText(i) != nullptr) {
+            el.push_back(score()->headerText(i));
+        }
+    }
+    for (int i = 0; i < MAX_FOOTERS; i++) {
+        if (score()->footerText(i) != nullptr) {
+            el.push_back(score()->footerText(i));
+        }
+    }
+    for (EngravingItem* e : el) {
+        e->itemDiscovered = 0;
+        if (!e->selectable() || e->isPage()) {
+            continue;
+        }
+        if (e->contains(p)) {
+            ll.push_back(e);
+        }
+    }
+    size_t n = ll.size();
+    if ((n == 0) || ((n == 1) && (ll[0]->isMeasure()))) {
+        //
+        // if no relevant element hit, look nearby
+        //
+        for (EngravingItem* e : el) {
+            if (e->isPage() || !e->selectable()) {
+                continue;
+            }
+            if (e->intersects(r)) {
+                ll.push_back(e);
+            }
+        }
+    }
+    if (!ll.empty()) {
+        std::sort(ll.begin(), ll.end(), elementLower);
+    }
+    return ll;
+}
+
+void NotationInteraction::setLogicClickPos(const PointF& logicPos)
+{
+    m_logicClickPos = logicPos;
+    return;
+}
+
 void NotationInteraction::select(const std::vector<EngravingItem*>& elements, SelectType type, staff_idx_t staffIndex)
 {
     TRACEFUNC;
@@ -782,8 +878,46 @@ void NotationInteraction::doSelect(const std::vector<EngravingItem*>& elements, 
             score()->setUpdateAll();
         }
 
-        if (elements.front()->selected()) {
-            score()->deselect(elements.front());
+        std::vector<EngravingItem*> ll = elementsNear(m_logicClickPos);
+        int n = ll.size();
+
+        // if there is only one element and its selected simply deselect it or select it if not selected
+        if (n == 1) {
+            if (elements.front()->selected()) {
+                score()->deselect(elements.front());
+                return;
+            }
+            else {
+                score()->select(elements.front(), type, staffIndex);
+                return;
+            }
+        }
+
+        // we start loop from the topmost element
+        int currTop = n - 1;
+        EngravingItem* e = ll[currTop];
+        bool found = false;
+
+        // e is the topmost element in stacking order,
+        // but we want to replace it with "first non-measure element after a selected element"
+        // (if such an element exists)
+        for (size_t i = 0; i <= ll.size(); ++i) {
+            if (found) {
+                e = ll[currTop];
+                if (!e->isMeasure()){
+                    break;
+                }
+            }
+            else if (ll[currTop]->selected()) {
+                found = true;
+                score()->deselect(ll[currTop]);
+                e = nullptr;
+            }
+            currTop = (currTop + 1) % n;
+        }
+
+        if (e && !e->selected()) {
+            score()->select(e, type, staffIndex);
             return;
         }
     }

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -766,25 +766,6 @@ void NotationInteraction::select(const std::vector<EngravingItem*>& elements, Se
     }
 }
 
-void NotationInteraction::deselect(EngravingItem* element)
-{
-    TRACEFUNC;
-
-    const mu::engraving::Selection& selection = score()->selection();
-    std::vector<EngravingItem*> oldSelectedElements = selection.elements();
-    mu::engraving::SelState oldSelectionState = selection.state();
-
-    if (element->selected()) {
-        score()->deselect(element);
-    }
-
-    if (oldSelectedElements != selection.elements() || oldSelectionState != selection.state()) {
-        notifyAboutSelectionChangedIfNeed();
-    } else {
-        score()->setSelectionChanged(false);
-    }
-}
-
 void NotationInteraction::doSelect(const std::vector<EngravingItem*>& elements, SelectType type, staff_idx_t staffIndex)
 {
     TRACEFUNC;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -291,6 +291,8 @@ public:
 
     void setGetViewRectFunc(const std::function<muse::RectF()>& func) override;
 
+    void setLogicClickPos(const muse::PointF& logicPos) override;
+
 private:
     mu::engraving::Score* score() const;
     void onScoreInited();
@@ -306,7 +308,7 @@ private:
     void doEndDrag();
 
     bool doDropStandard();
-    bool doDropTextBaseAndSymbols(const PointF& pos, bool applyUserOffset);
+    bool doDropTextBaseAndSymbols(const muse::PointF& pos, bool applyUserOffset);
 
     void onElementDestroyed(EngravingItem* element);
 
@@ -342,6 +344,8 @@ private:
     std::vector<EngravingItem*> hitElements(const muse::PointF& p_in, float w) const;
     std::vector<EngravingItem*> elementsAt(const muse::PointF& p) const;
     EngravingItem* elementAt(const muse::PointF& p) const;
+
+    std::vector<EngravingItem*> elementsNear(const muse::PointF& pos) const;
 
     // Sorting using this function will place the elements that are the most
     // interesting to be selected at the end of the list
@@ -450,6 +454,8 @@ private:
     HitElementContext m_hitElementContext;
 
     muse::async::Channel<ShowItemRequest> m_showItemRequested;
+
+    muse::PointF m_logicClickPos;
 };
 }
 

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -92,9 +92,6 @@ public:
     void selectTopOrBottomOfChord(MoveDirection d) override;
     void moveSegmentSelection(MoveDirection d) override;
 
-    // Deselect
-    void deselect(EngravingItem* element) override;
-
     // SelectionFilter
     bool isSelectionTypeFiltered(SelectionFilterType type) const override;
     void setSelectionTypeFiltered(SelectionFilterType type, bool filtered) override;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -73,6 +73,7 @@ public:
 
     // Hit
     EngravingItem* hitElement(const muse::PointF& pos, float width) const override;
+    std::vector<EngravingItem*> hitElements(const muse::PointF& pos, float width) const override;
     Staff* hitStaff(const muse::PointF& pos) const override;
     const HitElementContext& hitElementContext() const override;
     void setHitElementContext(const HitElementContext& context) override;
@@ -90,6 +91,9 @@ public:
     muse::async::Notification selectionChanged() const override;
     void selectTopOrBottomOfChord(MoveDirection d) override;
     void moveSegmentSelection(MoveDirection d) override;
+
+    // Deselect
+    void deselect(EngravingItem* element) override;
 
     // SelectionFilter
     bool isSelectionTypeFiltered(SelectionFilterType type) const override;
@@ -291,8 +295,6 @@ public:
 
     void setGetViewRectFunc(const std::function<muse::RectF()>& func) override;
 
-    void setLogicClickPos(const muse::PointF& logicPos) override;
-
 private:
     mu::engraving::Score* score() const;
     void onScoreInited();
@@ -341,11 +343,8 @@ private:
     bool needEndTextEdit() const;
 
     mu::engraving::Page* point2page(const muse::PointF& p, bool useNearestPage = false) const;
-    std::vector<EngravingItem*> hitElements(const muse::PointF& p_in, float w) const;
     std::vector<EngravingItem*> elementsAt(const muse::PointF& p) const;
     EngravingItem* elementAt(const muse::PointF& p) const;
-
-    std::vector<EngravingItem*> elementsNear(const muse::PointF& pos) const;
 
     // Sorting using this function will place the elements that are the most
     // interesting to be selected at the end of the list
@@ -454,8 +453,6 @@ private:
     HitElementContext m_hitElementContext;
 
     muse::async::Channel<ShowItemRequest> m_showItemRequested;
-
-    muse::PointF m_logicClickPos;
 };
 }
 

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -249,6 +249,8 @@ public:
     MOCK_METHOD(muse::async::Channel<ShowItemRequest>, showItemRequested, (), (const, override));
 
     MOCK_METHOD(void, setGetViewRectFunc, (const std::function<muse::RectF()>&), (override));
+
+    MOCK_METHOD(void, setLogicClickPos, (const muse::PointF&), (override));
 };
 }
 

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -47,7 +47,6 @@ public:
 
     MOCK_METHOD(void, moveChordNoteSelection, (MoveDirection), (override));
     MOCK_METHOD(void, select, (const std::vector<EngravingItem*>&, SelectType, engraving::staff_idx_t), (override));
-    MOCK_METHOD(void, deselect, (EngravingItem * element), (override));
     MOCK_METHOD(void, selectAll, (), (override));
     MOCK_METHOD(void, selectSection, (), (override));
     MOCK_METHOD(void, selectFirstElement, (bool), (override));

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -39,6 +39,7 @@ public:
     MOCK_METHOD(void, toggleVisible, (), (override));
 
     MOCK_METHOD(EngravingItem*, hitElement, (const muse::PointF&, float), (const, override));
+    MOCK_METHOD(std::vector<EngravingItem*>, hitElements, (const muse::PointF&, float), (const, override));
     MOCK_METHOD(Staff*, hitStaff, (const muse::PointF&), (const, override));
 
     MOCK_METHOD(const HitElementContext&, hitElementContext, (), (const, override));
@@ -46,6 +47,7 @@ public:
 
     MOCK_METHOD(void, moveChordNoteSelection, (MoveDirection), (override));
     MOCK_METHOD(void, select, (const std::vector<EngravingItem*>&, SelectType, engraving::staff_idx_t), (override));
+    MOCK_METHOD(void, deselect, (EngravingItem * element), (override));
     MOCK_METHOD(void, selectAll, (), (override));
     MOCK_METHOD(void, selectSection, (), (override));
     MOCK_METHOD(void, selectFirstElement, (bool), (override));
@@ -249,8 +251,6 @@ public:
     MOCK_METHOD(muse::async::Channel<ShowItemRequest>, showItemRequested, (), (const, override));
 
     MOCK_METHOD(void, setGetViewRectFunc, (const std::function<muse::RectF()>&), (override));
-
-    MOCK_METHOD(void, setLogicClickPos, (const muse::PointF&), (override));
 };
 }
 

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -638,29 +638,29 @@ void NotationViewInputController::mousePressEvent(QMouseEvent* event)
             selectType = SelectType::ADD;
         }
 
-        std::vector<EngravingItem*> ll = viewInteraction()->hitElements(ctx.logicClickPos, hitWidth());
-        int n = ll.size();
+        std::vector<EngravingItem*> hitElements = viewInteraction()->hitElements(ctx.logicClickPos, hitWidth());
+        size_t numHitElements = hitElements.size();
 
         // overlapping elements with ctrl modifier
-        if (ll.size() > 1 && (keyState & Qt::ControlModifier)) {
-            int currTop = n - 1;
-            EngravingItem* e = ll[currTop];
+        if (numHitElements > 1 && (keyState & Qt::ControlModifier)) {
+            size_t currTop = numHitElements - 1;
+            EngravingItem* e = hitElements[currTop];
             bool found = false;
 
             // e is the topmost element in stacking order,
             // but we want to replace it with "first non-measure element after a selected element"
             // (if such an element exists)
-            for (size_t i = 0; i <= ll.size(); ++i) {
+            for (size_t i = 0; i <= numHitElements; ++i) {
                 if (found) {
-                    e = ll[currTop];
+                    e = hitElements[currTop];
                     if (!e->isMeasure()) {
                         break;
                     }
-                } else if (ll[currTop]->selected()) {
+                } else if (hitElements[currTop]->selected()) {
                     found = true;
                     e = nullptr;
                 }
-                currTop = (currTop + 1) % n;
+                currTop = (currTop + 1) % numHitElements;
             }
 
             if (e && !e->selected()) {

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -637,6 +637,7 @@ void NotationViewInputController::mousePressEvent(QMouseEvent* event)
         } else if (keyState & Qt::ControlModifier) {
             selectType = SelectType::ADD;
         }
+        viewInteraction()->setLogicClickPos(ctx.logicClickPos);
         viewInteraction()->select({ hitElement }, selectType, hitStaffIndex);
     }
 

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -658,14 +658,13 @@ void NotationViewInputController::mousePressEvent(QMouseEvent* event)
                     }
                 } else if (ll[currTop]->selected()) {
                     found = true;
-                    viewInteraction()->deselect(ll[currTop]);
                     e = nullptr;
                 }
                 currTop = (currTop + 1) % n;
             }
 
             if (e && !e->selected()) {
-                viewInteraction()->select({ e }, selectType, hitStaffIndex);
+                viewInteraction()->select({ e }, SelectType::SINGLE, hitStaffIndex);
             }
         } else {
             viewInteraction()->select({ hitElement }, selectType, hitStaffIndex);


### PR DESCRIPTION
Resolves: #10225 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->


https://github.com/musescore/MuseScore/assets/105774228/1b2ccf61-e39b-4d64-ba55-caba5d98a76d

* If there is a single element, ctrl+click simply selects it if not selected and deselects it if selected.
* If there are overlapping elements and nothing is selected, ctrl+click will select the topmost element.
* If the topmost element is selected(for eg. by simple left click which also selects the topmost element) or any other element is selected in overlapped elements, ctrl+click cycles through the stacked elements starting from bottommost(or next element after any other element that is selected) as in MU3.

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] The code compiles and runs on my machine, preferably after each commit individually

