### PR TITLE
Uncrustify: Ignore deleted files and avoid recompiling unnecessarily

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -40,7 +40,7 @@ function get_staged_files()
         if ! path_under_any_of_dirs "${file}" "${untidy_dirs[@]}"; then
             STAGED_FILES+=("${file}")
         fi
-    done < <(git diff -z --name-only --cached -- "${tidy_globs[@]}")
+    done < <(git diff -z --name-only --cached --diff-filter=d -- "${tidy_globs[@]}")
 
     NUM_STAGED="${#STAGED_FILES[@]}"
 }

--- a/tools/codestyle/tidy_file.sh
+++ b/tools/codestyle/tidy_file.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 
-((${BASH_VERSION%%.*} >= 4)) || { echo >&2 "$0: Error: Please upgrade Bash."; exit 1; }
+FAIL_FAST=255 # exit code to make xargs terminate early (if this script is called by xargs)
 
-set -euo pipefail
+((${BASH_VERSION%%.*} >= 4)) || { echo >&2 "$0: Error: Please upgrade Bash."; exit ${FAIL_FAST}; }
+
+set -uo pipefail
+
+trap 'echo >&2 "$0: Error $?, line ${LINENO}, args: $*"; exit ${FAIL_FAST}' ERR
 
 # Call the right command to tidy a file based on purely on its extension.
 # For best performance, filter the list of files prior to calling this script.
@@ -15,34 +19,31 @@ HERE="${BASH_SOURCE%/*}" # path to dir that contains this script
 function uncrustify_file()
 {
     local file="$1" lang="$2" status
-    if ! uncrustify -c "${HERE}/uncrustify_musescore.cfg" --no-backup -l "${lang}" "${file}"; then
-        status=$?
-        rm -f "${file}.uncrustify" # remove possible temporary file
-        return ${status}
-    fi
+    uncrustify -c "${HERE}/uncrustify_musescore.cfg" --no-backup -l "${lang}" -f "${file}"
+    status=$?
+    rm -f "${file}.uncrustify" # remove possible temporary file
+    return ${status}
 }
 
 if (($# != 1)); then
-    echo >&2 "$0: Error: Too many arguments. Please specify a single file."
-    exit 255 # make xargs exit early and ensure non-zero status on macOS
+    echo >&2 "$0: Error: Wrong arguments. Please specify a single file."
+    exit ${FAIL_FAST}
 fi
 
 file="$1"
 base="${file%.unstaged}" # remove possible '.unstaged' extension (see hooks/pre-commit)
-ext="${base##*.}"
+extension="${base##*.}"
 
-set +e
-case "${ext,,}" in
-c)          uncrustify_file "${file}" 'CPP' ;;
-h|cpp|hpp)  uncrustify_file "${file}" 'CPP' ;;
-m)          uncrustify_file "${file}" 'OC'  ;;
-mm)         uncrustify_file "${file}" 'OC+' ;;
-*)          echo >&2 "Skipping: ${file}" ;;
+case "${extension,,}" in
+c)          tidy="$(uncrustify_file "${file}" 'C'  )" ;;
+h|cpp|hpp)  tidy="$(uncrustify_file "${file}" 'CPP')" ;;
+m)          tidy="$(uncrustify_file "${file}" 'OC' )" ;;
+mm)         tidy="$(uncrustify_file "${file}" 'OC+')" ;;
+*)          echo >&2 "Skipping: ${file}"; exit 0      ;;
 esac
-status=$?
-set -e
 
-if ((${status} != 0)); then
-    echo >&2 "$0: Error ${status} for ${file}"
-    exit 255 # make xargs exit early and ensure non-zero status on macOS
+# Only update the original file if the tidy version is different.
+if ! cmp --silent "${file}" - <<<"${tidy}"; then
+    echo >&2 "Tidying: ${file}"
+    printf '%s\n' "${tidy}" >"${file}" # restore final newline lost in command substitution
 fi


### PR DESCRIPTION
Modify the pre-commit hook to avoid running Uncrustify on files that have been staged for deletion.

For files that Uncrustify does run on, only update the file on disk if Uncrustify changes its contents. This preserves the modification timestamp (mtime) on files that were already tidy before Uncrustify was run, so they don't have to be recompiled on the next build.