### PR TITLE
Can't implicitly convert int-like types to QChar or QString anymore

### DIFF
--- a/src/importexport/bww/internal/bww/lexer.cpp
+++ b/src/importexport/bww/internal/bww/lexer.cpp
@@ -42,7 +42,7 @@ namespace Bww {
 Lexer::Lexer(QIODevice* inDevice)
     : in(inDevice),
     lineNumber(-1),
-    value(NONE)
+    value(QChar(NONE))
 {
     LOGD() << "Lexer::Lexer() begin";
 

--- a/src/importexport/ove/internal/ove.cpp
+++ b/src/importexport/ove/internal/ove.cpp
@@ -4187,7 +4187,7 @@ bool NameBlock::isEqual(const QString& name) const
     }
 
     for (int i = 0; i < size() && nsize; ++i) {
-        if (name[i] != data()[i]) {
+        if (name[i] != QChar(data()[i])) {
             return false;
         }
     }

--- a/src/palette/view/widgets/specialcharactersdialog.cpp
+++ b/src/palette/view/widgets/specialcharactersdialog.cpp
@@ -672,7 +672,7 @@ void SpecialCharactersDialog::populateCommon()
         std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(gpaletteScore->dummy());
         fs->setCode(id);
         fs->setFont(m_font);
-        m_pCommon->appendElement(fs, QString(id));
+        m_pCommon->appendElement(fs, QChar(id));
     }
 
     for (SymId id : commonScoreSymbols) {
@@ -685,7 +685,7 @@ void SpecialCharactersDialog::populateCommon()
         std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(gpaletteScore->dummy());
         fs->setCode(id);
         fs->setFont(m_font);
-        m_pCommon->appendElement(fs, QString(id));
+        m_pCommon->appendElement(fs, QChar(id));
     }
 }
 


### PR DESCRIPTION
merge https://github.com/musescore/MuseScore/pull/10108/commits/2f809dc6ff1879530c221397fa1205075689783e
merge https://github.com/musescore/MuseScore/pull/10108/commits/b297147cd2c9ec263ce68403d17a441b012c7734