### PR TITLE
Allow MIDI pedal events to start at the same tick as their starting note

### DIFF
--- a/src/engraving/compat/midi/compatmidirenderinternal.cpp
+++ b/src/engraving/compat/midi/compatmidirenderinternal.cpp
@@ -1115,7 +1115,7 @@ void CompatMidiRendererInternal::doRenderSpanners(EventsHolder& events, Spanner*
             pedalEventList.emplace(pedalEventList.cend() - 1,
                                    st + (2 - pedalEventsMinTicks), false, staffIdx);
         }
-        int a = st + 2;
+        int a = st + (3 - pedalEventsMinTicks);
         pedalEventList.emplace_back(a, true, staffIdx);
 
         int t = s->tick2().ticks() + (2 - pedalEventsMinTicks);

--- a/src/engraving/compat/midi/compatmidirenderinternal.cpp
+++ b/src/engraving/compat/midi/compatmidirenderinternal.cpp
@@ -64,6 +64,8 @@
 #include "dom/vibrato.h"
 #include "dom/volta.h"
 
+#include "importexport/midi/imidiconfiguration.h"
+
 #include "log.h"
 
 namespace mu::engraving {
@@ -1099,6 +1101,7 @@ void CompatMidiRendererInternal::doRenderSpanners(EventsHolder& events, Spanner*
 
     if (s->isPedal()) {
         PedalEvent lastEvent;
+        int pedalEventsMinTicks = midiImportExportConfiguration()->pedalEventsMinTicks();
 
         if (!pedalEventList.empty()) {
             lastEvent = pedalEventList.back();
@@ -1110,12 +1113,12 @@ void CompatMidiRendererInternal::doRenderSpanners(EventsHolder& events, Spanner*
 
         if (!lastEvent.on && lastEvent.tick >= (st + 2)) {
             pedalEventList.emplace(pedalEventList.cend() - 1,
-                                   st + (2 - MScore::pedalEventsMinTicks), false, staffIdx);
+                                   st + (2 - pedalEventsMinTicks), false, staffIdx);
         }
         int a = st + 2;
         pedalEventList.emplace_back(a, true, staffIdx);
 
-        int t = s->tick2().ticks() + (2 - MScore::pedalEventsMinTicks);
+        int t = s->tick2().ticks() + (2 - pedalEventsMinTicks);
         const RepeatSegment& lastRepeat = *score->repeatList().back();
         if (t > lastRepeat.utick + lastRepeat.len()) {
             t = lastRepeat.utick + lastRepeat.len();

--- a/src/engraving/compat/midi/compatmidirenderinternal.h
+++ b/src/engraving/compat/midi/compatmidirenderinternal.h
@@ -33,6 +33,8 @@
 #include "pausemap.h"
 #include "velocitymap.h"
 
+#include "importexport/midi/imidiconfiguration.h"
+
 namespace mu::engraving {
 class EventsHolder;
 class MasterScore;
@@ -120,6 +122,8 @@ static const std::vector<OrnamentExcursion> excursions = {
 
 class CompatMidiRendererInternal
 {
+    INJECT(iex::midi::IMidiImportExportConfiguration, midiImportExportConfiguration)
+
 public:
 
     //! @brief helper structure to find channel

--- a/src/engraving/dom/mscore.cpp
+++ b/src/engraving/dom/mscore.cpp
@@ -57,7 +57,6 @@ double MScore::horizontalPageGapOdd = 50.0;
 
 bool MScore::warnPitchRange;
 bool MScore::warnGuitarBends;
-int MScore::pedalEventsMinTicks;
 
 double MScore::nudgeStep;
 double MScore::nudgeStep10;

--- a/src/engraving/dom/mscore.h
+++ b/src/engraving/dom/mscore.h
@@ -210,7 +210,6 @@ public:
 
     static bool warnPitchRange;
     static bool warnGuitarBends;
-    static int pedalEventsMinTicks;
 
     static double nudgeStep;
     static double nudgeStep10;

--- a/src/engraving/engravingmodule.cpp
+++ b/src/engraving/engravingmodule.cpp
@@ -307,7 +307,6 @@ void EngravingModule::onInit(const IApplication::RunMode& mode)
     MScore::defaultPlayDuration = 300;            // ms
     MScore::warnPitchRange      = true;
     MScore::warnGuitarBends     = true;
-    MScore::pedalEventsMinTicks = 1;
 
     Drumset::initDrumset();
     FiguredBass::readConfigFile(String());

--- a/src/importexport/midi/imidiconfiguration.h
+++ b/src/importexport/midi/imidiconfiguration.h
@@ -47,6 +47,9 @@ public:
 
     virtual bool isMidiExportRpns() const = 0;
     virtual void setIsMidiExportRpns(bool exportRpns) = 0;
+
+    virtual int pedalEventsMinTicks() const = 0;
+    virtual void setpedalEventsMinTicks(int minTicks) = 0;
 };
 }
 

--- a/src/importexport/midi/internal/midiconfiguration.cpp
+++ b/src/importexport/midi/internal/midiconfiguration.cpp
@@ -34,12 +34,17 @@ using namespace mu::iex::midi;
 static const Settings::Key SHORTEST_NOTE_KEY("iex_midi", "io/midi/shortestNote");
 static const Settings::Key EXPORTRPNS_KEY("iex_midi", "io/midi/exportRPNs");
 static const Settings::Key EXPAND_REPEATS_KEY("iex_midi", "io/midi/expandRepeats");
+static const Settings::Key PEDAL_EVENTS_MIN_TICKS_KEY("iex_midi", "io/midi/pedalEventsMinTicks");
 
 void MidiConfiguration::init()
 {
     settings()->setDefaultValue(SHORTEST_NOTE_KEY, Val(mu::engraving::Constants::DIVISION / 4));
     settings()->setDefaultValue(EXPAND_REPEATS_KEY, Val(true));
     settings()->setDefaultValue(EXPORTRPNS_KEY, Val(true));
+
+    settings()->setDefaultValue(PEDAL_EVENTS_MIN_TICKS_KEY, Val(1));
+    settings()->setDescription(PEDAL_EVENTS_MIN_TICKS_KEY, muse::trc("iex_midi", "Min. tick value for pedal events"));
+    settings()->setCanBeManuallyEdited(PEDAL_EVENTS_MIN_TICKS_KEY, true);
 }
 
 int MidiConfiguration::midiShortestNote() const
@@ -77,4 +82,14 @@ bool MidiConfiguration::isMidiExportRpns() const
 void MidiConfiguration::setIsMidiExportRpns(bool exportRpns)
 {
     settings()->setSharedValue(EXPORTRPNS_KEY, Val(exportRpns));
+}
+
+int MidiConfiguration::pedalEventsMinTicks() const
+{
+    return settings()->value(PEDAL_EVENTS_MIN_TICKS_KEY).toInt();
+}
+
+void MidiConfiguration::setpedalEventsMinTicks(int minTicks)
+{
+    settings()->setSharedValue(PEDAL_EVENTS_MIN_TICKS_KEY, Val(minTicks));
 }

--- a/src/importexport/midi/internal/midiconfiguration.h
+++ b/src/importexport/midi/internal/midiconfiguration.h
@@ -43,6 +43,9 @@ public:
 
     bool isMidiExportRpns() const override;
     void setIsMidiExportRpns(bool exportRpns) override;
+
+    int pedalEventsMinTicks() const override;
+    void setpedalEventsMinTicks(int minTicks) override;
 };
 }
 


### PR DESCRIPTION
1. Add back Mu3 advanced property io/midi/pedaleventsminticks
2. Change one line in compatmidirenderinternal.cpp to use it too. To me looks like an ommision that it didn't earlier

Now setting it to 3 resolves: https://musescore.org/en/node/361768
As long as that value doesn't get manually changed the code behaves exactly as before, no risk at all.

This images shows that pedal event with a 2 ticks offset, before my change (and even after, unless that value gets changed):
![20240313_133110](https://github.com/musescore/MuseScore/assets/1786669/747ddfed-c758-4e93-a800-f0c77db9fbfe)
