### PR TITLE
Fix double codas on MMRs

### DIFF
--- a/src/engraving/rendering/dev/measurelayout.cpp
+++ b/src/engraving/rendering/dev/measurelayout.cpp
@@ -288,7 +288,7 @@ void MeasureLayout::createMMRest(LayoutContext& ctx, Measure* firstMeasure, Meas
     ElementList oldList = mmrMeasure->takeElements();
     ElementList newList = lastMeasure->el();
     for (EngravingItem* e : firstMeasure->el()) {
-        if (e->isMarker()) {
+        if (e->isMarker() && firstMeasure != lastMeasure) {
             newList.push_back(e);
         }
     }


### PR DESCRIPTION
Resolves: #20742 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

We add markers from the first and last bar of an MMR - when these are the same bar, markers are added twice.