### PR TITLE
Resolve inefficiency in BspTree

### DIFF
--- a/src/engraving/dom/bsp.cpp
+++ b/src/engraving/dom/bsp.cpp
@@ -222,7 +222,7 @@ void BspTree::initialize(const RectF& rec, int dep, int index)
     Node* node = &m_nodes[index];
     if (index == 0) {
         node->type = Node::Type::HORIZONTAL;
-        node->offset = rec.center().x();
+        node->offset = rec.center().y();
     }
 
     if (dep) {


### PR DESCRIPTION
If I’m not mistaken, it looks like we’ve had a small inaccuracy in our `BspTree` class for a very long time…  

The node at index 0 (the root node) has `HORIZONTAL` type and we’ve been setting the offset using the `x` coordinate of the area’s center. However, If you look at all other nodes of `HORIZONTAL` type, their offsets use the `y` coordinate. This becomes inefficient for areas that are not perfectly square. In tall “portrait” areas for example, the first partition is made too high and we end up with more granular partitioning in the top sliver of the rectangle (an uneven distribution of leaves).  

This PR simply ensures that the root node uses the `y` coordinate for the offset (so the first partition always cuts the area perfectly in half horizontally). The attached images show how the PR affects a portrait area (yes I failed art in school, how did you know?).

### Current behaviour:
![incorrect](https://github.com/musescore/MuseScore/assets/47119327/df51a3cc-f460-4437-9321-9efd68cedbe2)

### PR:
![correct](https://github.com/musescore/MuseScore/assets/47119327/948ad756-8d61-4e8e-b59a-72b91636dabe)
