### PR TITLE
Eliminate QQuickWidget and QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL)

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -116,10 +116,6 @@ int main(int argc, char** argv)
 
     QGuiApplication::styleHints()->setMousePressAndHoldInterval(250);
 
-    // Necessary for QQuickWidget, but potentially suboptimal for performance.
-    // Remove as soon as possible.
-    QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
-
     //! Needs to be set because we use transparent windows for PopupView.
     //! Needs to be called before any QQuickWindows are shown.
     QQuickWindow::setDefaultAlphaBuffer(true);

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -98,8 +98,6 @@ int main(int argc, char** argv)
 #ifdef Q_OS_WIN
     // NOTE: There are some problems with rendering the application window on some integrated graphics processors
     //       see https://github.com/musescore/MuseScore/issues/8270
-    QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);
-
     if (!qEnvironmentVariableIsSet("QT_OPENGL_BUGLIST")) {
         qputenv("QT_OPENGL_BUGLIST", ":/resources/win_opengl_buglist.json");
     }

--- a/src/notation/view/styledialog/accidentalgrouppagemodel.h
+++ b/src/notation/view/styledialog/accidentalgrouppagemodel.h
@@ -33,7 +33,7 @@ class AccidentalGroupPageModel : public AbstractStyleDialogModel
     Q_PROPERTY(StyleItem * accidFollowNoteOffset READ accidFollowNoteOffset CONSTANT)
     Q_PROPERTY(StyleItem * alignAccidentalOctavesAcrossSubChords READ alignAccidentalOctavesAcrossSubChords CONSTANT)
     Q_PROPERTY(StyleItem * keepAccidentalSecondsTogether READ keepAccidentalSecondsTogether CONSTANT)
-    Q_PROPERTY(StyleItem * alignOffsetOctaveAccidentals READ alignOffsetOctaveAccidentals)
+    Q_PROPERTY(StyleItem * alignOffsetOctaveAccidentals READ alignOffsetOctaveAccidentals CONSTANT)
 public:
     explicit AccidentalGroupPageModel(QObject* parent = nullptr);
 

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -23,9 +23,9 @@
 #include "editstyle.h"
 
 #include <QButtonGroup>
-#include <QQuickItem>
-#include <QQuickWidget>
 #include <QQmlContext>
+#include <QQuickItem>
+#include <QQuickView>
 #include <QSignalMapper>
 
 #include "translation.h"
@@ -44,7 +44,7 @@
 #include "engraving/style/textstyle.h"
 #include "engraving/types/symnames.h"
 #include "engraving/types/typesconv.h"
-#include "engraving/dom/instrumentname.h"
+#include "engraving/types/types.h"
 
 #include "ui/view/widgetstatestore.h"
 #include "ui/view/widgetutils.h"
@@ -207,6 +207,38 @@ static void fillDynamicHairpinComboBox(QComboBox* comboBox)
     comboBox->addItem(muse::qtrc("notation/editstyle", "Based on voice"), int(DirectionV::AUTO));
     comboBox->addItem(muse::qtrc("notation/editstyle", "Above"), int(DirectionV::UP));
     comboBox->addItem(muse::qtrc("notation/editstyle", "Below"), int(DirectionV::DOWN));
+}
+
+namespace {
+struct WidgetAndView {
+    QWidget* widget;
+    QQuickView* view;
+};
+}
+
+static WidgetAndView createQmlWidget(QWidget* parent, const QUrl& source, QQmlEngine* engine)
+{
+    QQuickView* view = new QQuickView(engine, nullptr);
+    view->setResizeMode(QQuickView::SizeRootObjectToView);
+    QObject::connect(view, &QQuickView::statusChanged, [source, view](QQuickView::Status status) {
+        if (status == QQuickView::Error) {
+            LOGE() << "Errors while loading QML file from " << source << ":";
+
+            for (const QQmlError& error : view->errors()) {
+                LOGE() << error.toString();
+            }
+        }
+    });
+    QObject::connect(view, &QQuickView::sceneGraphError, [ source](QQuickWindow::SceneGraphError error, const QString& message) {
+        LOGE() << "Scene graph error in QML file from " << source << ": [" << error << "] " << message;
+    });
+    view->setSource(source);
+
+    QWidget* container = QWidget::createWindowContainer(view, parent);
+    container->setMinimumSize(view->size());
+    container->setFocusPolicy(Qt::TabFocus);
+
+    return { container, view };
 }
 
 //---------------------------------------------------------
@@ -813,27 +845,23 @@ EditStyle::EditStyle(QWidget* parent)
     // Notes (QML)
     // ====================================================
 
-    QQuickWidget* noteFlagsTypeSelector = new QQuickWidget(/*QmlEngine*/ uiEngine()->qmlEngine(),
-                                                           /*parent*/ groupBox_noteFlags);
-    noteFlagsTypeSelector->setObjectName("noteFlagsTypeSelector_QQuickWidget");
-    noteFlagsTypeSelector->setSource(
-        QUrl(QString::fromUtf8("qrc:/qml/MuseScore/NotationScene/internal/EditStyle/NoteFlagsTypeSelector.qml")));
-    noteFlagsTypeSelector->setMinimumSize(224, 70);
-    noteFlagsTypeSelector->setResizeMode(QQuickWidget::SizeRootObjectToView);
-    groupBox_noteFlags->layout()->addWidget(noteFlagsTypeSelector);
+    auto noteFlagsTypeSelector = createQmlWidget(
+        groupBox_noteFlags,
+        QUrl(QString::fromUtf8("qrc:/qml/MuseScore/NotationScene/internal/EditStyle/NoteFlagsTypeSelector.qml")),
+        uiEngine()->qmlEngine());
+    noteFlagsTypeSelector.widget->setMinimumSize(224, 70);
+    groupBox_noteFlags->layout()->addWidget(noteFlagsTypeSelector.widget);
 
     // ====================================================
     // Rests (QML)
     // ====================================================
 
-    QQuickWidget* restOffsetSelector = new QQuickWidget(/*QmlEngine*/ uiEngine()->qmlEngine(),
-                                                        /*parent*/ groupBox_rests);
-    restOffsetSelector->setObjectName("restOffsetSelector_QQuickWidget");
-    restOffsetSelector->setSource(
-        QUrl(QString::fromUtf8("qrc:/qml/MuseScore/NotationScene/internal/EditStyle/RestOffsetSelector.qml")));
-    restOffsetSelector->setMinimumSize(224, 30);
-    restOffsetSelector->setResizeMode(QQuickWidget::SizeRootObjectToView);
-    groupBox_rests->layout()->addWidget(restOffsetSelector);
+    auto restOffsetSelector = createQmlWidget(
+        groupBox_rests,
+        QUrl(QString::fromUtf8("qrc:/qml/MuseScore/NotationScene/internal/EditStyle/RestOffsetSelector.qml")),
+        uiEngine()->qmlEngine());
+    restOffsetSelector.widget->setMinimumSize(224, 30);
+    groupBox_rests->layout()->addWidget(restOffsetSelector.widget);
 
     // ====================================================
     // Measure repeats
@@ -847,66 +875,57 @@ EditStyle::EditStyle(QWidget* parent)
     // BEAMS (QML)
     // ====================================================
 
-    QQuickWidget* beamsPage = new QQuickWidget(/*QmlEngine*/ uiEngine()->qmlEngine(),
-                                               /*parent*/ groupBox_beams);
-    beamsPage->setObjectName("beamsPage_QQuickWidget");
-    beamsPage->setSource(QUrl(QString::fromUtf8("qrc:/qml/MuseScore/NotationScene/internal/EditStyle/BeamsPage.qml")));
-    beamsPage->setMinimumSize(224, 418);
-    beamsPage->setResizeMode(QQuickWidget::SizeRootObjectToView);
-    groupBox_beams->layout()->addWidget(beamsPage);
+    auto beamsPage = createQmlWidget(
+        groupBox_beams,
+        QUrl(QString::fromUtf8("qrc:/qml/MuseScore/NotationScene/internal/EditStyle/BeamsPage.qml")),
+        uiEngine()->qmlEngine());
+    beamsPage.widget->setMinimumSize(224, 418);
+    groupBox_beams->layout()->addWidget(beamsPage.widget);
 
     // ====================================================
     // BENDS (QML)
     // ====================================================
 
-    QQuickWidget* fullBendStyleSelector = new QQuickWidget(/*QmlEngine*/ uiEngine()->qmlEngine(),
-                                                           /*parent*/ fullBendStyleBoxSelector);
-    fullBendStyleSelector->setObjectName("bendStyleSelector_QQuickWidget");
-    fullBendStyleSelector->setSource(QUrl(QString::fromUtf8(
-                                              "qrc:/qml/MuseScore/NotationScene/internal/EditStyle/FullBendStyleSelector.qml")));
-    fullBendStyleSelector->setMinimumSize(224, 60);
-    fullBendStyleSelector->setResizeMode(QQuickWidget::SizeRootObjectToView);
-    fullBendStyleBoxSelector->layout()->addWidget(fullBendStyleSelector);
+    auto fullBendStyleSelector = createQmlWidget(
+        fullBendStyleBoxSelector,
+        QUrl(QString::fromUtf8("qrc:/qml/MuseScore/NotationScene/internal/EditStyle/FullBendStyleSelector.qml")),
+        uiEngine()->qmlEngine());
+    fullBendStyleSelector.widget->setMinimumSize(224, 60);
+    fullBendStyleBoxSelector->layout()->addWidget(fullBendStyleSelector.widget);
 
     // ====================================================
     // TIE PLACEMENT (QML)
     // ====================================================
 
-    QQuickWidget* tiePlacementSelector = new QQuickWidget(/*QmlEngine*/ uiEngine()->qmlEngine(),
-                                                          /*parent*/ groupBox_ties);
-    tiePlacementSelector->setObjectName("tiePlacementSelector_QQuickWidget");
-    tiePlacementSelector->setSource(QUrl(QString::fromUtf8(
-                                             "qrc:/qml/MuseScore/NotationScene/internal/EditStyle/TiePlacementSelector.qml")));
-    tiePlacementSelector->setMinimumSize(224, 120);
-    tiePlacementSelector->setResizeMode(QQuickWidget::SizeRootObjectToView);
-    groupBox_ties->layout()->addWidget(tiePlacementSelector);
+    auto tiePlacementSelector = createQmlWidget(
+        groupBox_ties,
+        QUrl(QString::fromUtf8("qrc:/qml/MuseScore/NotationScene/internal/EditStyle/TiePlacementSelector.qml")),
+        uiEngine()->qmlEngine());
+    tiePlacementSelector.widget->setMinimumSize(224, 120);
+    groupBox_ties->layout()->addWidget(tiePlacementSelector.widget);
 
     // ====================================================
     // ACCIDENTAL GROUP PLACEMENT (QML)
     // ====================================================
 
-    QQuickWidget* accidPlacementSelector = new QQuickWidget(/*QmlEngine*/ uiEngine()->qmlEngine(),
-                                                            /*parent*/ groupBoxAccidentalStacking);
-    accidPlacementSelector->setObjectName("accidPlacementSelector_QQuickWidget");
-    accidPlacementSelector->setSource(QUrl(QString::fromUtf8(
-                                               "qrc:/qml/MuseScore/NotationScene/internal/EditStyle/AccidentalGroupPage.qml")));
-    accidPlacementSelector->setMinimumSize(224, 440);
-    accidPlacementSelector->setResizeMode(QQuickWidget::SizeRootObjectToView);
-    groupBoxAccidentalStacking->layout()->addWidget(accidPlacementSelector);
+    auto accidPlacementSelector = createQmlWidget(
+        groupBoxAccidentalStacking,
+        QUrl(QString::fromUtf8("qrc:/qml/MuseScore/NotationScene/internal/EditStyle/AccidentalGroupPage.qml")),
+        uiEngine()->qmlEngine());
+    accidPlacementSelector.widget->setMinimumSize(224, 440);
+    groupBoxAccidentalStacking->layout()->addWidget(accidPlacementSelector.widget);
 
     // ====================================================
     // FRETBOARDS STYLE PAGE (QML)
     // ====================================================
 
-    QQuickWidget* fretboardsPage = new QQuickWidget(/*QmlEngine*/ uiEngine()->qmlEngine(),
-                                                    /*parent*/ fretboardsWidget);
-    fretboardsPage->setObjectName("fretboardsPage_QQuickWidget");
-    fretboardsPage->setSource(QUrl(QString::fromUtf8(
-                                       "qrc:/qml/MuseScore/NotationScene/internal/EditStyle/FretboardsPage.qml")));
-    fretboardsPage->setMinimumSize(224, 1000);
-    fretboardsPage->setResizeMode(QQuickWidget::SizeRootObjectToView);
-    connect(fretboardsPage->rootObject(), SIGNAL(goToTextStylePage(QString)), this, SLOT(goToTextStylePage(QString)));
-    fretboardsWidget->layout()->addWidget(fretboardsPage);
+    auto fretboardsPage = createQmlWidget(
+        fretboardsWidget,
+        QUrl(QString::fromUtf8("qrc:/qml/MuseScore/NotationScene/internal/EditStyle/FretboardsPage.qml")),
+        uiEngine()->qmlEngine());
+    fretboardsPage.widget->setMinimumSize(224, 1000);
+    connect(fretboardsPage.view->rootObject(), SIGNAL(goToTextStylePage(QString)), this, SLOT(goToTextStylePage(QString)));
+    fretboardsWidget->layout()->addWidget(fretboardsPage.widget);
 
     // ====================================================
     // Figured Bass

--- a/src/notation/view/widgets/editstyle.h
+++ b/src/notation/view/widgets/editstyle.h
@@ -28,10 +28,13 @@
 #include "context/iglobalcontext.h"
 #include "inotationconfiguration.h"
 #include "iinteractive.h"
+#include "ui/iuiconfiguration.h"
 #include "ui/iuiengine.h"
 #include "engraving/iengravingfontsprovider.h"
 
 #include "engraving/style/textstyle.h"
+
+class QQuickView;
 
 namespace mu::notation {
 class EditStyle : public QDialog, private Ui::EditStyleBase, public muse::Injectable
@@ -44,6 +47,7 @@ class EditStyle : public QDialog, private Ui::EditStyleBase, public muse::Inject
     muse::Inject<mu::context::IGlobalContext> globalContext = { this };
     muse::Inject<mu::notation::INotationConfiguration> configuration = { this };
     muse::Inject<muse::IInteractive> interactive = { this };
+    muse::Inject<muse::ui::IUiConfiguration> uiConfiguration = { this };
     muse::Inject<muse::ui::IUiEngine> uiEngine = { this };
     muse::Inject<mu::engraving::IEngravingFontsProvider> engravingFonts = { this };
     muse::Inject<muse::accessibility::IAccessibilityController> accessibilityController = { this };
@@ -78,6 +82,13 @@ private:
     void retranslate();
     void setHeaderFooterToolTip();
     void adjustPagesStackSize(int currentPageIndex);
+
+    struct WidgetAndView {
+        QWidget* widget = nullptr;
+        QQuickView* view = nullptr;
+    };
+
+    WidgetAndView createQmlWidget(QWidget* parent, const QUrl& source);
 
     /// EditStylePage
     /// This is a type for a pointer to any QWidget that is a member of EditStyle.

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -251,9 +251,6 @@
       </item>
      </widget>
      <widget class="QStackedWidget" name="pageStack">
-      <property name="currentIndex">
-       <number>37</number>
-      </property>
       <widget class="QWidget" name="PageScore">
        <layout class="QVBoxLayout" name="verticalLayout_20">
         <item>


### PR DESCRIPTION
Eliminating the former was a requirement for eliminating the latter (at least with Qt 6.2.x); and removing the latter should resolve https://github.com/musescore/MuseScore/issues/22369.

There is a slight chance that this also resolves issues https://github.com/musescore/MuseScore/issues/23399 and https://github.com/musescore/MuseScore/issues/23299, but that is mostly wishful thinking.