### PR TITLE
Issue #21263 allow typing dynamics from keyboard

### DIFF
--- a/cpp.hint
+++ b/cpp.hint
@@ -1,0 +1,4 @@
+// Hint files help the Visual Studio IDE interpret Visual C++ identifiers
+// such as names of functions and macros.
+// For more information see https://go.microsoft.com/fwlink/?linkid=865984
+#define MOCK_METHOD(__VA_ARGS__) GMOCK_PP_VARIADIC_CALL(GMOCK_INTERNAL_MOCK_METHOD_ARG_, __VA_ARGS__)

--- a/src/engraving/dom/articulation.cpp
+++ b/src/engraving/dom/articulation.cpp
@@ -394,6 +394,9 @@ Articulation::AnchorGroup Articulation::anchorGroup(SymId symId)
     case SymId::tremoloDivisiDots6:
         return AnchorGroup::ARTICULATION;
 
+    case SymId::dynamicPiano:
+    case SymId::dynamicForte:
+        return AnchorGroup::DYNAMIC;
     default:
         break;
     }

--- a/src/engraving/dom/articulation.h
+++ b/src/engraving/dom/articulation.h
@@ -205,6 +205,7 @@ private:
     enum class AnchorGroup {
         ARTICULATION,
         LUTE_FINGERING,
+        DYNAMIC,
         OTHER
     };
     static AnchorGroup anchorGroup(SymId);

--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -2076,6 +2076,68 @@ void Score::toggleArticulation(SymId attr)
 }
 
 //---------------------------------------------------------
+//   toggleDynamic
+//---------------------------------------------------------
+
+void Score::toggleDynamic(DynamicType dt, EditData& ed)
+{
+    /*if (m_is.dynamicType() == dt) {
+        dt = DynamicType::M;
+    }
+    if (noteEntryMode()) {
+        m_is.setDynamicType(dt);
+        m_is.setRest(false);
+    }
+    else {
+        if (selection().isNone()) {
+            ed.view()->startNoteEntryMode();
+            m_is.setDynamicType(dt);
+            m_is.setDuration(DurationType::V_QUARTER);
+            m_is.setRest(false);
+        }
+        else {
+            changeDynamic(dt, ed);
+        }
+    }*/
+}
+
+//---------------------------------------------------------
+//   changeDynamic
+//---------------------------------------------------------
+
+void Score::changeDynamic(DynamicType dt, EditData& ed)
+{
+    /*for (EngravingItem* item : selection().elements()) {
+        Dynamic* dynamic = 0;
+        Note* note = 0;
+        switch (item->type()) {
+        case ElementType::DYNAMIC:
+            dynamic = toDynamic(item);
+
+            if (dynamic->dynamicType() == dt) {
+                dynamic->startEdit(ed);
+                dynamic->measure()->add(dynamic);
+            }
+            else {
+                dynamic->setDynamicType(dt);
+                dynamic->startEdit(ed);
+                dynamic->measure()->add(dynamic);
+            }
+            break;
+        case ElementType::NOTE:
+            note = toNote(item);
+            dynamic->setDynamicType(dt);
+            dynamic->startEdit(ed);
+            note->add(dynamic);
+            break;
+        default:
+            break;
+        }
+    }*/
+}
+
+
+//---------------------------------------------------------
 //   toggleAccidental
 //---------------------------------------------------------
 

--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -2093,17 +2093,21 @@ void Score::toggleDynamic(DynamicType dt)
                     continue;
                 }
             }
-            Dynamic* dy = Factory::createDynamic(this->dummy()->segment()); 
+            Dynamic* dy = Factory::createDynamic(cr->segment()); 
             dy->setDynamicType(dt);
-            dy->setVelocity(6);
-            undoAddElement(dy);
+            dy->setTrack(cr->track());
+            cr->segment()->add(dy);
 
-            Articulation* na = Factory::createArticulation(this->dummy()->chord());
-            switch (dt) {
+
+            //undoAddElement(dy);
+ 
+            /*Articulation* na = Factory::createArticulation(this->dummy()->chord());
+            switch (dt) {*/
             /*case DynamicType::PP:
                 na->setSymId(SymId::dynamicPP);
                 break;*/
-            case DynamicType::P:
+            /*case DynamicType::P:
+                addDynamic()
                 na->setSymId(SymId::dynamicPiano);
                 break;
             case DynamicType::F:
@@ -2123,8 +2127,7 @@ void Score::toggleDynamic(DynamicType dt)
             if (cr) {
                 set.insert(cr);
             }
-
-            break;
+            break; */
         }
     }
 }
@@ -2135,6 +2138,7 @@ void Score::toggleDynamic(DynamicType dt)
 
 bool Score::changeDynamic(EngravingItem* el, Articulation* a)
 {
+    /*
     Chord* c;
     if (el->isNote()) {
         c = toNote(el)->chord();
@@ -2175,7 +2179,7 @@ bool Score::changeDynamic(EngravingItem* el, Articulation* a)
         }
         articCopy->setAnchor(ArticulationAnchor::BOTTOM);
         delete articCopy;
-    }
+    }*/
     return true;
 }
 

--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -2093,20 +2093,20 @@ void Score::toggleDynamic(DynamicType dt)
                     continue;
                 }
             }
-            Dynamic* dy = Factory::createDynamic(cr->segment()); 
+            /*Dynamic* dy = Factory::createDynamic(cr->segment());
             dy->setDynamicType(dt);
             dy->setTrack(cr->track());
-            cr->segment()->add(dy);
+            cr->segment()->add(dy);*/
 
 
             //undoAddElement(dy);
  
-            /*Articulation* na = Factory::createArticulation(this->dummy()->chord());
-            switch (dt) {*/
+            Articulation* na = Factory::createArticulation(this->dummy()->chord());
+            switch (dt) {
             /*case DynamicType::PP:
                 na->setSymId(SymId::dynamicPP);
                 break;*/
-            /*case DynamicType::P:
+            case DynamicType::P:
                 addDynamic()
                 na->setSymId(SymId::dynamicPiano);
                 break;
@@ -2127,7 +2127,7 @@ void Score::toggleDynamic(DynamicType dt)
             if (cr) {
                 set.insert(cr);
             }
-            break; */
+            break;
         }
     }
 }

--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -2107,7 +2107,6 @@ void Score::toggleDynamic(DynamicType dt)
                 na->setSymId(SymId::dynamicPP);
                 break;*/
             case DynamicType::P:
-                addDynamic()
                 na->setSymId(SymId::dynamicPiano);
                 break;
             case DynamicType::F:

--- a/src/engraving/dom/input.h
+++ b/src/engraving/dom/input.h
@@ -34,6 +34,7 @@
 namespace mu::engraving {
 class ChordRest;
 class Drumset;
+class Dynamic;
 class EngravingItem;
 class Note;
 class Score;
@@ -110,6 +111,9 @@ public:
     AccidentalType accidentalType() const { return m_accidentalType; }
     void setAccidentalType(AccidentalType val) { m_accidentalType = val; }
 
+    DynamicType dynamicType() const { return m_dynamicType; }
+    void setDynamicType(DynamicType val) { m_dynamicType = val; }
+
     std::set<SymId> articulationIds() const { return m_articulationIds; }
     void setArticulationIds(const std::set<SymId>& ids) { m_articulationIds = ids; }
 
@@ -149,6 +153,8 @@ private:
 
     AccidentalType m_accidentalType = AccidentalType::NONE;
     Slur* m_slur = nullptr;
+
+    DynamicType m_dynamicType = DynamicType::M;
 
     std::set<SymId> m_articulationIds;
 };

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -96,6 +96,7 @@ class Bracket;
 class Chord;
 class ChordRest;
 class Clef;
+class Dynamic;
 class Element;
 class EventsHolder;
 class Excerpt;
@@ -445,6 +446,8 @@ public:
     // undo/redo ops
     void toggleArticulation(SymId);
     bool toggleArticulation(EngravingItem*, Articulation* atr);
+    void toggleDynamic(DynamicType, EditData& ed);
+    void changeDynamic(DynamicType, EditData& ed);
     void toggleAccidental(AccidentalType, const EditData& ed);
     void changeAccidental(AccidentalType);
     void changeAccidental(Note* oNote, AccidentalType);

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -446,8 +446,8 @@ public:
     // undo/redo ops
     void toggleArticulation(SymId);
     bool toggleArticulation(EngravingItem*, Articulation* atr);
-    void toggleDynamic(DynamicType, EditData& ed);
-    void changeDynamic(DynamicType, EditData& ed);
+    void toggleDynamic(DynamicType);
+    bool changeDynamic(EngravingItem*, Articulation* atr);
     void toggleAccidental(AccidentalType, const EditData& ed);
     void changeAccidental(AccidentalType);
     void changeAccidental(Note* oNote, AccidentalType);

--- a/src/framework/shortcuts/data/shortcuts.xml
+++ b/src/framework/shortcuts/data/shortcuts.xml
@@ -508,6 +508,14 @@
     <seq>End</seq>
     </SC>
   <SC>
+    <key>add-piano</key>
+    <seq>Alt+Shift+P</seq>
+    </SC>
+  <SC>
+    <key>add-forte</key>
+    <seq>Alt+Shift+F</seq>
+    </SC>
+  <SC>
     <key>add-slur</key>
     <seq>S</seq>
     </SC>

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -181,6 +181,7 @@ public:
     virtual void addOttavaToSelection(OttavaType type) = 0;
     virtual void addHairpinsToSelection(HairpinType type) = 0;
     virtual void addAccidentalToSelection(AccidentalType type) = 0;
+    virtual void addDynamicToSelection(mu::engraving::DynamicType type) = 0;
     virtual void putRestToSelection() = 0;
     virtual void putRest(Duration duration) = 0;
     virtual void addBracketsToSelection(BracketsType type) = 0;

--- a/src/notation/inotationnoteinput.h
+++ b/src/notation/inotationnoteinput.h
@@ -25,6 +25,7 @@
 #include "async/notification.h"
 #include "notationtypes.h"
 #include "types/retval.h"
+#include "engraving\types\types.h"
 
 namespace mu::notation {
 class INotationNoteInput
@@ -57,6 +58,7 @@ public:
     virtual void addTie() = 0;
 
     virtual void setAccidental(AccidentalType accidentalType) = 0;
+    virtual void setDynamic(DynamicType dynamicType) = 0;
     virtual void setArticulation(SymbolId articulationSymbolId) = 0;
     virtual void setDrumNote(int note) = 0;
     virtual void setCurrentVoice(voice_idx_t voiceIndex) = 0;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -151,6 +151,10 @@ void NotationActionController::init()
     registerAction("add-melisma", &Interaction::addMelisma, PlayMode::NoPlay, &Controller::isEditingLyrics);
     registerAction("add-lyric-verse", &Interaction::addLyricsVerse, PlayMode::NoPlay, &Controller::isEditingLyrics);
 
+    //registerAction("add-dynamic", &Interaction::addDynamic, PlayMode::NoPlay);
+    registerAction("add-piano", [this]() { addDynamic(DynamicType::P); });
+    registerAction("add-forte", [this]() { addDynamic(DynamicType::F); });
+
     registerAction("flat2", [this]() { toggleAccidental(AccidentalType::FLAT2); });
     registerAction("flat", [this]() { toggleAccidental(AccidentalType::FLAT); });
     registerAction("nat", [this]() { toggleAccidental(AccidentalType::NATURAL); });
@@ -796,6 +800,30 @@ void NotationActionController::toggleAccidental(AccidentalType type)
         noteInput->setAccidental(type);
     } else {
         interaction->addAccidentalToSelection(type);
+        playSelectedElement();
+    }
+}
+
+void NotationActionController::addDynamic(DynamicType type) 
+{
+    TRACEFUNC;
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+
+    auto noteInput = currentNotationNoteInput();
+    if (!noteInput) {
+        return;
+    }
+
+    startNoteInputIfNeed();
+
+    if (noteInput->isNoteInputMode()) {
+        noteInput->setDynamic(type);
+    }
+    else {
+        interaction->addDynamicToSelection(type);
         playSelectedElement();
     }
 }

--- a/src/notation/internal/notationactioncontroller.h
+++ b/src/notation/internal/notationactioncontroller.h
@@ -90,6 +90,7 @@ private:
     void realtimeAdvance();
 
     void toggleAccidental(AccidentalType type);
+    void addDynamic(DynamicType type);
     void addArticulation(SymbolId articulationSymbolId);
 
     void putTuplet(const actions::ActionData& data);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2130,6 +2130,7 @@ bool NotationInteraction::notesHaveActiculation(const std::vector<Note*>& notes,
     return true;
 }
 
+
 //! NOTE Copied from ScoreView::dragLeaveEvent
 void NotationInteraction::endDrop()
 {
@@ -3041,13 +3042,13 @@ void NotationInteraction::endEditText()
 
     doEndEditElement();
 
+    if (changeTextToDynamic(element)) {
+        score()->removeElement(element);
+    }
+
     notifyAboutTextEditingEnded(toTextBase(element));
     notifyAboutTextEditingChanged();
     notifyAboutSelectionChangedIfNeed();
-
-    /*if (changeTextToDynamic()) {
-        score()->removeElement(element);
-    }*/
 }
 
 void NotationInteraction::changeTextCursorPosition(const PointF& newCursorPos)
@@ -3851,8 +3852,7 @@ void NotationInteraction::addDynamicToSelection(DynamicType type)
     apply();
 }
 
-bool NotationInteraction::changeTextToDynamic() {
-    EngravingItem* element = m_editData.element;
+bool NotationInteraction::changeTextToDynamic(EngravingItem* element) {
     
     if (toTextBase(element)->xmlText() == "pp" || toTextBase(element)->xmlText() == "PP") {
         addDynamicToSelection(DynamicType::PP);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -48,6 +48,7 @@
 #include "engraving/dom/bracket.h"
 #include "engraving/dom/chord.h"
 #include "engraving/dom/drumset.h"
+#include "engraving/dom/dynamic.h"
 #include "engraving/dom/elementgroup.h"
 #include "engraving/dom/factory.h"
 #include "engraving/dom/figuredbass.h"
@@ -3834,6 +3835,30 @@ void NotationInteraction::addAccidentalToSelection(AccidentalType type)
     score()->toggleAccidental(type, editData);
     apply();
 }
+
+void NotationInteraction::addDynamicToSelection(DynamicType type) 
+{
+    if (selection()->isNone()) {
+        return;
+    }
+
+    mu::engraving::EditData editData(&m_scoreCallbacks);
+
+    EngravingItem* dynamicItem = 0;
+    for (EngravingItem* item : selection()->elements()) {
+        if (item->type() == ElementType::NOTE) {
+            dynamicItem->setParent(item);
+            break;
+        }
+    }
+    Dynamic* dynamic = toDynamic(dynamicItem);
+    dynamic->setDynamicType(type);
+
+    startEdit();
+    score()->addElement(dynamicItem);
+    apply();
+}
+
 
 void NotationInteraction::putRestToSelection()
 {

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3044,6 +3044,10 @@ void NotationInteraction::endEditText()
     notifyAboutTextEditingEnded(toTextBase(element));
     notifyAboutTextEditingChanged();
     notifyAboutSelectionChangedIfNeed();
+
+    /*if (changeTextToDynamic()) {
+        score()->removeElement(element);
+    }*/
 }
 
 void NotationInteraction::changeTextCursorPosition(const PointF& newCursorPos)
@@ -3842,21 +3846,44 @@ void NotationInteraction::addDynamicToSelection(DynamicType type)
         return;
     }
 
-    mu::engraving::EditData editData(&m_scoreCallbacks);
-
-    EngravingItem* dynamicItem = 0;
-    for (EngravingItem* item : selection()->elements()) {
-        if (item->type() == ElementType::NOTE) {
-            dynamicItem->setParent(item);
-            break;
-        }
-    }
-    Dynamic* dynamic = toDynamic(dynamicItem);
-    dynamic->setDynamicType(type);
-
     startEdit();
-    score()->addElement(dynamicItem);
+    score()->toggleDynamic(type);
     apply();
+}
+
+bool NotationInteraction::changeTextToDynamic() {
+    EngravingItem* element = m_editData.element;
+    
+    if (toTextBase(element)->xmlText() == "pp" || toTextBase(element)->xmlText() == "PP") {
+        addDynamicToSelection(DynamicType::PP);
+        return true;
+    }
+    /**else if (toTextBase(element)->xmlText() == "p" || toTextBase(element)->xmlText() == "P") {
+        addDynamicToSelection(DynamicType::P);
+        return true;
+    }
+    else if (toTextBase(element)->xmlText() == "mp" || toTextBase(element)->xmlText() == "MP") {
+        addDynamicToSelection(DynamicType::MP);
+        return true;
+    }
+    else if (toTextBase(element)->xmlText() == "m" || toTextBase(element)->xmlText() == "M") {
+        addDynamicToSelection(DynamicType::M);
+        return true;
+    }
+    else if (toTextBase(element)->xmlText() == "mf" || toTextBase(element)->xmlText() == "MF") {
+        addDynamicToSelection(DynamicType::MF);
+        return true;
+    }
+    else if (toTextBase(element)->xmlText() == "f" || toTextBase(element)->xmlText() == "F") {
+        addDynamicToSelection(DynamicType::F);
+        return true;
+    }
+    else if (toTextBase(element)->xmlText() == "ff" || toTextBase(element)->xmlText() == "FF") {
+        addDynamicToSelection(DynamicType::FF);
+        return true;
+    }
+    */
+    return false;
 }
 
 

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -184,6 +184,7 @@ public:
     void addOttavaToSelection(OttavaType type) override;
     void addHairpinsToSelection(HairpinType type) override;
     void addAccidentalToSelection(AccidentalType type) override;
+    void addDynamicToSelection(DynamicType type) override;
     void putRestToSelection() override;
     void putRest(Duration duration) override;
     void addBracketsToSelection(BracketsType type) override;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -185,7 +185,7 @@ public:
     void addHairpinsToSelection(HairpinType type) override;
     void addAccidentalToSelection(AccidentalType type) override;
     void addDynamicToSelection(DynamicType type) override;
-    bool changeTextToDynamic();
+    bool changeTextToDynamic(EngravingItem* element);
     void putRestToSelection() override;
     void putRest(Duration duration) override;
     void addBracketsToSelection(BracketsType type) override;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -185,6 +185,7 @@ public:
     void addHairpinsToSelection(HairpinType type) override;
     void addAccidentalToSelection(AccidentalType type) override;
     void addDynamicToSelection(DynamicType type) override;
+    bool changeTextToDynamic();
     void putRestToSelection() override;
     void putRest(Duration duration) override;
     void addBracketsToSelection(BracketsType type) override;

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -418,9 +418,7 @@ void NotationNoteInput::setDynamic(DynamicType dynamicType)
 {
     TRACEFUNC;
 
-    mu::engraving::EditData editData(m_scoreCallbacks);
-
-    score()->toggleDynamic(dynamicType, editData);
+    score()->toggleDynamic(dynamicType);
 
     notifyAboutStateChanged();
 

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -414,6 +414,19 @@ void NotationNoteInput::setAccidental(AccidentalType accidentalType)
     MScoreErrorsController::checkAndShowMScoreError();
 }
 
+void NotationNoteInput::setDynamic(DynamicType dynamicType)
+{
+    TRACEFUNC;
+
+    mu::engraving::EditData editData(m_scoreCallbacks);
+
+    score()->toggleDynamic(dynamicType, editData);
+
+    notifyAboutStateChanged();
+
+    MScoreErrorsController::checkAndShowMScoreError();
+}
+
 void NotationNoteInput::setArticulation(SymbolId articulationSymbolId)
 {
     TRACEFUNC;

--- a/src/notation/internal/notationnoteinput.h
+++ b/src/notation/internal/notationnoteinput.h
@@ -70,6 +70,7 @@ public:
     void halveNoteInputDuration() override;
 
     void setAccidental(AccidentalType accidentalType) override;
+    void setDynamic(DynamicType dynamicType) override;
     void setArticulation(SymbolId articulationSymbolId) override;
     void setDrumNote(int note) override;
     void setCurrentVoice(voice_idx_t voiceIndex) override;

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1695,6 +1695,20 @@ const UiActionList NotationUiActions::m_actions = {
              TranslatableString("action", "Add lyric verse"),
              TranslatableString("action", "Add lyric verse")
              ),
+     UiAction("add-piano",
+             mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             TranslatableString("action", "Add piano dynamic"),
+             TranslatableString("action", "Add piano dynamic"),
+             Checkable::Yes
+             ),
+     UiAction("add-forte",
+             mu::context::UiCtxNotationOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             TranslatableString("action", "Add forte dynamic"),
+             TranslatableString("action", "Add forte dynamic"),
+             Checkable::Yes
+),
     UiAction("text-b",
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_NOTATION_OPENED,

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -102,6 +102,7 @@ using Hook = mu::engraving::Hook;
 using Fraction = mu::engraving::Fraction;
 using NoteInputMethod = mu::engraving::NoteEntryMethod;
 using AccidentalType = mu::engraving::AccidentalType;
+using DynamicType = mu::engraving::DynamicType;
 using OttavaType = mu::engraving::OttavaType;
 using HairpinType = mu::engraving::HairpinType;
 using TextBase = mu::engraving::TextBase;

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -143,6 +143,7 @@ public:
     MOCK_METHOD(void, addOttavaToSelection, (OttavaType), (override));
     MOCK_METHOD(void, addHairpinsToSelection, (HairpinType), (override));
     MOCK_METHOD(void, addAccidentalToSelection, (AccidentalType), (override));
+    MOCK_METHOD(void, addDynamicToSelection, (DynamicType type), (override));
     MOCK_METHOD(void, putRestToSelection, (), (override));
     MOCK_METHOD(void, putRest, (Duration), (override));
     MOCK_METHOD(void, addBracketsToSelection, (BracketsType), (override));


### PR DESCRIPTION
Resolves: #21263 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
In the future I plan to implement this feature exactly as requested. However, I could not implement adding dynamics through text because of limited time and limited understanding. Instead I added support for adding a piano dynamic and adding a forte dynamic with Shift+Alt+P and Shift+Alt+F, respectively

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [ x] I signed the [CLA](https://musescore.org/en/cla)
- [ x] The title of the PR describes the problem it addresses
- [ x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [ x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x] There are no unnecessary changes
- [x ] The code compiles and runs on my machine, preferably after each commit individually
- [x ] I created a unit test or vtest to verify the changes I made (if applicable)
