### PR TITLE
Fix compiler/build warnings

### DIFF
--- a/src/notation/view/styledialog/abstractstyledialogmodel.cpp
+++ b/src/notation/view/styledialog/abstractstyledialogmodel.cpp
@@ -34,8 +34,8 @@ AbstractStyleDialogModel::AbstractStyleDialogModel(QObject* parent, std::set<Sty
 StyleItem* AbstractStyleDialogModel::styleItem(StyleId id) const
 {
     if (!m_inited) {
-        for (StyleId id : m_ids) {
-            m_items.insert_or_assign(id, buildStyleItem(id));
+        for (StyleId mid : m_ids) {
+            m_items.insert_or_assign(mid, buildStyleItem(mid));
         }
 
         currentNotationStyle()->styleChanged().onNotify(this, [this]() {

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -2800,7 +2800,7 @@ void EditStyle::resetUserStyleName()
 
 void EditStyle::updateParenthesisIndicatingTiesGroupState()
 {
-    groupBox_2->setEnabled(tabShowTies->isChecked() || tabShowNone->isChecked());
+    tieParen->setEnabled(tabShowTies->isChecked() || tabShowNone->isChecked());
 }
 
 void EditStyle::clefVisibilityChanged(bool checked)

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -3974,7 +3974,7 @@
              <height>471</height>
             </rect>
            </property>
-           <layout class="QVBoxLayout" name="verticalLayout_63">
+           <layout class="QVBoxLayout" name="verticalLayout_631">
             <item>
              <widget class="QGroupBox" name="groupBox_accidentals">
               <property name="title">
@@ -4126,7 +4126,7 @@
               <property name="title">
                <string>Multiple accidentals in chords</string>
               </property>
-              <layout class="QGridLayout" name="gridLayout_67"/>
+              <layout class="QGridLayout" name="gridLayout_671"/>
              </widget>
             </item>
             <item>
@@ -7890,7 +7890,7 @@
           <property name="title">
            <string>Dynamics</string>
           </property>
-          <layout class="QGridLayout" name="gridLayout_67">
+          <layout class="QGridLayout" name="gridLayout_672">
            <item row="5" column="0">
             <widget class="QLabel" name="label_220">
              <property name="text">
@@ -8051,7 +8051,7 @@
              </property>
              <layout class="QHBoxLayout" name="horizontalLayout_14">
               <item>
-               <widget class="QLabel" name="label_222">
+               <widget class="QLabel" name="label_224">
                 <property name="text">
                  <string>Font:</string>
                 </property>
@@ -8333,7 +8333,7 @@
             </widget>
            </item>
            <item row="0" column="3">
-            <spacer name="horizontalSpacer_67">
+            <spacer name="horizontalSpacer_671">
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
              </property>
@@ -11125,7 +11125,7 @@
                 </widget>
                </item>
                <item>
-                <layout class="QGridLayout" name="gridLayout_671" columnminimumwidth="0,0,0,0,0,0,0">
+                <layout class="QGridLayout" name="gridLayout_673" columnminimumwidth="0,0,0,0,0,0,0">
                  <item row="3" column="1">
                   <widget class="QDoubleSpinBox" name="yLyricsPosBelow">
                    <property name="suffix">
@@ -11431,7 +11431,7 @@
                   </widget>
                  </item>
                  <item row="3" column="3">
-                  <spacer name="horizontalSpacer_671">
+                  <spacer name="horizontalSpacer_672">
                    <property name="orientation">
                     <enum>Qt::Horizontal</enum>
                    </property>
@@ -11541,7 +11541,7 @@
                 <property name="title">
                  <string>Dash</string>
                 </property>
-                <layout class="QVBoxLayout" name="verticalLayout_631">
+                <layout class="QVBoxLayout" name="verticalLayout_632">
                  <item>
                   <layout class="QGridLayout" name="gridLayout_23">
                    <property name="topMargin">
@@ -11922,7 +11922,7 @@ first note of the system</string>
                     </widget>
                    </item>
                    <item row="0" column="0">
-                    <widget class="QLabel" name="label_220">
+                    <widget class="QLabel" name="label_222">
                      <property name="text">
                       <string>Min. underscore length:</string>
                      </property>

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -7886,7 +7886,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QGroupBox" name="groupBox_dynamics_2">
+         <widget class="QGroupBox" name="groupBox_dynamics">
           <property name="title">
            <string>Dynamics</string>
           </property>
@@ -14016,7 +14016,7 @@ first note of the system</string>
                 </layout>
                </item>
                <item>
-                <widget class="QGroupBox" name="groupBox_1">
+                <widget class="QGroupBox" name="groupBox_tied_fret_marks">
                  <property name="title">
                   <string>Tied fret marks</string>
                  </property>
@@ -14046,7 +14046,7 @@ first note of the system</string>
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="groupBox_2">
+                <widget class="QGroupBox" name="tieParen">
                  <property name="title">
                   <string>Parentheses indicating ties</string>
                  </property>

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -7812,7 +7812,7 @@
       <widget class="QWidget" name="PageDynamicsAndHairpins">
        <layout class="QVBoxLayout" name="verticalLayout_19">
         <item>
-         <widget class="QGroupBox" name="groupBox">
+         <widget class="QGroupBox" name="groupBox_dynamic_hairpin">
           <property name="title">
            <string>Default positions of dynamics and hairpins</string>
           </property>


### PR DESCRIPTION
* reg.:
   * The name 'verticalLayout_63' (QVBoxLayout) is already in use, defaulting to 'verticalLayout_631'.
   * The name 'gridLayout_67' (QGridLayout) is already in use, defaulting to 'gridLayout_671'.
   * The name 'gridLayout_671' (QGridLayout) is already in use, defaulting to 'gridLayout_6711'.
   * The name 'verticalLayout_631' (QVBoxLayout) is already in use, defaulting to 'verticalLayout_6311'.