### PR TITLE
Fix #21815: Layout all when migrating old scores without Leland or Edwin conversion (4.3.0)

### DIFF
--- a/src/project/internal/projectmigrator.cpp
+++ b/src/project/internal/projectmigrator.cpp
@@ -165,6 +165,7 @@ Ret ProjectMigrator::migrateProject(engraving::EngravingProjectPtr project, cons
 
     if (ok && m_resetStyleSettings) {
         resetStyleSettings(score);
+        score->setLayoutAll();
     }
     score->setResetDefaults(); // some defaults need to be reset on first layout
     score->endCmd();


### PR DESCRIPTION
Resolves (partially): #21815
Master PR: #21823 