### PR TITLE
Don't bracket accidentals if the XML says not to

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -2825,9 +2825,18 @@ static void writeAccidental(XmlWriter& xml, const String& tagName, const Acciden
             }
             String tag = tagName;
             if (acc->bracket() == AccidentalBracket::BRACKET) {
+                if (acc->role() == AccidentalRole::USER) {
+                    attrs.emplace_back(std::make_pair("editorial", "yes"));
+                }
                 attrs.emplace_back(std::make_pair("bracket", "yes"));
             } else if (acc->bracket() == AccidentalBracket::PARENTHESIS) {
+                if (acc->role() == AccidentalRole::USER) {
+                    attrs.emplace_back(std::make_pair("cautionary", "yes"));
+                }
                 attrs.emplace_back(std::make_pair("parentheses", "yes"));
+                //} else if (acc->role() == AccidentalRole::USER) {            // no way to tell "cautionary" from "editorial"
+                //    attrs.emplace_back(std::make_pair("cautionary", "yes")); // so pick one
+                //    attrs.emplace_back(std::make_pair("parentheses", "no")); // but use neither parenthesis nor bracket ;-)
             }
             if (tagName == "accidental-mark") {
                 if (acc->placeAbove()) {

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -2834,9 +2834,9 @@ static void writeAccidental(XmlWriter& xml, const String& tagName, const Acciden
                     attrs.emplace_back(std::make_pair("cautionary", "yes"));
                 }
                 attrs.emplace_back(std::make_pair("parentheses", "yes"));
-                //} else if (acc->role() == AccidentalRole::USER) {            // no way to tell "cautionary" from "editorial"
-                //    attrs.emplace_back(std::make_pair("cautionary", "yes")); // so pick one
-                //    attrs.emplace_back(std::make_pair("parentheses", "no")); // but use neither parenthesis nor bracket ;-)
+            } else if (acc->role() == AccidentalRole::USER) {            // no way to tell "cautionary" from "editorial"
+                attrs.emplace_back(std::make_pair("cautionary", "yes")); // so pick one
+                attrs.emplace_back(std::make_pair("parentheses", "no")); // but use neither parenthesis nor bracket ;-)
             }
             if (tagName == "accidental-mark") {
                 if (acc->placeAbove()) {

--- a/src/importexport/musicxml/internal/musicxml/importmxmlnotepitch.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlnotepitch.cpp
@@ -51,9 +51,11 @@ static Accidental* accidental(XmlStreamReader& e, Score* score)
     const bool cautionary = e.asciiAttribute("cautionary") == "yes";
     const bool editorial = e.asciiAttribute("editorial") == "yes";
     const bool parentheses = e.asciiAttribute("parentheses") == "yes";
+    const bool noParentheses = e.asciiAttribute("parentheses") == "no";
     const bool brackets = e.asciiAttribute("bracket") == "yes";
+    const bool noBrackets = e.asciiAttribute("bracket") == "no";
     const Color accColor = Color(e.asciiAttribute("color").ascii());
-    String smufl = e.attribute("smufl");
+    const String smufl = e.attribute("smufl");
 
     const String s = e.readText();
     const AccidentalType type = mxmlString2accidentalType(s, smufl);
@@ -61,12 +63,14 @@ static Accidental* accidental(XmlStreamReader& e, Score* score)
     if (type != AccidentalType::NONE) {
         auto a = Factory::createAccidental(score->dummy());
         a->setAccidentalType(type);
-        if (cautionary || parentheses) {
+        if (cautionary || editorial) { // no way to tell one from the other
+            a->setRole(AccidentalRole::USER);
+        } // except via the use of parentheses vs. brackets
+        if (noParentheses || noBrackets) { // explicitly none wanted
+        } else if (parentheses || cautionary) { // set to "yes" or "cautionary" and not set at all
             a->setBracket(AccidentalBracket(AccidentalBracket::PARENTHESIS));
-            a->setRole(AccidentalRole::USER);
-        } else if (editorial || brackets) {
+        } else if (brackets || editorial) { // set to "yes" or "editorial" and not set at all
             a->setBracket(AccidentalBracket(AccidentalBracket::BRACKET));
-            a->setRole(AccidentalRole::USER);
         }
         if (accColor.isValid()) {
             a->setColor(accColor);
@@ -74,7 +78,7 @@ static Accidental* accidental(XmlStreamReader& e, Score* score)
         return a;
     }
 
-    return 0;
+    return nullptr;
 }
 
 //---------------------------------------------------------

--- a/src/importexport/musicxml/tests/data/testAccidentals3.xml
+++ b/src/importexport/musicxml/tests/data/testAccidentals3.xml
@@ -114,7 +114,7 @@
         <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <accidental>natural</accidental>
+        <accidental cautionary="yes" parentheses="no">natural</accidental>
         <stem>up</stem>
         </note>
       <note>
@@ -126,7 +126,7 @@
         <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <accidental>flat</accidental>
+        <accidental cautionary="yes" parentheses="no">flat</accidental>
         <stem>up</stem>
         </note>
       <note>

--- a/src/importexport/musicxml/tests/data/testCueGraceNotes_ref.xml
+++ b/src/importexport/musicxml/tests/data/testCueGraceNotes_ref.xml
@@ -691,7 +691,7 @@
         <duration>2</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <accidental>natural</accidental>
+        <accidental cautionary="yes" parentheses="no">natural</accidental>
         <stem>down</stem>
         </note>
       <note>

--- a/src/importexport/musicxml/tests/data/testIncompleteTuplet_ref.xml
+++ b/src/importexport/musicxml/tests/data/testIncompleteTuplet_ref.xml
@@ -108,7 +108,7 @@
         <duration>107</duration>
         <voice>1</voice>
         <type>16th</type>
-        <accidental>flat</accidental>
+        <accidental cautionary="yes" parentheses="no">flat</accidental>
         <time-modification>
           <actual-notes>9</actual-notes>
           <normal-notes>8</normal-notes>
@@ -127,7 +127,7 @@
         <duration>107</duration>
         <voice>1</voice>
         <type>16th</type>
-        <accidental>flat</accidental>
+        <accidental cautionary="yes" parentheses="no">flat</accidental>
         <time-modification>
           <actual-notes>9</actual-notes>
           <normal-notes>8</normal-notes>
@@ -180,7 +180,7 @@
         <duration>107</duration>
         <voice>1</voice>
         <type>16th</type>
-        <accidental>flat</accidental>
+        <accidental cautionary="yes" parentheses="no">flat</accidental>
         <time-modification>
           <actual-notes>9</actual-notes>
           <normal-notes>8</normal-notes>
@@ -198,7 +198,7 @@
         <duration>107</duration>
         <voice>1</voice>
         <type>16th</type>
-        <accidental>natural</accidental>
+        <accidental cautionary="yes" parentheses="no">natural</accidental>
         <time-modification>
           <actual-notes>9</actual-notes>
           <normal-notes>8</normal-notes>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -123,7 +123,7 @@ MasterScore* Musicxml_Tests::readScore(const String& fileName, bool isAbsolutePa
 bool Musicxml_Tests::saveCompareMusicXmlScore(MasterScore* score, const String& saveName, const String& compareWithLocalPath)
 {
     EXPECT_TRUE(saveXml(score, saveName));
-    return ScoreComp::compareFiles(saveName,  ScoreRW::rootPath() + u"/" + compareWithLocalPath);
+    return ScoreComp::compareFiles(ScoreRW::rootPath() + u"/" + compareWithLocalPath, saveName);
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: #21847

Came via https://musescore.org/en/node/361415

Fixes a Mu3 regression (sort of: that ignored brackets altogether, knows only about parentheses, but even then ignores the 'no')