### PR TITLE
Fix #20547: Staff creation when instrument is selected

### DIFF
--- a/src/instrumentsscene/view/abstractinstrumentspaneltreeitem.cpp
+++ b/src/instrumentsscene/view/abstractinstrumentspaneltreeitem.cpp
@@ -202,6 +202,10 @@ void AbstractInstrumentsPanelTreeItem::appendChild(AbstractInstrumentsPanelTreeI
     child->setParentItem(this);
 
     m_children.append(child);
+
+    if (isSelected()) {
+        child->setIsSelected(true);
+    }
 }
 
 void AbstractInstrumentsPanelTreeItem::insertChild(AbstractInstrumentsPanelTreeItem* child, int beforeRow)
@@ -213,6 +217,10 @@ void AbstractInstrumentsPanelTreeItem::insertChild(AbstractInstrumentsPanelTreeI
     child->setParentItem(this);
 
     m_children.insert(beforeRow, child);
+
+    if (isSelected()) {
+        child->setIsSelected(true);
+    }
 }
 
 bool AbstractInstrumentsPanelTreeItem::isEmpty() const


### PR DESCRIPTION
Previously, when adding a new staff under a selected instrument, it was created as non-selected. This caused confusion, particularly when hiding staffs, as selected staffs affected the newly created one, but not vice versa. To resolve this issue, I have updated the behavior so that a newly created staff is automatically selected if the instrument it is created for is selected. This ensures consistency and clarity in managing staffs, addressing the confusion experienced by users.

Resolves: #20547<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
