### PR TITLE
Fix #23119: Ensure `TextLineBase` properties are written for hairpins

### DIFF
--- a/src/engraving/dom/hairpin.cpp
+++ b/src/engraving/dom/hairpin.cpp
@@ -473,7 +473,10 @@ Hairpin::Hairpin(Segment* parent)
     initElementStyle(&hairpinStyle);
 
     resetProperty(Pid::BEGIN_TEXT_PLACE);
+    resetProperty(Pid::END_TEXT_PLACE);
     resetProperty(Pid::CONTINUE_TEXT_PLACE);
+    resetProperty(Pid::BEGIN_HOOK_HEIGHT);
+    resetProperty(Pid::END_HOOK_HEIGHT);
     resetProperty(Pid::HAIRPIN_TYPE);
     resetProperty(Pid::LINE_VISIBLE);
 
@@ -657,6 +660,7 @@ PropertyValue Hairpin::propertyDefault(Pid id) const
 
     case Pid::BEGIN_TEXT_PLACE:
     case Pid::CONTINUE_TEXT_PLACE:
+    case Pid::END_TEXT_PLACE:
         return TextPlace::LEFT;
 
     case Pid::BEGIN_TEXT_OFFSET:
@@ -670,7 +674,7 @@ PropertyValue Hairpin::propertyDefault(Pid id) const
 
     case Pid::BEGIN_HOOK_HEIGHT:
     case Pid::END_HOOK_HEIGHT:
-        return Spatium(0.0);
+        return Spatium(1.9);
 
     case Pid::LINE_VISIBLE:
         return true;

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -1598,15 +1598,8 @@ void TWrite::write(const Hairpin* item, XmlWriter& xml, WriteContext& ctx)
     writeProperty(item, xml, Pid::VELO_CHANGE);
     writeProperty(item, xml, Pid::HAIRPIN_CIRCLEDTIP);
     writeProperty(item, xml, Pid::DYNAMIC_RANGE);
-//      writeProperty(xml, Pid::BEGIN_TEXT);
-    writeProperty(item, xml, Pid::END_TEXT);
-//      writeProperty(xml, Pid::CONTINUE_TEXT);
-    writeProperty(item, xml, Pid::LINE_VISIBLE);
     writeProperty(item, xml, Pid::SINGLE_NOTE_DYNAMICS);
     writeProperty(item, xml, Pid::VELO_CHANGE_METHOD);
-    writeProperty(item, xml, Pid::BEGIN_TEXT_OFFSET);
-    writeProperty(item, xml, Pid::CONTINUE_TEXT_OFFSET);
-    writeProperty(item, xml, Pid::END_TEXT_OFFSET);
 
     writeProperty(item, xml, Pid::VOICE_ASSIGNMENT);
     writeProperty(item, xml, Pid::DIRECTION);
@@ -1615,12 +1608,7 @@ void TWrite::write(const Hairpin* item, XmlWriter& xml, WriteContext& ctx)
     writeProperty(item, xml, Pid::SNAP_BEFORE);
     writeProperty(item, xml, Pid::SNAP_AFTER);
 
-    for (const StyledProperty& spp : *item->styledProperties()) {
-        if (!item->isStyled(spp.pid)) {
-            writeProperty(item, xml, spp.pid);
-        }
-    }
-    writeProperties(static_cast<const SLine*>(item), xml, ctx);
+    writeProperties(static_cast<const TextLineBase*>(item), xml, ctx);
     xml.endElement();
 }
 

--- a/src/importexport/mei/tests/data/hairpin-01.mscx
+++ b/src/importexport/mei/tests/data/hairpin-01.mscx
@@ -259,7 +259,6 @@
               <subtype>0</subtype>
               <direction>up</direction>
               <lineStyle>dashed</lineStyle>
-              <lineStyle>dashed</lineStyle>
               </HairPin>
             <next>
               <location>
@@ -312,7 +311,6 @@
             <HairPin>
               <subtype>1</subtype>
               <direction>up</direction>
-              <lineStyle>dotted</lineStyle>
               <lineStyle>dotted</lineStyle>
               </HairPin>
             <next>
@@ -690,7 +688,6 @@
             <HairPin>
               <subtype>3</subtype>
               <beginText>diminuendo</beginText>
-              <lineStyle>dotted</lineStyle>
               <lineStyle>dotted</lineStyle>
               </HairPin>
             <next>

--- a/src/importexport/musicxml/tests/data/testInferredCrescLines2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredCrescLines2_ref.mscx
@@ -191,8 +191,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>3</subtype>
-              <lineVisible>0</lineVisible>
               <direction>down</direction>
+              <lineVisible>0</lineVisible>
               </HairPin>
             <next>
               <location>
@@ -710,8 +710,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>2</subtype>
-              <lineVisible>0</lineVisible>
               <direction>down</direction>
+              <lineVisible>0</lineVisible>
               </HairPin>
             <next>
               <location>
@@ -1314,8 +1314,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>3</subtype>
-              <lineVisible>0</lineVisible>
               <direction>down</direction>
+              <lineVisible>0</lineVisible>
               </HairPin>
             <next>
               <location>

--- a/src/importexport/musicxml/tests/data/testInferredCrescLines_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredCrescLines_ref.mscx
@@ -191,8 +191,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>2</subtype>
-              <lineVisible>0</lineVisible>
               <direction>down</direction>
+              <lineVisible>0</lineVisible>
               </HairPin>
             <next>
               <location>
@@ -303,8 +303,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>2</subtype>
-              <lineVisible>0</lineVisible>
               <direction>down</direction>
+              <lineVisible>0</lineVisible>
               </HairPin>
             <next>
               <location>
@@ -352,8 +352,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>2</subtype>
-              <lineVisible>0</lineVisible>
               <direction>down</direction>
+              <lineVisible>0</lineVisible>
               </HairPin>
             <next>
               <location>
@@ -500,8 +500,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>3</subtype>
-              <lineVisible>0</lineVisible>
               <direction>down</direction>
+              <lineVisible>0</lineVisible>
               </HairPin>
             <next>
               <location>
@@ -606,8 +606,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>2</subtype>
-              <lineVisible>0</lineVisible>
               <direction>down</direction>
+              <lineVisible>0</lineVisible>
               </HairPin>
             <next>
               <location>

--- a/src/importexport/musicxml/tests/data/testInferredDynamicsExpression_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredDynamicsExpression_ref.mscx
@@ -248,8 +248,8 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>2</subtype>
-              <lineVisible>0</lineVisible>
               <direction>down</direction>
+              <lineVisible>0</lineVisible>
               </HairPin>
             <next>
               <location>


### PR DESCRIPTION
Resolves: #23119
Resolves: https://github.com/musescore/MuseScore/issues/23396

Inheritance goes `SLine <- TextLineBase <- Hairpin`. Hairpins were skipping `TextLineBase` properties (e.g. gap between text and line).