### PR TITLE
Retain dynamics and hairpins properties upon respective drop operations

### DIFF
--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -456,19 +456,24 @@ EngravingItem* Dynamic::drop(EditData& ed)
         return item;
     }
 
-    if (!(item->isDynamic() || item->isExpression())) {
-        return nullptr;
+    if (item->isDynamic()) {
+        Dynamic* dynamic = toDynamic(item);
+        undoChangeProperty(Pid::DYNAMIC_TYPE, dynamic->dynamicType());
+        undoChangeProperty(Pid::TEXT, dynamic->xmlText());
+        delete dynamic;
+        ed.dropElement = this;
+        return this;
     }
 
-    item->setTrack(track());
-    item->setParent(segment());
-    score()->undoAddElement(item);
-    item->undoChangeProperty(Pid::PLACEMENT, placement(), PropertyFlags::UNSTYLED);
-    if (item->isDynamic()) {
-        toDynamic(item)->setAnchorToEndOfPrevious(anchorToEndOfPrevious());
-        score()->undoRemoveElement(this); // swap this dynamic for the newly added one
+    if (item->isExpression()) {
+        item->setTrack(track());
+        item->setParent(segment());
+        toExpression(item)->setApplyToVoice(applyToVoice());
+        score()->undoAddElement(item);
+        return item;
     }
-    return item;
+
+    return nullptr;
 }
 
 int Dynamic::dynamicVelocity(DynamicType t)

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3853,6 +3853,8 @@ void Score::addHairpinToDynamic(Hairpin* hairpin, Dynamic* dynamic)
 
     hairpin->setTick2(endTick);
 
+    hairpin->setApplyToVoice(dynamic->applyToVoice());
+
     undoAddElement(hairpin);
 }
 

--- a/src/engraving/dom/hairpin.cpp
+++ b/src/engraving/dom/hairpin.cpp
@@ -115,6 +115,7 @@ EngravingItem* HairpinSegment::drop(EditData& data)
     Dynamic* d = toDynamic(e->clone());
     d->setTrack(hairpin()->track());
     d->setParent(segment);
+    d->setApplyToVoice(hairpin()->applyToVoice());
     score()->undoAddElement(d);
 
     return d;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2057,7 +2057,10 @@ void NotationInteraction::applyDropPaletteElement(mu::engraving::Score* score, m
         }
 
         if (el && el->hasVoiceApplicationProperties()) {
-            el->setInitialTrackAndVoiceApplication(el->track());
+            // If target has voice application properties, dropped element takes those and discards the default
+            if (!target->hasVoiceApplicationProperties()) {
+                el->setInitialTrackAndVoiceApplication(el->track());
+            }
         }
 
         if (el && !score->inputState().noteEntryMode()) {


### PR DESCRIPTION
Resolves: #23285 
Resolves: #23292 

This ensures that when dropping a dynamic on a hairpin (and viceverse) or dynamic on dynamic, the dropped element gets the same voice properties of the droppee.