### PR TITLE
Reduce use of auto in XML import and export

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -519,18 +519,18 @@ String ExportMusicXml::positioningAttributes(EngravingItem const* const el, bool
 
     if (span && !span->segmentsEmpty()) {
         if (isSpanStart) {
-            const auto seg = span->frontSegment();
-            const auto offset = seg->offset();
-            const auto p = seg->pos();
+            const LineSegment* seg = span->frontSegment();
+            const PointF offset = seg->offset();
+            const PointF p = seg->pos();
             rel.setX(offset.x());
             def.setY(p.y());
 
             //LOGD("sline start seg %p seg->pos x,y %f %f seg->userOff x,y %f %f spatium %f",
             //       seg, p.x(), p.y(), seg->offset().x(), seg->offset().y(), seg->spatium());
         } else {
-            const auto seg = span->backSegment();
-            const auto userOff = seg->offset();       // This is the offset accessible from the inspector
-            const auto userOff2 = seg->userOff2();       // Offset of the actual dragged anchor, which doesn't affect the inspector offset
+            const LineSegment* seg = span->backSegment();
+            const PointF userOff = seg->offset();       // This is the offset accessible from the inspector
+            const PointF userOff2 = seg->userOff2();       // Offset of the actual dragged anchor, which doesn't affect the inspector offset
             //auto pos = seg->pos();
             //auto pos2 = seg->pos2();
 
@@ -795,8 +795,8 @@ static const ChordRest* findFirstChordRest(const Slur* s)
         return nullptr;
     }
 
-    const auto c1 = static_cast<const Chord*>(e1);
-    const auto c2 = static_cast<const Chord*>(e2);
+    const Chord* c1 = static_cast<const Chord*>(e1);
+    const Chord* c2 = static_cast<const Chord*>(e2);
 
     // c1->tick() == c2->tick()
     if (!c1->isGrace() && !c2->isGrace()) {
@@ -839,8 +839,8 @@ void SlurHandler::doSlurs(const ChordRest* chordRest, Notations& notations, XmlW
                 continue;
             }
             if (chordRest == sp->startElement() || chordRest == sp->endElement()) {
-                const auto s = static_cast<const Slur*>(sp);
-                const auto firstChordRest = findFirstChordRest(s);
+                const Slur* s = static_cast<const Slur*>(sp);
+                const ChordRest* firstChordRest = findFirstChordRest(s);
                 if (firstChordRest) {
                     if (i == 0) {
                         // first time: do slur stops
@@ -1104,11 +1104,11 @@ public:
 static void findTrills(const Measure* const measure, track_idx_t strack, track_idx_t etrack, TrillHash& trillStart, TrillHash& trillStop)
 {
     // loop over all spanners in this measure
-    auto stick = measure->tick();
-    auto etick = measure->tick() + measure->ticks();
+    Fraction stick = measure->tick();
+    Fraction etick = measure->tick() + measure->ticks();
     for (auto it = measure->score()->spanner().lower_bound(stick.ticks());
          it != measure->score()->spanner().upper_bound(etick.ticks()); ++it) {
-        auto e = it->second;
+        EngravingItem* e = it->second;
         //LOGD("1 trill %p type %d track %d tick %s", e, e->type(), e->track(), muPrintable(e->tick().print()));
         if (e->isTrill() && ExportMusicXml::canWrite(e) && strack <= e->track() && e->track() < etrack
             && e->tick() >= measure->tick() && e->tick() < (measure->tick() + measure->ticks())) {
@@ -1116,9 +1116,9 @@ static void findTrills(const Measure* const measure, track_idx_t strack, track_i
             // a trill is found starting in this segment, trill end time is known
             // determine notes to write trill start and stop
 
-            const auto tr = toTrill(e);
-            auto elem1 = tr->startElement();
-            auto elem2 = tr->endElement();
+            const Trill* tr = toTrill(e);
+            EngravingItem* elem1 = tr->startElement();
+            EngravingItem* elem2 = tr->endElement();
 
             if (elem1 && elem1->isChordRest() && elem2 && elem2->isChordRest()) {
                 trillStart.insert({ toChordRest(elem1), tr });
@@ -1560,10 +1560,10 @@ static void textAsCreditWords(const ExportMusicXml* const expMxml, XmlWriter& xm
 void ExportMusicXml::credits(XmlWriter& xml)
 {
     // find the vboxes in every page and write their elements as credit-words
-    for (const auto page : m_score->pages()) {
-        const auto pageIdx = m_score->pageIdx(page);
-        for (const auto system : page->systems()) {
-            for (const auto mb : system->measures()) {
+    for (const Page* page : m_score->pages()) {
+        const page_idx_t pageIdx = m_score->pageIdx(page);
+        for (const System* system : page->systems()) {
+            for (const MeasureBase* mb : system->measures()) {
                 if (mb->isVBox()) {
                     for (const EngravingItem* element : mb->el()) {
                         if (element->isText()) {
@@ -1646,10 +1646,10 @@ static void tabpitch2xml(const int pitch, const int tpc, String& s, int& alter, 
 
 static void pitch2xml(const Note* note, String& s, int& alter, int& octave)
 {
-    const auto st = note->staff();
-    const auto tick = note->tick();
-    const auto instr = st->part()->instrument(tick);
-    const auto intval = note->concertPitch() ? 0 : instr->transpose();
+    const Staff* st = note->staff();
+    const Fraction tick = note->tick();
+    const Instrument* instr = st->part()->instrument(tick);
+    const Interval intval = note->concertPitch() ? 0 : instr->transpose();
 
     s      = tpc2stepName(note->tpc());
     alter  = tpc2alterByKey(note->tpc(), Key::C);
@@ -1868,7 +1868,7 @@ static String shortBarlineStyle(const BarLine* bl)
 
 static String normalBarlineStyle(const BarLine* bl)
 {
-    const auto bst = bl->barLineType();
+    const BarLineType bst = bl->barLineType();
 
     switch (bst) {
     case BarLineType::NORMAL:
@@ -1932,9 +1932,9 @@ String ExportMusicXml::fermataPosition(const Fermata* const fermata)
     if (configuration()->musicxmlExportLayout()) {
         constexpr double SPATIUM2TENTHS = 10;
         constexpr double EPSILON = 0.01;
-        const auto spatium = fermata->spatium();
-        const auto defY = -1 * SPATIUM2TENTHS * fermata->ldata()->pos().y() / spatium;
-        const auto relY = -1 * SPATIUM2TENTHS * fermata->offset().y() / spatium;
+        const double spatium = fermata->spatium();
+        const double defY = -1 * SPATIUM2TENTHS * fermata->ldata()->pos().y() / spatium;
+        const double relY = -1 * SPATIUM2TENTHS * fermata->offset().y() / spatium;
 
         if (std::abs(defY) >= EPSILON) {
             res += String(u" default-y=\"%1\"").arg(String::number(defY, 2));
@@ -1987,7 +1987,7 @@ static bool barlineHasFermata(const BarLine* const barline, const track_idx_t st
 {
     const Segment* seg = barline ? barline->segment() : 0;
     if (seg) {
-        for (const auto anno : seg->annotations()) {
+        for (const EngravingItem* anno : seg->annotations()) {
             if (anno->isFermata() && strack <= anno->track() && anno->track() < etrack) {
                 return true;
             }
@@ -2005,7 +2005,7 @@ static void writeBarlineFermata(const BarLine* const barline, XmlWriter& xml, co
 {
     const Segment* seg = barline ? barline->segment() : 0;
     if (seg) {
-        for (const auto anno : seg->annotations()) {
+        for (const EngravingItem* anno : seg->annotations()) {
             if (anno->isFermata() && strack <= anno->track() && anno->track() < etrack) {
                 fermata(toFermata(anno), xml);
             }
@@ -2051,7 +2051,7 @@ void ExportMusicXml::barlineRight(const Measure* const m, const track_idx_t stra
 
     // check fermata
     // no need to take mmrest into account, MS does not create mmrests for measure with fermatas
-    const auto hasFermata = barlineHasFermata(m->endBarLine(), strack, etrack);
+    const bool hasFermata = barlineHasFermata(m->endBarLine(), strack, etrack);
 
     if (!needBarStyle && !volta && special.isEmpty() && !hasFermata && color.isEmpty()) {
         return;
@@ -2607,7 +2607,7 @@ static bool isSimpleTuplet(const Tuplet* const t)
     if (t->tuplet()) {
         return false;
     }
-    for (const auto el : t->elements()) {
+    for (const EngravingItem* el : t->elements()) {
         if (!el->isChordRest()) {
             return false;
         }
@@ -2625,7 +2625,7 @@ static bool isSimpleTuplet(const Tuplet* const t)
 
 static bool isTupletStart(const DurationElement* const el)
 {
-    const auto t = el->tuplet();
+    const Tuplet* t = el->tuplet();
     if (!t) {
         return false;
     }
@@ -2642,7 +2642,7 @@ static bool isTupletStart(const DurationElement* const el)
 
 static bool isTupletStop(const DurationElement* const el)
 {
-    const auto t = el->tuplet();
+    const Tuplet* t = el->tuplet();
     if (!t) {
         return false;
     }
@@ -2718,7 +2718,7 @@ static void tupletActualAndNormal(const Tuplet* const t, XmlWriter& xml)
     addColorAttr(t, tNumAttrs);
     xml.tag("tuplet-number", tNumAttrs, t->ratio().numerator());
     int dots { 0 };
-    const auto s = tick2xml(t->baseLen().ticks(), &dots);
+    const String s = tick2xml(t->baseLen().ticks(), &dots);
     tupletTypeAndDots(s, dots, xml);
     xml.endElement();
     xml.startElement("tuplet-normal");
@@ -2786,17 +2786,17 @@ static void tupletStop(const Tuplet* const t, const int number, Notations& notat
 
 static void tupletStartStop(ChordRest* cr, Notations& notations, XmlWriter& xml)
 {
-    const auto nesting = tupletNesting(cr);
+    const int nesting = tupletNesting(cr);
     bool doActualAndNormal = (nesting > 1);
     if (cr->isChord() && isTwoNoteTremolo(toChord(cr))) {
         doActualAndNormal = true;
     }
     for (int level = nesting - 1; level >= 0; --level) {
-        const auto startTuplet = startTupletAtLevel(cr, level + 1);
+        const Tuplet* startTuplet = startTupletAtLevel(cr, level + 1);
         if (startTuplet) {
             tupletStart(startTuplet, nesting - level, doActualAndNormal, notations, xml);
         }
-        const auto stopTuplet = stopTupletAtLevel(cr, level + 1);
+        const Tuplet* stopTuplet = stopTupletAtLevel(cr, level + 1);
         if (stopTuplet) {
             tupletStop(stopTuplet, nesting - level, notations, xml);
         }
@@ -2910,8 +2910,8 @@ void ExportMusicXml::wavyLineStartStop(const ChordRest* cr, Notations& notations
                                        TrillHash& trillStart, TrillHash& trillStop)
 {
     if (muse::contains(trillStart, cr) && muse::contains(trillStop, cr)) {
-        const auto tr = trillStart.at(cr);
-        auto n = findTrill(0);
+        const Trill* tr = trillStart.at(cr);
+        int n = findTrill(0);
         if (n >= 0) {
             wavyLineStart(tr, n, notations, ornaments, m_xml);
             wavyLineStop(tr, n, notations, ornaments, m_xml);
@@ -2921,8 +2921,8 @@ void ExportMusicXml::wavyLineStartStop(const ChordRest* cr, Notations& notations
         }
     } else {
         if (muse::contains(trillStop, cr)) {
-            const auto tr = trillStop.at(cr);
-            auto n = findTrill(tr);
+            const Trill* tr = trillStop.at(cr);
+            int n = findTrill(tr);
             if (n >= 0) {
                 // trill stop after trill start
                 m_trills[n] = 0;
@@ -2942,8 +2942,8 @@ void ExportMusicXml::wavyLineStartStop(const ChordRest* cr, Notations& notations
             muse::remove(trillStop, cr);
         }
         if (muse::contains(trillStart, cr)) {
-            const auto tr = trillStart.at(cr);
-            auto n = findTrill(tr);
+            const Trill* tr = trillStart.at(cr);
+            int n = findTrill(tr);
             if (n >= 0) {
                 LOGD("wavyLineStartStop error");
             } else {
@@ -3467,8 +3467,8 @@ void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technic
             continue;
         }
 
-        auto sid = a->symId();
-        auto mxmlOrnam = symIdToOrnam(sid);
+        SymId sid = a->symId();
+        String mxmlOrnam = symIdToOrnam(sid);
 
         if (mxmlOrnam != "") {
             String placement;
@@ -3503,7 +3503,7 @@ void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technic
             continue;
         }
 
-        auto sid = a->symId();
+        SymId sid = a->symId();
         String placement;
         String direction;
 
@@ -3522,7 +3522,7 @@ void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technic
               attr += fontStyleToXML(static_cast<FontStyle>(a->getProperty(Pid::FONT_STYLE).toInt()), false);
         */
 
-        auto mxmlTechn = symIdToTechn(sid);
+        String mxmlTechn = symIdToTechn(sid);
         if (mxmlTechn != "") {
             notations.tag(m_xml, a);
             technical.tag(m_xml);
@@ -3550,7 +3550,7 @@ void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technic
             continue;
         }
 
-        auto sid = a->symId();
+        SymId sid = a->symId();
         if (symIdToArtic(sid).empty()
             && symIdToOrnam(sid) == ""
             && symIdToTechn(sid) == ""
@@ -3719,7 +3719,7 @@ static void writeBeam(XmlWriter& xml, ChordRest* const cr, Beam* const b)
     BeamMode bmn = BeamMode::AUTO; // beam mode next chord or rest
     // find beam level previous chord or rest
     for (size_t i = idx - 1; blp == -1 && i != muse::nidx; --i) {
-        const auto crst = elements[i];
+        const ChordRest* crst = elements[i];
         blp = crst->beams();
     }
     // find beam level current chord or rest
@@ -3727,7 +3727,7 @@ static void writeBeam(XmlWriter& xml, ChordRest* const cr, Beam* const b)
     bmc = cr->beamMode();
     // find beam level next chord or rest
     for (size_t i = idx + 1; bln == -1 && i < elements.size(); ++i) {
-        const auto crst = elements[i];
+        const ChordRest* crst = elements[i];
         bln = crst->beams();
         bmn = crst->beamMode();
     }
@@ -4025,9 +4025,9 @@ static Fraction timeModification(const Tuplet* const tuplet, const int tremolo =
 static void writeType(XmlWriter& xml, const Note* const note)
 {
     int dots = 0;
-    const auto ratio = timeModification(note->chord()->tuplet());
+    const Fraction ratio = timeModification(note->chord()->tuplet());
 
-    const auto strActFraction = stretchCorrActFraction(note);
+    const Fraction strActFraction = stretchCorrActFraction(note);
     const Fraction tt  = strActFraction * ratio * tremoloCorrection(note);
     const String s = tick2xml(tt, &dots);
     if (s.isEmpty()) {
@@ -4050,12 +4050,12 @@ static void writeType(XmlWriter& xml, const Note* const note)
 
 static void writeTimeModification(XmlWriter& xml, const Tuplet* const tuplet, const int tremolo = 1)
 {
-    const auto ratio = timeModification(tuplet, tremolo);
+    const Fraction ratio = timeModification(tuplet, tremolo);
     if (ratio != Fraction(1, 1)) {
-        const auto actNotes = ratio.numerator();
-        const auto nrmNotes = ratio.denominator();
+        const int actNotes = ratio.numerator();
+        const int nrmNotes = ratio.denominator();
 
-        const auto nrmTicks = determineTupletNormalTicks(tuplet);
+        const int nrmTicks = determineTupletNormalTicks(tuplet);
         xml.startElement("time-modification");
         xml.tag("actual-notes", actNotes);
         xml.tag("normal-notes", nrmNotes);
@@ -4086,7 +4086,7 @@ static void writePitch(XmlWriter& xml, const Note* const note, const bool useDru
     String step;
     int alter = 0;
     int octave = 0;
-    const auto chord = note->chord();
+    const Chord* chord = note->chord();
     if (chord->staff() && chord->staff()->isTabStaff(Fraction(0, 1))) {
         tabpitch2xml(note->pitch(), note->tpc(), step, alter, octave);
     } else {
@@ -4099,7 +4099,7 @@ static void writePitch(XmlWriter& xml, const Note* const note, const bool useDru
     xml.startElement(useDrumset ? "unpitched" : "pitch");
     xml.tag(useDrumset ? "display-step" : "step", step);
     // Check for microtonal accidentals and overwrite "alter" tag
-    auto acc = note->accidental();
+    const Accidental* acc = note->accidental();
     double alter2 = 0.0;
     if (acc) {
         switch (acc->accidentalType()) {
@@ -4136,7 +4136,7 @@ String ExportMusicXml::elementPosition(const ExportMusicXml* const expMxml, cons
     if (configuration()->musicxmlExportLayout()) {
         const double pageHeight  = expMxml->getTenthsFromInches(expMxml->score()->style().styleD(Sid::pageHeight));
 
-        const auto meas = elm->findMeasure();
+        const Measure* meas = elm->findMeasure();
         IF_ASSERT_FAILED(meas) {
             return res;
         }
@@ -4909,7 +4909,7 @@ static void wordsMetronome(XmlWriter& xml, const MStyle& s, TextBase const* cons
 
 void ExportMusicXml::tempoText(TempoText const* const text, staff_idx_t staff)
 {
-    const auto offset = calculateTimeDeltaInDivisions(text->tick(), tick(), m_div);
+    const int offset = calculateTimeDeltaInDivisions(text->tick(), tick(), m_div);
     /*
     LOGD("tick %s text->tick %s offset %d xmlText='%s')",
            muPrintable(tick().print()),
@@ -4938,7 +4938,7 @@ void ExportMusicXml::tempoText(TempoText const* const text, staff_idx_t staff)
 
 void ExportMusicXml::words(TextBase const* const text, staff_idx_t staff)
 {
-    const auto offset = calculateTimeDeltaInDivisions(text->tick(), tick(), m_div);
+    const int offset = calculateTimeDeltaInDivisions(text->tick(), tick(), m_div);
     /*
     LOGD("tick %s text->tick %s offset %d userOff.x=%f userOff.y=%f xmlText='%s' plainText='%s'",
            muPrintable(tick().print()),
@@ -4967,7 +4967,7 @@ void ExportMusicXml::words(TextBase const* const text, staff_idx_t staff)
 
 void ExportMusicXml::systemText(StaffTextBase const* const text, staff_idx_t staff)
 {
-    const auto offset = calculateTimeDeltaInDivisions(text->tick(), tick(), m_div);
+    const int offset = calculateTimeDeltaInDivisions(text->tick(), tick(), m_div);
 
     if (text->plainText() == "") {
         // sometimes empty Texts are present, exporting would result
@@ -5080,7 +5080,7 @@ void ExportMusicXml::rehearsal(RehearsalMark const* const rmk, staff_idx_t staff
     MScoreTextToMXML mttm(u"rehearsal", attr, defFmt, mtf);
     mttm.writeTextFragments(rmk->fragmentList(), m_xml);
     m_xml.endElement();
-    const auto offset = calculateTimeDeltaInDivisions(rmk->tick(), tick(), m_div);
+    const int offset = calculateTimeDeltaInDivisions(rmk->tick(), tick(), m_div);
     if (offset) {
         m_xml.tag("offset", offset);
     }
@@ -5114,7 +5114,7 @@ void ExportMusicXml::harpPedals(HarpPedalDiagram const* const hpd, staff_idx_t s
     }
     m_xml.endElement();
     m_xml.endElement();
-    const auto offset = calculateTimeDeltaInDivisions(hpd->tick(), tick(), m_div);
+    const int offset = calculateTimeDeltaInDivisions(hpd->tick(), tick(), m_div);
     if (offset) {
         m_xml.tag("offset", offset);
     }
@@ -5243,7 +5243,7 @@ static void writeHairpinText(XmlWriter& xml, const TextLineBase* const tlb, bool
 
 void ExportMusicXml::hairpin(Hairpin const* const hp, staff_idx_t staff, const Fraction& tick)
 {
-    const auto isLineType = hp->isLineType();
+    const bool isLineType = hp->isLineType();
     int n;
     if (isLineType) {
         if (!hp->lineVisible() && ((hp->beginText().isEmpty() && hp->tick() == tick)
@@ -5351,7 +5351,7 @@ int ExportMusicXml::findOttava(const Ottava* ot) const
 
 void ExportMusicXml::ottava(Ottava const* const ot, staff_idx_t staff, const Fraction& tick)
 {
-    auto n = findOttava(ot);
+    int n = findOttava(ot);
     if (n >= 0) {
         m_ottavas[n] = 0;
     } else {
@@ -5365,7 +5365,7 @@ void ExportMusicXml::ottava(Ottava const* const ot, staff_idx_t staff, const Fra
     }
 
     String octaveShiftXml;
-    const auto st = ot->ottavaType();
+    const OttavaType st = ot->ottavaType();
     if (ot->tick() == tick) {
         String sz;
         String tp;
@@ -5495,7 +5495,7 @@ void ExportMusicXml::textLine(TextLineBase const* const tl, staff_idx_t staff, c
 
     int n;
     // special case: a dashed line w/o hooks is written as dashes
-    const auto isDashes = tl->lineStyle() == LineType::DASHED && (tl->beginHookType() == HookType::NONE)
+    const bool isDashes = tl->lineStyle() == LineType::DASHED && (tl->beginHookType() == HookType::NONE)
                           && (tl->endHookType() == HookType::NONE);
 
     if (isDashes) {
@@ -5720,7 +5720,7 @@ void ExportMusicXml::dynamic(Dynamic const* const dyn, staff_idx_t staff)
 
     m_xml.endElement();
 
-    const auto offset = calculateTimeDeltaInDivisions(dyn->tick(), tick(), m_div);
+    const int offset = calculateTimeDeltaInDivisions(dyn->tick(), tick(), m_div);
     if (offset) {
         m_xml.tag("offset", offset);
     }
@@ -5760,7 +5760,7 @@ void ExportMusicXml::symbol(Symbol const* const sym, staff_idx_t staff)
     m_xml.startElement("direction-type");
     m_xml.tagRaw(mxmlName);
     m_xml.endElement();
-    const auto offset = calculateTimeDeltaInDivisions(sym->tick(), tick(), m_div);
+    const int offset = calculateTimeDeltaInDivisions(sym->tick(), tick(), m_div);
     if (offset) {
         m_xml.tag("offset", offset);
     }
@@ -6300,7 +6300,7 @@ static bool commonAnnotations(ExportMusicXml* exp, const EngravingItem* e, staff
     // note: write the changed instrument details (transposition) here,
     // optionally writing the associated staff text is done below
     if (e->isInstrumentChange()) {
-        const auto instrChange = toInstrumentChange(e);
+        const InstrumentChange* instrChange = toInstrumentChange(e);
         exp->writeInstrumentDetails(instrChange->instrument(), false);
         instrChangeHandled = true;
     }
@@ -7093,9 +7093,9 @@ void ExportMusicXml::print(const Measure* const m, const int partNr, const int f
             // Staff layout elements.
             for (int staffIdx = (firstStaffOfPart == 0) ? 1 : 0; staffIdx < nrStavesInPart; staffIdx++) {
                 // calculate distance between this and previous staff using the bounding boxes
-                const auto staffNr = firstStaffOfPart + staffIdx;
-                const auto prevBbox = system->staff(staffNr - 1)->bbox();
-                const auto staffDist = system->staff(staffNr)->bbox().y() - prevBbox.y() - prevBbox.height();
+                const int staffNr = firstStaffOfPart + staffIdx;
+                const RectF& prevBbox = system->staff(staffNr - 1)->bbox();
+                const double staffDist = system->staff(staffNr)->bbox().y() - prevBbox.y() - prevBbox.height();
 
                 m_xml.startElement("staff-layout", { { "number", staffIdx + 1 } });
                 m_xml.tag("staff-distance", String::number(getTenthsFromDots(staffDist), 2));
@@ -7120,10 +7120,10 @@ void ExportMusicXml::print(const Measure* const m, const int partNr, const int f
 
 void ExportMusicXml::exportDefaultClef(const Part* const part, const Measure* const m)
 {
-    const auto staves = part->nstaves();
+    const size_t staves = part->nstaves();
 
     if (m->tick() == Fraction(0, 1)) {
-        const auto clefSeg = m->findSegment(SegmentType::HeaderClef, Fraction(0, 1));
+        const Segment* clefSeg = m->findSegment(SegmentType::HeaderClef, Fraction(0, 1));
 
         if (clefSeg) {
             for (size_t i = 0; i < staves; ++i) {
@@ -7132,8 +7132,8 @@ void ExportMusicXml::exportDefaultClef(const Part* const part, const Measure* co
                 // special number 0 -> don’t show staff number in
                 // xml output (because there is only one staff)
 
-                auto sstaff = (staves > 1) ? i + 1 : 0;
-                auto track = part->startTrack() + VOICES * i;
+                size_t sstaff = (staves > 1) ? i + 1 : 0;
+                track_idx_t track = part->startTrack() + VOICES * i;
 
                 if (clefSeg->element(track) == nullptr) {
                     ClefType ct { ClefType::G };
@@ -7311,7 +7311,7 @@ static void partList(XmlWriter& xml, Score* score, MxmlInstrumentMap& instrMap)
         partGroupEnd[i] = -1;
     }
     for (size_t idx = 0; idx < parts.size(); ++idx) {
-        const auto part = parts.at(idx);
+        const Part* part = parts.at(idx);
         bool bracketFound = false;
         // handle brackets
         for (size_t i = 0; i < part->nstaves(); i++) {
@@ -7463,8 +7463,8 @@ void ExportMusicXml::writeElement(EngravingItem* el, const Measure* m, staff_idx
         // these have already been output
         // also ignore clefs at the end of a measure
         // these will be output at the start of the next measure
-        const auto cle = toClef(el);
-        const auto ti = cle->segment()->tick();
+        const Clef* cle = toClef(el);
+        const Fraction ti = cle->segment()->tick();
         const String visible = (!cle->visible()) ? u" print-object=\"no\"" : String();
         clefDebug("exportxml: clef in measure ti=%d ct=%d gen=%d", ti, int(cle->clefType()), el->generated());
         if (el->generated()) {
@@ -7477,26 +7477,26 @@ void ExportMusicXml::writeElement(EngravingItem* el, const Measure* m, staff_idx
             clefDebug("exportxml: clef not exported");
         }
     } else if (el->isChord()) {
-        const auto c = toChord(el);
+        Chord* const c = toChord(el);
         // ise grace after
         if (c) {
             const auto ll = c->lyrics();
-            for (const auto g : c->graceNotesBefore()) {
+            for (Chord* g : c->graceNotesBefore()) {
                 chord(g, sstaff, ll, useDrumset);
             }
             chord(c, sstaff, ll, useDrumset);
-            for (const auto g : c->graceNotesAfter()) {
+            for (Chord* g : c->graceNotesAfter()) {
                 chord(g, sstaff, ll, useDrumset);
             }
         }
     } else if (el->isRest()) {
-        const auto r = toRest(el);
+        Rest* r = toRest(el);
         if (!(r->isGap())) {
             const auto ll = r->lyrics();
             rest(r, sstaff, ll);
         }
     } else if (el->isBarLine()) {
-        const auto barln = toBarLine(el);
+        const BarLine* barln = toBarLine(el);
         if (tickIsInMiddleOfMeasure(barln->tick(), m)) {
             barlineMiddle(barln);
         }
@@ -7619,9 +7619,9 @@ void ExportMusicXml::writeInstrumentDetails(const Instrument* instrument, const 
 
 static void annotationsWithoutNote(ExportMusicXml* exp, const track_idx_t strack, const int staves, const Measure* const measure)
 {
-    for (auto segment = measure->first(); segment; segment = segment->next()) {
+    for (Segment* segment = measure->first(); segment; segment = segment->next()) {
         if (segment->segmentType() == SegmentType::ChordRest) {
-            for (const auto element : segment->annotations()) {
+            for (const EngravingItem* element : segment->annotations()) {
                 if (!element->isFiguredBass() && !element->isHarmony()) {               // handled elsewhere
                     if (!exp->canWrite(element)) {
                         continue;
@@ -7663,7 +7663,7 @@ void MeasureNumberStateHandler::updateForMeasure(const Measure* const m)
     }
 
     if (previousMB) {
-        const auto layoutSectionBreak = previousMB->sectionBreakElement();
+        const LayoutBreak* layoutSectionBreak = previousMB->sectionBreakElement();
         if (layoutSectionBreak && layoutSectionBreak->startWithMeasureOne()) {
             init();
         }
@@ -7700,8 +7700,8 @@ bool MeasureNumberStateHandler::isFirstActualMeasure() const
 static System* findLastSystemWithMeasures(const Page* const page)
 {
     for (int i = static_cast<int>(page->systems().size()) - 1; i >= 0; --i) {
-        const auto s = page->systems().at(i);
-        const auto m = s->firstMeasure();
+        System* const s = page->systems().at(i);
+        const Measure* m = s->firstMeasure();
         if (m) {
             return s;
         }
@@ -7715,9 +7715,9 @@ static System* findLastSystemWithMeasures(const Page* const page)
 
 static bool isFirstMeasureInSystem(const Measure* const measure)
 {
-    const auto system = measure->coveringMMRestOrThis()->system();
-    const auto firstMeasureInSystem = system->firstMeasure();
-    const auto realFirstMeasureInSystem = firstMeasureInSystem->isMMRest() ? firstMeasureInSystem->mmRestFirst() : firstMeasureInSystem;
+    const System* system = measure->coveringMMRestOrThis()->system();
+    const Measure* firstMeasureInSystem = system->firstMeasure();
+    const Measure* realFirstMeasureInSystem = firstMeasureInSystem->isMMRest() ? firstMeasureInSystem->mmRestFirst() : firstMeasureInSystem;
     return measure == realFirstMeasureInSystem;
 }
 
@@ -7727,8 +7727,8 @@ static bool isFirstMeasureInSystem(const Measure* const measure)
 
 static bool isFirstMeasureInLastSystem(const Measure* const measure)
 {
-    const auto system = measure->coveringMMRestOrThis()->system();
-    const auto page = system->page();
+    const System* system = measure->coveringMMRestOrThis()->system();
+    const Page* page = system->page();
 
     /*
      Notes on multi-measure rest handling:
@@ -7739,12 +7739,12 @@ static bool isFirstMeasureInLastSystem(const Measure* const measure)
      measure rest itself instead of the first covered measure.
      */
 
-    const auto lastSystem = findLastSystemWithMeasures(page);
+    const System* lastSystem = findLastSystemWithMeasures(page);
     if (!lastSystem) {
         return false;           // degenerate case: no system with measures found
     }
-    const auto firstMeasureInLastSystem = lastSystem->firstMeasure();
-    const auto realFirstMeasureInLastSystem
+    const Measure* firstMeasureInLastSystem = lastSystem->firstMeasure();
+    const Measure* realFirstMeasureInLastSystem
         = firstMeasureInLastSystem->isMMRest() ? firstMeasureInLastSystem->mmRestFirst() : firstMeasureInLastSystem;
     return measure == realFirstMeasureInLastSystem;
 }
@@ -7764,16 +7764,16 @@ static bool systemHasMeasures(const System* const system)
 
 static std::vector<TBox*> findTextFramesToWriteAsWordsAbove(const Measure* const measure)
 {
-    const auto system = measure->coveringMMRestOrThis()->system();
-    const auto page = system->page();
+    const System* system = measure->coveringMMRestOrThis()->system();
+    const Page* page = system->page();
     const size_t systemIndex = muse::indexOf(page->systems(), system);
     std::vector<TBox*> tboxes;
     if (isFirstMeasureInSystem(measure)) {
         for (int idx = static_cast<int>(systemIndex - 1); idx >= 0 && !systemHasMeasures(page->system(idx)); --idx) {
-            const auto sys = page->system(idx);
-            for (const auto mb : sys->measures()) {
+            const System* sys = page->system(idx);
+            for (MeasureBase* mb : sys->measures()) {
                 if (mb->isTBox()) {
-                    auto tbox = toTBox(mb);
+                    TBox* const tbox = toTBox(mb);
                     tboxes.insert(tboxes.begin(), tbox);
                 }
             }
@@ -7788,17 +7788,17 @@ static std::vector<TBox*> findTextFramesToWriteAsWordsAbove(const Measure* const
 
 static std::vector<TBox*> findTextFramesToWriteAsWordsBelow(const Measure* const measure)
 {
-    const auto system = measure->coveringMMRestOrThis()->system();
-    const auto page = system->page();
+    const System* system = measure->coveringMMRestOrThis()->system();
+    const Page* page = system->page();
     const size_t systemIndex = static_cast<int>(muse::indexOf(page->systems(), system));
     std::vector<TBox*> tboxes;
     if (isFirstMeasureInLastSystem(measure)) {
         for (size_t idx = systemIndex + 1; idx < page->systems().size() /* && !systemHasMeasures(page->system(idx))*/;
              ++idx) {
-            const auto sys = page->system(static_cast<int>(idx));
-            for (const auto mb : sys->measures()) {
+            const System* sys = page->system(static_cast<int>(idx));
+            for (MeasureBase* mb : sys->measures()) {
                 if (mb->isTBox()) {
-                    auto tbox = toTBox(mb);
+                    TBox* const tbox = toTBox(mb);
                     tboxes.insert(tboxes.begin(), tbox);
                 }
             }
@@ -7829,11 +7829,11 @@ void ExportMusicXml::writeMeasureTracks(const Measure* const m,
 
     track_idx_t etrack = strack + VOICES;
     for (track_idx_t track = strack; track < etrack; ++track) {
-        for (auto seg = m->first(); seg; seg = seg->next()) {
+        for (Segment* seg = m->first(); seg; seg = seg->next()) {
             if (seg->isTimeTickType()) {
                 continue;
             }
-            const auto el = seg->element(track);
+            EngravingItem* const el = seg->element(track);
             if (!el) {
                 continue;
             }
@@ -7854,7 +7854,7 @@ void ExportMusicXml::writeMeasureTracks(const Measure* const m,
                 const bool isFirstPart = (partIndex == 0);
                 const bool isLastPart = (partIndex == (static_cast<int>(m_score->parts().size()) - 1));
                 if (!m_tboxesAboveWritten && isFirstPart) {
-                    for (const auto tbox : tboxesAbove) {
+                    for (const TBox* tbox : tboxesAbove) {
                         // note: use mmRest1() to get at a possible multi-measure rest,
                         // as the covered measure would be positioned at 0,0.
                         tboxTextAsWords(tbox->text(), 0,
@@ -7863,10 +7863,10 @@ void ExportMusicXml::writeMeasureTracks(const Measure* const m,
                     m_tboxesAboveWritten = true;
                 }
                 if (!m_tboxesBelowWritten && isLastPart && isLastStaffOfPart) {
-                    for (const auto tbox : tboxesBelow) {
-                        const auto lastStaffNr = track2staff(track);
-                        const auto sys = m->coveringMMRestOrThis()->system();
-                        auto textPos = tbox->text()->canvasPos() - m->coveringMMRestOrThis()->canvasPos();
+                    for (const TBox* tbox : tboxesBelow) {
+                        const staff_idx_t lastStaffNr = track2staff(track);
+                        const System* sys = m->coveringMMRestOrThis()->system();
+                        PointF textPos = tbox->text()->canvasPos() - m->coveringMMRestOrThis()->canvasPos();
                         if (lastStaffNr < sys->staves().size()) {
                             // convert to position relative to last staff of system
                             textPos.setY(textPos.y() - (sys->staffCanvasYpage(lastStaffNr) - sys->staffCanvasYpage(0)));
@@ -7877,13 +7877,13 @@ void ExportMusicXml::writeMeasureTracks(const Measure* const m,
                 }
                 annotations(this, strack, etrack, track, partRelStaffNo, seg);
                 // look for more harmony
-                for (auto seg1 = seg->next(); seg1; seg1 = seg1->next()) {
+                for (Segment* seg1 = seg->next(); seg1; seg1 = seg1->next()) {
                     if (seg1->isChordRestType()) {
-                        const auto el1 = seg1->element(track);
+                        const EngravingItem* el1 = seg1->element(track);
                         if (el1) {           // found a ChordRest, next harmony will be attach to this one
                             break;
                         }
-                        for (auto annot : seg1->annotations()) {
+                        for (EngravingItem* annot : seg1->annotations()) {
                             if (annot->isHarmony() && annot->track() == track) {
                                 harmony(toHarmony(annot), 0, (seg1->tick() - seg->tick()).ticks() / m_div);
                             }
@@ -7958,7 +7958,7 @@ void ExportMusicXml::writeMeasureStaves(const Measure* m,
             }
         }
         // in case m was changed, also rewind _tick so as not to generate unnecessary backup/forward tags
-        auto tickDelta = m_tick - m->tick();
+        Fraction tickDelta = m_tick - m->tick();
         m_tick -= tickDelta;
 
         bool isLastStaffOfPart = (endStaff - 1 <= staffIdx); // for writing tboxes below
@@ -7987,7 +7987,7 @@ void ExportMusicXml::writeMeasure(const Measure* const m,
                                   const MeasurePrintContext& mpc,
                                   std::set<const Spanner*>& spannersStopped)
 {
-    const auto part = m_score->parts().at(partIndex);
+    const Part* part = m_score->parts().at(partIndex);
     const size_t staves = part->nstaves();
     const track_idx_t strack = part->startTrack();
     const track_idx_t etrack = part->endTrack();
@@ -8100,7 +8100,7 @@ void ExportMusicXml::writeParts()
     const auto& parts = m_score->parts();
 
     for (size_t partIndex = 0; partIndex < parts.size(); ++partIndex) {
-        const auto part = parts.at(partIndex);
+        const Part* part = parts.at(partIndex);
         m_tick = { 0, 1 };
         m_xml.startElementRaw(String(u"part id=\"P%1\"").arg(partIndex + 1));
 
@@ -8119,24 +8119,24 @@ void ExportMusicXml::writeParts()
         MeasurePrintContext mpc;
 
         for (size_t pageIndex = 0; pageIndex < pages.size(); ++pageIndex) {
-            const auto page = pages.at(pageIndex);
+            const Page* page = pages.at(pageIndex);
             mpc.pageStart = true;
             const auto& systems = page->systems();
 
             for (int systemIndex = 0; systemIndex < static_cast<int>(systems.size()); ++systemIndex) {
-                const auto system = systems.at(systemIndex);
+                const System* system = systems.at(systemIndex);
                 mpc.systemStart = true;
 
-                for (const auto mb : system->measures()) {
+                for (const MeasureBase* mb : system->measures()) {
                     if (!mb->isMeasure()) {
                         continue;
                     }
-                    const auto m = toMeasure(mb);
+                    const Measure* m = toMeasure(mb);
 
                     if (m->isMMRest()) {
                         // in case of a multimeasure rest (which is a single measure in MuseScore), write the measure range it replaces
-                        const auto m2 = m->mmRestLast()->nextMeasure();
-                        for (auto m1 = m->mmRestFirst(); m1 != m2; m1 = m1->nextMeasure()) {
+                        const Measure* m2 = m->mmRestLast()->nextMeasure();
+                        for (Measure* m1 = m->mmRestFirst(); m1 != m2; m1 = m1->nextMeasure()) {
                             if (m1->isMeasure()) {
                                 writeMeasure(m1, static_cast<int>(partIndex), staffCount, mnsh, fbMap, mpc, spannersStopped);
                                 mpc.measureWritten(m1);

--- a/src/importexport/musicxml/internal/musicxml/importmxmlnotepitch.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlnotepitch.cpp
@@ -61,7 +61,7 @@ static Accidental* accidental(muse::XmlStreamReader& e, Score* score)
     const AccidentalType type = mxmlString2accidentalType(s, smufl);
 
     if (type != AccidentalType::NONE) {
-        auto a = Factory::createAccidental(score->dummy());
+        Accidental* a = Factory::createAccidental(score->dummy());
         a->setAccidentalType(type);
         if (cautionary || editorial) { // no way to tell one from the other
             a->setRole(AccidentalRole::USER);
@@ -139,7 +139,7 @@ void MxmlNotePitch::pitch(muse::XmlStreamReader& e)
             if (!ok || m_alter < -2 || m_alter > 2) {
                 m_logger->logError(String(u"invalid alter '%1'").arg(alter), &e);
                 bool ok2;
-                const auto altervalue = alter.toDouble(&ok2);
+                const double altervalue = alter.toDouble(&ok2);
                 if (ok2 && (std::abs(altervalue) < 2.0) && (m_accType == AccidentalType::NONE)) {
                     // try to see if a microtonal accidental is needed
                     m_accType = microtonalGuess(altervalue);

--- a/src/importexport/musicxml/internal/musicxml/importxmlfirstpass.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importxmlfirstpass.cpp
@@ -85,8 +85,8 @@ Fraction MusicXmlPart::measureDuration(size_t i) const
 
 String MusicXmlPart::toString() const
 {
-    auto res = String(u"part id '%1' name '%2' print %3 abbr '%4' print %5 maxStaff %6\n")
-               .arg(m_id, m_name).arg(m_printName).arg(m_abbr).arg(m_printAbbr, m_maxStaff);
+    String res = String(u"part id '%1' name '%2' print %3 abbr '%4' print %5 maxStaff %6\n")
+                 .arg(m_id, m_name).arg(m_printName).arg(m_abbr).arg(m_printAbbr, m_maxStaff);
 
     for (VoiceList::const_iterator i = voicelist.cbegin(); i != voicelist.cend(); ++i) {
         res += String(u"voice %1 map staff data %2\n")


### PR DESCRIPTION
There's a lot of use of `auto` in the XML module which obscures types which could do with being visible.  We already have lots of `typedef`s and `using`s to clean up more complex templated types which I'd rather see than auto.  Additionally, I replaced uses for primitive types and engraving item pointers.

I have left some uses of `auto` representing `std::pair<...` when iterating over maps, and uses to represent iterators.