### PR TITLE
Add CMake option to build Universal on macOS

### DIFF
--- a/buildscripts/cmake/SetupBuildEnvironment.cmake
+++ b/buildscripts/cmake/SetupBuildEnvironment.cmake
@@ -127,5 +127,10 @@ endif()
 if (OS_IS_MAC)
     set(MACOSX_DEPLOYMENT_TARGET 10.14)
     set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14)
+
+    if (MUSE_COMPILE_MACOS_UNIVERSAL)
+        set(CMAKE_OSX_ARCHITECTURES x86_64 arm64)
+        # Otherwise, build for the architecture of the current machine only
+    endif()
 endif(OS_IS_MAC)
 

--- a/src/framework/cmake/MuseDeclareOptions.cmake
+++ b/src/framework/cmake/MuseDeclareOptions.cmake
@@ -55,7 +55,7 @@ declare_muse_module_opt(WORKSPACE ON)
 # === Enviropment ===
 option(MUSE_COMPILE_BUILD_64 "Build 64 bit version" ON)
 option(MUSE_COMPILE_ASAN "Enable Address Sanitizer" OFF)
-option(MUSE_COMPILE_MACOS_APPLE_SILICON "Build for Apple Silicon architecture. Only applicable on Macs with Apple Silicon, and requires suitable Qt version." OFF)
+option(MUSE_COMPILE_MACOS_UNIVERSAL "Build both x86_64 and arm64 into one executable" OFF)
 option(MUSE_COMPILE_USE_PCH "Use precompiled headers." ON)
 option(MUSE_COMPILE_STRING_DEBUG_HACK "Enable string debug hack (only clang)" ON)
 


### PR DESCRIPTION
Default off; requires universal libsndfile binary.

Edit: turning into draft for now, as I'm still not entirely sure that this is the best way, and it isn't very useful as long as we can't use it on CI because we don't have universal libsndfile.