### PR TITLE
Fix MSVC Assembler warnings

### DIFF
--- a/thirdparty/google_crashpad_client/CMakeLists.txt
+++ b/thirdparty/google_crashpad_client/CMakeLists.txt
@@ -251,7 +251,7 @@ if (NOT MSVC)
     set_target_properties(gcrashpad PROPERTIES COMPILE_FLAGS "-fPIC")
 endif (NOT MSVC)
 
-target_no_warning(gcrashpad -Wno-conversion)
+#target_no_warning(gcrashpad -Wno-conversion)
 target_no_warning(gcrashpad -Wno-multichar)
 target_no_warning(gcrashpad -Wno-unused-parameter)
 target_no_warning(gcrashpad -Wno-deprecated)


### PR DESCRIPTION
reg.: invalid command-line option: /wd4244, /wd4267, /wd4245, /wd4057, /wd4334 (A4018)
All 5 in one go...

5 more remain:
invalid command-line option value, default is used : /W (A4008)
invalid command-line option: /wd4127, /wd4100, /wd4996, /wd4201 (A4018)

![image](https://github.com/musescore/MuseScore/assets/1786669/855176f1-58e9-4154-9b4c-a16e009ee305)

Removing more `target_no_warning` would remove more assembler warnings, but add compiler warings...
Disabling this one (actually: these ones) does not have any negative effect as far as I can tell.

