### PR TITLE
Improve MusicXML articulations <-> SymId conversion

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -3066,8 +3066,6 @@ static std::vector<String> symIdToArtic(const SymId sid)
         return { u"staccato" };
         break;
 
-    case SymId::articStaccatissimoAbove:
-    case SymId::articStaccatissimoBelow:
     case SymId::articStaccatissimoWedgeAbove:
     case SymId::articStaccatissimoWedgeBelow:
         return { u"staccatissimo" };
@@ -3138,6 +3136,8 @@ static std::vector<String> symIdToArtic(const SymId sid)
         return { u"tenuto", u"accent" };
         break;
 
+    case SymId::articStaccatissimoAbove:
+    case SymId::articStaccatissimoBelow:
     case SymId::articStaccatissimoStrokeAbove:
     case SymId::articStaccatissimoStrokeBelow:
         return { u"spiccato" };

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -1216,7 +1216,7 @@ static bool convertArticulationToSymId(const String& mxmlName, SymId& id)
     static std::map<String, SymId> map;         // map MusicXML articulation name to MuseScore symbol
     if (map.empty()) {
         map[u"accent"]           = SymId::articAccentAbove;
-        map[u"staccatissimo"]    = SymId::articStaccatissimoAbove;
+        map[u"staccatissimo"]    = SymId::articStaccatissimoWedgeAbove;
         map[u"staccato"]         = SymId::articStaccatoAbove;
         map[u"tenuto"]           = SymId::articTenutoAbove;
         map[u"strong-accent"]    = SymId::articMarcatoAbove;
@@ -1227,7 +1227,7 @@ static bool convertArticulationToSymId(const String& mxmlName, SymId& id)
         map[u"up-bow"]           = SymId::stringsUpBow;
         map[u"down-bow"]         = SymId::stringsDownBow;
         map[u"detached-legato"]  = SymId::articTenutoStaccatoAbove;
-        map[u"spiccato"]         = SymId::articStaccatissimoStrokeAbove;
+        map[u"spiccato"]         = SymId::articStaccatissimoAbove;
         map[u"snap-pizzicato"]   = SymId::pluckedSnapPizzicatoAbove;
         map[u"schleifer"]        = SymId::ornamentPrecompSlide;
         map[u"open"]             = SymId::brassMuteOpen;


### PR DESCRIPTION
to match the images on the MusicXML spec website

See https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/spiccato/ and https://w3c.github.io/smufl/latest/tables/articulation.html

The MusicXML documentation says that "spiccato" should be a stroke articulation rather than a wedge. The accompanying image is actually SMuFL's `SymId::articStaccatissimoAbove` rather than `SymId::articStaccatissimoStrokeAbove`, so let's import it as the former.
Both symbols are exported to "spiccato".

The "staccatissimo" articulation on the other hand should specifically be a wedge, so let's have a one-to-one mapping between "staccatissimo" and `SymId::articStaccatissimoWedgeAbove`.

@rettinghaus Does this make sense to you?