### PR TITLE
Ensure hairpins and dynamic editable after inserted

### DIFF
--- a/src/engraving/dom/hairpin.cpp
+++ b/src/engraving/dom/hairpin.cpp
@@ -117,7 +117,7 @@ EngravingItem* HairpinSegment::drop(EditData& data)
     d->setParent(segment);
     score()->undoAddElement(d);
 
-    return nullptr;
+    return d;
 }
 
 //---------------------------------------------------------

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -313,6 +313,7 @@ private:
 
     void doSelect(const std::vector<EngravingItem*>& elements, SelectType type, engraving::staff_idx_t staffIndex = 0);
     void selectElementsWithSameTypeOnSegment(mu::engraving::ElementType elementType, mu::engraving::Segment* segment);
+    void selectAndStartEditIfNeeded(EngravingItem* element);
 
     void notifyAboutDragChanged();
     void notifyAboutDropChanged();


### PR DESCRIPTION
Resolves: #23140 

This ensures that hairpins and dynamics always remain in a selected and editable state after being dropped from palette, or otherwise inserted, or copy-pasted. It makes it possible, for example, to create a chain of dynamic-hairpin-dynamic very without moving the mouse out of the palette (one can just click dynamic-hairpin-dynamic).
