### PR TITLE
Remove unused flag no-webview from manpage

### DIFF
--- a/buildscripts/packaging/Linux+BSD/mscore.1.in
+++ b/buildscripts/packaging/Linux+BSD/mscore.1.in
@@ -41,7 +41,6 @@
 .Op Fl \-no\-fallback\-font
 .Op Fl \-no\-midi
 .Op Fl \-no\-synthesizer
-.Op Fl \-no\-webview
 .Op Fl \-raw\-diff
 .Op Fl \-revert\-settings
 .Op Fl \-run\-test\-script
@@ -229,8 +228,6 @@ Set test mode flag for all files
 .It Fl v | \-version
 Display the name and version of the application
 without starting the graphical user interface
-.It Fl w | \-no\-webview
-Disable the web view component in the Start Centre
 .It Fl x | Fl \-gui\-scaling Ar factor
 Scale the score display and other GUI elements by the specified
 .Ar factor ;


### PR DESCRIPTION
Resolves: #22138 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

Removed unused flag `-w | --no-webview`  from manual - Musescore no longer uses QtWebEngine.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
