### PR TITLE
Hide XML inferred cresc's continue text

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -3718,6 +3718,7 @@ void MusicXMLParserDirection::textToCrescLine(String& text)
 
     line->setHairpinType(cresc ? HairpinType::CRESC_LINE : HairpinType::DECRESC_LINE);
     line->setBeginText(simplifiedText);
+    line->setContinueText(u"");
     line->setProperty(Pid::LINE_VISIBLE, false);
     m_inferredHairpinStart = line;
 }


### PR DESCRIPTION
Fixes:
![image](https://github.com/musescore/MuseScore/assets/26510874/7f569bb3-7167-49c0-95e0-db48b47e0c1b)

The line is invisible, so we don't need any continue text.