### PR TITLE
Correct error in horizontal spacing calculations

### DIFF
--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -2786,12 +2786,12 @@ double Segment::computeDurationStretch(const Segment* prevSeg, Fraction minTicks
         static constexpr double maxRatio = 32.0;
         double dMinTicks = minTicks.toDouble();
         double dMaxTicks = maxTicks.toDouble();
-        double maxSysRatio = dMaxTicks / dMinTicks;
         if (muse::RealIsEqualOrMore(dMaxTicks / dMinTicks, 2.0) && dMinTicks < longNoteThreshold) {
             /* HACK: we trick the system to ignore the shortest note and use the "next"
              * shortest. For example, if the shortest is a 32nd, we make it a 16th. */
             dMinTicks *= 2.0;
         }
+        double maxSysRatio = dMaxTicks / dMinTicks;
         double ratio = curTicks.toDouble() / dMinTicks;
         if (maxSysRatio > maxRatio) {
             double A = (dMinTicks * (maxRatio - 1)) / (dMaxTicks - dMinTicks);


### PR DESCRIPTION
An error in the horizontal spacing calculations could cause a log(0) operation.

[Beethoven__Piano_Sonata_No._14__Moonlight-3.zip](https://github.com/musescore/MuseScore/files/15151439/Beethoven__Piano_Sonata_No._14__Moonlight-3.zip)
