### PR TITLE
Set spanner position by checking totalY

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -3064,8 +3064,12 @@ void MusicXMLParserDirection::direction(const String& partId,
         } else {
             String spannerPlacement = placement;
             // Case-based defaults
-            if (spannerPlacement.empty() && desc.sp->isHairpin()) {
-                spannerPlacement = isVocalStaff ? u"above" : u"below";
+            if (spannerPlacement.empty()) {
+                if (desc.sp->isHairpin()) {
+                    spannerPlacement = isVocalStaff ? u"above" : u"below";
+                } else {
+                    spannerPlacement = totalY() < 0 ? u"above" : u"below";
+                }
             }
             if (spdesc.isStopped) {
                 m_pass2.addSpanner(desc);


### PR DESCRIPTION
This makes spanner's placement consistent with other `direction` elements.  If the total Y offset is less than 0, we place the direction above the stave (as 0 represents the top of the stave), else we place it below.