### PR TITLE
feat: add support for laissezvibrer to MEI

### DIFF
--- a/src/importexport/mei/internal/meiconverter.cpp
+++ b/src/importexport/mei/internal/meiconverter.cpp
@@ -269,8 +269,6 @@ void Convert::arpegFromMEI(engraving::Arpeggio* arpeggio, const libmei::Arpeg& m
 
     // @color
     Convert::colorFromMEI(arpeggio, meiArpeg);
-
-    return;
 }
 
 libmei::Arpeg Convert::arpegToMEI(const engraving::Arpeggio* arpeggio)
@@ -374,8 +372,6 @@ void Convert::articFromMEI(engraving::Articulation* articulation, const libmei::
 
     // @color
     Convert::colorFromMEI(articulation, meiArtic);
-
-    return;
 }
 
 libmei::Artic Convert::articToMEI(const engraving::Articulation* articulation)
@@ -650,8 +646,6 @@ void Convert::breathFromMEI(engraving::Breath* breath, const libmei::Breath& mei
     Convert::colorFromMEI(breath, meiBreath);
 
     breath->setSymId(symId);
-
-    return;
 }
 
 libmei::Breath Convert::breathToMEI(const engraving::Breath* breath)
@@ -707,8 +701,6 @@ void Convert::caesuraFromMEI(engraving::Breath* breath, const libmei::Caesura& m
     Convert::colorFromMEI(breath, meiCeasura);
 
     breath->setSymId(symId);
-
-    return;
 }
 
 libmei::Caesura Convert::caesuraToMEI(const engraving::Breath* breath)
@@ -1081,8 +1073,6 @@ void Convert::dirFromMEI(engraving::TextBase* textBase, const StringList& meiLin
 
     // text
     textBase->setXmlText(meiLines.join(u"\n"));
-
-    return;
 }
 
 void Convert::dirFromMEI(engraving::TextLineBase* textLineBase, const StringList& meiLines, const libmei::Dir& meiDir, bool& warning)
@@ -1121,8 +1111,6 @@ void Convert::dirFromMEI(engraving::TextLineBase* textLineBase, const StringList
     // text
     textLineBase->setBeginText(meiLines.join(u"\n"));
     textLineBase->setPropertyFlags(engraving::Pid::BEGIN_TEXT, engraving::PropertyFlags::UNSTYLED);
-
-    return;
 }
 
 libmei::Dir Convert::dirToMEI(const engraving::TextBase* textBase, StringList& meiLines)
@@ -1297,8 +1285,6 @@ void Convert::dynamFromMEI(engraving::Dynamic* dynamic, const StringList& meiLin
         lines.push_back(line);
     }
     dynamic->setXmlText(lines.join(u"\n"));
-
-    return;
 }
 
 libmei::Dynam Convert::dynamToMEI(const engraving::Dynamic* dynamic, StringList& meiLines)
@@ -1395,8 +1381,6 @@ void Convert::endingFromMEI(engraving::Volta* volta, const libmei::Ending& meiEn
     } else {
         volta->setVoltaType(engraving::Volta::Type::CLOSED);
     }
-
-    return;
 }
 
 libmei::Ending Convert::endingToMEI(const engraving::Volta* volta)
@@ -1435,8 +1419,6 @@ void Convert::fFromMEI(engraving::FiguredBassItem* figuredBassItem, const String
     figuredBassItem->parse(text);
 
     UNUSED(meiF);
-
-    return;
 }
 
 libmei::F Convert::fToMEI(const engraving::FiguredBassItem* figuredBassItem, StringList& meiLines)
@@ -1457,8 +1439,6 @@ void Convert::fbFromMEI(engraving::FiguredBass* figuredBass, const libmei::Harm&
     UNUSED(figuredBass);
     UNUSED(meiHarm);
     UNUSED(meiFb);
-
-    return;
 }
 
 std::pair<libmei::Harm, libmei::Fb> Convert::fbToMEI(const engraving::FiguredBass* figuredBass)
@@ -1514,8 +1494,6 @@ void Convert::fermataFromMEI(engraving::Fermata* fermata, const libmei::Fermata&
 
     // @color
     Convert::colorFromMEI(fermata, meiFermata);
-
-    return;
 }
 
 libmei::Fermata Convert::fermataToMEI(const engraving::Fermata* fermata)
@@ -1627,8 +1605,6 @@ void Convert::hairpinFromMEI(engraving::Hairpin* hairpin, const libmei::Hairpin&
 
     // @color
     Convert::colorlineFromMEI(hairpin, meiHairpin);
-
-    return;
 }
 
 libmei::Hairpin Convert::hairpinToMEI(const engraving::Hairpin* hairpin)
@@ -1682,8 +1658,6 @@ void Convert::harmFromMEI(engraving::Harmony* harmony, const StringList& meiLine
         harmony->setPlacement(meiHarm.GetPlace() == libmei::STAFFREL_above ? engraving::PlacementV::ABOVE : engraving::PlacementV::BELOW);
         harmony->setPropertyFlags(engraving::Pid::PLACEMENT, engraving::PropertyFlags::UNSTYLED);
     }
-
-    return;
 }
 
 libmei::Harm Convert::harmToMEI(const engraving::Harmony* harmony, StringList& meiLines)
@@ -1737,8 +1711,6 @@ void Convert::lvFromMEI(engraving::Articulation* lv, const libmei::Lv& meiLv, bo
 
     // @color
     Convert::colorFromMEI(lv, meiLv);
-
-    return;
 }
 
 libmei::Lv Convert::lvToMEI(const engraving::Articulation* lv)
@@ -1796,8 +1768,6 @@ void Convert::jumpFromMEI(engraving::Jump* jump, const libmei::RepeatMark& meiRe
     }
 
     jump->setJumpType(jumpType);
-
-    return;
 }
 
 libmei::RepeatMark Convert::jumpToMEI(const engraving::Jump* jump, String& text)
@@ -1929,8 +1899,6 @@ void Convert::markerFromMEI(engraving::Marker* marker, const libmei::RepeatMark&
     }
 
     marker->setMarkerType(markerType);
-
-    return;
 }
 
 libmei::RepeatMark Convert::markerToMEI(const engraving::Marker* marker, String& text)
@@ -2274,8 +2242,6 @@ void Convert::octaveFromMEI(engraving::Ottava* ottava, const libmei::Octave& mei
 
     // @color
     Convert::colorlineFromMEI(ottava, meiOctave);
-
-    return;
 }
 
 libmei::Octave Convert::octaveToMEI(const engraving::Ottava* ottava)
@@ -2417,8 +2383,6 @@ void Convert::ornamToMEI(const engraving::Ornament* ornament, libmei::Element& m
 
     // @color
     Convert::colorToMEI(ornament, meiElement);
-
-    return;
 }
 
 void Convert::ornamintervaleFromMEI(engraving::Ornament* ornament, const std::string& meiType)
@@ -2500,8 +2464,6 @@ void Convert::pedalFromMEI(engraving::Pedal* pedal, const libmei::Pedal& meiPeda
 
     // @color
     Convert::colorlineFromMEI(pedal, meiPedal);
-
-    return;
 }
 
 libmei::Pedal Convert::pedalToMEI(const engraving::Pedal* pedal)
@@ -2693,8 +2655,6 @@ void Convert::slurFromMEI(engraving::SlurTie* slur, const libmei::Slur& meiSlur,
 
     // @color
     Convert::colorFromMEI(slur, meiSlur);
-
-    return;
 }
 
 libmei::Slur Convert::slurToMEI(const engraving::SlurTie* slur)
@@ -2879,8 +2839,6 @@ void Convert::sylFromMEI(engraving::Lyrics* lyrics, const libmei::Syl& meiSyl, E
         default: break;
         }
     }
-
-    return;
 }
 
 libmei::Syl Convert::sylToMEI(const engraving::Lyrics* lyrics, ElisionType elision)
@@ -2964,8 +2922,6 @@ void Convert::tempoFromMEI(engraving::TempoText* tempoText, const StringList& me
 
     // text
     tempoText->setXmlText(meiLines.join(u"\n"));
-
-    return;
 }
 
 libmei::Tempo Convert::tempoToMEI(const engraving::TempoText* tempoText, StringList& meiLines)
@@ -3135,7 +3091,6 @@ void Convert::tieFromMEI(engraving::SlurTie* tie, const libmei::Tie& meiTie, boo
     meiSlur.SetLform(meiTie.GetLform());
     meiSlur.SetColor(meiTie.GetColor());
     Convert::slurFromMEI(tie, meiSlur, warning);
-    return;
 }
 
 libmei::Tie Convert::tieToMEI(const engraving::SlurTie* tie)
@@ -3233,8 +3188,6 @@ void Convert::tupletFromMEI(engraving::Tuplet* tuplet, const libmei::Tuplet& mei
 
     // @color
     Convert::colorFromMEI(tuplet, meiTuplet);
-
-    return;
 }
 
 libmei::Tuplet Convert::tupletToMEI(const engraving::Tuplet* tuplet)

--- a/src/importexport/mei/internal/meiconverter.cpp
+++ b/src/importexport/mei/internal/meiconverter.cpp
@@ -269,6 +269,8 @@ void Convert::arpegFromMEI(engraving::Arpeggio* arpeggio, const libmei::Arpeg& m
 
     // @color
     Convert::colorFromMEI(arpeggio, meiArpeg);
+
+    return;
 }
 
 libmei::Arpeg Convert::arpegToMEI(const engraving::Arpeggio* arpeggio)
@@ -372,6 +374,8 @@ void Convert::articFromMEI(engraving::Articulation* articulation, const libmei::
 
     // @color
     Convert::colorFromMEI(articulation, meiArtic);
+
+    return;
 }
 
 libmei::Artic Convert::articToMEI(const engraving::Articulation* articulation)
@@ -646,6 +650,8 @@ void Convert::breathFromMEI(engraving::Breath* breath, const libmei::Breath& mei
     Convert::colorFromMEI(breath, meiBreath);
 
     breath->setSymId(symId);
+
+    return;
 }
 
 libmei::Breath Convert::breathToMEI(const engraving::Breath* breath)
@@ -701,6 +707,8 @@ void Convert::caesuraFromMEI(engraving::Breath* breath, const libmei::Caesura& m
     Convert::colorFromMEI(breath, meiCeasura);
 
     breath->setSymId(symId);
+
+    return;
 }
 
 libmei::Caesura Convert::caesuraToMEI(const engraving::Breath* breath)
@@ -1427,6 +1435,8 @@ void Convert::fFromMEI(engraving::FiguredBassItem* figuredBassItem, const String
     figuredBassItem->parse(text);
 
     UNUSED(meiF);
+
+    return;
 }
 
 libmei::F Convert::fToMEI(const engraving::FiguredBassItem* figuredBassItem, StringList& meiLines)
@@ -1447,6 +1457,8 @@ void Convert::fbFromMEI(engraving::FiguredBass* figuredBass, const libmei::Harm&
     UNUSED(figuredBass);
     UNUSED(meiHarm);
     UNUSED(meiFb);
+
+    return;
 }
 
 std::pair<libmei::Harm, libmei::Fb> Convert::fbToMEI(const engraving::FiguredBass* figuredBass)
@@ -1502,6 +1514,8 @@ void Convert::fermataFromMEI(engraving::Fermata* fermata, const libmei::Fermata&
 
     // @color
     Convert::colorFromMEI(fermata, meiFermata);
+
+    return;
 }
 
 libmei::Fermata Convert::fermataToMEI(const engraving::Fermata* fermata)
@@ -1613,6 +1627,8 @@ void Convert::hairpinFromMEI(engraving::Hairpin* hairpin, const libmei::Hairpin&
 
     // @color
     Convert::colorlineFromMEI(hairpin, meiHairpin);
+
+    return;
 }
 
 libmei::Hairpin Convert::hairpinToMEI(const engraving::Hairpin* hairpin)
@@ -2210,6 +2226,8 @@ void Convert::octaveFromMEI(engraving::Ottava* ottava, const libmei::Octave& mei
 
     // @color
     Convert::colorlineFromMEI(ottava, meiOctave);
+
+    return;
 }
 
 libmei::Octave Convert::octaveToMEI(const engraving::Ottava* ottava)
@@ -2351,6 +2369,8 @@ void Convert::ornamToMEI(const engraving::Ornament* ornament, libmei::Element& m
 
     // @color
     Convert::colorToMEI(ornament, meiElement);
+
+    return;
 }
 
 void Convert::ornamintervaleFromMEI(engraving::Ornament* ornament, const std::string& meiType)
@@ -2432,6 +2452,8 @@ void Convert::pedalFromMEI(engraving::Pedal* pedal, const libmei::Pedal& meiPeda
 
     // @color
     Convert::colorlineFromMEI(pedal, meiPedal);
+
+    return;
 }
 
 libmei::Pedal Convert::pedalToMEI(const engraving::Pedal* pedal)
@@ -2623,6 +2645,8 @@ void Convert::slurFromMEI(engraving::SlurTie* slur, const libmei::Slur& meiSlur,
 
     // @color
     Convert::colorFromMEI(slur, meiSlur);
+
+    return;
 }
 
 libmei::Slur Convert::slurToMEI(const engraving::SlurTie* slur)
@@ -2807,6 +2831,8 @@ void Convert::sylFromMEI(engraving::Lyrics* lyrics, const libmei::Syl& meiSyl, E
         default: break;
         }
     }
+
+    return;
 }
 
 libmei::Syl Convert::sylToMEI(const engraving::Lyrics* lyrics, ElisionType elision)
@@ -3061,6 +3087,7 @@ void Convert::tieFromMEI(engraving::SlurTie* tie, const libmei::Tie& meiTie, boo
     meiSlur.SetLform(meiTie.GetLform());
     meiSlur.SetColor(meiTie.GetColor());
     Convert::slurFromMEI(tie, meiSlur, warning);
+    return;
 }
 
 libmei::Tie Convert::tieToMEI(const engraving::SlurTie* tie)

--- a/src/importexport/mei/internal/meiconverter.cpp
+++ b/src/importexport/mei/internal/meiconverter.cpp
@@ -302,7 +302,7 @@ libmei::Arpeg Convert::arpegToMEI(const engraving::Arpeggio* arpeggio)
 
 void Convert::articFromMEI(engraving::Articulation* articulation, const libmei::Artic& meiArtic, bool& warning)
 {
-    engraving::SymId symId = engraving::SymId::articAccentAbove;
+    engraving::SymId symId = engraving::SymId::noSym;
 
     // @artic
     if (meiArtic.HasArtic() && (meiArtic.GetArtic().size() == 1)) {
@@ -1713,6 +1713,54 @@ libmei::Harm Convert::harmToMEI(const engraving::Harmony* harmony, StringList& m
     }
 
     return meiHarm;
+}
+
+void Convert::lvFromMEI(engraving::Articulation* lv, const libmei::Lv& meiLv, bool& warning)
+{
+    warning = false;
+
+    lv->setSymId(engraving::SymId::articLaissezVibrerAbove);
+
+    // @curvedir
+    switch (meiLv.GetCurvedir()) {
+    case (libmei::curvature_CURVEDIR_above):
+        lv->setAnchor(engraving::ArticulationAnchor::TOP);
+        break;
+    case (libmei::curvature_CURVEDIR_below):
+        lv->setAnchor(engraving::ArticulationAnchor::BOTTOM);
+        break;
+    default:
+        lv->setAnchor(engraving::ArticulationAnchor::AUTO);
+        break;
+    }
+    lv->setPropertyFlags(engraving::Pid::ARTICULATION_ANCHOR, engraving::PropertyFlags::UNSTYLED);
+
+    // @color
+    Convert::colorFromMEI(lv, meiLv);
+
+    return;
+}
+
+libmei::Lv Convert::lvToMEI(const engraving::Articulation* lv)
+{
+    libmei::Lv meiLv;
+
+    // @curvedir
+    switch (lv->anchor()) {
+    case (engraving::ArticulationAnchor::TOP):
+        meiLv.SetCurvedir(libmei::curvature_CURVEDIR_above);
+        break;
+    case (engraving::ArticulationAnchor::BOTTOM):
+        meiLv.SetCurvedir(libmei::curvature_CURVEDIR_below);
+        break;
+    default:
+        break;
+    }
+
+    // @color
+    Convert::colorToMEI(lv, meiLv);
+
+    return meiLv;
 }
 
 void Convert::jumpFromMEI(engraving::Jump* jump, const libmei::RepeatMark& meiRepeatMark, bool& warning)

--- a/src/importexport/mei/internal/meiconverter.cpp
+++ b/src/importexport/mei/internal/meiconverter.cpp
@@ -2630,7 +2630,7 @@ void Convert::slurFromMEI(engraving::SlurTie* slur, const libmei::Slur& meiSlur,
 {
     warning = false;
 
-    // @place
+    // @curvedir
     if (meiSlur.HasCurvedir()) {
         slur->setSlurDirection(Convert::curvedirFromMEI(meiSlur.GetCurvedir(), warning));
         //slur->setPropertyFlags(engraving::Pid::PLACEMENT, engraving::PropertyFlags::UNSTYLED);

--- a/src/importexport/mei/internal/meiconverter.h
+++ b/src/importexport/mei/internal/meiconverter.h
@@ -223,6 +223,9 @@ public:
     static void harmFromMEI(engraving::Harmony* harmony, const muse::StringList& meiLines, const libmei::Harm& meiHarm, bool& warning);
     static libmei::Harm harmToMEI(const engraving::Harmony* harmony, muse::StringList& meiLines);
 
+    static void lvFromMEI(engraving::Articulation* lv, const libmei::Lv& meiLv, bool& warning);
+    static libmei::Lv lvToMEI(const engraving::Articulation* lv);
+
     static void jumpFromMEI(engraving::Jump* jump, const libmei::RepeatMark& meiRepeatMark, bool& warning);
     static libmei::RepeatMark jumpToMEI(const engraving::Jump* jump, muse::String& text);
 

--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -818,6 +818,8 @@ bool MeiExporter::writeMeasure(const Measure* measure, int& measureN, bool& isFi
             success = success && this->writeHairpin(dynamic_cast<const Hairpin*>(controlEvent.first), controlEvent.second);
         } else if (controlEvent.first->isHarmony()) {
             success = success && this->writeHarm(dynamic_cast<const Harmony*>(controlEvent.first), controlEvent.second);
+        } else if (controlEvent.first->isArticulation() && !controlEvent.first->isOrnament()) {
+            success = success && this->writeLv(dynamic_cast<const Articulation*>(controlEvent.first), controlEvent.second);
         } else if (controlEvent.first->isOrnament()) {
             success = success && this->writeOrnament(dynamic_cast<const Ornament*>(controlEvent.first), controlEvent.second);
         } else if (controlEvent.first->isOttava()) {
@@ -968,7 +970,7 @@ bool MeiExporter::writeArtics(const Chord* chord)
     }
 
     for (const Articulation* articulation : chord->articulations()) {
-        if (articulation->isArticulation()) {
+        if (articulation->isArticulation() && !this->isLaissezVibrer(articulation->symId())) {
             this->writeArtic(articulation);
         }
     }
@@ -1762,6 +1764,24 @@ bool MeiExporter::writeHarm(const Harmony* harmony, const std::string& startid)
 }
 
 /**
+ * Write a lv.
+ */
+
+bool MeiExporter::writeLv(const Articulation* articulation, const std::string& startid)
+{
+    IF_ASSERT_FAILED(articulation) {
+        return false;
+    }
+
+    pugi::xml_node lvNode = m_currentNode.append_child();
+    libmei::Lv meiLv = Convert::lvToMEI(articulation);
+    meiLv.SetStartid(startid);
+    meiLv.Write(lvNode, this->getXmlIdFor(articulation, 'l'));
+
+    return true;
+}
+
+/**
  * Write a octave (ottava).
  */
 
@@ -2128,9 +2148,11 @@ void MeiExporter::fillControlEventMap(const std::string& xmlId, const ChordRest*
     // For chords only
     if (chordRest->isChord()) {
         const Chord* chord = toChord(chordRest);
-        // Ornaments
+        // Ornaments and laissez vibrer
         for (const Articulation* articulation : chord->articulations()) {
-            if (articulation->isOrnament()) {
+            if (this->isLaissezVibrer(articulation->symId())) {
+                m_startingControlEventList.push_back(std::make_pair(articulation, "#" + xmlId));
+            } else if (articulation->isOrnament()) {
                 m_startingControlEventList.push_back(std::make_pair(articulation, "#" + xmlId));
             }
         }
@@ -2531,4 +2553,13 @@ std::string MeiExporter::getLayerXmlIdFor(layerElementCounter elementType)
                                                                                                                                      elementType)));
     }
     return id.toStdString();
+}
+
+/**
+ * Return true if the used symbol is a laissez vibrer
+ */
+
+bool MeiExporter::isLaissezVibrer(const SymId id)
+{
+    return id == SymId::articLaissezVibrerAbove || id == SymId::articLaissezVibrerBelow;
 }

--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -819,6 +819,7 @@ bool MeiExporter::writeMeasure(const Measure* measure, int& measureN, bool& isFi
         } else if (controlEvent.first->isHarmony()) {
             success = success && this->writeHarm(dynamic_cast<const Harmony*>(controlEvent.first), controlEvent.second);
         } else if (controlEvent.first->isArticulation() && !controlEvent.first->isOrnament()) {
+            // laissez vibrer is the only non-ornamental articulation we find in the list, see MeiExporter::writeArtics
             success = success && this->writeLv(dynamic_cast<const Articulation*>(controlEvent.first), controlEvent.second);
         } else if (controlEvent.first->isOrnament()) {
             success = success && this->writeOrnament(dynamic_cast<const Ornament*>(controlEvent.first), controlEvent.second);
@@ -971,6 +972,7 @@ bool MeiExporter::writeArtics(const Chord* chord)
 
     for (const Articulation* articulation : chord->articulations()) {
         if (articulation->isArticulation() && !this->isLaissezVibrer(articulation->symId())) {
+            // laissez vibrer is handled as control element
             this->writeArtic(articulation);
         }
     }

--- a/src/importexport/mei/internal/meiexporter.h
+++ b/src/importexport/mei/internal/meiexporter.h
@@ -132,6 +132,7 @@ private:
     bool writeFermata(const engraving::Fermata* fermata, const libmei::xsdPositiveInteger_List& staffNs, double tstamp);
     bool writeHairpin(const engraving::Hairpin* hairpin, const std::string& startid);
     bool writeHarm(const engraving::Harmony* harmony, const std::string& startid);
+    bool writeLv(const engraving::Articulation* articulation, const std::string& startid);
     bool writeOctave(const engraving::Ottava* ottava, const std::string& startid);
     bool writeOrnament(const engraving::Ornament* ornament, const std::string& startid);
     bool writePedal(const engraving::Pedal* pedal, const std::string& startid);
@@ -164,6 +165,7 @@ private:
     pugi::xml_node getLastChordRest(pugi::xml_node node);
     void addNodeToOpenControlEvents(pugi::xml_node node, const engraving::Spanner* spanner, const std::string& startid);
     void addEndidToControlEvents();
+    bool isLaissezVibrer(const engraving::SymId id);
 
     /**
      * Methods for generating @xml:ids

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -536,7 +536,7 @@ EngravingItem* MeiImporter::addToChordRest(const libmei::Element& meiElement, Me
         if (chordRest->isChord()) {
             item = Factory::createArpeggio(toChord(chordRest));
         }
-    } else if (meiElement.m_name == "artic") {
+    } else if (meiElement.m_name == "artic" || meiElement.m_name == "lv") {
         item = Factory::createArticulation(chordRest);
     } else {
         return nullptr;
@@ -2191,6 +2191,8 @@ bool MeiImporter::readControlEvents(pugi::xml_node parentNode, Measure* measure)
             } else {
                 success = success && this->readHarm(xpathNode.node(), measure);
             }
+        } else if (elementName == "lv") {
+            success = success && this->readLv(xpathNode.node(), measure);
         } else if (elementName == "mordent") {
             success = success && this->readMordent(xpathNode.node(), measure);
         } else if (elementName == "octave") {
@@ -2529,6 +2531,31 @@ bool MeiImporter::readHarm(pugi::xml_node harmNode, Measure* measure)
     this->readLines(harmNode, meiLines, meiLine);
 
     Convert::harmFromMEI(harmony, meiLines, meiHarm, warning);
+
+    return true;
+}
+
+/**
+ * Read a lv.
+ */
+
+bool MeiImporter::readLv(pugi::xml_node lvNode, Measure* measure)
+{
+    IF_ASSERT_FAILED(measure) {
+        return false;
+    }
+
+    bool warning;
+    libmei::Lv meiLv;
+    meiLv.Read(lvNode);
+
+    Articulation* lv = static_cast<Articulation*>(this->addToChordRest(meiLv, measure));
+    if (!lv) {
+        // Warning message given in MeiImporter::addToChordRest
+        return true;
+    }
+
+    Convert::lvFromMEI(lv, meiLv, warning);
 
     return true;
 }

--- a/src/importexport/mei/internal/meiimporter.h
+++ b/src/importexport/mei/internal/meiimporter.h
@@ -133,6 +133,7 @@ private:
     bool readFermata(pugi::xml_node fermataNode, engraving::Measure* measure);
     bool readHairpin(pugi::xml_node hairpinNode, engraving::Measure* measure);
     bool readHarm(pugi::xml_node harmNode, engraving::Measure* measure);
+    bool readLv(pugi::xml_node lvNode, Measure* measure);
     bool readMordent(pugi::xml_node mordentNode, engraving::Measure* measure);
     bool readOctave(pugi::xml_node octaveNode, engraving::Measure* measure);
     bool readOrnam(pugi::xml_node ornamNode, engraving::Measure* measure);

--- a/src/importexport/mei/tests/data/laissez-vibrer-01.mei
+++ b/src/importexport/mei/tests/data/laissez-vibrer-01.mei
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/5.0/mei-basic.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.0/mei-basic.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0+basic">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title type="main">Laissez vibrer test</title>
+            <respStmt>
+               <persName role="composer">Klaus Rettinghaus</persName>
+            </respStmt>
+         </titleStmt>
+         <pubStmt>
+            <date isodate="2024-05-21T12:00:00" />
+         </pubStmt>
+      </fileDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef>
+                  <pgHead>
+                     <rend halign="center" valign="top">
+                        <rend type="title" fontsize="x-large">Laissez vibrer test</rend>
+                     </rend>
+                     <rend halign="right" valign="bottom">
+                        <rend type="composer">Klaus Rettinghaus</rend>
+                     </rend>
+                  </pgHead>
+                  <staffGrp>
+                     <staffDef n="1" lines="5" meter.count="2" meter.unit="4">
+                        <label>Oboe</label>
+                        <labelAbbr>Ob.</labelAbbr>
+                        <clef shape="G" line="2" />
+                     </staffDef>
+                  </staffGrp>
+               </scoreDef>
+               <section xml:id="s1">
+                  <measure xml:id="m10rbt48" n="1">
+                     <staff xml:id="m1s1" n="1">
+                        <layer xml:id="m1s1l1" n="1">
+                           <note xml:id="n19cl3ph" dur="2" pname="c" oct="5">
+                              <artic xml:id="a1cjn40" />
+                           </note>
+                        </layer>
+                     </staff>
+                     <lv xml:id="l1g1b4bt" startid="#n19cl3ph" curvedir="above" />
+                  </measure>
+                  <measure xml:id="m1lruvx2" n="2">
+                     <staff xml:id="m2s1" n="1">
+                        <layer xml:id="m2s1l1" n="1">
+                           <note xml:id="n19s9szz" dur="2" pname="c" oct="5">
+                              <artic xml:id="aj10287" place="below" />
+                           </note>
+                        </layer>
+                     </staff>
+                     <lv xml:id="l4vz2tp" startid="#n19s9szz" curvedir="below" />
+                  </measure>
+                  <measure xml:id="m1i0jnoo" n="3">
+                     <staff xml:id="m3s1" n="1">
+                        <layer xml:id="m3s1l1" n="1">
+                           <note xml:id="n154mkwr" dur="2" pname="c" oct="5">
+                              <artic xml:id="a1sen8gz" place="above" />
+                           </note>
+                        </layer>
+                     </staff>
+                     <lv xml:id="l1wv85md" startid="#n154mkwr" curvedir="above" />
+                  </measure>
+                  <measure xml:id="mucnjps" right="end" n="4">
+                     <staff xml:id="m4s1" n="1">
+                        <layer xml:id="m4s1l1" n="1">
+                           <note xml:id="ne85xiy" dur="2" pname="c" oct="5">
+                              <artic xml:id="a1klgotp" color="#FF2600" />
+                           </note>
+                        </layer>
+                     </staff>
+                     <lv xml:id="l41525" startid="#ne85xiy" color="#FF2600" curvedir="above" />
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
+</mei>

--- a/src/importexport/mei/tests/data/laissez-vibrer-01.mscx
+++ b/src/importexport/mei/tests/data/laissez-vibrer-01.mscx
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.40">
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <Spatium>1.74978</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Klaus Rettinghaus</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title type=&quot;main&quot;&gt;Laissez vibrer test&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Klaus Rettinghaus&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2024-05-21T12:00:00&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Laissez vibrer test</metaTag>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName></trackName>
+      <Instrument id="oboe">
+        <longName>Oboe</longName>
+        <shortName>Ob.</shortName>
+        <trackName></trackName>
+        <instrumentId>wind.reed.oboe</instrumentId>
+        <Channel>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>title</style>
+          <text>Laissez vibrer test</text>
+          </Text>
+        <Text>
+          <style>composer</style>
+          <text>Klaus Rettinghaus</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>2</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <durationType>half</durationType>
+            <Articulation>
+              <subtype>noSym</subtype>
+              </Articulation>
+            <Articulation>
+              <subtype>articLaissezVibrerAbove</subtype>
+              <anchor>0</anchor>
+              </Articulation>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Chord>
+            <durationType>half</durationType>
+            <Articulation>
+              <subtype>noSym</subtype>
+              <anchor>1</anchor>
+              </Articulation>
+            <Articulation>
+              <subtype>articLaissezVibrerBelow</subtype>
+              <anchor>1</anchor>
+              </Articulation>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Chord>
+            <durationType>half</durationType>
+            <Articulation>
+              <subtype>noSym</subtype>
+              </Articulation>
+            <Articulation>
+              <subtype>articLaissezVibrerAbove</subtype>
+              <anchor>0</anchor>
+              </Articulation>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Chord>
+            <durationType>half</durationType>
+            <Articulation>
+              <subtype>noSym</subtype>
+              <color r="255" g="38" b="0" a="255"/>
+              </Articulation>
+            <Articulation>
+              <subtype>articLaissezVibrerAbove</subtype>
+              <anchor>0</anchor>
+              <color r="255" g="38" b="0" a="255"/>
+              </Articulation>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/importexport/mei/tests/mei_tests.cpp
+++ b/src/importexport/mei/tests/mei_tests.cpp
@@ -195,6 +195,10 @@ TEST_F(Mei_Tests, mei_label_01) {
     meiReadTest("label-01");
 }
 
+TEST_F(Mei_Tests, laissez_vibrer_01) {
+    meiReadTest("laissez-vibrer-01");
+}
+
 TEST_F(Mei_Tests, mei_lyric_01) {
     meiReadTest("lyric-01");
 }


### PR DESCRIPTION
This adds (basic) import and export for _laissez vibrer_ to MEI support.

Another thing for @lpugin to have a look. 