### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -958,7 +958,8 @@ const muse::TranslatableString& TConv::userName(DynamicType v)
     });
 
     IF_ASSERT_FAILED(it != DYNAMIC_TYPES.cend()) {
-        return TranslatableString();
+        static TranslatableString dummy;
+        return dummy;
     }
     return it->userName;
 }


### PR DESCRIPTION
reg.: returning address of local variable or temporary (C4172)