### PR TITLE
MusicXML: add import/export of Nashville notation

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -134,6 +134,9 @@
 #include "global/realfn.h"
 #include "engraving/iengravingconfiguration.h"
 
+#include <QRegularExpression>
+#include <QRegularExpressionMatch>
+
 #include "log.h"
 
 using namespace mu;
@@ -8625,16 +8628,57 @@ void ExportMusicXml::harmony(Harmony const* const h, FretDiagram const* const fd
         const String textName = h->hTextName();
         switch (h->harmonyType()) {
         case HarmonyType::NASHVILLE: {
-            m_xml.tag("function", h->hFunction());
-            m_xml.tag("kind", { { "text", textName } }, "none");
+            String alter;
+            String functionText = h->hFunction();
+            if (!functionText.contains(std::wregex(L"[1-7]"))) {
+                m_xml.tag("function", textName);
+                m_xml.tag("kind", "none");
+                break;
+            } else if (!functionText.at(0).isDigit()) {
+                alter = functionText.at(0);
+                functionText = functionText.at(1);
+            }
+            m_xml.startElement("numeral");
+            m_xml.tag("numeral-root", functionText);
+            if (alter == u"b") {
+                m_xml.tag("numeral-alter", "-1");
+            } else if (alter == u"#") {
+                m_xml.tag("numeral-alter", "1");
+            }
+            m_xml.endElement();
+            if (!h->xmlKind().isEmpty()) {
+                String s = u"kind";
+                String kindText = h->musicXmlText();
+                if (h->musicXmlText() != "") {
+                    s += u" text=\"" + kindText + u"\"";
+                }
+                if (h->xmlSymbols() == "yes") {
+                    s += u" use-symbols=\"yes\"";
+                }
+                if (h->xmlParens() == "yes") {
+                    s += u" parentheses-degrees=\"yes\"";
+                }
+                m_xml.tagRaw(s, h->xmlKind());
+            } else {
+                m_xml.tag("kind", "none");
+            }
         }
         break;
         case HarmonyType::ROMAN: {
-            // TODO: parse?
-            m_xml.tag("function", h->hTextName());   // note: HTML escape done by tag()
-            m_xml.tag("kind", { { "text", "" } }, "none");
+            QRegularExpression romanRegex("[iv]+", QRegularExpression::CaseInsensitiveOption);
+            QRegularExpressionMatch romanMatch = romanRegex.match(textName);
+            QStringList caps = romanMatch.capturedTexts();
+            if (caps.size()) {
+                String text = caps[0];
+                m_xml.startElement("numeral");
+                m_xml.tag("numeral-root", { { "text", text } }, "1");
+                m_xml.endElement();
+                // only check for major or minor
+                m_xml.tag("kind", text.at(0).isUpper() ? "major" : "minor");
+                break;
+            }
         }
-        break;
+        // fallthrough
         case HarmonyType::STANDARD:
         default: {
             m_xml.startElement("root");

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -6877,7 +6877,7 @@ void MusicXMLParserPass2::harmony(const String& partId, Measure* measure, const 
     const String placement = m_e.attribute("placement");
     const bool printObject = m_e.asciiAttribute("print-object") != "no";
 
-    String kind, kindText, functionText, symbols, parens;
+    String kind, kindText, functionText, inversionText, symbols, parens;
     std::list<HDegree> degreeList;
 
     FretDiagram* fd = nullptr;
@@ -6920,8 +6920,33 @@ void MusicXMLParserPass2::harmony(const String& partId, Measure* measure, const 
             ha->setRootTpc(Tpc::TPC_INVALID);
             ha->setBaseTpc(Tpc::TPC_INVALID);
             functionText = m_e.readText();
-            // TODO: parse to decide between ROMAN and NASHVILLE
             ha->setHarmonyType(HarmonyType::ROMAN);
+        } else if (m_e.name() == "numeral") {
+            ha->setRootTpc(Tpc::TPC_INVALID);
+            ha->setBaseTpc(Tpc::TPC_INVALID);
+            while (m_e.readNextStartElement()) {
+                if (m_e.name() == "numeral-root") {
+                    String numeralRoot = m_e.readText();
+                    String numeralRootText = m_e.attribute("text");
+                    // TODO analyze text and import as roman numerals
+                    ha->setHarmonyType(HarmonyType::NASHVILLE);
+                    ha->setFunction(numeralRoot);
+                } else if (m_e.name() == "numeral-alter") {
+                    const int alter = m_e.readText().toInt();
+                    switch (alter) {
+                    case -1:
+                        ha->setFunction(u"b" + ha->hFunction());
+                        break;
+                    case 1:
+                        ha->setFunction(u"#" + ha->hFunction());
+                        break;
+                    default:
+                        break;
+                    }
+                } else {
+                    skipLogCurrElem();
+                }
+            }
         } else if (m_e.name() == "kind") {
             // attributes: use-symbols  yes-no
             //             text, stack-degrees, parentheses-degree, bracket-degrees,
@@ -6934,8 +6959,16 @@ void MusicXMLParserPass2::harmony(const String& partId, Measure* measure, const 
                 ha->setRootTpc(Tpc::TPC_INVALID);
             }
         } else if (m_e.name() == "inversion") {
-            // attributes: print-style
-            skipLogCurrElem();
+            const int inversion = m_e.readText().toInt();
+            switch (inversion) {
+            case 1: inversionText = "6";
+                break;
+            case 2: inversionText = "64";
+                break;
+            default:
+                inversionText = "";
+                break;
+            }
         } else if (m_e.name() == "bass") {
             String step;
             int alter = 0;
@@ -7011,7 +7044,7 @@ void MusicXMLParserPass2::harmony(const String& partId, Measure* measure, const 
         ha->setTextName(d->names.front());
     } else {
         ha->setId(-1);
-        String textName = functionText + kindText;
+        String textName = functionText + kindText + inversionText;
         ha->setTextName(textName);
     }
     ha->render();

--- a/src/importexport/musicxml/tests/data/testHarmony6_ref.xml
+++ b/src/importexport/musicxml/tests/data/testHarmony6_ref.xml
@@ -74,8 +74,10 @@ containing recognized text, unrecognized plaintext and unrecognized text requiri
       </measure>
     <measure number="2">
       <harmony print-frame="no">
-        <function>i</function>
-        <kind text="">none</kind>
+        <numeral>
+          <numeral-root text="i">1</numeral-root>
+          </numeral>
+        <kind>minor</kind>
         </harmony>
       <note>
         <pitch>
@@ -93,8 +95,10 @@ containing recognized text, unrecognized plaintext and unrecognized text requiri
       </measure>
     <measure number="3">
       <harmony print-frame="no">
-        <function>1</function>
-        <kind text="m">none</kind>
+        <numeral>
+          <numeral-root>1</numeral-root>
+          </numeral>
+        <kind text="m">minor</kind>
         </harmony>
       <note>
         <pitch>
@@ -134,8 +138,10 @@ containing recognized text, unrecognized plaintext and unrecognized text requiri
       </measure>
     <measure number="5">
       <harmony print-frame="no">
-        <function>xyz</function>
-        <kind text="">none</kind>
+        <root>
+          <root-step text="">C</root-step>
+          </root>
+        <kind text="xyz">none</kind>
         </harmony>
       <note>
         <pitch>
@@ -153,8 +159,8 @@ containing recognized text, unrecognized plaintext and unrecognized text requiri
       </measure>
     <measure number="6">
       <harmony print-frame="no">
-        <function></function>
-        <kind text="xyz">none</kind>
+        <function>xyz</function>
+        <kind>none</kind>
         </harmony>
       <note>
         <pitch>
@@ -194,8 +200,10 @@ containing recognized text, unrecognized plaintext and unrecognized text requiri
       </measure>
     <measure number="8">
       <harmony print-frame="no">
-        <function>&lt;&gt;&amp;&quot;</function>
-        <kind text="">none</kind>
+        <root>
+          <root-step text="">C</root-step>
+          </root>
+        <kind text="&lt;&gt;&amp;&quot;">none</kind>
         </harmony>
       <note>
         <pitch>
@@ -213,8 +221,8 @@ containing recognized text, unrecognized plaintext and unrecognized text requiri
       </measure>
     <measure number="9">
       <harmony print-frame="no">
-        <function></function>
-        <kind text="&lt;&gt;&amp;&quot;">none</kind>
+        <function>&lt;&gt;&amp;&quot;</function>
+        <kind>none</kind>
         </harmony>
       <note>
         <pitch>

--- a/src/importexport/musicxml/tests/data/testHarmony9.xml
+++ b/src/importexport/musicxml/tests/data/testHarmony9.xml
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Nashville Number System</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Klaus Rettinghaus</creator>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Akustischer Bass</part-name>
+      <part-abbreviation>Bass</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Akustischer Bass</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>37</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>2</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        <transpose>
+          <diatonic>0</diatonic>
+          <chromatic>0</chromatic>
+          <octave-change>-1</octave-change>
+          </transpose>
+        </attributes>
+      <harmony print-frame="no">
+        <numeral>
+          <numeral-root>1</numeral-root>
+          </numeral>
+        <kind>major</kind>
+        </harmony>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <harmony print-frame="no">
+        <numeral>
+          <numeral-root>7</numeral-root>
+          </numeral>
+        <kind use-symbols="yes">half-diminished</kind>
+        </harmony>
+      <note>
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <harmony print-frame="no">
+        <numeral>
+          <numeral-root>6</numeral-root>
+          </numeral>
+        <kind use-symbols="yes">minor</kind>
+        </harmony>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>2</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <harmony print-frame="no">
+        <numeral>
+          <numeral-root>4</numeral-root>
+          </numeral>
+        <kind text="m">minor</kind>
+        </harmony>
+      <note>
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>2</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <accidental>flat</accidental>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="2">
+      <harmony print-frame="no">
+        <numeral>
+          <numeral-root>5</numeral-root>
+          </numeral>
+        <kind text="7">dominant</kind>
+        </harmony>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>2</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <harmony print-frame="no">
+        <numeral>
+          <numeral-root>1</numeral-root>
+          </numeral>
+        <kind text="6">major-sixth</kind>
+        </harmony>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <harmony print-frame="no">
+        <numeral>
+          <numeral-root>2</numeral-root>
+          <numeral-alter>-1</numeral-alter>
+          </numeral>
+        <kind>major</kind>
+        </harmony>
+      <note>
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <accidental>flat</accidental>
+        <stem>down</stem>
+        </note>
+      <harmony print-frame="no">
+        <numeral>
+          <numeral-root>3</numeral-root>
+          <numeral-alter>-1</numeral-alter>
+          </numeral>
+        <kind>major</kind>
+        </harmony>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <accidental>natural</accidental>
+        <stem>down</stem>
+        </note>
+      </measure>
+    <measure number="3">
+      <harmony print-frame="no">
+        <numeral>
+          <numeral-root>1</numeral-root>
+          </numeral>
+        <kind text="5">power</kind>
+        </harmony>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <harmony print-frame="no">
+        <numeral>
+          <numeral-root>6</numeral-root>
+          </numeral>
+        <kind text="maj7">major-seventh</kind>
+        </harmony>
+      <note>
+        <pitch>
+          <step>D</step>
+          <alter>1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <accidental>sharp</accidental>
+        <stem>down</stem>
+        </note>
+      <harmony print-frame="no">
+        <numeral>
+          <numeral-root>2</numeral-root>
+          </numeral>
+        <kind text="m6">minor-sixth</kind>
+        </harmony>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <harmony print-frame="no">
+        <numeral>
+          <numeral-root>5</numeral-root>
+          </numeral>
+        <kind text="sus4">suspended-fourth</kind>
+        </harmony>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>2</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="4">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -673,6 +673,9 @@ TEST_F(Musicxml_Tests, harmony6) {
 TEST_F(Musicxml_Tests, harmony8) {
     mxmlIoTest("testHarmony8");
 }
+TEST_F(Musicxml_Tests, harmony9) {
+    mxmlIoTest("testHarmony9");
+}                                                                      // chordnames without chordrest
 TEST_F(Musicxml_Tests, hello) {
     mxmlIoTest("testHello");
 }


### PR DESCRIPTION
This PR adds proper handling of Nashville notation and basic export of Roman numerals to MusicXML support. 