### PR TITLE
Fix melisma shortcut

### DIFF
--- a/src/framework/shortcuts/data/shortcuts-Mac.xml
+++ b/src/framework/shortcuts/data/shortcuts-Mac.xml
@@ -892,7 +892,7 @@
   </SC>
   <SC>
     <key>add-melisma</key>
-    <seq>Shift+-</seq>
+    <seq>_</seq>
   </SC>
   <SC>
     <key>next-lyric-verse</key>

--- a/src/framework/shortcuts/data/shortcuts.xml
+++ b/src/framework/shortcuts/data/shortcuts.xml
@@ -891,7 +891,7 @@
   </SC>
   <SC>
     <key>add-melisma</key>
-    <seq>Shift+-</seq>
+    <seq>_</seq>
   </SC>
   <SC>
     <key>next-lyric-verse</key>


### PR DESCRIPTION
Resolves: #14914
Resolves: #16492

Changing the shortcut for entering lyrics melisma to use just `_`, which works on any keyboard, regardless of whether it actually is `Shift`+`-` (German or AZERTY keyboard) or `Shift`+`\` (Japanese Keyboard)