### PR TITLE
Add compatibility with FFMPEG 7.0

### DIFF
--- a/src/importexport/videoexport/internal/videoencoder.cpp
+++ b/src/importexport/videoexport/internal/videoencoder.cpp
@@ -352,8 +352,13 @@ bool VideoEncoder::encodeImage(const QImage& img)
 
     convertImage_sws(img);
 
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(60, 3, 100)
+    m_ffmpeg->ppicture->pts = av_rescale_q(m_ffmpeg->codecCtx->frame_num, m_ffmpeg->codecCtx->time_base,
+                                           m_ffmpeg->videoStream->time_base);
+#else
     m_ffmpeg->ppicture->pts = av_rescale_q(m_ffmpeg->codecCtx->frame_number, m_ffmpeg->codecCtx->time_base,
                                            m_ffmpeg->videoStream->time_base);
+#endif
 
     int ret = avcodec_send_frame(m_ffmpeg->codecCtx, m_ffmpeg->ppicture);
     if (ret < 0) {


### PR DESCRIPTION
frame_number was removed in FFMPEG 7.0. We use frame_num instead introduced in FFMPEG 6.0, with a version check on livavcodec.

Reference: https://github.com/FFmpeg/FFmpeg/commit/6b6f7db81932f94876ff4bcfd2da0582b8ab897e

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
