### PR TITLE
Fix note name translations in status bar

### DIFF
--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -836,7 +836,7 @@ String Note::tpcUserName(int tpc, int pitch, bool explicitAccidental, bool full)
         pitchStr.replace(u"#", u"♯");
     }
 
-    pitchStr = mtrc("engraving", pitchStr);
+    pitchStr = mtrc("global", pitchStr);
 
     const String octaveStr = String::number(((pitch - static_cast<int>(tpc2alter(tpc))) / PITCH_DELTA_OCTAVE) - 1);
 


### PR DESCRIPTION
Resolves: [(Discord message)](https://discord.com/channels/818804595450445834/818852942882275379/1229713754736824381)

Same as #22427