### PR TITLE
Treat svgz file as a vector image

### DIFF
--- a/src/engraving/dom/image.cpp
+++ b/src/engraving/dom/image.cpp
@@ -235,7 +235,7 @@ bool Image::load()
         path = m_linkPath;
     }
 
-    if (path.withSuffix("svg")) {
+    if (path.withSuffix("svg") || path.withSuffix("svgz")) {
         setImageType(ImageType::SVG);
     } else {
         setImageType(ImageType::RASTER);
@@ -277,7 +277,7 @@ bool Image::load(const muse::io::path_t& ss)
     m_linkPath = fi.canonicalFilePath();
     m_storeItem = imageStore.add(m_linkPath, ba);
     m_storeItem->reference(this);
-    if (path.withSuffix("svg")) {
+    if (path.withSuffix("svg") || path.withSuffix("svgz")) {
         setImageType(ImageType::SVG);
     } else {
         setImageType(ImageType::RASTER);
@@ -297,7 +297,7 @@ bool Image::loadFromData(const path_t& name, const muse::ByteArray& ba)
     m_linkPath = u"";
     m_storeItem = imageStore.add(name, ba);
     m_storeItem->reference(this);
-    if (name.withSuffix("svg")) {
+    if (name.withSuffix("svg") || name.withSuffix("svgz")) {
         setImageType(ImageType::SVG);
     } else {
         setImageType(ImageType::RASTER);

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -1241,13 +1241,14 @@ void NotationActionController::addImage()
         return;
     }
 
-    std::vector<std::string> filter = { muse::trc("notation", "All Supported Files") + " (*.svg *.jpg *.jpeg *.png *.bmp *.tif *.tiff)",
-                                        muse::trc("notation", "Scalable Vector Graphics") + " (*.svg)",
-                                        muse::trc("notation", "JPEG") + " (*.jpg *.jpeg)",
-                                        muse::trc("notation", "PNG Bitmap Graphic") + " (*.png)",
-                                        muse::trc("notation", "Bitmap") + " (*.bmp)",
-                                        muse::trc("notation", "TIFF") + " (*.tif *.tiff)",
-                                        muse::trc("notation", "All") + " (*)" };
+    std::vector<std::string> filter
+        = { muse::trc("notation", "All Supported Files") + " (*.svg *.svgz *.jpg *.jpeg *.png *.bmp *.tif *.tiff)",
+            muse::trc("notation", "Scalable Vector Graphics") + " (*.svg *.svgz)",
+            muse::trc("notation", "JPEG") + " (*.jpg *.jpeg)",
+            muse::trc("notation", "PNG Bitmap Graphic") + " (*.png)",
+            muse::trc("notation", "Bitmap") + " (*.bmp)",
+            muse::trc("notation", "TIFF") + " (*.tif *.tiff)",
+            muse::trc("notation", "All") + " (*)" };
 
     muse::io::path_t path = interactive()->selectOpeningFile(muse::qtrc("notation", "Insert Image"), "", filter);
     interaction->addImageToItem(path, item);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4289,6 +4289,7 @@ void NotationInteraction::addImageToItem(const muse::io::path_t& imagePath, Engr
 
     static std::map<muse::io::path_t, ImageType> suffixToType {
         { "svg", ImageType::SVG },
+        { "svgz", ImageType::SVG },
         { "jpg", ImageType::RASTER },
         { "jpeg", ImageType::RASTER },
         { "png", ImageType::RASTER },

--- a/src/palette/view/widgets/palettewidget.cpp
+++ b/src/palette/view/widgets/palettewidget.cpp
@@ -818,6 +818,7 @@ void PaletteWidget::dragEnterEvent(QDragEnterEvent* event)
             QFileInfo fi(u.path());
             QString suffix(fi.suffix().toLower());
             if (suffix == "svg"
+                || suffix == "svgz"
                 || suffix == "jpg"
                 || suffix == "jpeg"
                 || suffix == "png"


### PR DESCRIPTION
Musescore suddenly supports compressed svg  files (with `.svgz` extension) if you add them via drag&drop.
This PR fixes a situation where compressed svgs are incorrectly treated as raster images, which causes incorrect "pixelated" rendering and makes musescore slow.
Before:
![before](https://github.com/musescore/MuseScore/assets/919446/890571e5-cb5a-417e-a763-a51d954ccf5b)
After:
![after](https://github.com/musescore/MuseScore/assets/919446/5a6006c9-7b47-42ba-9dcb-170051c32840)

Explanations:
A compressed svg file is a regular gzipped svg.
Musescore accepts and renders svg files in these formats:
* plain svg with `.svg` extension (correct rendering)
* compressed svg with `.svg` extension (correct rendering)
* compressed svg with `.svgz` extension (incorrect raster rendering, fixed by this PR)
* compressed svg with `.svg.gz` extension (incorrect raster rendering, not covered by this PR)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
