### PR TITLE
Don't allow range-delete to delete anchors

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3357,10 +3357,9 @@ std::vector<ChordRest*> Score::deleteRange(Segment* s1, Segment* s2, track_idx_t
                 if (!s->isChordRestType()) {
                     // do not delete TimeSig/KeySig,
                     // it doesn't make sense to do it, except on full system
-                    if (s->segmentType() != SegmentType::TimeSig && s->segmentType() != SegmentType::KeySig) {
-                        if (!(e->isBarLine())) {
-                            undoRemoveElement(e);
-                        }
+                    if (!s->isTimeTickType() && !s->isTimeSigType() && !s->isKeySigType()
+                        && !s->isType(SegmentType::BarLineType) /*covers all barLine types*/) {
+                        undoRemoveElement(e);
                     }
                     continue;
                 }


### PR DESCRIPTION
Resolves: #22932 

User operations such as range-delete should never delete time anchors. It is perfectly fine (and actually desired) for anchors to stay there.

@zacjansheski this fixes the crash. There is still some weirdness going on as you'll see that the first time you delete the selected measure the rit. gets shortened, but the next times it doesn't. That's a separate issue that's among the many things fixed in my other open PR so you can safely ignore it for now.