### PR TITLE
Update Tom/Conga/China

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -7064,7 +7064,7 @@
                         <line>0</line>
                         <voice>0</voice>
                         <name>Concert Bass Drum</name>
-                        <stem>2</stem>
+                        <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
                   <Channel>
@@ -7094,7 +7094,7 @@
                         <line>0</line>
                         <voice>0</voice>
                         <name>Side Stick</name>
-                        <stem>2</stem>
+                        <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
                   <Drum pitch="38"> <!--Acoustic Snare-->
@@ -7102,7 +7102,7 @@
                         <line>0</line>
                         <voice>0</voice>
                         <name>Snare</name>
-                        <stem>2</stem>
+                        <stem>1</stem>
                         <shortcut>B</shortcut>
                   </Drum>
                   <Channel>
@@ -7555,7 +7555,7 @@
                         <line>0</line>
                         <voice>0</voice>
                         <name>Side Stick</name>
-                        <stem>2</stem>
+                        <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
                   <Drum pitch="38"> <!--Acoustic Snare-->
@@ -7563,7 +7563,7 @@
                         <line>0</line>
                         <voice>0</voice>
                         <name>Snare</name>
-                        <stem>2</stem>
+                        <stem>1</stem>
                         <shortcut>B</shortcut>
                   </Drum>
                   <Channel>
@@ -7616,7 +7616,7 @@
                         <line>0</line>
                         <voice>0</voice>
                         <name>Side Stick</name>
-                        <stem>2</stem>
+                        <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
                   <Drum pitch="40"> <!--Electric Snare-->
@@ -7624,7 +7624,7 @@
                         <line>0</line>
                         <voice>0</voice>
                         <name>Snare</name>
-                        <stem>2</stem>
+                        <stem>1</stem>
                         <shortcut>B</shortcut>
                   </Drum>
                   <Channel>
@@ -7880,7 +7880,7 @@
                         <line>0</line>
                         <voice>0</voice>
                         <name>Chinese Cymbal</name>
-                        <stem>2</stem>
+                        <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
                   <Channel>
@@ -7908,7 +7908,7 @@
                         <line>0</line>
                         <voice>0</voice>
                         <name>Cowbell</name>
-                        <stem>2</stem>
+                        <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
                   <Channel>
@@ -7935,7 +7935,7 @@
                         <line>0</line>
                         <voice>0</voice>
                         <name>Crash Cymbal 1</name>
-                        <stem>2</stem>
+                        <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
                   <Channel>
@@ -7966,7 +7966,7 @@
                         <line>0</line>
                         <voice>0</voice>
                         <name>Crash Cymbal 2</name>
-                        <stem>2</stem>
+                        <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
                   <Channel>
@@ -8174,7 +8174,7 @@
                         <line>0</line>
                         <voice>0</voice>
                         <name>Ride Cymbal 1</name>
-                        <stem>2</stem>
+                        <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
                   <Drum pitch="53"> <!--Ride Bell-->
@@ -8182,7 +8182,7 @@
                         <line>0</line>
                         <voice>0</voice>
                         <name>Ride Bell</name>
-                        <stem>2</stem>
+                        <stem>1</stem>
                         <shortcut>B</shortcut>
                   </Drum>
                   <Channel>
@@ -8235,7 +8235,7 @@
                         <line>0</line>
                         <voice>0</voice>
                         <name>Splash Cymbal</name>
-                        <stem>2</stem>
+                        <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
                   <Channel>
@@ -8318,7 +8318,7 @@
                         <line>0</line>
                         <voice>0</voice>
                         <name>Mute Triangle</name>
-                        <stem>2</stem>
+                        <stem>1</stem>
                         <shortcut>B</shortcut>
                   </Drum>
                   <Drum pitch="81"> <!--Open Triangle-->
@@ -8326,7 +8326,7 @@
                         <line>0</line>
                         <voice>0</voice>
                         <name>Open Triangle</name>
-                        <stem>2</stem>
+                        <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
                   <Channel>
@@ -8410,7 +8410,7 @@
                         <line>0</line>
                         <voice>0</voice>
                         <name>Claves</name>
-                        <stem>2</stem>
+                        <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
                   <Channel>
@@ -8625,7 +8625,7 @@
                         <line>0</line>
                         <voice>0</voice>
                         <name>Maracas</name>
-                        <stem>2</stem>
+                        <stem>1</stem>
                         <shortcut>A</shortcut>
                   </Drum>
                   <Channel>

--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -7868,7 +7868,7 @@
                   <trackName>China Cymbal</trackName>
                   <longName>China Cymbal</longName>
                   <shortName>Ch. Cym.</shortName>
-                  <description>Chinese cymbal.</description>
+                  <description>China cymbal for drum kit.</description>
                   <musicXMLid>metal.cymbal.chinese</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc1Line">percussion</stafftype>

--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -7130,45 +7130,51 @@
                   <singleNoteDynamics>0</singleNoteDynamics>
                   <Drum pitch="41"> <!--Low Floor Tom-->
                         <head>normal</head>
-                        <line>6</line>
+                        <line>9</line>
                         <voice>0</voice>
-                        <name>Low Floor Tom</name>
+                        <name>Tom 6</name>
                         <stem>1</stem>
+                        <shortcut>F</shortcut>
                   </Drum>
                   <Drum pitch="43"> <!--High Floor Tom-->
                         <head>normal</head>
-                        <line>5</line>
+                        <line>7</line>
                         <voice>0</voice>
-                        <name>High Floor Tom</name>
+                        <name>Tom 5</name>
                         <stem>1</stem>
+                        <shortcut>E</shortcut>
                   </Drum>
                   <Drum pitch="45"> <!--Low Tom-->
                         <head>normal</head>
-                        <line>4</line>
+                        <line>5</line>
                         <voice>0</voice>
-                        <name>Low Tom</name>
+                        <name>Tom 4</name>
                         <stem>1</stem>
+                        <shortcut>D</shortcut>
                   </Drum>
                   <Drum pitch="47"> <!--Low-Mid Tom-->
                         <head>normal</head>
-                        <line>2</line>
+                        <line>3</line>
                         <voice>0</voice>
-                        <name>Low-Mid Tom</name>
+                        <name>Tom 3</name>
                         <stem>1</stem>
+                        <shortcut>C</shortcut>
                   </Drum>
                   <Drum pitch="48"> <!--Hi-Mid Tom-->
                         <head>normal</head>
                         <line>1</line>
                         <voice>0</voice>
-                        <name>Hi-Mid Tom</name>
+                        <name>Tom 2</name>
                         <stem>1</stem>
+                        <shortcut>B</shortcut>
                   </Drum>
                   <Drum pitch="50"> <!--High Tom-->
                         <head>normal</head>
-                        <line>0</line>
+                        <line>-1</line>
                         <voice>0</voice>
-                        <name>High Tom</name>
+                        <name>Tom 1</name>
                         <stem>1</stem>
+                        <shortcut>A</shortcut>
                   </Drum>
                   <Channel>
                         <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
@@ -7197,15 +7203,15 @@
                         <voice>0</voice>
                         <name>Mute High Conga</name>
                         <stem>1</stem>
-                        <shortcut>B</shortcut>
+                        <shortcut>C</shortcut>
                   </Drum>
                   <Drum pitch="63"> <!--Open High Conga-->
                         <head>normal</head>
-                        <line>0</line>
+                        <line>-1</line>
                         <voice>0</voice>
                         <name>High Conga</name>
                         <stem>1</stem>
-                        <shortcut>C</shortcut>
+                        <shortcut>B</shortcut>
                   </Drum>
                   <Drum pitch="64"> <!--Low Conga-->
                         <head>normal</head>
@@ -7213,7 +7219,7 @@
                         <voice>0</voice>
                         <name>Low Conga</name>
                         <stem>1</stem>
-                        <shortcut>D</shortcut>
+                        <shortcut>A</shortcut>
                   </Drum>
                   <Channel>
                         <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
@@ -7859,8 +7865,8 @@
             </Instrument>
             <Instrument id="chinese-cymbal">
                   <family>unpitched-metal-percussion</family>
-                  <trackName>Chinese Cymbal</trackName>
-                  <longName>Chinese Cymbal</longName>
+                  <trackName>China Cymbal</trackName>
+                  <longName>China Cymbal</longName>
                   <shortName>Ch. Cym.</shortName>
                   <description>Chinese cymbal.</description>
                   <musicXMLid>metal.cymbal.chinese</musicXMLid>

--- a/share/instruments/instrumentsxml.h
+++ b/share/instruments/instrumentsxml.h
@@ -3997,7 +3997,7 @@ QT_TRANSLATE_NOOP3("engraving/instruments", "Chains", "chains longName"),
 QT_TRANSLATE_NOOP3("engraving/instruments", "Chn.", "chains shortName"),
 
 //: description for China Cymbal; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Chinese cymbal.", "chinese-cymbal description"),
+QT_TRANSLATE_NOOP3("engraving/instruments", "China cymbal for drum kit.", "chinese-cymbal description"),
 //: trackName for China Cymbal; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "China Cymbal", "chinese-cymbal trackName"),
 //: longName for China Cymbal; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names

--- a/share/instruments/instrumentsxml.h
+++ b/share/instruments/instrumentsxml.h
@@ -3996,13 +3996,13 @@ QT_TRANSLATE_NOOP3("engraving/instruments", "Chains", "chains longName"),
 //: shortName for Chains; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Chn.", "chains shortName"),
 
-//: description for Chinese Cymbal; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+//: description for China Cymbal; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Chinese cymbal.", "chinese-cymbal description"),
-//: trackName for Chinese Cymbal; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Chinese Cymbal", "chinese-cymbal trackName"),
-//: longName for Chinese Cymbal; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Chinese Cymbal", "chinese-cymbal longName"),
-//: shortName for Chinese Cymbal; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+//: trackName for China Cymbal; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "China Cymbal", "chinese-cymbal trackName"),
+//: longName for China Cymbal; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "China Cymbal", "chinese-cymbal longName"),
+//: shortName for China Cymbal; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Ch. Cym.", "chinese-cymbal shortName"),
 
 //: description for Cowbell; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names


### PR DESCRIPTION
"Concert toms" are arranged on the staff based on number of drums and preferring spaces.

Congas have high conga and high mute conga on seperate lines, mute is a technique performed on the same drum

Chinese Cymbal is misleading, there are various types of cymbals that are "Chinese" the instrument is a drumset China Cymbal (more specific)

Shortcuts are also updated to be more logical