### PR TITLE
Disable certain properties when not needed

### DIFF
--- a/src/inspector/models/notation/lines/textlinesettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/textlinesettingsmodel.cpp
@@ -92,13 +92,13 @@ void TextLineSettingsModel::createProperties()
 
     m_placement = buildPropertyItem(Pid::PLACEMENT);
 
-    m_beginningText = buildPropertyItem(Pid::BEGIN_TEXT);
+    m_beginningText = buildPropertyItem(Pid::BEGIN_TEXT, applyPropertyValueAndUpdateAvailability);
     m_beginningTextOffset = buildPointFPropertyItem(Pid::BEGIN_TEXT_OFFSET);
 
-    m_continuousText = buildPropertyItem(Pid::CONTINUE_TEXT);
+    m_continuousText = buildPropertyItem(Pid::CONTINUE_TEXT, applyPropertyValueAndUpdateAvailability);
     m_continuousTextOffset = buildPointFPropertyItem(Pid::CONTINUE_TEXT_OFFSET);
 
-    m_endText = buildPropertyItem(Pid::END_TEXT);
+    m_endText = buildPropertyItem(Pid::END_TEXT, applyPropertyValueAndUpdateAvailability);
     m_endTextOffset = buildPointFPropertyItem(Pid::END_TEXT_OFFSET);
 }
 
@@ -302,6 +302,15 @@ void TextLineSettingsModel::onUpdateLinePropertiesAvailability()
 
     m_dashLineLength->setIsEnabled(isLineAvailable && areDashPropertiesAvailable);
     m_dashGapLength->setIsEnabled(isLineAvailable && areDashPropertiesAvailable);
+
+    bool hasBeginText = !m_beginningText->value().toString().isEmpty();
+    bool hasContinueText = !m_continuousText->value().toString().isEmpty();
+    bool hasEndText = !m_endText->value().toString().isEmpty();
+
+    m_beginningTextOffset->setIsEnabled(hasBeginText);
+    m_continuousTextOffset->setIsEnabled(hasContinueText);
+    m_endTextOffset->setIsEnabled(hasEndText);
+    m_gapBetweenTextAndLine->setIsEnabled(isLineAvailable && (hasBeginText || hasContinueText || hasEndText));
 }
 
 void TextLineSettingsModel::setPossibleStartHookTypes(const QList<HookTypeInfo>& types)

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/LineTextSettingsTab.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/LineTextSettingsTab.qml
@@ -67,34 +67,13 @@ FocusableItem {
 
         SeparatorLine { anchors.margins: -12 }
 
-        SpinBoxPropertyView {
-            id: gapBetweenTextAndLineControl
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.rightMargin: 2
-
-            titleText: qsTrc("inspector", "Gap between text and line")
-            propertyItem: root.model ? root.model.gapBetweenTextAndLine : null
-
-            step: 0.1
-            maxValue: 100.0
-            minValue: 0.0
-            decimals: 2
-
-            navigationName: "GapBetweenTextAndLine"
-            navigationPanel: root.navigationPanel
-            navigationRowStart: beginningTextOffsetSection.navigationRowEnd + 1
-        }
-
-        SeparatorLine { anchors.margins: -12 }
-
         TextSection {
             id: continuousTextSection
             titleText: qsTrc("inspector", "Text when continuing to a new system")
             propertyItem: root.model ? root.model.continuousText : null
 
             navigationPanel: root.navigationPanel
-            navigationRowStart: gapBetweenTextAndLineControl.navigationRowEnd + 1
+            navigationRowStart: beginningTextOffsetSection.navigationRowEnd + 1
         }
 
         OffsetSection {
@@ -124,6 +103,27 @@ FocusableItem {
 
             navigationPanel: root.navigationPanel
             navigationRowStart: endTextSection.navigationRowEnd + 1
+        }
+
+        SeparatorLine { anchors.margins: -12 }
+
+        SpinBoxPropertyView {
+            id: gapBetweenTextAndLineControl
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.rightMargin: 2
+
+            titleText: qsTrc("inspector", "Gap between text and line")
+            propertyItem: root.model ? root.model.gapBetweenTextAndLine : null
+
+            step: 0.1
+            maxValue: 100.0
+            minValue: 0.0
+            decimals: 2
+
+            navigationName: "GapBetweenTextAndLine"
+            navigationPanel: root.navigationPanel
+            navigationRowStart: endTextOffsetSection.navigationRowEnd + 1
         }
     }
 }


### PR DESCRIPTION
This PR disables the Text Offset option for text in line elements when there is no text to be offset. Additionally, the 'Gap between text and line' option is disabled when there is no text to leave a gap between.

![image](https://github.com/musescore/MuseScore/assets/116587995/bcc340f4-acb0-4c1a-9bb2-10a20cba8d4e)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
