### PR TITLE
Eliminate data races in INJECT and INJECT_STATIC

### DIFF
--- a/src/framework/global/modularity/ioc.h
+++ b/src/framework/global/modularity/ioc.h
@@ -24,6 +24,7 @@
 #define MU_MODULARITY_IOC_H
 
 #include <memory>
+#include <mutex>
 
 #include "modulesioc.h"
 
@@ -33,8 +34,12 @@ private: \
 public: \
     std::shared_ptr<Interface> getter() const {  \
         if (!m_##getter) { \
-            static const std::string_view sig(IOC_FUNC_SIG); \
-            m_##getter = mu::modularity::ioc()->resolve<Interface>(mu::modularity::moduleNameBySig(sig), sig); \
+            static std::mutex getter##mutex; \
+            const std::lock_guard<std::mutex> getter##lock(getter##mutex); \
+            if (!m_##getter) { \
+                static const std::string_view sig(IOC_FUNC_SIG); \
+                m_##getter = mu::modularity::ioc()->resolve<Interface>(mu::modularity::moduleNameBySig(sig), sig); \
+            } \
         } \
         return m_##getter; \
     } \
@@ -45,8 +50,12 @@ public: \
     static std::shared_ptr<Interface>& getter() {  \
         static std::shared_ptr<Interface> s_##getter = nullptr; \
         if (!s_##getter) { \
-            static const std::string_view sig(IOC_FUNC_SIG); \
-            s_##getter = mu::modularity::ioc()->resolve<Interface>(mu::modularity::moduleNameBySig(sig), sig); \
+            static std::mutex getter##mutex; \
+            const std::lock_guard<std::mutex> getter##lock(getter##mutex); \
+            if (!s_##getter) { \
+                static const std::string_view sig(IOC_FUNC_SIG); \
+                s_##getter = mu::modularity::ioc()->resolve<Interface>(mu::modularity::moduleNameBySig(sig), sig); \
+            } \
         } \
         return s_##getter; \
     } \


### PR DESCRIPTION
I have built a version of MuseScore with `-fsanitize=thread` and have been reviewing the output.  There are many complaints about data races between two threads calling the getter method created by the `INJECT` or `INJECT_STATIC` macro.  Suppose thread 1 calls such a getter and sees that `m_##getter` is null.  It calls the resolve method to begin constructing the getter.  Then thread 2 calls the getter as well.  Since thread 1 is still working, it also sees that `m_##getter` is null and also calls the resolve method.  The two threads now race to see which one will store its result in `m_##getter` or `s_##getter`.

This PR adds locks.  The locks are only acquired if `m_##getter` or `s_##getter` is null, thereby skipping the lock overhead once the interface has been constructed.  While holding the lock, the thread checks again that `m_##getter` or `s_##getter` is null.  This is for the case where thread 1 calls the getter, acquires the lock, and calls resolve, then thread 2 calls the getter, and waits on the lock.  Once thread 1 releases the lock and thread 2 acquires it, thread 2 repeats the null check, finds that the pointer is now nonnull, and falls through to return the object constructed by thread 1.

After making this change, the thread sanitizer output contains no further mentions of `INJECT` or `INJECT_STATIC`.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
