### PR TITLE
MEI: make measure repeat symbol explicit

### DIFF
--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -1366,6 +1366,7 @@ bool MeiExporter::writeMRpt(const MeasureRepeat* measureRepeat)
 
     libmei::MRpt meiMRpt;
     Convert::colorToMEI(measureRepeat, meiMRpt);
+    meiMRpt.SetExpand(libmei::BOOLEAN_false);
     pugi::xml_node mRptNode = m_currentNode.append_child();
     meiMRpt.Write(mRptNode, this->getXmlIdFor(measureRepeat, 'm'));
 

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -1840,6 +1840,10 @@ bool MeiImporter::readMRpt(pugi::xml_node mRptNode, Measure* measure, int track,
     libmei::MRpt meiMRpt;
     meiMRpt.Read(mRptNode);
 
+    if (meiMRpt.GetExpand() == libmei::BOOLEAN_true) {
+        LOGD() << "MeiImporter::readMRpt cannot expand measure repeats";
+    }
+
     Segment* segment = measure->getSegment(SegmentType::ChordRest, ticks + measure->tick());
     MeasureRepeat* measureRepeat = Factory::createMeasureRepeat(segment);
     Convert::colorFromMEI(measureRepeat, meiMRpt);

--- a/src/importexport/mei/tests/data/measure-repeat-01.mei
+++ b/src/importexport/mei/tests/data/measure-repeat-01.mei
@@ -60,14 +60,14 @@
                   <measure xml:id="m5j6f22" n="3">
                      <staff xml:id="m3s1" n="1">
                         <layer xml:id="m3s1l1" n="1">
-                           <mRpt xml:id="m1arid13" />
+                           <mRpt xml:id="m1arid13" expand="false" />
                         </layer>
                      </staff>
                   </measure>
                   <measure xml:id="m182l9m2" n="4">
                      <staff xml:id="m4s1" n="1">
                         <layer xml:id="m4s1l1" n="1">
-                           <mRpt xml:id="ms3niss" color="#FF2600" />
+                           <mRpt xml:id="ms3niss" color="#FF2600" expand="false" />
                         </layer>
                      </staff>
                   </measure>


### PR DESCRIPTION
This PR adds support for the `@expand` attribute on MEI's `mRpt` element to make it explicit, that the abbreviation symbol has to be used.