### PR TITLE
fix rename uicomponents mu -> muse

### DIFF
--- a/src/project/view/pixmapscorethumbnailview.cpp
+++ b/src/project/view/pixmapscorethumbnailview.cpp
@@ -21,6 +21,7 @@
  */
 #include "pixmapscorethumbnailview.h"
 
+using namespace muse;
 using namespace mu::project;
 
 PixmapScoreThumbnailView::PixmapScoreThumbnailView(QQuickItem* parent)


### PR DESCRIPTION
- [x] I signed the [CLA](https://musescore.org/en/cla)

Fixes compilation error:

```
cd /builds/Linux-Qt-usr-Make-Debug/src/project && /usr/bin/c++ -DJACK_AUDIO -DKORS_LOGGER_QT_SUPPORT -DKORS_PROFILER_ENABLED -DMUE_BUILD_APPSHELL_MODULE -DMUE_BUILD_BRAILLE_MOD
ULE -DMUE_BUILD_CONVERTER_MODULE -DMUE_BUILD_CRASHPAD_CLIENT -DMUE_BUILD_DIAGNOSTICS_MODULE -DMUE_BUILD_IMAGESEXPORT_MODULE -DMUE_BUILD_IMPORTEXPORT_MODULE -DMUE_BUILD_INSPECTOR_MODULE -DMUE_
BUILD_INSTRUMENTSSCENE_MODULE -DMUE_BUILD_NOTATION_MODULE -DMUE_BUILD_PALETTE_MODULE -DMUE_BUILD_PLAYBACK_MODULE -DMUE_BUILD_PROJECT_MODULE -DMUE_BUILD_UPDATE_MODULE -DMUE_COMPILE_USE_QTFONTM
ETRICS -DMUSE_MODULE_GLOBAL_LOGGER_DEBUGLEVEL -DQT_CONCURRENT_LIB -DQT_CORE5COMPAT_LIB -DQT_CORE_LIB -DQT_DBUS_LIB -DQT_GUI_LIB -DQT_NETWORKAUTH_LIB -DQT_NETWORK_LIB -DQT_OPENGL_LIB -DQT_PRIN
TSUPPORT_LIB -DQT_QMLINTEGRATION_LIB -DQT_QMLMODELS_LIB -DQT_QML_DEBUG -DQT_QML_LIB -DQT_QUICKCONTROLS2_LIB -DQT_QUICKTEMPLATES2_LIB -DQT_QUICKWIDGETS_LIB -DQT_QUICK_LIB -DQT_STATEMACHINE_LIB
 -DQT_SUPPORT -DQT_SVG_LIB -DQT_WIDGETS_LIB -DQT_XML_LIB -DSCRIPT_INTERFACE -Dglobal_EXPORTS=1 -Dglobal_QML_IMPORT=\"\" -Dnotation_QML_IMPORT=\"/src/notation/qml\" -Dproject_QML_IMPORT=\"/src
/project/qml\" -Duicomponents_QML_IMPORT=\"/src/framework/uicomponents/qml\" -I/builds/Linux-Qt-usr-Make-Debug/src/project -I/src/project -I/builds/Linux-Qt-usr-Make-Debug/src/project/project
_autogen/include -I/builds/Linux-Qt-usr-Make-Debug -I/src -I -I/framework -I/framework/global -I/framework/testing/thirdparty/googletest/googletest/include -I/src/framework -I/src/framework/g
lobal -I/src/framework/testing/thirdparty/googletest/googletest/include -I/builds/Linux-Qt-usr-Make-Debug/src/framework/global -I/builds/Linux-Qt-usr-Make-Debug/src/framework/uicomponents -I/
builds/Linux-Qt-usr-Make-Debug/src/notation -isystem /usr/include/x86_64-linux-gnu/qt6/QtCore -isystem /usr/include/x86_64-linux-gnu/qt6 -isystem /usr/include/x86_64-linux-gnu/qt6/QtGui -isys
tem /usr/include/x86_64-linux-gnu/qt6/QtDBus -isystem /usr/include/x86_64-linux-gnu/qt6/QtWidgets -isystem /usr/include/x86_64-linux-gnu/qt6/QtNetwork -isystem /usr/include/x86_64-linux-gnu/q
t6/QtNetworkAuth -isystem /usr/include/x86_64-linux-gnu/qt6/QtQml -isystem /usr/include/x86_64-linux-gnu/qt6/QtQmlIntegration -isystem /usr/include/x86_64-linux-gnu/qt6/QtQuick -isystem /usr/
include/x86_64-linux-gnu/qt6/QtQmlModels -isystem /usr/include/x86_64-linux-gnu/qt6/QtOpenGL -isystem /usr/include/x86_64-linux-gnu/qt6/QtQuickControls2 -isystem /usr/include/x86_64-linux-gnu
/qt6/QtQuickTemplates2 -isystem /usr/include/x86_64-linux-gnu/qt6/QtQuickWidgets -isystem /usr/include/x86_64-linux-gnu/qt6/QtXml -isystem /usr/include/x86_64-linux-gnu/qt6/QtSvg -isystem /us
r/include/x86_64-linux-gnu/qt6/QtPrintSupport -isystem /usr/include/x86_64-linux-gnu/qt6/QtCore5Compat -isystem /usr/include/x86_64-linux-gnu/qt6/QtStateMachine -isystem /usr/include/x86_64-l
inux-gnu/qt6/QtConcurrent -isystem /usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -g -Wall -Wextra -fPIC -std=gnu++17 -Winvalid-pch -include /builds/Linux-Qt-usr-Make-Debug/src/framework/glo
bal/CMakeFiles/global.dir/cmake_pch.hxx -MD -MT src/project/CMakeFiles/project.dir/Unity/unity_2_cxx.cxx.o -MF CMakeFiles/project.dir/Unity/unity_2_cxx.cxx.o.d -o CMakeFiles/project.dir/Unity
/unity_2_cxx.cxx.o -c /builds/Linux-Qt-usr-Make-Debug/src/project/CMakeFiles/project.dir/Unity/unity_2_cxx.cxx
In file included from /builds/Linux-Qt-usr-Make-Debug/src/project/CMakeFiles/project.dir/Unity/unity_2_cxx.cxx:7:
/src/project/view/pixmapscorethumbnailview.cpp: In constructor ‘mu::project::PixmapScoreThumbnailView::PixmapScoreThumbnailView(QQuickItem*)’:
/src/project/view/pixmapscorethumbnailview.cpp:27:7: error: ‘uicomponents’ has not been declared
   27 |     : uicomponents::QuickPaintedView(parent)
      |       ^~~~~~~~~~~~
```