### PR TITLE
Change the name Orchestral to Orchestra

### DIFF
--- a/share/instruments/orders.xml
+++ b/share/instruments/orders.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore>
-    <Order id="orchestral">
-        <name>Orchestral</name>
+    <Order id="orchestra">
+        <name>Orchestra</name>
         <section id="woodwind">
             <family>flutes</family>
             <family>oboes</family>


### PR DESCRIPTION
I propose to change the name Orchestral to Orchestra in order to name the items of the Order dropdown box consistently after music ensembles.