### PR TITLE
Fix missing gliss and bend lines in continuous layout

### DIFF
--- a/src/engraving/rendering/dev/systemlayout.cpp
+++ b/src/engraving/rendering/dev/systemlayout.cpp
@@ -921,7 +921,7 @@ void SystemLayout::layoutSystemElements(System* system, LayoutContext& ctx)
 
     // ties
     if (ctx.conf().isLinearMode()) {
-        doLayoutTiesLinear(system, ctx);
+        doLayoutNoteSpannersLinear(system, ctx);
     } else {
         doLayoutTies(system, sl, stick, etick, ctx);
     }
@@ -1394,7 +1394,19 @@ void SystemLayout::doLayoutTies(System* system, std::vector<Segment*> sl, const 
     }
 }
 
-void SystemLayout::doLayoutTiesLinear(System* system, LayoutContext& ctx)
+void SystemLayout::layoutNoteAnchoredSpanners(System* system, Chord* chord)
+{
+    // Add all spanners attached to notes, otherwise these will be removed if outside of the layout range
+    for (Note* note : chord->notes()) {
+        for (Spanner* spanner : note->spannerFor()) {
+            for (SpannerSegment* spannerSeg : spanner->spannerSegments()) {
+                spannerSeg->setSystem(system);
+            }
+        }
+    }
+}
+
+void SystemLayout::doLayoutNoteSpannersLinear(System* system, LayoutContext& ctx)
 {
     constexpr Fraction start = Fraction(0, 1);
     for (Measure* measure = system->firstMeasure(); measure; measure = measure->nextMeasure()) {
@@ -1409,8 +1421,10 @@ void SystemLayout::doLayoutTiesLinear(System* system, LayoutContext& ctx)
                 Chord* c = toChord(e);
                 for (Chord* ch : c->graceNotes()) {
                     layoutTies(ch, system, start, ctx);
+                    layoutNoteAnchoredSpanners(system, ch);
                 }
                 layoutTies(c, system, start, ctx);
+                layoutNoteAnchoredSpanners(system, c);
             }
         }
     }

--- a/src/engraving/rendering/dev/systemlayout.h
+++ b/src/engraving/rendering/dev/systemlayout.h
@@ -68,7 +68,8 @@ private:
     static void processLines(System* system, LayoutContext& ctx, std::vector<Spanner*> lines, bool align);
     static void layoutTies(Chord* ch, System* system, const Fraction& stick, LayoutContext& ctx);
     static void doLayoutTies(System* system, std::vector<Segment*> sl, const Fraction& stick, const Fraction& etick, LayoutContext& ctx);
-    static void doLayoutTiesLinear(System* system, LayoutContext& ctx);
+    static void doLayoutNoteSpannersLinear(System* system, LayoutContext& ctx);
+    static void layoutNoteAnchoredSpanners(System* system, Chord* chord);
     static void layoutGuitarBends(const std::vector<Segment*>& sl, LayoutContext& ctx);
     static void justifySystem(System* system, double curSysWidth, double targetSystemWidth);
     static void updateCrossBeams(System* system, LayoutContext& ctx);


### PR DESCRIPTION
Resolves: #21441 

This bug affects note-anchored lines (glissandos, bends, add>lines>note anchored line) in continuous view.  These lines are added to their system when they are layed out.  If they are outside of the layout range for this layout operation and not layed out, they are never added to the system.  This means we need to add all note anchored lines to the system on system layout.