### PR TITLE
Import & export system=only-top for XML directions

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -4561,7 +4561,8 @@ static void directionTag(XmlWriter& xml, Attributes& attr, EngravingItem const* 
                    || el->type() == ElementType::STAFF_TEXT
                    || el->type() == ElementType::STRING_TUNINGS
                    || el->type() == ElementType::SYMBOL
-                   || el->type() == ElementType::TEXT) {
+                   || el->type() == ElementType::TEXT
+                   || el->type() == ElementType::SYSTEM_TEXT) {
             // handle other elements attached (e.g. via Segment / Measure) to a system
             // find the system containing this element
             for (const EngravingItem* e = el; e; e = e->parentItem()) {
@@ -4629,6 +4630,10 @@ static void directionTag(XmlWriter& xml, Attributes& attr, EngravingItem const* 
                 }
             }
         }           // if (pel && ...
+
+        if (el->systemFlag()) {
+            tagname += u" system=\"only-top\"";
+        }
     }
     xml.startElementRaw(tagname);
 }

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -2984,6 +2984,7 @@ void MusicXMLParserDirection::direction(const String& partId,
     bool isPercussionStaff = m_pass1.isPercussionStaff(partId);
     bool isExpressionText = false;
     bool delayOttava = m_pass1.exporterString().contains(u"sibelius");
+    m_systemDirection = m_e.attribute("system") == "only-top";
     //LOGD("direction track %d", track);
     std::vector<MusicXmlSpannerDesc> starts;
     std::vector<MusicXmlSpannerDesc> stops;
@@ -3107,6 +3108,8 @@ void MusicXMLParserDirection::direction(const String& partId,
                 isExpressionText = m_wordsText.contains(u"<i>") && m_metroText.empty();
                 if (isExpressionText) {
                     t = Factory::createExpression(m_score->dummy()->segment());
+                } else if (m_systemDirection) {
+                    t = Factory::createSystemText(m_score->dummy()->segment());
                 } else {
                     t = Factory::createStaffText(m_score->dummy()->segment());
                 }
@@ -4256,6 +4259,7 @@ void MusicXMLParserDirection::bracket(const String& type, const int number,
         } else if ((sline && sline->isTextLine()) || (!sline && !isWavy)) {
             if (!sline) {
                 sline = new TextLine(m_score->dummy());
+                sline->setSystemFlag(m_systemDirection);
             }
             auto textLine = toTextLine(sline);
             // if (placement == "") placement = "above";  // TODO ? set default

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
@@ -487,6 +487,7 @@ private:
     double m_tpoMetro = 0.0;                   // tempo according to metronome
     double m_tpoSound = 0.0;                   // tempo according to sound
     bool m_visible = true;
+    bool m_systemDirection = false;
     std::vector<EngravingItem*> m_elems;
     Fraction m_offset;
 };

--- a/src/importexport/musicxml/tests/data/testBreaksImplExpl_all_ref.xml
+++ b/src/importexport/musicxml/tests/data/testBreaksImplExpl_all_ref.xml
@@ -132,7 +132,7 @@
       </measure>
     <measure number="12">
       <print new-page="yes"/>
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>After system break</words>
           </direction-type>

--- a/src/importexport/musicxml/tests/data/testBreaksImplExpl_manual_ref.xml
+++ b/src/importexport/musicxml/tests/data/testBreaksImplExpl_manual_ref.xml
@@ -132,7 +132,7 @@
       </measure>
     <measure number="12">
       <print new-system="yes"/>
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>After system break</words>
           </direction-type>

--- a/src/importexport/musicxml/tests/data/testBreaksImplExpl_no_ref.xml
+++ b/src/importexport/musicxml/tests/data/testBreaksImplExpl_no_ref.xml
@@ -121,7 +121,7 @@
         </note>
       </measure>
     <measure number="12">
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>After system break</words>
           </direction-type>

--- a/src/importexport/musicxml/tests/data/testBreaksSystem_manual_ref.xml
+++ b/src/importexport/musicxml/tests/data/testBreaksSystem_manual_ref.xml
@@ -44,7 +44,7 @@
           <line>2</line>
           </clef>
         </attributes>
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>First system (no frames above)</words>
           </direction-type>
@@ -60,7 +60,7 @@
       <attributes>
         <divisions>1</divisions>
         </attributes>
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>After section break</words>
           </direction-type>
@@ -73,7 +73,7 @@
       </measure>
     <measure number="2">
       <print new-system="yes"/>
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>After system break in horizontal frame</words>
           </direction-type>
@@ -89,7 +89,7 @@
       <attributes>
         <divisions>1</divisions>
         </attributes>
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>After section break in horizontal frame</words>
           </direction-type>
@@ -102,7 +102,7 @@
       </measure>
     <measure number="2">
       <print new-page="yes"/>
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>After page break in horizontal frame</words>
           </direction-type>
@@ -115,7 +115,7 @@
       </measure>
     <measure number="3">
       <print new-system="yes"/>
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>After vframe</words>
           </direction-type>
@@ -133,7 +133,7 @@
           <words valign="top" font-size="12">Tframe</words>
           </direction-type>
         </direction>
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>After tframe</words>
           </direction-type>
@@ -146,7 +146,7 @@
       </measure>
     <measure number="5">
       <print new-system="yes"/>
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>After system break in hframe</words>
           </direction-type>

--- a/src/importexport/musicxml/tests/data/testBreaksSystem_no_ref.xml
+++ b/src/importexport/musicxml/tests/data/testBreaksSystem_no_ref.xml
@@ -44,7 +44,7 @@
           <line>2</line>
           </clef>
         </attributes>
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>First system (no frames above)</words>
           </direction-type>
@@ -59,7 +59,7 @@
       <attributes>
         <divisions>1</divisions>
         </attributes>
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>After section break</words>
           </direction-type>
@@ -71,7 +71,7 @@
         </note>
       </measure>
     <measure number="2">
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>After system break in horizontal frame</words>
           </direction-type>
@@ -86,7 +86,7 @@
       <attributes>
         <divisions>1</divisions>
         </attributes>
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>After section break in horizontal frame</words>
           </direction-type>
@@ -98,7 +98,7 @@
         </note>
       </measure>
     <measure number="2">
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>After page break in horizontal frame</words>
           </direction-type>
@@ -110,7 +110,7 @@
         </note>
       </measure>
     <measure number="3">
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>After vframe</words>
           </direction-type>
@@ -127,7 +127,7 @@
           <words valign="top" font-size="12">Tframe</words>
           </direction-type>
         </direction>
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>After tframe</words>
           </direction-type>
@@ -139,7 +139,7 @@
         </note>
       </measure>
     <measure number="5">
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>After system break in hframe</words>
           </direction-type>

--- a/src/importexport/musicxml/tests/data/testColorExport_ref.xml
+++ b/src/importexport/musicxml/tests/data/testColorExport_ref.xml
@@ -209,7 +209,7 @@
         </barline>
       </measure>
     <measure number="3">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <rehearsal color="#009193" font-weight="bold" font-size="14">B</rehearsal>
           </direction-type>

--- a/src/importexport/musicxml/tests/data/testDirections1_ref.xml
+++ b/src/importexport/musicxml/tests/data/testDirections1_ref.xml
@@ -220,7 +220,7 @@
         </note>
       </measure>
     <measure number="4">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <rehearsal font-weight="bold" font-size="14">A</rehearsal>
           </direction-type>

--- a/src/importexport/musicxml/tests/data/testDirections2.xml
+++ b/src/importexport/musicxml/tests/data/testDirections2.xml
@@ -109,7 +109,7 @@
         <duration>4</duration>
         <voice>1</voice>
         </note>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <rehearsal font-weight="bold" font-size="14">A</rehearsal>
           </direction-type>

--- a/src/importexport/musicxml/tests/data/testFormattedThings.xml
+++ b/src/importexport/musicxml/tests/data/testFormattedThings.xml
@@ -77,7 +77,7 @@
         </note>
       </measure>
     <measure number="3">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <rehearsal font-weight="bold" font-size="14">Default rehearsal mark</rehearsal>
           </direction-type>
@@ -93,7 +93,7 @@
         </note>
       </measure>
     <measure number="4">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <rehearsal font-size="24">Big, not bold</rehearsal>
           </direction-type>
@@ -121,7 +121,7 @@
         </note>
       </measure>
     <measure number="6">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <rehearsal font-style="italic" font-size="14">italic</rehearsal>
           </direction-type>
@@ -137,7 +137,7 @@
         </note>
       </measure>
     <measure number="7">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <rehearsal underline="1" font-size="14">underlined</rehearsal>
           </direction-type>
@@ -165,7 +165,7 @@
         </note>
       </measure>
     <measure number="9">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <rehearsal font-size="14">not bold</rehearsal>
           </direction-type>
@@ -181,7 +181,7 @@
         </note>
       </measure>
     <measure number="10">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <rehearsal enclosure="none" font-weight="bold" font-size="14">No frame</rehearsal>
           </direction-type>
@@ -209,7 +209,7 @@
         </note>
       </measure>
     <measure number="12">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <words enclosure="rectangle">Boxed Staff Text</words>
           </direction-type>
@@ -225,7 +225,7 @@
         </note>
       </measure>
     <measure number="13">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <words enclosure="circle">Circled</words>
           </direction-type>
@@ -242,7 +242,7 @@
       </measure>
     <measure number="14">
       <print new-system="yes"/>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>Normal Staff Text</words>
           </direction-type>

--- a/src/importexport/musicxml/tests/data/testMaxNumberLevel_ref.xml
+++ b/src/importexport/musicxml/tests/data/testMaxNumberLevel_ref.xml
@@ -105,7 +105,7 @@
           <line>2</line>
           </clef>
         </attributes>
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>Test MAX_NUMBER_LEVEL for all element types using a different implementation
 </words>

--- a/src/importexport/musicxml/tests/data/testSwing_ref.xml
+++ b/src/importexport/musicxml/tests/data/testSwing_ref.xml
@@ -151,7 +151,7 @@
         </note>
       </measure>
     <measure number="2">
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words font-weight="bold" font-size="12">Swing</words>
           </direction-type>
@@ -253,7 +253,7 @@
         </note>
       </measure>
     <measure number="3">
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words font-weight="bold" font-size="12">Straight</words>
           </direction-type>
@@ -547,7 +547,7 @@
         </note>
       </measure>
     <measure number="5">
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words font-weight="bold" font-size="12">Swing 16ths</words>
           </direction-type>
@@ -753,7 +753,7 @@
         </note>
       </measure>
     <measure number="6">
-      <direction>
+      <direction placement="above" system="only-top">
         <direction-type>
           <words font-weight="bold" font-size="12">Straight</words>
           </direction-type>

--- a/src/importexport/musicxml/tests/data/testSystemDirection.xml
+++ b/src/importexport/musicxml/tests/data/testSystemDirection.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="4.0">
+  <work>
+    <work-title>testSystemDirection</work-title>
+    </work>
   <identification>
+    <creator type="composer">James M</creator>
     <encoding>
       <software>MuseScore 0.7.0</software>
       <encoding-date>2007-09-10</encoding-date>
@@ -13,20 +17,39 @@
       </encoding>
     </identification>
   <part-list>
+    <part-group type="start" number="1">
+      <group-symbol>bracket</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
     <score-part id="P1">
-      <part-name>Voice</part-name>
-      <part-abbreviation>Vo.</part-abbreviation>
+      <part-name>Flute</part-name>
+      <part-abbreviation>Fl.</part-abbreviation>
       <score-instrument id="P1-I1">
-        <instrument-name>Voice</instrument-name>
+        <instrument-name>Flute</instrument-name>
         </score-instrument>
       <midi-device id="P1-I1" port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
-        <midi-program>53</midi-program>
+        <midi-program>74</midi-program>
         <volume>78.7402</volume>
         <pan>0</pan>
         </midi-instrument>
       </score-part>
+    <score-part id="P2">
+      <part-name>Oboe</part-name>
+      <part-abbreviation>Ob.</part-abbreviation>
+      <score-instrument id="P2-I1">
+        <instrument-name>Oboe</instrument-name>
+        </score-instrument>
+      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-instrument id="P2-I1">
+        <midi-channel>2</midi-channel>
+        <midi-program>69</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="1"/>
     </part-list>
   <part id="P1">
     <measure number="1">
@@ -44,25 +67,14 @@
           <line>2</line>
           </clef>
         </attributes>
-      <direction placement="above" system="only-top">
+      <direction placement="above">
         <direction-type>
-          <words>First system (no frames above)</words>
+          <words>Stave text</words>
           </direction-type>
         </direction>
-      <note>
-        <rest measure="yes"/>
-        <duration>4</duration>
-        <voice>1</voice>
-        </note>
-      </measure>
-    <measure number="1">
-      <print new-system="yes"/>
-      <attributes>
-        <divisions>1</divisions>
-        </attributes>
       <direction placement="above" system="only-top">
         <direction-type>
-          <words>After section break</words>
+          <words>System text</words>
           </direction-type>
         </direction>
       <note>
@@ -75,7 +87,10 @@
       <print new-system="yes"/>
       <direction placement="above" system="only-top">
         <direction-type>
-          <words>After system break in horizontal frame</words>
+          <words>System</words>
+          </direction-type>
+        <direction-type>
+          <bracket type="start" number="1" line-end="none" line-type="solid"/>
           </direction-type>
         </direction>
       <note>
@@ -83,43 +98,13 @@
         <duration>4</duration>
         <voice>1</voice>
         </note>
-      </measure>
-    <measure number="1">
-      <print new-system="yes"/>
-      <attributes>
-        <divisions>1</divisions>
-        </attributes>
       <direction placement="above" system="only-top">
         <direction-type>
-          <words>After section break in horizontal frame</words>
+          <bracket type="stop" number="1" line-end="down" end-length="15"/>
           </direction-type>
         </direction>
-      <note>
-        <rest measure="yes"/>
-        <duration>4</duration>
-        <voice>1</voice>
-        </note>
-      </measure>
-    <measure number="2">
-      <print new-page="yes"/>
-      <direction placement="above" system="only-top">
-        <direction-type>
-          <words>After page break in horizontal frame</words>
-          </direction-type>
-        </direction>
-      <note>
-        <rest measure="yes"/>
-        <duration>4</duration>
-        <voice>1</voice>
-        </note>
       </measure>
     <measure number="3">
-      <print new-system="yes"/>
-      <direction placement="above" system="only-top">
-        <direction-type>
-          <words>After vframe</words>
-          </direction-type>
-        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -130,13 +115,14 @@
       <print new-system="yes"/>
       <direction placement="above">
         <direction-type>
-          <words valign="top" font-size="12">Tframe</words>
+          <words>Stave text</words>
           </direction-type>
         </direction>
-      <direction placement="above" system="only-top">
+      <direction placement="above">
         <direction-type>
-          <words>After tframe</words>
+          <words font-weight="bold" font-size="12">Largo</words>
           </direction-type>
+        <sound tempo="50"/>
         </direction>
       <note>
         <rest measure="yes"/>
@@ -145,12 +131,96 @@
         </note>
       </measure>
     <measure number="5">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="6">
       <print new-system="yes"/>
-      <direction placement="above" system="only-top">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P2">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <direction placement="above">
         <direction-type>
-          <words>After system break in hframe</words>
+          <words>Stave text</words>
           </direction-type>
         </direction>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2">
+      <print new-system="yes"/>
+      <direction placement="above">
+        <direction-type>
+          <words>Staff</words>
+          </direction-type>
+        <direction-type>
+          <bracket type="start" number="1" line-end="none" line-type="solid"/>
+          </direction-type>
+        </direction>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <direction placement="above">
+        <direction-type>
+          <bracket type="stop" number="1" line-end="down" end-length="15"/>
+          </direction-type>
+        </direction>
+      </measure>
+    <measure number="3">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="4">
+      <print new-system="yes"/>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="5">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="6">
+      <print new-system="yes"/>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>

--- a/src/importexport/musicxml/tests/data/testTextLines_ref.xml
+++ b/src/importexport/musicxml/tests/data/testTextLines_ref.xml
@@ -129,7 +129,7 @@
         </note>
       </measure>
     <measure number="5">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <words>System</words>
           </direction-type>
@@ -157,7 +157,7 @@
         <voice>1</voice>
         <type>whole</type>
         </note>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <bracket type="stop" number="1" line-end="down" end-length="15"/>
           </direction-type>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -1002,6 +1002,9 @@ TEST_F(Musicxml_Tests, systemBrackets4) {
 TEST_F(Musicxml_Tests, systemBrackets5) {
     mxmlIoTest("testSystemBrackets1");
 }
+TEST_F(Musicxml_Tests, systemDirection) {
+    mxmlIoTest("testSystemDirection");
+}
 #ifndef DISABLED_SOME_TESTS
 TEST_F(Musicxml_Tests, systemDistance) {
     mxmlMscxExportTestRef("testSystemDistance", true);


### PR DESCRIPTION
This PR imports XML words directions with the attribute `system=only-top` as system text, and brackets as system text lines.  It also adds `system=only-top` to elements where `systemFlag()` is true.