### PR TITLE
Fix empty instruments and templates list on Windows

### DIFF
--- a/src/framework/global/internal/globalconfiguration.cpp
+++ b/src/framework/global/internal/globalconfiguration.cpp
@@ -74,7 +74,7 @@ QString GlobalConfiguration::resolveAppDataPath() const
 #endif
 
 #ifdef Q_OS_WIN
-    QDir dir(QCoreApplication::applicationDirPath() + QString("/../" MUSE_APP_INSTALL_NAME));
+    QDir dir(QCoreApplication::applicationDirPath() + QString("/../"));
     return dir.absolutePath() + "/";
 #elif defined(Q_OS_MAC)
     QDir dir(QCoreApplication::applicationDirPath() + QString("/../Resources"));


### PR DESCRIPTION
Fixes
![image](https://github.com/musescore/MuseScore/assets/1786669/27c20ef9-2caf-402c-a093-e3d73867e31c)and
![image](https://github.com/musescore/MuseScore/assets/1786669/2a44e4f0-3677-45e4-ac90-b98b2f1ac0eb)
