### PR TITLE
[qt6] Fix crash when opening QWidget dialog containing QQuickWidget

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -100,6 +100,12 @@ int App::run(int argc, char** argv)
 
     QGuiApplication::styleHints()->setMousePressAndHoldInterval(250);
 
+#ifndef MU_QT5_COMPAT
+    // Necessary for QQuickWidget, but potentially suboptimal for performance.
+    // Remove as soon as possible.
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
+#endif
+
     // ====================================================
     // Parse command line options
     // ====================================================


### PR DESCRIPTION
Resolves comment: https://github.com/musescore/MuseScore/issues/21542#issuecomment-1950631002

This is a temporary solution and should be undone as soon as we can get rid of QQuickWidget. 
(Instead of QQuickWidget, which is quick-and-easy, we could look into _embedding_ a QQuickWindow into the QWidget dialog, but that is a bit of work.)