### PR TITLE
Update license headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # MuseScore Studio
 # Music Composition & Notation
 #
-# Copyright (C) 2021 MuseScore Limited
+# Copyright (C) 2024 MuseScore Limited
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/sandbox/engraving/config.h
+++ b/sandbox/engraving/config.h
@@ -1,20 +1,23 @@
 //=============================================================================
-//  MusE
-//  Linux Music Editor
-//
-//  Copyright (C) 2002-2010 by Werner Schweer and others
-//
-//  This program is free software; you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License version 2.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
-//
-//  You should have received a copy of the GNU General Public License
-//  along with this program; if not, write to the Free Software
-//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+// SPDX-License-Identifier: GPL-3.0-only
+// MuseScore-Studio-CLA-applies
+
+// MuseScore Studio
+// Music Composition & Notation
+
+// Copyright (C) 2024 MuseScore Limited
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>. 
 //=============================================================================
 
 #ifndef MUSESCORE_CONFIG_H

--- a/sandbox/engraving/config.h
+++ b/sandbox/engraving/config.h
@@ -1,25 +1,24 @@
-//=============================================================================
-// SPDX-License-Identifier: GPL-3.0-only
-// MuseScore-Studio-CLA-applies
-
-// MuseScore Studio
-// Music Composition & Notation
-
-// Copyright (C) 2024 MuseScore Limited
-
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License version 3 as
-// published by the Free Software Foundation.
-
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <https://www.gnu.org/licenses/>. 
-//=============================================================================
-
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ * 
+ * MuseScore Studio
+ * Music Composition & Notation
+ * 
+ * Copyright (C) 2024 MuseScore Limited
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>. 
+ */
 #ifndef MUSESCORE_CONFIG_H
 #define MUSESCORE_CONFIG_H
 

--- a/share/styles/cchords_muse.xml
+++ b/share/styles/cchords_muse.xml
@@ -3,13 +3,17 @@
 
 <!--
 =====================================================================
-    MuseScore
-    Linux Music Score Editor
+    SPDX-License-Identifier: GPL-3.0-only
+    MuseScore-Studio-CLA-applies
 
-    Copyright (C) 2009 Werner Schweer and others
+    MuseScore Studio
+    Music Composition & Notation
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License version 2.
+    Copyright (C) 2024 MuseScore Limited
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3 as
+    published by the Free Software Foundation.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +21,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>. 
 
 =====================================================================
     This file describes, how chord symbols are parsed and rendered

--- a/share/styles/cchords_nrb.xml
+++ b/share/styles/cchords_nrb.xml
@@ -3,13 +3,17 @@
 
 <!--
 =====================================================================
-    MuseScore
-    Linux Music Score Editor
+    SPDX-License-Identifier: GPL-3.0-only
+    MuseScore-Studio-CLA-applies
 
-    Copyright (C) 2009 Werner Schweer and others
+    MuseScore Studio
+    Music Composition & Notation
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License version 2.
+    Copyright (C) 2021 MuseScore Limited
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3 as
+    published by the Free Software Foundation.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +21,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>. 
 
 =====================================================================
     This file describes, how chord symbols are parsed and rendered

--- a/share/styles/cchords_rb.xml
+++ b/share/styles/cchords_rb.xml
@@ -3,13 +3,17 @@
 
 <!--
 =====================================================================
-    MuseScore
-    Linux Music Score Editor
+    SPDX-License-Identifier: GPL-3.0-only
+    MuseScore-Studio-CLA-applies
 
-    Copyright (C) 2009 Werner Schweer and others
+    MuseScore Studio
+    Music Composition & Notation
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License version 2.
+    Copyright (C) 2024 MuseScore Limited
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3 as
+    published by the Free Software Foundation.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +21,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>. 
 
 =====================================================================
     This file describes, how chord symbols are parsed and rendered

--- a/share/styles/cchords_sym.xml
+++ b/share/styles/cchords_sym.xml
@@ -3,13 +3,17 @@
 
 <!--
 =====================================================================
-    MuseScore
-    Linux Music Score Editor
+    SPDX-License-Identifier: GPL-3.0-only
+    MuseScore-Studio-CLA-applies
 
-    Copyright (C) 2009 Werner Schweer and others
+    MuseScore Studio
+    Music Composition & Notation
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License version 2.
+    Copyright (C) 2024 MuseScore Limited
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3 as
+    published by the Free Software Foundation.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +21,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>. 
 
 =====================================================================
     This file describes, how chord symbols are parsed and rendered

--- a/share/styles/chords.xml
+++ b/share/styles/chords.xml
@@ -3,13 +3,17 @@
 
 <!--
 =====================================================================
-    MuseScore
-    Linux Music Score Editor
+    SPDX-License-Identifier: GPL-3.0-only
+    MuseScore-Studio-CLA-applies
 
-    Copyright (C) 2009 Werner Schweer and others
+    MuseScore Studio
+    Music Composition & Notation
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License version 2.
+    Copyright (C) 2024 MuseScore Limited
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3 as
+    published by the Free Software Foundation.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +21,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>. 
 
 =====================================================================
     This file contains a list of chords mscore knows of

--- a/share/styles/chords_jazz.xml
+++ b/share/styles/chords_jazz.xml
@@ -3,13 +3,17 @@
 
 <!--
 =====================================================================
-    MuseScore
-    Linux Music Score Editor
+    SPDX-License-Identifier: GPL-3.0-only
+    MuseScore-Studio-CLA-applies
 
-    Copyright (C) 2009 Werner Schweer and others
+    MuseScore Studio
+    Music Composition & Notation
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License version 2.
+    Copyright (C) 2024 MuseScore Limited
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3 as
+    published by the Free Software Foundation.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +21,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>. 
 
 =====================================================================
     This file describes how chord symbols are parsed and rendered

--- a/share/styles/chords_std.xml
+++ b/share/styles/chords_std.xml
@@ -2,13 +2,17 @@
 
 <!--
 =====================================================================
-    MuseScore
-    Linux Music Score Editor
+    SPDX-License-Identifier: GPL-3.0-only
+    MuseScore-Studio-CLA-applies
 
-    Copyright (C) 2009 Werner Schweer and others
+    MuseScore Studio
+    Music Composition & Notation
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License version 2.
+    Copyright (C) 2024 MuseScore Limited
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3 as
+    published by the Free Software Foundation.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -16,8 +20,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>. 
 
 =====================================================================
     This file describes how chord symbols are parsed and rendered

--- a/share/styles/jazzchords.xml
+++ b/share/styles/jazzchords.xml
@@ -3,13 +3,17 @@
 
 <!--
 =====================================================================
-    MuseScore
-    Linux Music Score Editor
+    SPDX-License-Identifier: GPL-3.0-only
+    MuseScore-Studio-CLA-applies
 
-    Copyright (C) 2009 Werner Schweer and others
+    MuseScore Studio
+    Music Composition & Notation
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License version 2.
+    Copyright (C) 2024 MuseScore Limited
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3 as
+    published by the Free Software Foundation.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +21,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>. 
 
 =====================================================================
     This file describes, how chord symbols are rendered

--- a/share/styles/stdchords.xml
+++ b/share/styles/stdchords.xml
@@ -3,13 +3,17 @@
 
 <!--
 =====================================================================
-    MuseScore
-    Linux Music Score Editor
+    SPDX-License-Identifier: GPL-3.0-only
+    MuseScore-Studio-CLA-applies
 
-    Copyright (C) 2009 Werner Schweer and others
+    MuseScore Studio
+    Music Composition & Notation
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License version 2.
+    Copyright (C) 2024 MuseScore Limited
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3 as
+    published by the Free Software Foundation.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +21,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>. 
 
 =====================================================================
     This file describes, how chord symbols are rendered

--- a/src/framework/testing/gtest.cmake
+++ b/src/framework/testing/gtest.cmake
@@ -1,4 +1,3 @@
-#=============================================================================
 # SPDX-License-Identifier: GPL-3.0-only
 # MuseScore-Studio-CLA-applies
 #
@@ -18,7 +17,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>. 
-#=============================================================================
 
 ## Setup
 # set(MODULE_TEST somename)          - set module (target) name

--- a/src/framework/testing/gtest.cmake
+++ b/src/framework/testing/gtest.cmake
@@ -1,20 +1,23 @@
 #=============================================================================
-#  MuseScore
-#  Music Composition & Notation
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-Studio-CLA-applies
 #
-#  Copyright (C) 2020 MuseScore BVBA and others
+# MuseScore Studio
+# Music Composition & Notation
 #
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License version 2.
+# Copyright (C) 2024 MuseScore Limited
 #
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
 #
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>. 
 #=============================================================================
 
 ## Setup

--- a/src/framework/testing/qtest.cmake
+++ b/src/framework/testing/qtest.cmake
@@ -1,4 +1,3 @@
-#=============================================================================
 # SPDX-License-Identifier: GPL-3.0-only
 # MuseScore-Studio-CLA-applies
 #
@@ -18,7 +17,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>. 
-#=============================================================================
 
 ## Setup
 # set(MODULE_TEST somename)          - set module (target) name

--- a/src/framework/testing/qtest.cmake
+++ b/src/framework/testing/qtest.cmake
@@ -1,20 +1,23 @@
 #=============================================================================
-#  MuseScore
-#  Music Composition & Notation
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-Studio-CLA-applies
 #
-#  Copyright (C) 2020 MuseScore BVBA and others
+# MuseScore Studio
+# Music Composition & Notation
 #
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License version 2.
+# Copyright (C) 2024 MuseScore Limited
 #
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
 #
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>. 
 #=============================================================================
 
 ## Setup

--- a/src/framework/uicomponents/view/selectmultipledirectoriesmodel.cpp
+++ b/src/framework/uicomponents/view/selectmultipledirectoriesmodel.cpp
@@ -1,11 +1,11 @@
 /*
  * SPDX-License-Identifier: GPL-3.0-only
- * MuseScore-CLA-applies
+ * MuseScore-Studio-CLA-applies
  *
- * MuseScore
+ * MuseScore Studio
  * Music Composition & Notation
  *
- * Copyright (C) 2021 MuseScore BVBA and others
+ * Copyright (C) 2024 MuseScore Limited
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/src/framework/uicomponents/view/selectmultipledirectoriesmodel.h
+++ b/src/framework/uicomponents/view/selectmultipledirectoriesmodel.h
@@ -1,11 +1,11 @@
 /*
  * SPDX-License-Identifier: GPL-3.0-only
- * MuseScore-CLA-applies
+ * MuseScore-Studio-CLA-applies
  *
- * MuseScore
+ * MuseScore Studio
  * Music Composition & Notation
  *
- * Copyright (C) 2021 MuseScore BVBA and others
+ * Copyright (C) 2024 MuseScore Limited
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/thirdparty/rtf2html/CMakeLists.txt
+++ b/thirdparty/rtf2html/CMakeLists.txt
@@ -1,4 +1,3 @@
-#=============================================================================
 # SPDX-License-Identifier: GPL-3.0-only
 # MuseScore-Studio-CLA-applies
 #
@@ -18,7 +17,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>. 
-#=============================================================================
 
 declare_module(rtf2html)
 

--- a/thirdparty/rtf2html/CMakeLists.txt
+++ b/thirdparty/rtf2html/CMakeLists.txt
@@ -1,20 +1,23 @@
 #=============================================================================
-#  Mscore
-#  Linux Music Score Editor
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-Studio-CLA-applies
 #
-#  Copyright (C) 2009 by Werner Schweer and others
+# MuseScore Studio
+# Music Composition & Notation
 #
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License version 2.
+# Copyright (C) 2024 MuseScore Limited
 #
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
 #
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>. 
 #=============================================================================
 
 declare_module(rtf2html)

--- a/tools/bww2mxml/bww2mxml.pro
+++ b/tools/bww2mxml/bww2mxml.pro
@@ -1,4 +1,3 @@
-#=============================================================================
 # SPDX-License-Identifier: GPL-3.0-only
 # MuseScore-Studio-CLA-applies
 # 
@@ -18,7 +17,6 @@
 # 
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>. 
-#=============================================================================
 
 QT -= gui
 TARGET = bww2mxml

--- a/tools/bww2mxml/bww2mxml.pro
+++ b/tools/bww2mxml/bww2mxml.pro
@@ -1,21 +1,23 @@
 #=============================================================================
-#  BWW to MusicXML converter
-#  Part of MusE Score
-#  Linux Music Score Editor
-#
-#  Copyright (C) 2002-2010 by Werner Schweer and others
-#
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License version 2.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-Studio-CLA-applies
+# 
+# MuseScore Studio
+# Music Composition & Notation
+# 
+# Copyright (C) 2024 MuseScore Limited
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>. 
 #=============================================================================
 
 QT -= gui

--- a/tools/bww2mxml/mxmlwriter.h
+++ b/tools/bww2mxml/mxmlwriter.h
@@ -1,21 +1,23 @@
 //=============================================================================
-//  BWW to MusicXML converter
-//  Part of MusE Score
-//  Linux Music Score Editor
+// SPDX-License-Identifier: GPL-3.0-only
+// MuseScore-Studio-CLA-applies
 //
-//  Copyright (C) 2010 Werner Schweer and others
+// MuseScore Studio
+// Music Composition & Notation
 //
-//  This program is free software; you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License version 2.
+// Copyright (C) 2024 MuseScore Limited
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
 //
-//  You should have received a copy of the GNU General Public License
-//  along with this program; if not, write to the Free Software
-//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>. 
 //=============================================================================
 
 #ifndef MXMLWRITER_H

--- a/tools/bww2mxml/mxmlwriter.h
+++ b/tools/bww2mxml/mxmlwriter.h
@@ -1,24 +1,24 @@
-//=============================================================================
-// SPDX-License-Identifier: GPL-3.0-only
-// MuseScore-Studio-CLA-applies
-//
-// MuseScore Studio
-// Music Composition & Notation
-//
-// Copyright (C) 2024 MuseScore Limited
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License version 3 as
-// published by the Free Software Foundation.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <https://www.gnu.org/licenses/>. 
-//=============================================================================
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 #ifndef MXMLWRITER_H
 #define MXMLWRITER_H


### PR DESCRIPTION
Resolves: #18710  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

Updated license headers. Wasn't sure about copyright year so I defaulted to 2024. Note that some files not listed in the original issue (eg. `sandbox/engraving/log.h`) have the correct license but an old copyright year.

TODO:
- [x] Remove `===` lines and replace `//` comments with `/**/`

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
