### PR TITLE
Fix stem direction on drumset XML import

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -5933,8 +5933,8 @@ static void setDrumset(Chord* c, MusicXMLParserPass1& pass1, const String& partI
     pass1.setDrumsetDefault(partId, instrumentId, headGroup, line, overruledStemDir);
 }
 
-static void xmlSetDrumsetPitch(Note* note, const Chord* const chord, const Staff* const staff, int step, int octave,
-                               NoteHeadGroup headGroup, const Instrument* const instrument)
+static void xmlSetDrumsetPitch(Note* note, const Chord* chord, const Staff* staff, int step, int octave,
+                               NoteHeadGroup headGroup, DirectionV& stemDir, const Instrument* instrument)
 {
     const Drumset* ds = instrument->drumset();
     // get line
@@ -5970,6 +5970,10 @@ static void xmlSetDrumsetPitch(Note* note, const Chord* const chord, const Staff
     // If there is no exact match, fall back to correct line but different head
     if (newPitch == pitch) {
         newPitch = lineMatch;
+    }
+
+    if (stemDir == DirectionV::AUTO) {
+        stemDir = ds->stemDirection(newPitch);
     }
 
     note->setPitch(newPitch);
@@ -6233,13 +6237,11 @@ Note* MusicXMLParserPass2::note(const String& partId,
         const int octaveShift = m_pass1.octaveShift(partId, ottavaStaff, noteStartTime);
         const Staff* st = c->staff();
         if (isSingleDrumset && mnp.unpitched() && instrumentId.empty()) {
-            xmlSetDrumsetPitch(note, c, st, mnp.displayStep(), mnp.displayOctave(), headGroup, instrument);
+            xmlSetDrumsetPitch(note, c, st, mnp.displayStep(), mnp.displayOctave(), headGroup, stemDir, instrument);
         } else {
             setPitch(note, instruments, instrumentId, mnp, octaveShift, instrument);
         }
         c->add(note);
-        //c->setStemDirection(stemDir); // already done in handleBeamAndStemDir()
-        //c->setNoStem(noStem);
         cr = c;
     }
     // end allocation

--- a/src/importexport/musicxml/tests/data/testImportDrums_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testImportDrums_ref.mscx
@@ -295,6 +295,7 @@
             </Tempo>
           <Chord>
             <durationType>quarter</durationType>
+            <StemDirection>down</StemDirection>
             <Note>
               <pitch>36</pitch>
               <tpc>14</tpc>
@@ -302,6 +303,7 @@
             </Chord>
           <Chord>
             <durationType>quarter</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
               <pitch>38</pitch>
               <tpc>16</tpc>
@@ -309,6 +311,7 @@
             </Chord>
           <Chord>
             <durationType>quarter</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
               <pitch>51</pitch>
               <tpc>11</tpc>
@@ -317,6 +320,7 @@
             </Chord>
           <Chord>
             <durationType>quarter</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
               <pitch>42</pitch>
               <tpc>20</tpc>
@@ -329,6 +333,7 @@
         <voice>
           <Chord>
             <durationType>quarter</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
               <pitch>47</pitch>
               <tpc>19</tpc>
@@ -336,6 +341,7 @@
             </Chord>
           <Chord>
             <durationType>quarter</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
               <pitch>45</pitch>
               <tpc>17</tpc>
@@ -343,6 +349,7 @@
             </Chord>
           <Chord>
             <durationType>quarter</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
               <pitch>41</pitch>
               <tpc>13</tpc>
@@ -350,6 +357,7 @@
             </Chord>
           <Chord>
             <durationType>quarter</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
               <pitch>49</pitch>
               <tpc>21</tpc>


### PR DESCRIPTION
Resolves: see images - an issue with incorrect stem directions after importing drumkit parts from an XML file
<img width="414" alt="Screenshot 2024-05-20 at 11 00 21" src="https://github.com/musescore/MuseScore/assets/26510874/2b39a14b-b72c-45fc-a911-c318300904c4">
<img width="414" alt="Screenshot 2024-05-20 at 11 00 59" src="https://github.com/musescore/MuseScore/assets/26510874/137c74e0-16df-4e3c-ba50-69f99678e289">
