### PR TITLE
Use triggerLayoutAll() when updating the measure number property of section breaks

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -1939,6 +1939,13 @@ void EngravingItem::triggerLayoutAll() const
     }
 }
 
+void EngravingItem::triggerLayoutToEnd() const
+{
+    if (explicitParent()) {
+        score()->setLayout(tick(), score()->endTick(), staffIdx(), staffIdx(), this);
+    }
+}
+
 //---------------------------------------------------------
 //   addData
 //---------------------------------------------------------

--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -487,6 +487,7 @@ public:
 
     virtual void triggerLayout() const;
     virtual void triggerLayoutAll() const;
+    virtual void triggerLayoutToEnd() const;
     virtual void drawEditMode(draw::Painter* painter, EditData& editData, double currentViewScaling);
 
     double styleP(Sid idx) const;

--- a/src/engraving/dom/layoutbreak.cpp
+++ b/src/engraving/dom/layoutbreak.cpp
@@ -241,10 +241,16 @@ bool LayoutBreak::setProperty(Pid propertyId, const PropertyValue& v)
         }
         break;
     }
-    triggerLayout();
-    if (explicitParent() && measure()->next()) {
-        measure()->next()->triggerLayout();
+
+    if (propertyId == Pid::START_WITH_MEASURE_ONE) {
+        triggerLayoutToEnd();
+    } else {
+        triggerLayout();
+        if (explicitParent() && measure()->next()) {
+            measure()->next()->triggerLayout();
+        }
     }
+
     setGenerated(false);
     return true;
 }

--- a/src/engraving/dom/measurebase.cpp
+++ b/src/engraving/dom/measurebase.cpp
@@ -130,6 +130,9 @@ void MeasureBase::add(EngravingItem* e)
             setLineBreak(false);
             setSectionBreak(true);
             setNoBreak(false);
+            if (b->startWithMeasureOne()) {
+                triggerLayoutToEnd();
+            }
             break;
         case LayoutBreakType:: NOBREAK:
             setPageBreak(false);
@@ -141,7 +144,6 @@ void MeasureBase::add(EngravingItem* e)
         if (next()) {
             next()->triggerLayout();
         }
-//            triggerLayoutAll();     // TODO
     }
     triggerLayout();
     m_el.push_back(e);
@@ -167,6 +169,9 @@ void MeasureBase::remove(EngravingItem* el)
         case LayoutBreakType::SECTION:
             setSectionBreak(false);
             score()->setPause(endTick(), 0);
+            if (lb->startWithMeasureOne()) {
+                triggerLayoutToEnd();
+            }
             break;
         case LayoutBreakType::NOBREAK:
             setNoBreak(false);


### PR DESCRIPTION
Resolves: #21621 

Due to the changes I made in #20141. This is a rare case where a layout of the whole score is actually necessary. 