### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/engraving/rendering/dev/slurtielayout.cpp
+++ b/src/engraving/rendering/dev/slurtielayout.cpp
@@ -1559,7 +1559,7 @@ TieSegment* SlurTieLayout::tieLayoutBack(Tie* item, System* system, LayoutContex
     segment->resetAdjustmentOffset();
 
     if (chord) {
-        segment->setStaffMove(chord->vStaffIdx() - segment->staffIdx());
+        segment->setStaffMove(static_cast<int>(chord->vStaffIdx() - segment->staffIdx()));
     }
 
     adjustY(segment);


### PR DESCRIPTION
Fix: `MuseScore\src\engraving\rendering\dev\slurtielayout.cpp(1562,71): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data`