### PR TITLE
Add support for MEI export and import of MuseScore IDs

### DIFF
--- a/src/importexport/mei/imeiconfiguration.h
+++ b/src/importexport/mei/imeiconfiguration.h
@@ -37,6 +37,9 @@ public:
 
     virtual bool meiExportLayout() const = 0;
     virtual void setMeiExportLayout(bool value) = 0;
+
+    virtual bool meiUseMscoreIds() const = 0;
+    virtual void setMeiUseMscoreIds(bool value) = 0;
 };
 }
 

--- a/src/importexport/mei/imeiconfiguration.h
+++ b/src/importexport/mei/imeiconfiguration.h
@@ -38,8 +38,8 @@ public:
     virtual bool meiExportLayout() const = 0;
     virtual void setMeiExportLayout(bool value) = 0;
 
-    virtual bool meiUseMscoreIds() const = 0;
-    virtual void setMeiUseMscoreIds(bool value) = 0;
+    virtual bool meiUseMuseScoreIds() const = 0;
+    virtual void setMeiUseMuseScoreIds(bool value) = 0;
 };
 }
 

--- a/src/importexport/mei/internal/meiconfiguration.cpp
+++ b/src/importexport/mei/internal/meiconfiguration.cpp
@@ -31,11 +31,13 @@ static const std::string module_name("iex_mei");
 
 static const Settings::Key MEI_IMPORT_LAYOUT_KEY(module_name, "import/mei/importMeiLayout");
 static const Settings::Key MEI_EXPORT_LAYOUT_KEY(module_name, "export/mei/exportMeiLayout");
+static const Settings::Key MEI_USE_MSCORE_IDS_KEY(module_name, "export/mei/useMscoreIds");
 
 void MeiConfiguration::init()
 {
     settings()->setDefaultValue(MEI_IMPORT_LAYOUT_KEY, Val(true));
     settings()->setDefaultValue(MEI_EXPORT_LAYOUT_KEY, Val(true));
+    settings()->setDefaultValue(MEI_USE_MSCORE_IDS_KEY, Val(false));
 }
 
 bool MeiConfiguration::meiImportLayout() const
@@ -56,4 +58,14 @@ bool MeiConfiguration::meiExportLayout() const
 void MeiConfiguration::setMeiExportLayout(bool value)
 {
     settings()->setSharedValue(MEI_EXPORT_LAYOUT_KEY, Val(value));
+}
+
+bool MeiConfiguration::meiUseMscoreIds() const
+{
+    return settings()->value(MEI_USE_MSCORE_IDS_KEY).toBool();
+}
+
+void MeiConfiguration::setMeiUseMscoreIds(bool value)
+{
+    settings()->setSharedValue(MEI_USE_MSCORE_IDS_KEY, Val(value));
 }

--- a/src/importexport/mei/internal/meiconfiguration.cpp
+++ b/src/importexport/mei/internal/meiconfiguration.cpp
@@ -31,13 +31,13 @@ static const std::string module_name("iex_mei");
 
 static const Settings::Key MEI_IMPORT_LAYOUT_KEY(module_name, "import/mei/importMeiLayout");
 static const Settings::Key MEI_EXPORT_LAYOUT_KEY(module_name, "export/mei/exportMeiLayout");
-static const Settings::Key MEI_USE_MSCORE_IDS_KEY(module_name, "export/mei/useMscoreIds");
+static const Settings::Key MEI_USE_MUSESCORE_IDS_KEY(module_name, "export/mei/useMuseScoreIds");
 
 void MeiConfiguration::init()
 {
     settings()->setDefaultValue(MEI_IMPORT_LAYOUT_KEY, Val(true));
     settings()->setDefaultValue(MEI_EXPORT_LAYOUT_KEY, Val(true));
-    settings()->setDefaultValue(MEI_USE_MSCORE_IDS_KEY, Val(false));
+    settings()->setDefaultValue(MEI_USE_MUSESCORE_IDS_KEY, Val(false));
 }
 
 bool MeiConfiguration::meiImportLayout() const
@@ -60,12 +60,12 @@ void MeiConfiguration::setMeiExportLayout(bool value)
     settings()->setSharedValue(MEI_EXPORT_LAYOUT_KEY, Val(value));
 }
 
-bool MeiConfiguration::meiUseMscoreIds() const
+bool MeiConfiguration::meiUseMuseScoreIds() const
 {
-    return settings()->value(MEI_USE_MSCORE_IDS_KEY).toBool();
+    return settings()->value(MEI_USE_MUSESCORE_IDS_KEY).toBool();
 }
 
-void MeiConfiguration::setMeiUseMscoreIds(bool value)
+void MeiConfiguration::setMeiUseMuseScoreIds(bool value)
 {
-    settings()->setSharedValue(MEI_USE_MSCORE_IDS_KEY, Val(value));
+    settings()->setSharedValue(MEI_USE_MUSESCORE_IDS_KEY, Val(value));
 }

--- a/src/importexport/mei/internal/meiconfiguration.h
+++ b/src/importexport/mei/internal/meiconfiguration.h
@@ -36,8 +36,8 @@ public:
     bool meiExportLayout() const override;
     void setMeiExportLayout(bool value) override;
 
-    bool meiUseMscoreIds() const override;
-    void setMeiUseMscoreIds(bool value) override;
+    bool meiUseMuseScoreIds() const override;
+    void setMeiUseMuseScoreIds(bool value) override;
 };
 }
 

--- a/src/importexport/mei/internal/meiconfiguration.h
+++ b/src/importexport/mei/internal/meiconfiguration.h
@@ -35,6 +35,9 @@ public:
 
     bool meiExportLayout() const override;
     void setMeiExportLayout(bool value) override;
+
+    bool meiUseMscoreIds() const override;
+    void setMeiUseMscoreIds(bool value) override;
 };
 }
 

--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -94,7 +94,7 @@ using namespace mu::engraving;
 
 bool MeiExporter::write(std::string& meiData)
 {
-    bool useMscoreIds = configuration()->meiUseMscoreIds();
+    const bool useMuseScoreIds = configuration()->meiUseMuseScoreIds();
 
     m_uids = UIDRegister::instance();
     m_xmlIDCounter = 0;
@@ -133,7 +133,7 @@ bool MeiExporter::write(std::string& meiData)
         m_mei.append_attribute("xmlns") = "http://www.music-encoding.org/ns/mei";
 
         // Option to use MuseScore Ids has priority
-        if (useMscoreIds) {
+        if (useMuseScoreIds) {
             std::stringstream xmlId;
             xmlId << "mscore-" << m_score->masterScore()->getEID()->lastID();
             m_mei.append_attribute("xml:id") = xmlId.str().c_str();
@@ -2551,9 +2551,9 @@ std::string MeiExporter::generateHashID()
 
 std::string MeiExporter::getXmlIdFor(const EngravingItem* item, const char c)
 {
-    bool useMscoreIds = configuration()->meiUseMscoreIds();
+    const bool useMuseScoreIds = configuration()->meiUseMuseScoreIds();
 
-    if (useMscoreIds) {
+    if (useMuseScoreIds) {
         return "mscore-" + item->eid().toStdString();
     } else if (m_uids->hasUid(item)) {
         return m_uids->uid(item);

--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -94,7 +94,7 @@ using namespace mu::engraving;
 
 bool MeiExporter::write(std::string& meiData)
 {
-    bool useMscoreIds = true; //configuration()->meiUseMscoreIds();
+    bool useMscoreIds = configuration()->meiUseMscoreIds();
 
     m_uids = UIDRegister::instance();
     m_xmlIDCounter = 0;
@@ -2551,7 +2551,7 @@ std::string MeiExporter::generateHashID()
 
 std::string MeiExporter::getXmlIdFor(const EngravingItem* item, const char c)
 {
-    bool useMscoreIds = true; //configuration()->meiUseMscoreIds();
+    bool useMscoreIds = configuration()->meiUseMscoreIds();
 
     if (useMscoreIds) {
         return "mscore-" + item->eid().toStdString();

--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -46,6 +46,7 @@
 #include "engraving/dom/laissezvib.h"
 #include "engraving/dom/lyrics.h"
 #include "engraving/dom/marker.h"
+#include "engraving/dom/masterscore.h"
 #include "engraving/dom/measure.h"
 #include "engraving/dom/measurerepeat.h"
 #include "engraving/dom/note.h"
@@ -93,6 +94,8 @@ using namespace mu::engraving;
 
 bool MeiExporter::write(std::string& meiData)
 {
+    bool useMscoreIds = true; //configuration()->meiUseMscoreIds();
+
     m_uids = UIDRegister::instance();
     m_xmlIDCounter = 0;
 
@@ -129,10 +132,19 @@ bool MeiExporter::write(std::string& meiData)
         m_mei = meiDoc.append_child("mei");
         m_mei.append_attribute("xmlns") = "http://www.music-encoding.org/ns/mei";
 
-        // Save xml:id metaTag's as mei@xml:id
-        String xmlId = m_score->metaTag(u"xml:id");
-        if (!xmlId.isEmpty()) {
-            m_mei.append_attribute("xml:id") = xmlId.toStdString().c_str();
+        // Option to use MuseScore Ids has priority
+        if (useMscoreIds) {
+            std::stringstream xmlId;
+            xmlId << "mscore-" << m_score->masterScore()->getEID()->lastID();
+            m_mei.append_attribute("xml:id") = xmlId.str().c_str();
+        }
+        // Otherwise check if we have a metaTag
+        else {
+            // Save xml:id metaTag's as mei@xml:id
+            String xmlId = m_score->metaTag(u"xml:id");
+            if (!xmlId.isEmpty()) {
+                m_mei.append_attribute("xml:id") = xmlId.toStdString().c_str();
+            }
         }
 
         libmei::AttConverter converter;
@@ -2539,7 +2551,11 @@ std::string MeiExporter::generateHashID()
 
 std::string MeiExporter::getXmlIdFor(const EngravingItem* item, const char c)
 {
-    if (m_uids->hasUid(item)) {
+    bool useMscoreIds = true; //configuration()->meiUseMscoreIds();
+
+    if (useMscoreIds) {
+        return "mscore-" + item->eid().toStdString();
+    } else if (m_uids->hasUid(item)) {
         return m_uids->uid(item);
     }
 

--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -135,7 +135,11 @@ bool MeiExporter::write(std::string& meiData)
         // Option to use MuseScore Ids has priority
         if (useMuseScoreIds) {
             std::stringstream xmlId;
-            xmlId << "mscore-" << m_score->masterScore()->getEID()->lastID();
+            EID eid = m_score->masterScore()->eid();
+            if (!eid.isValid()) {
+                eid = m_score->masterScore()->assignNewEID();
+            }
+            xmlId << "mscore-" << eid.toStdString();
             m_mei.append_attribute("xml:id") = xmlId.str().c_str();
         }
         // Otherwise check if we have a metaTag
@@ -2554,7 +2558,11 @@ std::string MeiExporter::getXmlIdFor(const EngravingItem* item, const char c)
     const bool useMuseScoreIds = configuration()->meiUseMuseScoreIds();
 
     if (useMuseScoreIds) {
-        return "mscore-" + item->eid().toStdString();
+        EID eid = item->eid();
+        if (!eid.isValid()) {
+            eid = item->assignNewEID();
+        }
+        return "mscore-" + eid.toStdString();
     } else if (m_uids->hasUid(item)) {
         return m_uids->uid(item);
     }

--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -139,7 +139,8 @@ bool MeiExporter::write(std::string& meiData)
             if (!eid.isValid()) {
                 eid = m_score->masterScore()->assignNewEID();
             }
-            xmlId << "mscore-" << eid.toStdString();
+            String eidStr = String::fromStdString(eid.toStdString().c_str());
+            xmlId << "mscore-" << eidStr.replace('/', '.').replace('+', '-').toStdString();
             m_mei.append_attribute("xml:id") = xmlId.str().c_str();
         }
         // Otherwise check if we have a metaTag
@@ -2562,7 +2563,8 @@ std::string MeiExporter::getXmlIdFor(const EngravingItem* item, const char c)
         if (!eid.isValid()) {
             eid = item->assignNewEID();
         }
-        return "mscore-" + eid.toStdString();
+        String eidStr = String::fromStdString(eid.toStdString().c_str());
+        return "mscore-" + eidStr.replace('/', '.').replace('+', '-').toStdString();
     } else if (m_uids->hasUid(item)) {
         return m_uids->uid(item);
     }

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -141,7 +141,7 @@ bool MeiImporter::read(const muse::io::path_t& path)
         hasRootXmlId = true;
         String xmlIdStr = String(xmlId.value());
         if (xmlIdStr.startsWith(u"mscore-")) {
-            // Keep a global flag since we are going to read them only if mei@xml:id is given with LastEID
+            // Keep a global flag since we are going to read them only if mei@xml:id is given with mscore EID
             m_hasMuseScoreIds = true;
             String valStr = xmlIdStr.remove(u"mscore-").replace('.', '/').replace('-', '+');
             // The  mei@xml:id store the score EID

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -878,7 +878,12 @@ void MeiImporter::readXmlId(engraving::EngravingItem* item, const std::string& m
     // We have a file that has MuseScore EIDs and one on this element
     if (m_hasMscoreIds && xmlIdStr.startsWith(u"mscore-")) {
         String valStr = xmlIdStr.remove(u"mscore-");
-        item->setEID(EID::fromStdString(valStr.toStdString()));
+        EID eid = EID::fromStdString(valStr.toStdString());
+        if (!eid.isValid()) {
+            Convert::logs.push_back(String("A valid MuseScore ID could not be extracted from '%1'").arg(xmlIdStr));
+        } else {
+            item->setEID(eid);
+        }
     } else {
         m_uids->reg(item, meiUID);
     }

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -143,7 +143,7 @@ bool MeiImporter::read(const muse::io::path_t& path)
         if (xmlIdStr.startsWith(u"mscore-")) {
             // Keep a global flag since we are going to read them only if mei@xml:id is given with LastEID
             m_hasMuseScoreIds = true;
-            String valStr = xmlIdStr.remove(u"mscore-");
+            String valStr = xmlIdStr.remove(u"mscore-").replace('.', '/').replace('-', '+');
             // The  mei@xml:id store the score EID
             EID eid = EID::fromStdString(valStr.toStdString());
             if (eid.isValid()) {
@@ -884,7 +884,7 @@ void MeiImporter::readXmlId(engraving::EngravingItem* item, const std::string& m
     String xmlIdStr = String::fromStdString(meiUID);
     // We have a file that has MuseScore EIDs and one on this element
     if (m_hasMuseScoreIds && xmlIdStr.startsWith(u"mscore-")) {
-        String valStr = xmlIdStr.remove(u"mscore-");
+        String valStr = xmlIdStr.remove(u"mscore-").replace('.', '/').replace('-', '+');
         EID eid = EID::fromStdString(valStr.toStdString());
         if (!eid.isValid()) {
             Convert::logs.push_back(String("A valid MuseScore ID could not be extracted from '%1'").arg(xmlIdStr));

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -98,7 +98,7 @@ bool MeiImporter::read(const muse::io::path_t& path)
 {
     m_uids = UIDRegister::instance();
     m_uids->clear();
-    m_hasMscoreIds = false;
+    m_hasMuseScoreIds = false;
 
     m_lastMeasure = nullptr;
     m_tremoloId.clear();
@@ -142,7 +142,7 @@ bool MeiImporter::read(const muse::io::path_t& path)
         String xmlIdStr = String(xmlId.value());
         if (xmlIdStr.startsWith(u"mscore-")) {
             // Keep a global flag since we are going to read them only if mei@xml:id is given with LastEID
-            m_hasMscoreIds = true;
+            m_hasMuseScoreIds = true;
             String valStr = xmlIdStr.remove(u"mscore-");
             // The  mei@xml:id store the LastEID
             m_score->masterScore()->getEID()->init(valStr.toInt());
@@ -876,7 +876,7 @@ void MeiImporter::readXmlId(engraving::EngravingItem* item, const std::string& m
 {
     String xmlIdStr = String::fromStdString(meiUID);
     // We have a file that has MuseScore EIDs and one on this element
-    if (m_hasMscoreIds && xmlIdStr.startsWith(u"mscore-")) {
+    if (m_hasMuseScoreIds && xmlIdStr.startsWith(u"mscore-")) {
         String valStr = xmlIdStr.remove(u"mscore-");
         EID eid = EID::fromStdString(valStr.toStdString());
         if (!eid.isValid()) {

--- a/src/importexport/mei/internal/meiimporter.h
+++ b/src/importexport/mei/internal/meiimporter.h
@@ -198,11 +198,17 @@ private:
     void extendLyrics();
     void setOrnamentAccid(engraving::Ornament* ornament, const Convert::OrnamStruct& ornamSt);
 
+    /** Read the xmlId and process it appropriately */
+    void readXmlId(engraving::EngravingItem* item, const std::string& meiUID);
+
     /** The Score pointer */
     engraving::Score* m_score = nullptr;
 
     /** The uid register */
     UIDRegister* m_uids;
+
+    /** A flag indicating the file has MuseScore EIDs as xml:ids */
+    bool m_hasMscoreIds;
 
     engraving::Fraction m_ticks;
     int m_lastMeasureN;

--- a/src/importexport/mei/internal/meiimporter.h
+++ b/src/importexport/mei/internal/meiimporter.h
@@ -208,7 +208,7 @@ private:
     UIDRegister* m_uids;
 
     /** A flag indicating the file has MuseScore EIDs as xml:ids */
-    bool m_hasMscoreIds;
+    bool m_hasMuseScoreIds;
 
     engraving::Fraction m_ticks;
     int m_lastMeasureN;

--- a/src/project/qml/MuseScore/Project/internal/Export/MeiSettingsPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/MeiSettingsPage.qml
@@ -39,4 +39,18 @@ ExportSettingsPage {
             root.model.meiExportLayout = !checked
         }
     }
+
+    CheckBox {
+        width: parent.width
+        text: qsTrc("project/export", "Use MuseScore Ids")
+
+        navigation.name: "MeiUseMscoreIds"
+        navigation.panel: root.navigationPanel
+        navigation.row: root.navigationOrder + 1
+
+        checked: root.model.meiUseMscoreIds
+        onClicked: {
+            root.model.meiUseMscoreIds = !checked
+        }
+    }
 }

--- a/src/project/qml/MuseScore/Project/internal/Export/MeiSettingsPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/MeiSettingsPage.qml
@@ -44,13 +44,13 @@ ExportSettingsPage {
         width: parent.width
         text: qsTrc("project/export", "Use MuseScore element IDs")
 
-        navigation.name: "MeiUseMscoreIds"
+        navigation.name: "MeiUseMuseScoreIds"
         navigation.panel: root.navigationPanel
         navigation.row: root.navigationOrder + 1
 
-        checked: root.model.meiUseMscoreIds
+        checked: root.model.meiUseMuseScoreIds
         onClicked: {
-            root.model.meiUseMscoreIds = !checked
+            root.model.meiUseMuseScoreIds = !checked
         }
     }
 }

--- a/src/project/qml/MuseScore/Project/internal/Export/MeiSettingsPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/MeiSettingsPage.qml
@@ -42,7 +42,7 @@ ExportSettingsPage {
 
     CheckBox {
         width: parent.width
-        text: qsTrc("project/export", "Use MuseScore Ids")
+        text: qsTrc("project/export", "Use MuseScore element IDs")
 
         navigation.name: "MeiUseMscoreIds"
         navigation.panel: root.navigationPanel

--- a/src/project/view/exportdialogmodel.cpp
+++ b/src/project/view/exportdialogmodel.cpp
@@ -553,6 +553,21 @@ void ExportDialogModel::setMeiExportLayout(bool exportLayout)
     emit meiExportLayoutChanged(exportLayout);
 }
 
+bool ExportDialogModel::meiUseMscoreIds() const
+{
+    return meiConfiguration()->meiUseMscoreIds();
+}
+
+void ExportDialogModel::setMeiUseMscoreIds(bool useMscoreIds)
+{
+    if (useMscoreIds == meiUseMscoreIds()) {
+        return;
+    }
+
+    meiConfiguration()->setMeiUseMscoreIds(useMscoreIds);
+    emit meiUseMscoreIdsChanged(useMscoreIds);
+}
+
 QVariantList ExportDialogModel::musicXmlLayoutTypes() const
 {
     QMap<MusicXmlLayoutType, QString> musicXmlLayoutTypeNames {

--- a/src/project/view/exportdialogmodel.cpp
+++ b/src/project/view/exportdialogmodel.cpp
@@ -553,19 +553,19 @@ void ExportDialogModel::setMeiExportLayout(bool exportLayout)
     emit meiExportLayoutChanged(exportLayout);
 }
 
-bool ExportDialogModel::meiUseMscoreIds() const
+bool ExportDialogModel::meiUseMuseScoreIds() const
 {
-    return meiConfiguration()->meiUseMscoreIds();
+    return meiConfiguration()->meiUseMuseScoreIds();
 }
 
-void ExportDialogModel::setMeiUseMscoreIds(bool useMscoreIds)
+void ExportDialogModel::setMeiUseMuseScoreIds(bool useMuseScoreIds)
 {
-    if (useMscoreIds == meiUseMscoreIds()) {
+    if (useMuseScoreIds == meiUseMuseScoreIds()) {
         return;
     }
 
-    meiConfiguration()->setMeiUseMscoreIds(useMscoreIds);
-    emit meiUseMscoreIdsChanged(useMscoreIds);
+    meiConfiguration()->setMeiUseMuseScoreIds(useMuseScoreIds);
+    emit meiUseMuseScoreIdsChanged(useMuseScoreIds);
 }
 
 QVariantList ExportDialogModel::musicXmlLayoutTypes() const

--- a/src/project/view/exportdialogmodel.h
+++ b/src/project/view/exportdialogmodel.h
@@ -86,6 +86,7 @@ class ExportDialogModel : public QAbstractListModel, public muse::async::Asyncab
     Q_PROPERTY(MusicXmlLayoutType musicXmlLayoutType READ musicXmlLayoutType WRITE setMusicXmlLayoutType NOTIFY musicXmlLayoutTypeChanged)
 
     Q_PROPERTY(int meiExportLayout READ meiExportLayout WRITE setMeiExportLayout NOTIFY meiExportLayoutChanged)
+    Q_PROPERTY(int meiUseMscoreIds READ meiUseMscoreIds WRITE setMeiUseMscoreIds NOTIFY meiUseMscoreIdsChanged)
 
     Q_PROPERTY(bool shouldDestinationFolderBeOpenedOnExport READ shouldDestinationFolderBeOpenedOnExport
                WRITE setShouldDestinationFolderBeOpenedOnExport NOTIFY shouldDestinationFolderBeOpenedOnExportChanged)
@@ -149,6 +150,9 @@ public:
     bool meiExportLayout() const;
     void setMeiExportLayout(bool exportLayout);
 
+    bool meiUseMscoreIds() const;
+    void setMeiUseMscoreIds(bool useMscoreIds);
+
     enum class MusicXmlLayoutType {
         AllLayout,
         AllBreaks,
@@ -191,6 +195,7 @@ signals:
     void musicXmlLayoutTypeChanged(MusicXmlLayoutType layoutType);
 
     void meiExportLayoutChanged(bool exportLayout);
+    void meiUseMscoreIdsChanged(bool useMscoreIds);
 
     void shouldDestinationFolderBeOpenedOnExportChanged(bool shouldDestinationFolderBeOpenedOnExport);
 

--- a/src/project/view/exportdialogmodel.h
+++ b/src/project/view/exportdialogmodel.h
@@ -86,7 +86,7 @@ class ExportDialogModel : public QAbstractListModel, public muse::async::Asyncab
     Q_PROPERTY(MusicXmlLayoutType musicXmlLayoutType READ musicXmlLayoutType WRITE setMusicXmlLayoutType NOTIFY musicXmlLayoutTypeChanged)
 
     Q_PROPERTY(int meiExportLayout READ meiExportLayout WRITE setMeiExportLayout NOTIFY meiExportLayoutChanged)
-    Q_PROPERTY(int meiUseMscoreIds READ meiUseMscoreIds WRITE setMeiUseMscoreIds NOTIFY meiUseMscoreIdsChanged)
+    Q_PROPERTY(int meiUseMuseScoreIds READ meiUseMuseScoreIds WRITE setMeiUseMuseScoreIds NOTIFY meiUseMuseScoreIdsChanged)
 
     Q_PROPERTY(bool shouldDestinationFolderBeOpenedOnExport READ shouldDestinationFolderBeOpenedOnExport
                WRITE setShouldDestinationFolderBeOpenedOnExport NOTIFY shouldDestinationFolderBeOpenedOnExportChanged)
@@ -150,8 +150,8 @@ public:
     bool meiExportLayout() const;
     void setMeiExportLayout(bool exportLayout);
 
-    bool meiUseMscoreIds() const;
-    void setMeiUseMscoreIds(bool useMscoreIds);
+    bool meiUseMuseScoreIds() const;
+    void setMeiUseMuseScoreIds(bool useMuseScoreIds);
 
     enum class MusicXmlLayoutType {
         AllLayout,
@@ -195,7 +195,7 @@ signals:
     void musicXmlLayoutTypeChanged(MusicXmlLayoutType layoutType);
 
     void meiExportLayoutChanged(bool exportLayout);
-    void meiUseMscoreIdsChanged(bool useMscoreIds);
+    void meiUseMuseScoreIdsChanged(bool useMuseScoreIds);
 
     void shouldDestinationFolderBeOpenedOnExportChanged(bool shouldDestinationFolderBeOpenedOnExport);
 


### PR DESCRIPTION
Adds an option so enable the use of MuseScore EIDs in the MEI export.

<img width="369" alt="image" src="https://github.com/musescore/MuseScore/assets/689412/957ef01c-f8b3-4ec7-90d9-f1cc88534688">

The option is not selected by default at this stage.

When selected, MEI elements take the MuseScore EID as `@xml:id` whenever appropriate, always prefixed with `mscore-`
```xml
<note xml:id="mscore-1786706395156" dur="8" pname="b" oct="4">
``` 

The LastEID is stored in the `mei@xml:id`, also prefixed with `mscore-`. The values are preserved in the importer. When re-exporting the file, only the `mei@xml:id` is expected to change in the same way is does with MuseScore files.