### PR TITLE
Resolved Spoken Note Accessibility

### DIFF
--- a/src/notation/internal/notationactioncontroller.h
+++ b/src/notation/internal/notationactioncontroller.h
@@ -250,6 +250,9 @@ private:
     void registerAction(const mu::actions::ActionCode&, void (INotationInteraction::*)(P1, P2), P1, P2, PlayMode = PlayMode::NoPlay,
                         bool (NotationActionController::*)() const = &NotationActionController::isNotationPage);
 
+    void notifyAccessibilityAboutActionTriggered(const mu::actions::ActionCode& actionCode);
+    void notifyAccessibilityAboutVoiceInfo(const std::string& info);
+
     async::Notification m_currentNotationNoteInputChanged;
 
     using IsActionEnabledFunc = std::function<bool ()>;


### PR DESCRIPTION
Resolves: #16909 

Implemented Spoken Feedback for screen readers (when hitting numbers from 1 to 7 for note navigation).

Output -
https://github.com/musescore/MuseScore/assets/123376721/f307a456-20a0-4ffe-aa75-c973596bab02

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
