### PR TITLE
Prevent various crashes when inserting measures in release builds

### DIFF
--- a/src/engraving/dom/segmentlist.cpp
+++ b/src/engraving/dom/segmentlist.cpp
@@ -139,19 +139,26 @@ void SegmentList::insert(Segment* e, Segment* el)
 
 void SegmentList::remove(Segment* e)
 {
+    // TODO: These types are problematic in certain circumstances. findBeforeRemove is a workaround for
+    // crashes #21049, #21098, and #21501 in release builds. It does not address the root cause.
+    bool findBeforeRemove = e->isHeaderClefType() || e->isKeySigType();
 #ifndef NDEBUG
-    check();
-    bool found = false;
-    for (Segment* s = m_first; s; s = s->next()) {
-        if (e == s) {
-            found = true;
-            break;
+    findBeforeRemove = true;
+#endif
+    if (findBeforeRemove) {
+        check();
+        bool found = false;
+        for (Segment* s = m_first; s; s = s->next()) {
+            if (e == s) {
+                found = true;
+                break;
+            }
+        }
+        IF_ASSERT_FAILED(found) {
+            LOGE() << String(u"segment %1 not in list").arg(String::fromAscii(e->subTypeName()));
+            return;
         }
     }
-    if (!found) {
-        ASSERT_X(String(u"segment %1 not in list").arg(String::fromAscii(e->subTypeName())));
-    }
-#endif
     --m_size;
     if (e == m_first) {
         m_first = m_first->next();


### PR DESCRIPTION
Resolves (partially): #21098
Resolves (partially): #21501
Maybe resolves (partially): #21049

These crashes are related to the manner in which we handle headers when inserting before the first measure. They were initially introduced with #17919 and compounded by #19405

Our current logic is to remove the headers from the old first measure, then add them to the new one (see `MasterScore::insertMeasure`). When undoing this action, we re-add the headers to the old first measure. In most circumstances this works as expected, but sometimes (in the steps described in the above issues) we fail to re-add the headers. This causes a crash when we try to access them through the measure's segment list at a later stage.

This PR offers a preventative fix for release builds (we'll still have an assertion failure in debug builds).