### PR TITLE
ci(macOS): refine brew commands

### DIFF
--- a/buildscripts/ci/macos/setup.sh
+++ b/buildscripts/ci/macos/setup.sh
@@ -91,9 +91,9 @@ installBottleManually libsndfile
 
 # fixing install python 3.9 error (it is a dependency for ninja)
 rm '/usr/local/bin/2to3'
-brew install ninja pkg-config
+brew install ninja pkg-config --quiet
 
-brew install cmake
+brew install cmake --formula --quiet
 
 # Qt
 


### PR DESCRIPTION
This PR improves the macOS setup script to silence the following warnings:

<img width="912" alt="image" src="https://github.com/musescore/MuseScore/assets/7693447/d84bccf6-ddea-4da3-9a5c-810919a7a33e">
