### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -1276,8 +1276,8 @@ bool MeiExporter::writeNote(const Note* note, const Chord* chord, const Staff* s
         Accidental* acc = note->accidental();
         if (acc) {
             Convert::colorToMEI(acc, meiAccid);
-            std::string xmlId = this->getXmlIdFor(acc, 'a');
-            meiAccid.Write(accidNode, xmlId);
+            std::string xmlIdAcc = this->getXmlIdFor(acc, 'a');
+            meiAccid.Write(accidNode, xmlIdAcc);
         } else {
             meiAccid.Write(accidNode, this->getLayerXmlIdFor(ACCID_L));
         }

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -6672,6 +6672,7 @@ FretDiagram* MusicXMLParserPass2::frame()
 
 void MusicXMLParserPass2::harmony(const String& partId, Measure* measure, const Fraction& sTime, HarmonyMap& harmonyMap)
 {
+    UNUSED(measure);
     track_idx_t track = m_pass1.trackForPart(partId);
 
     const Color color = Color::fromString(m_e.asciiAttribute("color").ascii());


### PR DESCRIPTION
* reg.: 'measure': unreferenced formal parameter (C4100)
* reg.: declaration of 'xmlId' hides previous local declaration (C4456)