### PR TITLE
Expressions can also be assigned to timeTick segment when reading

### DIFF
--- a/src/engraving/rw/read410/measureread.cpp
+++ b/src/engraving/rw/read410/measureread.cpp
@@ -446,7 +446,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             TRead::read(dyn, e, ctx);
             segment->add(dyn);
         } else if (tag == "Expression") {
-            segment = measure->getSegment(SegmentType::ChordRest, ctx.tick());
+            segment = measure->getChordRestOrTimeTickSegment(ctx.tick());
             Expression* expr = Factory::createExpression(segment);
             expr->setTrack(ctx.track());
             TRead::read(expr, e, ctx);


### PR DESCRIPTION
Resolves: this beauty
<img width="509" alt="image" src="https://github.com/musescore/MuseScore/assets/93707756/82b4dd16-1f41-4d0e-9d55-cfe3617d06c9">