### PR TITLE
Fixes to system text and system text lines (#22811)

### DIFF
--- a/share/templates/01-General/01-Treble_Clef/score_style.mss
+++ b/share/templates/01-General/01-Treble_Clef/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/01-General/02-Bass_Clef/score_style.mss
+++ b/share/templates/01-General/02-Bass_Clef/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/01-General/03-Grand_Staff/score_style.mss
+++ b/share/templates/01-General/03-Grand_Staff/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/02-Choral/01-SATB/score_style.mss
+++ b/share/templates/02-Choral/01-SATB/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/02-Choral/02-SATB_+_Organ/score_style.mss
+++ b/share/templates/02-Choral/02-SATB_+_Organ/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/02-Choral/03-SATB_+_Piano/score_style.mss
+++ b/share/templates/02-Choral/03-SATB_+_Piano/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/02-Choral/04-SATB_Closed_Score/score_style.mss
+++ b/share/templates/02-Choral/04-SATB_Closed_Score/score_style.mss
@@ -925,7 +925,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/02-Choral/05-SATB_Closed_Score_+_Organ/score_style.mss
+++ b/share/templates/02-Choral/05-SATB_Closed_Score_+_Organ/score_style.mss
@@ -925,7 +925,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/02-Choral/06-SATB_Closed_Score_+_Piano/score_style.mss
+++ b/share/templates/02-Choral/06-SATB_Closed_Score_+_Piano/score_style.mss
@@ -925,7 +925,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/02-Choral/07-Voice_+_Piano/score_style.mss
+++ b/share/templates/02-Choral/07-Voice_+_Piano/score_style.mss
@@ -925,7 +925,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/02-Choral/08-Barbershop_Quartet_(Men)/score_style.mss
+++ b/share/templates/02-Choral/08-Barbershop_Quartet_(Men)/score_style.mss
@@ -925,7 +925,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/02-Choral/09-Barbershop_Quartet_(Women)/score_style.mss
+++ b/share/templates/02-Choral/09-Barbershop_Quartet_(Women)/score_style.mss
@@ -925,7 +925,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/02-Choral/10-Liturgical_Unmetrical/score_style.mss
+++ b/share/templates/02-Choral/10-Liturgical_Unmetrical/score_style.mss
@@ -925,7 +925,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/02-Choral/11-Liturgical_Unmetrical_+_Organ/score_style.mss
+++ b/share/templates/02-Choral/11-Liturgical_Unmetrical_+_Organ/score_style.mss
@@ -925,7 +925,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/03-Chamber_Music/01-String_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/01-String_Quartet/score_style.mss
@@ -925,7 +925,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/03-Chamber_Music/02-Wind_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/02-Wind_Quartet/score_style.mss
@@ -925,7 +925,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/03-Chamber_Music/03-Wind_Quintet/score_style.mss
+++ b/share/templates/03-Chamber_Music/03-Wind_Quintet/score_style.mss
@@ -925,7 +925,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/03-Chamber_Music/04-Saxophone_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/04-Saxophone_Quartet/score_style.mss
@@ -925,7 +925,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/03-Chamber_Music/05-Brass_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/05-Brass_Quartet/score_style.mss
@@ -925,7 +925,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/03-Chamber_Music/06-Brass_Quintet/score_style.mss
+++ b/share/templates/03-Chamber_Music/06-Brass_Quintet/score_style.mss
@@ -925,7 +925,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/04-Solo/01-Guitar/score_style.mss
+++ b/share/templates/04-Solo/01-Guitar/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/04-Solo/02-Guitar_+_Tablature/score_style.mss
+++ b/share/templates/04-Solo/02-Guitar_+_Tablature/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/04-Solo/03-Guitar_Tablature/score_style.mss
+++ b/share/templates/04-Solo/03-Guitar_Tablature/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/04-Solo/04-Piano/score_style.mss
+++ b/share/templates/04-Solo/04-Piano/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/05-Jazz/01-Jazz_Lead_Sheet/score_style.mss
+++ b/share/templates/05-Jazz/01-Jazz_Lead_Sheet/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/05-Jazz/02-Big_Band/score_style.mss
+++ b/share/templates/05-Jazz/02-Big_Band/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/05-Jazz/03-Jazz_Combo/score_style.mss
+++ b/share/templates/05-Jazz/03-Jazz_Combo/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/06-Popular/01-Rock_Band/score_style.mss
+++ b/share/templates/06-Popular/01-Rock_Band/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/06-Popular/02-Bluegrass_Band/score_style.mss
+++ b/share/templates/06-Popular/02-Bluegrass_Band/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/07-Band_and_Percussion/01-Concert_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/01-Concert_Band/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/07-Band_and_Percussion/02-Small_Concert_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/02-Small_Concert_Band/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/07-Band_and_Percussion/03-Brass_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/03-Brass_Band/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/07-Band_and_Percussion/04-Marching_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/04-Marching_Band/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/07-Band_and_Percussion/05-Small_Marching_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/05-Small_Marching_Band/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/07-Band_and_Percussion/06-Battery_Percussion/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/06-Battery_Percussion/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/07-Band_and_Percussion/07-Large_Pit_Percussion/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/07-Large_Pit_Percussion/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/07-Band_and_Percussion/08-Small_Pit_Percussion/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/08-Small_Pit_Percussion/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/07-Band_and_Percussion/09-European_Concert_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/09-European_Concert_Band/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/08-Orchestral/01-Classical_Orchestra/score_style.mss
+++ b/share/templates/08-Orchestral/01-Classical_Orchestra/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/08-Orchestral/02-Symphony_Orchestra/score_style.mss
+++ b/share/templates/08-Orchestral/02-Symphony_Orchestra/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/share/templates/08-Orchestral/03-String_Orchestra/score_style.mss
+++ b/share/templates/08-Orchestral/03-String_Orchestra/score_style.mss
@@ -923,7 +923,6 @@
     <textLineTextAlign>left,center</textLineTextAlign>
     <textLineSystemFlag>0</textLineSystemFlag>
     <systemTextLineFontFace>Edwin</systemTextLineFontFace>
-    <systemTextLineFontSize>12</systemTextLineFontSize>
     <systemTextLineFontSpatiumDependent>1</systemTextLineFontSpatiumDependent>
     <systemTextLineFontStyle>0</systemTextLineFontStyle>
     <systemTextLineColor r="0" g="0" b="0" a="255"/>

--- a/src/engraving/dom/textline.cpp
+++ b/src/engraving/dom/textline.cpp
@@ -145,8 +145,6 @@ TextLine::TextLine(EngravingItem* parent, bool system)
     setEndHookHeight(Spatium(1.5));
     setGapBetweenTextAndLine(Spatium(0.5));
 
-    initElementStyle(&textLineStyle);
-
     resetProperty(Pid::BEGIN_TEXT_PLACE);
     resetProperty(Pid::CONTINUE_TEXT_PLACE);
     resetProperty(Pid::END_TEXT_PLACE);

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -1233,7 +1233,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     styleDef(textLineSystemFlag,                         false),
 
     styleDef(systemTextLineFontFace,                     "Edwin"),
-    styleDef(systemTextLineFontSize,                     12.0),
+    styleDef(systemTextLineFontSize,                     10.0),
     styleDef(systemTextLineFontSpatiumDependent,         true),
     styleDef(systemTextLineFontStyle,                    int(FontStyle::Normal)),
     styleDef(systemTextLineColor,                        PropertyValue::fromValue(Color::BLACK)),

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1727,15 +1727,8 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
                 // Ensure that list-selection results in the same endSegment as range selection
                 endSegment = cr2->nextSegmentAfterCR(SegmentType::ChordRest | SegmentType::EndBarLine | SegmentType::Clef);
             }
-
-            ByteArray a = element->mimeData();
-//printf("<<%s>>\n", a.data());
-            mu::engraving::XmlReader e(a);
-            mu::engraving::Fraction duration;        // dummy
-            PointF dragOffset;
-            mu::engraving::ElementType type = mu::engraving::EngravingItem::readType(e, &dragOffset, &duration);
-            mu::engraving::Spanner* spanner = static_cast<mu::engraving::Spanner*>(engraving::Factory::createItem(type, score->dummy()));
-            rw::RWRegister::reader()->readItem(spanner, e);
+            mu::engraving::Spanner* spanner = static_cast<mu::engraving::Spanner*>(element->clone());
+            spanner->setScore(score);
             spanner->styleChanged();
             if (spanner->isHairpin()) {
                 score->addHairpin(toHairpin(spanner), cr1, cr2);
@@ -1745,7 +1738,9 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
                     startEditElement(frontSegment);
                 }
             } else {
-                score->cmdAddSpanner(spanner, cr1->staffIdx(), startSegment, endSegment, modifiers & Qt::ControlModifier);
+                bool firstStaffOnly = isSystemTextLine(element) && !(modifiers & Qt::ControlModifier);
+                staff_idx_t targetStaff = firstStaffOnly ? 0 : cr1->staffIdx();
+                score->cmdAddSpanner(spanner, targetStaff, startSegment, endSegment, modifiers & Qt::ControlModifier);
             }
             if (spanner->hasVoiceAssignmentProperties()) {
                 spanner->setInitialTrackAndVoiceAssignment(cr1->track());

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -90,32 +90,51 @@ using namespace mu;
 using namespace mu::palette;
 using namespace mu::engraving;
 
-template<typename T> std::shared_ptr<T> makeElement(mu::engraving::Score* score)
-{
-    return std::make_shared<T>(score->dummy());
-}
+// Default wrapper...
+template<class C>
+struct makeElementImplWrapper {
+    template<typename ... Args>
+    static std::shared_ptr<C> makeElementImpl(mu::engraving::Score* score, Args&&... args)
+    {
+        return std::make_shared<C>(score->dummy(), std::forward<Args>(args)...);
+    }
+};
 
-#define MAKE_ELEMENT(T, P) \
+// Specialised wrappers...
+#define IMPL_WRAPPER(T, P) \
     template<> \
-    std::shared_ptr<T> makeElement<T>(mu::engraving::Score * score) { return std::make_shared<T>(P); } \
+    struct makeElementImplWrapper<T> { \
+        template<typename ... Args> \
+        static std::shared_ptr<T> makeElementImpl(mu::engraving::Score * score, Args && ... args) \
+        { \
+            return std::make_shared<T>(P, std::forward<Args>(args)...); \
+        } \
+    }; \
 
-MAKE_ELEMENT(Dynamic, score->dummy()->segment())
-MAKE_ELEMENT(MeasureRepeat, score->dummy()->segment())
-MAKE_ELEMENT(Hairpin, score->dummy()->segment())
-MAKE_ELEMENT(SystemText, score->dummy()->segment())
-MAKE_ELEMENT(TempoText, score->dummy()->segment())
-MAKE_ELEMENT(StaffText, score->dummy()->segment())
-MAKE_ELEMENT(Expression, score->dummy()->segment())
-MAKE_ELEMENT(PlayTechAnnotation, score->dummy()->segment())
-MAKE_ELEMENT(Capo, score->dummy()->segment())
-MAKE_ELEMENT(StringTunings, score->dummy()->segment())
-MAKE_ELEMENT(RehearsalMark, score->dummy()->segment())
+IMPL_WRAPPER(Dynamic, score->dummy()->segment())
+IMPL_WRAPPER(MeasureRepeat, score->dummy()->segment())
+IMPL_WRAPPER(Hairpin, score->dummy()->segment())
+IMPL_WRAPPER(SystemText, score->dummy()->segment())
+IMPL_WRAPPER(TempoText, score->dummy()->segment())
+IMPL_WRAPPER(StaffText, score->dummy()->segment())
+IMPL_WRAPPER(Expression, score->dummy()->segment())
+IMPL_WRAPPER(PlayTechAnnotation, score->dummy()->segment())
+IMPL_WRAPPER(Capo, score->dummy()->segment())
+IMPL_WRAPPER(StringTunings, score->dummy()->segment())
+IMPL_WRAPPER(RehearsalMark, score->dummy()->segment())
 
-MAKE_ELEMENT(Jump, score->dummy()->measure())
-MAKE_ELEMENT(MeasureNumber, score->dummy()->measure())
+IMPL_WRAPPER(Jump, score->dummy()->measure())
+IMPL_WRAPPER(MeasureNumber, score->dummy()->measure())
 
-MAKE_ELEMENT(Fingering, score->dummy()->note())
-MAKE_ELEMENT(NoteHead, score->dummy()->note())
+IMPL_WRAPPER(Fingering, score->dummy()->note())
+IMPL_WRAPPER(NoteHead, score->dummy()->note())
+
+// Dispatcher method ...
+template<class C, typename ... Args>
+std::shared_ptr<C> makeElement(mu::engraving::Score* score, Args&&... args)
+{
+    return makeElementImplWrapper<C>::makeElementImpl(score, std::forward<Args>(args)...);
+}
 
 PaletteTreePtr PaletteCreator::newMasterPaletteTree()
 {
@@ -1274,8 +1293,7 @@ PalettePtr PaletteCreator::newLinesPalette(bool defaultPalette)
     staffTextLine->setEndHookType(HookType::HOOK_90);
     sp->appendElement(staffTextLine, QT_TRANSLATE_NOOP("palette", "Staff text line"));
 
-    auto systemTextLine = makeElement<TextLine>(gpaletteScore);
-    systemTextLine->setSystemFlag(true);
+    auto systemTextLine = makeElement<TextLine>(gpaletteScore, true);
     systemTextLine->setLen(w * 1.5);
     systemTextLine->setBeginText(u"System");
     systemTextLine->setEndHookType(HookType::HOOK_90);
@@ -1509,8 +1527,7 @@ PalettePtr PaletteCreator::newTextPalette(bool defaultPalette)
     stxt->setXmlText(QT_TRANSLATE_NOOP("palette", "System text"));
     sp->appendElement(stxt, QT_TRANSLATE_NOOP("palette", "System text"))->setElementTranslated(true);
 
-    auto systemTextLine = makeElement<TextLine>(gpaletteScore);
-    systemTextLine->setSystemFlag(true);
+    auto systemTextLine = makeElement<TextLine>(gpaletteScore, true);
     systemTextLine->setLen(w * 1.5);
     systemTextLine->setBeginText(u"System");
     systemTextLine->setEndHookType(HookType::HOOK_90);


### PR DESCRIPTION
Resolves: #22811

While working on this issue I noticed that system text lines added to _list selections_ and system text lines added to _range selections_ had different font sizes. This is because, in the range case, the spanner was being initialised without the "system flag" and was being treated as a regular text line. This PR ensures that we use identical initialisations in both cases.

Additionally, the decision was made to change our default `systemTextLineFontSize` to 10pt, bringing it in-line with `systemTextFontSize`. Whether these _should_ be different styles at all is a question for another day (somewhat related to #14238).