### PR TITLE
[master] Update translations URL for 4.3

### DIFF
--- a/build/ci/translation/s3_packandsend.py
+++ b/build/ci/translation/s3_packandsend.py
@@ -13,7 +13,7 @@ import zipfile
 #needs to be equal or smaller than the cron
 period = 300
 outputDir = "share/locale/"
-s3Urls = ["s3://extensions.musescore.org/4.2/languages/"]
+s3Urls = ["s3://extensions.musescore.org/4.3/languages/"]
 
 def processTsFile(prefix, langCode, data):
     print("Processing " + langCode)

--- a/src/app/configs/languages.cfg
+++ b/src/app/configs/languages.cfg
@@ -1,3 +1,3 @@
 {
-    "server_url": "http://extensions.musescore.org/4.2/languages/"
+    "server_url": "http://extensions.musescore.org/4.3/languages/"
 }


### PR DESCRIPTION
The reason that this 4.3-related commit goes to the master (4.4) branch is that the CI job for pulling & pushing translations from Transifex to S3 runs "scheduled" from the master branch