### PR TITLE
Fix wrong layout with mmRests in old files

### DIFF
--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -2641,6 +2641,7 @@ Fraction Segment::shortestChordRest() const
             continue;
         }
         cur = toChordRest(elem)->actualTicks();
+        assert(cur.isNotZero());
         if (cur < shortest) {
             shortest = cur;
         }

--- a/src/engraving/rw/read114/read114.cpp
+++ b/src/engraving/rw/read114/read114.cpp
@@ -1786,6 +1786,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx
                 mmr->setParent(segment);
                 mmr->setTrack(ctx.track());
                 read400::TRead::read(mmr, e, ctx);
+                mmr->setTicks(m->ticks());
                 segment->add(mmr);
                 lastTick = ctx.tick();
                 ctx.incTick(mmr->actualTicks());

--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -2593,6 +2593,7 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
                 mmr->setParent(segment);
                 mmr->setTrack(ctx.track());
                 read400::TRead::read(mmr, e, ctx);
+                mmr->setTicks(m->ticks());
                 segment->add(mmr);
                 lastTick = ctx.tick();
                 ctx.incTick(mmr->actualTicks());


### PR DESCRIPTION

![image](https://github.com/musescore/MuseScore/assets/93707756/68262188-18a4-4da8-92b9-51fe22ab2359)

![image](https://github.com/musescore/MuseScore/assets/93707756/75661da5-82c8-41bc-afa7-ebb1e9ab7f00)
