### PR TITLE
Fix new ENTITY parser

### DIFF
--- a/src/framework/global/serialization/xmlstreamreader.cpp
+++ b/src/framework/global/serialization/xmlstreamreader.cpp
@@ -228,7 +228,7 @@ void XmlStreamReader::tryParseEntity(Xml* xml)
         token = std::strtok(NULL, sep); // read 2nd token
         String value = String::fromUtf8(token);
         free(string); // not needed anymore
-        if (!name.empty() && !value.empty()) {
+        if (!name.empty()) {
             m_entities[u'&' + name + u';'] = value;
             return;
         }


### PR DESCRIPTION
As a unit test reveals:
```
2024-04-29T10:31:07.0821194Z 10: [0;32m[ RUN      ] [mEngraving_Compat114Tests.textstyles
2024-04-29T10:31:07.1833345Z 10: [1;33m10:31:07.182 | WARN  | main_thread     | XmlStreamReader::tryParseEntity | Ignoring malformed ENTITY: ENTITY display_suspended4_post ""[0m
2024-04-29T10:31:07.1836601Z 10: [1;33m10:31:07.183 | WARN  | main_thread     | XmlStreamReader::tryParseEntity | Ignoring malformed ENTITY: ENTITY parse_suspended4_post ""[0m
2024-04-29T10:31:07.1839094Z 10: [1;33m10:31:07.183 | WARN  | main_thread     | XmlStreamReader::tryParseEntity | Ignoring malformed ENTITY: ENTITY d_alp ""[0m
2024-04-29T10:31:07.1841727Z 10: [1;33m10:31:07.183 | WARN  | main_thread     | XmlStreamReader::tryParseEntity | Ignoring malformed ENTITY: ENTITY d_arp ""[0m
2024-04-29T10:31:07.4357878Z 10: [0;32m[       OK ] [mEngraving_Compat114Tests.textstyles (353 ms)
```
the ENTITY `value` is allowed to be empty (an empty `String`, ""), see cchords_muse.xml:
https://github.com/musescore/MuseScore/blob/4b9397fc9da0edaa89449fc71a8b693bc594475a/share/styles/cchords_muse.xml#L114-L115
somthing I've missed in my implementation.