### PR TITLE
Fix spanner disappearing from closed parts

### DIFF
--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -1115,19 +1115,6 @@ void Excerpt::cloneStaves(Score* sourceScore, Score* dstScore, const std::vector
             dstTrack  = 0;
             dstTrack2 = 0;
             cloneSpanner(s, dstScore, dstTrack, dstTrack2);
-        } else if (s->isHairpin()) {
-            //always export these spanners to first voice of the destination staff
-
-            std::vector<track_idx_t> track1;
-            for (track_idx_t ii = s->track(); ii < s->track() + VOICES; ii++) {
-                mu::join(track1, mu::values(trackList, ii));
-            }
-
-            for (track_idx_t track : track1) {
-                if (!(track % VOICES)) {
-                    cloneSpanner(s, dstScore, track, track);
-                }
-            }
         } else {
             if (mu::value(trackList, s->track(), mu::nidx) == mu::nidx
                 || mu::value(trackList, s->track2(), mu::nidx) == mu::nidx) {

--- a/src/engraving/dom/range.cpp
+++ b/src/engraving/dom/range.cpp
@@ -750,16 +750,12 @@ bool ScoreRange::write(Score* score, const Fraction& tick) const
                 size_t idx = sc->graceIndex();
                 Chord* dc = toChord(score->findCR(s->tick(), s->track()));
                 s->setStartElement(dc->graceNotes()[idx]);
-            } else {
-                s->setStartElement(0);
             }
             if (slur->endCR() && slur->endCR()->isGrace()) {
                 Chord* sc = slur->endChord();
                 size_t idx = sc->graceIndex();
                 Chord* dc = toChord(score->findCR(s->tick2(), s->track2()));
                 s->setEndElement(dc->graceNotes()[idx]);
-            } else {
-                s->setEndElement(0);
             }
         }
         score->undoAddElement(s);

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -694,11 +694,6 @@ void Segment::add(EngravingItem* el)
                     measure()->setHasVoices(track / VOICES, true);
                 }
             }
-            // the tick position of a tuplet is the tick position of its
-            // first element:
-//                  ChordRest* cr = toChordRest(el);
-//                  if (cr->tuplet() && !cr->tuplet()->elements().empty() && cr->tuplet()->elements().front() == cr && cr->tuplet()->tick() < 0)
-//                        cr->tuplet()->setTick(cr->tick());
             score()->setPlaylistDirty();
         }
     // fall through

--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -3109,6 +3109,9 @@ static void readStaffContent206(Score* score, XmlReader& e, ReadContext& ctx)
                 measure->checkMeasure(staff);
                 if (!measure->isMMRest()) {
                     score->measures()->add(measure);
+                    if (m && m->mmRest()) {
+                        m->mmRest()->setNext(measure);
+                    }
                     ctx.setLastMeasure(measure);
                     ctx.setTick(measure->endTick());
                 } else {
@@ -3119,6 +3122,7 @@ static void readStaffContent206(Score* score, XmlReader& e, ReadContext& ctx)
                     if (lm) {
                         lm->setMMRest(measure);
                         measure->setTick(lm->tick());
+                        measure->setPrev(lm->prev());
                     }
                 }
             } else if (tag == "HBox" || tag == "VBox" || tag == "TBox" || tag == "FBox") {

--- a/src/engraving/rw/read400/staffrw.cpp
+++ b/src/engraving/rw/read400/staffrw.cpp
@@ -63,6 +63,9 @@ void StaffRead::readStaff(Score* score, XmlReader& e, ReadContext& ctx)
                 measure->checkMeasure(staff);
                 if (!measure->isMMRest()) {
                     score->measures()->add(measure);
+                    if (m && m->mmRest()) {
+                        m->mmRest()->setNext(measure);
+                    }
                     score->checkSpanner(ctx.tick(), ctx.tick() + measure->ticks(), /*removeOrphans*/ false);
                     ctx.setLastMeasure(measure);
                     ctx.setTick(measure->tick() + measure->ticks());
@@ -74,6 +77,7 @@ void StaffRead::readStaff(Score* score, XmlReader& e, ReadContext& ctx)
                     if (m1) {
                         m1->setMMRest(measure);
                         measure->setTick(m1->tick());
+                        measure->setPrev(m1->prev());
                     }
                 }
             } else if (tag == "HBox" || tag == "VBox" || tag == "TBox" || tag == "FBox") {

--- a/src/engraving/rw/read410/staffread.cpp
+++ b/src/engraving/rw/read410/staffread.cpp
@@ -63,6 +63,9 @@ void StaffRead::readStaff(Score* score, XmlReader& e, ReadContext& ctx)
                 measure->checkMeasure(staff);
                 if (!measure->isMMRest()) {
                     score->measures()->add(measure);
+                    if (m && m->mmRest()) {
+                        m->mmRest()->setNext(measure);
+                    }
                     score->checkSpanner(ctx.tick(), ctx.tick() + measure->ticks(), /*removeOrphans*/ false);
                     ctx.setLastMeasure(measure);
                     ctx.setTick(measure->tick() + measure->ticks());
@@ -74,6 +77,7 @@ void StaffRead::readStaff(Score* score, XmlReader& e, ReadContext& ctx)
                     if (m1) {
                         m1->setMMRest(measure);
                         measure->setTick(m1->tick());
+                        measure->setPrev(m1->prev());
                     }
                 }
             } else if (tag == "HBox" || tag == "VBox" || tag == "TBox" || tag == "FBox") {

--- a/src/engraving/rw/write/connectorinfowriter.cpp
+++ b/src/engraving/rw/write/connectorinfowriter.cpp
@@ -105,11 +105,13 @@ SpannerWriter::SpannerWriter(XmlWriter& xml, WriteContext* ctx, const EngravingI
     : ConnectorInfoWriter(xml, ctx, current, sp, track, frac)
 {
     const bool clipboardmode = ctx->clipboardmode();
-    if (!sp->startElement() || !sp->endElement()) {
+    if ((!sp->startElement() || !sp->endElement())
+        && (sp->anchor() == Spanner::Anchor::CHORD || sp->anchor() == Spanner::Anchor::NOTE)) {
         LOGW("SpannerWriter: spanner (%s) doesn't have an endpoint!", sp->typeName());
         return;
     }
-    if (current->isMeasure() || current->isSegment() || (sp->startElement()->type() != current->type())) {
+    if (current->isMeasure() || current->isSegment() || !sp->startElement() || !sp->endElement()
+        || (sp->startElement()->type() != current->type())) {
         // (The latter is the hairpins' case, for example, though they are
         // covered by the other checks too.)
         // We cannot determine position of the spanner from its start/end

--- a/src/importexport/musicxml/tests/data/testBackupRoundingError_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBackupRoundingError_ref.mscx
@@ -1759,6 +1759,14 @@
             <fractions>-1/8</fractions>
             </location>
           <Spanner type="Pedal">
+            <Pedal>
+              <endHookType>1</endHookType>
+              </Pedal>
+            <next>
+              <location>
+                <fractions>1/8</fractions>
+                </location>
+              </next>
             </Spanner>
           <location>
             <fractions>1/8</fractions>
@@ -1768,6 +1776,11 @@
             <placement>below</placement>
             </Fermata>
           <Spanner type="Pedal">
+            <prev>
+              <location>
+                <fractions>-1/8</fractions>
+                </location>
+              </prev>
             </Spanner>
           <Chord>
             <durationType>quarter</durationType>


### PR DESCRIPTION
Resolves: #21286  Specifically, the cases reproduced in [this comment](https://github.com/musescore/MuseScore/issues/21286#issuecomment-1979368122), and [this comment](https://github.com/musescore/MuseScore/issues/21286#issuecomment-1986446190).
Resolves: #19852  (and hopefully many other similar issues reported without clear steps for reproducing)

It seems that the whole problem (for hairpins and other lines) was caused by an error in reading part scores with multi measure rests. This error was masked in previous version because it gets corrected during layout, but since 4.0 we do not layout closed parts to avoid waste of performance, so the error came up. As far as I can tell, this seems to fix it.

The problem with slurs was more involved (and also used to be masked in previous versions for the same reasons).
