### PR TITLE
Fix MSVC compiler warning(s)

### DIFF
--- a/src/notation/view/abstractelementpopupmodel.h
+++ b/src/notation/view/abstractelementpopupmodel.h
@@ -100,7 +100,7 @@ private:
 
 using PopupModelType = AbstractElementPopupModel::PopupModelType;
 #ifndef NO_QT_SUPPORT
-inline uint qHash(mu::notation::PopupModelType key)
+inline size_t qHash(mu::notation::PopupModelType key)
 {
     return ::qHash(int(key));
 }


### PR DESCRIPTION
reg.: 'return': conversion from 'size_t' to 'uint', possible loss of data (C4267)