### PR TITLE
Fix crash when inserting text frame after cross-staff slur

### DIFF
--- a/src/engraving/rendering/dev/pagelayout.cpp
+++ b/src/engraving/rendering/dev/pagelayout.cpp
@@ -409,15 +409,17 @@ void PageLayout::collectPage(LayoutContext& ctx)
     // HACK: we relayout here cross-staff slurs because only now the information
     // about staff distances is fully available.
     for (System* system : page->systems()) {
-        long int stick = 0;
-        long int etick = 0;
-        if (system->firstMeasure()) {
-            stick = system->firstMeasure()->tick().ticks();
-        }
-        etick = system->endTick().ticks();
-        if (stick == 0 && etick == 0) {
+        if (!system->firstMeasure()) {
             continue;
         }
+
+        long int stick = system->firstMeasure()->tick().ticks();
+        long int etick = system->endTick().ticks();
+
+        IF_ASSERT_FAILED(stick < etick) {
+            continue;
+        }
+
         auto spanners = ctx.dom().spannerMap().findOverlapping(stick, etick);
         for (auto interval : spanners) {
             Spanner* sp = interval.value;


### PR DESCRIPTION
- If the system has no first measure, it has no measures at all, so no need to consider this system
- Add extra safety check that stick < etick, but this should not be necessary, because at that point it is already clear that the system contains at least one measure, and a measure cannot have a length of zero ticks, so etick will necessary be greater than stick.

The cause of the crash was that the calculation of stick and etick was wrong, resulting in a non-empty range when the second system contains no measures (but only a text frame for example). In this non-empty range, the spanners belonging to the previous system would be found, and we call `SlurTieLayout::layoutSystem` with these spanners and the current non-measure system, while `SlurTieLayout::layoutSystem` assumes that the system does have measures. This led to the crash.

Resolves: https://github.com/musescore/MuseScore/issues/23294