### PR TITLE
fixed #22409: Expose new text inference MusicXML option as command-line flag

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -444,6 +444,7 @@ void App::applyCommandLineOptions(const CommandLineParser::Options& options, IAp
     midiImportExportConfiguration()->setMidiImportOperationsFile(options.importMidi.operationsFile);
     guitarProConfiguration()->setLinkedTabStaffCreated(options.guitarPro.linkedTabStaffCreated);
     guitarProConfiguration()->setExperimental(options.guitarPro.experimental);
+    musicXmlConfiguration()->setInferTextTypeOverride(options.importMusicXML.inferTextType);
 #endif
 
     if (options.app.revertToFactorySettings) {

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -45,6 +45,7 @@
 #include "importexport/audioexport/iaudioexportconfiguration.h"
 #include "importexport/videoexport/ivideoexportconfiguration.h"
 #include "importexport/guitarpro/iguitarproconfiguration.h"
+#include "importexport/musicxml/imusicxmlconfiguration.h"
 
 #include "commandlineparser.h"
 
@@ -68,6 +69,7 @@ class App
     INJECT(iex::audioexport::IAudioExportConfiguration, audioExportConfiguration)
     INJECT(iex::videoexport::IVideoExportConfiguration, videoExportConfiguration)
     INJECT(iex::guitarpro::IGuitarProConfiguration, guitarProConfiguration)
+    INJECT(iex::musicxml::IMusicXmlConfiguration, musicXmlConfiguration)
 
 public:
     App();

--- a/src/app/commandlineparser.cpp
+++ b/src/app/commandlineparser.cpp
@@ -110,6 +110,10 @@ void CommandLineParser::init()
                                           "Use with '-o <file>.mp3' or with '-j <file>', override the sound profile in the given score(s). "
                                           "Possible values: \"MuseScore Basic\", \"Muse Sounds\"", "sound-profile"));
 
+    // MusicXML
+    m_parser.addOption(QCommandLineOption("musicxml-infer-text-type",
+                                          "Infer text type based on content where possible"));
+
     // Video export
 #ifdef MUE_BUILD_VIDEOEXPORT_MODULE
     m_parser.addOption(QCommandLineOption("score-video", "Generate video for the given score and export it to file"));
@@ -348,6 +352,11 @@ void CommandLineParser::parse(int argc, char** argv)
         } else {
             LOGW() << "Option: --source-update no source specified";
         }
+    }
+
+    // MusicXML
+    if (m_parser.isSet("musicxml-infer-text-type")) {
+        m_options.importMusicXML.inferTextType = true;
     }
 
     // Video

--- a/src/app/commandlineparser.h
+++ b/src/app/commandlineparser.h
@@ -76,6 +76,10 @@ public:
         } importMidi;
 
         struct {
+            std::optional<bool> inferTextType;
+        } importMusicXML;
+
+        struct {
             std::optional<bool> linkedTabStaffCreated;
             std::optional<bool> experimental;
         } guitarPro;

--- a/src/importexport/musicxml/imusicxmlconfiguration.h
+++ b/src/importexport/musicxml/imusicxmlconfiguration.h
@@ -60,6 +60,7 @@ public:
 
     virtual bool inferTextType() const = 0;
     virtual void setInferTextType(bool value) = 0;
+    virtual void setInferTextTypeOverride(std::optional<bool> value) = 0;
 };
 }
 

--- a/src/importexport/musicxml/internal/musicxmlconfiguration.cpp
+++ b/src/importexport/musicxml/internal/musicxmlconfiguration.cpp
@@ -122,10 +122,19 @@ void MusicXmlConfiguration::setNeedAskAboutApplyingNewStyle(bool value)
 
 bool MusicXmlConfiguration::inferTextType() const
 {
+    if (m_inferTextTypeOverride.has_value()) {
+        return m_inferTextTypeOverride.value();
+    }
+
     return settings()->value(MUSICXML_IMPORT_INFER_TEXT_TYPE).toBool();
 }
 
 void MusicXmlConfiguration::setInferTextType(bool value)
 {
     settings()->setSharedValue(MUSICXML_IMPORT_INFER_TEXT_TYPE, Val(value));
+}
+
+void MusicXmlConfiguration::setInferTextTypeOverride(std::optional<bool> value)
+{
+    m_inferTextTypeOverride = value;
 }

--- a/src/importexport/musicxml/internal/musicxmlconfiguration.h
+++ b/src/importexport/musicxml/internal/musicxmlconfiguration.h
@@ -53,6 +53,10 @@ public:
 
     bool inferTextType() const override;
     void setInferTextType(bool value) override;
+    void setInferTextTypeOverride(std::optional<bool> value) override;
+
+private:
+    std::optional<bool> m_inferTextTypeOverride;
 };
 }
 


### PR DESCRIPTION
Resolves: #22409