### PR TITLE
Instruments: Fix Helicon short name & add Pardessus de viole string data

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -5990,7 +5990,7 @@
                   <family>sousaphones</family>
                   <trackName>Helicon</trackName>
                   <longName>Helicon</longName>
-                  <shortName>Helicon</shortName>
+                  <shortName>Hel.</shortName>
                   <description>Instrument of the tuba family.</description>
                   <musicXMLid>brass.helicon</musicXMLid>
                   <clef>F</clef>
@@ -13776,10 +13776,18 @@
                   <shortName>Pds. v.</shortName>
                   <description>Highest-pitched member of the viol family.</description>
                   <musicXMLid>strings.viol</musicXMLid>
+                  <StringData>
+                        <frets>13</frets>
+                        <string>55</string>
+                        <string>62</string>
+                        <string>69</string>
+                        <string>74</string>
+                        <string>79</string>
+                  </StringData>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>55-91</aPitchRange>
-                  <pPitchRange>43-96</pPitchRange>
+                  <pPitchRange>55-96</pPitchRange>
                   <Channel name="arco">
                         <!--MIDI: Bank 0, Prog 40; MS General: Violin-->
                         <program value="40"/> <!--Violin-->
@@ -13903,6 +13911,9 @@
                   <longName>Viola da gamba</longName>
                   <shortName>Vla. d. g.</shortName>
                   <description>Viola da gamba (tablature).</description>
+                  <StringData>
+                        <frets>13</frets>
+                  </StringData>
                   <stafftype staffTypePreset="tab6StrFrench">tablature</stafftype>
                   <genre>earlymusic</genre>
             </Instrument>

--- a/share/instruments/instrumentsxml.h
+++ b/share/instruments/instrumentsxml.h
@@ -3337,7 +3337,7 @@ QT_TRANSLATE_NOOP3("engraving/instruments", "Helicon", "helicon trackName"),
 //: longName for Helicon; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Helicon", "helicon longName"),
 //: shortName for Helicon; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Helicon", "helicon shortName"),
+QT_TRANSLATE_NOOP3("engraving/instruments", "Hel.", "helicon shortName"),
 
 //: description for Conch; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Conch shell, sometimes fitted with a mouthpiece.", "conch description"),
@@ -6245,7 +6245,7 @@ QT_TRANSLATE_NOOP3("engraving/instruments", "pizzicato", "nyckelharpa channel"),
 QT_TRANSLATE_NOOP3("engraving/instruments", "tremolo", "nyckelharpa channel"),
 
 // Score orders
-QT_TRANSLATE_NOOP("engraving/scoreorder", "Orchestral"),
+QT_TRANSLATE_NOOP("engraving/scoreorder", "Orchestra"),
 QT_TRANSLATE_NOOP("engraving/scoreorder", "Choir"),
 QT_TRANSLATE_NOOP("engraving/scoreorder", "Marching Band"),
 QT_TRANSLATE_NOOP("engraving/scoreorder", "Big Band"),


### PR DESCRIPTION
Run the Python script to fetch latest spreadsheet data and fix the translation for 'Orchestra' score order, changed in PR #22514.

Score orders aren't in the online spreadsheet, but their translations are extracted from `orders.xml` by the same Python script `share/instruments/update_instruments_xml.py`.

Fix #22562.