### PR TITLE
 Properly deal with `</font>`

### DIFF
--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -2120,11 +2120,16 @@ String TextBase::genText(const LayoutData* ldata) const
                 }
             }
 
-            if (format.fontSize() != fmt.fontSize()) {
-                text += String(u"<font size=\"%1\"/>").arg(format.fontSize());
-            }
-            if (format.fontFamily() != "ScoreText" && format.fontFamily() != fmt.fontFamily()) {
-                text += String(u"<font face=\"%1\"/>").arg(TextBase::escape(format.fontFamily()));
+            if (fmt.fontSize() != format.fontSize()
+                || (fmt.fontFamily() != format.fontFamily() && format.fontFamily() != "ScoreText")) {
+                text += String(u"<font");
+                if (fmt.fontSize() != format.fontSize()) {
+                    text += String(u" size=\"%1\"").arg(format.fontSize());
+                }
+                if (fmt.fontFamily() != format.fontFamily() && format.fontFamily() != "ScoreText") {
+                    text += String(u" face=\"%1\"").arg(TextBase::escape(format.fontFamily()));
+                }
+                text += u"/>"; // TODO: proper nesting and end tag "</font>"
             }
 
             VerticalAlignment va = format.valign();

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -1822,24 +1822,30 @@ bool TextBase::prepareFormat(const String& token, CharFormat& format, String& pr
     } else if (token == "/sup") {
         format.setValign(VerticalAlignment::AlignNormal);
     } else if (token.startsWith(u"font ")) {
-        String remainder = token.mid(5);
-        if (remainder.startsWith(u"size=\"")) {
-            if (!token.endsWith(u"/")) {
-                prevFontSize = format.fontSize();
+        String remainder = token.mid(5).trimmed();
+        while (!remainder.empty()) {
+            if (remainder.startsWith(u"size=\"")) {
+                double size = parseNumProperty(remainder.mid(6));
+                remainder = remainder.mid(remainder.indexOf(u'"', 6) + 1).trimmed();
+                if (!token.endsWith(u"/")) {
+                    prevFontSize = format.fontSize();
+                }
+                format.setFontSize(size);
+            } else if (remainder.startsWith(u"face=\"")) {
+                String face = unEscape(parseStringProperty(remainder.mid(6)));
+                remainder = remainder.mid(remainder.indexOf(u'"', 6) + 1).trimmed();
+                if (!token.endsWith(u"/")) {
+                    prevFontFace = format.fontFamily();
+                }
+                format.setFontFamily(face);
+            } else if (remainder == u"/") {
+                break;
+            } else {
+                LOGD("cannot parse html property <%s> in text <%s>", muPrintable(remainder), muPrintable(m_text));
+                break;
             }
-            format.setFontSize(parseNumProperty(remainder.mid(6)));
-            return true;
-        } else if (remainder.startsWith(u"face=\"")) {
-            String face = parseStringProperty(remainder.mid(6));
-            face = unEscape(face);
-            if (!token.endsWith(u"/")) {
-                prevFontFace = format.fontFamily();
-            }
-            format.setFontFamily(face);
-            return true;
-        } else {
-            LOGD("cannot parse html property <%s> in text <%s>", muPrintable(token), muPrintable(m_text));
         }
+        return true;
     } else if (token == u"/font") {
         if (prevFontSize) {
             format.setFontSize(prevFontSize);

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -1824,13 +1824,17 @@ bool TextBase::prepareFormat(const String& token, CharFormat& format, String& pr
     } else if (token.startsWith(u"font ")) {
         String remainder = token.mid(5);
         if (remainder.startsWith(u"size=\"")) {
-            prevFontSize = format.fontSize();
+            if (!token.endsWith(u"/")) {
+                prevFontSize = format.fontSize();
+            }
             format.setFontSize(parseNumProperty(remainder.mid(6)));
             return true;
         } else if (remainder.startsWith(u"face=\"")) {
             String face = parseStringProperty(remainder.mid(6));
             face = unEscape(face);
-            prevFontFace = format.fontFamily();
+            if (!token.endsWith(u"/")) {
+                prevFontFace = format.fontFamily();
+            }
             format.setFontFamily(face);
             return true;
         } else {

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -1827,15 +1827,25 @@ bool TextBase::prepareFormat(const String& token, CharFormat& format, String& pr
         String remainder = token.mid(5).trimmed();
         while (!remainder.empty()) {
             if (remainder.startsWith(u"size=\"")) {
+                const size_t endQuote = remainder.indexOf(u'"', 6);
+                if (endQuote == muse::nidx) {
+                    LOGD("cannot parse html property <%s> in text <%s>", muPrintable(remainder), muPrintable(m_text));
+                    break;
+                }
                 double size = parseNumProperty(remainder.mid(6));
-                remainder = remainder.mid(remainder.indexOf(u'"', 6) + 1).trimmed();
+                remainder = remainder.mid(endQuote + 1).trimmed();
                 if (!token.endsWith(u"/")) {
                     prevFontSize = format.fontSize();
                 }
                 format.setFontSize(size);
             } else if (remainder.startsWith(u"face=\"")) {
+                const size_t endQuote = remainder.indexOf(u'"', 6);
+                if (endQuote == muse::nidx) {
+                    LOGD("cannot parse html property <%s> in text <%s>", muPrintable(remainder), muPrintable(m_text));
+                    break;
+                }
                 String face = unEscape(parseStringProperty(remainder.mid(6)));
-                remainder = remainder.mid(remainder.indexOf(u'"', 6) + 1).trimmed();
+                remainder = remainder.mid(endQuote + 1).trimmed();
                 if (!token.endsWith(u"/")) {
                     prevFontFace = format.fontFamily();
                 }

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -1815,10 +1815,12 @@ bool TextBase::prepareFormat(const String& token, CharFormat& format, String& pr
         format.setStrike(false);
     } else if (token == "sub") {
         format.setValign(VerticalAlignment::AlignSubScript);
+        return true;
     } else if (token == "/sub") {
         format.setValign(VerticalAlignment::AlignNormal);
     } else if (token == "sup") {
         format.setValign(VerticalAlignment::AlignSuperScript);
+        return true;
     } else if (token == "/sup") {
         format.setValign(VerticalAlignment::AlignNormal);
     } else if (token.startsWith(u"font ")) {
@@ -1864,9 +1866,19 @@ bool TextBase::prepareFormat(const String& token, CharFormat& format, String& pr
 //---------------------------------------------------------
 void TextBase::prepareFormat(const String& token, TextCursor& cursor, String& prevFontFace, double& prevFontSize)
 {
-    if (prepareFormat(token, *cursor.format(), prevFontFace, prevFontSize)
-        && cursor.format()->fontFamily() != propertyDefault(Pid::FONT_FACE).value<String>()) {
-        setPropertyFlags(Pid::FONT_FACE, PropertyFlags::UNSTYLED);
+    if (prepareFormat(token, *cursor.format(), prevFontFace, prevFontSize)) {
+        if (cursor.format()->fontFamily() != propertyDefault(Pid::FONT_FACE).value<String>()) {
+            setPropertyFlags(Pid::FONT_FACE, PropertyFlags::UNSTYLED);
+        }
+        if (cursor.format()->fontSize() != propertyDefault(Pid::FONT_SIZE).value<double>()) {
+            setPropertyFlags(Pid::FONT_SIZE, PropertyFlags::UNSTYLED);
+        }
+        if (cursor.format()->style() != propertyDefault(Pid::FONT_STYLE).value<FontStyle>()) {
+            setPropertyFlags(Pid::FONT_STYLE, PropertyFlags::UNSTYLED);
+        }
+        if (cursor.format()->valign() != propertyDefault(Pid::TEXT_SCRIPT_ALIGN).value<VerticalAlignment>()) {
+            setPropertyFlags(Pid::TEXT_SCRIPT_ALIGN, PropertyFlags::UNSTYLED);
+        }
     }
 }
 

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -1789,6 +1789,9 @@ void TextBase::createBlocks(LayoutData* ldata) const
 //---------------------------------------------------------
 bool TextBase::prepareFormat(const String& token, CharFormat& format)
 {
+    static String prevFontFace;
+    static double prevFontSize = 0;
+
     if (token == "b") {
         format.setBold(true);
         return true;
@@ -1820,15 +1823,26 @@ bool TextBase::prepareFormat(const String& token, CharFormat& format)
     } else if (token.startsWith(u"font ")) {
         String remainder = token.mid(5);
         if (remainder.startsWith(u"size=\"")) {
+            prevFontSize = format.fontSize();
             format.setFontSize(parseNumProperty(remainder.mid(6)));
             return true;
         } else if (remainder.startsWith(u"face=\"")) {
             String face = parseStringProperty(remainder.mid(6));
             face = unEscape(face);
+            prevFontFace = format.fontFamily();
             format.setFontFamily(face);
             return true;
         } else {
             LOGD("cannot parse html property <%s> in text <%s>", muPrintable(token), muPrintable(m_text));
+        }
+    } else if (token == u"/font") {
+        if (prevFontSize) {
+            format.setFontSize(prevFontSize);
+            prevFontSize = 0;
+        }
+        if (!prevFontFace.isEmpty()) {
+            format.setFontFamily(prevFontFace);
+            prevFontFace = u"";
         }
     }
     return false;

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -1687,6 +1687,10 @@ void TextBase::createBlocks(LayoutData* ldata) const
     String token;
     String sym;
     bool symState = false;
+
+    String prevFontFace;
+    double prevFontSize = 0;
+
     for (size_t i = 0; i < m_text.size(); i++) {
         const Char& c = m_text.at(i);
         if (state == 0) {
@@ -1736,7 +1740,7 @@ void TextBase::createBlocks(LayoutData* ldata) const
         } else if (state == 1) {
             if (c == '>') {
                 state = 0;
-                const_cast<TextBase*>(this)->prepareFormat(token, cursor);
+                const_cast<TextBase*>(this)->prepareFormat(token, cursor, prevFontFace, prevFontSize);
                 if (token == "sym") {
                     symState = true;
                     sym.clear();
@@ -1787,11 +1791,8 @@ void TextBase::createBlocks(LayoutData* ldata) const
 //---------------------------------------------------------
 //   prepareFormat - used when reading from XML and when pasting from clipboard
 //---------------------------------------------------------
-bool TextBase::prepareFormat(const String& token, CharFormat& format)
+bool TextBase::prepareFormat(const String& token, CharFormat& format, String& prevFontFace, double& prevFontSize) const
 {
-    static String prevFontFace;
-    static double prevFontSize = 0;
-
     if (token == "b") {
         format.setBold(true);
         return true;
@@ -1851,9 +1852,10 @@ bool TextBase::prepareFormat(const String& token, CharFormat& format)
 //---------------------------------------------------------
 //   prepareFormat - used when reading from XML
 //---------------------------------------------------------
-void TextBase::prepareFormat(const String& token, TextCursor& cursor)
+void TextBase::prepareFormat(const String& token, TextCursor& cursor, String& prevFontFace, double& prevFontSize)
 {
-    if (prepareFormat(token, *cursor.format()) && cursor.format()->fontFamily() != propertyDefault(Pid::FONT_FACE).value<String>()) {
+    if (prepareFormat(token, *cursor.format(), prevFontFace, prevFontSize)
+        && cursor.format()->fontFamily() != propertyDefault(Pid::FONT_FACE).value<String>()) {
         setPropertyFlags(Pid::FONT_FACE, PropertyFlags::UNSTYLED);
     }
 }

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -1817,10 +1817,12 @@ bool TextBase::prepareFormat(const String& token, CharFormat& format, String& pr
         format.setStrike(false);
     } else if (token == "sub") {
         format.setValign(VerticalAlignment::AlignSubScript);
+        return true;
     } else if (token == "/sub") {
         format.setValign(VerticalAlignment::AlignNormal);
     } else if (token == "sup") {
         format.setValign(VerticalAlignment::AlignSuperScript);
+        return true;
     } else if (token == "/sup") {
         format.setValign(VerticalAlignment::AlignNormal);
     } else if (token.startsWith(u"font ")) {
@@ -1866,9 +1868,19 @@ bool TextBase::prepareFormat(const String& token, CharFormat& format, String& pr
 //---------------------------------------------------------
 void TextBase::prepareFormat(const String& token, TextCursor& cursor, String& prevFontFace, double& prevFontSize)
 {
-    if (prepareFormat(token, *cursor.format(), prevFontFace, prevFontSize)
-        && cursor.format()->fontFamily() != propertyDefault(Pid::FONT_FACE).value<String>()) {
-        setPropertyFlags(Pid::FONT_FACE, PropertyFlags::UNSTYLED);
+    if (prepareFormat(token, *cursor.format(), prevFontFace, prevFontSize)) {
+        if (cursor.format()->fontFamily() != propertyDefault(Pid::FONT_FACE).value<String>()) {
+            setPropertyFlags(Pid::FONT_FACE, PropertyFlags::UNSTYLED);
+        }
+        if (cursor.format()->fontSize() != propertyDefault(Pid::FONT_SIZE).value<double>()) {
+            setPropertyFlags(Pid::FONT_SIZE, PropertyFlags::UNSTYLED);
+        }
+        if (cursor.format()->style() != propertyDefault(Pid::FONT_STYLE).value<FontStyle>()) {
+            setPropertyFlags(Pid::FONT_STYLE, PropertyFlags::UNSTYLED);
+        }
+        if (cursor.format()->valign() != propertyDefault(Pid::TEXT_SCRIPT_ALIGN).value<VerticalAlignment>()) {
+            setPropertyFlags(Pid::TEXT_SCRIPT_ALIGN, PropertyFlags::UNSTYLED);
+        }
     }
 }
 

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -1829,15 +1829,25 @@ bool TextBase::prepareFormat(const String& token, CharFormat& format, String& pr
         String remainder = token.mid(5).trimmed();
         while (!remainder.empty()) {
             if (remainder.startsWith(u"size=\"")) {
+                const size_t endQuote = remainder.indexOf(u'"', 6);
+                if (endQuote == muse::nidx) {
+                    LOGD("cannot parse html property <%s> in text <%s>", muPrintable(remainder), muPrintable(m_text));
+                    break;
+                }
                 double size = parseNumProperty(remainder.mid(6));
-                remainder = remainder.mid(remainder.indexOf(u'"', 6) + 1).trimmed();
+                remainder = remainder.mid(endQuote + 1).trimmed();
                 if (!token.endsWith(u"/")) {
                     prevFontSize = format.fontSize();
                 }
                 format.setFontSize(size);
             } else if (remainder.startsWith(u"face=\"")) {
+                const size_t endQuote = remainder.indexOf(u'"', 6);
+                if (endQuote == muse::nidx) {
+                    LOGD("cannot parse html property <%s> in text <%s>", muPrintable(remainder), muPrintable(m_text));
+                    break;
+                }
                 String face = unEscape(parseStringProperty(remainder.mid(6)));
-                remainder = remainder.mid(remainder.indexOf(u'"', 6) + 1).trimmed();
+                remainder = remainder.mid(endQuote + 1).trimmed();
                 if (!token.endsWith(u"/")) {
                     prevFontFace = format.fontFamily();
                 }

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -1689,6 +1689,10 @@ void TextBase::createBlocks(LayoutData* ldata) const
     String token;
     String sym;
     bool symState = false;
+
+    String prevFontFace;
+    double prevFontSize = 0;
+
     for (size_t i = 0; i < m_text.size(); i++) {
         const Char& c = m_text.at(i);
         if (state == 0) {
@@ -1738,7 +1742,7 @@ void TextBase::createBlocks(LayoutData* ldata) const
         } else if (state == 1) {
             if (c == '>') {
                 state = 0;
-                const_cast<TextBase*>(this)->prepareFormat(token, cursor);
+                const_cast<TextBase*>(this)->prepareFormat(token, cursor, prevFontFace, prevFontSize);
                 if (token == "sym") {
                     symState = true;
                     sym.clear();
@@ -1789,11 +1793,8 @@ void TextBase::createBlocks(LayoutData* ldata) const
 //---------------------------------------------------------
 //   prepareFormat - used when reading from XML and when pasting from clipboard
 //---------------------------------------------------------
-bool TextBase::prepareFormat(const String& token, CharFormat& format)
+bool TextBase::prepareFormat(const String& token, CharFormat& format, String& prevFontFace, double& prevFontSize) const
 {
-    static String prevFontFace;
-    static double prevFontSize = 0;
-
     if (token == "b") {
         format.setBold(true);
         return true;
@@ -1853,9 +1854,10 @@ bool TextBase::prepareFormat(const String& token, CharFormat& format)
 //---------------------------------------------------------
 //   prepareFormat - used when reading from XML
 //---------------------------------------------------------
-void TextBase::prepareFormat(const String& token, TextCursor& cursor)
+void TextBase::prepareFormat(const String& token, TextCursor& cursor, String& prevFontFace, double& prevFontSize)
 {
-    if (prepareFormat(token, *cursor.format()) && cursor.format()->fontFamily() != propertyDefault(Pid::FONT_FACE).value<String>()) {
+    if (prepareFormat(token, *cursor.format(), prevFontFace, prevFontSize)
+        && cursor.format()->fontFamily() != propertyDefault(Pid::FONT_FACE).value<String>()) {
         setPropertyFlags(Pid::FONT_FACE, PropertyFlags::UNSTYLED);
     }
 }

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -1791,6 +1791,9 @@ void TextBase::createBlocks(LayoutData* ldata) const
 //---------------------------------------------------------
 bool TextBase::prepareFormat(const String& token, CharFormat& format)
 {
+    static String prevFontFace;
+    static double prevFontSize = 0;
+
     if (token == "b") {
         format.setBold(true);
         return true;
@@ -1822,15 +1825,26 @@ bool TextBase::prepareFormat(const String& token, CharFormat& format)
     } else if (token.startsWith(u"font ")) {
         String remainder = token.mid(5);
         if (remainder.startsWith(u"size=\"")) {
+            prevFontSize = format.fontSize();
             format.setFontSize(parseNumProperty(remainder.mid(6)));
             return true;
         } else if (remainder.startsWith(u"face=\"")) {
             String face = parseStringProperty(remainder.mid(6));
             face = unEscape(face);
+            prevFontFace = format.fontFamily();
             format.setFontFamily(face);
             return true;
         } else {
             LOGD("cannot parse html property <%s> in text <%s>", muPrintable(token), muPrintable(m_text));
+        }
+    } else if (token == u"/font") {
+        if (prevFontSize) {
+            format.setFontSize(prevFontSize);
+            prevFontSize = 0;
+        }
+        if (!prevFontFace.isEmpty()) {
+            format.setFontFamily(prevFontFace);
+            prevFontFace = u"";
         }
     }
     return false;

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -1826,13 +1826,17 @@ bool TextBase::prepareFormat(const String& token, CharFormat& format, String& pr
     } else if (token.startsWith(u"font ")) {
         String remainder = token.mid(5);
         if (remainder.startsWith(u"size=\"")) {
-            prevFontSize = format.fontSize();
+            if (!token.endsWith(u"/")) {
+                prevFontSize = format.fontSize();
+            }
             format.setFontSize(parseNumProperty(remainder.mid(6)));
             return true;
         } else if (remainder.startsWith(u"face=\"")) {
             String face = parseStringProperty(remainder.mid(6));
             face = unEscape(face);
-            prevFontFace = format.fontFamily();
+            if (!token.endsWith(u"/")) {
+                prevFontFace = format.fontFamily();
+            }
             format.setFontFamily(face);
             return true;
         } else {

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -1824,24 +1824,30 @@ bool TextBase::prepareFormat(const String& token, CharFormat& format, String& pr
     } else if (token == "/sup") {
         format.setValign(VerticalAlignment::AlignNormal);
     } else if (token.startsWith(u"font ")) {
-        String remainder = token.mid(5);
-        if (remainder.startsWith(u"size=\"")) {
-            if (!token.endsWith(u"/")) {
-                prevFontSize = format.fontSize();
+        String remainder = token.mid(5).trimmed();
+        while (!remainder.empty()) {
+            if (remainder.startsWith(u"size=\"")) {
+                double size = parseNumProperty(remainder.mid(6));
+                remainder = remainder.mid(remainder.indexOf(u'"', 6) + 1).trimmed();
+                if (!token.endsWith(u"/")) {
+                    prevFontSize = format.fontSize();
+                }
+                format.setFontSize(size);
+            } else if (remainder.startsWith(u"face=\"")) {
+                String face = unEscape(parseStringProperty(remainder.mid(6)));
+                remainder = remainder.mid(remainder.indexOf(u'"', 6) + 1).trimmed();
+                if (!token.endsWith(u"/")) {
+                    prevFontFace = format.fontFamily();
+                }
+                format.setFontFamily(face);
+            } else if (remainder == u"/") {
+                break;
+            } else {
+                LOGD("cannot parse html property <%s> in text <%s>", muPrintable(remainder), muPrintable(m_text));
+                break;
             }
-            format.setFontSize(parseNumProperty(remainder.mid(6)));
-            return true;
-        } else if (remainder.startsWith(u"face=\"")) {
-            String face = parseStringProperty(remainder.mid(6));
-            face = unEscape(face);
-            if (!token.endsWith(u"/")) {
-                prevFontFace = format.fontFamily();
-            }
-            format.setFontFamily(face);
-            return true;
-        } else {
-            LOGD("cannot parse html property <%s> in text <%s>", muPrintable(token), muPrintable(m_text));
         }
+        return true;
     } else if (token == u"/font") {
         if (prevFontSize) {
             format.setFontSize(prevFontSize);

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -2122,11 +2122,16 @@ String TextBase::genText(const LayoutData* ldata) const
                 }
             }
 
-            if (format.fontSize() != fmt.fontSize()) {
-                text += String(u"<font size=\"%1\"/>").arg(format.fontSize());
-            }
-            if (format.fontFamily() != "ScoreText" && format.fontFamily() != fmt.fontFamily()) {
-                text += String(u"<font face=\"%1\"/>").arg(TextBase::escape(format.fontFamily()));
+            if (fmt.fontSize() != format.fontSize()
+                || (fmt.fontFamily() != format.fontFamily() && format.fontFamily() != "ScoreText")) {
+                text += String(u"<font");
+                if (fmt.fontSize() != format.fontSize()) {
+                    text += String(u" size=\"%1\"").arg(format.fontSize());
+                }
+                if (fmt.fontFamily() != format.fontFamily() && format.fontFamily() != "ScoreText") {
+                    text += String(u" face=\"%1\"").arg(TextBase::escape(format.fontFamily()));
+                }
+                text += u"/>"; // TODO: proper nesting and end tag "</font>"
             }
 
             VerticalAlignment va = format.valign();

--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -532,8 +532,8 @@ protected:
     bool nudge(const EditData& ed);
 
     void insertSym(SymId id);
-    void prepareFormat(const String& token, TextCursor& cursor);
-    bool prepareFormat(const String& token, CharFormat& format);
+    void prepareFormat(const String& token, TextCursor& cursor, String& prevFontFace, double& prevFontSize);
+    bool prepareFormat(const String& token, CharFormat& format, String& prevFontFace, double& prevFontSize) const;
 
     virtual void commitText();
 

--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -531,8 +531,8 @@ protected:
     bool nudge(const EditData& ed);
 
     void insertSym(SymId id);
-    void prepareFormat(const String& token, TextCursor& cursor);
-    bool prepareFormat(const String& token, CharFormat& format);
+    void prepareFormat(const String& token, TextCursor& cursor, String& prevFontFace, double& prevFontSize);
+    bool prepareFormat(const String& token, CharFormat& format, String& prevFontFace, double& prevFontSize) const;
 
     virtual void commitText();
 

--- a/src/engraving/editing/textedit.cpp
+++ b/src/engraving/editing/textedit.cpp
@@ -892,6 +892,9 @@ void TextBase::paste(const String& txt)
     bool symState = false;
     CharFormat format = *cursor()->format();
 
+    String prevFontFace;
+    double prevFontSize = 0;
+
     score()->startCmd(TranslatableString("undoableAction", "Paste text"));
     for (size_t i = 0; i < txt.size(); i++) {
         Char c = txt.at(i);
@@ -934,7 +937,7 @@ void TextBase::paste(const String& txt)
                     cursor()->setFormat(format);
                     insertSym(SymNames::symIdByName(sym));
                 } else {
-                    prepareFormat(token, format);
+                    prepareFormat(token, format, prevFontFace, prevFontSize);
                 }
             } else {
                 token += c;

--- a/src/engraving/editing/textedit.cpp
+++ b/src/engraving/editing/textedit.cpp
@@ -918,6 +918,9 @@ void TextBase::paste(const String& txt)
     bool symState = false;
     CharFormat format = *cursor()->format();
 
+    String prevFontFace;
+    double prevFontSize = 0;
+
     score()->startCmd(TranslatableString("undoableAction", "Paste text"));
     for (size_t i = 0; i < txt.size(); i++) {
         Char c = txt.at(i);
@@ -960,7 +963,7 @@ void TextBase::paste(const String& txt)
                     cursor()->setFormat(format);
                     insertSym(SymNames::symIdByName(sym));
                 } else {
-                    prepareFormat(token, format);
+                    prepareFormat(token, format, prevFontFace, prevFontSize);
                 }
             } else {
                 token += c;


### PR DESCRIPTION
instead of ignoring it altogether, reset font face and -size back to what it was before `<font ...>`

To allow stuff like this in instrument names:

```xml
Sopran
<font size="8">(u. Gemeinde)</font>
Alt
```
Which currently results in the last part of the string ("Alt") to also be in size (8) of the middle part instead of having the same size as the 1st part ("Sopran"):
![image](https://github.com/musescore/MuseScore/assets/1786669/cde86bb7-ed02-45bf-8020-77ffebb0a801)
Now looks like this>
![image](https://github.com/musescore/MuseScore/assets/1786669/1566623c-f515-4641-b28b-9518edee401c)

Also useful for header/footer texts, which also can't get formatted with different parts
