### PR TITLE
Add MUE_COMPILE_USE_SYSTEM_OPUS cmake option to help prevent library conflicts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ option(MUE_COMPILE_USE_UNITY "Use unity build." ON)
 option(MUE_COMPILE_USE_CCACHE "Try use ccache" ON)
 option(MUE_COMPILE_USE_SHARED_LIBS_IN_DEBUG "Build shared libs if possible in debug" OFF)
 option(MUE_COMPILE_USE_SYSTEM_FREETYPE "Try use system freetype" OFF) # Important for the maintainer of Linux distributions
+option(MUE_COMPILE_USE_SYSTEM_OPUS "Try use system opus" OFF) # Important for the maintainers of Linux distributions
 option(MUE_COMPILE_USE_QTFONTMETRICS "Use Qt font metrics" ON)
 
 # === Debug ===

--- a/src/framework/audio/thirdparty/opusenc/CMakeLists.txt
+++ b/src/framework/audio/thirdparty/opusenc/CMakeLists.txt
@@ -8,8 +8,7 @@ set(OPUSENC_VERSION 0.2.1)
 set(OPUSENC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libopusenc-${OPUSENC_VERSION})
 
 # libopusenc dependent on libopus
-set(OPUS_LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../opus)
-add_subdirectory(${OPUS_LIB_DIR} opus)
+include(cmake/SetupOpusLibrary.cmake)
 
 aux_source_directory(${OPUSENC_DIR}/src SOURCE_LIB)
 
@@ -23,14 +22,14 @@ set(MODULE_INCLUDE
     ${OPUSENC_DIR}/include
     ${OPUSENC_DIR}/src
     ${OPUSENC_DIR}
-    ${OPUS_LIB_DIR}/include
+    ${OPUS_INCLUDE_DIRS}
     )
 
 set(MODULE_SRC
     ${SOURCE_LIB}
     )
 
-set(MODULE_LINK opus)
+set(MODULE_LINK ${OPUS_LIBRARIES})
 
 set(MODULE_USE_PCH_NONE ON)
 set(MODULE_USE_UNITY_NONE ON)

--- a/src/framework/audio/thirdparty/opusenc/cmake/SetupOpusLibrary.cmake
+++ b/src/framework/audio/thirdparty/opusenc/cmake/SetupOpusLibrary.cmake
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-CLA-applies
+#
+# MuseScore
+# Music Composition & Notation
+#
+# Copyright (C) 2023 MuseScore BVBA and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+if (MUE_COMPILE_USE_SYSTEM_OPUS)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(OPUS opus)
+    if (OPUS_FOUND)
+        message(STATUS "Found opus: ${OPUS_VERSION}")
+    else ()
+        message(WARNING "Set MUE_COMPILE_USE_SYSTEM_OPUS=ON, but system opus not found, built-in will be used")
+    endif ()
+endif ()
+
+
+if (NOT OPUS_FOUND)
+    set(OPUS_LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../opus)
+    add_subdirectory(${OPUS_LIB_DIR} opus)
+
+    set(OPUS_INCLUDE_DIRS ${OPUS_LIB_DIR}/include)
+    set(OPUS_LIBRARIES opus)
+endif ()


### PR DESCRIPTION
This PR creates a simple way for using the system library version of opus which solves the problem of at same time dynamically linking to system libopus.so through libMuseSamplerCore.so and statically linking to a different version in an elegant way. Using this option can prevent conflicts arising because of this leading to hard-to-diagnose bugs/crashes (e.g. #21838)

As has been shown with #21838 using two different versions of libopus can lead and has led to hard-to-diagnose problems as explained in https://github.com/musescore/MuseScore/issues/21838#issuecomment-2040619807
As there is API and ABI compatibility between different versions of libopus, there is nothing preventing us from both times linking to the same library instead of different versions by both times linking to the system opus lib.
This is often a more sensible option as it resolves the following issue: In the current state, each time a new opus sys lib is packaged the musescore packager would have to update/replace the libopus under src/framework/audio/thirdparty/opus with the system version and release a new package. While building they also need to make sure that the compile options always match to avoid crashes/bugs/breakage.
Relying on such exact timing and precision and always updating the opus and musescore package together is unfeasible, at the very least unnecessary and will likely lead to breakage on other distros (other than Arch Linux) as well in the future when they update their opus system library. Therefore, I propose adding the cmake variable to `MUE_COMPILE_USE_SYSTEM_OPUS` to make the job of package maintainers of MuseScore easier and more failsafe.

Resolves: #21838 (the issue is closed but there was no elegant and sustainable solution brought into musescore; this PR aims to be this)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
