### PR TITLE
Fix #21617: Only count top system rehearsal marks

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -4071,18 +4071,20 @@ void Score::cmdResequenceRehearsalMarks()
         return;
     }
 
-    RehearsalMark* last = 0;
+    RehearsalMark* last = nullptr;
     for (Segment* s = selection().startSegment(); s && s != selection().endSegment(); s = s->next1()) {
         for (EngravingItem* e : s->annotations()) {
             if (e->type() == ElementType::REHEARSAL_MARK) {
                 RehearsalMark* rm = toRehearsalMark(e);
-                if (last) {
-                    String rmText = nextRehearsalMarkText(last, rm);
-                    for (EngravingObject* le : rm->linkList()) {
-                        le->undoChangeProperty(Pid::TEXT, rmText);
+                if (rm->isTopSystemObject()) {
+                    if (last) {
+                        String rmText = nextRehearsalMarkText(last, rm);
+                        for (EngravingObject* le : rm->linkList()) {
+                            le->undoChangeProperty(Pid::TEXT, rmText);
+                        }
                     }
+                    last = rm;
                 }
-                last = rm;
             }
         }
     }


### PR DESCRIPTION
Resolves: #21617

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
