### PR TITLE
Limit expression text to below the stave on XML import

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -3104,7 +3104,7 @@ void MusicXMLParserDirection::direction(const String& partId,
             }
         } else {
             if (m_wordsText != "" || m_metroText != "") {
-                isExpressionText = m_wordsText.contains(u"<i>") && m_metroText.empty();
+                isExpressionText = m_wordsText.contains(u"<i>") && m_metroText.empty() && placement() == u"below";
                 if (isExpressionText) {
                     t = Factory::createExpression(m_score->dummy()->segment());
                 } else if (m_systemDirection) {

--- a/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
@@ -310,9 +310,9 @@
         </Measure>
       <Measure>
         <voice>
-          <Expression>
+          <StaffText>
             <text><i>increasingly grave in spirit</i></text>
-            </Expression>
+            </StaffText>
           <Spanner type="HairPin">
             <prev>
               <location>
@@ -554,9 +554,9 @@
         </Measure>
       <Measure>
         <voice>
-          <Expression>
+          <StaffText>
             <text><i>with care</i></text>
-            </Expression>
+            </StaffText>
           <Chord>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>


### PR DESCRIPTION
This adds a further limit to when we want `<words>` to be inferred as expression text.
