### PR TITLE
Fix: wrong Lilypond Lyrics plugin description

### DIFF
--- a/share/plugins/lilyrics/lilyrics.qml
+++ b/share/plugins/lilyrics/lilyrics.qml
@@ -8,7 +8,7 @@ import Muse.UiComponents 1.0
 
 MuseScore {
     version: "1.2" // 21 - June - 2022
-    description: qsTr("Apply lyrics in lilypond format.")
+    description: "Apply lyrics in Lilypond format"
     title: "Lilypond Lyrics"
     categoryCode: "lyrics"
     thumbnailName: "lilyrics.png"


### PR DESCRIPTION
In Home -> Plugins -> Lilypond Lyrics, MuseScore Studio shows wrong description: 'sTr("Apply lyrics in lilypond format."'
'qsTr()' is unnecessary here. The plugin descriptions are also without dot at the end.

Greetings,
Gootector

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
