### PR TITLE
Feat musescore#17467: Mixer Search

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledSearchMenuLoader.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledSearchMenuLoader.qml
@@ -1,0 +1,147 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+
+import Muse.UiComponents 1.0
+
+import "internal"
+
+Loader {
+    id: loader
+
+    signal handleMenuItem(string itemId)
+    signal opened()
+    signal closed(bool force)
+
+    property alias menu: loader.item
+    property var menuAnchorItem: null
+
+    property alias isMenuOpened: loader.active
+
+    QtObject {
+        id: prv
+
+        function loadMenu() {
+            loader.active = true
+        }
+
+        function unloadMenu(force) {
+            loader.active = false
+            Qt.callLater(loader.closed, force)
+        }
+    }
+
+    active: false
+
+    sourceComponent: StyledSearchMenu {
+        id: itemMenu
+
+        openPolicies: PopupView.ActivateFocus
+
+        onHandleMenuItem: function(itemId) {
+            itemMenu.close()
+            Qt.callLater(loader.handleMenuItem, itemId)
+        }
+
+        onClosed: function(force) {
+            Qt.callLater(prv.unloadMenu, force)
+        }
+
+        onOpened: {
+            focusOnOpenedMenuTimer.start()
+        }
+    }
+
+    function open(model, x = -1, y = -1) {
+        prv.loadMenu()
+
+        var menu = loader.menu
+        menu.parent = loader.parent
+        menu.anchorItem = menuAnchorItem
+
+        update(model, x, y)
+        menu.open()
+
+        Qt.callLater(loader.opened)
+    }
+
+    function toggleOpened(model, x = -1, y = -1) {
+        prv.loadMenu()
+
+        var menu = loader.menu
+        if (menu.isOpened) {
+            menu.close()
+            return
+        }
+
+        open(model, x, y)
+    }
+
+    function toggleOpenedWithAlign(model, align) {
+        prv.loadMenu()
+
+        loader.menu.preferredAlign = align
+
+        toggleOpened(model)
+    }
+
+    function close() {
+        if (loader.isMenuOpened) {
+            loader.menu.close()
+        }
+    }
+
+    function update(model, x = -1, y = -1) {
+        var menu = loader.menu
+        if (!Boolean(menu)) {
+            return
+        }
+
+        menu.closeSubMenu()
+
+        if (x !== -1) {
+            menu.x = x
+        }
+
+        if (y !== -1) {
+            menu.y = y
+        }
+
+        menu.model = model
+
+        menu.calculateSize()
+    }
+
+    Timer {
+        id: focusOnOpenedMenuTimer
+
+        interval: 50
+        running: false
+        repeat: false
+
+        onTriggered: {
+            if (loader.menu) {
+                loader.menu.requestFocus()
+            }
+        }
+    }
+}

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledSearchMenu.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledSearchMenu.qml
@@ -1,0 +1,398 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Window 2.15
+
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+
+MenuView {
+    id: root
+
+    property alias model: view.model
+    property var originalModelState: JSON.parse(JSON.stringify(model))
+
+    property alias searchText: searchField.searchText
+    property alias searching: searchField.hasText
+
+    property int preferredAlign: Qt.AlignRight // Left, HCenter, Right
+
+    signal handleMenuItem(string itemId)
+
+    property alias width: content.width
+    property alias height: content.height
+
+    signal loaded()
+
+    function requestFocus() {
+        var focused = prv.focusOnSelected()
+        if (!focused) {
+            focused = prv.focusOnFirstEnabled()
+        }
+
+        return focused
+    }
+
+    function calculateSize() {
+        var menuMetricsComponent = Qt.createComponent("MenuMetrics.qml");
+        root.menuMetrics = menuMetricsComponent.createObject(root)
+        root.menuMetrics.calculate(model)
+
+        //! NOTE: Due to the fact that the view has a dynamic delegate,
+        //  the height calculation occurs with an error
+        //  (by default, the delegate height is taken as the menu item height).
+        //  Let's manually adjust the height of the content
+        var sepCount = 0
+        for (let i = 0; i < model.length; i++) {
+            let item = Boolean(model.get) ? model.get(i).itemRole : model[i]
+            if (!Boolean(item.title)) {
+                sepCount++
+            }
+        }
+
+        var itemHeight = 0
+        for(var child in view.contentItem.children) {
+            itemHeight = Math.max(itemHeight, view.contentItem.children[child].height)
+        }
+
+        var itemsCount = model.length - sepCount
+
+        var anchorItemHeight = root.anchorGeometry().height
+
+        root.contentWidth = root.menuMetrics.itemWidth
+        root.contentHeight = Math.min(itemHeight * itemsCount + sepCount * prv.separatorHeight +
+                                      prv.viewVerticalMargin * 2 + searchField.height, 
+                                      anchorItemHeight - padding * 2 + searchField.height)
+    
+        x = 0
+        y = parent.height
+    }
+
+    onAboutToClose: function(closeEvent) {
+        closeSubMenu()
+    }
+
+    function closeSubMenu() {
+        if (root.subMenuLoader.isMenuOpened) {
+            root.subMenuLoader.close()
+        }
+    }
+
+    function filterModel(searchText) {
+
+        var filteredModel = []
+        var totalModel = []
+        for (let i = 0; i < view.fullModel.length; i++) {
+            let item = Boolean(view.fullModel.get) ? view.fullModel.get(i).itemRole : view.fullModel[i]
+            if (Boolean(item.title) && item.title.toLowerCase().includes(searchText.toLowerCase())) {
+                filteredModel.push(item)
+            }
+            totalModel.push(item)  
+        }
+
+        view.model = filteredModel
+        view.fullModel = totalModel
+    }
+
+    property var subMenuLoader: null
+    property MenuMetrics menuMetrics: null
+
+    contentItem: PopupContent {
+        id: content
+
+        property alias cascadeAlign: root.cascadeAlign
+
+        objectName: "Menu"
+
+        contentWidth: root.contentWidth
+        contentHeight: root.contentHeight
+
+        padding: root.padding
+        margins: 0
+
+        showArrow: root.showArrow
+        opensUpward: root.opensUpward
+        isOpened: root.isOpened
+
+        animationEnabled: false //! NOTE disabled - because trouble with simultaneous opening of submenu
+        closeOnEscape: false
+
+        navigationSection.onNavigationEvent: function(event) {
+            if (event.type === NavigationEvent.Escape) {
+                if (root.subMenuLoader.isMenuOpened) {
+                    root.subMenuLoader.close()
+                } else {
+                    root.close()
+                }
+            }
+        }
+
+        property NavigationPanel navigationPanel: NavigationPanel {
+            name: "StyledSearchMenu"
+            section: content.navigationSection
+            direction: NavigationPanel.Vertical
+            order: 1
+
+            onNavigationEvent: function(event) {
+                switch (event.type) {
+                case NavigationEvent.Right:
+                    var selectedItem = prv.selectedItem()
+                    if (!Boolean(selectedItem) || !selectedItem.hasSubMenu) {
+                        return
+                    }
+
+                    //! NOTE Go to submenu if shown
+                    selectedItem.openSubMenuRequested(false)
+
+                    event.accepted = true
+
+                    break
+                case NavigationEvent.Left:
+                    if (root.subMenuLoader.isMenuOpened) {
+                        root.subMenuLoader.close()
+                        event.accepted = true
+                        return
+                    }
+
+                    //! NOTE Go to parent item
+                    if (root.navigationParentControl) {
+                        root.navigationParentControl.requestActive()
+                    }
+
+                    root.close()
+                    break
+                case NavigationEvent.Up:
+                case NavigationEvent.Down:
+                    if (root.subMenuLoader.isMenuOpened) {
+                        root.subMenuLoader.close()
+                    }
+
+                    break
+                }
+            }
+        }
+
+        onCloseRequested: {
+            root.close()
+        }
+
+        Component.onCompleted: {
+            var menuLoaderComponent = Qt.createComponent("../StyledSearchMenuLoader.qml");
+            root.subMenuLoader = menuLoaderComponent.createObject(root)
+            root.subMenuLoader.menuAnchorItem = root.anchorItem
+
+            root.subMenuLoader.handleMenuItem.connect(function(itemId) {
+                Qt.callLater(root.handleMenuItem, itemId)
+                root.subMenuLoader.close()
+            })
+
+            root.subMenuLoader.opened.connect(function(itemId) {
+                root.closePolicies = PopupView.NoAutoClose
+            })
+
+            root.subMenuLoader.closed.connect(function(force) {
+                root.closePolicies = PopupView.CloseOnPressOutsideParent
+
+                if (force) {
+                    root.close(true)
+                }
+            })
+        }
+
+        SearchField {
+            id: searchField
+
+            anchors.top: parent.top
+            anchors.left: parent.left
+            anchors.topMargin: 2.5
+            anchors.leftMargin: 2.5
+            width: parent.width - 5
+            height: searchField.height - 5
+            
+            Rectangle {
+                width: parent.parent.width
+                height: 0.1
+                color: ui.theme.strokeColor
+                anchors.left: parent.left
+                anchors.top: parent.bottom
+                anchors.leftMargin: -2.5
+                anchors.topMargin: 2.5
+
+            }
+
+            navigation.name: "Search"
+            navigation.panel: content.navigationPanel
+            navigation.row: 0
+
+            onSearchTextChanged: {
+                root.filterModel(searchText)
+                calculateSize()
+            }
+
+            clearTextButtonVisible: searching
+            onTextCleared: {
+                root.filterModel(searchText)
+                calculateSize()
+            }
+        }
+
+        StyledListView {
+            id: view
+
+            anchors.fill: parent
+            anchors.topMargin: prv.viewVerticalMargin + searchField.height
+            anchors.bottomMargin: prv.viewVerticalMargin
+
+            property var fullModel: model
+
+            spacing: 0
+            interactive: contentHeight > root.height
+            arrowControlsAvailable: true
+
+            QtObject {
+                id: prv
+
+                readonly property int separatorHeight: 1
+                readonly property int viewVerticalMargin: root.viewVerticalMargin()
+
+                function focusOnFirstEnabled() {
+                    for (var i = 0; i < view.count; ++i) {
+                        var loader = view.itemAtIndex(i)
+                        if (loader && !loader.isSeparator && loader.item && loader.item.enabled) {
+                            loader.item.navigation.requestActive()
+                            return true
+                        }
+                    }
+
+                    return false
+                }
+
+                function focusOnSelected() {
+                    var item = selectedItem()
+                    if (Boolean(item)) {
+                        item.navigation.requestActive()
+                        return true
+                    }
+
+                    return false
+                }
+
+                function selectedItem() {
+                    for (var i = 0; i < view.count; ++i) {
+                        var loader = view.itemAtIndex(i)
+                        if (loader && !loader.isSeparator && loader.item && loader.item.isSelected) {
+                            return loader.item
+                        }
+                    }
+
+                    return null
+                }
+            }
+
+            delegate: Loader {
+                id: loader
+
+                property var itemData: Boolean(root.model.get) ? model.itemRole : modelData
+                property bool isSeparator: !Boolean(itemData) || !Boolean(itemData.title) || itemData.title === ""
+
+                sourceComponent: isSeparator ? separatorComp : menuItemComp
+
+                onLoaded: {
+                    loader.item.modelData = Qt.binding(() => (itemData))
+                    loader.item.width = Qt.binding(() => ( Boolean(root.menuMetrics) ? root.menuMetrics.itemWidth : 0 ))
+                    if (Boolean(loader.item.navigation)) {
+                        loader.item.navigation.panel = content.navigationPanel
+                    }
+                }
+
+                Component {
+                    id: menuItemComp
+
+                    StyledMenuItem {
+                        id: item
+
+                        property string title: Boolean (loader.itemData) ? loader.itemData.title : ""
+
+                        menuAnchorItem: root.anchorItem
+                        parentWindow: root.window
+
+                        navigation.panel: content.navigationPanel
+                        navigation.row: model.index + 1
+
+                        iconAndCheckMarkMode: Boolean(root.menuMetrics) ? root.menuMetrics.iconAndCheckMarkMode : StyledMenuItem.None
+
+                        reserveSpaceForShortcutsOrSubmenuIndicator: Boolean(root.menuMetrics) ?
+                                                                        (root.menuMetrics.hasItemsWithShortcut || root.menuMetrics.hasItemsWithSubmenu) : false
+
+                        padding: root.padding
+
+                        subMenuShowed: root.subMenuLoader.isMenuOpened && root.subMenuLoader.parent === item
+
+                        onOpenSubMenuRequested: function(byHover) {
+                            if (!hasSubMenu) {
+                                if (byHover) {
+                                    root.subMenuLoader.close()
+                                }
+
+                                return
+                            }
+
+                            if (!byHover) {
+                                if (subMenuShowed) {
+                                    root.subMenuLoader.close()
+                                    return
+                                }
+                            }
+
+                            root.subMenuLoader.parent = item
+                            root.subMenuLoader.open(subMenuItems)
+                        }
+
+                        onCloseSubMenuRequested: {
+                            root.subMenuLoader.close()
+                        }
+
+                        onHandleMenuItem: function(itemId) {
+                            // NOTE: reset view state
+                            view.update()
+
+                            root.handleMenuItem(itemId)
+                        }
+                    }
+                }
+
+                Component {
+                    id: separatorComp
+
+                    Rectangle {
+                        height: prv.separatorHeight
+                        color: ui.theme.strokeColor
+
+                        property var modelData
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/framework/uicomponents/qml/Muse/UiComponents/qmldir
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/qmldir
@@ -42,6 +42,7 @@ TimeInputField 1.0 TimeInputField.qml
 StyledPopupView 1.0 StyledPopupView.qml
 StyledDialogView 1.0 StyledDialogView.qml
 StyledMenuLoader 1.0 StyledMenuLoader.qml
+StyledSearchMenuLoader 1.0 StyledSearchMenuLoader.qml
 ContextMenuLoader 1.0 ContextMenuLoader.qml
 MenuButton 1.0 MenuButton.qml
 FilePicker 1.0 FilePicker.qml

--- a/src/framework/uicomponents/uicomponents.qrc
+++ b/src/framework/uicomponents/uicomponents.qrc
@@ -47,6 +47,7 @@
         <file>qml/Muse/UiComponents/internal/ValueListItem.qml</file>
         <file>qml/Muse/UiComponents/FocusableControl.qml</file>
         <file>qml/Muse/UiComponents/StyledMenuLoader.qml</file>
+        <file>qml/Muse/UiComponents/StyledSearchMenuLoader.qml</file>
         <file>qml/Muse/UiComponents/ContextMenuLoader.qml</file>
         <file>qml/Muse/UiComponents/StyledDropShadow.qml</file>
         <file>qml/Muse/UiComponents/StyledToolTip.qml</file>
@@ -69,6 +70,7 @@
         <file>qml/Muse/UiComponents/internal/StyledDropdownView.qml</file>
         <file>qml/Muse/UiComponents/internal/StyledMenuItem.qml</file>
         <file>qml/Muse/UiComponents/internal/StyledMenu.qml</file>
+        <file>qml/Muse/UiComponents/internal/StyledSearchMenu.qml</file>
         <file>qml/Muse/UiComponents/internal/MenuMetrics.qml</file>
         <file>qml/Muse/UiComponents/StyledBusyIndicator.qml</file>
         <file>qml/Muse/UiComponents/ButtonBox.qml</file>

--- a/src/playback/qml/MuseScore/Playback/internal/AudioResourceControl.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/AudioResourceControl.qml
@@ -324,7 +324,7 @@ Item {
                     }
                 }
 
-                StyledMenuLoader {
+                StyledSearchMenuLoader {
                     id: menuLoader
 
                     onHandleMenuItem: function(itemId) {


### PR DESCRIPTION
The Sound Mixer and AudioFX submeus had unruly long lists, that could be made worse via the installation of plugins. We have created a search bar on the aforementioned submenus, allowing users to search for the options they wish to utilize from the shown menu, thus avoiding scrolling and manual search

Resolves: #17467 

We implemented a new styled menu along with its loader for the purpose of creating menus with a working search bar.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
