### PR TITLE
Remove resetSlurTieDefaults method (improves load times of older scores - #21620) (4.3.0)

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -2787,39 +2787,6 @@ void Score::resetAutoplace()
 }
 
 //---------------------------------------------------------
-//   resetDefaults
-//    Resets slur and tie positioning. Used in score migration.
-//---------------------------------------------------------
-
-void Score::resetSlurTieDefaults()
-{
-    TRACEFUNC;
-
-    for (System* sys : systems()) {
-        for (SpannerSegment* spannerSegment : sys->spannerSegments()) {
-            if (spannerSegment->isSlurTieSegment()) {
-                bool retainDirection = true;
-                SlurTieSegment* slurTieSegment = toSlurTieSegment(spannerSegment);
-                if (slurTieSegment->slurTie()->isTie()) {
-                    Tie* tie = toTie(slurTieSegment->slurTie());
-                    if (tie->isInside()) {
-                        retainDirection = false;
-                    }
-                }
-                auto dir = slurTieSegment->slurTie()->slurDirection();
-                bool autoplace = slurTieSegment->slurTie()->autoplace();
-                slurTieSegment->reset();
-                if (retainDirection) {
-                    slurTieSegment->slurTie()->setSlurDirection(dir);
-                }
-                slurTieSegment->slurTie()->setAutoplace(autoplace);
-            }
-        }
-    }
-    doLayout();
-}
-
-//---------------------------------------------------------
 //   move
 //    move current selection
 //---------------------------------------------------------

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -5694,11 +5694,6 @@ void Score::doLayoutRange(const Fraction& st, const Fraction& et)
         m_resetAutoplace = false;
         resetAutoplace();
     }
-
-    if (m_resetDefaults) {
-        m_resetDefaults = false;
-        resetSlurTieDefaults();
-    }
 }
 
 void Score::createPaddingTable()

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -288,14 +288,12 @@ public:
     void addMeasure(MeasureBase*, MeasureBase*);
     void linkMeasures(Score* score);
     void setResetAutoplace() { m_resetAutoplace = true; }
-    void setResetDefaults() { m_resetDefaults = true; }
 
     Excerpt* excerpt() { return m_excerpt; }
     void setExcerpt(Excerpt* e) { m_excerpt = e; }
 
     // methods for resetting elements for pre-4.0 score migration
     void resetAutoplace();
-    void resetSlurTieDefaults();
 
     void cmdAddBracket();
     void cmdAddParentheses();
@@ -1079,7 +1077,6 @@ private:
 
     ScoreOrder m_scoreOrder;                 // used for score ordering
     bool m_resetAutoplace = false;
-    bool m_resetDefaults = false;
     int m_mscVersion = Constants::MSC_VERSION;     // version of current loading *.msc file
 
     bool m_isOpen = false;

--- a/src/project/internal/projectmigrator.cpp
+++ b/src/project/internal/projectmigrator.cpp
@@ -166,7 +166,6 @@ Ret ProjectMigrator::migrateProject(engraving::EngravingProjectPtr project, cons
     if (ok && m_resetStyleSettings) {
         resetStyleSettings(score);
     }
-    score->setResetDefaults(); // some defaults need to be reset on first layout
     score->endCmd();
 
     return ok ? make_ret(Ret::Code::Ok) : make_ret(Ret::Code::InternalError);


### PR DESCRIPTION
Improves the situation mentioned in #21620 
Master PR: #21803 