### PR TITLE
Fix #21294: Style settings reset between scores

### DIFF
--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -194,6 +194,14 @@ public:
 
     virtual io::path_t styleFileImportPath() const = 0;
     virtual void setStyleFileImportPath(const io::path_t& path) = 0;
+
+    virtual int styleDialogLastPageIndex() const = 0;
+    virtual void setStyleDialogLastPageIndex(int value) = 0;
+
+    virtual int styleDialogLastSubPageIndex() const = 0;
+    virtual void setStyleDialogLastSubPageIndex(int value) = 0;
+
+    virtual void resetStyleDialogPageIndices() = 0;
 };
 }
 

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -223,6 +223,10 @@ void NotationConfiguration::init()
 
     mu::engraving::MScore::setHRaster(DEFAULT_GRID_SIZE_SPATIUM);
     mu::engraving::MScore::setVRaster(DEFAULT_GRID_SIZE_SPATIUM);
+
+    context()->currentProjectChanged().onNotify(this, [this]() {
+        resetStyleDialogPageIndices();
+    });
 }
 
 QColor NotationConfiguration::anchorLineColor() const
@@ -887,4 +891,30 @@ mu::io::path_t NotationConfiguration::styleFileImportPath() const
 void NotationConfiguration::setStyleFileImportPath(const io::path_t& path)
 {
     settings()->setSharedValue(STYLE_FILE_IMPORT_PATH_KEY, Val(path.toStdString()));
+}
+
+int NotationConfiguration::styleDialogLastPageIndex() const
+{
+    return m_styleDialogLastPageIndex;
+}
+
+void NotationConfiguration::setStyleDialogLastPageIndex(int value)
+{
+    m_styleDialogLastPageIndex = value;
+}
+
+int NotationConfiguration::styleDialogLastSubPageIndex() const
+{
+    return m_styleDialogLastSubPageIndex;
+}
+
+void NotationConfiguration::setStyleDialogLastSubPageIndex(int value)
+{
+    m_styleDialogLastSubPageIndex = value;
+}
+
+void NotationConfiguration::resetStyleDialogPageIndices()
+{
+    setStyleDialogLastPageIndex(0);
+    setStyleDialogLastSubPageIndex(0);
 }

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -39,6 +39,7 @@ class NotationConfiguration : public INotationConfiguration, public async::Async
     INJECT(io::IFileSystem, fileSystem)
     INJECT(ui::IUiConfiguration, uiConfiguration)
     INJECT(engraving::IEngravingConfiguration, engravingConfiguration)
+    INJECT(context::IGlobalContext, context)
 
 public:
     void init();
@@ -198,6 +199,14 @@ public:
     io::path_t styleFileImportPath() const override;
     void setStyleFileImportPath(const io::path_t& path) override;
 
+    int styleDialogLastPageIndex() const override;
+    void setStyleDialogLastPageIndex(int value) override;
+
+    int styleDialogLastSubPageIndex() const override;
+    void setStyleDialogLastSubPageIndex(int value) override;
+
+    void resetStyleDialogPageIndices() override;
+
 private:
     io::path_t firstScoreOrderListPath() const;
     void setFirstScoreOrderListPath(const io::path_t& path);
@@ -214,6 +223,9 @@ private:
     async::Notification m_isPlayRepeatsChanged;
     async::Notification m_isPlayChordSymbolsChanged;
     ValCh<int> m_pianoKeyboardNumberOfKeys;
+
+    int m_styleDialogLastPageIndex = 0;
+    int m_styleDialogLastSubPageIndex = 0;
 };
 }
 

--- a/src/notation/tests/mocks/notationconfigurationmock.h
+++ b/src/notation/tests/mocks/notationconfigurationmock.h
@@ -184,6 +184,13 @@ public:
 
     MOCK_METHOD(io::path_t, styleFileImportPath, (), (const, override));
     MOCK_METHOD(void, setStyleFileImportPath, (const io::path_t&), (override));
+
+    MOCK_METHOD(int, styleDialogLastPageIndex, (), (const, override));
+    MOCK_METHOD(void, setStyleDialogLastPageIndex, (int), (override));
+    MOCK_METHOD(int, styleDialogLastSubPageIndex, (), (const, override));
+    MOCK_METHOD(void, setStyleDialogLastSubPageIndex, (int), (override));
+
+    MOCK_METHOD(void, resetStyleDialogPageIndices, (), (override));
 };
 }
 

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1141,11 +1141,11 @@ EditStyle::EditStyle(QWidget* parent)
     });
 
     connect(textStyles, &QListWidget::currentRowChanged, this, &EditStyle::textStyleChanged);
-    textStyles->setCurrentRow(s_lastSubPageRow);
+    textStyles->setCurrentRow(configuration()->styleDialogLastSubPageIndex());
 
     connect(pageList, &QListWidget::currentRowChanged, pageStack, &QStackedWidget::setCurrentIndex);
     connect(pageList, &QListWidget::currentRowChanged, this, &EditStyle::on_pageRowSelectionChanged);
-    pageList->setCurrentRow(s_lastPageRow);
+    pageList->setCurrentRow(configuration()->styleDialogLastPageIndex());
 
     adjustPagesStackSize(0);
 
@@ -1381,10 +1381,6 @@ QString EditStyle::currentSubPageCode() const
 {
     return m_currentSubPageCode;
 }
-
-int EditStyle::s_lastPageRow = 0;
-
-int EditStyle::s_lastSubPageRow = 0;
 
 QString EditStyle::pageCodeForElement(const EngravingItem* element)
 {
@@ -1900,7 +1896,7 @@ void EditStyle::on_resetTabStylesButton_clicked()
 
 void EditStyle::on_pageRowSelectionChanged()
 {
-    s_lastPageRow = pageList->currentRow();
+    configuration()->setStyleDialogLastPageIndex(pageList->currentRow());
 }
 
 //---------------------------------------------------------
@@ -2644,7 +2640,7 @@ void EditStyle::textStyleChanged(int row)
                                                  || tid == TextStyleType::HARP_PEDAL_DIAGRAM);
     row_textStyleMusicalSymbolsScale->setEnabled(tid != TextStyleType::TUPLET || tupletUseSymbols->isChecked());
 
-    s_lastSubPageRow = row;
+    configuration()->setStyleDialogLastSubPageIndex(row);
 }
 
 //---------------------------------------------------------

--- a/src/notation/view/widgets/editstyle.h
+++ b/src/notation/view/widgets/editstyle.h
@@ -150,9 +150,6 @@ private slots:
 private:
     QString m_currentPageCode;
     QString m_currentSubPageCode;
-
-    static int s_lastPageRow;
-    static int s_lastSubPageRow;
 };
 }
 


### PR DESCRIPTION
Resolves: #21294 

This change includes:
- When no element is selected in the notation context menu and style menu is called, it shows default “score” setting.
- When score appearance style setting is clicked, shows default “score” setting.
- When style setting is clicked from the format menu, shows default “score” setting.
- No style setting is kept outside a score.

Video: https://github.com/musescore/MuseScore/issues/21294#issuecomment-1968022830

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually