### PR TITLE
Check result of `init` call to MuseSampler

### DIFF
--- a/src/framework/musesampler/internal/musesamplerresolver.cpp
+++ b/src/framework/musesampler/internal/musesamplerresolver.cpp
@@ -317,7 +317,6 @@ bool MuseSamplerResolver::checkLibrary()
         return false;
     }
 
-
     return true;
 }
 

--- a/src/framework/musesampler/internal/musesamplerresolver.cpp
+++ b/src/framework/musesampler/internal/musesamplerresolver.cpp
@@ -304,12 +304,19 @@ std::vector<Instrument> MuseSamplerResolver::instruments() const
     return result;
 }
 
-bool MuseSamplerResolver::checkLibrary() const
+bool MuseSamplerResolver::checkLibrary()
 {
     if (!m_libHandler->isValid()) {
         LOGE() << "Incompatible MuseSampler library; ignoring";
         return false;
     }
+
+    if (m_libHandler->initLib() != ms_Result_OK) {
+        LOGE() << "Could not initialize MuseSampler library; ignoring";
+        m_libHandler.reset();
+        return false;
+    }
+
 
     return true;
 }

--- a/src/framework/musesampler/internal/musesamplerresolver.h
+++ b/src/framework/musesampler/internal/musesamplerresolver.h
@@ -55,7 +55,7 @@ public:
     std::vector<Instrument> instruments() const override;
 
 private:
-    bool checkLibrary() const;
+    bool checkLibrary();
     bool isVersionSupported() const;
 
     void loadSoundPresetAttributes(muse::audio::SoundPresetAttributes& attributes, int instrumentId, const char* presetCode) const;

--- a/src/framework/musesampler/internal/musesamplerwrapper.cpp
+++ b/src/framework/musesampler/internal/musesamplerwrapper.cpp
@@ -41,8 +41,6 @@ MuseSamplerWrapper::MuseSamplerWrapper(MuseSamplerLibHandlerPtr samplerLib,
         return;
     }
 
-    m_samplerLib->initLib();
-
     m_sequencer.setOnOffStreamFlushed([this]() {
         revokePlayingNotes();
     });


### PR DESCRIPTION
- If the `ms_init` call does not return "OK", use of the MuseSampler library can lead to segfaults.
- This PR checks the return value and disallows use of the library on failure.
- Also, as `init` should only be called once, this moves where `init` is called.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)