### PR TITLE
Fix GH#16363: Accidentals in chord symbols rendered incorrectly when using custom XML file

### DIFF
--- a/src/engraving/dom/chordlist.cpp
+++ b/src/engraving/dom/chordlist.cpp
@@ -1780,7 +1780,8 @@ void ChordList::write(XmlWriter& xml) const
                 if (s.code.isNull()) {
                     xml.tag("sym", { { "name", s.name }, { "value", s.value } });
                 } else {
-                    xml.tag("sym", { { "name", s.name }, { "code", String::number(s.code.unicode(), 16) } });
+                    // write hex numbers with a "0x" prefix, so they can convert back properly on read
+                    xml.tag("sym", { { "name", s.name }, { "code", u"0x" + String::number(s.code.unicode(), 16) } });
                 }
             }
         }


### PR DESCRIPTION
Resolves: #16363