### PR TITLE
Fix crash on insert measures at start

### DIFF
--- a/src/engraving/dom/masterscore.cpp
+++ b/src/engraving/dom/masterscore.cpp
@@ -656,7 +656,11 @@ MeasureBase* MasterScore::insertMeasure(MeasureBase* beforeMeasure, const Insert
                         if (ee) {
                             doUndoRemoveElement(ee);
                             if (s->empty()) {
-                                undoRemoveElement(s);
+                                if (ee->isTimeSig()) {
+                                    undoRemoveElement(s);
+                                } else {
+                                    s->setEnabled(false);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Resolves: #21098 
Resolves: #21501 

@mathesoncalum @DmitryArefiev just trying this solution. Let me know if it holds up. 

The point is that Clefs and KeySigs segments are treated a bit differently (because they get added / removed many times during layout as they are part of all the system headers). If these segments aren't needed anymore, they don't get deleted but just `setEnabled(false)` (which I don't love, but that's how the system works), so it's reasonable to do the same here.