### PR TITLE
BeamLayout::checkCross…: Update seg shape after layoutChords1

### DIFF
--- a/src/engraving/rendering/dev/beamlayout.cpp
+++ b/src/engraving/rendering/dev/beamlayout.cpp
@@ -961,6 +961,7 @@ void BeamLayout::checkCrossPosAndStemConsistency(Beam* beam, LayoutContext& ctx)
             inconsistencyFound = true;
             chord->setUp(actualUp);
             ChordLayout::layoutChords1(ctx, chord->segment(), chord->staffIdx());
+            chord->segment()->createShape(chord->staffIdx());
         }
         if (actualUp) {
             correctCrossStaffIdx = std::min(correctCrossStaffIdx, chord->staffMove());


### PR DESCRIPTION
Among other things, calling `layoutChords1` results in the ledger lines being re-created. If we don't update the segment shape, it will contain pointers to the old ledger lines that had been deleted, which causes problems later on in the layout process.

Resolves: https://github.com/musescore/MuseScore/issues/21185