### PR TITLE
Flip cross-staff beams

### DIFF
--- a/src/engraving/dom/beambase.h
+++ b/src/engraving/dom/beambase.h
@@ -51,6 +51,8 @@ public:
     virtual PropertyValue propertyDefault(Pid propertyId) const override;
 
     int crossStaffIdx() const;
+    int defaultCrossStaffIdx() const;
+    bool acceptCrossStaffMove(int move) const;
 
     bool up() const { return m_up; }
     void setUp(bool v) { m_up = v; }
@@ -86,10 +88,6 @@ protected:
     BeamBase(const BeamBase&);
 
     bool m_up = true;
-
-private:
-    int defaultCrossStaffIdx() const;
-    bool acceptCrossStaffMove(int move) const;
 };
 }
 

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -2239,10 +2239,20 @@ void Score::cmdFlip()
         }
 
         if (e->isBeam()) {
-            auto beam = toBeam(e);
+            Beam* beam = toBeam(e);
             flipOnce(beam, [beam]() {
-                DirectionV dir = beam->up() ? DirectionV::DOWN : DirectionV::UP;
-                beam->undoChangeProperty(Pid::STEM_DIRECTION, dir);
+                if (beam->cross()) {
+                    int newCrossStaffMove = beam->crossStaffMove() + 1;
+                    if (beam->acceptCrossStaffMove(newCrossStaffMove)) {
+                        beam->undoChangeProperty(Pid::BEAM_CROSS_STAFF_MOVE, newCrossStaffMove);
+                    } else {
+                        beam->undoChangeProperty(Pid::BEAM_CROSS_STAFF_MOVE,
+                                                 beam->minCRMove() - beam->defaultCrossStaffIdx());
+                    }
+                } else {
+                    DirectionV dir = beam->up() ? DirectionV::DOWN : DirectionV::UP;
+                    beam->undoChangeProperty(Pid::STEM_DIRECTION, dir);
+                }
             });
         } else if (e->isType(ElementType::TREMOLO_TWOCHORD)) {
             TremoloTwoChord* tremolo = item_cast<TremoloTwoChord*>(e);


### PR DESCRIPTION
Flipping the direction of cross-staff beams previously had no visible effect. This PR changes that, looping through the possible beam positions from top to bottom.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
