### PR TITLE
refactor: Turn `POS` into `LoopBoundaryType`

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -464,10 +464,6 @@ void Score::update(bool resetCmdState, bool layoutAllParts)
             }
             m_updateState.refresh = RectF();
         }
-        const InputState& is = inputState();
-        if (is.noteEntryMode() && is.segment()) {
-            setPlayPos(is.segment()->tick());
-        }
         if (playlistDirty()) {
             masterScore()->setPlaylistClean();
         }

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3987,7 +3987,6 @@ void Score::nextInputPos(ChordRest* cr, bool doSelect)
         if (doSelect) {
             select(ncr, SelectType::SINGLE, 0);
         }
-        setPlayPos(ncr->tick());
         for (MuseScoreView* v : m_viewer) {
             v->moveCursor();
         }

--- a/src/engraving/dom/masterscore.cpp
+++ b/src/engraving/dom/masterscore.cpp
@@ -24,7 +24,6 @@
 #include "io/buffer.h"
 
 #include "compat/writescorehook.h"
-#include "infrastructure/mscwriter.h"
 
 #include "rw/mscloader.h"
 #include "rw/xmlreader.h"
@@ -34,7 +33,6 @@
 
 #include "engravingproject.h"
 
-#include "audio.h"
 #include "barline.h"
 #include "excerpt.h"
 #include "factory.h"
@@ -66,10 +64,6 @@ MasterScore::MasterScore(std::weak_ptr<engraving::EngravingProject> project)
     m_expandedRepeatList  = new RepeatList(this);
     m_nonExpandedRepeatList = new RepeatList(this);
     setMasterScore(this);
-
-    m_pos[int(POS::CURRENT)] = Fraction(0, 1);
-    m_pos[int(POS::LEFT)]    = Fraction(0, 1);
-    m_pos[int(POS::RIGHT)]   = Fraction(0, 1);
 
 #if defined(Q_OS_WIN)
     metaTags().insert({ u"platform", u"Microsoft Windows" });
@@ -284,8 +278,19 @@ Score* MasterScore::createScore(const MStyle& s)
 //   setPos
 //---------------------------------------------------------
 
-void MasterScore::setPos(POS pos, Fraction tick)
+Fraction MasterScore::loopBoundaryTick(LoopBoundaryType type) const
 {
+    IF_ASSERT_FAILED(type != LoopBoundaryType::Unknown) {
+        return Fraction();
+    }
+    return m_loopBoundaries[size_t(type)];
+}
+
+void MasterScore::setLoopBoundaryTick(LoopBoundaryType type, Fraction tick)
+{
+    IF_ASSERT_FAILED(type != LoopBoundaryType::Unknown) {
+        return;
+    }
     if (tick < Fraction(0, 1)) {
         tick = Fraction(0, 1);
     }
@@ -294,12 +299,12 @@ void MasterScore::setPos(POS pos, Fraction tick)
         tick = lastMeasure()->endTick();
     }
 
-    m_pos[int(pos)] = tick;
+    m_loopBoundaries[size_t(type)] = tick;
     // even though tick position might not have changed, layout might have
     // so we should update cursor here
-    // however, we must be careful not to call setPos() again while handling posChanged, or recursion results
+    // however, we must be careful not to call setLoopBoundaryTick() again while handling posChanged, or recursion results
     for (Score* s : scoreList()) {
-        s->notifyPosChanged(pos, unsigned(tick.ticks()));
+        s->notifyLoopBoundaryTickChanged(type, unsigned(tick.ticks()));
     }
 }
 

--- a/src/engraving/dom/masterscore.h
+++ b/src/engraving/dom/masterscore.h
@@ -22,6 +22,8 @@
 #ifndef MU_ENGRAVING_MASTERSCORE_H
 #define MU_ENGRAVING_MASTERSCORE_H
 
+#include <array>
+
 #include "../infrastructure/ifileinfoprovider.h"
 #include "../infrastructure/geteid.h"
 
@@ -153,9 +155,9 @@ public:
     void updateExpressive(Synthesizer* synth);
     void updateExpressive(Synthesizer* synth, bool expressive, bool force = false);
 
-    using Score::pos;
-    Fraction pos(POS pos) const { return m_pos[int(pos)]; }
-    void setPos(POS pos, Fraction tick);
+    using Score::loopBoundaryTick;
+    Fraction loopBoundaryTick(LoopBoundaryType type) const;
+    void setLoopBoundaryTick(LoopBoundaryType type, Fraction tick);
 
     void addExcerpt(Excerpt*, size_t index = mu::nidx);
     void removeExcerpt(Excerpt*);
@@ -225,7 +227,7 @@ private:
 
     CmdState m_cmdState;       // modified during cmd processing
 
-    Fraction m_pos[3];                      ///< 0 - current, 1 - left loop, 2 - right loop
+    std::array<Fraction, 2> m_loopBoundaries; ///< 0 - LoopIn, 1 - LoopOut
 
     int m_midiPortCount = 0;                           // A count of ALSA midi out ports
     //    QQueue<MidiInputEvent> _midiInputQueue;           // MIDI events that have yet to be processed

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -150,8 +150,10 @@ enum class HDuration : signed char;
 enum class AccidentalType;
 enum class LayoutBreakType;
 
-enum class POS : char {
-    CURRENT, LEFT, RIGHT
+enum class LoopBoundaryType : signed char {
+    Unknown = -1,
+    LoopIn = 0,
+    LoopOut = 1
 };
 
 enum class Pad : char {
@@ -271,8 +273,8 @@ public:
 
     ShadowNote* shadowNote() const;
 
-    mu::async::Channel<POS, unsigned> posChanged() const;
-    void notifyPosChanged(POS pos, unsigned ticks);
+    mu::async::Channel<LoopBoundaryType, unsigned> loopBoundaryTickChanged() const;
+    void notifyLoopBoundaryTickChanged(LoopBoundaryType type, unsigned ticks);
 
     mu::async::Channel<EngravingItem*> elementDestroyed();
 
@@ -628,15 +630,13 @@ public:
     TranslatableString getTextStyleUserName(TextStyleType tid);
 
     // These position are in ticks and not uticks
-    Fraction playPos() const { return pos(POS::CURRENT); }
-    void setPlayPos(const Fraction& tick) { setPos(POS::CURRENT, tick); }
-    Fraction loopInTick() const { return pos(POS::LEFT); }
-    Fraction loopOutTick() const { return pos(POS::RIGHT); }
-    void setLoopInTick(const Fraction& tick) { setPos(POS::LEFT, tick); }
-    void setLoopOutTick(const Fraction& tick) { setPos(POS::RIGHT, tick); }
+    Fraction loopInTick() const { return loopBoundaryTick(LoopBoundaryType::LoopIn); }
+    Fraction loopOutTick() const { return loopBoundaryTick(LoopBoundaryType::LoopOut); }
+    void setLoopInTick(const Fraction& tick) { setLoopBoundaryTick(LoopBoundaryType::LoopIn, tick); }
+    void setLoopOutTick(const Fraction& tick) { setLoopBoundaryTick(LoopBoundaryType::LoopOut, tick); }
 
-    Fraction pos(POS pos) const;
-    void setPos(POS pos, Fraction tick);
+    Fraction loopBoundaryTick(LoopBoundaryType type) const;
+    void setLoopBoundaryTick(LoopBoundaryType type, Fraction tick);
 
     bool noteEntryMode() const { return inputState().noteEntryMode(); }
     void setNoteEntryMode(bool val) { inputState().setNoteEntryMode(val); }
@@ -1088,7 +1088,7 @@ private:
 
     ShadowNote* m_shadowNote = nullptr;
 
-    mu::async::Channel<POS, unsigned> m_posChanged;
+    mu::async::Channel<LoopBoundaryType, unsigned> m_loopBoundaryTickChanged;
 
     PaddingTable m_paddingTable;
     double m_minimumPaddingUnit = 0.0;

--- a/src/notation/internal/notationplayback.cpp
+++ b/src/notation/internal/notationplayback.cpp
@@ -94,12 +94,8 @@ void NotationPlayback::init()
         }
     });
 
-    score()->posChanged().onReceive(this, [this](mu::engraving::POS pos, int tick) {
-        if (mu::engraving::POS::CURRENT == pos) {
-            m_playPositionTickChanged.send(tick);
-        } else {
-            updateLoopBoundaries();
-        }
+    score()->loopBoundaryTickChanged().onReceive(this, [this](LoopBoundaryType, unsigned) {
+        updateLoopBoundaries();
     });
 }
 

--- a/src/notation/internal/notationplayback.h
+++ b/src/notation/internal/notationplayback.h
@@ -93,7 +93,6 @@ private:
     const engraving::TempoText* tempoText(int tick) const;
 
     IGetScore* m_getScore = nullptr;
-    async::Channel<int> m_playPositionTickChanged;
 
     LoopBoundaries m_loopBoundaries;
     async::Notification m_loopBoundariesChanged;

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -153,6 +153,7 @@ using voice_idx_t = mu::engraving::voice_idx_t;
 using track_idx_t = mu::engraving::track_idx_t;
 using ChangesRange = mu::engraving::ScoreChangesRange;
 using GuitarBendType = mu::engraving::GuitarBendType;
+using engraving::LoopBoundaryType;
 
 static const String COMMON_GENRE_ID("common");
 
@@ -521,13 +522,6 @@ struct TupletOptions
     TupletNumberType numberType = TupletNumberType::SHOW_NUMBER;
     TupletBracketType bracketType = TupletBracketType::AUTO_BRACKET;
     bool autoBaseLen = false;
-};
-
-enum class LoopBoundaryType
-{
-    Unknown,
-    LoopIn,
-    LoopOut
 };
 
 struct LoopBoundaries


### PR DESCRIPTION
and remove dead code relating to POS::CURRENT and playPos/setPlayPos