### PR TITLE
Fix lyrics layout bug and reintroduce showing short melisma for invalid one-chord melismas

### DIFF
--- a/src/engraving/dom/lyrics.h
+++ b/src/engraving/dom/lyrics.h
@@ -47,10 +47,7 @@ public:
     // it should be cleared to 0 at some point, so that it will not be carried over
     // if the melisma is not extended beyond a single chord, but no suitable place to do this
     // has been identified yet.
-    static constexpr Fraction TEMP_MELISMA_TICKS = Fraction::fromTicks(1);
-
-    // WORD_MIN_DISTANCE has never been implemented
-    // static constexpr double  LYRICS_WORD_MIN_DISTANCE = 0.33;     // min. distance between lyrics from different words
+    static constexpr Fraction TEMP_MELISMA_TICKS = Fraction::fromTicks(1); // THIS WAS A HORRIBLE HACK. At some point we must remove it and replace it with a proper solution. (M.S.)
 
     ~Lyrics();
 

--- a/src/engraving/rendering/dev/lyricslayout.cpp
+++ b/src/engraving/rendering/dev/lyricslayout.cpp
@@ -280,10 +280,10 @@ void LyricsLayout::layoutMelismaLine(LyricsLineSegment* item)
 
     double tolerance = 0.05 * item->spatium();
     if (endX - startX < style.styleMM(Sid::lyricsMelismaMinLength) - tolerance) {
-        if (style.styleB(Sid::lyricsMelismaForce)) {
+        if (style.styleB(Sid::lyricsMelismaForce) || startLyrics->ticks() == Lyrics::TEMP_MELISMA_TICKS) {
             endX = startX + style.styleMM(Sid::lyricsMelismaMinLength);
         } else {
-            return;
+            endX = startX;
         }
     }
 
@@ -588,6 +588,9 @@ void LyricsLayout::collectLyricsVerses(staff_idx_t staffIdx, System* system, Lyr
 
     for (SpannerSegment* spannerSegment : system->spannerSegments()) {
         if (spannerSegment->staffIdx() == staffIdx && spannerSegment->isLyricsLineSegment()) {
+            if (muse::RealIsNull(spannerSegment->pos2().x())) {
+                continue;
+            }
             LyricsLineSegment* lyricsLineSegment = toLyricsLineSegment(spannerSegment);
             Lyrics* lyrics = lyricsLineSegment->lyricsLine()->lyrics();
             int verse = lyrics->no();

--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -6693,19 +6693,6 @@ SpannerSegment* TLayout::layoutSystem(LyricsLine* line, System* system, LayoutCo
         return nullptr;
     }
 
-    // if temp melisma extend the first line segment to be
-    // after the lyrics syllable (otherwise the melisma segment
-    // will be too short).
-    const bool tempMelismaTicks = (line->lyrics()->ticks() == Lyrics::TEMP_MELISMA_TICKS);
-    if (tempMelismaTicks && line->spannerSegments().size() > 0 && line->spannerSegments().front() == lineSegm) {
-        lineSegm->rxpos2() += line->lyrics()->width();
-    }
-
-    // avoid backwards melisma
-    if (lineSegm->pos2().x() < 0) {
-        lineSegm->rxpos2() = 0;
-    }
-
     return lineSegm;
 }
 


### PR DESCRIPTION
Resolves: #12601

### Context 

We are still paying the price of a hack that was introduced [almost ten years ago](https://github.com/musescore/MuseScore/pull/1636). 

The fundamental issue is quite simple: when editing lyrics, typing an underscore moves the cursor to the next note and creates an underscore melisma line. But correct engraving requires a melisma line to span at least two notes and to terminate right below the final note. This means that, when the underscore is typed for the _first_ time, there is no valid melisma that can be drawn, because the end note would coincide with its start note. Only after the _second_ underscore is typed the melisma becomes valid.

<img height="200" alt="image" src="https://github.com/musescore/MuseScore/assets/93707756/f9a75787-17ee-4092-8300-f58abc8fbb4b"> 
<img height="200" alt="image" src="https://github.com/musescore/MuseScore/assets/93707756/ccfb06bd-7b38-458e-8232-ba3e51a31495">


The question is what to do when the first underscore is typed. The most straightforward solution is to not draw anything, but this results in a weird user experience, as it seems like nothing has happened. @oktophonie has given here a [great explanation and sensible suggestions](https://github.com/musescore/MuseScore/issues/12601#issuecomment-1230236918). 

What definitely should _not_ be done is to allow the program to represent an invalid melisma just to make UI nicer, but unfortunately that's exactly what was done back then. Now we have a situation where there can be invalid melismas in the score, and not just temporarily during editing, but in some cases they can also persist and even be saved to file and reloaded.

That is a terrible situation which will need a proper solution at some point. For now, I am bringing back the drawing of a short melisma for the invalid cases (which was otherwise omitted as too short). That is absolutely incorrect notation, let's be clear, but at least it makes the invalid state evident. Otherwise the only clue that there is an invalid melisma would be that the start syllable is left aligned.

Btw this also resolves the following (caused by recent changes in lyrics layout and skyline implementation):

https://github.com/musescore/MuseScore/assets/93707756/edda449d-2c77-4898-80a4-a10f233fb914

