### PR TITLE
Fix more anchors-related issues

### DIFF
--- a/src/engraving/dom/anchors.cpp
+++ b/src/engraving/dom/anchors.cpp
@@ -56,7 +56,8 @@ void EditTimeTickAnchors::updateAnchors(const EngravingItem* item, track_idx_t t
     }
 
     staff_idx_t staff = track2staff(track);
-    for (MeasureBase* mb = startMeasure; mb && mb->tick() <= endMeasure->tick(); mb = mb->next()) {
+    Measure* startOneBefore = startMeasure->prevMeasure();
+    for (MeasureBase* mb = startOneBefore ? startOneBefore : startMeasure; mb && mb->tick() <= endMeasure->tick(); mb = mb->next()) {
         if (!mb->isMeasure()) {
             continue;
         }

--- a/src/engraving/dom/anchors.cpp
+++ b/src/engraving/dom/anchors.cpp
@@ -98,19 +98,30 @@ void EditTimeTickAnchors::updateAnchors(Measure* measure, staff_idx_t staffIdx)
 
 TimeTickAnchor* EditTimeTickAnchors::createTimeTickAnchor(Measure* measure, Fraction relTick, staff_idx_t staffIdx)
 {
-    Segment* segment = measure->getSegmentR(SegmentType::TimeTick, relTick);
+    TimeTickAnchor* returnAnchor = nullptr;
 
-    track_idx_t track = staff2track(staffIdx);
-    EngravingItem* element = segment->elementAt(track);
-    TimeTickAnchor* anchor = element ? toTimeTickAnchor(element) : nullptr;
-    if (!anchor) {
-        anchor = Factory::createTimeTickAnchor(segment);
-        anchor->setParent(segment);
-        anchor->setTrack(track);
-        segment->add(anchor);
+    for (EngravingObject* linkedObj : measure->linkList()) {
+        IF_ASSERT_FAILED(linkedObj) {
+            continue;
+        }
+        Measure* linkedMeasure = toMeasure(linkedObj);
+        Segment* segment = linkedMeasure->getSegmentR(SegmentType::TimeTick, relTick);
+
+        track_idx_t track = staff2track(staffIdx);
+        EngravingItem* element = segment->elementAt(track);
+        TimeTickAnchor* anchor = element ? toTimeTickAnchor(element) : nullptr;
+        if (!anchor) {
+            anchor = Factory::createTimeTickAnchor(segment);
+            anchor->setParent(segment);
+            anchor->setTrack(track);
+            segment->add(anchor);
+        }
+        if (linkedMeasure == measure) {
+            returnAnchor = anchor;
+        }
     }
 
-    return anchor;
+    return returnAnchor;
 }
 
 void EditTimeTickAnchors::updateLayout(Measure* measure)

--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -135,6 +135,7 @@ Dynamic::Dynamic(const Dynamic& d)
     _avoidBarLines = d._avoidBarLines;
     _dynamicsSize = d._dynamicsSize;
     _centerOnNotehead = d._centerOnNotehead;
+    m_anchorToEndOfPrevious = d.m_anchorToEndOfPrevious;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -517,14 +517,21 @@ bool Dynamic::editNonTextual(EditData& ed)
 
     bool changeAnchorType = shiftMod && altMod && leftRightKey;
     if (changeAnchorType) {
-        if (changeTimeAnchorType(ed)) {
-            return true;
-        }
+        undoChangeProperty(Pid::ANCHOR_TO_END_OF_PREVIOUS, !anchorToEndOfPrevious(), propertyFlags(Pid::ANCHOR_TO_END_OF_PREVIOUS));
+    }
+    bool doesntNeedMoveSeg = changeAnchorType && ((ed.key == Key_Left && anchorToEndOfPrevious())
+                                                  || (ed.key == Key_Right && !anchorToEndOfPrevious()));
+    if (doesntNeedMoveSeg) {
+        checkMeasureBoundariesAndMoveIfNeed();
+        return true;
     }
 
     bool moveSeg = shiftMod && (ed.key == Key_Left || ed.key == Key_Right);
     if (moveSeg) {
-        return moveSegment(ed);
+        bool moved = moveSegment(ed);
+        EditTimeTickAnchors::updateAnchors(this, track());
+        checkMeasureBoundariesAndMoveIfNeed();
+        return moved;
     }
 
     if (shiftMod) {
@@ -539,50 +546,61 @@ bool Dynamic::editNonTextual(EditData& ed)
     return true;
 }
 
-bool Dynamic::changeTimeAnchorType(const EditData& ed)
+void Dynamic::checkMeasureBoundariesAndMoveIfNeed()
 {
+    /* Dynamics are always assigned to a ChordRest segment if available at this tick,
+     * EXCEPT if we are at a measure boundary. In this case, if anchorToEndOfPrevious()
+     * we must assign to a TimeTick segment at the end of previous measure, otherwise to a
+     * ChordRest segment at the start of the next measure. */
+
     Segment* curSeg = segment();
+    Fraction curTick = curSeg->tick();
+    Measure* curMeasure = curSeg->measure();
+    Measure* prevMeasure = curMeasure->prevMeasure();
+    bool needMoveToNext = curTick == curMeasure->endTick() && !anchorToEndOfPrevious();
+    bool needMoveToPrevious = curSeg->rtick().isZero() && anchorToEndOfPrevious() && prevMeasure;
 
-    undoChangeProperty(Pid::ANCHOR_TO_END_OF_PREVIOUS, !anchorToEndOfPrevious(), propertyFlags(Pid::ANCHOR_TO_END_OF_PREVIOUS));
-    if (anchorToEndOfPrevious() && curSeg->rtick().isZero() && ed.key == Key_Left) {
-        Segment* endOfPrevMeasTick = curSeg->prev1(SegmentType::TimeTick);
-        if (endOfPrevMeasTick && endOfPrevMeasTick->tick() == curSeg->tick()) {
-            score()->undoChangeParent(this, endOfPrevMeasTick, staffIdx());
-            if (snappedExpression()) {
-                score()->undoChangeParent(snappedExpression(), endOfPrevMeasTick, staffIdx());
-            }
-            return true;
-        }
-    } else if (!anchorToEndOfPrevious() && curSeg->rtick() == curSeg->measure()->ticks() && ed.key == Key_Right) {
-        Segment* startOfNextMeas = curSeg->next1(SegmentType::ChordRest);
-        if (startOfNextMeas && startOfNextMeas->tick() == curSeg->tick()) {
-            score()->undoChangeParent(this, startOfNextMeas, staffIdx());
-            if (snappedExpression()) {
-                score()->undoChangeParent(snappedExpression(), startOfNextMeas, staffIdx());
-            }
-            return true;
-        }
-    }
-    if ((anchorToEndOfPrevious() && ed.key == Key_Left)
-        || (!anchorToEndOfPrevious() && ed.key == Key_Right)) {
-        return true;
+    if (!needMoveToPrevious && !needMoveToNext) {
+        return;
     }
 
-    return false;
+    Segment* newSeg = nullptr;
+    if (needMoveToPrevious) {
+        newSeg = prevMeasure->findSegment(SegmentType::TimeTick, curSeg->tick());
+        if (!newSeg) {
+            TimeTickAnchor* anchor = EditTimeTickAnchors::createTimeTickAnchor(prevMeasure, curTick - prevMeasure->tick(), staffIdx());
+            EditTimeTickAnchors::updateLayout(prevMeasure);
+            newSeg = anchor->segment();
+        }
+    } else {
+        newSeg = curSeg->next1(SegmentType::ChordRest);
+    }
+
+    if (newSeg && newSeg->tick() == curTick) {
+        score()->undoChangeParent(this, newSeg, staffIdx());
+        if (snappedExpression()) {
+            score()->undoChangeParent(snappedExpression(), newSeg, staffIdx());
+        }
+    }
 }
 
 bool Dynamic::moveSegment(const EditData& ed)
 {
-    if (!(ed.modifiers & AltModifier) && anchorToEndOfPrevious()) {
-        undoResetProperty(Pid::ANCHOR_TO_END_OF_PREVIOUS);
-        return true;
+    bool forward = ed.key == Key_Right;
+    if (!(ed.modifiers & AltModifier)) {
+        if (anchorToEndOfPrevious()) {
+            undoResetProperty(Pid::ANCHOR_TO_END_OF_PREVIOUS);
+            if (forward) {
+                return true;
+            }
+        }
     }
+
     Segment* curSeg = segment();
-    if (!curSeg) {
+    IF_ASSERT_FAILED(curSeg) {
         return false;
     }
 
-    bool forward = ed.key == Key_Right;
     Segment* newSeg = forward ? curSeg->next1ChordRestOrTimeTick() : curSeg->prev1ChordRestOrTimeTick();
     if (!newSeg) {
         return false;
@@ -593,7 +611,6 @@ bool Dynamic::moveSegment(const EditData& ed)
         score()->undoChangeParent(snappedExpression(), newSeg, staffIdx());
     }
 
-    EditTimeTickAnchors::updateAnchors(this, track());
     return true;
 }
 

--- a/src/engraving/dom/dynamic.h
+++ b/src/engraving/dom/dynamic.h
@@ -124,6 +124,7 @@ public:
 
     bool anchorToEndOfPrevious() const { return m_anchorToEndOfPrevious; }
     void setAnchorToEndOfPrevious(bool v) { m_anchorToEndOfPrevious = v; }
+    void checkMeasureBoundariesAndMoveIfNeed();
 
     bool hasVoiceApplicationProperties() const override { return true; }
 
@@ -133,7 +134,6 @@ private:
     M_PROPERTY(double, dynamicsSize, setDynamicsSize)
     M_PROPERTY(bool, centerOnNotehead, setCenterOnNotehead)
 
-    bool changeTimeAnchorType(const EditData& ed);
     bool moveSegment(const EditData& ed);
     bool nudge(const EditData& ed);
 

--- a/src/engraving/dom/dynamic.h
+++ b/src/engraving/dom/dynamic.h
@@ -135,6 +135,7 @@ private:
     M_PROPERTY(bool, centerOnNotehead, setCenterOnNotehead)
 
     bool moveSegment(const EditData& ed);
+    void moveSnappedItems(Segment* newSeg, Fraction tickDiff) const;
     bool nudge(const EditData& ed);
 
     DynamicType m_dynamicType = DynamicType::OTHER;

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -4881,8 +4881,9 @@ void Score::undoChangeParent(EngravingItem* element, EngravingItem* parent, staf
             if (parent->isSegment()) {
                 // Get parent segment in linked score
                 Segment* oldSeg = toSegment(parent);
-                Measure* m = linkedScore->tick2measure(oldSeg->tick());
-                linkedParent = m->tick2segment(oldSeg->tick(), oldSeg->segmentType());
+                Measure* oldMeas = oldSeg->measure();
+                Measure* newMeas = linkedScore->tick2measure(oldMeas->tick());
+                linkedParent = newMeas->tick2segment(oldSeg->tick(), oldSeg->segmentType());
             } else {
                 linkedParent = parent->findLinkedInScore(linkedScore);
             }

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3354,6 +3354,7 @@ std::vector<ChordRest*> Score::deleteRange(Segment* s1, Segment* s2, track_idx_t
         Fraction tick2 = s2 ? s2->tick() : Fraction::max();
 
         deleteOrShortenOutSpannersFromRange(stick1, stick2, track1, track2, filter);
+        deleteAnnotationsFromRange(s1, s2, track1, track2, filter);
 
         for (track_idx_t track = track1; track < track2; ++track) {
             if (!filter.canSelectVoice(track)) {
@@ -3367,8 +3368,6 @@ std::vector<ChordRest*> Score::deleteRange(Segment* s1, Segment* s2, track_idx_t
                     deleteItem(s->element(track));
                     continue;
                 }
-                // delete annotations just from this segment and track
-                deleteAnnotationsFromRange(s, s->next1(), track, track + 1, filter);
 
                 EngravingItem* e = s->element(track);
                 if (!e) {

--- a/src/engraving/dom/hairpin.cpp
+++ b/src/engraving/dom/hairpin.cpp
@@ -774,7 +774,7 @@ PointF Hairpin::linePos(Grip grip, System** system) const
 
     *system = segment->measure()->system();
     double x = segment->x() + segment->measure()->x();
-    if (!start && !segment->isTimeTickType()) {
+    if (!start) {
         x -= spatium();
     }
 

--- a/src/engraving/dom/measure.h
+++ b/src/engraving/dom/measure.h
@@ -216,7 +216,7 @@ public:
     void setLayoutStretch(double stretchCoeff) { m_layoutStretch = stretchCoeff; }
     double layoutStretch() const { return m_layoutStretch; }
 
-    Fraction computeTicks();
+    void computeTicks();
     Fraction anacrusisOffset() const;
     Fraction shortestChordRest() const;
     Fraction maxTicks() const;

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -1506,6 +1506,7 @@ void Score::addElement(EngravingItem* element)
     break;
 
     case ElementType::DYNAMIC:
+        toDynamic(element)->checkMeasureBoundariesAndMoveIfNeed();
         setPlaylistDirty();
         break;
 

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -1267,6 +1267,10 @@ bool Segment::hasElements(staff_idx_t staffIdx) const
 
 bool Segment::allElementsInvisible() const
 {
+    if (isType(SegmentType::TimeTick)) {
+        return true;
+    }
+
     if (isType(SegmentType::BarLineType | SegmentType::ChordRest)) {
         return false;
     }

--- a/src/engraving/dom/types.h
+++ b/src/engraving/dom/types.h
@@ -404,13 +404,12 @@ enum class SegmentType {
     BarLine            = 0x80,
     Breath             = 0x100,
     //--
-    ChordRest          = 0x200,
+    TimeTick           = 0x200,
+    ChordRest          = 0x400,
     //--
-    EndBarLine         = 0x400,
-    KeySigAnnounce     = 0x800,
-    TimeSigAnnounce    = 0x1000,
-    //--
-    TimeTick           = 0x2000,
+    EndBarLine         = 0x800,
+    KeySigAnnounce     = 0x1000,
+    TimeSigAnnounce    = 0x2000,
     //--
     All                = -1,   ///< Includes all barline types
     /// Alias for `BeginBarLine | StartRepeatBarLine | BarLine | EndBarLine`

--- a/src/engraving/tests/compat206_data/textstyles-ref.mscx
+++ b/src/engraving/tests/compat206_data/textstyles-ref.mscx
@@ -612,9 +612,6 @@
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
-          <BarLine>
-            <subtype>end</subtype>
-            </BarLine>
           <Spanner type="TextLine">
             <prev>
               <location>
@@ -622,6 +619,16 @@
                 </location>
               </prev>
             </Spanner>
+          <Spanner type="TextLine">
+            <prev>
+              <location>
+                <fractions>-1/1</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
           </voice>
         </Measure>
       </Staff>

--- a/src/engraving/tests/spanners_data/smallstaff01-ref.mscx
+++ b/src/engraving/tests/spanners_data/smallstaff01-ref.mscx
@@ -162,6 +162,13 @@
                 </location>
               </prev>
             </Spanner>
+          <Spanner type="Pedal">
+            <prev>
+              <location>
+                <fractions>-1/1</fractions>
+                </location>
+              </prev>
+            </Spanner>
           </voice>
         </Measure>
       </Staff>

--- a/src/importexport/guitarpro/tests/data/artificial-harmonic.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/artificial-harmonic.gp-ref.mscx
@@ -326,6 +326,13 @@
                 </location>
               </prev>
             </Spanner>
+          <Spanner type="HarmonicMark">
+            <prev>
+              <location>
+                <fractions>-3/4</fractions>
+                </location>
+              </prev>
+            </Spanner>
           </voice>
         </Measure>
       </Staff>

--- a/src/importexport/guitarpro/tests/data/artificial-harmonic.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/artificial-harmonic.gpx-ref.mscx
@@ -326,6 +326,13 @@
                 </location>
               </prev>
             </Spanner>
+          <Spanner type="HarmonicMark">
+            <prev>
+              <location>
+                <fractions>-3/4</fractions>
+                </location>
+              </prev>
+            </Spanner>
           </voice>
         </Measure>
       </Staff>

--- a/src/importexport/guitarpro/tests/data/crescendo-diminuendo.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/crescendo-diminuendo.gp-ref.mscx
@@ -161,6 +161,13 @@
                 </location>
               </prev>
             </Spanner>
+          <Spanner type="HairPin">
+            <prev>
+              <location>
+                <fractions>-3/4</fractions>
+                </location>
+              </prev>
+            </Spanner>
           </voice>
         </Measure>
       </Staff>

--- a/src/importexport/guitarpro/tests/data/crescendo-diminuendo.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/crescendo-diminuendo.gpx-ref.mscx
@@ -161,6 +161,13 @@
                 </location>
               </prev>
             </Spanner>
+          <Spanner type="HairPin">
+            <prev>
+              <location>
+                <fractions>-3/4</fractions>
+                </location>
+              </prev>
+            </Spanner>
           </voice>
         </Measure>
       </Staff>

--- a/src/importexport/guitarpro/tests/data/line_elements.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/line_elements.gp-ref.mscx
@@ -1217,6 +1217,14 @@
                 </location>
               </prev>
             </Spanner>
+          <Spanner type="HarmonicMark">
+            <prev>
+              <location>
+                <measures>-1</measures>
+                <fractions>-1/2</fractions>
+                </location>
+              </prev>
+            </Spanner>
           </voice>
         </Measure>
       </Staff>

--- a/src/importexport/guitarpro/tests/data/line_elements.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/line_elements.gp5-ref.mscx
@@ -1031,6 +1031,14 @@
                 </location>
               </prev>
             </Spanner>
+          <Spanner type="HarmonicMark">
+            <prev>
+              <location>
+                <measures>-1</measures>
+                <fractions>-1/2</fractions>
+                </location>
+              </prev>
+            </Spanner>
           </voice>
         </Measure>
       </Staff>

--- a/src/importexport/guitarpro/tests/data/vibrato.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/vibrato.gp5-ref.mscx
@@ -147,6 +147,14 @@
                 </location>
               </prev>
             </Spanner>
+          <Spanner type="Vibrato">
+            <prev>
+              <location>
+                <measures>-1</measures>
+                <fractions>-1/1</fractions>
+                </location>
+              </prev>
+            </Spanner>
           </voice>
         </Measure>
       </Staff>

--- a/src/importexport/musicxml/tests/data/testBracketTypes_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBracketTypes_ref.mscx
@@ -246,9 +246,6 @@
               <tpc>13</tpc>
               </Note>
             </Chord>
-          <BarLine>
-            <subtype>end</subtype>
-            </BarLine>
           <Spanner type="Trill">
             <prev>
               <location>
@@ -256,6 +253,16 @@
                 </location>
               </prev>
             </Spanner>
+          <Spanner type="Trill">
+            <prev>
+              <location>
+                <fractions>-1/1</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
           </voice>
         </Measure>
       </Staff>

--- a/src/importexport/musicxml/tests/data/testPedalChangesBroken_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPedalChangesBroken_ref.mscx
@@ -463,9 +463,6 @@
           <Rest>
             <durationType>half</durationType>
             </Rest>
-          <BarLine>
-            <subtype>end</subtype>
-            </BarLine>
           <Spanner type="Pedal">
             <prev>
               <location>
@@ -474,6 +471,17 @@
                 </location>
               </prev>
             </Spanner>
+          <Spanner type="Pedal">
+            <prev>
+              <location>
+                <measures>-2</measures>
+                <fractions>-1/1</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
           </voice>
         </Measure>
       </Staff>

--- a/src/importexport/musicxml/tests/data/testTimeTick_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTimeTick_ref.mscx
@@ -134,9 +134,8 @@
             </Spanner>
           <location>
             <fractions>7/16</fractions>
+            <timeTick>1</timeTick>
             </location>
-          <BarLine>
-            </BarLine>
           <Spanner type="HairPin">
             <prev>
               <location>
@@ -144,6 +143,15 @@
                 </location>
               </prev>
             </Spanner>
+          <Spanner type="HairPin">
+            <prev>
+              <location>
+                <fractions>-7/16</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          <BarLine>
+            </BarLine>
           </voice>
         </Measure>
       </Staff>


### PR DESCRIPTION
Resolves: #22880 
Resolves: #23185 
Resolves: #23206 
Resolves: #23209

A couple of noteworthy changes:
1) When two segments are at the same tick (i.e. happen at the same time), we establish which one goes before from the order of this enumeration. Given that the TimeTick segment isn't really an engraving thing but an invisible ruler, the choice of putting it before or after the other segments seemed just a matter of convention, so I originally put it last. From working on these issues thoguh I've realized that the more convenient choice is to put it before ChordRest type. This simplifies several things downstream.
![image](https://github.com/musescore/MuseScore/assets/93707756/8edd9668-46a9-4d3a-a364-192c02cce88d)

2) I've also realized that it makes sense for Segment::allElementsInvisible to always return true for TimeTick segments, because from an engraving point of view anchors _are_ always invisible. This also simplifies a few things downstream.
