### PR TITLE
Prevent crash when opening ms1/2 score with invalid trill in excerpt

### DIFF
--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -692,6 +692,16 @@ void Excerpt::cloneSpanner(Spanner* s, Score* score, track_idx_t dstTrack, track
     }
 
     if (!ns->startElement() || !ns->endElement()) {
+        if (EngravingItem* startElement = ns->startElement()) {
+            if (startElement->isChord()) {
+                toChord(startElement)->removeStartingSpanner(ns);
+            }
+        }
+        if (EngravingItem* endElement = ns->endElement()) {
+            if (endElement->isChord()) {
+                toChord(endElement)->removeEndingSpanner(ns);
+            }
+        }
         delete ns;
         return;
     }


### PR DESCRIPTION
```cpp
=================================================================
==82255==ERROR: AddressSanitizer: heap-use-after-free on address 0x0001722e8668 at pc 0x0001008fb410 bp 0x00016fde99c0 sp 0x00016fde99b8
READ of size 4 at 0x0001722e8668 thread T0
    #0 0x1008fb40c in mu::engraving::EngravingObject::type() const engravingobject.h:216
    #1 0x100fa3ae4 in mu::engraving::EngravingObject::isTrill() const engravingobject.h:403
    #2 0x100fa273c in mu::engraving::Chord::cmdUpdateNotes(mu::engraving::AccidentalState*) chord.cpp:1709
    #3 0x102f8a9f8 in mu::engraving::rendering::dev::ModifyDom::cmdUpdateNotes(mu::engraving::Measure const*, mu::engraving::rendering::dev::DomAccessor const&) modifydom.cpp:89
    #4 0x102d1e0cc in mu::engraving::rendering::dev::MeasureLayout::layoutMeasure(mu::engraving::MeasureBase*, mu::engraving::rendering::dev::LayoutContext&) measurelayout.cpp:872
    #5 0x102d1fb3c in mu::engraving::rendering::dev::MeasureLayout::getNextMeasure(mu::engraving::rendering::dev::LayoutContext&) measurelayout.cpp:1005
    #6 0x102e63068 in mu::engraving::rendering::dev::SystemLayout::collectSystem(mu::engraving::rendering::dev::LayoutContext&) systemlayout.cpp:354
    #7 0x102ed99b4 in mu::engraving::rendering::dev::PageLayout::collectPage(mu::engraving::rendering::dev::LayoutContext&) pagelayout.cpp:227
    #8 0x102cc18b0 in mu::engraving::rendering::dev::ScorePageViewLayout::doLayout(mu::engraving::rendering::dev::LayoutContext&) scorepageviewlayout.cpp:208
    #9 0x102cc1608 in mu::engraving::rendering::dev::ScorePageViewLayout::layoutPageView(mu::engraving::Score*, mu::engraving::rendering::dev::LayoutContext&, mu::engraving::Fraction const&, mu::engraving::Fraction const&) scorepageviewlayout.cpp:190
    #10 0x102cb5300 in mu::engraving::rendering::dev::ScoreLayout::layoutRange(mu::engraving::Score*, mu::engraving::Fraction const&, mu::engraving::Fraction const&) scorelayout.cpp:87
    #11 0x102b4e014 in mu::engraving::rendering::dev::ScoreRenderer::layoutScore(mu::engraving::Score*, mu::engraving::Fraction const&, mu::engraving::Fraction const&) const scorerenderer.cpp:48
    #12 0x101cb18c8 in mu::engraving::Score::doLayoutRange(mu::engraving::Fraction const&, mu::engraving::Fraction const&) score.cpp:5679
    #13 0x101c77c68 in mu::engraving::Score::doLayout() score.cpp:5650
    #14 0x1014464b8 in mu::engraving::Excerpt::createExcerpt(mu::engraving::Excerpt*) excerpt.cpp:416
    #15 0x102411088 in mu::engraving::read114::Read114::readScore(mu::engraving::Score*, mu::engraving::XmlReader&, mu::engraving::rw::ReadInOutData*) read114.cpp:3217
    #16 0x102330988 in mu::engraving::MscLoader::readMasterScore(mu::engraving::MasterScore*, mu::engraving::XmlReader&, bool, mu::engraving::rw::ReadInOutData*, mu::engraving::compat::ReadStyleHook*) mscloader.cpp:238
    #17 0x10232ee10 in mu::engraving::MscLoader::loadMscz(mu::engraving::MasterScore*, mu::engraving::MscReader const&, mu::engraving::SettingsCompat&, bool) mscloader.cpp:130
    #18 0x100d28a84 in mu::engraving::EngravingProject::loadMscz(mu::engraving::MscReader const&, mu::engraving::SettingsCompat&, bool) engravingproject.cpp:148
    #19 0x10608d74c in mu::project::NotationProject::doLoad(mu::io::path_t const&, mu::io::path_t const&, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) notationproject.cpp:161
    #20 0x1060893f4 in mu::project::NotationProject::load(mu::io::path_t const&, mu::io::path_t const&, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) notationproject.cpp:123
    #21 0x10620d6cc in mu::project::ProjectActionsController::loadProject(mu::io::path_t const&) projectactionscontroller.cpp:271
    #22 0x10620c2c0 in mu::project::ProjectActionsController::doOpenProject(mu::io::path_t const&) projectactionscontroller.cpp:306
    #23 0x10620834c in mu::project::ProjectActionsController::openProject(mu::io::path_t const&, QString const&) projectactionscontroller.cpp:254
    #24 0x1062051f8 in mu::project::ProjectActionsController::openProject(mu::project::ProjectFile const&) projectactionscontroller.cpp:188
    #25 0x1061fd954 in mu::project::ProjectActionsController::openProject(mu::actions::ActionData const&) projectactionscontroller.cpp:170
    #26 0x10625140c in void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) const iactionsdispatcher.h:86
    #27 0x1062512dc in decltype(std::declval<mu::project::ProjectActionsController>()(std::declval<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>(), std::declval<mu::actions::ActionData const&>())) std::__1::__invoke[abi:ue170006]<void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&>(mu::project::ProjectActionsController&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) invoke.h:340
    #28 0x106251284 in void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ue170006]<void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&>(void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) invoke.h:415
    #29 0x106251250 in std::__1::__function::__alloc_func<void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&), std::__1::allocator<void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)>, void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)>::operator()[abi:ue170006](std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) function.h:193
    #30 0x10624d3f8 in std::__1::__function::__func<void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&), std::__1::allocator<void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)>, void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)>::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) function.h:364
    #31 0x103857e88 in std::__1::__function::__value_func<void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)>::operator()[abi:ue170006](std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) const function.h:518
    #32 0x10385180c in std::__1::function<void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)>::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) const function.h:1169
    #33 0x103850420 in mu::actions::ActionsDispatcher::dispatch(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) actionsdispatcher.cpp:69
    #34 0x1065cb064 in mu::project::ScoresPageModel::openScore(QString const&, QString const&) scorespagemodel.cpp:51
    #35 0x105fd0850 in mu::project::ScoresPageModel::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) moc_scorespagemodel.cpp:115
    #36 0x105fd1200 in mu::project::ScoresPageModel::qt_metacall(QMetaObject::Call, int, void**) moc_scorespagemodel.cpp:197
    #37 0x11c12c630  (QtQml:arm64+0x134630)
    #38 0x11c129138  (QtQml:arm64+0x131138)
    #39 0x11c127b48 in QV4::QObjectMethod::callInternal(QV4::Value const*, QV4::Value const*, int) const+0x324 (QtQml:arm64+0x12fb48)
    #40 0x11c1be270  (QtQml:arm64+0x1c6270)
    #41 0x11c1bef58  (QtQml:arm64+0x1c6f58)
    #42 0x11da0af74 in QObject::event(QEvent*)+0x244 (QtCore:arm64+0xcef74)
    #43 0x11b12ca54 in QApplicationPrivate::notify_helper(QObject*, QEvent*)+0x10c (QtWidgets:arm64+0xca54)
    #44 0x11b12dc88 in QApplication::notify(QObject*, QEvent*)+0x210 (QtWidgets:arm64+0xdc88)
    #45 0x11d9cab7c in QCoreApplication::notifyInternal2(QObject*, QEvent*)+0xcc (QtCore:arm64+0x8eb7c)
    #46 0x11d9cbed0 in QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*)+0x338 (QtCore:arm64+0x8fed0)
    #47 0x11a9957b0  (libqcocoa.dylib:arm64+0x157b0)
    #48 0x11a995e14  (libqcocoa.dylib:arm64+0x15e14)
    #49 0x19c8b5eac in __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__+0x18 (CoreFoundation:arm64e+0x7deac)
    #50 0x19c8b5e40 in __CFRunLoopDoSource0+0xac (CoreFoundation:arm64e+0x7de40)
    #51 0x19c8b5bb0 in __CFRunLoopDoSources0+0xf0 (CoreFoundation:arm64e+0x7dbb0)
    #52 0x19c8b479c in __CFRunLoopRun+0x338 (CoreFoundation:arm64e+0x7c79c)
    #53 0x19c8b3e08 in CFRunLoopRunSpecific+0x25c (CoreFoundation:arm64e+0x7be08)
    #54 0x1a704effc in RunCurrentEventLoopInMode+0x120 (HIToolbox:arm64e+0x32ffc)
    #55 0x1a704ee38 in ReceiveNextEventCommon+0x284 (HIToolbox:arm64e+0x32e38)
    #56 0x1a704eb90 in _BlockUntilNextEventMatchingListInModeWithFilter+0x48 (HIToolbox:arm64e+0x32b90)
    #57 0x1a010c96c in _DPSNextEvent+0x290 (AppKit:arm64e+0x3a96c)
    #58 0x1a08fede8 in -[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]+0x2b8 (AppKit:arm64e+0x82cde8)
    #59 0x1a00ffcb4 in -[NSApplication run]+0x1d8 (AppKit:arm64e+0x2dcb4)
    #60 0x11a994d30  (libqcocoa.dylib:arm64+0x14d30)
    #61 0x11d9d3ee4 in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>)+0x1f0 (QtCore:arm64+0x97ee4)
    #62 0x11d9cb258 in QCoreApplication::exec()+0x7c (QtCore:arm64+0x8f258)
    #63 0x100086f68 in mu::app::App::run(int, char**) app.cpp:355
    #64 0x1000122d0 in main main.cpp:373
    #65 0x19c44e0dc  (<unknown module>)

0x0001722e8668 is located 40 bytes inside of 408-byte region [0x0001722e8640,0x0001722e87d8)
freed by thread T0 here:
    #0 0x11de9db8c in wrap__ZdlPv+0x74 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x61b8c)
    #1 0x10148bed4 in mu::engraving::Trill::operator delete(void*) trill.h:74
    #2 0x101d6fba8 in mu::engraving::Trill::~Trill() trill.h:72
    #3 0x10144d090 in mu::engraving::Excerpt::cloneSpanner(mu::engraving::Spanner*, mu::engraving::Score*, unsigned long, unsigned long) excerpt.cpp:700
    #4 0x101448c84 in mu::engraving::Excerpt::cloneStaves(mu::engraving::Score*, mu::engraving::Score*, std::__1::vector<unsigned long, std::__1::allocator<unsigned long>> const&, std::__1::multimap<unsigned long, unsigned long, std::__1::less<unsigned long>, std::__1::allocator<std::__1::pair<unsigned long const, unsigned long>>> const&) excerpt.cpp:1139
    #5 0x101446018 in mu::engraving::Excerpt::createExcerpt(mu::engraving::Excerpt*) excerpt.cpp:386
    #6 0x102411088 in mu::engraving::read114::Read114::readScore(mu::engraving::Score*, mu::engraving::XmlReader&, mu::engraving::rw::ReadInOutData*) read114.cpp:3217
    #7 0x102330988 in mu::engraving::MscLoader::readMasterScore(mu::engraving::MasterScore*, mu::engraving::XmlReader&, bool, mu::engraving::rw::ReadInOutData*, mu::engraving::compat::ReadStyleHook*) mscloader.cpp:238
    #8 0x10232ee10 in mu::engraving::MscLoader::loadMscz(mu::engraving::MasterScore*, mu::engraving::MscReader const&, mu::engraving::SettingsCompat&, bool) mscloader.cpp:130
    #9 0x100d28a84 in mu::engraving::EngravingProject::loadMscz(mu::engraving::MscReader const&, mu::engraving::SettingsCompat&, bool) engravingproject.cpp:148
    #10 0x10608d74c in mu::project::NotationProject::doLoad(mu::io::path_t const&, mu::io::path_t const&, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) notationproject.cpp:161
    #11 0x1060893f4 in mu::project::NotationProject::load(mu::io::path_t const&, mu::io::path_t const&, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) notationproject.cpp:123
    #12 0x10620d6cc in mu::project::ProjectActionsController::loadProject(mu::io::path_t const&) projectactionscontroller.cpp:271
    #13 0x10620c2c0 in mu::project::ProjectActionsController::doOpenProject(mu::io::path_t const&) projectactionscontroller.cpp:306
    #14 0x10620834c in mu::project::ProjectActionsController::openProject(mu::io::path_t const&, QString const&) projectactionscontroller.cpp:254
    #15 0x1062051f8 in mu::project::ProjectActionsController::openProject(mu::project::ProjectFile const&) projectactionscontroller.cpp:188
    #16 0x1061fd954 in mu::project::ProjectActionsController::openProject(mu::actions::ActionData const&) projectactionscontroller.cpp:170
    #17 0x10625140c in void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) const iactionsdispatcher.h:86
    #18 0x1062512dc in decltype(std::declval<mu::project::ProjectActionsController>()(std::declval<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>(), std::declval<mu::actions::ActionData const&>())) std::__1::__invoke[abi:ue170006]<void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&>(mu::project::ProjectActionsController&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) invoke.h:340
    #19 0x106251284 in void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ue170006]<void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&>(void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) invoke.h:415
    #20 0x106251250 in std::__1::__function::__alloc_func<void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&), std::__1::allocator<void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)>, void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)>::operator()[abi:ue170006](std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) function.h:193
    #21 0x10624d3f8 in std::__1::__function::__func<void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&), std::__1::allocator<void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)>, void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)>::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) function.h:364
    #22 0x103857e88 in std::__1::__function::__value_func<void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)>::operator()[abi:ue170006](std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) const function.h:518
    #23 0x10385180c in std::__1::function<void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)>::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) const function.h:1169
    #24 0x103850420 in mu::actions::ActionsDispatcher::dispatch(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) actionsdispatcher.cpp:69
    #25 0x1065cb064 in mu::project::ScoresPageModel::openScore(QString const&, QString const&) scorespagemodel.cpp:51
    #26 0x105fd0850 in mu::project::ScoresPageModel::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) moc_scorespagemodel.cpp:115
    #27 0x105fd1200 in mu::project::ScoresPageModel::qt_metacall(QMetaObject::Call, int, void**) moc_scorespagemodel.cpp:197
    #28 0x11c12c630  (QtQml:arm64+0x134630)
    #29 0x11c129138  (QtQml:arm64+0x131138)

previously allocated by thread T0 here:
    #0 0x11de9d74c in wrap__Znwm+0x74 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x6174c)
    #1 0x10148be78 in mu::engraving::Trill::operator new(unsigned long) trill.h:74
    #2 0x101d6fbd4 in mu::engraving::Trill::clone() const trill.h:85
    #3 0x1021dd624 in mu::engraving::Trill::linkedClone() trill.cpp:202
    #4 0x10144c0bc in mu::engraving::Excerpt::cloneSpanner(mu::engraving::Spanner*, mu::engraving::Score*, unsigned long, unsigned long) excerpt.cpp:652
    #5 0x101448c84 in mu::engraving::Excerpt::cloneStaves(mu::engraving::Score*, mu::engraving::Score*, std::__1::vector<unsigned long, std::__1::allocator<unsigned long>> const&, std::__1::multimap<unsigned long, unsigned long, std::__1::less<unsigned long>, std::__1::allocator<std::__1::pair<unsigned long const, unsigned long>>> const&) excerpt.cpp:1139
    #6 0x101446018 in mu::engraving::Excerpt::createExcerpt(mu::engraving::Excerpt*) excerpt.cpp:386
    #7 0x102411088 in mu::engraving::read114::Read114::readScore(mu::engraving::Score*, mu::engraving::XmlReader&, mu::engraving::rw::ReadInOutData*) read114.cpp:3217
    #8 0x102330988 in mu::engraving::MscLoader::readMasterScore(mu::engraving::MasterScore*, mu::engraving::XmlReader&, bool, mu::engraving::rw::ReadInOutData*, mu::engraving::compat::ReadStyleHook*) mscloader.cpp:238
    #9 0x10232ee10 in mu::engraving::MscLoader::loadMscz(mu::engraving::MasterScore*, mu::engraving::MscReader const&, mu::engraving::SettingsCompat&, bool) mscloader.cpp:130
    #10 0x100d28a84 in mu::engraving::EngravingProject::loadMscz(mu::engraving::MscReader const&, mu::engraving::SettingsCompat&, bool) engravingproject.cpp:148
    #11 0x10608d74c in mu::project::NotationProject::doLoad(mu::io::path_t const&, mu::io::path_t const&, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) notationproject.cpp:161
    #12 0x1060893f4 in mu::project::NotationProject::load(mu::io::path_t const&, mu::io::path_t const&, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) notationproject.cpp:123
    #13 0x10620d6cc in mu::project::ProjectActionsController::loadProject(mu::io::path_t const&) projectactionscontroller.cpp:271
    #14 0x10620c2c0 in mu::project::ProjectActionsController::doOpenProject(mu::io::path_t const&) projectactionscontroller.cpp:306
    #15 0x10620834c in mu::project::ProjectActionsController::openProject(mu::io::path_t const&, QString const&) projectactionscontroller.cpp:254
    #16 0x1062051f8 in mu::project::ProjectActionsController::openProject(mu::project::ProjectFile const&) projectactionscontroller.cpp:188
    #17 0x1061fd954 in mu::project::ProjectActionsController::openProject(mu::actions::ActionData const&) projectactionscontroller.cpp:170
    #18 0x10625140c in void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) const iactionsdispatcher.h:86
    #19 0x1062512dc in decltype(std::declval<mu::project::ProjectActionsController>()(std::declval<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>(), std::declval<mu::actions::ActionData const&>())) std::__1::__invoke[abi:ue170006]<void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&>(mu::project::ProjectActionsController&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) invoke.h:340
    #20 0x106251284 in void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ue170006]<void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&>(void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) invoke.h:415
    #21 0x106251250 in std::__1::__function::__alloc_func<void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&), std::__1::allocator<void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)>, void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)>::operator()[abi:ue170006](std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) function.h:193
    #22 0x10624d3f8 in std::__1::__function::__func<void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&), std::__1::allocator<void mu::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(mu::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(mu::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)>, void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)>::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) function.h:364
    #23 0x103857e88 in std::__1::__function::__value_func<void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)>::operator()[abi:ue170006](std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) const function.h:518
    #24 0x10385180c in std::__1::function<void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&)>::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) const function.h:1169
    #25 0x103850420 in mu::actions::ActionsDispatcher::dispatch(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::actions::ActionData const&) actionsdispatcher.cpp:69
    #26 0x1065cb064 in mu::project::ScoresPageModel::openScore(QString const&, QString const&) scorespagemodel.cpp:51
    #27 0x105fd0850 in mu::project::ScoresPageModel::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) moc_scorespagemodel.cpp:115
    #28 0x105fd1200 in mu::project::ScoresPageModel::qt_metacall(QMetaObject::Call, int, void**) moc_scorespagemodel.cpp:197
    #29 0x11c12c630  (QtQml:arm64+0x134630)

SUMMARY: AddressSanitizer: heap-use-after-free engravingobject.h:216 in mu::engraving::EngravingObject::type() const
Shadow bytes around the buggy address:
  0x0001722e8380: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0001722e8400: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0001722e8480: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0001722e8500: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0001722e8580: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x0001722e8600: fa fa fa fa fa fa fa fa fd fd fd fd fd[fd]fd fd
  0x0001722e8680: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0001722e8700: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0001722e8780: fd fd fd fd fd fd fd fd fd fd fd fa fa fa fa fa
  0x0001722e8800: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0001722e8880: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==82255==ABORTING
```