### PR TITLE
fix: take breath into account for layer elements

### DIFF
--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -928,6 +928,8 @@ bool MeiExporter::writeLayer(track_idx_t track, const Staff* staff, const Measur
             this->writeRest(dynamic_cast<const Rest*>(item), staff);
         } else if (item->isBarLine()) {
             //
+        } else if (item->isBreath()) {
+            //
         } else if (item->isKeySig()) {
             if (m_keySig && (seg != m_keySig)) {
                 LOGD() << "MeiExporter::writeLayer unexpected KeySig segment";


### PR DESCRIPTION
Small change to not run into `unknown segment type` warning during MEI export (Breath markings are handled elsewhere). 