### PR TITLE
Items must retain their voice upon UndoChangeParent operation

### DIFF
--- a/src/engraving/dom/undo.cpp
+++ b/src/engraving/dom/undo.cpp
@@ -2782,7 +2782,7 @@ void ChangeParent::flip(EditData*)
     staff_idx_t si = element->staffIdx();
     p->remove(element);
     element->setParent(parent);
-    element->setTrack(staffIdx * VOICES);
+    element->setTrack(staffIdx * VOICES + element->voice());
     parent->add(element);
     staffIdx = si;
     parent = p;


### PR DESCRIPTION
Resolves: #23139 

Using `staffIdx * VOICES` implicitely always puts the item in voice zero. I'm actually surprised this has never caused problems before.