### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -1837,7 +1837,6 @@ bool MeiImporter::readMRpt(pugi::xml_node mRptNode, Measure* measure, int track,
         return false;
     }
 
-    bool warning = false;
     libmei::MRpt meiMRpt;
     meiMRpt.Read(mRptNode);
 


### PR DESCRIPTION
reg.: local variable is initialized but not referenced (C4189)