### PR TITLE
Extend MEI metadata import/export

### DIFF
--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -180,6 +180,12 @@ bool MeiExporter::writeHeader()
         pugi::xml_node title = titleStmt.append_child("title");
         if (!m_score->metaTag(u"workTitle").isEmpty()) {
             title.text().set(m_score->metaTag(u"workTitle").toStdString().c_str());
+            title.append_attribute("type") = u"main";
+        }
+        if (!m_score->metaTag(u"subtitle").isEmpty()) {
+            pugi::xml_node title = titleStmt.append_child("title");
+            title.text().set(m_score->metaTag(u"subtitle").toStdString().c_str());
+            title.append_attribute("type") = u"subordinate";
         }
 
         pugi::xml_node respStmt;

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -889,6 +889,20 @@ bool MeiImporter::readMeiHead(pugi::xml_node root)
         }
     }
 
+    // check for dedicated elements (only for import)
+    pugi::xml_node composer = root.select_node("//meiHead/fileDesc/titleStmt/composer").node();
+    if (composer) {
+        m_score->setMetaTag(u"composer", String(composer.text().as_string()));
+    }
+    pugi::xml_node lyricist = root.select_node("//meiHead/fileDesc/titleStmt/lyricist").node();
+    if (lyricist) {
+        m_score->setMetaTag(u"lyricist", String(lyricist.text().as_string()));
+    }
+    pugi::xml_node arranger = root.select_node("//meiHead/fileDesc/titleStmt/arranger").node();
+    if (arranger) {
+        m_score->setMetaTag(u"arranger", String(arranger.text().as_string()));
+    }
+
     StringList persNames;
     // the creator types commonly found in MusicXML
     persNames << u"arranger" << u"composer" << u"lyricist" << u"translator";

--- a/src/importexport/mei/tests/data/metadata-01.mei
+++ b/src/importexport/mei/tests/data/metadata-01.mei
@@ -5,7 +5,8 @@
    <meiHead>
       <fileDesc>
          <titleStmt>
-            <title>Metadata test (title)</title>
+            <title type="main">Metadata test (title)</title>
+            <title type="subordinate">Subtitle</title>
             <respStmt>
                <persName role="arranger">Arranger of the piece</persName>
                <persName role="composer">Composer of the piece</persName>

--- a/src/importexport/mei/tests/data/metadata-01.mscx
+++ b/src/importexport/mei/tests/data/metadata-01.mscx
@@ -13,10 +13,11 @@
     <metaTag name="composer">Composer of the piece</metaTag>
     <metaTag name="copyright">Public domain</metaTag>
     <metaTag name="lyricist">Metastasio</metaTag>
-    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title&gt;Metadata test (title)&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;arranger&quot;&gt;Arranger of the piece&lt;/persName&gt;&lt;persName role=&quot;composer&quot;&gt;Composer of the piece&lt;/persName&gt;&lt;persName role=&quot;lyricist&quot;&gt;Metastasio&lt;/persName&gt;&lt;persName role=&quot;translator&quot;&gt;Deepl&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:53:16&quot;/&gt;&lt;availability&gt;Public domain&lt;/availability&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title type=&quot;main&quot;&gt;Metadata test (title)&lt;/title&gt;&lt;title type=&quot;subordinate&quot;&gt;Subtitle&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;arranger&quot;&gt;Arranger of the piece&lt;/persName&gt;&lt;persName role=&quot;composer&quot;&gt;Composer of the piece&lt;/persName&gt;&lt;persName role=&quot;lyricist&quot;&gt;Metastasio&lt;/persName&gt;&lt;persName role=&quot;translator&quot;&gt;Deepl&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2023-08-11T14:53:16&quot;/&gt;&lt;availability&gt;Public domain&lt;/availability&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="source"></metaTag>
+    <metaTag name="subtitle">Subtitle</metaTag>
     <metaTag name="translator">Deepl</metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle">Metadata test (title)</metaTag>


### PR DESCRIPTION
This PR adds import of dedicated MEI header elements `composer`,  `lyricist`, and `arranger`. Also it differentiates between main title and subtitle.

@lpugin please have a look.