### PR TITLE
Made extensions dialog not modal by default

### DIFF
--- a/share/extensions/example1/manifest.json
+++ b/share/extensions/example1/manifest.json
@@ -1,6 +1,7 @@
 {
     "uri": "musescore://extensions/dev/example_1",
     "type": "form",
+    "modal": true,
     "title": "Example 1 (default)",
 
     "main": "main.qml"

--- a/src/framework/extensions/extensionstypes.h
+++ b/src/framework/extensions/extensionstypes.h
@@ -36,6 +36,9 @@ namespace mu::extensions {
 //! 2 - extensions
 constexpr int DEFAULT_API_VERSION = 2;
 
+//! NOTE Default extension dialog modality
+constexpr bool DEFAULT_MODAL = false;
+
 enum class Type {
     Undefined = 0,
     Form,       // Have UI, controls, user interaction
@@ -74,6 +77,7 @@ enum Filter {
 struct Action {
     std::string code;
     Type type = Type::Undefined;
+    bool modal = DEFAULT_MODAL;
     String title;
     mu::io::path_t main;
     int apiversion = DEFAULT_API_VERSION;

--- a/src/framework/extensions/internal/extensionsloader.cpp
+++ b/src/framework/extensions/internal/extensionsloader.cpp
@@ -126,6 +126,7 @@ Manifest ExtensionsLoader::parseManifest(const io::path_t& path) const
             Action a;
             a.code = ao.value("code").toStdString();
             a.type = typeFromString(ao.value("type").toStdString());
+            a.modal = ao.value("modal", DEFAULT_MODAL).toBool();
             a.title = ao.value("title").toString();
             a.main = ao.value("main").toStdString();
             a.apiversion = m.apiversion;
@@ -135,6 +136,7 @@ Manifest ExtensionsLoader::parseManifest(const io::path_t& path) const
         Action a;
         a.code = "main";
         a.type = m.type;
+        a.modal = obj.value("modal", DEFAULT_MODAL).toBool();
         a.title = m.title;
         a.main = obj.value("main").toStdString();
         a.apiversion = m.apiversion;

--- a/src/framework/extensions/internal/extensionsprovider.cpp
+++ b/src/framework/extensions/internal/extensionsprovider.cpp
@@ -156,9 +156,13 @@ mu::Ret ExtensionsProvider::perform(const UriQuery& uri)
 {
     Action a = action(uri);
     switch (a.type) {
-    case Type::Form:
-        return interactive()->open(uri).ret;
-        break;
+    case Type::Form: {
+        UriQuery q = uri;
+        if (!q.contains("modal")) {
+            q.addParam("modal", Val(a.modal));
+        }
+        return interactive()->open(q).ret;
+    } break;
     case Type::Macros:
         return run(uri);
     default:

--- a/src/framework/ui/view/interactiveprovider.cpp
+++ b/src/framework/ui/view/interactiveprovider.cpp
@@ -339,8 +339,14 @@ void InteractiveProvider::fillExtData(QmlLaunchData* data, const UriQuery& q) co
     QVariantMap params;
     params["uri"] = QString::fromStdString(q.toString());
 
+    //! NOTE Extension dialogs open as non-modal by default
+    //! The modal parameter must be present in the uri
+    //! But here, just in case, `true` is indicated by default,
+    //! since this value is set in the base class of the dialog by default
+    params["modal"] = q.param("modal", Val(true)).toBool();
+
+    data->setValue("uri", QString::fromStdString(VIEWER_URI.toString()));
     data->setValue("sync", params.value("sync", false));
-    data->setValue("modal", params.value("modal", ""));
     data->setValue("params", params);
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/22084 

Now all dialogs with plugins are not modal by default.
For extensions of the new format, we can specify a modality (also not modal by default).

(documentation about extensions of the new format will come later)