### PR TITLE
Fix lost slur and crash

### DIFF
--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -634,7 +634,8 @@ static bool scoreContainsSpanner(const Score* score, Spanner* spanner)
     const std::multimap<int, Spanner*>& spanners = score->spanner();
 
     for (auto it = spanners.cbegin(); it != spanners.cend(); ++it) {
-        if (it->second->links()->contains(spanner)) {
+        const Spanner* curSpanner = it->second;
+        if (curSpanner->links() && curSpanner->links()->contains(spanner)) {
             return true;
         }
     }

--- a/src/engraving/rendering/dev/slurtielayout.cpp
+++ b/src/engraving/rendering/dev/slurtielayout.cpp
@@ -2122,6 +2122,8 @@ void SlurTieLayout::computeBezier(SlurSegment* slurSeg, PointF shoulderOffset)
              slurSeg->slur()->tick().ticks(), slurSeg->slur()->ticks().ticks());
         slurSeg->slur()->setBroken(true);
         return;
+    } else {
+        slurSeg->slur()->setBroken(false);
     }
 
     // Set up coordinate transforms


### PR DESCRIPTION
Resolves: #22241 

This PR resolves the reported crash (which is indeed related to the lost slur, even though it involves a volta), and it resolves the fact that the slur disappears _as shown in the issue_, i.e. after its end points have been adjusted onto the last eight note. That adjustment brings the slur into a valid state, so we must ensure that it's saved/reloaded correctly.
 
If that end-point adjustment is _not_ performed, then the slur remains in an invalid state, in which case it is intentionally skipped when writing the file, so it will still be lost. Fixing that (i.e. dealing with invalid slurs, or rather ensuring that they never become invalid) is a whole different story and beyond the scope of this PR.