### PR TITLE
Align spanners only when placement matches

### DIFF
--- a/src/engraving/rendering/dev/systemlayout.cpp
+++ b/src/engraving/rendering/dev/systemlayout.cpp
@@ -1448,11 +1448,12 @@ void SystemLayout::processLines(System* system, LayoutContext& ctx, std::vector<
     if (align && segments.size() > 1) {
         const size_t nstaves = system->staves().size();
         const double defaultY = segments[0]->ldata()->pos().y();
-        std::vector<double> y(nstaves, -DBL_MAX);
+        std::vector<double> yAbove(nstaves, -DBL_MAX);
+        std::vector<double> yBelow(nstaves, -DBL_MAX);
 
         for (SpannerSegment* ss : segments) {
             if (ss->visible()) {
-                double& staffY = y[ss->staffIdx()];
+                double& staffY = ss->spanner() && ss->spanner()->placeAbove() ? yAbove[ss->staffIdx()] : yBelow[ss->staffIdx()];
                 staffY = std::max(staffY, ss->ldata()->pos().y());
             }
         }
@@ -1460,7 +1461,7 @@ void SystemLayout::processLines(System* system, LayoutContext& ctx, std::vector<
             if (!ss->isStyled(Pid::OFFSET)) {
                 continue;
             }
-            const double staffY = y[ss->staffIdx()];
+            const double& staffY = ss->spanner() && ss->spanner()->placeAbove() ? yAbove[ss->staffIdx()] : yBelow[ss->staffIdx()];
             if (staffY > -DBL_MAX) {
                 ss->mutldata()->setPosY(staffY);
             } else {


### PR DESCRIPTION
Resolves: see image.
![Screenshot 2024-03-20 at 13 23 52](https://github.com/musescore/MuseScore/assets/26510874/d0ca9557-be3d-4e0c-b640-c23ebb0829a4)
When aligning pedal lines, we only want to match the position of those with the same placement (above/below the stave).  Matching a line with a different placement value causes unwanted placement - in the image all lines are given the same offset as the final line on the system.