### PR TITLE
Fix iocCtx/AccessibleItem crash when opening score with mixer open

### DIFF
--- a/src/framework/global/modularity/ioc.cpp
+++ b/src/framework/global/modularity/ioc.cpp
@@ -30,10 +30,9 @@
 muse::Injectable::GetContext muse::iocCtxForQmlObject(const QObject* o)
 {
     return [o]() {
-        QQmlEngine* engine = qmlEngine(o);
-        if (!engine) {
-            engine = qmlEngine(o->parent());
-        }
+        const QObject* p = o;
+        QQmlEngine* engine = nullptr;
+        while (!(engine = qmlEngine(p)) && (p = p->parent())) {}
 
         IF_ASSERT_FAILED(engine) {
             return modularity::ContextPtr();

--- a/src/framework/global/modularity/ioc.cpp
+++ b/src/framework/global/modularity/ioc.cpp
@@ -31,8 +31,11 @@ muse::Injectable::GetContext muse::iocCtxForQmlObject(const QObject* o)
 {
     return [o]() {
         const QObject* p = o;
-        QQmlEngine* engine = nullptr;
-        while (!(engine = qmlEngine(p)) && (p = p->parent())) {}
+        QQmlEngine* engine = qmlEngine(p);
+        while (!engine && p->parent()) {
+            p = p->parent();
+            engine = qmlEngine(p);
+        }
 
         IF_ASSERT_FAILED(engine) {
             return modularity::ContextPtr();


### PR DESCRIPTION
The ioc context for `AccessibleItem`s was not found, because `AcessibleItem`s are children of `AbstractNavigation`s, and `AbstractNavigation`s are instantiated as children of QML items, and only those QML items have a QML engine. So now we need to look not just for the parent of the `AccessibleItem`, but for the parent of the parent. This modifies the `iocCtxForQmlObject` method, so that we can move up in the QObject parent hierarchy as many steps as necessary.