### PR TITLE
Discard relative-y for lyric placement

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -7092,9 +7092,11 @@ void MusicXMLParserLyric::parse()
     const String lyricNumber = m_e.attribute("number");
     const Color lyricColor = Color::fromString(m_e.asciiAttribute("color").ascii());
     const bool printLyric = m_e.asciiAttribute("print-object") != "no";
-    const String placement = m_e.attribute("placement");
-    double relX = m_e.doubleAttribute("relative-x") / 10 * DPMM;
-    double relY = m_e.doubleAttribute("relative-y") / 10 * DPMM;
+    m_placement = m_e.attribute("placement");
+    double relX = m_e.doubleAttribute("relative-x") * 0.1 * DPMM;
+    m_relativeY = m_e.doubleAttribute("relative-y") * -0.1 * DPMM;
+    m_defaultY = m_e.doubleAttribute("default-y") * -0.1 * DPMM;
+
     String extendType;
     String formattedText;
 
@@ -7149,15 +7151,13 @@ void MusicXMLParserLyric::parse()
         lyric->setPropertyFlags(Pid::COLOR, PropertyFlags::UNSTYLED);
     }
     lyric->setVisible(printLyric);
-    if (!placement.empty()) {
-        lyric->setPlacement(placement == "above" ? PlacementV::ABOVE : PlacementV::BELOW);
-        lyric->setPropertyFlags(Pid::PLACEMENT, PropertyFlags::UNSTYLED);
-    }
 
-    if (relX != 0 || relY != 0) {
+    lyric->setPlacement(placement() == "above" ? PlacementV::ABOVE : PlacementV::BELOW);
+    lyric->setPropertyFlags(Pid::PLACEMENT, PropertyFlags::UNSTYLED);
+
+    if (!RealIsNull(relX)) {
         PointF offset = lyric->offset();
-        offset.setX(relX != 0 ? relX : lyric->offset().x());
-        offset.setY(relY != 0 ? relY : lyric->offset().y());
+        offset.setX(relX);
         lyric->setOffset(offset);
         lyric->setPropertyFlags(Pid::OFFSET, PropertyFlags::UNSTYLED);
     }
@@ -7169,6 +7169,15 @@ void MusicXMLParserLyric::parse()
         && (extendType == "" || extendType == "start")
         && (l->syllabic() == LyricsSyllabic::SINGLE || l->syllabic() == LyricsSyllabic::END)) {
         m_extendedLyrics.insert(l);
+    }
+}
+
+String MusicXMLParserLyric::placement() const
+{
+    if (m_placement == "" && hasTotalY()) {
+        return totalY() < 0 ? u"above" : u"below";
+    } else {
+        return m_placement;
     }
 }
 

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
@@ -152,6 +152,12 @@ private:
     MxmlLogger* m_logger = nullptr;            // Error logger
     std::map<int, Lyrics*> m_numberedLyrics;   // lyrics with valid number
     std::set<Lyrics*> m_extendedLyrics;        // lyrics with the extend flag set
+    double m_defaultY = 0.0;
+    double m_relativeY = 0.0;
+    String m_placement;
+    String placement() const;
+    double totalY() const { return m_defaultY + m_relativeY; }
+    bool hasTotalY() const { return !muse::RealIsNull(m_defaultY) || !muse::RealIsNull(m_relativeY); }
 };
 
 //---------------------------------------------------------

--- a/src/importexport/musicxml/tests/data/testCueNotes3_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testCueNotes3_ref.mscx
@@ -149,7 +149,6 @@
           <Chord>
             <durationType>half</durationType>
             <Lyrics>
-              <offset x="0" y="-1.7145"/>
               <text>Whose</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -161,7 +160,6 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.7145"/>
               <text>broad</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -175,7 +173,6 @@
             <Lyrics>
               <ticks>480</ticks>
               <ticks_f>1/4</ticks_f>
-              <offset x="0" y="-1.7145"/>
               <text>stripes</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -217,7 +214,6 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.7145"/>
               <text>and</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -231,7 +227,6 @@
             <small>1</small>
             <durationType>16th</durationType>
             <Lyrics>
-              <offset x="0" y="-1.7145"/>
               <text>bright</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -254,7 +249,6 @@
             <small>1</small>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.7145"/>
               <text>stars</text>
               </Lyrics>
             <Articulation>
@@ -280,7 +274,6 @@
             <small>1</small>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.7145"/>
               <text>through</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -295,7 +288,6 @@
           <Chord>
             <durationType>half</durationType>
             <Lyrics>
-              <offset x="0" y="-1.7145"/>
               <text>the</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -313,7 +305,6 @@
             <small>1</small>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.7145"/>
               <text>per'l's</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -341,7 +332,6 @@
             <dots>1</dots>
             <durationType>half</durationType>
             <Lyrics>
-              <offset x="0" y="-1.7145"/>
               <text>fight</text>
               </Lyrics>
             <StemDirection>up</StemDirection>

--- a/src/importexport/musicxml/tests/data/testElision_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testElision_ref.mscx
@@ -138,7 +138,6 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.7145"/>
               <text>ce<sym>lyricsElision</sym>e<sym>lyricsElision</sym>in</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -150,7 +149,6 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.7145"/>
               <text>ce‿e in</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -162,7 +160,6 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.7145"/>
               <text>ce<sym>lyricsElision</sym>e<sym>lyricsElision</sym>in</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -174,7 +171,6 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.7145"/>
               <text>ce<sym>lyricsElision</sym>e‿in</text>
               </Lyrics>
             <StemDirection>down</StemDirection>

--- a/src/importexport/musicxml/tests/data/testInferredCredits1_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredCredits1_ref.mscx
@@ -156,7 +156,6 @@ the video game: a tone poem</text>
             <durationType>eighth</durationType>
             <Lyrics>
               <syllabic>begin</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>ha</text>
               </Lyrics>
             <Note>
@@ -168,7 +167,6 @@ the video game: a tone poem</text>
             <durationType>eighth</durationType>
             <Lyrics>
               <syllabic>end</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>ha</text>
               </Lyrics>
             <Note>
@@ -189,7 +187,6 @@ the video game: a tone poem</text>
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>nice.</text>
               </Lyrics>
             <StemDirection>up</StemDirection>

--- a/src/importexport/musicxml/tests/data/testInferredCredits2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredCredits2_ref.mscx
@@ -164,7 +164,6 @@ Words &amp; Music by also Henry Ives (and ampersands)
             <durationType>eighth</durationType>
             <Lyrics>
               <syllabic>begin</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>ha</text>
               </Lyrics>
             <Note>
@@ -176,7 +175,6 @@ Words &amp; Music by also Henry Ives (and ampersands)
             <durationType>eighth</durationType>
             <Lyrics>
               <syllabic>end</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>ha</text>
               </Lyrics>
             <Note>
@@ -197,7 +195,6 @@ Words &amp; Music by also Henry Ives (and ampersands)
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>nice.</text>
               </Lyrics>
             <StemDirection>up</StemDirection>

--- a/src/importexport/musicxml/tests/data/testLyricBracket_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testLyricBracket_ref.mscx
@@ -146,13 +146,11 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>here</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
               <syllabic>begin</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>surp</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -164,13 +162,11 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>are</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
               <syllabic>end</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>rise</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -182,12 +178,10 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>some</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
-              <offset x="0" y="-1.71429"/>
               <text>there</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -200,12 +194,10 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>begin</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>ly</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
-              <offset x="0" y="-1.71429"/>
               <text>is</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -222,12 +214,10 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>end</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>rics</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
-              <offset x="0" y="-1.71429"/>
               <text>a</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -239,13 +229,11 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>that</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
               <syllabic>begin</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>brack</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -257,13 +245,11 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>end</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
               <syllabic>end</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>et</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -276,12 +262,10 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>begin</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>with</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
-              <offset x="0" y="-1.71429"/>
               <text>in</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -299,12 +283,10 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>end</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>out</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
-              <offset x="0" y="-1.71429"/>
               <text>the</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -316,12 +298,10 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>a</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
-              <offset x="0" y="-1.71429"/>
               <text>X</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -334,12 +314,10 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>begin</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>brack</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
-              <offset x="0" y="-1.71429"/>
               <text>M</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -352,12 +330,10 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>end</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>et</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
-              <offset x="0" y="-1.71429"/>
               <text>L</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -381,7 +357,6 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>nice</text>
               </Lyrics>
             <StemDirection>up</StemDirection>

--- a/src/importexport/musicxml/tests/data/testLyricPos_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testLyricPos_ref.mscx
@@ -140,7 +140,6 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <placement>above</placement>
-              <offset x="0" y="1.143"/>
               <text>Lyrics</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -153,7 +152,6 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <placement>above</placement>
-              <offset x="0" y="1.143"/>
               <text>above</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -166,7 +164,6 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <placement>above</placement>
-              <offset x="0" y="1.143"/>
               <text>the</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -179,7 +176,6 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <placement>above</placement>
-              <offset x="0" y="1.143"/>
               <text>stave</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -196,7 +192,6 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.7145"/>
               <text>Lyrics</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -208,7 +203,6 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.7145"/>
               <text>below</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -220,7 +214,6 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.7145"/>
               <text>the</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -232,7 +225,6 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.7145"/>
               <text>stave!</text>
               </Lyrics>
             <StemDirection>down</StemDirection>

--- a/src/importexport/musicxml/tests/data/testPartNames_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPartNames_ref.mscx
@@ -826,7 +826,6 @@
             <Lyrics>
               <ticks>26880</ticks>
               <ticks_f>56/4</ticks_f>
-              <offset x="0" y="-1.7145"/>
               <text>yes!</text>
               </Lyrics>
             <Note>
@@ -1235,7 +1234,6 @@
             <Lyrics>
               <ticks>26880</ticks>
               <ticks_f>56/4</ticks_f>
-              <offset x="0" y="-1.7145"/>
               <text>no</text>
               </Lyrics>
             <Note>

--- a/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
@@ -235,7 +235,6 @@
             <Lyrics>
               <ticks>9600</ticks>
               <ticks_f>20/4</ticks_f>
-              <offset x="0" y="-1.71429"/>
               <text>ahh</text>
               </Lyrics>
             <Note>

--- a/src/importexport/musicxml/tests/data/testSecondVoiceMelismata_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSecondVoiceMelismata_ref.mscx
@@ -147,12 +147,10 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>begin</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>Bo</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
-              <offset x="0" y="-1.71429"/>
               <text>Much</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -165,13 +163,11 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>end</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>ring</text>
               </Lyrics>
             <Lyrics>
               <no>1</no>
               <syllabic>begin</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>cool</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -184,7 +180,6 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>begin</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>ly</text>
               </Lyrics>
             <Lyrics>
@@ -192,7 +187,6 @@
               <syllabic>end</syllabic>
               <ticks>960</ticks>
               <ticks_f>8/16</ticks_f>
-              <offset x="0" y="-1.71429"/>
               <text>er</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -205,7 +199,6 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>end</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>rics</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -233,7 +226,6 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>on</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -245,7 +237,6 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>the</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -257,7 +248,6 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>first</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -282,7 +272,6 @@
             <Lyrics>
               <no>1</no>
               <syllabic>begin</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>ly</text>
               </Lyrics>
             </Rest>
@@ -292,7 +281,6 @@
             <Lyrics>
               <no>1</no>
               <syllabic>end</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>rics</text>
               </Lyrics>
             </Rest>
@@ -307,7 +295,6 @@
           <Chord>
             <durationType>half</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>line</text>
               </Lyrics>
             <StemDirection>up</StemDirection>
@@ -358,7 +345,6 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>begin</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>place</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -376,7 +362,6 @@
               <syllabic>end</syllabic>
               <ticks>960</ticks>
               <ticks_f>2/4</ticks_f>
-              <offset x="0" y="-1.71429"/>
               <text>ment's</text>
               </Lyrics>
             <StemDirection>down</StemDirection>

--- a/src/importexport/musicxml/tests/data/testTextOrder_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTextOrder_ref.mscx
@@ -168,7 +168,6 @@
             <BeamMode>begin</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>glare</text>
               </Lyrics>
             <Note>
@@ -180,7 +179,6 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>The</text>
               </Lyrics>
             <Note>
@@ -192,7 +190,6 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>bombs</text>
               </Lyrics>
             <Note>
@@ -204,7 +201,6 @@
             <durationType>16th</durationType>
             <Lyrics>
               <syllabic>begin</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>burst</text>
               </Lyrics>
             <Note>
@@ -222,7 +218,6 @@
             <durationType>16th</durationType>
             <Lyrics>
               <syllabic>end</syllabic>
-              <offset x="0" y="-1.71429"/>
               <text>ing</text>
               </Lyrics>
             <Note>
@@ -234,7 +229,6 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>in</text>
               </Lyrics>
             <Note>
@@ -246,7 +240,6 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>air</text>
               </Lyrics>
             <Note>
@@ -257,7 +250,6 @@
           <Chord>
             <durationType>16th</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>gave</text>
               </Lyrics>
             <Note>
@@ -278,7 +270,6 @@
             <BeamMode>begin</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>proof</text>
               </Lyrics>
             <Note>
@@ -290,7 +281,6 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>through</text>
               </Lyrics>
             <Note>
@@ -305,7 +295,6 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>the</text>
               </Lyrics>
             <Note>
@@ -316,7 +305,6 @@
           <Chord>
             <durationType>16th</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>night</text>
               </Lyrics>
             <Note>
@@ -339,7 +327,6 @@
             <BeamMode>begin</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>that</text>
               </Lyrics>
             <Note>
@@ -351,7 +338,6 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>our</text>
               </Lyrics>
             <Note>
@@ -366,7 +352,6 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>SWAG</text>
               </Lyrics>
             <Note>
@@ -377,7 +362,6 @@
           <Chord>
             <durationType>16th</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>was</text>
               </Lyrics>
             <Note>
@@ -398,7 +382,6 @@
             <BeamMode>begin</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>still</text>
               </Lyrics>
             <Note>
@@ -410,7 +393,6 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>there</text>
               </Lyrics>
             <Note>
@@ -422,7 +404,6 @@
             <BeamMode>mid</BeamMode>
             <durationType>16th</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>oh</text>
               </Lyrics>
             <Note>
@@ -433,7 +414,6 @@
           <Chord>
             <durationType>16th</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>say</text>
               </Lyrics>
             <Note>
@@ -445,7 +425,6 @@
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>does</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -477,7 +456,6 @@
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>that</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
@@ -505,7 +483,6 @@
             <BeamMode>no</BeamMode>
             <durationType>eighth</durationType>
             <Lyrics>
-              <offset x="0" y="-1.71429"/>
               <text>star</text>
               </Lyrics>
             <StemDirection>down</StemDirection>


### PR DESCRIPTION
Resolves: #22739 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

This was introduced in https://github.com/musescore/MuseScore/pull/21862.  `relative-y` is usually garbage and unneeded anyway as we can lay out lyrics correctly ourselves.