### PR TITLE
Prevent cross-measure beams to produce invalid MEI

### DIFF
--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -1072,6 +1072,11 @@ bool MeiExporter::writeBeam(const Beam* beam, const ChordRest* chordRest, bool& 
         return false;
     }
 
+    // Cross-staff beams are not supported in the export to MEI Basic
+    if (beam->elements().front()->measure() != beam->elements().back()->measure()) {
+        return true;
+    }
+
     if (beam->elements().front() == chordRest) {
         libmei::Beam meiBeam;
         m_currentNode = m_currentNode.append_child();


### PR DESCRIPTION
MEI files with cross-measure would not crash but be invalid. This makes sure the MEI file is still valid - even though the beam is dropped.