### PR TITLE
feat: add "displayed measure" in status bar

### DIFF
--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -489,7 +489,13 @@ public:
     bool colorsInversionEnabled() const;
     void setColorsInverionEnabled(bool enabled);
 
-    std::pair<int, float> barbeat() const;
+    struct BarBeat
+    {
+        int bar;
+        int displayedBar;
+        double beat;
+    };
+    BarBeat barbeat() const;
 
     virtual EngravingItem* findLinkedInScore(const Score* score) const;
     EngravingItem* findLinkedInStaff(const Staff* staff) const;

--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -1511,16 +1511,28 @@ String SpannerSegment::formatBarsAndBeats() const
 
 String SpannerSegment::formatStartBarsAndBeats(const Segment* segment) const
 {
-    std::pair<int, float> barbeat = segment->barbeat();
-    return muse::mtrc("engraving", "Start measure: %1; Start beat: %2")
-           .arg(String::number(barbeat.first), String::number(barbeat.second));
+    EngravingItem::BarBeat barbeat = segment->barbeat();
+    String result = muse::mtrc("engraving", "Start measure: %1").arg(String::number(barbeat.bar));
+
+    if (barbeat.displayedBar != barbeat.bar) {
+        result += u"; " + muse::mtrc("engraving", "Start displayed measure: %1").arg(barbeat.displayedBar);
+    }
+
+    result += u"; " + muse::mtrc("engraving", "Start beat: %1").arg(barbeat.beat);
+    return result;
 }
 
 String SpannerSegment::formatEndBarsAndBeats(const Segment* segment) const
 {
-    std::pair<int, float> barbeat = segment->barbeat();
-    return muse::mtrc("engraving", "End measure: %1; End beat: %2")
-           .arg(String::number(barbeat.first), String::number(barbeat.second));
+    EngravingItem::BarBeat barbeat = segment->barbeat();
+    String result = muse::mtrc("engraving", "End measure: %1").arg(String::number(barbeat.bar));
+
+    if (barbeat.displayedBar != barbeat.bar) {
+        result += u"; " + muse::mtrc("engraving", "End displayed measure: %1").arg(barbeat.displayedBar);
+    }
+
+    result += u"; " + muse::mtrc("engraving", "End beat: %1").arg(barbeat.beat);
+    return result;
 }
 
 //---------------------------------------------------------

--- a/src/notation/internal/notationaccessibility.cpp
+++ b/src/notation/internal/notationaccessibility.cpp
@@ -165,15 +165,20 @@ QString NotationAccessibility::rangeAccessibilityInfo() const
         endSegment = endSegment->prev1MM();
     }
 
-    std::pair<int, float> startBarbeat = selection()->startSegment()->barbeat();
-    QString start =  muse::qtrc("notation", "Start measure: %1; Start beat: %2")
-                    .arg(startBarbeat.first)
-                    .arg(startBarbeat.second);
+    EngravingItem::BarBeat startBarbeat = selection()->startSegment()->barbeat();
 
-    std::pair<int, float> endBarbeat = endSegment->barbeat();
-    QString end =  muse::qtrc("notation", "End measure: %1; End beat: %2")
-                  .arg(endBarbeat.first)
-                  .arg(endBarbeat.second);
+    QString start = muse::qtrc("engraving", "Start measure: %1").arg(String::number(startBarbeat.bar));
+    if (startBarbeat.displayedBar != startBarbeat.bar) {
+        start += u"; " + muse::qtrc("engraving", "Start displayed measure: %1").arg(startBarbeat.displayedBar);
+    }
+    start += u"; " + muse::qtrc("engraving", "Start beat: %1").arg(startBarbeat.beat);
+
+    EngravingItem::BarBeat endBarbeat = endSegment->barbeat();
+    QString end = muse::qtrc("engraving", "End measure: %1").arg(String::number(endBarbeat.bar));
+    if (endBarbeat.displayedBar != endBarbeat.bar) {
+        end += u"; " + muse::qtrc("engraving", "End displayed measure: %1").arg(endBarbeat.displayedBar);
+    }
+    end += u"; " + muse::qtrc("engraving", "End beat: %1").arg(endBarbeat.beat);
 
     return muse::qtrc("notation", "Range selection; %1; %2")
            .arg(start)


### PR DESCRIPTION
Resolves: #22755 

<!-- Add a short description of and motivation for the changes here -->
When a bar number is changed manually, display an additional entry in the status bar. This only applies to bars with a different internal bar number and displayed bar number.

<img width="1365" alt="Screenshot 2024-06-22 at 13 29 22" src="https://github.com/musescore/MuseScore/assets/26880953/d24bcd7f-0001-4dea-ac33-88dd5baab17d">

_When selecting a range of measures_


<img width="1378" alt="Screenshot 2024-06-22 at 13 35 53" src="https://github.com/musescore/MuseScore/assets/26880953/98739b76-5418-4418-bce2-a3824b35798f">

_When selecting a single element inside a measure_


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
