### PR TITLE
Fix ARM CI with QT6

### DIFF
--- a/.github/workflows/ci_linux_arm_mu4.yml
+++ b/.github/workflows/ci_linux_arm_mu4.yml
@@ -131,7 +131,7 @@ jobs:
       if: env.DO_BUILD == 'true'
       run: |
         C_URL=${SENTRY_URL}; if [ -z "$C_URL" ]; then C_URL="''"; fi
-        sudo docker run -i -v "${PWD}:/MuseScore" -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static "arm32v7/ubuntu:focal" /bin/bash -c "cd /MuseScore && \
+        sudo docker run -i -v "${PWD}:/MuseScore" -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static "arm32v7/ubuntu:jammy" /bin/bash -c "cd /MuseScore && \
         bash /MuseScore/buildscripts/ci/linux/setup-arm.sh --arch armv7l && \
         bash /MuseScore/buildscripts/ci/linux/build.sh -n ${{ env.BUILD_NUMBER }} --crash_log_url $C_URL --arch armv7l && \
         bash ./buildscripts/ci/linux/dumpsyms.sh && \
@@ -251,7 +251,7 @@ jobs:
       if: env.DO_BUILD == 'true'
       run: |
         C_URL=${SENTRY_URL}; if [ -z "$C_URL" ]; then C_URL="''"; fi
-        sudo docker run -i -v "${PWD}:/MuseScore" -v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static "arm64v8/ubuntu:focal" /bin/bash -c "cd /MuseScore && \
+        sudo docker run -i -v "${PWD}:/MuseScore" -v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static "arm64v8/ubuntu:jammy" /bin/bash -c "cd /MuseScore && \
         bash /MuseScore/buildscripts/ci/linux/setup-arm.sh --arch aarch64 && \
         bash /MuseScore/buildscripts/ci/linux/build.sh -n ${{ env.BUILD_NUMBER }} --crash_log_url $C_URL --arch aarch64 && \
         bash ./buildscripts/ci/linux/dumpsyms.sh && \

--- a/build.cmake
+++ b/build.cmake
@@ -95,7 +95,7 @@ if(DEFINED ENV{QTDIR})
     endif()
 endif()
 
-fn__require_program(QMAKE Qt --version "https://musescore.org/en/handbook/developers-handbook/compilation" qmake)
+fn__require_program(QMAKE Qt --version "https://musescore.org/en/handbook/developers-handbook/compilation" qmake6 qmake)
 fn__set_qt_variables("${QMAKE}")
 message(STATUS "QT_LOCATION: ${QT_LOCATION}")
 message(STATUS "QT_VERSION: ${QT_VERSION}")

--- a/buildscripts/ci/linux/setup-arm.sh
+++ b/buildscripts/ci/linux/setup-arm.sh
@@ -139,64 +139,12 @@ DEBIAN_FRONTEND="noninteractive" TZ="Europe/London" apt-get install -y --no-inst
   "${apt_packages_runtime[@]}" \
   "${apt_packages_ffmpeg[@]}"
 
-# Add additional ppas (Qt 5.15.2, Cmake, and patchelf)
-# Poor naming of the cmake ppa, this ppa has bionic/focal/jammy dists
-# add-apt-repository --yes ppa:theofficialgman/cmake-bionic
-# add-apt-repository --yes ppa:theofficialgman/opt-qt-5.15.2-focal-arm
-# minimum patchelf 0.12 needed for proper elf load memory alignment
-# add-apt-repository --yes ppa:theofficialgman/patchelf
-apt-get update
-apt-get upgrade -y
-
 # add an exception for the "detected dubious ownership in repository" (only seen inside a Docker image)
 git config --global --add safe.directory /MuseScore
 
 ##########################################################################
-# GET TOOLS
-##########################################################################
-
-# COMPILER
-apt_packages_compiler=(
-  automake
-  gcc
-  g++
-  )
-
-apt-get install -y --no-install-recommends \
-  "${apt_packages_compiler[@]}"
-
-# CMAKE
-# Get newer CMake (only used cached version if it is the same)
-apt-get install -y --no-install-recommends cmake
-cmake --version
-
-# Ninja
-apt-get install -y --no-install-recommends ninja-build
-echo "ninja version"
-ninja --version
-
-##########################################################################
 # GET QT
 ##########################################################################
-
-# Get newer Qt (only used cached version if it is the same)
-
-# apt_packages_qt=(
-#   qt515base
-#   qt515declarative
-#   qt515quickcontrols
-#   qt515quickcontrols2
-#   qt515graphicaleffects
-#   qt515imageformats
-#   qt515networkauth-no-lgpl
-#   qt515remoteobjects
-#   qt515svg
-#   qt515tools
-#   qt515translations
-#   qt515wayland
-#   qt515x11extras
-#   qt515xmlpatterns
-#   )
 
 apt_packages_qt6=(
   qt6-base-dev
@@ -227,130 +175,29 @@ apt-get install -y \
 qt_version="624"
 qt_dir="/usr/lib/aarch64-linux-gnu/qt6"
 
-# ##########################################################################
-# # Compile and install nlohmann-json
-# ##########################################################################
-# export CFLAGS="-Wno-psabi"
-# export CXXFLAGS="-Wno-psabi"
-# CURRDIR=${PWD}
-# cd /
+##########################################################################
+# GET TOOLS
+##########################################################################
 
-# git clone https://github.com/nlohmann/json
-# cd /json/
-# git checkout --recurse-submodules v3.10.4
-# git submodule update --init --recursive
-# mkdir -p build
-# cd build
-# cmake -DJSON_BuildTests=OFF ..
-# cmake --build . -j $(nproc)
-# cmake --build . --target install
-# cd /
+# COMPILER
+apt_packages_compiler=(
+  automake
+  gcc
+  g++
+  )
 
-# ##########################################################################
-# # Compile and install linuxdeploy
-# ##########################################################################
+apt-get install -y --no-install-recommends \
+  "${apt_packages_compiler[@]}"
 
-# git clone https://github.com/linuxdeploy/linuxdeploy
-# cd /linuxdeploy/
-# git checkout --recurse-submodules 1-alpha-20231206-1
-# git submodule update --init --recursive
+# CMAKE
+# Get newer CMake (only used cached version if it is the same)
+apt-get install -y --no-install-recommends cmake
+cmake --version
 
-# # patch src/core/generate-excludelist.sh to use curl instead of wget which fails on armhf
-# sed -i 's/wget --quiet "$url" -O -/curl "$url"/g' src/core/generate-excludelist.sh
-
-# mkdir -p build
-# cd build
-# cmake -DBUILD_TESTING=OFF -DUSE_SYSTEM_BOOST=ON ..
-# cmake --build . -j $(nproc)
-# mkdir -p $BUILD_TOOLS/linuxdeploy
-# mv /linuxdeploy/build/bin/* $BUILD_TOOLS/linuxdeploy/
-# $BUILD_TOOLS/linuxdeploy/linuxdeploy --version
-# cd /
-
-# ##########################################################################
-# # Compile and install linuxdeploy-plugin-qt
-# ##########################################################################
-
-# git clone https://github.com/linuxdeploy/linuxdeploy-plugin-qt
-# cd /linuxdeploy-plugin-qt/
-# git checkout --recurse-submodules 9a388d32b1e95d8b69e201356f050137eb6c0aa3
-# git submodule update --init --recursive
-
-# # patch src/core/generate-excludelist.sh to use curl instead of wget which fails on armhf
-# sed -i 's/wget --quiet "$url" -O -/curl "$url"/g' lib/linuxdeploy/src/core/generate-excludelist.sh
-
-# mkdir -p build
-# cd build
-# cmake -DBUILD_TESTING=OFF -DUSE_SYSTEM_BOOST=ON ..
-# cmake --build . -j $(nproc)
-# mkdir -p $BUILD_TOOLS/linuxdeploy
-# mv /linuxdeploy-plugin-qt/build/bin/linuxdeploy-plugin-qt $BUILD_TOOLS/linuxdeploy/linuxdeploy-plugin-qt
-# # $BUILD_TOOLS/linuxdeploy/linuxdeploy --list-plugins
-# cd /
-
-# ##########################################################################
-# # Compile and install linuxdeploy-plugin-appimage
-# ##########################################################################
-
-# git clone https://github.com/linuxdeploy/linuxdeploy-plugin-appimage
-# cd /linuxdeploy-plugin-appimage/
-# git checkout --recurse-submodules 1-alpha-20230713-1
-# git submodule update --init --recursive
-# mkdir -p build
-# cd build
-# cmake -DBUILD_TESTING=OFF ..
-# cmake --build . -j $(nproc)
-# mv /linuxdeploy-plugin-appimage/build/src/linuxdeploy-plugin-appimage $BUILD_TOOLS/linuxdeploy/linuxdeploy-plugin-appimage
-# cd /
-# $BUILD_TOOLS/linuxdeploy/linuxdeploy --list-plugins
-
-# ##########################################################################
-# # Compile and install AppImageKit
-# ##########################################################################
-
-# git clone https://github.com/AppImage/AppImageKit
-# cd /AppImageKit/
-# git checkout --recurse-submodules 13
-# git submodule update --init --recursive
-# mkdir -p build
-# cd build
-# cmake -DBUILD_TESTING=OFF ..
-# cmake --build . -j $(nproc)
-# cmake --build . --target install
-# mkdir -p $BUILD_TOOLS/appimagetool
-# cd /
-# appimagetool --version
-
-# ##########################################################################
-# # Compile and install appimageupdatetool
-# ##########################################################################
-
-# git clone https://github.com/AppImageCommunity/AppImageUpdate.git
-# cd AppImageUpdate
-# git checkout --recurse-submodules 2.0.0-alpha-1-20220512
-# git submodule update --init --recursive
-# mkdir -p build
-# cd build
-
-# cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_SYSTEM_NAME=Linux ..
-# make -j"$(nproc)"
-# # create the extracted appimage directory
-# mkdir -p $BUILD_TOOLS/appimageupdatetool
-# make install DESTDIR=$BUILD_TOOLS/appimageupdatetool/appimageupdatetool-${PACKARCH}.AppDir
-# mkdir -p $BUILD_TOOLS/appimageupdatetool/appimageupdatetool-${PACKARCH}.AppDir/resources
-# cp -v ../resources/*.xpm $BUILD_TOOLS/appimageupdatetool/appimageupdatetool-${PACKARCH}.AppDir/resources/
-# $BUILD_TOOLS/linuxdeploy/linuxdeploy -v0 --appdir $BUILD_TOOLS/appimageupdatetool/appimageupdatetool-${PACKARCH}.AppDir  --output appimage -d ../resources/appimageupdatetool.desktop -i ../resources/appimage.png
-# cd $BUILD_TOOLS/appimageupdatetool
-# ln -s "appimageupdatetool-${PACKARCH}.AppDir/AppRun" appimageupdatetool # symlink for convenience
-# cd /
-# $BUILD_TOOLS/appimageupdatetool/appimageupdatetool --version
-
-# cd ${CURRDIR}
-
-# # delete build folders
-# rm -rf /linuxdeploy*
-# rm -rf /AppImageKit
-# rm -rf /AppImageUpdate
+# Ninja
+apt-get install -y --no-install-recommends ninja-build
+echo "ninja version"
+ninja --version
 
 # Dump syms
 if [ "$PACKARCH" == "armv7l" ]; then
@@ -371,8 +218,6 @@ else
   echo export DUMPSYMS_BIN="$breakpad_dir/dump_syms" >> $ENV_FILE
 fi
 
-# echo export PATH="${qt_dir}/bin:\${PATH}" >> ${ENV_FILE}
-# echo export LD_LIBRARY_PATH="${qt_dir}/lib:\${LD_LIBRARY_PATH}" >> ${ENV_FILE}
 echo export QT_PATH="${qt_dir}" >> ${ENV_FILE}
 echo export QT_PLUGIN_PATH="${qt_dir}/plugins" >> ${ENV_FILE}
 echo export QML2_IMPORT_PATH="${qt_dir}/qml" >> ${ENV_FILE}

--- a/buildscripts/ci/linux/setup-arm.sh
+++ b/buildscripts/ci/linux/setup-arm.sh
@@ -227,24 +227,24 @@ apt-get install -y \
 qt_version="624"
 qt_dir="/usr/lib/aarch64-linux-gnu/qt6"
 
-##########################################################################
-# Compile and install nlohmann-json
-##########################################################################
-export CFLAGS="-Wno-psabi"
-export CXXFLAGS="-Wno-psabi"
-CURRDIR=${PWD}
-cd /
+# ##########################################################################
+# # Compile and install nlohmann-json
+# ##########################################################################
+# export CFLAGS="-Wno-psabi"
+# export CXXFLAGS="-Wno-psabi"
+# CURRDIR=${PWD}
+# cd /
 
-git clone https://github.com/nlohmann/json
-cd /json/
-git checkout --recurse-submodules v3.10.4
-git submodule update --init --recursive
-mkdir -p build
-cd build
-cmake -DJSON_BuildTests=OFF ..
-cmake --build . -j $(nproc)
-cmake --build . --target install
-cd /
+# git clone https://github.com/nlohmann/json
+# cd /json/
+# git checkout --recurse-submodules v3.10.4
+# git submodule update --init --recursive
+# mkdir -p build
+# cd build
+# cmake -DJSON_BuildTests=OFF ..
+# cmake --build . -j $(nproc)
+# cmake --build . --target install
+# cd /
 
 # ##########################################################################
 # # Compile and install linuxdeploy
@@ -267,26 +267,26 @@ cd /
 # $BUILD_TOOLS/linuxdeploy/linuxdeploy --version
 # cd /
 
-##########################################################################
-# Compile and install linuxdeploy-plugin-qt
-##########################################################################
+# ##########################################################################
+# # Compile and install linuxdeploy-plugin-qt
+# ##########################################################################
 
-git clone https://github.com/linuxdeploy/linuxdeploy-plugin-qt
-cd /linuxdeploy-plugin-qt/
-git checkout --recurse-submodules 9a388d32b1e95d8b69e201356f050137eb6c0aa3
-git submodule update --init --recursive
+# git clone https://github.com/linuxdeploy/linuxdeploy-plugin-qt
+# cd /linuxdeploy-plugin-qt/
+# git checkout --recurse-submodules 9a388d32b1e95d8b69e201356f050137eb6c0aa3
+# git submodule update --init --recursive
 
-# patch src/core/generate-excludelist.sh to use curl instead of wget which fails on armhf
-sed -i 's/wget --quiet "$url" -O -/curl "$url"/g' lib/linuxdeploy/src/core/generate-excludelist.sh
+# # patch src/core/generate-excludelist.sh to use curl instead of wget which fails on armhf
+# sed -i 's/wget --quiet "$url" -O -/curl "$url"/g' lib/linuxdeploy/src/core/generate-excludelist.sh
 
-mkdir -p build
-cd build
-cmake -DBUILD_TESTING=OFF -DUSE_SYSTEM_BOOST=ON ..
-cmake --build . -j $(nproc)
-mkdir -p $BUILD_TOOLS/linuxdeploy
-mv /linuxdeploy-plugin-qt/build/bin/linuxdeploy-plugin-qt $BUILD_TOOLS/linuxdeploy/linuxdeploy-plugin-qt
-# $BUILD_TOOLS/linuxdeploy/linuxdeploy --list-plugins
-cd /
+# mkdir -p build
+# cd build
+# cmake -DBUILD_TESTING=OFF -DUSE_SYSTEM_BOOST=ON ..
+# cmake --build . -j $(nproc)
+# mkdir -p $BUILD_TOOLS/linuxdeploy
+# mv /linuxdeploy-plugin-qt/build/bin/linuxdeploy-plugin-qt $BUILD_TOOLS/linuxdeploy/linuxdeploy-plugin-qt
+# # $BUILD_TOOLS/linuxdeploy/linuxdeploy --list-plugins
+# cd /
 
 # ##########################################################################
 # # Compile and install linuxdeploy-plugin-appimage
@@ -345,12 +345,12 @@ cd /
 # cd /
 # $BUILD_TOOLS/appimageupdatetool/appimageupdatetool --version
 
-cd ${CURRDIR}
+# cd ${CURRDIR}
 
-# delete build folders
-rm -rf /linuxdeploy*
-rm -rf /AppImageKit
-rm -rf /AppImageUpdate
+# # delete build folders
+# rm -rf /linuxdeploy*
+# rm -rf /AppImageKit
+# rm -rf /AppImageUpdate
 
 # Dump syms
 if [ "$PACKARCH" == "armv7l" ]; then

--- a/buildscripts/ci/linux/setup-arm.sh
+++ b/buildscripts/ci/linux/setup-arm.sh
@@ -121,6 +121,9 @@ apt_packages_runtime=(
   libxcb-randr0
   libxcb-render-util0
   libxcb-xinerama0
+  libxcb-xkb-dev
+  libxkbcommon-dev
+  libvulkan-dev
   )
 
 apt_packages_ffmpeg=(
@@ -138,10 +141,10 @@ DEBIAN_FRONTEND="noninteractive" TZ="Europe/London" apt-get install -y --no-inst
 
 # Add additional ppas (Qt 5.15.2, Cmake, and patchelf)
 # Poor naming of the cmake ppa, this ppa has bionic/focal/jammy dists
-add-apt-repository --yes ppa:theofficialgman/cmake-bionic
-add-apt-repository --yes ppa:theofficialgman/opt-qt-5.15.2-focal-arm
+# add-apt-repository --yes ppa:theofficialgman/cmake-bionic
+# add-apt-repository --yes ppa:theofficialgman/opt-qt-5.15.2-focal-arm
 # minimum patchelf 0.12 needed for proper elf load memory alignment
-add-apt-repository --yes ppa:theofficialgman/patchelf
+# add-apt-repository --yes ppa:theofficialgman/patchelf
 apt-get update
 apt-get upgrade -y
 
@@ -178,28 +181,51 @@ ninja --version
 
 # Get newer Qt (only used cached version if it is the same)
 
-apt_packages_qt=(
-  qt515base
-  qt515declarative
-  qt515quickcontrols
-  qt515quickcontrols2
-  qt515graphicaleffects
-  qt515imageformats
-  qt515networkauth-no-lgpl
-  qt515remoteobjects
-  qt515svg
-  qt515tools
-  qt515translations
-  qt515wayland
-  qt515x11extras
-  qt515xmlpatterns
+# apt_packages_qt=(
+#   qt515base
+#   qt515declarative
+#   qt515quickcontrols
+#   qt515quickcontrols2
+#   qt515graphicaleffects
+#   qt515imageformats
+#   qt515networkauth-no-lgpl
+#   qt515remoteobjects
+#   qt515svg
+#   qt515tools
+#   qt515translations
+#   qt515wayland
+#   qt515x11extras
+#   qt515xmlpatterns
+#   )
+
+apt_packages_qt6=(
+  qt6-base-dev
+  qt6-declarative-dev
+  qt6-base-private-dev
+  libqt6networkauth6-dev
+  libqt6qml6
+  qml6-module-* # installs all qml modules
+  libqt6quick6
+  libqt6quickcontrols2-6
+  libqt6quicktemplates2-6
+  libqt6quickwidgets6
+  libqt6xml6
+  libqt6svg6-dev
+  qt6-tools-dev
+  qt6-tools-dev-tools
+  libqt6printsupport6
+  libqt6opengl6-dev
+  qt6-l10n-tools
+  libqt6core5compat6-dev
+  qt6-scxml-dev
+  qt6-wayland
   )
 
 apt-get install -y \
-  "${apt_packages_qt[@]}"
+  "${apt_packages_qt6[@]}"
 
-qt_version="5152"
-qt_dir="/opt/qt515"
+qt_version="624"
+qt_dir="/usr/lib/aarch64-linux-gnu/qt6"
 
 ##########################################################################
 # Compile and install nlohmann-json
@@ -345,13 +371,15 @@ else
   echo export DUMPSYMS_BIN="$breakpad_dir/dump_syms" >> $ENV_FILE
 fi
 
-echo export PATH="${qt_dir}/bin:\${PATH}" >> ${ENV_FILE}
-echo export LD_LIBRARY_PATH="${qt_dir}/lib:\${LD_LIBRARY_PATH}" >> ${ENV_FILE}
+# echo export PATH="${qt_dir}/bin:\${PATH}" >> ${ENV_FILE}
+# echo export LD_LIBRARY_PATH="${qt_dir}/lib:\${LD_LIBRARY_PATH}" >> ${ENV_FILE}
 echo export QT_PATH="${qt_dir}" >> ${ENV_FILE}
 echo export QT_PLUGIN_PATH="${qt_dir}/plugins" >> ${ENV_FILE}
 echo export QML2_IMPORT_PATH="${qt_dir}/qml" >> ${ENV_FILE}
 echo export CFLAGS="-Wno-psabi" >> ${ENV_FILE}
 echo export CXXFLAGS="-Wno-psabi" >> ${ENV_FILE}
+# explicitly set QMAKE path for linuxdeploy-plugin-qt
+echo export QMAKE="/usr/bin/qmake6" >> ${ENV_FILE}
 
 ##########################################################################
 # POST INSTALL

--- a/buildscripts/cmake/FindQt6.cmake
+++ b/buildscripts/cmake/FindQt6.cmake
@@ -2,7 +2,7 @@
 include(GetUtilsFunctions) # library of CMake functions ("fn__" namespace)
 
 # Print Qt version or fail the build if Qt (qmake) is not in PATH.
-fn__require_program(QMAKE Qt --version "https://musescore.org/en/handbook/developers-handbook/compilation" qmake)
+fn__require_program(QMAKE Qt --version "https://musescore.org/en/handbook/developers-handbook/compilation" qmake6 qmake)
 
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/22178
Resolves: https://github.com/musescore/MuseScore/issues/18598

<!-- Add a short description of and motivation for the changes here -->
The ARM CI was not updated to support QT6 and so builds have been failing (eg: https://github.com/musescore/MuseScore/actions/runs/9026607087)

This PR firstly fixes the use of `qmake6` from distro repositories (where `qmake` is only QT5).
It makes the necessary changes to the ARM CI to use QT6 from the distro repositories on Ubuntu Jammy.
~~And finally it changes all remaining CI to use Ubuntu Jammy (as mentioned here https://github.com/musescore/MuseScore/issues/18598#issuecomment-1850072156).~~

If desired, the x64 Linux build could be swapped over to using the distro QT6 instead of the custom QT6 build and this would allow the `setup.sh` and `setup-arm.sh` to be fully combined

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
