### PR TITLE
Add support for reading XML symbol, other-direction and other-notation tags

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -1197,10 +1197,14 @@ void MusicXMLParserPass1::identification()
         } else if (m_e.name() == "encoding") {
             // TODO
             while (m_e.readNextStartElement()) {
-                if (m_e.name() == "supports" && m_e.asciiAttribute("element") == "beam" && m_e.asciiAttribute("type") == "yes") {
+                if (m_e.name() == "software") {
+                    m_exporterString += m_e.readText();
+                } else if (m_e.name() == "supports" && m_e.asciiAttribute("element") == "beam" && m_e.asciiAttribute("type") == "yes") {
                     m_hasBeamingInfo = true;
+                    m_e.skipCurrentElement();
+                } else {
+                    m_e.skipCurrentElement();
                 }
-                m_e.skipCurrentElement();
             }
             // _score->setMetaTag("encoding", _e.readText()); works with DOM but not with pull parser
             // temporarily fake the encoding tag (compliant with DOM parser) to help the autotester

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.h
@@ -186,6 +186,7 @@ public:
     void insertAdjustedDuration(Fraction key, Fraction value) { m_adjustedDurations.insert({ key, value }); }
     std::map<Fraction, Fraction>& adjustedDurations() { return m_adjustedDurations; }
     void insertSeenDenominator(int val) { m_seenDenominators.emplace(val); }
+    String exporterString() const { return m_exporterString; }
 
 private:
     // functions
@@ -193,6 +194,7 @@ private:
 
     // generic pass 1 data
     XmlStreamReader m_e;
+    String m_exporterString;                    // Name of the software which exported the file
     int m_divs = 0;                              // Current MusicXML divisions value
     std::map<String, MusicXmlPart> m_parts;     // Parts data, mapped on part id
     std::set<int> m_systemStartMeasureNrs;       // Measure numbers of measures starting a page

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -6957,6 +6957,8 @@ void MusicXMLParserNotations::parse()
             tied();
         } else if (m_e.name() == "tuplet") {
             tuplet();
+        } else if (m_e.name() == "other-notation") {
+            otherNotation();
         } else {
             skipLogCurrElem();
         }
@@ -7165,6 +7167,20 @@ void MusicXMLParserNotations::tuplet()
         // ignore
     } else {
         m_logger->logError(String(u"unknown tuplet placement: %1").arg(tupletPlacement), &m_e);
+    }
+}
+
+void MusicXMLParserNotations::otherNotation()
+{
+    const String type = m_e.attribute("type");
+    const String smufl = m_e.attribute("smufl");
+
+    if (!smufl.empty()) {
+        SymId id = SymNames::symIdByName(smufl, SymId::noSym);
+        Notation notation = Notation::notationWithAttributes(String::fromAscii(m_e.name().ascii()),
+                                                             m_e.attributes(), u"notations", id);
+        m_notations.push_back(notation);
+        m_e.skipCurrentElement();
     }
 }
 

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -3122,6 +3122,11 @@ void MusicXMLParserDirection::directionType(std::vector<MusicXmlSpannerDesc>& st
         } else if (m_e.name() == "segno") {
             m_wordsText += u"<sym>segno</sym>";
             m_e.skipCurrentElement();
+        } else if (m_e.name() == "symbol") {
+            const String smufl = m_e.readText();
+            if (!smufl.empty()) {
+                m_wordsText += u"<sym>" + smufl + u"</sym>";
+            }
         } else {
             skipLogCurrElem();
         }

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
@@ -383,6 +383,7 @@ private:
     String metronome(double& r);
     void sound();
     void dynamics();
+    void otherDirection();
     void handleRepeats(Measure* measure, const track_idx_t track, const Fraction tick);
     void handleNmiCmi(Measure* measure, const track_idx_t track, const Fraction tick, DelayedDirectionsList& delayedDirections);
     String matchRepeat() const;
@@ -411,6 +412,7 @@ private:
     String m_sndFine;
     String m_sndSegno;
     String m_sndToCoda;
+    bool visible = true;
     bool m_hasDefaultY = false;
     double m_defaultY = 0.0;
     bool m_hasRelativeY = false;

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
@@ -230,6 +230,7 @@ private:
     void technical();
     void tied();
     void tuplet();
+    void otherNotation();
     XmlStreamReader& m_e;
     const Score* m_score = nullptr;                         // the score
     MxmlLogger* m_logger = nullptr;                              // the error logger

--- a/src/importexport/musicxml/tests/data/testBackupRoundingError_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBackupRoundingError_ref.mscx
@@ -1814,6 +1814,15 @@
             <visible>0</visible>
             <durationType>half</durationType>
             </Rest>
+          <location>
+            <fractions>-103/1024</fractions>
+            </location>
+          <Symbol>
+            <name>gClef</name>
+            </Symbol>
+          <location>
+            <fractions>103/1024</fractions>
+            </location>
           <BarLine>
             <visible>0</visible>
             </BarLine>
@@ -1978,6 +1987,15 @@
             <visible>0</visible>
             <durationType>quarter</durationType>
             </Rest>
+          <location>
+            <fractions>-1/12</fractions>
+            </location>
+          <Symbol>
+            <name>fClef</name>
+            </Symbol>
+          <location>
+            <fractions>1/12</fractions>
+            </location>
           <BarLine>
             <subtype>end</subtype>
             </BarLine>


### PR DESCRIPTION
[`<symbol>`](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/symbol/), [`<other-direction>`](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/other-direction/), and [`<other-notation>`](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/other-notation/) tags are used to represent elements which don't have their own XML tags.  Frequently these are stored as their SMuFL symbol names, but Sibelius uses its own names.  Some common Sibelius symbols have been added.