### PR TITLE
Revert "Remove unnecessary Qt components"

### DIFF
--- a/buildscripts/cmake/FindQt6.cmake
+++ b/buildscripts/cmake/FindQt6.cmake
@@ -17,10 +17,12 @@ set(_components
     Qml
     Quick
     QuickControls2
+    QuickTemplates2
     QuickWidgets
     Xml
     Svg
     PrintSupport
+    OpenGL
     LinguistTools
 
     Core5Compat


### PR DESCRIPTION
Reverts musescore/MuseScore#23261

Turns out to result in missing DLL files on Windows. So apparently, the OpenGL module is a dependency of some other Qt module. In my opinion we should not need to manually specify things that are dependencies of other Qt modules, so I will reinvestigate this situation later. But for now I will revert that PR, as a hotfix. 