### PR TITLE
Fix #21786: Prevent crash when pasting list selection including hairpins (4.3.0)

### DIFF
--- a/src/engraving/rw/read400/read400.cpp
+++ b/src/engraving/rw/read400/read400.cpp
@@ -854,6 +854,11 @@ void Read400::pasteSymbols(XmlReader& e, ChordRest* dst)
                     d->setParent(destCR->segment());
                     score->undoAddElement(d);
                 } else if (tag == "HairPin") {
+                    if (destTrack >= maxTrack) {
+                        LOGD("PasteSymbols: no track for %s", tag.ascii());
+                        e.skipCurrentElement();
+                        continue;
+                    }
                     Hairpin* h = Factory::createHairpin(score->dummy()->segment());
                     h->setTrack(destTrack);
                     TRead::read(h, e, ctx);

--- a/src/engraving/rw/read410/read410.cpp
+++ b/src/engraving/rw/read410/read410.cpp
@@ -865,6 +865,11 @@ void Read410::pasteSymbols(XmlReader& e, ChordRest* dst)
                     d->setParent(destCR->segment());
                     score->undoAddElement(d);
                 } else if (tag == "HairPin") {
+                    if (destTrack >= maxTrack) {
+                        LOGD("PasteSymbols: no track for %s", tag.ascii());
+                        e.skipCurrentElement();
+                        continue;
+                    }
                     Hairpin* h = Factory::createHairpin(score->dummy()->segment());
                     h->setTrack(destTrack);
                     TRead::read(h, e, ctx);


### PR DESCRIPTION
Resolves: #21786
Master PR: #21990