### PR TITLE
Fix nonsense warnings in MusicXML

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -4785,7 +4785,6 @@ static bool determineBarLineType(const String& barStyle, const String& repeat,
         } else if (repeat == u"forward") {
             type = BarLineType::START_REPEAT;
         } else {
-            LOGD("empty bar type");             // TODO
             return false;
         }
     } else if ((barStyle == u"tick") || (barStyle == u"short")) {

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -8105,30 +8105,8 @@ void MusicXMLParserNotations::addNotation(const Notation& notation, ChordRest* c
         String notationType = notation.attribute(u"type");
         String placement = notation.attribute(u"placement");
         if (notation.name() == u"fermata") {
-            if (!notationType.empty() && notationType != u"upright" && notationType != u"inverted") {
-                notationType.clear();
-                m_logger->logError(String(u"unknown fermata type %1").arg(notationType), &m_e);
-            }
             addFermataToChord(notation, cr);
         } else {
-            if (notation.name() == u"strong-accent") {
-                if (!notationType.empty() && notationType != u"up" && notationType != u"down") {
-                    notationType.clear();
-                    m_logger->logError(String(u"unknown %1 type %2").arg(notation.name(), notationType), &m_e);
-                }
-            } else if (notation.name() == u"harmonic" || notation.name() == u"delayed-turn"
-                       || notation.name() == u"turn" || notation.name() == u"inverted-turn") {
-                if (notation.name() == u"delayed-turn") {
-                    // TODO: actually this should be offset a bit to the right
-                }
-                if (placement != u"above" && placement != u"below") {
-                    placement.clear();
-                    m_logger->logError(String(u"unknown %1 placement %2").arg(notation.name(), placement), &m_e);
-                }
-            } else {
-                notationType.clear();           // TODO: Check for other symbols that have type
-                placement.clear();           // TODO: Check for other symbols that have placement
-            }
             addArticulationToChord(notation, cr);
         }
     } else if (notation.parent() == u"ornaments") {

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -8099,8 +8099,6 @@ void MusicXMLParserNotations::parse()
 void MusicXMLParserNotations::addNotation(const Notation& notation, ChordRest* const cr, Note* const note)
 {
     if (notation.symId() != SymId::noSym) {
-        String notationType = notation.attribute(u"type");
-        String placement = notation.attribute(u"placement");
         if (notation.name() == u"fermata") {
             addFermataToChord(notation, cr);
         } else {

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -1288,8 +1288,6 @@ static SymId convertFermataToSymId(const String& mxmlName)
 
     if (muse::contains(map, mxmlName)) {
         return map.at(mxmlName);
-    } else {
-        LOGD("unknown fermata %s", muPrintable(mxmlName));
     }
     return SymId::fermataAbove;
 }

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -7758,8 +7758,6 @@ static void addArpeggio(ChordRest* cr, String& arpeggioType, int arpeggioNo, Arp
                 arpeggio->setArpeggioType(ArpeggioType::DOWN);
             } else if (arpeggioType == "non-arpeggiate") {
                 arpeggio->setArpeggioType(ArpeggioType::BRACKET);
-            } else {
-                logger->logError(String(u"unknown arpeggio type %1").arg(arpeggioType), xmlreader);
             }
             // there can be only one
             if (!(static_cast<Chord*>(cr))->arpeggio()) {

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -7714,7 +7714,7 @@ static void addGlissandoSlide(const Notation& notation, Note* note,
 //---------------------------------------------------------
 
 static void addArpeggio(ChordRest* cr, String& arpeggioType, int arpeggioNo, ArpeggioMap& arpMap,
-                        MxmlLogger* logger, const XmlStreamReader* const xmlreader, DelayedArpMap& delayedArps)
+                        DelayedArpMap& delayedArps)
 {
     if (cr->isRest() && !arpeggioType.empty()) {
         // If the arpeggio is attached to a rest, store to add to the next available chord
@@ -8136,7 +8136,7 @@ void MusicXMLParserNotations::addToScore(ChordRest* const cr, Note* const note, 
                                          Glissando* glissandi[MAX_NUMBER_LEVEL][2], MusicXmlSpannerMap& spanners,
                                          TrillStack& trills, std::map<int, Tie*>& ties, ArpeggioMap& arpMap, DelayedArpMap& delayedArps)
 {
-    addArpeggio(cr, m_arpeggioType, m_arpeggioNo, arpMap, m_logger, &m_e, delayedArps);
+    addArpeggio(cr, m_arpeggioType, m_arpeggioNo, arpMap, delayedArps);
     addBreath(cr, cr->tick(), m_breath);
     addWavyLine(cr, Fraction::fromTicks(tick), m_wavyLineNo, m_wavyLineType, spanners, trills, m_logger, &m_e);
 


### PR DESCRIPTION
This removes debug warnings about unknown attribute values in MusicXML importer. 

1. Files are validated on load, so invalid values will be reported anyway
2. Most of these were false positives, warning when there actually was no attribute in the first place
