### PR TITLE
Fix more comparison of real values

### DIFF
--- a/src/framework/audio/internal/fx/reverb/reverbprocessor.cpp
+++ b/src/framework/audio/internal/fx/reverb/reverbprocessor.cpp
@@ -657,7 +657,7 @@ void ReverbProcessor::_processLines(float** signalPtr, int32_t numSamples)
     d->work_buffer.assignSamples(1, signal_in[1]);
     d->pre_delay.processBlock(work_ptr, 2, numSamples);
 
-    const bool velvet_input = (getParameter(VelvetIn) != 0.f);
+    const bool velvet_input = !RealIsNull(getParameter(VelvetIn));
 
     bool er_muted = d->er_gain_smooth.isStaticAtValue(0.f);
     bool late_muted = d->late_gain_smooth.isStaticAtValue(0.f);
@@ -745,7 +745,7 @@ void ReverbProcessor::_processLines(float** signalPtr, int32_t numSamples)
         } // end of feedback loop
 
         // output velvet decorrelation
-        if (getParameter(VelvetOut) != 0.f) {
+        if (!RealIsNull(getParameter(VelvetOut))) {
             for (int i = 0; i < num_lines; ++i) {
                 d->ivnd_out[i].processBlock(delay_out_ptr[i], delay_out_ptr[i], numSamples);
             }
@@ -788,7 +788,7 @@ void ReverbProcessor::_processLines(float** signalPtr, int32_t numSamples)
     vo::constantMultiplyAndAdd(work_ptr[0], stereo_2, late_ptr[1], numSamples);
 
     // filtering
-    if (getParameter(PeakGain) != 0.f) {
+    if (!RealIsNull(getParameter(PeakGain))) {
         d->peakFilter.process(late_ptr, 2, numSamples);
     }
 


### PR DESCRIPTION
Follow up to #22275
Found by searching with regex ` [\!=]= \d*\.\d*`
Ignoring those in src/engraving/rendering/stable/ and all thirdparty