### PR TITLE
Fix truncated default file name in save dialog for new scores

### DIFF
--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -301,7 +301,7 @@ muse::io::path_t ProjectConfiguration::defaultSavingFilePath(INotationProjectPtr
                 folderPath = io::dirpath(projectPath);
             }
 
-            filename = io::filename(projectPath, false);
+            filename = project->metaInfo().title;
         } else {
             projectPath = engraving::containerPath(projectPath);
             folderPath = io::dirpath(projectPath);

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -298,10 +298,11 @@ muse::io::path_t ProjectConfiguration::defaultSavingFilePath(INotationProjectPtr
     if (isLocalProject) {
         if (project->isNewlyCreated()) {
             if (io::isAbsolute(projectPath)) {
+                filename = io::filename(projectPath, false);
                 folderPath = io::dirpath(projectPath);
+            } else {
+                filename = io::filename(projectPath, true);
             }
-
-            filename = project->metaInfo().title;
         } else {
             projectPath = engraving::containerPath(projectPath);
             folderPath = io::dirpath(projectPath);


### PR DESCRIPTION
Resolves: #22027 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->


https://github.com/musescore/MuseScore/assets/105774228/48655f6c-3500-4d5c-a455-94b922c8af44



<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
