### PR TITLE
Fix #22055: button size changes when button is selected

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/PageTabButton.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/PageTabButton.qml
@@ -131,6 +131,11 @@ RadioDelegate {
         implicitWidth: root.leftPadding + contentRow.implicitWidth + root.rightPadding
         implicitHeight: contentRow.implicitHeight
 
+        FontMetrics {
+            id: fontMetricsSelected
+            font: root.selectedStateFont
+        }
+
         Row {
             id: contentRow
             anchors.fill: parent
@@ -145,10 +150,12 @@ RadioDelegate {
             StyledTextLabel {
                 id: textLabel
                 anchors.verticalCenter: parent.verticalCenter
-
-                horizontalAlignment: Text.AlignLeft
+ 
+                horizontalAlignment: root.isVertical ? Text.AlignHCenter : Text.AlignLeft
                 font: root.normalStateFont
                 text: root.title
+                elide: Text.ElideNone
+                width: fontMetricsSelected.boundingRect(text).width
 
                 visible: !root.iconOnly
             }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/PageTabButton.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/PageTabButton.qml
@@ -131,9 +131,10 @@ RadioDelegate {
         implicitWidth: root.leftPadding + contentRow.implicitWidth + root.rightPadding
         implicitHeight: contentRow.implicitHeight
 
-        FontMetrics {
-            id: fontMetricsSelected
+        TextMetrics {
+            id: textMetricsSelected
             font: root.selectedStateFont
+            text: root.title
         }
 
         Row {
@@ -150,12 +151,11 @@ RadioDelegate {
             StyledTextLabel {
                 id: textLabel
                 anchors.verticalCenter: parent.verticalCenter
- 
+
                 horizontalAlignment: root.isVertical ? Text.AlignHCenter : Text.AlignLeft
                 font: root.normalStateFont
                 text: root.title
-                elide: Text.ElideNone
-                width: fontMetricsSelected.boundingRect(text).width
+                width: textMetricsSelected.advanceWidth
 
                 visible: !root.iconOnly
             }


### PR DESCRIPTION
Resolves: #22055

The size of buttons in the MainToolBar was being determined by the size of the displayed text within them. Since this text size changed when the button was selected (the text becomes bold, thus increasing in size), the button size changed. I have set the button size to always be determined by the Selected Font Size, so size does not change upon selecting the button. A re-centering of the text was also required.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [] I created a unit test or vtest to verify the changes I made (if applicable)
