### PR TITLE
Only apply credit swap to Sibelius scores on XML import

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -866,7 +866,7 @@ static void inferFromTitle(String& title, String& inferredSubtitle, String& infe
 
 static VBox* addCreditWords(Score* score, const CreditWordsList& crWords,
                             const int pageNr, const Size& pageSize,
-                            const bool top)
+                            const bool top, const bool isSibeliusScore)
 {
     VBox* vbox = nullptr;
 
@@ -889,7 +889,7 @@ static VBox* addCreditWords(Score* score, const CreditWordsList& crWords,
         // frame with the title on top of the page.
         // Sibelius (direct export) typically exports no header
         // and puts the title etc. in the footer
-        const bool doSwap = footerWords.size() > headerWords.size();
+        const bool doSwap = footerWords.size() > headerWords.size() && isSibeliusScore;
         if (top) {
             words = doSwap ? footerWords : headerWords;
         } else {
@@ -1011,7 +1011,7 @@ void MusicXMLParserPass1::createMeasuresAndVboxes(Score* score,
         // add a header vbox if the this measure is the first in the score or the first on a new page
         if (pageStartMeasureNrs.count(int(i)) || i == 0) {
             ++pageNr;
-            vbox = addCreditWords(score, crWords, pageNr, pageSize, true);
+            vbox = addCreditWords(score, crWords, pageNr, pageSize, true, m_exporterString.contains(u"sibelius"));
             if (i == 0 && vbox) {
                 vbox->setExcludeFromOtherParts(false);
             }
@@ -1037,7 +1037,7 @@ void MusicXMLParserPass1::createMeasuresAndVboxes(Score* score,
 
         // add a footer vbox if the next measure is on a new page or end of score has been reached
         if (pageStartMeasureNrs.count(int(i + 1)) || i == (ml.size() - 1)) {
-            addCreditWords(score, crWords, pageNr, pageSize, false);
+            addCreditWords(score, crWords, pageNr, pageSize, false, m_exporterString.contains(u"sibelius"));
         }
     }
 }

--- a/src/importexport/musicxml/tests/data/testTitleSwapMu.xml
+++ b/src/importexport/musicxml/tests/data/testTitleSwapMu.xml
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Title</work-title>
+    </work>
+  <identification>
+    <rights>Copyright © </rights>
+    <encoding>
+      <software>MuseScore 4.2.1</software>
+      <encoding-date>2024-04-16</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>4.8768</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>2435.77</page-height>
+      <page-width>1722.44</page-width>
+      <page-margins type="both">
+        <left-margin>103.346</left-margin>
+        <right-margin>103.346</right-margin>
+        <top-margin>86.9423</top-margin>
+        <bottom-margin>86.9423</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <appearance>
+      <line-width type="light barline">1.8</line-width>
+      <line-width type="heavy barline">5.5</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="bracket">4.4</line-width>
+      <line-width type="dashes">1.5</line-width>
+      <line-width type="enclosure">1</line-width>
+      <line-width type="ending">1.1</line-width>
+      <line-width type="extend">1</line-width>
+      <line-width type="leger">1.6</line-width>
+      <line-width type="pedal">1.1</line-width>
+      <line-width type="octave shift">1.1</line-width>
+      <line-width type="slur middle">2.1</line-width>
+      <line-width type="slur tip">0.7</line-width>
+      <line-width type="staff">1.1</line-width>
+      <line-width type="stem">1.1</line-width>
+      <line-width type="tie middle">2.1</line-width>
+      <line-width type="tie tip">0.7</line-width>
+      <line-width type="tuplet bracket">1</line-width>
+      <line-width type="wedge">1.2</line-width>
+      <note-size type="cue">70</note-size>
+      <note-size type="grace">70</note-size>
+      <note-size type="grace-cue">49</note-size>
+      </appearance>
+    <music-font font-family="Leland"/>
+    <word-font font-family="Plantin MT Std" font-size="11.9365"/>
+    <lyric-font font-family="MS Shell Dlg 2" font-size="14.47"/>
+    </defaults>
+  <credit page="1">
+    <credit-type>title</credit-type>
+    <credit-words default-x="861.221" default-y="2348.83" justify="center" valign="top" font-size="22.0128">Title</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="103.346" default-y="256.942" justify="left" valign="top" font-family="Edwin" font-size="10">2</credit-words>
+    </credit>
+  <credit page="2">
+    <credit-words default-x="1619.1" default-y="220.812" justify="right" valign="top" font-family="Edwin" font-size="10">3</credit-words>
+    </credit>
+  <credit page="3">
+    <credit-words default-x="103.346" default-y="317.674" justify="left" valign="top" font-family="Edwin" font-size="10">4</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-type>rights</credit-type>
+    <credit-words default-x="861.221" default-y="86.9423" justify="center" valign="bottom">Copyright © </credit-words>
+    </credit>
+  <credit page="2">
+    <credit-type>rights</credit-type>
+    <credit-words default-x="861.221" default-y="86.9423" justify="center" valign="bottom">Copyright © </credit-words>
+    </credit>
+  <credit page="3">
+    <credit-type>rights</credit-type>
+    <credit-words default-x="861.221" default-y="86.9423" justify="center" valign="bottom">Copyright © </credit-words>
+    </credit>
+  <credit page="4">
+    <credit-type>rights</credit-type>
+    <credit-words default-x="861.221" default-y="86.9423" justify="center" valign="bottom">Copyright © </credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Soprano/Tenor</part-name>
+      <part-abbreviation>S./T.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        <instrument-sound>keyboard.piano</instrument-sound>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P2">
+      <part-name>Alto</part-name>
+      <part-abbreviation>A.</part-abbreviation>
+      <score-instrument id="P2-I1">
+        <instrument-name>Piano</instrument-name>
+        <instrument-sound>keyboard.piano</instrument-sound>
+        </score-instrument>
+      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-instrument id="P2-I1">
+        <midi-channel>4</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P3">
+      <part-name>Bass</part-name>
+      <part-abbreviation>B.</part-abbreviation>
+      <score-instrument id="P3-I1">
+        <instrument-name>Piano</instrument-name>
+        <instrument-sound>keyboard.piano</instrument-sound>
+        </score-instrument>
+      <midi-device id="P3-I1" port="1"></midi-device>
+      <midi-instrument id="P3-I1">
+        <midi-channel>5</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P4">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P4-I1">
+        <instrument-name>Piano (2)</instrument-name>
+        <instrument-sound>keyboard.piano.grand</instrument-sound>
+        </score-instrument>
+      <midi-device id="P4-I1" port="1"></midi-device>
+      <midi-instrument id="P4-I1">
+        <midi-channel>2</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+  <measure number="1" width="147.22">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50</left-margin>
+            <right-margin>831.82</right-margin>
+            </system-margins>
+          <top-system-distance>170</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="91.72" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+</part>
+  <part id="P2">
+  <measure number="1" width="147.22">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50</left-margin>
+            <right-margin>831.82</right-margin>
+            </system-margins>
+          <top-system-distance>170</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="91.72" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+</part>
+  <part id="P3">
+  <measure number="1" width="147.22">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50</left-margin>
+            <right-margin>831.82</right-margin>
+            </system-margins>
+          <top-system-distance>170</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="91.72" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+</part>
+  <part id="P4">
+  <measure number="1" width="147.22">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50</left-margin>
+            <right-margin>831.82</right-margin>
+            </system-margins>
+          <top-system-distance>170</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="91.72" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+</part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/data/testTitleSwapMu_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTitleSwapMu_ref.mscx
@@ -1,0 +1,502 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.40">
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.26771</pageWidth>
+      <pageHeight>11.6917</pageHeight>
+      <pagePrintableWidth>7.27559</pagePrintableWidth>
+      <pageEvenLeftMargin>0.496061</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.496061</pageOddLeftMargin>
+      <pageEvenTopMargin>0.417323</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.417323</pageEvenBottomMargin>
+      <pageOddTopMargin>0.417323</pageOddTopMargin>
+      <pageOddBottomMargin>0.417323</pageOddBottomMargin>
+      <pageTwosided>0</pageTwosided>
+      <lyricsDashLineThickness>0.15</lyricsDashLineThickness>
+      <lyricsOddFontFace>MS Shell Dlg 2</lyricsOddFontFace>
+      <lyricsOddFontSize>14.47</lyricsOddFontSize>
+      <lyricsEvenFontFace>MS Shell Dlg 2</lyricsEvenFontFace>
+      <lyricsEvenFontSize>14.47</lyricsEvenFontSize>
+      <bracketWidth>0.44</bracketWidth>
+      <stemWidth>0.11</stemWidth>
+      <chordSymbolAFontFace>Plantin MT Std</chordSymbolAFontFace>
+      <chordSymbolAFontSize>11.9365</chordSymbolAFontSize>
+      <chordSymbolBFontFace>Plantin MT Std</chordSymbolBFontFace>
+      <chordSymbolBFontSize>11.9365</chordSymbolBFontSize>
+      <romanNumeralFontFace>Plantin MT Std</romanNumeralFontFace>
+      <nashvilleNumberFontFace>Plantin MT Std</nashvilleNumberFontFace>
+      <nashvilleNumberFontSize>11.9365</nashvilleNumberFontSize>
+      <slurEndWidth>0.07</slurEndWidth>
+      <tieEndWidth>0.07</tieEndWidth>
+      <tupletFontFace>Plantin MT Std</tupletFontFace>
+      <tupletFontSize>11.9365</tupletFontSize>
+      <titleFontFace>Plantin MT Std</titleFontFace>
+      <subTitleFontFace>Plantin MT Std</subTitleFontFace>
+      <composerFontFace>Plantin MT Std</composerFontFace>
+      <lyricistFontFace>Plantin MT Std</lyricistFontFace>
+      <fingeringFontFace>Plantin MT Std</fingeringFontFace>
+      <fingeringFontSize>11.9365</fingeringFontSize>
+      <lhGuitarFingeringFontFace>Plantin MT Std</lhGuitarFingeringFontFace>
+      <lhGuitarFingeringFontSize>11.9365</lhGuitarFingeringFontSize>
+      <rhGuitarFingeringFontFace>Plantin MT Std</rhGuitarFingeringFontFace>
+      <rhGuitarFingeringFontSize>11.9365</rhGuitarFingeringFontSize>
+      <stringNumberFontFace>Plantin MT Std</stringNumberFontFace>
+      <stringNumberFontSize>11.9365</stringNumberFontSize>
+      <stringTuningsFontSize>11.9365</stringTuningsFontSize>
+      <harpPedalDiagramFontFace>Plantin MT Std</harpPedalDiagramFontFace>
+      <harpPedalTextDiagramFontFace>Plantin MT Std</harpPedalTextDiagramFontFace>
+      <longInstrumentFontFace>Plantin MT Std</longInstrumentFontFace>
+      <longInstrumentFontSize>11.9365</longInstrumentFontSize>
+      <shortInstrumentFontFace>Plantin MT Std</shortInstrumentFontFace>
+      <shortInstrumentFontSize>11.9365</shortInstrumentFontSize>
+      <partInstrumentFontFace>Plantin MT Std</partInstrumentFontFace>
+      <partInstrumentFontSize>11.9365</partInstrumentFontSize>
+      <expressionFontFace>Plantin MT Std</expressionFontFace>
+      <expressionFontSize>11.9365</expressionFontSize>
+      <tempoFontFace>Plantin MT Std</tempoFontFace>
+      <tempoFontSize>11.9365</tempoFontSize>
+      <tempoChangeFontFace>Plantin MT Std</tempoChangeFontFace>
+      <tempoChangeFontSize>11.9365</tempoChangeFontSize>
+      <metronomeFontFace>Plantin MT Std</metronomeFontFace>
+      <metronomeFontSize>11.9365</metronomeFontSize>
+      <measureNumberFontFace>Plantin MT Std</measureNumberFontFace>
+      <measureNumberFontSize>11.9365</measureNumberFontSize>
+      <mmRestRangeFontFace>Plantin MT Std</mmRestRangeFontFace>
+      <mmRestRangeFontSize>11.9365</mmRestRangeFontSize>
+      <translatorFontFace>Plantin MT Std</translatorFontFace>
+      <translatorFontSize>11.9365</translatorFontSize>
+      <systemFontFace>Plantin MT Std</systemFontFace>
+      <systemFontSize>11.9365</systemFontSize>
+      <staffFontFace>Plantin MT Std</staffFontFace>
+      <staffFontSize>11.9365</staffFontSize>
+      <rehearsalMarkFontFace>Plantin MT Std</rehearsalMarkFontFace>
+      <rehearsalMarkFontSize>11.9365</rehearsalMarkFontSize>
+      <repeatLeftFontFace>Plantin MT Std</repeatLeftFontFace>
+      <repeatLeftFontSize>11.9365</repeatLeftFontSize>
+      <repeatRightFontFace>Plantin MT Std</repeatRightFontFace>
+      <repeatRightFontSize>11.9365</repeatRightFontSize>
+      <frameFontFace>Plantin MT Std</frameFontFace>
+      <frameFontSize>11.9365</frameFontSize>
+      <glissandoFontFace>Plantin MT Std</glissandoFontFace>
+      <glissandoFontSize>11.9365</glissandoFontSize>
+      <bendFontFace>Plantin MT Std</bendFontFace>
+      <bendFontSize>11.9365</bendFontSize>
+      <headerFontFace>Plantin MT Std</headerFontFace>
+      <headerFontSize>11.9365</headerFontSize>
+      <footerFontFace>Plantin MT Std</footerFontFace>
+      <footerFontSize>11.9365</footerFontSize>
+      <instrumentChangeFontFace>Plantin MT Std</instrumentChangeFontFace>
+      <instrumentChangeFontSize>11.9365</instrumentChangeFontSize>
+      <stickingFontFace>Plantin MT Std</stickingFontFace>
+      <stickingFontSize>11.9365</stickingFontSize>
+      <user1FontFace>Plantin MT Std</user1FontFace>
+      <user1FontSize>11.9365</user1FontSize>
+      <user2FontFace>Plantin MT Std</user2FontFace>
+      <user2FontSize>11.9365</user2FontSize>
+      <user3FontFace>Plantin MT Std</user3FontFace>
+      <user3FontSize>11.9365</user3FontSize>
+      <user4FontFace>Plantin MT Std</user4FontFace>
+      <user4FontSize>11.9365</user4FontSize>
+      <user5FontFace>Plantin MT Std</user5FontFace>
+      <user5FontSize>11.9365</user5FontSize>
+      <user6FontFace>Plantin MT Std</user6FontFace>
+      <user6FontSize>11.9365</user6FontSize>
+      <user7FontFace>Plantin MT Std</user7FontFace>
+      <user7FontSize>11.9365</user7FontSize>
+      <user8FontFace>Plantin MT Std</user8FontFace>
+      <user8FontSize>11.9365</user8FontSize>
+      <user9FontFace>Plantin MT Std</user9FontFace>
+      <user9FontSize>11.9365</user9FontSize>
+      <user10FontFace>Plantin MT Std</user10FontFace>
+      <user10FontSize>11.9365</user10FontSize>
+      <user11FontFace>Plantin MT Std</user11FontFace>
+      <user11FontSize>11.9365</user11FontSize>
+      <user12FontFace>Plantin MT Std</user12FontFace>
+      <user12FontSize>11.9365</user12FontSize>
+      <Spatium>1.2192</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright">Copyright © </metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Title</metaTag>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        </Staff>
+      <trackName>Soprano/Tenor</trackName>
+      <Instrument id="piano">
+        <longName>Soprano/Tenor</longName>
+        <shortName>S./T.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <controller ctrl="10" value="63"/>
+          <midiPort>0</midiPort>
+          <midiChannel>0</midiChannel>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part id="2">
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        </Staff>
+      <trackName>Alto</trackName>
+      <Instrument id="piano">
+        <longName>Alto</longName>
+        <shortName>A.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <controller ctrl="10" value="63"/>
+          <midiPort>0</midiPort>
+          <midiChannel>3</midiChannel>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part id="3">
+      <Staff id="3">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        </Staff>
+      <trackName>Bass</trackName>
+      <Instrument id="piano">
+        <longName>Bass</longName>
+        <shortName>B.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <controller ctrl="10" value="63"/>
+          <midiPort>0</midiPort>
+          <midiChannel>4</midiChannel>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part id="4">
+      <Staff id="4">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument id="piano">
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano (2)</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <singleNoteDynamics>0</singleNoteDynamics>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <controller ctrl="10" value="63"/>
+          <midiPort>0</midiPort>
+          <midiChannel>1</midiChannel>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>3.5</height>
+        <Text>
+          <style>title</style>
+          <offset x="0" y="-0.101194"/>
+          <text><font size="22.0128"/>Title</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      <VBox>
+        <height>19.5</height>
+        <Text>
+          <offset x="0" y="-0.0942"/>
+          <text><font size="10"/><font face="Edwin"/>2</text>
+          </Text>
+        </VBox>
+      </Staff>
+    <Staff id="2">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="3">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="4">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/importexport/musicxml/tests/data/testTitleSwapSib.xml
+++ b/src/importexport/musicxml/tests/data/testTitleSwapSib.xml
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Title</work-title>
+    </work>
+  <identification>
+    <rights>Copyright © </rights>
+    <encoding>
+      <software>Sibelius</software>
+      <encoding-date>2024-04-16</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>4.8768</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>2435.77</page-height>
+      <page-width>1722.44</page-width>
+      <page-margins type="both">
+        <left-margin>103.346</left-margin>
+        <right-margin>103.346</right-margin>
+        <top-margin>86.9423</top-margin>
+        <bottom-margin>86.9423</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <appearance>
+      <line-width type="light barline">1.8</line-width>
+      <line-width type="heavy barline">5.5</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="bracket">4.4</line-width>
+      <line-width type="dashes">1.5</line-width>
+      <line-width type="enclosure">1</line-width>
+      <line-width type="ending">1.1</line-width>
+      <line-width type="extend">1</line-width>
+      <line-width type="leger">1.6</line-width>
+      <line-width type="pedal">1.1</line-width>
+      <line-width type="octave shift">1.1</line-width>
+      <line-width type="slur middle">2.1</line-width>
+      <line-width type="slur tip">0.7</line-width>
+      <line-width type="staff">1.1</line-width>
+      <line-width type="stem">1.1</line-width>
+      <line-width type="tie middle">2.1</line-width>
+      <line-width type="tie tip">0.7</line-width>
+      <line-width type="tuplet bracket">1</line-width>
+      <line-width type="wedge">1.2</line-width>
+      <note-size type="cue">70</note-size>
+      <note-size type="grace">70</note-size>
+      <note-size type="grace-cue">49</note-size>
+      </appearance>
+    <music-font font-family="Leland"/>
+    <word-font font-family="Plantin MT Std" font-size="11.9365"/>
+    <lyric-font font-family="MS Shell Dlg 2" font-size="14.47"/>
+    </defaults>
+  <credit page="1">
+    <credit-type>title</credit-type>
+    <credit-words default-x="861.221" default-y="2348.83" justify="center" valign="top" font-size="22.0128">Title</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="103.346" default-y="256.942" justify="left" valign="top" font-family="Edwin" font-size="10">2</credit-words>
+    </credit>
+  <credit page="2">
+    <credit-words default-x="1619.1" default-y="220.812" justify="right" valign="top" font-family="Edwin" font-size="10">3</credit-words>
+    </credit>
+  <credit page="3">
+    <credit-words default-x="103.346" default-y="317.674" justify="left" valign="top" font-family="Edwin" font-size="10">4</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-type>rights</credit-type>
+    <credit-words default-x="861.221" default-y="86.9423" justify="center" valign="bottom">Copyright © </credit-words>
+    </credit>
+  <credit page="2">
+    <credit-type>rights</credit-type>
+    <credit-words default-x="861.221" default-y="86.9423" justify="center" valign="bottom">Copyright © </credit-words>
+    </credit>
+  <credit page="3">
+    <credit-type>rights</credit-type>
+    <credit-words default-x="861.221" default-y="86.9423" justify="center" valign="bottom">Copyright © </credit-words>
+    </credit>
+  <credit page="4">
+    <credit-type>rights</credit-type>
+    <credit-words default-x="861.221" default-y="86.9423" justify="center" valign="bottom">Copyright © </credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Soprano/Tenor</part-name>
+      <part-abbreviation>S./T.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        <instrument-sound>keyboard.piano</instrument-sound>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P2">
+      <part-name>Alto</part-name>
+      <part-abbreviation>A.</part-abbreviation>
+      <score-instrument id="P2-I1">
+        <instrument-name>Piano</instrument-name>
+        <instrument-sound>keyboard.piano</instrument-sound>
+        </score-instrument>
+      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-instrument id="P2-I1">
+        <midi-channel>4</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P3">
+      <part-name>Bass</part-name>
+      <part-abbreviation>B.</part-abbreviation>
+      <score-instrument id="P3-I1">
+        <instrument-name>Piano</instrument-name>
+        <instrument-sound>keyboard.piano</instrument-sound>
+        </score-instrument>
+      <midi-device id="P3-I1" port="1"></midi-device>
+      <midi-instrument id="P3-I1">
+        <midi-channel>5</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P4">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P4-I1">
+        <instrument-name>Piano (2)</instrument-name>
+        <instrument-sound>keyboard.piano.grand</instrument-sound>
+        </score-instrument>
+      <midi-device id="P4-I1" port="1"></midi-device>
+      <midi-instrument id="P4-I1">
+        <midi-channel>2</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+  <measure number="1" width="147.22">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50</left-margin>
+            <right-margin>831.82</right-margin>
+            </system-margins>
+          <top-system-distance>170</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="91.72" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+</part>
+  <part id="P2">
+  <measure number="1" width="147.22">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50</left-margin>
+            <right-margin>831.82</right-margin>
+            </system-margins>
+          <top-system-distance>170</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="91.72" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+</part>
+  <part id="P3">
+  <measure number="1" width="147.22">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50</left-margin>
+            <right-margin>831.82</right-margin>
+            </system-margins>
+          <top-system-distance>170</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="91.72" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+</part>
+  <part id="P4">
+  <measure number="1" width="147.22">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50</left-margin>
+            <right-margin>831.82</right-margin>
+            </system-margins>
+          <top-system-distance>170</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="91.72" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+</part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/data/testTitleSwapSib_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTitleSwapSib_ref.mscx
@@ -1,0 +1,505 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.40">
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.26771</pageWidth>
+      <pageHeight>11.6917</pageHeight>
+      <pagePrintableWidth>7.27559</pagePrintableWidth>
+      <pageEvenLeftMargin>0.496061</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.496061</pageOddLeftMargin>
+      <pageEvenTopMargin>0.417323</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.417323</pageEvenBottomMargin>
+      <pageOddTopMargin>0.417323</pageOddTopMargin>
+      <pageOddBottomMargin>0.417323</pageOddBottomMargin>
+      <pageTwosided>0</pageTwosided>
+      <lyricsDashLineThickness>0.15</lyricsDashLineThickness>
+      <lyricsOddFontFace>MS Shell Dlg 2</lyricsOddFontFace>
+      <lyricsOddFontSize>14.47</lyricsOddFontSize>
+      <lyricsEvenFontFace>MS Shell Dlg 2</lyricsEvenFontFace>
+      <lyricsEvenFontSize>14.47</lyricsEvenFontSize>
+      <bracketWidth>0.44</bracketWidth>
+      <stemWidth>0.11</stemWidth>
+      <chordSymbolAFontFace>Plantin MT Std</chordSymbolAFontFace>
+      <chordSymbolAFontSize>11.9365</chordSymbolAFontSize>
+      <chordSymbolBFontFace>Plantin MT Std</chordSymbolBFontFace>
+      <chordSymbolBFontSize>11.9365</chordSymbolBFontSize>
+      <romanNumeralFontFace>Plantin MT Std</romanNumeralFontFace>
+      <nashvilleNumberFontFace>Plantin MT Std</nashvilleNumberFontFace>
+      <nashvilleNumberFontSize>11.9365</nashvilleNumberFontSize>
+      <slurEndWidth>0.07</slurEndWidth>
+      <tieEndWidth>0.07</tieEndWidth>
+      <tupletFontFace>Plantin MT Std</tupletFontFace>
+      <tupletFontSize>11.9365</tupletFontSize>
+      <titleFontFace>Plantin MT Std</titleFontFace>
+      <subTitleFontFace>Plantin MT Std</subTitleFontFace>
+      <composerFontFace>Plantin MT Std</composerFontFace>
+      <lyricistFontFace>Plantin MT Std</lyricistFontFace>
+      <fingeringFontFace>Plantin MT Std</fingeringFontFace>
+      <fingeringFontSize>11.9365</fingeringFontSize>
+      <lhGuitarFingeringFontFace>Plantin MT Std</lhGuitarFingeringFontFace>
+      <lhGuitarFingeringFontSize>11.9365</lhGuitarFingeringFontSize>
+      <rhGuitarFingeringFontFace>Plantin MT Std</rhGuitarFingeringFontFace>
+      <rhGuitarFingeringFontSize>11.9365</rhGuitarFingeringFontSize>
+      <stringNumberFontFace>Plantin MT Std</stringNumberFontFace>
+      <stringNumberFontSize>11.9365</stringNumberFontSize>
+      <stringTuningsFontSize>11.9365</stringTuningsFontSize>
+      <harpPedalDiagramFontFace>Plantin MT Std</harpPedalDiagramFontFace>
+      <harpPedalTextDiagramFontFace>Plantin MT Std</harpPedalTextDiagramFontFace>
+      <longInstrumentFontFace>Plantin MT Std</longInstrumentFontFace>
+      <longInstrumentFontSize>11.9365</longInstrumentFontSize>
+      <shortInstrumentFontFace>Plantin MT Std</shortInstrumentFontFace>
+      <shortInstrumentFontSize>11.9365</shortInstrumentFontSize>
+      <partInstrumentFontFace>Plantin MT Std</partInstrumentFontFace>
+      <partInstrumentFontSize>11.9365</partInstrumentFontSize>
+      <expressionFontFace>Plantin MT Std</expressionFontFace>
+      <expressionFontSize>11.9365</expressionFontSize>
+      <tempoFontFace>Plantin MT Std</tempoFontFace>
+      <tempoFontSize>11.9365</tempoFontSize>
+      <tempoChangeFontFace>Plantin MT Std</tempoChangeFontFace>
+      <tempoChangeFontSize>11.9365</tempoChangeFontSize>
+      <metronomeFontFace>Plantin MT Std</metronomeFontFace>
+      <metronomeFontSize>11.9365</metronomeFontSize>
+      <measureNumberFontFace>Plantin MT Std</measureNumberFontFace>
+      <measureNumberFontSize>11.9365</measureNumberFontSize>
+      <mmRestRangeFontFace>Plantin MT Std</mmRestRangeFontFace>
+      <mmRestRangeFontSize>11.9365</mmRestRangeFontSize>
+      <translatorFontFace>Plantin MT Std</translatorFontFace>
+      <translatorFontSize>11.9365</translatorFontSize>
+      <systemFontFace>Plantin MT Std</systemFontFace>
+      <systemFontSize>11.9365</systemFontSize>
+      <staffFontFace>Plantin MT Std</staffFontFace>
+      <staffFontSize>11.9365</staffFontSize>
+      <rehearsalMarkFontFace>Plantin MT Std</rehearsalMarkFontFace>
+      <rehearsalMarkFontSize>11.9365</rehearsalMarkFontSize>
+      <repeatLeftFontFace>Plantin MT Std</repeatLeftFontFace>
+      <repeatLeftFontSize>11.9365</repeatLeftFontSize>
+      <repeatRightFontFace>Plantin MT Std</repeatRightFontFace>
+      <repeatRightFontSize>11.9365</repeatRightFontSize>
+      <frameFontFace>Plantin MT Std</frameFontFace>
+      <frameFontSize>11.9365</frameFontSize>
+      <glissandoFontFace>Plantin MT Std</glissandoFontFace>
+      <glissandoFontSize>11.9365</glissandoFontSize>
+      <bendFontFace>Plantin MT Std</bendFontFace>
+      <bendFontSize>11.9365</bendFontSize>
+      <headerFontFace>Plantin MT Std</headerFontFace>
+      <headerFontSize>11.9365</headerFontSize>
+      <footerFontFace>Plantin MT Std</footerFontFace>
+      <footerFontSize>11.9365</footerFontSize>
+      <instrumentChangeFontFace>Plantin MT Std</instrumentChangeFontFace>
+      <instrumentChangeFontSize>11.9365</instrumentChangeFontSize>
+      <stickingFontFace>Plantin MT Std</stickingFontFace>
+      <stickingFontSize>11.9365</stickingFontSize>
+      <user1FontFace>Plantin MT Std</user1FontFace>
+      <user1FontSize>11.9365</user1FontSize>
+      <user2FontFace>Plantin MT Std</user2FontFace>
+      <user2FontSize>11.9365</user2FontSize>
+      <user3FontFace>Plantin MT Std</user3FontFace>
+      <user3FontSize>11.9365</user3FontSize>
+      <user4FontFace>Plantin MT Std</user4FontFace>
+      <user4FontSize>11.9365</user4FontSize>
+      <user5FontFace>Plantin MT Std</user5FontFace>
+      <user5FontSize>11.9365</user5FontSize>
+      <user6FontFace>Plantin MT Std</user6FontFace>
+      <user6FontSize>11.9365</user6FontSize>
+      <user7FontFace>Plantin MT Std</user7FontFace>
+      <user7FontSize>11.9365</user7FontSize>
+      <user8FontFace>Plantin MT Std</user8FontFace>
+      <user8FontSize>11.9365</user8FontSize>
+      <user9FontFace>Plantin MT Std</user9FontFace>
+      <user9FontSize>11.9365</user9FontSize>
+      <user10FontFace>Plantin MT Std</user10FontFace>
+      <user10FontSize>11.9365</user10FontSize>
+      <user11FontFace>Plantin MT Std</user11FontFace>
+      <user11FontSize>11.9365</user11FontSize>
+      <user12FontFace>Plantin MT Std</user12FontFace>
+      <user12FontSize>11.9365</user12FontSize>
+      <Spatium>1.2192</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright">Copyright © </metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Title</metaTag>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        </Staff>
+      <trackName>Soprano/Tenor</trackName>
+      <Instrument id="piano">
+        <longName>Soprano/Tenor</longName>
+        <shortName>S./T.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <controller ctrl="10" value="63"/>
+          <midiPort>0</midiPort>
+          <midiChannel>0</midiChannel>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part id="2">
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        </Staff>
+      <trackName>Alto</trackName>
+      <Instrument id="piano">
+        <longName>Alto</longName>
+        <shortName>A.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <controller ctrl="10" value="63"/>
+          <midiPort>0</midiPort>
+          <midiChannel>3</midiChannel>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part id="3">
+      <Staff id="3">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        </Staff>
+      <trackName>Bass</trackName>
+      <Instrument id="piano">
+        <longName>Bass</longName>
+        <shortName>B.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <controller ctrl="10" value="63"/>
+          <midiPort>0</midiPort>
+          <midiChannel>4</midiChannel>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part id="4">
+      <Staff id="4">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument id="piano">
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano (2)</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <singleNoteDynamics>0</singleNoteDynamics>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <controller ctrl="10" value="63"/>
+          <midiPort>0</midiPort>
+          <midiChannel>1</midiChannel>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>19.5</height>
+        <Text>
+          <style>poet</style>
+          <family>Edwin</family>
+          <align>left,top</align>
+          <offset x="0" y="-0.114849"/>
+          <text><font size="10"/><font face="Edwin"/>2</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      <VBox>
+        <height>3.5</height>
+        <Text>
+          <align>center,top</align>
+          <offset x="0" y="-0.083"/>
+          <text><font size="22.0128"/>Title</text>
+          </Text>
+        </VBox>
+      </Staff>
+    <Staff id="2">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="3">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="4">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -1163,6 +1163,12 @@ TEST_F(Musicxml_Tests, timesig3) {
 TEST_F(Musicxml_Tests, timeTick) {
     mxmlImportTestRef("testTimeTick");
 }
+TEST_F(Musicxml_Tests, titleSwapMu) {
+    mxmlImportTestRef("testTitleSwapMu");
+}
+TEST_F(Musicxml_Tests, titleSwapSib) {
+    mxmlImportTestRef("testTitleSwapSib");
+}
 TEST_F(Musicxml_Tests, trackHandling) {
     mxmlIoTest("testTrackHandling");
 }


### PR DESCRIPTION
Resolves: #22467 

The workaround for Sibelius scores' credits is only applied to Sibelius scores.
