### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/tests/bsptree_tests.cpp
+++ b/src/engraving/tests/bsptree_tests.cpp
@@ -53,7 +53,7 @@ TEST_F(Engraving_BspTreeTests, NearestNeighbor)
     // [GIVEN] A set of notes in scattered positions, and a BspTree containing those notes
     BspTree bsp;
     std::set<EngravingItem*> notes;
-    bsp.initialize(page->pageBoundingRect(), page->elements().size());
+    bsp.initialize(page->pageBoundingRect(), static_cast<int>(page->elements().size()));
     for (EngravingItem* elem : page->elements()) {
         if (elem->isNote()) {
             notes.emplace(elem);
@@ -76,7 +76,7 @@ TEST_F(Engraving_BspTreeTests, NearestNeighbor)
     EngravingItem* singleNote = *notes.begin();
     EXPECT_TRUE(singleNote);
 
-    bsp.initialize(page->pageBoundingRect(), page->elements().size());
+    bsp.initialize(page->pageBoundingRect(), static_cast<int>(page->elements().size()));
     bsp.insert(singleNote);
 
     // [WHEN] Iterating through the set of notes, and passing each note's position to nearestNeighbor

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2293,7 +2293,7 @@ bool NotationInteraction::dragStandardElement(const PointF& pos, Qt::KeyboardMod
 
         // Where "m" is the number of page elements and "n" is the number of elements accepting a drop...
         // O(log m) operation
-        m_droppableTree.initialize(page->pageBoundingRect(), page->elements().size());
+        m_droppableTree.initialize(page->pageBoundingRect(), static_cast<int>(page->elements().size()));
 
         // O(m log n) operation
         for (EngravingItem* elem : page->elements()) {


### PR DESCRIPTION
reg.: 'argument': conversion from 'size_t' to 'int', possible loss of data (C4267)