### PR TITLE
Fix arpeggio cross stave check

### DIFF
--- a/src/engraving/dom/arpeggio.cpp
+++ b/src/engraving/dom/arpeggio.cpp
@@ -428,7 +428,7 @@ void Arpeggio::reset()
 
 bool Arpeggio::crossStaff() const
 {
-    return (track() + span() - 1) / VOICES != staffIdx();
+    return (track() + span() - 1) / VOICES != vStaffIdx();
 }
 
 staff_idx_t Arpeggio::vStaffIdx() const


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/20691
This removes extra space between staves when the top voice of a cross stave arpeggio is itself cross stave.
Before:
![image](https://github.com/musescore/MuseScore/assets/26510874/430c5354-9ae8-4f39-ba64-1a6a85c61985)
After:
![image](https://github.com/musescore/MuseScore/assets/26510874/05941feb-cf2c-4a7d-a1f1-76f3b9d273f8)
