### PR TITLE
Fix crash when opening special characters dialog

### DIFF
--- a/src/palette/view/widgets/specialcharactersdialog.cpp
+++ b/src/palette/view/widgets/specialcharactersdialog.cpp
@@ -662,7 +662,7 @@ void SpecialCharactersDialog::populateCommon()
         std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(gpaletteScore->dummy());
         fs->setCode(id);
         fs->setFont(m_font);
-        m_pCommon->appendElement(fs, QChar(id));
+        m_pCommon->appendElement(fs, QString::fromUcs4(&id, 1));
     }
 
     for (SymId id : commonScoreSymbols) {
@@ -675,7 +675,7 @@ void SpecialCharactersDialog::populateCommon()
         std::shared_ptr<FSymbol> fs = std::make_shared<FSymbol>(gpaletteScore->dummy());
         fs->setCode(id);
         fs->setFont(m_font);
-        m_pCommon->appendElement(fs, QChar(id));
+        m_pCommon->appendElement(fs, QString::fromUcs4(&id, 1));
     }
 }
 


### PR DESCRIPTION
We were passing more-than-16-bit characters to QChar, which is only 16 bits. This causes an assertion failure in the QChar constructor. Maybe this assertion was added in Qt 6, because I don't remember having seen it before we switched.

Note for testing: the crash might not occur in nightly builds, because perhaps it only occurs in debug builds. Still, would be good to check that the special characters dialog still works as it should.