### PR TITLE
Fix crash on opening file with tempo line

### DIFF
--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -1099,7 +1099,8 @@ Segment* Spanner::endSegment() const
     bool mmRest = style().styleB(Sid::createMultiMeasureRests);
     Measure* m = mmRest ? score()->tick2measureMM(tick()) : score()->tick2measure(tick());
 
-    SegmentType st = (systemFlag() && tick2() == score()->endTick()) || m->isMMRest() ? SPANNER_ANCHOR_SEG_TYPE : SegmentType::ChordRest;
+    SegmentType st = (systemFlag() && tick2() == score()->endTick())
+                     || (m && m->isMMRest()) ? SPANNER_ANCHOR_SEG_TYPE : SegmentType::ChordRest;
     return score()->tick2leftSegment(tick2(), mmRest, st);
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/21783
(crash arising from #21306)
Added a missing null check.