### PR TITLE
Infer sticking on XML import

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -6308,7 +6308,7 @@ static bool commonAnnotations(ExportMusicXml* exp, const EngravingItem* e, staff
         exp->tempoText(toTempoText(e), sstaff);
     } else if (e->isPlayTechAnnotation() || e->isCapo() || e->isStringTunings() || e->isStaffText()
                || e->isTripletFeel() || e->isText()
-               || e->isExpression() || (e->isInstrumentChange() && e->visible())) {
+               || e->isExpression() || (e->isInstrumentChange() && e->visible()) || e->isSticking()) {
         exp->words(toTextBase(e), sstaff);
     } else if (e->isDynamic()) {
         exp->dynamic(toDynamic(e), sstaff);

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.h
@@ -183,6 +183,7 @@ public:
     const CreditWordsList& credits() const { return m_credits; }
     bool hasBeamingInfo() const { return m_hasBeamingInfo; }
     bool isVocalStaff(const String& id) const { return m_parts.at(id).isVocalStaff(); }
+    bool isPercussionStaff(const String& id) const { return m_parts.at(id).isPercussionStaff(); }
     static VBox* createAndAddVBoxForCreditWords(Score* score, const int miny = 0, const int maxy = 75);
     static void reformatHeaderVBox(MeasureBase* mb);
     void createDefaultHeader(Score* const score);

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
@@ -451,6 +451,7 @@ private:
     Text* addTextToHeader(const TextStyleType textStyleType);
     void hideRedundantHeaderText(const Text* inferredText, const std::vector<String> metaTags);
     bool isLikelyFingering() const;
+    bool isLikelySticking();
 
     bool hasTotalY() const { return m_hasRelativeY || m_hasDefaultY; }
 
@@ -482,6 +483,7 @@ private:
     double m_defaultY = 0.0;
     bool m_hasRelativeY = false;
     double m_relativeY = 0.0;
+    double m_relativeX = 0.0;
     double m_tpoMetro = 0.0;                   // tempo according to metronome
     double m_tpoSound = 0.0;                   // tempo according to sound
     std::vector<EngravingItem*> m_elems;

--- a/src/importexport/musicxml/internal/musicxml/importxmlfirstpass.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importxmlfirstpass.cpp
@@ -37,6 +37,25 @@ static const std::vector<String> vocalInstrumentNames = { u"Voice",
                                                           u"Women",
                                                           u"Men" };
 
+static const std::vector<String> percussionInstrumentNames = { u"Percussion",
+                                                               u"Timpani",
+                                                               u"Glockenspiel",
+                                                               u"Xylophone",
+                                                               u"Vibraphone",
+                                                               u"Marimba",
+                                                               u"Bell",
+                                                               u"Drum"
+                                                               u"Cymbal",
+                                                               u"Triangle",
+                                                               u"Claves",
+                                                               u"Wood Blocks",
+                                                               u"Tambourine",
+                                                               u"Finger Snap",
+                                                               u"Hand Clap",
+                                                               u"Slap",
+                                                               u"Stamp"
+};
+
 MusicXmlPart::MusicXmlPart(String id, String name)
     : m_id(id), m_name(name)
 {
@@ -149,6 +168,16 @@ bool MusicXmlPart::isVocalStaff() const
 {
     return std::find(vocalInstrumentNames.begin(), vocalInstrumentNames.end(), m_name) != vocalInstrumentNames.end()
            || m_hasLyrics;
+}
+
+bool MusicXmlPart::isPercussionStaff() const
+{
+    for (const String& name : percussionInstrumentNames) {
+        if (m_name.contains(name)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 //---------------------------------------------------------

--- a/src/importexport/musicxml/internal/musicxml/importxmlfirstpass.h
+++ b/src/importexport/musicxml/internal/musicxml/importxmlfirstpass.h
@@ -99,6 +99,7 @@ public:
     void setMaxStaff(const int staff);
     int maxStaff() const { return m_maxStaff; }
     bool isVocalStaff() const;
+    bool isPercussionStaff() const;
     void hasLyrics(bool b) { m_hasLyrics = b; }
 private:
     String m_id;

--- a/src/importexport/musicxml/tests/data/testSticking.xml
+++ b/src/importexport/musicxml/tests/data/testSticking.xml
@@ -1,0 +1,699 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Untitled score</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Composer / arranger</creator>
+    <encoding>
+      <software>MuseScore 4.4.0</software>
+      <encoding-date>2024-04-22</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>6.99911</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1696.94</page-height>
+      <page-width>1200.48</page-width>
+      <page-margins type="even">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <appearance>
+      <line-width type="light barline">1.8</line-width>
+      <line-width type="heavy barline">5.5</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="bracket">4.5</line-width>
+      <line-width type="dashes">1</line-width>
+      <line-width type="enclosure">1</line-width>
+      <line-width type="ending">1.1</line-width>
+      <line-width type="extend">1</line-width>
+      <line-width type="leger">1.6</line-width>
+      <line-width type="pedal">1.1</line-width>
+      <line-width type="octave shift">1.1</line-width>
+      <line-width type="slur middle">2.1</line-width>
+      <line-width type="slur tip">0.5</line-width>
+      <line-width type="staff">1.1</line-width>
+      <line-width type="stem">1</line-width>
+      <line-width type="tie middle">2.1</line-width>
+      <line-width type="tie tip">0.5</line-width>
+      <line-width type="tuplet bracket">1</line-width>
+      <line-width type="wedge">1.2</line-width>
+      <note-size type="cue">70</note-size>
+      <note-size type="grace">70</note-size>
+      <note-size type="grace-cue">49</note-size>
+      </appearance>
+    <music-font font-family="Leland"/>
+    <word-font font-family="Edwin" font-size="10"/>
+    <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Percussion</part-name>
+      <part-abbreviation>Perc.</part-abbreviation>
+      <score-instrument id="P1-I28">
+        <instrument-name>Closed Hi-Hat</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I29">
+        <instrument-name>Pedal Hi-Hat</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I30">
+        <instrument-name>Open Hi-Hat</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I31">
+        <instrument-name>Ride Cymbal 1</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I37">
+        <instrument-name>Bass Drum 1</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I38">
+        <instrument-name>Side Stick</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I39">
+        <instrument-name>Acoustic Snare</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I55">
+        <instrument-name>Tambourine</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I56">
+        <instrument-name>Splash Cymbal</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I57">
+        <instrument-name>Cowbell</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I59">
+        <instrument-name>Vibraslap</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I60">
+        <instrument-name>Ride Cymbal 2</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I63">
+        <instrument-name>Mute High Conga</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I64">
+        <instrument-name>Open High Conga</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I65">
+        <instrument-name>Low Conga</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I71">
+        <instrument-name>Maracas</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I76">
+        <instrument-name>Claves</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I82">
+        <instrument-name>Open Triangle</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I83">
+        <instrument-name>Shaker</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I85">
+        <instrument-name>Mark Tree</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I86">
+        <instrument-name>Castanets</instrument-name>
+        </score-instrument>
+      <midi-device port="1"></midi-device>
+      <midi-instrument id="P1-I28">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>28</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I29">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>29</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I30">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>30</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I31">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>31</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I37">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>37</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I38">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>38</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I39">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>39</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I55">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>55</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I56">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>56</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I57">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>57</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I59">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>59</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I60">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>60</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I63">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>63</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I64">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>64</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I65">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>65</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I71">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>71</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I76">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>76</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I82">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>82</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I83">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>83</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I85">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>85</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P1-I86">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <midi-unpitched>86</midi-unpitched>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="389">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50</left-margin>
+            <right-margin>-0</right-margin>
+            </system-margins>
+          <top-system-distance>70</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>4</divisions>
+        <key>
+          <fifths>0</fifths>
+          <mode>none</mode>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>percussion</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <direction>
+        <direction-type>
+          <words default-y="-40.1" relative-y="-20">L</words>
+          </direction-type>
+        </direction>
+      <note default-x="68.7" default-y="-15">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <duration>1</duration>
+        <instrument id="P1-I39"/>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+        </note>
+      <direction>
+        <direction-type>
+          <words default-y="-40.1" relative-y="-20">R</words>
+          </direction-type>
+        </direction>
+      <note default-x="96.7" default-y="-15">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <duration>1</duration>
+        <instrument id="P1-I39"/>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <direction>
+        <direction-type>
+          <words default-y="-40.1" relative-y="-20">L</words>
+          </direction-type>
+        </direction>
+      <note default-x="124.7" default-y="-15">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <duration>1</duration>
+        <instrument id="P1-I39"/>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <direction>
+        <direction-type>
+          <words default-y="-40.1" relative-y="-20">B</words>
+          </direction-type>
+        </direction>
+      <note default-x="152.7" default-y="-15">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <duration>1</duration>
+        <instrument id="P1-I39"/>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+        </note>
+      <direction>
+        <direction-type>
+          <words default-y="-40.41" relative-y="-20">l</words>
+          </direction-type>
+        </direction>
+      <note default-x="180.7" default-y="-15">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <duration>1</duration>
+        <instrument id="P1-I39"/>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+        </note>
+      <direction>
+        <direction-type>
+          <words default-y="-40" relative-y="-20">r</words>
+          </direction-type>
+        </direction>
+      <note default-x="208.7" default-y="-15">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <duration>1</duration>
+        <instrument id="P1-I39"/>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <direction>
+        <direction-type>
+          <words default-y="-40.41" relative-y="-20">l</words>
+          </direction-type>
+        </direction>
+      <note default-x="236.7" default-y="-15">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <duration>1</duration>
+        <instrument id="P1-I39"/>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <direction>
+        <direction-type>
+          <words default-y="-40.41" relative-y="-20">b</words>
+          </direction-type>
+        </direction>
+      <note default-x="264.7" default-y="-15">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <duration>1</duration>
+        <instrument id="P1-I39"/>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+        </note>
+      <note default-x="292.7" default-y="-20">
+        <rest/>
+        <duration>8</duration>
+        <voice>1</voice>
+        <type>half</type>
+        </note>
+      </measure>
+    <measure number="2" width="296.09">
+      <direction>
+        <direction-type>
+          <words default-y="-40.1" relative-x="-20" relative-y="-20">L</words>
+          </direction-type>
+        </direction>
+      <direction>
+        <direction-type>
+          <words default-y="-40.1" relative-y="-20">R</words>
+          </direction-type>
+        </direction>
+      <note default-x="11.05" default-y="-15">
+        <grace slash="yes"/>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <instrument id="P1-I39"/>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <notations>
+          <slur type="start" number="1"/>
+          </notations>
+        </note>
+      <note default-x="31.79" default-y="-15">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <duration>2</duration>
+        <instrument id="P1-I39"/>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <slur type="stop" number="1"/>
+          <articulations>
+            <accent placement="above"/>
+            </articulations>
+          </notations>
+        </note>
+      <direction>
+        <direction-type>
+          <words default-y="-40.1" relative-y="-20">L</words>
+          </direction-type>
+        </direction>
+      <note default-x="73.79" default-y="-15">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <duration>2</duration>
+        <instrument id="P1-I39"/>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        </note>
+      <direction>
+        <direction-type>
+          <words default-y="-40.1" relative-y="-20">R</words>
+          </direction-type>
+        </direction>
+      <note default-x="115.79" default-y="-15">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <duration>2</duration>
+        <instrument id="P1-I39"/>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        </note>
+      <direction>
+        <direction-type>
+          <words default-y="-40.1" relative-x="-20" relative-y="-20">L</words>
+          </direction-type>
+        </direction>
+      <direction>
+        <direction-type>
+          <words default-y="-40.1" relative-y="-20">R</words>
+          </direction-type>
+        </direction>
+      <note default-x="137.05" default-y="-15">
+        <grace slash="yes"/>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <instrument id="P1-I39"/>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <notations>
+          <slur type="start" number="1"/>
+          </notations>
+        </note>
+      <note default-x="157.79" default-y="-15">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <duration>2</duration>
+        <instrument id="P1-I39"/>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <slur type="stop" number="1"/>
+          <articulations>
+            <accent placement="above"/>
+            </articulations>
+          </notations>
+        </note>
+      <note default-x="199.79" default-y="-20">
+        <rest/>
+        <duration>8</duration>
+        <voice>1</voice>
+        <type>half</type>
+        </note>
+      </measure>
+    <measure number="3" width="293.94">
+      <direction>
+        <direction-type>
+          <words default-y="-40" relative-x="-50" relative-y="-20">l</words>
+          </direction-type>
+        </direction>
+      <direction>
+        <direction-type>
+          <words default-y="-40" relative-x="-40" relative-y="-20">r</words>
+          </direction-type>
+        </direction>
+      <direction>
+        <direction-type>
+          <words default-y="-40" relative-x="-25" relative-y="-20">l</words>
+          </direction-type>
+        </direction>
+      <direction>
+        <direction-type>
+          <words default-y="-40" relative-x="-10" relative-y="-20">r</words>
+          </direction-type>
+        </direction>
+      <direction>
+        <direction-type>
+          <words default-y="-40.41" relative-y="-20">l</words>
+          </direction-type>
+        </direction>
+      <note default-x="11.05" default-y="-15">
+        <grace/>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <instrument id="P1-I39"/>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+        </note>
+      <note default-x="23.65" default-y="-15">
+        <grace/>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <instrument id="P1-I39"/>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note default-x="36.25" default-y="-15">
+        <grace/>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <instrument id="P1-I39"/>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note default-x="48.84" default-y="-15">
+        <grace/>
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <instrument id="P1-I39"/>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+        </note>
+      <note default-x="62.44" default-y="-15">
+        <unpitched>
+          <display-step>C</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <duration>4</duration>
+        <instrument id="P1-I39"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <articulations>
+            <accent placement="above"/>
+            </articulations>
+          </notations>
+        </note>
+      <note default-x="125.44" default-y="-20">
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note default-x="188.44" default-y="-20">
+        <rest/>
+        <duration>8</duration>
+        <voice>1</voice>
+        <type>half</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/data/testSticking_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSticking_ref.mscx
@@ -1,0 +1,652 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.40">
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.26997</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.08887</pagePrintableWidth>
+      <pageEvenLeftMargin>0.590551</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.590551</pageOddLeftMargin>
+      <pageEvenTopMargin>0.590551</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
+      <pageOddTopMargin>0.590551</pageOddTopMargin>
+      <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
+      <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
+      <tupletFontSize>10</tupletFontSize>
+      <fingeringFontSize>10</fingeringFontSize>
+      <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
+      <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
+      <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
+      <partInstrumentFontSize>10</partInstrumentFontSize>
+      <tempoFontSize>10</tempoFontSize>
+      <tempoChangeFontSize>10</tempoChangeFontSize>
+      <metronomeFontSize>10</metronomeFontSize>
+      <measureNumberFontSize>10</measureNumberFontSize>
+      <mmRestRangeFontSize>10</mmRestRangeFontSize>
+      <rehearsalMarkFontSize>10</rehearsalMarkFontSize>
+      <repeatLeftFontSize>10</repeatLeftFontSize>
+      <repeatRightFontSize>10</repeatRightFontSize>
+      <glissandoFontSize>10</glissandoFontSize>
+      <bendFontSize>10</bendFontSize>
+      <headerFontSize>10</headerFontSize>
+      <footerFontSize>10</footerFontSize>
+      <Spatium>1.74978</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Composer / arranger</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Untitled score</metaTag>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="percussion">
+          <name>perc5Line</name>
+          <keysig>0</keysig>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        </Staff>
+      <trackName>Percussion</trackName>
+      <Instrument id="strings">
+        <longName>Percussion</longName>
+        <shortName>Perc.</shortName>
+        <trackName>Closed Hi-Hat</trackName>
+        <minPitchP>24</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>24</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>strings.group</instrumentId>
+        <useDrumset>1</useDrumset>
+        <Drum pitch="27">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Closed Hi-Hat</name>
+          <stem>0</stem>
+          </Drum>
+        <Drum pitch="28">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Pedal Hi-Hat</name>
+          <stem>0</stem>
+          </Drum>
+        <Drum pitch="29">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Open Hi-Hat</name>
+          <stem>0</stem>
+          </Drum>
+        <Drum pitch="30">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Ride Cymbal 1</name>
+          <stem>0</stem>
+          </Drum>
+        <Drum pitch="36">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Bass Drum 1</name>
+          <stem>0</stem>
+          </Drum>
+        <Drum pitch="37">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Side Stick</name>
+          <stem>0</stem>
+          </Drum>
+        <Drum pitch="38">
+          <head>normal</head>
+          <line>3</line>
+          <voice>0</voice>
+          <name>Acoustic Snare</name>
+          <stem>1</stem>
+          </Drum>
+        <Drum pitch="54">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Tambourine</name>
+          <stem>0</stem>
+          </Drum>
+        <Drum pitch="55">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Splash Cymbal</name>
+          <stem>0</stem>
+          </Drum>
+        <Drum pitch="56">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Cowbell</name>
+          <stem>0</stem>
+          </Drum>
+        <Drum pitch="58">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Vibraslap</name>
+          <stem>0</stem>
+          </Drum>
+        <Drum pitch="59">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Ride Cymbal 2</name>
+          <stem>0</stem>
+          </Drum>
+        <Drum pitch="62">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Mute High Conga</name>
+          <stem>0</stem>
+          </Drum>
+        <Drum pitch="63">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Open High Conga</name>
+          <stem>0</stem>
+          </Drum>
+        <Drum pitch="64">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Low Conga</name>
+          <stem>0</stem>
+          </Drum>
+        <Drum pitch="70">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Maracas</name>
+          <stem>0</stem>
+          </Drum>
+        <Drum pitch="75">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Claves</name>
+          <stem>0</stem>
+          </Drum>
+        <Drum pitch="81">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Open Triangle</name>
+          <stem>0</stem>
+          </Drum>
+        <Drum pitch="82">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Shaker</name>
+          <stem>0</stem>
+          </Drum>
+        <Drum pitch="84">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Mark Tree</name>
+          <stem>0</stem>
+          </Drum>
+        <Drum pitch="85">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Castanets</name>
+          <stem>0</stem>
+          </Drum>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel name="arco">
+          <controller ctrl="0" value="1"/>
+          <program value="48"/>
+          <controller ctrl="10" value="63"/>
+          </Channel>
+        <Channel name="pizzicato">
+          <program value="45"/>
+          </Channel>
+        <Channel name="tremolo">
+          <program value="44"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>title</style>
+          <text>Untitled score</text>
+          </Text>
+        <Text>
+          <style>composer</style>
+          <text>Composer / arranger</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>PERC</concertClefType>
+            <transposingClefType>PERC</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <KeySig>
+            <custom>1</custom>
+            <mode>none</mode>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Sticking>
+            <text>L</text>
+            </Sticking>
+          <Beam>
+            <StemDirection>up</StemDirection>
+            <l1>-12</l1>
+            <l2>-12</l2>
+            </Beam>
+          <Chord>
+            <BeamMode>begin</BeamMode>
+            <durationType>16th</durationType>
+            <Note>
+              <pitch>38</pitch>
+              <tpc>-9</tpc>
+              <tpc2>16</tpc2>
+              </Note>
+            </Chord>
+          <Sticking>
+            <text>R</text>
+            </Sticking>
+          <Chord>
+            <BeamMode>mid</BeamMode>
+            <durationType>16th</durationType>
+            <Note>
+              <pitch>38</pitch>
+              <tpc>-9</tpc>
+              <tpc2>16</tpc2>
+              </Note>
+            </Chord>
+          <Sticking>
+            <text>L</text>
+            </Sticking>
+          <Chord>
+            <BeamMode>mid</BeamMode>
+            <durationType>16th</durationType>
+            <Note>
+              <pitch>38</pitch>
+              <tpc>-9</tpc>
+              <tpc2>16</tpc2>
+              </Note>
+            </Chord>
+          <Sticking>
+            <text>B</text>
+            </Sticking>
+          <Chord>
+            <durationType>16th</durationType>
+            <Note>
+              <pitch>38</pitch>
+              <tpc>-9</tpc>
+              <tpc2>16</tpc2>
+              </Note>
+            </Chord>
+          <Sticking>
+            <text>l</text>
+            </Sticking>
+          <Beam>
+            <StemDirection>up</StemDirection>
+            <l1>-12</l1>
+            <l2>-12</l2>
+            </Beam>
+          <Chord>
+            <BeamMode>begin</BeamMode>
+            <durationType>16th</durationType>
+            <Note>
+              <pitch>38</pitch>
+              <tpc>-9</tpc>
+              <tpc2>16</tpc2>
+              </Note>
+            </Chord>
+          <Sticking>
+            <text>r</text>
+            </Sticking>
+          <Chord>
+            <BeamMode>mid</BeamMode>
+            <durationType>16th</durationType>
+            <Note>
+              <pitch>38</pitch>
+              <tpc>-9</tpc>
+              <tpc2>16</tpc2>
+              </Note>
+            </Chord>
+          <Sticking>
+            <text>l</text>
+            </Sticking>
+          <Chord>
+            <BeamMode>mid</BeamMode>
+            <durationType>16th</durationType>
+            <Note>
+              <pitch>38</pitch>
+              <tpc>-9</tpc>
+              <tpc2>16</tpc2>
+              </Note>
+            </Chord>
+          <Sticking>
+            <text>b</text>
+            </Sticking>
+          <Chord>
+            <durationType>16th</durationType>
+            <Note>
+              <pitch>38</pitch>
+              <tpc>-9</tpc>
+              <tpc2>16</tpc2>
+              </Note>
+            </Chord>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Sticking>
+            <offset x="-2" y="2"/>
+            <text>L</text>
+            </Sticking>
+          <Sticking>
+            <text>R</text>
+            </Sticking>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Spanner type="Slur">
+              <Slur>
+                </Slur>
+              <next>
+                <location>
+                  </location>
+                </next>
+              </Spanner>
+            <acciaccatura/>
+            <Note>
+              <Events>
+                <Event>
+                  <len>0</len>
+                  </Event>
+                </Events>
+              <pitch>38</pitch>
+              <tpc>-9</tpc>
+              <tpc2>16</tpc2>
+              </Note>
+            </Chord>
+          <Beam>
+            <StemDirection>up</StemDirection>
+            <l1>-10</l1>
+            <l2>-10</l2>
+            </Beam>
+          <Chord>
+            <BeamMode>begin</BeamMode>
+            <durationType>eighth</durationType>
+            <Spanner type="Slur">
+              <prev>
+                <location>
+                  <grace>0</grace>
+                  </location>
+                </prev>
+              </Spanner>
+            <Articulation>
+              <subtype>articAccentAbove</subtype>
+              <anchor>0</anchor>
+              </Articulation>
+            <Note>
+              <pitch>38</pitch>
+              <tpc>-9</tpc>
+              <tpc2>16</tpc2>
+              </Note>
+            </Chord>
+          <Sticking>
+            <text>L</text>
+            </Sticking>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>38</pitch>
+              <tpc>-9</tpc>
+              <tpc2>16</tpc2>
+              </Note>
+            </Chord>
+          <Sticking>
+            <text>R</text>
+            </Sticking>
+          <Beam>
+            <StemDirection>up</StemDirection>
+            <l1>-10</l1>
+            <l2>-10</l2>
+            </Beam>
+          <Chord>
+            <BeamMode>begin</BeamMode>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>38</pitch>
+              <tpc>-9</tpc>
+              <tpc2>16</tpc2>
+              </Note>
+            </Chord>
+          <Sticking>
+            <offset x="-2" y="2"/>
+            <text>L</text>
+            </Sticking>
+          <Sticking>
+            <text>R</text>
+            </Sticking>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Spanner type="Slur">
+              <Slur>
+                </Slur>
+              <next>
+                <location>
+                  </location>
+                </next>
+              </Spanner>
+            <acciaccatura/>
+            <Note>
+              <Events>
+                <Event>
+                  <len>0</len>
+                  </Event>
+                </Events>
+              <pitch>38</pitch>
+              <tpc>-9</tpc>
+              <tpc2>16</tpc2>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Spanner type="Slur">
+              <prev>
+                <location>
+                  <grace>0</grace>
+                  </location>
+                </prev>
+              </Spanner>
+            <Articulation>
+              <subtype>articAccentAbove</subtype>
+              <anchor>0</anchor>
+              </Articulation>
+            <Note>
+              <pitch>38</pitch>
+              <tpc>-9</tpc>
+              <tpc2>16</tpc2>
+              </Note>
+            </Chord>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Sticking>
+            <offset x="-5" y="2"/>
+            <text>l</text>
+            </Sticking>
+          <Sticking>
+            <offset x="-4" y="2"/>
+            <text>r</text>
+            </Sticking>
+          <Sticking>
+            <offset x="-2.5" y="2"/>
+            <text>l</text>
+            </Sticking>
+          <Sticking>
+            <offset x="-1" y="2"/>
+            <text>r</text>
+            </Sticking>
+          <Sticking>
+            <text>l</text>
+            </Sticking>
+          <Beam>
+            <l1>-6</l1>
+            <l2>-6</l2>
+            </Beam>
+          <Chord>
+            <durationType>16th</durationType>
+            <grace16/>
+            <Note>
+              <Events>
+                <Event>
+                  <len>0</len>
+                  </Event>
+                </Events>
+              <pitch>38</pitch>
+              <tpc>-9</tpc>
+              <tpc2>16</tpc2>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <grace16/>
+            <Note>
+              <Events>
+                <Event>
+                  <len>0</len>
+                  </Event>
+                </Events>
+              <pitch>38</pitch>
+              <tpc>-9</tpc>
+              <tpc2>16</tpc2>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <grace16/>
+            <Note>
+              <Events>
+                <Event>
+                  <len>0</len>
+                  </Event>
+                </Events>
+              <pitch>38</pitch>
+              <tpc>-9</tpc>
+              <tpc2>16</tpc2>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>16th</durationType>
+            <grace16/>
+            <Note>
+              <Events>
+                <Event>
+                  <len>0</len>
+                  </Event>
+                </Events>
+              <pitch>38</pitch>
+              <tpc>-9</tpc>
+              <tpc2>16</tpc2>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Articulation>
+              <subtype>articAccentAbove</subtype>
+              <anchor>0</anchor>
+              </Articulation>
+            <StemDirection>up</StemDirection>
+            <Note>
+              <pitch>38</pitch>
+              <tpc>-9</tpc>
+              <tpc2>16</tpc2>
+              </Note>
+            </Chord>
+          <Rest>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -969,6 +969,9 @@ TEST_F(Musicxml_Tests, staffSize) {
 TEST_F(Musicxml_Tests, staffTwoKeySigs) {
     mxmlIoTest("testStaffTwoKeySigs");
 }
+TEST_F(Musicxml_Tests, sticking) {
+    mxmlImportTestRef("testSticking");
+}
 TEST_F(Musicxml_Tests, stringData) {
     mxmlIoTest("testStringData");
 }


### PR DESCRIPTION
This PR infers sticking from staff text matching 'L', 'R', 'B', 'l', 'r', 'b'.  The x and y positioning data is read to align sticking with grace notes and make sure the characters sit on the same baseline (we only do this on input currently).  
It was also necessary to restrict the dynamics inference to not pick up single 'm', 'r', 's', 'z' characters and only infer chord symbols when they are above the stave.
