### PR TITLE
fix hardcoded samplerate

### DIFF
--- a/src/framework/audio/audiomodule.cpp
+++ b/src/framework/audio/audiomodule.cpp
@@ -273,6 +273,7 @@ void AudioModule::setupAudioDriver(const IApplication::RunMode& mode)
 
         IAudioDriver::Spec activeSpec;
         if (m_audioDriver->open(requiredSpec, &activeSpec)) {
+            m_configuration->setSampleRate(activeSpec.sampleRate);
             setupAudioWorker(activeSpec);
             return;
         }

--- a/src/framework/audio/internal/fx/reverb/reverbprocessor.cpp
+++ b/src/framework/audio/internal/fx/reverb/reverbprocessor.cpp
@@ -287,7 +287,7 @@ ReverbProcessor::ReverbProcessor(const AudioFxParams& params, audioch_t audioCha
     setParameter(Params::PreDelayMs, getParameter(Params::PreDelayMs));
     setParameter(Params::FeedbackTop, getParameter(Params::FeedbackTop));
 
-    setFormat(audioChannelsCount, 44100.0 /*sampleRate*/, 512 /*maximumBlockSize*/);
+    setFormat(audioChannelsCount, audioConfiguration()->sampleRate(), 512 /*maximumBlockSize*/);
 }
 
 ReverbProcessor::~ReverbProcessor()
@@ -380,7 +380,7 @@ float ReverbProcessor::getParameter(int32_t index)
 void ReverbProcessor::calculateTailParams()
 {
     const int* delayTimes = _delayTimesForN(m_delays);
-    float scale = float(getParameter(LateRoomScale) * m_processor._sampleRate / 44100.);
+    float scale = float(getParameter(LateRoomScale) * m_processor._sampleRate / static_cast<float>(audioConfiguration()->sampleRate()));
 
     const float log_db60 = std::log(fromDecibel(-60.f));
 
@@ -438,7 +438,7 @@ void ReverbProcessor::calculateModParams()
 
     float modDepthSmp = float(depthMs * 0.001f * m_processor._sampleRate);
     d->sinLfo.setup(m_delays, freqHz * d->modStep, modDepthSmp, m_processor._sampleRate);
-    float scale = float(getParameter(LateRoomScale) * m_processor._sampleRate / 44100.);
+    float scale = float(getParameter(LateRoomScale) * m_processor._sampleRate / static_cast<float>(audioConfiguration()->sampleRate()));
     for (int i = 0; i < m_delays; ++i) {
         d->modDelay[i].setBaseDelay(delayTimes[i] * scale, modDepthSmp * 2.f);
     }

--- a/src/framework/audio/internal/fx/reverb/reverbprocessor.h
+++ b/src/framework/audio/internal/fx/reverb/reverbprocessor.h
@@ -28,11 +28,14 @@
 #include <utility>
 #include <vector>
 
+#include "modularity/ioc.h"
+#include "iaudioconfiguration.h"
 #include "ifxprocessor.h"
 
 namespace muse::audio::fx {
 class ReverbProcessor : public IFxProcessor
 {
+    Inject<muse::audio::IAudioConfiguration> audioConfiguration;
 public:
     ReverbProcessor(const audio::AudioFxParams& params, audioch_t audioChannelsCount = 2);
     ~ReverbProcessor() override;


### PR DESCRIPTION
- [x] I signed the [CLA](https://musescore.org/en/cla)

* fx/reverb/reverbprocessor.cpp take samplerate from audio-configuration
* audio/audiomodule.cpp
  write back the samplerate gotten from audiodriver (though this really doesn't work for alsa).
