### PR TITLE
MidiRenderer: fix crash when tremolo would have zero length because appoggiatura

### DIFF
--- a/src/engraving/compat/midi/compatmidirender.cpp
+++ b/src/engraving/compat/midi/compatmidirender.cpp
@@ -1,5 +1,7 @@
 #include "compatmidirender.h"
 
+#include "global/realfn.h"
+
 #include "dom/tremolosinglechord.h"
 #include "dom/tremolotwochord.h"
 
@@ -279,6 +281,10 @@ void CompatMidiRender::renderArpeggio(Chord* chord, std::vector<NoteEventList>& 
 
 void CompatMidiRender::renderTremolo(Chord* chord, std::vector<NoteEventList>& ell, int& ontime, double tremoloPartOfChord /* = 1.0 */)
 {
+    if (muse::RealIsNull(tremoloPartOfChord)) {
+        return;
+    }
+
     struct TremoloAdapter {
         TremoloSingleChord* singleChord = nullptr;
         TremoloTwoChord* twoChord = nullptr;


### PR DESCRIPTION
Resolves: #22796

The steps to reproduce the crash don't work in master because the call to `CompatMidiRender::createPlayEvents` has been removed from `Score::addElement`, but the situation seems basically still the same. 