### PR TITLE
Improve key signature shape and distances

### DIFF
--- a/share/styles/MuseJazz.mss
+++ b/share/styles/MuseJazz.mss
@@ -86,7 +86,7 @@
     <timesigLeftMargin>0.5</timesigLeftMargin>
     <timesigScale w="1" h="1"/>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>

--- a/share/templates/01-General/01-Treble_Clef/score_style.mss
+++ b/share/templates/01-General/01-Treble_Clef/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/01-General/02-Bass_Clef/score_style.mss
+++ b/share/templates/01-General/02-Bass_Clef/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/01-General/03-Grand_Staff/score_style.mss
+++ b/share/templates/01-General/03-Grand_Staff/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/02-Choral/01-SATB/score_style.mss
+++ b/share/templates/02-Choral/01-SATB/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/02-Choral/02-SATB_+_Organ/score_style.mss
+++ b/share/templates/02-Choral/02-SATB_+_Organ/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/02-Choral/03-SATB_+_Piano/score_style.mss
+++ b/share/templates/02-Choral/03-SATB_+_Piano/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/02-Choral/04-SATB_Closed_Score/score_style.mss
+++ b/share/templates/02-Choral/04-SATB_Closed_Score/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/02-Choral/05-SATB_Closed_Score_+_Organ/score_style.mss
+++ b/share/templates/02-Choral/05-SATB_Closed_Score_+_Organ/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/02-Choral/06-SATB_Closed_Score_+_Piano/score_style.mss
+++ b/share/templates/02-Choral/06-SATB_Closed_Score_+_Piano/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/02-Choral/07-Voice_+_Piano/score_style.mss
+++ b/share/templates/02-Choral/07-Voice_+_Piano/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/02-Choral/08-Barbershop_Quartet_(Men)/score_style.mss
+++ b/share/templates/02-Choral/08-Barbershop_Quartet_(Men)/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/02-Choral/09-Barbershop_Quartet_(Women)/score_style.mss
+++ b/share/templates/02-Choral/09-Barbershop_Quartet_(Women)/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/02-Choral/10-Liturgical_Unmetrical/score_style.mss
+++ b/share/templates/02-Choral/10-Liturgical_Unmetrical/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/02-Choral/11-Liturgical_Unmetrical_+_Organ/score_style.mss
+++ b/share/templates/02-Choral/11-Liturgical_Unmetrical_+_Organ/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/03-Chamber_Music/01-String_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/01-String_Quartet/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/03-Chamber_Music/02-Wind_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/02-Wind_Quartet/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/03-Chamber_Music/03-Wind_Quintet/score_style.mss
+++ b/share/templates/03-Chamber_Music/03-Wind_Quintet/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/03-Chamber_Music/04-Saxophone_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/04-Saxophone_Quartet/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/03-Chamber_Music/05-Brass_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/05-Brass_Quartet/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/03-Chamber_Music/06-Brass_Quintet/score_style.mss
+++ b/share/templates/03-Chamber_Music/06-Brass_Quintet/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/04-Solo/01-Guitar/score_style.mss
+++ b/share/templates/04-Solo/01-Guitar/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/04-Solo/02-Guitar_+_Tablature/score_style.mss
+++ b/share/templates/04-Solo/02-Guitar_+_Tablature/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/04-Solo/03-Guitar_Tablature/score_style.mss
+++ b/share/templates/04-Solo/03-Guitar_Tablature/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/04-Solo/04-Piano/score_style.mss
+++ b/share/templates/04-Solo/04-Piano/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/05-Jazz/01-Jazz_Lead_Sheet/score_style.mss
+++ b/share/templates/05-Jazz/01-Jazz_Lead_Sheet/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/05-Jazz/02-Big_Band/score_style.mss
+++ b/share/templates/05-Jazz/02-Big_Band/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/05-Jazz/03-Jazz_Combo/score_style.mss
+++ b/share/templates/05-Jazz/03-Jazz_Combo/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/06-Popular/01-Rock_Band/score_style.mss
+++ b/share/templates/06-Popular/01-Rock_Band/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/06-Popular/02-Bluegrass_Band/score_style.mss
+++ b/share/templates/06-Popular/02-Bluegrass_Band/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/07-Band_and_Percussion/01-Concert_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/01-Concert_Band/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/07-Band_and_Percussion/02-Small_Concert_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/02-Small_Concert_Band/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/07-Band_and_Percussion/03-Brass_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/03-Brass_Band/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/07-Band_and_Percussion/04-Marching_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/04-Marching_Band/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/07-Band_and_Percussion/05-Small_Marching_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/05-Small_Marching_Band/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/07-Band_and_Percussion/06-Battery_Percussion/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/06-Battery_Percussion/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/07-Band_and_Percussion/07-Large_Pit_Percussion/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/07-Large_Pit_Percussion/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/07-Band_and_Percussion/08-Small_Pit_Percussion/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/08-Small_Pit_Percussion/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/07-Band_and_Percussion/09-European_Concert_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/09-European_Concert_Band/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/08-Orchestral/01-Classical_Orchestra/score_style.mss
+++ b/share/templates/08-Orchestral/01-Classical_Orchestra/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/08-Orchestral/02-Symphony_Orchestra/score_style.mss
+++ b/share/templates/08-Orchestral/02-Symphony_Orchestra/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/share/templates/08-Orchestral/03-String_Orchestra/score_style.mss
+++ b/share/templates/08-Orchestral/03-String_Orchestra/score_style.mss
@@ -110,7 +110,7 @@
     <timesigScale w="1" h="1"/>
     <midClefKeyRightMargin>1</midClefKeyRightMargin>
     <clefKeyRightMargin>0.8</clefKeyRightMargin>
-    <clefKeyDistance>1</clefKeyDistance>
+    <clefKeyDistance>0.75</clefKeyDistance>
     <clefTimesigDistance>1</clefTimesigDistance>
     <keyTimesigDistance>1</keyTimesigDistance>
     <keyBarlineDistance>1</keyBarlineDistance>

--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -3858,12 +3858,13 @@ void TLayout::layoutKeySig(const KeySig* item, KeySig::LayoutData* ldata, const 
         }
     }
 
-    // compute bbox
+    Shape keySigShape;
     for (const KeySym& ks : ldata->keySymbols) {
         double x = ks.xPos * spatium;
         double y = ks.line * step;
-        ldata->addBbox(item->symBbox(ks.sym).translated(x, y));
+        keySigShape.add(item->symBbox(ks.sym).translated(x, y), item);
     }
+    ldata->setShape(keySigShape);
 }
 
 void TLayout::layoutLayoutBreak(const LayoutBreak* item, LayoutBreak::LayoutData* ldata)

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -160,7 +160,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::dividerRightX,           "dividerRightX",           0.0 },
     { Sid::dividerRightY,           "dividerRightY",           0.0 },
 
-    { Sid::clefLeftMargin,          "clefLeftMargin",          Spatium(0.75) },     // 0.64 (gould: <= 1)
+    { Sid::clefLeftMargin,          "clefLeftMargin",          Spatium(0.75) },
     { Sid::keysigLeftMargin,        "keysigLeftMargin",        Spatium(0.5) },
     { Sid::ambitusMargin,           "ambitusMargin",           Spatium(0.5) },
 
@@ -168,12 +168,12 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     { Sid::timesigScale,            "timesigScale",            ScaleF(1.0, 1.0) },
     { Sid::midClefKeyRightMargin,   "midClefKeyRightMargin",   Spatium(1.0) },
     { Sid::clefKeyRightMargin,      "clefKeyRightMargin",      Spatium(0.8) },
-    { Sid::clefKeyDistance,         "clefKeyDistance",         Spatium(1.0) },   // gould: 1 - 1.25
+    { Sid::clefKeyDistance,         "clefKeyDistance",         Spatium(0.75) },
     { Sid::clefTimesigDistance,     "clefTimesigDistance",     Spatium(1.0) },
-    { Sid::keyTimesigDistance,      "keyTimesigDistance",      Spatium(1.0) },    // gould: 1 - 1.5
+    { Sid::keyTimesigDistance,      "keyTimesigDistance",      Spatium(1.0) },
     { Sid::keyBarlineDistance,      "keyBarlineDistance",      Spatium(1.0) },
-    { Sid::systemHeaderDistance,    "systemHeaderDistance",    Spatium(2.5) },     // gould: 2.5
-    { Sid::systemHeaderTimeSigDistance, "systemHeaderTimeSigDistance", Spatium(2.0) },  // gould: 2.0
+    { Sid::systemHeaderDistance,    "systemHeaderDistance",    Spatium(2.5) },
+    { Sid::systemHeaderTimeSigDistance, "systemHeaderTimeSigDistance", Spatium(2.0) },
     { Sid::systemTrailerRightMargin, "systemTrailerRightMargin", Spatium(0.5) },
 
     { Sid::clefBarlineDistance,     "clefBarlineDistance",     Spatium(0.5) },

--- a/src/importexport/musicxml/tests/data/testLayout.xml
+++ b/src/importexport/musicxml/tests/data/testLayout.xml
@@ -78,12 +78,12 @@
       </score-part>
     </part-list>
   <part id="P1">
-    <measure number="1" width="235.41">
+    <measure number="1" width="232.91">
       <print>
         <system-layout>
           <system-margins>
             <left-margin>50</left-margin>
-            <right-margin>743.62</right-margin>
+            <right-margin>746.12</right-margin>
             </system-margins>
           <top-system-distance>170</top-system-distance>
           </system-layout>
@@ -110,7 +110,7 @@
           <line>4</line>
           </clef>
         </attributes>
-      <note default-x="134.94" default-y="-10">
+      <note default-x="132.44" default-y="-10">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
@@ -125,7 +125,7 @@
           </direction-type>
         <staff>2</staff>
         </direction>
-      <note default-x="83.18" default-y="-130">
+      <note default-x="80.68" default-y="-130">
         <pitch>
           <step>C</step>
           <octave>4</octave>
@@ -142,7 +142,7 @@
           </direction-type>
         <staff>2</staff>
         </direction>
-      <note default-x="107.08" default-y="-115">
+      <note default-x="104.58" default-y="-115">
         <grace slash="yes"/>
         <pitch>
           <step>F</step>
@@ -155,7 +155,7 @@
         <stem>up</stem>
         <staff>2</staff>
         </note>
-      <note default-x="128.52" default-y="-110">
+      <note default-x="126.02" default-y="-110">
         <pitch>
           <step>G</step>
           <octave>4</octave>
@@ -166,7 +166,7 @@
         <stem>down</stem>
         <staff>2</staff>
         </note>
-      <note default-x="158.92" default-y="-135">
+      <note default-x="156.42" default-y="-135">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -183,7 +183,7 @@
           </direction-type>
         <staff>2</staff>
         </direction>
-      <note default-x="189.31" default-y="-125">
+      <note default-x="186.81" default-y="-125">
         <pitch>
           <step>D</step>
           <octave>3</octave>

--- a/src/importexport/musicxml/tests/data/testSystemDistance_ref.xml
+++ b/src/importexport/musicxml/tests/data/testSystemDistance_ref.xml
@@ -86,7 +86,7 @@
       </score-part>
     </part-list>
   <part id="P1">
-    <measure number="1" width="158.4">
+    <measure number="1" width="156.15">
       <print>
         <system-layout>
           <system-margins>
@@ -110,7 +110,7 @@
           <line>2</line>
           </clef>
         </attributes>
-      <note default-x="74.22" default-y="-25">
+      <note default-x="71.72" default-y="-25">
         <pitch>
           <step>A</step>
           <octave>4</octave>
@@ -120,29 +120,7 @@
         <type>half</type>
         <stem>up</stem>
         </note>
-      <note default-x="115.41" default-y="-25">
-        <pitch>
-          <step>A</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>2</duration>
-        <voice>1</voice>
-        <type>half</type>
-        <stem>up</stem>
-        </note>
-      </measure>
-    <measure number="2" width="97.18">
-      <note default-x="13" default-y="-25">
-        <pitch>
-          <step>A</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>2</duration>
-        <voice>1</voice>
-        <type>half</type>
-        <stem>up</stem>
-        </note>
-      <note default-x="54.19" default-y="-25">
+      <note default-x="113.03" default-y="-25">
         <pitch>
           <step>A</step>
           <octave>4</octave>
@@ -153,7 +131,7 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="3" width="97.18">
+    <measure number="2" width="97.44">
       <note default-x="13" default-y="-25">
         <pitch>
           <step>A</step>
@@ -164,7 +142,7 @@
         <type>half</type>
         <stem>up</stem>
         </note>
-      <note default-x="54.19" default-y="-25">
+      <note default-x="54.32" default-y="-25">
         <pitch>
           <step>A</step>
           <octave>4</octave>
@@ -175,7 +153,7 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="4" width="97.18">
+    <measure number="3" width="97.44">
       <note default-x="13" default-y="-25">
         <pitch>
           <step>A</step>
@@ -186,7 +164,7 @@
         <type>half</type>
         <stem>up</stem>
         </note>
-      <note default-x="54.19" default-y="-25">
+      <note default-x="54.32" default-y="-25">
         <pitch>
           <step>A</step>
           <octave>4</octave>
@@ -197,7 +175,7 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="5" width="97.18">
+    <measure number="4" width="97.44">
       <note default-x="13" default-y="-25">
         <pitch>
           <step>A</step>
@@ -208,7 +186,7 @@
         <type>half</type>
         <stem>up</stem>
         </note>
-      <note default-x="54.19" default-y="-25">
+      <note default-x="54.32" default-y="-25">
         <pitch>
           <step>A</step>
           <octave>4</octave>
@@ -219,7 +197,7 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="6" width="97.18">
+    <measure number="5" width="97.44">
       <note default-x="13" default-y="-25">
         <pitch>
           <step>A</step>
@@ -230,7 +208,7 @@
         <type>half</type>
         <stem>up</stem>
         </note>
-      <note default-x="54.19" default-y="-25">
+      <note default-x="54.32" default-y="-25">
         <pitch>
           <step>A</step>
           <octave>4</octave>
@@ -241,7 +219,7 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="7" width="97.18">
+    <measure number="6" width="97.44">
       <note default-x="13" default-y="-25">
         <pitch>
           <step>A</step>
@@ -252,7 +230,7 @@
         <type>half</type>
         <stem>up</stem>
         </note>
-      <note default-x="54.19" default-y="-25">
+      <note default-x="54.32" default-y="-25">
         <pitch>
           <step>A</step>
           <octave>4</octave>
@@ -263,7 +241,7 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="8" width="97.18">
+    <measure number="7" width="97.44">
       <note default-x="13" default-y="-25">
         <pitch>
           <step>A</step>
@@ -274,7 +252,7 @@
         <type>half</type>
         <stem>up</stem>
         </note>
-      <note default-x="54.19" default-y="-25">
+      <note default-x="54.32" default-y="-25">
         <pitch>
           <step>A</step>
           <octave>4</octave>
@@ -285,7 +263,7 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="9" width="97.18">
+    <measure number="8" width="97.44">
       <note default-x="13" default-y="-25">
         <pitch>
           <step>A</step>
@@ -296,7 +274,29 @@
         <type>half</type>
         <stem>up</stem>
         </note>
-      <note default-x="54.19" default-y="-25">
+      <note default-x="54.32" default-y="-25">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="9" width="97.44">
+      <note default-x="13" default-y="-25">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="54.32" default-y="-25">
         <pitch>
           <step>A</step>
           <octave>4</octave>

--- a/src/importexport/musicxml/tests/data/testSystemDividers.xml
+++ b/src/importexport/musicxml/tests/data/testSystemDividers.xml
@@ -136,7 +136,7 @@
     <part-group type="stop" number="1"/>
     </part-list>
   <part id="P1">
-    <measure number="1" width="152.47">
+    <measure number="1" width="150.22">
       <print>
         <system-layout>
           <system-margins>
@@ -160,70 +160,70 @@
           <line>2</line>
           </clef>
         </attributes>
-      <note default-x="100.32" default-y="-10">
+      <note default-x="97.95" default-y="-10">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="2" width="83.29">
-      <note default-x="34.65" default-y="-10">
+    <measure number="2" width="83.54">
+      <note default-x="34.77" default-y="-10">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="3" width="83.29">
-      <note default-x="34.65" default-y="-10">
+    <measure number="3" width="83.54">
+      <note default-x="34.77" default-y="-10">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="4" width="83.29">
-      <note default-x="34.65" default-y="-10">
+    <measure number="4" width="83.54">
+      <note default-x="34.77" default-y="-10">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="5" width="83.29">
-      <note default-x="34.65" default-y="-10">
+    <measure number="5" width="83.54">
+      <note default-x="34.77" default-y="-10">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="6" width="83.29">
-      <note default-x="34.65" default-y="-10">
+    <measure number="6" width="83.54">
+      <note default-x="34.77" default-y="-10">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="7" width="83.29">
-      <note default-x="34.65" default-y="-10">
+    <measure number="7" width="83.54">
+      <note default-x="34.77" default-y="-10">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="8" width="83.29">
-      <note default-x="34.65" default-y="-10">
+    <measure number="8" width="83.54">
+      <note default-x="34.77" default-y="-10">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="9" width="83.29">
-      <note default-x="34.65" default-y="-10">
+    <measure number="9" width="83.54">
+      <note default-x="34.77" default-y="-10">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="10" width="83.29">
-      <note default-x="34.65" default-y="-10">
+    <measure number="10" width="83.54">
+      <note default-x="34.77" default-y="-10">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
@@ -406,7 +406,7 @@
       </measure>
     </part>
   <part id="P2">
-    <measure number="1" width="152.47">
+    <measure number="1" width="150.22">
       <print>
         <staff-layout number="1">
           <staff-distance>57.53</staff-distance>
@@ -426,70 +426,70 @@
           <line>2</line>
           </clef>
         </attributes>
-      <note default-x="100.32" default-y="-107.53">
+      <note default-x="97.95" default-y="-107.53">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="2" width="83.29">
-      <note default-x="34.65" default-y="-107.53">
+    <measure number="2" width="83.54">
+      <note default-x="34.77" default-y="-107.53">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="3" width="83.29">
-      <note default-x="34.65" default-y="-107.53">
+    <measure number="3" width="83.54">
+      <note default-x="34.77" default-y="-107.53">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="4" width="83.29">
-      <note default-x="34.65" default-y="-107.53">
+    <measure number="4" width="83.54">
+      <note default-x="34.77" default-y="-107.53">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="5" width="83.29">
-      <note default-x="34.65" default-y="-107.53">
+    <measure number="5" width="83.54">
+      <note default-x="34.77" default-y="-107.53">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="6" width="83.29">
-      <note default-x="34.65" default-y="-107.53">
+    <measure number="6" width="83.54">
+      <note default-x="34.77" default-y="-107.53">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="7" width="83.29">
-      <note default-x="34.65" default-y="-107.53">
+    <measure number="7" width="83.54">
+      <note default-x="34.77" default-y="-107.53">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="8" width="83.29">
-      <note default-x="34.65" default-y="-107.53">
+    <measure number="8" width="83.54">
+      <note default-x="34.77" default-y="-107.53">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="9" width="83.29">
-      <note default-x="34.65" default-y="-107.53">
+    <measure number="9" width="83.54">
+      <note default-x="34.77" default-y="-107.53">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="10" width="83.29">
-      <note default-x="34.65" default-y="-107.53">
+    <measure number="10" width="83.54">
+      <note default-x="34.77" default-y="-107.53">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
@@ -664,7 +664,7 @@
       </measure>
     </part>
   <part id="P3">
-    <measure number="1" width="152.47">
+    <measure number="1" width="150.22">
       <print>
         <staff-layout number="1">
           <staff-distance>57.53</staff-distance>
@@ -684,70 +684,70 @@
           <line>3</line>
           </clef>
         </attributes>
-      <note default-x="100.32" default-y="-205.07">
+      <note default-x="97.95" default-y="-205.07">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="2" width="83.29">
-      <note default-x="34.65" default-y="-205.07">
+    <measure number="2" width="83.54">
+      <note default-x="34.77" default-y="-205.07">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="3" width="83.29">
-      <note default-x="34.65" default-y="-205.07">
+    <measure number="3" width="83.54">
+      <note default-x="34.77" default-y="-205.07">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="4" width="83.29">
-      <note default-x="34.65" default-y="-205.07">
+    <measure number="4" width="83.54">
+      <note default-x="34.77" default-y="-205.07">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="5" width="83.29">
-      <note default-x="34.65" default-y="-205.07">
+    <measure number="5" width="83.54">
+      <note default-x="34.77" default-y="-205.07">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="6" width="83.29">
-      <note default-x="34.65" default-y="-205.07">
+    <measure number="6" width="83.54">
+      <note default-x="34.77" default-y="-205.07">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="7" width="83.29">
-      <note default-x="34.65" default-y="-205.07">
+    <measure number="7" width="83.54">
+      <note default-x="34.77" default-y="-205.07">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="8" width="83.29">
-      <note default-x="34.65" default-y="-205.07">
+    <measure number="8" width="83.54">
+      <note default-x="34.77" default-y="-205.07">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="9" width="83.29">
-      <note default-x="34.65" default-y="-205.07">
+    <measure number="9" width="83.54">
+      <note default-x="34.77" default-y="-205.07">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="10" width="83.29">
-      <note default-x="34.65" default-y="-205.07">
+    <measure number="10" width="83.54">
+      <note default-x="34.77" default-y="-205.07">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
@@ -922,7 +922,7 @@
       </measure>
     </part>
   <part id="P4">
-    <measure number="1" width="152.47">
+    <measure number="1" width="150.22">
       <print>
         <staff-layout number="1">
           <staff-distance>57.53</staff-distance>
@@ -942,70 +942,70 @@
           <line>4</line>
           </clef>
         </attributes>
-      <note default-x="100.32" default-y="-302.6">
+      <note default-x="97.95" default-y="-302.6">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="2" width="83.29">
-      <note default-x="34.65" default-y="-302.6">
+    <measure number="2" width="83.54">
+      <note default-x="34.77" default-y="-302.6">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="3" width="83.29">
-      <note default-x="34.65" default-y="-302.6">
+    <measure number="3" width="83.54">
+      <note default-x="34.77" default-y="-302.6">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="4" width="83.29">
-      <note default-x="34.65" default-y="-302.6">
+    <measure number="4" width="83.54">
+      <note default-x="34.77" default-y="-302.6">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="5" width="83.29">
-      <note default-x="34.65" default-y="-302.6">
+    <measure number="5" width="83.54">
+      <note default-x="34.77" default-y="-302.6">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="6" width="83.29">
-      <note default-x="34.65" default-y="-302.6">
+    <measure number="6" width="83.54">
+      <note default-x="34.77" default-y="-302.6">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="7" width="83.29">
-      <note default-x="34.65" default-y="-302.6">
+    <measure number="7" width="83.54">
+      <note default-x="34.77" default-y="-302.6">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="8" width="83.29">
-      <note default-x="34.65" default-y="-302.6">
+    <measure number="8" width="83.54">
+      <note default-x="34.77" default-y="-302.6">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="9" width="83.29">
-      <note default-x="34.65" default-y="-302.6">
+    <measure number="9" width="83.54">
+      <note default-x="34.77" default-y="-302.6">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
         </note>
       </measure>
-    <measure number="10" width="83.29">
-      <note default-x="34.65" default-y="-302.6">
+    <measure number="10" width="83.54">
+      <note default-x="34.77" default-y="-302.6">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>


### PR DESCRIPTION
Before:
![image](https://github.com/musescore/MuseScore/assets/93707756/732c0632-8018-4098-9dd3-accce9a1571e)
After:
![image](https://github.com/musescore/MuseScore/assets/93707756/88e62529-8df6-4c63-afc5-46464e3a3920)

This does _not_ affect the position of individual accidentals within the key signature (we may want to do that later using cutouts etc). This just makes sure that the shape of the key signature isn't a single big rectangle (which has cause [lots of annoyance](https://github.com/musescore/MuseScore/pull/22662#issuecomment-2112709635) in the past as it also affects the skyline).