### PR TITLE
Fix width of Add separator line button in NoteInputBar Customize Popup

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/internal/CustomiseControlPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/CustomiseControlPanel.qml
@@ -72,7 +72,6 @@ RowLayout {
     }
 
     FlatButton {
-        Layout.alignment: Qt.AlignRight
         Layout.preferredWidth: 30
 
         icon: IconCode.DELETE_TANK
@@ -89,7 +88,6 @@ RowLayout {
     }
 
     FlatButton {
-        Layout.alignment: Qt.AlignRight
         Layout.preferredWidth: 30
 
         icon: IconCode.ARROW_UP
@@ -106,7 +104,6 @@ RowLayout {
     }
 
     FlatButton {
-        Layout.alignment: Qt.AlignRight
         Layout.preferredWidth: 30
 
         icon: IconCode.ARROW_DOWN


### PR DESCRIPTION
from https://github.com/musescore/MuseScore/pull/10108/commits/c5b45d8f419cd6c5ac0b3c8102f5e1de6dbd13df