### PR TITLE
Fix #19425 ensure measure properties dialog properly handles various selections

### DIFF
--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -222,6 +222,7 @@ public:
 
     virtual void addStretch(qreal value) = 0;
 
+    virtual Measure* selectedMeasure() const = 0;
     virtual void addTimeSignature(Measure* measure, engraving::staff_idx_t staffIndex, TimeSignature* timeSignature) = 0;
 
     virtual void explodeSelectedStaff() = 0;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -1911,7 +1911,9 @@ void NotationActionController::openStaffTextPropertiesDialog()
 
 void NotationActionController::openMeasurePropertiesDialog()
 {
-    interactive()->open("musescore://notation/measureproperties?sync=false");
+    if (currentNotationInteraction()->selectedMeasure() != nullptr) {
+        interactive()->open("musescore://notation/measureproperties?sync=false");
+    }
 }
 
 void NotationActionController::openEditGridSizeDialog()

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4643,6 +4643,22 @@ void NotationInteraction::addStretch(qreal value)
     apply();
 }
 
+Measure* NotationInteraction::selectedMeasure() const
+{
+    INotationInteraction::HitElementContext context = hitElementContext();
+    mu::engraving::Measure* measure = context.element && context.element->isMeasure() ? mu::engraving::toMeasure(context.element) : nullptr;
+
+    if (!measure) {
+        INotationSelectionPtr selection = this->selection();
+        if (selection->isRange()) {
+            measure = selection->range()->measureRange().endMeasure;
+        } else if (selection->element()) {
+            measure = selection->element()->findMeasure();
+        }
+    }
+    return measure;
+}
+
 void NotationInteraction::addTimeSignature(Measure* measure, staff_idx_t staffIndex, TimeSignature* timeSignature)
 {
     startEdit();

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -225,6 +225,7 @@ public:
 
     void addStretch(qreal value) override;
 
+    Measure* selectedMeasure() const override;
     void addTimeSignature(Measure* measure, engraving::staff_idx_t staffIndex, TimeSignature* timeSignature) override;
 
     void explodeSelectedStaff() override;

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -184,6 +184,7 @@ public:
 
     MOCK_METHOD(void, addStretch, (qreal), (override));
 
+    MOCK_METHOD(Measure*, selectedMeasure, (), (const, override));
     MOCK_METHOD(void, addTimeSignature, (Measure*, engraving::staff_idx_t, TimeSignature*), (override));
 
     MOCK_METHOD(void, explodeSelectedStaff, (), (override));

--- a/src/notation/view/widgets/measureproperties.cpp
+++ b/src/notation/view/widgets/measureproperties.cpp
@@ -85,15 +85,7 @@ void MeasurePropertiesDialog::initMeasure()
         return;
     }
 
-    INotationInteraction::HitElementContext ctx = m_notation->interaction()->hitElementContext();
-    mu::engraving::Measure* measure = mu::engraving::toMeasure(ctx.element);
-
-    if (!measure) {
-        INotationSelectionPtr selection = m_notation->interaction()->selection();
-        if (selection->isRange()) {
-            measure = selection->range()->measureRange().endMeasure;
-        }
-    }
+    mu::engraving::Measure* measure = m_notation->interaction()->selectedMeasure();
 
     IF_ASSERT_FAILED(measure) {
         return;


### PR DESCRIPTION


Resolves: #19425

Measure properties dialog crashing when selection not valid (measure selected)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
