### PR TITLE
Fix #22859: Open Settings page by default when navigating to DevTools

### DIFF
--- a/src/appshell/qml/DevTools/DevToolsPage.qml
+++ b/src/appshell/qml/DevTools/DevToolsPage.qml
@@ -92,7 +92,7 @@ DockPage {
         }
     ]
 
-    central: extensionsComp
+    central: settingsComp
 
     Component {
         id: settingsComp


### PR DESCRIPTION
Resolves: #22859