### PR TITLE
Fix #22426: Update default window titles to MuseScore Studio naming (4.3.0)

### DIFF
--- a/src/framework/uicomponents/view/dialogview.cpp
+++ b/src/framework/uicomponents/view/dialogview.cpp
@@ -37,6 +37,12 @@ DialogView::DialogView(QQuickItem* parent)
 {
     setObjectName("DialogView");
     setClosePolicies(NoAutoClose);
+
+//! NOTE: Ideally we would change appName in App::run and the following would not be necessary. However, this would
+//! also change various paths (something we want to avoid outside of major releases).
+#ifndef Q_OS_MAC
+    setTitle(framework::MUVersion::unstable() ? "MuseScore Studio Development" : "MuseScore Studio");
+#endif
 }
 
 bool DialogView::isDialog() const

--- a/src/framework/uicomponents/view/dialogview.h
+++ b/src/framework/uicomponents/view/dialogview.h
@@ -26,6 +26,7 @@
 #include <QEventLoop>
 
 #include "popupview.h"
+#include "muversion.h"
 
 namespace mu::uicomponents {
 class DialogView : public PopupView


### PR DESCRIPTION
Resolves: #22426
Master PR: #22431