### PR TITLE
Don't draw anchor lines during text editing

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3541,7 +3541,7 @@ void NotationInteraction::editElement(QKeyEvent* event)
         if (!isShiftRelease) {
             if (isGripEditStarted()) {
                 updateGripAnchorLines();
-            } else if (isElementEditStarted()) {
+            } else if (isElementEditStarted() && !m_editData.editTextualProperties) {
                 updateDragAnchorLines();
             }
         }


### PR DESCRIPTION
Resolves: #23322 

Anchor lines shouldn't be drawn we the user is inside textual edit.