### PR TITLE
Set hairpin's default placement to 'Above' on vocal staves

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -3062,16 +3062,21 @@ void MusicXMLParserDirection::direction(const String& partId,
             m_logger->logError(u"spanner already started", &m_e);
             delete desc.sp;
         } else {
+            String spannerPlacement = placement;
+            // Case-based defaults
+            if (spannerPlacement.empty() && desc.sp->isHairpin()) {
+                spannerPlacement = isVocalStaff ? u"above" : u"below";
+            }
             if (spdesc.isStopped) {
                 m_pass2.addSpanner(desc);
                 // handleSpannerStart and handleSpannerStop must be called in order
                 // due to allocation of elements in the map
-                handleSpannerStart(desc.sp, track, placement, tick + m_offset, spanners);
+                handleSpannerStart(desc.sp, track, spannerPlacement, tick + m_offset, spanners);
                 handleSpannerStop(spdesc.sp, spdesc.track2, spdesc.tick2, spanners);
                 m_pass2.clearSpanner(desc);
             } else {
                 m_pass2.addSpanner(desc);
-                handleSpannerStart(desc.sp, track, placement, tick + m_offset, spanners);
+                handleSpannerStart(desc.sp, track, spannerPlacement, tick + m_offset, spanners);
                 spdesc.isStarted = true;
             }
         }

--- a/src/importexport/musicxml/tests/data/testPlacementDefaults.xml
+++ b/src/importexport/musicxml/tests/data/testPlacementDefaults.xml
@@ -124,6 +124,11 @@
           </direction-type>
         <sound tempo="35"/>
         </direction>
+        <direction>
+          <direction-type>
+            <wedge type="crescendo" number="1"/>
+            </direction-type>
+          </direction>
       <note default-x="81.56" default-y="20.00">
         <pitch>
           <step>C</step>
@@ -176,6 +181,11 @@
           <tied type="start"/>
           </notations>
         </note>
+        <direction>
+          <direction-type>
+            <wedge type="stop" number="1"/>
+            </direction-type>
+          </direction>
       </measure>
     <measure number="4" width="147.74">
       <direction> 

--- a/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
@@ -219,6 +219,17 @@
             <velocity>33</velocity>
             <placement>above</placement>
             </Dynamic>
+          <Spanner type="HairPin">
+            <HairPin>
+              <subtype>0</subtype>
+              <placement>above</placement>
+              </HairPin>
+            <next>
+              <location>
+                <measures>3</measures>
+                </location>
+              </next>
+            </Spanner>
           <Chord>
             <durationType>whole</durationType>
             <Lyrics>
@@ -301,6 +312,13 @@
           <StaffText>
             <text><i>increasingly grave in spirit</i></text>
             </StaffText>
+          <Spanner type="HairPin">
+            <prev>
+              <location>
+                <measures>-3</measures>
+                </location>
+              </prev>
+            </Spanner>
           <Chord>
             <durationType>whole</durationType>
             <Note>


### PR DESCRIPTION
This matches the default placement of dynamics when no placement information is provided in the musicXML.

<img width="644" alt="Screenshot 2024-02-29 at 16 11 36" src="https://github.com/musescore/MuseScore/assets/26510874/57d1351c-5040-4d07-853b-918cb414e785">
