### PR TITLE
Fix MSVC/GCC compiler warnings (master)

### DIFF
--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -563,7 +563,7 @@ bool Dynamic::changeTimeAnchorType(const EditData& ed)
 
 bool Dynamic::moveSegment(const EditData& ed)
 {
-    if (!ed.modifiers & AltModifier && anchorToEndOfPrevious()) {
+    if (!(ed.modifiers & AltModifier) && anchorToEndOfPrevious()) {
         undoResetProperty(Pid::ANCHOR_TO_END_OF_PREVIOUS);
         return true;
     }

--- a/src/engraving/dom/line.cpp
+++ b/src/engraving/dom/line.cpp
@@ -487,7 +487,7 @@ PointF LineSegment::deltaRebaseLeft(const Segment* oldSeg, const Segment* newSeg
 ///   Helper function for anchors rebasing when dragging.
 //---------------------------------------------------------
 
-PointF LineSegment::deltaRebaseRight(const Segment* oldSeg, const Segment* newSeg, staff_idx_t staffIndex)
+PointF LineSegment::deltaRebaseRight(const Segment* oldSeg, const Segment* newSeg)
 {
     if (oldSeg == newSeg) {
         return PointF();

--- a/src/engraving/dom/line.h
+++ b/src/engraving/dom/line.h
@@ -80,7 +80,7 @@ private:
 
     Segment* findSegmentForGrip(Grip grip, mu::PointF pos) const;
     static mu::PointF deltaRebaseLeft(const Segment* oldSeg, const Segment* newSeg);
-    static mu::PointF deltaRebaseRight(const Segment* oldSeg, const Segment* newSeg, staff_idx_t staffIdx);
+    static mu::PointF deltaRebaseRight(const Segment* oldSeg, const Segment* newSeg);
     static Fraction lastSegmentEndTick(const Segment* lastSeg, const Spanner* s);
     LineSegment* rebaseAnchor(Grip grip, Segment* newSeg);
     void rebaseAnchors(EditData&, Grip);

--- a/src/engraving/dom/navigate.cpp
+++ b/src/engraving/dom/navigate.cpp
@@ -834,6 +834,7 @@ EngravingItem* Score::nextElement()
         }
         case ElementType::LAYOUT_BREAK: {
             staffId = 0;             // otherwise it will equal -1, which breaks the navigation
+            break;
         }
         case ElementType::SOUND_FLAG:
             if (EngravingItem* parent = toSoundFlag(e)->parentItem()) {
@@ -1002,6 +1003,7 @@ EngravingItem* Score::prevElement()
         break;
         case ElementType::LAYOUT_BREAK: {
             staffId = 0;             // otherwise it will equal -1, which breaks the navigation
+            break;
         }
         default:
             break;

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -2644,8 +2644,9 @@ bool TextBase::validateText(String& s)
         s = d;
         return true;
     }
-    LOGD("xml error at line %lld column %lld: %s", xml.lineNumber(), xml.columnNumber(), muPrintable(xml.errorString()));
-    LOGD("text: |%s|", muPrintable(ss));
+    LOGD() << "xml error at line " << xml.lineNumber() << " column " << xml.columnNumber()
+           << ": " << xml.errorString();
+    LOGD() << "text: |" << ss << "|";
     return false;
 }
 

--- a/src/engraving/rw/read114/read114.cpp
+++ b/src/engraving/rw/read114/read114.cpp
@@ -3017,7 +3017,7 @@ Err Read114::readScore(Score* score, XmlReader& e, ReadInOutData* out)
     }
 
     if (e.error() != XmlStreamReader::NoError) {
-        LOGD("%lld %lld: %s ", e.lineNumber(), e.columnNumber(), muPrintable(e.errorString()));
+        LOGD() << e.lineNumber() << " " << e.columnNumber() << ": " << e.errorString();
         return Err::FileBadFormat;
     }
 

--- a/src/engraving/rw/xmlreader.cpp
+++ b/src/engraving/rw/xmlreader.cpp
@@ -144,10 +144,10 @@ void XmlReader::unknown()
         LOGD("%s ", muPrintable(errorString()));
     }
     if (!m_docName.isEmpty()) {
-        LOGD("tag in <%s> line %lld col %lld: %s", muPrintable(m_docName), lineNumber() + m_offsetLines,
-             columnNumber(), name().ascii());
+        LOGD() << "tag in <" << m_docName << "> line " << lineNumber() + m_offsetLines << " col "
+               << columnNumber() << ": " << name();
     } else {
-        LOGD("line %lld col %lld: %s", lineNumber() + m_offsetLines, columnNumber(), name().ascii());
+        LOGD() << "line " << lineNumber() + m_offsetLines << " col " << columnNumber() << ": " << name();
     }
     skipCurrentElement();
 }


### PR DESCRIPTION
* reg.: 'staffIndex': unreferenced formal parameter (C4100)
   resp.: unused parameter ‘staffIndex’ [-Wunused-parameter]
* reg.: '&': unsafe operation: no value of type 'bool' promoted to type 'mu::engraving::KeyboardModifier' can equal the given constant (C4806)
   resp.: suggest parentheses around operand of ‘!’ or change ‘&’ to ‘&&’ or ‘!’ to ‘~’ [-Wparentheses]
* reg.: this statement may fall through [-Wimplicit-fallthrough=]
* reg.: format ‘%lld’ expects argument of type ‘long long int’, but argument has type ‘int64_t’ {aka ‘long int’} [-Wformat=]