### PR TITLE
FIx #21244: Ensure all tracks are updated when a caesura is edited

### DIFF
--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -591,6 +591,7 @@ bool PlaybackModel::hasToReloadScore(const ScoreChangesRange& changesRange) cons
         ElementType::SYSTEM_TEXT,
         ElementType::JUMP,
         ElementType::MARKER,
+        ElementType::BREATH,
     };
 
     for (const ElementType type : REQUIRED_TYPES) {


### PR DESCRIPTION
Resolves: #21244

Caesura needs to be added to the list of types here so that `trackBoundaries` encompasses all tracks.