### PR TITLE
Fix #21815: Layout all when migrating old scores without Leland or Edwin conversion (Master)

### DIFF
--- a/src/project/internal/projectmigrator.cpp
+++ b/src/project/internal/projectmigrator.cpp
@@ -165,6 +165,7 @@ Ret ProjectMigrator::migrateProject(engraving::EngravingProjectPtr project, cons
 
     if (ok && m_resetStyleSettings) {
         resetStyleSettings(score);
+        score->setLayoutAll();
     }
     score->endCmd();
 


### PR DESCRIPTION
Resolves (partially): #21815

Bug introduced with #21803 