### PR TITLE
Fix #21672: Prevent crash when realizing chords over multi-measure rests (4.3.0)

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -4161,6 +4161,12 @@ Segment* Score::setChord(Segment* segment, track_idx_t track, const Chord* chord
             LOGD("reached end of score");
             break;
         }
+
+        //it is possible that the next measure's ticks have not been computed yet. compute them now
+        if (nseg->ticks().isZero()) {
+            nseg->measure()->computeTicks();
+        }
+
         segment = nseg;
 
         cr = toChordRest(segment->element(track));


### PR DESCRIPTION
Resolves: #21672
Master PR: #21975