### PR TITLE
Infer 'shift' fingering on XML import

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -484,8 +484,8 @@ static std::pair<String, String> separateTransposition(const String& name)
     String n = name;
     n.replace(u"♭", u"b").replace(u"♯", u"#");
     std::pair<String, String> ret;
-    static const std::regex re("(^| )([ABCDEF][b#]?)( |$)");
-    static const std::regex in(" in");
+    static const std::regex re("(^|(?:\\s|\\u00A0))([ABCDEF][b#]?)((?:\\s|\\u00A0)|$)");
+    static const std::regex in("(?:\\s|\\u00A0)in");
 
     const StringList results = n.search(re, { 2 });
     if (!results.empty()) {
@@ -3392,7 +3392,7 @@ bool MusicXMLParserDirection::isLikelyLegallyDownloaded(const Fraction& tick) co
            && m_rehearsalText.empty()
            && m_metroText.empty()
            && m_tpoSound < 0.1
-           && m_wordsText.contains(std::wregex(L"This music has been legally downloaded\\.\\sDo not photocopy\\."));
+           && m_wordsText.contains(std::wregex(L"This music has been legally downloaded\\.(?:\\s|\\u00A0)Do not photocopy\\."));
 }
 
 bool MusicXMLParserDirection::isLikelyTempoText(const track_idx_t track) const
@@ -3710,7 +3710,7 @@ bool MusicXMLParserDirection::isLikelyFingering() const
         return false;
     }
     // One or more newline-separated digits, possibly lead or trailed by whitespace
-    static const std::wregex re(L"^\\s*[0-5pimac](?:[-–][0-5pimac])?(?:\\n[0-5pimac](?:[-–][0-5pimac])?)*\\s*$");
+    static const std::wregex re(L"^(?:\\s|\\u00A0)*[0-5pimac](?:[-–][0-5pimac])?(?:\\n[0-5pimac](?:[-–][0-5pimac])?)*(?:\\s|\\u00A0)*$");
     return m_wordsText.contains(re)
            && m_rehearsalText.empty()
            && m_metroText.empty()
@@ -4203,7 +4203,7 @@ void MusicXMLParserDirection::handleTempo()
     // which we need to map to SMuFL syms
     String plainWords = MScoreTextToMXML::toPlainText(m_wordsText.simplified());
 
-    static const std::regex tempo(".*([yxeqhVwW])(\\.?)\\s*=[^0-9]*([0-9]+).*");
+    static const std::regex tempo(".*([yxeqhVwW])(\\.?)(?:\\s|\\u00A0)*=[^0-9]*([0-9]+).*");
     StringList tempoMatches = plainWords.search(tempo, { 1, 2, 3 }, SplitBehavior::SkipEmptyParts);
 
     // Not a tempo
@@ -4228,7 +4228,7 @@ void MusicXMLParserDirection::handleTempo()
         { u"W", { u"<sym>metNoteDoubleWhole</sym>", DurationType::V_BREVE } }
     };
 
-    static const std::regex replace("(.*)[yxeqhVwW]\\.?(\\s*=[^0-9]*[0-9]+.*)");
+    static const std::regex replace("(.*)[yxeqhVwW]\\.?((?:\\s|\\u00A0)*=[^0-9]*[0-9]+.*)");
     const String newStr = u"$1" + syms.at(dur).first + dotStr + u"$2";
     plainWords.replace(replace, newStr);
     m_wordsText = plainWords;

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
@@ -461,7 +461,7 @@ private:
     bool isLikelyTempoText(const track_idx_t track) const;
     Text* addTextToHeader(const TextStyleType textStyleType);
     void hideRedundantHeaderText(const Text* inferredText, const std::vector<String> metaTags);
-    bool isLikelyFingering() const;
+    bool isLikelyFingering(const String& fingeringStr) const;
     bool isLikelySticking();
     PlayingTechniqueType getPlayingTechnique() const;
 

--- a/src/importexport/musicxml/tests/data/testInferredFingerings.xml
+++ b/src/importexport/musicxml/tests/data/testInferredFingerings.xml
@@ -101,6 +101,13 @@
           <line>4</line>
           </clef>
         </attributes>
+    <direction placement="above">
+        <direction-type>
+            <words default-y="16" font-size="7.2" relative-x="3">–</words>
+            <words font-size="2.9"> </words>
+            <words font-size="7.2">1</words>
+        </direction-type>
+    </direction>
       <note default-x="83.49" default-y="-15.00">
         <pitch>
           <step>C</step>
@@ -112,11 +119,6 @@
         <stem>up</stem>
         <staff>1</staff>
         <beam number="1">begin</beam>
-        <notations>
-          <technical>
-            <fingering>0</fingering>
-            </technical>
-          </notations>
         </note>
       <note default-x="136.85" default-y="-15.00">
         <pitch>

--- a/src/importexport/musicxml/tests/data/testInferredFingerings_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredFingerings_ref.mscx
@@ -161,7 +161,7 @@
             <durationType>eighth</durationType>
             <Note>
               <Fingering>
-                <text>0</text>
+                <text>–1</text>
                 </Fingering>
               <pitch>72</pitch>
               <tpc>14</tpc>


### PR DESCRIPTION
This PR improves the fingering inference by adding support for negative 'shift' fingerings, and strips formatting information.  
It also improves whitespace checks in regexes to include no break spaces.  

<img width="352" alt="Screenshot 2024-06-13 at 14 51 55" src="https://github.com/musescore/MuseScore/assets/26510874/1e9c3bb9-ef14-4019-8170-38643558a4f7">
