### PR TITLE
correct globalSig

### DIFF
--- a/src/engraving/dom/timesig.h
+++ b/src/engraving/dom/timesig.h
@@ -108,7 +108,7 @@ public:
     const Groups& groups() const { return m_groups; }
     void setGroups(const Groups& e) { m_groups = e; }
 
-    Fraction globalSig() const { return (m_sig * m_stretch).reduced(); }
+    Fraction globalSig() const { return (m_sig / m_stretch).reduced(); }
     void setGlobalSig(const Fraction& f) { m_stretch = (m_sig / f).reduced(); }
 
     bool isLocal() const { return m_stretch != Fraction(1, 1); }


### PR DESCRIPTION
if 
`stretch = local / global` 

see f.ex.: https://github.com/musescore/MuseScore/blob/b5b34e22c7d55068a448bc12f0cdbbb9613d61d9/src/engraving/dom/edit.cpp#L1319
then
`global = local / stretch`

--
alternatively, (and more loggicaly in my opinion) `stretch` should be `global / local`, then `global` would be `local * stretch` but it would require correcting all places in code, where it is used (one example is above)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
