### PR TITLE
[4.3.1] Fix #21300: Correct tie positoning for dotted slashed notes

### DIFF
--- a/build/ci/withoutqt/setup.sh
+++ b/build/ci/withoutqt/setup.sh
@@ -108,7 +108,7 @@ sudo apt-get install -y --no-install-recommends \
 
 # COMPILER
 
-gcc_version="11"
+gcc_version="10"
 sudo apt-get install -y --no-install-recommends "g++-${gcc_version}"
 sudo update-alternatives \
   --install /usr/bin/gcc gcc "/usr/bin/gcc-${gcc_version}" 40 \

--- a/buildscripts/ci/withoutqt/setup.sh
+++ b/buildscripts/ci/withoutqt/setup.sh
@@ -108,7 +108,7 @@ sudo apt-get install -y --no-install-recommends \
 
 # COMPILER
 
-gcc_version="11"
+gcc_version="10"
 sudo apt-get install -y --no-install-recommends "g++-${gcc_version}"
 sudo update-alternatives \
   --install /usr/bin/gcc gcc "/usr/bin/gcc-${gcc_version}" 40 \

--- a/src/engraving/rendering/dev/slurtielayout.cpp
+++ b/src/engraving/rendering/dev/slurtielayout.cpp
@@ -1269,9 +1269,9 @@ double SlurTieLayout::noteOpticalCenterForTie(const Note* note, bool up)
 {
     if (note->headGroup() == NoteHeadGroup::HEAD_SLASH) {
         double singleSlashWidth = note->symBbox(SymId::noteheadSlashHorizontalEnds).width();
-        double noteWidth = note->width();
+        double noteWidth = note->headWidth();
         double center = 0.20 * note->spatium() + 0.5 * (noteWidth - singleSlashWidth);
-        return up ? note->shape().right() - center : note->shape().left() + center;
+        return up ? note->ldata()->bbox().right() - center : note->ldata()->bbox().left() + center;
     }
     SymId symId = note->ldata()->cachedNoteheadSym.value();
     PointF cutOutLeft = note->symSmuflAnchor(symId, up ? SmuflAnchorId::cutOutNW : SmuflAnchorId::cutOutSW);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/21300

Ports: #21568 (with Bradley's and Simon's approval)
(and https://github.com/musescore/MuseScore/pull/22701/commits/63e01f141039e63ead238680d6ececf5948b97bd)