### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/framework/uicomponents/view/treeview/qquickrangemodel.cpp
+++ b/src/framework/uicomponents/view/treeview/qquickrangemodel.cpp
@@ -508,7 +508,7 @@ void QQuickRangeModel1::setValue(qreal newValue)
 void QQuickRangeModel1::setInverted(bool inverted)
 {
     Q_D(QQuickRangeModel1);
-    if (inverted == d->inverted)
+    if (inverted == bool(d->inverted))
         return;
 
     d->inverted = inverted;

--- a/src/framework/uicomponents/view/treeview/qquickrangemodel.cpp
+++ b/src/framework/uicomponents/view/treeview/qquickrangemodel.cpp
@@ -125,7 +125,7 @@ qreal QQuickRangeModel1Private::publicPosition(qreal position) const
     and \a value that is passed as parameter.
 */
 
-qreal QQuickRangeModel1Private::publicValue(qreal value) const
+qreal QQuickRangeModel1Private::publicValue(qreal pValue) const
 {
     // It is important to do value-within-range check this
     // late (as opposed to during setPosition()). The reason is
@@ -133,9 +133,9 @@ qreal QQuickRangeModel1Private::publicValue(qreal value) const
     // outside the range, might become valid later if the range changes.
 
     if (stepSize == 0)
-        return qBound(minimum, value, maximum);
+        return qBound(minimum, pValue, maximum);
 
-    const int stepSizeMultiplier = (value - minimum) / stepSize;
+    const int stepSizeMultiplier = (pValue - minimum) / stepSize;
 
     // Test whether value is below minimum range
     if (stepSizeMultiplier < 0)
@@ -145,7 +145,7 @@ qreal QQuickRangeModel1Private::publicValue(qreal value) const
     const qreal rightEdge = qMin(maximum, ((stepSizeMultiplier + 1) * stepSize) + minimum);
     const qreal middle = (leftEdge + rightEdge) / 2;
 
-    return (value <= middle) ? leftEdge : rightEdge;
+    return (pValue <= middle) ? leftEdge : rightEdge;
 }
 
 /*!

--- a/src/framework/uicomponents/view/treeview/qquickrangemodel_p_p.h
+++ b/src/framework/uicomponents/view/treeview/qquickrangemodel_p_p.h
@@ -82,17 +82,17 @@ public:
         return inverted ? posatmin : posatmax;
     }
 
-    inline qreal equivalentPosition(qreal value) const {
+    inline qreal equivalentPosition(qreal aValue) const {
         // Return absolute position from absolute value
         const qreal valueRange = maximum - minimum;
         if (valueRange == 0)
             return effectivePosAtMin();
 
         const qreal scale = (effectivePosAtMax() - effectivePosAtMin()) / valueRange;
-        return (value - minimum) * scale + effectivePosAtMin();
+        return (aValue - minimum) * scale + effectivePosAtMin();
     }
 
-    inline qreal equivalentValue(qreal pos) const {
+    inline qreal equivalentValue(qreal aPos) const {
         // Return absolute value from absolute position
         const qreal posRange = effectivePosAtMax() - effectivePosAtMin();
         if (posRange == 0)
@@ -101,9 +101,9 @@ public:
         const qreal scale = (maximum - minimum) / posRange;
         // Avoid perverse rounding glitches when at an end:
         const qreal mid = (effectivePosAtMax() + effectivePosAtMin()) * 0.5;
-        if (pos < mid)
-            return (pos - effectivePosAtMin()) * scale + minimum;
-        return maximum - scale * (effectivePosAtMax() - pos);
+        if (aPos < mid)
+            return (aPos - effectivePosAtMin()) * scale + minimum;
+        return maximum - scale * (effectivePosAtMax() - aPos);
     }
 
     qreal publicPosition(qreal position) const;

--- a/src/framework/uicomponents/view/treeview/qquicktreemodeladaptor.cpp
+++ b/src/framework/uicomponents/view/treeview/qquicktreemodeladaptor.cpp
@@ -751,8 +751,8 @@ void QQuickTreeModelAdaptor1::modelRowsAboutToBeMoved(const QModelIndex & source
 
         int destIndex = -1;
         if (destinationRow == m_model->rowCount(destinationParent)) {
-            const QModelIndex &emi = m_model->index(destinationRow - 1, 0, destinationParent);
-            destIndex = lastChildIndex(emi) + 1;
+            const QModelIndex &emi1 = m_model->index(destinationRow - 1, 0, destinationParent);
+            destIndex = lastChildIndex(emi1) + 1;
         } else {
             destIndex = itemIndex(m_model->index(destinationRow, 0, destinationParent));
         }
@@ -810,10 +810,10 @@ void QQuickTreeModelAdaptor1::modelRowsAboutToBeMoved(const QModelIndex & source
         queueDataChanged(topLeft, bottomRight, changedRole);
 
         if (depthDifference != 0) {
-            const QModelIndex &topLeft = index(bufferCopyOffset, 0, QModelIndex());
-            const QModelIndex &bottomRight = index(bufferCopyOffset + totalMovedCount - 1, 0, QModelIndex());
-            const QVector<int> changedRole(1, DepthRole);
-            queueDataChanged(topLeft, bottomRight, changedRole);
+            const QModelIndex &topLeft1 = index(bufferCopyOffset, 0, QModelIndex());
+            const QModelIndex &bottomRight1 = index(bufferCopyOffset + totalMovedCount - 1, 0, QModelIndex());
+            const QVector<int> changedRole1(1, DepthRole);
+            queueDataChanged(topLeft1, bottomRight1, changedRole1);
         }
     }
 }


### PR DESCRIPTION
* reg.: declaration hides class member (C4458)
* reg.:'==': signed/unsigned mismatch (C4389)

Leaves 27 times "declaration of 'd' hides class member (C4458)", not sure how to fix those, seem to stem from Qt