### PR TITLE
Add Vendor and Pack Layer to MuseSounds menu hierarchy

### DIFF
--- a/src/framework/musesampler/internal/apitypes.h
+++ b/src/framework/musesampler/internal/apitypes.h
@@ -259,6 +259,8 @@ typedef int (* ms_Instrument_get_id)(ms_InstrumentInfo instrument);
 typedef const char*(* ms_Instrument_get_name)(ms_InstrumentInfo);
 typedef const char*(* ms_Instrument_get_category)(ms_InstrumentInfo);
 typedef const char*(* ms_Instrument_get_package)(ms_InstrumentInfo);
+typedef const char*(* ms_Instrument_get_pack_name)(ms_InstrumentInfo);
+typedef const char*(* ms_Instrument_get_vendor_name)(ms_InstrumentInfo);
 typedef const char*(* ms_Instrument_get_musicxml_sound)(ms_InstrumentInfo);
 typedef const char*(* ms_Instrument_get_mpe_sound)(ms_InstrumentInfo);
 typedef float (* ms_Instrument_get_reverb_level)(ms_InstrumentInfo);

--- a/src/framework/musesampler/internal/libhandler.h
+++ b/src/framework/musesampler/internal/libhandler.h
@@ -192,6 +192,8 @@ struct MuseSamplerLibHandler
     ms_Instrument_get_name getInstrumentName = nullptr;
     ms_Instrument_get_category getInstrumentCategory = nullptr;
     ms_Instrument_get_package getInstrumentPackage = nullptr;
+    ms_Instrument_get_pack_name getInstrumentPackName = nullptr;
+    ms_Instrument_get_vendor_name getInstrumentVendorName = nullptr;
     ms_Instrument_get_musicxml_sound getMusicXmlSoundId = nullptr;
     ms_Instrument_get_mpe_sound getMpeSoundId = nullptr;
     ms_Instrument_get_reverb_level getReverbLevel = nullptr;
@@ -314,6 +316,14 @@ public:
         getInstrumentName = (ms_Instrument_get_name)getLibFunc(m_lib, "ms_Instrument_get_name");
         getInstrumentCategory = (ms_Instrument_get_category)getLibFunc(m_lib, "ms_Instrument_get_category");
         getInstrumentPackage = (ms_Instrument_get_package)getLibFunc(m_lib, "ms_Instrument_get_package");
+        if (at_least_v_0_6) {
+            getInstrumentVendorName = (ms_Instrument_get_vendor_name)getLibFunc(m_lib, "ms_Instrument_get_vendor_name");
+            getInstrumentPackName = (ms_Instrument_get_pack_name)getLibFunc(m_lib, "ms_Instrument_get_pack_name");
+        } else {
+            getInstrumentVendorName = [](ms_InstrumentInfo) { return ""; };
+            getInstrumentPackName = [](ms_InstrumentInfo) { return ""; };
+        }
+
         getMusicXmlSoundId = (ms_Instrument_get_musicxml_sound)getLibFunc(m_lib, "ms_Instrument_get_musicxml_sound");
         getMpeSoundId = (ms_Instrument_get_mpe_sound)getLibFunc(m_lib, "ms_Instrument_get_mpe_sound");
 
@@ -524,6 +534,8 @@ public:
                && getInstrumentName
                && getInstrumentCategory
                && getInstrumentPackage
+               && getInstrumentPackName
+               && getInstrumentVendorName
                && getMusicXmlSoundId
                && getMpeSoundId
                && getPresetList

--- a/src/framework/musesampler/internal/musesamplerresolver.cpp
+++ b/src/framework/musesampler/internal/musesamplerresolver.cpp
@@ -110,20 +110,27 @@ AudioResourceMetaList MuseSamplerResolver::resolveResources() const
         int uniqueId = m_libHandler->getInstrumentId(instrument);
         String internalName = String::fromUtf8(m_libHandler->getInstrumentName(instrument));
         String internalCategory = String::fromUtf8(m_libHandler->getInstrumentCategory(instrument));
-        String instrumentPack = String::fromUtf8(m_libHandler->getInstrumentPackage(instrument));
+        String instrumentPackName = String::fromUtf8(m_libHandler->getInstrumentPackName(instrument));
         String instrumentSoundId = String::fromUtf8(m_libHandler->getMpeSoundId(instrument));
+        String vendorName = String::fromUtf8(m_libHandler->getInstrumentVendorName(instrument));
 
         if (instrumentSoundId.empty()) {
             LOGE() << "MISSING INSTRUMENT ID for: " << internalName;
         }
 
+        if (instrumentPackName.empty()) {
+            instrumentPackName = internalCategory;
+        }
+
         AudioResourceMeta meta;
         meta.id = buildMuseInstrumentId(internalCategory, internalName, uniqueId).toStdString();
         meta.type = AudioResourceType::MuseSamplerSoundPack;
-        meta.vendor = instrumentPack.toStdString();
+        meta.vendor = "MuseSounds";
         meta.attributes = {
             { u"playbackSetupData", instrumentSoundId },
             { u"museCategory", internalCategory },
+            { u"musePack", instrumentPackName },
+            { u"museVendorName", vendorName },
             { u"museName", internalName },
             { u"museUID", String::fromStdString(std::to_string(uniqueId)) },
         };


### PR DESCRIPTION
Adds additional organisation options to the menu hierarchy for improved readability and responsiveness.


- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
