### PR TITLE
Fix GH15404: German note name "H" not recognized in German locale

### DIFF
--- a/src/framework/shortcuts/data/shortcuts-Mac.xml
+++ b/src/framework/shortcuts/data/shortcuts-Mac.xml
@@ -207,6 +207,7 @@
   <SC>
     <key>note-b</key>
     <seq>B</seq>
+    <seq>H</seq>
     </SC>
   <SC>
     <key>note-c</key>
@@ -235,6 +236,7 @@
   <SC>
     <key>chord-b</key>
     <seq>Shift+B</seq>
+    <seq>Shift+H</seq>
     </SC>
   <SC>
     <key>chord-c</key>
@@ -267,6 +269,7 @@
   <SC>
     <key>insert-b</key>
     <seq>Ctrl+Shift+B</seq>
+    <seq>Ctrl+Shift+H</seq>
     </SC>
   <SC>
     <key>insert-c</key>

--- a/src/framework/shortcuts/data/shortcuts.xml
+++ b/src/framework/shortcuts/data/shortcuts.xml
@@ -207,6 +207,7 @@
   <SC>
     <key>note-b</key>
     <seq>B</seq>
+    <seq>H</seq>
     </SC>
   <SC>
     <key>note-c</key>
@@ -235,6 +236,7 @@
   <SC>
     <key>chord-b</key>
     <seq>Shift+B</seq>
+    <seq>Shift+H</seq>
     </SC>
   <SC>
     <key>chord-c</key>
@@ -267,6 +269,7 @@
   <SC>
     <key>insert-b</key>
     <seq>Ctrl+Shift+B</seq>
+    <seq>Ctrl+Shift+H</seq>
     </SC>
   <SC>
     <key>insert-c</key>

--- a/src/framework/shortcuts/data/shortcuts_AZERTY.xml
+++ b/src/framework/shortcuts/data/shortcuts_AZERTY.xml
@@ -215,6 +215,7 @@
   <SC>
     <key>note-b</key>
     <seq>B</seq>
+    <seq>H</seq>
     </SC>
   <SC>
     <key>note-c</key>
@@ -243,6 +244,7 @@
   <SC>
     <key>chord-b</key>
     <seq>Shift+B</seq>
+    <seq>Shift+H</seq>
     </SC>
   <SC>
     <key>chord-c</key>
@@ -275,6 +277,7 @@
   <SC>
     <key>insert-b</key>
     <seq>Ctrl+Shift+B</seq>
+    <seq>Ctrl+Shift+H</seq>
     </SC>
   <SC>
     <key>insert-c</key>


### PR DESCRIPTION
Now H is an alternative shortcut to B, in every locale

Resolves: #15404