### PR TITLE
Fix MSVC compiler warning when building with Qt6

### DIFF
--- a/src/plugins/api/qqmlsettings.cpp
+++ b/src/plugins/api/qqmlsettings.cpp
@@ -343,7 +343,12 @@ void QQmlSettingsPrivate::load()
         const QVariant currentValue = instance()->value(property.name(), previousValue);
 
         if (!currentValue.isNull() && (!previousValue.isValid()
-                                       || (currentValue.canConvert(previousValue.userType()) && previousValue != currentValue))) {
+#if MU_QT5_COMPAT
+                                       || (currentValue.canConvert(previousValue.userType())
+#else
+                                       || (currentValue.canConvert(QMetaType(previousValue.userType()))
+#endif
+                                           && previousValue != currentValue))) {
             property.write(q, currentValue);
             qCDebug(lcSettings) << "QQmlSettings: load" << property.name() << "setting:" << currentValue << "default:" << previousValue;
         }


### PR DESCRIPTION
reg.: 'QVariant::canConvert': was declared deprecated (C4996)