### PR TITLE
'Play' property for spanners

### DIFF
--- a/src/engraving/compat/midi/compatmidirender.cpp
+++ b/src/engraving/compat/midi/compatmidirender.cpp
@@ -599,10 +599,8 @@ void CompatMidiRender::renderGlissando(NoteEventList* events, Note* notestart, d
 {
     std::vector<int> empty = {};
     std::vector<int> body;
-    for (Spanner* spanner : notestart->spannerFor()) {
-        if (spanner->type() == ElementType::GLISSANDO
-            && toGlissando(spanner)->playGlissando()
-            && Glissando::pitchSteps(spanner, body)) {
+    for (Spanner* s : notestart->spannerFor()) {
+        if (s->isGlissando() && s->playSpanner() && Glissando::pitchSteps(s, body)) {
             CompatMidiRender::renderNoteArticulation(events, notestart, true, Constants::DIVISION, empty, body, false, true, empty, 16, 0,
                                                      graceOnBeatProportion, tremoloBefore);
         }
@@ -974,7 +972,7 @@ Trill* CompatMidiRender::findFirstTrill(Chord* chord)
             continue;
         }
         Trill* trill = toTrill(i.value);
-        if (!trill->playArticulation()) {
+        if (!trill->playSpanner()) {
             continue;
         }
         return trill;

--- a/src/engraving/compat/midi/compatmidirenderinternal.cpp
+++ b/src/engraving/compat/midi/compatmidirenderinternal.cpp
@@ -1167,7 +1167,7 @@ static Trill* findFirstTrill(Chord* chord)
             continue;
         }
         Trill* trill = toTrill(i.value);
-        if (trill->playArticulation() == false) {
+        if (!trill->playSpanner()) {
             continue;
         }
         return trill;

--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -2695,28 +2695,6 @@ Chord* Chord::nextTiedChord(bool backwards, bool sameSize) const
     return next;   // all notes in this chord are tied to notes in next chord
 }
 
-bool Chord::containsTieEnd() const
-{
-    for (const Note* note : m_notes) {
-        if (note->tieBack() && !note->tieFor()) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-bool Chord::containsTieStart() const
-{
-    for (const Note* note : m_notes) {
-        if (!note->tieBack() && note->tieFor()) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 //---------------------------------------------------------
 //   setNoteType
 //---------------------------------------------------------

--- a/src/engraving/dom/chord.h
+++ b/src/engraving/dom/chord.h
@@ -272,8 +272,6 @@ public:
     void sortNotes();
 
     Chord* nextTiedChord(bool backwards = false, bool sameSize = true) const;
-    bool containsTieEnd() const;
-    bool containsTieStart() const;
 
     Fraction endTickIncludingTied() const;
 

--- a/src/engraving/dom/glissando.cpp
+++ b/src/engraving/dom/glissando.cpp
@@ -86,7 +86,6 @@ EngravingItem* GlissandoSegment::propertyDelegate(Pid pid)
     case Pid::GLISS_SHIFT:
     case Pid::GLISS_EASEIN:
     case Pid::GLISS_EASEOUT:
-    case Pid::PLAY:
     case Pid::FONT_FACE:
     case Pid::FONT_SIZE:
     case Pid::FONT_STYLE:
@@ -110,7 +109,6 @@ Glissando::Glissando(EngravingItem* parent)
     initElementStyle(&glissandoElementStyle);
 
     resetProperty(Pid::GLISS_SHOW_TEXT);
-    resetProperty(Pid::PLAY);
     resetProperty(Pid::GLISS_STYLE);
     resetProperty(Pid::GLISS_SHIFT);
     resetProperty(Pid::GLISS_TYPE);
@@ -131,7 +129,6 @@ Glissando::Glissando(const Glissando& g)
     _easeIn         = g._easeIn;
     _easeOut        = g._easeOut;
     _showText       = g._showText;
-    _playGlissando  = g._playGlissando;
     _fontStyle      = g._fontStyle;
     m_isHarpGliss   = g.m_isHarpGliss;
 }
@@ -191,7 +188,7 @@ bool Glissando::pitchSteps(const Spanner* spanner, std::vector<int>& pitchOffset
         return false;
     }
     const Glissando* glissando = toGlissando(spanner);
-    if (!glissando->playGlissando()) {
+    if (!glissando->playSpanner()) {
         return false;
     }
     GlissandoStyle glissandoStyle = glissando->glissandoStyle();
@@ -466,8 +463,6 @@ PropertyValue Glissando::getProperty(Pid propertyId) const
         return easeIn();
     case Pid::GLISS_EASEOUT:
         return easeOut();
-    case Pid::PLAY:
-        return bool(playGlissando());
     case Pid::FONT_FACE:
         return _fontFace;
     case Pid::FONT_SIZE:
@@ -515,9 +510,6 @@ bool Glissando::setProperty(Pid propertyId, const PropertyValue& v)
     case Pid::GLISS_EASEOUT:
         setEaseOut(v.toInt());
         break;
-    case Pid::PLAY:
-        setPlayGlissando(v.toBool());
-        break;
     case Pid::FONT_FACE:
         setFontFace(v.value<String>());
         break;
@@ -555,8 +547,6 @@ PropertyValue Glissando::propertyDefault(Pid propertyId) const
     case Pid::GLISS_EASEIN:
     case Pid::GLISS_EASEOUT:
         return 0;
-    case Pid::PLAY:
-        return true;
     default:
         break;
     }

--- a/src/engraving/dom/glissando.h
+++ b/src/engraving/dom/glissando.h
@@ -71,7 +71,6 @@ class Glissando final : public SLine
     M_PROPERTY(String, fontFace, setFontFace)
     M_PROPERTY(double, fontSize, setFontSize)
     M_PROPERTY(bool, showText, setShowText)
-    M_PROPERTY(bool, playGlissando, setPlayGlissando)
     M_PROPERTY(FontStyle, fontStyle, setFontStyle)
     M_PROPERTY(int, easeIn, setEaseIn)
     M_PROPERTY(int, easeOut, setEaseOut)

--- a/src/engraving/dom/hairpin.cpp
+++ b/src/engraving/dom/hairpin.cpp
@@ -232,7 +232,6 @@ EngravingItem* HairpinSegment::propertyDelegate(Pid pid)
         || pid == Pid::HAIRPIN_CONT_HEIGHT
         || pid == Pid::DYNAMIC_RANGE
         || pid == Pid::LINE_STYLE
-        || pid == Pid::PLAY
         || pid == Pid::APPLY_TO_VOICE
         || pid == Pid::DIRECTION
         || pid == Pid::CENTER_BETWEEN_STAVES
@@ -500,7 +499,6 @@ Hairpin::Hairpin(Segment* parent)
     m_dynRange              = DynamicRange::PART;
     m_singleNoteDynamics    = true;
     m_veloChangeMethod      = ChangeMethod::NORMAL;
-    m_playHairpin           = true;
 }
 
 int Hairpin::subtype() const
@@ -573,8 +571,6 @@ PropertyValue Hairpin::getProperty(Pid id) const
         return m_singleNoteDynamics;
     case Pid::VELO_CHANGE_METHOD:
         return m_veloChangeMethod;
-    case Pid::PLAY:
-        return m_playHairpin;
     case Pid::APPLY_TO_VOICE:
         return applyToVoice();
     case Pid::CENTER_BETWEEN_STAVES:
@@ -621,9 +617,6 @@ bool Hairpin::setProperty(Pid id, const PropertyValue& v)
         break;
     case Pid::VELO_CHANGE_METHOD:
         m_veloChangeMethod = v.value<ChangeMethod>();
-        break;
-    case Pid::PLAY:
-        setPlayHairpin(v.toBool());
         break;
     case Pid::APPLY_TO_VOICE:
         setApplyToVoice(v.value<VoiceApplication>());
@@ -715,9 +708,6 @@ PropertyValue Hairpin::propertyDefault(Pid id) const
 
     case Pid::PLACEMENT:
         return style().styleV(Sid::hairpinPlacement);
-
-    case Pid::PLAY:
-        return true;
 
     case Pid::APPLY_TO_VOICE:
         return VoiceApplication::ALL_VOICE_IN_INSTRUMENT;

--- a/src/engraving/dom/hairpin.h
+++ b/src/engraving/dom/hairpin.h
@@ -141,9 +141,6 @@ public:
     ChangeMethod veloChangeMethod() const { return m_veloChangeMethod; }
     void setVeloChangeMethod(ChangeMethod val) { m_veloChangeMethod = val; }
 
-    bool playHairpin() const { return m_playHairpin; }
-    void setPlayHairpin(bool val) { m_playHairpin = val; }
-
     bool isCrescendo() const
     {
         return m_hairpinType == HairpinType::CRESC_HAIRPIN || m_hairpinType == HairpinType::CRESC_LINE;
@@ -192,7 +189,6 @@ private:
     DynamicRange m_dynRange = DynamicRange::STAFF;
     bool m_singleNoteDynamics = false;
     ChangeMethod m_veloChangeMethod = ChangeMethod::NORMAL;
-    bool m_playHairpin = false;
 
     Spatium m_hairpinHeight;
     Spatium m_hairpinContHeight;

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -3539,12 +3539,12 @@ EngravingItem* Note::prevSegmentElement()
 //   lastTiedNote
 //---------------------------------------------------------
 
-const Note* Note::lastTiedNote() const
+const Note* Note::lastTiedNote(bool ignorePlayback) const
 {
     std::vector<const Note*> notes;
     const Note* note = this;
     notes.push_back(note);
-    while (note->tieFor()) {
+    while (note->tieFor() && (ignorePlayback || note->tieFor()->playSpanner())) {
         if (std::find(notes.begin(), notes.end(), note->tieFor()->endNote()) != notes.end()) {
             break;
         }
@@ -3563,12 +3563,12 @@ const Note* Note::lastTiedNote() const
 //    - handle recursion in connected notes
 //---------------------------------------------------------
 
-Note* Note::firstTiedNote() const
+Note* Note::firstTiedNote(bool ignorePlayback) const
 {
     std::vector<const Note*> notes;
     const Note* note = this;
     notes.push_back(note);
-    while (note->tieBack()) {
+    while (note->tieBack() && (ignorePlayback || note->tieBack()->playSpanner())) {
         if (std::find(notes.begin(), notes.end(), note->tieBack()->startNote()) != notes.end()) {
             break;
         }

--- a/src/engraving/dom/note.h
+++ b/src/engraving/dom/note.h
@@ -296,9 +296,13 @@ public:
     Tie* tieBack() const { return m_tieBack; }
     void setTieFor(Tie* t) { m_tieFor = t; }
     void setTieBack(Tie* t) { m_tieBack = t; }
-    Note* firstTiedNote() const;
-    const Note* lastTiedNote() const;
-    Note* lastTiedNote() { return const_cast<Note*>(static_cast<const Note*>(this)->lastTiedNote()); }
+    Note* firstTiedNote(bool ignorePlayback = true) const;
+    const Note* lastTiedNote(bool ignorePlayback = true) const;
+    Note* lastTiedNote(bool ignorePlayback = true)
+    {
+        return const_cast<Note*>(static_cast<const Note*>(this)->lastTiedNote(ignorePlayback));
+    }
+
     int unisonIndex() const;
     void disconnectTiedNotes();
     void connectTiedNotes();

--- a/src/engraving/dom/ottava.cpp
+++ b/src/engraving/dom/ottava.cpp
@@ -301,6 +301,11 @@ PropertyValue Ottava::getProperty(Pid propertyId) const
 bool Ottava::setProperty(Pid propertyId, const PropertyValue& val)
 {
     switch (propertyId) {
+    case Pid::PLAY:
+        setPlaySpanner(val.toBool());
+        staff()->updateOttava();
+        break;
+
     case Pid::OTTAVA_TYPE:
         setOttavaType(OttavaType(val.toInt()));
         break;

--- a/src/engraving/dom/repeatlist.cpp
+++ b/src/engraving/dom/repeatlist.cpp
@@ -387,7 +387,7 @@ void RepeatList::collectRepeatListElements()
     // so we will pre-process them into cloned versions that handle those overlaps.
     // This assumes that spanners are ordered from first to last tick-wise
     for (const auto& spannerEntry : m_score->spanner()) {
-        if (!spannerEntry.second->isVolta()) {
+        if (!spannerEntry.second->isVolta() || !spannerEntry.second->playSpanner()) {
             continue;
         }
 

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -436,7 +436,7 @@ void Score::setUpTempoMap()
     if (isMaster()) {
         for (const auto& pair : spanner()) {
             const Spanner* spannerItem = pair.second;
-            if (!spannerItem || !spannerItem->isGradualTempoChange()) {
+            if (!spannerItem || !spannerItem->isGradualTempoChange() || !spannerItem->playSpanner()) {
                 continue;
             }
 

--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -135,6 +135,7 @@ muse::ByteArray SpannerSegment::mimeData(const PointF& dragOffset) const
 EngravingItem* SpannerSegment::propertyDelegate(Pid pid)
 {
     switch (pid) {
+    case Pid::PLAY:
     case Pid::COLOR:
     case Pid::VISIBLE:
     case Pid::PLACEMENT:
@@ -431,6 +432,7 @@ Spanner::Spanner(const ElementType& type, EngravingItem* parent, ElementFlags f)
 Spanner::Spanner(const Spanner& s)
     : EngravingItem(s)
 {
+    m_playSpanner  = s.m_playSpanner;
     m_anchor       = s.m_anchor;
     m_startElement = s.m_startElement;
     m_endElement   = s.m_endElement;
@@ -630,6 +632,8 @@ void Spanner::setScore(Score* s)
 PropertyValue Spanner::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
+    case Pid::PLAY:
+        return m_playSpanner;
     case Pid::SPANNER_TICK:
         return m_tick;
     case Pid::SPANNER_TICKS:
@@ -661,6 +665,9 @@ PropertyValue Spanner::getProperty(Pid propertyId) const
 bool Spanner::setProperty(Pid propertyId, const PropertyValue& v)
 {
     switch (propertyId) {
+    case Pid::PLAY:
+        setPlaySpanner(v.toBool());
+        break;
     case Pid::SPANNER_TICK:
         triggerLayout();           // spanner may have moved to another system
         setTick(v.value<Fraction>());
@@ -716,6 +723,8 @@ bool Spanner::setProperty(Pid propertyId, const PropertyValue& v)
 PropertyValue Spanner::propertyDefault(Pid propertyId) const
 {
     switch (propertyId) {
+    case Pid::PLAY:
+        return true;
     case Pid::ANCHOR:
         return int(Anchor::SEGMENT);
     default:

--- a/src/engraving/dom/spanner.h
+++ b/src/engraving/dom/spanner.h
@@ -180,6 +180,9 @@ public:
     bool broken() const { return m_broken; }
     void setBroken(bool v) { m_broken = v; }
 
+    bool playSpanner() const { return m_playSpanner; }
+    void setPlaySpanner(bool p) { m_playSpanner = p; }
+
     Anchor anchor() const { return m_anchor; }
     void setAnchor(Anchor a) { m_anchor = a; }
 
@@ -276,6 +279,8 @@ private:
 
     EngravingItem* m_startElement = nullptr;
     EngravingItem* m_endElement = nullptr;
+
+    bool m_playSpanner = true;
 
     Anchor m_anchor = Anchor::SEGMENT;
     Fraction m_tick = Fraction(-1, 1);

--- a/src/engraving/dom/staff.cpp
+++ b/src/engraving/dom/staff.cpp
@@ -1259,8 +1259,8 @@ void Staff::updateOttava()
     m_pitchOffsets.clear();
     for (auto i : score()->spanner()) {
         const Spanner* s = i.second;
-        if (s->type() == ElementType::OTTAVA && s->staffIdx() == staffIdx) {
-            const Ottava* o = static_cast<const Ottava*>(s);
+        if (s->isOttava() && s->staffIdx() == staffIdx && s->playSpanner()) {
+            const Ottava* o = toOttava(s);
             m_pitchOffsets.setPitchOffset(o->tick().ticks(), o->pitchShift());
             m_pitchOffsets.setPitchOffset(o->tick2().ticks(), 0);
         }

--- a/src/engraving/dom/trill.cpp
+++ b/src/engraving/dom/trill.cpp
@@ -145,7 +145,7 @@ void TrillSegment::scanElements(void* data, void (* func)(void*, EngravingItem*)
 
 EngravingItem* TrillSegment::propertyDelegate(Pid pid)
 {
-    if (pid == Pid::TRILL_TYPE || pid == Pid::ORNAMENT_STYLE || pid == Pid::PLACEMENT || pid == Pid::PLAY) {
+    if (pid == Pid::TRILL_TYPE || pid == Pid::ORNAMENT_STYLE || pid == Pid::PLACEMENT) {
         return spanner();
     }
     return LineSegment::propertyDelegate(pid);
@@ -183,7 +183,6 @@ Trill::Trill(EngravingItem* parent)
     m_accidental = nullptr;
     m_cueNoteChord = nullptr;
     m_ornamentStyle = OrnamentStyle::DEFAULT;
-    setPlayArticulation(true);
     initElementStyle(&trillStyle);
 }
 
@@ -193,7 +192,6 @@ Trill::Trill(const Trill& t)
     m_trillType = t.m_trillType;
     m_ornament = t.m_ornament ? t.m_ornament->clone() : nullptr;
     m_ornamentStyle = t.m_ornamentStyle;
-    m_playArticulation = t.m_playArticulation;
     initElementStyle(&trillStyle);
 }
 
@@ -281,8 +279,6 @@ PropertyValue Trill::getProperty(Pid propertyId) const
         return int(trillType());
     case Pid::ORNAMENT_STYLE:
         return ornamentStyle();
-    case Pid::PLAY:
-        return bool(playArticulation());
     default:
         break;
     }
@@ -298,9 +294,6 @@ bool Trill::setProperty(Pid propertyId, const PropertyValue& val)
     switch (propertyId) {
     case Pid::TRILL_TYPE:
         setTrillType(TrillType(val.toInt()));
-        break;
-    case Pid::PLAY:
-        setPlayArticulation(val.toBool());
         break;
     case Pid::ORNAMENT_STYLE:
         setOrnamentStyle(val.value<OrnamentStyle>());
@@ -329,8 +322,6 @@ PropertyValue Trill::propertyDefault(Pid propertyId) const
         return 0;
     case Pid::ORNAMENT_STYLE:
         return OrnamentStyle::DEFAULT;
-    case Pid::PLAY:
-        return true;
     case Pid::PLACEMENT:
         return style().styleV(Sid::trillPlacement);
 

--- a/src/engraving/dom/trill.h
+++ b/src/engraving/dom/trill.h
@@ -94,8 +94,6 @@ public:
     TrillType trillType() const { return m_trillType; }
     void setOrnamentStyle(OrnamentStyle val) { m_ornamentStyle = val; }
     OrnamentStyle ornamentStyle() const { return m_ornamentStyle; }
-    void setPlayArticulation(bool val) { m_playArticulation = val; }
-    bool playArticulation() const { return m_playArticulation; }
     String trillTypeUserName() const;
     Accidental* accidental() const { return m_accidental; }
     void setAccidental(Accidental* a) { m_accidental = a; }
@@ -124,7 +122,6 @@ private:
     Accidental* m_accidental = nullptr;
     Chord* m_cueNoteChord = nullptr;
     OrnamentStyle m_ornamentStyle = OrnamentStyle::DEFAULT;   // for use in ornaments such as trill
-    bool m_playArticulation = true;
     Ornament* m_ornament = nullptr;
 };
 } // namespace mu::engraving

--- a/src/engraving/dom/vibrato.cpp
+++ b/src/engraving/dom/vibrato.cpp
@@ -93,7 +93,7 @@ void VibratoSegment::symbolLine(SymId start, SymId fill, SymId end)
 
 EngravingItem* VibratoSegment::propertyDelegate(Pid pid)
 {
-    if (pid == Pid::VIBRATO_TYPE || pid == Pid::PLACEMENT || pid == Pid::PLAY) {
+    if (pid == Pid::VIBRATO_TYPE || pid == Pid::PLACEMENT) {
         return spanner();
     }
     return LineSegment::propertyDelegate(pid);
@@ -117,7 +117,6 @@ Vibrato::Vibrato(EngravingItem* parent)
 {
     initElementStyle(&vibratoStyle);
     m_vibratoType = VibratoType::GUITAR_VIBRATO;
-    setPlayArticulation(true);
 }
 
 Vibrato::~Vibrato()
@@ -180,8 +179,6 @@ PropertyValue Vibrato::getProperty(Pid propertyId) const
     switch (propertyId) {
     case Pid::VIBRATO_TYPE:
         return int(vibratoType());
-    case Pid::PLAY:
-        return bool(playArticulation());
     default:
         break;
     }
@@ -197,9 +194,6 @@ bool Vibrato::setProperty(Pid propertyId, const PropertyValue& val)
     switch (propertyId) {
     case Pid::VIBRATO_TYPE:
         setVibratoType(VibratoType(val.toInt()));
-        break;
-    case Pid::PLAY:
-        setPlayArticulation(val.toBool());
         break;
     case Pid::COLOR:
         setColor(val.value<Color>());
@@ -223,8 +217,6 @@ PropertyValue Vibrato::propertyDefault(Pid propertyId) const
     switch (propertyId) {
     case Pid::VIBRATO_TYPE:
         return 0;
-    case Pid::PLAY:
-        return true;
     case Pid::PLACEMENT:
         return style().styleV(Sid::vibratoPlacement);
     default:

--- a/src/engraving/dom/vibrato.h
+++ b/src/engraving/dom/vibrato.h
@@ -78,8 +78,6 @@ public:
     void undoSetVibratoType(VibratoType val);
     void setVibratoType(VibratoType tt) { m_vibratoType = tt; }
     VibratoType vibratoType() const { return m_vibratoType; }
-    void setPlayArticulation(bool val) { m_playArticulation = val; }
-    bool playArticulation() const { return m_playArticulation; }
     String vibratoTypeUserName() const;
 
     Segment* segment() const { return (Segment*)explicitParent(); }
@@ -94,7 +92,6 @@ private:
     Sid getPropertyStyle(Pid) const override;
 
     VibratoType m_vibratoType = VibratoType::GUITAR_VIBRATO;
-    bool m_playArticulation = false;
 };
 } // namespace mu::engraving
 

--- a/src/engraving/playback/metaparsers/internal/spannersmetaparser.cpp
+++ b/src/engraving/playback/metaparsers/internal/spannersmetaparser.cpp
@@ -59,6 +59,10 @@ void SpannersMetaParser::doParse(const EngravingItem* item, const RenderingConte
 
     const Spanner* spanner = toSpanner(item);
 
+    if (!spanner->playSpanner()) {
+        return;
+    }
+
     mpe::ArticulationType type = mpe::ArticulationType::Undefined;
 
     mpe::pitch_level_t overallPitchRange = 0;
@@ -92,10 +96,6 @@ void SpannersMetaParser::doParse(const EngravingItem* item, const RenderingConte
     case ElementType::TRILL: {
         const Trill* trill = toTrill(spanner);
 
-        if (!trill->playArticulation()) {
-            return;
-        }
-
         if (trill->trillType() == TrillType::TRILL_LINE) {
             type = mpe::ArticulationType::Trill;
         } else if (trill->trillType() == TrillType::UPPRALL_LINE) {
@@ -109,10 +109,6 @@ void SpannersMetaParser::doParse(const EngravingItem* item, const RenderingConte
     }
     case ElementType::GLISSANDO: {
         const Glissando* glissando = toGlissando(spanner);
-        if (!glissando->playGlissando()) {
-            break;
-        }
-
         const Note* startNote = toNote(glissando->startElement());
         const Note* endNote = toNote(glissando->endElement());
 

--- a/src/engraving/playback/playbackcontext.cpp
+++ b/src/engraving/playback/playbackcontext.cpp
@@ -350,7 +350,7 @@ void PlaybackContext::handleSpanners(const ID partId, const Score* score, const 
     for (const auto& interval : intervals) {
         const Spanner* spanner = interval.value;
 
-        if (!spanner->isHairpin() || !toHairpin(spanner)->playHairpin()) {
+        if (!spanner->isHairpin() || !spanner->playSpanner()) {
             continue;
         }
 

--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -860,8 +860,8 @@ PlaybackModel::TickBoundaries PlaybackModel::tickBoundaries(const ScoreChangesRa
                 continue;
             }
 
-            const Note* firstTiedNote = startNote->firstTiedNote();
-            const Note* lastTiedNote = endNote->lastTiedNote();
+            const Note* firstTiedNote = startNote->firstTiedNote(false);
+            const Note* lastTiedNote = endNote->lastTiedNote(false);
 
             IF_ASSERT_FAILED(firstTiedNote && lastTiedNote) {
                 continue;

--- a/src/engraving/playback/renderers/bendsrenderer.cpp
+++ b/src/engraving/playback/renderers/bendsrenderer.cpp
@@ -139,7 +139,7 @@ void BendsRenderer::renderMultibend(const Score* score, const Note* startNote, c
         }
 
         if (currNote->tieFor()) {
-            currBend = currNote->lastTiedNote()->bendFor();
+            currBend = currNote->lastTiedNote(false)->bendFor();
             appendBendTimeFactors(score, currBend, bendTimeFactorMap);
         }
 

--- a/src/engraving/playback/renderingcontext.h
+++ b/src/engraving/playback/renderingcontext.h
@@ -138,7 +138,7 @@ inline bool isNotePlayable(const Note* note, const muse::mpe::ArticulationMap& a
 
     const Tie* tie = note->tieBack();
 
-    if (tie) {
+    if (tie && tie->playSpanner()) {
         if (!tie->startNote() || !tie->endNote()) {
             return false;
         }

--- a/src/engraving/playback/utils/arrangementutils.h
+++ b/src/engraving/playback/utils/arrangementutils.h
@@ -108,10 +108,13 @@ inline muse::mpe::duration_t tiedNotesTotalDuration(const Score* score, const No
     IF_ASSERT_FAILED(secondNote) {
         return firstNoteDuration;
     }
+    if (!firstNote->tieFor()->playSpanner()) {
+        return firstNoteDuration;
+    }
 
     int startTick = secondNote->tick().ticks();
 
-    const Note* lastNote = firstNote->lastTiedNote();
+    const Note* lastNote = firstNote->lastTiedNote(false);
 
     int endTick = lastNote
                   ? lastNote->tick().ticks() + lastNote->chord()->actualTicks().ticks()

--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -2195,7 +2195,7 @@ void Read206::readTrill206(XmlReader& e, ReadContext& ctx, Trill* t)
         } else if (tag == "ornamentStyle") {
             read400::TRead::readProperty(t, e, ctx, Pid::ORNAMENT_STYLE);
         } else if (tag == "play") {
-            t->setPlayArticulation(e.readBool());
+            t->setPlaySpanner(e.readBool());
         } else if (!TRead::readProperties(static_cast<SLine*>(t), e, ctx)) {
             e.unknown();
         }

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -2692,8 +2692,6 @@ void TRead::read(Glissando* g, XmlReader& e, ReadContext& ctx)
             g->setEaseIn(e.readInt());
         } else if (tag == "easeOutSpin") {
             g->setEaseOut(e.readInt());
-        } else if (tag == "play") {
-            g->setPlayGlissando(e.readBool());
         } else if (TRead::readStyledProperty(g, tag, e, ctx)) {
         } else if (!TRead::readProperties(static_cast<SLine*>(g), e, ctx)) {
             e.unknown();
@@ -3609,13 +3607,16 @@ void TRead::read(SlurTieSegment* s, XmlReader& e, ReadContext& ctx)
 bool TRead::readProperties(Spanner* s, XmlReader& e, ReadContext& ctx)
 {
     const AsciiStringView tag(e.name());
-    if (ctx.pasteMode()) {
-        if (tag == "ticks_f") {
-            s->setTicks(e.readFraction());
-            return true;
-        }
+    if (ctx.pasteMode() && (tag == "ticks_f")) {
+        s->setTicks(e.readFraction());
+        return true;
+    } else if (tag == "play") {
+        s->setPlaySpanner(e.readBool());
+        return true;
+    } else if (!readItemProperties(s, e, ctx)) {
+        return false;
     }
-    return readItemProperties(s, e, ctx);
+    return true;
 }
 
 void TRead::read(Spacer* s, XmlReader& e, ReadContext& ctx)
@@ -4314,8 +4315,6 @@ void TRead::read(Trill* t, XmlReader& e, ReadContext& ctx)
             }
         } else if (tag == "ornamentStyle") {
             readProperty(t, e, ctx, Pid::ORNAMENT_STYLE);
-        } else if (tag == "play") {
-            t->setPlayArticulation(e.readBool());
         } else if (!readProperties(static_cast<SLine*>(t), e, ctx)) {
             e.unknown();
         }
@@ -4330,8 +4329,6 @@ void TRead::read(Vibrato* v, XmlReader& e, ReadContext& ctx)
         const AsciiStringView tag(e.name());
         if (tag == "subtype") {
             v->setVibratoType(TConv::fromXml(e.readAsciiText(), VibratoType::GUITAR_VIBRATO));
-        } else if (tag == "play") {
-            v->setPlayArticulation(e.readBool());
         } else if (!readProperties(static_cast<SLine*>(v), e, ctx)) {
             e.unknown();
         }

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -2939,8 +2939,6 @@ void TRead::read(Glissando* g, XmlReader& e, ReadContext& ctx)
             g->setEaseIn(e.readInt());
         } else if (tag == "easeOutSpin") {
             g->setEaseOut(e.readInt());
-        } else if (tag == "play") {
-            g->setPlayGlissando(e.readBool());
         } else if (tag == "glissandoShift") {
             g->setGlissandoShift(e.readBool());
         } else if (TRead::readStyledProperty(g, tag, e, ctx)) {
@@ -3075,8 +3073,6 @@ void TRead::read(Hairpin* h, XmlReader& e, ReadContext& ctx)
             h->setSingleNoteDynamics(e.readBool());
         } else if (tag == "veloChangeMethod") {
             h->setVeloChangeMethod(TConv::fromXml(e.readAsciiText(), ChangeMethod::NORMAL));
-        } else if (tag == "play") {
-            h->setPlayHairpin(e.readBool());
         } else if (readProperty(h, tag, e, ctx, Pid::APPLY_TO_VOICE)) {
         } else if (readProperty(h, tag, e, ctx, Pid::DIRECTION)) {
         } else if (readProperty(h, tag, e, ctx, Pid::CENTER_BETWEEN_STAVES)) {
@@ -3246,7 +3242,7 @@ void TRead::read(LetRing* r, XmlReader& e, ReadContext& ctx)
         ctx.addSpanner(e.intAttribute("id", -1), r);
     }
     while (e.readNextStartElement()) {
-        if (TRead::readProperty(r, e.name(), e, ctx, Pid::LINE_WIDTH)) {
+        if (readProperty(r, e.name(), e, ctx, Pid::LINE_WIDTH)) {
             r->setPropertyFlags(Pid::LINE_WIDTH, PropertyFlags::UNSTYLED);
         } else if (!readProperties(static_cast<TextLineBase*>(r), e, ctx)) {
             e.unknown();
@@ -3931,13 +3927,16 @@ void TRead::read(SlurTieSegment* s, XmlReader& e, ReadContext& ctx)
 bool TRead::readProperties(Spanner* s, XmlReader& e, ReadContext& ctx)
 {
     const AsciiStringView tag(e.name());
-    if (ctx.pasteMode()) {
-        if (tag == "ticks_f") {
-            s->setTicks(e.readFraction());
-            return true;
-        }
+    if (ctx.pasteMode() && (tag == "ticks_f")) {
+        s->setTicks(e.readFraction());
+        return true;
+    } else if (tag == "play") {
+        s->setPlaySpanner(e.readBool());
+        return true;
+    } else if (!readItemProperties(s, e, ctx)) {
+        return false;
     }
-    return readItemProperties(s, e, ctx);
+    return true;
 }
 
 void TRead::read(Spacer* s, XmlReader& e, ReadContext& ctx)
@@ -4657,8 +4656,6 @@ void TRead::read(Trill* t, XmlReader& e, ReadContext& ctx)
             }
         } else if (tag == "ornamentStyle") {
             readProperty(t, e, ctx, Pid::ORNAMENT_STYLE);
-        } else if (tag == "play") {
-            t->setPlayArticulation(e.readBool());
         } else if (!readProperties(static_cast<SLine*>(t), e, ctx)) {
             e.unknown();
         }
@@ -4673,8 +4670,6 @@ void TRead::read(Vibrato* v, XmlReader& e, ReadContext& ctx)
         const AsciiStringView tag(e.name());
         if (tag == "subtype") {
             v->setVibratoType(TConv::fromXml(e.readAsciiText(), VibratoType::GUITAR_VIBRATO));
-        } else if (tag == "play") {
-            v->setPlayArticulation(e.readBool());
         } else if (!readProperties(static_cast<SLine*>(v), e, ctx)) {
             e.unknown();
         }

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -1451,7 +1451,7 @@ void TWrite::write(const Glissando* item, XmlWriter& xml, WriteContext& ctx)
         xml.tagProperty("isHarpGliss", PropertyValue(item->isHarpGliss().value()));
     }
 
-    for (auto id : { Pid::GLISS_TYPE, Pid::PLAY, Pid::GLISS_STYLE, Pid::GLISS_SHIFT, Pid::GLISS_EASEIN, Pid::GLISS_EASEOUT }) {
+    for (auto id : { Pid::GLISS_TYPE, Pid::GLISS_STYLE, Pid::GLISS_SHIFT, Pid::GLISS_EASEIN, Pid::GLISS_EASEOUT }) {
         writeProperty(item, xml, id);
     }
     for (const StyledProperty& spp : *item->styledProperties()) {
@@ -1551,6 +1551,7 @@ void TWrite::writeProperties(const Spanner* item, XmlWriter& xml, WriteContext& 
     if (ctx.clipboardmode()) {
         xml.tagFraction("ticks_f", item->ticks());
     }
+    writeProperty(item, xml, Pid::PLAY);
     writeItemProperties(item, xml, ctx);
 }
 
@@ -1601,7 +1602,6 @@ void TWrite::write(const Hairpin* item, XmlWriter& xml, WriteContext& ctx)
     writeProperty(item, xml, Pid::LINE_VISIBLE);
     writeProperty(item, xml, Pid::SINGLE_NOTE_DYNAMICS);
     writeProperty(item, xml, Pid::VELO_CHANGE_METHOD);
-    writeProperty(item, xml, Pid::PLAY);
     writeProperty(item, xml, Pid::BEGIN_TEXT_OFFSET);
     writeProperty(item, xml, Pid::CONTINUE_TEXT_OFFSET);
     writeProperty(item, xml, Pid::END_TEXT_OFFSET);
@@ -3073,7 +3073,6 @@ void TWrite::write(const Trill* item, XmlWriter& xml, WriteContext& ctx)
     }
     xml.startElement(item);
     xml.tag("subtype", TConv::toXml(item->trillType()));
-    writeProperty(item, xml, Pid::PLAY);
     writeProperty(item, xml, Pid::ORNAMENT_STYLE);
     writeProperty(item, xml, Pid::PLACEMENT);
     writeProperties(static_cast<const SLine*>(item), xml, ctx);
@@ -3117,7 +3116,6 @@ void TWrite::write(const Vibrato* item, XmlWriter& xml, WriteContext& ctx)
     }
     xml.startElement(item);
     xml.tag("subtype", TConv::toXml(item->vibratoType()));
-    writeProperty(item, xml, Pid::PLAY);
     for (const StyledProperty& spp : *item->styledProperties()) {
         writeProperty(item, xml, spp.pid);
     }


### PR DESCRIPTION
Resolves: #21104
Resolves: #23380

Pedal lines, ottavas, and other similar elements now can have their playback turned on or off.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
