### PR TITLE
Fix #14678: Tempo set in New Score other than quarter note doesn't reflect supposed BPM

### DIFF
--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -413,37 +413,48 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
         QString text("<sym>metNoteQuarterUp</sym> = %1");
         double bpm = scoreOptions.tempo.valueBpm;
 
+        double quarterNotesPerDuration = 1;
+
         bool withDot = scoreOptions.tempo.withDot;
         switch (scoreOptions.tempo.duration) {
         case DurationType::V_WHOLE:
             text = "<sym>metNoteWhole</sym> = %1";
+            quarterNotesPerDuration = 4;
             break;
         case DurationType::V_HALF:
             if (withDot) {
                 text = "<sym>metNoteHalfUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = %1";
+                quarterNotesPerDuration = 3;
             } else {
                 text = "<sym>metNoteHalfUp</sym> = %1";
+                quarterNotesPerDuration = 2;
             }
             break;
         case DurationType::V_QUARTER:
             if (withDot) {
                 text = "<sym>metNoteQuarterUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = %1";
+                quarterNotesPerDuration = 1.5;
             } else {
                 text = "<sym>metNoteQuarterUp</sym> = %1";
+                quarterNotesPerDuration = 1;
             }
             break;
         case DurationType::V_EIGHTH:
             if (withDot) {
                 text = "<sym>metNote8thUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = %1";
+                quarterNotesPerDuration = 0.75;
             } else {
                 text = "<sym>metNote8thUp</sym> = %1";
+                quarterNotesPerDuration = 0.5;
             }
             break;
         case DurationType::V_16TH:
             if (withDot) {
                 text = "<sym>metNote16thUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = %1";
+                quarterNotesPerDuration = 0.375;
             } else {
                 text = "<sym>metNote16thUp</sym> = %1";
+                quarterNotesPerDuration = 0.25;
             }
             break;
         default:
@@ -455,6 +466,7 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
         tt->setXmlText(text.arg(bpm));
 
         double tempo = scoreOptions.tempo.valueBpm;
+        tempo *= quarterNotesPerDuration; // setTempo expects a value in Quarter Notes Per Second
         tempo /= 60; // bpm -> bps
 
         tt->setTempo(tempo);


### PR DESCRIPTION
Resolves: #14678 

Resolves a bug where new scores would not have the correct tempo marking when a non-quarter-note tempo was specified. This is accomplished by correcting the implementation of the `MasterNotation::applyOptions` method. When setting the tempo of the score, we use the tempo's `duration` option to scale the bpm value so that it is in units of "Quarter Notes / Second" rather than "Duration / Second".

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)

I don't know enough about this repository to write unit tests for this change. If maintainers feel that these changes necessitate unit tests, please point me in the direction of some similar samples and/or documentation, and I'll see what I can do.