### PR TITLE
Use correct accidental symbols in instrument names 

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -1998,6 +1998,20 @@ static void createTimeTick(const Score* score, const Fraction& tick, const staff
     }
 }
 
+static String replacePartNameAccidentals(const String& partName)
+{
+    String name = partName;
+    static const std::regex re("((^|\\s|\\u00A0)[ABCDEF][b#]($|\\s|\u00A0))");
+    StringList res = name.search(re, { 1 }, SplitBehavior::SkipEmptyParts);
+
+    if (!res.empty()) {
+        String transp = res.at(0).replace(u"b", u"♭").replace(u"#", u"♯");
+        name.replace(re, transp);
+        return name;
+    }
+    return partName;
+}
+
 //---------------------------------------------------------
 //   part
 //---------------------------------------------------------
@@ -2027,9 +2041,11 @@ void MusicXMLParserPass2::part()
 
     // set the part name
     MusicXmlPart mxmlPart = m_pass1.getMusicXmlPart(id);
-    part->setPartName(mxmlPart.getName());
-    if (mxmlPart.getPrintName() && !isLikelyIncorrectPartName(mxmlPart.getName())) {
-        part->setLongNameAll(mxmlPart.getName());
+    String partName = mxmlPart.getName();
+    partName = replacePartNameAccidentals(partName);
+    part->setPartName(partName);
+    if (mxmlPart.getPrintName() && !isLikelyIncorrectPartName(partName)) {
+        part->setLongNameAll(partName);
     } else {
         m_pass1.getPart(id)->setLongNameAll(u"");
     }

--- a/src/importexport/musicxml/tests/data/testFinaleInstr_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testFinaleInstr_ref.mscx
@@ -348,9 +348,9 @@
         <bracket type="0" span="4" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <trackName>Bb Clarinet 1</trackName>
+      <trackName>B♭ Clarinet 1</trackName>
       <Instrument id="bb-clarinet">
-        <longName>Bb Clarinet 1</longName>
+        <longName>B♭ Clarinet 1</longName>
         <shortName>Cl. 1</shortName>
         <trackName>Bb Clarinet 1</trackName>
         <minPitchP>50</minPitchP>
@@ -415,9 +415,9 @@
         <hideWhenEmpty>3</hideWhenEmpty>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <trackName>Bb Clarinet 2, 3</trackName>
+      <trackName>B♭ Clarinet 2, 3</trackName>
       <Instrument id="bb-clarinet">
-        <longName>Bb Clarinet 2, 3</longName>
+        <longName>B♭ Clarinet 2, 3</longName>
         <shortName>Cl. 2, 3</shortName>
         <trackName>Bb Clarinet 2, 3</trackName>
         <minPitchP>50</minPitchP>
@@ -482,9 +482,9 @@
         <hideWhenEmpty>3</hideWhenEmpty>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <trackName>Eb Alto Clarinet</trackName>
+      <trackName>E♭ Alto Clarinet</trackName>
       <Instrument id="alto-clarinet">
-        <longName>Eb Alto Clarinet</longName>
+        <longName>E♭ Alto Clarinet</longName>
         <shortName>A. Cl.</shortName>
         <trackName>Eb Alto Clarinet</trackName>
         <minPitchP>43</minPitchP>
@@ -548,9 +548,9 @@
           </StaffType>
         <hideWhenEmpty>3</hideWhenEmpty>
         </Staff>
-      <trackName>Bb Bass Clarinet</trackName>
+      <trackName>B♭ Bass Clarinet</trackName>
       <Instrument id="bb-bass-clarinet">
-        <longName>Bb Bass Clarinet</longName>
+        <longName>B♭ Bass Clarinet</longName>
         <shortName>Bs. Cl.</shortName>
         <trackName>Bb Bass Clarinet</trackName>
         <minPitchP>34</minPitchP>
@@ -618,9 +618,9 @@
         <bracket type="0" span="3" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <trackName>Eb Alto Sax. 1, 2</trackName>
+      <trackName>E♭ Alto Sax. 1, 2</trackName>
       <Instrument id="alto-saxophone">
-        <longName>Eb Alto Sax. 1, 2</longName>
+        <longName>E♭ Alto Sax. 1, 2</longName>
         <shortName>A. Sx. 1, 2</shortName>
         <trackName>Eb Alto Sax. 1, 2</trackName>
         <minPitchP>49</minPitchP>
@@ -685,9 +685,9 @@
         <hideWhenEmpty>3</hideWhenEmpty>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <trackName>Bb Tenor Sax.</trackName>
+      <trackName>B♭ Tenor Sax.</trackName>
       <Instrument id="tenor-saxophone">
-        <longName>Bb Tenor Sax.</longName>
+        <longName>B♭ Tenor Sax.</longName>
         <shortName>T. Sx.</shortName>
         <trackName>Bb Tenor Sax.</trackName>
         <minPitchP>44</minPitchP>
@@ -753,9 +753,9 @@
           </StaffType>
         <hideWhenEmpty>3</hideWhenEmpty>
         </Staff>
-      <trackName>Eb Bari. Sax.</trackName>
+      <trackName>E♭ Bari. Sax.</trackName>
       <Instrument id="baritone-saxophone">
-        <longName>Eb Bari. Sax.</longName>
+        <longName>E♭ Bari. Sax.</longName>
         <shortName>B. Sx.</shortName>
         <trackName>Eb Bari. Sax.</trackName>
         <minPitchP>36</minPitchP>
@@ -823,9 +823,9 @@
         <bracket type="0" span="3" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <trackName>Bb Trumpet 1</trackName>
+      <trackName>B♭ Trumpet 1</trackName>
       <Instrument id="bb-trumpet">
-        <longName>Bb Trumpet 1</longName>
+        <longName>B♭ Trumpet 1</longName>
         <shortName>Tpt. 1</shortName>
         <trackName>Bb Trumpet 1</trackName>
         <minPitchP>52</minPitchP>
@@ -895,9 +895,9 @@
         <hideWhenEmpty>3</hideWhenEmpty>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <trackName>Bb Trumpet 2, 3</trackName>
+      <trackName>B♭ Trumpet 2, 3</trackName>
       <Instrument id="bb-trumpet">
-        <longName>Bb Trumpet 2, 3</longName>
+        <longName>B♭ Trumpet 2, 3</longName>
         <shortName>Tpt. 2, 3</shortName>
         <trackName>Bb Trumpet 2, 3</trackName>
         <minPitchP>52</minPitchP>

--- a/src/importexport/musicxml/tests/data/testInstrImport_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInstrImport_ref.mscx
@@ -235,9 +235,9 @@
           </StaffType>
         <hideWhenEmpty>3</hideWhenEmpty>
         </Staff>
-      <trackName>Bb Clarinet</trackName>
+      <trackName>B♭ Clarinet</trackName>
       <Instrument id="bb-clarinet">
-        <longName>Bb Clarinet</longName>
+        <longName>B♭ Clarinet</longName>
         <shortName>B¯ Clarinet B¯ Bass Clar.</shortName>
         <trackName>Bb Clarinet</trackName>
         <minPitchP>50</minPitchP>
@@ -300,9 +300,9 @@
           </StaffType>
         <hideWhenEmpty>3</hideWhenEmpty>
         </Staff>
-      <trackName>Eb Alto Clarinet</trackName>
+      <trackName>E♭ Alto Clarinet</trackName>
       <Instrument id="alto-clarinet">
-        <longName>Eb Alto Clarinet</longName>
+        <longName>E♭ Alto Clarinet</longName>
         <shortName>Alto Cl.</shortName>
         <trackName>Eb Alto Clarinet</trackName>
         <minPitchP>43</minPitchP>
@@ -365,9 +365,9 @@
           </StaffType>
         <hideWhenEmpty>3</hideWhenEmpty>
         </Staff>
-      <trackName>Bb Bass Clarinet</trackName>
+      <trackName>B♭ Bass Clarinet</trackName>
       <Instrument id="bb-bass-clarinet">
-        <longName>Bb Bass Clarinet</longName>
+        <longName>B♭ Bass Clarinet</longName>
         <shortName>B. Cl.</shortName>
         <trackName>Bb Bass Clarinet</trackName>
         <minPitchP>34</minPitchP>
@@ -432,9 +432,9 @@
           </StaffType>
         <hideWhenEmpty>3</hideWhenEmpty>
         </Staff>
-      <trackName>Eb Alto Sax.</trackName>
+      <trackName>E♭ Alto Sax.</trackName>
       <Instrument id="alto-saxophone">
-        <longName>Eb Alto Sax.</longName>
+        <longName>E♭ Alto Sax.</longName>
         <shortName>E¯ Alto Sax. E¯ Bar. Sax.</shortName>
         <trackName>Eb Alto Sax.</trackName>
         <minPitchP>49</minPitchP>
@@ -497,9 +497,9 @@
           </StaffType>
         <hideWhenEmpty>3</hideWhenEmpty>
         </Staff>
-      <trackName> Bb Tenor Sax.</trackName>
+      <trackName> B♭ Tenor Sax.</trackName>
       <Instrument id="tenor-saxophone">
-        <longName> Bb Tenor Sax.</longName>
+        <longName> B♭ Tenor Sax.</longName>
         <shortName>Ten. Sax.</shortName>
         <trackName> Bb Tenor Sax.</trackName>
         <minPitchP>44</minPitchP>
@@ -564,9 +564,9 @@
           </StaffType>
         <hideWhenEmpty>3</hideWhenEmpty>
         </Staff>
-      <trackName>Eb Baritone Sax.</trackName>
+      <trackName>E♭ Baritone Sax.</trackName>
       <Instrument id="baritone-saxophone">
-        <longName>Eb Baritone Sax.</longName>
+        <longName>E♭ Baritone Sax.</longName>
         <shortName>Bari. Sax.</shortName>
         <trackName>Eb Baritone Sax.</trackName>
         <minPitchP>36</minPitchP>
@@ -631,9 +631,9 @@
           </StaffType>
         <hideWhenEmpty>3</hideWhenEmpty>
         </Staff>
-      <trackName>Bb Trumpet</trackName>
+      <trackName>B♭ Trumpet</trackName>
       <Instrument id="bb-trumpet">
-        <longName>Bb Trumpet</longName>
+        <longName>B♭ Trumpet</longName>
         <shortName>Tpt.</shortName>
         <trackName>Bb Trumpet</trackName>
         <minPitchP>52</minPitchP>


### PR DESCRIPTION
This PR replaces 'b' or '#' symbols in instrument names with '♭' and '♯' when they are part of a transposition or key.
This happens on XML import.