### PR TITLE
Fix cross system anchors issues

### DIFF
--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -726,10 +726,10 @@ void Dynamic::editDrag(EditData& ed)
     KeyboardModifiers km = ed.modifiers;
     if (km != (ShiftModifier | ControlModifier)) {
         staff_idx_t si = staffIdx();
-        Segment* seg = segment();
-        static constexpr double spacingFactor = 1.0;
+        Segment* seg = nullptr; // don't prefer any segment while dragging, just snap to the closest
+        static constexpr double spacingFactor = 0.5;
         score()->dragPosition(canvasPos(), &si, &seg, spacingFactor, allowTimeAnchor());
-        if (seg != segment() || staffIdx() != si) {
+        if (seg && seg != segment() || staffIdx() != si) {
             const PointF oldOffset = offset();
             PointF pos1(canvasPos());
             score()->undoChangeParent(this, seg, staffIdx());

--- a/src/engraving/dom/dynamic.h
+++ b/src/engraving/dom/dynamic.h
@@ -113,6 +113,8 @@ public:
     Expression* snappedExpression() const;
     HairpinSegment* findSnapBeforeHairpinAcrossSystemBreak() const;
 
+    void undoMoveSegment(Segment* newSeg, Fraction tickDiff);
+
     bool playDynamic() const { return m_playDynamic; }
     void setPlayDynamic(bool v) { m_playDynamic = v; }
 

--- a/src/engraving/dom/dynamic.h
+++ b/src/engraving/dom/dynamic.h
@@ -111,6 +111,7 @@ public:
     bool hasCustomText() const { return dynamicText(m_dynamicType) != xmlText(); }
 
     Expression* snappedExpression() const;
+    HairpinSegment* findSnapBeforeHairpinAcrossSystemBreak() const;
 
     bool playDynamic() const { return m_playDynamic; }
     void setPlayDynamic(bool v) { m_playDynamic = v; }

--- a/src/engraving/dom/hairpin.cpp
+++ b/src/engraving/dom/hairpin.cpp
@@ -287,10 +287,6 @@ EngravingItem* HairpinSegment::findElementToSnapBefore() const
 
     Hairpin* thisHairpin = hairpin();
     Fraction startTick = hairpin()->tick();
-    System* sys = system();
-    if (sys && !sys->measures().empty() && startTick == sys->measures().front()->tick()) {
-        return nullptr;
-    }
 
     auto intervals = score()->spannerMap().findOverlapping(startTick.ticks(), startTick.ticks());
     for (auto interval : intervals) {
@@ -331,9 +327,6 @@ TextBase* HairpinSegment::findStartDynamicOrExpression() const
     dynamicsAndExpr.reserve(2);
 
     for (Segment* segment = measure->last(); segment; segment = segment->prev1()) {
-        if (segment->system() != system()) {
-            continue;
-        }
         Fraction segmentTick = segment->tick();
         if (segmentTick > refTick) {
             continue;
@@ -388,9 +381,6 @@ TextBase* HairpinSegment::findEndDynamicOrExpression() const
     dynamicsAndExpr.reserve(2);
 
     for (Segment* segment = measure->first(); segment; segment = segment->next1()) {
-        if (segment->system() != system()) {
-            continue;
-        }
         Fraction segmentTick = segment->tick();
         if (segmentTick < refTick) {
             continue;

--- a/src/engraving/dom/line.cpp
+++ b/src/engraving/dom/line.cpp
@@ -225,18 +225,7 @@ void LineSegment::startEditDrag(EditData& ed)
 
 bool LineSegment::isEditAllowed(EditData& ed) const
 {
-    const bool moveStart = ed.curGrip == Grip::START;
-    const bool moveEnd = ed.curGrip == Grip::END || ed.curGrip == Grip::MIDDLE;
-
-    bool shiftModifier = ed.modifiers & ShiftModifier;
-    bool canMoveStart = isSingleBeginType() && moveStart;
-    bool canMoveEnd = isSingleEndType() && moveEnd;
-
-    if (!shiftModifier && !canMoveStart && !canMoveEnd) {
-        return false;
-    }
-
-    return true;
+    return ed.modifiers & ShiftModifier;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/line.cpp
+++ b/src/engraving/dom/line.cpp
@@ -693,6 +693,11 @@ void LineSegment::rebaseAnchors(EditData& ed, Grip grip)
             return;
         }
 
+        System* sys = system();
+        if (!sys) {
+            return;
+        }
+
         SLine* l = line();
 
         // If dragging middle grip (or the entire hairpin), mouse position
@@ -711,7 +716,6 @@ void LineSegment::rebaseAnchors(EditData& ed, Grip grip)
             return;
         }
 
-        System* sys = system();
         PointF oldStartPos = line()->linePos(Grip::START, &sys);
         PointF oldEndPos = line()->linePos(Grip::END, &sys);
 
@@ -1085,7 +1089,10 @@ PropertyValue SLine::propertyDefault(Pid pid) const
 
 void SLine::undoMoveStart(Fraction tickDiff)
 {
-    undoChangeProperty(Pid::SPANNER_TICK, tick() + tickDiff);
+    Fraction newTick = tick() + tickDiff;
+    if (newTick >= Fraction(0, 1)) {
+        undoChangeProperty(Pid::SPANNER_TICK, newTick);
+    }
     Fraction newDuration = ticks() - tickDiff;
     if (newDuration > Fraction(0, 1)) {
         undoChangeProperty(Pid::SPANNER_TICKS, newDuration);
@@ -1098,7 +1105,10 @@ void SLine::undoMoveEnd(Fraction tickDiff)
     if (newDuration > Fraction(0, 1)) {
         undoChangeProperty(Pid::SPANNER_TICKS, newDuration);
     } else {
-        undoChangeProperty(Pid::SPANNER_TICK, tick() + tickDiff);
+        Fraction newTick = tick() + tickDiff;
+        if (newTick >= Fraction(0, 1)) {
+            undoChangeProperty(Pid::SPANNER_TICK, tick() + tickDiff);
+        }
     }
 }
 }

--- a/src/engraving/dom/line.cpp
+++ b/src/engraving/dom/line.cpp
@@ -227,8 +227,11 @@ bool LineSegment::isEditAllowed(EditData& ed) const
     const bool moveStart = ed.curGrip == Grip::START;
     const bool moveEnd = ed.curGrip == Grip::END || ed.curGrip == Grip::MIDDLE;
 
-    if (!((ed.modifiers & ShiftModifier) && ((isSingleBeginType() && moveStart)
-                                             || (isSingleEndType() && moveEnd)))) {
+    bool shiftModifier = ed.modifiers & ShiftModifier;
+    bool canMoveStart = isSingleBeginType() && moveStart;
+    bool canMoveEnd = isSingleEndType() && moveEnd;
+
+    if (!shiftModifier && !canMoveStart && !canMoveEnd) {
         return false;
     }
 

--- a/src/engraving/dom/line.cpp
+++ b/src/engraving/dom/line.cpp
@@ -1002,4 +1002,23 @@ PropertyValue SLine::propertyDefault(Pid pid) const
         return Spanner::propertyDefault(pid);
     }
 }
+
+void SLine::undoMoveStart(Fraction tickDiff)
+{
+    undoChangeProperty(Pid::SPANNER_TICK, tick() + tickDiff);
+    Fraction newDuration = ticks() - tickDiff;
+    if (newDuration > Fraction(0, 1)) {
+        undoChangeProperty(Pid::SPANNER_TICKS, newDuration);
+    }
+}
+
+void SLine::undoMoveEnd(Fraction tickDiff)
+{
+    Fraction newDuration = ticks() + tickDiff;
+    if (newDuration > Fraction(0, 1)) {
+        undoChangeProperty(Pid::SPANNER_TICKS, newDuration);
+    } else {
+        undoChangeProperty(Pid::SPANNER_TICK, tick() + tickDiff);
+    }
+}
 }

--- a/src/engraving/dom/line.h
+++ b/src/engraving/dom/line.h
@@ -85,6 +85,7 @@ private:
     static PointF deltaRebaseRight(const Segment* oldSeg, const Segment* newSeg);
     static Fraction lastSegmentEndTick(const Segment* lastSeg, const Spanner* s);
     LineSegment* rebaseAnchor(Grip grip, Segment* newSeg);
+    void rebaseOffsetsOnAnchorChanged(Grip grip, const PointF& oldPos, System* sys);
     void rebaseAnchors(EditData&, Grip);
 };
 

--- a/src/engraving/dom/line.h
+++ b/src/engraving/dom/line.h
@@ -131,6 +131,9 @@ public:
     virtual PointF linePos(Grip grip, System** system) const;
     virtual bool allowTimeAnchor() const override { return true; }
 
+    void undoMoveStart(Fraction tickDiff);
+    void undoMoveEnd(Fraction tickDiff);
+
 private:
 
     friend class LineSegment;

--- a/src/engraving/dom/line.h
+++ b/src/engraving/dom/line.h
@@ -75,6 +75,7 @@ public:
     std::vector<LineF> dragAnchorLines() const override;
     RectF drag(EditData& ed) override;
 private:
+    void undoMoveStartEndAndSnappedItems(bool moveStart, bool moveEnd, Segment* s1, Segment* s2);
     PointF leftAnchorPosition(const double& systemPositionY) const;
     PointF rightAnchorPosition(const double& systemPositionY) const;
 

--- a/src/engraving/dom/line.h
+++ b/src/engraving/dom/line.h
@@ -75,6 +75,7 @@ public:
     std::vector<LineF> dragAnchorLines() const override;
     RectF drag(EditData& ed) override;
 private:
+    Segment* findNewAnchorSegment(const EditData& ed, const Segment* curSeg);
     void undoMoveStartEndAndSnappedItems(bool moveStart, bool moveEnd, Segment* s1, Segment* s2);
     PointF leftAnchorPosition(const double& systemPositionY) const;
     PointF rightAnchorPosition(const double& systemPositionY) const;

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -340,7 +340,7 @@ Segment* Segment::next1ChordRestOrTimeTick() const
     return nextSeg;
 }
 
-Segment* Segment::next1WithElemsOnStaff(staff_idx_t staffIdx, SegmentType segType)
+Segment* Segment::next1WithElemsOnStaff(staff_idx_t staffIdx, SegmentType segType) const
 {
     Segment* next = next1(segType);
 
@@ -455,7 +455,7 @@ Segment* Segment::prev1ChordRestOrTimeTick() const
     return prevSeg;
 }
 
-Segment* Segment::prev1WithElemsOnStaff(staff_idx_t staffIdx, SegmentType segType)
+Segment* Segment::prev1WithElemsOnStaff(staff_idx_t staffIdx, SegmentType segType) const
 {
     Segment* prev = prev1(segType);
 

--- a/src/engraving/dom/segment.h
+++ b/src/engraving/dom/segment.h
@@ -124,12 +124,12 @@ public:
     Segment* next1MMenabled() const;
     Segment* next1(SegmentType) const;
     Segment* next1ChordRestOrTimeTick() const;
-    Segment* next1WithElemsOnStaff(staff_idx_t staffIdx, SegmentType segType = SegmentType::ChordRest);
+    Segment* next1WithElemsOnStaff(staff_idx_t staffIdx, SegmentType segType = SegmentType::ChordRest) const;
     Segment* next1MM(SegmentType) const;
 
     Segment* prev1() const;
     Segment* prev1ChordRestOrTimeTick() const;
-    Segment* prev1WithElemsOnStaff(staff_idx_t staffIdx, SegmentType segType = SegmentType::ChordRest);
+    Segment* prev1WithElemsOnStaff(staff_idx_t staffIdx, SegmentType segType = SegmentType::ChordRest) const;
     Segment* prev1enabled() const;
     Segment* prev1MM() const;
     Segment* prev1MMenabled() const;

--- a/src/engraving/rendering/dev/alignmentlayout.cpp
+++ b/src/engraving/rendering/dev/alignmentlayout.cpp
@@ -55,8 +55,8 @@ void AlignmentLayout::alignItems(const std::vector<EngravingItem*>& elements, co
             continue;
         }
         firstItem = true;
-        scanConnectedItems(item, computeOutermostY);
-        scanConnectedItems(item, moveElementsToOutermostY);
+        scanConnectedItems(item, system, computeOutermostY);
+        scanConnectedItems(item, system, moveElementsToOutermostY);
     }
 }
 
@@ -91,10 +91,10 @@ void AlignmentLayout::alignStaffCenteredItems(const std::vector<EngravingItem*>&
             continue;
         }
         vecOfCurrentY.clear();
-        scanConnectedItems(item, collectCurrentYandComputeEdges);
+        scanConnectedItems(item, system, collectCurrentYandComputeEdges);
         averageY = computeAverageY(vecOfCurrentY);
-        scanConnectedItems(item, limitAverageYInsideAvailableSpace);
-        scanConnectedItems(item, moveElementsToAverageY);
+        scanConnectedItems(item, system, limitAverageYInsideAvailableSpace);
+        scanConnectedItems(item, system, moveElementsToAverageY);
     }
 }
 
@@ -138,18 +138,18 @@ double AlignmentLayout::yOpticalCenter(const EngravingItem* item)
     return curY;
 }
 
-void AlignmentLayout::scanConnectedItems(EngravingItem* item, std::function<void(EngravingItem*)> func)
+void AlignmentLayout::scanConnectedItems(EngravingItem* item, const System* system, std::function<void(EngravingItem*)> func)
 {
     func(item);
 
     EngravingItem* snappedBefore = item->ldata()->itemSnappedBefore();
-    while (snappedBefore) {
+    while (snappedBefore && snappedBefore->findAncestor(ElementType::SYSTEM) == system) {
         func(snappedBefore);
         snappedBefore = snappedBefore->ldata()->itemSnappedBefore();
     }
 
     EngravingItem* snappedAfter = item->ldata()->itemSnappedAfter();
-    while (snappedAfter) {
+    while (snappedAfter && snappedAfter->findAncestor(ElementType::SYSTEM) == system) {
         func(snappedAfter);
         snappedAfter = snappedAfter->ldata()->itemSnappedAfter();
     }

--- a/src/engraving/rendering/dev/alignmentlayout.h
+++ b/src/engraving/rendering/dev/alignmentlayout.h
@@ -42,7 +42,7 @@ public:
 private:
     static void moveItemToY(EngravingItem* item, double y, const System* system, std::set<EngravingItem*>& alignedItems);
     static double yOpticalCenter(const EngravingItem* item);
-    static void scanConnectedItems(EngravingItem* item, std::function<void(EngravingItem*)> func);
+    static void scanConnectedItems(EngravingItem* item, const System* system, std::function<void(EngravingItem*)> func);
     static double computeAverageY(const std::vector<double>& vecOfY);
 };
 } // namespace mu::engraving::rendering::dev

--- a/src/engraving/rendering/dev/systemlayout.cpp
+++ b/src/engraving/rendering/dev/systemlayout.cpp
@@ -2774,7 +2774,7 @@ void SystemLayout::centerElementsBetweenStaves(const System* system)
 
 bool SystemLayout::elementShouldBeCenteredBetweenStaves(const EngravingItem* item, const System* system)
 {
-    if (!item->isStyled(Pid::OFFSET)) {
+    if (item->offset() != item->propertyDefault(Pid::OFFSET).value<PointF>()) {
         // NOTE: because of current limitations of the offset system, we can't center an element that's been manually moved.
         return false;
     }

--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -1875,6 +1875,11 @@ void TLayout::layoutDynamic(Dynamic* item, Dynamic::LayoutData* ldata, const Lay
     ldata->disconnectItemSnappedAfter();
     ldata->disconnectItemSnappedBefore();
 
+    HairpinSegment* snapBeforeHairpinAcrossSysBreak = item->findSnapBeforeHairpinAcrossSystemBreak();
+    if (snapBeforeHairpinAcrossSysBreak) {
+        ldata->connectItemSnappedBefore(snapBeforeHairpinAcrossSysBreak);
+    }
+
     const StaffType* stType = item->staffType();
     if (stType && stType->isHiddenElementOnTab(conf.style(), Sid::dynamicsShowTabCommon, Sid::dynamicsShowTabSimple)) {
         ldata->setIsSkipDraw(true);

--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -3120,7 +3120,8 @@ void TLayout::layoutHairpinSegment(HairpinSegment* item, LayoutContext& ctx)
 
     // In case of dynamics/expressions before or after, make space for them horizontally
     double hairpinDistToDynOrExpr = ctx.conf().style().styleMM(Sid::autoplaceHairpinDynamicsDistance);
-    if (possibleSnapBeforeElement && (possibleSnapBeforeElement->isDynamic() || possibleSnapBeforeElement->isExpression())) {
+    if (possibleSnapBeforeElement && possibleSnapBeforeElement->findAncestor(ElementType::SYSTEM) == item->system()
+        && (possibleSnapBeforeElement->isDynamic() || possibleSnapBeforeElement->isExpression())) {
         double xItemPos = possibleSnapBeforeElement->pageX() - item->system()->pageX();
         double itemRightEdge = xItemPos + possibleSnapBeforeElement->ldata()->bbox().right();
         double xMinHairpinStart = itemRightEdge + hairpinDistToDynOrExpr;
@@ -3130,7 +3131,8 @@ void TLayout::layoutHairpinSegment(HairpinSegment* item, LayoutContext& ctx)
             item->rxpos2() += xStartDiff;
         }
     }
-    if (possibleSnapAfterElement && (possibleSnapAfterElement->isDynamic() || possibleSnapAfterElement->isExpression())) {
+    if (possibleSnapAfterElement && possibleSnapAfterElement->findAncestor(ElementType::SYSTEM) == item->system()
+        && (possibleSnapAfterElement->isDynamic() || possibleSnapAfterElement->isExpression())) {
         double xItemPos = possibleSnapAfterElement->pageX() - item->system()->pageX();
         double itemLeftEdge = xItemPos + possibleSnapAfterElement->ldata()->bbox().left();
         double xMaxHairpinEnd = itemLeftEdge - hairpinDistToDynOrExpr;

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -719,7 +719,11 @@ void NotationViewInputController::handleLeftClick(const ClickContext& ctx)
 
     if (!selection->isRange()) {
         if (ctx.hitElement && ctx.hitElement->needStartEditingAfterSelecting()) {
-            viewInteraction()->startEditElement(ctx.hitElement, false);
+            if (ctx.hitElement->hasGrips()) {
+                viewInteraction()->startEditGrip(ctx.hitElement, ctx.hitElement->gripsCount() > 4 ? Grip::DRAG : Grip::MIDDLE);
+            } else {
+                viewInteraction()->startEditElement(ctx.hitElement, false);
+            }
             return;
         }
     }

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -255,17 +255,6 @@ PalettePtr PaletteCreator::newDynamicsPalette(bool defaultPalette)
         sp->appendElement(hairpin, pair.second, mag, offset);
     }
 
-    if (!defaultPalette) {
-        auto gabel = Factory::makeHairpin(gpaletteScore->dummy()->segment());
-        gabel->setHairpinType(HairpinType::CRESC_HAIRPIN);
-        gabel->setBeginText(u"<sym>dynamicMezzo</sym><sym>dynamicForte</sym>");
-        gabel->setPropertyFlags(Pid::BEGIN_TEXT, PropertyFlags::UNSTYLED);
-        gabel->setBeginTextAlign({ AlignH::LEFT, AlignV::VCENTER });
-        gabel->setPropertyFlags(Pid::BEGIN_TEXT_ALIGN, PropertyFlags::UNSTYLED);
-        gabel->setLen(w);
-        sp->appendElement(gabel, QT_TRANSLATE_NOOP("palette", "Dynamic + hairpin"));
-    }
-
     return sp;
 }
 


### PR DESCRIPTION
Resolves: #23327

This PR resolves points 1-3 of the related issue. Namely:

- Lets items snap to each other also across system breaks (contrary to what happens now, whereby system breaks also break any snapping chain). This lets a dynamic keep its preceding hairpin attached if the hairpin is in the previous or next system.
- Lets hairpins also move around their snapped items when shift+arrowing (contrary to what happens now, where only dynamics can do that).
- Makes sure that shift+arrow editing works on a split-system-hairpins.

This PR doesn't attempt to solve point 4, i.e. dragging items to a different system, because that's something that's always been a jankfest in Musescore so it needs separate work. But also because dragging an item like that is a criminal offense sanctioned by every country in the United Nations.