### PR TITLE
Fix #22344: calculate divisions and duration using Fractions

### DIFF
--- a/src/importexport/musicxml/tests/data/testDivisionsDuration.xml
+++ b/src/importexport/musicxml/tests/data/testDivisionsDuration.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="4.0">
   <work>
-    <work-title>Title</work-title>
+    <work-number>MuseScore testfile</work-number>
+    <work-title>Divisions and duration</work-title>
     </work>
   <identification>
     <encoding>
@@ -17,10 +18,10 @@
     </identification>
   <part-list>
     <score-part id="P1">
-      <part-name>Harp</part-name>
-      <part-abbreviation>Hrp.</part-abbreviation>
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
       <score-instrument id="P1-I1">
-        <instrument-name>Harp</instrument-name>
+        <instrument-name>Piano</instrument-name>
         </score-instrument>
       <midi-device id="P1-I1" port="1"></midi-device>
       <midi-instrument id="P1-I1">
@@ -34,13 +35,12 @@
   <part id="P1">
     <measure number="1">
       <attributes>
-        <divisions>9</divisions>
+        <divisions>7</divisions>
         <key>
-          <fifths>-3</fifths>
-          <mode>major</mode>
+          <fifths>0</fifths>
           </key>
         <time>
-          <beats>4</beats>
+          <beats>1</beats>
           <beat-type>4</beat-type>
           </time>
         <staves>2</staves>
@@ -54,42 +54,16 @@
           </clef>
         </attributes>
       <note>
-        <rest/>
-        <duration>36</duration>
-        <voice>1</voice>
-        <type>whole</type>
-        <staff>1</staff>
-        </note>
-      <backup>
-        <duration>36</duration>
-        </backup>
-      <note>
-        <rest/>
-        <duration>36</duration>
-        <voice>5</voice>
-        <type>whole</type>
-        <staff>2</staff>
-        </note>
-      </measure>
-    <measure number="2">
-      <note>
-        <rest/>
-        <duration>18</duration>
-        <voice>1</voice>
-        <type>half</type>
-        <staff>1</staff>
-        </note>
-      <note>
         <pitch>
-          <step>G</step>
-          <octave>4</octave>
+          <step>E</step>
+          <octave>5</octave>
           </pitch>
-        <duration>2</duration>
+        <duration>1</duration>
         <voice>1</voice>
         <type>16th</type>
         <time-modification>
-          <actual-notes>9</actual-notes>
-          <normal-notes>8</normal-notes>
+          <actual-notes>7</actual-notes>
+          <normal-notes>4</normal-notes>
           </time-modification>
         <stem>down</stem>
         <staff>1</staff>
@@ -101,70 +75,15 @@
         </note>
       <note>
         <pitch>
-          <step>A</step>
-          <alter>-1</alter>
-          <octave>4</octave>
-          </pitch>
-        <duration>2</duration>
-        <voice>1</voice>
-        <type>16th</type>
-        <accidental cautionary="yes" parentheses="no">flat</accidental>
-        <time-modification>
-          <actual-notes>9</actual-notes>
-          <normal-notes>8</normal-notes>
-          </time-modification>
-        <stem>down</stem>
-        <staff>1</staff>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        </note>
-      <note>
-        <pitch>
-          <step>B</step>
-          <alter>-1</alter>
-          <octave>4</octave>
-          </pitch>
-        <duration>2</duration>
-        <voice>1</voice>
-        <type>16th</type>
-        <accidental cautionary="yes" parentheses="no">flat</accidental>
-        <time-modification>
-          <actual-notes>9</actual-notes>
-          <normal-notes>8</normal-notes>
-          </time-modification>
-        <stem>down</stem>
-        <staff>1</staff>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        </note>
-      <note>
-        <pitch>
-          <step>C</step>
+          <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>2</duration>
+        <duration>1</duration>
         <voice>1</voice>
         <type>16th</type>
         <time-modification>
-          <actual-notes>9</actual-notes>
-          <normal-notes>8</normal-notes>
-          </time-modification>
-        <stem>down</stem>
-        <staff>1</staff>
-        <beam number="1">continue</beam>
-        <beam number="2">continue</beam>
-        </note>
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>5</octave>
-          </pitch>
-        <duration>2</duration>
-        <voice>1</voice>
-        <type>16th</type>
-        <time-modification>
-          <actual-notes>9</actual-notes>
-          <normal-notes>8</normal-notes>
+          <actual-notes>7</actual-notes>
+          <normal-notes>4</normal-notes>
           </time-modification>
         <stem>down</stem>
         <staff>1</staff>
@@ -174,16 +93,14 @@
       <note>
         <pitch>
           <step>E</step>
-          <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>2</duration>
+        <duration>1</duration>
         <voice>1</voice>
         <type>16th</type>
-        <accidental cautionary="yes" parentheses="no">flat</accidental>
         <time-modification>
-          <actual-notes>9</actual-notes>
-          <normal-notes>8</normal-notes>
+          <actual-notes>7</actual-notes>
+          <normal-notes>4</normal-notes>
           </time-modification>
         <stem>down</stem>
         <staff>1</staff>
@@ -195,13 +112,12 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>2</duration>
+        <duration>1</duration>
         <voice>1</voice>
         <type>16th</type>
-        <accidental cautionary="yes" parentheses="no">natural</accidental>
         <time-modification>
-          <actual-notes>9</actual-notes>
-          <normal-notes>8</normal-notes>
+          <actual-notes>7</actual-notes>
+          <normal-notes>4</normal-notes>
           </time-modification>
         <stem>down</stem>
         <staff>1</staff>
@@ -210,48 +126,74 @@
         </note>
       <note>
         <pitch>
-          <step>G</step>
+          <step>E</step>
           <octave>5</octave>
           </pitch>
-        <duration>2</duration>
+        <duration>1</duration>
         <voice>1</voice>
         <type>16th</type>
         <time-modification>
-          <actual-notes>9</actual-notes>
-          <normal-notes>8</normal-notes>
+          <actual-notes>7</actual-notes>
+          <normal-notes>4</normal-notes>
+          </time-modification>
+        <stem>down</stem>
+        <staff>1</staff>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>7</actual-notes>
+          <normal-notes>4</normal-notes>
+          </time-modification>
+        <stem>down</stem>
+        <staff>1</staff>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>7</actual-notes>
+          <normal-notes>4</normal-notes>
           </time-modification>
         <stem>down</stem>
         <staff>1</staff>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
-        </note>
-      <note>
-        <rest/>
-        <duration>2</duration>
-        <voice>1</voice>
-        <type>16th</type>
-        <time-modification>
-          <actual-notes>9</actual-notes>
-          <normal-notes>8</normal-notes>
-          </time-modification>
-        <staff>1</staff>
         <notations>
           <tuplet type="stop"/>
           </notations>
         </note>
       <backup>
-        <duration>36</duration>
+        <duration>7</duration>
         </backup>
       <note>
-        <rest/>
-        <duration>36</duration>
+        <pitch>
+          <step>E</step>
+          <octave>2</octave>
+          </pitch>
+        <duration>7</duration>
         <voice>5</voice>
-        <type>whole</type>
+        <type>quarter</type>
+        <stem>up</stem>
         <staff>2</staff>
         </note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>
-        <repeat direction="backward"/>
         </barline>
       </measure>
     </part>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -544,6 +544,9 @@ TEST_F(Musicxml_Tests, divisionsDefinedTooLate1) {
 TEST_F(Musicxml_Tests, divisionsDefinedTooLate2) {
     mxmlIoTestRef("testDivsDefinedTooLate2");
 }
+TEST_F(Musicxml_Tests, divisionsDuration) {
+    mxmlIoTest("testDivisionsDuration");
+}
 TEST_F(Musicxml_Tests, doubleClefError) {
     mxmlIoTestRef("testDoubleClefError");
 }


### PR DESCRIPTION
Resolves: #22344

For historical reasons, the MusicXML exporter calculates the MusicXML divisions and duration values using ticks (the code predates the introduction of Fraction and was never updated). This works reasonably OK only for non-nested tuples up to quintuplets, but may introduce slight rounding errors.

Solution is to use Fractions in these calculations.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
