### PR TITLE
Fix GH#20991: Chord symbols do not display correctly in parts when a custom score style is set (4.3.0)

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -182,8 +182,6 @@ Score::Score(MasterScore* parent, bool forcePartStyle /* = true */)
         // inherit most style settings from parent
         m_style = parent->style();
 
-        checkChordList();
-
         static const Sid styles[] = {
             Sid::pageWidth,
             Sid::pageHeight,
@@ -211,6 +209,7 @@ Score::Score(MasterScore* parent, bool forcePartStyle /* = true */)
     }
     // update style values
     m_style.precomputeValues();
+    checkChordList();
     m_synthesizerState = parent->m_synthesizerState;
     m_mscVersion = parent->m_mscVersion;
     createPaddingTable();


### PR DESCRIPTION
Backport of #21348

Resolves: #20991

Fixes the scenario described at https://github.com/musescore/MuseScore/issues/20991#issuecomment-1890196996