### PR TITLE
Fix Time Signature height in New Score Dialog

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/NewScore/TimeSignatureView.qml
+++ b/src/project/qml/MuseScore/Project/internal/NewScore/TimeSignatureView.qml
@@ -53,6 +53,7 @@ Item {
                 StyledIconLabel {
                     font.family: ui.theme.musicalFont.family
                     font.pixelSize: 60
+                    height: 30
                     lineHeightMode: Text.FixedHeight
                     lineHeight: 30
                     iconCode: modelData
@@ -70,6 +71,7 @@ Item {
                 StyledIconLabel {
                     font.family: ui.theme.musicalFont.family
                     font.pixelSize: 60
+                    height: 30
                     lineHeightMode: Text.FixedHeight
                     lineHeight: 30
                     iconCode: modelData


### PR DESCRIPTION
Resolves: #21871 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Setting the height of `StyledIconLabel` should fix it

![Screenshot_2024-03-10_18-01-01](https://github.com/musescore/MuseScore/assets/105774228/da1cc1ac-2554-498a-91f7-b023862c5d9c)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
