### PR TITLE
Use normal notehead for tamtam and omit bells

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -8172,7 +8172,7 @@
                         <shortcut>A</shortcut>
                   </Drum>
                   <Drum pitch="53"> <!--Ride Bell-->
-                        <head>normal</head>
+                        <head>diamond</head>
                         <line>0</line>
                         <voice>0</voice>
                         <name>Ride Bell</name>

--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -7805,31 +7805,6 @@
                   </Channel>
                   <genre>world</genre>
             </Instrument>
-            <Instrument id="bells">
-                  <family>unpitched-metal-percussion</family>
-                  <trackName>Bells</trackName>
-                  <longName>Bells</longName>
-                  <shortName>Be.</shortName>
-                  <description>Bells.</description>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc1Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="53"> <!--Ride Bell-->
-                        <head>cross</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Ride Bell</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-            </Instrument>
             <Instrument id="bowl-gongs">
                   <family>unpitched-metal-percussion</family>
                   <trackName>Bowl Gongs</trackName>
@@ -8278,7 +8253,7 @@
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
                   <Drum pitch="52"> <!--Chinese Cymbal-->
-                        <head>cross</head>
+                        <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
                         <name>Tam-tam</name>

--- a/share/instruments/instrumentsxml.h
+++ b/share/instruments/instrumentsxml.h
@@ -3978,15 +3978,6 @@ QT_TRANSLATE_NOOP3("engraving/instruments", "Bell Tree", "bell-tree longName"),
 //: shortName for Bell Tree; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Be. Tr.", "bell-tree shortName"),
 
-//: description for Bells; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Bells.", "bells description"),
-//: trackName for Bells; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Bells", "bells trackName"),
-//: longName for Bells; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Bells", "bells longName"),
-//: shortName for Bells; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Be.", "bells shortName"),
-
 //: description for Bowl Gongs; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Bowl gongs.", "bowl-gongs description"),
 //: trackName for Bowl Gongs; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names


### PR DESCRIPTION
Use normal notehead for tamtam and omit bells

As a stand-alone instrument (not part of a drum kit or mixed percussion) tam-tam should use normal noteheads.
The "Bells" instrument was the bell of a ride cymbal, no value, its existence only causes confusion.

Update spreadsheet and run python script