### PR TITLE
Remove xml import pedal endpoint hack

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -1989,10 +1989,6 @@ void MusicXMLParserPass2::part()
         auto sp = i->first;
         Fraction tick1 = Fraction::fromTicks(i->second.first);
         Fraction tick2 = Fraction::fromTicks(i->second.second);
-        if (sp->isPedal() && toPedal(sp)->endHookType() == HookType::HOOK_45) {
-            // Handle pedal change end tick (slightly hacky)
-            tick2 += m_score->findCR(tick2, sp->track())->ticks();
-        }
         //LOGD("spanner %p tp %d isHairpin %d tick1 %s tick2 %s track1 %d track2 %d start %p end %p",
         //       sp, sp->type(), sp->isHairpin(), muPrintable(tick1.toString()), muPrintable(tick2.toString()),
         //       sp->track(), sp->track2(), sp->startElement(), sp->endElement());

--- a/src/importexport/musicxml/tests/data/testPedalChangesBroken_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPedalChangesBroken_ref.mscx
@@ -293,7 +293,7 @@
               </Pedal>
             <next>
               <location>
-                <fractions>3/4</fractions>
+                <fractions>1/2</fractions>
                 </location>
               </next>
             </Spanner>
@@ -314,6 +314,13 @@
               </Note>
             </Chord>
           <Spanner type="Pedal">
+            <prev>
+              <location>
+                <fractions>-1/2</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          <Spanner type="Pedal">
             <Pedal>
               <endHookType>2</endHookType>
               <beginHookType>2</beginHookType>
@@ -321,7 +328,7 @@
             <next>
               <location>
                 <measures>1</measures>
-                <fractions>-1/4</fractions>
+                <fractions>-1/2</fractions>
                 </location>
               </next>
             </Spanner>
@@ -333,13 +340,6 @@
               <tpc>17</tpc>
               </Note>
             </Chord>
-          <Spanner type="Pedal">
-            <prev>
-              <location>
-                <fractions>-3/4</fractions>
-                </location>
-              </prev>
-            </Spanner>
           <Chord>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
@@ -352,6 +352,14 @@
         </Measure>
       <Measure>
         <voice>
+          <Spanner type="Pedal">
+            <prev>
+              <location>
+                <measures>-1</measures>
+                <fractions>1/2</fractions>
+                </location>
+              </prev>
+            </Spanner>
           <Chord>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
@@ -360,14 +368,6 @@
               <tpc>13</tpc>
               </Note>
             </Chord>
-          <Spanner type="Pedal">
-            <prev>
-              <location>
-                <measures>-1</measures>
-                <fractions>1/4</fractions>
-                </location>
-              </prev>
-            </Spanner>
           <Chord>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>


### PR DESCRIPTION
Resolves: See image
![image](https://github.com/musescore/MuseScore/assets/26510874/73112f58-3aee-4d13-8eec-2966d097153e)

At some point our pedal layout code improved, and this hack is no longer needed.

