### PR TITLE
fix #20932: bracket color not saved

### DIFF
--- a/src/engraving/dom/bracket.h
+++ b/src/engraving/dom/bracket.h
@@ -79,8 +79,8 @@ public:
     void editDrag(EditData&) override;
     void endEditDrag(EditData&) override;
 
-    Color color() const override { return m_bi->color(); }
-
+    Color color() const override { return m_bi->bracketColor(); }
+    
     bool acceptDrop(EditData&) const override;
     EngravingItem* drop(EditData&) override;
 

--- a/src/engraving/dom/bracketItem.h
+++ b/src/engraving/dom/bracketItem.h
@@ -54,6 +54,9 @@ public:
     size_t column() const { return m_column; }
     void setColumn(size_t v) { m_column = v; }
 
+    Color bracketColor() const { return m_color; }
+    void setBracketColor(Color c) { m_color = c; }
+
 private:
 
     friend class Factory;
@@ -65,6 +68,8 @@ private:
     size_t m_column = 0;
     size_t m_bracketSpan = 0;
     Staff* m_staff = nullptr;
+
+    Color m_color;
 };
 }
 #endif

--- a/src/engraving/dom/staff.cpp
+++ b/src/engraving/dom/staff.cpp
@@ -177,7 +177,19 @@ size_t Staff::bracketSpan(size_t idx) const
 }
 
 //---------------------------------------------------------
-//   setBracket
+//   bracketColor
+//---------------------------------------------------------
+
+Color Staff::bracketColor(size_t idx) const
+{
+    if (idx < m_brackets.size()) {
+        return m_brackets[idx]->bracketColor();
+    }
+    return 0x000000;
+}
+
+//---------------------------------------------------------
+//   setBracketType
 //---------------------------------------------------------
 
 void Staff::setBracketType(size_t idx, BracketType val)
@@ -229,6 +241,20 @@ void Staff::setBracketSpan(size_t idx, size_t val)
     fillBrackets(idx);
     m_brackets[idx]->setBracketSpan(val);
 }
+
+//---------------------------------------------------------
+//   setBracketColor
+//---------------------------------------------------------
+
+void Staff::setBracketColor(size_t idx, const Color& color)
+{
+    fillBrackets(idx);
+    m_brackets[idx]->setBracketColor(color);
+}
+
+//---------------------------------------------------------
+//   setBracketVisible
+//---------------------------------------------------------
 
 void Staff::setBracketVisible(size_t idx, bool v)
 {

--- a/src/engraving/dom/staff.h
+++ b/src/engraving/dom/staff.h
@@ -87,6 +87,8 @@ public:
     size_t bracketSpan(size_t idx) const;
     void setBracketType(size_t idx, BracketType val);
     void setBracketSpan(size_t idx, size_t val);
+    Color bracketColor(size_t idx) const;
+    void setBracketColor(size_t idx, const Color& val);
     void setBracketVisible(size_t idx, bool v);
     void swapBracket(size_t oldIdx, size_t newIdx);
     void changeBracketColumn(size_t oldColumn, size_t newColumn);

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -502,6 +502,10 @@ void TWrite::writeItemProperties(const EngravingItem* item, XmlWriter& xml, Writ
             writeProperty(item, xml, pid);
         }
     }
+    
+    if (item->color() != engravingConfiguration()->defaultColor()) {
+        xml.tagProperty(Pid::COLOR, item->color());
+    }
 
     writeProperty(item, xml, Pid::POSITION_LINKED_TO_MASTER);
     writeProperty(item, xml, Pid::APPEARANCE_LINKED_TO_MASTER);
@@ -2331,7 +2335,7 @@ void TWrite::write(const Part* item, XmlWriter& xml, WriteContext& ctx)
     xml.tag("trackName", item->partName());
 
     if (item->color() != Part::DEFAULT_COLOR) {
-        xml.tag("color", item->color());
+        xml.tagProperty(Pid::COLOR, item->color());
     }
 
     if (item->preferSharpFlat() != PreferSharpFlat::AUTO) {
@@ -2594,6 +2598,9 @@ void TWrite::write(const Staff* item, XmlWriter& xml, WriteContext& ctx)
         bool v = i->visible();
         if (a != BracketType::NO_BRACKET || b > 0) {
             xml.tag("bracket", { { "type", static_cast<int>(a) }, { "span", b }, { "col", c }, { "visible", v } });
+        }
+        if (i->color() != engravingConfiguration()->defaultColor()) {
+            xml.tagProperty(Pid::COLOR, item->color());
         }
     }
 


### PR DESCRIPTION
Resolves: #20932 

The bug fix allows the behavior of the brackets to match the behavior of the rest of the elements in the score

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
