### PR TITLE
Fix #21900: Note highlighting on the piano keyboard ignores ottava.

### DIFF
--- a/src/notation/view/pianokeyboard/pianokeyboardcontroller.cpp
+++ b/src/notation/view/pianokeyboard/pianokeyboardcontroller.cpp
@@ -132,9 +132,9 @@ void PianoKeyboardController::updateNotesKeys(const std::vector<const Note*>& re
     };
 
     for (const mu::engraving::Note* note : receivedNotes) {
-        newKeys.insert(static_cast<piano_key_t>(note->epitch()));
+        newKeys.insert(static_cast<piano_key_t>(note->ppitch()));
         for (const mu::engraving::Note* otherNote : note->chord()->notes()) {
-            newOtherNotesInChord.insert(static_cast<piano_key_t>(otherNote->epitch()));
+            newOtherNotesInChord.insert(static_cast<piano_key_t>(otherNote->ppitch()));
         }
     }
 }


### PR DESCRIPTION
Resolves: #21900

Bug: The pianokeyboard view was not taking into account the ottavas, so if you put an ottava on the score you would hear the pitched-up note, but the note you would see on the keyboard view would not be pitched-up by an octave as well.

Solution: In the class Note there are multiple computations for pitch, for different purposes. I've used the playback pitch (ppitch) instead of the effective pitch (epitch) on the pianokeyboardcontroller.cpp, because the playback audio was using the pitch I wanted shown on the keyboard.

Tested on Windows.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
