### PR TITLE
Fix cmdFlip for items with voiceApplication property

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -2179,7 +2179,10 @@ void Score::cmdFlip()
     };
 
     for (EngravingItem* e : el) {
-        if (e->isNote() || e->isStem() || e->isHook()) {
+        if (e->hasVoiceApplicationProperties()) {
+            PlacementV curPlacement = e->getProperty(Pid::PLACEMENT).value<PlacementV>();
+            e->undoChangeProperty(Pid::DIRECTION, curPlacement == PlacementV::ABOVE ? DirectionV::DOWN : DirectionV::UP);
+        } else if (e->isNote() || e->isStem() || e->isHook()) {
             Chord* chord = nullptr;
             if (e->isNote()) {
                 chord = toNote(e)->chord();

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -2180,8 +2180,10 @@ void Score::cmdFlip()
 
     for (EngravingItem* e : el) {
         if (e->hasVoiceApplicationProperties()) {
-            PlacementV curPlacement = e->getProperty(Pid::PLACEMENT).value<PlacementV>();
-            e->undoChangeProperty(Pid::DIRECTION, curPlacement == PlacementV::ABOVE ? DirectionV::DOWN : DirectionV::UP);
+            flipOnce(e, [e]() {
+                PlacementV curPlacement = e->getProperty(Pid::PLACEMENT).value<PlacementV>();
+                e->undoChangeProperty(Pid::DIRECTION, curPlacement == PlacementV::ABOVE ? DirectionV::DOWN : DirectionV::UP);
+            });
         } else if (e->isNote() || e->isStem() || e->isHook()) {
             Chord* chord = nullptr;
             if (e->isNote()) {
@@ -2295,12 +2297,8 @@ void Score::cmdFlip()
                    || e->isStringTunings()
                    || e->isSticking()
                    || e->isFingering()
-                   || e->isDynamic()
-                   || e->isExpression()
                    || e->isHarmony()
                    || e->isFretDiagram()
-                   || e->isHairpin()
-                   || e->isHairpinSegment()
                    || e->isOttava()
                    || e->isOttavaSegment()
                    || e->isTrill()

--- a/src/inspector/models/notation/lines/textlinesettingsmodel.cpp
+++ b/src/inspector/models/notation/lines/textlinesettingsmodel.cpp
@@ -323,9 +323,10 @@ void TextLineSettingsModel::setPossibleEndHookTypes(const QList<HookTypeInfo>& t
     m_possibleEndHookTypes = hookTypesToObjList(types);
 }
 
-void TextLineSettingsModel::onNotationChanged(const PropertyIdSet& changedPropertyIdSet, const StyleIdSet&)
+void TextLineSettingsModel::onNotationChanged(const PropertyIdSet& changedPropertyIdSet, const StyleIdSet& styleIdSet)
 {
     loadProperties(changedPropertyIdSet);
+    InspectorModelWithVoiceAndPositionOptions::onNotationChanged(changedPropertyIdSet, styleIdSet);
 }
 
 void TextLineSettingsModel::loadProperties(const PropertyIdSet& propertyIdSet)


### PR DESCRIPTION
Resolves: #23369 

Reintroduces the functionality of the X shortcut for flipping direction of items with voice application properties (most importantly dynamics and hairpins).