### PR TITLE
MEI export: fix attribute values

### DIFF
--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -180,12 +180,12 @@ bool MeiExporter::writeHeader()
         pugi::xml_node title = titleStmt.append_child("title");
         if (!m_score->metaTag(u"workTitle").isEmpty()) {
             title.text().set(m_score->metaTag(u"workTitle").toStdString().c_str());
-            title.append_attribute("type") = u"main";
+            title.append_attribute("type") = "main";
         }
         if (!m_score->metaTag(u"subtitle").isEmpty()) {
             pugi::xml_node subtitle = titleStmt.append_child("title");
             subtitle.text().set(m_score->metaTag(u"subtitle").toStdString().c_str());
-            subtitle.append_attribute("type") = u"subordinate";
+            subtitle.append_attribute("type") = "subordinate";
         }
 
         pugi::xml_node respStmt;


### PR DESCRIPTION
This small PR fixes an issue with MEI export: 
attribute values have to be plain strings, otherwise it just prints `type="true"`.