### PR TITLE
[Tab Layout] Allow fingering string text to affect which tablature string is attempted to apply on a linked staff/tab staff

### DIFF
--- a/src/engraving/dom/stringdata.cpp
+++ b/src/engraving/dom/stringdata.cpp
@@ -92,7 +92,7 @@ void StringData::set(const StringData& src)
 //          from highest (0) to lowest (strings()-1)
 //---------------------------------------------------------
 
-bool StringData::convertPitch(int pitch, Staff* staff, int* string, int* fret) const
+bool StringData::convertPitch(int pitch, const Staff* staff, int* string, int* fret) const
 {
     return convertPitch(pitch, pitchOffsetAt(staff), string, fret);
 }
@@ -105,7 +105,7 @@ bool StringData::convertPitch(int pitch, Staff* staff, int* string, int* fret) c
 //    Note: frets above max fret are accepted.
 //---------------------------------------------------------
 
-int StringData::getPitch(int string, int fret, Staff* staff) const
+int StringData::getPitch(int string, int fret, const Staff* staff) const
 {
     return getPitch(string, fret, pitchOffsetAt(staff));
 }
@@ -117,7 +117,7 @@ int StringData::getPitch(int string, int fret, Staff* staff) const
 //    Returns INVALID_FRET_INDEX if not possible
 //---------------------------------------------------------
 
-int StringData::fret(int pitch, int string, Staff* staff) const
+int StringData::fret(int pitch, int string, const Staff* staff) const
 {
     return fret(pitch, string, pitchOffsetAt(staff));
 }
@@ -303,7 +303,7 @@ int StringData::frettedStrings() const
 //   For string data calculations, pitch offset may depend on transposition, capos and, possibly, ottavas.
 //---------------------------------------------------------
 
-int StringData::pitchOffsetAt(Staff* staff)
+int StringData::pitchOffsetAt(const Staff* staff)
 {
     return -(staff ? staff->part()->instrument()->transpose().chromatic : 0);
 }

--- a/src/engraving/dom/stringdata.h
+++ b/src/engraving/dom/stringdata.h
@@ -60,11 +60,11 @@ public:
     bool isNull() const;
 
     void        set(const StringData& src);
-    bool        convertPitch(int pitch, Staff* staff, int* string, int* fret) const;
-    int         fret(int pitch, int string, Staff* staff) const;
+    bool        convertPitch(int pitch, const Staff* staff, int* string, int* fret) const;
+    int         fret(int pitch, int string, const Staff* staff) const;
     void        fretChords(Chord* chord) const;
-    int         getPitch(int string, int fret, Staff* staff) const;
-    static int  pitchOffsetAt(Staff* staff);
+    int         getPitch(int string, int fret, const Staff* staff) const;
+    static int  pitchOffsetAt(const Staff* staff);
     size_t      strings() const { return m_stringTable.size(); }
     int         frettedStrings() const;
     const std::vector<instrString>& stringList() const { return m_stringTable; }


### PR DESCRIPTION
Port of https://github.com/Jojo-Schmitz/MuseScore/pull/403

Resolves: #22228, the 1st part:

https://github.com/musescore/MuseScore/assets/1786669/526b0e19-285d-4a58-aa63-6e9881e6e3e2

And now 2nd part too.

https://github.com/musescore/MuseScore/assets/1786669/a995e269-0d4c-4d2b-90c0-88d116dc119c