### PR TITLE
Add Braille panel to View menu and assign Alt+F11 shortcut

### DIFF
--- a/src/appshell/appshelltypes.h
+++ b/src/appshell/appshelltypes.h
@@ -35,6 +35,7 @@ static const DockName INSPECTOR_PANEL_NAME("inspectorPanel");
 static const DockName SELECTION_FILTERS_PANEL_NAME("selectionFiltersPanel");
 
 static const DockName NOTATION_NAVIGATOR_PANEL_NAME("notationNavigatorPanel");
+static const DockName NOTATION_BRAILLE_PANEL_NAME("notationBraillePanel");
 
 static const DockName MIXER_PANEL_NAME("mixerPanel");
 static const DockName PIANO_KEYBOARD_PANEL_NAME("pianoKeyboardPanel");

--- a/src/appshell/internal/applicationuiactions.cpp
+++ b/src/appshell/internal/applicationuiactions.cpp
@@ -36,6 +36,7 @@ using namespace mu::dock;
 
 static const ActionCode FULL_SCREEN_CODE("fullscreen");
 static const ActionCode TOGGLE_NAVIGATOR_ACTION_CODE("toggle-navigator");
+static const ActionCode TOGGLE_BRAILLE_ACTION_CODE("toggle-braille-panel");
 
 const UiActionList ApplicationUiActions::m_actions = {
     UiAction("quit",
@@ -152,6 +153,15 @@ const UiActionList ApplicationUiActions::m_actions = {
              Checkable::Yes
              ),
 
+    // Braille panel
+    UiAction(TOGGLE_BRAILLE_ACTION_CODE,
+             mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             TranslatableString("action", "&Braille"),
+             TranslatableString("action", "Show/hide braille panel"),
+             Checkable::Yes
+             ),
+
     // Horizontal panels
     UiAction("toggle-timeline",
              mu::context::UiCtxNotationOpened,
@@ -214,6 +224,10 @@ void ApplicationUiActions::init()
         m_actionCheckedChanged.send({ TOGGLE_NAVIGATOR_ACTION_CODE });
     });
 
+    brailleConfiguration()->braillePanelEnabledChanged().onNotify(this, [this]() {
+        m_actionCheckedChanged.send({ TOGGLE_BRAILLE_ACTION_CODE });
+    });
+
     dockWindowProvider()->windowChanged().onNotify(this, [this]() {
         listenOpenedDocksChanged(dockWindowProvider()->window());
     });
@@ -273,6 +287,10 @@ bool ApplicationUiActions::actionChecked(const UiAction& act) const
         return configuration()->isNotationNavigatorVisible();
     }
 
+    if (dockName == NOTATION_BRAILLE_PANEL_NAME) {
+        return brailleConfiguration()->braillePanelEnabled();
+    }
+
     const IDockWindow* window = dockWindowProvider()->window();
     return window ? window->isDockOpen(dockName) : false;
 }
@@ -299,6 +317,7 @@ const QMap<mu::actions::ActionCode, DockName>& ApplicationUiActions::toggleDockA
         { "toggle-selection-filter", SELECTION_FILTERS_PANEL_NAME },
 
         { TOGGLE_NAVIGATOR_ACTION_CODE, NOTATION_NAVIGATOR_PANEL_NAME },
+        { TOGGLE_BRAILLE_ACTION_CODE, NOTATION_BRAILLE_PANEL_NAME },
 
         { "toggle-timeline", TIMELINE_PANEL_NAME },
         { "toggle-mixer", MIXER_PANEL_NAME },

--- a/src/appshell/internal/applicationuiactions.h
+++ b/src/appshell/internal/applicationuiactions.h
@@ -28,6 +28,7 @@
 #include "context/iuicontextresolver.h"
 #include "async/asyncable.h"
 #include "ui/imainwindow.h"
+#include "view/preferences/braillepreferencesmodel.h"
 
 #include "view/dockwindow/idockwindowprovider.h"
 
@@ -37,6 +38,7 @@ class ApplicationUiActions : public ui::IUiActionsModule, public async::Asyncabl
     INJECT(ui::IMainWindow, mainWindow)
     INJECT(dock::IDockWindowProvider, dockWindowProvider)
     INJECT(IAppShellConfiguration, configuration)
+    INJECT(braille::IBrailleConfiguration, brailleConfiguration)
 
 public:
     ApplicationUiActions(std::shared_ptr<ApplicationActionController> controller);

--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -194,6 +194,7 @@ MenuItem* AppMenuModel::makeViewMenu()
         makeMenuItem("inspector"),
         makeMenuItem("toggle-selection-filter"),
         makeMenuItem("toggle-navigator"),
+        makeMenuItem("toggle-braille-panel"),
         makeMenuItem("toggle-timeline"),
         makeMenuItem("toggle-mixer"),
         makeMenuItem("toggle-piano-keyboard"),

--- a/src/appshell/view/notationpagemodel.cpp
+++ b/src/appshell/view/notationpagemodel.cpp
@@ -152,6 +152,12 @@ void NotationPageModel::toggleDock(const QString& name)
         return;
     }
 
+    if (name == NOTATION_BRAILLE_PANEL_NAME) {
+        brailleConfiguration()->setBraillePanelEnabled(!isBraillePanelVisible());
+        emit isBraillePanelVisibleChanged();
+        return;
+    }
+
     dispatcher()->dispatch("dock-toggle", ActionData::make_arg1<QString>(name));
 }
 

--- a/src/framework/shortcuts/data/shortcuts-Mac.xml
+++ b/src/framework/shortcuts/data/shortcuts-Mac.xml
@@ -675,6 +675,10 @@
     <seq>F10</seq>
     </SC>
   <SC>
+    <key>toggle-braille-panel</key>
+    <seq>Alt+F11</seq>
+    </SC>
+  <SC>
     <key>toggle-timeline</key>
     <seq>F12</seq>
     </SC>

--- a/src/framework/shortcuts/data/shortcuts.xml
+++ b/src/framework/shortcuts/data/shortcuts.xml
@@ -675,6 +675,10 @@
     <seq>F10</seq>
     </SC>
   <SC>
+    <key>toggle-braille-panel</key>
+    <seq>Alt+F11</seq>
+    </SC>
+  <SC>
     <key>toggle-timeline</key>
     <seq>F12</seq>
     </SC>

--- a/src/framework/shortcuts/data/shortcuts_AZERTY.xml
+++ b/src/framework/shortcuts/data/shortcuts_AZERTY.xml
@@ -701,6 +701,10 @@
     <seq>F10</seq>
     </SC>
   <SC>
+    <key>toggle-braille-panel</key>
+    <seq>Alt+F11</seq>
+    </SC>
+  <SC>
     <key>toggle-timeline</key>
     <seq>F12</seq>
     </SC>


### PR DESCRIPTION
Alt+F11 was chosen to match the music shortcut in Sao Mai Braille (SMB), a program that blind musicians often use in conjunction with MuesScore.

- https://saomaicenter.org/en/blog/sao-mai-braille-user-guide#text-editing-keystrokes

- https://saomaicenter.org/en/blog/sao-mai-braille-user-guide#music-score

Fix #19556

Replaces PR #21929