### PR TITLE
Fix #20361: Clicking the end of a text selection does nothing.

### DIFF
--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -617,8 +617,6 @@ bool TextCursor::set(const PointF& p, TextCursor::MoveMode mode)
     if (!m_text->ldata()->bbox().contains(pt)) {
         return false;
     }
-    size_t oldRow    = m_row;
-    size_t oldColumn = m_column;
 
 //      if (_text->_layout.empty())
 //            _text->_layout.append(TextBlock());
@@ -638,13 +636,12 @@ bool TextCursor::set(const PointF& p, TextCursor::MoveMode mode)
     }
     m_column = curLine().column(pt.x(), m_text);
 
-    if (oldRow != m_row || oldColumn != m_column) {
-        m_text->score()->setUpdateAll();
-        if (mode == TextCursor::MoveMode::MoveAnchor) {
-            clearSelection();
-        }
-        updateCursorFormat();
+    m_text->score()->setUpdateAll();
+    if (mode == TextCursor::MoveMode::MoveAnchor) {
+        clearSelection();
     }
+    updateCursorFormat();
+
     return true;
 }
 


### PR DESCRIPTION
MuseScore has an odd feature that allows you to resize text selections in the Notation View with the mouse by dragging on the end and moving it back and forward. This however means that, because of the way that inputs are processed, clicking on the end of a selection must not simply place the cursor there as would be expected. This commit changes that feature to be reserved to only be active while Shift is held down, which makes much more sense. Clicking on the end of the selection now behaves as would be expected, clearing the current selection and placing the cursor at the mouse pointer's location.

Tested on Windows.

Resolves: #20361

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
