### PR TITLE
Fix #22426: Update default window titles to MuseScore Studio naming (Master)

### DIFF
--- a/src/framework/uicomponents/view/dialogview.cpp
+++ b/src/framework/uicomponents/view/dialogview.cpp
@@ -38,6 +38,12 @@ DialogView::DialogView(QQuickItem* parent)
 {
     setObjectName("DialogView");
     setClosePolicies(NoAutoClose);
+
+//! NOTE: Ideally we would change appName in App::run and the following would not be necessary. However, this would
+//! also change various paths (something we want to avoid outside of major releases).
+#ifndef Q_OS_MAC
+    setTitle(application()->unstable() ? "MuseScore Studio Development" : "MuseScore Studio");
+#endif
 }
 
 bool DialogView::isDialog() const

--- a/src/framework/uicomponents/view/dialogview.h
+++ b/src/framework/uicomponents/view/dialogview.h
@@ -26,11 +26,14 @@
 #include <QEventLoop>
 
 #include "popupview.h"
+#include "global/iapplication.h"
 
 namespace muse::uicomponents {
 class DialogView : public PopupView
 {
     Q_OBJECT
+
+    Inject<muse::IApplication> application;
 
 public:
     explicit DialogView(QQuickItem* parent = nullptr);


### PR DESCRIPTION
Resolves: #22426 