### PR TITLE
Fix GH#20856: Fix ignored color on trill after opening score

### DIFF
--- a/src/engraving/dom/trill.cpp
+++ b/src/engraving/dom/trill.cpp
@@ -256,7 +256,7 @@ LineSegment* Trill::createLineSegment(System* parent)
 {
     TrillSegment* seg = new TrillSegment(this, parent);
     seg->setTrack(track());
-    seg->setColor(color());
+    seg->setColor(lineColor());
     seg->initElementStyle(&trillSegmentStyle);
     return seg;
 }


### PR DESCRIPTION
Resolves: #20856

As taken from https://github.com/krasko78/MuseScore/commit/7470a15dc919228606a9849d557f863abd672c19