### PR TITLE
Infer percussion instruments and follow display-step and notehead in XML

### DIFF
--- a/src/engraving/dom/instrtemplate.cpp
+++ b/src/engraving/dom/instrtemplate.cpp
@@ -812,7 +812,7 @@ const InstrumentTemplate* searchTemplateForMusicXmlId(const String& mxmlId)
     return 0;
 }
 
-const InstrumentTemplate* searchTemplateForInstrNameList(const std::list<String>& nameList, bool useDrumset)
+const InstrumentTemplate* searchTemplateForInstrNameList(const std::list<String>& nameList, bool useDrumset, bool caseSensitive)
 {
     const InstrumentTemplate* bestMatch = nullptr; // default if no matches
     int bestMatchStrength = 0; // higher for better matches
@@ -822,11 +822,26 @@ const InstrumentTemplate* searchTemplateForInstrNameList(const std::list<String>
                 if (name.isEmpty() || it->useDrumset != useDrumset) {
                     continue;
                 }
+                String trackName = it->trackName;
+                StaffNameList longNames = it->longNames;
+                StaffNameList shortNames = it->shortNames;
+                String instrName = name;
+
+                if (!caseSensitive) {
+                    instrName = instrName.toLower();
+                    trackName = trackName.toLower();
+                    for (StaffName& n : longNames) {
+                        n.setName(n.name().toLower());
+                    }
+                    for (StaffName& n : shortNames) {
+                        n.setName(n.name().toLower());
+                    }
+                }
 
                 int matchStrength = 0
-                                    + (4 * (it->trackName == name ? 1 : 0)) // most weight to track name since there are fewer duplicates
-                                    + (2 * (muse::contains(it->longNames, StaffName(name)) ? 1 : 0))
-                                    + (1 * (muse::contains(it->shortNames, StaffName(name)) ? 1 : 0)); // least weight to short name
+                                    + (4 * (trackName == instrName ? 1 : 0)) // most weight to track name since there are fewer duplicates
+                                    + (2 * (muse::contains(longNames, StaffName(instrName)) ? 1 : 0))
+                                    + (1 * (muse::contains(shortNames, StaffName(instrName)) ? 1 : 0)); // least weight to short name
                 const int perfectMatchStrength = 7;
                 assert(matchStrength <= perfectMatchStrength);
                 if (matchStrength > bestMatchStrength) {

--- a/src/engraving/dom/instrtemplate.h
+++ b/src/engraving/dom/instrtemplate.h
@@ -182,7 +182,8 @@ extern InstrumentIndex searchTemplateIndexForTrackName(const String& trackName);
 extern InstrumentIndex searchTemplateIndexForId(const String& id);
 extern const InstrumentTemplate* searchTemplate(const String& name);
 extern const InstrumentTemplate* searchTemplateForMusicXmlId(const String& mxmlId);
-extern const InstrumentTemplate* searchTemplateForInstrNameList(const std::list<String>& nameList, bool useDrumset = false);
+extern const InstrumentTemplate* searchTemplateForInstrNameList(const std::list<String>& nameList, bool useDrumset = false,
+                                                                bool caseSensitive = true);
 extern const InstrumentTemplate* searchTemplateForMidiProgram(int bank, int program, bool useDrumset = false);
 extern const InstrumentGenre* searchInstrumentGenre(const String& id);
 

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -1623,6 +1623,7 @@ void MusicXMLParserPass2::initPartState(const String& partId)
     m_graceNoteLyrics.clear();
     m_inferredHairpins.clear();
     m_inferredTempoLines.clear();
+    m_inferredPerc.clear();
 
     m_nstaves = m_pass1.getPart(partId)->nstaves();
     m_measureRepeatNumMeasures.assign(m_nstaves, 0);
@@ -3160,6 +3161,7 @@ void MusicXMLParserDirection::direction(const String& partId,
     handleNmiCmi(measure, tick + m_offset, delayedDirections);
     handleFraction();
     handleChordSym(tick + m_offset, harmonyMap);
+    handleDrumInstrument(isPercussionStaff, tick + m_offset);
 
     // fix for Sibelius 7.1.3 (direct export) which creates metronomes without <sound tempo="..."/>:
     // if necessary, use the value calculated by metronome()
@@ -4520,6 +4522,36 @@ PlayingTechniqueType MusicXMLParserDirection::getPlayingTechnique() const
     return PlayingTechniqueType::Undefined;
 }
 
+void MusicXMLParserDirection::handleDrumInstrument(bool isPerc, Fraction tick) const
+{
+    if (!configuration()->inferTextType() || m_wordsText.empty() || !m_rehearsalText.empty() || !m_metroText.empty() || m_tpoSound > 0.1
+        || !isPerc) {
+        return;
+    }
+
+    String plainWords = m_wordsText;
+
+    static const std::regex to("to ", std::regex_constants::icase);
+    static const std::regex brackets("\\(.*\\)");
+    plainWords.remove(to);
+    plainWords.remove(brackets);
+
+    plainWords = MScoreTextToMXML::toPlainText(plainWords.simplified());
+
+    const InstrumentTemplate* it = searchTemplateForInstrNameList({ plainWords }, true, false);
+
+    // Ignore marching percussion, as these won't map correctly to the standard drumkit
+    if (it && it->familyId() != u"batterie") {
+        int pitch = it->useDrumset && it->drumset ? it->drumset->nextPitch(0) : 0;
+
+        // Text under the staff will be for voice 2 and 4 even if it's in voice 1
+        track_idx_t track = placement() == u"below" && !(m_track & 1) ? m_track + 1 : m_track;
+
+        InferredPercInstr instr = InferredPercInstr(pitch, track, it->id, tick);
+        m_pass2.addInferredPercInstr(instr);
+    }
+}
+
 //---------------------------------------------------------
 //   bracket
 //---------------------------------------------------------
@@ -4940,6 +4972,23 @@ void MusicXMLParserPass2::deleteHandledSpanner(SLine* const& spanner)
 {
     muse::remove(m_spanners, spanner);
     delete spanner;
+}
+
+InferredPercInstr MusicXMLParserPass2::inferredPercInstr(const Fraction& tick, const track_idx_t trackIdx)
+{
+    InferredPercInstr instr = InferredPercInstr();
+
+    for (InferredPercList::iterator iter = m_inferredPerc.begin(); iter != m_inferredPerc.end();) {
+        if (iter->tick == tick && iter->track == trackIdx) {
+            instr = *iter;
+            iter = m_inferredPerc.erase(iter);
+            break;
+        } else {
+            ++iter;
+        }
+    }
+
+    return instr;
 }
 
 //---------------------------------------------------------
@@ -6223,10 +6272,10 @@ static void setDrumset(Chord* c, MusicXMLParserPass1& pass1, const String& partI
     pass1.setDrumsetDefault(partId, instrumentId, headGroup, line, overruledStemDir);
 }
 
-static void xmlSetDrumsetPitch(Note* note, const Chord* chord, const Staff* staff, int step, int octave,
-                               NoteHeadGroup headGroup, DirectionV& stemDir, const Instrument* instrument)
+void MusicXMLParserPass2::xmlSetDrumsetPitch(Note* note, const Chord* chord, const Staff* staff, int step, int octave,
+                                             NoteHeadGroup headGroup, DirectionV& stemDir, Instrument* instrument)
 {
-    const Drumset* ds = instrument->drumset();
+    Drumset* ds = instrument->drumset();
     // get line
     // determine staff line based on display-step / -octave and clef type
     const ClefType clef = staff->clef(chord->tick());
@@ -6243,26 +6292,45 @@ static void xmlSetDrumsetPitch(Note* note, const Chord* chord, const Staff* staf
 
     const int firstDrum = ds->nextPitch(0);
     int curDrum = firstDrum;
-    // if line matches but not headgroup, set pitch anyway
-    int lineMatch = pitch;
     int newPitch = pitch;
+    bool matchFound = false;
     do {
         if (ds->line(curDrum) == line) {
-            lineMatch = curDrum;
             if (ds->noteHead(curDrum) == headGroup) {
                 newPitch = curDrum;
+                matchFound = true;
                 break;
             }
         }
         curDrum = ds->nextPitch(curDrum);
     } while (curDrum != firstDrum);
 
-    // If there is no exact match, fall back to correct line but different head
-    if (newPitch == pitch) {
-        newPitch = lineMatch;
+    // Find inferred instruments at this tick
+    if (configuration()->inferTextType()) {
+        InferredPercInstr instr = inferredPercInstr(chord->tick(), chord->track());
+        if (instr.track != muse::nidx) {
+            // Clear old instrument
+            ds->drum(newPitch) = DrumInstrument();
+
+            newPitch = instr.pitch;
+            ds->drum(newPitch) = ds->drum(newPitch) = DrumInstrument(
+                instr.name.toStdString().c_str(), headGroup, line, stemDir, chord->voice());
+        }
     }
 
-    if (stemDir == DirectionV::AUTO) {
+    // If there is no exact match add an entry to the drumkit with the XML line and notehead
+    if (!matchFound) {
+        // Create new instrument in drumkit
+        if (stemDir == DirectionV::AUTO) {
+            if (line > 4) {
+                stemDir = DirectionV::DOWN;
+            } else {
+                stemDir = DirectionV::UP;
+            }
+        }
+
+        ds->drum(newPitch) = DrumInstrument("drum", headGroup, line, stemDir, chord->voice());
+    } else if (stemDir == DirectionV::AUTO) {
         stemDir = ds->stemDirection(newPitch);
     }
 
@@ -6485,8 +6553,8 @@ Note* MusicXMLParserPass2::note(const String& partId,
 
     TDuration duration = determineDuration(rest, type, mnd.dots(), dura, measure->ticks());
 
-    const Part* part = m_pass1.getPart(partId);
-    const Instrument* instrument = part->instrument(noteStartTime);
+    Part* part = m_pass1.getPart(partId);
+    Instrument* instrument = part->instrument(noteStartTime);
     const MusicXMLInstruments& instruments = m_pass1.getInstruments(partId);
     isSingleDrumset = instrument->drumset() && instruments.size() == 1;
     // begin allocation

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
@@ -27,8 +27,10 @@
 
 #include "importmxmlpass1.h"
 #include "importxmlfirstpass.h"
+#include "internal/musicxml/musicxmlsupport.h"
 #include "musicxml.h" // a.o. for Slur
 
+#include "engraving/dom/instrument.h"
 #include "engraving/dom/types.h"
 
 namespace mu::engraving {
@@ -329,6 +331,12 @@ public:
     void addSystemElement(EngravingItem* el, const Fraction& tick) { m_sysElements.insert({ tick.ticks(), el }); }
     const SystemElements systemElements() const { return m_sysElements; }
 
+    InferredPercInstr inferredPercInstr(const Fraction& tick, const track_idx_t trackIdx);
+    void addInferredPercInstr(InferredPercInstr instr)
+    {
+        m_inferredPerc.push_back(instr);
+    }
+
 private:
     void addError(const String& error);      // Add an error to be shown in the GUI
     void initPartState(const String& partId);
@@ -373,6 +381,9 @@ private:
     // multi-measure rest state handling
     void setMultiMeasureRestCount(int count);
     int getAndDecMultiMeasureRestCount();
+
+    void xmlSetDrumsetPitch(Note* note, const Chord* chord, const Staff* staff, int step, int octave, NoteHeadGroup headGroup,
+                            DirectionV& stemDir, Instrument* instrument);
 
     // generic pass 2 data
 
@@ -426,6 +437,7 @@ private:
     std::vector<int> m_measureRepeatCount;
 
     SystemElements m_sysElements;
+    InferredPercList m_inferredPerc;
 };
 
 //---------------------------------------------------------
@@ -482,6 +494,7 @@ private:
     bool isLikelySticking();
     bool isLikelyDynamicRange() const;
     PlayingTechniqueType getPlayingTechnique() const;
+    void handleDrumInstrument(bool isPerc, Fraction tick) const;
 
     // void terminateInferredLine(const std::vector<TextLineBase*> lines, const Fraction& tick);
 

--- a/src/importexport/musicxml/internal/musicxml/musicxmlsupport.h
+++ b/src/importexport/musicxml/internal/musicxml/musicxmlsupport.h
@@ -221,6 +221,21 @@ struct MusicXMLInstrument {
      */
 };
 
+struct InferredPercInstr {
+    int pitch;
+    track_idx_t track;
+    String name;
+    Fraction tick;
+
+    InferredPercInstr(int pitch, track_idx_t track, String name, Fraction tick)
+        : pitch(pitch), track(track), name(name), tick(tick) {}
+
+    InferredPercInstr()
+        : pitch(-1), track(muse::nidx), name(u""), tick(Fraction(0, -1)) {}
+};
+
+typedef std::vector<InferredPercInstr> InferredPercList;
+
 /**
  A MusicXML drumset or set of instruments in a multi-instrument part.
  */

--- a/src/importexport/musicxml/tests/data/testImportDrums2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testImportDrums2_ref.mscx
@@ -225,6 +225,13 @@
           <name>Ride Cymbal 2</name>
           <stem>1</stem>
           </Drum>
+        <Drum pitch="81">
+          <head>normal</head>
+          <line>-2</line>
+          <voice>0</voice>
+          <name>drum</name>
+          <stem>2</stem>
+          </Drum>
         <clef>PERC</clef>
         <singleNoteDynamics>0</singleNoteDynamics>
         <Articulation>
@@ -357,9 +364,8 @@
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
-              <pitch>49</pitch>
-              <tpc>21</tpc>
-              <head>cross</head>
+              <pitch>81</pitch>
+              <tpc>17</tpc>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/musicxml/tests/data/testImportDrums_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testImportDrums_ref.mscx
@@ -214,6 +214,13 @@
           <name>Ride Cymbal 2</name>
           <stem>1</stem>
           </Drum>
+        <Drum pitch="81">
+          <head>normal</head>
+          <line>-2</line>
+          <voice>0</voice>
+          <name>drum</name>
+          <stem>1</stem>
+          </Drum>
         <clef>PERC</clef>
         <singleNoteDynamics>0</singleNoteDynamics>
         <Articulation>
@@ -354,9 +361,8 @@
             <durationType>quarter</durationType>
             <StemDirection>up</StemDirection>
             <Note>
-              <pitch>49</pitch>
-              <tpc>21</tpc>
-              <head>cross</head>
+              <pitch>81</pitch>
+              <tpc>17</tpc>
               </Note>
             </Chord>
           </voice>


### PR DESCRIPTION
In PR https://github.com/musescore/MuseScore/pull/22719, notes read from percussion staves in XML files were mapped to the closest match to notes in the existing drumset.  This PR instead honours the `display` information in the XML file and adds a corresponding entry to the drumset if one does not already exist.
When text inference is turned on, staff text is matched with instrument templates.  If a match is found, we attempt to match the relevant pitch to an unmapped note at the same tick. 