### PR TITLE
Fix corrupted templates

### DIFF
--- a/share/templates/02-Choral/08-Barbershop_Quartet_(Men)/08-Barbershop_Quartet_(Men).mscx
+++ b/share/templates/02-Choral/08-Barbershop_Quartet_(Men)/08-Barbershop_Quartet_(Men).mscx
@@ -48,7 +48,7 @@
       <Instrument id="tenor">
         <longName>TENOR
 LEAD</longName>
-        <shortName>T/L<shortName>
+        <shortName>T/L</shortName>
         <trackName>Tenor/Lead</trackName>
         <minPitchP>48</minPitchP>
         <maxPitchP>72</maxPitchP>

--- a/share/templates/02-Choral/09-Barbershop_Quartet_(Women)/09-Barbershop_Quartet_(Women).mscx
+++ b/share/templates/02-Choral/09-Barbershop_Quartet_(Women)/09-Barbershop_Quartet_(Women).mscx
@@ -47,7 +47,7 @@
       <Instrument id="soprano">
         <longName>TENOR
 LEAD</longName>
-        <shortName>T/L<shortName>
+        <shortName>T/L</shortName>
         <trackName>Tenor/Lead</trackName>
         <minPitchP>56</minPitchP>
         <maxPitchP>84</maxPitchP>

--- a/share/templates/03-Chamber_Music/01-String_Quartet/01-String_Quartet.mscx
+++ b/share/templates/03-Chamber_Music/01-String_Quartet/01-String_Quartet.mscx
@@ -47,7 +47,7 @@
       <trackName>Violin I</trackName>
       <Instrument id="violin">
         <longName>Violin I</longName>
-        <shortName>Vln. I</longName>
+        <shortName>Vln. I</shortName>
         <trackName>Violin</trackName>
         <minPitchP>55</minPitchP>
         <maxPitchP>103</maxPitchP>
@@ -129,7 +129,7 @@
       <trackName>Violin II</trackName>
       <Instrument id="violin">
         <longName>Violin II</longName>
-        <shortName>Vln. II</longName>
+        <shortName>Vln. II</shortName>
         <trackName>Violin</trackName>
         <minPitchP>55</minPitchP>
         <maxPitchP>103</maxPitchP>
@@ -212,7 +212,7 @@
       <trackName>Viola</trackName>
       <Instrument id="viola">
         <longName>Viola</longName>
-        <shortName>Vla.</longName>
+        <shortName>Vla.</shortName>
         <trackName>Viola</trackName>
         <minPitchP>48</minPitchP>
         <maxPitchP>93</maxPitchP>
@@ -295,7 +295,7 @@
       <trackName>Violoncello</trackName>
       <Instrument id="violoncello">
         <longName>Violoncello</longName>
-        <shortName>Vc.</longName>
+        <shortName>Vc.</shortName>
         <trackName>Violoncello</trackName>
         <minPitchP>36</minPitchP>
         <maxPitchP>90</maxPitchP>


### PR DESCRIPTION
The string quartet, barbershop (men) and barbershop (women) templates were corrupted in this PR : https://github.com/musescore/MuseScore/pull/22550