### PR TITLE
Set composer text align to bottom on XML import

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -576,7 +576,7 @@ static bool overrideTextStyleForComposer(const String& creditString)
 
 static void addText2(VBox* vbx, Score* score, const String& strTxt, const TextStyleType stl, const Align align, const double yoffs)
 {
-    if (overrideTextStyleForComposer(strTxt)) {
+    if (stl != TextStyleType::COMPOSER && overrideTextStyleForComposer(strTxt)) {
         // HACK: in some Dolet 8 files the composer is written as a subtitle, which leads to stupid formatting.
         // This overrides the formatting and introduces proper composer text
         Text* text = Factory::createText(vbx, TextStyleType::COMPOSER);
@@ -627,7 +627,7 @@ static void findYMinYMaxInWords(const std::vector<const CreditWords*>& words, in
 //   alignForCreditWords
 //---------------------------------------------------------
 
-static Align alignForCreditWords(const CreditWords* const w, const int pageWidth)
+static Align alignForCreditWords(const CreditWords* const w, const int pageWidth, const TextStyleType tid)
 {
     Align align = AlignH::LEFT;
     if (w->defaultX > (pageWidth / 3)) {
@@ -636,6 +636,9 @@ static Align alignForCreditWords(const CreditWords* const w, const int pageWidth
         } else {
             align = AlignH::RIGHT;
         }
+    }
+    if (tid == TextStyleType::COMPOSER) {
+        align.vertical = AlignV::BOTTOM;
     }
     return align;
 }
@@ -895,9 +898,9 @@ static VBox* addCreditWords(Score* score, const CreditWordsList& crWords,
 
     for (const CreditWords* w : words) {
         if (mustAddWordToVbox(w->type)) {
-            const Align align = alignForCreditWords(w, pageSize.width());
             const TextStyleType tid = (pageNr == 1 && top) ? tidForCreditWords(w, words, pageSize.width()) : TextStyleType::DEFAULT;
-            double yoffs = (maxy - w->defaultY) * score->style().spatium() / 10;
+            const Align align = alignForCreditWords(w, pageSize.width(), tid);
+            double yoffs = tid == TextStyleType::COMPOSER ? 0.0 : (maxy - w->defaultY) * score->style().spatium() / 10;
             if (!vbox) {
                 vbox = MusicXMLParserPass1::createAndAddVBoxForCreditWords(score, miny, maxy);
             }

--- a/src/importexport/musicxml/tests/data/testBeamModes_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBeamModes_ref.mscx
@@ -127,8 +127,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4247"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testBracketTypes_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBracketTypes_ref.mscx
@@ -127,8 +127,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4247"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testCueGraceNotes_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testCueGraceNotes_ref.mscx
@@ -127,8 +127,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4247"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testCueNotes3_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testCueNotes3_ref.mscx
@@ -127,8 +127,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.3876"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testDSalCodaMisplaced_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDSalCodaMisplaced_ref.mscx
@@ -127,8 +127,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4247"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testDSalCoda_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDSalCoda_ref.mscx
@@ -127,8 +127,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4247"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testExcessHiddenStaves_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testExcessHiddenStaves_ref.mscx
@@ -137,8 +137,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4247"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testInferredFingerings_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredFingerings_ref.mscx
@@ -135,8 +135,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4247"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testInferredTechnique_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredTechnique_ref.mscx
@@ -128,8 +128,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.461"/>
           <text>Composer / arranger</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testLyricBracket_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testLyricBracket_ref.mscx
@@ -127,8 +127,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4247"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testNegativeOffset_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testNegativeOffset_ref.mscx
@@ -135,8 +135,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4247"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testPartNames_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPartNames_ref.mscx
@@ -259,8 +259,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4803"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testPedalChangesBroken_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPedalChangesBroken_ref.mscx
@@ -127,8 +127,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4247"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
@@ -194,8 +194,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4247"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testSecondVoiceMelismata_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSecondVoiceMelismata_ref.mscx
@@ -127,8 +127,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4247"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testStaffEmptiness_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testStaffEmptiness_ref.mscx
@@ -135,8 +135,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4247"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testTempoTextSpace1_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTempoTextSpace1_ref.mscx
@@ -135,8 +135,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4247"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testTempoTextSpace2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTempoTextSpace2_ref.mscx
@@ -135,8 +135,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4247"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testTextOrder_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTextOrder_ref.mscx
@@ -127,8 +127,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4247"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testTextQuirkInference_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTextQuirkInference_ref.mscx
@@ -127,8 +127,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4247"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testUnterminatedTies_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testUnterminatedTies_ref.mscx
@@ -127,8 +127,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4247"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testVoltaHiding_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testVoltaHiding_ref.mscx
@@ -199,8 +199,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.489"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>

--- a/src/importexport/musicxml/tests/data/testWedgeOffset_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testWedgeOffset_ref.mscx
@@ -127,8 +127,6 @@
           </Text>
         <Text>
           <style>composer</style>
-          <align>right,top</align>
-          <offset x="0" y="17.4247"/>
           <text>Henry Ives</text>
           </Text>
         </VBox>


### PR DESCRIPTION
This resolves composer text escaping the bottom of the header box.  We are now discarding the `default-y` value for composer text, as more often than not using this leads to unwanted results.