### PR TITLE
fixed #22568: Unable to log in to Audio.com

### DIFF
--- a/src/framework/cloud/internal/abstractcloudservice.cpp
+++ b/src/framework/cloud/internal/abstractcloudservice.cpp
@@ -119,7 +119,7 @@ void AbstractCloudService::initOAuthIfNecessary()
 #else
     m_oauth2->setModifyParametersFunction([this](QAbstractOAuth::Stage, QMultiMap<QString, QVariant>* parameters) {
         for (const QString& key : m_serverConfig.authorizationParameters.keys()) {
-            parameters->insert(key, m_serverConfig.authorizationParameters.value(key));
+            parameters->replace(key, m_serverConfig.authorizationParameters.value(key));
         }
     });
 #endif


### PR DESCRIPTION
Resolves: #22568

After switching to Qt6, the container was replaced ещ QMultiMap and as a result, we had several values for one key: one Qt added, one we added