### PR TITLE
Fix GH#23241: Header/footer special symbols tooltip closes too quickly

### DIFF
--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1402,9 +1402,9 @@ void EditStyle::setHeaderFooterToolTip()
 
     toolTipHeaderFooter += QString("</table></body></html>");
     showHeader->setToolTip(toolTipHeaderFooter);
-    showHeader->setToolTipDuration(5000);   // leaving the default value of -1 calculates the duration automatically and it takes too long
+    showHeader->setToolTipDuration(10000);   // leaving the default value of -1 calculates the duration automatically and it takes too long
     showFooter->setToolTip(toolTipHeaderFooter);
-    showFooter->setToolTipDuration(5000);
+    showFooter->setToolTipDuration(10000);
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: #23241