### PR TITLE
Read 'print-object' for directions and write for tempo

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -4855,6 +4855,9 @@ static void wordsMetronome(XmlWriter& xml, const MStyle& s, TextBase const* cons
         String tagName = String(u"metronome parentheses=\"%1\"").arg(hasParen ? u"yes" : u"no");
         tagName += color2xml(text);
         tagName += ExportMusicXml::positioningAttributes(text);
+        if (!text->visible()) {
+            tagName += u" print-object=\"no\"";
+        }
         xml.startElementRaw(tagName);
         int len1 = 0;
         TDuration dur;

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -3062,6 +3062,7 @@ void MusicXMLParserDirection::direction(const String& partId,
                 tt->setFollowText(true);
             }
         }
+        tt->setVisible(m_visible);
 
         addElemOffset(tt, track, placement(), measure, tick + m_offset);
     } else if (isLikelySticking() && isPercussionStaff) {
@@ -3137,6 +3138,8 @@ void MusicXMLParserDirection::direction(const String& partId,
                 t->setColor(m_color);
             }
 
+            t->setVisible(m_visible);
+
             String wordsPlacement = m_placement;
             // Case-based defaults
             if (wordsPlacement.empty()) {
@@ -3198,6 +3201,8 @@ void MusicXMLParserDirection::direction(const String& partId,
             }
             dyn->setVelocity(dynaValue);
         }
+
+        dyn->setVisible(m_visible);
 
         String dynamicsPlacement = placement();
         // Case-based defaults
@@ -3285,6 +3290,7 @@ void MusicXMLParserDirection::direction(const String& partId,
                     spannerPlacement = totalY() < 0 ? u"above" : u"below";
                 }
             }
+            desc.sp->setVisible(m_visible);
             if (spdesc.isStopped) {
                 m_pass2.addSpanner(desc);
                 // handleSpannerStart and handleSpannerStop must be called in order
@@ -3440,6 +3446,7 @@ void MusicXMLParserDirection::directionType(std::vector<MusicXmlSpannerDesc>& st
         m_defaultY = m_e.asciiAttribute("default-y").toDouble(&m_hasDefaultY) * -0.1;
         m_relativeX = m_e.doubleAttribute("relative-x") / 10 * m_score->style().spatium();
         m_relativeY = m_e.doubleAttribute("relative-y") / -10 * m_score->style().spatium();
+        m_visible = m_e.asciiAttribute("print-object") != "no";
         String number = m_e.attribute("number");
         int n = 0;
         if (!number.empty()) {
@@ -4020,6 +4027,7 @@ void MusicXMLParserDirection::handleRepeats(Measure* measure, const track_idx_t 
                 MeasureBase* gap = m_score->insertBox(ElementType::HBOX, measure);
                 toHBox(gap)->setBoxWidth(Spatium(10));
             }
+            tb->setVisible(m_visible);
             measure->add(tb);
         }
     }
@@ -4124,6 +4132,7 @@ void MusicXMLParserDirection::handleChordSym(const track_idx_t track, const Frac
     ha->setTrack(track);
     ha->setPlacement(placement() == u"above" ? PlacementV::ABOVE : PlacementV::BELOW);
     ha->setPropertyFlags(Pid::PLACEMENT, PropertyFlags::UNSTYLED);
+    ha->setVisible(m_visible);
     HarmonyDesc newHarmonyDesc(track, ha, nullptr);
 
     const int ticks = tick.ticks();

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
@@ -486,6 +486,7 @@ private:
     double m_relativeX = 0.0;
     double m_tpoMetro = 0.0;                   // tempo according to metronome
     double m_tpoSound = 0.0;                   // tempo according to sound
+    bool m_visible = true;
     std::vector<EngravingItem*> m_elems;
     Fraction m_offset;
 };

--- a/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_invisible_ref.xml
+++ b/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_invisible_ref.xml
@@ -188,7 +188,7 @@
         </note>
       <direction placement="above">
         <direction-type>
-          <metronome parentheses="no">
+          <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
             <per-minute>90</per-minute>
             </metronome>

--- a/src/importexport/musicxml/tests/data/testInvisibleDirection.xml
+++ b/src/importexport/musicxml/tests/data/testInvisibleDirection.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Untitled score</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Composer / arranger</creator>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Flute</part-name>
+      <part-abbreviation>Fl.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Flute</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>74</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>64</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="64"/>
+        </direction>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="3">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/data/testSound1_ref.xml
+++ b/src/importexport/musicxml/tests/data/testSound1_ref.xml
@@ -45,7 +45,7 @@
         </attributes>
       <direction placement="above">
         <direction-type>
-          <metronome parentheses="no">
+          <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
             <per-minute>60</per-minute>
             </metronome>

--- a/src/importexport/musicxml/tests/data/testSound2_ref.xml
+++ b/src/importexport/musicxml/tests/data/testSound2_ref.xml
@@ -45,7 +45,7 @@
         </attributes>
       <direction placement="above">
         <direction-type>
-          <metronome parentheses="no">
+          <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
             <per-minute>60</per-minute>
             </metronome>

--- a/src/importexport/musicxml/tests/data/testTempoOverlap_ref.xml
+++ b/src/importexport/musicxml/tests/data/testTempoOverlap_ref.xml
@@ -213,7 +213,7 @@
         </direction>
       <direction placement="above">
         <direction-type>
-          <metronome parentheses="no">
+          <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
             <per-minute>81</per-minute>
             </metronome>
@@ -229,7 +229,7 @@
     <measure number="9">
       <direction placement="above">
         <direction-type>
-          <metronome parentheses="no">
+          <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
             <per-minute>82</per-minute>
             </metronome>
@@ -246,7 +246,7 @@
       <print new-system="yes"/>
       <direction placement="above">
         <direction-type>
-          <metronome parentheses="no">
+          <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
             <per-minute>81</per-minute>
             </metronome>
@@ -272,7 +272,7 @@
     <measure number="11">
       <direction placement="above">
         <direction-type>
-          <metronome parentheses="no">
+          <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
             <per-minute>82</per-minute>
             </metronome>
@@ -288,7 +288,7 @@
     <measure number="12">
       <direction placement="above">
         <direction-type>
-          <metronome parentheses="no">
+          <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
             <per-minute>83</per-minute>
             </metronome>
@@ -304,7 +304,7 @@
     <measure number="13">
       <direction placement="above">
         <direction-type>
-          <metronome parentheses="no">
+          <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
             <per-minute>84</per-minute>
             </metronome>
@@ -321,7 +321,7 @@
       <print new-system="yes"/>
       <direction placement="above">
         <direction-type>
-          <metronome parentheses="no">
+          <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
             <per-minute>85</per-minute>
             </metronome>
@@ -342,7 +342,7 @@
     <measure number="15">
       <direction placement="above">
         <direction-type>
-          <metronome parentheses="no">
+          <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
             <per-minute>86</per-minute>
             </metronome>
@@ -358,7 +358,7 @@
     <measure number="16">
       <direction placement="above">
         <direction-type>
-          <metronome parentheses="no">
+          <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
             <per-minute>87</per-minute>
             </metronome>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -730,6 +730,9 @@ TEST_F(Musicxml_Tests, invalidLayout) {
 TEST_F(Musicxml_Tests, invalidTimesig) {
     mxmlIoTestRef("testInvalidTimesig");
 }
+TEST_F(Musicxml_Tests, invisibleDirection) {
+    mxmlIoTest("testInvisibleDirection");
+}
 TEST_F(Musicxml_Tests, invisibleElements) {
     mxmlIoTest("testInvisibleElements");
 }


### PR DESCRIPTION
This PR reads the `print-object` tag for [`<direction>`](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/direction/) elements.  It also writes this tag when exporting tempo text as metronome markings.
