### PR TITLE
[4.3.1] Fix crash when opening score where TAB clefs are not shown

### DIFF
--- a/src/engraving/rendering/dev/measurelayout.cpp
+++ b/src/engraving/rendering/dev/measurelayout.cpp
@@ -1778,7 +1778,8 @@ void MeasureLayout::addSystemHeader(Measure* m, bool isFirstSystem, LayoutContex
                 if (isFirstClef && searchMeasure->tick() >= clefTick) {
                     // Need to check previous measure for clef change if one not found in this measure
                     Segment* clefSeg = searchMeasure->findFirstR(SegmentType::Clef | SegmentType::HeaderClef, Fraction(0, 0));
-                    if (Measure* prevMeas = searchMeasure->prevMeasure(); !clefSeg) {
+                    Measure* prevMeas = searchMeasure->prevMeasure();
+                    if (prevMeas && !clefSeg) {
                         clefSeg = prevMeas->findSegment(SegmentType::Clef, m->tick());
                     }
                     if (clefSeg && clefSeg->enabled()) {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/22759

Ports: #22802