### PR TITLE
Synced the mute button on the mixer metronome with the playback metronome button

### DIFF
--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -303,8 +303,17 @@ mu::notation::INotationSoloMuteState::SoloMuteState PlaybackController::trackSol
 }
 
 void PlaybackController::setTrackSoloMuteState(const InstrumentTrackId& trackId,
-                                               const notation::INotationSoloMuteState::SoloMuteState& state) const
+                                               const notation::INotationSoloMuteState::SoloMuteState& state)
 {
+    if (trackId == notationPlayback()->metronomeTrackId()) {
+        if (state.mute != notationConfiguration()->isMetronomeEnabled()) {
+            return;
+        }
+
+        toggleMetronome();
+        return;
+    }
+
     m_notation->soloMuteState()->setTrackSoloMuteState(trackId, state);
 }
 

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -92,7 +92,7 @@ public:
 
     notation::INotationSoloMuteState::SoloMuteState trackSoloMuteState(const engraving::InstrumentTrackId& trackId) const override;
     void setTrackSoloMuteState(const engraving::InstrumentTrackId& trackId,
-                               const notation::INotationSoloMuteState::SoloMuteState& state) const override;
+                               const notation::INotationSoloMuteState::SoloMuteState& state) override;
 
     void playElements(const std::vector<const notation::EngravingItem*>& elements) override;
     void playMetronome(int tick) override;

--- a/src/playback/iplaybackcontroller.h
+++ b/src/playback/iplaybackcontroller.h
@@ -77,7 +77,7 @@ public:
 
     virtual notation::INotationSoloMuteState::SoloMuteState trackSoloMuteState(const engraving::InstrumentTrackId& trackId) const = 0;
     virtual void setTrackSoloMuteState(const engraving::InstrumentTrackId& trackId,
-                                       const notation::INotationSoloMuteState::SoloMuteState& state) const = 0;
+                                       const notation::INotationSoloMuteState::SoloMuteState& state) = 0;
 
     virtual void playElements(const std::vector<const notation::EngravingItem*>& elements) = 0;
     virtual void playMetronome(int tick) = 0;

--- a/src/playback/qml/MuseScore/Playback/internal/MixerMuteAndSoloSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerMuteAndSoloSection.qml
@@ -52,7 +52,7 @@ MixerPanelSection {
                 checked: channelItem.muted
 
                 // TODO: not use `enabled` for this, but present visually in some other way
-                enabled: !(channelItem.muted && channelItem.forceMute) && channelItem.type !== MixerChannelItem.Metronome
+                enabled: !(channelItem.muted && channelItem.forceMute)
 
                 navigation.name: "MuteButton"
                 navigation.panel: channelItem.panel

--- a/src/playback/tests/mocks/playbackcontrollermock.h
+++ b/src/playback/tests/mocks/playbackcontrollermock.h
@@ -63,7 +63,7 @@ public:
     MOCK_METHOD(notation::INotationSoloMuteState::SoloMuteState, trackSoloMuteState, (const engraving::InstrumentTrackId&),
                 (const, override));
     MOCK_METHOD(void, setTrackSoloMuteState, (const engraving::InstrumentTrackId&, const notation::INotationSoloMuteState::SoloMuteState&),
-                (const, override));
+                (override));
 
     MOCK_METHOD(void, playElements, ((const std::vector<const notation::EngravingItem*>&)), (override));
     MOCK_METHOD(void, playMetronome, (int), (override));

--- a/src/stubs/playback/playbackcontrollerstub.cpp
+++ b/src/stubs/playback/playbackcontrollerstub.cpp
@@ -126,7 +126,7 @@ mu::notation::INotationSoloMuteState::SoloMuteState PlaybackControllerStub::trac
 }
 
 void PlaybackControllerStub::setTrackSoloMuteState(const engraving::InstrumentTrackId&,
-                                                   const notation::INotationSoloMuteState::SoloMuteState&) const
+                                                   const notation::INotationSoloMuteState::SoloMuteState&)
 {
 }
 

--- a/src/stubs/playback/playbackcontrollerstub.h
+++ b/src/stubs/playback/playbackcontrollerstub.h
@@ -59,7 +59,7 @@ public:
 
     notation::INotationSoloMuteState::SoloMuteState trackSoloMuteState(const engraving::InstrumentTrackId& trackId) const override;
     void setTrackSoloMuteState(const engraving::InstrumentTrackId& trackId,
-                               const notation::INotationSoloMuteState::SoloMuteState& state) const override;
+                               const notation::INotationSoloMuteState::SoloMuteState& state) override;
 
     void playElements(const std::vector<const notation::EngravingItem*>& elements) override;
     void playMetronome(int tick) override;


### PR DESCRIPTION
Resolves: [#11031](https://github.com/musescore/MuseScore/issues/11031)

<!-- Add a short description of and motivation for the changes here -->
Previously, the metronome mute button was not toggleable on the mixer panel, but this issue syncs it with the playback panel's metronome. In the issue above, it appears to be quite outdated for the behavior with chords so I believe we can ignore that part as muting a single chord should not affect the playback panel since there can be multiple chords.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
