### PR TITLE
Fix unit tests due to chords_std.xml not found

### DIFF
--- a/.github/workflows/ci_utests.yml
+++ b/.github/workflows/ci_utests.yml
@@ -23,16 +23,16 @@ jobs:
 
         echo "BUILD_NUMBER=$BUILD_NUMBER" >> $GITHUB_ENV
         echo "BUILD_NUMBER: $BUILD_NUMBER"
-        
+
     - name: Ccache cache files
       uses: actions/cache@v4
       with:
         path: ~/.ccache
         key: ${{github.workflow}}-ccache-$(date -u +"%F-%T")
-        restore-keys: ${{github.workflow}}-ccache-  # restore ccache from either previous build on this branch or on master  
+        restore-keys: ${{github.workflow}}-ccache- # restore ccache from either previous build on this branch or on master
     - name: Setup ccache
       run: |
-        sudo bash ./buildscripts/ci/tools/setup_ccache.sh     
+        sudo bash ./buildscripts/ci/tools/setup_ccache.sh
     - name: Setup environment
       run: |
         sudo bash ./buildscripts/ci/linux/setup.sh
@@ -40,13 +40,13 @@ jobs:
       run: |
         mkdir -p build.artifacts/env
         sudo bash ./buildscripts/ci/linux/build_utest.sh -n ${{ env.BUILD_NUMBER }}
-    - name: Run tests 
+    - name: Free up disk space
+      # After building, too little disk space is left. Remove unnecessary tools to free up disk space.
       run: |
-        # At moment build and run tests consume 13.4 Gb of the disk.
-        # After left too little free space.
-        # So, we remove unnecessary tools, for more free space
         sudo docker system prune -a -f
         sudo rm -rf /usr/local/lib/android
+    - name: Run tests
+      run: |
         sudo bash ./buildscripts/ci/linux/runutests.sh
-      env: 
+      env:
         ASAN_OPTIONS: "detect_leaks=0"

--- a/buildscripts/ci/linux/build_utest.sh
+++ b/buildscripts/ci/linux/build_utest.sh
@@ -64,6 +64,6 @@ MUSESCORE_VST3_SDK_PATH=$VST3_SDK_PATH \
 MUSESCORE_QT5_COMPAT=OFF \
 MUSESCORE_DOWNLOAD_SOUNDFONT=OFF \
 MUSESCORE_BUILD_UNIT_TESTS=ON \
-bash ./ninja_build.sh -t debug          
+bash ./ninja_build.sh -t installdebug          
 
 df -h .

--- a/src/engraving/tests/compat114_data/chord_symbol-ref.mscx
+++ b/src/engraving/tests/compat114_data/chord_symbol-ref.mscx
@@ -96,6 +96,7 @@
           <Harmony>
             <root>16</root>
             <extension>64</extension>
+            <name>7</name>
             </Harmony>
           <Rest>
             <durationType>measure</durationType>
@@ -108,6 +109,7 @@
           <Harmony>
             <root>11</root>
             <extension>16</extension>
+            <name>m</name>
             </Harmony>
           <Rest>
             <durationType>measure</durationType>
@@ -120,6 +122,7 @@
           <Harmony>
             <root>20</root>
             <extension>6</extension>
+            <name>Maj7</name>
             </Harmony>
           <Rest>
             <durationType>measure</durationType>
@@ -134,6 +137,7 @@
           <Harmony>
             <root>15</root>
             <extension>33</extension>
+            <name>dim</name>
             </Harmony>
           <Rest>
             <durationType>measure</durationType>
@@ -148,6 +152,7 @@
           <Harmony>
             <root>17</root>
             <extension>76</extension>
+            <name>7b9</name>
             </Harmony>
           <Rest>
             <durationType>measure</durationType>
@@ -161,7 +166,8 @@
         <voice>
           <Harmony>
             <root>19</root>
-            <name>o</name>
+            <extension>33</extension>
+            <name>dim</name>
             </Harmony>
           <Rest>
             <durationType>measure</durationType>

--- a/src/engraving/tests/compat114_data/text_scaling-ref.mscx
+++ b/src/engraving/tests/compat114_data/text_scaling-ref.mscx
@@ -128,6 +128,7 @@
           <Harmony>
             <root>14</root>
             <extension>64</extension>
+            <name>7</name>
             </Harmony>
           <Rest>
             <durationType>measure</durationType>

--- a/src/engraving/tests/remove_tests.cpp
+++ b/src/engraving/tests/remove_tests.cpp
@@ -57,7 +57,7 @@ static void inStaff(void* staffCheckData, EngravingItem* e)
 {
     StaffCheckData* checkData = static_cast<StaffCheckData*>(staffCheckData);
     if (e->staffIdx() == checkData->staffIdx) {
-        LOGE() << e->typeName() << " is in staff " << checkData->staffIdx;
+        LOGD() << e->typeName() << " is in staff " << checkData->staffIdx;
         checkData->staffHasElements = true;
     }
 }
@@ -67,7 +67,7 @@ static bool staffHasElements(Score* score, staff_idx_t staffIdx)
     for (auto i = score->spannerMap().cbegin(); i != score->spannerMap().cend(); ++i) {
         Spanner* s = i->second;
         if (s->staffIdx() == staffIdx) {
-            LOGE() << s->typeName() << " is in staff " << staffIdx;
+            LOGD() << s->typeName() << " is in staff " << staffIdx;
             return true;
         }
     }

--- a/src/framework/global/serialization/xmlstreamreader.cpp
+++ b/src/framework/global/serialization/xmlstreamreader.cpp
@@ -205,23 +205,37 @@ XmlStreamReader::TokenType XmlStreamReader::readNext()
     return m_token;
 }
 
+#if (defined (_MSCVER) || defined (_MSC_VER))
+#define strdup _strdup // avoid a warning from MSVC on a perfectly valid POSIX function
+#endif
 void XmlStreamReader::tryParseEntity(Xml* xml)
 {
     static const char* ENTITY = { "ENTITY" };
 
     const char* str = xml->node->Value();
     if (std::strncmp(str, ENTITY, 6) == 0) {
-        String val = String::fromUtf8(str);
-        StringList list = val.split(' ');
-        if (list.size() == 3) {
-            String name = list.at(1);
-            String val2 = list.at(2);
-            m_entities[u'&' + name + u';'] = val2.mid(1, val2.size() - 2);
-        } else {
-            LOGW() << "unknown ENTITY: " << val;
+        // Syntax: '<!ENTITY [%] Name [SYSTEM|PUBLIC] "Value" [additional info] >'
+        // the '<!' and '>' stripped away already from str
+        // let's ignore %, SYSTEM, PUBLIC and any spaces in the 1st token
+        // and not read the (optional) 3rd token at all
+        char* string = strdup(str); // create local copy
+        const char sep[] = "\"";
+        char* token = std::strtok(string + 6, sep); // start at the space after "ENTITY"
+        String name = String::fromUtf8(token).remove(u"%").remove(u"SYSTEM").remove(u"PUBLIC").remove(u" ");
+        token = std::strtok(NULL, sep); // read 2nd token
+        String value = String::fromUtf8(token);
+        free(string); // not needed anymore
+        if (!name.empty() && !value.empty()) {
+            m_entities[u'&' + name + u';'] = value;
+            return;
         }
+        LOGW() << "Ignoring malformed ENTITY: " << str;
     }
 }
+
+#if (defined(_MSCVER) || defined(_MSC_VER))
+#undef strdup
+#endif
 
 String XmlStreamReader::nodeValue(Xml* xml) const
 {


### PR DESCRIPTION
Resolves #22500

* Run install target before running unit tests, so chords_std.xml are actually found (cherry-picked from #22503).
* Fix unit tests in two Mu1 engreaving/import tests due to chords_std.xml now being found.
* Use debug log rather than error log, to fix erroneous error output in unit tests and vtests.
* Fix ENTITY parser, to fix an erroneous warning output (which actually pointed at a bug in said parser).