### PR TITLE
Fix #19503 - soft hyphens cause layout issues

### DIFF
--- a/src/framework/draw/internal/qfontprovider.cpp
+++ b/src/framework/draw/internal/qfontprovider.cpp
@@ -139,7 +139,12 @@ RectF QFontProvider::boundingRect(const Font& f, const RectF& r, int flags, cons
 
 RectF QFontProvider::tightBoundingRect(const Font& f, const String& string) const
 {
-    return RectF::fromQRectF(QFontMetricsF(f.toQFont(), &device).tightBoundingRect(string));
+    auto boundingRect = QFontMetricsF(f.toQFont(), &device).tightBoundingRect(string);
+    if (!boundingRect.isValid()) {
+        // fix for https://github.com/musescore/MuseScore/issues/19503 - Qt can return garbage bounding rectangles that corrupt layout
+        return RectF();
+    }
+    return RectF::fromQRectF(boundingRect);
 }
 
 // Score symbols


### PR DESCRIPTION
Resolves: #19503

Ensure that garbage bounding rectangles returned by Qt for special characters don't break layout.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
