### PR TITLE
Fix build

### DIFF
--- a/src/engraving/rendering/dev/pagelayout.cpp
+++ b/src/engraving/rendering/dev/pagelayout.cpp
@@ -366,7 +366,7 @@ void PageLayout::collectPage(LayoutContext& ctx)
                                                     = fingering->ldata()->bbox().translated(
                                                           fingering->pos() + n->pos() + n->chord()->pos() + segment->pos()
                                                           + segment->measure()->pos());
-                                                s->staff(fingering->note()->chord()->vStaffIdx())->skyline().add(r);
+                                                s->staff(fingering->note()->chord()->vStaffIdx())->skyline().add(r, fingering);
                                             }
                                         }
                                     }


### PR DESCRIPTION
"call of overloaded ‘add(const RectF&)’ is ambiguous", because it is unclear whether the `Rect` needs to be converted to `Shape` or `ShapeElement`. Instead, both the rect and the element it belongs to need to be specified.

Probably the result of two PRs being merged in quick succession.