### PR TITLE
Rename to MuseScore Studio in Mac installation (images, dmg names) (#21722) (Master)

### DIFF
--- a/buildscripts/ci/macos/package.sh
+++ b/buildscripts/ci/macos/package.sh
@@ -102,11 +102,11 @@ if [ "$BUILD_MODE" == "nightly_build" ]; then
 
   BUILD_NUMBER=$(cat $ARTIFACTS_DIR/env/build_number.env)
   BUILD_BRANCH=$(cat $ARTIFACTS_DIR/env/build_branch.env)
-  ARTIFACT_NAME=MuseScoreNightly-${BUILD_NUMBER}-${BUILD_BRANCH}-${BUILD_REVISION}.dmg
+  ARTIFACT_NAME=MuseScore-Studio-Nightly-${BUILD_NUMBER}-${BUILD_BRANCH}-${BUILD_REVISION}.dmg
 
 else
 
-  ARTIFACT_NAME=MuseScore-${BUILD_VERSION}.dmg  
+  ARTIFACT_NAME=MuseScore-Studio-${BUILD_VERSION}.dmg
 
 fi
 

--- a/buildscripts/packaging/MacOS/package_mac
+++ b/buildscripts/packaging/MacOS/package_mac
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+# LONG_NAME is used for dmg naming, LONGER_NAME is used when renaming the .app later. LONGER_NAME can't be updated
+# to "MuseScore Studio" yet, as it will prevent users from seeing the prompt asking them to replace an old version
+# of MuseScore (potentially resulting in 2 copies of version 4). This will be updated on the next major release.
 APPNAME=mscore
-LONG_NAME="MuseScore"
+LONG_NAME="MuseScore-Studio"
 LONGER_NAME="MuseScore 4"
 VERSION=0
 

--- a/version.cmake
+++ b/version.cmake
@@ -20,7 +20,7 @@
 
 set(MUSE_APP_NAME "MuseScoreStudio")
 set(MUSE_APP_NAME_WITH_SPACE "MuseScore Studio")
-set(MUSE_APP_GUI_IDENTIFIER org.musescore.${MUSE_APP_NAME})
+set(MUSE_APP_GUI_IDENTIFIER org.musescore.MuseScore)
 set(MUSE_APP_VERSION_MAJOR "4")
 set(MUSE_APP_VERSION_MINOR "4")
 set(MUSE_APP_VERSION_PATCH "0")


### PR DESCRIPTION
Resolves (partially): #21722 