### PR TITLE
Fix #7819 - adjustment to previous page-clipping fix

### DIFF
--- a/src/engraving/rendering/score/paint.cpp
+++ b/src/engraving/rendering/score/paint.cpp
@@ -116,6 +116,14 @@ void Paint::paintScore(Painter* painter, Score* score, const IScoreRenderer::Pai
 
             painter->beginObject("page_" + std::to_string(pi));
 
+            if (opt.isPrinting && painter->hasClipping() && (drawRect.top() < pageAbsRect.top() || drawRect.bottom() > pageAbsRect.bottom()
+                                                             || drawRect.left() < pageAbsRect.left()
+                                                             || drawRect.right() > pageAbsRect.right())) {
+                // prevent elements from being drawn off the edge of the page (e.g. too many staves),
+                // for now only in "Publish" mode (opt.isPrinting == true)
+                painter->setClipRect(pageAbsRect.intersected(drawRect));
+            }
+
             if (opt.isMultiPage) {
                 painter->translate(pagePos);
             } else if (opt.trimMarginPixelSize >= 0) {

--- a/src/engraving/rendering/score/paint.cpp
+++ b/src/engraving/rendering/score/paint.cpp
@@ -116,9 +116,7 @@ void Paint::paintScore(Painter* painter, Score* score, const IScoreRenderer::Pai
 
             painter->beginObject("page_" + std::to_string(pi));
 
-            if (opt.isPrinting && painter->hasClipping() && (drawRect.top() < pageAbsRect.top() || drawRect.bottom() > pageAbsRect.bottom()
-                                                             || drawRect.left() < pageAbsRect.left()
-                                                             || drawRect.right() > pageAbsRect.right())) {
+            if (opt.isPrinting && painter->hasClipping()) {
                 // prevent elements from being drawn off the edge of the page (e.g. too many staves),
                 // for now only in "Publish" mode (opt.isPrinting == true)
                 painter->setClipRect(pageAbsRect.intersected(drawRect));


### PR DESCRIPTION
Resolves: #7819 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

Had previously fixed this but code had been moved around since and additional logic around when to apply clipping added by others.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
