### PR TITLE
Style dialog tweaks

### DIFF
--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1436,6 +1436,7 @@ QString EditStyle::pageCodeForElement(const EngravingItem* element)
     case ElementType::STEM:
     case ElementType::STEM_SLASH:
     case ElementType::LEDGER_LINE:
+    case ElementType::NOTEDOT:
         return "notes";
 
     case ElementType::REST:

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -243,9 +243,6 @@
      <widget class="QStackedWidget" name="pageStack">
       <widget class="QWidget" name="PageScore">
        <layout class="QVBoxLayout" name="verticalLayout_20">
-        <property name="spacing">
-         <number>0</number>
-        </property>
         <item>
          <widget class="QGroupBox" name="groupBox_score">
           <property name="title">
@@ -836,9 +833,6 @@
       </widget>
       <widget class="QWidget" name="PagePage">
        <layout class="QVBoxLayout" name="verticalLayout_21">
-        <property name="spacing">
-         <number>0</number>
-        </property>
         <item>
          <widget class="QGroupBox" name="groupBox_page">
           <property name="title">
@@ -1935,9 +1929,6 @@
       </widget>
       <widget class="QWidget" name="PageSizes">
        <layout class="QVBoxLayout" name="verticalLayout_18">
-        <property name="spacing">
-         <number>0</number>
-        </property>
         <item>
          <widget class="QGroupBox" name="groupBox_sizes">
           <property name="title">
@@ -4044,9 +4035,6 @@ By default, they will be placed such as that their right end are at the same lev
         </sizepolicy>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_4">
-        <property name="spacing">
-         <number>0</number>
-        </property>
         <property name="sizeConstraint">
          <enum>QLayout::SetMinimumSize</enum>
         </property>
@@ -5331,9 +5319,6 @@ By default, they will be placed such as that their right end are at the same lev
       </widget>
       <widget class="QWidget" name="PageNotes">
        <layout class="QVBoxLayout" name="verticalLayout_7">
-        <property name="spacing">
-         <number>0</number>
-        </property>
         <item>
          <widget class="QGroupBox" name="groupBox_noteFlags">
           <property name="title">
@@ -6270,9 +6255,6 @@ By default, they will be placed such as that their right end are at the same lev
       </widget>
       <widget class="QWidget" name="PageBeams">
        <layout class="QVBoxLayout" name="verticalLayout_14">
-        <property name="spacing">
-         <number>0</number>
-        </property>
         <item>
          <widget class="QGroupBox" name="groupBox_beams">
           <property name="title">
@@ -6315,9 +6297,6 @@ By default, they will be placed such as that their right end are at the same lev
       </widget>
       <widget class="QWidget" name="PageTuplets">
        <layout class="QVBoxLayout" name="verticalLayout_301">
-        <property name="spacing">
-         <number>0</number>
-        </property>
         <item>
          <widget class="QGroupBox" name="groupBox_tuplets">
           <property name="title">
@@ -7080,9 +7059,6 @@ By default, they will be placed such as that their right end are at the same lev
       </widget>
       <widget class="QWidget" name="PageArpeggios">
        <layout class="QVBoxLayout" name="verticalLayout_15">
-        <property name="spacing">
-         <number>0</number>
-        </property>
         <item>
          <widget class="QGroupBox" name="groupBox_arpeggios">
           <property name="title">
@@ -7717,9 +7693,6 @@ By default, they will be placed such as that their right end are at the same lev
       </widget>
       <widget class="QWidget" name="PageHairpins">
        <layout class="QVBoxLayout" name="verticalLayout_19">
-        <property name="spacing">
-         <number>0</number>
-        </property>
         <item>
          <widget class="QGroupBox" name="groupBox_hairpins">
           <property name="title">
@@ -9940,9 +9913,6 @@ By default, they will be placed such as that their right end are at the same lev
       </widget>
       <widget class="QWidget" name="PageArticulationsOrnaments">
        <layout class="QVBoxLayout" name="verticalLayout_24">
-        <property name="spacing">
-         <number>0</number>
-        </property>
         <item>
          <widget class="QGroupBox" name="groupBox_articulationsOrnaments">
           <property name="title">
@@ -12264,9 +12234,6 @@ By default, they will be placed such as that their right end are at the same lev
       </widget>
       <widget class="QWidget" name="PageChordSymbols">
        <layout class="QVBoxLayout" name="verticalLayout_12">
-        <property name="spacing">
-         <number>0</number>
-        </property>
         <item>
          <widget class="QGroupBox" name="groupBox_chordSymbols">
           <property name="title">

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -5560,7 +5560,7 @@ By default, they will be placed such as that their right end are at the same lev
            <item row="2" column="0">
             <widget class="QLabel" name="label_43">
              <property name="text">
-              <string>Accidental distance:</string>
+              <string>Accidental to accidental distance:</string>
              </property>
              <property name="buddy">
               <cstring>accidentalDistance</cstring>


### PR DESCRIPTION
Small PR with a few changes to the style dialog:
- Note dots now open the 'Notes' subpage
- 'Accidental distance' renamed to 'Accidental to accidental distance', to match 'Dot to dot distance'
- The two sections on the 'Notes' subpage are spaced apart like e.g. the 'Barlines' subpage. Previously they were too close together. Similar code causing this in other subpages was also removed, but since those subpages only had one section it wasn't visible there.
<br>

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
