### PR TITLE
MEI: improve accid handling

### DIFF
--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -1273,7 +1273,14 @@ bool MeiExporter::writeNote(const Note* note, const Chord* chord, const Staff* s
 
     if (meiAccid.HasAccid() || meiAccid.HasAccidGes()) {
         pugi::xml_node accidNode = m_currentNode.append_child();
-        meiAccid.Write(accidNode, this->getLayerXmlIdFor(ACCID_L));
+        Accidental* acc = note->accidental();
+        if (acc) {
+            Convert::colorToMEI(acc, meiAccid);
+            std::string xmlId = this->getXmlIdFor(acc, 'a');
+            meiAccid.Write(accidNode, xmlId);
+        } else {
+            meiAccid.Write(accidNode, this->getLayerXmlIdFor(ACCID_L));
+        }
     }
 
     // non critical assert

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -1895,6 +1895,7 @@ bool MeiImporter::readNote(pugi::xml_node noteNode, Measure* measure, int track,
     note->setPitch(pitchSt.pitch, tpc1, pitchSt.tpc2);
 
     Accidental* accid = Factory::createAccidental(note);
+    Convert::colorFromMEI(accid, meiAccid);
     m_uids->reg(accid, meiAccid.m_xmlId);
     accid->setAccidentalType(pitchSt.accidType);
     //accid->setBracket(AccidentalBracket::BRACKET); // Not supported in MEI-Basic

--- a/src/importexport/mei/tests/data/color-01.mei
+++ b/src/importexport/mei/tests/data/color-01.mei
@@ -109,8 +109,10 @@
                               <rest xml:id="r13mu556" type="mscore-beam-none" dur="8" />
                               <rest xml:id="r9bkfps" type="mscore-beam-none" dur="8" />
                            </tuplet>
-                           <clef xml:id="cdi1p4m" shape="G" line="2" color="#00F900" />
-                           <note xml:id="n12rdkm" dur="4" pname="e" oct="4" />
+                           <clef xml:id="c14ip5c8" shape="G" line="2" color="#00F900" />
+                           <note xml:id="nyi0wv4" dur="4" pname="e" oct="4">
+                              <accid xml:id="a9iw28ka" accid="f" color="#D783FF" />
+                           </note>
                         </layer>
                      </staff>
                      <slur xml:id="srexdvh" startid="#nl6vufl" color="#00F900" endid="#n12rdkm" />

--- a/src/importexport/mei/tests/data/color-01.mei
+++ b/src/importexport/mei/tests/data/color-01.mei
@@ -115,7 +115,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <slur xml:id="srexdvh" startid="#nl6vufl" color="#00F900" endid="#n12rdkm" />
+                     <slur xml:id="srexdvh" startid="#nl6vufl" color="#00F900" endid="#nyi0wv4" />
                   </measure>
                   <measure xml:id="mtp12q1" n="5">
                      <staff xml:id="m5s1" n="1">

--- a/src/importexport/mei/tests/data/color-01.mscx
+++ b/src/importexport/mei/tests/data/color-01.mscx
@@ -354,8 +354,13 @@
                 </prev>
               </Spanner>
             <Note>
-              <pitch>64</pitch>
-              <tpc>18</tpc>
+              <Accidental>
+                <role>1</role>
+                <subtype>accidentalFlat</subtype>
+                <color r="215" g="131" b="255" a="255"/>
+                </Accidental>
+              <pitch>63</pitch>
+              <tpc>11</tpc>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -42,6 +42,7 @@
 #include <math.h>
 
 #include "containers.h"
+#include "realfn.h"
 #include "io/iodevice.h"
 #include "io/buffer.h"
 #include "io/file.h"
@@ -7535,7 +7536,7 @@ static void writeStaffDetails(XmlWriter& xml, const Part* part)
     for (size_t i = 0; i < staves; i++) {
         Staff* st = part->staff(i);
         const double mag = st->staffMag(Fraction(0, 1));
-        if (st->lines(Fraction(0, 1)) != 5 || st->isTabStaff(Fraction(0, 1)) || !RealIsEqual(mag, 1.0) || !st->show()) {
+        if (st->lines(Fraction(0, 1)) != 5 || st->isTabStaff(Fraction(0, 1)) || !muse::RealIsEqual(mag, 1.0) || !st->show()) {
             XmlWriter::Attributes attributes;
             if (staves > 1) {
                 attributes.push_back({ "number", i + 1 });
@@ -7564,7 +7565,7 @@ static void writeStaffDetails(XmlWriter& xml, const Part* part)
                 }
             }
 
-            if (!RealIsEqual(mag, 1.0)) {
+            if (!muse::RealIsEqual(mag, 1.0)) {
                 xml.tag("staff-size", mag * 100);
             }
 


### PR DESCRIPTION
This PR adds support for `xml:id` and `color` attributes to MEI's accidental import/export.