### PR TITLE
fix #22336 - mute technique incorrectly maps to pizz strings

### DIFF
--- a/src/framework/audio/internal/synthesizers/fluidsynth/soundmapping.h
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/soundmapping.h
@@ -843,14 +843,14 @@ inline const ArticulationMapping& articulationSounds(const mpe::PlaybackSetupDat
         { mpe::ArticulationType::SnapPizzicato, midi::Program(0, 45) },
         { mpe::ArticulationType::Pizzicato, midi::Program(0, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(0, 45) },
-        { mpe::ArticulationType::Mute, midi::Program(0, 45) }
+        { mpe::ArticulationType::Mute, midi::Program(0, 49) }
     };
 
     static const ArticulationMapping BASIC_VIOL_SECTION = {
         { mpe::ArticulationType::SnapPizzicato, midi::Program(0, 45) },
         { mpe::ArticulationType::Pizzicato, midi::Program(0, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(0, 45) },
-        { mpe::ArticulationType::Mute, midi::Program(0, 45) },
+        { mpe::ArticulationType::Mute, midi::Program(0, 49) },
         { mpe::ArticulationType::Tremolo8th, midi::Program(0, 44) },
         { mpe::ArticulationType::Tremolo16th, midi::Program(0, 44) },
         { mpe::ArticulationType::Tremolo32nd, midi::Program(0, 44) },
@@ -861,7 +861,7 @@ inline const ArticulationMapping& articulationSounds(const mpe::PlaybackSetupDat
         { mpe::ArticulationType::SnapPizzicato, midi::Program(20, 45) },
         { mpe::ArticulationType::Pizzicato, midi::Program(20, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(20, 45) },
-        { mpe::ArticulationType::Mute, midi::Program(20, 45) },
+        { mpe::ArticulationType::Mute, midi::Program(20, 49) },
         { mpe::ArticulationType::Tremolo8th, midi::Program(20, 44) },
         { mpe::ArticulationType::Tremolo16th, midi::Program(20, 44) },
         { mpe::ArticulationType::Tremolo32nd, midi::Program(20, 44) },
@@ -872,14 +872,14 @@ inline const ArticulationMapping& articulationSounds(const mpe::PlaybackSetupDat
         { mpe::ArticulationType::SnapPizzicato, midi::Program(20, 45) },
         { mpe::ArticulationType::Pizzicato, midi::Program(20, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(20, 45) },
-        { mpe::ArticulationType::Mute, midi::Program(20, 45) }
+        { mpe::ArticulationType::Mute, midi::Program(20, 40) }
     };
 
     static const ArticulationMapping VIOLA_SECTION = {
         { mpe::ArticulationType::SnapPizzicato, midi::Program(30, 45) },
         { mpe::ArticulationType::Pizzicato, midi::Program(30, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(30, 45) },
-        { mpe::ArticulationType::Mute, midi::Program(30, 45) },
+        { mpe::ArticulationType::Mute, midi::Program(30, 49) },
         { mpe::ArticulationType::Tremolo8th, midi::Program(30, 44) },
         { mpe::ArticulationType::Tremolo16th, midi::Program(30, 44) },
         { mpe::ArticulationType::Tremolo32nd, midi::Program(30, 44) },
@@ -890,14 +890,14 @@ inline const ArticulationMapping& articulationSounds(const mpe::PlaybackSetupDat
         { mpe::ArticulationType::SnapPizzicato, midi::Program(30, 45) },
         { mpe::ArticulationType::Pizzicato, midi::Program(30, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(30, 45) },
-        { mpe::ArticulationType::Mute, midi::Program(30, 45) }
+        { mpe::ArticulationType::Mute, midi::Program(30, 41) }
     };
 
     static const ArticulationMapping VIOLONCELLO_SECTION = {
         { mpe::ArticulationType::SnapPizzicato, midi::Program(40, 45) },
         { mpe::ArticulationType::Pizzicato, midi::Program(40, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(40, 45) },
-        { mpe::ArticulationType::Mute, midi::Program(40, 45) },
+        { mpe::ArticulationType::Mute, midi::Program(40, 49) },
         { mpe::ArticulationType::Tremolo8th, midi::Program(40, 44) },
         { mpe::ArticulationType::Tremolo16th, midi::Program(40, 44) },
         { mpe::ArticulationType::Tremolo32nd, midi::Program(40, 44) },
@@ -908,14 +908,14 @@ inline const ArticulationMapping& articulationSounds(const mpe::PlaybackSetupDat
         { mpe::ArticulationType::SnapPizzicato, midi::Program(40, 45) },
         { mpe::ArticulationType::Pizzicato, midi::Program(40, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(40, 45) },
-        { mpe::ArticulationType::Mute, midi::Program(40, 45) }
+        { mpe::ArticulationType::Mute, midi::Program(40, 49) }
     };
 
     static const ArticulationMapping CONTRABASS_SECTION = {
         { mpe::ArticulationType::SnapPizzicato, midi::Program(50, 45) },
         { mpe::ArticulationType::Pizzicato, midi::Program(50, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(50, 45) },
-        { mpe::ArticulationType::Mute, midi::Program(50, 45) },
+        { mpe::ArticulationType::Mute, midi::Program(50, 49) },
         { mpe::ArticulationType::Tremolo8th, midi::Program(50, 44) },
         { mpe::ArticulationType::Tremolo16th, midi::Program(50, 44) },
         { mpe::ArticulationType::Tremolo32nd, midi::Program(50, 44) },
@@ -926,10 +926,10 @@ inline const ArticulationMapping& articulationSounds(const mpe::PlaybackSetupDat
         { mpe::ArticulationType::SnapPizzicato, midi::Program(50, 45) },
         { mpe::ArticulationType::Pizzicato, midi::Program(50, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(50, 45) },
-        { mpe::ArticulationType::Mute, midi::Program(50, 45) },
+        { mpe::ArticulationType::Mute, midi::Program(50, 43) },
     };
 
-    static const ArticulationMapping WINDS = {
+    static const ArticulationMapping BRASS = {
         { mpe::ArticulationType::Mute, midi::Program(0, 59) }
     };
 
@@ -1000,7 +1000,14 @@ inline const ArticulationMapping& articulationSounds(const mpe::PlaybackSetupDat
     }
 
     if (setupData.category == mpe::SoundCategory::Winds) {
-        return WINDS;
+        static const std::unordered_set<mpe::SoundId> BRASS_SECTION {
+            mpe::SoundId::Bugle, mpe::SoundId::Euphonium,
+            mpe::SoundId::Horn, mpe::SoundId::Trumpet, mpe::SoundId::Trombone, mpe::SoundId::Tuba
+        };
+
+        if (muse::contains(BRASS_SECTION, soundId)) {
+            return BRASS;
+        }
     }
 
     static ArticulationMapping empty;


### PR DESCRIPTION
Resolves: #22336

Fix issue with MS Basic where by "mute" playing technique caused strings to play back as pizzicato (also fixed woodwinds not to play back as muted trumpet)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
