### PR TITLE
gp-import: fixed arpeggio stretch for gp5

### DIFF
--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -149,8 +149,14 @@ int GuitarPro5::readBeatEffects(int track, Segment* segment)
         // representation is different in guitar pro 5 - the up/down order below is correct
         if (strokeup > 0) {
             a->setArpeggioType(ArpeggioType::UP_STRAIGHT);
+            if (strokeup < 7) {
+                a->setStretch(1.0 / std::pow(2, 6 - strokeup));
+            }
         } else if (strokedown > 0) {
             a->setArpeggioType(ArpeggioType::DOWN_STRAIGHT);
+            if (strokedown < 7) {
+                a->setStretch(1.0 / std::pow(2, 6 - strokedown));
+            }
         } else {
             delete a;
             a = 0;

--- a/src/importexport/guitarpro/tests/data/brush.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/brush.gp5-ref.mscx
@@ -85,6 +85,7 @@
               </Note>
             <Arpeggio>
               <subtype>5</subtype>
+              <timeStretch>0.5</timeStretch>
               </Arpeggio>
             </Chord>
           </voice>
@@ -113,6 +114,7 @@
               </Note>
             <Arpeggio>
               <subtype>4</subtype>
+              <timeStretch>0.5</timeStretch>
               </Arpeggio>
             </Chord>
           </voice>


### PR DESCRIPTION
arpeggio in midi wasn't stretched according to guitar pro 5 file.
Examples in archive:
[arpeggio-lengths.zip](https://github.com/user-attachments/files/15817283/arpeggio-lengths.zip)

This PR makes arpeggio stretch the same as in imported from guitar pro 6/7 files