### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -780,21 +780,14 @@ static void inferFromTitle(String& title, String& inferredSubtitle, String& infe
     StringList subtitleLines;
     StringList creditLines;
     StringList titleLines = title.split(std::regex("\\n"));
-    for (int i = titleLines.size() - 1; i > 0; --i) {
-        String line = titleLines[i];
+    for (size_t i = titleLines.size(); i > 0; --i) {
+        String line = titleLines[i - 1];
         if (isLikelyCreditText(line, true)) {
-            for (int j = titleLines.size() - 1; j >= i; --j) {
-                creditLines.insert(0, titleLines[j]);
-                titleLines.removeAt(j);
-            }
-            continue;
-        }
-        if (isLikelySubtitleText(line, true)) {
-            for (int j = titleLines.size() - 1; j >= i; --j) {
-                subtitleLines.insert(0, titleLines[j]);
-                titleLines.removeAt(j);
-            }
-            continue;
+            creditLines.insert(0, line);
+            titleLines.erase(titleLines.begin() + i - 1);
+        } else if (isLikelySubtitleText(line, true)) {
+            subtitleLines.insert(0, line);
+            titleLines.erase(titleLines.begin() + i - 1);
         }
     }
     title = titleLines.join(u"\n");

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -3568,7 +3568,7 @@ bool MusicXMLParserDirection::isLikelyFingering() const
 MusicXMLInferredFingering::MusicXMLInferredFingering(double totalY,
                                                      EngravingItem* element,
                                                      String& text,
-                                                     int track,
+                                                     track_idx_t track,
                                                      String placement,
                                                      Measure* measure,
                                                      Fraction tick)
@@ -3612,7 +3612,7 @@ bool MusicXMLInferredFingering::findAndAddToNotes(Measure* measure)
 {
     roundTick(measure);
     std::vector<Note*> collectedNotes;
-    for (int track = m_track; track < m_track + 4; ++track) {
+    for (track_idx_t track = m_track; track < m_track + 4; ++track) {
         Chord* candidateChord = measure->findChord(tick(), track);
         if (candidateChord) {
             if (candidateChord->notes().size() >= fingerings().size()) {

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
@@ -501,11 +501,11 @@ private:
 class MusicXMLInferredFingering
 {
 public:
-    MusicXMLInferredFingering(double totalY, EngravingItem* element, String& text, int track, String placement, Measure* measure,
+    MusicXMLInferredFingering(double totalY, EngravingItem* element, String& text, track_idx_t track, String placement, Measure* measure,
                               Fraction tick);
     double totalY() const { return m_totalY; }
     Fraction tick() const { return m_tick; }
-    int track() const { return m_track; }
+    track_idx_t track() const { return m_track; }
     std::vector<String> fingerings() const { return m_fingerings; }
     bool findAndAddToNotes(Measure* measure);
     MusicXMLDelayedDirectionElement* toDelayedDirection();
@@ -515,7 +515,7 @@ private:
     EngravingItem* m_element;
     String m_text;
     std::vector<String> m_fingerings;
-    int m_track;
+    track_idx_t m_track;
     String m_placement;
     Measure* m_measure;
     Fraction m_tick;


### PR DESCRIPTION
reg.: conversion from 'size_t' to 'int', possible loss of data (C4267)