### PR TITLE
Fix spacing glitches caused by anchors

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -2703,6 +2703,11 @@ void EngravingItem::LayoutData::doSetPosDebugHook(double x, double y)
     UNUSED(y);
 }
 
+void EngravingItem::LayoutData::setWidthDebugHook(double w)
+{
+    UNUSED(w);
+}
+
 #endif
 
 void EngravingItem::LayoutData::dump(std::stringstream& ss) const

--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -568,6 +568,9 @@ public:
 
         void setWidth(double v)
         {
+#ifndef NDEBUG
+            setWidthDebugHook(v);
+#endif
             RectF r = bbox();
             r.setWidth(v);
             setBbox(r);
@@ -601,6 +604,7 @@ public:
 
 #ifndef NDEBUG
         void doSetPosDebugHook(double x, double y);
+        void setWidthDebugHook(double w);
 #endif
 
         inline void doSetPos(double x, double y)

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -3388,10 +3388,10 @@ void Measure::respaceSegments()
         }
     }
     // Start respacing segments
-    for (Segment& s : m_segments) {
-        s.mutldata()->setPosX(x);
-        if (s.enabled() && s.visible() && !s.allElementsInvisible()) {
-            x += s.width(LD_ACCESS::BAD);
+    for (Segment* s = firstActive(); s; s = s->nextActive()) {
+        s->mutldata()->setPosX(x);
+        if (s->enabled() && s->visible() && !s->allElementsInvisible()) {
+            x += s->width(LD_ACCESS::BAD);
         }
     }
     // Update measure width

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -3388,10 +3388,13 @@ void Measure::respaceSegments()
         }
     }
     // Start respacing segments
-    for (Segment* s = firstActive(); s; s = s->nextActive()) {
-        s->mutldata()->setPosX(x);
-        if (s->enabled() && s->visible() && !s->allElementsInvisible()) {
-            x += s->width(LD_ACCESS::BAD);
+    for (Segment& s : m_segments) {
+        if (s.isTimeTickType()) {
+            continue;
+        }
+        s.mutldata()->setPosX(x);
+        if (s.enabled() && s.visible() && !s.allElementsInvisible()) {
+            x += s.width(LD_ACCESS::BAD);
         }
     }
     // Update measure width

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -3116,19 +3116,23 @@ String Measure::accessibleInfo() const
 
 void Measure::computeTicks()
 {
-    for (Segment* segment = firstEnabled(); segment; segment = segment->nextActive()) {
+    for (Segment* segment = firstActive(); segment; segment = segment->nextActive()) {
         Segment* nextSegment = segment->nextActive();
-        if (segment->isTimeTickType()) {
-            while (nextSegment && nextSegment->rtick() == segment->rtick()) {
-                nextSegment = nextSegment->nextActive();
-            }
-        } else {
-            while (nextSegment && nextSegment->isTimeTickType()) {
-                nextSegment = nextSegment->nextActive();
-            }
-        }
         Fraction nextTick = nextSegment ? nextSegment->rtick() : ticks();
         segment->setTicks(nextTick - segment->rtick());
+    }
+
+    for (Segment* segment = first(SegmentType::TimeTick); segment; segment = segment->next(SegmentType::TimeTick)) {
+        segment->setTicks(Fraction(0, 1));
+        Segment* nextSegment = segment->next();
+        while (nextSegment) {
+            Fraction tickDiff = nextSegment->rtick() - segment->rtick();
+            if (!tickDiff.isZero()) {
+                segment->setTicks(tickDiff);
+                break;
+            }
+            nextSegment = nextSegment->next();
+        }
     }
 }
 

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -3386,7 +3386,7 @@ void Measure::respaceSegments()
     // Start respacing segments
     for (Segment& s : m_segments) {
         s.mutldata()->setPosX(x);
-        if (s.enabled() && s.visible() && !s.allElementsInvisible() && !s.isTimeTickType()) {
+        if (s.enabled() && s.visible() && !s.allElementsInvisible()) {
             x += s.width(LD_ACCESS::BAD);
         }
     }

--- a/src/engraving/dom/measure.h
+++ b/src/engraving/dom/measure.h
@@ -204,6 +204,7 @@ public:
     Segment* first() const { return m_segments.first(); }
     Segment* first(SegmentType t) const { return m_segments.first(t); }
     Segment* firstEnabled() const { return m_segments.first(ElementFlag::ENABLED); }
+    Segment* firstActive() const { return m_segments.firstActive(); }
 
     Segment* last() const { return m_segments.last(); }
     Segment* lastEnabled() const { return m_segments.last(ElementFlag::ENABLED); }

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -515,6 +515,42 @@ Segment* Segment::prev1MM(SegmentType types) const
     return 0;
 }
 
+Segment* Segment::nextActive() const
+{
+    Segment* ns = next();
+    while (ns && !ns->isActive()) {
+        ns = ns->next();
+    }
+    return ns;
+}
+
+Segment* Segment::nextEnabled() const
+{
+    Segment* ns = next();
+    while (ns && !ns->enabled()) {
+        ns = ns->next();
+    }
+    return ns;
+}
+
+Segment* Segment::prevActive() const
+{
+    Segment* ps = prev();
+    while (ps && !ps->isActive()) {
+        ps = ps->prev();
+    }
+    return ps;
+}
+
+Segment* Segment::prevEnabled() const
+{
+    Segment* ps = prev();
+    while (ps && !ps->enabled()) {
+        ps = ps->prev();
+    }
+    return ps;
+}
+
 //---------------------------------------------------------
 //   nextCR
 //    get next ChordRest Segment

--- a/src/engraving/dom/segment.h
+++ b/src/engraving/dom/segment.h
@@ -102,6 +102,8 @@ public:
 
     void setScore(Score*) override;
 
+    inline bool isActive() const { return !isTimeTickType() && enabled() && visible(); }
+
     Segment* next() const { return m_next; }
     Segment* next(SegmentType) const;
     Segment* nextActive() const;
@@ -333,58 +335,6 @@ private:
 
     CrossBeamType m_crossBeamType; // Will affect segment-to-segment horizontal spacing
 };
-
-//---------------------------------------------------------
-//   nextActive
-//---------------------------------------------------------
-
-inline Segment* Segment::nextActive() const
-{
-    Segment* ns = next();
-    while (ns && !(ns->enabled() && ns->visible())) {
-        ns = ns->next();
-    }
-    return ns;
-}
-
-//---------------------------------------------------------
-//   nextEnabled
-//---------------------------------------------------------
-
-inline Segment* Segment::nextEnabled() const
-{
-    Segment* ns = next();
-    while (ns && !ns->enabled()) {
-        ns = ns->next();
-    }
-    return ns;
-}
-
-//---------------------------------------------------------
-//   prevActive
-//---------------------------------------------------------
-
-inline Segment* Segment::prevActive() const
-{
-    Segment* ps = prev();
-    while (ps && !(ps->enabled() && ps->visible())) {
-        ps = ps->prev();
-    }
-    return ps;
-}
-
-//---------------------------------------------------------
-//   prevEnabled
-//---------------------------------------------------------
-
-inline Segment* Segment::prevEnabled() const
-{
-    Segment* ps = prev();
-    while (ps && !ps->enabled()) {
-        ps = ps->prev();
-    }
-    return ps;
-}
 } // namespace mu::engraving
 
 #ifndef NO_QT_SUPPORT

--- a/src/engraving/dom/segmentlist.cpp
+++ b/src/engraving/dom/segmentlist.cpp
@@ -46,6 +46,15 @@ SegmentList SegmentList::clone() const
     return dl;
 }
 
+Segment* SegmentList::firstActive() const
+{
+    Segment* segment = m_first;
+    if (segment->isActive()) {
+        return segment;
+    }
+    return segment->nextActive();
+}
+
 //---------------------------------------------------------
 //   check
 //---------------------------------------------------------

--- a/src/engraving/dom/segmentlist.h
+++ b/src/engraving/dom/segmentlist.h
@@ -46,6 +46,7 @@ public:
     int size() const { return m_size; }
 
     Segment* first() const { return m_first; }
+    Segment* firstActive() const;
     Segment* first(SegmentType) const;
     Segment* first(ElementFlag) const;
 

--- a/src/engraving/rendering/dev/horizontalspacing.cpp
+++ b/src/engraving/rendering/dev/horizontalspacing.cpp
@@ -256,13 +256,13 @@ void HorizontalSpacing::spaceRightAlignedSegments(Measure* m, double segmentShap
     for (Segment* raSegment : rightAlignedSegments) {
         // 1) right-align the segment against the following ones
         double minDistAfter = -DBL_MAX;
-        for (Segment* seg = raSegment->next(); seg; seg = seg->next()) {
+        for (Segment* seg = raSegment->nextActive(); seg; seg = seg->nextActive()) {
             double xDiff = seg->x() - raSegment->x();
             double minDist = minHorizontalCollidingDistance(raSegment, seg, segmentShapeSqueezeFactor);
             minDistAfter = std::max(minDistAfter, minDist - xDiff);
         }
         if (minDistAfter != -DBL_MAX && raSegment->prevActive()) {
-            Segment* prevSegment = raSegment->prev();
+            Segment* prevSegment = raSegment->prevActive();
             prevSegment->setWidth(prevSegment->width() - minDistAfter);
             prevSegment->setWidthOffset(prevSegment->widthOffset() - minDistAfter);
             raSegment->mutldata()->moveX(-minDistAfter);
@@ -279,7 +279,7 @@ void HorizontalSpacing::spaceRightAlignedSegments(Measure* m, double segmentShap
         if (prevSegment) {
             prevSegment->setWidth(prevSegment->width() + minDistBefore);
         }
-        for (Segment* seg = raSegment; seg; seg = seg->next()) {
+        for (Segment* seg = raSegment; seg; seg = seg->nextActive()) {
             seg->mutldata()->moveX(minDistBefore);
         }
         m->setWidth(m->width() + minDistBefore);

--- a/src/engraving/rendering/dev/measurelayout.cpp
+++ b/src/engraving/rendering/dev/measurelayout.cpp
@@ -2143,7 +2143,7 @@ void MeasureLayout::computeWidth(Measure* m, LayoutContext& ctx, Fraction minTic
     Segment* s = nullptr;
 
     // skip disabled segment
-    for (s = m->first(); s && (!s->enabled() || s->allElementsInvisible()); s = s->next()) {
+    for (s = m->first(); s && (!s->enabled() || !s->isActive() || s->allElementsInvisible()); s = s->next()) {
         s->mutldata()->setPosX(HorizontalSpacing::computeFirstSegmentXPosition(m, s, ctx.state().segmentShapeSqueezeFactor()));  // this is where placement of hidden key/time sigs is set
         s->setWidth(0);                                // it shouldn't affect the width of the bar no matter what it is
     }
@@ -2232,6 +2232,11 @@ void MeasureLayout::computeWidth(Measure* m, LayoutContext& ctx, Segment* s, dou
     }
     // PASS 1: compute the spacing of all left-aligned segments by stacking them one after the other
     while (s) {
+        if (s->isTimeTickType()) {
+            s = s->next();
+            continue;
+        }
+
         s->setWidthOffset(0.0);
         s->mutldata()->setPosX(x);
         // skip disabled / invisible segments

--- a/src/engraving/rendering/dev/measurelayout.cpp
+++ b/src/engraving/rendering/dev/measurelayout.cpp
@@ -2239,8 +2239,7 @@ void MeasureLayout::computeWidth(Measure* m, LayoutContext& ctx, Segment* s, dou
         // skipped in computeMinWidth() -- the only way this would be an issue here is
         // if this method was called specifically with the invisible segment specified
         // which I'm pretty sure doesn't happen at this point. still...
-        if (!s->enabled() || !s->visible() || s->allElementsInvisible() || (s->isRightAligned() && s != m->firstEnabled())
-            || s->isTimeTickType()) {
+        if (!s->enabled() || !s->visible() || s->allElementsInvisible() || (s->isRightAligned() && s != m->firstEnabled())) {
             s->setWidth(0);
             s = s->next();
             continue;


### PR DESCRIPTION
This PR ensures that anchors are completely invisible for the horizontal spacing system, by making sure that TimeTick segments are always skipped/ignored where relevant. Anchors should be touched only _after_ we know all the spacing.

Resolves:
![image](https://github.com/musescore/MuseScore/assets/93707756/4b57d31b-9f4f-4be8-a140-1bf57c7dac60)
