### PR TITLE
Improve anchors visualization and fix anchors appearing in wrong staff

### DIFF
--- a/src/engraving/dom/anchors.h
+++ b/src/engraving/dom/anchors.h
@@ -30,7 +30,7 @@ namespace mu::engraving {
 class EditTimeTickAnchors
 {
 public:
-    static void updateAnchors(const EngravingItem* item, Fraction absTick, track_idx_t track);
+    static void updateAnchors(const EngravingItem* item, track_idx_t track);
     static TimeTickAnchor* createTimeTickAnchor(Measure* measure, Fraction relTick, staff_idx_t staffIdx);
     static void updateLayout(Measure* measure);
 
@@ -47,7 +47,15 @@ public:
 
     TimeTickAnchor* clone() const override { return new TimeTickAnchor(*this); }
 
-    bool isDraw() const;
+    enum class DrawRegion {
+        OUT_OF_RANGE,
+        EXTENDED_REGION,
+        MAIN_REGION
+    };
+
+    DrawRegion drawRegion() const;
+
+    voice_idx_t voiceIdx() const;
 
     struct LayoutData : public EngravingItem::LayoutData {
         bool darker() const { return m_darker; }

--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -593,7 +593,7 @@ bool Dynamic::moveSegment(const EditData& ed)
         score()->undoChangeParent(snappedExpression(), newSeg, staffIdx());
     }
 
-    EditTimeTickAnchors::updateAnchors(this, staffIdx());
+    EditTimeTickAnchors::updateAnchors(this, track());
     return true;
 }
 

--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -501,7 +501,7 @@ bool Dynamic::editNonTextual(EditData& ed)
         if (ed.isKeyRelease) {
             score()->hideAnchors();
         } else {
-            EditTimeTickAnchors::updateAnchors(this, tick(), track());
+            EditTimeTickAnchors::updateAnchors(this, track());
         }
         triggerLayout();
         return true;
@@ -593,7 +593,7 @@ bool Dynamic::moveSegment(const EditData& ed)
         score()->undoChangeParent(snappedExpression(), newSeg, staffIdx());
     }
 
-    EditTimeTickAnchors::updateAnchors(this, tick(), staffIdx());
+    EditTimeTickAnchors::updateAnchors(this, staffIdx());
     return true;
 }
 
@@ -624,7 +624,7 @@ bool Dynamic::nudge(const EditData& ed)
 
 void Dynamic::editDrag(EditData& ed)
 {
-    EditTimeTickAnchors::updateAnchors(this, tick(), track());
+    EditTimeTickAnchors::updateAnchors(this, track());
 
     KeyboardModifiers km = ed.modifiers;
     if (km != (ShiftModifier | ControlModifier)) {

--- a/src/engraving/dom/line.cpp
+++ b/src/engraving/dom/line.cpp
@@ -257,7 +257,7 @@ bool LineSegment::edit(EditData& ed)
         if (ed.isKeyRelease) {
             score()->hideAnchors();
         } else {
-            EditTimeTickAnchors::updateAnchors(this, moveStart ? spanner()->tick() : spanner()->tick2(), moveStart ? track : track2);
+            EditTimeTickAnchors::updateAnchors(this, moveStart ? track : track2);
         }
         triggerLayout();
         return true;
@@ -283,7 +283,6 @@ bool LineSegment::edit(EditData& ed)
             LOGD("LineSegment::edit: no start/end segment");
             return true;
         }
-        EditTimeTickAnchors::updateAnchors(this, moveStart ? spanner()->tick() : spanner()->tick2(), moveStart ? track : track2);
         if (ed.key == Key_Left) {
             if (moveStart) {
                 s1 = allowTimeAnchor ? s1->prev1ChordRestOrTimeTick() : s1->prev1WithElemsOnStaff(track2staff(track));
@@ -307,6 +306,8 @@ bool LineSegment::edit(EditData& ed)
         }
         spanner()->undoChangeProperty(Pid::SPANNER_TICK, s1->tick());
         spanner()->undoChangeProperty(Pid::SPANNER_TICKS, s2->tick() - s1->tick());
+
+        EditTimeTickAnchors::updateAnchors(this, moveStart ? track : track2);
     }
     break;
     case Spanner::Anchor::NOTE:
@@ -745,8 +746,7 @@ void LineSegment::updateAnchors(EditData& ed) const
     if (ed.curGrip != Grip::START && ed.curGrip != Grip::END) {
         return;
     }
-    EditTimeTickAnchors::updateAnchors(this, ed.curGrip == Grip::START ? line()->tick() : line()->tick2(),
-                                       ed.curGrip == Grip::START ? line()->track() : line()->track2());
+    EditTimeTickAnchors::updateAnchors(this, ed.curGrip == Grip::START ? line()->track() : line()->track2());
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -752,15 +752,9 @@ void Score::setMarkIrregularMeasures(bool v)
     m_markIrregularMeasures = v;
 }
 
-void Score::updateShowAnchors(staff_idx_t staffIdx, const Fraction& startTick, const Fraction& endTick)
+void Score::setShowAnchors(const ShowAnchors& showAnchors)
 {
-    m_showAnchors.staffIdx = staffIdx;
-    if (m_showAnchors.startTick == Fraction(-1, 1) || startTick < m_showAnchors.startTick) {
-        m_showAnchors.startTick = startTick;
-    }
-    if (m_showAnchors.endTick == Fraction(-1, 1) || endTick > m_showAnchors.endTick) {
-        m_showAnchors.endTick = endTick;
-    }
+    m_showAnchors = showAnchors;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -213,16 +213,28 @@ enum class PlayMode : char {
 };
 
 struct ShowAnchors {
-    staff_idx_t staffIdx;
-    Fraction startTick;
-    Fraction endTick;
+    ShowAnchors() = default;
+    ShowAnchors(voice_idx_t vIdx, staff_idx_t stfIdx, const Fraction& sTickMain, const Fraction& eTickMain,
+                const Fraction& sTickExt, const Fraction& eTickExt)
+        : voiceIdx(vIdx), staffIdx(stfIdx), startTickMainRegion(sTickMain), endTickMainRegion(eTickMain),
+        startTickExtendedRegion(sTickExt), endTickExtendedRegion(eTickExt) {}
 
     void reset()
     {
+        voiceIdx = muse::nidx;
         staffIdx = muse::nidx;
-        startTick = Fraction(-1, 1);
-        endTick = Fraction(-1, 1);
+        startTickMainRegion = Fraction(-1, 1);
+        endTickMainRegion = Fraction(-1, 1);
+        startTickExtendedRegion = Fraction(-1, 1);
+        endTickExtendedRegion = Fraction(-1, 1);
     }
+
+    voice_idx_t voiceIdx = muse::nidx;
+    staff_idx_t staffIdx = muse::nidx;
+    Fraction startTickMainRegion = Fraction(-1, 1);
+    Fraction endTickMainRegion = Fraction(-1, 1);
+    Fraction startTickExtendedRegion = Fraction(-1, 1);
+    Fraction endTickExtendedRegion = Fraction(-1, 1);
 };
 
 //---------------------------------------------------------------------------------------
@@ -572,7 +584,7 @@ public:
     void setShowInstrumentNames(bool v) { m_showInstrumentNames = v; }
 
     void hideAnchors() { m_showAnchors.reset(); }
-    void updateShowAnchors(staff_idx_t staffIdx, const Fraction& startTick, const Fraction& endTick);
+    void setShowAnchors(const ShowAnchors& showAnchors);
     const ShowAnchors& showAnchors() const { return m_showAnchors; }
 
     void print(muse::draw::Painter* printer, int page);

--- a/src/engraving/iengravingconfiguration.h
+++ b/src/engraving/iengravingconfiguration.h
@@ -64,9 +64,7 @@ public:
     virtual Color thumbnailBackgroundColor() const = 0;
     virtual Color noteBackgroundColor() const = 0;
     virtual Color fontPrimaryColor() const = 0;
-
-    virtual Color timeTickAnchorColorLighter() const = 0;
-    virtual Color timeTickAnchorColorDarker() const = 0;
+    virtual Color voiceColor(voice_idx_t voiceIdx) const = 0;
 
     virtual double guiScaling() const = 0;
 

--- a/src/engraving/internal/engravingconfiguration.cpp
+++ b/src/engraving/internal/engravingconfiguration.cpp
@@ -232,14 +232,9 @@ Color EngravingConfiguration::fontPrimaryColor() const
     return Color(uiConfiguration()->currentTheme().values[muse::ui::ThemeStyleKey::FONT_PRIMARY_COLOR].toString());
 }
 
-Color EngravingConfiguration::timeTickAnchorColorLighter() const
+Color EngravingConfiguration::voiceColor(voice_idx_t voiceIdx) const
 {
-    return Color(204, 234, 255);
-}
-
-Color EngravingConfiguration::timeTickAnchorColorDarker() const
-{
-    return Color(153, 213, 255);
+    return VOICE_COLORS[voiceIdx].color;
 }
 
 double EngravingConfiguration::guiScaling() const

--- a/src/engraving/internal/engravingconfiguration.cpp
+++ b/src/engraving/internal/engravingconfiguration.cpp
@@ -252,11 +252,9 @@ Color EngravingConfiguration::selectionColor(voice_idx_t voice, bool itemVisible
 
     constexpr float tint = .6f; // Between 0 and 1. Higher means lighter, lower means darker
 
-    int red = color.red();
-    int green = color.green();
-    int blue = color.blue();
+    color.applyTint(tint);
 
-    return Color(red + tint * (255 - red), green + tint * (255 - green), blue + tint * (255 - blue));
+    return color;
 }
 
 void EngravingConfiguration::setSelectionColor(voice_idx_t voiceIndex, Color color)

--- a/src/engraving/internal/engravingconfiguration.h
+++ b/src/engraving/internal/engravingconfiguration.h
@@ -70,9 +70,7 @@ public:
     Color thumbnailBackgroundColor() const override;
     Color noteBackgroundColor() const override;
     Color fontPrimaryColor() const override;
-
-    Color timeTickAnchorColorLighter() const override;
-    Color timeTickAnchorColorDarker() const override;
+    Color voiceColor(voice_idx_t voiceIdx) const override;
 
     double guiScaling() const override;
 

--- a/src/engraving/rendering/dev/measurelayout.cpp
+++ b/src/engraving/rendering/dev/measurelayout.cpp
@@ -2164,7 +2164,7 @@ void MeasureLayout::computeWidth(Measure* m, LayoutContext& ctx, Fraction minTic
 
 void MeasureLayout::layoutTimeTickAnchors(Measure* m, LayoutContext& ctx)
 {
-    bool darker = false;
+    bool darker = true;
     for (Segment& segment : m->segments()) {
         if (!segment.isTimeTickType()) {
             continue;

--- a/src/engraving/rendering/dev/tdraw.cpp
+++ b/src/engraving/rendering/dev/tdraw.cpp
@@ -3044,12 +3044,10 @@ void TDraw::draw(const TimeTickAnchor* item, Painter* painter)
                   ? item->ldata()->darker() ? TINT_MAIN_DARKER : TINT_MAIN_LIGHTER
                   : item->ldata()->darker() ? TINT_EXTENDED_DARKER : TINT_EXTENDED_LIGHTER;
 
-    int red = std::round(voiceColor.red() * (1 - tint) + 255 * tint);
-    int green = std::round(voiceColor.green() * (1 - tint) + 255 * tint);
-    int blue = std::round(voiceColor.blue() * (1 - tint) + 255 * tint);
+    voiceColor.applyTint(tint);
 
     Brush brush;
-    brush.setColor(Color(red, green, blue));
+    brush.setColor(voiceColor);
     brush.setStyle(BrushStyle::SolidPattern);
     painter->setBrush(brush);
     painter->setNoPen();

--- a/src/engraving/rendering/dev/tdraw.cpp
+++ b/src/engraving/rendering/dev/tdraw.cpp
@@ -3027,15 +3027,29 @@ void TDraw::draw(const TimeSig* item, Painter* painter)
 
 void TDraw::draw(const TimeTickAnchor* item, Painter* painter)
 {
-    if (!item->isDraw()) {
+    TimeTickAnchor::DrawRegion drawRegion = item->drawRegion();
+
+    if (drawRegion == TimeTickAnchor::DrawRegion::OUT_OF_RANGE) {
         return;
     }
 
-    static const Color lighterColor = item->configuration()->timeTickAnchorColorLighter();
-    static const Color darkerColor =  item->configuration()->timeTickAnchorColorDarker();
+    Color voiceColor = item->configuration()->voiceColor(item->voiceIdx());
+
+    static constexpr double TINT_MAIN_DARKER = 0.45;
+    static constexpr double TINT_MAIN_LIGHTER = 0.55;
+    static constexpr double TINT_EXTENDED_DARKER = 0.75;
+    static constexpr double TINT_EXTENDED_LIGHTER = 0.85;
+
+    double tint = drawRegion == TimeTickAnchor::DrawRegion::MAIN_REGION
+                  ? item->ldata()->darker() ? TINT_MAIN_DARKER : TINT_MAIN_LIGHTER
+                  : item->ldata()->darker() ? TINT_EXTENDED_DARKER : TINT_EXTENDED_LIGHTER;
+
+    int red = std::round(voiceColor.red() * (1 - tint) + 255 * tint);
+    int green = std::round(voiceColor.green() * (1 - tint) + 255 * tint);
+    int blue = std::round(voiceColor.blue() * (1 - tint) + 255 * tint);
 
     Brush brush;
-    brush.setColor(item->ldata()->darker() ? darkerColor : lighterColor);
+    brush.setColor(Color(red, green, blue));
     brush.setStyle(BrushStyle::SolidPattern);
     painter->setBrush(brush);
     painter->setNoPen();

--- a/src/engraving/tests/mocks/engravingconfigurationmock.h
+++ b/src/engraving/tests/mocks/engravingconfigurationmock.h
@@ -54,9 +54,7 @@ public:
     MOCK_METHOD(Color, thumbnailBackgroundColor, (), (const, override));
     MOCK_METHOD(Color, noteBackgroundColor, (), (const, override));
     MOCK_METHOD(Color, fontPrimaryColor, (), (const, override));
-
-    MOCK_METHOD(Color, timeTickAnchorColorLighter, (), (const, override));
-    MOCK_METHOD(Color, timeTickAnchorColorDarker, (), (const, override));
+    MOCK_METHOD(Color, voiceColor, (voice_idx_t), (const, override));
 
     MOCK_METHOD(double, guiScaling, (), (const, override));
 

--- a/src/framework/draw/types/color.cpp
+++ b/src/framework/draw/types/color.cpp
@@ -177,6 +177,11 @@ void Color::setAlpha(int value)
     setRgba(red(), green(), blue(), value);
 }
 
+void Color::applyTint(double tint)
+{
+    setRgba(red() + (255 - red()) * tint, green() + (255 - green()) * tint, blue() + (255 - blue()) * tint, alpha());
+}
+
 void Color::setRgba(int r, int g, int b, int a)
 {
     if (!isRgbaValid(r, g, b, a)) {

--- a/src/framework/draw/types/color.h
+++ b/src/framework/draw/types/color.h
@@ -70,6 +70,8 @@ public:
     void setBlue(int value);
     void setAlpha(int value);
 
+    void applyTint(double tint);
+
     Color inverted() const;
 
     bool operator==(const Color& other) const;


### PR DESCRIPTION
Resolves: #23044 

@avvvvve All yours!

For context, the main differences are:
- The color matches the voice-selection color. The different shades are obtained using "tints" (the formula was alrady used to calculate the selection color for invisible items, I've now made it into a method of the Color class).
- Hairpins have a "main" region (which spans the hairpin duration) and an extended region (which fills the remainder of the measure on each side).
![image](https://github.com/musescore/MuseScore/assets/93707756/ded1fff4-d845-4c70-9912-6b8d05badc43)
- When moving dynamics, only one measure at a time gets the anchors drawn (before, it persisted on all the measures)