### PR TITLE
Identify system object staves on xml import

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -1921,6 +1921,20 @@ void MusicXMLParserPass2::scorePartwise()
 
     for (EngravingItem* el : muse::values(m_sysElements)) {
         m_score->undoAddElement(el);
+        LOGI() << "el: " << toTextBase(el)->plainText();
+
+        // Remove potential duplicated text
+        const Segment* seg = toSegment(el->parentItem());
+        for (EngravingItem* existingEl : seg->annotations()) {
+            const bool bothText = existingEl->isTextBase() && el->isTextBase();
+            if (existingEl && existingEl != el && bothText) {
+                const bool textMatches = toTextBase(existingEl)->plainText() == toTextBase(el)->plainText();
+                const bool placementMatches = existingEl->placement() == el->placement();
+                if (textMatches && !existingEl->systemFlag() && placementMatches) {
+                    m_score->removeElement(existingEl);
+                }
+            }
+        }
     }
 
     // This method relies heavily on text metrics which differ from system to system and can be very volatile

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -922,7 +922,8 @@ static void addGraceNoteLyrics(const std::map<int, Lyrics*>& numberedLyrics, std
 //   addElemOffset
 //---------------------------------------------------------
 
-static void addElemOffset(EngravingItem* el, track_idx_t track, const String& placement, Measure* measure, const Fraction& tick)
+static void addElemOffset(EngravingItem* el, track_idx_t track, const String& placement, Measure* measure, const Fraction& tick,
+                          MusicXMLParserPass2& _pass2)
 {
     if (!measure) {
         return;
@@ -940,7 +941,26 @@ static void addElemOffset(EngravingItem* el, track_idx_t track, const String& pl
 
     el->setTrack(el->isTempoText() ? 0 : track);      // TempoText must be in track 0
     Segment* s = measure->getSegment(SegmentType::ChordRest, tick);
-    s->add(el);
+    if (el->systemFlag()) {
+        Score* score = measure->score();
+        Staff* st = score->staff(track2staff(track));
+        if (!score->isSystemObjectStaff(st) && st->idx() != 0) {
+            score->addSystemObjectStaff(st);
+        }
+        bool found = false;
+        for (EngravingItem* existingEl : muse::values(_pass2.systemElements(), tick.ticks())) {
+            if (el->type() == existingEl->type()) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            el->setParent(s);
+            _pass2.addSystemElement(el, tick);
+        }
+    } else {
+        s->add(el);
+    }
 }
 
 //---------------------------------------------------------
@@ -1899,6 +1919,10 @@ void MusicXMLParserPass2::scorePartwise()
     }
     addError(checkAtEndElement(m_e, u"score-partwise"));
 
+    for (EngravingItem* el : muse::values(m_sysElements)) {
+        m_score->undoAddElement(el);
+    }
+
     // This method relies heavily on text metrics which differ from system to system and can be very volatile
     // To avoid having to update the majority of musicxml tests on every change to engraving, don't run this during testing
     if (!MScore::testMode) {
@@ -2540,7 +2564,7 @@ void MusicXMLParserPass2::measure(const String& partId, const Fraction time)
 
                     m_score->setTempo(tick, tpo);
 
-                    addElemOffset(t, m_pass1.trackForPart(partId), u"above", measure, tick);
+                    addElemOffset(t, m_pass1.trackForPart(partId), u"above", measure, tick, *this);
                 }
             }
             m_e.skipCurrentElement();
@@ -2621,7 +2645,7 @@ void MusicXMLParserPass2::measure(const String& partId, const Fraction time)
     }
               );
     for (MusicXMLDelayedDirectionElement* direction : delayedDirections) {
-        direction->addElem();
+        direction->addElem(*this);
         delete direction;
     }
 
@@ -2976,9 +3000,9 @@ static void preventNegativeTick(const Fraction& tick, Fraction& offset, MxmlLogg
     }
 }
 
-void MusicXMLDelayedDirectionElement::addElem()
+void MusicXMLDelayedDirectionElement::addElem(MusicXMLParserPass2& _pass2)
 {
-    addElemOffset(m_element, m_track, m_placement, m_measure, m_tick);
+    addElemOffset(m_element, m_track, m_placement, m_measure, m_tick, _pass2);
 }
 
 String MusicXMLParserDirection::placement() const
@@ -3098,7 +3122,7 @@ void MusicXMLParserDirection::direction(const String& partId,
         }
         tt->setVisible(m_visible);
 
-        addElemOffset(tt, track, placement(), measure, tick + m_offset);
+        addElemOffset(tt, track, placement(), measure, tick + m_offset, m_pass2);
     } else if (isLikelySticking() && isPercussionStaff) {
         Sticking* sticking = Factory::createSticking(m_score->dummy()->segment());
         sticking->setXmlText(m_wordsText);
@@ -3116,7 +3140,7 @@ void MusicXMLParserDirection::direction(const String& partId,
                 totalY(), sticking, track, placement(), measure, tick + m_offset);
             delayedDirections.push_back(delayedDirection);
         } else {
-            addElemOffset(sticking, track, placement(), measure, tick + m_offset);
+            addElemOffset(sticking, track, placement(), measure, tick + m_offset, m_pass2);
         }
     } else if (isLikelyDynamicRange()) {
         isDynamicRange = true;
@@ -3207,7 +3231,7 @@ void MusicXMLParserDirection::direction(const String& partId,
                         totalY(), t, track, placement(), measure, tick + m_offset);
                     delayedDirections.push_back(delayedDirection);
                 } else {
-                    addElemOffset(t, track, placement(), measure, tick + m_offset);
+                    addElemOffset(t, track, placement(), measure, tick + m_offset, m_pass2);
                 }
             }
         }
@@ -3227,7 +3251,7 @@ void MusicXMLParserDirection::direction(const String& partId,
             // TBD may want ro use tick + _offset if sound is affected
             m_score->setTempo(tick, tpo);
 
-            addElemOffset(t, track, placement(), measure, tick + m_offset);
+            addElemOffset(t, track, placement(), measure, tick + m_offset, m_pass2);
         }
     }
 
@@ -3300,7 +3324,7 @@ void MusicXMLParserDirection::direction(const String& partId,
                 totalY(), elem, track, placement(), measure, tick + m_offset);
             delayedDirections.push_back(delayedDirection);
         } else {
-            addElemOffset(elem, track, placement(), measure, tick + m_offset);
+            addElemOffset(elem, track, placement(), measure, tick + m_offset, m_pass2);
         }
     }
 
@@ -6161,7 +6185,7 @@ Note* MusicXMLParserPass2::note(const String& partId,
     String instrumentId;
     String tieType;
     MusicXMLParserLyric lyric { m_pass1.getMusicXmlPart(partId).lyricNumberHandler(), m_e, m_score, m_logger };
-    MusicXMLParserNotations notations { m_e, m_score, m_logger, m_pass1 };
+    MusicXMLParserNotations notations { m_e, m_score, m_logger, m_pass1, *this };
 
     MxmlNoteDuration mnd { m_divs, m_logger, &m_pass1 };
     MxmlNotePitch mnp { m_logger };
@@ -8148,8 +8172,9 @@ String Notation::print() const
 //   MusicXMLParserNotations
 //---------------------------------------------------------
 
-MusicXMLParserNotations::MusicXMLParserNotations(XmlStreamReader& e, Score* score, MxmlLogger* logger, MusicXMLParserPass1& pass1)
-    : m_e(e), m_pass1(pass1), m_score(score), m_logger(logger)
+MusicXMLParserNotations::MusicXMLParserNotations(XmlStreamReader& e, Score* score, MxmlLogger* logger, MusicXMLParserPass1& pass1,
+                                                 mu::engraving::MusicXMLParserPass2& pass2)
+    : m_e(e), m_pass1(pass1), m_pass2(pass2), m_score(score), m_logger(logger)
 {
     // nothing
 }
@@ -8301,7 +8326,7 @@ void MusicXMLParserNotations::addToScore(ChordRest* const cr, Note* const note, 
     for (const String& d : std::as_const(m_dynamicsList)) {
         Dynamic* dynamic = Factory::createDynamic(m_score->dummy()->segment());
         dynamic->setDynamicType(d);
-        addElemOffset(dynamic, cr->track(), m_dynamicsPlacement, cr->measure(), Fraction::fromTicks(tick));
+        addElemOffset(dynamic, cr->track(), m_dynamicsPlacement, cr->measure(), Fraction::fromTicks(tick), m_pass2);
     }
 }
 

--- a/src/importexport/musicxml/tests/data/testImportDrums_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testImportDrums_ref.mscx
@@ -288,11 +288,6 @@
             <followText>1</followText>
             <text><sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
-          <Tempo>
-            <tempo>2</tempo>
-            <followText>1</followText>
-            <text><sym>metNoteQuarterUp</sym> = 120</text>
-            </Tempo>
           <Chord>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>

--- a/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
@@ -208,15 +208,15 @@
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
-          <Tempo>
-            <tempo>0.583333</tempo>
-            <text><font size="12"/><b>Grave</b></text>
-            </Tempo>
           <Dynamic>
             <subtype>pp</subtype>
             <velocity>33</velocity>
             <direction>up</direction>
             </Dynamic>
+          <Tempo>
+            <tempo>0.583333</tempo>
+            <text><font size="12"/><b>Grave</b></text>
+            </Tempo>
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>

--- a/src/importexport/musicxml/tests/data/testSystemObjectStaves.xml
+++ b/src/importexport/musicxml/tests/data/testSystemObjectStaves.xml
@@ -1,0 +1,400 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Untitled score</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Composer / arranger</creator>
+    <encoding>
+      <software>MuseScore 4.4.0</software>
+      <encoding-date>2024-06-20</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>6.99911</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1696.94</page-height>
+      <page-width>1200.48</page-width>
+      <page-margins type="even">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <appearance>
+      <line-width type="light barline">1.8</line-width>
+      <line-width type="heavy barline">5.5</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="bracket">4.5</line-width>
+      <line-width type="dashes">1</line-width>
+      <line-width type="enclosure">1</line-width>
+      <line-width type="ending">1.1</line-width>
+      <line-width type="extend">1</line-width>
+      <line-width type="leger">1.6</line-width>
+      <line-width type="pedal">1.1</line-width>
+      <line-width type="octave shift">1.1</line-width>
+      <line-width type="slur middle">2.1</line-width>
+      <line-width type="slur tip">0.5</line-width>
+      <line-width type="staff">1.1</line-width>
+      <line-width type="stem">1</line-width>
+      <line-width type="tie middle">2.1</line-width>
+      <line-width type="tie tip">0.5</line-width>
+      <line-width type="tuplet bracket">1</line-width>
+      <line-width type="wedge">1.2</line-width>
+      <note-size type="cue">70</note-size>
+      <note-size type="grace">70</note-size>
+      <note-size type="grace-cue">49</note-size>
+      </appearance>
+    <music-font font-family="Leland"/>
+    <word-font font-family="Edwin" font-size="10"/>
+    <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+  <credit page="1">
+    <credit-type>title</credit-type>
+    <credit-words default-x="600.241935" default-y="1611.210312" justify="center" valign="top" font-size="22">Untitled score</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-type>subtitle</credit-type>
+    <credit-words default-x="600.241935" default-y="1554.060198" justify="center" valign="top" font-size="14">Subtitle</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-type>composer</credit-type>
+    <credit-words default-x="1114.7587" default-y="1511.210312" justify="right" valign="bottom">Composer / arranger</credit-words>
+    </credit>
+  <part-list>
+    <part-group type="start" number="1">
+      <group-symbol>bracket</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
+    <score-part id="P1">
+      <part-name>Flute</part-name>
+      <part-abbreviation>Fl.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Flute</instrument-name>
+        <instrument-sound>wind.flutes.flute</instrument-sound>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>74</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P2">
+      <part-name>Oboe</part-name>
+      <part-abbreviation>Ob.</part-abbreviation>
+      <score-instrument id="P2-I1">
+        <instrument-name>Oboe</instrument-name>
+        <instrument-sound>wind.reed.oboe</instrument-sound>
+        </score-instrument>
+      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-instrument id="P2-I1">
+        <midi-channel>2</midi-channel>
+        <midi-program>69</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P3">
+      <part-name>Clarinet in Bb</part-name>
+      <part-name-display>
+        <display-text>Clarinet in B</display-text>
+        <accidental-text>flat</accidental-text>
+        </part-name-display>
+      <part-abbreviation>Cl. in Bb</part-abbreviation>
+      <part-abbreviation-display>
+        <display-text>Cl. in B</display-text>
+        <accidental-text>flat</accidental-text>
+        </part-abbreviation-display>
+      <score-instrument id="P3-I1">
+        <instrument-name>Clarinet</instrument-name>
+        <instrument-sound>wind.reed.clarinet.bflat</instrument-sound>
+        </score-instrument>
+      <midi-device id="P3-I1" port="1"></midi-device>
+      <midi-instrument id="P3-I1">
+        <midi-channel>3</midi-channel>
+        <midi-program>72</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="1"/>
+    <score-part id="P4">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P4-I1">
+        <instrument-name>Piano</instrument-name>
+        <instrument-sound>keyboard.piano</instrument-sound>
+        </score-instrument>
+      <midi-device id="P4-I1" port="1"></midi-device>
+      <midi-instrument id="P4-I1">
+        <midi-channel>4</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="354.3">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>151.39</left-margin>
+            <right-margin>-0</right-margin>
+            </system-margins>
+          <top-system-distance>170</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" default-x="-37.68" relative-y="20">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>80</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="80"/>
+        </direction>
+      <note default-x="214.87" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2" width="257.07">
+      <direction placement="above" system="only-top">
+        <direction-type>
+          <rehearsal default-x="-13" relative-y="30" font-weight="bold" font-size="14">A</rehearsal>
+          </direction-type>
+        </direction>
+      <note default-x="121.14" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="3" width="266.27">
+      <note default-x="121.14" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P2">
+    <measure number="1" width="354.3">
+      <print>
+        <staff-layout number="1">
+          <staff-distance>96.08</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="214.87" default-y="-146.08">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2" width="257.07">
+      <note default-x="121.14" default-y="-146.08">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="3" width="266.27">
+      <note default-x="121.14" default-y="-146.08">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P3">
+    <measure number="1" width="354.3">
+      <print>
+        <staff-layout number="1">
+          <staff-distance>96.08</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>2</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>-1</diatonic>
+          <chromatic>-2</chromatic>
+          </transpose>
+        </attributes>
+      <note default-x="214.87" default-y="-282.16">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2" width="257.07">
+      <note default-x="121.14" default-y="-282.16">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="3" width="266.27">
+      <note default-x="121.14" default-y="-282.16">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P4">
+    <measure number="1" width="354.3">
+      <print>
+        <staff-layout number="1">
+          <staff-distance>115.29</staff-distance>
+          </staff-layout>
+        <staff-layout number="2">
+          <staff-distance>65</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note default-x="214.87" default-y="-437.45">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="214.87" default-y="-542.45">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="2" width="257.07">
+    <direction placement="above" system="only-top">
+      <direction-type>
+        <rehearsal default-x="-13" relative-y="30" font-weight="bold" font-size="14">A</rehearsal>
+        </direction-type>
+      </direction>
+      <note default-x="121.14" default-y="-437.45">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="121.14" default-y="-542.45">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="3" width="266.27">
+      <note default-x="121.14" default-y="-437.45">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="121.14" default-y="-542.45">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/data/testSystemObjectStaves.xml
+++ b/src/importexport/musicxml/tests/data/testSystemObjectStaves.xml
@@ -205,6 +205,11 @@
         </note>
       </measure>
     <measure number="3" width="266.27">
+    <direction placement="above">
+      <direction-type>
+        <words relative-y="10">Allegro</words>
+        </direction-type>
+      </direction>
       <note default-x="121.14" default-y="-10">
         <rest measure="yes"/>
         <duration>4</duration>
@@ -377,6 +382,11 @@
         </note>
       </measure>
     <measure number="3" width="266.27">
+    <direction placement="above">
+      <direction-type>
+        <words relative-y="10">Allegro</words>
+        </direction-type>
+      </direction>
       <note default-x="121.14" default-y="-437.45">
         <rest measure="yes"/>
         <duration>4</duration>

--- a/src/importexport/musicxml/tests/data/testSystemObjectStaves_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSystemObjectStaves_ref.mscx
@@ -1,0 +1,561 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.40">
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.26997</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.08887</pagePrintableWidth>
+      <pageEvenLeftMargin>0.590551</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.590551</pageOddLeftMargin>
+      <pageEvenTopMargin>0.590551</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
+      <pageOddTopMargin>0.590551</pageOddTopMargin>
+      <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
+      <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
+      <tupletFontSize>10</tupletFontSize>
+      <fingeringFontSize>10</fingeringFontSize>
+      <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
+      <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
+      <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
+      <partInstrumentFontSize>10</partInstrumentFontSize>
+      <tempoFontSize>10</tempoFontSize>
+      <tempoChangeFontSize>10</tempoChangeFontSize>
+      <metronomeFontSize>10</metronomeFontSize>
+      <measureNumberFontSize>10</measureNumberFontSize>
+      <mmRestRangeFontSize>10</mmRestRangeFontSize>
+      <rehearsalMarkFontSize>10</rehearsalMarkFontSize>
+      <repeatLeftFontSize>10</repeatLeftFontSize>
+      <repeatRightFontSize>10</repeatRightFontSize>
+      <glissandoFontSize>10</glissandoFontSize>
+      <bendFontSize>10</bendFontSize>
+      <headerFontSize>10</headerFontSize>
+      <footerFontSize>10</footerFontSize>
+      <Spatium>1.74978</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Composer / arranger</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Untitled score</metaTag>
+    <SystemObjects>
+      <Instance staffId="4" barNumbers="false"/>
+      </SystemObjects>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        <bracket type="0" span="3" col="0" visible="1"/>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <trackName>Flute</trackName>
+      <Instrument id="flute">
+        <longName>Flute</longName>
+        <shortName>Fl.</shortName>
+        <trackName>Flute</trackName>
+        <minPitchP>59</minPitchP>
+        <maxPitchP>98</maxPitchP>
+        <minPitchA>60</minPitchA>
+        <maxPitchA>93</maxPitchA>
+        <instrumentId>wind.flutes.flute</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="73"/>
+          <controller ctrl="10" value="63"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part id="2">
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <trackName>Oboe</trackName>
+      <Instrument id="oboe">
+        <longName>Oboe</longName>
+        <shortName>Ob.</shortName>
+        <trackName>Oboe</trackName>
+        <minPitchP>58</minPitchP>
+        <maxPitchP>96</maxPitchP>
+        <minPitchA>58</minPitchA>
+        <maxPitchA>87</maxPitchA>
+        <instrumentId>wind.reed.oboe</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="68"/>
+          <controller ctrl="10" value="63"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part id="3">
+      <Staff id="3">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        </Staff>
+      <trackName>Clarinet in B♭</trackName>
+      <Instrument id="bb-clarinet">
+        <longName>Clarinet in B♭</longName>
+        <shortName>Cl. in B♭</shortName>
+        <trackName>Clarinet</trackName>
+        <minPitchP>50</minPitchP>
+        <maxPitchP>94</maxPitchP>
+        <minPitchA>50</minPitchA>
+        <maxPitchA>89</maxPitchA>
+        <transposeDiatonic>-1</transposeDiatonic>
+        <transposeChromatic>-2</transposeChromatic>
+        <instrumentId>wind.reed.clarinet.bflat</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="71"/>
+          <controller ctrl="10" value="63"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part id="4">
+      <Staff id="4">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        <bracket type="1" span="2" col="1" visible="1"/>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <Staff id="5">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument id="piano">
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <controller ctrl="10" value="63"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>12.5</height>
+        <Text>
+          <style>title</style>
+          <offset x="0" y="-0.0367999"/>
+          <text><font size="22"/>Untitled score</text>
+          </Text>
+        <Text>
+          <style>subtitle</style>
+          <offset x="0" y="9.9632"/>
+          <text><font size="14"/>Subtitle</text>
+          </Text>
+        <Text>
+          <style>composer</style>
+          <text>Composer / arranger</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Tempo>
+            <tempo>1.333333</tempo>
+            <followText>1</followText>
+            <linkedMain/>
+            <text><sym>metNoteQuarterUp</sym> = 80</text>
+            </Tempo>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <RehearsalMark>
+            <linkedMain/>
+            <text><font size="14"/><b>A</b></text>
+            </RehearsalMark>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="2">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="3">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <KeySig>
+            <concertKey>0</concertKey>
+            <actualKey>2</actualKey>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="4">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Tempo>
+            <tempo>1.333333</tempo>
+            <followText>1</followText>
+            <linked>
+              <location>
+                <staves>-3</staves>
+                </location>
+              </linked>
+            <text><sym>metNoteQuarterUp</sym> = 80</text>
+            </Tempo>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <RehearsalMark>
+            <linked>
+              <location>
+                <staves>-3</staves>
+                </location>
+              </linked>
+            <text><font size="14"/><b>A</b></text>
+            </RehearsalMark>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="5">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>F</concertClefType>
+            <transposingClefType>F</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/importexport/musicxml/tests/data/testSystemObjectStaves_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSystemObjectStaves_ref.mscx
@@ -373,6 +373,11 @@
         </Measure>
       <Measure>
         <voice>
+          <Tempo>
+            <tempo>2</tempo>
+            <linkedMain/>
+            <text>Allegro</text>
+            </Tempo>
           <Rest>
             <durationType>measure</durationType>
             <duration>1/1</duration>
@@ -509,6 +514,15 @@
         </Measure>
       <Measure>
         <voice>
+          <Tempo>
+            <tempo>2</tempo>
+            <linked>
+              <location>
+                <staves>-3</staves>
+                </location>
+              </linked>
+            <text>Allegro</text>
+            </Tempo>
           <Rest>
             <durationType>measure</durationType>
             <duration>1/1</duration>

--- a/src/importexport/musicxml/tests/data/testTempo1.xml
+++ b/src/importexport/musicxml/tests/data/testTempo1.xml
@@ -241,15 +241,6 @@
           </direction-type>
         <sound tempo="120"/>
         </direction>
-      <direction placement="above">
-        <direction-type>
-          <metronome parentheses="yes">
-            <beat-unit>quarter</beat-unit>
-            <per-minute>126</per-minute>
-            </metronome>
-          </direction-type>
-        <sound tempo="126"/>
-        </direction>
       <note>
         <pitch>
           <step>B</step>

--- a/src/importexport/musicxml/tests/data/testTempo3_ref.xml
+++ b/src/importexport/musicxml/tests/data/testTempo3_ref.xml
@@ -51,17 +51,17 @@
         </attributes>
       <direction placement="above">
         <direction-type>
+          <words>Swing!</words>
+          </direction-type>
+        </direction>
+      <direction placement="above">
+        <direction-type>
           <metronome parentheses="no">
             <beat-unit>half</beat-unit>
             <per-minute>80</per-minute>
             </metronome>
           </direction-type>
         <sound tempo="160"/>
-        </direction>
-      <direction placement="above">
-        <direction-type>
-          <words>Swing!</words>
-          </direction-type>
         </direction>
       <note>
         <pitch>

--- a/src/importexport/musicxml/tests/data/testTempo4_ref.xml
+++ b/src/importexport/musicxml/tests/data/testTempo4_ref.xml
@@ -102,6 +102,15 @@
           <line>2</line>
           </clef>
         </attributes>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>80</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="80"/>
+        </direction>
       <note>
         <pitch>
           <step>G</step>

--- a/src/importexport/musicxml/tests/data/testTempoOverlap_ref.xml
+++ b/src/importexport/musicxml/tests/data/testTempoOverlap_ref.xml
@@ -74,15 +74,6 @@
         </attributes>
       <direction placement="above">
         <direction-type>
-          <metronome parentheses="no">
-            <beat-unit>quarter</beat-unit>
-            <per-minute>81</per-minute>
-            </metronome>
-          </direction-type>
-        <sound tempo="81"/>
-        </direction>
-      <direction placement="above">
-        <direction-type>
           <words>Voice</words>
           </direction-type>
         </direction>
@@ -90,6 +81,15 @@
         <direction-type>
           <words>Direction metronome with sound tempo</words>
           </direction-type>
+        </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>81</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="81"/>
         </direction>
       <note>
         <rest measure="yes"/>
@@ -149,17 +149,17 @@
       <print new-system="yes"/>
       <direction placement="above">
         <direction-type>
+          <words>Voice</words>
+          </direction-type>
+        </direction>
+      <direction placement="above">
+        <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
             <per-minute>85</per-minute>
             </metronome>
           </direction-type>
         <sound tempo="85"/>
-        </direction>
-      <direction placement="above">
-        <direction-type>
-          <words>Voice</words>
-          </direction-type>
         </direction>
       <note>
         <rest measure="yes"/>
@@ -186,17 +186,17 @@
     <measure number="7">
       <direction placement="above">
         <direction-type>
+          <words>Voice</words>
+          </direction-type>
+        </direction>
+      <direction placement="above">
+        <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
             <per-minute>87</per-minute>
             </metronome>
           </direction-type>
         <sound tempo="87"/>
-        </direction>
-      <direction placement="above">
-        <direction-type>
-          <words>Voice</words>
-          </direction-type>
         </direction>
       <note>
         <rest measure="yes"/>
@@ -246,15 +246,6 @@
       <print new-system="yes"/>
       <direction placement="above">
         <direction-type>
-          <metronome parentheses="no" print-object="no">
-            <beat-unit>quarter</beat-unit>
-            <per-minute>81</per-minute>
-            </metronome>
-          </direction-type>
-        <sound tempo="81"/>
-        </direction>
-      <direction placement="above">
-        <direction-type>
           <words>Voice</words>
           </direction-type>
         </direction>
@@ -262,6 +253,15 @@
         <direction-type>
           <words>Sound tempo only</words>
           </direction-type>
+        </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>81</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="81"/>
         </direction>
       <note>
         <rest measure="yes"/>
@@ -321,17 +321,17 @@
       <print new-system="yes"/>
       <direction placement="above">
         <direction-type>
+          <words>Voice</words>
+          </direction-type>
+        </direction>
+      <direction placement="above">
+        <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
             <per-minute>85</per-minute>
             </metronome>
           </direction-type>
         <sound tempo="85"/>
-        </direction>
-      <direction placement="above">
-        <direction-type>
-          <words>Voice</words>
-          </direction-type>
         </direction>
       <note>
         <rest measure="yes"/>
@@ -358,17 +358,17 @@
     <measure number="16">
       <direction placement="above">
         <direction-type>
+          <words>Voice</words>
+          </direction-type>
+        </direction>
+      <direction placement="above">
+        <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
             <per-minute>87</per-minute>
             </metronome>
           </direction-type>
         <sound tempo="87"/>
-        </direction>
-      <direction placement="above">
-        <direction-type>
-          <words>Voice</words>
-          </direction-type>
         </direction>
       <note>
         <rest measure="yes"/>
@@ -401,6 +401,16 @@
           <line>4</line>
           </clef>
         </attributes>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>81</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>1</staff>
+        <sound tempo="81"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -410,6 +420,16 @@
       <backup>
         <duration>4</duration>
         </backup>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>81</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>2</staff>
+        <sound tempo="81"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -424,6 +444,16 @@
           </direction-type>
         <staff>1</staff>
         </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>82</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>1</staff>
+        <sound tempo="82"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -433,6 +463,16 @@
       <backup>
         <duration>4</duration>
         </backup>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>82</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>2</staff>
+        <sound tempo="82"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -441,6 +481,16 @@
         </note>
       </measure>
     <measure number="3">
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>83</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>1</staff>
+        <sound tempo="83"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -456,6 +506,16 @@
           </direction-type>
         <staff>2</staff>
         </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>83</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>2</staff>
+        <sound tempo="83"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -464,6 +524,16 @@
         </note>
       </measure>
     <measure number="4">
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>84</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>1</staff>
+        <sound tempo="84"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -473,6 +543,16 @@
       <backup>
         <duration>4</duration>
         </backup>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>84</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>2</staff>
+        <sound tempo="84"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -482,6 +562,16 @@
       </measure>
     <measure number="5">
       <print new-system="yes"/>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>85</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>1</staff>
+        <sound tempo="85"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -491,6 +581,16 @@
       <backup>
         <duration>4</duration>
         </backup>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>85</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>2</staff>
+        <sound tempo="85"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -505,6 +605,16 @@
           </direction-type>
         <staff>1</staff>
         </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>86</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>1</staff>
+        <sound tempo="86"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -519,6 +629,16 @@
           <words>Piano lower</words>
           </direction-type>
         <staff>2</staff>
+        </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>86</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>2</staff>
+        <sound tempo="86"/>
         </direction>
       <note>
         <rest measure="yes"/>
@@ -534,6 +654,16 @@
           </direction-type>
         <staff>1</staff>
         </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>87</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>1</staff>
+        <sound tempo="87"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -543,6 +673,16 @@
       <backup>
         <duration>4</duration>
         </backup>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>87</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>2</staff>
+        <sound tempo="87"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -558,6 +698,16 @@
           </direction-type>
         <staff>1</staff>
         </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>81</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>1</staff>
+        <sound tempo="81"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -567,6 +717,16 @@
       <backup>
         <duration>4</duration>
         </backup>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>81</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>2</staff>
+        <sound tempo="81"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -581,6 +741,16 @@
           </direction-type>
         <staff>1</staff>
         </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>82</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>1</staff>
+        <sound tempo="82"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -596,6 +766,16 @@
           </direction-type>
         <staff>2</staff>
         </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>82</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>2</staff>
+        <sound tempo="82"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -605,6 +785,16 @@
       </measure>
     <measure number="10">
       <print new-system="yes"/>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>81</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>1</staff>
+        <sound tempo="81"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -614,6 +804,16 @@
       <backup>
         <duration>4</duration>
         </backup>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>81</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>2</staff>
+        <sound tempo="81"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -628,6 +828,16 @@
           </direction-type>
         <staff>1</staff>
         </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>82</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>1</staff>
+        <sound tempo="82"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -637,6 +847,16 @@
       <backup>
         <duration>4</duration>
         </backup>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>82</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>2</staff>
+        <sound tempo="82"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -645,6 +865,16 @@
         </note>
       </measure>
     <measure number="12">
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>83</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>1</staff>
+        <sound tempo="83"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -660,6 +890,16 @@
           </direction-type>
         <staff>2</staff>
         </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>83</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>2</staff>
+        <sound tempo="83"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -668,6 +908,16 @@
         </note>
       </measure>
     <measure number="13">
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>84</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>1</staff>
+        <sound tempo="84"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -677,6 +927,16 @@
       <backup>
         <duration>4</duration>
         </backup>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>84</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>2</staff>
+        <sound tempo="84"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -686,6 +946,16 @@
       </measure>
     <measure number="14">
       <print new-system="yes"/>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>85</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>1</staff>
+        <sound tempo="85"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -695,6 +965,16 @@
       <backup>
         <duration>4</duration>
         </backup>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>85</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>2</staff>
+        <sound tempo="85"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -709,6 +989,16 @@
           </direction-type>
         <staff>1</staff>
         </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>86</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>1</staff>
+        <sound tempo="86"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -723,6 +1013,16 @@
           <words>Piano lower</words>
           </direction-type>
         <staff>2</staff>
+        </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>86</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>2</staff>
+        <sound tempo="86"/>
         </direction>
       <note>
         <rest measure="yes"/>
@@ -738,6 +1038,16 @@
           </direction-type>
         <staff>1</staff>
         </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>87</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>1</staff>
+        <sound tempo="87"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -747,6 +1057,16 @@
       <backup>
         <duration>4</duration>
         </backup>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>87</per-minute>
+            </metronome>
+          </direction-type>
+        <staff>2</staff>
+        <sound tempo="87"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -779,6 +1099,15 @@
           <octave-change>-1</octave-change>
           </transpose>
         </attributes>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>81</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="81"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -786,6 +1115,15 @@
         </note>
       </measure>
     <measure number="2">
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>82</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="82"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -793,6 +1131,15 @@
         </note>
       </measure>
     <measure number="3">
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>83</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="83"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -804,6 +1151,15 @@
         <direction-type>
           <words>Bass</words>
           </direction-type>
+        </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>84</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="84"/>
         </direction>
       <note>
         <rest measure="yes"/>
@@ -818,6 +1174,15 @@
           <words>Bass</words>
           </direction-type>
         </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>85</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="85"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -825,6 +1190,15 @@
         </note>
       </measure>
     <measure number="6">
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>86</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="86"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -837,6 +1211,15 @@
           <words>Bass</words>
           </direction-type>
         </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>87</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="87"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -845,6 +1228,15 @@
       </measure>
     <measure number="8">
       <print new-system="yes"/>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>81</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="81"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -852,6 +1244,15 @@
         </note>
       </measure>
     <measure number="9">
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>82</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="82"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -860,6 +1261,15 @@
       </measure>
     <measure number="10">
       <print new-system="yes"/>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>81</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="81"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -867,6 +1277,15 @@
         </note>
       </measure>
     <measure number="11">
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>82</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="82"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -874,6 +1293,15 @@
         </note>
       </measure>
     <measure number="12">
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>83</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="83"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -885,6 +1313,15 @@
         <direction-type>
           <words>Bass</words>
           </direction-type>
+        </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>84</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="84"/>
         </direction>
       <note>
         <rest measure="yes"/>
@@ -899,6 +1336,15 @@
           <words>Bass</words>
           </direction-type>
         </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>85</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="85"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -906,6 +1352,15 @@
         </note>
       </measure>
     <measure number="15">
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>86</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="86"/>
+        </direction>
       <note>
         <rest measure="yes"/>
         <duration>4</duration>
@@ -917,6 +1372,15 @@
         <direction-type>
           <words>Bass</words>
           </direction-type>
+        </direction>
+      <direction placement="above">
+        <direction-type>
+          <metronome parentheses="no" print-object="no">
+            <beat-unit>quarter</beat-unit>
+            <per-minute>87</per-minute>
+            </metronome>
+          </direction-type>
+        <sound tempo="87"/>
         </direction>
       <note>
         <rest measure="yes"/>

--- a/src/importexport/musicxml/tests/data/testTextOrder_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTextOrder_ref.mscx
@@ -150,14 +150,14 @@
           <StaffText>
             <text>3rd time senza Invisalign</text>
             </StaffText>
-          <Tempo>
-            <tempo>2</tempo>
-            <text><font size="12"/><b>Straight</b></text>
-            </Tempo>
           <Expression>
             <direction>down</direction>
             <text><i>Cantabile</i></text>
             </Expression>
+          <Tempo>
+            <tempo>2</tempo>
+            <text><font size="12"/><b>Straight</b></text>
+            </Tempo>
           <Beam>
             <StemDirection>down</StemDirection>
             <l1>44</l1>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -1058,6 +1058,9 @@ TEST_F(Musicxml_Tests, DISABLED_EXCEPT_ON_LINUX(systemDistance)) {
 TEST_F(Musicxml_Tests, DISABLED_EXCEPT_ON_LINUX(systemDividers)) {
     mxmlIoTest("testSystemDividers", true);
 }
+TEST_F(Musicxml_Tests, systemObjectStaves) {
+    mxmlImportTestRef("testSystemObjectStaves");
+}
 TEST_F(Musicxml_Tests, tablature1) {
     mxmlIoTest("testTablature1");
 }


### PR DESCRIPTION
When a system level element is read, the stave is added to the score's list of system object staves.  System objects are added at the very end of score reading, so we can be sure that all system object staves have been identified.
In the example below, the tempo text was only included on the first stave in the XML, while the rehearsal mark was included on both staves.  This turns the piano stave into a system object stave, so the tempo text is duplicated there as well.
<img width="650" alt="Screenshot 2024-06-20 at 09 35 32" src="https://github.com/musescore/MuseScore/assets/26510874/9bc0d76f-06a4-40c1-974f-d7f32cbe0361">
