### PR TITLE
fixed #22320: Score corrupt after copy/paste whole note and change duration

### DIFF
--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -1888,6 +1888,7 @@ EngravingItem* Note::drop(EditData& data)
         }
         score()->undoRemoveElement(this);
         score()->undoAddElement(n);
+        return n;
     }
     break;
 


### PR DESCRIPTION
Resolves: #22320