### PR TITLE
fix MSVC compiler warning

### DIFF
--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -6281,7 +6281,6 @@ void TLayout::layoutTremoloBar(const TremoloBar* item, TremoloBar::LayoutData* l
 void TLayout::layoutTrillSegment(TrillSegment* item, LayoutContext& ctx)
 {
     LAYOUT_CALL_ITEM(item);
-    const double sp = item->spatium();
     TrillSegment::LayoutData* ldata = item->mutldata();
     Trill* trill = item->trill();
     EngravingItem* startItem = trill->startElement();


### PR DESCRIPTION
reg.: 'sp': local variable is initialized but not referenced (C4189)