### PR TITLE
Fix GCC compiler warnings (4.3.0)

### DIFF
--- a/src/braille/internal/notationbraille.cpp
+++ b/src/braille/internal/notationbraille.cpp
@@ -512,7 +512,7 @@ void NotationBraille::setKeys(const QString& sequence)
                 String accidental; // needed for tpc2name
                 tpc2name(rootNote->tpc(), NoteSpellingType::STANDARD, NoteCaseType::UPPER, pitchName, accidental);
                 size_t inote = String("CDEFGAB").indexOf(pitchName.at(0));
-                IF_ASSERT_FAILED(inote >= 0 && inote <= 6) {
+                IF_ASSERT_FAILED(inote <= 6) {
                 } else {
                     prevNoteName = static_cast<NoteName>(inote);
                     prevNoteOctave = rootNote->octave();

--- a/src/engraving/dom/connector.cpp
+++ b/src/engraving/dom/connector.cpp
@@ -37,7 +37,7 @@ namespace mu::engraving {
 //---------------------------------------------------------
 
 ConnectorInfo::ConnectorInfo(const EngravingItem* current, int track, Fraction frac)
-    : m_current(current), m_score(current->score()), m_currentLoc(Location::absolute())
+    : m_currentLoc(Location::absolute()), m_current(current), m_score(current->score())
 {
     IF_ASSERT_FAILED(current) {
         return;
@@ -60,7 +60,7 @@ ConnectorInfo::ConnectorInfo(const EngravingItem* current, int track, Fraction f
 //---------------------------------------------------------
 
 ConnectorInfo::ConnectorInfo(const Score* score, const Location& currentLocation)
-    : m_score(score), m_currentLoc(currentLocation)
+    : m_currentLoc(currentLocation), m_score(score)
 {}
 
 //---------------------------------------------------------

--- a/src/engraving/dom/factory.cpp
+++ b/src/engraving/dom/factory.cpp
@@ -276,6 +276,10 @@ EngravingItem* Factory::doCreateItem(ElementType type, EngravingItem* parent)
     case ElementType::OSSIA:
     case ElementType::GRACE_NOTES_GROUP:
     case ElementType::ROOT_ITEM:
+    case ElementType::FIGURED_BASS_ITEM:
+    case ElementType::GUITAR_BEND_HOLD:
+    case ElementType::GUITAR_BEND_HOLD_SEGMENT:
+    case ElementType::GUITAR_BEND_TEXT:
     case ElementType::DUMMY:
         break;
     }

--- a/src/engraving/dom/navigate.cpp
+++ b/src/engraving/dom/navigate.cpp
@@ -834,6 +834,7 @@ EngravingItem* Score::nextElement()
         }
         case ElementType::LAYOUT_BREAK: {
             staffId = 0;             // otherwise it will equal -1, which breaks the navigation
+            break;
         }
         case ElementType::SOUND_FLAG:
             if (EngravingItem* parent = toSoundFlag(e)->parentItem()) {

--- a/src/engraving/dom/rest.cpp
+++ b/src/engraving/dom/rest.cpp
@@ -784,6 +784,8 @@ void Rest::add(EngravingItem* e)
         break;
     case ElementType::DEAD_SLAPPED:
         m_deadSlapped = toDeadSlapped(e);
+        e->added();
+        break;
     default:
         ChordRest::add(e);
         break;

--- a/src/engraving/dom/stem.cpp
+++ b/src/engraving/dom/stem.cpp
@@ -172,6 +172,7 @@ bool Stem::setProperty(Pid propertyId, const PropertyValue& v)
             chord()->relinkPropertyToMaster(Pid::STEM_DIRECTION);
             break;
         }
+    // fall through
     default:
         return EngravingItem::setProperty(propertyId, v);
     }

--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -1643,7 +1643,6 @@ void TLayout::layoutClef(const Clef* item, Clef::LayoutData* ldata, const Layout
     // check clef visibility and type compatibility
     if (clefSeg && item->staff()) {
         const Fraction tick = clefSeg->tick();
-        const Fraction tickPrev = tick - Fraction::eps();
         const StaffType* st = item->staff()->staffType(tick);
         bool show = st->genClef();            // check staff type allows clef display
         StaffGroup staffGroup = st->group();

--- a/src/framework/global/internal/interactive.cpp
+++ b/src/framework/global/internal/interactive.cpp
@@ -118,6 +118,7 @@ IInteractive::ButtonData Interactive::buttonData(Button b) const
     case IInteractive::Button::Select:
     case IInteractive::Button::Clear:
     case IInteractive::Button::Done:
+    case IInteractive::Button::RestoreDefaults:
     case IInteractive::Button::CustomButton: break;
     }
 

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -3651,8 +3651,8 @@ static void writeBeam(XmlWriter& xml, ChordRest* const cr, Beam* const b)
         // TODO: correctly handle Beam::Mode::AUTO
         // when equivalent to BEGIN32 or BEGIN64
         if ((blp < i && bln >= i)
-            || bmc == BeamMode::BEGIN16 && i > 1
-            || bmc == BeamMode::BEGIN32 && i > 2) {
+            || (bmc == BeamMode::BEGIN16 && i > 1)
+            || (bmc == BeamMode::BEGIN32 && i > 2)) {
             text = "begin";
         } else if (blp < i && bln < i) {
             if (bln > 0) {
@@ -3661,8 +3661,8 @@ static void writeBeam(XmlWriter& xml, ChordRest* const cr, Beam* const b)
                 text = "backward hook";
             }
         } else if ((blp >= i && bln < i)
-                   || bmn == BeamMode::BEGIN16 && i > 1
-                   || bmn == BeamMode::BEGIN32 && i > 2) {
+                   || (bmn == BeamMode::BEGIN16 && i > 1)
+                   || (bmn == BeamMode::BEGIN32 && i > 2)) {
             text = "end";
         } else if (blp >= i && bln >= i) {
             text = "continue";

--- a/src/importexport/musicxml/internal/musicxml/importmxmlnoteduration.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlnoteduration.h
@@ -62,8 +62,8 @@ private:
     Fraction _dura;
     TDuration _normalType;
     Fraction _timeMod { 1, 1 };                       // default to no time modification
-    MusicXMLParserPass1* _pass1;
     MxmlLogger* _logger;                              ///< Error logger
+    MusicXMLParserPass1* _pass1;
 };
 } // namespace Ms
 

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -3452,7 +3452,7 @@ void MusicXMLParserPass1::note(const QString& partId,
             IF_ASSERT_FAILED(part) {
                 continue;
             }
-            if (!ok || staff < 0 || staff >= part->nstaves()) {
+            if (!ok || staff < 0 || staff >= int(part->nstaves())) {
                 _logger->logError(QString("illegal or hidden staff '%1'").arg(strStaff), &_e);
             }
         } else if (_e.name() == "stem") {

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.h
@@ -187,7 +187,7 @@ public:
                                  const CreditWordsList& crWords, const QSize pageSize);
     void setHasInferredHeaderText(bool b) { _hasInferredHeaderText = b; }
     bool hasInferredHeaderText() const { return _hasInferredHeaderText; }
-    const int maxDiff() { return _maxDiff; }
+    int maxDiff() const { return _maxDiff; }
     void insertAdjustedDuration(Fraction key, Fraction value) { _adjustedDurations.insert(key, value); }
     QMap<Fraction, Fraction>& adjustedDurations() { return _adjustedDurations; }
     void insertSeenDenominator(int val) { _seenDenominators.emplace(val); }

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -2948,7 +2948,7 @@ void MusicXMLParserDirection::direction(const QString& partId,
             sound();
         } else if (_e.name() == "staff") {
             QString strStaff = _e.readElementText();
-            staff_idx_t staff = _pass1.getMusicXmlPart(partId).staffNumberToIndex(strStaff.toInt());
+            int staff = _pass1.getMusicXmlPart(partId).staffNumberToIndex(strStaff.toInt());
             if (staff >= 0) {
                 track += staff * VOICES;
             } else {
@@ -4890,11 +4890,11 @@ void MusicXMLParserPass2::clef(const QString& partId, Measure* measure, const Fr
     // TODO: check error handling for
     // - single staff
     // - multi-staff with same clef
-    size_t clefno = 0;   // default
+    int clefno = 0;   // default
     if (strClefno != "") {
         clefno = _pass1.getMusicXmlPart(partId).staffNumberToIndex(strClefno.toInt());
     }
-    if (clefno < 0 || clefno >= part->nstaves()) {
+    if (clefno < 0 || clefno >= int(part->nstaves())) {
         // conversion error (0) or other issue, assume staff 1
         // Also for Cubase 6.5.5 which generates clef number="2" in a single staff part
         // Same fix is required in pass 1 and pass 2

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -2679,7 +2679,7 @@ void MusicXMLParserPass2::staffDetails(const QString& partId, Measure* measure)
     int n = 0;  // default
     if (strNumber != "") {
         n = _pass1.getMusicXmlPart(partId).staffNumberToIndex(strNumber.toInt());
-        if (n < 0 || n >= staves) {
+        if (n < 0 || n >= int(staves)) {
             _logger->logError(QString("invalid staff-details number %1 (may be hidden)").arg(strNumber), &_e);
             n = 0;
         }
@@ -6416,7 +6416,7 @@ void MusicXMLParserPass2::harmony(const QString& partId, Measure* measure, const
             size_t nstaves = _pass1.getPart(partId)->nstaves();
             QString strStaff = _e.readElementText();
             int staff = _pass1.getMusicXmlPart(partId).staffNumberToIndex(strStaff.toInt());
-            if (staff >= 0 && staff < nstaves) {
+            if (staff >= 0 && staff < int(nstaves)) {
                 track += staff * VOICES;
             } else {
                 _logger->logError(QString("invalid staff %1").arg(strStaff), &_e);

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -5530,7 +5530,6 @@ Note* MusicXMLParserPass2::note(const QString& partId,
     QString voice;
     DirectionV stemDir = DirectionV::AUTO;
     bool noStem = false;
-    bool hasHead = true;
     NoteHeadGroup headGroup = NoteHeadGroup::HEAD_NORMAL;
     const QColor noteColor { _e.attributes().value("color").toString() };
     QColor noteheadColor = QColor::Invalid;
@@ -5581,9 +5580,7 @@ Note* MusicXMLParserPass2::note(const QString& partId,
             noteheadParentheses = _e.attributes().value("parentheses") == "yes";
             noteheadFilled = _e.attributes().value("filled").toString();
             auto noteheadValue = _e.readElementText();
-            if (noteheadValue == "none") {
-                hasHead = false;
-            } else {
+            if (noteheadValue != "none") {
                 headGroup = convertNotehead(noteheadValue);
             }
         } else if (_e.name() == "rest") {


### PR DESCRIPTION
* reg.: enumeration value not handled in switch [-Wswitch]
* reg.: will be initialized after [-Wreorder]
* reg.: this statement may fall through [-Wimplicit-fallthrough=]
* reg.: variable set but not used [-Wunused-but-set-variable]
* reg.: comparison of unsigned expression in ‘>= 0’ is always true [-Wtype-limits]
* reg.: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
* reg.: type qualifiers ignored on function return type [-Wignored-qualifiers]
* reg.: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]

All checked against how master has it.