### PR TITLE
Fix #19009: Avoid setting the tempo to 0 BPM

### DIFF
--- a/src/engraving/dom/tempo.cpp
+++ b/src/engraving/dom/tempo.cpp
@@ -100,6 +100,9 @@ void TempoMap::setPause(int tick, double pause)
 
 void TempoMap::setTempo(int tick, BeatsPerSecond tempo)
 {
+    IF_ASSERT_FAILED(tempo > BeatsPerSecond(0.0)) {
+        tempo = BeatsPerSecond(0.01);
+    }
     auto e = find(tick);
     if (e != end()) {
         e->second.tempo = tempo;

--- a/src/inspector/view/qml/MuseScore/Inspector/general/playback/internal/GradualTempoChangeBlank.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/general/playback/internal/GradualTempoChangeBlank.qml
@@ -50,7 +50,7 @@ ExpandableBlank {
             titleText: qsTrc("inspector", "Amount")
             propertyItem: root.model ? root.model.tempoChangeFactor : null
 
-            minValue: 0
+            minValue: 1
             maxValue: 1000
             decimals: 0
             step: 1


### PR DESCRIPTION
Resolves: #19009 
Resolves: https://musescore.org/en/comment/1238212 (added an assertion for dev builds)

I also sketched out a more complex fix for this one but decided against it:

  In `TempoText` we define a range of allowed tempos and it follows that `GradualTempoChange` should also adhere to these limits (we shouldn’t allow users to enter a factor yielding a tempo outwith the limits). In my sketch, I used the tempo at the start of the gradual tempo change to dynamically set the min/max values of the “factor” spinbox to values that reflect our min/max desired tempos.  
  
  I eventually decided against this because it added quite a lot of complexity only to accommodate edge cases where the user is working with extremely high/low tempos. It also doesn’t completely alleviate the issue - I get the sense that gradual tempo changes could do with a more holistic rework.
  
    For now let’s just address the crash and we can perhaps return to this later.