### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -6849,7 +6849,7 @@ static void addArpeggio(ChordRest* cr, const String& arpeggioType, const int arp
         track_idx_t arpTrack = curArp->track();
         track_idx_t span = cr->track() - curArp->track();
         if (chordTrack > arpTrack && span != 0) {
-            curArp->setSpan(span + 1);
+            curArp->setSpan(static_cast<int>(span + 1));
         }
     } else {
         if (!arpeggioType.empty() && cr->type() == ElementType::CHORD) {


### PR DESCRIPTION
reg.: 'argument': conversion from 'size_t' to 'int', possible loss of data (C4267)