### PR TITLE
Solved buttons accessibility in EditShortcutDialog

### DIFF
--- a/src/framework/shortcuts/qml/Muse/Shortcuts/EditShortcutDialog.qml
+++ b/src/framework/shortcuts/qml/Muse/Shortcuts/EditShortcutDialog.qml
@@ -38,10 +38,21 @@ StyledDialogView {
 
     signal applySequenceRequested(string newSequence, int conflictShortcutIndex)
 
+    property NavigationPanel navigationPanel: NavigationPanel {
+            name: "EditShortcutSequenceDialog"
+            section: root.navigationSection
+            enabled: root.enabled && root.visible
+            order: 1
+            direction: NavigationPanel.Horizontal
+        }
+
     function startEdit(shortcut, allShortcuts) {
         model.load(shortcut, allShortcuts)
         open()
-        content.forceActiveFocus()
+    }
+
+    onNavigationActivateRequested: {
+        newSequenceField.navigation.requestActive()
     }
 
     Rectangle {
@@ -123,6 +134,9 @@ StyledDialogView {
 
                         background.border.color: ui.theme.accentColor
 
+                        navigation.panel: root.navigationPanel
+                        navigation.order: 1
+
                         hint: qsTrc("shortcuts", "Type to set shortcut")
                         readOnly: true
                         currentText: model.newSequence
@@ -141,6 +155,8 @@ StyledDialogView {
 
                 buttons: [ ButtonBoxModel.Cancel, ButtonBoxModel.Save ]
 
+                navigationPanel.section: root.navigationSection
+
                 onStandardButtonClicked: function(buttonId) {
                     if (buttonId === ButtonBoxModel.Cancel) {
                         root.reject()
@@ -153,7 +169,10 @@ StyledDialogView {
         }
 
         Keys.onShortcutOverride: function(event) {
-            event.accepted = event.key !== Qt.Key_Escape && event.key !== Qt.Key_Tab
+            if(event.key === Qt.Key_Tab) {
+                content.focus = false
+            }
+            event.accepted = event.key !== Qt.Key_Escape && event.key !== Qt.Key_Tab 
         }
 
         Keys.onPressed: function(event) {


### PR DESCRIPTION
Resolves: #16157 

Solved accessibility issue for save and cancel button in EditShortcutDialog

Output - 

https://github.com/musescore/MuseScore/assets/123376721/52d2e7b1-cf96-4180-aa06-9bd21425068e



- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
