### PR TITLE
Set fermata direction if none is specified

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -1078,6 +1078,8 @@ static void addFermataToChord(const Notation& notation, ChordRest* cr)
     }
     if (!direction.empty()) {
         na->setPlacement(direction == "inverted" ? PlacementV::BELOW : PlacementV::ABOVE);
+    } else {
+        na->setPlacement(na->propertyDefault(Pid::PLACEMENT).value<PlacementV>());
     }
     setElementPropertyFlags(na, Pid::PLACEMENT, direction);
     if (cr->segment() == nullptr && cr->isGrace()) {
@@ -3950,6 +3952,9 @@ void MusicXMLParserPass2::barline(const String& partId, Measure* measure, const 
             }
             if (fermataType == u"inverted") {
                 fermata->setPlacement(PlacementV::BELOW);
+            } else if (fermataType == u"") {
+                LOGI() << "Set placement: " << (int)fermata->propertyDefault(Pid::PLACEMENT).value<PlacementV>();
+                fermata->setPlacement(fermata->propertyDefault(Pid::PLACEMENT).value<PlacementV>());
             }
         } else if (m_e.name() == "repeat") {
             repeat = m_e.attribute("direction");

--- a/src/importexport/musicxml/tests/data/testBackupRoundingError_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBackupRoundingError_ref.mscx
@@ -2007,8 +2007,7 @@
               </Note>
             </Chord>
           <Fermata>
-            <subtype>fermataAbove</subtype>
-            <placement>above</placement>
+            <subtype>fermataBelow</subtype>
             </Fermata>
           <Chord>
             <durationType>half</durationType>


### PR DESCRIPTION
Fermata direction is set to our default (above the stave on voices 1 & 3, below on 2 & 4) when no placement direction is specified in the MusicXML file.