### PR TITLE
fixed #21993: Crash when rearranging a palette after right-clicking it

### DIFF
--- a/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
@@ -425,6 +425,8 @@ StyledListView {
                     togglePopup();
                 }
 
+                paletteHeader.closeContextMenu()
+
                 paletteTree.itemDragged = true;
                 DelegateModel.inPersistedItems = true;
                 DelegateModel.inItems = false;

--- a/src/palette/qml/MuseScore/Palette/internal/TreePaletteHeader.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/TreePaletteHeader.qml
@@ -45,6 +45,14 @@ Item {
     property NavigationPanel navigationPanel: null
     property int navigationRow: 0
 
+    function closeContextMenu() {
+        if (!menuButton.isMenuOpened) {
+            return
+        }
+
+        menuButton.toggleMenu(null)
+    }
+
     signal toggleExpandRequested()
     signal enableEditingToggled(bool val)
     signal hideSelectedElementsRequested()


### PR DESCRIPTION
Resolves: #21993