### PR TITLE
Transpose keysigs in parts after changing instrument

### DIFF
--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -190,14 +190,19 @@ void MasterNotationParts::replaceInstrument(const InstrumentKey& instrumentKey, 
 
     startGlobalEdit();
 
-    const Part* part = partModifiable(instrumentKey.partId);
+    Part* part = partModifiable(instrumentKey.partId);
     bool isMainInstrument = part && isMainInstrumentForPart(instrumentKey, part);
+
+    mu::engraving::Interval oldTranspose = part ? part->instrument()->transpose() : mu::engraving::Interval(0, 0);
 
     NotationParts::replaceInstrument(instrumentKey, newInstrument);
 
     for (INotationPartsPtr parts : excerptsParts()) {
         parts->replaceInstrument(instrumentKey, newInstrument);
     }
+
+    // this also transposes all linked parts
+    score()->transpositionChanged(part, Part::MAIN_INSTRUMENT_TICK, oldTranspose);
 
     if (isMainInstrument) {
         if (mu::engraving::Excerpt* excerpt = findExcerpt(part->id())) {

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -574,14 +574,8 @@ void NotationParts::replaceInstrument(const InstrumentKey& instrumentKey, const 
     startEdit();
 
     if (isMainInstrumentForPart(instrumentKey, part)) {
-        mu::engraving::Interval oldTranspose = part->instrument()->transpose();
-
         QString newInstrumentPartName = formatInstrumentTitle(newInstrument.trackName(), newInstrument.trait());
         score()->undo(new mu::engraving::ChangePart(part, new mu::engraving::Instrument(newInstrument), newInstrumentPartName));
-        if (score()->isMaster()) {
-            // this also transposes all linked parts
-            score()->transpositionChanged(part, Part::MAIN_INSTRUMENT_TICK, oldTranspose);
-        }
 
         // Update clefs
         for (staff_idx_t staffIdx = 0; staffIdx < part->nstaves(); ++staffIdx) {


### PR DESCRIPTION
Resolves: #20706 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

Key signatures were being replaced before the instrument had been changed in individual parts.  This PR makes sure we change all the relevant instruments in all parts before transposing key signatures.