### PR TITLE
MusicXML: set all note components invisible

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -6380,6 +6380,7 @@ Note* MusicXMLParserPass2::note(const String& partId,
         }
 
         if (acc) {
+            acc->setVisible(printObject);
             note->add(acc);
             // save alter value for user accidental
             if (acc->accidentalType() != AccidentalType::NONE) {

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -6071,6 +6071,7 @@ Note* MusicXMLParserPass2::note(const String& partId,
     NoteHeadScheme headScheme = NoteHeadScheme::HEAD_AUTO;
     const Color noteColor = Color::fromString(m_e.asciiAttribute("color").ascii());
     Color noteheadColor;
+    Color stemColor;
     bool noteheadParentheses = false;
     String noteheadFilled;
     int velocity = round(m_e.doubleAttribute("dynamics") * 0.9);
@@ -6138,6 +6139,7 @@ Note* MusicXMLParserPass2::note(const String& partId,
                 staff = -1;
             }
         } else if (m_e.name() == "stem") {
+            stemColor = Color::fromString(m_e.asciiAttribute("color").ascii());
             stem(stemDir, noStem);
         } else if (m_e.name() == "tie") {
             tieType = m_e.attribute("type");
@@ -6327,6 +6329,12 @@ Note* MusicXMLParserPass2::note(const String& partId,
         if (!stem) {
             stem = Factory::createStem(c);
             c->add(stem);
+            if (noteColor.isValid()) {
+                stem->setColor(noteColor);
+            }
+            if (stemColor.isValid()) {
+                stem->setColor(stemColor);
+            }
         }
         setNoteHead(note, noteheadColor, noteheadParentheses, noteheadFilled);
         note->setVisible(hasHead && printObject); // TODO also set the stem to invisible

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -6323,8 +6323,14 @@ Note* MusicXMLParserPass2::note(const String& partId,
         if (noteColor.isValid()) {
             note->setColor(noteColor);
         }
+        Stem* stem = c->stem();
+        if (!stem) {
+            stem = Factory::createStem(c);
+            c->add(stem);
+        }
         setNoteHead(note, noteheadColor, noteheadParentheses, noteheadFilled);
         note->setVisible(hasHead && printObject); // TODO also set the stem to invisible
+        stem->setVisible(printObject);
 
         if (!grace) {
             // regular note

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -6328,13 +6328,12 @@ Note* MusicXMLParserPass2::note(const String& partId,
         Stem* stem = c->stem();
         if (!stem) {
             stem = Factory::createStem(c);
-            c->add(stem);
-            if (noteColor.isValid()) {
-                stem->setColor(noteColor);
-            }
             if (stemColor.isValid()) {
                 stem->setColor(stemColor);
+            } else if (noteColor.isValid()) {
+                stem->setColor(noteColor);
             }
+            c->add(stem);
         }
         setNoteHead(note, noteheadColor, noteheadParentheses, noteheadFilled);
         note->setVisible(hasHead && printObject); // TODO also set the stem to invisible

--- a/src/importexport/musicxml/tests/data/testColors.xml
+++ b/src/importexport/musicxml/tests/data/testColors.xml
@@ -120,7 +120,7 @@
         <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <stem>down</stem>
+        <stem color="#2468AC">down</stem>
         <notations>
           <slur type="start" color="#EFCDAB" number="1"/>
           </notations>


### PR DESCRIPTION
Resolves:  #21193

This PR is an addition to #22864. Previously when a note with `print-object="no"` was imported, stem and accidentals stayed visible.

### before:

<img width="180" alt="image" src="https://github.com/musescore/MuseScore/assets/7693447/160779a5-7c27-478a-88b0-9864e2c15473">

### after:

<img width="179" alt="image" src="https://github.com/musescore/MuseScore/assets/7693447/b2bea2f4-4a09-4951-82e6-5e0550686549">

Also this adds import of stem color.
