### PR TITLE
Highlight notes under playback cursor

### DIFF
--- a/src/notation/view/abstractnotationpaintview.cpp
+++ b/src/notation/view/abstractnotationpaintview.cpp
@@ -26,6 +26,7 @@
 #include "actions/actiontypes.h"
 
 #include "log.h"
+#include "view/playbackcursor.h"
 
 using namespace mu;
 using namespace mu::notation;
@@ -1333,7 +1334,7 @@ void AbstractNotationPaintView::movePlaybackCursor(muse::midi::tick_t tick)
     }
 
     RectF oldCursorRect = m_playbackCursor->rect();
-    m_playbackCursor->move(tick);
+    RemarkingResult rr = m_playbackCursor->move(tick);
     const RectF& newCursorRect = m_playbackCursor->rect();
 
     if (!m_playbackCursor->visible() || newCursorRect.isNull()) {
@@ -1368,6 +1369,7 @@ void AbstractNotationPaintView::movePlaybackCursor(muse::midi::tick_t tick)
         scheduleRedraw(dirtyRect1);
         scheduleRedraw(dirtyRect2);
     }
+    scheduleRedraw(rr.region);
 }
 
 bool AbstractNotationPaintView::needAdjustCanvasVerticallyWhilePlayback(const RectF& cursorRect)

--- a/src/notation/view/playbackcursor.h
+++ b/src/notation/view/playbackcursor.h
@@ -31,6 +31,10 @@
 class QColor;
 
 namespace mu::notation {
+struct RemarkingResult {
+    muse::RectF region;
+};
+
 class PlaybackCursor
 {
     INJECT(INotationConfiguration, configuration)
@@ -41,7 +45,7 @@ public:
     void paint(muse::draw::Painter* painter);
 
     void setNotation(INotationPtr notation);
-    void move(muse::midi::tick_t tick);
+    RemarkingResult move(muse::midi::tick_t tick);
 
     bool visible() const;
     void setVisible(bool arg);
@@ -49,11 +53,13 @@ public:
     const muse::RectF& rect() const;
 
 private:
+    bool unmarkNotes();
     QColor color() const;
-    muse::RectF resolveCursorRectByTick(muse::midi::tick_t tick) const;
+    std::pair<muse::RectF, const engraving::Segment*> resolveCursorRectByTick(muse::midi::tick_t tick) const;
 
     bool m_visible = false;
     muse::RectF m_rect;
+    std::vector<Note*> m_markedNotes;
 
     INotationPtr m_notation;
 };


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/11313

<!-- Add a short description of and motivation for the changes here -->

Re-adds the MuseScore 3 feature where notes under the playback cursor are highlighted during playback.

This PR is a draft because the implementation is extremely hacky. I don’t think `PlaybackCursor` is the right place to implement this. MuseScore 3 implements this feature in [`Seq::heartbeatTimeout`](https://github.com/musescore/MuseScore/blob/3.6.2/mscore/seq.cpp#L1578), but as the playback engine in MS4 is completely different, I have no idea where this is best implemented.

Also, arpeggios and grace notes are not highlighted properly.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
