### PR TITLE
Fix #22045: Maintain staff type when enabling small staff / cutaway

### DIFF
--- a/src/instrumentsscene/view/staffsettingsmodel.cpp
+++ b/src/instrumentsscene/view/staffsettingsmodel.cpp
@@ -42,7 +42,6 @@ void StaffSettingsModel::load(const QString& staffId)
 
     m_staffId = staffId;
     m_config = notationParts()->staffConfig(m_staffId);
-    m_type = staff->staffType()->type();
 
     m_voicesVisibility.clear();
     for (const bool& voice : staff->visibilityVoices()) {
@@ -128,19 +127,25 @@ bool StaffSettingsModel::isMainScore() const
 
 int StaffSettingsModel::staffType() const
 {
-    return static_cast<int>(m_type);
+    return static_cast<int>(m_config.staffType.type());
 }
 
 void StaffSettingsModel::setStaffType(int type)
 {
     auto type_ = static_cast<StaffTypeId>(type);
 
-    if (m_type == type_ || !notationParts()) {
+    if (m_config.staffType.type() == type_ || !notationParts()) {
         return;
     }
 
-    m_type = type_;
-    notationParts()->setStaffType(m_staffId, m_type);
+    bool wasSmall = m_config.staffType.isSmall();
+
+    notationParts()->setStaffType(m_staffId, type_);
+    m_config = notationParts()->staffConfig(m_staffId);
+
+    if (wasSmall != m_config.staffType.isSmall()) {
+        emit isSmallStaffChanged();
+    }
 
     emit staffTypeChanged();
 }

--- a/src/instrumentsscene/view/staffsettingsmodel.h
+++ b/src/instrumentsscene/view/staffsettingsmodel.h
@@ -84,7 +84,6 @@ private:
 
     ID m_staffId;
     QList<bool> m_voicesVisibility;
-    notation::StaffTypeId m_type = notation::StaffTypeId::STANDARD;
     notation::StaffConfig m_config;
 };
 }


### PR DESCRIPTION
Resolves: #22045

Note that `cutaway` and `small` are handled a little differently - `cutaway` is preserved when changing the staff type, while `small` is reset (hence the need for `wasSmall`). Perhaps we should bring these in-line with each other at some point, but that doesn't seem entirely trivial and is beyond the scope of this PR.