### PR TITLE
MusicXML: mark linked staves when writing staff-details

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -7573,6 +7573,10 @@ static void writeStaffDetails(XmlWriter& xml, const Part* part)
             }
             xml.startElement("staff-details", attributes);
 
+            if (st->links()) {
+                xml.tag("staff-type", "alternate");
+            }
+
             xml.tag("staff-lines", st->lines(Fraction(0, 1)));
             if (st->isTabStaff(Fraction(0, 1)) && instrument->stringData()) {
                 std::vector<instrString> l = instrument->stringData()->stringList();

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -7574,7 +7574,7 @@ static void writeStaffDetails(XmlWriter& xml, const Part* part)
             }
             xml.startElement("staff-details", attributes);
 
-            if (st->links() && st->links()->contains(part->staff(i - 1))) {
+            if (i > 0 && st->links() && st->links()->contains(part->staff(i - 1))) {
                 xml.tag("staff-type", "alternate");
             }
 

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -84,6 +84,7 @@
 #include "engraving/dom/keysig.h"
 #include "engraving/dom/layoutbreak.h"
 #include "engraving/dom/letring.h"
+#include "engraving/dom/linkedobjects.h"
 #include "engraving/dom/lyrics.h"
 #include "engraving/dom/marker.h"
 #include "engraving/dom/masterscore.h"
@@ -7573,7 +7574,7 @@ static void writeStaffDetails(XmlWriter& xml, const Part* part)
             }
             xml.startElement("staff-details", attributes);
 
-            if (st->links()) {
+            if (st->links() && st->links()->contains(part->staff(i - 1))) {
                 xml.tag("staff-type", "alternate");
             }
 


### PR DESCRIPTION
Small addition to MusicXML export for marking linked staves as "alternate".

See https://www.w3.org/2021/06/musicxml40/musicxml-reference/examples/staff-type-element/