### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/playback/playbackcontext.cpp
+++ b/src/engraving/playback/playbackcontext.cpp
@@ -225,8 +225,8 @@ void PlaybackContext::updatePlayTechMap(const ID partId, const Score* score, con
             return;
         }
 
-        mpe::staff_layer_idx_t startIdx = part->staves().front()->idx();
-        mpe::staff_layer_idx_t endIdx = startIdx + part->nstaves();
+        mpe::staff_layer_idx_t startIdx = static_cast <staff_layer_idx_t>(part->staves().front()->idx());
+        mpe::staff_layer_idx_t endIdx = static_cast <staff_layer_idx_t>(startIdx + part->nstaves());
 
         for (mpe::staff_layer_idx_t idx = startIdx; idx < endIdx; ++idx) {
             PlaybackParam ordTechnique { mpe::PLAY_TECHNIQUE_PARAM_CODE, Val(mpe::ORDINARY_PLAYING_TECHNIQUE_CODE), idx };

--- a/src/framework/update/updatetypes.h
+++ b/src/framework/update/updatetypes.h
@@ -84,7 +84,7 @@ static PrevReleasesNotesList releasesNotesFromValList(const ValList& list)
     return notes;
 }
 
-static ValMap releaseInfoToValMap(const ReleaseInfo& info)
+static inline ValMap releaseInfoToValMap(const ReleaseInfo& info)
 {
     return {
         { "version", Val(info.version) },
@@ -96,7 +96,7 @@ static ValMap releaseInfoToValMap(const ReleaseInfo& info)
     };
 }
 
-static ReleaseInfo releaseInfoFromValMap(const ValMap& map)
+static inline ReleaseInfo releaseInfoFromValMap(const ValMap& map)
 {
     ReleaseInfo info;
     info.version = map.at("version").toString();

--- a/src/instrumentsscene/view/instrumentsonscorelistmodel.cpp
+++ b/src/instrumentsscene/view/instrumentsonscorelistmodel.cpp
@@ -200,7 +200,7 @@ int InstrumentsOnScoreListModel::resolveInstrumentSequenceNumber(const String& i
     }
 
     const InstrumentTemplateList& allTemplates = repository()->instrumentTemplates();
-    return allTemplates.size();
+    return static_cast<int>(allTemplates.size());
 }
 
 void InstrumentsOnScoreListModel::addInstruments(const QStringList& instrumentIdList)

--- a/src/notation/internal/instrumentsrepository.cpp
+++ b/src/notation/internal/instrumentsrepository.cpp
@@ -289,8 +289,8 @@ void InstrumentsRepository::loadMuseInstruments(const InstrumentTemplateMap& sta
         templ->clefTypes[0].transposingClef = clefType;
 
         if (instrument.staffType == musesampler::StaffType::Grand) {
-            templ->bracketSpan[0] = templ->staffCount;
-            templ->barlineSpan[0] = templ->staffCount;
+            templ->bracketSpan[0] = static_cast<int>(templ->staffCount);
+            templ->barlineSpan[0] = static_cast<int>(templ->staffCount);
 
             for (size_t i = 0; i < templ->staffCount; ++i) {
                 templ->bracket[i] = mu::engraving::BracketType::BRACE;
@@ -301,7 +301,7 @@ void InstrumentsRepository::loadMuseInstruments(const InstrumentTemplateMap& sta
         }
 
         for (int i = 0; i < MAX_STAVES; ++i) {
-            templ->staffLines[i] = instrument.staffLines;
+            templ->staffLines[i] = static_cast<int>(instrument.staffLines);
         }
 
         if (!instrument.musicXmlId.empty()) {


### PR DESCRIPTION
* reg.: conversion from 'size_t' to 'xxx', possible loss of data (C4267)
* reg.: unreferenced function with internal linkage has been removed (C4505)