### PR TITLE
Added buttons for PianoKeyboard to switch between Notated Pitch (effective pitch) and Playback Pitch.

### DIFF
--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -192,6 +192,9 @@ public:
     virtual muse::ValCh<int> pianoKeyboardNumberOfKeys() const = 0;
     virtual void setPianoKeyboardNumberOfKeys(int number) = 0;
 
+    virtual muse::ValCh<bool> pianoKeyboardPitchState() const = 0;
+    virtual void setPianoKeyboardPitchState(bool useNotatedPitch) = 0;
+
     virtual muse::io::path_t styleFileImportPath() const = 0;
     virtual void setStyleFileImportPath(const muse::io::path_t& path) = 0;
 

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -192,8 +192,8 @@ public:
     virtual muse::ValCh<int> pianoKeyboardNumberOfKeys() const = 0;
     virtual void setPianoKeyboardNumberOfKeys(int number) = 0;
 
-    virtual muse::ValCh<bool> pianoKeyboardPitchState() const = 0;
-    virtual void setPianoKeyboardPitchState(bool useNotatedPitch) = 0;
+    virtual muse::ValCh<bool> pianoKeyboardUsingNotatedPitch() const = 0;
+    virtual void setPianoKeyboardUseNotatedPitch(bool useNotatedPitch) = 0;
 
     virtual muse::io::path_t styleFileImportPath() const = 0;
     virtual void setStyleFileImportPath(const muse::io::path_t& path) = 0;

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -89,6 +89,8 @@ static const Settings::Key NEED_TO_SHOW_ADD_GUITAR_BEND_ERROR_MESSAGE_KEY(module
 
 static const Settings::Key PIANO_KEYBOARD_NUMBER_OF_KEYS(module_name,  "pianoKeyboard/numberOfKeys");
 
+static const Settings::Key PIANO_KEYBOARD_PITCH_STATE(module_name,  "pianoKeyboard/useNotatedPitch");
+
 static const Settings::Key STYLE_FILE_IMPORT_PATH_KEY(module_name, "import/style/styleFile");
 
 static constexpr int DEFAULT_GRID_SIZE_SPATIUM = 2;
@@ -212,6 +214,12 @@ void NotationConfiguration::init()
     m_pianoKeyboardNumberOfKeys.val = settings()->value(PIANO_KEYBOARD_NUMBER_OF_KEYS).toInt();
     settings()->valueChanged(PIANO_KEYBOARD_NUMBER_OF_KEYS).onReceive(this, [this](const Val& val) {
         m_pianoKeyboardNumberOfKeys.set(val.toInt());
+    });
+
+    settings()->setDefaultValue(PIANO_KEYBOARD_PITCH_STATE, Val(true));
+    m_pianoKeyboardPitchState.val = settings()->value(PIANO_KEYBOARD_PITCH_STATE).toBool();
+    settings()->valueChanged(PIANO_KEYBOARD_PITCH_STATE).onReceive(this, [this](const Val& val) {
+        m_pianoKeyboardPitchState.set(val.toBool());
     });
 
     engravingConfiguration()->scoreInversionChanged().onNotify(this, [this]() {
@@ -862,6 +870,16 @@ ValCh<int> NotationConfiguration::pianoKeyboardNumberOfKeys() const
 void NotationConfiguration::setPianoKeyboardNumberOfKeys(int number)
 {
     settings()->setSharedValue(PIANO_KEYBOARD_NUMBER_OF_KEYS, Val(number));
+}
+
+ValCh<bool> NotationConfiguration::pianoKeyboardPitchState() const
+{
+    return m_pianoKeyboardPitchState;
+}
+
+void NotationConfiguration::setPianoKeyboardPitchState(bool useNotatedPitch)
+{
+    settings()->setSharedValue(PIANO_KEYBOARD_PITCH_STATE, Val(useNotatedPitch));
 }
 
 muse::io::path_t NotationConfiguration::firstScoreOrderListPath() const

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -217,9 +217,9 @@ void NotationConfiguration::init()
     });
 
     settings()->setDefaultValue(PIANO_KEYBOARD_PITCH_STATE, Val(true));
-    m_pianoKeyboardPitchState.val = settings()->value(PIANO_KEYBOARD_PITCH_STATE).toBool();
+    m_pianoKeyboardUsingNotatedPitch.val = settings()->value(PIANO_KEYBOARD_PITCH_STATE).toBool();
     settings()->valueChanged(PIANO_KEYBOARD_PITCH_STATE).onReceive(this, [this](const Val& val) {
-        m_pianoKeyboardPitchState.set(val.toBool());
+        m_pianoKeyboardUsingNotatedPitch.set(val.toBool());
     });
 
     engravingConfiguration()->scoreInversionChanged().onNotify(this, [this]() {
@@ -872,12 +872,12 @@ void NotationConfiguration::setPianoKeyboardNumberOfKeys(int number)
     settings()->setSharedValue(PIANO_KEYBOARD_NUMBER_OF_KEYS, Val(number));
 }
 
-ValCh<bool> NotationConfiguration::pianoKeyboardPitchState() const
+ValCh<bool> NotationConfiguration::pianoKeyboardUsingNotatedPitch() const
 {
-    return m_pianoKeyboardPitchState;
+    return m_pianoKeyboardUsingNotatedPitch;
 }
 
-void NotationConfiguration::setPianoKeyboardPitchState(bool useNotatedPitch)
+void NotationConfiguration::setPianoKeyboardUseNotatedPitch(bool useNotatedPitch)
 {
     settings()->setSharedValue(PIANO_KEYBOARD_PITCH_STATE, Val(useNotatedPitch));
 }

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -197,6 +197,9 @@ public:
     muse::ValCh<int> pianoKeyboardNumberOfKeys() const override;
     void setPianoKeyboardNumberOfKeys(int number) override;
 
+    muse::ValCh<bool> pianoKeyboardPitchState() const override;
+    void setPianoKeyboardPitchState(bool useNotatedPitch) override;
+
     muse::io::path_t styleFileImportPath() const override;
     void setStyleFileImportPath(const muse::io::path_t& path) override;
 
@@ -224,6 +227,7 @@ private:
     muse::async::Notification m_isPlayRepeatsChanged;
     muse::async::Notification m_isPlayChordSymbolsChanged;
     muse::ValCh<int> m_pianoKeyboardNumberOfKeys;
+    muse::ValCh<bool> m_pianoKeyboardPitchState;
 
     int m_styleDialogLastPageIndex = 0;
     int m_styleDialogLastSubPageIndex = 0;

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -197,8 +197,8 @@ public:
     muse::ValCh<int> pianoKeyboardNumberOfKeys() const override;
     void setPianoKeyboardNumberOfKeys(int number) override;
 
-    muse::ValCh<bool> pianoKeyboardPitchState() const override;
-    void setPianoKeyboardPitchState(bool useNotatedPitch) override;
+    muse::ValCh<bool> pianoKeyboardUsingNotatedPitch() const override;
+    void setPianoKeyboardUseNotatedPitch(bool useNotatedPitch) override;
 
     muse::io::path_t styleFileImportPath() const override;
     void setStyleFileImportPath(const muse::io::path_t& path) override;
@@ -227,7 +227,7 @@ private:
     muse::async::Notification m_isPlayRepeatsChanged;
     muse::async::Notification m_isPlayChordSymbolsChanged;
     muse::ValCh<int> m_pianoKeyboardNumberOfKeys;
-    muse::ValCh<bool> m_pianoKeyboardPitchState;
+    muse::ValCh<bool> m_pianoKeyboardUsingNotatedPitch;
 
     int m_styleDialogLastPageIndex = 0;
     int m_styleDialogLastSubPageIndex = 0;

--- a/src/notation/tests/mocks/notationconfigurationmock.h
+++ b/src/notation/tests/mocks/notationconfigurationmock.h
@@ -182,6 +182,9 @@ public:
     MOCK_METHOD(muse::ValCh<int>, pianoKeyboardNumberOfKeys, (), (const, override));
     MOCK_METHOD(void, setPianoKeyboardNumberOfKeys, (int), (override));
 
+    MOCK_METHOD(muse::ValCh<bool>, pianoKeyboardPitchState, (), (const, override));
+    MOCK_METHOD(void, setPianoKeyboardPitchState, (bool), (override));
+
     MOCK_METHOD(muse::io::path_t, styleFileImportPath, (), (const, override));
     MOCK_METHOD(void, setStyleFileImportPath, (const muse::io::path_t&), (override));
 

--- a/src/notation/tests/mocks/notationconfigurationmock.h
+++ b/src/notation/tests/mocks/notationconfigurationmock.h
@@ -182,8 +182,8 @@ public:
     MOCK_METHOD(muse::ValCh<int>, pianoKeyboardNumberOfKeys, (), (const, override));
     MOCK_METHOD(void, setPianoKeyboardNumberOfKeys, (int), (override));
 
-    MOCK_METHOD(muse::ValCh<bool>, pianoKeyboardPitchState, (), (const, override));
-    MOCK_METHOD(void, setPianoKeyboardPitchState, (bool), (override));
+    MOCK_METHOD(muse::ValCh<bool>, pianoKeyboardUsingNotatedPitch, (), (const, override));
+    MOCK_METHOD(void, setPianoKeyboardUseNotatedPitch, (bool), (override));
 
     MOCK_METHOD(muse::io::path_t, styleFileImportPath, (), (const, override));
     MOCK_METHOD(void, setStyleFileImportPath, (const muse::io::path_t&), (override));

--- a/src/notation/view/pianokeyboard/pianokeyboardcontroller.cpp
+++ b/src/notation/view/pianokeyboard/pianokeyboardcontroller.cpp
@@ -132,9 +132,9 @@ void PianoKeyboardController::updateNotesKeys(const std::vector<const Note*>& re
     };
 
     for (const mu::engraving::Note* note : receivedNotes) {
-        newKeys.insert(static_cast<piano_key_t>(note->epitch()));
+        newKeys.insert(static_cast<piano_key_t>(pianoKeyboardPitchState() ? note->epitch() : note->ppitch()));
         for (const mu::engraving::Note* otherNote : note->chord()->notes()) {
-            newOtherNotesInChord.insert(static_cast<piano_key_t>(otherNote->epitch()));
+            newOtherNotesInChord.insert(static_cast<piano_key_t>(pianoKeyboardPitchState() ? otherNote->epitch() : otherNote->ppitch()));
         }
     }
 }
@@ -173,4 +173,18 @@ void PianoKeyboardController::sendNoteOff(piano_key_t key)
 INotationPtr PianoKeyboardController::currentNotation() const
 {
     return context()->currentNotation();
+}
+
+bool PianoKeyboardController::pianoKeyboardPitchState() const
+{
+    return configuration()->pianoKeyboardPitchState().val;
+}
+
+void PianoKeyboardController::setPianoKeyboardPitchState(bool useNotatedPitch)
+{
+    if (configuration()->pianoKeyboardPitchState().val == useNotatedPitch) {
+        return;
+    }
+
+    configuration()->setPianoKeyboardPitchState(useNotatedPitch);
 }

--- a/src/notation/view/pianokeyboard/pianokeyboardcontroller.cpp
+++ b/src/notation/view/pianokeyboard/pianokeyboardcontroller.cpp
@@ -132,9 +132,9 @@ void PianoKeyboardController::updateNotesKeys(const std::vector<const Note*>& re
     };
 
     for (const mu::engraving::Note* note : receivedNotes) {
-        newKeys.insert(static_cast<piano_key_t>(pianoKeyboardPitchState() ? note->epitch() : note->ppitch()));
+        newKeys.insert(static_cast<piano_key_t>(usingNotatedPitch() ? note->epitch() : note->ppitch()));
         for (const mu::engraving::Note* otherNote : note->chord()->notes()) {
-            newOtherNotesInChord.insert(static_cast<piano_key_t>(pianoKeyboardPitchState() ? otherNote->epitch() : otherNote->ppitch()));
+            newOtherNotesInChord.insert(static_cast<piano_key_t>(usingNotatedPitch() ? otherNote->epitch() : otherNote->ppitch()));
         }
     }
 }
@@ -175,16 +175,7 @@ INotationPtr PianoKeyboardController::currentNotation() const
     return context()->currentNotation();
 }
 
-bool PianoKeyboardController::pianoKeyboardPitchState() const
+bool PianoKeyboardController::usingNotatedPitch() const
 {
-    return configuration()->pianoKeyboardPitchState().val;
-}
-
-void PianoKeyboardController::setPianoKeyboardPitchState(bool useNotatedPitch)
-{
-    if (configuration()->pianoKeyboardPitchState().val == useNotatedPitch) {
-        return;
-    }
-
-    configuration()->setPianoKeyboardPitchState(useNotatedPitch);
+    return configuration()->pianoKeyboardUsingNotatedPitch().val;
 }

--- a/src/notation/view/pianokeyboard/pianokeyboardcontroller.h
+++ b/src/notation/view/pianokeyboard/pianokeyboardcontroller.h
@@ -22,10 +22,7 @@
 #ifndef MU_NOTATION_PIANOKEYBOARDCONTROLLER_H
 #define MU_NOTATION_PIANOKEYBOARDCONTROLLER_H
 
-#include <QObject>
-
 #include "async/asyncable.h"
-#include "actions/actionable.h"
 
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
@@ -33,7 +30,7 @@
 #include "pianokeyboardtypes.h"
 
 namespace mu::notation {
-class PianoKeyboardController : public muse::async::Asyncable, public muse::actions::Actionable
+class PianoKeyboardController : public muse::async::Asyncable
 {
     INJECT(INotationConfiguration, configuration)
     INJECT(context::IGlobalContext, context)
@@ -51,8 +48,7 @@ public:
 
     bool isFromMidi() const;
 
-    bool pianoKeyboardPitchState() const;
-    void setPianoKeyboardPitchState(bool useNotatedPitch);
+    bool usingNotatedPitch() const;
 
 private:
     INotationPtr currentNotation() const;

--- a/src/notation/view/pianokeyboard/pianokeyboardcontroller.h
+++ b/src/notation/view/pianokeyboard/pianokeyboardcontroller.h
@@ -22,7 +22,10 @@
 #ifndef MU_NOTATION_PIANOKEYBOARDCONTROLLER_H
 #define MU_NOTATION_PIANOKEYBOARDCONTROLLER_H
 
+#include <QObject>
+
 #include "async/asyncable.h"
+#include "actions/actionable.h"
 
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
@@ -30,8 +33,9 @@
 #include "pianokeyboardtypes.h"
 
 namespace mu::notation {
-class PianoKeyboardController : public muse::async::Asyncable
+class PianoKeyboardController : public muse::async::Asyncable, public muse::actions::Actionable
 {
+    INJECT(INotationConfiguration, configuration)
     INJECT(context::IGlobalContext, context)
 
 public:
@@ -46,6 +50,9 @@ public:
     muse::async::Notification keyStatesChanged() const;
 
     bool isFromMidi() const;
+
+    bool pianoKeyboardPitchState() const;
+    void setPianoKeyboardPitchState(bool useNotatedPitch);
 
 private:
     INotationPtr currentNotation() const;

--- a/src/notation/view/pianokeyboard/pianokeyboardpanelcontextmenumodel.cpp
+++ b/src/notation/view/pianokeyboard/pianokeyboardpanelcontextmenumodel.cpp
@@ -73,11 +73,6 @@ int PianoKeyboardPanelContextMenuModel::numberOfKeys() const
     return configuration()->pianoKeyboardNumberOfKeys().val;
 }
 
-bool PianoKeyboardPanelContextMenuModel::pianoKeyboardPitchState() const
-{
-    return configuration()->pianoKeyboardPitchState().val;
-}
-
 MenuItem* PianoKeyboardPanelContextMenuModel::makePitchMenu()
 {
     MenuItemList items;
@@ -91,7 +86,7 @@ MenuItem* PianoKeyboardPanelContextMenuModel::makePitchMenu()
         items << makeToggleNotatedPitchItem(title, notationState);
     }
 
-    configuration()->pianoKeyboardPitchState().ch.onReceive(this, [this](bool) {
+    configuration()->pianoKeyboardUsingNotatedPitch().ch.onReceive(this, [this](bool) {
         emit pianoKeyboardPitchStateChanged();
     });
 
@@ -100,7 +95,7 @@ MenuItem* PianoKeyboardPanelContextMenuModel::makePitchMenu()
             return;
         }
 
-        configuration()->setPianoKeyboardPitchState(args.arg<bool>(0));
+        configuration()->setPianoKeyboardUseNotatedPitch(args.arg<bool>(0));
         emit pianoKeyboardPitchStateChanged();
     });
 
@@ -213,7 +208,7 @@ MenuItem* PianoKeyboardPanelContextMenuModel::makeToggleNotatedPitchItem(const m
     MenuItem* item = new MenuItem(action, this);
     item->setId(QString::fromStdString(SET_NOTATED_PITCH_CODE) + (isNotatedPitch ? "-notated" : "-playback"));
 
-    ValCh<bool> currentState = configuration()->pianoKeyboardPitchState();
+    ValCh<bool> currentState = configuration()->pianoKeyboardUsingNotatedPitch();
 
     bool checked = !(isNotatedPitch ^ currentState.val);
     item->setState(UiActionState::make_enabled(checked));

--- a/src/notation/view/pianokeyboard/pianokeyboardpanelcontextmenumodel.h
+++ b/src/notation/view/pianokeyboard/pianokeyboardpanelcontextmenumodel.h
@@ -54,16 +54,22 @@ public:
 
     int numberOfKeys() const;
 
+    bool pianoKeyboardPitchState() const;
+
 signals:
     void keyWidthScalingChanged();
     void setKeyWidthScalingRequested(qreal scaling);
     void numberOfKeysChanged();
+    void pianoKeyboardPitchStateChanged();
 
 private:
     muse::uicomponents::MenuItem* makeViewMenu();
+    muse::uicomponents::MenuItem* makePitchMenu();
 
     muse::uicomponents::MenuItem* makeKeyWidthScalingItem(const muse::TranslatableString& title, qreal scaling);
     muse::uicomponents::MenuItem* makeNumberOfKeysItem(const muse::TranslatableString& title, int numberOfKeys);
+
+    muse::uicomponents::MenuItem* makeToggleNotatedPitchItem(const muse::TranslatableString& title, bool isNotatedPitch);
 
     void updateKeyWidthScalingItems();
 

--- a/src/notation/view/pianokeyboard/pianokeyboardpanelcontextmenumodel.h
+++ b/src/notation/view/pianokeyboard/pianokeyboardpanelcontextmenumodel.h
@@ -54,8 +54,6 @@ public:
 
     int numberOfKeys() const;
 
-    bool pianoKeyboardPitchState() const;
-
 signals:
     void keyWidthScalingChanged();
     void setKeyWidthScalingRequested(qreal scaling);

--- a/src/stubs/notation/notationconfigurationstub.cpp
+++ b/src/stubs/notation/notationconfigurationstub.cpp
@@ -465,6 +465,16 @@ void NotationConfigurationStub::setPianoKeyboardNumberOfKeys(int)
 {
 }
 
+ValCh<bool> NotationConfigurationStub::pianoKeyboardPitchState() const
+{
+    static ValCh<bool> vch;
+    return vch;
+}
+
+void NotationConfigurationStub::setPianoKeyboardPitchState(bool)
+{
+}
+
 muse::io::path_t NotationConfigurationStub::styleFileImportPath() const
 {
     return muse::io::path_t();

--- a/src/stubs/notation/notationconfigurationstub.cpp
+++ b/src/stubs/notation/notationconfigurationstub.cpp
@@ -465,13 +465,13 @@ void NotationConfigurationStub::setPianoKeyboardNumberOfKeys(int)
 {
 }
 
-ValCh<bool> NotationConfigurationStub::pianoKeyboardPitchState() const
+ValCh<bool> NotationConfigurationStub::pianoKeyboardUsingNotatedPitch() const
 {
     static ValCh<bool> vch;
     return vch;
 }
 
-void NotationConfigurationStub::setPianoKeyboardPitchState(bool)
+void NotationConfigurationStub::setPianoKeyboardUseNotatedPitch(bool)
 {
 }
 

--- a/src/stubs/notation/notationconfigurationstub.h
+++ b/src/stubs/notation/notationconfigurationstub.h
@@ -171,8 +171,8 @@ public:
     ValCh<int> pianoKeyboardNumberOfKeys() const override;
     void setPianoKeyboardNumberOfKeys(int number)  override;
 
-    ValCh<bool> pianoKeyboardPitchState() const override;
-    void setPianoKeyboardPitchState(bool value)  override;
+    ValCh<bool> pianoKeyboardUseNotatedPitch() const override;
+    void setPianoKeyboardUseNotatedPitch(bool notated)  override;
 
     muse::io::path_t styleFileImportPath() const override;
     void setStyleFileImportPath(const muse::io::path_t& path)  override;

--- a/src/stubs/notation/notationconfigurationstub.h
+++ b/src/stubs/notation/notationconfigurationstub.h
@@ -171,6 +171,9 @@ public:
     ValCh<int> pianoKeyboardNumberOfKeys() const override;
     void setPianoKeyboardNumberOfKeys(int number)  override;
 
+    ValCh<bool> pianoKeyboardPitchState() const override;
+    void setPianoKeyboardPitchState(bool value)  override;
+
     muse::io::path_t styleFileImportPath() const override;
     void setStyleFileImportPath(const muse::io::path_t& path)  override;
 };


### PR DESCRIPTION
Resolves: #15594

Title describes well enough. We just added buttons in the PianoKeyboardPanelContextMenuModel class that communicate with the PianoKeyboardController class to change a boolean variable. The aim is to address a limitation in the current implementation of MuseScore's keyboard view, which struggles with differently-tuned instruments. When users click on a key, the corresponding note used to be placed on the score as notated pitch, while the equivalent standard pitch was highlighted on the keyboard UI, leading to potential confusion.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
