### PR TITLE
fixed #21844: Shift + Tab skips left panel tabs when right panel is open 

### DIFF
--- a/src/appshell/view/dockwindow/dockpageview.cpp
+++ b/src/appshell/view/dockwindow/dockpageview.cpp
@@ -292,7 +292,7 @@ void DockPageView::reorderDocksNavigationSections(QList<DockBase*>& docks)
             continue;
         }
 
-        ui::INavigationSection* section = panel ? panel->section() : nullptr;
+        ui::INavigationSection* section = panel->section();
         if (section && !orderedSections.contains(section)) {
             auto index = section->index();
             index.setOrder(i++);

--- a/src/appshell/view/dockwindow/internal/dockbase.cpp
+++ b/src/appshell/view/dockwindow/internal/dockbase.cpp
@@ -468,7 +468,7 @@ void DockBase::setFramePanelOrder(int order)
         return;
     }
 
-    if (!frame->beingDeletedLater()) {
+    if (frame->beingDeletedLater()) {
         return;
     }
 


### PR DESCRIPTION
Resolves: #21844