### PR TITLE
Shortcuts. Fixed key mapping for macOS

### DIFF
--- a/src/framework/shortcuts/CMakeLists.txt
+++ b/src/framework/shortcuts/CMakeLists.txt
@@ -76,7 +76,6 @@ if (OS_IS_MAC)
 
     set(MODULE_INCLUDE
         ${CARBON_LIBRARY}
-        ${Qt6Gui_PRIVATE_INCLUDE_DIRS}
     )
 endif(OS_IS_MAC)
 

--- a/src/framework/shortcuts/data/shortcuts-Mac.xml
+++ b/src/framework/shortcuts/data/shortcuts-Mac.xml
@@ -642,7 +642,7 @@
     </SC>
   <SC>
     <key>tie</key>
-    <seq>t</seq>
+    <seq>T</seq>
     </SC>
   <SC>
     <key>acciaccatura</key>

--- a/src/framework/shortcuts/data/shortcuts.xml
+++ b/src/framework/shortcuts/data/shortcuts.xml
@@ -642,7 +642,7 @@
     </SC>
   <SC>
     <key>tie</key>
-    <seq>t</seq>
+    <seq>T</seq>
     </SC>
   <SC>
     <key>acciaccatura</key>

--- a/src/framework/shortcuts/data/shortcuts_AZERTY.xml
+++ b/src/framework/shortcuts/data/shortcuts_AZERTY.xml
@@ -668,7 +668,7 @@
     </SC>
   <SC>
     <key>tie</key>
-    <seq>t</seq>
+    <seq>T</seq>
     </SC>
   <SC>
     <key>acciaccatura</key>

--- a/src/framework/shortcuts/internal/platform/macos/macosshortcutsinstancemodel.mm
+++ b/src/framework/shortcuts/internal/platform/macos/macosshortcutsinstancemodel.mm
@@ -26,12 +26,64 @@
 #include <QApplication>
 #include <QKeyEvent>
 
-#include <private/qguiapplication_p.h>
-#include <qpa/qplatformintegration.h>
-
 #include "log.h"
 
 using namespace muse::shortcuts;
+
+static std::map<UInt32, QString> specialKeysMap = {
+    { kVK_F1, "F1" },
+    { kVK_F2, "F2" },
+    { kVK_F3, "F3" },
+    { kVK_F4, "F4" },
+    { kVK_F5, "F5" },
+    { kVK_F6, "F6" },
+    { kVK_F7, "F7" },
+    { kVK_F8, "F8" },
+    { kVK_F9, "F9" },
+    { kVK_F10, "F10" },
+    { kVK_F11, "F11" },
+    { kVK_F12, "F12" },
+    { kVK_F13, "F13" },
+    { kVK_F14, "F14" },
+    { kVK_F15, "F15" },
+    { kVK_F16, "F16" },
+    { kVK_F17, "F17" },
+    { kVK_F18, "F18" },
+    { kVK_F19, "F19" },
+    { kVK_Space, "Space" },
+    { kVK_Escape, "Esc" },
+    { kVK_Delete, "Backspace" },
+    { kVK_ForwardDelete, "Delete" },
+    { kVK_LeftArrow, "Left" },
+    { kVK_RightArrow, "Right" },
+    { kVK_UpArrow, "Up" },
+    { kVK_DownArrow, "Down" },
+    { kVK_Help, "" },
+    { kVK_PageUp, "PgUp" },
+    { kVK_PageDown, "PgDown" },
+    { kVK_Tab, "Tab" },
+    { kVK_Return, "Return" },
+    { kVK_Home, "Home" },
+    { kVK_End, "End" },
+    { kVK_ANSI_Keypad0, "0" },
+    { kVK_ANSI_Keypad1, "1" },
+    { kVK_ANSI_Keypad2, "2" },
+    { kVK_ANSI_Keypad3, "3" },
+    { kVK_ANSI_Keypad4, "4" },
+    { kVK_ANSI_Keypad5, "5" },
+    { kVK_ANSI_Keypad6, "6" },
+    { kVK_ANSI_Keypad7, "7" },
+    { kVK_ANSI_Keypad8, "8" },
+    { kVK_ANSI_Keypad9, "9" },
+    { kVK_ANSI_KeypadDecimal, "." },
+    { kVK_ANSI_KeypadMultiply, "*" },
+    { kVK_ANSI_KeypadPlus, "+" },
+    { kVK_ANSI_KeypadClear, "Clear" },
+    { kVK_ANSI_KeypadDivide, "/" },
+    { kVK_ANSI_KeypadEnter, "Enter" },
+    { kVK_ANSI_KeypadMinus, "-" },
+    { kVK_ANSI_KeypadEquals, "=" }
+};
 
 static UCKeyboardLayout* keyboardLayout()
 {
@@ -57,7 +109,7 @@ static UCKeyboardLayout* keyboardLayout()
     return (UCKeyboardLayout*)CFDataGetBytePtr(uchr);
 }
 
-static quint32 nativeKeycode(UCKeyboardLayout* keyboard, Qt::Key keyCode)
+static UInt32 nativeKeycode(UCKeyboardLayout* keyboard, Qt::Key keyCode)
 {
     switch (keyCode) {
     case Qt::Key_Return:
@@ -148,7 +200,7 @@ static quint32 nativeKeycode(UCKeyboardLayout* keyboard, Qt::Key keyCode)
     UCKeyboardTypeHeader* table = keyboard->keyboardTypeList;
 
     uint8_t* data = (uint8_t*)keyboard;
-    for (quint32 i = 0; i < keyboard->keyboardTypeCount; i++) {
+    for (UInt32 i = 0; i < keyboard->keyboardTypeCount; i++) {
         UCKeyStateRecordsIndex* stateRec = 0;
         if (table[i].keyStateRecordsIndexOffset != 0) {
             stateRec = reinterpret_cast<UCKeyStateRecordsIndex*>(data + table[i].keyStateRecordsIndexOffset);
@@ -162,9 +214,9 @@ static quint32 nativeKeycode(UCKeyboardLayout* keyboard, Qt::Key keyCode)
             continue;
         }
 
-        for (quint32 j = 0; j < charTable->keyToCharTableCount; j++) {
+        for (UInt32 j = 0; j < charTable->keyToCharTableCount; j++) {
             UCKeyOutput* keyToChar = reinterpret_cast<UCKeyOutput*>(data + charTable->keyToCharTableOffsets[j]);
-            for (quint32 k = 0; k < charTable->keyToCharTableSize; k++) {
+            for (UInt32 k = 0; k < charTable->keyToCharTableSize; k++) {
                 if (keyToChar[k] & kUCKeyOutputTestForIndexMask) {
                     long idx = keyToChar[k] & kUCKeyOutputGetIndexMask;
                     if (stateRec && idx < stateRec->keyStateRecordCount) {
@@ -185,9 +237,9 @@ static quint32 nativeKeycode(UCKeyboardLayout* keyboard, Qt::Key keyCode)
     return 0;
 }
 
-quint32 nativeModifiers(UCKeyboardLayout* keyboard, int key, Qt::KeyboardModifiers modifiers, quint32 keyNativeCode)
+UInt32 nativeModifiers(Qt::KeyboardModifiers modifiers)
 {
-    quint32 result = 0;
+    UInt32 result = 0;
     if (modifiers & Qt::ShiftModifier) {
         result |= shiftKey;
     }
@@ -204,105 +256,81 @@ quint32 nativeModifiers(UCKeyboardLayout* keyboard, int key, Qt::KeyboardModifie
         result |= kEventKeyModifierNumLockMask;
     }
 
-    if (result == 0) {
-        //! NOTE: Some symbols are available only through modifiers;
-        //! if modifiers are not explicitly specified,
-        //! we will get them through the native key
-
-        //!NOTE: The algorithm below does not work correctly for this key
-        if (key == Qt::Key_Plus) {
-            return result;
-        }
-
-        UTF16Char keyCodeChar = key;
-
-        int withoutModifiers = 0;
-        int alt = (optionKey >> 8) & 0xff;
-        int shift = (shiftKey >> 8) & 0xff;
-        int altShift = ((optionKey | shiftKey) >> 8) & 0xff;
-
-        UInt32 deadKeyState = 0;
-        UniCharCount count;
-        UniChar character;
-
-        static UInt8 (* LMGetKbdType)(void);
-
-        CFBundleRef bundle = CFBundleGetBundleWithIdentifier(CFSTR("com.apple.Carbon"));
-
-        if (bundle) {
-            *(void**)& LMGetKbdType = CFBundleGetFunctionPointerForName(bundle, CFSTR("LMGetKbdType"));
-        }
-
-        UInt8 keyboardType = LMGetKbdType();
-
-        OSStatus err = UCKeyTranslate(keyboard, keyNativeCode, kUCKeyActionDown, withoutModifiers, keyboardType, 0,
-                                      &deadKeyState, 1, &count, &character);
-
-        if (err == noErr && count > 0 && character == keyCodeChar) {
-            //! no need modifiers for key
-            return result;
-        }
-
-        err = UCKeyTranslate(keyboard, keyNativeCode, kUCKeyActionDown, alt, keyboardType, 0,
-                             &deadKeyState, 1, &count, &character);
-
-        if (err == noErr && count > 0 && character == keyCodeChar) {
-            return optionKey;
-        }
-
-        err = UCKeyTranslate(keyboard, keyNativeCode, kUCKeyActionDown, shift, keyboardType, 0,
-                             &deadKeyState, 1, &count, &character);
-
-        if (err == noErr && count > 0 && character == keyCodeChar) {
-            return shiftKey;
-        }
-
-        err = UCKeyTranslate(keyboard, keyNativeCode, kUCKeyActionDown, altShift, keyboardType, 0,
-                             &deadKeyState, 1, &count, &character);
-
-        if (err == noErr && count > 0 && character == keyCodeChar) {
-            return optionKey | shiftKey;
-        }
-    }
-
     return result;
 }
 
-Qt::KeyboardModifiers qtModifiers(int keys)
+QString keyCodeToString(UCKeyboardLayout* keyboard, UInt32 keyNativeCode)
 {
-    static QMap<int, Qt::KeyboardModifier> qtModifiers = {
-        { shiftKey, Qt::ShiftModifier },
-        { rightShiftKey, Qt::ShiftModifier },
-        { controlKey, Qt::MetaModifier },
-        { rightControlKey, Qt::MetaModifier },
-        { cmdKey, Qt::ControlModifier },
-        { optionKey, Qt::AltModifier },
-        { rightOptionKey, Qt::AltModifier },
-        { kEventKeyModifierNumLockMask, Qt::KeypadModifier },
-        { 0, Qt::NoModifier }
+    if (muse::contains(specialKeysMap, keyNativeCode)) {
+        return specialKeysMap[keyNativeCode];
+    }
+
+    static UInt8 (* LMGetKbdType)(void);
+
+    CFBundleRef bundle = CFBundleGetBundleWithIdentifier(CFSTR("com.apple.Carbon"));
+
+    if (bundle) {
+        *(void**)& LMGetKbdType = CFBundleGetFunctionPointerForName(bundle, CFSTR("LMGetKbdType"));
+    }
+
+    UInt32 deadKeyState = 0;
+    UniCharCount actualLength = 0;
+    const int maxLength = 4;
+
+    UniChar actualString[maxLength] = { 0 };
+
+    OSStatus error = UCKeyTranslate(keyboard,
+                                    UInt16(keyNativeCode),
+                                    UInt16(kUCKeyActionDisplay),
+                                    UInt32((0 >> 8) & 0xFF),
+                                    UInt32(LMGetKbdType()),
+                                    OptionBits(kUCKeyTranslateNoDeadKeysBit),
+                                    &deadKeyState,
+                                    maxLength,
+                                    &actualLength,
+                                    actualString);
+    if (error == 0) {
+        NSString* nsString = [NSString stringWithCharacters:actualString length:(NSUInteger)actualLength];
+        return QString::fromNSString(nsString).toUpper();
+    }
+
+    return "";
+}
+
+QString keyModifiersToString(UInt32 keyNativeModifiers)
+{
+    static QMap<int, QString> qtModifiers = {
+        { shiftKey, "Shift" },
+        { rightShiftKey, "Shift" },
+        { controlKey, "Ctrl" },
+        { rightControlKey, "Ctrl" },
+        { cmdKey, "Ctrl" },
+        { optionKey, "Alt" },
+        { rightOptionKey, "Alt" },
+        { kEventKeyModifierNumLockMask, "Num" }
     };
 
-    Qt::KeyboardModifiers result = Qt::NoModifier;
-    QMapIterator<int, Qt::KeyboardModifier> it(qtModifiers);
+    QString result;
+    QMapIterator<int, QString> it(qtModifiers);
     while (it.hasNext()) {
         it.next();
 
-        if (keys & it.key()) {
-            result |= it.value();
+        if (keyNativeModifiers & it.key()) {
+            if (!result.isEmpty()) {
+                result += "+";
+            }
+            result += it.value();
         }
     }
 
     return result;
 }
 
-QSet<QKeyCombination> possibleKeys(const QKeySequence& sequence)
+QString translateToCurrentKeyboardLayout(const QKeySequence& sequence)
 {
     const QKeyCombination keyCombination = sequence[0];
 
     const Qt::Key qKey = keyCombination.key();
-    if (qKey == Qt::Key_Insert) {
-        return { keyCombination };
-    }
 
     UCKeyboardLayout* keyboard = keyboardLayout();
     if (!keyboard) {
@@ -310,35 +338,15 @@ QSet<QKeyCombination> possibleKeys(const QKeySequence& sequence)
         return {};
     }
 
+    UInt32 keyNativeCode = nativeKeycode(keyboard, qKey);
+
     Qt::KeyboardModifiers modifiers = keyCombination.keyboardModifiers();
+    UInt32 keyNativeModifiers = nativeModifiers(modifiers);
 
-    quint32 keyNativeCode = nativeKeycode(keyboard, qKey);
-    quint32 keyNativeModifiers = nativeModifiers(keyboard, qKey, modifiers, keyNativeCode);
+    QString keyStr = keyCodeToString(keyboard, keyNativeCode);
+    QString modifStr = keyModifiersToString(keyNativeModifiers);
 
-    //! NOTE: It may be that we resolved modifiers through the native key,
-    //! then we should update the qt modifiers
-    modifiers = qtModifiers(keyNativeModifiers);
-
-    QKeyEvent fakeKey(QKeyEvent::None, keyCombination.toCombined(), modifiers, keyNativeCode, keyNativeCode, keyNativeModifiers);
-    QList<int> keys = QGuiApplicationPrivate::platformIntegration()->possibleKeys(&fakeKey);
-
-    QSet<QKeyCombination> result;
-    for (int key : keys) {
-        QKeyCombination combination = QKeyCombination::fromCombined(key);
-        if (modifiers != Qt::NoModifier) {
-            if (combination.keyboardModifiers() == Qt::NoModifier) {
-                combination = QKeyCombination(modifiers, combination.key());
-            }
-
-            if (combination.keyboardModifiers() != modifiers) {
-                continue;
-            }
-        }
-
-        result << combination;
-    }
-
-    return result;
+    return (modifStr.isEmpty() ? "" : modifStr + "+") + keyStr;
 }
 
 MacOSShortcutsInstanceModel::MacOSShortcutsInstanceModel(QObject* parent)
@@ -360,17 +368,13 @@ void MacOSShortcutsInstanceModel::doLoadShortcuts()
         for (const std::string& seq : sc.sequences) {
             QString sequence = QString::fromStdString(seq);
 
-            QSet<QKeyCombination> keys = possibleKeys(QKeySequence::fromString(sequence, QKeySequence::PortableText));
-            for (QKeyCombination key : keys) {
-                QKeySequence keySeq(key);
-                QString seqStr = keySeq.toString(QKeySequence::PortableText);
+            QString seqStr = translateToCurrentKeyboardLayout(QKeySequence::fromString(sequence, QKeySequence::PortableText));
 
-                //! NOTE There may be several identical shortcuts for different contexts.
-                //! We only need a list of unique ones.
-                if (!m_shortcuts.contains(seqStr)) {
-                    m_shortcuts << seqStr;
-                    m_shortcutMap.insert(seqStr, sequence);
-                }
+            //! NOTE There may be several identical shortcuts for different contexts.
+            //! We only need a list of unique ones.
+            if (!m_shortcuts.contains(seqStr)) {
+                m_shortcuts << seqStr;
+                m_shortcutMap.insert(seqStr, sequence);
             }
         }
     }


### PR DESCRIPTION
In Qt6 they changed the behavior of the private class QAppleKeyMapper::possibleKeys (they can afford it because it is a private class) - they added a return if keyCode == 0, which corresponds to the code for 'A' key in the our previous algorithm. We got hooked on this class and we have problems. 

Now we are completely independent of the private Qt class:
- We obtain native codes for keys and modifiers
- We map symbols for these keys according to the current layout using UCKeyTranslate. For special symbols, we use a hardcoded map since UCKeyTranslate does not work with them. Also, modifiers are translated through a hardcoded map.
- Finally, we combine key and modifiers and register them in the Qt shortcuts system.

Resolves: #22966
Resolves: #21736