### PR TITLE
support OS directory separator convention when loading libraries

### DIFF
--- a/src/framework/global/dlib.h
+++ b/src/framework/global/dlib.h
@@ -37,9 +37,9 @@ namespace muse {
 inline void* loadLib(const io::path_t& path)
 {
 #if defined(Q_OS_WIN) && !defined(__MINGW64__)
-    return LoadLibrary(path.toStdWString().c_str());
+    return LoadLibrary(io::toNativeSeparators(path).toStdWString().data());
 #else
-    return dlopen(path.c_str(), RTLD_LAZY);
+    return dlopen(io::toNativeSeparators(path).toStdString().data(), RTLD_LAZY);
 #endif
 }
 

--- a/src/framework/musesampler/internal/musesamplerconfiguration.cpp
+++ b/src/framework/musesampler/internal/musesamplerconfiguration.cpp
@@ -60,7 +60,8 @@ static const muse::io::path_t FALLBACK_PATH = LIB_NAME;
 
 muse::io::path_t MuseSamplerConfiguration::defaultPath() const
 {
-    return globalConfig()->genericDataPath() + "\\MuseSampler\\lib\\" + LIB_NAME;
+    io::path_t path = globalConfig()->genericDataPath() + "/MuseSampler/lib/" + LIB_NAME;
+    return path;
 }
 
 #endif


### PR DESCRIPTION

Dynamic Libraries that are retrieved from Windows require a "\\" directory separator, whereas other OS's use "/",  In addition,  the path to the museSampler.lib was incorrectly defined with both "/" and "\\" separators.   

This update fixes both problems - the path to museSampler is now in the standard "/" format and library paths are made OS specific. 

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [N/A] I created a unit test or vtest to verify the changes I made (if applicable)
