### PR TITLE
style: unify checks for empty strings

### DIFF
--- a/src/engraving/dom/chordlist.cpp
+++ b/src/engraving/dom/chordlist.cpp
@@ -489,7 +489,7 @@ void ParsedChord::correctXmlText(const String& s)
 {
     String xmlText = m_xmlText;
     xmlText.remove(std::regex("[0-9]"));
-    if (s != "") {
+    if (!s.empty()) {
         size_t pos = xmlText.lastIndexOf(u')');
         if (pos == muse::nidx) {
             pos = xmlText.size();
@@ -546,7 +546,7 @@ bool ParsedChord::parse(const String& s, const ChordList* cl, bool syntaxOnly, b
     }
     // quality and first modifier ran together with no separation - eg, mima7, augadd
     // keep quality portion, reset index to read modifier portion later
-    if (initial != "" && initial != tok1 && tok1L != "tristan" && tok1L != "omit") {
+    if (!initial.empty() && initial != tok1 && tok1L != "tristan" && tok1L != "omit") {
         i -= (tok1.size() - initial.size());
         tok1 = initial;
         tok1L = initial.toLower();
@@ -589,7 +589,7 @@ bool ParsedChord::parse(const String& s, const ChordList* cl, bool syntaxOnly, b
         if (!syntaxOnly) {
             m_chord = HChord(u"C Eb Gb Bb");
         }
-    } else if (tok1L == "") {
+    } else if (tok1L.empty()) {
         // empty quality - this will turn out to be major or dominant (or minor if preferMinor)
         m_quality = u"";
         if (!syntaxOnly) {
@@ -613,7 +613,7 @@ bool ParsedChord::parse(const String& s, const ChordList* cl, bool syntaxOnly, b
         tok1 = u"";
         tok1L = u"";
     }
-    if (tok1 != "") {
+    if (!tok1.empty()) {
         addToken(tok1, ChordTokenClass::QUALITY);
     }
     if (!syntaxOnly) {
@@ -641,7 +641,7 @@ bool ParsedChord::parse(const String& s, const ChordList* cl, bool syntaxOnly, b
         tok1.append(s.at(i));
     }
     m_extension = tok1;
-    if (m_quality == "") {
+    if (m_quality.empty()) {
         if (m_extension == "7" || m_extension == "9" || m_extension == "11" || m_extension == "13") {
             m_quality = preferMinor ? u"minor" : u"dominant";
             if (!syntaxOnly) {
@@ -663,7 +663,7 @@ bool ParsedChord::parse(const String& s, const ChordList* cl, bool syntaxOnly, b
             take13 = true;
         }
     }
-    if (tok1 != "") {
+    if (!tok1.empty()) {
         addToken(tok1, ChordTokenClass::EXTENSION);
     }
     if (!syntaxOnly) {
@@ -807,10 +807,10 @@ bool ParsedChord::parse(const String& s, const ChordList* cl, bool syntaxOnly, b
         }
         // if we reached the end of the string and never got a token,
         // then nothing to do, and no sense in looking for a second token
-        if (i == len && tok1 == "") {
+        if (i == len && tok1.empty()) {
             break;
         }
-        if (initial != "" && initial != tok1) {
+        if (!initial.empty() && initial != tok1) {
             // two modifiers ran together with no separation - eg, susb9
             // keep first, reset index to read second later
             i -= (tok1.size() - initial.size());
@@ -857,9 +857,9 @@ bool ParsedChord::parse(const String& s, const ChordList* cl, bool syntaxOnly, b
             tok1L = u"major";
         } else if (tok1L == "omit") {
             tok1L = u"no";
-        } else if (tok1L == "sus" && tok2L == "") {
+        } else if (tok1L == "sus" && tok2L.empty()) {
             tok2L = u"4";
-        } else if (m_augmented.contains(tok1L) && tok2L == "") {
+        } else if (m_augmented.contains(tok1L) && tok2L.empty()) {
             if (m_quality == "dominant" && m_extension == "7") {
                 m_quality = u"augmented";
                 if (!syntaxOnly) {
@@ -884,7 +884,7 @@ bool ParsedChord::parse(const String& s, const ChordList* cl, bool syntaxOnly, b
                 m_chord += 6;
             }
             tok1L = u"";
-        } else if ((m_lower.contains(tok1L) || m_raise.contains(tok1L)) && tok2L == "") {
+        } else if ((m_lower.contains(tok1L) || m_raise.contains(tok1L)) && tok2L.empty()) {
             // trailing alteration - treat as applying to extension (and convert to modifier)
             // this handles C5b, C9#, etc
             tok2L = m_extension;
@@ -912,18 +912,18 @@ bool ParsedChord::parse(const String& s, const ChordList* cl, bool syntaxOnly, b
             tok1L = u"#";
         }
         String m = tok1L + tok2L;
-        if (m != "") {
+        if (!m.empty()) {
             m_modifierList << m;
         }
-        if (tok1 != "") {
+        if (!tok1.empty()) {
             addToken(tok1, ChordTokenClass::MODIFIER);
         }
-        if (tok2 != "") {
+        if (!tok2.empty()) {
             addToken(tok2, ChordTokenClass::MODIFIER);
         }
         if (!syntaxOnly) {
             int d;
-            if (tok2L == "") {
+            if (tok2L.empty()) {
                 d = 0;
             } else {
                 d = tok2L.toInt();
@@ -936,7 +936,7 @@ bool ParsedChord::parse(const String& s, const ChordList* cl, bool syntaxOnly, b
             if (tok1L == "add") {
                 if (d) {
                     hdl.push_back(HDegree(d, 0, HDegreeType::ADD));
-                } else if (tok2L != "") {
+                } else if (!tok2L.empty()) {
                     // this was result of addPending
                     // alteration; tok1 = alter, tok2 = value
                     d = tok2.toInt();
@@ -979,7 +979,7 @@ bool ParsedChord::parse(const String& s, const ChordList* cl, bool syntaxOnly, b
                     // in export, we will set the degree text to null
                     m_xmlText = m_extension + m_xmlText;
                     degree = u"";
-                } else if (m_extension != "") {
+                } else if (!m_extension.empty()) {
                     degree = u"add" + m_extension;
                 }
                 if (m_extension == u"13") {
@@ -1071,7 +1071,7 @@ bool ParsedChord::parse(const String& s, const ChordList* cl, bool syntaxOnly, b
                 } else {
                     hdl.push_back(HDegree(d, 0, HDegreeType::ADD));
                 }
-            } else if (tok1L == "" && tok2L != "") {
+            } else if (tok1L.empty() && !tok2L.empty()) {
                 degree = u"add" + tok2L;
                 hdl.push_back(HDegree(d, 0, HDegreeType::ADD));
             } else if (m_lower.contains(tok1L)) {
@@ -1080,7 +1080,7 @@ bool ParsedChord::parse(const String& s, const ChordList* cl, bool syntaxOnly, b
             } else if (m_raise.contains(tok1L)) {
                 tok1L = u"#";
                 alter = true;
-            } else if (tok1L == "") {
+            } else if (tok1L.empty()) {
                 // token was already handled fully
             } else {
                 m_understandable = false;
@@ -1112,7 +1112,7 @@ bool ParsedChord::parse(const String& s, const ChordList* cl, bool syntaxOnly, b
                     hdl.push_back(HDegree(d, -1, HDegreeType::ADD));
                 }
             }
-            if (degree != "") {
+            if (!degree.empty()) {
                 m_xmlDegrees << degree;
             }
         }
@@ -1296,7 +1296,7 @@ String ParsedChord::fromXml(const String& rawKind, const String& rawKindText, co
             extension = 69;
             mod = u"";
         }
-        if (mod != "") {
+        if (!mod.empty()) {
             m_modifierList << mod;
         }
     }
@@ -1320,7 +1320,7 @@ String ParsedChord::fromXml(const String& rawKind, const String& rawKindText, co
     // force parens where necessary)
     if (!parens && extension == 0 && !m_modifierList.empty()) {
         String firstMod = m_modifierList.front();
-        if (firstMod != "" && (firstMod.startsWith(u'#') || firstMod.startsWith(u'b'))) {
+        if (!firstMod.empty() && (firstMod.startsWith(u'#') || firstMod.startsWith(u'b'))) {
             parens = true;
         }
     }
@@ -1331,7 +1331,7 @@ String ParsedChord::fromXml(const String& rawKind, const String& rawKindText, co
     }
 
     // validate kindText
-    if (kindText != "" && kind != "none" && kind != "other") {
+    if (!kindText.empty() && kind != "none" && kind != "other") {
         ParsedChord validate;
         validate.parse(kindText, cl, false);
         // kindText should parse to produce same kind, no degrees
@@ -1342,8 +1342,8 @@ String ParsedChord::fromXml(const String& rawKind, const String& rawKindText, co
 
     // construct name & handle
     m_name = u"";
-    if (kindText != "") {
-        if (m_extension != "" && kind.contains(u"suspended")) {
+    if (!kindText.empty()) {
+        if (!m_extension.empty() && kind.contains(u"suspended")) {
             m_name += m_extension;
         }
         m_name += kindText;
@@ -1373,9 +1373,9 @@ String ParsedChord::fromXml(const String& rawKind, const String& rawKindText, co
     }
     for (String mod : m_modifierList) {
         mod.replace(u"major", u"maj");
-        if (kindText != "" && kind.contains(u"suspended") && mod.startsWith(u"sus")) {
+        if (!kindText.empty() && kind.contains(u"suspended") && mod.startsWith(u"sus")) {
             continue;
-        } else if (kindText != "" && kind == "major-minor" && mod.startsWith(u"maj")) {
+        } else if (!kindText.empty() && kind == "major-minor" && mod.startsWith(u"maj")) {
             continue;
         }
         m_name += mod;
@@ -1506,7 +1506,7 @@ const std::list<RenderAction>& ParsedChord::renderList(const ChordList* cl)
 
 void ParsedChord::addToken(String s, ChordTokenClass tc)
 {
-    if (s == "") {
+    if (s.empty()) {
         return;
     }
     ChordToken tok;
@@ -1570,7 +1570,7 @@ void ChordDescription::complete(ParsedChord* pc, const ChordList* cl)
         renderList = pc->renderList(cl);
         renderListGenerated = true;
     }
-    if (xmlKind == "") {
+    if (xmlKind.empty()) {
         xmlKind = pc->xmlKind();
         xmlDegrees = pc->xmlDegrees();
     }

--- a/src/engraving/dom/harmony.cpp
+++ b/src/engraving/dom/harmony.cpp
@@ -72,7 +72,7 @@ String Harmony::harmonyName() const
         r = m_function;
     }
 
-    if (m_textName != "") {
+    if (!m_textName.empty()) {
         e = m_textName;
         if (m_harmonyType != HarmonyType::ROMAN) {
             e.remove(u'=');
@@ -274,7 +274,7 @@ void Harmony::afterRead()
             // and we will generate a new one if necessary
             getDescription(m_textName);
         }
-    } else if (m_textName == "") {
+    } else if (m_textName.empty()) {
         // unrecognized chords prior to 2.0 were stored as text with markup
         // we need to strip away the markup
         // this removes any user-applied formatting,
@@ -397,7 +397,7 @@ static int convertNote(const String& s, NoteSpellingType noteSpelling, NoteCaseT
         3, 10, 17, 24, 31,      // A
         5, 12, 19, 26, 33,      // B
     };
-    if (s == "") {
+    if (s.empty()) {
         return Tpc::TPC_INVALID;
     }
     noteCase = s.at(0).isLower() ? NoteCaseType::LOWER : NoteCaseType::CAPITAL;
@@ -423,7 +423,7 @@ static int convertNote(const String& s, NoteSpellingType noteSpelling, NoteCaseT
     int alter = 0;
     size_t n = s.size();
     String acc = s.right(n - acci);
-    if (acc != "") {
+    if (!acc.empty()) {
         if (acc.startsWith(u"bb")) {
             alter = -2;
             idx += 2;
@@ -1161,7 +1161,7 @@ const ChordDescription* Harmony::getDescription()
     const ChordDescription* cd = descr();
     if (cd && !cd->names.empty()) {
         m_textName = cd->names.front();
-    } else if (m_textName != "") {
+    } else if (!m_textName.empty()) {
         cd = generateDescription();
         m_id = cd->id;
     }
@@ -1435,7 +1435,7 @@ void Harmony::render(const std::list<RenderAction>& renderList, double& x, doubl
             if (tpc == Tpc::TPC_B_B && noteSpelling == NoteSpellingType::GERMAN) {
                 context = u"german_B";
             }
-            if (acc != "") {
+            if (!acc.empty()) {
                 TextSegment* ts = new TextSegment(m_fontList[fontIdx], x, y);
                 String lookup = context + acc;
                 ChordSymbol cs = chordList->symbol(lookup);

--- a/src/engraving/style/style.cpp
+++ b/src/engraving/style/style.cpp
@@ -362,13 +362,13 @@ void MStyle::read(XmlReader& e, compat::ReadChordListHook* readChordListHook)
         } else if (tag == "pedalText" && m_version < 420) {
             // Ignore old default
             String pedText = e.readText();
-            if (pedText != "") {
+            if (!pedText.empty()) {
                 set(Sid::pedalText, pedText);
             }
         } else if (tag == "pedalContinueText" && m_version < 420 && e.readAsciiText() == "") {
             // Ignore old default
             String pedContText = e.readText();
-            if (pedContText != "") {
+            if (!pedContText.empty()) {
                 set(Sid::pedalText, pedContText);
             }
         } else if ((tag == "slurEndWidth"

--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -968,7 +968,7 @@ static void glissando(const Glissando* gli, int number, bool start, Notations& n
         tagName += ExportMusicXml::positioningAttributes(gli, start);
     }
     notations.tag(xml, gli);
-    if (start && gli->showText() && gli->text() != "") {
+    if (start && gli->showText() && !gli->text().empty()) {
         xml.tagRaw(tagName, gli->text());
     } else {
         xml.tagRaw(tagName);
@@ -2827,7 +2827,7 @@ static void writeAccidental(XmlWriter& xml, const String& tagName, const Acciden
 {
     if (acc) {
         String s = accidentalType2MxmlString(acc->accidentalType());
-        if (s != "") {
+        if (!s.empty()) {
             XmlWriter::Attributes attrs;
             if (s == "other") {
                 attrs = { { "smufl", accidentalType2SmuflMxmlString(acc->accidentalType()) } };
@@ -3335,7 +3335,7 @@ static void writeChordLines(const Chord* const chord, XmlWriter& xml, Notations&
             default:
                 LOGD("unknown ChordLine subtype %d", int(cl->chordLineType()));
             }
-            if (subtype != "") {
+            if (!subtype.empty()) {
                 notations.tag(xml, e);
                 articulations.tag(xml);
                 xml.tagRaw(subtype);
@@ -3476,7 +3476,7 @@ void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technic
         SymId sid = a->symId();
         String mxmlOrnam = symIdToOrnam(sid);
 
-        if (mxmlOrnam != "") {
+        if (!mxmlOrnam.empty()) {
             String placement;
 
             if (!a->isStyled(Pid::ARTICULATION_ANCHOR) && a->anchor() != ArticulationAnchor::AUTO) {
@@ -3529,20 +3529,20 @@ void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technic
         */
 
         String mxmlTechn = symIdToTechn(sid);
-        if (mxmlTechn != "") {
+        if (!mxmlTechn.empty()) {
             notations.tag(m_xml, a);
             technical.tag(m_xml);
             mxmlTechn += color2xml(a);
             mxmlTechn += ExportMusicXml::positioningAttributes(a);
             if (sid == SymId::stringsHarmonic) {
-                if (placement != "") {
+                if (!placement.empty()) {
                     attr += String(u" placement=\"%1\"").arg(placement);
                 }
                 m_xml.startElementRaw(mxmlTechn + attr);
                 m_xml.tag("natural");
                 m_xml.endElement();
             } else {
-                if (placement != "") {
+                if (!placement.empty()) {
                     attr += String(u" placement=\"%1\"").arg(placement);
                 }
                 m_xml.tagRaw(mxmlTechn + attr);
@@ -5413,7 +5413,7 @@ void ExportMusicXml::ottava(Ottava const* const ot, staff_idx_t staff, const Fra
         }
     }
 
-    if (octaveShiftXml != "") {
+    if (!octaveShiftXml.empty()) {
         directionTag(m_xml, m_attr, ot);
         m_xml.startElement("direction-type");
         octaveShiftXml += color2xml(ot);
@@ -5669,7 +5669,7 @@ void ExportMusicXml::dynamic(Dynamic const* const dyn, staff_idx_t staff)
 
     if (muse::contains(set, dynTypeName) && !hasCustomText) {
         m_xml.tagRaw(dynTypeName);
-    } else if (dynTypeName != "") {
+    } else if (!dynTypeName.empty()) {
         static std::map<ushort, Char> map = {
             { 0xE520, u'p' },
             { 0xE521, u'm' },
@@ -5902,19 +5902,19 @@ static void directionJump(XmlWriter& xml, const Jump* const jp)
         }
     }
 
-    if (sound != "") {
+    if (!sound.empty()) {
         xml.startElement("direction", { { "placement", (jp->placement() == PlacementV::BELOW) ? "below" : "above" } });
         xml.startElement("direction-type");
         String attrs = color2xml(jp);
         attrs += ExportMusicXml::positioningAttributes(jp);
-        if (type != "") {
+        if (!type.empty()) {
             xml.tagRaw(type + attrs);
         }
-        if (words != "") {
+        if (!words.empty()) {
             xml.tagRaw(u"words" + attrs, words);
         }
         xml.endElement();
-        if (sound != "") {
+        if (!sound.empty()) {
             xml.tagRaw(u"sound " + sound);
         }
         xml.endElement();
@@ -6020,7 +6020,7 @@ static void directionMarker(XmlWriter& xml, const Marker* const m, const std::ve
             words = m->xmlText();
         }
         const String codaLabel = findCodaLabel(jumps, m->label());
-        if (codaLabel == "") {
+        if (codaLabel.empty()) {
             sound = u"tocoda=\"1\"";
         } else {
             sound = u"tocoda=\"" + codaLabel + u"\"";
@@ -6443,14 +6443,14 @@ static void writeMusicXML(const FiguredBassItem* item, XmlWriter& xml, bool isOr
     // by the user, rather than automatically by the "duration" extend method.
     if (isOriginalFigure) {
         String strPrefix = Modifier2MusicXML(item->prefix());
-        if (strPrefix != "") {
+        if (!strPrefix.empty()) {
             xml.tag("prefix", strPrefix);
         }
         if (item->digit() != FBIDigitNone) {
             xml.tag("figure-number", item->digit());
         }
         String strSuffix = Modifier2MusicXML(item->suffix());
-        if (strSuffix != "") {
+        if (!strSuffix.empty()) {
             xml.tag("suffix", strSuffix);
         }
 
@@ -6460,7 +6460,7 @@ static void writeMusicXML(const FiguredBassItem* item, XmlWriter& xml, bool isOr
             if (item->contLine() == FiguredBassItem::ContLine::SIMPLE) {
                 xml.tag("extend", { { "type", "stop" } });
             } else if (item->contLine() == FiguredBassItem::ContLine::EXTENDED) {
-                bool hasFigure = (strPrefix != "" || item->digit() != FBIDigitNone || strSuffix != "");
+                bool hasFigure = (!strPrefix.empty() || item->digit() != FBIDigitNone || !strSuffix.empty());
                 if (hasFigure) {
                     xml.tag("extend", { { "type", "start" } });
                 } else {
@@ -7060,7 +7060,7 @@ void ExportMusicXml::print(const Measure* const m, const int partNr, const int f
         }
     }
 
-    bool doBreak = mpc.scoreStart || (newSystemOrPage != "");
+    bool doBreak = mpc.scoreStart || (!newSystemOrPage.empty());
     bool doLayout = configuration()->musicxmlExportLayout();
 
     if (doBreak) {
@@ -7127,7 +7127,7 @@ void ExportMusicXml::print(const Measure* const m, const int partNr, const int f
             }
 
             m_xml.endElement();
-        } else if (newSystemOrPage != "") {
+        } else if (!newSystemOrPage.empty()) {
             m_xml.tagRaw(String(u"print%1").arg(newSystemOrPage));
         }
     }

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -1546,7 +1546,7 @@ void MusicXMLParserPass1::credit(CreditWordsList& credits)
             skipLogCurrElem();
         }
     }
-    if (crwords != "") {
+    if (!crwords.empty()) {
         // as the meaning of multiple credit-types is undocumented,
         // use credit-type only if exactly one was found
         String crtype = (crtypes.size() == 1) ? crtypes.at(0) : String();
@@ -2966,7 +2966,7 @@ void MusicXMLParserPass1::directionType(const Fraction cTime,
         if (m_e.name() == "octave-shift") {
             String number = m_e.attribute("number");
             int n = 0;
-            if (number != "") {
+            if (!number.empty()) {
                 n = number.toInt();
                 if (n <= 0) {
                     m_logger->logError(String(u"invalid number %1").arg(number), &m_e);
@@ -3555,7 +3555,7 @@ void MusicXMLParserPass1::note(const String& partId,
     // keep in this order as checkTiming() might change dura
     String errorStr = mnd.checkTiming(type, bRest, grace);
     dura = mnd.duration();
-    if (errorStr != "") {
+    if (!errorStr.empty()) {
         m_logger->logError(errorStr, &m_e);
     }
 

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -1075,10 +1075,10 @@ static void addArticulationToChord(const Notation& notation, ChordRest* cr)
 
     // when setting anchor, assume type up/down without explicit placement
     // implies placement above/below
-    if (place == "above" || (dir == "up" && place == "")) {
+    if (place == "above" || (dir == "up" && place.empty())) {
         na->setAnchor(ArticulationAnchor::TOP);
         na->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
-    } else if (place == "below" || (dir == "down" && place == "")) {
+    } else if (place == "below" || (dir == "down" && place.empty())) {
         na->setAnchor(ArticulationAnchor::BOTTOM);
         na->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
     }
@@ -1139,27 +1139,27 @@ static void addMordentToChord(const Notation& notation, ChordRest* cr)
     const String attrDep = notation.attribute(u"departure");
     SymId articSym = SymId::noSym;   // legal but impossible ArticulationType value here indicating "not found"
     if (name == "inverted-mordent") {
-        if ((attrLong == "" || attrLong == "no") && attrAppr == "" && attrDep == "") {
+        if ((attrLong.empty() || attrLong == "no") && attrAppr.empty() && attrDep.empty()) {
             articSym = SymId::ornamentShortTrill;
-        } else if (attrLong == "yes" && attrAppr == "" && attrDep == "") {
+        } else if (attrLong == "yes" && attrAppr.empty() && attrDep.empty()) {
             articSym = SymId::ornamentTremblement;
-        } else if (attrLong == "yes" && attrAppr == "below" && attrDep == "") {
+        } else if (attrLong == "yes" && attrAppr == "below" && attrDep.empty()) {
             articSym = SymId::ornamentUpPrall;
-        } else if (attrLong == "yes" && attrAppr == "above" && attrDep == "") {
+        } else if (attrLong == "yes" && attrAppr == "above" && attrDep.empty()) {
             articSym = SymId::ornamentPrecompMordentUpperPrefix;
-        } else if (attrLong == "yes" && attrAppr == "" && attrDep == "below") {
+        } else if (attrLong == "yes" && attrAppr.empty() && attrDep == "below") {
             articSym = SymId::ornamentPrallDown;
-        } else if (attrLong == "yes" && attrAppr == "" && attrDep == "above") {
+        } else if (attrLong == "yes" && attrAppr.empty() && attrDep == "above") {
             articSym = SymId::ornamentPrallUp;
         }
     } else if (name == "mordent") {
-        if ((attrLong == "" || attrLong == "no") && attrAppr == "" && attrDep == "") {
+        if ((attrLong.empty() || attrLong == "no") && attrAppr.empty() && attrDep.empty()) {
             articSym = SymId::ornamentMordent;
-        } else if (attrLong == "yes" && attrAppr == "" && attrDep == "") {
+        } else if (attrLong == "yes" && attrAppr.empty() && attrDep.empty()) {
             articSym = SymId::ornamentPrallMordent;
-        } else if (attrLong == "yes" && attrAppr == "below" && attrDep == "") {
+        } else if (attrLong == "yes" && attrAppr == "below" && attrDep.empty()) {
             articSym = SymId::ornamentUpMordent;
-        } else if (attrLong == "yes" && attrAppr == "above" && attrDep == "") {
+        } else if (attrLong == "yes" && attrAppr == "above" && attrDep.empty()) {
             articSym = SymId::ornamentDownMordent;
         }
     }
@@ -2740,7 +2740,7 @@ void MusicXMLParserPass2::staffDetails(const String& partId, Measure* measure)
 
     String strNumber = m_e.attribute("number");
     int n = 0;  // default
-    if (strNumber != "") {
+    if (!strNumber.empty()) {
         n = m_pass1.getMusicXmlPart(partId).staffNumberToIndex(strNumber.toInt());
         if (n < 0 || n >= int(staves)) {
             m_logger->logError(String(u"invalid staff-details number %1 (may be hidden)").arg(strNumber), &m_e);
@@ -2962,7 +2962,7 @@ void MusicXMLDelayedDirectionElement::addElem()
 
 String MusicXMLParserDirection::placement() const
 {
-    if (m_placement == "" && hasTotalY()) {
+    if (m_placement.empty() && hasTotalY()) {
         return totalY() < 0 ? u"above" : u"below";
     } else {
         return m_placement;
@@ -3096,7 +3096,7 @@ void MusicXMLParserDirection::direction(const String& partId,
         } else {
             addElemOffset(sticking, track, placement(), measure, tick + m_offset);
         }
-    } else if (m_wordsText != "" || m_rehearsalText != "" || m_metroText != "") {
+    } else if (!m_wordsText.empty() || !m_rehearsalText.empty() || !m_metroText.empty()) {
         TextBase* t = 0;
         if (m_tpoSound > 0.1) {
             if (canAddTempoText(m_score->tempomap(), tick.ticks())) {
@@ -3114,7 +3114,7 @@ void MusicXMLParserDirection::direction(const String& partId,
                 m_score->setTempo(tick, m_tpoSound);
             }
         } else {
-            if (m_wordsText != "" || m_metroText != "") {
+            if (!m_wordsText.empty() || !m_metroText.empty()) {
                 isExpressionText = m_wordsText.contains(u"<i>") && m_metroText.empty() && placement() == u"below";
                 if (isExpressionText) {
                     t = Factory::createExpression(m_score->dummy()->segment());
@@ -3483,7 +3483,7 @@ void MusicXMLParserDirection::directionType(std::vector<MusicXmlSpannerDesc>& st
             m_wordsText += nextPart;
         } else if (m_e.name() == "rehearsal") {
             m_enclosure      = m_e.attribute("enclosure");
-            if (m_enclosure == "") {
+            if (m_enclosure.empty()) {
                 m_enclosure = u"square";          // note different default
             }
             m_rehearsalText += xmlpass2::nextPartOfFormattedString(m_e);
@@ -4273,7 +4273,7 @@ void MusicXMLParserDirection::bracket(const String& type, const int number,
                 sline->setSystemFlag(m_systemDirection);
             }
             TextLine* textLine = toTextLine(sline);
-            // if (placement == "") placement = "above";  // TODO ? set default
+            // if (placement.empty()) placement = "above";  // TODO ? set default
 
             textLine->setBeginHookType(lineEnd != "none" ? HookType::HOOK_90 : HookType::NONE);
             if (lineEnd == "up") {
@@ -4343,7 +4343,7 @@ void MusicXMLParserDirection::dashes(const String& type, const int number,
     const MusicXmlExtendedSpannerDesc& spdesc = m_pass2.getSpanner({ ElementType::HAIRPIN, number });
     if (type == u"start") {
         TextLine* b = spdesc.isStopped ? toTextLine(spdesc.sp) : Factory::createTextLine(m_score->dummy());
-        // if (placement == "") placement = "above";  // TODO ? set default
+        // if (placement.empty()) placement = "above";  // TODO ? set default
 
         // hack: combine with a previous words element
         if (!m_wordsText.empty()) {
@@ -4386,7 +4386,7 @@ void MusicXMLParserDirection::octaveShift(const String& type, const int number,
         } else {
             Ottava* o = spdesc.isStopped ? toOttava(spdesc.sp) : Factory::createOttava(m_score->dummy());
 
-            // if (placement == "") placement = "above";  // TODO ? set default
+            // if (placement.empty()) placement = "above";  // TODO ? set default
 
             if (type == u"down" && ottavasize == 8) {
                 o->setOttavaType(OttavaType::OTTAVA_8VA);
@@ -4724,7 +4724,7 @@ String MusicXMLParserDirection::metronome(double& r)
         tempoText += u" = ";
         tempoText += perMinute;
     }
-    if (dur1.isValid() && !dur2.isValid() && perMinute != "") {
+    if (dur1.isValid() && !dur2.isValid() && !perMinute.empty()) {
         bool ok;
         double d = perMinute.toDouble(&ok);
         if (ok) {
@@ -5118,7 +5118,7 @@ void MusicXMLParserPass2::key(const String& partId, Measure* measure, const Frac
 {
     String strKeyno = m_e.attribute("number");
     int keyno = -1;   // assume no number (see below)
-    if (strKeyno != "") {
+    if (!strKeyno.empty()) {
         keyno = m_pass1.getMusicXmlPart(partId).staffNumberToIndex(strKeyno.toInt());
         if (keyno < 0) {
             // conversion error (-1), assume staff 0
@@ -5320,7 +5320,7 @@ void MusicXMLParserPass2::clef(const String& partId, Measure* measure, const Fra
     // - single staff
     // - multi-staff with same clef
     int clefno = 0;   // default
-    if (strClefno != "") {
+    if (!strClefno.empty()) {
         clefno = m_pass1.getMusicXmlPart(partId).staffNumberToIndex(strClefno.toInt());
     }
     if (clefno < 0 || clefno >= int(part->nstaves())) {
@@ -6127,7 +6127,7 @@ Note* MusicXMLParserPass2::note(const String& partId,
     // keep in this order as checkTiming() might change dura
     String errorStr = mnd.checkTiming(type, rest, grace);
     dura = mnd.duration();
-    if (errorStr != "") {
+    if (!errorStr.empty()) {
         m_logger->logError(errorStr, &m_e);
     }
 
@@ -7129,7 +7129,7 @@ void MusicXMLParserLyric::parse()
     }
 
     // if no lyric read (e.g. only 'extend "type=stop"'), no further action required
-    if (formattedText == "") {
+    if (formattedText.empty()) {
         return;
     }
 
@@ -7167,7 +7167,7 @@ void MusicXMLParserLyric::parse()
     m_numberedLyrics[lyricNo] = l;
 
     if (hasExtend
-        && (extendType == "" || extendType == "start")
+        && (extendType.empty() || extendType == "start")
         && (l->syllabic() == LyricsSyllabic::SINGLE || l->syllabic() == LyricsSyllabic::END)) {
         m_extendedLyrics.insert(l);
     }
@@ -7607,7 +7607,7 @@ void MusicXMLParserNotations::addTechnical(const Notation& notation, Note* note)
 void MusicXMLParserNotations::arpeggio()
 {
     m_arpeggioType = m_e.attribute("direction");
-    if (m_arpeggioType == "") {
+    if (m_arpeggioType.empty()) {
         m_arpeggioType = u"none";
     }
     m_arpeggioNo = m_e.intAttribute("number");
@@ -8024,7 +8024,7 @@ MusicXMLParserNotations::MusicXMLParserNotations(XmlStreamReader& e, Score* scor
 
 void MusicXMLParserNotations::addError(const String& error)
 {
-    if (error != "") {
+    if (!error.empty()) {
         m_logger->logError(error, &m_e);
         m_errors += error;
     }

--- a/tools/bww2mxml/mxmlwriter.cpp
+++ b/tools/bww2mxml/mxmlwriter.cpp
@@ -244,7 +244,7 @@ void MxmlWriter::note(const QString pitch, QVector<BeamType> beamList,
         default:               s = "";
             break;
         }
-        if (s != "") {
+        if (!s.empty()) {
             out << "        <beam number=\"" << i + 1 << "\">"
                 << s << "</beam>" << Qt::endl;
         } else {


### PR DESCRIPTION
This PR unifies the checks for if a string actually contains something to use the `empty` keyword.