### PR TITLE
Fix #20718: Prevent crash when adding time signature before instrument change (Master)

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3267,7 +3267,7 @@ void Score::deleteAnnotationsFromRange(Segment* s1, Segment* s2, track_idx_t tra
                 if (!filter.canSelect(annotation)) {
                     continue;
                 }
-                if (!annotation->systemFlag() && annotation->track() == track && !(annotation->type() == ElementType::INSTRUMENT_CHANGE)) {
+                if (!annotation->systemFlag() && annotation->track() == track) {
                     deleteItem(annotation);
                 }
             }


### PR DESCRIPTION
Resolves: #20718

The fact that instrument changes survive range deletions looks to be an unintended side effect of [this commit](https://github.com/musescore/MuseScore/commit/9c6dbce56c4225032721ce2f6e5514182ee757a6).

Something else I discovered while investigating; it also introduced the behaviour shown in the video below (notes remain audible despite deletion).

https://github.com/musescore/MuseScore/assets/47119327/f7a8f76c-99df-4c41-9133-1d4f7f7669c5

