### PR TITLE
Fixes to tremolo resets (#21811)

### DIFF
--- a/src/engraving/dom/tremolosinglechord.cpp
+++ b/src/engraving/dom/tremolosinglechord.cpp
@@ -200,9 +200,9 @@ void TremoloSingleChord::computeShape()
 
 void TremoloSingleChord::reset()
 {
+    EngravingItem::reset();
     undoChangeProperty(Pid::STEM_DIRECTION, DirectionV::AUTO);
     resetProperty(Pid::BEAM_NO_SLOPE);
-    setGenerated(true);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/tremolotwochord.cpp
+++ b/src/engraving/dom/tremolotwochord.cpp
@@ -178,13 +178,13 @@ void TremoloTwoChord::setTremoloType(TremoloType t)
 
 void TremoloTwoChord::reset()
 {
+    EngravingItem::reset();
     if (userModified()) {
         //undoChangeProperty(Pid::BEAM_POS, PropertyValue::fromValue(beamPos()));
         undoChangeProperty(Pid::USER_MODIFIED, false);
     }
     undoChangeProperty(Pid::STEM_DIRECTION, DirectionV::AUTO);
     resetProperty(Pid::BEAM_NO_SLOPE);
-    setGenerated(true);
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: #21811

While investigating the above issue I also found that manually offset tremolos were not being reset to their original positions, this has been addressed in this PR.