### PR TITLE
Fix #20718: Prevent crash when adding time signature before instrument change (4.3.0)

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3257,7 +3257,7 @@ void Score::deleteAnnotationsFromRange(Segment* s1, Segment* s2, track_idx_t tra
                 if (!filter.canSelect(annotation)) {
                     continue;
                 }
-                if (!annotation->systemFlag() && annotation->track() == track && !(annotation->type() == ElementType::INSTRUMENT_CHANGE)) {
+                if (!annotation->systemFlag() && annotation->track() == track) {
                     deleteItem(annotation);
                 }
             }


### PR DESCRIPTION
Resolves: #20718
Master PR: #21845