### PR TITLE
Fix #22932 - ensure correct behaviour when deleting segments used by spanners, such that undo/redo works without crashing

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -26,6 +26,7 @@
 #include "infrastructure/messagebox.h"
 
 #include "accidental.h"
+#include "anchors.h"
 #include "articulation.h"
 #include "barline.h"
 #include "beam.h"
@@ -3950,7 +3951,15 @@ void Score::removeChordRest(ChordRest* cr, bool clearSegment)
     }
     for (Segment* s : segments) {
         if (s->empty()) {
+            auto needAnchor = isSpannerStartEnd(s->tick(), cr->track());
             doUndoRemoveElement(s);
+            if (needAnchor) {
+                TimeTickAnchor* anchor = EditTimeTickAnchors::createTimeTickAnchor(s->measure(),
+                                                                                   s->tick() - s->measure()->tick(),
+                                                                                   track2staff(cr->track()));
+                doUndoAddElement(anchor->parentItem());
+                doUndoAddElement(anchor);
+            }
         }
     }
     if (cr->beam()) {
@@ -6519,7 +6528,15 @@ void Score::undoRemoveElement(EngravingItem* element, bool removeLinked)
             if (s->header() || s->trailer()) {        // probably more segment types (system header)
                 s->setEnabled(false);
             } else {
+                auto needAnchor = isSpannerStartEnd(s->tick(), element->track());
                 doUndoRemoveElement(s);
+                if (needAnchor) {
+                    TimeTickAnchor* anchor = EditTimeTickAnchors::createTimeTickAnchor(s->measure(),
+                                                                                       s->tick() - s->measure()->tick(),
+                                                                                       track2staff(element->track()));
+                    doUndoAddElement(anchor->parentItem());
+                    doUndoAddElement(anchor);
+                }
             }
         }
     }

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -4395,7 +4395,7 @@ void Score::removeSpanner(Spanner* s)
 bool Score::isSpannerStartEnd(const Fraction& tick, track_idx_t track) const
 {
     for (auto i : m_spanner.map()) {
-        if (i.second->track() != track) {
+        if (i.second->track() != track && !i.second->isGradualTempoChange()) {
             continue;
         }
         if (i.second->tick() == tick || i.second->tick2() == tick) {


### PR DESCRIPTION
Resolves: #22932


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
