### PR TITLE
Revert "Set PopupView as parent of PopupWindow_QQuickView"

### DIFF
--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -132,7 +132,7 @@ void PopupView::init()
         return;
     }
 
-    m_window = new PopupWindow_QQuickView(this);
+    m_window = new PopupWindow_QQuickView();
     m_window->init(engine, isDialog(), frameless());
     m_window->setOnHidden([this]() { onHidden(); });
     m_window->setContent(m_component, m_contentItem);


### PR DESCRIPTION
This reverts commit 2fa36e3371700c49c37ac1a19b1eb47872c772c7. That commit did fix a real problem (and a memory leak), but that problem should not occur anymore because of d18f9b3b43784db8164ee7204d8a6f470d9d68d6, and the commit caused other problems that are not quite trivial (#22640 and #22641). Therefore, we'll revert this commit for now.

Resolves: #22640
Resolves: #22641

Ports #22644 to master