### PR TITLE
Fix #22563: Ensure slur is deleted with parent chord & crash fix

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3912,7 +3912,7 @@ void Score::removeChordRest(ChordRest* cr, bool clearSegment)
         if (cr->isChord()) {
             std::set<Spanner*> startingSpanners = toChord(e)->startingSpanners();
             for (Spanner* spanner : startingSpanners) {
-                if (spanner->isTrill()) {
+                if (spanner->isTrill() || spanner->isSlur()) {
                     doUndoRemoveElement(spanner);
                 }
             }

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3910,7 +3910,8 @@ void Score::removeChordRest(ChordRest* cr, bool clearSegment)
     std::set<Segment*> segments;
     for (EngravingObject* e : cr->linkList()) {
         if (cr->isChord()) {
-            for (Spanner* spanner : toChord(e)->startingSpanners()) {
+            std::set<Spanner*> startingSpanners = toChord(e)->startingSpanners();
+            for (Spanner* spanner : startingSpanners) {
                 if (spanner->isTrill()) {
                     doUndoRemoveElement(spanner);
                 }


### PR DESCRIPTION
Resolves: #22563

Also prevents a crash I found while working on this issue (see video). It seems that `doUndoRemoveElement` can cause an iterator invalidation as it modifies `toChord(e)->startingSpanners()` mid-way through iteration. If we instead iterate through a copy of the set, we avoid this problem.

https://github.com/musescore/MuseScore/assets/47119327/3b56a505-ee51-4e88-8403-e813ad7bad74

