### PR TITLE
Fix #20513: Disable copy-dragging for bends (Master)

### DIFF
--- a/src/engraving/rendering/single/singlelayout.cpp
+++ b/src/engraving/rendering/single/singlelayout.cpp
@@ -978,6 +978,7 @@ void SingleLayout::layout(GradualTempoChangeSegment* item, const Context& ctx)
 void SingleLayout::layout(GuitarBend*, const Context&)
 {
     NOT_IMPLEMENTED;
+    //! NOTE: Bends can be removed from disallowed elements in NotationInteraction::dragCopyAllowed once this has been implemented
 }
 
 void SingleLayout::layout(GuitarBendSegment*, const Context&)

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -95,6 +95,7 @@ public:
     virtual async::Notification dragChanged() const = 0;
 
     virtual bool isDragCopyStarted() const = 0;
+    virtual bool dragCopyAllowed(const EngravingItem* element) const = 0;
     virtual void startDragCopy(const EngravingItem* element, QObject* dragSource) = 0;
     virtual void endDragCopy() = 0;
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1131,17 +1131,30 @@ bool NotationInteraction::isDragCopyStarted() const
     return m_drag != nullptr;
 }
 
+bool NotationInteraction::dragCopyAllowed(const EngravingItem* element) const
+{
+    if (!element) {
+        return false;
+    }
+
+    switch (element->type()) {
+    case ElementType::MEASURE:
+    case ElementType::NOTE:
+    case ElementType::VBOX:
+    // TODO: Bends can't be copy-dragged until corresponding SingleLayout::layout and SingleDraw::draw methods have been implemented
+    case ElementType::GUITAR_BEND:
+    case ElementType::GUITAR_BEND_SEGMENT:
+    case ElementType::GUITAR_BEND_HOLD:
+    case ElementType::GUITAR_BEND_HOLD_SEGMENT:
+    case ElementType::GUITAR_BEND_TEXT:
+        return false;
+    default: return true;
+    }
+}
+
 //! NOTE: Copied from ScoreView::cloneElement
 void NotationInteraction::startDragCopy(const EngravingItem* element, QObject* dragSource)
 {
-    if (!element) {
-        return;
-    }
-
-    if (element->isMeasure() || element->isNote() || element->isVBox()) {
-        return;
-    }
-
     if (isDragStarted()) {
         endDragCopy();
     }

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -103,6 +103,7 @@ public:
     async::Notification dragChanged() const override;
 
     bool isDragCopyStarted() const override;
+    bool dragCopyAllowed(const EngravingItem* element) const override;
     void startDragCopy(const EngravingItem* element, QObject* dragSource) override;
     void endDragCopy() override;
 

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -65,6 +65,7 @@ public:
     MOCK_METHOD(async::Notification, dragChanged, (), (const, override));
 
     MOCK_METHOD(bool, isDragCopyStarted, (), (const, override));
+    MOCK_METHOD(bool, dragCopyAllowed, (const EngravingItem*), (const, override));
     MOCK_METHOD(void, startDragCopy, (const EngravingItem*, QObject*), (override));
     MOCK_METHOD(void, endDragCopy, (), (override));
 

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -605,7 +605,9 @@ void NotationViewInputController::mousePressEvent(QMouseEvent* event)
     }
 
     if (keyState == (Qt::ShiftModifier | Qt::ControlModifier)) {
-        viewInteraction()->startDragCopy(hitElement, m_view->asItem());
+        if (viewInteraction()->dragCopyAllowed(hitElement)) {
+            viewInteraction()->startDragCopy(hitElement, m_view->asItem());
+        }
         return;
     }
 


### PR DESCRIPTION
Resolves: #20513

This is a temporary fix - we don't currently have `SingleLayout::layout` or `SingleDraw::draw` methods for bends which is necessary for having fully functioning copy-drag and palette interactions with bends (amongst other things).