### PR TITLE
Add: Accessibility Panel - Score Style Preset option

### DIFF
--- a/share/styles/CMakeLists.txt
+++ b/share/styles/CMakeLists.txt
@@ -31,4 +31,4 @@ install(FILES
       cchords_sym.xml
       DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME}styles
       )
-
+add_subdirectory(MSN)

--- a/share/styles/MSN/16mm_MSN.mss
+++ b/share/styles/MSN/16mm_MSN.mss
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="4.40">
-  <Style>
+  <Style preset="16mm MSN" edited="false">
     <pageWidth>8.27</pageWidth>
     <pageHeight>11.69</pageHeight>
     <pagePrintableWidth>7.8763</pagePrintableWidth>

--- a/share/styles/MSN/18mm_MSN.mss
+++ b/share/styles/MSN/18mm_MSN.mss
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="4.40">
-  <Style>
+  <Style preset="18mm MSN" edited="false">
     <pageWidth>8.27</pageWidth>
     <pageHeight>11.69</pageHeight>
     <pagePrintableWidth>7.8763</pagePrintableWidth>

--- a/share/styles/MSN/20mm_MSN.mss
+++ b/share/styles/MSN/20mm_MSN.mss
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="4.40">
-  <Style>
+  <Style preset="20mm MSN" edited="false">
     <pageWidth>16.54</pageWidth>
     <pageHeight>11.69</pageHeight>
     <pagePrintableWidth>15.7526</pagePrintableWidth>

--- a/share/styles/MSN/22mm_MSN.mss
+++ b/share/styles/MSN/22mm_MSN.mss
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="4.40">
-  <Style>
+  <Style preset="22mm MSN" edited="false">
     <pageWidth>16.54</pageWidth>
     <pageHeight>11.69</pageHeight>
     <pagePrintableWidth>15.7526</pagePrintableWidth>

--- a/share/styles/MSN/25mm_MSN.mss
+++ b/share/styles/MSN/25mm_MSN.mss
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="4.40">
-  <Style>
+  <Style preset="25mm MSN" edited="false">
     <pageWidth>16.54</pageWidth>
     <pageHeight>11.69</pageHeight>
     <pagePrintableWidth>15.7526</pagePrintableWidth>

--- a/share/styles/MSN/CMakeLists.txt
+++ b/share/styles/MSN/CMakeLists.txt
@@ -1,0 +1,8 @@
+install(FILES
+      16mm_MSN.mss
+      18mm_MSN.mss
+      20mm_MSN.mss
+      22mm_MSN.mss
+      25mm_MSN.mss
+      DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME}styles/MSN
+      )

--- a/src/engraving/style/style.cpp
+++ b/src/engraving/style/style.cpp
@@ -299,6 +299,8 @@ bool MStyle::read(IODevice* device, bool ign)
             readVersion(e.attribute("version"));
             while (e.readNextStartElement()) {
                 if (e.name() == "Style") {
+                    m_preset = TConv::fromXml(e.asciiAttribute("preset", "Default"), ScoreStylePreset::DEFAULT);
+                    m_presetEdited = e.attribute("edited", String(u"false")) == "true";
                     read(e, nullptr);
                 } else {
                     e.unknown();
@@ -555,7 +557,17 @@ bool MStyle::write(IODevice* device)
 
 void MStyle::save(XmlWriter& xml, bool optimize)
 {
-    xml.startElement("Style");
+    muse::XmlStreamWriter::Attributes attributes;
+
+    if (preset() != ScoreStylePreset::DEFAULT) {
+        attributes.push_back({ "preset", TConv::toXml(preset()) });
+    }
+
+    if (presetEdited()) {
+        attributes.push_back({ "edited", String(u"true") });
+    }
+
+    xml.startElement("Style", attributes);
 
     for (const StyleDef::StyleValue& st : StyleDef::styleValues) {
         Sid idx = st.styleIdx();

--- a/src/engraving/style/style.h
+++ b/src/engraving/style/style.h
@@ -74,6 +74,11 @@ public:
     void setDefaultStyleVersion(const int defaultsVersion);
     int defaultStyleVersion() const;
 
+    ScoreStylePreset preset() const { return m_preset; }
+    void setPreset(ScoreStylePreset preset) { m_preset = preset; }
+    bool presetEdited() const { return m_presetEdited; }
+    void setPresetEdited(bool isEdited) { m_presetEdited = isEdited; }
+
     bool read(muse::io::IODevice* device, bool ign = false);
     bool write(muse::io::IODevice* device);
     void save(XmlWriter& xml, bool optimize);
@@ -100,6 +105,8 @@ private:
 
     void readVersion(String versionTag);
     int m_version = 0;
+    ScoreStylePreset m_preset = ScoreStylePreset::DEFAULT;
+    bool m_presetEdited = false;
 };
 } // namespace mu::engraving
 

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -1185,6 +1185,16 @@ struct std::hash<mu::engraving::InstrumentTrackId>
     }
 };
 
+enum class ScoreStylePreset {
+    DEFAULT = 0,
+    MSN_16MM,
+    MSN_18MM,
+    MSN_20MM,
+    MSN_22MM,
+    MSN_25MM,
+    MAX_PRESET
+};
+
 #ifndef NO_QT_SUPPORT
 Q_DECLARE_METATYPE(mu::engraving::BeamMode)
 Q_DECLARE_METATYPE(mu::engraving::JumpType)

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -2789,3 +2789,42 @@ String TConv::translatedUserName(Key v, bool isAtonal, bool isCustom)
 {
     return userName(v, isAtonal, isCustom).translated();
 }
+
+const std::array<Item<ScoreStylePreset>, 6> SCORE_STYLE_PRESETS = { {
+    //: Score notation style: Default
+    { ScoreStylePreset::DEFAULT,  "Default",  muse::TranslatableString("engraving/scorestylepreset", "Default") },
+    //: Score notation style: Modified Stave Notation (MSN) with 16mm staff size. Intended for visually-impaired musicians.
+    { ScoreStylePreset::MSN_16MM, "16mm MSN", muse::TranslatableString("engraving/scorestylepreset", "16mm MSN") },
+    //: Score notation style: Modified Stave Notation (MSN) with 18mm staff size. Intended for visually-impaired musicians.
+    { ScoreStylePreset::MSN_18MM, "18mm MSN", muse::TranslatableString("engraving/scorestylepreset", "18mm MSN") },
+    //: Score notation style: Modified Stave Notation (MSN) with 20mm staff size. Intended for visually-impaired musicians.
+    { ScoreStylePreset::MSN_20MM, "20mm MSN", muse::TranslatableString("engraving/scorestylepreset", "20mm MSN") },
+    //: Score notation style: Modified Stave Notation (MSN) with 22mm staff size. Intended for visually-impaired musicians.
+    { ScoreStylePreset::MSN_22MM, "22mm MSN", muse::TranslatableString("engraving/scorestylepreset", "22mm MSN") },
+    //: Score notation style: Modified Stave Notation (MSN) with 25mm staff size. Intended for visually-impaired musicians.
+    { ScoreStylePreset::MSN_25MM, "25mm MSN", muse::TranslatableString("engraving/scorestylepreset", "25mm MSN") }
+} };
+
+AsciiStringView TConv::toXml(ScoreStylePreset preset)
+{
+    return findXmlTagByType<ScoreStylePreset>(SCORE_STYLE_PRESETS, preset);
+}
+
+ScoreStylePreset TConv::fromXml(const AsciiStringView& tag, ScoreStylePreset def)
+{
+    if (tag == "Default") {
+        return def;
+    }
+
+    return findTypeByXmlTag<ScoreStylePreset>(SCORE_STYLE_PRESETS, tag, def);
+}
+
+const muse::TranslatableString& TConv::userName(ScoreStylePreset v)
+{
+    return findUserNameByType<ScoreStylePreset>(SCORE_STYLE_PRESETS, v);
+}
+
+String TConv::translatedUserName(ScoreStylePreset v)
+{
+    return findUserNameByType<ScoreStylePreset>(SCORE_STYLE_PRESETS, v).translated();
+}

--- a/src/engraving/types/typesconv.h
+++ b/src/engraving/types/typesconv.h
@@ -246,5 +246,11 @@ public:
 
     static AsciiStringView toXml(PartialSpannerDirection v);
     static PartialSpannerDirection fromXml(const AsciiStringView& str, PartialSpannerDirection def);
+
+    static AsciiStringView toXml(ScoreStylePreset preset);
+    static ScoreStylePreset fromXml(const AsciiStringView& tag, ScoreStylePreset def);
+
+    static const TranslatableString& userName(ScoreStylePreset v);
+    static String translatedUserName(ScoreStylePreset v);
 };
 }

--- a/src/inspector/CMakeLists.txt
+++ b/src/inspector/CMakeLists.txt
@@ -86,6 +86,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/models/measures/measuressettingsmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/models/score/scoreappearancesettingsmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/models/score/scoreappearancesettingsmodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/models/score/scoreaccessibilitysettingsmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/models/score/scoreaccessibilitysettingsmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/models/score/scoredisplaysettingsmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/models/score/scoredisplaysettingsmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/models/score/internal/pagetypelistmodel.cpp

--- a/src/inspector/models/abstractinspectormodel.h
+++ b/src/inspector/models/abstractinspectormodel.h
@@ -67,6 +67,7 @@ public:
         SECTION_TEXT,
         SECTION_SCORE_DISPLAY,
         SECTION_SCORE_APPEARANCE,
+        SECTION_SCORE_ACCESSIBILITY,
         SECTION_PARTS,
     };
     Q_ENUM(InspectorSectionType)

--- a/src/inspector/models/inspectorlistmodel.cpp
+++ b/src/inspector/models/inspectorlistmodel.cpp
@@ -28,6 +28,7 @@
 #include "text/textsettingsmodel.h"
 #include "score/scoredisplaysettingsmodel.h"
 #include "score/scoreappearancesettingsmodel.h"
+#include "score/scoreaccessibilitysettingsmodel.h"
 #include "notation/inotationinteraction.h"
 
 #include "internal/services/elementrepositoryservice.h"
@@ -73,7 +74,8 @@ void InspectorListModel::buildModelsForEmptySelection()
 
     static const InspectorSectionTypeSet persistentSections {
         InspectorSectionType::SECTION_SCORE_DISPLAY,
-        InspectorSectionType::SECTION_SCORE_APPEARANCE
+        InspectorSectionType::SECTION_SCORE_APPEARANCE,
+        InspectorSectionType::SECTION_SCORE_ACCESSIBILITY
     };
 
     removeUnusedModels({}, false /*isRangeSelection*/, {}, persistentSections);
@@ -194,6 +196,9 @@ void InspectorListModel::createModelsBySectionType(const InspectorSectionTypeSet
             break;
         case InspectorSectionType::SECTION_SCORE_APPEARANCE:
             newModel = new ScoreAppearanceSettingsModel(this, m_repository);
+            break;
+        case InspectorSectionType::SECTION_SCORE_ACCESSIBILITY:
+            newModel = new ScoreAccessibilitySettingsModel(this, m_repository);
             break;
         case InspectorSectionType::SECTION_PARTS:
             newModel = new PartsSettingsModel(this, m_repository);

--- a/src/inspector/models/score/scoreaccessibilitysettingsmodel.cpp
+++ b/src/inspector/models/score/scoreaccessibilitysettingsmodel.cpp
@@ -1,0 +1,220 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "scoreaccessibilitysettingsmodel.h"
+
+#include "translation.h"
+#include "log.h"
+#include "engraving/types/typesconv.h"
+
+using namespace mu::engraving;
+using namespace mu::inspector;
+using namespace mu::notation;
+
+ScoreAccessibilitySettingsModel::ScoreAccessibilitySettingsModel(QObject* parent, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, repository)
+{
+    setSectionType(InspectorSectionType::SECTION_SCORE_ACCESSIBILITY);
+    setTitle(muse::qtrc("inspector", "Accessibility"));
+
+    notationStyle()->styleChanged().onNotify(this, [this]() {
+        if (!m_ignoreStyleChanges && !m_currentPresetEdited) {
+            m_currentPresetEdited = true;
+            engravingStyle().setPresetEdited(m_currentPresetEdited);
+            emit possibleStylePresetsChanged();
+            emit currentStylePresetIndexChanged();
+        }
+    });
+}
+
+void ScoreAccessibilitySettingsModel::createProperties()
+{
+    NOT_IMPLEMENTED;
+}
+
+void ScoreAccessibilitySettingsModel::loadProperties()
+{
+    NOT_IMPLEMENTED;
+}
+
+void ScoreAccessibilitySettingsModel::resetProperties()
+{
+    NOT_IMPLEMENTED;
+}
+
+void ScoreAccessibilitySettingsModel::requestElements()
+{
+    // Avoid calling virtual ancestor.
+}
+
+QVariantList ScoreAccessibilitySettingsModel::possibleStylePresets() const
+{
+    QVariantList presets;
+
+    QString text = "text";
+    QString value = "value";
+    QString preset = "preset";
+    QString edited = "edited";
+
+    for (int i = 0; i < static_cast<int>(ScoreStylePreset::MAX_PRESET); ++i) {
+        ScoreStylePreset presetEnum = static_cast<ScoreStylePreset>(i);
+        QString presetName = TConv::translatedUserName(presetEnum);
+
+        presets.append(QVariantMap {
+            { text, presetName },
+            {
+                value,
+                QVariantMap {
+                    { preset, i },
+                    { edited, false }
+                }
+            }
+        });
+
+        if (i == static_cast<int>(m_currentPreset) && m_currentPresetEdited) {
+            QString editedPresetName = muse::qtrc("inspector", "%1 (edited)").arg(presetName);
+            presets.append(QVariantMap {
+                { text, editedPresetName },
+                {
+                    value,
+                    QVariantMap {
+                        { preset, i },
+                        { edited, true }
+                    }
+                }
+            });
+        }
+    }
+
+    return presets;
+}
+
+int ScoreAccessibilitySettingsModel::currentStylePresetIndex() const
+{
+    return static_cast<int>(m_currentPreset) + (m_currentPresetEdited ? 1 : 0);
+}
+
+void ScoreAccessibilitySettingsModel::setCurrentStylePresetIndex(int index)
+{
+    int currentIndex = currentStylePresetIndex();
+
+    if (index == currentIndex) {
+        return;
+    }
+
+    if (m_currentPresetEdited && index > currentIndex) {
+        --index; // enum's values don't include the edited option
+    }
+
+    IF_ASSERT_FAILED(0 <= index && index < static_cast<int>(ScoreStylePreset::MAX_PRESET)) {
+        return;
+    }
+
+    auto preset = static_cast<ScoreStylePreset>(index);
+
+    m_ignoreStyleChanges = true;
+    bool success = applyStylePreset(preset);
+    m_ignoreStyleChanges = false;
+
+    IF_ASSERT_FAILED(success) {
+        return;
+    }
+
+    MStyle& style = engravingStyle();
+    style.setPreset(preset);
+    style.setPresetEdited(false);
+    m_currentPreset = preset;
+
+    if (m_currentPresetEdited) {
+        m_currentPresetEdited = false;
+        emit possibleStylePresetsChanged(); // "(edited)" option removed
+    }
+
+    emit currentStylePresetIndexChanged();
+}
+
+void ScoreAccessibilitySettingsModel::updateCurrentStylePreset()
+{
+    int oldIndex = currentStylePresetIndex();
+    MStyle& style = engravingStyle();
+    m_currentPreset = style.preset();
+    bool presetEdited = style.presetEdited();
+
+    if (presetEdited != m_currentPresetEdited) {
+        m_currentPresetEdited = presetEdited;
+        emit possibleStylePresetsChanged(); // "(edited)" option added or removed
+    }
+
+    if (currentStylePresetIndex() != oldIndex) {
+        emit currentStylePresetIndexChanged();
+    }
+}
+
+bool ScoreAccessibilitySettingsModel::applyStylePreset(ScoreStylePreset preset) const
+{
+    muse::io::path_t filePath = styleFilePath(preset);
+
+    if (preset == ScoreStylePreset::DEFAULT && filePath.empty()) {
+        LOGI() << "Loading default style values";
+        StyleIdSet emptySet;
+        notationStyle()->resetAllStyleValues(emptySet);
+        return true;
+    }
+
+    IF_ASSERT_FAILED(!filePath.empty()) {
+        return false;
+    }
+
+    LOGI() << "Loading style from file: " << filePath;
+    return notationStyle()->loadStyle(filePath, true);
+}
+
+muse::io::path_t ScoreAccessibilitySettingsModel::styleFilePath(ScoreStylePreset preset) const
+{
+    const muse::io::path_t basePath = globalConfiguration()->appDataPath() + "styles/MSN/";
+
+    switch (preset) {
+    case ScoreStylePreset::DEFAULT:
+        return engravingConfiguration()->defaultStyleFilePath();
+    case ScoreStylePreset::MSN_16MM:
+        return basePath + "16mm_MSN.mss";
+    case ScoreStylePreset::MSN_18MM:
+        return basePath + "18mm_MSN.mss";
+    case ScoreStylePreset::MSN_20MM:
+        return basePath + "20mm_MSN.mss";
+    case ScoreStylePreset::MSN_22MM:
+        return basePath + "22mm_MSN.mss";
+    case ScoreStylePreset::MSN_25MM:
+        return basePath + "25mm_MSN.mss";
+    default:
+        return muse::io::path_t();
+    }
+}
+
+MStyle& ScoreAccessibilitySettingsModel::engravingStyle() const
+{
+    return currentNotation()->elements()->msScore()->score()->style();
+}
+
+INotationStylePtr ScoreAccessibilitySettingsModel::notationStyle() const
+{
+    return currentNotation()->style();
+}

--- a/src/inspector/models/score/scoreaccessibilitysettingsmodel.h
+++ b/src/inspector/models/score/scoreaccessibilitysettingsmodel.h
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <QObject>
+
+#include "models/abstractinspectormodel.h"
+#include "context/iglobalcontext.h"
+#include "global/iglobalconfiguration.h"
+#include "engraving/iengravingconfiguration.h"
+#include "engraving/types/types.h"
+
+namespace mu::inspector {
+class ScoreAccessibilitySettingsModel : public AbstractInspectorModel
+{
+    Q_OBJECT
+    INJECT(mu::context::IGlobalContext, globalContext)
+    INJECT(muse::IGlobalConfiguration, globalConfiguration);
+    INJECT(engraving::IEngravingConfiguration, engravingConfiguration);
+
+    Q_PROPERTY(QVariantList possibleStylePresets
+               READ possibleStylePresets
+               NOTIFY possibleStylePresetsChanged);
+
+    Q_PROPERTY(int currentStylePresetIndex
+               READ currentStylePresetIndex
+               WRITE setCurrentStylePresetIndex
+               NOTIFY currentStylePresetIndexChanged);
+
+public:
+    explicit ScoreAccessibilitySettingsModel(QObject* parent, IElementRepositoryService* repository);
+
+    void createProperties() override;
+    void loadProperties() override;
+    void resetProperties() override;
+    void requestElements() override;
+
+    QVariantList possibleStylePresets() const;
+    int currentStylePresetIndex() const;
+    void setCurrentStylePresetIndex(int index);
+    Q_INVOKABLE void updateCurrentStylePreset();
+
+signals:
+    void possibleStylePresetsChanged();
+    void currentStylePresetIndexChanged();
+
+private:
+    bool applyStylePreset(ScoreStylePreset preset) const;
+    muse::io::path_t styleFilePath(ScoreStylePreset preset) const;
+    mu::engraving::MStyle& engravingStyle() const;
+    mu::notation::INotationStylePtr notationStyle() const;
+
+    ScoreStylePreset m_currentPreset = ScoreStylePreset::DEFAULT;
+    bool m_currentPresetEdited = false;
+    bool m_ignoreStyleChanges = false;
+};
+}

--- a/src/inspector/view/inspector_resources.qrc
+++ b/src/inspector/view/inspector_resources.qrc
@@ -50,6 +50,7 @@
         <file>qml/MuseScore/Inspector/notation/fretdiagrams/internal/FretAdvancedSettingsTab.qml</file>
         <file>qml/MuseScore/Inspector/score/ScoreDisplayInspectorView.qml</file>
         <file>qml/MuseScore/Inspector/score/ScoreAppearanceInspectorView.qml</file>
+        <file>qml/MuseScore/Inspector/score/ScoreAccessibilityInspectorView.qml</file>
         <file>qml/MuseScore/Inspector/score/HideEmptyStavesSettings.qml</file>
         <file>qml/MuseScore/Inspector/common/InspectorPropertyView.qml</file>
         <file>qml/MuseScore/Inspector/common/TextSection.qml</file>

--- a/src/inspector/view/qml/MuseScore/Inspector/InspectorSectionDelegate.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/InspectorSectionDelegate.qml
@@ -72,6 +72,7 @@ ExpandableBlank {
             }
         case Inspector.SECTION_SCORE_DISPLAY: return scoreSection
         case Inspector.SECTION_SCORE_APPEARANCE: return scoreAppearanceSection
+        case Inspector.SECTION_SCORE_ACCESSIBILITY: return scoreAccessibilitySection
         case Inspector.SECTION_PARTS: return partsSection
         }
 
@@ -196,6 +197,25 @@ ExpandableBlank {
             }
 
             onPopupOpened: function(openedPopup, control) {
+                root.popupOpened(openedPopup, control)
+            }
+        }
+    }
+
+    Component {
+        id: scoreAccessibilitySection
+
+        ScoreAccessibilityInspectorView {
+            model: root.sectionModel
+            navigationPanel: root.navigationPanel
+            navigationRowStart: root.navigation.row + 1
+            anchorItem: root.anchorItem
+
+            onEnsureContentVisibleRequested: function(invisibleContentHeight) {
+                root.ensureContentVisibleRequested(-invisibleContentHeight)
+            }
+
+            onPopupOpened: {
                 root.popupOpened(openedPopup, control)
             }
         }

--- a/src/inspector/view/qml/MuseScore/Inspector/score/ScoreAccessibilityInspectorView.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/score/ScoreAccessibilityInspectorView.qml
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import MuseScore.Inspector 1.0
+import Muse.UiComponents 1.0
+import Muse.Ui 1.0
+
+import "../common"
+
+InspectorSectionView {
+    id: root
+
+    implicitHeight: contentColumn.implicitHeight
+
+    Column {
+        id: contentColumn
+        width: parent.width
+        spacing: 8
+
+        Text {
+            text: qsTr("Score style preset")
+            color: ui.theme.fontPrimaryColor
+        }
+
+        StyledDropdown {
+            id: scoreStylePreset
+            width: parent.width
+            currentIndex: root.model ? root.model.currentStylePresetIndex : -1
+            model: root.model ? root.model.possibleStylePresets : null
+
+            Component.onCompleted: {
+                root.model.updateCurrentStylePreset()
+            }
+
+            onActivated: function(index, value) {
+                root.model.currentStylePresetIndex = index
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi All,
This is the PR related to GSoC '24 - Accessibility Profiles project. To check what is goal for this project, kindly refer to: https://musescore.org/en/user/1088561/blog/2024/05/27/gsoc-2024-project-accessibility-profiles-musescore

### Adds Accessibility section to the Properties panel

The new section appears when there is nothing selected in the score. Press Esc or click on an empty region of page to see it.

![image](https://github.com/user-attachments/assets/5c34ce08-b9bc-4b9f-8dd9-72dfef5617ce)

### Adds score style preset dropdown to control notation size

The dropdown provides various sizes of **Modified Stave Notation (MSN)**, which modifies staff size, line thickness, and changes text fonts for easier viewing by partially sighted musicians.

![image](https://github.com/user-attachments/assets/fe186b65-c260-4623-b9ce-4c629492cc3f)

If the user makes manual changes to styles then the current dropdown value changes to say "(edited)".

![image](https://github.com/user-attachments/assets/475e94cc-b420-485f-867c-15b99513198c)

The user can remove the edits by choosing one of the non-edited options.

For the MVP:

- The "(edited)" text appears whenever the user edits any style value.
    - Ideally it would only appear if the user changes a style setting that is relevant to MSN.
- Choosing "Default" resets all style values.
    - Ideally it would reset only the specific values that are relevant to MSN.

--------------------------------------------------------------------------------------------------------------------------
- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
