### PR TITLE
Make creation of hairpins and dynamics more consistent 

### DIFF
--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -1519,6 +1519,20 @@ double Chord::calcDefaultStemLength()
     return finalStemLength + extraLength;
 }
 
+Fraction Chord::endTickIncludingTied() const
+{
+    const Chord* lastTied = this;
+    while (lastTied) {
+        const Chord* next = lastTied->nextTiedChord();
+        if (next) {
+            lastTied = next;
+        } else {
+            break;
+        }
+    }
+    return lastTied->tick() + lastTied->actualTicks();
+}
+
 Chord* Chord::prev() const
 {
     ChordRest* prev = prevChordRest(const_cast<Chord*>(this));
@@ -2651,7 +2665,7 @@ void Chord::sortNotes()
 //    back to this one. Set sameSize=true to return 0 in this case.
 //---------------------------------------------------------
 
-Chord* Chord::nextTiedChord(bool backwards, bool sameSize)
+Chord* Chord::nextTiedChord(bool backwards, bool sameSize) const
 {
     Segment* nextSeg = backwards ? segment()->prev1(SegmentType::ChordRest) : segment()->next1(SegmentType::ChordRest);
     if (!nextSeg) {

--- a/src/engraving/dom/chord.h
+++ b/src/engraving/dom/chord.h
@@ -271,9 +271,11 @@ public:
 
     void sortNotes();
 
-    Chord* nextTiedChord(bool backwards = false, bool sameSize = true);
+    Chord* nextTiedChord(bool backwards = false, bool sameSize = true) const;
     bool containsTieEnd() const;
     bool containsTieStart() const;
+
+    Fraction endTickIncludingTied() const;
 
     EngravingItem* nextElement() override;
     EngravingItem* prevElement() override;

--- a/src/engraving/dom/chordrest.h
+++ b/src/engraving/dom/chordrest.h
@@ -129,6 +129,8 @@ public:
         return m_crossMeasure == CrossMeasure::FIRST ? m_crossMeasureTDur.ticks() : m_durationType.ticks();
     }
 
+    Fraction endTick() const { return tick() + actualTicks(); }
+
     String durationUserName() const;
 
     void setTrack(track_idx_t val) override;

--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -622,61 +622,6 @@ void Score::cmdAddSpanner(Spanner* spanner, staff_idx_t staffIdx, Segment* start
     undoAddElement(spanner, true, ctrlModifier);
 }
 
-void Score::addHairpinToChordRest(Hairpin* hairpin, ChordRest* chordRest)
-{
-    track_idx_t track = chordRest->track();
-    hairpin->setTrack(track);
-    hairpin->setTrack2(track);
-
-    hairpin->setTick(chordRest->tick());
-
-    // End the hairpin at the end of the chord or, if present, at the next dynamic
-    Fraction endTick = chordRest->tick() + chordRest->actualTicks();
-
-    Segment* startSegment = chordRest->segment();
-    Segment* endSegment = nullptr;
-    for (Segment* segment = startSegment; segment && segment->tick() < endTick;
-         segment = segment->next1(SegmentType::ChordRest | SegmentType::TimeTick)) {
-        if (segment == startSegment) {
-            continue;
-        }
-        if (segment->findAnnotation(ElementType::DYNAMIC, track, track)) {
-            endSegment = segment;
-            break;
-        }
-    }
-    if (endSegment) {
-        endTick = std::min(endTick, endSegment->tick());
-    }
-
-    hairpin->setTick2(endTick);
-
-    undoAddElement(hairpin);
-}
-
-void Score::addHairpinToDynamic(Hairpin* hairpin, Dynamic* dynamic)
-{
-    track_idx_t track = dynamic->track();
-    hairpin->setTrack(track);
-    hairpin->setTrack2(track);
-
-    hairpin->setTick(dynamic->tick());
-
-    ChordRest* startCR = nullptr;
-    for (Segment* segment = dynamic->segment(); segment; segment = segment->prev(SegmentType::ChordRest)) {
-        EngravingItem* element = segment->elementAt(track);
-        if (element && element->isChordRest()) {
-            startCR = toChordRest(element);
-            break;
-        }
-    }
-
-    Fraction endTick = startCR ? startCR->tick() + startCR->actualTicks() : dynamic->segment()->measure()->endTick();
-    hairpin->setTick2(endTick);
-
-    undoAddElement(hairpin);
-}
-
 //---------------------------------------------------------
 //   expandVoice
 //    fills gaps in voice with rests,

--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -459,6 +459,7 @@ EngravingItem* Dynamic::drop(EditData& ed)
     score()->undoAddElement(item);
     item->undoChangeProperty(Pid::PLACEMENT, placement(), PropertyFlags::UNSTYLED);
     if (item->isDynamic()) {
+        toDynamic(item)->setAnchorToEndOfPrevious(anchorToEndOfPrevious());
         score()->undoRemoveElement(this); // swap this dynamic for the newly added one
     }
     return item;

--- a/src/engraving/dom/hairpin.cpp
+++ b/src/engraving/dom/hairpin.cpp
@@ -102,6 +102,12 @@ EngravingItem* HairpinSegment::drop(EditData& data)
         return nullptr;
     }
 
+    if (EngravingItem* item = ldata()->itemSnappedAfter()) {
+        if (item->isDynamic()) {
+            return item->drop(data);
+        }
+    }
+
     Fraction endTick = hairpin()->tick2();
     Measure* measure = score()->tick2measure(endTick);
     Segment* segment = measure->getChordRestOrTimeTickSegment(endTick);

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -590,7 +590,7 @@ public:
     void print(muse::draw::Painter* printer, int page);
     ChordRest* getSelectedChordRest() const;
     std::set<ChordRest*> getSelectedChordRests() const;
-    void getSelectedChordRest2(ChordRest** cr1, ChordRest** cr2) const;
+    void getSelectedStartEndChordRests(ChordRest*& cr1, ChordRest*& cr2) const;
 
     void select(EngravingItem* item, SelectType = SelectType::SINGLE, staff_idx_t staff = 0);
     void select(const std::vector<EngravingItem*>& items, SelectType = SelectType::SINGLE, staff_idx_t staff = 0);
@@ -906,11 +906,9 @@ public:
     void addUnmanagedSpanner(Spanner*);
     void removeUnmanagedSpanner(Spanner*);
 
-    void addHairpinToChordRest(Hairpin* hairpin, ChordRest* chordRest);
+    Hairpin* addHairpin(HairpinType type, ChordRest* cr1, ChordRest* cr2 = nullptr);
+    void addHairpin(Hairpin* hairpin, ChordRest* cr1, ChordRest* cr2 = nullptr);
     void addHairpinToDynamic(Hairpin* hairpin, Dynamic* dynamic);
-
-    Hairpin* addHairpin(HairpinType, const Fraction& tickStart, const Fraction& tickEnd, track_idx_t track);
-    Hairpin* addHairpin(HairpinType, ChordRest* cr1, ChordRest* cr2 = nullptr);
 
     ChordRest* findCR(Fraction tick, track_idx_t track) const;
     ChordRest* findChordRestEndingBeforeTickInStaff(const Fraction& tick, staff_idx_t staffIdx) const;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1729,8 +1729,8 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
             mu::engraving::Spanner* spanner = static_cast<mu::engraving::Spanner*>(engraving::Factory::createItem(type, score->dummy()));
             rw::RWRegister::reader()->readItem(spanner, e);
             spanner->styleChanged();
-            if (spanner->isHairpin() && cr1 == cr2) {
-                score->addHairpinToChordRest(toHairpin(spanner), cr1);
+            if (spanner->isHairpin()) {
+                score->addHairpin(toHairpin(spanner), cr1, cr2);
             } else {
                 score->cmdAddSpanner(spanner, cr1->staffIdx(), startSegment, endSegment, modifiers & Qt::ControlModifier);
             }


### PR DESCRIPTION
Resolves: #23210 

When applying a hairpin to a note, the hairpin extends until the end of the selected note or to the next dynamic (whichever comes first). The same when applying the hairpin to a dynamic: it extends intil the end of the current note or to the next dynamic if one comes first. If the note is tied, we extend until the end of the tied duration.

This does not apply to range-selection. On range selection, the hairpin always goes from the start to the end of the selected range.