### PR TITLE
MusicXML: Add support for part-name-display

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -2861,6 +2861,34 @@ static void writeAccidental(XmlWriter& xml, const String& tagName, const Acciden
 }
 
 //---------------------------------------------------------
+//   writeDisplayName
+//---------------------------------------------------------
+
+static void writeDisplayName(XmlWriter& xml, const String& partName)
+{
+    String displayText;
+    for (size_t i = 0; i < partName.size(); ++i) {
+        Char ch = partName.at(i);
+        if (ch != u'♭' && ch != u'♯') {
+            displayText += ch;
+        } else {
+            if (!displayText.empty()) {
+                xml.tag("display-text", displayText);
+            }
+            if (ch == u'♭') {
+                xml.tag("accidental-text", "flat");
+            } else if (ch == u'♯') {
+                xml.tag("accidental-text", "sharp");
+            }
+            displayText.clear();
+        }
+    }
+    if (!displayText.empty()) {
+        xml.tag("display-text", displayText);
+    }
+}
+
+//---------------------------------------------------------
 //   wavyLineStart
 //---------------------------------------------------------
 
@@ -7382,21 +7410,30 @@ static void partList(XmlWriter& xml, Score* score, MxmlInstrumentMap& instrMap)
 
         xml.startElementRaw(String(u"score-part id=\"P%1\"").arg(idx + 1));
         initInstrMap(instrMap, part->instruments(), score);
+        static const std::wregex acc(L"[♭♯]");
+        XmlWriter::Attributes attributes;
         // by default export the parts long name as part-name
-        if (part->longName() != "") {
-            xml.tag("part-name", MScoreTextToMXML::toPlainText(part->longName()));
-        } else {
-            if (part->partName() != "") {
-                // use the track name if no part long name
-                // to prevent an empty track name on import
-                xml.tag("part-name", { { "print-object", "no" } }, MScoreTextToMXML::toPlainText(part->partName()));
-            } else {
-                // part-name is required
-                xml.tag("part-name", "");
+        String partName = part->longName();
+        // use the track name if no part long name
+        if (partName.empty()) {
+            partName = part->partName();
+            if (!partName.empty()) {
+                attributes.push_back({ "print-object", "no" });
             }
         }
+        xml.tag("part-name", attributes, MScoreTextToMXML::toPlainText(partName).replace(u"♭", u"b").replace(u"♯", u"#"));
+        if (partName.contains(acc)) {
+            xml.startElement("part-name-display");
+            writeDisplayName(xml, partName);
+            xml.endElement();
+        }
         if (!part->shortName().isEmpty()) {
-            xml.tag("part-abbreviation", MScoreTextToMXML::toPlainText(part->shortName()));
+            xml.tag("part-abbreviation", MScoreTextToMXML::toPlainText(part->shortName()).replace(u"♭", u"b").replace(u"♯", u"#"));
+            if (part->shortName().contains(acc)) {
+                xml.startElement("part-abbreviation-display");
+                writeDisplayName(xml, part->shortName());
+                xml.endElement();
+            }
         }
 
         if (part->instrument()->useDrumset()) {

--- a/src/importexport/musicxml/internal/musicxml/importmxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxml.cpp
@@ -72,34 +72,6 @@ static IInteractive::Button musicXMLImportErrorDialog(const String& text, const 
 
 #endif
 
-static void updateNamesForAccidentals(Instrument* inst)
-{
-    auto replace = [](String name) {
-        name = name.replace(std::regex(
-                                R"(((?:^|\s)([A-Ga-g]|[Uu][Tt]|[Dd][Oo]|[Rr][EeÉé]|[MmSsTt][Ii]|[FfLl][Aa]|[Ss][Oo][Ll]))b(?=\s|$))"),
-                            String::fromStdString(R"($1♭)"));
-
-        name = name.replace(std::regex(
-                                R"(((?:^|\s)([A-Ga-g]|[Uu][Tt]|[Dd][Oo]|[Rr][EeÉé]|[MmSsTt][Ii]|[FfLl][Aa]|[Ss][Oo][Ll]))#(?=\s|$))"),
-                            String::fromStdString(R"($1♯)"));
-
-        return name;
-    };
-    // change staff names from simple text (eg 'Eb') to text using accidental symbols (eg 'E♭')
-
-    // Instrument::longNames() is const af so we need to make a deep copy, update it, and then set it again
-    StaffNameList longNamesCopy = inst->longNames();
-    for (StaffName& sn : longNamesCopy) {
-        sn.setName(replace(sn.name()));
-    }
-    StaffNameList shortNamesCopy = inst->shortNames();
-    for (StaffName& sn : shortNamesCopy) {
-        sn.setName(replace(sn.name()));
-    }
-    inst->setLongNames(longNamesCopy);
-    inst->setShortNames(shortNamesCopy);
-}
-
 //---------------------------------------------------------
 //   importMusicXMLfromBuffer
 //---------------------------------------------------------
@@ -125,7 +97,6 @@ Err importMusicXMLfromBuffer(Score* score, const String& /*name*/, const ByteArr
     for (const Part* part : score->parts()) {
         for (const auto& pair : part->instruments()) {
             pair.second->updateInstrumentId();
-            updateNamesForAccidentals(pair.second);
         }
     }
 

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -2187,8 +2187,19 @@ void MusicXMLParserPass1::scorePart()
             String name = m_e.readText();
             m_parts[id].setName(name);
         } else if (m_e.name() == "part-name-display") {
-            // TODO
-            m_e.skipCurrentElement();       // skip but don't log
+            String name;
+            while (m_e.readNextStartElement()) {
+                if (m_e.name() == "display-text") {
+                    name += m_e.readText();
+                } else if (m_e.name() == "accidental-text") {
+                    name += mxmlAccidentalTextToChar(m_e.readText());
+                } else {
+                    skipLogCurrElem();
+                }
+            }
+            if (!name.empty()) {
+                m_parts[id].setName(name);
+            }
         } else if (m_e.name() == "part-abbreviation") {
             // EngravingItem part-name contains the displayed (abbreviated) part name
             // It is displayed by default, but can be suppressed (print-object=”no”)
@@ -2198,9 +2209,27 @@ void MusicXMLParserPass1::scorePart()
             String name = m_e.readText();
             m_parts[id].setAbbr(name);
         } else if (m_e.name() == "part-abbreviation-display") {
-            m_e.skipCurrentElement();        // skip but don't log
+            String name;
+            while (m_e.readNextStartElement()) {
+                if (m_e.name() == "display-text") {
+                    name += m_e.readText();
+                } else if (m_e.name() == "accidental-text") {
+                    name += mxmlAccidentalTextToChar(m_e.readText());
+                } else {
+                    skipLogCurrElem();
+                }
+            }
+            if (!name.empty()) {
+                m_parts[id].setAbbr(name);
+            }
+        } else if (m_e.name() == "group") {
+            // TODO
+            m_e.skipCurrentElement();          // skip but don't log
         } else if (m_e.name() == "score-instrument") {
             scoreInstrument(id);
+        } else if (m_e.name() == "player") {
+            // unsupported
+            m_e.skipCurrentElement();          // skip but don't log
         } else if (m_e.name() == "midi-device") {
             if (!m_e.hasAttribute("port")) {
                 m_e.readText();         // empty string

--- a/src/importexport/musicxml/internal/musicxml/musicxmlsupport.cpp
+++ b/src/importexport/musicxml/internal/musicxml/musicxmlsupport.cpp
@@ -704,6 +704,31 @@ AccidentalType mxmlString2accidentalType(const String mxmlName, const String smu
 }
 
 //---------------------------------------------------------
+//   mxmlAccidentalTextToChar
+//---------------------------------------------------------
+
+/**
+ Convert a MusicXML accidental text to a accidental character.
+ */
+
+String mxmlAccidentalTextToChar(const String mxmlName)
+{
+    static std::map<String, String> map;   // map MusicXML accidental name to MuseScore enum AccidentalType
+    if (map.empty()) {
+        map[u"sharp"] = u"♯";
+        map[u"natural"] = u"♮";
+        map[u"flat"] = u"♭";
+    }
+
+    if (muse::contains(map, mxmlName)) {
+        return map.at(mxmlName);
+    } else {
+        LOGD("mxmlAccidentalTextToChar: unsupported accidental '%s'", muPrintable(mxmlName));
+    }
+    return u"";
+}
+
+//---------------------------------------------------------
 //   isAppr
 //---------------------------------------------------------
 

--- a/src/importexport/musicxml/internal/musicxml/musicxmlsupport.h
+++ b/src/importexport/musicxml/internal/musicxml/musicxmlsupport.h
@@ -244,6 +244,7 @@ extern String accSymId2SmuflMxmlString(const SymId id);
 extern String accidentalType2MxmlString(const AccidentalType type);
 extern String accidentalType2SmuflMxmlString(const AccidentalType type);
 extern AccidentalType mxmlString2accidentalType(const String mxmlName, const String smufl);
+extern String mxmlAccidentalTextToChar(const String mxmlName);
 extern SymId mxmlString2accSymId(const String mxmlName, const String smufl = {});
 extern AccidentalType microtonalGuess(double val);
 extern bool isLaissezVibrer(const SymId id);

--- a/src/importexport/musicxml/tests/data/testBarlineSpan.xml
+++ b/src/importexport/musicxml/tests/data/testBarlineSpan.xml
@@ -64,8 +64,16 @@
         </midi-instrument>
       </score-part>
     <score-part id="P4">
-      <part-name>Clarinet in B♭</part-name>
-      <part-abbreviation>Cl. in B♭</part-abbreviation>
+      <part-name>Clarinet in Bb</part-name>
+      <part-name-display>
+        <display-text>Clarinet in B</display-text>
+        <accidental-text>flat</accidental-text>
+        </part-name-display>
+      <part-abbreviation>Cl. in Bb</part-abbreviation>
+      <part-abbreviation-display>
+        <display-text>Cl. in B</display-text>
+        <accidental-text>flat</accidental-text>
+        </part-abbreviation-display>
       <score-instrument id="P4-I1">
         <instrument-name>Clarinet</instrument-name>
         </score-instrument>

--- a/src/importexport/musicxml/tests/data/testInstrImport_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInstrImport_ref.mscx
@@ -237,7 +237,7 @@
         </Staff>
       <trackName>Bb Clarinet</trackName>
       <Instrument id="bb-clarinet">
-        <longName>B♭ Clarinet</longName>
+        <longName>Bb Clarinet</longName>
         <shortName>B¯ Clarinet B¯ Bass Clar.</shortName>
         <trackName>Bb Clarinet</trackName>
         <minPitchP>50</minPitchP>
@@ -302,7 +302,7 @@
         </Staff>
       <trackName>Eb Alto Clarinet</trackName>
       <Instrument id="alto-clarinet">
-        <longName>E♭ Alto Clarinet</longName>
+        <longName>Eb Alto Clarinet</longName>
         <shortName>Alto Cl.</shortName>
         <trackName>Eb Alto Clarinet</trackName>
         <minPitchP>43</minPitchP>
@@ -367,7 +367,7 @@
         </Staff>
       <trackName>Bb Bass Clarinet</trackName>
       <Instrument id="bb-bass-clarinet">
-        <longName>B♭ Bass Clarinet</longName>
+        <longName>Bb Bass Clarinet</longName>
         <shortName>B. Cl.</shortName>
         <trackName>Bb Bass Clarinet</trackName>
         <minPitchP>34</minPitchP>
@@ -434,7 +434,7 @@
         </Staff>
       <trackName>Eb Alto Sax.</trackName>
       <Instrument id="alto-saxophone">
-        <longName>E♭ Alto Sax.</longName>
+        <longName>Eb Alto Sax.</longName>
         <shortName>E¯ Alto Sax. E¯ Bar. Sax.</shortName>
         <trackName>Eb Alto Sax.</trackName>
         <minPitchP>49</minPitchP>
@@ -499,7 +499,7 @@
         </Staff>
       <trackName> Bb Tenor Sax.</trackName>
       <Instrument id="tenor-saxophone">
-        <longName> B♭ Tenor Sax.</longName>
+        <longName> Bb Tenor Sax.</longName>
         <shortName>Ten. Sax.</shortName>
         <trackName> Bb Tenor Sax.</trackName>
         <minPitchP>44</minPitchP>
@@ -566,7 +566,7 @@
         </Staff>
       <trackName>Eb Baritone Sax.</trackName>
       <Instrument id="baritone-saxophone">
-        <longName>E♭ Baritone Sax.</longName>
+        <longName>Eb Baritone Sax.</longName>
         <shortName>Bari. Sax.</shortName>
         <trackName>Eb Baritone Sax.</trackName>
         <minPitchP>36</minPitchP>
@@ -633,7 +633,7 @@
         </Staff>
       <trackName>Bb Trumpet</trackName>
       <Instrument id="bb-trumpet">
-        <longName>B♭ Trumpet</longName>
+        <longName>Bb Trumpet</longName>
         <shortName>Tpt.</shortName>
         <trackName>Bb Trumpet</trackName>
         <minPitchP>52</minPitchP>

--- a/src/importexport/musicxml/tests/data/testKeysig2.xml
+++ b/src/importexport/musicxml/tests/data/testKeysig2.xml
@@ -19,8 +19,18 @@
     </identification>
   <part-list>
     <score-part id="P1">
-      <part-name>B♭ Clarinet</part-name>
-      <part-abbreviation>B♭ Cl.</part-abbreviation>
+      <part-name>Bb Clarinet</part-name>
+      <part-name-display>
+        <display-text>B</display-text>
+        <accidental-text>flat</accidental-text>
+        <display-text> Clarinet</display-text>
+        </part-name-display>
+      <part-abbreviation>Bb Cl.</part-abbreviation>
+      <part-abbreviation-display>
+        <display-text>B</display-text>
+        <accidental-text>flat</accidental-text>
+        <display-text> Cl.</display-text>
+        </part-abbreviation-display>
       <score-instrument id="P1-I1">
         <instrument-name>B♭ Clarinet</instrument-name>
         </score-instrument>

--- a/src/importexport/musicxml/tests/data/testPartNames2.xml
+++ b/src/importexport/musicxml/tests/data/testPartNames2.xml
@@ -1,0 +1,569 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Part names</work-title>
+    </work>
+  <identification>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <part-group type="start" number="1">
+      <group-symbol>bracket</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
+    <score-part id="P1">
+      <part-name>Eb Bass</part-name>
+      <part-name-display>
+        <display-text>E</display-text>
+        <accidental-text>flat</accidental-text>
+        <display-text> Bass</display-text>
+        </part-name-display>
+      <part-abbreviation>Eb Bs.</part-abbreviation>
+      <part-abbreviation-display>
+        <display-text>E</display-text>
+        <accidental-text>flat</accidental-text>
+        <display-text> Bs.</display-text>
+        </part-abbreviation-display>
+      <score-instrument id="P1-I1">
+        <instrument-name>Eb Tuba (Treble Clef)</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="2"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>6</midi-channel>
+        <midi-program>59</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P2">
+      <part-name>Bb Bass</part-name>
+      <part-name-display>
+        <display-text>B</display-text>
+        <accidental-text>flat</accidental-text>
+        <display-text> Bass</display-text>
+        </part-name-display>
+      <part-abbreviation>Bb Bs.</part-abbreviation>
+      <part-abbreviation-display>
+        <display-text>B</display-text>
+        <accidental-text>flat</accidental-text>
+        <display-text> Bs.</display-text>
+        </part-abbreviation-display>
+      <score-instrument id="P2-I1">
+        <instrument-name>Bb Tuba (Treble Clef)</instrument-name>
+        </score-instrument>
+      <midi-device id="P2-I1" port="2"></midi-device>
+      <midi-instrument id="P2-I1">
+        <midi-channel>7</midi-channel>
+        <midi-program>59</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="1"/>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>3</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>-5</diatonic>
+          <chromatic>-9</chromatic>
+          <octave-change>-1</octave-change>
+          </transpose>
+        </attributes>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="3">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="4">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="5">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="6">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="7">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="8">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="9">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="10">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="11">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="12">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="13">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="14">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="15">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="16">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="17">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="18">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="19">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="20">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="21">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="22">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="23">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="24">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="25">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="26">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="27">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="28">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="29">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="30">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="31">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="32">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P2">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>2</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>-1</diatonic>
+          <chromatic>-2</chromatic>
+          <octave-change>-2</octave-change>
+          </transpose>
+        </attributes>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="3">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="4">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="5">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="6">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="7">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="8">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="9">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="10">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="11">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="12">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="13">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="14">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="15">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="16">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="17">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="18">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="19">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="20">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="21">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="22">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="23">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="24">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="25">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="26">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="27">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="28">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="29">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="30">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="31">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="32">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/data/testTextLines_ref.xml
+++ b/src/importexport/musicxml/tests/data/testTextLines_ref.xml
@@ -28,8 +28,18 @@
         </midi-instrument>
       </score-part>
     <score-part id="P2">
-      <part-name>B♭ Clarinet</part-name>
-      <part-abbreviation>B♭ Cl.</part-abbreviation>
+      <part-name>Bb Clarinet</part-name>
+      <part-name-display>
+        <display-text>B</display-text>
+        <accidental-text>flat</accidental-text>
+        <display-text> Clarinet</display-text>
+        </part-name-display>
+      <part-abbreviation>Bb Cl.</part-abbreviation>
+      <part-abbreviation-display>
+        <display-text>B</display-text>
+        <accidental-text>flat</accidental-text>
+        <display-text> Cl.</display-text>
+        </part-abbreviation-display>
       <score-instrument id="P2-I1">
         <instrument-name>B♭ Clarinet</instrument-name>
         </score-instrument>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -922,6 +922,15 @@ TEST_F(Musicxml_Tests, notesRests2) {
 TEST_F(Musicxml_Tests, numberedLyrics) {
     mxmlIoTestRef("testNumberedLyrics");
 }
+TEST_F(Musicxml_Tests, overlappingSpanners) {
+    mxmlIoTest("testOverlappingSpanners");
+}
+TEST_F(Musicxml_Tests, partNames) {
+    mxmlImportTestRef("testPartNames");
+}
+TEST_F(Musicxml_Tests, partNames2) {
+    mxmlIoTest("testPartNames2");
+}
 TEST_F(Musicxml_Tests, pedalChanges) {
     mxmlIoTest("testPedalChanges");
 }
@@ -933,12 +942,6 @@ TEST_F(Musicxml_Tests, pedalStyles) {
 }
 TEST_F(Musicxml_Tests, placementDefaults) {
     mxmlImportTestRef("testPlacementDefaults");
-}
-TEST_F(Musicxml_Tests, overlappingSpanners) {
-    mxmlIoTest("testOverlappingSpanners");
-}
-TEST_F(Musicxml_Tests, partNames) {
-    mxmlImportTestRef("testPartNames");
 }
 TEST_F(Musicxml_Tests, printSpacingNo) {
     mxmlIoTestRef("testPrintSpacingNo");


### PR DESCRIPTION
This PR adds import/export of MusicXML's [`part-name-display`](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/part-name-display/).

fixes https://musescore.org/en/node/330480
