### PR TITLE
Fix lyrics jumps when editing

### DIFF
--- a/src/engraving/rendering/dev/lyricslayout.cpp
+++ b/src/engraving/rendering/dev/lyricslayout.cpp
@@ -195,7 +195,6 @@ void LyricsLayout::layout(Lyrics* item, LayoutContext& ctx)
     }
 
     ldata->setPosX(x);
-    item->setYRelativeToStaff(0.0);
 
     if (item->ticks().isNotZero()) {
         // set melisma end


### PR DESCRIPTION
Resolves: #22856 

The issue mentions other problems but doesn't give clear steps to reproduce. This PR fixes the jumps reported there. There has been some big work on lyrics, so it's good to keep an eye on them in general @DmitryArefiev 