### PR TITLE
Remove duplicate release from appdata

### DIFF
--- a/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in
+++ b/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in
@@ -136,9 +136,6 @@
         <release date="2020-10-09" version="3.5.1">
             <url>https://musescore.org/en/3.5.1</url>
         </release>
-        <release date="2020-10-09" version="3.5.1">
-            <url>https://musescore.org/en/3.5.1</url>
-        </release>
         <release date="2020-08-07" version="3.5">
             <url>https://musescore.org/en/3.5</url>
         </release>


### PR DESCRIPTION
<!-- Add a short description of and motivation for the changes here -->

The Fedora project uses appstream-util from libappstream-glib to validate appstream files.  The MuseScore appstream file currently fails validation:
```
$ appstream-util validate-relax org.musescore.MuseScore.appdata.xml
org.musescore.MuseScore.appdata.xml: FAILED:
• tag-invalid           : <icon> not allowed in desktop appdata
• tag-invalid           : <release> version was duplicated
• tag-invalid           : stock icon is not valid [mscore]
Validation of files failed
```
This PR addresses the second error, that `<release>` data is duplicated.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
