### PR TITLE
reload_musesampler_menu_item

### DIFF
--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -362,6 +362,10 @@ MenuItem* AppMenuModel::makeDiagnosticMenu()
         makeMenuItem("musesampler-check"),
     };
 
+    if (globalConfiguration()->devModeEnabled()) {
+        museSamplerItems << makeMenuItem("musesampler-reload");
+    }
+
     items << makeMenu(TranslatableString("appshell/menu/diagnostic", "&Muse Sampler"), museSamplerItems, "menu-musesampler");
 #endif
 

--- a/src/framework/musesampler/internal/apitypes.h
+++ b/src/framework/musesampler/internal/apitypes.h
@@ -308,6 +308,9 @@ typedef ms_Result (* ms_MuseSampler_add_track_text_articulation_event)(ms_MuseSa
 typedef const char*(* ms_get_drum_mapping)(int instrument_id);
 // ------------------------------------------------------------
 
+// Added in 0.7
+typedef ms_Result (* ms_reload_all_instruments)(); // Useful for sound developers
+
 namespace muse::musesampler {
 using track_idx_t = size_t;
 using TrackList = std::vector<ms_Track>;

--- a/src/framework/musesampler/internal/libhandler.h
+++ b/src/framework/musesampler/internal/libhandler.h
@@ -101,6 +101,8 @@ struct MuseSamplerLibHandler
     ms_MuseSampler_process process = nullptr;
     ms_MuseSampler_all_notes_off allNotesOff = nullptr;
 
+    ms_reload_all_instruments reloadAllInstruments = nullptr;
+
 private:
     ms_init initLib = nullptr;
     ms_disable_reverb disableReverb = nullptr;
@@ -258,6 +260,12 @@ public:
         setPlaying = (ms_MuseSampler_set_playing)muse::getLibFunc(m_lib, "ms_MuseSampler_set_playing");
         process = (ms_MuseSampler_process)muse::getLibFunc(m_lib, "ms_MuseSampler_process");
         allNotesOff = (ms_MuseSampler_all_notes_off)muse::getLibFunc(m_lib, "ms_MuseSampler_all_notes_off");
+
+        if (at_least_v_0_7) {
+            reloadAllInstruments = (ms_reload_all_instruments)muse::getLibFunc(m_lib, "ms_reload_all_instruments");
+        } else {
+            reloadAllInstruments = []() { return ms_Result_Error; };
+        }
     }
 
     ~MuseSamplerLibHandler()

--- a/src/framework/musesampler/internal/musesampleractioncontroller.cpp
+++ b/src/framework/musesampler/internal/musesampleractioncontroller.cpp
@@ -22,12 +22,16 @@
 #include "musesampleractioncontroller.h"
 
 #include "translation.h"
+#include "log.h"
 
 using namespace muse::musesampler;
 
-void MuseSamplerActionController::init()
+void MuseSamplerActionController::init(const ReloadMuseSamplerFunc& reloadMuseSampler)
 {
+    m_reloadMuseSampler = reloadMuseSampler;
+
     dispatcher()->reg(this, "musesampler-check", this, &MuseSamplerActionController::checkLibraryIsDetected);
+    dispatcher()->reg(this, "musesampler-reload", this, &MuseSamplerActionController::reloadMuseSampler);
 }
 
 void MuseSamplerActionController::checkLibraryIsDetected()
@@ -43,4 +47,15 @@ void MuseSamplerActionController::checkLibraryIsDetected()
     }
 
     interactive()->info(status, std::string());
+}
+
+void MuseSamplerActionController::reloadMuseSampler()
+{
+    IF_ASSERT_FAILED(m_reloadMuseSampler) {
+        return;
+    }
+
+    if (!m_reloadMuseSampler()) {
+        interactive()->error("", std::string("Could not reload Muse Sampler library"));
+    }
 }

--- a/src/framework/musesampler/internal/musesampleractioncontroller.h
+++ b/src/framework/musesampler/internal/musesampleractioncontroller.h
@@ -38,10 +38,15 @@ class MuseSamplerActionController : public muse::actions::Actionable, public asy
     INJECT(IMuseSamplerInfo, museSamplerInfo)
 
 public:
-    void init();
+    using ReloadMuseSamplerFunc = std::function<bool ()>;
+
+    void init(const ReloadMuseSamplerFunc& reloadMuseSampler);
 
 private:
     void checkLibraryIsDetected();
+    void reloadMuseSampler();
+
+    ReloadMuseSamplerFunc m_reloadMuseSampler;
 };
 }
 

--- a/src/framework/musesampler/internal/musesamplerresolver.cpp
+++ b/src/framework/musesampler/internal/musesamplerresolver.cpp
@@ -92,6 +92,15 @@ void MuseSamplerResolver::init()
     doInit(configuration()->fallbackLibraryPath());
 }
 
+bool MuseSamplerResolver::reloadMuseSampler()
+{
+    if (!m_libHandler) {
+        return false;
+    }
+
+    return m_libHandler->reloadAllInstruments() == ms_Result_OK;
+}
+
 bool MuseSamplerResolver::doInit(const io::path_t& libPath)
 {
     m_libHandler = std::make_shared<MuseSamplerLibHandler>(libPath);
@@ -106,6 +115,7 @@ bool MuseSamplerResolver::doInit(const io::path_t& libPath)
         m_libHandler.reset();
     }
 
+    LOGI() << "MuseSampler successfully inited: " << libPath;
     return ok;
 }
 

--- a/src/framework/musesampler/internal/musesamplerresolver.h
+++ b/src/framework/musesampler/internal/musesamplerresolver.h
@@ -37,6 +37,7 @@ class MuseSamplerResolver : public muse::audio::synth::ISynthResolver::IResolver
 
 public:
     void init();
+    bool reloadMuseSampler();
 
     muse::audio::synth::ISynthesizerPtr resolveSynth(const muse::audio::TrackId trackId,
                                                      const muse::audio::AudioInputParams& params) const override;

--- a/src/framework/musesampler/internal/musesampleruiactions.cpp
+++ b/src/framework/musesampler/internal/musesampleruiactions.cpp
@@ -35,6 +35,11 @@ const UiActionList MuseSamplerUiActions::m_actions = {
              muse::ui::UiCtxAny,
              muse::shortcuts::CTX_ANY,
              TranslatableString("action", "Check Muse Sampler")
+             ),
+    UiAction("musesampler-reload",
+             muse::ui::UiCtxAny,
+             muse::shortcuts::CTX_ANY,
+             TranslatableString("action", "Reload Muse Sampler")
              )
 };
 

--- a/src/framework/musesampler/musesamplermodule.cpp
+++ b/src/framework/musesampler/musesamplermodule.cpp
@@ -76,8 +76,10 @@ void MuseSamplerModule::onInit(const IApplication::RunMode& mode)
     }
 
     m_configuration->init();
-    m_actionController->init();
     m_resolver->init();
+    m_actionController->init([this]() {
+        return m_resolver->reloadMuseSampler();
+    });
 
     auto pr = ioc()->resolve<muse::diagnostics::IDiagnosticsPathsRegister>(moduleName());
     if (pr) {


### PR DESCRIPTION
This feature was implicitly available before [this problem](https://github.com/musescore/MuseScore/pull/22535) was fixed and was actively used by the MuseSounds devs