### PR TITLE
Fix selection box errors

### DIFF
--- a/src/notation/internal/inotationselectionrange.h
+++ b/src/notation/internal/inotationselectionrange.h
@@ -49,6 +49,7 @@ public:
 
     virtual std::vector<muse::RectF> boundingArea() const = 0;
     virtual bool containsPoint(const muse::PointF& point) const = 0;
+    virtual bool containsItem(const engraving::EngravingItem* item) const = 0;
 };
 
 using INotationSelectionRangePtr = std::shared_ptr<INotationSelectionRange>;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2432,7 +2432,7 @@ void NotationInteraction::drawSelectionRange(muse::draw::Painter* painter)
     std::vector<RectF> rangeArea = m_selection->range()->boundingArea();
     for (const RectF& rect: rangeArea) {
         PainterPath path;
-        path.addRoundedRect(rect, 6, 6);
+        path.addRect(rect);
 
         QColor fillColor = selectionColor;
         fillColor.setAlpha(10);

--- a/src/notation/internal/notationselectionrange.cpp
+++ b/src/notation/internal/notationselectionrange.cpp
@@ -156,6 +156,27 @@ bool NotationSelectionRange::containsPoint(const PointF& point) const
     return false;
 }
 
+bool NotationSelectionRange::containsItem(const EngravingItem* item) const
+{
+    Fraction itemTick = item->tick();
+    Fraction selectionStartTick = startTick();
+    Fraction selectionEndTick = endTick();
+
+    if (itemTick < selectionStartTick || itemTick > selectionEndTick) {
+        return false;
+    }
+
+    if (itemTick == selectionEndTick) {
+        return item->rtick() > Fraction(0, 1);
+    }
+
+    track_idx_t itemTrack = item->track();
+    track_idx_t selectionStartTrack = VOICES * startStaffIndex();
+    track_idx_t selectionEndTrack = VOICES * (endStaffIndex() - 1) + VOICES;
+
+    return itemTrack >= selectionStartTrack && itemTrack < selectionEndTrack;
+}
+
 std::vector<const Part*> NotationSelectionRange::selectedParts() const
 {
     std::vector<const Part*> result;

--- a/src/notation/internal/notationselectionrange.cpp
+++ b/src/notation/internal/notationselectionrange.cpp
@@ -31,8 +31,6 @@
 
 #include "log.h"
 
-static constexpr int SELECTION_SIDE_PADDING = 8;
-
 using namespace mu::notation;
 using namespace mu::engraving;
 
@@ -94,8 +92,6 @@ std::vector<muse::RectF> NotationSelectionRange::boundingArea() const
 
     std::vector<RangeSection> rangeSections = splitRangeBySections(startSegment, endSegment);
 
-    bool linearMode = score()->linearMode();
-
     for (const RangeSection& rangeSection: rangeSections) {
         const mu::engraving::System* sectionSystem = rangeSection.system;
         const mu::engraving::Segment* sectionStartSegment = rangeSection.startSegment;
@@ -129,10 +125,10 @@ std::vector<muse::RectF> NotationSelectionRange::boundingArea() const
             bottomY += 0.5 * diff;
         }
 
-        double x1 = sectionStartSegment->pagePos().x() - SELECTION_SIDE_PADDING;
+        double x1 = sectionStartSegment->pagePos().x();
         double x2 = sectionEndSegment->pageBoundingRect().topRight().x();
-        double y1 = topY + segmentFirstStaff->y() + sectionStartSegment->pagePos().y() - SELECTION_SIDE_PADDING;
-        double y2 = bottomY + segmentLastStaff->y() + sectionStartSegment->pagePos().y() + SELECTION_SIDE_PADDING;
+        double y1 = topY + segmentFirstStaff->y() + sectionStartSegment->pagePos().y();
+        double y2 = bottomY + segmentLastStaff->y() + sectionStartSegment->pagePos().y();
 
         if (sectionStartSegment->measure()->firstEnabled() == sectionStartSegment) {
             x1 = sectionStartSegment->measure()->pagePos().x();

--- a/src/notation/internal/notationselectionrange.h
+++ b/src/notation/internal/notationselectionrange.h
@@ -66,9 +66,6 @@ private:
     std::vector<RangeSection> splitRangeBySections(const mu::engraving::Segment* rangeStartSegment,
                                                    const mu::engraving::Segment* rangeEndSegment) const;
 
-    double sectionElementsMaxY(const RangeSection& selection) const;
-    double sectionElementsMinY(const RangeSection& selection) const;
-
     IGetScore* m_getScore = nullptr;
 };
 }

--- a/src/notation/internal/notationselectionrange.h
+++ b/src/notation/internal/notationselectionrange.h
@@ -48,6 +48,7 @@ public:
 
     std::vector<muse::RectF> boundingArea() const override;
     bool containsPoint(const muse::PointF& point) const override;
+    bool containsItem(const EngravingItem* item) const override;
 
 private:
     mu::engraving::Score* score() const;

--- a/src/notation/internal/notationselectionrange.h
+++ b/src/notation/internal/notationselectionrange.h
@@ -55,7 +55,8 @@ private:
     mu::engraving::Segment* rangeStartSegment() const;
     mu::engraving::Segment* rangeEndSegment() const;
 
-    int selectionLastVisibleStaff() const;
+    mu::engraving::staff_idx_t selectionLastVisibleStaff(const System* system) const;
+    mu::engraving::staff_idx_t selectionFirstVisibleStaff(const System* system) const;
 
     struct RangeSection {
         const mu::engraving::System* system = nullptr;
@@ -65,8 +66,8 @@ private:
     std::vector<RangeSection> splitRangeBySections(const mu::engraving::Segment* rangeStartSegment,
                                                    const mu::engraving::Segment* rangeEndSegment) const;
 
-    int sectionElementsMaxY(const RangeSection& selection) const;
-    int sectionElementsMinY(const RangeSection& selection) const;
+    double sectionElementsMaxY(const RangeSection& selection) const;
+    double sectionElementsMinY(const RangeSection& selection) const;
 
     IGetScore* m_getScore = nullptr;
 };

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -667,7 +667,7 @@ bool NotationViewInputController::needSelect(const ClickContext& ctx) const
     if (ctx.event->button() == Qt::LeftButton && ctx.event->modifiers() & Qt::ControlModifier) {
         return true;
     } else if (ctx.event->button() == Qt::RightButton && selection->isRange()) {
-        return !selection->range()->containsPoint(ctx.logicClickPos);
+        return !selection->range()->containsItem(ctx.hitElement);
     } else if (!ctx.hitElement->selected()) {
         return true;
     }


### PR DESCRIPTION
Resolves: #22113 
Resolves: #21261 (probably, can't be tested without the file)
Resolves: #10342 
Resolves: #11054 
Resolves: #15483
Resolves: #19097 

Continuous view has a technical limitation: because the entire piece is one long system, the skyline (i.e. the geometrical line that defines the vertical contour of the staff, shown here in the green-purple lines) gets calculated only around the area that has been last edited (for performance reasons, it can't be calculated on the entire score). So we cannot rely on the skyline to compute the height of the selection box, because it's often not available (that's the cause of the reported bug). We will need a different approach in future, but for now the only solution is to just draw the box around the staff lines (which is anyway what was happening already most of the time in continous view) without tryinig to include the staff elements.
![image](https://github.com/musescore/MuseScore/assets/93707756/f57e15fe-c9cd-4c58-bf8f-61a30a1ec8f6)

In page view we don't have the same limitation, so we can nicely draw the selection box around the staff elements. Page view, however, does have some more issues of its own, which are also fixed in this PR:

a) The height of the selection box includes the height of the top notes, but in the wrong measure:
![image](https://github.com/musescore/MuseScore/assets/93707756/9429f9a5-a94b-4e86-b2ed-23fb0926c8c3)
![image](https://github.com/musescore/MuseScore/assets/93707756/61e4980c-bc66-45a5-82cf-169cdc531237)

b) Selecting one measure should produce a selection box that starts at the barline. However, if that measure is sent to the next system and then brought back, the selection will start at the first chord.
 

https://github.com/musescore/MuseScore/assets/93707756/0af9f27c-0655-4b0c-8c10-395f21648bd9

