### PR TITLE
Change mmrest default shortcut

### DIFF
--- a/src/framework/shortcuts/data/shortcuts-Mac.xml
+++ b/src/framework/shortcuts/data/shortcuts-Mac.xml
@@ -1096,7 +1096,7 @@
     </SC>
   <SC>
     <key>toggle-mmrest</key>
-    <seq>M</seq>
+    <seq>Ctrl+Shift+M</seq>
     </SC>
   <SC>
     <key>text-b</key>

--- a/src/framework/shortcuts/data/shortcuts.xml
+++ b/src/framework/shortcuts/data/shortcuts.xml
@@ -1095,7 +1095,7 @@
     </SC>
   <SC>
     <key>toggle-mmrest</key>
-    <seq>M</seq>
+    <seq>Ctrl+Shift+M</seq>
     </SC>
   <SC>
     <key>text-b</key>

--- a/src/framework/shortcuts/data/shortcuts_AZERTY.xml
+++ b/src/framework/shortcuts/data/shortcuts_AZERTY.xml
@@ -1102,7 +1102,7 @@
     </SC>
   <SC>
     <key>toggle-mmrest</key>
-    <seq>M</seq>
+    <seq>Ctrl+Shift+M</seq>
     </SC>
   <SC>
     <key>text-b</key>


### PR DESCRIPTION
Resolves: #20650  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

Change mmrest default shortcut from `M` to `Ctrl+Shift+M`. This is a resubmission of #21179 as original author has not responded. 

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
