### PR TITLE
Apply default font to all elements only when XML import config option is set

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -1496,24 +1496,26 @@ static void updateStyles(Score* score,
         // and text types used in the title frame
         // Some further tweaking may still be required.
 
-        if (tid == TextStyleType::LYRICS_ODD || tid == TextStyleType::LYRICS_EVEN
-            || tid == TextStyleType::HARMONY_ROMAN
-            || isTitleFrameStyle(tid)
-            || isHarpPedalStyle(tid)) {
+        if (tid == TextStyleType::LYRICS_ODD || tid == TextStyleType::LYRICS_EVEN) {
             continue;
         }
+
+        bool needUseDefaultSize = tid == TextStyleType::HARMONY_ROMAN
+                                  || isTitleFrameStyle(tid)
+                                  || isHarpPedalStyle(tid);
+
         const TextStyle* ts = textStyle(tid);
         for (const auto& a :*ts) {
-            if (a.pid == Pid::FONT_FACE && wordFamily != "" && !needUseDefaultFont) {
+            if (a.pid == Pid::FONT_FACE && !needUseDefaultFont) {
                 score->style().set(a.sid, wordFamily);
-            } else if (a.pid == Pid::FONT_SIZE && dblWordSize > epsilon) {
+            } else if (a.pid == Pid::FONT_SIZE && dblWordSize > epsilon && !needUseDefaultSize) {
                 score->style().set(a.sid, dblWordSize);
             }
         }
     }
 
     // handle lyrics odd and even lines separately
-    if (!lyricFamily.empty() && !needUseDefaultFont) {
+    if (!needUseDefaultFont) {
         score->style().set(Sid::lyricsOddFontFace, lyricFamily);
         score->style().set(Sid::lyricsEvenFontFace, lyricFamily);
     }
@@ -1706,7 +1708,10 @@ void MusicXMLParserPass1::defaults()
            muPrintable(wordFontFamily), muPrintable(wordFontSize),
            muPrintable(lyricFontFamily), muPrintable(lyricFontSize));
     */
+    wordFontFamily = wordFontFamily.empty() ? u"Edwin" : wordFontFamily;
+    lyricFontFamily = lyricFontFamily.empty() ? wordFontFamily : lyricFontFamily;
     updateStyles(m_score, wordFontFamily, wordFontSize, lyricFontFamily, lyricFontSize);
+
     scaleCopyrightText(m_score);
 }
 

--- a/src/importexport/musicxml/tests/data/testArpCrossVoice_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testArpCrossVoice_ref.mscx
@@ -12,6 +12,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testBeamModes_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBeamModes_ref.mscx
@@ -11,6 +11,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testBracketTypes_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBracketTypes_ref.mscx
@@ -11,6 +11,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testCodaHBox_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testCodaHBox_ref.mscx
@@ -12,6 +12,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testCopyrightScale_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testCopyrightScale_ref.mscx
@@ -12,6 +12,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.19685</pageOddTopMargin>
       <pageOddBottomMargin>0.19685</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testCueGraceNotes_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testCueGraceNotes_ref.mscx
@@ -11,6 +11,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testCueNotes3_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testCueNotes3_ref.mscx
@@ -12,6 +12,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testDSalCodaMisplaced_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDSalCodaMisplaced_ref.mscx
@@ -11,6 +11,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testDSalCoda_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDSalCoda_ref.mscx
@@ -11,6 +11,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testElision_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testElision_ref.mscx
@@ -12,6 +12,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testExcessHiddenStaves_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testExcessHiddenStaves_ref.mscx
@@ -11,6 +11,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <hideEmptyStaves>1</hideEmptyStaves>
       <dontHideStavesInFirstSystem>0</dontHideStavesInFirstSystem>

--- a/src/importexport/musicxml/tests/data/testInferredSubtitle_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredSubtitle_ref.mscx
@@ -11,6 +11,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testLyricBracket_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testLyricBracket_ref.mscx
@@ -11,6 +11,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testLyricPos_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testLyricPos_ref.mscx
@@ -12,6 +12,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testMeasureStyleSlash_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testMeasureStyleSlash_ref.mscx
@@ -14,6 +14,7 @@
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
       <lyricsOddFontSize>11</lyricsOddFontSize>
       <lyricsEvenFontSize>11</lyricsEvenFontSize>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testNegativeOffset_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testNegativeOffset_ref.mscx
@@ -11,6 +11,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testPartNames_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPartNames_ref.mscx
@@ -12,6 +12,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testPedalChangesBroken_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPedalChangesBroken_ref.mscx
@@ -11,6 +11,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
@@ -11,6 +11,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testSecondVoiceMelismata_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSecondVoiceMelismata_ref.mscx
@@ -11,6 +11,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testSibMetronomeMarks_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSibMetronomeMarks_ref.mscx
@@ -14,6 +14,8 @@
       <pageOddBottomMargin>0.5</pageOddBottomMargin>
       <pageTwosided>0</pageTwosided>
       <minSystemDistance>12</minSystemDistance>
+      <lyricsOddFontFace>Times New Roman</lyricsOddFontFace>
+      <lyricsEvenFontFace>Times New Roman</lyricsEvenFontFace>
       <barWidth>0.15625</barWidth>
       <endBarWidth>0.5</endBarWidth>
       <stemWidth>0.125</stemWidth>
@@ -21,6 +23,7 @@
       <ledgerLineWidth>0.15625</ledgerLineWidth>
       <chordSymbolAFontFace>Times New Roman</chordSymbolAFontFace>
       <chordSymbolBFontFace>Times New Roman</chordSymbolBFontFace>
+      <romanNumeralFontFace>Times New Roman</romanNumeralFontFace>
       <nashvilleNumberFontFace>Times New Roman</nashvilleNumberFontFace>
       <smallNoteMag>0.75</smallNoteMag>
       <graceNoteMag>0.6</graceNoteMag>
@@ -29,10 +32,16 @@
       <tieEndWidth>0.0625</tieEndWidth>
       <tieMidWidth>0.21875</tieMidWidth>
       <tupletFontFace>Times New Roman</tupletFontFace>
+      <titleFontFace>Times New Roman</titleFontFace>
+      <subTitleFontFace>Times New Roman</subTitleFontFace>
+      <composerFontFace>Times New Roman</composerFontFace>
+      <lyricistFontFace>Times New Roman</lyricistFontFace>
       <fingeringFontFace>Times New Roman</fingeringFontFace>
       <lhGuitarFingeringFontFace>Times New Roman</lhGuitarFingeringFontFace>
       <rhGuitarFingeringFontFace>Times New Roman</rhGuitarFingeringFontFace>
       <stringNumberFontFace>Times New Roman</stringNumberFontFace>
+      <harpPedalDiagramFontFace>Times New Roman</harpPedalDiagramFontFace>
+      <harpPedalTextDiagramFontFace>Times New Roman</harpPedalTextDiagramFontFace>
       <longInstrumentFontFace>Times New Roman</longInstrumentFontFace>
       <shortInstrumentFontFace>Times New Roman</shortInstrumentFontFace>
       <partInstrumentFontFace>Times New Roman</partInstrumentFontFace>

--- a/src/importexport/musicxml/tests/data/testSibOttavas_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSibOttavas_ref.mscx
@@ -14,6 +14,8 @@
       <pageOddBottomMargin>0.5</pageOddBottomMargin>
       <pageTwosided>0</pageTwosided>
       <minSystemDistance>12</minSystemDistance>
+      <lyricsOddFontFace>Times New Roman</lyricsOddFontFace>
+      <lyricsEvenFontFace>Times New Roman</lyricsEvenFontFace>
       <barWidth>0.15625</barWidth>
       <endBarWidth>0.5</endBarWidth>
       <stemWidth>0.125</stemWidth>
@@ -21,6 +23,7 @@
       <ledgerLineWidth>0.15625</ledgerLineWidth>
       <chordSymbolAFontFace>Times New Roman</chordSymbolAFontFace>
       <chordSymbolBFontFace>Times New Roman</chordSymbolBFontFace>
+      <romanNumeralFontFace>Times New Roman</romanNumeralFontFace>
       <nashvilleNumberFontFace>Times New Roman</nashvilleNumberFontFace>
       <smallNoteMag>0.75</smallNoteMag>
       <graceNoteMag>0.6</graceNoteMag>
@@ -29,10 +32,16 @@
       <tieEndWidth>0.0625</tieEndWidth>
       <tieMidWidth>0.21875</tieMidWidth>
       <tupletFontFace>Times New Roman</tupletFontFace>
+      <titleFontFace>Times New Roman</titleFontFace>
+      <subTitleFontFace>Times New Roman</subTitleFontFace>
+      <composerFontFace>Times New Roman</composerFontFace>
+      <lyricistFontFace>Times New Roman</lyricistFontFace>
       <fingeringFontFace>Times New Roman</fingeringFontFace>
       <lhGuitarFingeringFontFace>Times New Roman</lhGuitarFingeringFontFace>
       <rhGuitarFingeringFontFace>Times New Roman</rhGuitarFingeringFontFace>
       <stringNumberFontFace>Times New Roman</stringNumberFontFace>
+      <harpPedalDiagramFontFace>Times New Roman</harpPedalDiagramFontFace>
+      <harpPedalTextDiagramFontFace>Times New Roman</harpPedalTextDiagramFontFace>
       <longInstrumentFontFace>Times New Roman</longInstrumentFontFace>
       <shortInstrumentFontFace>Times New Roman</shortInstrumentFontFace>
       <partInstrumentFontFace>Times New Roman</partInstrumentFontFace>

--- a/src/importexport/musicxml/tests/data/testStaffEmptiness_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testStaffEmptiness_ref.mscx
@@ -11,6 +11,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testTempoTextSpace1_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTempoTextSpace1_ref.mscx
@@ -11,6 +11,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testTempoTextSpace2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTempoTextSpace2_ref.mscx
@@ -11,6 +11,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testTextOrder_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTextOrder_ref.mscx
@@ -11,6 +11,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testTextQuirkInference_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTextQuirkInference_ref.mscx
@@ -11,6 +11,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testVoltaHiding_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testVoltaHiding_ref.mscx
@@ -12,6 +12,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>

--- a/src/importexport/musicxml/tests/data/testWedgeOffset_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testWedgeOffset_ref.mscx
@@ -11,6 +11,7 @@
       <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
       <pageOddTopMargin>0.590551</pageOddTopMargin>
       <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
       <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
       <tupletFontSize>10</tupletFontSize>
       <fingeringFontSize>10</fingeringFontSize>


### PR DESCRIPTION
There appears to be some confusion between font size and font face import of XML files.  This PR ensures that either all text elements are reset to Edwin when the below option is checked, or they use the XML's provided font.  Previously, exceptions were made for title frames, roman numerals and harp pedal diagrams.
<img width="355" alt="Screenshot 2024-03-04 at 15 19 53" src="https://github.com/musescore/MuseScore/assets/26510874/ea6a98f2-3c37-48a9-96f2-f556eb988aa0">


These elements do however need an exception for font size, which is upheld.  
If no lyric font is specified, we fall back to the XML text font then to Edwin.
