### PR TITLE
Scale title text on XML import

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.h
@@ -115,6 +115,7 @@ void determineTupletFractionAndFullDuration(const Fraction duration, Fraction& f
 Fraction missingTupletDuration(const Fraction duration);
 bool isLikelyCreditText(const String& text, const bool caseInsensitive);
 bool isLikelySubtitleText(const String& text, const bool caseInsensitive);
+static void scaleTitle(Score* score, Text* t);
 
 //---------------------------------------------------------
 //   MusicXMLParserPass1

--- a/src/importexport/musicxml/tests/data/testCopyrightScale.xml
+++ b/src/importexport/musicxml/tests/data/testCopyrightScale.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="4.0">
   <work>
-    <work-title>Untitled score</work-title>
+    <work-title>Title title title title title title title title title title title title title title title title title title title title title title title</work-title>
     </work>
   <identification>
     <creator type="composer">Composer / arranger</creator>
@@ -69,6 +69,10 @@ copyright copyright</rights>
     <word-font font-family="Edwin" font-size="10"/>
     <lyric-font font-family="Edwin" font-size="10"/>
     </defaults>
+    <credit page="1">
+        <credit-type>title</credit-type>
+        <credit-words default-x="1020" default-y="3250" font-size="24" justify="right" valign="top">Title title title title title title title title title title title title title title title title title title title title title title title</credit-words>
+    </credit>
   <credit page="1">
     <credit-type>rights</credit-type>
     <credit-words default-x="148.790134" default-y="28.574964" justify="center" valign="bottom" font-size="9">Copyright copyright copyright copyright copyright copyright copyright copyright copyright copyright copyright 

--- a/src/importexport/musicxml/tests/data/testCopyrightScale_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testCopyrightScale_ref.mscx
@@ -51,7 +51,7 @@ copyright copyright</metaTag>
     <metaTag name="source"></metaTag>
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
-    <metaTag name="workTitle">Untitled score</metaTag>
+    <metaTag name="workTitle">Title title title title title title title title title title title title title title title title title title title title title title title</metaTag>
     <Part id="1">
       <Staff id="1">
         <StaffType group="pitched">
@@ -116,6 +116,15 @@ copyright copyright</metaTag>
         </Instrument>
       </Part>
     <Staff id="1">
+      <VBox>
+        <height>3.5</height>
+        <Text>
+          <style>title</style>
+          <size>2.3</size>
+          <align>right,top</align>
+          <text><font size="2.3"/>Title title title title title title title title title title title title title title title title title title title title title title title</text>
+          </Text>
+        </VBox>
       <Measure>
         <voice>
           <Clef>


### PR DESCRIPTION
This prevents long titles spilling off the page. eg.
<img width="1001" alt="Screenshot 2024-05-10 at 11 04 56" src="https://github.com/musescore/MuseScore/assets/26510874/9a72cec9-5833-4234-8723-6987515d511b">
