### PR TITLE
Fix minor regressions to mixer solo/mutes

### DIFF
--- a/src/playback/qml/MuseScore/Playback/internal/MixerMuteAndSoloSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerMuteAndSoloSection.qml
@@ -78,7 +78,7 @@ MixerPanelSection {
                 icon: IconCode.SOLO
                 checked: channelItem.solo
 
-                enabled: channelItem.type !== MixerChannelItem.Aux && (!channelItem.muted || channelItem.forceMuted)
+                enabled: channelItem.type !== MixerChannelItem.Aux && (!channelItem.muted || channelItem.forceMute)
                 visible: channelItem.type !== MixerChannelItem.Master && channelItem.type !== MixerChannelItem.Metronome
 
                 navigation.name: "SoloButton"

--- a/src/playback/view/internal/mixerchannelitem.cpp
+++ b/src/playback/view/internal/mixerchannelitem.cpp
@@ -471,6 +471,10 @@ void MixerChannelItem::setMuted(bool mute)
 
     emit soloMuteStateChanged(soloMuteState);
     emit mutedChanged();
+
+    if (mute && m_outParams.solo) {
+        setSolo(false);
+    }
 }
 
 void MixerChannelItem::setAudioChannelVolumePressure(const audio::audioch_t chNum, const float newValue)


### PR DESCRIPTION
Fixing a couple regressions introduced with #19433

  Firstly, a typo meant that the solo button wasn’t “locking” when a track was manually muted as it was before (well spotted @Eism).  
  
  Second, toggling the mute button on a soloed track previously un-soloed the track in question. This functionality was also lost in the above PR.