### PR TITLE
Fix #22821 - can no longer drag to palette after dismissing More popup

### DIFF
--- a/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
@@ -642,6 +642,9 @@ StyledListView {
                             customPaletteRootIndex = paletteTree.paletteProvider.customElementsPaletteIndex(control.modelIndex) // TODO: make a property binding? (but that works incorrectly)
                             customPaletteController = paletteTree.paletteProvider.customElementsPaletteController
                         }
+                        if (!isOpened) {
+                            paletteTree.expandedPopupIndex = null
+                        }
                     }
 
                     property bool needScrollToBottom: false


### PR DESCRIPTION
Resolves: #22821<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
