### PR TITLE
Convert MDL1 scores to MDL2

### DIFF
--- a/share/templates/CMakeLists.txt
+++ b/share/templates/CMakeLists.txt
@@ -23,6 +23,10 @@
 # like by running ../instruments/update_instruments_xml.py
 
 install(FILES
+      Marching_Bass_Drums.drm
+      Marching_Cymbals.drm
+      Marching_Snare_Drums.drm
+      Marching_Tenors.drm
       drumset_fr.drm
       orchestral.drm
       My_First_Score.mscx

--- a/share/templates/Marching_Bass_Drums.drm
+++ b/share/templates/Marching_Bass_Drums.drm
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.40">
+  <Drum pitch="37">
+    <head>normal</head>
+    <line>9</line>
+    <voice>0</voice>
+    <name>Drum 5 Hits</name>
+    <stem>1</stem>
+    <shortcut>A</shortcut>
+    </Drum>
+  <Drum pitch="39">
+    <head>cross</head>
+    <line>9</line>
+    <voice>0</voice>
+    <name>Drum 5 Rims</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="49">
+    <head>normal</head>
+    <line>7</line>
+    <voice>0</voice>
+    <name>Drum 4 Hits</name>
+    <stem>1</stem>
+    <shortcut>B</shortcut>
+    </Drum>
+  <Drum pitch="51">
+    <head>cross</head>
+    <line>7</line>
+    <voice>0</voice>
+    <name>Drum 4 Rims</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="61">
+    <head>normal</head>
+    <line>5</line>
+    <voice>0</voice>
+    <name>Drum 3 Hits</name>
+    <stem>1</stem>
+    <shortcut>C</shortcut>
+    </Drum>
+  <Drum pitch="63">
+    <head>cross</head>
+    <line>5</line>
+    <voice>0</voice>
+    <name>Drum 3 Rims</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="90">
+    <head>slash</head>
+    <line>4</line>
+    <voice>0</voice>
+    <name>Unison Hits</name>
+    <stem>1</stem>
+    <shortcut>F</shortcut>
+    </Drum>
+  <Drum pitch="73">
+    <head>normal</head>
+    <line>3</line>
+    <voice>0</voice>
+    <name>Drum 2 Hits</name>
+    <stem>1</stem>
+    <shortcut>D</shortcut>
+    </Drum>
+  <Drum pitch="75">
+    <head>cross</head>
+    <line>3</line>
+    <voice>0</voice>
+    <name>Drum 2 Rims</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="92">
+    <head>normal</head>
+    <noteheads>
+      <whole>noteheadSlashX</whole>
+      <half>noteheadSlashX</half>
+      <quarter>noteheadSlashX</quarter>
+      <breve>noteheadSlashX</breve>
+      </noteheads>
+    <line>4</line>
+    <voice>0</voice>
+    <name>Unison Rims</name>
+    <stem>1</stem>
+    <shortcut>G</shortcut>
+    </Drum>
+  <Drum pitch="85">
+    <head>normal</head>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Drum 1 Hits</name>
+    <stem>1</stem>
+    <shortcut>E</shortcut>
+    </Drum>
+  <Drum pitch="87">
+    <head>cross</head>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Drum 1 Rims</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="91">
+    <head>normal</head>
+    <noteheads>
+      <whole>noteheadXOrnate</whole>
+      <half>noteheadXOrnate</half>
+      <quarter>noteheadXOrnate</quarter>
+      <breve>noteheadXOrnate</breve>
+      </noteheads>
+    <line>4</line>
+    <voice>0</voice>
+    <name>Unison Rimshots</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="38">
+    <head>normal</head>
+    <noteheads>
+      <whole>noteheadXOrnate</whole>
+      <half>noteheadXOrnate</half>
+      <quarter>noteheadXOrnate</quarter>
+      <breve>noteheadXOrnate</breve>
+      </noteheads>
+    <line>9</line>
+    <voice>0</voice>
+    <name>Drum 5 Rimshots</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="50">
+    <head>normal</head>
+    <noteheads>
+      <whole>noteheadXOrnate</whole>
+      <half>noteheadXOrnate</half>
+      <quarter>noteheadXOrnate</quarter>
+      <breve>noteheadXOrnate</breve>
+      </noteheads>
+    <line>7</line>
+    <voice>0</voice>
+    <name>Drum 4 Rimshots</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="62">
+    <head>normal</head>
+    <noteheads>
+      <whole>noteheadXOrnate</whole>
+      <half>noteheadXOrnate</half>
+      <quarter>noteheadXOrnate</quarter>
+      <breve>noteheadXOrnate</breve>
+      </noteheads>
+    <line>5</line>
+    <voice>0</voice>
+    <name>Drum 3 Rimshots</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="74">
+    <head>normal</head>
+    <noteheads>
+      <whole>noteheadXOrnate</whole>
+      <half>noteheadXOrnate</half>
+      <quarter>noteheadXOrnate</quarter>
+      <breve>noteheadXOrnate</breve>
+      </noteheads>
+    <line>3</line>
+    <voice>0</voice>
+    <name>Drum 2 Rimshots</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="86">
+    <head>normal</head>
+    <noteheads>
+      <whole>noteheadXOrnate</whole>
+      <half>noteheadXOrnate</half>
+      <quarter>noteheadXOrnate</quarter>
+      <breve>noteheadXOrnate</breve>
+      </noteheads>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Drum 1 Rimshots</name>
+    <stem>1</stem>
+    </Drum>
+  </museScore>

--- a/share/templates/Marching_Cymbals.drm
+++ b/share/templates/Marching_Cymbals.drm
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.20">
+  <Drum pitch="72">
+    <head>normal</head>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Crash</name>
+    <stem>1</stem>
+    <shortcut>A</shortcut>
+    </Drum>
+  <Drum pitch="79">
+    <head>normal</head>
+    <noteheads>
+      <whole>noteheadXOrnate</whole>
+      <half>noteheadXOrnate</half>
+      <quarter>noteheadXOrnate</quarter>
+      <breve>noteheadXOrnate</breve>
+      </noteheads>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Punch</name>
+    <stem>1</stem>
+    <shortcut>G</shortcut>
+    </Drum>
+  <Drum pitch="89">
+    <head>plus</head>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Suc</name>
+    <stem>1</stem>
+    <shortcut>B</shortcut>
+    </Drum>
+  <Drum pitch="81">
+    <head>triangle-up</head>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Tap</name>
+    <stem>1</stem>
+    <shortcut>D</shortcut>
+    </Drum>
+  <Drum pitch="76">
+    <head>cross</head>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Crunch (HH)</name>
+    <stem>1</stem>
+    <shortcut>C</shortcut>
+    </Drum>
+  <Drum pitch="84">
+    <head>normal</head>
+    <noteheads>
+      <whole>noteheadTriangleRoundDownWhite</whole>
+      <half>noteheadTriangleRoundDownWhite</half>
+      <quarter>noteheadTriangleRoundDownBlack</quarter>
+      <breve>noteShapeTriangleRoundDoubleWhole</breve>
+      </noteheads>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Ting</name>
+    <stem>1</stem>
+    <shortcut>E</shortcut>
+    </Drum>
+  <Drum pitch="91">
+    <head>slashed1</head>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Zing</name>
+    <stem>1</stem>
+    <shortcut>F</shortcut>
+    </Drum>
+  <Drum pitch="77">
+    <head>diamond</head>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Sizzle</name>
+    <stem>1</stem>
+    </Drum>
+  </museScore>

--- a/share/templates/Marching_Snare_Drums.drm
+++ b/share/templates/Marching_Snare_Drums.drm
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.40">
+  <Drum pitch="55">
+    <head>plus</head>
+    <line>-1</line>
+    <voice>0</voice>
+    <name>Stick click</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="50">
+    <head>normal</head>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Hit</name>
+    <stem>1</stem>
+    <shortcut>A</shortcut>
+    </Drum>
+  <Drum pitch="53">
+    <head>cross</head>
+    <line>0</line>
+    <voice>0</voice>
+    <name>Rim</name>
+    <stem>1</stem>
+    <shortcut>C</shortcut>
+    </Drum>
+  <Drum pitch="57">
+    <head>slashed2</head>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Stick Shot</name>
+    <stem>1</stem>
+    <shortcut>F</shortcut>
+    </Drum>
+  <Drum pitch="56">
+    <head>slashed1</head>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Cross Stick</name>
+    <stem>1</stem>
+    <shortcut>E</shortcut>
+    </Drum>
+  <Drum pitch="49">
+    <head>normal</head>
+    <noteheads>
+      <whole>noteheadRoundWhiteWithDot</whole>
+      <half>noteheadRoundWhiteWithDot</half>
+      <quarter>noteheadRoundWhiteWithDot</quarter>
+      <breve>noteheadRoundWhiteWithDot</breve>
+      </noteheads>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Ping Shot</name>
+    <stem>1</stem>
+    <shortcut>D</shortcut>
+    </Drum>
+  <Drum pitch="51">
+    <head>normal</head>
+    <noteheads>
+      <whole>noteheadXOrnate</whole>
+      <half>noteheadXOrnate</half>
+      <quarter>noteheadXOrnate</quarter>
+      <breve>noteheadXOrnate</breve>
+      </noteheads>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Rim Shot</name>
+    <stem>1</stem>
+    <shortcut>B</shortcut>
+    </Drum>
+  <Drum pitch="52">
+    <head>normal</head>
+    <noteheads>
+      <whole>noteheadCircleX</whole>
+      <half>noteheadCircleX</half>
+      <quarter>noteheadCircleX</quarter>
+      <breve>noteheadCircleX</breve>
+      </noteheads>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Gok Shot</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="60">
+    <head>normal</head>
+    <noteheads>
+      <whole>noteheadTriangleRoundDownWhite</whole>
+      <half>noteheadTriangleRoundDownWhite</half>
+      <quarter>noteheadTriangleRoundDownBlack</quarter>
+      <breve>noteShapeTriangleRoundDoubleWhole</breve>
+      </noteheads>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Back Stick</name>
+    <stem>1</stem>
+    <shortcut>G</shortcut>
+    </Drum>
+  </museScore>

--- a/share/templates/Marching_Tenors.drm
+++ b/share/templates/Marching_Tenors.drm
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.20">
+  <Drum pitch="36">
+    <head>normal</head>
+    <line>7</line>
+    <voice>0</voice>
+    <name>Drum 4</name>
+    <stem>1</stem>
+    <shortcut>A</shortcut>
+    </Drum>
+  <Drum pitch="48">
+    <head>normal</head>
+    <line>5</line>
+    <voice>0</voice>
+    <name>Drum 3</name>
+    <stem>1</stem>
+    <shortcut>B</shortcut>
+    </Drum>
+  <Drum pitch="60">
+    <head>normal</head>
+    <line>3</line>
+    <voice>0</voice>
+    <name>Drum 2</name>
+    <stem>1</stem>
+    <shortcut>C</shortcut>
+    </Drum>
+  <Drum pitch="72">
+    <head>normal</head>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Drum 1</name>
+    <stem>1</stem>
+    <shortcut>D</shortcut>
+    </Drum>
+  <Drum pitch="84">
+    <head>normal</head>
+    <line>-1</line>
+    <voice>0</voice>
+    <name>Spock 2</name>
+    <stem>1</stem>
+    <shortcut>E</shortcut>
+    </Drum>
+  <Drum pitch="96">
+    <head>normal</head>
+    <line>-2</line>
+    <voice>0</voice>
+    <name>Spock 1</name>
+    <stem>1</stem>
+    <shortcut>F</shortcut>
+    </Drum>
+  <Drum pitch="41">
+    <head>normal</head>
+    <noteheads>
+      <whole>noteheadXOrnate</whole>
+      <half>noteheadXOrnate</half>
+      <quarter>noteheadXOrnate</quarter>
+      <breve>noteheadXOrnate</breve>
+      </noteheads>
+    <line>7</line>
+    <voice>0</voice>
+    <name>Drum 4 Shot</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="53">
+    <head>normal</head>
+    <noteheads>
+      <whole>noteheadXOrnate</whole>
+      <half>noteheadXOrnate</half>
+      <quarter>noteheadXOrnate</quarter>
+      <breve>noteheadXOrnate</breve>
+      </noteheads>
+    <line>5</line>
+    <voice>0</voice>
+    <name>Drum 3 Shot</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="65">
+    <head>normal</head>
+    <noteheads>
+      <whole>noteheadXOrnate</whole>
+      <half>noteheadXOrnate</half>
+      <quarter>noteheadXOrnate</quarter>
+      <breve>noteheadXOrnate</breve>
+      </noteheads>
+    <line>3</line>
+    <voice>0</voice>
+    <name>Drum 2 Shot</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="77">
+    <head>normal</head>
+    <noteheads>
+      <whole>noteheadXOrnate</whole>
+      <half>noteheadXOrnate</half>
+      <quarter>noteheadXOrnate</quarter>
+      <breve>noteheadXOrnate</breve>
+      </noteheads>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Drum 1 Shot</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="89">
+    <head>normal</head>
+    <noteheads>
+      <whole>noteheadXOrnate</whole>
+      <half>noteheadXOrnate</half>
+      <quarter>noteheadXOrnate</quarter>
+      <breve>noteheadXOrnate</breve>
+      </noteheads>
+    <line>-1</line>
+    <voice>0</voice>
+    <name>Spock 2 Shot</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="101">
+    <head>normal</head>
+    <noteheads>
+      <whole>noteheadXOrnate</whole>
+      <half>noteheadXOrnate</half>
+      <quarter>noteheadXOrnate</quarter>
+      <breve>noteheadXOrnate</breve>
+      </noteheads>
+    <line>-2</line>
+    <voice>0</voice>
+    <name>Spock 1 Shot</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="37">
+    <head>cross</head>
+    <line>7</line>
+    <voice>0</voice>
+    <name>Drum 4 Rim</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="49">
+    <head>cross</head>
+    <line>5</line>
+    <voice>0</voice>
+    <name>Drum 3 Rim</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="61">
+    <head>cross</head>
+    <line>3</line>
+    <voice>0</voice>
+    <name>Drum 2 Rim</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="73">
+    <head>cross</head>
+    <line>1</line>
+    <voice>0</voice>
+    <name>Drum 1 Rim</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="85">
+    <head>cross</head>
+    <line>-1</line>
+    <voice>0</voice>
+    <name>Spock 2 Rim</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="97">
+    <head>cross</head>
+    <line>-2</line>
+    <voice>0</voice>
+    <name>Spock 1 Rim</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="40">
+    <head>xcircle</head>
+    <line>7</line>
+    <voice>0</voice>
+    <name>Drum 4 Shell</name>
+    <stem>1</stem>
+    </Drum>
+  <Drum pitch="52">
+    <head>xcircle</head>
+    <line>5</line>
+    <voice>0</voice>
+    <name>Drum 3 Shell</name>
+    <stem>1</stem>
+    </Drum>
+  </museScore>

--- a/src/app/internal/consoleapp.cpp
+++ b/src/app/internal/consoleapp.cpp
@@ -223,6 +223,7 @@ void ConsoleApp::applyCommandLineOptions(const CmdOptions& options, IApplication
             migration.isApplyMigration = isMigration;
             migration.isApplyEdwin = isMigration;
             migration.isApplyLeland = isMigration;
+            migration.isRemapPercussion = isMigration;
         }
 
         //! NOTE Don't write to settings, just on current session

--- a/src/engraving/dom/drumset.h
+++ b/src/engraving/dom/drumset.h
@@ -95,6 +95,7 @@ public:
     int prevPitch(int) const;
     DrumInstrument& drum(int i) { return m_drum[i]; }
     const DrumInstrument& drum(int i) const { return m_drum[i]; }
+    void setDrum(int pitch, const DrumInstrument& di) { m_drum[pitch] = di; }
     DrumInstrumentVariant findVariant(int pitch, const std::vector<Articulation*>& articulations, TremoloType tremType) const;
 
     static void initDrumset();

--- a/src/engraving/rw/read302/read302.cpp
+++ b/src/engraving/rw/read302/read302.cpp
@@ -316,6 +316,19 @@ void Read302::fixInstrumentId(Instrument* instrument)
         id = u"marching-cymbals";
     } else if (id == u"bass-drum" && trackName == u"bass drums") {
         id = u"marching-bass-drums";
+    } else if (id.startsWith(u"mdl-")) {
+        // See https://github.com/musescore/mdl/blob/master/resources/instruments/mdl_1_3_0.xml
+        if (id == u"mdl-snareline" || id == u"mdl-snareline-a" || id == u"mdl-snaresolo" || id == u"mdl-snaresolo-a") {
+            id = u"marching-snare";
+        } else if (id == u"mdl-tenorline" || id == u"mdl-tenorsolo" || id == u"mdl-flubs") {
+            id = u"marching-tenor-drums";
+        } else if (id == u"mdl-bassline-10" || id == u"mdl-bassline-5") {
+            id = u"marching-bass-drums";
+        } else if (id == u"mdl-cymballine") {
+            id = u"marching-cymbals";
+        } else if (id == u"mdl-showtenorline" || id == u"mdl-rail" || id == u"mdl-drumset" || id == u"mdl-sampler") {
+            id = u"drumset";
+        }
     }
 
     instrument->setId(id);

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -799,13 +799,7 @@ void TRead::read(Instrument* item, XmlReader& e, ReadContext& ctx, Part* part)
         }
     }
 
-    if (item->musicXmlId().isEmpty()) {
-        item->setMusicXmlId(item->recognizeMusicXmlId());
-    }
-
-    if (item->id().isEmpty()) {
-        item->setId(item->recognizeId());
-    }
+    item->updateInstrumentId();
 
     if (item->channel(0) && item->channel(0)->program() == -1) {
         item->channel(0)->setProgram(item->recognizeMidiProgram());

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -978,13 +978,7 @@ void TRead::read(Instrument* item, XmlReader& e, ReadContext& ctx, Part* part)
         }
     }
 
-    if (item->musicXmlId().isEmpty()) {
-        item->setMusicXmlId(item->recognizeMusicXmlId());
-    }
-
-    if (item->id().isEmpty()) {
-        item->setId(item->recognizeId());
-    }
+    item->updateInstrumentId();
 
     if (item->channel(0) && item->channel(0)->program() == -1) {
         item->channel(0)->setProgram(item->recognizeMidiProgram());

--- a/src/framework/uicomponents/qml/Muse/UiComponents/CheckBox.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/CheckBox.qml
@@ -118,7 +118,8 @@ FocusScope {
         anchors.fill: contentRow
         anchors.margins: -4
 
-        hoverEnabled: true
+        hoverEnabled: !label.hoveredLink
+        z: label.z - 1 // enable clicking on links in label text
 
         onClicked: {
             navigation.requestActiveByInteraction()

--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -102,6 +102,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/itemplatesrepository.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/templatesrepository.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/templatesrepository.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/mdlmigrator.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/mdlmigrator.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/projectmigrator.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/projectmigrator.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/projectfileinfoprovider.cpp

--- a/src/project/internal/mdlmigrator.cpp
+++ b/src/project/internal/mdlmigrator.cpp
@@ -1,0 +1,289 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "mdlmigrator.h"
+
+#include "engraving/dom/chord.h"
+#include "engraving/dom/drumset.h"
+#include "engraving/dom/masterscore.h"
+#include "engraving/dom/note.h"
+#include "engraving/dom/part.h"
+
+#include "log.h"
+
+using namespace mu;
+using namespace mu::project;
+using namespace mu::engraving;
+using namespace muse;
+using namespace muse::io;
+
+void MdlMigrator::remapPercussion()
+{
+    IF_ASSERT_FAILED(m_score) {
+        return;
+    }
+
+    for (Part* part : m_score->parts()) {
+        const track_idx_t startTrack = part->startTrack();
+        const track_idx_t endTrack = part->endTrack();
+        const InstrumentList& instruments = part->instruments();
+
+        // First instrument in list is the "default instrument".
+        // It's at tick -1 but we must start at tick 0.
+        auto it = instruments.cbegin();
+        for (Fraction startTick(0, 1), endTick; it != instruments.cend(); startTick = endTick) {
+            Instrument* instr = it->second;
+            ++it; // careful, iterator now points to next instrument in the list
+            endTick = (it == instruments.cend())
+                      ? m_score->endTick()
+                      : Fraction::fromTicks(it->first);
+
+            if (!instr || !instr->useDrumset() || !instr->musicXmlId().startsWith(u"mdl.")) {
+                continue;
+            }
+
+            RepitchFunc repitch;
+
+            if (!needToRemap(*instr, repitch)) {
+                continue;
+            }
+
+            remapPitches(startTrack, endTrack, startTick, endTick, repitch);
+
+            Drumset* drumset = instr->drumset();
+            Drumset newDrumset;
+            newDrumset.clear();
+            for (int i = 0; i < DRUM_INSTRUMENTS; ++i) {
+                if (drumset->isValid(i)) {
+                    newDrumset.setDrum(repitch(i), drumset->drum(i));
+                }
+            }
+            instr->setDrumset(&newDrumset);
+            // Note: The new drumset may have fewer drums than the old one.
+            // This happens if there were two pitches X and Y for which
+            // repitch(X) == repitch(Y), and the old drumset had drums on
+            // both X and Y. The winning drum is the higher of X and Y.
+        }
+    }
+}
+
+void MdlMigrator::remapPitches(track_idx_t startTrack, track_idx_t endTrack, Fraction startTick, Fraction endTick,
+                               const RepitchFunc& repitch)
+{
+    const auto repitchChord = [repitch] (Chord* chord) {
+        for (Note* note : chord->notes()) {
+            note->setPitch(repitch(note->pitch()));
+            note->setTpcFromPitch(Prefer::SHARPS); // required for playback
+        }
+    };
+
+    for (
+        Segment* seg = m_score->tick2segment(startTick, true, SegmentType::ChordRest);
+        seg && seg->tick() < endTick;
+        seg = seg->next1(SegmentType::ChordRest)
+        ) {
+        for (track_idx_t track = startTrack; track < endTrack; ++track) {
+            EngravingItem* el = seg->element(track);
+            if (!el || !el->isChord()) {
+                continue;
+            }
+            Chord* ch = toChord(el);
+            repitchChord(ch);
+            for (Chord* gch : ch->graceNotes()) {
+                repitchChord(gch);
+            }
+        }
+    }
+}
+
+bool MdlMigrator::needToRemap(const Instrument& instr, RepitchFunc& repitch)
+{
+    const Drumset* drumset = instr.drumset();
+    const InstrChannel* channel = instr.channel(0);
+
+    if (!drumset || !channel || channel->synti() != u"Zerberus") {
+        return false;
+    }
+
+    const int program = channel->program();
+    const String musicXmlId = instr.musicXmlId();
+
+    if (musicXmlId == u"mdl.drum.snare-drum" && (program == 5 || program == 6)) {
+        // MDL Snare Line   (id="mdl-snareline")
+        // MDL Snare Line A (id="mdl-snareline-a")
+        // MDL Snare        (id="mdl-snaresolo")
+        // MDL Snare A      (id="mdl-snaresolo-a")
+        repitch = repitchMdlSnares;
+    } else if (musicXmlId == u"mdl.drum.tenor-drum" && (program == 7 || program == 8)) {
+        // MDL Tenor Line   (id="mdl-tenorline")
+        // MDL Tenors       (id="mdl-tenorsolo")
+        repitch = repitchMdlTenors;
+    } else if (musicXmlId == u"mdl.drum.bass-drum" && program == 0) {
+        if (drumset->isValid(61)) {
+            // MDL Bass Line (10)   (id="mdl-bassline-10")
+            repitch = repitchMdlBassline10;
+        } else {
+            // MDL Bass Line (5)    (id="mdl-bassline-5")
+            repitch = repitchMdlBassline5;
+        }
+    } else if (musicXmlId == u"mdl.metal.cymbal.crash" && program == 1) {
+        // MDL Cymbal Line  (id="mdl-cymballine")
+        repitch = repitchMdlCymballine;
+    } else {
+        return false;
+    }
+    return true;
+}
+
+int MdlMigrator::repitchMdlSnares(int pitch)
+{
+    switch (pitch) {
+    case 23: return 55;
+    case 27: return 25;
+    case 29: return 92;
+    case 30: return 91;
+    case 31: return 89;
+    case 32: return 58;
+    case 33: return 71;
+    case 36: return 76;
+    case 38: return 40;
+    case 39: return 38;
+    case 40: return 36;
+    case 60: return 50;
+    case 61: return 51;
+    case 62: return 56;
+    case 63: return 53;
+    case 64: return 49;
+    case 65: return 57;
+    case 67: return 60;
+    case 68: return 60;
+    case 72: return 65;
+    case 73: return 67;
+    case 74: return 59;
+    case 76: return 55;
+    case 77: return 24;
+    }
+    return pitch;
+}
+
+int MdlMigrator::repitchMdlTenors(int pitch)
+{
+    switch (pitch) {
+    case 47: return 40;
+    case 60: return 36;
+    case 61: return 48;
+    case 62: return 60;
+    case 63: return 72;
+    case 64: return 84;
+    case 65: return 96;
+    case 72: return 41;
+    case 73: return 53;
+    case 74: return 65;
+    case 75: return 77;
+    case 76: return 89;
+    case 77: return 101;
+    case 78: return 37;
+    case 79: return 49;
+    case 80: return 61;
+    case 81: return 73;
+    case 82: return 85;
+    case 83: return 97;
+    case 96: return 37;
+    case 97: return 49;
+    case 98: return 61;
+    case 107: return 36;
+    }
+    return pitch;
+}
+
+int MdlMigrator::repitchMdlBassline10(int pitch)
+{
+    switch (pitch) {
+    case 60: return 90;
+    case 61: return 37;
+    case 62: return 37;
+    case 63: return 49;
+    case 64: return 49;
+    case 65: return 61;
+    case 66: return 61;
+    case 67: return 73;
+    case 68: return 73;
+    case 69: return 85;
+    case 70: return 85;
+    case 72: return 92;
+    case 73: return 39;
+    case 74: return 39;
+    case 75: return 51;
+    case 76: return 51;
+    case 77: return 63;
+    case 78: return 63;
+    case 79: return 75;
+    case 80: return 75;
+    case 81: return 87;
+    case 82: return 87;
+    }
+    return pitch;
+}
+
+int MdlMigrator::repitchMdlBassline5(int pitch)
+{
+    switch (pitch) {
+    case 60: return 90;
+    case 62: return 37;
+    case 64: return 49;
+    case 67: return 61;
+    case 68: return 73;
+    case 70: return 85;
+    case 72: return 92;
+    case 74: return 39;
+    case 76: return 51;
+    case 79: return 63;
+    case 80: return 75;
+    case 82: return 87;
+    }
+    return pitch;
+}
+
+int MdlMigrator::repitchMdlCymballine(int pitch)
+{
+    switch (pitch) {
+    case 38: return 72;
+    case 43: return 81;
+    case 45: return 76;
+    case 47: return 77;
+    case 50: return 84;
+    case 51: return 91;
+    case 62: return 72;
+    case 67: return 81;
+    case 69: return 76;
+    case 71: return 77;
+    case 74: return 84;
+    case 75: return 91;
+    case 86: return 72;
+    case 91: return 81;
+    case 93: return 76;
+    case 95: return 77;
+    case 98: return 84;
+    case 99: return 91;
+    }
+    return pitch;
+}

--- a/src/project/internal/mdlmigrator.h
+++ b/src/project/internal/mdlmigrator.h
@@ -22,7 +22,9 @@
 
 #pragma once
 
+#include "modularity/ioc.h"
 #include "engraving/types/types.h"
+#include "iglobalconfiguration.h"
 
 namespace mu::engraving {
 class Drumset;
@@ -36,15 +38,18 @@ using RepitchFunc = std::function<int (int)>;
 
 class MdlMigrator
 {
+    INJECT(muse::IGlobalConfiguration, globalConfiguration)
+
 public:
     MdlMigrator(mu::engraving::MasterScore* score)
         : m_score(score) {}
     void remapPercussion();
 
 private:
+    bool loadDrumset(mu::engraving::Drumset* drumset, muse::io::path_t path);
     void remapPitches(mu::engraving::track_idx_t startTrack, mu::engraving::track_idx_t endTrack, mu::engraving::Fraction startTick,
                       mu::engraving::Fraction endTick, const RepitchFunc& repitch);
-    bool needToRemap(const mu::engraving::Instrument& instr, RepitchFunc& repitch);
+    bool needToRemap(const mu::engraving::Instrument& instr, RepitchFunc& repitch, muse::io::path_t& drumsetPath);
 
     // Repitch functions
     static int repitchMdlSnares(int pitch);

--- a/src/project/internal/mdlmigrator.h
+++ b/src/project/internal/mdlmigrator.h
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "engraving/types/types.h"
+
+namespace mu::engraving {
+class Drumset;
+class Instrument;
+class MasterScore;
+class Score;
+}
+
+namespace mu::project {
+using RepitchFunc = std::function<int (int)>;
+
+class MdlMigrator
+{
+public:
+    MdlMigrator(mu::engraving::MasterScore* score)
+        : m_score(score) {}
+    void remapPercussion();
+
+private:
+    void remapPitches(mu::engraving::track_idx_t startTrack, mu::engraving::track_idx_t endTrack, mu::engraving::Fraction startTick,
+                      mu::engraving::Fraction endTick, const RepitchFunc& repitch);
+    bool needToRemap(const mu::engraving::Instrument& instr, RepitchFunc& repitch);
+
+    // Repitch functions
+    static int repitchMdlSnares(int pitch);
+    static int repitchMdlTenors(int pitch);
+    static int repitchMdlBassline10(int pitch);
+    static int repitchMdlBassline5(int pitch);
+    static int repitchMdlCymballine(int pitch);
+
+    mu::engraving::MasterScore* m_score = nullptr;
+};
+}

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -455,6 +455,7 @@ MigrationOptions ProjectConfiguration::migrationOptions(MigrationType type) cons
         opt.isAskAgain = optionsObj["isAskAgain"].toBool();
         opt.isApplyLeland = optionsObj["isApplyLeland"].toBool();
         opt.isApplyEdwin = optionsObj["isApplyEdwin"].toBool();
+        opt.isRemapPercussion = optionsObj["isRemapPercussion"].toBool();
 
         m_migrationOptions[migrationType] = opt;
 
@@ -498,6 +499,7 @@ void ProjectConfiguration::setMigrationOptions(MigrationType type, const Migrati
         options["isAskAgain"] = o.isAskAgain;
         options["isApplyLeland"] = o.isApplyLeland;
         options["isApplyEdwin"] = o.isApplyEdwin;
+        options["isRemapPercussion"] = o.isRemapPercussion;
 
         QJsonObject obj;
         obj["migrationType"] = migrationTypeToString(it->first);

--- a/src/project/internal/projectmigrator.cpp
+++ b/src/project/internal/projectmigrator.cpp
@@ -23,6 +23,8 @@
 
 #include <QVersionNumber>
 
+#include "mdlmigrator.h"
+
 #include "engraving/types/constants.h"
 #include "engraving/dom/score.h"
 #include "engraving/dom/excerpt.h"
@@ -98,6 +100,8 @@ Ret ProjectMigrator::askAboutMigration(MigrationOptions& out, const QString& app
     query.addParam("migrationType", Val(migrationType));
     query.addParam("isApplyLeland", Val(out.isApplyLeland));
     query.addParam("isApplyEdwin", Val(out.isApplyEdwin));
+    query.addParam("isRemapPercussion", Val(out.isRemapPercussion));
+
     RetVal<Val> rv = interactive()->open(query);
     if (!rv.ret) {
         return rv.ret;
@@ -109,6 +113,7 @@ Ret ProjectMigrator::askAboutMigration(MigrationOptions& out, const QString& app
     out.isAskAgain = vals.value("isAskAgain").toBool();
     out.isApplyLeland = vals.value("isApplyLeland").toBool();
     out.isApplyEdwin = vals.value("isApplyEdwin").toBool();
+    out.isRemapPercussion = vals.value("isRemapPercussion").toBool();
 
     return true;
 }
@@ -160,6 +165,10 @@ Ret ProjectMigrator::migrateProject(engraving::EngravingProjectPtr project, cons
     if (ok && opt.isApplyEdwin) {
         ok = applyEdwinStyle(score);
         m_resetStyleSettings = false;
+    }
+
+    if (ok && opt.isRemapPercussion) {
+        MdlMigrator(score).remapPercussion();
     }
 
     if (ok && score->mscVersion() < 300) {

--- a/src/project/qml/MuseScore/Project/MigrationDialog.qml
+++ b/src/project/qml/MuseScore/Project/MigrationDialog.qml
@@ -39,6 +39,7 @@ StyledDialogView {
 
     property bool isApplyLeland: true
     property bool isApplyEdwin: true
+    property bool isRemapPercussion: true
     property bool isAskAgain: true
 
     contentHeight: {
@@ -85,6 +86,7 @@ StyledDialogView {
                 isAskAgain: dialog.isAskAgain,
                 isApplyLeland: dialog.isApplyLeland,
                 isApplyEdwin: dialog.isApplyEdwin,
+                isRemapPercussion: dialog.isRemapPercussion,
             }
         }
 
@@ -114,8 +116,13 @@ StyledDialogView {
 
             appVersion: dialog.appVersion
             isAskAgain: dialog.isAskAgain
+            isRemapPercussion: dialog.isRemapPercussion
 
             navigationPanel.section: dialog.navigationSection
+
+            onIsRemapPercussionChangeRequested: function(remapPercussion) {
+                dialog.isRemapPercussion = remapPercussion
+            }
 
             onIsAskAgainChangeRequested: function(askAgain) {
                 dialog.isAskAgain = askAgain
@@ -144,6 +151,7 @@ StyledDialogView {
 
             isApplyLeland: dialog.isApplyLeland
             isApplyEdwin: dialog.isApplyEdwin
+            isRemapPercussion: dialog.isRemapPercussion
 
             navigationSection: dialog.navigationSection
 
@@ -153,6 +161,10 @@ StyledDialogView {
 
             onIsApplyLelandChangeRequested: function(applyLeland) {
                 dialog.isApplyLeland = applyLeland
+            }
+
+            onIsRemapPercussionChangeRequested: function(remapPercussion) {
+                dialog.isRemapPercussion = remapPercussion
             }
 
             onIsAskAgainChangeRequested: function(askAgain) {

--- a/src/project/qml/MuseScore/Project/internal/Migration/MigrationContentFor362.qml
+++ b/src/project/qml/MuseScore/Project/internal/Migration/MigrationContentFor362.qml
@@ -32,6 +32,7 @@ ColumnLayout {
 
     property string appVersion: ""
     property bool isAskAgain: false
+    property bool isRemapPercussion: true
 
     property NavigationPanel navigationPanel: NavigationPanel {
         name: "MigrationPanel"
@@ -44,6 +45,7 @@ ColumnLayout {
     }
 
     signal isAskAgainChangeRequested(bool askAgain)
+    signal isRemapPercussionChangeRequested(bool remapPercussion)
     signal watchVideoRequested()
     signal access()
 
@@ -91,6 +93,24 @@ ColumnLayout {
         elide: Text.ElideNone
 
         text: qsTrc("project/migration", "Please note that the appearance of your score will change due to improvements we have made to default settings for beaming, ties, slurs, system objects and horizontal spacing.")
+    }
+
+    CheckBox {
+        id: percussionOption
+
+        Layout.fillWidth: true
+        height: 32
+
+        text: qsTrc("project/migration", "Use our new notation and sound mapping for <a href=\"%1\">MDL percussion</a>")
+              .arg("https://musescore.org/en/handbook/4") // TODO: Replace with link to page about MDL migration.
+        checked: root.isRemapPercussion
+
+        navigation.panel: navigationPanel
+        navigation.row: 3
+
+        onClicked: {
+            root.isRemapPercussionChangeRequested(!checked)
+        }
     }
 
     CheckBox {

--- a/src/project/qml/MuseScore/Project/internal/Migration/MigrationContentForPre362.qml
+++ b/src/project/qml/MuseScore/Project/internal/Migration/MigrationContentForPre362.qml
@@ -34,6 +34,7 @@ Item {
 
     property bool isApplyLeland: true
     property bool isApplyEdwin: true
+    property bool isRemapPercussion: true
 
     property NavigationSection navigationSection: null
 
@@ -45,6 +46,7 @@ Item {
     signal isAskAgainChangeRequested(bool askAgain)
     signal isApplyLelandChangeRequested(bool applyLeland)
     signal isApplyEdwinChangeRequested(bool applyEdwin)
+    signal isRemapPercussionChangeRequested(bool remapPercussion)
 
     signal watchVideoRequested()
     signal access()
@@ -155,9 +157,20 @@ Item {
             }
         }
 
-        Item {
-            width: 1
-            height: 16
+        CheckBox {
+            id: percussionOption
+            anchors.left: parent.left
+            height: 32
+            text: qsTrc("project/migration", "Our new notation and sound mapping for <a href=\"%1\">MDL percussion</a>")
+                  .arg("https://musescore.org/en/handbook/4") // TODO: Replace with link to page about MDL migration.
+            checked: root.isRemapPercussion
+
+            navigation.panel: mainContent.navigationPanel
+            navigation.row: 3
+
+            onClicked: {
+                root.isRemapPercussionChangeRequested(!checked)
+            }
         }
 
         StyledTextLabel {
@@ -201,14 +214,6 @@ Item {
             section: root.navigationSection
             accessible.role: MUAccessible.Dialog
             order: 1
-        }
-
-        Rectangle {
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.margins: -16
-            height: 2
-            color: ui.theme.buttonColor
         }
 
         CheckBox {

--- a/src/project/types/projecttypes.h
+++ b/src/project/types/projecttypes.h
@@ -61,6 +61,7 @@ struct MigrationOptions
 
     bool isApplyLeland = true;
     bool isApplyEdwin = true;
+    bool isRemapPercussion = true;
 
     bool isValid() const { return appVersion != 0; }
 };


### PR DESCRIPTION
Remap notes in _MuseScore Drumline_ (MDL1) scores to match the pitches in _Muse Drumline_ (MDL2) and MS Basic.

Pitches are changed both in the score and in the Edit Drumset dialog.

Notation is changed thanks to drumset definitions from Muse Drumline, which are included in this PR in case the user does not have Muse Drumline installed. (We want to use the new notation even with MS Basic.)

[Test_Scores.zip](https://github.com/user-attachments/files/16317323/Test_Scores.zip), download and extract (don't rename to MSCZ).