### PR TITLE
Fix #21953: Crash on regroup rhythms in some scores (Master)

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -5233,7 +5233,7 @@ static Chord* findLinkedChord(Chord* c, Staff* nstaff)
     Measure* nm = nstaff->score()->tick2measure(s->tick());
     Segment* ns = nm->findSegment(s->segmentType(), s->tick());
     EngravingItem* ne = ns->element(dtrack);
-    if (!ne->isChord()) {
+    if (!ne || !ne->isChord()) {
         return 0;
     }
     Chord* nc = toChord(ne);
@@ -6244,6 +6244,11 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
                 }
                 Chord* c1 = findLinkedChord(cr1, score->staff(staffIdx));
                 Chord* c2 = findLinkedChord(cr2, score->staff(staffIdx + sm));
+
+                IF_ASSERT_FAILED(c1) {
+                    return;
+                }
+
                 Note* nn1 = c1->findNote(n1->pitch(), n1->unisonIndex());
                 Note* nn2 = c2 ? c2->findNote(n2->pitch(), n2->unisonIndex()) : 0;
 


### PR DESCRIPTION
Resolves: #21953

This is the result of a corrupted score where the notes in the excerpts don't match those in the main score. The crash happens when calling `findLinkedChord`. This seems to be a pretty rare situation and its unclear how the score reached this state. Regardless, we should try to avoid a crash here with a null check (and assert).