### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/playback/playbackcontext.cpp
+++ b/src/engraving/playback/playbackcontext.cpp
@@ -247,14 +247,14 @@ void PlaybackContext::updatePlaybackParamMap(const ID partId, const Score* score
             return;
         }
 
-        mpe::staff_layer_idx_t startIdx = part->staves().front()->idx();
-        mpe::staff_layer_idx_t endIdx = startIdx + part->nstaves();
+        mpe::staff_layer_idx_t startIdx = static_cast <staff_layer_idx_t>(part->staves().front()->idx());
+        mpe::staff_layer_idx_t endIdx = static_cast <staff_layer_idx_t>(startIdx + part->nstaves());
 
         for (mpe::staff_layer_idx_t idx = startIdx; idx < endIdx; ++idx) {
             addParams(flag, idx);
         }
     } else {
-        addParams(flag, flag->staffIdx());
+        addParams(flag, static_cast <staff_layer_idx_t>(flag->staffIdx()));
     }
 
     IF_ASSERT_FAILED(!params.empty()) {

--- a/src/engraving/tests/playbackcontext_tests.cpp
+++ b/src/engraving/tests/playbackcontext_tests.cpp
@@ -138,7 +138,7 @@ TEST_F(Engraving_PlaybackContextTests, ParseSoundFlags)
 
     // [THEN] Expected params
     staff_layer_idx_t startIdx = 0;
-    staff_layer_idx_t endIdx = part->nstaves();
+    staff_layer_idx_t endIdx = static_cast<staff_layer_idx_t>(part->nstaves());
 
     PlaybackParamList studio, pop;
     for (staff_layer_idx_t i = startIdx; i < endIdx; ++i) {


### PR DESCRIPTION
reg.: conversion from 'size_t' to 'muse::mpe::staff_layer_idx_t', possible loss of data (C4267)