### PR TITLE
Fix crash on insert measures at start (second attempt)

### DIFF
--- a/src/engraving/dom/masterscore.cpp
+++ b/src/engraving/dom/masterscore.cpp
@@ -579,6 +579,7 @@ MeasureBase* MasterScore::insertMeasure(MeasureBase* beforeMeasure, const Insert
         //
         // remove clef, barlines, time and key signatures
         //
+        bool headerKeySig = false;
         if (measureInsert) {
             // if inserting before first measure, always preserve clefs and signatures
             // at the begining of the score (move them back)
@@ -640,6 +641,9 @@ MeasureBase* MasterScore::insertMeasure(MeasureBase* beforeMeasure, const Insert
                             } else {
                                 ee = e;
                             }
+                            if (s->header()) {
+                                headerKeySig = true;
+                            }
                         } else if (e->isTimeSig()) {
                             TimeSig* ts = toTimeSig(e);
                             timeSigList.push_back(ts);
@@ -655,7 +659,7 @@ MeasureBase* MasterScore::insertMeasure(MeasureBase* beforeMeasure, const Insert
                         }
                         if (ee) {
                             doUndoRemoveElement(ee);
-                            if (s->empty()) {
+                            if (s->empty() && s->isTimeSigType()) {
                                 undoRemoveElement(s);
                             }
                         }
@@ -705,6 +709,9 @@ MeasureBase* MasterScore::insertMeasure(MeasureBase* beforeMeasure, const Insert
         for (KeySig* ks : keySigList) {
             KeySig* nks = Factory::copyKeySig(*ks);
             Segment* s  = newMeasure->undoGetSegmentR(SegmentType::KeySig, Fraction(0, 1));
+            if (headerKeySig || newMeasure->tick().isZero()) {
+                s->setHeader(true);
+            }
             nks->setParent(s);
             if (!nks->isAtonal()) {
                 nks->setKey(nks->concertKey());  // to set correct (transposing) key
@@ -714,6 +721,7 @@ MeasureBase* MasterScore::insertMeasure(MeasureBase* beforeMeasure, const Insert
         for (Clef* clef : clefList) {
             Clef* nClef = Factory::copyClef(*clef);
             Segment* s  = newMeasure->undoGetSegmentR(SegmentType::HeaderClef, Fraction(0, 1));
+            s->setHeader(true);
             nClef->setParent(s);
             undoAddElement(nClef);
         }


### PR DESCRIPTION
Resolves: #21098 
Resolves: #21501 

(...hopefully)

The principle of the solution is the same as before: because HeaderClef and KeySig segments are generated as headers at the beginning of each system, we shouldn't try to add/remove them by using undoRemoveElement here (the crash happens because the undo operation finds an auto-generated header where it should re-add the segment, so it will not be re-added, and therefore the redo will try to remove a segment that wasn't added). Let's hope this does it