### PR TITLE
Fix tuplets in MEI importer

### DIFF
--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -208,7 +208,7 @@ int MeiImporter::getVoiceIndex(int staffIdx, int layerN)
  * When reading tuplet, increase the ticks value to the corrected ratio, and not at all when reading grace notes.
  */
 
-ChordRest* MeiImporter::addChordRest(pugi::xml_node node, Measure* measure, int track, const libmei::Element& meiElement, int& ticks,
+ChordRest* MeiImporter::addChordRest(pugi::xml_node node, Measure* measure, int track, const libmei::Element& meiElement, Fraction& ticks,
                                      bool isRest)
 {
     IF_ASSERT_FAILED(measure) {
@@ -244,7 +244,7 @@ ChordRest* MeiImporter::addChordRest(pugi::xml_node node, Measure* measure, int 
     if (m_readingGraceNotes) {
         segment = m_score->dummy()->segment();
     } else {
-        segment = measure->getSegment(SegmentType::ChordRest, Fraction::fromTicks(ticks) + measure->tick());
+        segment = measure->getSegment(SegmentType::ChordRest, ticks + measure->tick());
     }
 
     ChordRest* chordRest = nullptr;
@@ -321,7 +321,7 @@ ChordRest* MeiImporter::addChordRest(pugi::xml_node node, Measure* measure, int 
     }
     // For grace notes, no tick advance
     if (!m_readingGraceNotes) {
-        ticks += chordTicks.ticks();
+        ticks += chordTicks;
         // Check if we have an AttBeamSecondary and read it for the next ChordRest
         if (beamSecondaryAtt) {
             m_beamBeginMode = Convert::breaksecFromMEI(beamSecondaryAtt->GetBreaksec(), warning);
@@ -1358,14 +1358,14 @@ bool MeiImporter::readMeasure(pugi::xml_node measureNode)
     }
     measure->setIrregular(measureSt.irregular);
 
-    int measureTicks = 0;
+    Fraction measureTicks(0,1);
     success = success & this->readStaves(measureNode, measure, measureTicks);
     // Make sure we correct empty content because this would crash MuseScore
-    if (measureTicks == 0) {
-        measureTicks = m_currentTimeSig.ticks();
+    if (measureTicks.isZero()) {
+        measureTicks = m_currentTimeSig;
         LOGD() << "MeiImporter::readMeasure empty content in " << meiMeasure.GetN();
     }
-    measure->setTicks(Fraction::fromTicks(measureTicks));
+    measure->setTicks(measureTicks);
 
     success = success & this->readControlEvents(measureNode, measure);
 
@@ -1435,7 +1435,7 @@ bool MeiImporter::readSb(pugi::xml_node pbNode)
  * Lookup (and clear) the time signature and key signature maps to add them if necessary.
  */
 
-bool MeiImporter::readStaves(pugi::xml_node parentNode, Measure* measure, int& measureTicks)
+bool MeiImporter::readStaves(pugi::xml_node parentNode, Measure* measure, Fraction& measureTicks)
 {
     IF_ASSERT_FAILED(measure) {
         return false;
@@ -1504,7 +1504,7 @@ bool MeiImporter::readStaves(pugi::xml_node parentNode, Measure* measure, int& m
  * Relies on the m_lastChord pointer for adding grace notes to the correct ChordRest
  */
 
-bool MeiImporter::readLayers(pugi::xml_node parentNode, Measure* measure, int staffN, int& measureTicks)
+bool MeiImporter::readLayers(pugi::xml_node parentNode, Measure* measure, int staffN, Fraction& measureTicks)
 {
     IF_ASSERT_FAILED(measure) {
         return false;
@@ -1530,7 +1530,7 @@ bool MeiImporter::readLayers(pugi::xml_node parentNode, Measure* measure, int st
         meiLayer.Read(xpathNode.node());
 
         m_lastChord = nullptr;
-        int ticks = 0;
+        Fraction ticks;
         int track = staffN * VOICES + static_cast<int>(i);
         success = success && this->readElements(xpathNode.node(), measure, track, ticks);
         measureTicks = std::max(measureTicks, ticks);
@@ -1545,7 +1545,7 @@ bool MeiImporter::readLayers(pugi::xml_node parentNode, Measure* measure, int st
  * Read the layer content, including through a recursive call for nested elements.
  */
 
-bool MeiImporter::readElements(pugi::xml_node parentNode, Measure* measure, int track, int& ticks)
+bool MeiImporter::readElements(pugi::xml_node parentNode, Measure* measure, int track, Fraction& ticks)
 {
     IF_ASSERT_FAILED(measure) {
         return false;
@@ -1635,7 +1635,7 @@ bool MeiImporter::readArtic(pugi::xml_node articNode, Chord* chord)
  * Set MuseScore flags based on custom `@type` values.
  */
 
-bool MeiImporter::readBeam(pugi::xml_node beamNode, Measure* measure, int track, int& ticks)
+bool MeiImporter::readBeam(pugi::xml_node beamNode, Measure* measure, int track, Fraction& ticks)
 {
     IF_ASSERT_FAILED(measure) {
         return false;
@@ -1663,7 +1663,7 @@ bool MeiImporter::readBeam(pugi::xml_node beamNode, Measure* measure, int track,
  * Set MuseScore TremoloType.
  */
 
-bool MeiImporter::readBTrem(pugi::xml_node bTremNode, Measure* measure, int track, int& ticks)
+bool MeiImporter::readBTrem(pugi::xml_node bTremNode, Measure* measure, int track, Fraction& ticks)
 {
     IF_ASSERT_FAILED(measure) {
         return false;
@@ -1686,7 +1686,7 @@ bool MeiImporter::readBTrem(pugi::xml_node bTremNode, Measure* measure, int trac
  * Read a chord and its content (note elements).
  */
 
-bool MeiImporter::readChord(pugi::xml_node chordNode, Measure* measure, int track, int& ticks)
+bool MeiImporter::readChord(pugi::xml_node chordNode, Measure* measure, int track, Fraction& ticks)
 {
     IF_ASSERT_FAILED(measure) {
         return false;
@@ -1695,7 +1695,7 @@ bool MeiImporter::readChord(pugi::xml_node chordNode, Measure* measure, int trac
     libmei::Chord meiChord;
     meiChord.Read(chordNode);
 
-    int chordTicks = ticks;
+    Fraction chordTicks = ticks;
 
     // Support for @grace without <graceGrp>
     this->readGracedAtt(meiChord);
@@ -1727,7 +1727,7 @@ bool MeiImporter::readChord(pugi::xml_node chordNode, Measure* measure, int trac
  * Read a clef.
  */
 
-bool MeiImporter::readClef(pugi::xml_node clefNode, Measure* measure, int track, int& ticks)
+bool MeiImporter::readClef(pugi::xml_node clefNode, Measure* measure, int track, Fraction& ticks)
 {
     IF_ASSERT_FAILED(measure) {
         return false;
@@ -1737,7 +1737,7 @@ bool MeiImporter::readClef(pugi::xml_node clefNode, Measure* measure, int track,
     libmei::Clef meiClef;
     meiClef.Read(clefNode);
 
-    Segment* segment = measure->getSegment(SegmentType::Clef, Fraction::fromTicks(ticks) + measure->tick());
+    Segment* segment = measure->getSegment(SegmentType::Clef, ticks + measure->tick());
     Clef* clef = Factory::createClef(segment);
     Convert::colorFromMEI(clef, meiClef);
     m_uids->reg(clef, meiClef.m_xmlId);
@@ -1759,7 +1759,7 @@ bool MeiImporter::readClef(pugi::xml_node clefNode, Measure* measure, int track,
  * Otherwise, only reset the flag and adding the grace notes will be performed in MeiImporter::addChordRest when the next <chord> / <note> is read
  */
 
-bool MeiImporter::readGraceGrp(pugi::xml_node graceGrpNode, Measure* measure, int track, int& ticks)
+bool MeiImporter::readGraceGrp(pugi::xml_node graceGrpNode, Measure* measure, int track, Fraction& ticks)
 {
     IF_ASSERT_FAILED(measure) {
         return false;
@@ -1793,7 +1793,7 @@ bool MeiImporter::readGraceGrp(pugi::xml_node graceGrpNode, Measure* measure, in
  * Read a mRest.
  */
 
-bool MeiImporter::readMRest(pugi::xml_node mRestNode, Measure* measure, int track, int& ticks)
+bool MeiImporter::readMRest(pugi::xml_node mRestNode, Measure* measure, int track, Fraction& ticks)
 {
     IF_ASSERT_FAILED(measure) {
         return false;
@@ -1804,7 +1804,7 @@ bool MeiImporter::readMRest(pugi::xml_node mRestNode, Measure* measure, int trac
 
     TDuration duration;
 
-    Segment* segment = measure->getSegment(SegmentType::ChordRest, Fraction::fromTicks(ticks) + measure->tick());
+    Segment* segment = measure->getSegment(SegmentType::ChordRest, ticks + measure->tick());
     Rest* rest = Factory::createRest(segment, TDuration(DurationType::V_MEASURE));
     Convert::colorFromMEI(rest, meiMRest);
     m_uids->reg(rest, meiMRest.m_xmlId);
@@ -1822,7 +1822,7 @@ bool MeiImporter::readMRest(pugi::xml_node mRestNode, Measure* measure, int trac
     }
 
     // The duration is the duration according to the timesig
-    ticks += rest->ticks().ticks();
+    ticks += rest->ticks();
 
     return true;
 }
@@ -1831,7 +1831,7 @@ bool MeiImporter::readMRest(pugi::xml_node mRestNode, Measure* measure, int trac
  * Read a mRpt.
  */
 
-bool MeiImporter::readMRpt(pugi::xml_node mRptNode, Measure* measure, int track, int& ticks)
+bool MeiImporter::readMRpt(pugi::xml_node mRptNode, Measure* measure, int track, Fraction& ticks)
 {
     IF_ASSERT_FAILED(measure) {
         return false;
@@ -1840,7 +1840,7 @@ bool MeiImporter::readMRpt(pugi::xml_node mRptNode, Measure* measure, int track,
     libmei::MRpt meiMRpt;
     meiMRpt.Read(mRptNode);
 
-    Segment* segment = measure->getSegment(SegmentType::ChordRest, Fraction::fromTicks(ticks) + measure->tick());
+    Segment* segment = measure->getSegment(SegmentType::ChordRest, ticks + measure->tick());
     MeasureRepeat* measureRepeat = Factory::createMeasureRepeat(segment);
     Convert::colorFromMEI(measureRepeat, meiMRpt);
     m_uids->reg(measureRepeat, meiMRpt.m_xmlId);
@@ -1857,7 +1857,7 @@ bool MeiImporter::readMRpt(pugi::xml_node mRptNode, Measure* measure, int track,
  * Read a note.
  */
 
-bool MeiImporter::readNote(pugi::xml_node noteNode, Measure* measure, int track, int& ticks, Chord* chord)
+bool MeiImporter::readNote(pugi::xml_node noteNode, Measure* measure, int track, Fraction& ticks, Chord* chord)
 {
     IF_ASSERT_FAILED(measure) {
         return false;
@@ -1941,7 +1941,7 @@ bool MeiImporter::readNote(pugi::xml_node noteNode, Measure* measure, int track,
  * Read a rest.
  */
 
-bool MeiImporter::readRest(pugi::xml_node restNode, Measure* measure, int track, int& ticks)
+bool MeiImporter::readRest(pugi::xml_node restNode, Measure* measure, int track, Fraction& ticks)
 {
     IF_ASSERT_FAILED(measure) {
         return false;
@@ -1962,7 +1962,7 @@ bool MeiImporter::readRest(pugi::xml_node restNode, Measure* measure, int track,
  * Read a space.
  */
 
-bool MeiImporter::readSpace(pugi::xml_node spaceNode, Measure* measure, int track, int& ticks)
+bool MeiImporter::readSpace(pugi::xml_node spaceNode, Measure* measure, int track, Fraction& ticks)
 {
     IF_ASSERT_FAILED(measure) {
         return false;
@@ -2002,7 +2002,7 @@ bool MeiImporter::readSyl(pugi::xml_node sylNode, Lyrics* lyrics, Convert::textW
  * Read a tuplet.
  */
 
-bool MeiImporter::readTuplet(pugi::xml_node tupletNode, Measure* measure, int track, int& ticks)
+bool MeiImporter::readTuplet(pugi::xml_node tupletNode, Measure* measure, int track, Fraction& ticks)
 {
     IF_ASSERT_FAILED(measure) {
         return false;
@@ -2016,7 +2016,7 @@ bool MeiImporter::readTuplet(pugi::xml_node tupletNode, Measure* measure, int tr
     bool warning = false;
     bool success = true;
 
-    int startTicks = ticks;
+    Fraction startTicks = ticks;
     libmei::Tuplet meiTuplet;
     meiTuplet.Read(tupletNode);
 
@@ -2032,13 +2032,13 @@ bool MeiImporter::readTuplet(pugi::xml_node tupletNode, Measure* measure, int tr
 
     success = readElements(tupletNode, measure, track, ticks);
 
-    Fraction tupletTicks = Fraction::fromTicks(ticks - startTicks);
+    Fraction tupletTicks = ticks - startTicks;
 
     TDuration d;
     d.setVal((tupletTicks / m_tuplet->ratio().denominator()).ticks());
 
     m_tuplet->setBaseLen(d);
-    m_tuplet->setTick(Fraction::fromTicks(startTicks) + measure->tick());
+    m_tuplet->setTick(startTicks + measure->tick());
     m_tuplet->setTicks(tupletTicks);
 
     m_tuplet = nullptr;

--- a/src/importexport/mei/internal/meiimporter.h
+++ b/src/importexport/mei/internal/meiimporter.h
@@ -94,27 +94,27 @@ private:
     bool readMeasure(pugi::xml_node measureNode);
     bool readPb(pugi::xml_node pbNode);
     bool readSb(pugi::xml_node sbNode);
-    bool readStaves(pugi::xml_node parentNode, engraving::Measure* measure, int& measureTicks);
-    bool readLayers(pugi::xml_node parentNode, engraving::Measure* measure, int staffIdx, int& measureTicks);
+    bool readStaves(pugi::xml_node parentNode, engraving::Measure* measure, engraving::Fraction& measureTicks);
+    bool readLayers(pugi::xml_node parentNode, engraving::Measure* measure, int staffIdx, engraving::Fraction& measureTicks);
 
     /**
      * Methods for parsing MEI elements within a <layer>
      */
-    bool readElements(pugi::xml_node parentNode, engraving::Measure* measure, int track, int& ticks);
+    bool readElements(pugi::xml_node parentNode, engraving::Measure* measure, int track, engraving::Fraction& ticks);
     bool readArtics(pugi::xml_node parentNode, engraving::Chord* chord);
     bool readArtic(pugi::xml_node articNode, engraving::Chord* chord);
-    bool readBeam(pugi::xml_node beamNode, engraving::Measure* measure, int track, int& ticks);
-    bool readBTrem(pugi::xml_node bTremNode, engraving::Measure* measure, int track, int& ticks);
-    bool readClef(pugi::xml_node clefNode, engraving::Measure* measure, int track, int& ticks);
-    bool readChord(pugi::xml_node chordNode, engraving::Measure* measure, int track, int& ticks);
-    bool readGraceGrp(pugi::xml_node graceGrpNode, engraving::Measure* measure, int track, int& ticks);
-    bool readMRest(pugi::xml_node mRestNode, engraving::Measure* measure, int track, int& ticks);
-    bool readMRpt(pugi::xml_node mRptNode, engraving::Measure* measure, int track, int& ticks);
-    bool readNote(pugi::xml_node noteNode, engraving::Measure* measure, int track, int& ticks, engraving::Chord* chord = nullptr);
-    bool readRest(pugi::xml_node restNode, engraving::Measure* measure, int track, int& ticks);
-    bool readSpace(pugi::xml_node spaceNode, engraving::Measure* measure, int track, int& ticks);
+    bool readBeam(pugi::xml_node beamNode, engraving::Measure* measure, int track, engraving::Fraction& ticks);
+    bool readBTrem(pugi::xml_node bTremNode, engraving::Measure* measure, int track, engraving::Fraction& ticks);
+    bool readClef(pugi::xml_node clefNode, engraving::Measure* measure, int track, engraving::Fraction& ticks);
+    bool readChord(pugi::xml_node chordNode, engraving::Measure* measure, int track, engraving::Fraction& ticks);
+    bool readGraceGrp(pugi::xml_node graceGrpNode, engraving::Measure* measure, int track, engraving::Fraction& ticks);
+    bool readMRest(pugi::xml_node mRestNode, engraving::Measure* measure, int track, engraving::Fraction& ticks);
+    bool readMRpt(pugi::xml_node mRptNode, engraving::Measure* measure, int track, engraving::Fraction& ticks);
+    bool readNote(pugi::xml_node noteNode, engraving::Measure* measure, int track, engraving::Fraction& ticks, engraving::Chord* chord = nullptr);
+    bool readRest(pugi::xml_node restNode, engraving::Measure* measure, int track, engraving::Fraction& ticks);
+    bool readSpace(pugi::xml_node spaceNode, engraving::Measure* measure, int track, engraving::Fraction& ticks);
     bool readSyl(pugi::xml_node sylNode, engraving::Lyrics* lyrics, Convert::textWithSmufl& textBlocks, ElisionType elision);
-    bool readTuplet(pugi::xml_node tupletNode, engraving::Measure* measure, int track, int& ticks);
+    bool readTuplet(pugi::xml_node tupletNode, engraving::Measure* measure, int track, engraving::Fraction& ticks);
     bool readVerses(pugi::xml_node parentNode, engraving::Chord* chord);
     bool readVerse(pugi::xml_node verseNode, engraving::Chord* chord);
 
@@ -173,7 +173,7 @@ private:
     void addLog(const std::string& msg, pugi::xml_node node);
     bool isNode(pugi::xml_node node, const muse::String& name);
     engraving::ChordRest* addChordRest(pugi::xml_node node, engraving::Measure* measure, int track, const libmei::Element& meiElement,
-                                       int& ticks, bool isRest);
+                                       engraving::Fraction& ticks, bool isRest);
     bool addGraceNotesToChord(engraving::ChordRest* chordRest, bool isAfter = false);
     engraving::EngravingItem* addAnnotation(const libmei::Element& meiElement, engraving::Measure* measure);
     engraving::Spanner* addSpanner(const libmei::Element& meiElement, engraving::Measure* measure, pugi::xml_node node);

--- a/src/importexport/mei/tests/data/lyric-01.mscx
+++ b/src/importexport/mei/tests/data/lyric-01.mscx
@@ -113,7 +113,7 @@
             <durationType>eighth</durationType>
             <Lyrics>
               <ticks>960</ticks>
-              <ticks_f>1/2</ticks_f>
+              <ticks_f>4/8</ticks_f>
               <text>due</text>
               </Lyrics>
             <Note>
@@ -168,7 +168,7 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <ticks>2400</ticks>
-              <ticks_f>5/4</ticks_f>
+              <ticks_f>20/16</ticks_f>
               <text>ter</text>
               </Lyrics>
             <Note>

--- a/src/importexport/mei/tests/data/lyric-03.mscx
+++ b/src/importexport/mei/tests/data/lyric-03.mscx
@@ -113,7 +113,7 @@
               <no>1</no>
               <syllabic>end</syllabic>
               <ticks>1920</ticks>
-              <ticks_f>2/2</ticks_f>
+              <ticks_f>8/8</ticks_f>
               <text>que</text>
               </Lyrics>
             <Lyrics>
@@ -190,7 +190,7 @@
               </Lyrics>
             <Lyrics>
               <ticks>1920</ticks>
-              <ticks_f>1/1</ticks_f>
+              <ticks_f>8/8</ticks_f>
               <text>màs,</text>
               </Lyrics>
             <Note>
@@ -328,7 +328,7 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <ticks>1920</ticks>
-              <ticks_f>2/2</ticks_f>
+              <ticks_f>8/8</ticks_f>
               <text>màs</text>
               </Lyrics>
             <Note>
@@ -476,7 +476,7 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <ticks>1920</ticks>
-              <ticks_f>1/1</ticks_f>
+              <ticks_f>8/8</ticks_f>
               <text>màs,</text>
               </Lyrics>
             <Lyrics>

--- a/src/importexport/mei/tests/data/measure-repeat-01.mscx
+++ b/src/importexport/mei/tests/data/measure-repeat-01.mscx
@@ -127,7 +127,7 @@
           <MeasureRepeat>
             <subtype>1</subtype>
             <durationType>measure</durationType>
-            <duration>1/1</duration>
+            <duration>4/4</duration>
             </MeasureRepeat>
           </voice>
         </Measure>
@@ -138,7 +138,7 @@
             <subtype>1</subtype>
             <color r="255" g="38" b="0" a="255"/>
             <durationType>measure</durationType>
-            <duration>1/1</duration>
+            <duration>4/4</duration>
             </MeasureRepeat>
           <BarLine>
             </BarLine>


### PR DESCRIPTION
This PR fixes the MEI importer where the use of `int` would cause rounding error with some tuplets.