### PR TITLE
Fix usage of command line args in GUI mode (and thus fix opening second scores)

### DIFF
--- a/src/app/internal/consoleapp.cpp
+++ b/src/app/internal/consoleapp.cpp
@@ -256,20 +256,6 @@ void ConsoleApp::applyCommandLineOptions(const CmdOptions& options, IApplication
         appshellConfiguration()->revertToFactorySettings(options.app.revertToFactorySettings.value());
     }
 
-    if (runMode == IApplication::RunMode::GuiApp) {
-        startupScenario()->setStartupType(options.startup.type);
-
-        if (options.startup.scoreUrl.has_value()) {
-            project::ProjectFile file { options.startup.scoreUrl.value() };
-
-            if (options.startup.scoreDisplayNameOverride.has_value()) {
-                file.displayNameOverride = options.startup.scoreDisplayNameOverride.value();
-            }
-
-            startupScenario()->setStartupScoreFile(file);
-        }
-    }
-
     if (options.app.loggerLevel) {
         m_globalModule.setLoggerLevel(options.app.loggerLevel.value());
     }

--- a/src/app/internal/guiapp.cpp
+++ b/src/app/internal/guiapp.cpp
@@ -66,8 +66,7 @@ void GuiApp::perform()
     // ====================================================
     // Setup modules: apply the command line options
     // ====================================================
-
-    //applyCommandLineOptions(commandLineParser.options(), runMode);
+    applyCommandLineOptions(options);
 
     // ====================================================
     // Setup modules: onPreInit
@@ -229,4 +228,27 @@ void GuiApp::finish()
     m_modules.clear();
 
     removeIoC();
+}
+
+void GuiApp::applyCommandLineOptions(const CmdOptions& options)
+{
+    if (options.app.revertToFactorySettings) {
+        appshellConfiguration()->revertToFactorySettings(options.app.revertToFactorySettings.value());
+    }
+
+    startupScenario()->setStartupType(options.startup.type);
+
+    if (options.startup.scoreUrl.has_value()) {
+        project::ProjectFile file { options.startup.scoreUrl.value() };
+
+        if (options.startup.scoreDisplayNameOverride.has_value()) {
+            file.displayNameOverride = options.startup.scoreDisplayNameOverride.value();
+        }
+
+        startupScenario()->setStartupScoreFile(file);
+    }
+
+    if (options.app.loggerLevel) {
+        m_globalModule.setLoggerLevel(options.app.loggerLevel.value());
+    }
 }

--- a/src/app/internal/guiapp.h
+++ b/src/app/internal/guiapp.h
@@ -13,6 +13,7 @@
 #include "modularity/ioc.h"
 #include "global/iapplication.h"
 #include "multiinstances/imultiinstancesprovider.h"
+#include "appshell/iappshellconfiguration.h"
 #include "appshell/internal/istartupscenario.h"
 
 namespace mu::app {
@@ -20,6 +21,7 @@ class GuiApp : public muse::BaseApplication, public std::enable_shared_from_this
 {
     muse::Inject<muse::IApplication> muapplication;
     muse::Inject<muse::mi::IMultiInstancesProvider> multiInstancesProvider;
+    muse::Inject<appshell::IAppShellConfiguration> appshellConfiguration;
     muse::Inject<appshell::IStartupScenario> startupScenario;
 
 public:
@@ -31,6 +33,7 @@ public:
     void finish() override;
 
 private:
+    void applyCommandLineOptions(const CmdOptions& options);
 
     CmdOptions m_options;
 


### PR DESCRIPTION
Resolves: #22682

(@igorkorsukov I know that you're probably going to change things around this soon, but this is just to keep the nightly builds working as bug-free as possible 🙂)