### PR TITLE
Fix #21056: Don't add empty whole measure rests to second+ voices

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -1754,7 +1754,6 @@ void Score::changeCRlen(ChordRest* cr, const Fraction& dstF, bool fillWithRest)
             break;
         }
         Segment* s = m1->first(SegmentType::ChordRest);
-        expandVoice(s, track);
         cr1 = toChordRest(s->element(track));
     }
     connectTies();


### PR DESCRIPTION
Resolves: #21056

When changing note lengths in voices 2-4, a whole measure rest no longer gets added to the next measure. Historically this may have been needed for note input but it seems to work fine without.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
