### PR TITLE
[test] Use appimagetool from AppImage/appimagetool

### DIFF
--- a/buildscripts/ci/linux/tools/make_appimage.sh
+++ b/buildscripts/ci/linux/tools/make_appimage.sh
@@ -58,14 +58,14 @@ function download_appimage_release()
   local -r github_repo_slug="$1" binary_name="$2" tag="$3"
   local -r appimage="${binary_name}-${PACKARCH}.AppImage"
   download_github_release "${github_repo_slug}" "${tag}" "${appimage}"
-  extract_appimage "${appimage}" "${binary_name}"
-  # mv "${appimage}" "${binary_name}" # use this instead of the previous line for the static runtime AppImage
+  # extract_appimage "${appimage}" "${binary_name}"
+  mv "${appimage}" "${binary_name}" # use this instead of the previous line for the static runtime AppImage
 }
 
 if [[ ! -d $BUILD_TOOLS/appimagetool ]]; then
   mkdir $BUILD_TOOLS/appimagetool
   cd $BUILD_TOOLS/appimagetool
-  download_appimage_release AppImage/AppImageKit appimagetool continuous # use AppImage/appimagetool for the static runtime AppImage
+  download_appimage_release AppImage/appimagetool appimagetool continuous # use AppImage/appimagetool for the static runtime AppImage
   cd $ORIGIN_DIR
 fi
 export PATH="$BUILD_TOOLS/appimagetool:$PATH"


### PR DESCRIPTION
instead of AppImage/AppImageKit.

It's very unclear, but it looks like this version is more recent, and uses a static runtime that doesn't depend on libfuse2 being installed on the host machine.