### PR TITLE
Set lyric position precisely on XML import

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -6269,6 +6269,8 @@ void MusicXMLParserLyric::parse()
     const Color lyricColor = Color::fromString(m_e.asciiAttribute("color").ascii());
     const bool printLyric = m_e.asciiAttribute("print-object") != "no";
     const String placement = m_e.attribute("placement");
+    double relX = m_e.doubleAttribute("relative-x") / 10 * DPMM;
+    double relY = m_e.doubleAttribute("relative-y") / 10 * DPMM;
     String extendType;
     String formattedText;
 
@@ -6326,6 +6328,14 @@ void MusicXMLParserLyric::parse()
     if (!placement.empty()) {
         lyric->setPlacement(placement == "above" ? PlacementV::ABOVE : PlacementV::BELOW);
         lyric->setPropertyFlags(Pid::PLACEMENT, PropertyFlags::UNSTYLED);
+    }
+
+    if (relX != 0 || relY != 0) {
+        PointF offset = lyric->offset();
+        offset.setX(relX != 0 ? relX : lyric->offset().x());
+        offset.setY(relY != 0 ? relY : lyric->offset().y());
+        lyric->setOffset(offset);
+        lyric->setPropertyFlags(Pid::OFFSET, PropertyFlags::UNSTYLED);
     }
 
     const auto l = lyric.release();

--- a/src/importexport/musicxml/tests/data/testCueNotes3_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testCueNotes3_ref.mscx
@@ -148,6 +148,7 @@
           <Chord>
             <durationType>half</durationType>
             <Lyrics>
+              <offset x="0" y="-1.7145"/>
               <text>Whose</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -159,6 +160,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.7145"/>
               <text>broad</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -172,6 +174,7 @@
             <Lyrics>
               <ticks>480</ticks>
               <ticks_f>1/4</ticks_f>
+              <offset x="0" y="-1.7145"/>
               <text>stripes</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -213,6 +216,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.7145"/>
               <text>and</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -226,6 +230,7 @@
             <small>1</small>
             <durationType>16th</durationType>
             <Lyrics>
+              <offset x="0" y="-1.7145"/>
               <text>bright</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -248,6 +253,7 @@
             <small>1</small>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.7145"/>
               <text>stars</text>
               </Lyrics>
             <Articulation>
@@ -273,6 +279,7 @@
             <small>1</small>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.7145"/>
               <text>through</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -287,6 +294,7 @@
           <Chord>
             <durationType>half</durationType>
             <Lyrics>
+              <offset x="0" y="-1.7145"/>
               <text>the</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -304,6 +312,7 @@
             <small>1</small>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.7145"/>
               <text>per'l's</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -331,6 +340,7 @@
             <dots>1</dots>
             <durationType>half</durationType>
             <Lyrics>
+              <offset x="0" y="-1.7145"/>
               <text>fight</text>
               </Lyrics>
             <StemDirection>up</StemDirection>

--- a/src/importexport/musicxml/tests/data/testElision_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testElision_ref.mscx
@@ -137,6 +137,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.7145"/>
               <text>ce<sym>lyricsElision</sym>e<sym>lyricsElision</sym>in</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -148,6 +149,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.7145"/>
               <text>ce‿e in</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -159,6 +161,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.7145"/>
               <text>ce<sym>lyricsElision</sym>e<sym>lyricsElision</sym>in</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -170,6 +173,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.7145"/>
               <text>ce<sym>lyricsElision</sym>e‿in</text>
               </Lyrics>
             <StemDirection>down</StemDirection>

--- a/src/importexport/musicxml/tests/data/testInferredSubtitle_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredSubtitle_ref.mscx
@@ -145,6 +145,7 @@
             <durationType>eighth</durationType>
             <Lyrics>
               <syllabic>begin</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>ha</text>
               </Lyrics>
             <Note>
@@ -156,6 +157,7 @@
             <durationType>eighth</durationType>
             <Lyrics>
               <syllabic>end</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>ha</text>
               </Lyrics>
             <Note>
@@ -176,6 +178,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>nice.</text>
               </Lyrics>
             <StemDirection>up</StemDirection>

--- a/src/importexport/musicxml/tests/data/testLyricBracket_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testLyricBracket_ref.mscx
@@ -145,11 +145,13 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>here</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
               <syllabic>begin</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>surp</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -161,11 +163,13 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>are</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
               <syllabic>end</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>rise</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -177,10 +181,12 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>some</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
+              <offset x="0" y="-1.71429"/>
               <text>there</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -193,10 +199,12 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>begin</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>ly</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
+              <offset x="0" y="-1.71429"/>
               <text>is</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -213,10 +221,12 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>end</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>rics</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
+              <offset x="0" y="-1.71429"/>
               <text>a</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -228,11 +238,13 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>that</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
               <syllabic>begin</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>brack</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -244,11 +256,13 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>end</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
               <syllabic>end</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>et</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -261,10 +275,12 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>begin</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>with</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
+              <offset x="0" y="-1.71429"/>
               <text>in</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -282,10 +298,12 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>end</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>out</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
+              <offset x="0" y="-1.71429"/>
               <text>the</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -297,10 +315,12 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>a</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
+              <offset x="0" y="-1.71429"/>
               <text>X</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -313,10 +333,12 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>begin</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>brack</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
+              <offset x="0" y="-1.71429"/>
               <text>M</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -329,10 +351,12 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>end</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>et</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
+              <offset x="0" y="-1.71429"/>
               <text>L</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -356,6 +380,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>nice</text>
               </Lyrics>
             <StemDirection>up</StemDirection>

--- a/src/importexport/musicxml/tests/data/testLyricPos_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testLyricPos_ref.mscx
@@ -139,6 +139,7 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <placement>above</placement>
+              <offset x="0" y="1.143"/>
               <text>Lyrics</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -151,6 +152,7 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <placement>above</placement>
+              <offset x="0" y="1.143"/>
               <text>above</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -163,6 +165,7 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <placement>above</placement>
+              <offset x="0" y="1.143"/>
               <text>the</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -175,6 +178,7 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <placement>above</placement>
+              <offset x="0" y="1.143"/>
               <text>stave</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -191,6 +195,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.7145"/>
               <text>Lyrics</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -202,6 +207,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.7145"/>
               <text>below</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -213,6 +219,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.7145"/>
               <text>the</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -224,6 +231,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.7145"/>
               <text>stave!</text>
               </Lyrics>
             <StemDirection>down</StemDirection>

--- a/src/importexport/musicxml/tests/data/testPartNames_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPartNames_ref.mscx
@@ -825,6 +825,7 @@
             <Lyrics>
               <ticks>26880</ticks>
               <ticks_f>56/4</ticks_f>
+              <offset x="0" y="-1.7145"/>
               <text>yes!</text>
               </Lyrics>
             <Note>
@@ -1233,6 +1234,7 @@
             <Lyrics>
               <ticks>26880</ticks>
               <ticks_f>56/4</ticks_f>
+              <offset x="0" y="-1.7145"/>
               <text>no</text>
               </Lyrics>
             <Note>

--- a/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
@@ -235,6 +235,7 @@
             <Lyrics>
               <ticks>9600</ticks>
               <ticks_f>20/4</ticks_f>
+              <offset x="0" y="-1.71429"/>
               <text>ahh</text>
               </Lyrics>
             <Note>

--- a/src/importexport/musicxml/tests/data/testSecondVoiceMelismata_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSecondVoiceMelismata_ref.mscx
@@ -146,10 +146,12 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>begin</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>Bo</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
+              <offset x="0" y="-1.71429"/>
               <text>Much</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -162,11 +164,13 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>end</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>ring</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
               <syllabic>begin</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>cool</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -179,6 +183,7 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>begin</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>ly</text>
               </Lyrics>
             <Lyrics>
@@ -186,6 +191,7 @@
               <syllabic>end</syllabic>
               <ticks>960</ticks>
               <ticks_f>8/16</ticks_f>
+              <offset x="0" y="-1.71429"/>
               <text>er</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -198,6 +204,7 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>end</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>rics</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -225,6 +232,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>on</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -236,6 +244,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>the</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -247,6 +256,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>first</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -271,6 +281,7 @@
             <Lyrics>
               <no>1</no>
               <syllabic>begin</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>ly</text>
               </Lyrics>
             </Rest>
@@ -280,6 +291,7 @@
             <Lyrics>
               <no>1</no>
               <syllabic>end</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>rics</text>
               </Lyrics>
             </Rest>
@@ -294,6 +306,7 @@
           <Chord>
             <durationType>half</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>line</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -344,6 +357,7 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>begin</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>place</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -361,6 +375,7 @@
               <syllabic>end</syllabic>
               <ticks>960</ticks>
               <ticks_f>2/4</ticks_f>
+              <offset x="0" y="-1.71429"/>
               <text>ment's</text>
               </Lyrics>
             <StemDirection>down</StemDirection>

--- a/src/importexport/musicxml/tests/data/testTextOrder_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTextOrder_ref.mscx
@@ -167,6 +167,7 @@
             <BeamMode>begin</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>glare</text>
               </Lyrics>
             <Note>
@@ -178,6 +179,7 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>The</text>
               </Lyrics>
             <Note>
@@ -189,6 +191,7 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>bombs</text>
               </Lyrics>
             <Note>
@@ -200,6 +203,7 @@
             <durationType>16th</durationType>
             <Lyrics>
               <syllabic>begin</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>burst</text>
               </Lyrics>
             <Note>
@@ -217,6 +221,7 @@
             <durationType>16th</durationType>
             <Lyrics>
               <syllabic>end</syllabic>
+              <offset x="0" y="-1.71429"/>
               <text>ing</text>
               </Lyrics>
             <Note>
@@ -228,6 +233,7 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>in</text>
               </Lyrics>
             <Note>
@@ -239,6 +245,7 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>air</text>
               </Lyrics>
             <Note>
@@ -249,6 +256,7 @@
           <Chord>
             <durationType>16th</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>gave</text>
               </Lyrics>
             <Note>
@@ -269,6 +277,7 @@
             <BeamMode>begin</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>proof</text>
               </Lyrics>
             <Note>
@@ -280,6 +289,7 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>through</text>
               </Lyrics>
             <Note>
@@ -294,6 +304,7 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>the</text>
               </Lyrics>
             <Note>
@@ -304,6 +315,7 @@
           <Chord>
             <durationType>16th</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>night</text>
               </Lyrics>
             <Note>
@@ -326,6 +338,7 @@
             <BeamMode>begin</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>that</text>
               </Lyrics>
             <Note>
@@ -337,6 +350,7 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>our</text>
               </Lyrics>
             <Note>
@@ -351,6 +365,7 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>SWAG</text>
               </Lyrics>
             <Note>
@@ -361,6 +376,7 @@
           <Chord>
             <durationType>16th</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>was</text>
               </Lyrics>
             <Note>
@@ -381,6 +397,7 @@
             <BeamMode>begin</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>still</text>
               </Lyrics>
             <Note>
@@ -392,6 +409,7 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>there</text>
               </Lyrics>
             <Note>
@@ -403,6 +421,7 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>oh</text>
               </Lyrics>
             <Note>
@@ -413,6 +432,7 @@
           <Chord>
             <durationType>16th</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>say</text>
               </Lyrics>
             <Note>
@@ -424,6 +444,7 @@
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>does</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -455,6 +476,7 @@
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>that</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -482,6 +504,7 @@
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <Lyrics>
+              <offset x="0" y="-1.71429"/>
               <text>star</text>
               </Lyrics>
             <StemDirection>down</StemDirection>


### PR DESCRIPTION
This PR sets lyric placement based on the the `relative-x` and `relative-y` values in the XML file.  This mostly has the advantage of preserving placement of lyrics attached to grace notes more accurately.  In the screenshot below, the lyrics are read, attached to the B, and then their position moved to the left to be under the grace notes.
<img width="363" alt="Screenshot 2024-03-08 at 09 08 08" src="https://github.com/musescore/MuseScore/assets/26510874/c13078ee-06ba-4482-8f02-491e260bbd21">
