### PR TITLE
Untick 'Follow written tempo' for verbal tempo indications on XML import

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -2964,7 +2964,9 @@ void MusicXMLParserDirection::direction(const String& partId,
                 String sep = !m_metroText.empty() && !m_wordsText.empty() && rawWordsText.back() != ' ' ? u" " : String();
                 t->setXmlText(m_wordsText + sep + m_metroText);
                 ((TempoText*)t)->setTempo(m_tpoSound);
-                ((TempoText*)t)->setFollowText(true);
+                if (t->plainText().contains(u"=")) {
+                    ((TempoText*)t)->setFollowText(true);
+                }
                 m_score->setTempo(tick, m_tpoSound);
             }
         } else {


### PR DESCRIPTION
When verbal tempo markings are added to the score from the palette, 'Follow written tempo' is unticked.  This should be the same on XML import.  Verbal tempo markings do not contain an '=' symbol.

![Screenshot 2024-04-05 at 14 46 22](https://github.com/musescore/MuseScore/assets/26510874/89362f7f-fbc2-4371-ae73-d71170fee024)
